### PR TITLE
Fix v3 auth with project scope

### DIFF
--- a/openstack/client.go
+++ b/openstack/client.go
@@ -174,16 +174,16 @@ func v3auth(client *gophercloud.ProviderClient, endpoint string, options gopherc
 	}
 
 	v3Opts := tokens3.AuthOptions{
-		IdentityEndpoint: options.IdentityEndpoint,
-		Username:         options.Username,
-		UserID:           options.UserID,
-		Password:         options.Password,
-		DomainID:         options.DomainID,
-		DomainName:       options.DomainName,
-		TenantID:         options.TenantID,
-		TenantName:       options.TenantName,
-		AllowReauth:      options.AllowReauth,
-		TokenID:          options.TokenID,
+		IdentityEndpoint: v3Options.IdentityEndpoint,
+		Username:         v3Options.Username,
+		UserID:           v3Options.UserID,
+		Password:         v3Options.Password,
+		DomainID:         v3Options.DomainID,
+		DomainName:       v3Options.DomainName,
+		TenantID:         v3Options.TenantID,
+		TenantName:       v3Options.TenantName,
+		AllowReauth:      v3Options.AllowReauth,
+		TokenID:          v3Options.TokenID,
 	}
 
 	result := tokens3.Create(v3Client, v3Opts, scope)

--- a/openstack/testing/client_test.go
+++ b/openstack/testing/client_test.go
@@ -49,8 +49,10 @@ func TestAuthenticatedClientV3(t *testing.T) {
 	})
 
 	options := gophercloud.AuthOptions{
-		UserID:           "me",
+		Username:         "me",
 		Password:         "secret",
+		DomainName:       "default",
+		TenantName: 	  "project",
 		IdentityEndpoint: th.Endpoint(),
 	}
 	client, err := openstack.AuthenticatedClient(options)


### PR DESCRIPTION
When I use the AuthenticatedClient to authenticate using identity v3 and a project scope is specified (i.e. TenantName), I receive the following error

```go
auth := gophercloud.AuthOptions{
		IdentityEndpoint: "http://example.com/v3",
		Username:  "carolyn",
		Password: "secret",
		TenantName: "admin",
		DomainName: "default",
	}
	identityService, authErr := openstack.AuthenticatedClient(auth)
```

```
The base Identity V3 API does not accept authentication by TenantName
```

I have updated the client to use the modified auth options, so that the Tenant ID/Name is cleared out to pass validation. I've also updated the v3 auth test so that without this fix, the test fails with the error above.