### PR TITLE
Change Block Storage v1 Volume.CreatedAt Type

### DIFF
--- a/openstack/blockstorage/v1/volumes/results.go
+++ b/openstack/blockstorage/v1/volumes/results.go
@@ -18,7 +18,7 @@ type Volume struct {
 	// Indicates whether this is a bootable volume.
 	Bootable string `json:"bootable"`
 	// The date when this volume was created.
-	CreatedAt gophercloud.JSONRFC3339Milli `json:"created_at"`
+	CreatedAt gophercloud.JSONRFC3339MilliNoZ `json:"created_at"`
 	// Human-readable description for the volume.
 	Description string `json:"display_description"`
 	// The type of volume to create, either SATA or SSD.

--- a/openstack/blockstorage/v1/volumes/testing/fixtures.go
+++ b/openstack/blockstorage/v1/volumes/testing/fixtures.go
@@ -66,7 +66,7 @@ func MockGetResponse(t *testing.T) {
 			                "device": "/"
 			            }
 			        ],
-			        "created_at": "2012-02-14T20:53:07Z"
+			        "created_at": "2012-02-14T20:53:07"
 			    }
 			}
       `)

--- a/openstack/blockstorage/v1/volumes/testing/requests_test.go
+++ b/openstack/blockstorage/v1/volumes/testing/requests_test.go
@@ -98,7 +98,7 @@ func TestGet(t *testing.T) {
 		},
 		AvailabilityZone: "us-east1",
 		Bootable:         "false",
-		CreatedAt:        gophercloud.JSONRFC3339Milli(time.Date(2012, 2, 14, 20, 53, 07, 0, time.UTC)),
+		CreatedAt:        gophercloud.JSONRFC3339MilliNoZ(time.Date(2012, 2, 14, 20, 53, 07, 0, time.UTC)),
 		Description:      "Another volume.",
 		VolumeType:       "289da7f8-6440-407c-9fb4-7db01ec49164",
 		SnapshotID:       "",


### PR DESCRIPTION
This commit changes the Volume.CreatedAt type from
gophercloud.JSONRFC3339Milli to gophercloud.JSONRFC3339MilliNoZ.

For #22 