### PR TITLE
Change Block Storage v1 Snapshots.CreatedAt Type

### DIFF
--- a/openstack/blockstorage/v1/snapshots/results.go
+++ b/openstack/blockstorage/v1/snapshots/results.go
@@ -23,10 +23,10 @@ type Snapshot struct {
 	Bootable string `json:"bootable"`
 
 	// Date created.
-	CreatedAt gophercloud.JSONRFC3339Milli `json:"created_at"`
+	CreatedAt gophercloud.JSONRFC3339MilliNoZ `json:"created_at"`
 
 	// Display description.
-	Description string `json:"display_discription"`
+	Description string `json:"display_description"`
 
 	// See VolumeType object for more information.
 	VolumeType string `json:"volume_type"`

--- a/openstack/blockstorage/v1/snapshots/testing/fixtures.go
+++ b/openstack/blockstorage/v1/snapshots/testing/fixtures.go
@@ -22,11 +22,21 @@ func MockListResponse(t *testing.T) {
       "snapshots": [
         {
           "id": "289da7f8-6440-407c-9fb4-7db01ec49164",
-          "display_name": "snapshot-001"
+          "display_name": "snapshot-001",
+          "volume_id": "521752a6-acf6-4b2d-bc7a-119f9148cd8c",
+          "display_description": "Daily Backup",
+          "status": "available",
+          "size": 30,
+          "created_at": "2012-02-14T20:53:07"
         },
         {
           "id": "96c3bda7-c82a-4f50-be73-ca7621794835",
-          "display_name": "snapshot-002"
+          "display_name": "snapshot-002",
+          "volume_id": "76b8950a-8594-4e5b-8dce-0dfa9c696358",
+          "display_description": "Weekly Backup",
+          "status": "available",
+          "size": 25,
+          "created_at": "2012-02-14T20:53:08"
         }
       ]
     }
@@ -44,8 +54,13 @@ func MockGetResponse(t *testing.T) {
 		fmt.Fprintf(w, `
 {
     "snapshot": {
+        "id": "d32019d3-bc6e-4319-9c1d-6722fc136a22",
         "display_name": "snapshot-001",
-        "id": "d32019d3-bc6e-4319-9c1d-6722fc136a22"
+        "display_description": "Daily backup",
+        "volume_id": "521752a6-acf6-4b2d-bc7a-119f9148cd8c",
+        "status": "available",
+        "size": 30,
+        "created_at": "2012-02-29T03:50:07"
     }
 }
       `)
@@ -75,8 +90,13 @@ func MockCreateResponse(t *testing.T) {
     "snapshot": {
         "volume_id": "1234",
         "display_name": "snapshot-001",
-        "id": "d32019d3-bc6e-4319-9c1d-6722fc136a22"
-    }
+        "id": "d32019d3-bc6e-4319-9c1d-6722fc136a22",
+        "display_description": "Daily backup",
+        "volume_id": "1234",
+        "status": "available",
+        "size": 30,
+        "created_at": "2012-02-29T03:50:07"
+  }
 }
     `)
 	})

--- a/openstack/blockstorage/v1/snapshots/testing/requests_test.go
+++ b/openstack/blockstorage/v1/snapshots/testing/requests_test.go
@@ -29,20 +29,22 @@ func TestList(t *testing.T) {
 
 		expected := []snapshots.Snapshot{
 			{
-				ID:        "289da7f8-6440-407c-9fb4-7db01ec49164",
-				Name:      "snapshot-001",
-				VolumeID:  "521752a6-acf6-4b2d-bc7a-119f9148cd8c",
-				Status:    "available",
-				Size:      30,
-				CreatedAt: gophercloud.JSONRFC3339MilliNoZ(time.Date(2012, 2, 14, 20, 53, 7, 0, time.UTC)),
+				ID:          "289da7f8-6440-407c-9fb4-7db01ec49164",
+				Name:        "snapshot-001",
+				VolumeID:    "521752a6-acf6-4b2d-bc7a-119f9148cd8c",
+				Status:      "available",
+				Size:        30,
+				CreatedAt:   gophercloud.JSONRFC3339MilliNoZ(time.Date(2012, 2, 14, 20, 53, 7, 0, time.UTC)),
+				Description: "Daily Backup",
 			},
 			{
-				ID:        "96c3bda7-c82a-4f50-be73-ca7621794835",
-				Name:      "snapshot-002",
-				VolumeID:  "76b8950a-8594-4e5b-8dce-0dfa9c696358",
-				Status:    "available",
-				Size:      25,
-				CreatedAt: gophercloud.JSONRFC3339MilliNoZ(time.Date(2012, 2, 14, 20, 53, 8, 0, time.UTC)),
+				ID:          "96c3bda7-c82a-4f50-be73-ca7621794835",
+				Name:        "snapshot-002",
+				VolumeID:    "76b8950a-8594-4e5b-8dce-0dfa9c696358",
+				Status:      "available",
+				Size:        25,
+				CreatedAt:   gophercloud.JSONRFC3339MilliNoZ(time.Date(2012, 2, 14, 20, 53, 8, 0, time.UTC)),
+				Description: "Weekly Backup",
 			},
 		}
 

--- a/openstack/blockstorage/v1/snapshots/testing/requests_test.go
+++ b/openstack/blockstorage/v1/snapshots/testing/requests_test.go
@@ -2,7 +2,9 @@ package testing
 
 import (
 	"testing"
+	"time"
 
+	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v1/snapshots"
 	"github.com/gophercloud/gophercloud/pagination"
 	th "github.com/gophercloud/gophercloud/testhelper"
@@ -27,12 +29,20 @@ func TestList(t *testing.T) {
 
 		expected := []snapshots.Snapshot{
 			{
-				ID:   "289da7f8-6440-407c-9fb4-7db01ec49164",
-				Name: "snapshot-001",
+				ID:        "289da7f8-6440-407c-9fb4-7db01ec49164",
+				Name:      "snapshot-001",
+				VolumeID:  "521752a6-acf6-4b2d-bc7a-119f9148cd8c",
+				Status:    "available",
+				Size:      30,
+				CreatedAt: gophercloud.JSONRFC3339MilliNoZ(time.Date(2012, 2, 14, 20, 53, 7, 0, time.UTC)),
 			},
 			{
-				ID:   "96c3bda7-c82a-4f50-be73-ca7621794835",
-				Name: "snapshot-002",
+				ID:        "96c3bda7-c82a-4f50-be73-ca7621794835",
+				Name:      "snapshot-002",
+				VolumeID:  "76b8950a-8594-4e5b-8dce-0dfa9c696358",
+				Status:    "available",
+				Size:      25,
+				CreatedAt: gophercloud.JSONRFC3339MilliNoZ(time.Date(2012, 2, 14, 20, 53, 8, 0, time.UTC)),
 			},
 		}
 


### PR DESCRIPTION
This commit changes the Snapshots.CreatedAt type from
gophercloud.JSONRFC3339Milli to gophercloud.JSONRFC3339MilliNoZ.

For #30 