### PR TITLE
[wip]: Add support for Designate Zones and Recordsets

### DIFF
--- a/openstack/client.go
+++ b/openstack/client.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/url"
 	"reflect"
+	"strings"
 
 	"github.com/gophercloud/gophercloud"
 	tokens2 "github.com/gophercloud/gophercloud/openstack/identity/v2/tokens"
@@ -26,7 +27,18 @@ func NewClient(endpoint string) (*gophercloud.ProviderClient, error) {
 		return nil, err
 	}
 	hadPath := u.Path != ""
-	u.Path, u.RawQuery, u.Fragment = "", "", ""
+	u.RawQuery, u.Fragment = "", ""
+
+	if strings.HasSuffix(u.Path, "v3/") {
+
+		u.Path = strings.TrimSuffix(u.Path, "v3/")
+
+	}
+	if strings.HasSuffix(u.Path, "v2.0/") {
+
+		u.Path = strings.TrimSuffix(u.Path, "v2.0/")
+
+	}
 	base := u.String()
 
 	endpoint = gophercloud.NormalizeURL(endpoint)
@@ -298,4 +310,14 @@ func NewDBV1(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*
 		return nil, err
 	}
 	return &gophercloud.ServiceClient{ProviderClient: client, Endpoint: url}, nil
+}
+
+// NewDBV1 creates a ServiceClient that may be used to access the v1 DB service.
+func NewDNSV2(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
+	eo.ApplyDefaults("dns")
+	url, err := client.EndpointLocator(eo)
+	if err != nil {
+		return nil, err
+	}
+	return &gophercloud.ServiceClient{ProviderClient: client, Endpoint: url, ResourceBase: url + "v2/"}, nil
 }

--- a/openstack/dns/v2/recordsets/doc.go
+++ b/openstack/dns/v2/recordsets/doc.go
@@ -1,0 +1,6 @@
+// Package tokens provides information and interaction with the zone API
+// resource for the OpenStack DNS service.
+//
+// For more information, see:
+// http://developer.openstack.org/api-ref/dns/#zone
+package recordsets

--- a/openstack/dns/v2/recordsets/requests.go
+++ b/openstack/dns/v2/recordsets/requests.go
@@ -1,0 +1,96 @@
+package recordsets
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// Zone Object
+
+type ListOptsBuilder interface {
+	ToRRSetListMap() (string, error)
+}
+
+// ListOpts allows you to query the List method.
+type ListOpts struct {
+	Marker string `q:"marker"`
+	Limit  int    `q:"limit"`
+}
+
+func (opts ListOpts) ToRRSetListMap() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+func List(client *gophercloud.ServiceClient, zoneID string) pagination.Pager {
+	u := listURL(client, zoneID)
+	return pagination.NewPager(client, u, func(r pagination.PageResult) pagination.Page {
+		return RRSetPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// UpdateOptsBuilder allows extensions to add additional attributes to the Update request.
+type CreateOptsBuilder interface {
+	ToZoneCreateMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts specifies the base attributes that may be updated on an existing server.
+type CreateOpts struct {
+	Records []string `json:"records,omitempty"`
+}
+
+// ToServerUpdateMap formats an UpdateOpts structure into a request body.
+func (opts CreateOpts) ToZoneCreateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "")
+}
+
+// Update changes the service type of an existing service.
+func Create(client *gophercloud.ServiceClient, zoneID string, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToZoneCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(listURL(client, zoneID), &b, &r.Body, nil)
+	return
+}
+
+// Get returns additional information about a service, given its ID.
+func Get(client *gophercloud.ServiceClient, zoneID string, rrsetID string) (r GetResult) {
+	_, r.Err = client.Get(rrsetURL(client, zoneID, rrsetID), &r.Body, nil)
+	return
+}
+
+// UpdateOptsBuilder allows extensions to add additional attributes to the Update request.
+type UpdateOptsBuilder interface {
+	ToRRSetUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts specifies the base attributes that may be updated on an existing server.
+type UpdateOpts struct {
+	Email string `json:"email,omitempty"`
+	TTL   int    `json:"ttl,omitempty"`
+}
+
+// ToServerUpdateMap formats an UpdateOpts structure into a request body.
+func (opts UpdateOpts) ToRRSetUpdateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "")
+}
+
+// Update changes the service type of an existing service.
+func Update(client *gophercloud.ServiceClient, zoneID string, rrsetID string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToRRSetUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Patch(rrsetURL(client, zoneID, rrsetID), &b, &r.Body, nil)
+	return
+}
+
+// Delete removes an existing service.
+// It either deletes all associated endpoints, or fails until all endpoints are deleted.
+func Delete(client *gophercloud.ServiceClient, zoneID string, rrsetID string) (r DeleteResult) {
+	_, r.Err = client.Delete(rrsetURL(client, zoneID, rrsetID), nil)
+	return
+}

--- a/openstack/dns/v2/recordsets/results.go
+++ b/openstack/dns/v2/recordsets/results.go
@@ -1,0 +1,70 @@
+package recordsets
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// Extract interprets a GetResult, CreateResult or UpdateResult as a concrete Zone.
+// An error is returned if the original call or the extraction failed.
+func (r commonResult) Extract() (RecordSet, error) {
+	var s RecordSet
+	err := r.ExtractInto(&s)
+	return s, err
+}
+
+// CreateResult is the deferred result of a Create call.
+type CreateResult struct {
+	commonResult
+}
+
+// GetResult is the deferred result of a Get call.
+type GetResult struct {
+	commonResult
+}
+
+// UpdateResult is the deferred result of an Update call.
+type UpdateResult struct {
+	commonResult
+}
+
+// DeleteResult is the deferred result of an Delete call.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
+// ZonePage is a single page of Zonje results.
+type RRSetPage struct {
+	pagination.LinkedPageBase
+}
+
+// IsEmpty returns true if the page contains no results.
+func (p RRSetPage) IsEmpty() (bool, error) {
+	services, err := ExtractRRSets(p)
+	return len(services) == 0, err
+}
+
+// ExtractServices extracts a slice of Services from a Collection acquired from List.
+func ExtractRRSets(r pagination.Page) ([]RecordSet, error) {
+	var s struct {
+		RRSets []RecordSet `json:"recordsets"`
+	}
+	err := (r.(RRSetPage)).ExtractInto(&s)
+	return s.RRSets, err
+}
+
+type RecordSet struct {
+	ProjectID string   `json:"project_id,omitempty"`
+	ID        string   `json:"id,omitempty"`
+	ZoneID    string   `json:"zone_id,omitempty"`
+	ZoneName  string   `json:"zone_name,omitempty"`
+	Name      string   `json:"name,omitempty"`
+	Records   []string `json:"records,omitempty"`
+	TTL       int      `json:"ttl,omitempty"`
+	Status    string   `json:"status,omitempty"`
+	Type      string   `json:"type,omitempty"`
+}

--- a/openstack/dns/v2/recordsets/urls.go
+++ b/openstack/dns/v2/recordsets/urls.go
@@ -1,0 +1,11 @@
+package recordsets
+
+import "github.com/gophercloud/gophercloud"
+
+func listURL(c *gophercloud.ServiceClient, zoneID string) string {
+	return c.ServiceURL("zones", zoneID, "recordsets")
+}
+
+func rrsetURL(c *gophercloud.ServiceClient, zoneID string, rrsetID string) string {
+	return c.ServiceURL("zones", zoneID, "recordsets", rrsetID)
+}

--- a/openstack/dns/v2/zones/doc.go
+++ b/openstack/dns/v2/zones/doc.go
@@ -1,0 +1,6 @@
+// Package tokens provides information and interaction with the zone API
+// resource for the OpenStack DNS service.
+//
+// For more information, see:
+// http://developer.openstack.org/api-ref/dns/#zone
+package zones

--- a/openstack/dns/v2/zones/requests.go
+++ b/openstack/dns/v2/zones/requests.go
@@ -1,0 +1,98 @@
+package zones
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// Zone Object
+
+type ListOptsBuilder interface {
+	ToZoneListMap() (string, error)
+}
+
+// ListOpts allows you to query the List method.
+type ListOpts struct {
+	Marker string `q:"marker"`
+	Limit  int    `q:"limit"`
+}
+
+func (opts ListOpts) ToZoneListMap() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+func List(client *gophercloud.ServiceClient) pagination.Pager {
+	u := listURL(client)
+	return pagination.NewPager(client, u, func(r pagination.PageResult) pagination.Page {
+		return ZonePage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// UpdateOptsBuilder allows extensions to add additional attributes to the Update request.
+type CreateOptsBuilder interface {
+	ToZoneCreateMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts specifies the base attributes that may be updated on an existing server.
+type CreateOpts struct {
+	Email string `json:"email,omitempty"`
+	TTL   int    `json:"ttl,omitempty"`
+	Name  string `json:"name"`
+}
+
+// ToServerUpdateMap formats an UpdateOpts structure into a request body.
+func (opts CreateOpts) ToZoneCreateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "")
+}
+
+// Update changes the service type of an existing service.
+func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToZoneCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(listURL(client), &b, &r.Body, nil)
+	return
+}
+
+// Get returns additional information about a service, given its ID.
+func Get(client *gophercloud.ServiceClient, zoneID string) (r GetResult) {
+	_, r.Err = client.Get(zoneURL(client, zoneID), &r.Body, nil)
+	return
+}
+
+// UpdateOptsBuilder allows extensions to add additional attributes to the Update request.
+type UpdateOptsBuilder interface {
+	ToZoneUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts specifies the base attributes that may be updated on an existing server.
+type UpdateOpts struct {
+	Email string `json:"email,omitempty"`
+	TTL   int    `json:"ttl,omitempty"`
+}
+
+// ToServerUpdateMap formats an UpdateOpts structure into a request body.
+func (opts UpdateOpts) ToZoneUpdateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "")
+}
+
+// Update changes the service type of an existing service.
+func Update(client *gophercloud.ServiceClient, zoneID string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToZoneUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Patch(zoneURL(client, zoneID), &b, &r.Body, nil)
+	return
+}
+
+// Delete removes an existing service.
+// It either deletes all associated endpoints, or fails until all endpoints are deleted.
+func Delete(client *gophercloud.ServiceClient, zoneID string) (r DeleteResult) {
+	_, r.Err = client.Delete(zoneURL(client, zoneID), nil)
+	return
+}

--- a/openstack/dns/v2/zones/results.go
+++ b/openstack/dns/v2/zones/results.go
@@ -1,0 +1,70 @@
+package zones
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// Extract interprets a GetResult, CreateResult or UpdateResult as a concrete Zone.
+// An error is returned if the original call or the extraction failed.
+func (r commonResult) Extract() (Zone, error) {
+	var s Zone
+	err := r.ExtractInto(&s)
+	return s, err
+}
+
+// CreateResult is the deferred result of a Create call.
+type CreateResult struct {
+	commonResult
+}
+
+// GetResult is the deferred result of a Get call.
+type GetResult struct {
+	commonResult
+}
+
+// UpdateResult is the deferred result of an Update call.
+type UpdateResult struct {
+	commonResult
+}
+
+// DeleteResult is the deferred result of an Delete call.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
+// ZonePage is a single page of Zonje results.
+type ZonePage struct {
+	pagination.LinkedPageBase
+}
+
+// IsEmpty returns true if the page contains no results.
+func (p ZonePage) IsEmpty() (bool, error) {
+	services, err := ExtractZones(p)
+	return len(services) == 0, err
+}
+
+// ExtractServices extracts a slice of Services from a Collection acquired from List.
+func ExtractZones(r pagination.Page) ([]Zone, error) {
+	var s struct {
+		Zones []Zone `json:"zones"`
+	}
+	err := (r.(ZonePage)).ExtractInto(&s)
+	return s.Zones, err
+}
+
+type Zone struct {
+	ProjectID string  `json:"project_id,omitempty"`
+	ID        string  `json:"id,omitempty"`
+	PoolID    string  `json:"pool_id,omitempty"`
+	Name      string  `json:"name,omitempty"`
+	Email     string  `json:"email,omitempty"`
+	TTL       int     `json:"ttl,omitempty"`
+	Status    string  `json:"status,omitempty"`
+	Serial    float64 `json:"serial,omitempty"`
+	Type      string  `json:"type,omitempty"`
+}

--- a/openstack/dns/v2/zones/urls.go
+++ b/openstack/dns/v2/zones/urls.go
@@ -1,0 +1,11 @@
+package zones
+
+import "github.com/gophercloud/gophercloud"
+
+func listURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("zones")
+}
+
+func zoneURL(c *gophercloud.ServiceClient, zoneID string) string {
+	return c.ServiceURL("zones", zoneID)
+}

--- a/openstack/identity/v3/services/results.go
+++ b/openstack/identity/v3/services/results.go
@@ -41,7 +41,7 @@ type DeleteResult struct {
 
 // Service is the result of a list or information query.
 type Service struct {
-	Description string `json:"description`
+	Description string `json:"description"`
 	ID          string `json:"id"`
 	Name        string `json:"name"`
 	Type        string `json:"type"`


### PR DESCRIPTION
Adds openstack.dns.v2.zones & openstack.dns.v2.recordsets

For #52 

https://github.com/openstack/designate/blob/stable/mitaka/designate/objects/zone.py

https://github.com/openstack/designate/blob/stable/mitaka/designate/objects/recordset.py
