### PR TITLE
Add VolumeType option to bootfromvolume extension

### DIFF
--- a/acceptance/openstack/compute/v2/bootfromvolume_test.go
+++ b/acceptance/openstack/compute/v2/bootfromvolume_test.go
@@ -29,6 +29,8 @@ func TestBootFromVolumeSingleVolume(t *testing.T) {
 			UUID:       choices.ImageID,
 			SourceType: bootfromvolume.Image,
 			VolumeSize: 10,
+			VolumeType: "fast",
+			DestinationType: "volume",
 		},
 	}
 

--- a/openstack/compute/v2/extensions/bootfromvolume/requests.go
+++ b/openstack/compute/v2/extensions/bootfromvolume/requests.go
@@ -39,6 +39,8 @@ type BlockDevice struct {
 	GuestFormat string `json:"guest_format,omitempty"`
 	// VolumeSize is the size of the volume to create (in gigabytes).
 	VolumeSize int `json:"volume_size"`
+	// VolumeType specifies type of cinder volume(can be get via `cinder type-list` command)
+	VolumeType string `json:"volume_type,omitempty"`
 }
 
 // CreateOptsExt is a structure that extends the server `CreateOpts` structure

--- a/openstack/compute/v2/extensions/bootfromvolume/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/bootfromvolume/testing/requests_test.go
@@ -24,6 +24,7 @@ func TestCreateOpts(t *testing.T) {
 				DestinationType:     "volume",
 				VolumeSize:          10,
 				DeleteOnTermination: false,
+				VolumeType:	     "fast",
 			},
 		},
 	}
@@ -41,7 +42,8 @@ func TestCreateOpts(t *testing.T) {
             "destination_type":"volume",
             "boot_index": 0,
             "delete_on_termination": false,
-            "volume_size": 10
+            "volume_size": 10,
+            "volume_type": "fast"
           }
         ]
       }


### PR DESCRIPTION
Useful when need to choose volume-type for boot device.
