### PR TITLE
Use new endpoint type for magnum

### DIFF
--- a/openstack/client.go
+++ b/openstack/client.go
@@ -336,7 +336,7 @@ func NewDBV1(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*
 
 // NewContainerOrchestrationV1 creates a ServiceClient that may be used with the v1 container orchestration package.
 func NewContainerOrchestrationV1(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
-	eo.ApplyDefaults("container")
+	eo.ApplyDefaults("container-infra")
 	url, err := client.EndpointLocator(eo)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Magnum has changed the endpoint type in the service catalog from "container" to "container-infra".