### PR TITLE
Add BeginDetaching call for Cinder v2

### DIFF
--- a/openstack/blockstorage/extensions/volumeactions/requests.go
+++ b/openstack/blockstorage/extensions/volumeactions/requests.go
@@ -50,6 +50,15 @@ func Attach(client *gophercloud.ServiceClient, id string, opts AttachOptsBuilder
 	return
 }
 
+// BeginDetach will mark the volume as detaching
+func BeginDetaching(client *gophercloud.ServiceClient, id string) (r BeginDetachingResult) {
+	b := map[string]interface{}{"os-begin_detaching": make(map[string]interface{})}
+	_, r.Err = client.Post(beginDetachingURL(client, id), b, nil, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+	})
+	return
+}
+
 // DetachOptsBuilder allows extensions to add additional parameters to the
 // Detach request.
 type DetachOptsBuilder interface {

--- a/openstack/blockstorage/extensions/volumeactions/results.go
+++ b/openstack/blockstorage/extensions/volumeactions/results.go
@@ -7,6 +7,11 @@ type AttachResult struct {
 	gophercloud.ErrResult
 }
 
+// BeginDetachingResult contains the response body and error from a Get request.
+type BeginDetachingResult struct {
+	gophercloud.ErrResult
+}
+
 // DetachResult contains the response body and error from a Get request.
 type DetachResult struct {
 	gophercloud.ErrResult

--- a/openstack/blockstorage/extensions/volumeactions/testing/fixtures.go
+++ b/openstack/blockstorage/extensions/volumeactions/testing/fixtures.go
@@ -34,6 +34,26 @@ func MockAttachResponse(t *testing.T) {
 		})
 }
 
+func MockBeginDetachingResponse(t *testing.T) {
+	th.Mux.HandleFunc("/volumes/cd281d77-8217-4830-be95-9528227c105c/action",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "POST")
+			th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+			th.TestHeader(t, r, "Content-Type", "application/json")
+			th.TestHeader(t, r, "Accept", "application/json")
+			th.TestJSONRequest(t, r, `
+{
+    "os-begin_detaching": {}
+}
+          `)
+
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusAccepted)
+
+			fmt.Fprintf(w, `{}`)
+		})
+}
+
 func MockDetachResponse(t *testing.T) {
 	th.Mux.HandleFunc("/volumes/cd281d77-8217-4830-be95-9528227c105c/action",
 		func(w http.ResponseWriter, r *http.Request) {

--- a/openstack/blockstorage/extensions/volumeactions/testing/requests_test.go
+++ b/openstack/blockstorage/extensions/volumeactions/testing/requests_test.go
@@ -24,6 +24,16 @@ func TestAttach(t *testing.T) {
 	th.AssertNoErr(t, err)
 }
 
+func TestBeginDetaching(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockBeginDetachingResponse(t)
+
+	err := volumeactions.BeginDetaching(client.ServiceClient(), "cd281d77-8217-4830-be95-9528227c105c").ExtractErr()
+	th.AssertNoErr(t, err)
+}
+
 func TestDetach(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()

--- a/openstack/blockstorage/extensions/volumeactions/urls.go
+++ b/openstack/blockstorage/extensions/volumeactions/urls.go
@@ -6,6 +6,10 @@ func attachURL(c *gophercloud.ServiceClient, id string) string {
 	return c.ServiceURL("volumes", id, "action")
 }
 
+func beginDetachingURL(c *gophercloud.ServiceClient, id string) string {
+	return attachURL(c, id)
+}
+
 func detachURL(c *gophercloud.ServiceClient, id string) string {
 	return attachURL(c, id)
 }


### PR DESCRIPTION
Per Cinder API, os-begin_detaching action needs to
be called prior to os-terminate_connection. For #117 

Corresponding Cinder code: https://github.com/openstack/cinder/blob/stable/newton/cinder/api/contrib/volume_actions.py#L138