### PR TITLE
Check for token not being returned in JSON response

### DIFF
--- a/openstack/identity/v3/tokens/results.go
+++ b/openstack/identity/v3/tokens/results.go
@@ -1,5 +1,6 @@
 package tokens
 
+import "errors"
 import "github.com/gophercloud/gophercloud"
 
 // Endpoint represents a single API endpoint offered by a service.
@@ -57,6 +58,10 @@ func (r commonResult) ExtractToken() (*Token, error) {
 	err := r.ExtractInto(&s)
 	if err != nil {
 		return nil, err
+	}
+
+	if s.Token == nil {
+		return nil, errors.New("'token' missing in JSON response")
 	}
 
 	// Parse the token itself from the stored headers.

--- a/openstack/identity/v3/tokens/testing/requests_test.go
+++ b/openstack/identity/v3/tokens/testing/requests_test.go
@@ -509,3 +509,24 @@ func TestRevokeRequestError(t *testing.T) {
 		t.Errorf("Missing expected error from Revoke")
 	}
 }
+
+func TestNoTokenInResponse(t *testing.T) {
+	testhelper.SetupHTTP()
+	defer testhelper.TeardownHTTP()
+
+	client := gophercloud.ServiceClient{
+		ProviderClient: &gophercloud.ProviderClient{},
+		Endpoint:       testhelper.Endpoint(),
+	}
+
+	testhelper.Mux.HandleFunc("/auth/tokens", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprintf(w, `{}`)
+	})
+
+	options := tokens.AuthOptions{UserID: "me", Password: "squirrel!"}
+	_, err := tokens.Create(&client, &options).Extract()
+	if err == nil {
+		t.Error("Create succeeded with no token returned")
+	}
+}


### PR DESCRIPTION
This avoid a potential nil pointer dereference since
JSON decoding can succeed with missing fields.

For #108 