### PR TITLE
Check that Create token request succeeded

### DIFF
--- a/openstack/identity/v3/tokens/requests.go
+++ b/openstack/identity/v3/tokens/requests.go
@@ -158,8 +158,8 @@ func Create(c *gophercloud.ServiceClient, opts AuthOptionsBuilder) (r CreateResu
 	resp, err := c.Post(tokenURL(c), b, &r.Body, &gophercloud.RequestOpts{
 		MoreHeaders: map[string]string{"X-Auth-Token": ""},
 	})
+	r.Err = err
 	if resp != nil {
-		r.Err = err
 		r.Header = resp.Header
 	}
 	return

--- a/openstack/testing/client_test.go
+++ b/openstack/testing/client_test.go
@@ -52,7 +52,7 @@ func TestAuthenticatedClientV3(t *testing.T) {
 		Username:         "me",
 		Password:         "secret",
 		DomainName:       "default",
-		TenantName: 	  "project",
+		TenantName:       "project",
 		IdentityEndpoint: th.Endpoint(),
 	}
 	client, err := openstack.AuthenticatedClient(options)
@@ -290,4 +290,26 @@ func TestIdentityAdminV3Client(t *testing.T) {
 	})
 	th.AssertNoErr(t, err)
 	th.CheckEquals(t, "http://localhost:35357/", sc.Endpoint)
+}
+
+func testAuthenticatedClientFails(t *testing.T, endpoint string) {
+	options := gophercloud.AuthOptions{
+		Username:         "me",
+		Password:         "secret",
+		DomainName:       "default",
+		TenantName:       "project",
+		IdentityEndpoint: endpoint,
+	}
+	_, err := openstack.AuthenticatedClient(options)
+	if err == nil {
+		t.Fatal("expected error but call succeeded")
+	}
+}
+
+func TestAuthenticatedClientV3Fails(t *testing.T) {
+	testAuthenticatedClientFails(t, "http://bad-address.example.com/v3")
+}
+
+func TestAuthenticatedClientV2Fails(t *testing.T) {
+	testAuthenticatedClientFails(t, "http://bad-address.example.com/v2.0")
 }


### PR DESCRIPTION
If there was a network error, this needs to be
handled to avoid nil pointer derferences later.

For #109 