### PR TITLE
Server Metadata Update

### DIFF
--- a/acceptance/openstack/compute/v2/compute.go
+++ b/acceptance/openstack/compute/v2/compute.go
@@ -243,6 +243,9 @@ func CreateServer(t *testing.T, client *gophercloud.ServiceClient, choices *clie
 		Networks: []servers.Network{
 			servers.Network{UUID: networkID},
 		},
+		Metadata: map[string]string{
+			"abc": "def",
+		},
 		Personality: servers.Personality{
 			&servers.File{
 				Path:     "/etc/test",

--- a/openstack/compute/v2/servers/requests.go
+++ b/openstack/compute/v2/servers/requests.go
@@ -156,7 +156,7 @@ type CreateOpts struct {
 	Networks []Network `json:"-"`
 
 	// Metadata contains key-value pairs (up to 255 bytes each) to attach to the server.
-	Metadata map[string]string `json:"-"`
+	Metadata map[string]string `json:"metadata,omitempty"`
 
 	// Personality includes files to inject into the server at launch.
 	// Create will base64-encode file contents for you.

--- a/openstack/compute/v2/servers/results.go
+++ b/openstack/compute/v2/servers/results.go
@@ -154,7 +154,7 @@ type Server struct {
 	// Addresses includes a list of all IP addresses assigned to the server, keyed by pool.
 	Addresses map[string]interface{}
 	// Metadata includes a list of all user-specified key-value pairs attached to the server.
-	Metadata map[string]interface{}
+	Metadata map[string]string
 	// Links includes HTTP references to the itself, useful for passing along to other APIs that might want a server reference.
 	Links []interface{}
 	// KeyName indicates which public key was injected into the server on launch.

--- a/openstack/compute/v2/servers/testing/fixtures.go
+++ b/openstack/compute/v2/servers/testing/fixtures.go
@@ -352,7 +352,7 @@ var (
 		Name:     "herp",
 		Created:  "2014-09-25T13:10:02Z",
 		TenantID: "fcad67a6189847c4aecfa3c81a05783b",
-		Metadata: map[string]interface{}{},
+		Metadata: map[string]string{},
 		SecurityGroups: []map[string]interface{}{
 			map[string]interface{}{
 				"name": "default",
@@ -408,7 +408,7 @@ var (
 		Name:     "derp",
 		Created:  "2014-09-25T13:04:41Z",
 		TenantID: "fcad67a6189847c4aecfa3c81a05783b",
-		Metadata: map[string]interface{}{},
+		Metadata: map[string]string{},
 		SecurityGroups: []map[string]interface{}{
 			map[string]interface{}{
 				"name": "default",
@@ -456,7 +456,7 @@ var (
 		Name:     "merp",
 		Created:  "2014-09-25T13:04:41Z",
 		TenantID: "fcad67a6189847c4aecfa3c81a05783b",
-		Metadata: map[string]interface{}{},
+		Metadata: map[string]string{},
 		SecurityGroups: []map[string]interface{}{
 			map[string]interface{}{
 				"name": "default",
@@ -594,6 +594,29 @@ func HandleServerCreationWithCustomFieldSuccessfully(t *testing.T, response stri
 				"imageRef": "f90f6034-2570-4974-8351-6b49732ef2eb",
 				"flavorRef": "1",
 				"foo": "bar"
+			}
+		}`)
+
+		w.WriteHeader(http.StatusAccepted)
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprintf(w, response)
+	})
+}
+
+// HandleServerCreationWithMetadata sets up the test server to respond to a server creation request
+// with a given response.
+func HandleServerCreationWithMetadata(t *testing.T, response string) {
+	th.Mux.HandleFunc("/servers", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, `{
+			"server": {
+				"name": "derp",
+				"imageRef": "f90f6034-2570-4974-8351-6b49732ef2eb",
+				"flavorRef": "1",
+				"metadata": {
+					"abc": "def"
+				}
 			}
 		}`)
 

--- a/openstack/compute/v2/servers/testing/requests_test.go
+++ b/openstack/compute/v2/servers/testing/requests_test.go
@@ -89,6 +89,24 @@ func TestCreateServerWithCustomField(t *testing.T) {
 	th.CheckDeepEquals(t, ServerDerp, *actual)
 }
 
+func TestCreateServerWithMetadata(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleServerCreationWithMetadata(t, SingleServerBody)
+
+	actual, err := servers.Create(client.ServiceClient(), servers.CreateOpts{
+		Name:      "derp",
+		ImageRef:  "f90f6034-2570-4974-8351-6b49732ef2eb",
+		FlavorRef: "1",
+		Metadata: map[string]string{
+			"abc": "def",
+		},
+	}).Extract()
+	th.AssertNoErr(t, err)
+
+	th.CheckDeepEquals(t, ServerDerp, *actual)
+}
+
 func TestCreateServerWithImageNameAndFlavorName(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()


### PR DESCRIPTION
This commit updates the Server Metadata so it can be parsed and
translated using JSON tags.

The Server Metadata result has been changed to map[string]string to
match the request.

A unit test was added to verify the above and a piece of metadata has
been added to the server creation acceptance test.

For #86 