### PR TITLE
Fix Floating IP Disassociation

### DIFF
--- a/openstack/networking/v2/extensions/layer3/floatingips/requests.go
+++ b/openstack/networking/v2/extensions/layer3/floatingips/requests.go
@@ -111,7 +111,7 @@ type UpdateOptsBuilder interface {
 // linked to. To associate the floating IP with a new internal port, provide its
 // ID. To disassociate the floating IP from all ports, provide an empty string.
 type UpdateOpts struct {
-	PortID string `json:"port_id"`
+	PortID *string `json:"port_id"`
 }
 
 // ToFloatingIPUpdateMap allows UpdateOpts to satisfy the UpdateOptsBuilder

--- a/openstack/networking/v2/extensions/layer3/floatingips/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/layer3/floatingips/testing/requests_test.go
@@ -293,10 +293,11 @@ func TestAssociate(t *testing.T) {
 	`)
 	})
 
-	ip, err := floatingips.Update(fake.ServiceClient(), "2f245a7b-796b-4f26-9cf9-9e82d248fda7", floatingips.UpdateOpts{PortID: "423abc8d-2991-4a55-ba98-2aaea84cc72e"}).Extract()
+	portID := "423abc8d-2991-4a55-ba98-2aaea84cc72e"
+	ip, err := floatingips.Update(fake.ServiceClient(), "2f245a7b-796b-4f26-9cf9-9e82d248fda7", floatingips.UpdateOpts{PortID: &portID}).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertDeepEquals(t, "423abc8d-2991-4a55-ba98-2aaea84cc72e", ip.PortID)
+	th.AssertDeepEquals(t, portID, ip.PortID)
 }
 
 func TestDisassociate(t *testing.T) {
@@ -311,7 +312,7 @@ func TestDisassociate(t *testing.T) {
 		th.TestJSONRequest(t, r, `
 {
     "floatingip": {
-      "port_id": ""
+      "port_id": null
     }
 }
       `)
@@ -334,7 +335,7 @@ func TestDisassociate(t *testing.T) {
     `)
 	})
 
-	ip, err := floatingips.Update(fake.ServiceClient(), "2f245a7b-796b-4f26-9cf9-9e82d248fda7", floatingips.UpdateOpts{}).Extract()
+	ip, err := floatingips.Update(fake.ServiceClient(), "2f245a7b-796b-4f26-9cf9-9e82d248fda7", floatingips.UpdateOpts{PortID: nil}).Extract()
 	th.AssertNoErr(t, err)
 
 	th.AssertDeepEquals(t, "", ip.FixedIP)


### PR DESCRIPTION
This commit fixes floating IP disassociation by changing the PortID to a
string pointer rather than a string. This allows a value of "null" to be
passed which is what the Networking API is looking for.

For #99 