### PR TITLE
Add create multiple servers

### DIFF
--- a/openstack/compute/v2/servers/errors.go
+++ b/openstack/compute/v2/servers/errors.go
@@ -69,3 +69,20 @@ type ErrServerNotFound struct {
 func (e ErrServerNotFound) Error() string {
 	return fmt.Sprintf("I couldn't find server [%s]", e.ID)
 }
+
+type ErrMinGreaterThanMax struct {
+	Min int
+	Max int
+}
+
+func (err ErrMinGreaterThanMax) Error() string {
+	return fmt.Sprintf("Min %d is greater than Max %d", err.Min, err.Max)
+}
+
+type ErrNegativeValue struct {
+	Value int
+}
+
+func (err ErrNegativeValue) Error() string {
+	return fmt.Sprintf("Count cannot be negative %d", err.Value)
+}

--- a/openstack/compute/v2/servers/requests.go
+++ b/openstack/compute/v2/servers/requests.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 
+	"fmt"
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/flavors"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/images"
@@ -200,7 +201,7 @@ func setMinMaxCount(opts CreateOpts, request map[string]interface{}) error {
 	}
 
 	// Check min is less than max
-	if opts.MinCount > opts.MaxCount {
+	if opts.MinCount > opts.MaxCount && opts.MaxCount > 0 {
 		if opts.MinCount > opts.MaxCount {
 			err := ErrMinGreaterThanMax{
 				Min: opts.MinCount,
@@ -211,11 +212,11 @@ func setMinMaxCount(opts CreateOpts, request map[string]interface{}) error {
 		}
 	} else {
 		if opts.MinCount > 0 {
-			request["min_count"] = string(opts.MinCount)
+			request["min_count"] = fmt.Sprintf("%d", opts.MinCount)
 		}
 
 		if opts.MaxCount > 0 {
-			request["max_count"] = string(opts.MaxCount)
+			request["max_count"] = fmt.Sprintf("%d", opts.MaxCount)
 		}
 	}
 

--- a/openstack/compute/v2/servers/requests.go
+++ b/openstack/compute/v2/servers/requests.go
@@ -178,6 +178,48 @@ type CreateOpts struct {
 	// ServiceClient will allow calls to be made to retrieve an image or
 	// flavor ID by name.
 	ServiceClient *gophercloud.ServiceClient `json:"-"`
+
+	// Minimal count of servers to create
+	MinCount int `json:"_"`
+	// Maximal count of servers to be created
+	MaxCount int `json:"_"`
+}
+
+func setMinMaxCount(opts CreateOpts, request map[string]interface{}) error {
+	// Check count values are not negative
+	if opts.MinCount < 0 {
+		return ErrNegativeValue{
+			Value: opts.MinCount,
+		}
+	}
+
+	if opts.MaxCount < 0 {
+		return ErrNegativeValue{
+			Value: opts.MaxCount,
+		}
+	}
+
+	// Check min is less than max
+	if opts.MinCount > opts.MaxCount {
+		if opts.MinCount > opts.MaxCount {
+			err := ErrMinGreaterThanMax{
+				Min: opts.MinCount,
+				Max: opts.MaxCount,
+			}
+
+			return err
+		}
+	} else {
+		if opts.MinCount > 0 {
+			request["min_count"] = string(opts.MinCount)
+		}
+
+		if opts.MaxCount > 0 {
+			request["max_count"] = string(opts.MaxCount)
+		}
+	}
+
+	return nil
 }
 
 // ToServerCreateMap assembles a request body based on the contents of a CreateOpts.
@@ -186,6 +228,10 @@ func (opts CreateOpts) ToServerCreateMap() (map[string]interface{}, error) {
 	opts.ServiceClient = nil
 	b, err := gophercloud.BuildRequestBody(opts, "")
 	if err != nil {
+		return nil, err
+	}
+
+	if err = setMinMaxCount(opts, b); err != nil {
 		return nil, err
 	}
 

--- a/openstack/compute/v2/servers/testing/fixtures.go
+++ b/openstack/compute/v2/servers/testing/fixtures.go
@@ -582,6 +582,26 @@ func HandleServerCreationSuccessfully(t *testing.T, response string) {
 	})
 }
 
+func HandleServerMultipleCreationSuccessfully(t *testing.T, response string) {
+	th.Mux.HandleFunc("/servers", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, `{
+			"server": {
+				"name": "derp",
+				"imageRef": "f90f6034-2570-4974-8351-6b49732ef2eb",
+				"flavorRef": "1",
+				"max_count":  "4",
+				"min_count":  "2"
+			}
+		}`)
+
+		w.WriteHeader(http.StatusAccepted)
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprintf(w, response)
+	})
+}
+
 // HandleServerCreationWithCustomFieldSuccessfully sets up the test server to respond to a server creation request
 // with a given response.
 func HandleServerCreationWithCustomFieldSuccessfully(t *testing.T, response string) {

--- a/openstack/compute/v2/servers/testing/requests_test.go
+++ b/openstack/compute/v2/servers/testing/requests_test.go
@@ -123,28 +123,21 @@ func TestCreateServerWithImageNameAndFlavorName(t *testing.T) {
 	th.CheckDeepEquals(t, ServerDerp, *actual)
 }
 
-func TestCreateMultipleServersPositive(t *testing.T) {
+func TestCreateMultipleServersPositiveWithMax(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
-	HandleServerCreationSuccessfully(t, SingleServerBody)
+	HandleServerMultipleCreationSuccessfully(t, SingleServerBody)
 
 	actual, err := servers.Create(client.ServiceClient(), servers.CreateOpts{
 		Name:      "derp",
 		ImageRef:  "f90f6034-2570-4974-8351-6b49732ef2eb",
 		FlavorRef: "1",
-		MaxCount:  2,
-	}).Extract()
-	th.AssertNoErr(t, err)
-	th.CheckDeepEquals(t, ServerDerp, *actual)
-
-	actual, err = servers.Create(client.ServiceClient(), servers.CreateOpts{
-		Name:      "derp",
-		ImageRef:  "f90f6034-2570-4974-8351-6b49732ef2eb",
-		FlavorRef: "1",
+		MaxCount:  4,
 		MinCount:  2,
 	}).Extract()
 	th.AssertNoErr(t, err)
-	th.CheckDeepEquals(t, ServerDerp, *actual)
+	th.AssertEquals(t, true, len(actual.Links) >= 2)
+	th.AssertEquals(t, true, len(actual.Links) <= 4)
 }
 
 func TestCreateMultipleServersNegative(t *testing.T) {
@@ -159,7 +152,7 @@ func TestCreateMultipleServersNegative(t *testing.T) {
 		MinCount:  2,
 		MaxCount:  1,
 	}).Extract()
-	th.AssertNotEquals(t, err, nil)
+	th.AssertNotEquals(t, nil, err)
 
 	_, err = servers.Create(client.ServiceClient(), servers.CreateOpts{
 		Name:      "derp",
@@ -167,7 +160,7 @@ func TestCreateMultipleServersNegative(t *testing.T) {
 		FlavorRef: "1",
 		MaxCount:  -1,
 	}).Extract()
-	th.AssertNotEquals(t, err, nil)
+	th.AssertNotEquals(t, nil, err)
 }
 
 func TestDeleteServer(t *testing.T) {

--- a/openstack/compute/v2/servers/testing/requests_test.go
+++ b/openstack/compute/v2/servers/testing/requests_test.go
@@ -123,6 +123,53 @@ func TestCreateServerWithImageNameAndFlavorName(t *testing.T) {
 	th.CheckDeepEquals(t, ServerDerp, *actual)
 }
 
+func TestCreateMultipleServersPositive(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleServerCreationSuccessfully(t, SingleServerBody)
+
+	actual, err := servers.Create(client.ServiceClient(), servers.CreateOpts{
+		Name:      "derp",
+		ImageRef:  "f90f6034-2570-4974-8351-6b49732ef2eb",
+		FlavorRef: "1",
+		MaxCount:  2,
+	}).Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, ServerDerp, *actual)
+
+	actual, err = servers.Create(client.ServiceClient(), servers.CreateOpts{
+		Name:      "derp",
+		ImageRef:  "f90f6034-2570-4974-8351-6b49732ef2eb",
+		FlavorRef: "1",
+		MinCount:  2,
+	}).Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, ServerDerp, *actual)
+}
+
+func TestCreateMultipleServersNegative(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleServerCreationSuccessfully(t, SingleServerBody)
+
+	_, err := servers.Create(client.ServiceClient(), servers.CreateOpts{
+		Name:      "derp",
+		ImageRef:  "f90f6034-2570-4974-8351-6b49732ef2eb",
+		FlavorRef: "1",
+		MinCount:  2,
+		MaxCount:  1,
+	}).Extract()
+	th.AssertNotEquals(t, err, nil)
+
+	_, err = servers.Create(client.ServiceClient(), servers.CreateOpts{
+		Name:      "derp",
+		ImageRef:  "f90f6034-2570-4974-8351-6b49732ef2eb",
+		FlavorRef: "1",
+		MaxCount:  -1,
+	}).Extract()
+	th.AssertNotEquals(t, err, nil)
+}
+
 func TestDeleteServer(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()

--- a/testhelper/convenience.go
+++ b/testhelper/convenience.go
@@ -224,6 +224,13 @@ func CheckEquals(t *testing.T, expected, actual interface{}) {
 	}
 }
 
+// Useful to assert err != nil
+func AssertNotEquals(t *testing.T, expected, actual interface{}) {
+	if expected != actual {
+		logError(t, fmt.Sprintf("expected %s but got %s", green(expected), yellow(actual)))
+	}
+}
+
 // AssertDeepEquals - like Equals - performs a comparison - but on more complex
 // structures that requires deeper inspection
 func AssertDeepEquals(t *testing.T, expected, actual interface{}) {

--- a/testhelper/convenience.go
+++ b/testhelper/convenience.go
@@ -226,8 +226,8 @@ func CheckEquals(t *testing.T, expected, actual interface{}) {
 
 // Useful to assert err != nil
 func AssertNotEquals(t *testing.T, expected, actual interface{}) {
-	if expected != actual {
-		logError(t, fmt.Sprintf("expected %s but got %s", green(expected), yellow(actual)))
+	if expected == actual {
+		logError(t, fmt.Sprintf("%s equals %s", green(expected), yellow(actual)))
 	}
 }
 


### PR DESCRIPTION
Add min_count and max_count fields to request,
for creating multiple servers.

Closes https://github.com/rackspace/gophercloud/issues/597
