### PR TITLE
support skipping the validity check for the server's certificate

### DIFF
--- a/auth_options.go
+++ b/auth_options.go
@@ -52,6 +52,8 @@ type AuthOptions struct {
 	// TokenID allows users to authenticate (possibly as another user) with an
 	// authentication token ID.
 	TokenID string `json:"-"`
+
+	InsecureSkipTlsVerify bool
 }
 
 // ToTokenV2CreateMap allows AuthOptions to satisfy the AuthOptionsBuilder

--- a/openstack/client.go
+++ b/openstack/client.go
@@ -4,7 +4,8 @@ import (
 	"fmt"
 	"net/url"
 	"reflect"
-
+	"crypto/tls"
+	"net/http"
 	"github.com/gophercloud/gophercloud"
 	tokens2 "github.com/gophercloud/gophercloud/openstack/identity/v2/tokens"
 	tokens3 "github.com/gophercloud/gophercloud/openstack/identity/v3/tokens"
@@ -53,6 +54,11 @@ func AuthenticatedClient(options gophercloud.AuthOptions) (*gophercloud.Provider
 	client, err := NewClient(options.IdentityEndpoint)
 	if err != nil {
 		return nil, err
+	}
+
+	if options.InsecureSkipTlsVerify {
+		tr := &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, }
+		client.HTTPClient.Transport = tr
 	}
 
 	err = Authenticate(client, options)


### PR DESCRIPTION
Sometimes the certificate is self-signed, mainly used for internal development, testing and etc.

> x509: certificate signed by unknown authority

This patch supports such scenario.
