### PR TITLE
feature/shared file systems: delete a share

### DIFF
--- a/openstack/sharedfilesystems/v2/shares/requests.go
+++ b/openstack/sharedfilesystems/v2/shares/requests.go
@@ -67,3 +67,9 @@ func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r Create
 	})
 	return
 }
+
+// Delete will delete an existing Share with the given UUID.
+func Delete(client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+	_, r.Err = client.Delete(deleteURL(client, id), nil)
+	return
+}

--- a/openstack/sharedfilesystems/v2/shares/results.go
+++ b/openstack/sharedfilesystems/v2/shares/results.go
@@ -80,3 +80,8 @@ func (r commonResult) Extract() (*Share, error) {
 type CreateResult struct {
 	commonResult
 }
+
+// DeleteResult contains the delete results
+type DeleteResult struct {
+	gophercloud.ErrResult
+}

--- a/openstack/sharedfilesystems/v2/shares/testing/fixtures.go
+++ b/openstack/sharedfilesystems/v2/shares/testing/fixtures.go
@@ -10,6 +10,7 @@ import (
 
 const (
 	shareEndpoint = "/shares"
+	shareID       = "011d21e2-fbc3-4e4a-9993-9ea223f73264"
 )
 
 var createRequest = `{
@@ -76,5 +77,14 @@ func MockCreateResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprintf(w, createResponse)
+	})
+}
+
+// MockDeleteResponse creates a mock delete response
+func MockDeleteResponse(t *testing.T) {
+	th.Mux.HandleFunc(shareEndpoint+"/"+shareID, func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.WriteHeader(http.StatusAccepted)
 	})
 }

--- a/openstack/sharedfilesystems/v2/shares/testing/request_test.go
+++ b/openstack/sharedfilesystems/v2/shares/testing/request_test.go
@@ -21,3 +21,13 @@ func TestCreate(t *testing.T) {
 	th.AssertEquals(t, n.Size, 1)
 	th.AssertEquals(t, n.ShareProto, "NFS")
 }
+
+func TestDelete(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockDeleteResponse(t)
+
+	result := shares.Delete(client.ServiceClient(), shareID)
+	th.AssertNoErr(t, result.Err)
+}

--- a/openstack/sharedfilesystems/v2/shares/urls.go
+++ b/openstack/sharedfilesystems/v2/shares/urls.go
@@ -5,3 +5,7 @@ import "github.com/gophercloud/gophercloud"
 func createURL(c *gophercloud.ServiceClient) string {
 	return c.ServiceURL("shares")
 }
+
+func deleteURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("shares", id)
+}


### PR DESCRIPTION
This PR implements [`deleting`][1] a Manila [`share`][2].

Manila implementation of delete can be found:
https://github.com/openstack/manila/blob/16c522bf5e5c3d37018caef11dd7852462193327/manila/share/api.py#L675

For #129 

[1]: http://developer.openstack.org/api-ref/shared-file-systems/?expanded=delete-share-detail#delete-share
[2]: http://docs.openstack.org/admin-guide/shared-file-systems-key-concepts.html#share