### PR TITLE
Compute Limits

### DIFF
--- a/acceptance/openstack/compute/v2/limits_test.go
+++ b/acceptance/openstack/compute/v2/limits_test.go
@@ -1,0 +1,52 @@
+// +build acceptance compute limits
+
+package v2
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/acceptance/clients"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/limits"
+)
+
+func TestLimits(t *testing.T) {
+	client, err := clients.NewComputeV2Client()
+	if err != nil {
+		t.Fatalf("Unable to create a compute client: %v", err)
+	}
+
+	absolute, err := limits.Get(client, nil).ExtractAbsolute()
+	if err != nil {
+		t.Fatalf("Unable to get absolute limits: %v", err)
+	}
+
+	t.Logf("Limits for scoped user:")
+	t.Logf("%#v", absolute)
+}
+
+func TestLimitsForTenant(t *testing.T) {
+	client, err := clients.NewComputeV2Client()
+	if err != nil {
+		t.Fatalf("Unable to create a compute client: %v", err)
+	}
+
+	// I think this is the easiest way to get the tenant ID while being
+	// agnostic to Identity v2 and v3.
+	// Technically we're just returning the limits for ourselves, but it's
+	// the fact that we're specifying a tenant ID that is important here.
+	endpointParts := strings.Split(client.Endpoint, "/")
+	tenantID := endpointParts[4]
+
+	getOpts := limits.GetOpts{
+		TenantID: tenantID,
+	}
+
+	absolute, err := limits.Get(client, getOpts).ExtractAbsolute()
+	if err != nil {
+		t.Fatalf("Unable to get absolute limits: %v", err)
+	}
+
+	t.Logf("Limits for tenant %s:", tenantID)
+	t.Logf("%#v", absolute)
+}

--- a/acceptance/openstack/compute/v2/limits_test.go
+++ b/acceptance/openstack/compute/v2/limits_test.go
@@ -16,13 +16,13 @@ func TestLimits(t *testing.T) {
 		t.Fatalf("Unable to create a compute client: %v", err)
 	}
 
-	absolute, err := limits.Get(client, nil).ExtractAbsolute()
+	limits, err := limits.Get(client, nil).Extract()
 	if err != nil {
-		t.Fatalf("Unable to get absolute limits: %v", err)
+		t.Fatalf("Unable to get limits: %v", err)
 	}
 
 	t.Logf("Limits for scoped user:")
-	t.Logf("%#v", absolute)
+	t.Logf("%#v", limits)
 }
 
 func TestLimitsForTenant(t *testing.T) {
@@ -42,11 +42,11 @@ func TestLimitsForTenant(t *testing.T) {
 		TenantID: tenantID,
 	}
 
-	absolute, err := limits.Get(client, getOpts).ExtractAbsolute()
+	limits, err := limits.Get(client, getOpts).Extract()
 	if err != nil {
 		t.Fatalf("Unable to get absolute limits: %v", err)
 	}
 
 	t.Logf("Limits for tenant %s:", tenantID)
-	t.Logf("%#v", absolute)
+	t.Logf("%#v", limits)
 }

--- a/openstack/compute/v2/extensions/limits/requests.go
+++ b/openstack/compute/v2/extensions/limits/requests.go
@@ -1,0 +1,39 @@
+package limits
+
+import (
+	"github.com/gophercloud/gophercloud"
+)
+
+// GetOptsBuilder allows extensions to add additional parameters to the
+// Get request.
+type GetOptsBuilder interface {
+	ToLimitsQuery() (string, error)
+}
+
+// GetOpts enables retrieving limits by a specific tenant.
+type GetOpts struct {
+	// The tenant ID to retrieve limits for
+	TenantID string `q:"tenant_id"`
+}
+
+// ToLimitsQuery formats a GetOpts into a query string.
+func (opts GetOpts) ToLimitsQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// Get returns the limits about the currently scoped tenant.
+func Get(client *gophercloud.ServiceClient, opts GetOptsBuilder) (r GetResult) {
+	url := getURL(client)
+	if opts != nil {
+		query, err := opts.ToLimitsQuery()
+		if err != nil {
+			r.Err = err
+			return
+		}
+		url += query
+	}
+
+	_, r.Err = client.Get(url, &r.Body, nil)
+	return
+}

--- a/openstack/compute/v2/extensions/limits/results.go
+++ b/openstack/compute/v2/extensions/limits/results.go
@@ -74,23 +74,13 @@ type Absolute struct {
 	TotalServerGroupsUsed int `json:"totalServerGroupsUsed"`
 }
 
-// ExtractLimits interprets a limits result as a Limits.
-func (r GetResult) ExtractLimits() (*Limits, error) {
+// Extract interprets a limits result as a Limits.
+func (r GetResult) Extract() (*Limits, error) {
 	var s struct {
 		Limits *Limits `json:"limits"`
 	}
 	err := r.ExtractInto(&s)
 	return s.Limits, err
-}
-
-// ExtractAbsolute returns the tenant usage and limits data as an Absolute.
-func (r GetResult) ExtractAbsolute() (*Absolute, error) {
-	limits, err := r.ExtractLimits()
-	if err != nil {
-		return &Absolute{}, err
-	}
-
-	return &limits.Absolute, nil
 }
 
 // GetResult is the response from a Get operation. Call its ExtractAbsolute

--- a/openstack/compute/v2/extensions/limits/results.go
+++ b/openstack/compute/v2/extensions/limits/results.go
@@ -51,7 +51,8 @@ type Absolute struct {
 	// MaxTotalInstances is the number of instances/servers available to a tenant.
 	MaxTotalInstances int `json:"maxTotalInstances"`
 
-	// MaxTotalRAMSize is the total amount of RAM available to a tenant.
+	// MaxTotalRAMSize is the total amount of RAM available to a tenant measured
+	// in megabytes (MB).
 	MaxTotalRAMSize int `json:"maxTotalRAMSize"`
 
 	// TotalCoresUsed is the number of cores currently in use.
@@ -63,7 +64,7 @@ type Absolute struct {
 	// TotalFloatingIpsUsed is the number of floating IPs in use.
 	TotalFloatingIpsUsed int `json:"totalFloatingIpsUsed"`
 
-	// TotalRAMUsed is the total RAM/memory in use.
+	// TotalRAMUsed is the total RAM/memory in use measured in megabytes (MB).
 	TotalRAMUsed int `json:"totalRAMUsed"`
 
 	// TotalSecurityGroupsUsed is the total number of security groups in use.

--- a/openstack/compute/v2/extensions/limits/results.go
+++ b/openstack/compute/v2/extensions/limits/results.go
@@ -1,0 +1,99 @@
+package limits
+
+import (
+	"github.com/gophercloud/gophercloud"
+)
+
+// Limits is a struct that contains the response of a limit query.
+type Limits struct {
+	// Absolute contains the limits and usage information.
+	Absolute Absolute `json:"absolute"`
+}
+
+// Usage is a struct that contains the current resource usage and limits
+// of a tenant.
+type Absolute struct {
+	// MaxTotalCores is the number of cores available to a tenant.
+	MaxTotalCores int `json:"maxTotalCores"`
+
+	// MaxImageMeta is the amount of image metadata available to a tenant.
+	MaxImageMeta int `json:"maxImageMeta"`
+
+	// MaxServerMeta is the amount of server metadata available to a tenant.
+	MaxServerMeta int `json:"maxServerMeta"`
+
+	// MaxPersonality is the amount of personality/files available to a tenant.
+	MaxPersonality int `json:"maxPersonality"`
+
+	// MaxPersonalitySize is the personality file size available to a tenant.
+	MaxPersonalitySize int `json:"maxPersonalitySize"`
+
+	// MaxTotalKeypairs is the total keypairs available to a tenant.
+	MaxTotalKeypairs int `json:maxTotalKeypairs"`
+
+	// MaxSecurityGroups is the number of security groups available to a tenant.
+	MaxSecurityGroups int `json:"maxSecurityGroups"`
+
+	// MaxSecurityGroupRules is the number of security group rules available to
+	// a tenant.
+	MaxSecurityGroupRules int `json:"maxSecurityGroupRules"`
+
+	// MaxServerGroups is the number of server groups available to a tenant.
+	MaxServerGroups int `json:"maxServerGroups"`
+
+	// MaxServerGroupMembers is the number of server group members available
+	// to a tenant.
+	MaxServerGroupMembers int `json:"maxServerGroupMembers"`
+
+	// MaxTotalFloatingIps is the number of floating IPs available to a tenant.
+	MaxTotalFloatingIps int `json:"maxTotalFloatingIps"`
+
+	// MaxTotalInstances is the number of instances/servers available to a tenant.
+	MaxTotalInstances int `json:"maxTotalInstances"`
+
+	// MaxTotalRAMSize is the total amount of RAM available to a tenant.
+	MaxTotalRAMSize int `json:"maxTotalRAMSize"`
+
+	// TotalCoresUsed is the number of cores currently in use.
+	TotalCoresUsed int `json:"totalCoresUsed"`
+
+	// TotalInstancesUsed is the number of instances/servers in use.
+	TotalInstancesUsed int `json:"totalInstancesUsed"`
+
+	// TotalFloatingIpsUsed is the number of floating IPs in use.
+	TotalFloatingIpsUsed int `json:"totalFloatingIpsUsed"`
+
+	// TotalRAMUsed is the total RAM/memory in use.
+	TotalRAMUsed int `json:"totalRAMUsed"`
+
+	// TotalSecurityGroupsUsed is the total number of security groups in use.
+	TotalSecurityGroupsUsed int `json:"totalSecurityGroupsUsed"`
+
+	// TotalServerGroupsUsed is the total number of server groups in use.
+	TotalServerGroupsUsed int `json:"totalServerGroupsUsed"`
+}
+
+// ExtractLimits interprets a limits result as a Limits.
+func (r GetResult) ExtractLimits() (*Limits, error) {
+	var s struct {
+		Limits *Limits `json:"limits"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Limits, err
+}
+
+// ExtractAbsolute returns the tenant usage and limits data as an Absolute.
+func (r GetResult) ExtractAbsolute() (*Absolute, error) {
+	limits, err := r.ExtractLimits()
+	if err != nil {
+		return &Absolute{}, err
+	}
+
+	return &limits.Absolute, nil
+}
+
+// GetResult is the response from a Get operation. Call its ExtractAbsolute
+// method to interpret it as an Absolute.
+type GetResult struct {
+	gophercloud.Result
+}

--- a/openstack/compute/v2/extensions/limits/testing/fixtures.go
+++ b/openstack/compute/v2/extensions/limits/testing/fixtures.go
@@ -1,0 +1,78 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/limits"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+// GetOutput is a sample response to a Get call.
+const GetOutput = `
+{
+    "limits": {
+        "rate": [],
+        "absolute": {
+            "maxServerMeta": 128,
+            "maxPersonality": 5,
+            "totalServerGroupsUsed": 0,
+            "maxImageMeta": 128,
+            "maxPersonalitySize": 10240,
+            "maxTotalKeypairs": 100,
+            "maxSecurityGroupRules": 20,
+            "maxServerGroups": 10,
+            "totalCoresUsed": 1,
+            "totalRAMUsed": 2048,
+            "totalInstancesUsed": 1,
+            "maxSecurityGroups": 10,
+            "totalFloatingIpsUsed": 0,
+            "maxTotalCores": 20,
+            "maxServerGroupMembers": 10,
+            "maxTotalFloatingIps": 10,
+            "totalSecurityGroupsUsed": 1,
+            "maxTotalInstances": 10,
+            "maxTotalRAMSize": 51200
+        }
+    }
+}
+`
+
+// AbsoluteResult is the result of the limits in GetOutput.
+var AbsoluteResult = limits.Absolute{
+	MaxServerMeta:           128,
+	MaxPersonality:          5,
+	TotalServerGroupsUsed:   0,
+	MaxImageMeta:            128,
+	MaxPersonalitySize:      10240,
+	MaxTotalKeypairs:        100,
+	MaxSecurityGroupRules:   20,
+	MaxServerGroups:         10,
+	TotalCoresUsed:          1,
+	TotalRAMUsed:            2048,
+	TotalInstancesUsed:      1,
+	MaxSecurityGroups:       10,
+	TotalFloatingIpsUsed:    0,
+	MaxTotalCores:           20,
+	MaxServerGroupMembers:   10,
+	MaxTotalFloatingIps:     10,
+	TotalSecurityGroupsUsed: 1,
+	MaxTotalInstances:       10,
+	MaxTotalRAMSize:         51200,
+}
+
+const TenantID = "555544443333222211110000ffffeeee"
+
+// HandleGetSuccessfully configures the test server to respond to a Get request
+// for a limit.
+func HandleGetSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/limits", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprintf(w, GetOutput)
+	})
+}

--- a/openstack/compute/v2/extensions/limits/testing/fixtures.go
+++ b/openstack/compute/v2/extensions/limits/testing/fixtures.go
@@ -40,27 +40,29 @@ const GetOutput = `
 }
 `
 
-// AbsoluteResult is the result of the limits in GetOutput.
-var AbsoluteResult = limits.Absolute{
-	MaxServerMeta:           128,
-	MaxPersonality:          5,
-	TotalServerGroupsUsed:   0,
-	MaxImageMeta:            128,
-	MaxPersonalitySize:      10240,
-	MaxTotalKeypairs:        100,
-	MaxSecurityGroupRules:   20,
-	MaxServerGroups:         10,
-	TotalCoresUsed:          1,
-	TotalRAMUsed:            2048,
-	TotalInstancesUsed:      1,
-	MaxSecurityGroups:       10,
-	TotalFloatingIpsUsed:    0,
-	MaxTotalCores:           20,
-	MaxServerGroupMembers:   10,
-	MaxTotalFloatingIps:     10,
-	TotalSecurityGroupsUsed: 1,
-	MaxTotalInstances:       10,
-	MaxTotalRAMSize:         51200,
+// LimitsResult is the result of the limits in GetOutput.
+var LimitsResult = limits.Limits{
+	limits.Absolute{
+		MaxServerMeta:           128,
+		MaxPersonality:          5,
+		TotalServerGroupsUsed:   0,
+		MaxImageMeta:            128,
+		MaxPersonalitySize:      10240,
+		MaxTotalKeypairs:        100,
+		MaxSecurityGroupRules:   20,
+		MaxServerGroups:         10,
+		TotalCoresUsed:          1,
+		TotalRAMUsed:            2048,
+		TotalInstancesUsed:      1,
+		MaxSecurityGroups:       10,
+		TotalFloatingIpsUsed:    0,
+		MaxTotalCores:           20,
+		MaxServerGroupMembers:   10,
+		MaxTotalFloatingIps:     10,
+		TotalSecurityGroupsUsed: 1,
+		MaxTotalInstances:       10,
+		MaxTotalRAMSize:         51200,
+	},
 }
 
 const TenantID = "555544443333222211110000ffffeeee"

--- a/openstack/compute/v2/extensions/limits/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/limits/testing/requests_test.go
@@ -17,7 +17,7 @@ func TestGet(t *testing.T) {
 		TenantID: TenantID,
 	}
 
-	actual, err := limits.Get(client.ServiceClient(), getOpts).ExtractAbsolute()
+	actual, err := limits.Get(client.ServiceClient(), getOpts).Extract()
 	th.AssertNoErr(t, err)
-	th.CheckDeepEquals(t, &AbsoluteResult, actual)
+	th.CheckDeepEquals(t, &LimitsResult, actual)
 }

--- a/openstack/compute/v2/extensions/limits/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/limits/testing/requests_test.go
@@ -1,0 +1,23 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/limits"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func TestGet(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleGetSuccessfully(t)
+
+	getOpts := limits.GetOpts{
+		TenantID: TenantID,
+	}
+
+	actual, err := limits.Get(client.ServiceClient(), getOpts).ExtractAbsolute()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, &AbsoluteResult, actual)
+}

--- a/openstack/compute/v2/extensions/limits/urls.go
+++ b/openstack/compute/v2/extensions/limits/urls.go
@@ -1,0 +1,11 @@
+package limits
+
+import (
+	"github.com/gophercloud/gophercloud"
+)
+
+const resourcePath = "limits"
+
+func getURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL(resourcePath)
+}


### PR DESCRIPTION
This commit adds support for the /limits API. It includes the ability
to query limits for the currently scoped user as well as to query the
limits for a specific tenant.

For #113 
