### PR TITLE
feature/shared file systems: list shares

### DIFF
--- a/acceptance/openstack/sharedfilesystems/v2/shares.go
+++ b/acceptance/openstack/sharedfilesystems/v2/shares.go
@@ -10,9 +10,35 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/shares"
 )
 
+// CreateShares creates `n` shares
+func CreateShares(t *testing.T, client *gophercloud.ServiceClient, names []string) ([]shares.Share, error) {
+	if testing.Short() {
+		t.Skip("Skipping test that requres share creation in short mode.")
+	}
+
+	created := []shares.Share{}
+	for _, name := range names {
+		share, err := CreateShare(t, client, name)
+		if err != nil {
+			t.Fatalf("Failed to create a share %v", err)
+		}
+
+		created = append(created, *share)
+	}
+
+	return created, nil
+}
+
+// DeleteShares will delete all shares
+func DeleteShares(t *testing.T, client *gophercloud.ServiceClient, sharesToDel []shares.Share) {
+	for _, s := range sharesToDel {
+		DeleteShare(t, client, &s)
+	}
+}
+
 // CreateShare will create a share with a name, and a size of 1Gb. An
 // error will be returned if the share could not be created
-func CreateShare(t *testing.T, client *gophercloud.ServiceClient) (*shares.Share, error) {
+func CreateShare(t *testing.T, client *gophercloud.ServiceClient, name string) (*shares.Share, error) {
 	if testing.Short() {
 		t.Skip("Skipping test that requres share creation in short mode.")
 	}
@@ -22,11 +48,10 @@ func CreateShare(t *testing.T, client *gophercloud.ServiceClient) (*shares.Share
 		t.Fatalf("Unable to fetch environment information")
 	}
 
-	t.Logf("Share network id %s", choices.ShareNetworkID)
 	createOpts := shares.CreateOpts{
 		Size:           1,
-		Name:           "My Test Share",
-		ShareProto:     "NFS",
+		Name:           name,
+		ShareProto:     "nfs",
 		ShareNetworkID: choices.ShareNetworkID,
 	}
 

--- a/acceptance/openstack/sharedfilesystems/v2/shares_test.go
+++ b/acceptance/openstack/sharedfilesystems/v2/shares_test.go
@@ -27,7 +27,7 @@ func TestShareCreate(t *testing.T) {
 	PrintShare(t, created)
 }
 
-func TestShareList(t *testing.T) {
+func TestShareListShort(t *testing.T) {
 	client, err := clients.NewSharedFileSystemV2Client()
 	if err != nil {
 		t.Fatalf("Unable to create a sharedfs client: %v", err)
@@ -43,6 +43,36 @@ func TestShareList(t *testing.T) {
 	defer DeleteShares(t, client, created)
 
 	pages, err := shares.List(client, &shares.ListOpts{}, false).AllPages()
+	if err != nil {
+		t.Fatalf("Failed to list shares: %v", err)
+	}
+
+	shares, err := shares.ExtractShares(pages)
+	if err != nil {
+		t.Fatalf("Unable to extract shares: %v", err)
+	}
+
+	for _, share := range shares {
+		PrintShare(t, &share)
+	}
+}
+
+func TestShareListDetail(t *testing.T) {
+	client, err := clients.NewSharedFileSystemV2Client()
+	if err != nil {
+		t.Fatalf("Unable to create a sharedfs client: %v", err)
+	}
+
+	names := []string{"share_one", "share_two", "share_three"}
+
+	created, err := CreateShares(t, client, names)
+	if err != nil {
+		t.Fatalf("Unable to create a share: %v", err)
+	}
+
+	defer DeleteShares(t, client, created)
+
+	pages, err := shares.List(client, &shares.ListOpts{}, true).AllPages()
 	if err != nil {
 		t.Fatalf("Failed to list shares: %v", err)
 	}

--- a/acceptance/openstack/sharedfilesystems/v2/shares_test.go
+++ b/acceptance/openstack/sharedfilesystems/v2/shares_test.go
@@ -157,7 +157,7 @@ func TestShareListDetailPaginateLimitOffset(t *testing.T) {
 				t.Fatalf("Unexpected number of shares: %d", len(l))
 			}
 
-			count++
+			count += len(l)
 
 			t.Logf("Got %d shares for this page", len(l))
 			for _, share := range l {

--- a/acceptance/openstack/sharedfilesystems/v2/shares_test.go
+++ b/acceptance/openstack/sharedfilesystems/v2/shares_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gophercloud/gophercloud/acceptance/clients"
 	"github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/shares"
+	"github.com/gophercloud/gophercloud/pagination"
 )
 
 func TestShareCreate(t *testing.T) {
@@ -85,4 +86,27 @@ func TestShareListDetail(t *testing.T) {
 	for _, share := range shares {
 		PrintShare(t, &share)
 	}
+}
+
+func TestShareListDetailPaginate(t *testing.T) {
+	client, err := clients.NewSharedFileSystemV2Client()
+	if err != nil {
+		t.Fatalf("Unable to create a sharedfs client: %v", err)
+	}
+
+	names := []string{"share_one", "share_two", "share_three"}
+
+	created, err := CreateShares(t, client, names)
+	if err != nil {
+		t.Fatalf("Unable to create a share: %v", err)
+	}
+
+	defer DeleteShares(t, client, created)
+
+	err = shares.List(client, &shares.ListOpts{}, true).EachPage(func(page pagination.Page) (bool, error) {
+		l, _ := shares.ExtractShares(page)
+		t.Logf("Got some shares: %+v\n", l)
+		return true, nil
+	})
+
 }

--- a/acceptance/openstack/sharedfilesystems/v2/shares_test.go
+++ b/acceptance/openstack/sharedfilesystems/v2/shares_test.go
@@ -13,7 +13,7 @@ func TestShareCreate(t *testing.T) {
 		t.Fatalf("Unable to create a sharedfs client: %v", err)
 	}
 
-	share, err := CreateShare(t, client)
+	share, err := CreateShare(t, client, "my test share")
 	if err != nil {
 		t.Fatalf("Unable to create a share: %v", err)
 	}
@@ -25,4 +25,34 @@ func TestShareCreate(t *testing.T) {
 		t.Errorf("Unable to retrieve share: %v", err)
 	}
 	PrintShare(t, created)
+}
+
+func TestShareList(t *testing.T) {
+	client, err := clients.NewSharedFileSystemV2Client()
+	if err != nil {
+		t.Fatalf("Unable to create a sharedfs client: %v", err)
+	}
+
+	names := []string{"share_one", "share_two", "share_three"}
+
+	created, err := CreateShares(t, client, names)
+	if err != nil {
+		t.Fatalf("Unable to create a share: %v", err)
+	}
+
+	defer DeleteShares(t, client, created)
+
+	pages, err := shares.List(client, &shares.ListOpts{}, false).AllPages()
+	if err != nil {
+		t.Fatalf("Failed to list shares: %v", err)
+	}
+
+	shares, err := shares.ExtractShares(pages)
+	if err != nil {
+		t.Fatalf("Unable to extract shares: %v", err)
+	}
+
+	for _, share := range shares {
+		PrintShare(t, &share)
+	}
 }

--- a/openstack/sharedfilesystems/v2/sharenetworks/testing/fixtures.go
+++ b/openstack/sharedfilesystems/v2/sharenetworks/testing/fixtures.go
@@ -151,6 +151,7 @@ func MockFilteredListResponse(t *testing.T) {
 
 		r.ParseForm()
 		marker := r.Form.Get("offset")
+		fmt.Println(marker)
 		switch marker {
 		case "":
 			fmt.Fprintf(w, `

--- a/openstack/sharedfilesystems/v2/shares/requests.go
+++ b/openstack/sharedfilesystems/v2/shares/requests.go
@@ -93,7 +93,7 @@ type ListOpts struct {
 	// Offset can be used to define the starting point of share listing
 	Offset int `q:"offset"`
 	// Admin-only option to list shares from all tenants
-	AllTenants bool `q:"tenant_id"`
+	AllTenants bool `q:"all_tenants"`
 	// Name of the share
 	Name string `q:"name"`
 	// Status of the share

--- a/openstack/sharedfilesystems/v2/shares/requests.go
+++ b/openstack/sharedfilesystems/v2/shares/requests.go
@@ -124,8 +124,8 @@ func (l ListOpts) ToShareListQuery() (string, error) {
 
 // List returns shares filtered by the conditions provided in ListOpts. If ListOpts
 // is not nil, returns a list of shares with details.
-func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
-	url := listURL(client)
+func List(client *gophercloud.ServiceClient, opts ListOptsBuilder, detail bool) pagination.Pager {
+	url := listURL(client, detail)
 	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
 		return SharePage{pagination.SinglePageBase(r)}
 	})

--- a/openstack/sharedfilesystems/v2/shares/requests.go
+++ b/openstack/sharedfilesystems/v2/shares/requests.go
@@ -2,6 +2,7 @@ package shares
 
 import (
 	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
 )
 
 // CreateOptsBuilder allows extensions to add additional parameters to the
@@ -78,4 +79,54 @@ func Delete(client *gophercloud.ServiceClient, id string) (r DeleteResult) {
 func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {
 	_, r.Err = client.Get(getURL(client, id), &r.Body, nil)
 	return
+}
+
+// ListOptsBuilder allows extensions to add additional parameters to the List request
+type ListOptsBuilder interface {
+	ToShareListQuery() (string, error)
+}
+
+// ListOpts is used to filter the List() call
+type ListOpts struct {
+	// Admin-only option to list shares from all tenants
+	AllTenants bool `q:"tenant_id"`
+	// Name of the share
+	Name string `q:"name"`
+	// Status of the share
+	Status string `q:"status"`
+	// ShareServerID is the UUID of the share server
+	ShareServerID string `q:"share_server_id"`
+	// MetaData is key-value-pairs of custom metadata
+	MetaData map[string]string `q:"metadata"`
+	// ShareTypeID is the UUID of the share type
+	ShareTypeID string `q:"share_type_id"`
+	// SortKey defines the sorting key
+	SortKey string `q:"sort_key"`
+	// SortDir defines the sorting direction
+	SortDir string `q:"sort_dir"`
+	// SnapShotID is the UUID of the snapshot used to create this share
+	SnapShotID string `q:"snapshot_id"`
+	// ShareNetworkID is the UUID of the share network of this share
+	ShareNetworkID string `q:"share_network_id"`
+	// ProjectID is the UUID of the project in which the share belongs to
+	ProjectID string `q:"project_id"`
+	// IsPublic determines the level of visibility of the share
+	IsPublic bool `q:"is_public"`
+	// ConsistencyGroupID is the UUID of the consistency group to which the share belongs to
+	ConsistencyGroupID string `q:"consistency_group_id"`
+}
+
+// ToShareListQuery converts a foo to bar
+func (l ListOpts) ToShareListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(l)
+	return q.String(), err
+}
+
+// List returns shares filtered by the conditions provided in ListOpts. If ListOpts
+// is not nil, returns a list of shares with details.
+func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(client)
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return SharePage{pagination.SinglePageBase(r)}
+	})
 }

--- a/openstack/sharedfilesystems/v2/shares/results.go
+++ b/openstack/sharedfilesystems/v2/shares/results.go
@@ -4,10 +4,11 @@ import (
 	"encoding/json"
 	"time"
 
-	"github.com/gophercloud/gophercloud"
-	"github.com/gophercloud/gophercloud/pagination"
 	"net/url"
 	"strconv"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
 )
 
 var maxInt = strconv.Itoa(int(^uint(0) >> 1))

--- a/openstack/sharedfilesystems/v2/shares/results.go
+++ b/openstack/sharedfilesystems/v2/shares/results.go
@@ -25,48 +25,48 @@ type Share struct {
 	// Both DisplayName and Name can be used
 	DisplayName string `json:"display_name,omitempty"`
 	// Indicates whether a share has replicas or not.
-	HasReplicas bool `json:"has_replicas,omitempty"`
+	HasReplicas bool `json:"has_replicas"`
 	// The host name of the share
-	Host string `json:"host,omitempty"`
+	Host string `json:"host"`
 	// The UUID of the share
-	ID string `json:"id,omitempty"`
+	ID string `json:"id"`
 	// Indicates the visibility of the share
 	IsPublic bool `json:"is_public,omitempty"`
 	// Share links for pagination
-	Links []map[string]string `json:"links,omitempty"`
+	Links []map[string]string `json:"links"`
 	// Key, value -pairs of custom metadata
 	Metadata map[string]string `json:"metadata,omitempty"`
 	// The name of the share
 	Name string `json:"name,omitempty"`
 	// The UUID of the project to which this share belongs to
-	ProjectID string `json:"project_id,omitempty"`
+	ProjectID string `json:"project_id"`
 	// The share replication type
 	ReplicationType string `json:"replication_type,omitempty"`
 	// The UUID of the share network
-	ShareNetworkID string `json:"share_network_id,omitempty"`
+	ShareNetworkID string `json:"share_network_id"`
 	// The shared file system protocol
-	ShareProto string `json:"share_proto,omitempty"`
+	ShareProto string `json:"share_proto"`
 	// The UUID of the share server
-	ShareServerID string `json:"share_server_id,omitempty"`
+	ShareServerID string `json:"share_server_id"`
 	// The UUID of the share type.
-	ShareType string `json:"share_type,omitempty"`
+	ShareType string `json:"share_type"`
 	// The name of the share type.
-	ShareTypeName string `json:"share_type_name,omitempty"`
+	ShareTypeName string `json:"share_type_name"`
 	// Size of the share in GB
-	Size int `json:"size,omitempty"`
+	Size int `json:"size"`
 	// UUID of the snapshot from which to create the share
-	SnapshotID string `json:"snapshot_id,omitempty"`
+	SnapshotID string `json:"snapshot_id"`
 	// The share status
-	Status string `json:"status,omitempty"`
+	Status string `json:"status"`
 	// The task state, used for share migration
-	TaskState string `json:"task_state,omitempty"`
+	TaskState string `json:"task_state"`
 	// The type of the volume
 	VolumeType string `json:"volume_type,omitempty"`
 	// The UUID of the consistency group this share belongs to
-	ConsistencyGroupID string `json:"consistency_group_id,omitempty"`
+	ConsistencyGroupID string `json:"consistency_group_id"`
 	// Used for filtering backends which either support or do not support share snapshots
-	SnapshotSupport          bool   `json:"snapshot_support,omitempty"`
-	SourceCgsnapshotMemberID string `json:"source_cgsnapshot_member_id,omitempty"`
+	SnapshotSupport          bool   `json:"snapshot_support"`
+	SourceCgsnapshotMemberID string `json:"source_cgsnapshot_member_id"`
 	// Timestamp when the share was created
 	CreatedAt time.Time `json:"-"`
 }
@@ -113,7 +113,6 @@ func (r SharePage) NextPageURL() (string, error) {
 	if err != nil {
 		return "", err
 	}
-
 	q := currentURL.Query()
 	q.Set("offset", mark)
 	currentURL.RawQuery = q.Encode()

--- a/openstack/sharedfilesystems/v2/shares/results.go
+++ b/openstack/sharedfilesystems/v2/shares/results.go
@@ -5,12 +5,13 @@ import (
 	"time"
 
 	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
 )
 
 // Share contains all information associated with an OpenStack Share
 type Share struct {
 	// The availability zone of the share
-	AvailabilityZone string `json:"availability_zone"`
+	AvailabilityZone string `json:"availability_zone,omitempty"`
 	// A description of the share
 	Description string `json:"description,omitempty"`
 	// DisplayDescription is inherited from BlockStorage API.
@@ -20,48 +21,48 @@ type Share struct {
 	// Both DisplayName and Name can be used
 	DisplayName string `json:"display_name,omitempty"`
 	// Indicates whether a share has replicas or not.
-	HasReplicas bool `json:"has_replicas"`
+	HasReplicas bool `json:"has_replicas,omitempty"`
 	// The host name of the share
-	Host string `json:"host"`
+	Host string `json:"host,omitempty"`
 	// The UUID of the share
-	ID string `json:"id"`
+	ID string `json:"id,omitempty"`
 	// Indicates the visibility of the share
 	IsPublic bool `json:"is_public,omitempty"`
 	// Share links for pagination
-	Links []map[string]string `json:"links"`
+	Links []map[string]string `json:"links,omitempty"`
 	// Key, value -pairs of custom metadata
 	Metadata map[string]string `json:"metadata,omitempty"`
 	// The name of the share
 	Name string `json:"name,omitempty"`
 	// The UUID of the project to which this share belongs to
-	ProjectID string `json:"project_id"`
+	ProjectID string `json:"project_id,omitempty"`
 	// The share replication type
 	ReplicationType string `json:"replication_type,omitempty"`
 	// The UUID of the share network
-	ShareNetworkID string `json:"share_network_id"`
+	ShareNetworkID string `json:"share_network_id,omitempty"`
 	// The shared file system protocol
-	ShareProto string `json:"share_proto"`
+	ShareProto string `json:"share_proto,omitempty"`
 	// The UUID of the share server
-	ShareServerID string `json:"share_server_id"`
+	ShareServerID string `json:"share_server_id,omitempty"`
 	// The UUID of the share type.
-	ShareType string `json:"share_type"`
+	ShareType string `json:"share_type,omitempty"`
 	// The name of the share type.
-	ShareTypeName string `json:"share_type_name"`
+	ShareTypeName string `json:"share_type_name,omitempty"`
 	// Size of the share in GB
-	Size int `json:"size"`
+	Size int `json:"size,omitempty"`
 	// UUID of the snapshot from which to create the share
-	SnapshotID string `json:"snapshot_id"`
+	SnapshotID string `json:"snapshot_id,omitempty"`
 	// The share status
-	Status string `json:"status"`
+	Status string `json:"status,omitempty"`
 	// The task state, used for share migration
-	TaskState string `json:"task_state"`
+	TaskState string `json:"task_state,omitempty"`
 	// The type of the volume
 	VolumeType string `json:"volume_type,omitempty"`
 	// The UUID of the consistency group this share belongs to
-	ConsistencyGroupID string `json:"consistency_group_id"`
+	ConsistencyGroupID string `json:"consistency_group_id,omitempty"`
 	// Used for filtering backends which either support or do not support share snapshots
-	SnapshotSupport          bool   `json:"snapshot_support"`
-	SourceCgsnapshotMemberID string `json:"source_cgsnapshot_member_id"`
+	SnapshotSupport          bool   `json:"snapshot_support,omitempty"`
+	SourceCgsnapshotMemberID string `json:"source_cgsnapshot_member_id,omitempty"`
 	// Timestamp when the share was created
 	CreatedAt time.Time `json:"-"`
 }
@@ -94,6 +95,20 @@ func (r commonResult) Extract() (*Share, error) {
 	}
 	err := r.ExtractInto(&s)
 	return s.Share, err
+}
+
+// SharePage is a pagination.pager that is returned from a call to the List func
+type SharePage struct {
+	pagination.SinglePageBase
+}
+
+// ExtractShares extracts and returns Shares when iterating over a shares.List() call
+func ExtractShares(r pagination.Page) ([]Share, error) {
+	var s struct {
+		Shares []Share `json:"shares"`
+	}
+	err := (r.(SharePage)).ExtractInto(&s)
+	return s.Shares, err
 }
 
 // CreateResult contains the result..

--- a/openstack/sharedfilesystems/v2/shares/testing/fixtures.go
+++ b/openstack/sharedfilesystems/v2/shares/testing/fixtures.go
@@ -183,3 +183,116 @@ func MockListResponse(t *testing.T) {
 		}
 	})
 }
+
+// MockListDetailResponse creates a mock list response with details
+func MockListDetailResponse(t *testing.T) {
+	th.Mux.HandleFunc(shareEndpoint+"/detail", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		r.ParseForm()
+		marker := r.Form.Get("offset")
+		switch marker {
+		case "":
+			fallthrough
+		case "1":
+			fmt.Fprintf(w, `
+{
+    "shares": [
+        {
+            "links": [
+                {
+                    "href": "http://172.18.198.54:8786/v2/16e1ab15c35a457e9c2b2aa189f544e1/shares/f45cc5b2-d1bb-4a3e-ba5b-5c4125613adc",
+                    "rel": "self"
+                },
+                {
+                    "href": "http://172.18.198.54:8786/16e1ab15c35a457e9c2b2aa189f544e1/shares/f45cc5b2-d1bb-4a3e-ba5b-5c4125613adc",
+                    "rel": "bookmark"
+                }
+            ],
+            "availability_zone": "nova",
+            "share_network_id": "f9b2e754-ac01-4466-86e1-5c569424754e",
+            "export_locations": [],
+            "share_server_id": "87d8943a-f5da-47a4-b2f2-ddfa6794aa82",
+            "snapshot_id": null,
+            "id": "f45cc5b2-d1bb-4a3e-ba5b-5c4125613adc",
+            "size": 1,
+            "share_type": "25747776-08e5-494f-ab40-a64b9d20d8f7",
+            "share_type_name": "default",
+            "export_location": null,
+            "consistency_group_id": "9397c191-8427-4661-a2e8-b23820dc01d4",
+            "project_id": "16e1ab15c35a457e9c2b2aa189f544e1",
+            "metadata": {},
+            "status": "error",
+            "access_rules_status": "active",
+            "description": "There is a share description.",
+            "host": "manila2@generic1#GENERIC1",
+            "task_state": null,
+            "is_public": true,
+            "snapshot_support": true,
+            "name": "my_share4",
+            "has_replicas": false,
+            "replication_type": null,
+            "created_at": "2015-09-16T18:19:50.000000",
+            "share_proto": "NFS",
+            "volume_type": "default",
+            "source_cgsnapshot_member_id": null
+        }
+	]
+}`)
+		case "2":
+			fmt.Fprintf(w, `
+{
+    "shares": [
+        {
+            "links": [
+                {
+                    "href": "http://172.18.198.54:8786/v2/16e1ab15c35a457e9c2b2aa189f544e1/shares/c4a2ced4-2c9f-4ae1-adaa-6171833e64df",
+                    "rel": "self"
+                },
+                {
+                    "href": "http://172.18.198.54:8786/16e1ab15c35a457e9c2b2aa189f544e1/shares/c4a2ced4-2c9f-4ae1-adaa-6171833e64df",
+                    "rel": "bookmark"
+                }
+            ],
+            "availability_zone": "nova",
+            "share_network_id": "f9b2e754-ac01-4466-86e1-5c569424754e",
+            "export_locations": [
+                "10.254.0.5:/shares/share-50ad5e7b-f6f1-4b78-a651-0812cef2bb67"
+            ],
+            "share_server_id": "87d8943a-f5da-47a4-b2f2-ddfa6794aa82",
+            "snapshot_id": null,
+            "id": "c4a2ced4-2c9f-4ae1-adaa-6171833e64df",
+            "size": 1,
+            "share_type": "25747776-08e5-494f-ab40-a64b9d20d8f7",
+            "share_type_name": "default",
+            "export_location": "10.254.0.5:/shares/share-50ad5e7b-f6f1-4b78-a651-0812cef2bb67",
+            "consistency_group_id": "9397c191-8427-4661-a2e8-b23820dc01d4",
+            "project_id": "16e1ab15c35a457e9c2b2aa189f544e1",
+            "metadata": {},
+            "status": "available",
+            "access_rules_status": "active",
+            "description": "Changed description.",
+            "host": "manila2@generic1#GENERIC1",
+            "task_state": null,
+            "is_public": true,
+            "snapshot_support": true,
+            "name": "my_share3",
+            "has_replicas": false,
+            "replication_type": null,
+            "created_at": "2015-09-16T17:26:28.000000",
+            "share_proto": "NFS",
+            "volume_type": "default",
+            "source_cgsnapshot_member_id": null
+        }
+    ]
+}`)
+		default:
+			fmt.Fprintf(w, `
+{
+"shares": []
+}`)
+		}
+	})
+}

--- a/openstack/sharedfilesystems/v2/shares/testing/fixtures.go
+++ b/openstack/sharedfilesystems/v2/shares/testing/fixtures.go
@@ -173,6 +173,13 @@ func MockListResponse(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, shortListResponse)
+		r.ParseForm()
+		marker := r.Form.Get("offset")
+		switch marker {
+		case "":
+			fmt.Fprintf(w, shortListResponse)
+		default:
+			fmt.Fprintf(w, `{"shares": []}`)
+		}
 	})
 }

--- a/openstack/sharedfilesystems/v2/shares/testing/fixtures.go
+++ b/openstack/sharedfilesystems/v2/shares/testing/fixtures.go
@@ -141,3 +141,38 @@ func MockGetResponse(t *testing.T) {
 		fmt.Fprintf(w, getResponse)
 	})
 }
+
+var shortListResponse = `{
+	"shares": [{
+		"id": "d94a8548-2079-4be0-b21c-0a887acd31ca",
+		"links": [{
+			"href": "http://172.18.198.54:8786/v1/16e1ab15c35a457e9c2b2aa189f544e1/shares/d94a8548-2079-4be0-b21c-0a887acd31ca",
+			"rel": "self"
+		}, {
+			"href": "http://172.18.198.54:8786/16e1ab15c35a457e9c2b2aa189f544e1/shares/d94a8548-2079-4be0-b21c-0a887acd31ca",
+			"rel": "bookmark"
+		}],
+		"name": "My_share"
+	}, {
+		"id": "406ea93b-32e9-4907-a117-148b3945749f",
+		"links": [{
+			"href": "http://172.18.198.54:8786/v1/16e1ab15c35a457e9c2b2aa189f544e1/shares/406ea93b-32e9-4907-a117-148b3945749f",
+			"rel": "self"
+		}, {
+			"href": "http://172.18.198.54:8786/16e1ab15c35a457e9c2b2aa189f544e1/shares/406ea93b-32e9-4907-a117-148b3945749f",
+			"rel": "bookmark"
+		}],
+		"name": "Share1"
+	}]
+}`
+
+// MockListResponse creates a mock list response
+func MockListResponse(t *testing.T) {
+	th.Mux.HandleFunc(shareEndpoint, func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, shortListResponse)
+	})
+}

--- a/openstack/sharedfilesystems/v2/shares/testing/request_test.go
+++ b/openstack/sharedfilesystems/v2/shares/testing/request_test.go
@@ -82,3 +82,41 @@ func TestGet(t *testing.T) {
 		},
 	})
 }
+
+func TestListAllShort(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockListResponse(t)
+	pages, err := shares.List(client.ServiceClient(), &shares.ListOpts{}).AllPages()
+	th.AssertNoErr(t, err)
+	act, err := shares.ExtractShares(pages)
+	th.AssertNoErr(t, err)
+	shortList := []shares.Share{
+		{
+			ID:   "d94a8548-2079-4be0-b21c-0a887acd31ca",
+			Name: "My_share",
+			Links: []map[string]string{
+				{
+					"href": "http://172.18.198.54:8786/v1/16e1ab15c35a457e9c2b2aa189f544e1/shares/d94a8548-2079-4be0-b21c-0a887acd31ca",
+					"rel":  "self",
+				},
+				{
+					"href": "http://172.18.198.54:8786/16e1ab15c35a457e9c2b2aa189f544e1/shares/d94a8548-2079-4be0-b21c-0a887acd31ca",
+					"rel":  "bookmark",
+				},
+			},
+		},
+		{
+			ID:   "406ea93b-32e9-4907-a117-148b3945749f",
+			Name: "Share1",
+			Links: []map[string]string{
+				{
+					"href": "http://172.18.198.54:8786/16e1ab15c35a457e9c2b2aa189f544e1/shares/d94a8548-2079-4be0-b21c-0a887acd31ca",
+					"rel":  "bookmark",
+				},
+			},
+		},
+	}
+	th.CheckDeepEquals(t, shortList, act)
+}

--- a/openstack/sharedfilesystems/v2/shares/testing/request_test.go
+++ b/openstack/sharedfilesystems/v2/shares/testing/request_test.go
@@ -4,7 +4,10 @@ import (
 	"testing"
 	"time"
 
+	"encoding/json"
+	"fmt"
 	"github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/shares"
+	"github.com/gophercloud/gophercloud/pagination"
 	th "github.com/gophercloud/gophercloud/testhelper"
 	"github.com/gophercloud/gophercloud/testhelper/client"
 )
@@ -120,4 +123,32 @@ func TestListAllShort(t *testing.T) {
 		},
 	}
 	th.CheckDeepEquals(t, shortList, act)
+}
+
+func TestListPaginateDetail(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockListDetailResponse(t)
+
+	opts := &shares.ListOpts{
+		Offset: 0,
+		Limit:  1,
+	}
+	count := 0
+	err := shares.List(client.ServiceClient(), opts, true).EachPage(func(page pagination.Page) (bool, error) {
+		s, err := shares.ExtractShares(page)
+		if err != nil {
+			t.Errorf("Unable to extract shares: %v", err)
+			return false, err
+		}
+		for i, share := range s {
+			asJSON, _ := json.MarshalIndent(share, "", " ")
+			fmt.Printf("share %d: \n%s\n", i, asJSON)
+		}
+		count++
+		return true, nil
+	})
+	th.AssertEquals(t, 3, count)
+	th.AssertNoErr(t, err)
 }

--- a/openstack/sharedfilesystems/v2/shares/testing/request_test.go
+++ b/openstack/sharedfilesystems/v2/shares/testing/request_test.go
@@ -6,6 +6,7 @@ import (
 
 	"encoding/json"
 	"fmt"
+
 	"github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/shares"
 	"github.com/gophercloud/gophercloud/pagination"
 	th "github.com/gophercloud/gophercloud/testhelper"

--- a/openstack/sharedfilesystems/v2/shares/testing/request_test.go
+++ b/openstack/sharedfilesystems/v2/shares/testing/request_test.go
@@ -88,6 +88,7 @@ func TestListAllShort(t *testing.T) {
 	defer th.TeardownHTTP()
 
 	MockListResponse(t)
+
 	pages, err := shares.List(client.ServiceClient(), &shares.ListOpts{}, false).AllPages()
 	th.AssertNoErr(t, err)
 	act, err := shares.ExtractShares(pages)

--- a/openstack/sharedfilesystems/v2/shares/testing/request_test.go
+++ b/openstack/sharedfilesystems/v2/shares/testing/request_test.go
@@ -88,7 +88,7 @@ func TestListAllShort(t *testing.T) {
 	defer th.TeardownHTTP()
 
 	MockListResponse(t)
-	pages, err := shares.List(client.ServiceClient(), &shares.ListOpts{}).AllPages()
+	pages, err := shares.List(client.ServiceClient(), &shares.ListOpts{}, false).AllPages()
 	th.AssertNoErr(t, err)
 	act, err := shares.ExtractShares(pages)
 	th.AssertNoErr(t, err)

--- a/openstack/sharedfilesystems/v2/shares/urls.go
+++ b/openstack/sharedfilesystems/v2/shares/urls.go
@@ -14,6 +14,9 @@ func getURL(c *gophercloud.ServiceClient, id string) string {
 	return c.ServiceURL("shares", id)
 }
 
-func listURL(c *gophercloud.ServiceClient) string {
+func listURL(c *gophercloud.ServiceClient, detail bool) string {
+	if detail {
+		return c.ServiceURL("shares", "detail")
+	}
 	return c.ServiceURL("shares")
 }

--- a/openstack/sharedfilesystems/v2/shares/urls.go
+++ b/openstack/sharedfilesystems/v2/shares/urls.go
@@ -13,3 +13,7 @@ func deleteURL(c *gophercloud.ServiceClient, id string) string {
 func getURL(c *gophercloud.ServiceClient, id string) string {
 	return c.ServiceURL("shares", id)
 }
+
+func listURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("shares")
+}


### PR DESCRIPTION
This pull request implements [`listing of shares`](http://developer.openstack.org/api-ref/shared-file-systems/?expanded=list-shares-detail#list-shares) with and without details

Manila implementation details:
https://github.com/openstack/manila/blob/16c522bf5e5c3d37018caef11dd7852462193327/manila/api/v1/shares.py#L110
https://github.com/openstack/manila/blob/16c522bf5e5c3d37018caef11dd7852462193327/manila/api/v1/shares.py#L153

For #129 
