### PR TITLE
Bugfix: use gophercloud.JSONRFC3339NoZ in db/v1 APIs

### DIFF
--- a/openstack/db/v1/configurations/results.go
+++ b/openstack/db/v1/configurations/results.go
@@ -1,19 +1,17 @@
 package configurations
 
 import (
-	"time"
-
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/pagination"
 )
 
 // Config represents a configuration group API resource.
 type Config struct {
-	Created              time.Time `json:"created"`
-	Updated              time.Time `json:"updated"`
-	DatastoreName        string    `json:"datastore_name"`
-	DatastoreVersionID   string    `json:"datastore_version_id"`
-	DatastoreVersionName string    `json:"datastore_version_name"`
+	Created              gophercloud.JSONRFC3339NoZ `json:"created"`
+	Updated              gophercloud.JSONRFC3339NoZ `json:"updated"`
+	DatastoreName        string                     `json:"datastore_name"`
+	DatastoreVersionID   string                     `json:"datastore_version_id"`
+	DatastoreVersionName string                     `json:"datastore_version_name"`
 	Description          string
 	ID                   string
 	Name                 string

--- a/openstack/db/v1/configurations/testing/fixtures.go
+++ b/openstack/db/v1/configurations/testing/fixtures.go
@@ -4,12 +4,13 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/db/v1/configurations"
 )
 
 var (
-	timestamp  = "2015-11-12T14:22:42Z"
-	timeVal, _ = time.Parse(time.RFC3339, timestamp)
+	timestamp = "2015-11-12T14:22:42"
+	timeVal   = gophercloud.JSONRFC3339NoZ(time.Date(2015, 11, 12, 14, 22, 42, 0, time.UTC))
 )
 
 var singleConfigJSON = `

--- a/openstack/db/v1/instances/results.go
+++ b/openstack/db/v1/instances/results.go
@@ -1,8 +1,6 @@
 package instances
 
 import (
-	"time"
-
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/db/v1/datastores"
 	"github.com/gophercloud/gophercloud/openstack/db/v1/flavors"
@@ -21,10 +19,10 @@ type Volume struct {
 // Instance represents a remote MySQL instance.
 type Instance struct {
 	// Indicates the datetime that the instance was created
-	Created time.Time `json:"created"`
+	Created gophercloud.JSONRFC3339NoZ `json:"created"`
 
 	// Indicates the most recent datetime that the instance was updated.
-	Updated time.Time `json:"updated"`
+	Updated gophercloud.JSONRFC3339NoZ `json:"updated"`
 
 	// Indicates the hardware flavor the instance uses.
 	Flavor flavors.Flavor

--- a/openstack/db/v1/instances/testing/fixtures.go
+++ b/openstack/db/v1/instances/testing/fixtures.go
@@ -13,8 +13,8 @@ import (
 )
 
 var (
-	timestamp  = "2015-11-12T14:22:42Z"
-	timeVal, _ = time.Parse(time.RFC3339, timestamp)
+	timestamp = "2015-11-12T14:22:42"
+	timeVal   = gophercloud.JSONRFC3339NoZ(time.Date(2015, 11, 12, 14, 22, 42, 0, time.UTC))
 )
 
 var instance = `


### PR DESCRIPTION
db/v1 APIs return time values with the "2006-01-02T15:04:05" format.
https://github.com/openstack/trove/blob/129fac7d5374e18a428afa1b5c0259743677222e/api-ref/source/samples/db-instance-status-detail-response.json

But trove api documentation is different.
http://developer.openstack.org/api-ref-database-v1.html#Database_Instances
