### PR TITLE
Use json.Number for flavorId

### DIFF
--- a/openstack/db/v1/flavors/results.go
+++ b/openstack/db/v1/flavors/results.go
@@ -1,6 +1,7 @@
 package flavors
 
 import (
+	"encoding/json"
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/pagination"
 )
@@ -22,7 +23,7 @@ func (r GetResult) Extract() (*Flavor, error) {
 // Flavor records represent (virtual) hardware configurations for server resources in a region.
 type Flavor struct {
 	// The flavor's unique identifier.
-	ID int `json:"id"`
+	ID json.Number `json:"id"`
 
 	// The RAM capacity for the flavor.
 	RAM int `json:"ram"`

--- a/openstack/db/v1/flavors/testing/requests_test.go
+++ b/openstack/db/v1/flavors/testing/requests_test.go
@@ -26,7 +26,7 @@ func TestListFlavors(t *testing.T) {
 
 		expected := []flavors.Flavor{
 			{
-				ID:   1,
+				ID:   "1",
 				Name: "m1.tiny",
 				RAM:  512,
 				Links: []gophercloud.Link{
@@ -35,7 +35,7 @@ func TestListFlavors(t *testing.T) {
 				},
 			},
 			{
-				ID:   2,
+				ID:   "2",
 				Name: "m1.small",
 				RAM:  1024,
 				Links: []gophercloud.Link{
@@ -44,7 +44,7 @@ func TestListFlavors(t *testing.T) {
 				},
 			},
 			{
-				ID:   3,
+				ID:   "3",
 				Name: "m1.medium",
 				RAM:  2048,
 				Links: []gophercloud.Link{
@@ -53,7 +53,7 @@ func TestListFlavors(t *testing.T) {
 				},
 			},
 			{
-				ID:   4,
+				ID:   "4",
 				Name: "m1.large",
 				RAM:  4096,
 				Links: []gophercloud.Link{
@@ -80,7 +80,7 @@ func TestGetFlavor(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	expected := &flavors.Flavor{
-		ID:   1,
+		ID:   "1",
 		Name: "m1.tiny",
 		RAM:  512,
 		Links: []gophercloud.Link{

--- a/openstack/db/v1/instances/testing/fixtures.go
+++ b/openstack/db/v1/instances/testing/fixtures.go
@@ -113,7 +113,7 @@ var expectedInstance = instances.Instance{
 	Created: timeVal,
 	Updated: timeVal,
 	Flavor: flavors.Flavor{
-		ID: 1,
+		ID: "1",
 		Links: []gophercloud.Link{
 			{Href: "https://my-openstack.com/v1.0/1234/flavors/1", Rel: "self"},
 			{Href: "https://my-openstack.com/v1.0/1234/flavors/1", Rel: "bookmark"},


### PR DESCRIPTION
flavorId is defined as "xsd:string".
But it must be an integer value.
json.Number is suitable for this situation.
http://developer.openstack.org/api-ref-database-v1.html#flavors

https://bugs.launchpad.net/trove/+bug/1165077
