### PR TITLE
Expose server type on baymodels

### DIFF
--- a/openstack/containerorchestration/v1/baymodels/results.go
+++ b/openstack/containerorchestration/v1/baymodels/results.go
@@ -32,6 +32,9 @@ type BayModel struct {
 	// The type of container orchestration engine used by the bay.
 	COE string `json:"coe"`
 
+	// The underlying type of the host nodes, such as lxc or vm
+	ServerType string `json:"server_type"`
+
 	// The flavor used by nodes in the bay.
 	FlavorID string `json:"flavor_id"`
 

--- a/openstack/containerorchestration/v1/baymodels/testing/requests_test.go
+++ b/openstack/containerorchestration/v1/baymodels/testing/requests_test.go
@@ -88,6 +88,7 @@ func TestList(t *testing.T) {
 				Name:        "k8sbaymodel",
 				ID:          "5b793604-fc76-4886-a834-ed522812cdcb",
 				COE:         "kubernetes",
+				ServerType:  "vm",
 				FlavorID:    "m1.small",
 				ImageID:     "fedora-atomic-latest",
 				KeyPairID:   "testkey",
@@ -167,6 +168,7 @@ func TestGet(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, "kubernetes-dev", m.Name)
 	th.AssertEquals(t, "kubernetes", m.COE)
+	th.AssertEquals(t, "vm", m.ServerType)
 	th.AssertEquals(t, "m1.small", m.FlavorID)
 	th.AssertEquals(t, "fedora-atomic-latest", m.ImageID)
 	th.AssertEquals(t, "testkey", m.KeyPairID)


### PR DESCRIPTION
Server type specifies if a bay (cluster) is vm or lxc.