### PR TITLE
computer/v2/servers: Check if opts.UserData is already Base64 Encoded

### DIFF
--- a/openstack/compute/v2/servers/requests.go
+++ b/openstack/compute/v2/servers/requests.go
@@ -190,16 +190,13 @@ func (opts CreateOpts) ToServerCreateMap() (map[string]interface{}, error) {
 	}
 
 	if opts.UserData != nil {
-		// Check if we've already got a Base64 encoded string; dont double-encode
-		_, base64DecodeError := base64.StdEncoding.DecodeString(string(opts.UserData))
-
-		if base64DecodeError == nil {
-			preEncoded := string(opts.UserData)
-			b["user_data"] = &preEncoded
+		var userData string
+		if _, err := base64.StdEncoding.DecodeString(string(opts.UserData)); err != nil {
+			userData = base64.StdEncoding.EncodeToString(opts.UserData)
 		} else {
-			encoded := base64.StdEncoding.EncodeToString(opts.UserData)
-			b["user_data"] = &encoded
+			userData = string(opts.UserData)
 		}
+		b["user_data"] = &userData
 	}
 
 	if len(opts.SecurityGroups) > 0 {

--- a/openstack/compute/v2/servers/testing/fixtures.go
+++ b/openstack/compute/v2/servers/testing/fixtures.go
@@ -603,6 +603,27 @@ func HandleServerCreationWithCustomFieldSuccessfully(t *testing.T, response stri
 	})
 }
 
+// HandleServerCreationWithUserdata sets up the test server to respond to a server creation request
+// with a given response.
+func HandleServerCreationWithUserdata(t *testing.T, response string) {
+	th.Mux.HandleFunc("/servers", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, `{
+			"server": {
+				"name": "derp",
+				"imageRef": "f90f6034-2570-4974-8351-6b49732ef2eb",
+				"flavorRef": "1",
+				"user_data": "dXNlcmRhdGEgc3RyaW5n"
+			}
+		}`)
+
+		w.WriteHeader(http.StatusAccepted)
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprintf(w, response)
+	})
+}
+
 // HandleServerCreationWithMetadata sets up the test server to respond to a server creation request
 // with a given response.
 func HandleServerCreationWithMetadata(t *testing.T, response string) {

--- a/openstack/compute/v2/servers/testing/requests_test.go
+++ b/openstack/compute/v2/servers/testing/requests_test.go
@@ -107,6 +107,40 @@ func TestCreateServerWithMetadata(t *testing.T) {
 	th.CheckDeepEquals(t, ServerDerp, *actual)
 }
 
+func TestCreateServerWithUserdataString(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleServerCreationWithUserdata(t, SingleServerBody)
+
+	actual, err := servers.Create(client.ServiceClient(), servers.CreateOpts{
+		Name:      "derp",
+		ImageRef:  "f90f6034-2570-4974-8351-6b49732ef2eb",
+		FlavorRef: "1",
+		UserData:  []byte("userdata string"),
+	}).Extract()
+	th.AssertNoErr(t, err)
+
+	th.CheckDeepEquals(t, ServerDerp, *actual)
+}
+
+func TestCreateServerWithUserdataEncoded(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleServerCreationWithUserdata(t, SingleServerBody)
+
+	encoded := base64.StdEncoding.EncodeToString([]byte("userdata string"))
+
+	actual, err := servers.Create(client.ServiceClient(), servers.CreateOpts{
+		Name:      "derp",
+		ImageRef:  "f90f6034-2570-4974-8351-6b49732ef2eb",
+		FlavorRef: "1",
+		UserData:  []byte(encoded),
+	}).Extract()
+	th.AssertNoErr(t, err)
+
+	th.CheckDeepEquals(t, ServerDerp, *actual)
+}
+
 func TestCreateServerWithImageNameAndFlavorName(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()


### PR DESCRIPTION
Currently, the `UserData` field is always Base64 encoded, even if it could already be Base64 encoded. 

This improves the behaviour by checking if the current value is already Base64 encoded, and skips the encoding if it is. 
Otherwise, it will Base64 encode before submitting the request. 