### PR TITLE
Nova Hypervisors API

### DIFF
--- a/openstack/compute/v2/hypervisors/doc.go
+++ b/openstack/compute/v2/hypervisors/doc.go
@@ -1,0 +1,3 @@
+// Package hypervisors gives information and control of the os-hypervisors
+// portion of the compute API
+package hypervisors

--- a/openstack/compute/v2/hypervisors/requests.go
+++ b/openstack/compute/v2/hypervisors/requests.go
@@ -5,43 +5,9 @@ import (
 	"github.com/gophercloud/gophercloud/pagination"
 )
 
-// ListOptsBuilder allows extensions to add additional parameters to the
-// List request.
-type ListOptsBuilder interface {
-	ToHypervisorListQuery() (string, error)
-}
-
-// ListOpts allows the filtering and sorting of paginated collections through
-// the API. Filtering is achieved by passing in struct field values that map to
-// the server attributes you want to see returned. Marker and Limit are used
-// for pagination.
-type ListOpts struct {
-	// ID of the server at which you want to set a marker.
-	Marker string `q:"marker"`
-
-	// Integer value for the limit of values to return.
-	Limit int `q:"limit"`
-}
-
-// ToHypervisorListQuery formats a ListOpts into a query string.
-func (opts ListOpts) ToHypervisorListQuery() (string, error) {
-	q, err := gophercloud.BuildQueryString(opts)
-	return q.String(), err
-}
-
 // List makes a request against the API to list hypervisors.
-func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
-	url := hypervisorsListDetailURL(client)
-	if opts != nil {
-		query, err := opts.ToHypervisorListQuery()
-		if err != nil {
-			return pagination.Pager{Err: err}
-		}
-		url += query
-	}
-	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
-		p := HypervisorPage{pagination.MarkerPageBase{PageResult: r}}
-		p.MarkerPageBase.Owner = p
-		return p
+func List(client *gophercloud.ServiceClient) pagination.Pager {
+	return pagination.NewPager(client, hypervisorsListDetailURL(client), func(r pagination.PageResult) pagination.Page {
+		return HypervisorPage{pagination.SinglePageBase(r)}
 	})
 }

--- a/openstack/compute/v2/hypervisors/requests.go
+++ b/openstack/compute/v2/hypervisors/requests.go
@@ -40,6 +40,8 @@ func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pa
 		url += query
 	}
 	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
-		return HypervisorPage{pagination.LinkedPageBase{PageResult: r}}
+		p := HypervisorPage{pagination.MarkerPageBase{PageResult: r}}
+		p.MarkerPageBase.Owner = p
+		return p
 	})
 }

--- a/openstack/compute/v2/hypervisors/requests.go
+++ b/openstack/compute/v2/hypervisors/requests.go
@@ -1,0 +1,45 @@
+package hypervisors
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// ListOptsBuilder allows extensions to add additional parameters to the
+// List request.
+type ListOptsBuilder interface {
+	ToHypervisorListQuery() (string, error)
+}
+
+// ListOpts allows the filtering and sorting of paginated collections through
+// the API. Filtering is achieved by passing in struct field values that map to
+// the server attributes you want to see returned. Marker and Limit are used
+// for pagination.
+type ListOpts struct {
+	// ID of the server at which you want to set a marker.
+	Marker string `q:"marker"`
+
+	// Integer value for the limit of values to return.
+	Limit int `q:"limit"`
+}
+
+// ToHypervisorListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToHypervisorListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List makes a request against the API to list hypervisors.
+func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := hypervisorsListDetailURL(client)
+	if opts != nil {
+		query, err := opts.ToHypervisorListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return HypervisorPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}

--- a/openstack/compute/v2/hypervisors/results.go
+++ b/openstack/compute/v2/hypervisors/results.go
@@ -78,6 +78,8 @@ func (h *Hypervisor) UnmarshalJSON(b []byte) error {
 		tmp
 		CpuInfo           interface{} `json:"cpu_info"`
 		HypervisorVersion interface{} `json:"hypervisor_version"`
+		FreeDiskGB        interface{} `json:"free_disk_gb"`
+		LocalGB           interface{} `json:"local_gb"`
 	}
 
 	err := json.Unmarshal(b, &hypervisor)
@@ -147,6 +149,24 @@ func (h *Hypervisor) UnmarshalJSON(b []byte) error {
 		h.HypervisorVersion = int(t)
 	default:
 		return fmt.Errorf("Hypervisor version of unexpected type")
+	}
+
+	switch t := hypervisor.FreeDiskGB.(type) {
+	case int:
+		h.FreeDiskGB = t
+	case float64:
+		h.FreeDiskGB = int(t)
+	default:
+		return fmt.Errorf("Free disk GB of unexpected type")
+	}
+
+	switch t := hypervisor.LocalGB.(type) {
+	case int:
+		h.LocalGB = t
+	case float64:
+		h.LocalGB = int(t)
+	default:
+		return fmt.Errorf("Local GB of unexpected type")
 	}
 
 	return nil

--- a/openstack/compute/v2/hypervisors/results.go
+++ b/openstack/compute/v2/hypervisors/results.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/gophercloud/gophercloud/pagination"
+	"strconv"
 )
 
 type Topology struct {
@@ -143,12 +144,23 @@ func (r *Hypervisor) UnmarshalJSON(b []byte) error {
 }
 
 type HypervisorPage struct {
-	pagination.LinkedPageBase
+	pagination.MarkerPageBase
 }
 
 func (page HypervisorPage) IsEmpty() (bool, error) {
 	hypervisors, err := ExtractHypervisors(page)
 	return len(hypervisors) == 0, err
+}
+
+func (r HypervisorPage) LastMarker() (string, error) {
+	hypervisors, err := ExtractHypervisors(r)
+	if err != nil {
+		return "", nil
+	}
+	if len(hypervisors) == 0 {
+		return "", nil
+	}
+	return strconv.Itoa(hypervisors[len(hypervisors)-1].ID), nil
 }
 
 func ExtractHypervisors(p pagination.Page) ([]Hypervisor, error) {

--- a/openstack/compute/v2/hypervisors/results.go
+++ b/openstack/compute/v2/hypervisors/results.go
@@ -1,0 +1,170 @@
+package hypervisors
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+type Topology struct {
+	Sockets int `json:"sockets"`
+	Cores   int `json:"cores"`
+	Threads int `json:"threads"`
+}
+
+type CpuInfo struct {
+	Vendor   string   `json:"vendor"`
+	Arch     string   `json:"arch"`
+	Model    string   `json:"model"`
+	Features []string `json:"features"`
+	Topology `json:"topology"`
+}
+
+type Service struct {
+	Host           string `json:"host"`
+	ID             int    `json:"id"`
+	DisabledReason string `json:"disabled_reason"`
+}
+
+type Hypervisor struct {
+	// A structure that contains cpu information like arch, model, vendor, features and topology
+	CpuInfo `json:"cpu_info"`
+	// The current_workload is the number of tasks the hypervisor is responsible for.
+	// This will be equal or greater than the number of active VMs on the system
+	// (it can be greater when VMs are being deleted and the hypervisor is still cleaning up).
+	CurrentWorkload int `json:"current_workload"`
+	// Status of the hypervisor, either "enabled" or "disabled"
+	Status string `json:"status"`
+	// State of the hypervisor, either "up" or "down"
+	State string `json:"state"`
+	// Actual free disk on this hypervisor in GB
+	DiskAvailableLeast int `json:"disk_available_least"`
+	// The hypervisor's IP address
+	HostIP string `json:"host_ip"`
+	// The free disk remaining on this hypervisor in GB
+	FreeDiskGB int `json:"free_disk_gb"`
+	// The free RAM in this hypervisor in MB
+	FreeRamMB int `json:"free_ram_mb"`
+	// The hypervisor host name
+	HypervisorHostname string `json:"hypervisor_hostname"`
+	// The hypervisor type
+	HypervisorType string `json:"hypervisor_type"`
+	// The hypervisor version
+	HypervisorVersion int `json:"hypervisor_version"`
+	// Unique ID of the hypervisor
+	ID int `json:"id"`
+	// The disk in this hypervisor in GB
+	LocalGB int `json:"local_gb"`
+	// The disk used in this hypervisor in GB
+	LocalGBUsed int `json:"local_gb_used"`
+	// The memory of this hypervisor in MB
+	MemoryMB int `json:"memory_mb"`
+	// The memory used in this hypervisor in MB
+	MemoryMBUsed int `json:"memory_mb_used"`
+	// The number of running vms on this hypervisor
+	RunningVMs int `json:"running_vms"`
+	// The hypervisor service object
+	Service `json:"service"`
+	// The number of vcpu in this hypervisor
+	VCPUs int `json:"vcpus"`
+	// The number of vcpu used in this hypervisor
+	VCPUsUsed int `json:"vcpus_used"`
+}
+
+func (h *Hypervisor) UnmarshalJSON(b []byte) error {
+
+	type tmp Hypervisor
+	var hypervisor *struct {
+		tmp
+		CpuInfo           interface{} `json:"cpu_info"`
+		HypervisorVersion interface{} `json:"hypervisor_version"`
+	}
+
+	err := json.Unmarshal(b, &hypervisor)
+	if err != nil {
+		return err
+	}
+
+	*h = Hypervisor(hypervisor.tmp)
+
+	// Newer versions pass the CPU into around as the correct types, this just needs
+	// converting and copying into place. Older versions pass CPU info around as a string
+	// and can simply be unmarshalled by the json parser
+	switch t := hypervisor.CpuInfo.(type) {
+	case map[string]interface{}:
+		var ok bool
+		if h.CpuInfo.Vendor, ok = t["vendor"].(string); !ok {
+			return fmt.Errorf("CPU info vendor expected to be a string")
+		}
+		if h.CpuInfo.Arch, ok = t["arch"].(string); !ok {
+			return fmt.Errorf("CPU info arch expected to be a string")
+		}
+		if h.CpuInfo.Model, ok = t["model"].(string); !ok {
+			return fmt.Errorf("CPU info model expected to be a string")
+		}
+		if features, ok := t["features"].([]interface{}); ok {
+			for _, feature := range features {
+				if temp, ok := feature.(string); ok {
+					h.CpuInfo.Features = append(h.CpuInfo.Features, temp)
+				} else {
+					return fmt.Errorf("CPU info feaure expected to be a string")
+				}
+			}
+		} else {
+			return fmt.Errorf("CPU info features to be an array")
+		}
+		if topology, ok := t["topology"].(map[string]interface{}); ok {
+			if temp, ok := topology["sockets"].(float64); ok {
+				h.CpuInfo.Topology.Sockets = int(temp)
+			} else {
+				return fmt.Errorf("CPU info topology sockets expected to be numeric")
+			}
+			if temp, ok := topology["cores"].(float64); ok {
+				h.CpuInfo.Topology.Cores = int(temp)
+			} else {
+				return fmt.Errorf("CPU info topology cores expected to be numeric")
+			}
+			if temp, ok := topology["threads"].(float64); ok {
+				h.CpuInfo.Topology.Threads = int(temp)
+			} else {
+				return fmt.Errorf("CPU info topology threads expected to be numeric")
+			}
+		} else {
+			return fmt.Errorf("CPU info topology expected to be a map")
+		}
+	case string:
+		err := json.Unmarshal([]byte(t), &h.CpuInfo)
+		if err != nil {
+			return err
+		}
+	}
+
+	// A feature in OpenStack may return this value as floating point
+	switch t := hypervisor.HypervisorVersion.(type) {
+	case int:
+		h.HypervisorVersion = t
+	case float64:
+		h.HypervisorVersion = int(t)
+	default:
+		return fmt.Errorf("Hypervisor version of unexpected type")
+	}
+
+	return nil
+}
+
+type HypervisorPage struct {
+	pagination.LinkedPageBase
+}
+
+func (page HypervisorPage) IsEmpty() (bool, error) {
+	hypervisors, err := ExtractHypervisors(page)
+	return len(hypervisors) == 0, err
+}
+
+func ExtractHypervisors(p pagination.Page) ([]Hypervisor, error) {
+	var h struct {
+		Hypervisors []Hypervisor `json:"hypervisors"`
+	}
+	err := (p.(HypervisorPage)).ExtractInto(&h)
+	return h.Hypervisors, err
+}

--- a/openstack/compute/v2/hypervisors/results.go
+++ b/openstack/compute/v2/hypervisors/results.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/gophercloud/gophercloud/pagination"
-	"strconv"
 )
 
 type Topology struct {
@@ -144,23 +143,12 @@ func (r *Hypervisor) UnmarshalJSON(b []byte) error {
 }
 
 type HypervisorPage struct {
-	pagination.MarkerPageBase
+	pagination.SinglePageBase
 }
 
 func (page HypervisorPage) IsEmpty() (bool, error) {
-	hypervisors, err := ExtractHypervisors(page)
-	return len(hypervisors) == 0, err
-}
-
-func (r HypervisorPage) LastMarker() (string, error) {
-	hypervisors, err := ExtractHypervisors(r)
-	if err != nil {
-		return "", nil
-	}
-	if len(hypervisors) == 0 {
-		return "", nil
-	}
-	return strconv.Itoa(hypervisors[len(hypervisors)-1].ID), nil
+        va, err := ExtractHypervisors(page)
+        return len(va) == 0, err
 }
 
 func ExtractHypervisors(p pagination.Page) ([]Hypervisor, error) {

--- a/openstack/compute/v2/hypervisors/testing/fixtures.go
+++ b/openstack/compute/v2/hypervisors/testing/fixtures.go
@@ -1,0 +1,144 @@
+package testing
+
+import (
+	"fmt"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/hypervisors"
+	"github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+	"net/http"
+	"testing"
+)
+
+// The first hypervisor represents what the specification says (~Newton)
+// The second is exactly the same, but what you can get off a real system (~Kilo)
+const HypervisorListBody = `
+{
+    "hypervisors": [
+        {
+            "cpu_info": {
+                "arch": "x86_64",
+                "model": "Nehalem",
+                "vendor": "Intel",
+                "features": [
+                    "pge",
+                    "clflush"
+                ],
+                "topology": {
+                    "cores": 1,
+                    "threads": 1,
+                    "sockets": 4
+                }
+            },
+            "current_workload": 0,
+            "status": "enabled",
+            "state": "up",
+            "disk_available_least": 0,
+            "host_ip": "1.1.1.1",
+            "free_disk_gb": 1028,
+            "free_ram_mb": 7680,
+            "hypervisor_hostname": "fake-mini",
+            "hypervisor_type": "fake",
+            "hypervisor_version": 2002000,
+            "id": 1,
+            "local_gb": 1028,
+            "local_gb_used": 0,
+            "memory_mb": 8192,
+            "memory_mb_used": 512,
+            "running_vms": 0,
+            "service": {
+                "host": "e6a37ee802d74863ab8b91ade8f12a67",
+                "id": 2,
+                "disabled_reason": null
+            },
+            "vcpus": 1,
+            "vcpus_used": 0
+        },
+        {
+            "cpu_info": "{\"arch\": \"x86_64\", \"model\": \"Nehalem\", \"vendor\": \"Intel\", \"features\": [\"pge\", \"clflush\"], \"topology\": {\"cores\": 1, \"threads\": 1, \"sockets\": 4}}",
+            "current_workload": 0,
+            "status": "enabled",
+            "state": "up",
+            "disk_available_least": 0,
+            "host_ip": "1.1.1.1",
+            "free_disk_gb": 1028,
+            "free_ram_mb": 7680,
+            "hypervisor_hostname": "fake-mini",
+            "hypervisor_type": "fake",
+            "hypervisor_version": 2.002e+06,
+            "id": 1,
+            "local_gb": 1028,
+            "local_gb_used": 0,
+            "memory_mb": 8192,
+            "memory_mb_used": 512,
+            "running_vms": 0,
+            "service": {
+                "host": "e6a37ee802d74863ab8b91ade8f12a67",
+                "id": 2,
+                "disabled_reason": null
+            },
+            "vcpus": 1,
+            "vcpus_used": 0
+        }
+    ]
+}`
+
+var (
+	HypervisorFake = hypervisors.Hypervisor{
+		CpuInfo: hypervisors.CpuInfo{
+			Arch:   "x86_64",
+			Model:  "Nehalem",
+			Vendor: "Intel",
+			Features: []string{
+				"pge",
+				"clflush",
+			},
+			Topology: hypervisors.Topology{
+				Cores:   1,
+				Threads: 1,
+				Sockets: 4,
+			},
+		},
+		CurrentWorkload:    0,
+		Status:             "enabled",
+		State:              "up",
+		DiskAvailableLeast: 0,
+		HostIP:             "1.1.1.1",
+		FreeDiskGB:         1028,
+		FreeRamMB:          7680,
+		HypervisorHostname: "fake-mini",
+		HypervisorType:     "fake",
+		HypervisorVersion:  2002000,
+		ID:                 1,
+		LocalGB:            1028,
+		LocalGBUsed:        0,
+		MemoryMB:           8192,
+		MemoryMBUsed:       512,
+		RunningVMs:         0,
+		Service: hypervisors.Service{
+			Host:           "e6a37ee802d74863ab8b91ade8f12a67",
+			ID:             2,
+			DisabledReason: "",
+		},
+		VCPUs:     1,
+		VCPUsUsed: 0,
+	}
+)
+
+func HandleHypervisorListSuccessfully(t *testing.T) {
+	testhelper.Mux.HandleFunc("/os-hypervisors/detail", func(w http.ResponseWriter, r *http.Request) {
+		testhelper.TestMethod(t, r, "GET")
+		testhelper.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		r.ParseForm()
+		marker := r.Form.Get("marker")
+		switch marker {
+		case "":
+			fmt.Fprintf(w, HypervisorListBody)
+		case "1":
+			fmt.Fprintf(w, `{ "hypervisors": [] }`)
+		default:
+			t.Fatalf("/hypervisors/detail invoked with unexpected marker=[%s]", marker)
+		}
+	})
+}

--- a/openstack/compute/v2/hypervisors/testing/fixtures.go
+++ b/openstack/compute/v2/hypervisors/testing/fixtures.go
@@ -84,7 +84,7 @@ const HypervisorListBody = `
 
 var (
 	HypervisorFake = hypervisors.Hypervisor{
-		CpuInfo: hypervisors.CpuInfo{
+		CPUInfo: hypervisors.CPUInfo{
 			Arch:   "x86_64",
 			Model:  "Nehalem",
 			Vendor: "Intel",

--- a/openstack/compute/v2/hypervisors/testing/fixtures.go
+++ b/openstack/compute/v2/hypervisors/testing/fixtures.go
@@ -130,15 +130,6 @@ func HandleHypervisorListSuccessfully(t *testing.T) {
 		testhelper.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
-		r.ParseForm()
-		marker := r.Form.Get("marker")
-		switch marker {
-		case "":
-			fmt.Fprintf(w, HypervisorListBody)
-		case "1":
-			fmt.Fprintf(w, `{ "hypervisors": [] }`)
-		default:
-			t.Fatalf("/hypervisors/detail invoked with unexpected marker=[%s]", marker)
-		}
+		fmt.Fprintf(w, HypervisorListBody)
 	})
 }

--- a/openstack/compute/v2/hypervisors/testing/requests_test.go
+++ b/openstack/compute/v2/hypervisors/testing/requests_test.go
@@ -1,0 +1,52 @@
+package testing
+
+import (
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/hypervisors"
+	"github.com/gophercloud/gophercloud/pagination"
+	"github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+	"testing"
+)
+
+func TestListHypervisors(t *testing.T) {
+	testhelper.SetupHTTP()
+	defer testhelper.TeardownHTTP()
+	HandleHypervisorListSuccessfully(t)
+
+	pages := 0
+	err := hypervisors.List(client.ServiceClient(), hypervisors.ListOpts{}).EachPage(func(page pagination.Page) (bool, error) {
+		pages++
+
+		actual, err := hypervisors.ExtractHypervisors(page)
+		if err != nil {
+			return false, err
+		}
+
+		if len(actual) != 2 {
+			t.Fatalf("Expected 2 hypervisors, got %d", len(actual))
+		}
+		testhelper.CheckDeepEquals(t, HypervisorFake, actual[0])
+		testhelper.CheckDeepEquals(t, HypervisorFake, actual[1])
+
+		return true, nil
+	})
+
+	testhelper.AssertNoErr(t, err)
+
+	if pages != 1 {
+		t.Errorf("Expected 1 page, saw %d", pages)
+	}
+}
+
+func TestListAllHypervisors(t *testing.T) {
+	testhelper.SetupHTTP()
+	defer testhelper.TeardownHTTP()
+	HandleHypervisorListSuccessfully(t)
+
+	allPages, err := hypervisors.List(client.ServiceClient(), hypervisors.ListOpts{}).AllPages()
+	testhelper.AssertNoErr(t, err)
+	actual, err := hypervisors.ExtractHypervisors(allPages)
+	testhelper.AssertNoErr(t, err)
+	testhelper.CheckDeepEquals(t, HypervisorFake, actual[0])
+	testhelper.CheckDeepEquals(t, HypervisorFake, actual[1])
+}

--- a/openstack/compute/v2/hypervisors/testing/requests_test.go
+++ b/openstack/compute/v2/hypervisors/testing/requests_test.go
@@ -14,7 +14,7 @@ func TestListHypervisors(t *testing.T) {
 	HandleHypervisorListSuccessfully(t)
 
 	pages := 0
-	err := hypervisors.List(client.ServiceClient(), hypervisors.ListOpts{}).EachPage(func(page pagination.Page) (bool, error) {
+	err := hypervisors.List(client.ServiceClient()).EachPage(func(page pagination.Page) (bool, error) {
 		pages++
 
 		actual, err := hypervisors.ExtractHypervisors(page)
@@ -43,7 +43,7 @@ func TestListAllHypervisors(t *testing.T) {
 	defer testhelper.TeardownHTTP()
 	HandleHypervisorListSuccessfully(t)
 
-	allPages, err := hypervisors.List(client.ServiceClient(), hypervisors.ListOpts{}).AllPages()
+	allPages, err := hypervisors.List(client.ServiceClient()).AllPages()
 	testhelper.AssertNoErr(t, err)
 	actual, err := hypervisors.ExtractHypervisors(allPages)
 	testhelper.AssertNoErr(t, err)

--- a/openstack/compute/v2/hypervisors/urls.go
+++ b/openstack/compute/v2/hypervisors/urls.go
@@ -1,0 +1,7 @@
+package hypervisors
+
+import "github.com/gophercloud/gophercloud"
+
+func hypervisorsListDetailURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("os-hypervisors", "detail")
+}


### PR DESCRIPTION
Adds in support to list all available hypervisors (detailed) for applications
such as monitoring and capacity planning.

API: https://github.com/openstack/nova/blob/master/nova/api/openstack/compute/hypervisors.py#L46

Pay particular attention to line 71 where the horrible cpu_info hack is introduced

For #179 