### PR TITLE
db/instances: expect non-Z time format

### DIFF
--- a/openstack/db/v1/instances/results.go
+++ b/openstack/db/v1/instances/results.go
@@ -57,31 +57,23 @@ type Instance struct {
 	Datastore datastores.DatastorePartial
 }
 
-func (s *Instance) UnmarshalJSON(b []byte) error {
+func (r *Instance) UnmarshalJSON(b []byte) error {
 	type tmp Instance
-	var p *struct {
+	var s struct {
 		tmp
-		Created string `json:"created"`
-		Updated string `json:"updated"`
+		Created gophercloud.JSONRFC3339NoZ `json:"created"`
+		Updated gophercloud.JSONRFC3339NoZ `json:"updated"`
 	}
-	err := json.Unmarshal(b, &p)
+	err := json.Unmarshal(b, &s)
 	if err != nil {
 		return err
 	}
-	*s = Instance(p.tmp)
+	*r = Instance(s.tmp)
 
-	if p.Created != "" {
-		s.Created, err = time.Parse(gophercloud.RFC3339NoZ, p.Created)
-		if err != nil {
-			return err
-		}
-	}
+	r.Created = time.Time(s.Created)
+	r.Updated = time.Time(s.Updated)
 
-	if p.Updated != "" {
-		s.Updated, err = time.Parse(gophercloud.RFC3339NoZ, p.Updated)
-	}
-
-	return err
+	return nil
 }
 
 type commonResult struct {

--- a/openstack/db/v1/instances/testing/fixtures.go
+++ b/openstack/db/v1/instances/testing/fixtures.go
@@ -13,8 +13,8 @@ import (
 )
 
 var (
-	timestamp  = "2015-11-12T14:22:42Z"
-	timeVal, _ = time.Parse(time.RFC3339, timestamp)
+	timestamp  = "2015-11-12T14:22:42"
+	timeVal, _ = time.Parse(gophercloud.RFC3339NoZ, timestamp)
 )
 
 var instance = `


### PR DESCRIPTION
Changes parsing of time fields for database instances to match the non-Z format returned by trove.

Trove stores the times as `datetime` objects:
(created) https://github.com/openstack/trove/blob/stable/newton/trove/db/models.py#L35
(updated) https://github.com/openstack/trove/blob/stable/newton/trove/db/models.py#L60

The `datetime` is converted to a string using `isoformat()`, meaning no Z:
https://github.com/openstack/trove/blob/stable/newton/trove/common/base_wsgi.py#L453

This PR solves the same issue as #155 but keeps using `time.Time` in the `Instance` struct.

For #159 