### PR TITLE
db: fix flavor id parsing

### DIFF
--- a/openstack/db/v1/flavors/results.go
+++ b/openstack/db/v1/flavors/results.go
@@ -22,6 +22,7 @@ func (r GetResult) Extract() (*Flavor, error) {
 // Flavor records represent (virtual) hardware configurations for server resources in a region.
 type Flavor struct {
 	// The flavor's unique identifier.
+	// Contains 0 if the ID is not an integer.
 	ID int `json:"id"`
 
 	// The RAM capacity for the flavor.
@@ -32,6 +33,9 @@ type Flavor struct {
 
 	// Links to access the flavor.
 	Links []gophercloud.Link
+
+	// The flavor's unique identifier as a string
+	StrID string `json:"str_id"`
 }
 
 // FlavorPage contains a single page of the response from a List call.

--- a/openstack/db/v1/flavors/testing/fixtures.go
+++ b/openstack/db/v1/flavors/testing/fixtures.go
@@ -9,19 +9,20 @@ import (
 
 const flavor = `
 {
-	"id": %d,
+	"id": %s,
 	"links": [
 		{
-			"href": "https://openstack.example.com/v1.0/1234/flavors/%d",
+			"href": "https://openstack.example.com/v1.0/1234/flavors/%s",
 			"rel": "self"
 		},
 		{
-			"href": "https://openstack.example.com/flavors/%d",
+			"href": "https://openstack.example.com/flavors/%s",
 			"rel": "bookmark"
 		}
 	],
 	"name": "%s",
-	"ram": %d
+	"ram": %d,
+	"str_id": "%s"
 }
 `
 
@@ -32,12 +33,13 @@ var (
 )
 
 var (
-	flavor1 = fmt.Sprintf(flavor, 1, 1, 1, "m1.tiny", 512)
-	flavor2 = fmt.Sprintf(flavor, 2, 2, 2, "m1.small", 1024)
-	flavor3 = fmt.Sprintf(flavor, 3, 3, 3, "m1.medium", 2048)
-	flavor4 = fmt.Sprintf(flavor, 4, 4, 4, "m1.large", 4096)
+	flavor1 = fmt.Sprintf(flavor, "1", "1", "1", "m1.tiny", 512, "1")
+	flavor2 = fmt.Sprintf(flavor, "2", "2", "2", "m1.small", 1024, "2")
+	flavor3 = fmt.Sprintf(flavor, "3", "3", "3", "m1.medium", 2048, "3")
+	flavor4 = fmt.Sprintf(flavor, "4", "4", "4", "m1.large", 4096, "4")
+	flavor5 = fmt.Sprintf(flavor, "null", "d1", "d1", "ds512M", 512, "d1")
 
-	listFlavorsResp = fmt.Sprintf(`{"flavors":[%s, %s, %s, %s]}`, flavor1, flavor2, flavor3, flavor4)
+	listFlavorsResp = fmt.Sprintf(`{"flavors":[%s, %s, %s, %s, %s]}`, flavor1, flavor2, flavor3, flavor4, flavor5)
 	getFlavorResp   = fmt.Sprintf(`{"flavor": %s}`, flavor1)
 )
 

--- a/openstack/db/v1/flavors/testing/requests_test.go
+++ b/openstack/db/v1/flavors/testing/requests_test.go
@@ -33,6 +33,7 @@ func TestListFlavors(t *testing.T) {
 					{Href: "https://openstack.example.com/v1.0/1234/flavors/1", Rel: "self"},
 					{Href: "https://openstack.example.com/flavors/1", Rel: "bookmark"},
 				},
+				StrID: "1",
 			},
 			{
 				ID:   2,
@@ -42,6 +43,7 @@ func TestListFlavors(t *testing.T) {
 					{Href: "https://openstack.example.com/v1.0/1234/flavors/2", Rel: "self"},
 					{Href: "https://openstack.example.com/flavors/2", Rel: "bookmark"},
 				},
+				StrID: "2",
 			},
 			{
 				ID:   3,
@@ -51,6 +53,7 @@ func TestListFlavors(t *testing.T) {
 					{Href: "https://openstack.example.com/v1.0/1234/flavors/3", Rel: "self"},
 					{Href: "https://openstack.example.com/flavors/3", Rel: "bookmark"},
 				},
+				StrID: "3",
 			},
 			{
 				ID:   4,
@@ -60,6 +63,17 @@ func TestListFlavors(t *testing.T) {
 					{Href: "https://openstack.example.com/v1.0/1234/flavors/4", Rel: "self"},
 					{Href: "https://openstack.example.com/flavors/4", Rel: "bookmark"},
 				},
+				StrID: "4",
+			},
+			{
+				ID:   0,
+				Name: "ds512M",
+				RAM:  512,
+				Links: []gophercloud.Link{
+					{Href: "https://openstack.example.com/v1.0/1234/flavors/d1", Rel: "self"},
+					{Href: "https://openstack.example.com/flavors/d1", Rel: "bookmark"},
+				},
+				StrID: "d1",
 			},
 		}
 
@@ -86,6 +100,7 @@ func TestGetFlavor(t *testing.T) {
 		Links: []gophercloud.Link{
 			{Href: "https://openstack.example.com/v1.0/1234/flavors/1", Rel: "self"},
 		},
+		StrID: "1",
 	}
 
 	th.AssertDeepEquals(t, expected, actual)

--- a/openstack/db/v1/instances/results.go
+++ b/openstack/db/v1/instances/results.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/db/v1/datastores"
-	"github.com/gophercloud/gophercloud/openstack/db/v1/flavors"
 	"github.com/gophercloud/gophercloud/openstack/db/v1/users"
 	"github.com/gophercloud/gophercloud/pagination"
 )
@@ -18,6 +17,14 @@ type Volume struct {
 	Used float64
 }
 
+// Flavor represents (virtual) hardware configurations for server resources in a region.
+type Flavor struct {
+	// The flavor's unique identifier.
+	ID string
+	// Links to access the flavor.
+	Links []gophercloud.Link
+}
+
 // Instance represents a remote MySQL instance.
 type Instance struct {
 	// Indicates the datetime that the instance was created
@@ -27,7 +34,7 @@ type Instance struct {
 	Updated time.Time `json:"updated"`
 
 	// Indicates the hardware flavor the instance uses.
-	Flavor flavors.Flavor
+	Flavor Flavor
 
 	// A DNS-resolvable hostname associated with the database instance (rather
 	// than an IPv4 address). Since the hostname always resolves to the correct

--- a/openstack/db/v1/instances/testing/fixtures.go
+++ b/openstack/db/v1/instances/testing/fixtures.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/db/v1/datastores"
-	"github.com/gophercloud/gophercloud/openstack/db/v1/flavors"
 	"github.com/gophercloud/gophercloud/openstack/db/v1/instances"
 	"github.com/gophercloud/gophercloud/testhelper/fixture"
 )
@@ -25,7 +24,7 @@ var instance = `
     "version": "5.6"
   },
   "flavor": {
-    "id": 1,
+    "id": "1",
     "links": [
       {
         "href": "https://my-openstack.com/v1.0/1234/flavors/1",
@@ -112,8 +111,8 @@ var (
 var expectedInstance = instances.Instance{
 	Created: timeVal,
 	Updated: timeVal,
-	Flavor: flavors.Flavor{
-		ID: 1,
+	Flavor: instances.Flavor{
+		ID: "1",
 		Links: []gophercloud.Link{
 			{Href: "https://my-openstack.com/v1.0/1234/flavors/1", Rel: "self"},
 			{Href: "https://my-openstack.com/v1.0/1234/flavors/1", Rel: "bookmark"},


### PR DESCRIPTION
* Trove flavor IDs returned with instances are always strings
https://github.com/openstack/trove/blob/stable/newton/trove/instance/models.py#L212
* Trove flavor IDs returned with flavors are integers or null, there is a
  str_id parameter that contains the ID in string format
https://github.com/openstack/trove/blob/stable/newton/trove/flavor/views.py#L33

Because of the differing return types this PR solves #160 by not referring to `flavor.Flavors` from instance. Instead instance uses its own struct with the ID as type string.

For #160