### PR TITLE
db/instance: add support for IPs in response body

### DIFF
--- a/openstack/db/v1/instances/results.go
+++ b/openstack/db/v1/instances/results.go
@@ -37,6 +37,10 @@ type Instance struct {
 	// to the correct database instance.
 	Hostname string
 
+	// The IP addresses associated with the database instance
+	// Is empty if the instance has a hostname
+	IP []string
+
 	// Indicates the unique identifier for the instance resource.
 	ID string
 


### PR DESCRIPTION
For #198 

Parses IP addresses returned by Trove when no hostname is available:
https://github.com/openstack/trove/blob/stable/newton/trove/instance/views.py#L46
