### PR TITLE
add support to operate NetworkExtAttrs

### DIFF
--- a/openstack/networking/v2/extensions/provider/requests.go
+++ b/openstack/networking/v2/extensions/provider/requests.go
@@ -5,10 +5,17 @@ import (
 	"github.com/gophercloud/gophercloud/pagination"
 )
 
+// ListOptsBuilder allows extensions to add additional parameters to the
+// List request.
 type ListOptsBuilder interface {
 	ToProviderNetworkListQuery() (string, error)
 }
 
+// ListOpts allows the filtering and sorting of paginated collections through
+// the API. Filtering is achieved by passing in struct field values that map to
+// the network attributes you want to see returned. SortKey allows you to sort
+// by a particular network attribute. SortDir sets the direction, and is either
+// `asc' or `desc'. Marker and Limit are used for pagination.
 type ListOpts struct {
 	Status          string `q:"status"`
 	Name            string `q:"name"`
@@ -25,11 +32,15 @@ type ListOpts struct {
 	SortDir         string `q:"sort_dir"`
 }
 
+// ToProviderNetworkListQuery formats a ListOpts into a query string.
 func (opts ListOpts) ToProviderNetworkListQuery() (string, error) {
 	q, err := gophercloud.BuildQueryString(opts)
 	return q.String(), err
 }
 
+// List returns a Pager which allows you to iterate over a collection of
+// provider networks. It accepts a ListOpts struct, which allows you to filter and sort
+// the returned collection for greater efficiency.
 func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(c)
 	if opts != nil {
@@ -44,15 +55,21 @@ func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 	})
 }
 
+// Get retrieves a specific provider network based on its unique ID.
 func Get(c *gophercloud.ServiceClient, id string) (r GetResult) {
 	_, r.Err = c.Get(getURL(c, id), &r.Body, nil)
 	return
 }
 
+// CreateOptsBuilder is the interface options structs have to satisfy in order
+// to be used in the main Create operation in this package. Since many
+// extensions decorate or modify the common logic, it is useful for them to
+// satisfy a basic interface in order for them to be used.
 type CreateOptsBuilder interface {
 	ToProviderNetworkCreateMap() (map[string]interface{}, error)
 }
 
+// CreateOpts satisfies the CreateOptsBuilder interface
 type CreateOpts struct {
 	AdminStateUp    *bool  `json:"admin_state_up,omitempty"`
 	Name            string `json:"name,omitempty"`
@@ -63,10 +80,17 @@ type CreateOpts struct {
 	SegmentationID  string `json:"provider:segmentation_id,omitempty"`
 }
 
+// ToProviderNetworkCreateMap casts a CreateOpts struct to a map.
 func (opts CreateOpts) ToProviderNetworkCreateMap() (map[string]interface{}, error) {
 	return gophercloud.BuildRequestBody(opts, "network")
 }
-
+// Create accepts a CreateOpts struct and creates a new provider network using the values
+// provided. This operation does not actually require a request body, i.e. the
+// CreateOpts struct argument can be empty.
+//
+// The tenant ID that is contained in the URI is the tenant that creates the
+// network. An admin user, however, has the option of specifying another tenant
+// ID in the CreateOpts struct.
 func Create(c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToProviderNetworkCreateMap()
 	if err != nil {
@@ -77,10 +101,15 @@ func Create(c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResul
 	return
 }
 
+// UpdateOptsBuilder is the interface options structs have to satisfy in order
+// to be used in the main Update operation in this package. Since many
+// extensions decorate or modify the common logic, it is useful for them to
+// satisfy a basic interface in order for them to be used.
 type UpdateOptsBuilder interface {
 	ToProviderNetworkUpdateMap() (map[string]interface{}, error)
 }
 
+// UpdateOpts satisfies the UpdateOptsBuilder interface
 type UpdateOpts struct {
 	AdminStateUp    *bool  `json:"admin_state_up,omitempty"`
 	Name            string `json:"name,omitempty"`
@@ -90,10 +119,13 @@ type UpdateOpts struct {
 	SegmentationID  string `json:"provider:segmentation_id"`
 }
 
+// ToProviderNetworkUpdateMap casts a UpdateOpts struct to a map.
 func (opts UpdateOpts) ToProviderNetworkUpdateMap() (map[string]interface{}, error) {
 	return gophercloud.BuildRequestBody(opts, "network")
 }
 
+// Update accepts a UpdateOpts struct and updates an existing provider network using the
+// values provided. For more information, see the Create function.
 func Update(c *gophercloud.ServiceClient, networkID string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToProviderNetworkUpdateMap()
 	if err != nil {
@@ -106,11 +138,13 @@ func Update(c *gophercloud.ServiceClient, networkID string, opts UpdateOptsBuild
 	return
 }
 
+// Delete accepts a unique ID and deletes the provider network associated with it.
 func Delete(c *gophercloud.ServiceClient, networkID string) (r DeleteResult) {
 	_, r.Err = c.Delete(deleteURL(c, networkID), nil)
 	return
 }
 
+// IDFromName is a convenience function that returns a provider network's ID given its name.
 func IDFromName(client *gophercloud.ServiceClient, name string) (string, error) {
 	count := 0
 	id := ""

--- a/openstack/networking/v2/extensions/provider/requests.go
+++ b/openstack/networking/v2/extensions/provider/requests.go
@@ -119,7 +119,7 @@ func IDFromName(client *gophercloud.ServiceClient, name string) (string, error) 
 		return "", err
 	}
 
-	all, err := ExtractList(pages)
+	all, err := ExtractNetworkExtAttrs(pages)
 	if err != nil {
 		return "", err
 	}

--- a/openstack/networking/v2/extensions/provider/requests.go
+++ b/openstack/networking/v2/extensions/provider/requests.go
@@ -1,0 +1,142 @@
+package provider
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+type ListOptsBuilder interface {
+	ToProviderNetworkListQuery() (string, error)
+}
+
+type ListOpts struct {
+	Status          string `q:"status"`
+	Name            string `q:"name"`
+	AdminStateUp    *bool  `q:"admin_state_up"`
+	TenantID        string `q:"tenant_id"`
+	Shared          *bool  `q:"shared"`
+	ID              string `q:"id"`
+	NetworkType     string `q:"provider:network_type"`
+	PhysicalNetwork string `q:"provider:physical_network"`
+	SegmentationID  string `q:"provider:segmentation_id"`
+	Marker          string `q:"marker"`
+	Limit           int    `q:"limit"`
+	SortKey         string `q:"sort_key"`
+	SortDir         string `q:"sort_dir"`
+}
+
+func (opts ListOpts) ToProviderNetworkListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(c)
+	if opts != nil {
+		query, err := opts.ToProviderNetworkListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		return NetworkPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+func Get(c *gophercloud.ServiceClient, id string) (r GetResult) {
+	_, r.Err = c.Get(getURL(c, id), &r.Body, nil)
+	return
+}
+
+type CreateOptsBuilder interface {
+	ToProviderNetworkCreateMap() (map[string]interface{}, error)
+}
+
+type CreateOpts struct {
+	AdminStateUp    *bool  `json:"admin_state_up,omitempty"`
+	Name            string `json:"name,omitempty"`
+	Shared          *bool  `json:"shared,omitempty"`
+	TenantID        string `json:"tenant_id,omitempty"`
+	NetworkType     string `json:"provider:network_type,omitempty"`
+	PhysicalNetwork string `json:"provider:physical_network,omitempty"`
+	SegmentationID  string `json:"provider:segmentation_id,omitempty"`
+}
+
+func (opts CreateOpts) ToProviderNetworkCreateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "network")
+}
+
+func Create(c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToProviderNetworkCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Post(createURL(c), b, &r.Body, nil)
+	return
+}
+
+type UpdateOptsBuilder interface {
+	ToProviderNetworkUpdateMap() (map[string]interface{}, error)
+}
+
+type UpdateOpts struct {
+	AdminStateUp    *bool  `json:"admin_state_up,omitempty"`
+	Name            string `json:"name,omitempty"`
+	Shared          *bool  `json:"shared,omitempty"`
+	NetworkType     string `json:"provider:network_type"`
+	PhysicalNetwork string `json:"provider:physical_network"`
+	SegmentationID  string `json:"provider:segmentation_id"`
+}
+
+func (opts UpdateOpts) ToProviderNetworkUpdateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "network")
+}
+
+func Update(c *gophercloud.ServiceClient, networkID string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToProviderNetworkUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Put(updateURL(c, networkID), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200, 201},
+	})
+	return
+}
+
+func Delete(c *gophercloud.ServiceClient, networkID string) (r DeleteResult) {
+	_, r.Err = c.Delete(deleteURL(c, networkID), nil)
+	return
+}
+
+func IDFromName(client *gophercloud.ServiceClient, name string) (string, error) {
+	count := 0
+	id := ""
+	pages, err := List(client, nil).AllPages()
+	if err != nil {
+		return "", err
+	}
+
+	all, err := ExtractList(pages)
+	if err != nil {
+		return "", err
+	}
+
+	for _, s := range all {
+		if s.Name == name {
+			count++
+			id = s.ID
+		}
+	}
+
+	switch count {
+	case 0:
+		return "", gophercloud.ErrResourceNotFound{Name: name, ResourceType: "network"}
+	case 1:
+		return id, nil
+	default:
+		return "", gophercloud.ErrMultipleResourcesFound{Name: name, Count: count, ResourceType: "network"}
+	}
+}

--- a/openstack/networking/v2/extensions/provider/results.go
+++ b/openstack/networking/v2/extensions/provider/results.go
@@ -13,6 +13,7 @@ type commonResult struct {
 	gophercloud.Result
 }
 
+// Extract is a function that accepts a result and extracts a provider network resource.
 func (r commonResult) Extract() (*NetworkExtAttrs, error) {
 	var s struct {
 		NetworkExtAttrs *NetworkExtAttrs `json:"network"`
@@ -21,18 +22,22 @@ func (r commonResult) Extract() (*NetworkExtAttrs, error) {
 	return s.NetworkExtAttrs, err
 }
 
+// CreateResult represents the result of a create operation.
 type CreateResult struct {
 	commonResult
 }
 
+// GetResult represents the result of a get operation.
 type GetResult struct {
 	commonResult
 }
 
+// UpdateResult represents the result of an update operation.
 type UpdateResult struct {
 	commonResult
 }
 
+// DeleteResult represents the result of a delete operation.
 type DeleteResult struct {
 	gophercloud.ErrResult
 }
@@ -147,6 +152,7 @@ func ExtractList(r pagination.Page) ([]NetworkExtAttrs, error) {
 	err := (r.(networks.NetworkPage)).ExtractInto(&s)
 	return s.Networks, err
 }
+
 func (r NetworkPage) NextPageURL() (string, error) {
 	var s struct {
 		Links []gophercloud.Link `json:"networks_links"`
@@ -163,6 +169,9 @@ func (r NetworkPage) IsEmpty() (bool, error) {
 	return len(is) == 0, err
 }
 
+// ExtractNetworkExtAttrs accepts a Page struct, specifically a NetworkPage struct,
+// and extracts the elements into a slice of NetworkExtAttrs structs. In other words,
+// a generic collection is mapped into a relevant slice.
 func ExtractNetworkExtAttrs(r pagination.Page) ([]NetworkExtAttrs, error) {
 	var s struct {
 		Networks []NetworkExtAttrs `json:"networks"`

--- a/openstack/networking/v2/extensions/provider/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/provider/testing/requests_test.go
@@ -359,11 +359,10 @@ func TestIDFromName(t *testing.T) {
 	client := fake.ServiceClient()
 	expectID := "d32019d3-bc6e-4319-9c1d-6722fc136a22"
 
-	id, err := provider.IDFromName(client, "provider-network")
+	id, err := provider.IDFromName(client, "private-network")
 	if err != nil {
 		t.Errorf("Network %s not found.", id)
-		return "", err
 	}
 
-	th.AssertEquals(t, id, expectID)
+	th.AssertEquals(t, expectID, id)
 }

--- a/openstack/networking/v2/extensions/provider/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/provider/testing/requests_test.go
@@ -1,0 +1,311 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	fake "github.com/gophercloud/gophercloud/openstack/networking/v2/common"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/provider"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
+	"github.com/gophercloud/gophercloud/pagination"
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestList(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/networks", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, `
+{
+    "networks": [
+        {
+            "status": "ACTIVE",
+            "subnets": [
+                "54d6f61d-db07-451c-9ab3-b9609b6b6f0b"
+            ],
+            "name": "private-network",
+            "admin_state_up": true,
+            "tenant_id": "4fd44f30292945e481c7b8a0c8908869",
+            "shared": true,
+            "id": "d32019d3-bc6e-4319-9c1d-6722fc136a22",
+            "provider:segmentation_id": "2",
+            "provider:physical_network": "8bab8453-1bc9-45af-8c70-f83aa9b50453",
+            "provider:network_type": "vlan"
+        },
+        {
+            "status": "ACTIVE",
+            "subnets": [
+                "08eae331-0402-425a-923c-34f7cfe39c1b"
+            ],
+            "name": "private",
+            "admin_state_up": true,
+            "tenant_id": "26a7980765d0414dbc1fc1f88cdb7e6e",
+            "shared": true,
+            "id": "db193ab3-96e3-4cb3-8fc5-05f4296d0324",
+            "provider:physical_network": "8bab8453-1bc9-45af-8c70-f83aa9b50453",
+            "provider:network_type": "stt"
+        }
+    ]
+}
+			`)
+	})
+
+	client := fake.ServiceClient()
+	count := 0
+
+	provider.List(client, provider.ListOpts{}).EachPage(func(page pagination.Page) (bool, error) {
+		count++
+		actual, err := provider.ExtractNetworkExtAttrs(page)
+		if err != nil {
+			t.Errorf("Failed to extract networks: %v", err)
+			return false, err
+		}
+
+		expected := []provider.NetworkExtAttrs{
+			{
+				Status:          "ACTIVE",
+				Subnets:         []string{"54d6f61d-db07-451c-9ab3-b9609b6b6f0b"},
+				Name:            "private-network",
+				AdminStateUp:    true,
+				TenantID:        "4fd44f30292945e481c7b8a0c8908869",
+				Shared:          true,
+				ID:              "d32019d3-bc6e-4319-9c1d-6722fc136a22",
+				SegmentationID:  "2",
+				PhysicalNetwork: "8bab8453-1bc9-45af-8c70-f83aa9b50453",
+				NetworkType:     "vlan",
+			},
+			{
+				Status:          "ACTIVE",
+				Subnets:         []string{"08eae331-0402-425a-923c-34f7cfe39c1b"},
+				Name:            "private",
+				AdminStateUp:    true,
+				TenantID:        "26a7980765d0414dbc1fc1f88cdb7e6e",
+				Shared:          true,
+				ID:              "db193ab3-96e3-4cb3-8fc5-05f4296d0324",
+				PhysicalNetwork: "8bab8453-1bc9-45af-8c70-f83aa9b50453",
+				NetworkType:     "stt",
+			},
+		}
+
+		th.CheckDeepEquals(t, expected, actual)
+
+		return true, nil
+	})
+
+	if count != 1 {
+		t.Errorf("Expected 1 page, got %d", count)
+	}
+}
+
+func TestGet(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/networks/d32019d3-bc6e-4319-9c1d-6722fc136a22", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, `
+{
+    "network": {
+        "status": "ACTIVE",
+        "subnets": [
+            "54d6f61d-db07-451c-9ab3-b9609b6b6f0b"
+        ],
+        "name": "private-network",
+        "admin_state_up": true,
+        "tenant_id": "4fd44f30292945e481c7b8a0c8908869",
+        "shared": true,
+        "id": "d32019d3-bc6e-4319-9c1d-6722fc136a22",
+        "provider:segmentation_id": 2,
+        "provider:physical_network": "8bab8453-1bc9-45af-8c70-f83aa9b50453",
+        "provider:network_type": "vlan"
+    }
+}
+			`)
+	})
+
+	n, err := provider.Get(fake.ServiceClient(), "d32019d3-bc6e-4319-9c1d-6722fc136a22").Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, n.Status, "ACTIVE")
+	th.AssertDeepEquals(t, n.Subnets, []string{"54d6f61d-db07-451c-9ab3-b9609b6b6f0b"})
+	th.AssertEquals(t, n.Name, "private-network")
+	th.AssertEquals(t, n.AdminStateUp, true)
+	th.AssertEquals(t, n.TenantID, "4fd44f30292945e481c7b8a0c8908869")
+	th.AssertEquals(t, n.Shared, true)
+	th.AssertEquals(t, n.ID, "d32019d3-bc6e-4319-9c1d-6722fc136a22")
+	th.AssertEquals(t, n.PhysicalNetwork, "8bab8453-1bc9-45af-8c70-f83aa9b50453")
+	th.AssertEquals(t, n.NetworkType, "vlan")
+	th.AssertEquals(t, n.SegmentationID, "2")
+}
+
+func TestCreate(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/networks", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, `
+{
+    "network": {
+        "name": "sample_network",
+        "admin_state_up": true
+    }
+}
+			`)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+
+		fmt.Fprintf(w, `
+{
+    "network": {
+        "status": "ACTIVE",
+        "subnets": [],
+        "name": "net1",
+        "admin_state_up": true,
+        "tenant_id": "9bacb3c5d39d41a79512987f338cf177",
+        "shared": false,
+        "id": "4e8e5957-649f-477b-9e5b-f1f75b21c03c"
+    }
+}
+		`)
+	})
+
+	iTrue := true
+	options := provider.CreateOpts{Name: "sample_network", AdminStateUp: &iTrue}
+	n, err := provider.Create(fake.ServiceClient(), options).Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, n.Status, "ACTIVE")
+	th.AssertDeepEquals(t, n.Subnets, []string{})
+	th.AssertEquals(t, n.Name, "net1")
+	th.AssertEquals(t, n.AdminStateUp, true)
+	th.AssertEquals(t, n.TenantID, "9bacb3c5d39d41a79512987f338cf177")
+	th.AssertEquals(t, n.Shared, false)
+	th.AssertEquals(t, n.ID, "4e8e5957-649f-477b-9e5b-f1f75b21c03c")
+}
+
+func TestCreateWithOptionalFields(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/networks", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, `
+{
+	"network": {
+			"name": "sample_network",
+			"admin_state_up": true,
+			"shared": true,
+			"tenant_id": "12345",
+                        "provider:segmentation_id": "2",
+                        "provider:physical_network": "8bab8453-1bc9-45af-8c70-f83aa9b50453",
+                        "provider:network_type": "vlan"
+	}
+}
+		`)
+
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprintf(w, `{}`)
+	})
+
+	iTrue := true
+	options := provider.CreateOpts{Name: "sample_network", AdminStateUp: &iTrue, Shared: &iTrue, TenantID: "12345", SegmentationID: "2", PhysicalNetwork: "8bab8453-1bc9-45af-8c70-f83aa9b50453", NetworkType: "vlan"}
+	_, err := provider.Create(fake.ServiceClient(), options).Extract()
+	th.AssertNoErr(t, err)
+}
+
+func TestUpdate(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/networks/4e8e5957-649f-477b-9e5b-f1f75b21c03c", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, `
+{
+		"network": {
+				"name": "new_network_name",
+				"admin_state_up": false,
+				"shared": true,
+                                "provider:segmentation_id": "2",
+                                "provider:physical_network": "8bab8453-1bc9-45af-8c70-f83aa9b50453",
+                                "provider:network_type": "vlan"
+		}
+}
+			`)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, `
+{
+    "network": {
+        "status": "ACTIVE",
+        "subnets": [],
+        "name": "new_network_name",
+        "admin_state_up": false,
+        "tenant_id": "4fd44f30292945e481c7b8a0c8908869",
+        "shared": true,
+        "id": "4e8e5957-649f-477b-9e5b-f1f75b21c03c",
+        "provider:segmentation_id": 2,
+        "provider:physical_network": "8bab8453-1bc9-45af-8c70-f83aa9b50453",
+        "provider:network_type": "vlan"
+    }
+}
+		`)
+	})
+
+	iTrue, iFalse := true, false
+	options := provider.UpdateOpts{
+		Name:            "new_network_name",
+		AdminStateUp:    &iFalse,
+		Shared:          &iTrue,
+		SegmentationID:  "2",
+		PhysicalNetwork: "8bab8453-1bc9-45af-8c70-f83aa9b50453",
+		NetworkType:     "vlan",
+	}
+	n, err := provider.Update(fake.ServiceClient(), "4e8e5957-649f-477b-9e5b-f1f75b21c03c", options).Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, n.Name, "new_network_name")
+	th.AssertEquals(t, n.AdminStateUp, false)
+	th.AssertEquals(t, n.Shared, true)
+	th.AssertEquals(t, n.ID, "4e8e5957-649f-477b-9e5b-f1f75b21c03c")
+	th.AssertEquals(t, n.TenantID, "4fd44f30292945e481c7b8a0c8908869")
+}
+
+func TestDelete(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/networks/4e8e5957-649f-477b-9e5b-f1f75b21c03c", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	res := networks.Delete(fake.ServiceClient(), "4e8e5957-649f-477b-9e5b-f1f75b21c03c")
+	th.AssertNoErr(t, res.Err)
+}

--- a/openstack/networking/v2/extensions/provider/testing/results_test.go
+++ b/openstack/networking/v2/extensions/provider/testing/results_test.go
@@ -13,7 +13,7 @@ import (
 	th "github.com/gophercloud/gophercloud/testhelper"
 )
 
-func TestList(t *testing.T) {
+func TestExtractList(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 
@@ -107,7 +107,7 @@ func TestList(t *testing.T) {
 	}
 }
 
-func TestGet(t *testing.T) {
+func TestExtractGet(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 
@@ -148,7 +148,7 @@ func TestGet(t *testing.T) {
 	th.AssertEquals(t, "", n.SegmentationID)
 }
 
-func TestCreate(t *testing.T) {
+func TestExtractCreate(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 
@@ -200,7 +200,7 @@ func TestCreate(t *testing.T) {
 	th.AssertEquals(t, "", n.SegmentationID)
 }
 
-func TestUpdate(t *testing.T) {
+func TestExtractUpdate(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 

--- a/openstack/networking/v2/extensions/provider/urls.go
+++ b/openstack/networking/v2/extensions/provider/urls.go
@@ -1,0 +1,31 @@
+package provider
+
+import "github.com/gophercloud/gophercloud"
+
+func resourceURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("networks", id)
+}
+
+func rootURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("networks")
+}
+
+func getURL(c *gophercloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
+}
+
+func listURL(c *gophercloud.ServiceClient) string {
+	return rootURL(c)
+}
+
+func createURL(c *gophercloud.ServiceClient) string {
+	return rootURL(c)
+}
+
+func updateURL(c *gophercloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
+}
+
+func deleteURL(c *gophercloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
+}


### PR DESCRIPTION
This PR add to operate provider network.
refs: https://github.com/hashicorp/terraform/pull/10265

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/neutron/blob/stable/mitaka/neutron/extensions/providernet.py#L22
