### PR TITLE
db/instances: add support for fault information in response body

### DIFF
--- a/openstack/db/v1/instances/results.go
+++ b/openstack/db/v1/instances/results.go
@@ -71,26 +71,21 @@ type Instance struct {
 	Datastore datastores.DatastorePartial
 }
 
-func (s *Fault) UnmarshalJSON(b []byte) error {
+func (r *Fault) UnmarshalJSON(b []byte) error {
 	type tmp Fault
-	var p *struct {
+	var s struct {
 		tmp
-		Created string `json:"created"`
+		Created gophercloud.JSONRFC3339NoZ `json:"created"`
 	}
-	err := json.Unmarshal(b, &p)
+	err := json.Unmarshal(b, &s)
 	if err != nil {
 		return err
 	}
-	*s = Fault(p.tmp)
+	*r = Fault(s.tmp)
 
-	if p.Created != "" {
-		s.Created, err = time.Parse(gophercloud.RFC3339NoZ, p.Created)
-		if err != nil {
-			return err
-		}
-	}
+	r.Created = time.Time(s.Created)
 
-	return err
+	return nil
 }
 
 type commonResult struct {


### PR DESCRIPTION
For #224 

Parses fault information returned by Trove when a DB instance has faulted:
https://github.com/openstack/trove/blob/stable/newton/trove/instance/views.py#L96
