### PR TITLE
Removing unused createErr functions from Identity packages

### DIFF
--- a/openstack/identity/v2/tokens/results.go
+++ b/openstack/identity/v2/tokens/results.go
@@ -132,11 +132,6 @@ func (r CreateResult) ExtractServiceCatalog() (*ServiceCatalog, error) {
 	return &ServiceCatalog{Entries: s.Access.Entries}, err
 }
 
-// createErr quickly packs an error in a CreateResult.
-func createErr(err error) CreateResult {
-	return CreateResult{gophercloud.Result{Err: err}}
-}
-
 // ExtractUser returns the User from a GetResult.
 func (r GetResult) ExtractUser() (*User, error) {
 	var s struct {

--- a/openstack/identity/v3/endpoints/results.go
+++ b/openstack/identity/v3/endpoints/results.go
@@ -24,11 +24,6 @@ type CreateResult struct {
 	commonResult
 }
 
-// createErr quickly wraps an error in a CreateResult.
-func createErr(err error) CreateResult {
-	return CreateResult{commonResult{gophercloud.Result{Err: err}}}
-}
-
 // UpdateResult is the deferred result of an Update call.
 type UpdateResult struct {
 	commonResult

--- a/openstack/identity/v3/tokens/results.go
+++ b/openstack/identity/v3/tokens/results.go
@@ -87,13 +87,6 @@ type CreateResult struct {
 	commonResult
 }
 
-// createErr quickly creates a CreateResult that reports an error.
-func createErr(err error) CreateResult {
-	return CreateResult{
-		commonResult: commonResult{Result: gophercloud.Result{Err: err}},
-	}
-}
-
 // GetResult is the deferred response from a Get call.
 type GetResult struct {
 	commonResult


### PR DESCRIPTION
For #228 