### PR TITLE
Ports: Remove Security Groups and Address Pairs

### DIFF
--- a/acceptance/openstack/networking/v2/ports_test.go
+++ b/acceptance/openstack/networking/v2/ports_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/gophercloud/gophercloud/acceptance/clients"
+	extensions "github.com/gophercloud/gophercloud/acceptance/openstack/networking/v2/extensions"
 	"github.com/gophercloud/gophercloud/acceptance/tools"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
 )
@@ -71,4 +72,121 @@ func TestPortsCRUD(t *testing.T) {
 	}
 
 	PrintPort(t, newPort)
+}
+
+func TestPortsRemoveSecurityGroups(t *testing.T) {
+	client, err := clients.NewNetworkV2Client()
+	if err != nil {
+		t.Fatalf("Unable to create a network client: %v", err)
+	}
+
+	// Create Network
+	network, err := CreateNetwork(t, client)
+	if err != nil {
+		t.Fatalf("Unable to create network: %v", err)
+	}
+	defer DeleteNetwork(t, client, network.ID)
+
+	// Create Subnet
+	subnet, err := CreateSubnet(t, client, network.ID)
+	if err != nil {
+		t.Fatalf("Unable to create subnet: %v", err)
+	}
+	defer DeleteSubnet(t, client, subnet.ID)
+
+	// Create port
+	port, err := CreatePort(t, client, network.ID, subnet.ID)
+	if err != nil {
+		t.Fatalf("Unable to create port: %v", err)
+	}
+	defer DeletePort(t, client, port.ID)
+
+	PrintPort(t, port)
+
+	// Create a Security Group
+	group, err := extensions.CreateSecurityGroup(t, client)
+	if err != nil {
+		t.Fatalf("Unable to create security group: %v", err)
+	}
+	defer extensions.DeleteSecurityGroup(t, client, group.ID)
+
+	// Add the group to the port
+	updateOpts := ports.UpdateOpts{
+		SecurityGroups: []string{group.ID},
+	}
+	newPort, err := ports.Update(client, port.ID, updateOpts).Extract()
+	if err != nil {
+		t.Fatalf("Could not update port: %v", err)
+	}
+
+	// Remove the group
+	updateOpts = ports.UpdateOpts{
+		SecurityGroups: []string{},
+	}
+	newPort, err = ports.Update(client, port.ID, updateOpts).Extract()
+	if err != nil {
+		t.Fatalf("Could not update port: %v", err)
+	}
+
+	PrintPort(t, newPort)
+
+	if len(newPort.SecurityGroups) > 0 {
+		t.Fatalf("Unable to remove security group from port")
+	}
+}
+
+func TestPortsRemoveAddressPair(t *testing.T) {
+	client, err := clients.NewNetworkV2Client()
+	if err != nil {
+		t.Fatalf("Unable to create a network client: %v", err)
+	}
+
+	// Create Network
+	network, err := CreateNetwork(t, client)
+	if err != nil {
+		t.Fatalf("Unable to create network: %v", err)
+	}
+	defer DeleteNetwork(t, client, network.ID)
+
+	// Create Subnet
+	subnet, err := CreateSubnet(t, client, network.ID)
+	if err != nil {
+		t.Fatalf("Unable to create subnet: %v", err)
+	}
+	defer DeleteSubnet(t, client, subnet.ID)
+
+	// Create port
+	port, err := CreatePort(t, client, network.ID, subnet.ID)
+	if err != nil {
+		t.Fatalf("Unable to create port: %v", err)
+	}
+	defer DeletePort(t, client, port.ID)
+
+	PrintPort(t, port)
+
+	// Add an address pair to the port
+	updateOpts := ports.UpdateOpts{
+		AllowedAddressPairs: []ports.AddressPair{
+			ports.AddressPair{IPAddress: "192.168.255.10", MACAddress: "aa:bb:cc:dd:ee:ff"},
+		},
+	}
+	newPort, err := ports.Update(client, port.ID, updateOpts).Extract()
+	if err != nil {
+		t.Fatalf("Could not update port: %v", err)
+	}
+
+	// Remove the address pair
+	updateOpts = ports.UpdateOpts{
+		AllowedAddressPairs: []ports.AddressPair{},
+	}
+	newPort, err = ports.Update(client, port.ID, updateOpts).Extract()
+	if err != nil {
+		t.Fatalf("Could not update port: %v", err)
+	}
+
+	PrintPort(t, newPort)
+
+	if len(newPort.AllowedAddressPairs) > 0 {
+		t.Fatalf("Unable to remove the address pair")
+	}
 }

--- a/openstack/networking/v2/ports/requests.go
+++ b/openstack/networking/v2/ports/requests.go
@@ -119,8 +119,8 @@ type UpdateOpts struct {
 	FixedIPs            interface{}   `json:"fixed_ips,omitempty"`
 	DeviceID            string        `json:"device_id,omitempty"`
 	DeviceOwner         string        `json:"device_owner,omitempty"`
-	SecurityGroups      []string      `json:"security_groups,omitempty"`
-	AllowedAddressPairs []AddressPair `json:"allowed_address_pairs,omitempty"`
+	SecurityGroups      []string      `json:"security_groups"`
+	AllowedAddressPairs []AddressPair `json:"allowed_address_pairs"`
 }
 
 // ToPortUpdateMap casts an UpdateOpts struct to a map.


### PR DESCRIPTION
This commit enables security groups and address pairs to be removed
from a port. This is done by allowing an empty value to be passed
for either attribute in the port update request.

For #226 