### PR TITLE
Use AvailabilityZone instead of Availability

### DIFF
--- a/openstack/blockstorage/v1/volumes/requests.go
+++ b/openstack/blockstorage/v1/volumes/requests.go
@@ -15,15 +15,15 @@ type CreateOptsBuilder interface {
 // the volumes.Create function. For more information about these parameters,
 // see the Volume object.
 type CreateOpts struct {
-	Size         int               `json:"size" required:"true"`
-	Availability string            `json:"availability,omitempty"`
-	Description  string            `json:"display_description,omitempty"`
-	Metadata     map[string]string `json:"metadata,omitempty"`
-	Name         string            `json:"display_name,omitempty"`
-	SnapshotID   string            `json:"snapshot_id,omitempty"`
-	SourceVolID  string            `json:"source_volid,omitempty"`
-	ImageID      string            `json:"imageRef,omitempty"`
-	VolumeType   string            `json:"volume_type,omitempty"`
+	Size             int               `json:"size" required:"true"`
+	AvailabilityZone string            `json:"availability_zone,omitempty"`
+	Description      string            `json:"display_description,omitempty"`
+	Metadata         map[string]string `json:"metadata,omitempty"`
+	Name             string            `json:"display_name,omitempty"`
+	SnapshotID       string            `json:"snapshot_id,omitempty"`
+	SourceVolID      string            `json:"source_volid,omitempty"`
+	ImageID          string            `json:"imageRef,omitempty"`
+	VolumeType       string            `json:"volume_type,omitempty"`
 }
 
 // ToVolumeCreateMap assembles a request body based on the contents of a

--- a/openstack/blockstorage/v1/volumes/testing/fixtures.go
+++ b/openstack/blockstorage/v1/volumes/testing/fixtures.go
@@ -82,7 +82,8 @@ func MockCreateResponse(t *testing.T) {
 		th.TestJSONRequest(t, r, `
 {
     "volume": {
-        "size": 75
+        "size": 75,
+        "availability_zone": "us-east1"
     }
 }
       `)

--- a/openstack/blockstorage/v1/volumes/testing/requests_test.go
+++ b/openstack/blockstorage/v1/volumes/testing/requests_test.go
@@ -119,7 +119,10 @@ func TestCreate(t *testing.T) {
 
 	MockCreateResponse(t)
 
-	options := &volumes.CreateOpts{Size: 75}
+	options := &volumes.CreateOpts{
+		Size:             75,
+		AvailabilityZone: "us-east1",
+	}
 	n, err := volumes.Create(client.ServiceClient(), options).Extract()
 	th.AssertNoErr(t, err)
 


### PR DESCRIPTION
This commit updates the Block Storage v1 create request to use
AvailabilityZone instead of Availability.

For #245 