### PR TITLE
ImageService v2: Fix paging when next URL is blank

### DIFF
--- a/openstack/imageservice/v2/images/results.go
+++ b/openstack/imageservice/v2/images/results.go
@@ -156,6 +156,11 @@ func (r ImagePage) NextPageURL() (string, error) {
 	if err != nil {
 		return "", err
 	}
+
+	if s.Next == "" {
+		return "", nil
+	}
+
 	return nextPageURL(r.URL.String(), s.Next), nil
 }
 


### PR DESCRIPTION
For #251 

If I get some time, I'll write up some acceptance tests for the ImageService package. As an interim, [Terraform image data source](https://github.com/jtopjian/terraform/blob/e077dd1e7be407a41cb8cab664db64d9b7fe2969/builtin/providers/openstack/data_source_openstack_images_image.go) I'm working on was able to succeed with this patch, so it kind of acts like an acceptance test.

side note: I'll probably be writing more data sources in the future. They map very well with ListOpts, so they might prove useful for finding other bugs in the List areas.