### PR TITLE
remove case for map[string]interface from switch statement in AllPages

### DIFF
--- a/pagination/pager.go
+++ b/pagination/pager.go
@@ -155,10 +155,8 @@ func (p Pager) AllPages() (Page, error) {
 			for k, v := range b {
 				// If it's a linked page, we don't want the `links`, we want the other one.
 				if !strings.HasSuffix(k, "links") {
+					// check the field's type. we only want []interface{} (which is really []map[string]interface{})
 					switch vt := v.(type) {
-					case map[string]interface{}:
-						key = k
-						pagesSlice = append(pagesSlice, vt)
 					case []interface{}:
 						key = k
 						pagesSlice = append(pagesSlice, vt...)


### PR DESCRIPTION
When building the single page in `AllPages`, if the result is a `map[string]interface{}`, we need the key to the `[]map[string]interface{}`, but we don't know what it is a priori. So we iterate over the keys in the `map[string]interface{}` and look for a field of type `[]interface{}`. In this search, there was a case for a field of type `map[string]interface{}` which I don't think is possible, and which also was causing non-deterministic behavior in `AllPages` (because we are iterating over `map` fields, which are not guaranteed to be ordered).

For #275 