### PR TITLE
DNS v2: RecordSet List, Get

### DIFF
--- a/acceptance/openstack/dns/v2/recordsets_test.go
+++ b/acceptance/openstack/dns/v2/recordsets_test.go
@@ -37,3 +37,34 @@ func TestRecordSetsListByZone(t *testing.T) {
 		tools.PrintResource(t, &recordset)
 	}
 }
+
+func TestRecordSetsListByZoneLimited(t *testing.T) {
+	client, err := clients.NewDNSV2Client()
+	if err != nil {
+		t.Fatalf("Unable to create a DNS client: %v", err)
+	}
+
+	zone, err := CreateZone(t, client)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer DeleteZone(t, client, zone)
+
+	var allRecordSets []recordsets.RecordSet
+	listOpts := recordsets.ListOpts{
+		Limit: 1,
+	}
+	allPages, err := recordsets.ListByZone(client, zone.ID, listOpts).AllPages()
+	if err != nil {
+		t.Fatalf("Unable to retrieve recordsets: %v", err)
+	}
+
+	allRecordSets, err = recordsets.ExtractRecordSets(allPages)
+	if err != nil {
+		t.Fatalf("Unable to extract recordsets: %v", err)
+	}
+
+	for _, recordset := range allRecordSets {
+		tools.PrintResource(t, &recordset)
+	}
+}

--- a/acceptance/openstack/dns/v2/recordsets_test.go
+++ b/acceptance/openstack/dns/v2/recordsets_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/dns/v2/recordsets"
 )
 
-func TestRecordSetsList(t *testing.T) {
+func TestRecordSetsListByZone(t *testing.T) {
 	client, err := clients.NewDNSV2Client()
 	if err != nil {
 		t.Fatalf("Unable to create a DNS client: %v", err)
@@ -23,7 +23,7 @@ func TestRecordSetsList(t *testing.T) {
 	defer DeleteZone(t, client, zone)
 
 	var allRecordSets []recordsets.RecordSet
-	allPages, err := recordsets.List(client, zone.ID, nil).AllPages()
+	allPages, err := recordsets.ListByZone(client, zone.ID, nil).AllPages()
 	if err != nil {
 		t.Fatalf("Unable to retrieve recordsets: %v", err)
 	}

--- a/acceptance/openstack/dns/v2/recordsets_test.go
+++ b/acceptance/openstack/dns/v2/recordsets_test.go
@@ -1,0 +1,39 @@
+// +build acceptance dns recordsets
+
+package v2
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/acceptance/clients"
+	"github.com/gophercloud/gophercloud/acceptance/tools"
+	"github.com/gophercloud/gophercloud/openstack/dns/v2/recordsets"
+)
+
+func TestRecordSetsList(t *testing.T) {
+	client, err := clients.NewDNSV2Client()
+	if err != nil {
+		t.Fatalf("Unable to create a DNS client: %v", err)
+	}
+
+	zone, err := CreateZone(t, client)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer DeleteZone(t, client, zone)
+
+	var allRecordSets []recordsets.RecordSet
+	allPages, err := recordsets.List(client, zone.ID, nil).AllPages()
+	if err != nil {
+		t.Fatalf("Unable to retrieve recordsets: %v", err)
+	}
+
+	allRecordSets, err = recordsets.ExtractRecordSets(allPages)
+	if err != nil {
+		t.Fatalf("Unable to extract recordsets: %v", err)
+	}
+
+	for _, recordset := range allRecordSets {
+		tools.PrintResource(t, &recordset)
+	}
+}

--- a/openstack/dns/v2/recordsets/doc.go
+++ b/openstack/dns/v2/recordsets/doc.go
@@ -1,0 +1,6 @@
+// Package tokens provides information and interaction with the zone API
+// resource for the OpenStack DNS service.
+//
+// For more information, see:
+// http://developer.openstack.org/api-ref/dns/#recordsets
+package recordsets

--- a/openstack/dns/v2/recordsets/doc.go
+++ b/openstack/dns/v2/recordsets/doc.go
@@ -1,4 +1,4 @@
-// Package tokens provides information and interaction with the zone API
+// Package recordsets provides information and interaction with the zone API
 // resource for the OpenStack DNS service.
 //
 // For more information, see:

--- a/openstack/dns/v2/recordsets/requests.go
+++ b/openstack/dns/v2/recordsets/requests.go
@@ -1,0 +1,36 @@
+package recordsets
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// Zone Object
+
+type ListOptsBuilder interface {
+	ToRRSetListMap() (string, error)
+}
+
+// ListOpts allows you to query the List method.
+type ListOpts struct {
+	Marker string `q:"marker"`
+	Limit  int    `q:"limit"`
+}
+
+func (opts ListOpts) ToRRSetListMap() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+func List(client *gophercloud.ServiceClient, zoneID string) pagination.Pager {
+	u := listURL(client, zoneID)
+	return pagination.NewPager(client, u, func(r pagination.PageResult) pagination.Page {
+		return RRSetPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// Get returns additional information about a service, given its ID.
+func Get(client *gophercloud.ServiceClient, zoneID string, rrsetID string) (r GetResult) {
+	_, r.Err = client.Get(rrsetURL(client, zoneID, rrsetID), &r.Body, nil)
+	return
+}

--- a/openstack/dns/v2/recordsets/requests.go
+++ b/openstack/dns/v2/recordsets/requests.go
@@ -40,8 +40,8 @@ func (opts ListOpts) ToRecordSetListQuery() (string, error) {
 	return q.String(), err
 }
 
-// List implements the recordset list request.
-func List(client *gophercloud.ServiceClient, zoneID string, opts ListOptsBuilder) pagination.Pager {
+// ListByZone implements the recordset list request.
+func ListByZone(client *gophercloud.ServiceClient, zoneID string, opts ListOptsBuilder) pagination.Pager {
 	url := baseURL(client, zoneID)
 	if opts != nil {
 		query, err := opts.ToRecordSetListQuery()

--- a/openstack/dns/v2/recordsets/requests.go
+++ b/openstack/dns/v2/recordsets/requests.go
@@ -5,31 +5,57 @@ import (
 	"github.com/gophercloud/gophercloud/pagination"
 )
 
-// Zone Object
-
+// ListOptsBuilder allows extensions to add additional parameters to the
+// List request.
 type ListOptsBuilder interface {
-	ToRRSetListMap() (string, error)
+	ToRecordSetListQuery() (string, error)
 }
 
-// ListOpts allows you to query the List method.
+// ListOpts allows the filtering and sorting of paginated collections through
+// the API. Filtering is achieved by passing in struct field values that map to
+// the server attributes you want to see returned. Marker and Limit are used
+// for pagination.
+// https://developer.openstack.org/api-ref/dns/
 type ListOpts struct {
+	// Integer value for the limit of values to return.
+	Limit int `q:"limit"`
+
+	// UUID of the recordset at which you want to set a marker.
 	Marker string `q:"marker"`
-	Limit  int    `q:"limit"`
+
+	Data        string `q:"data"`
+	Description string `q:"description"`
+	Name        string `q:"name"`
+	SortDir     string `q:"sort_dir"`
+	SortKey     string `q:"sort_key"`
+	Status      string `q:"status"`
+	TTL         int    `q:"ttl"`
+	Type        string `q:"type"`
+	ZoneID      string `q:"zone_id"`
 }
 
-func (opts ListOpts) ToRRSetListMap() (string, error) {
+// ToRecordSetListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToRecordSetListQuery() (string, error) {
 	q, err := gophercloud.BuildQueryString(opts)
 	return q.String(), err
 }
 
-func List(client *gophercloud.ServiceClient, zoneID string) pagination.Pager {
-	u := listURL(client, zoneID)
-	return pagination.NewPager(client, u, func(r pagination.PageResult) pagination.Page {
-		return RRSetPage{pagination.LinkedPageBase{PageResult: r}}
+// List implements the recordset list request.
+func List(client *gophercloud.ServiceClient, zoneID string, opts ListOptsBuilder) pagination.Pager {
+	url := baseURL(client, zoneID)
+	if opts != nil {
+		query, err := opts.ToRecordSetListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return RecordSetPage{pagination.LinkedPageBase{PageResult: r}}
 	})
 }
 
-// Get returns additional information about a service, given its ID.
+// Get implements the recordset get request.
 func Get(client *gophercloud.ServiceClient, zoneID string, rrsetID string) (r GetResult) {
 	_, r.Err = client.Get(rrsetURL(client, zoneID, rrsetID), &r.Body, nil)
 	return

--- a/openstack/dns/v2/recordsets/results.go
+++ b/openstack/dns/v2/recordsets/results.go
@@ -1,6 +1,9 @@
 package recordsets
 
 import (
+	"encoding/json"
+	"time"
+
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/pagination"
 )
@@ -9,10 +12,10 @@ type commonResult struct {
 	gophercloud.Result
 }
 
-// Extract interprets a GetResult, CreateResult or UpdateResult as a concrete Zone.
+// Extract interprets a GetResult, CreateResult or UpdateResult as a concrete RecordSet.
 // An error is returned if the original call or the extraction failed.
-func (r commonResult) Extract() (RecordSet, error) {
-	var s RecordSet
+func (r commonResult) Extract() (*RecordSet, error) {
+	var s *RecordSet
 	err := r.ExtractInto(&s)
 	return s, err
 }
@@ -22,37 +25,89 @@ type GetResult struct {
 	commonResult
 }
 
-// RRSetPage is a single page of RecordSet results.
-type RRSetPage struct {
+// RecordSetPage is a single page of RecordSet results.
+type RecordSetPage struct {
 	pagination.LinkedPageBase
 }
 
 // IsEmpty returns true if the page contains no results.
-func (p RRSetPage) IsEmpty() (bool, error) {
-	services, err := ExtractRRSets(p)
-	return len(services) == 0, err
+func (r RecordSetPage) IsEmpty() (bool, error) {
+	s, err := ExtractRecordSets(r)
+	return len(s) == 0, err
 }
 
-// ExtractServices extracts a slice of Services from a Collection acquired from List.
-func ExtractRRSets(r pagination.Page) ([]RecordSet, error) {
+// ExtractRecordSets extracts a slice of RecordSets from a Collection acquired from List.
+func ExtractRecordSets(r pagination.Page) ([]RecordSet, error) {
 	var s struct {
-		RRSets []RecordSet `json:"recordsets"`
+		RecordSets []RecordSet `json:"recordsets"`
 	}
-	err := (r.(RRSetPage)).ExtractInto(&s)
-	return s.RRSets, err
+	err := (r.(RecordSetPage)).ExtractInto(&s)
+	return s.RecordSets, err
 }
 
 type RecordSet struct {
-	ID        string                          `json:"id,omitempty"`
-	ZoneID    string                          `json:"zone_id,omitempty"`
-	ProjectID string                          `json:"project_id,omitempty"`
-	Name      string                          `json:"name,omitempty"`
-	ZoneName  string                          `json:"zone_name,omitempty"`
-	Type      string                          `json:"type,omitempty"`
-	Records   []string                        `json:"records,omitempty"`
-	TTL       int                             `json:"ttl,omitempty"`
-	Status    string                          `json:"status,omitempty"`
-	Action    string                          `json:"action,omitempty"`
-	CreatedAt gophercloud.JSONRFC3339MilliNoZ `json:"created_at,omitempty"`
-	UpdatedAt gophercloud.JSONRFC3339MilliNoZ `json:"updated_at,omitempty"`
+	// ID is the unique ID of the recordset
+	ID string `json:"id"`
+
+	// ZoneID is the ID of the zone the recordset belongs to.
+	ZoneID string `json:"zone_id"`
+
+	// ProjectID is the ID of the project that owns the recordset.
+	ProjectID string `json:"project_id"`
+
+	// Name is the name of the recordset.
+	Name string `json:"name"`
+
+	// ZoneName is the name of the zone the recordset belongs to.
+	ZoneName string `json:"zone_name"`
+
+	// Type is the RRTYPE of the recordset.
+	Type string `json:"type"`
+
+	// Records are the DNS records of the recordset.
+	Records []string `json:"records"`
+
+	// TTL is the time to live of the recordset.
+	TTL int `json:"ttl"`
+
+	// Status is the status of the recordset.
+	Status string `json:"status"`
+
+	// Action is the current action in progress of the recordset.
+	Action string `json:"action"`
+
+	// Description is the description of the recordset.
+	Description string `json:"description"`
+
+	// Version is the revision of the recordset.
+	Version int `json:version"`
+
+	// CreatedAt is the date when the recordset was created.
+	CreatedAt time.Time `json:"-"`
+
+	// UpdatedAt is the date when the recordset was updated.
+	UpdatedAt time.Time `json:"-"`
+
+	// Links includes HTTP references to the itself,
+	// useful for passing along to other APIs that might want a recordset reference.
+	Links map[string]interface{} `json:"links"`
+}
+
+func (r *RecordSet) UnmarshalJSON(b []byte) error {
+	type tmp RecordSet
+	var s struct {
+		tmp
+		CreatedAt gophercloud.JSONRFC3339MilliNoZ `json:"created_at"`
+		UpdatedAt gophercloud.JSONRFC3339MilliNoZ `json:"updated_at"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	*r = RecordSet(s.tmp)
+
+	r.CreatedAt = time.Time(s.CreatedAt)
+	r.UpdatedAt = time.Time(s.UpdatedAt)
+
+	return err
 }

--- a/openstack/dns/v2/recordsets/results.go
+++ b/openstack/dns/v2/recordsets/results.go
@@ -90,7 +90,7 @@ type RecordSet struct {
 
 	// Links includes HTTP references to the itself,
 	// useful for passing along to other APIs that might want a recordset reference.
-	Links map[string]interface{} `json:"links"`
+	Links []gophercloud.Link `json:"-"`
 }
 
 func (r *RecordSet) UnmarshalJSON(b []byte) error {
@@ -99,6 +99,7 @@ func (r *RecordSet) UnmarshalJSON(b []byte) error {
 		tmp
 		CreatedAt gophercloud.JSONRFC3339MilliNoZ `json:"created_at"`
 		UpdatedAt gophercloud.JSONRFC3339MilliNoZ `json:"updated_at"`
+		Links     map[string]interface{}          `json:"links"`
 	}
 	err := json.Unmarshal(b, &s)
 	if err != nil {
@@ -108,6 +109,18 @@ func (r *RecordSet) UnmarshalJSON(b []byte) error {
 
 	r.CreatedAt = time.Time(s.CreatedAt)
 	r.UpdatedAt = time.Time(s.UpdatedAt)
+
+	if s.Links != nil {
+		for rel, href := range s.Links {
+			if v, ok := href.(string); ok {
+				link := gophercloud.Link{
+					Rel:  rel,
+					Href: v,
+				}
+				r.Links = append(r.Links, link)
+			}
+		}
+	}
 
 	return err
 }

--- a/openstack/dns/v2/recordsets/results.go
+++ b/openstack/dns/v2/recordsets/results.go
@@ -1,0 +1,58 @@
+package recordsets
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// Extract interprets a GetResult, CreateResult or UpdateResult as a concrete Zone.
+// An error is returned if the original call or the extraction failed.
+func (r commonResult) Extract() (RecordSet, error) {
+	var s RecordSet
+	err := r.ExtractInto(&s)
+	return s, err
+}
+
+// GetResult is the deferred result of a Get call.
+type GetResult struct {
+	commonResult
+}
+
+// RRSetPage is a single page of RecordSet results.
+type RRSetPage struct {
+	pagination.LinkedPageBase
+}
+
+// IsEmpty returns true if the page contains no results.
+func (p RRSetPage) IsEmpty() (bool, error) {
+	services, err := ExtractRRSets(p)
+	return len(services) == 0, err
+}
+
+// ExtractServices extracts a slice of Services from a Collection acquired from List.
+func ExtractRRSets(r pagination.Page) ([]RecordSet, error) {
+	var s struct {
+		RRSets []RecordSet `json:"recordsets"`
+	}
+	err := (r.(RRSetPage)).ExtractInto(&s)
+	return s.RRSets, err
+}
+
+type RecordSet struct {
+	ID        string                          `json:"id,omitempty"`
+	ZoneID    string                          `json:"zone_id,omitempty"`
+	ProjectID string                          `json:"project_id,omitempty"`
+	Name      string                          `json:"name,omitempty"`
+	ZoneName  string                          `json:"zone_name,omitempty"`
+	Type      string                          `json:"type,omitempty"`
+	Records   []string                        `json:"records,omitempty"`
+	TTL       int                             `json:"ttl,omitempty"`
+	Status    string                          `json:"status,omitempty"`
+	Action    string                          `json:"action,omitempty"`
+	CreatedAt gophercloud.JSONRFC3339MilliNoZ `json:"created_at,omitempty"`
+	UpdatedAt gophercloud.JSONRFC3339MilliNoZ `json:"updated_at,omitempty"`
+}

--- a/openstack/dns/v2/recordsets/testing/doc.go
+++ b/openstack/dns/v2/recordsets/testing/doc.go
@@ -1,0 +1,2 @@
+// dns recordsets v2
+package testing

--- a/openstack/dns/v2/recordsets/testing/fixtures.go
+++ b/openstack/dns/v2/recordsets/testing/fixtures.go
@@ -61,10 +61,46 @@ const ListByZoneOutput = `
         }
     ],
     "links": {
-        "self": "http://127.0.0.1:9001/v2/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets?limit=1"
+        "self": "http://127.0.0.1:9001/v2/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets"
     },
     "metadata": {
         "total_count": 2
+    }
+}
+`
+
+// ListByZoneOutputLimited is a sample response to a ListByZone call with a requested limit.
+const ListByZoneOutputLimited = `
+{
+    "recordsets": [
+        {
+            "description": "This is another example record set.",
+            "links": {
+                "self": "https://127.0.0.1:9001/v2/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets/f7b10e9b-0cae-4a91-b162-562bc6096648"
+            },
+            "updated_at": "2017-03-04T14:29:07.000000",
+            "records": [
+                "10.1.0.3",
+                "10.1.0.4"
+            ],
+            "ttl": 3600,
+            "id": "7423aeaf-b354-4bd7-8aba-2e831567b478",
+            "name": "foo.example.org.",
+            "project_id": "4335d1f0-f793-11e2-b778-0800200c9a66",
+            "zone_id": "2150b1bf-dee2-4221-9d85-11f7886fb15f",
+            "zone_name": "example.com.",
+            "created_at": "2014-10-24T19:59:44.000000",
+            "version": 1,
+            "type": "A",
+            "status": "PENDING",
+            "action": "CREATE"
+        }
+    ],
+    "links": {
+        "self": "http://127.0.0.1:9001/v2/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets?limit=1"
+    },
+    "metadata": {
+        "total_count": 1
     }
 }
 `
@@ -91,6 +127,16 @@ const GetOutput = `
 		"type": "A",
 		"status": "PENDING",
 		"action": "CREATE"
+}
+`
+
+// NextPageRequest is a sample request to test pagination.
+const NextPageRequest = `
+{
+  "links": {
+    "self": "http://127.0.0.1:9001/v2/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets?limit=1",
+    "next": "http://127.0.0.1:9001/v2/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets?limit=1&marker=f7b10e9b-0cae-4a91-b162-562bc6096648"
+  }
 }
 `
 
@@ -143,6 +189,10 @@ var SecondRecordSet = recordsets.RecordSet{
 // from ListByZoneOutput, in the expected order.
 var ExpectedRecordSetSlice = []recordsets.RecordSet{FirstRecordSet, SecondRecordSet}
 
+// ExpectedRecordSetSliceLimited is the slice of limited results that should be parsed
+// from ListByZoneOutput.
+var ExpectedRecordSetSliceLimited = []recordsets.RecordSet{SecondRecordSet}
+
 // HandleListByZoneSuccessfully configures the test server to respond to a ListByZone request.
 func HandleListByZoneSuccessfully(t *testing.T) {
 	th.Mux.HandleFunc("/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets",
@@ -151,7 +201,14 @@ func HandleListByZoneSuccessfully(t *testing.T) {
 			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 			w.Header().Add("Content-Type", "application/json")
-			fmt.Fprintf(w, ListByZoneOutput)
+			r.ParseForm()
+			marker := r.Form.Get("marker")
+			switch marker {
+			case "f7b10e9b-0cae-4a91-b162-562bc6096648":
+				fmt.Fprintf(w, ListByZoneOutputLimited)
+			case "":
+				fmt.Fprintf(w, ListByZoneOutput)
+			}
 		})
 }
 

--- a/openstack/dns/v2/recordsets/testing/fixtures.go
+++ b/openstack/dns/v2/recordsets/testing/fixtures.go
@@ -12,8 +12,8 @@ import (
 	"github.com/gophercloud/gophercloud/testhelper/client"
 )
 
-// ListOutput is a sample response to a List call.
-const ListOutput = `
+// ListByZoneOutput is a sample response to a ListByZone call.
+const ListByZoneOutput = `
 {
     "recordsets": [
         {
@@ -94,7 +94,7 @@ const GetOutput = `
 }
 `
 
-// FirstRecordSet is the first result in ListOutput
+// FirstRecordSet is the first result in ListByZoneOutput
 var FirstRecordSetCreatedAt, _ = time.Parse(gophercloud.RFC3339MilliNoZ, "2014-10-24T19:59:44.000000")
 var FirstRecordSet = recordsets.RecordSet{
 	ID:          "f7b10e9b-0cae-4a91-b162-562bc6096648",
@@ -116,7 +116,7 @@ var FirstRecordSet = recordsets.RecordSet{
 	},
 }
 
-// SecondRecordSet is the first result in ListOutput
+// SecondRecordSet is the first result in ListByZoneOutput
 var SecondRecordSetCreatedAt, _ = time.Parse(gophercloud.RFC3339MilliNoZ, "2014-10-24T19:59:44.000000")
 var SecondRecordSetUpdatedAt, _ = time.Parse(gophercloud.RFC3339MilliNoZ, "2017-03-04T14:29:07.000000")
 var SecondRecordSet = recordsets.RecordSet{
@@ -140,22 +140,22 @@ var SecondRecordSet = recordsets.RecordSet{
 }
 
 // ExpectedRecordSetSlice is the slice of results that should be parsed
-// from ListOutput, in the expected order.
+// from ListByZoneOutput, in the expected order.
 var ExpectedRecordSetSlice = []recordsets.RecordSet{FirstRecordSet, SecondRecordSet}
 
-// HandleListSuccessfully configures the test server to respond to a List request.
-func HandleListSuccessfully(t *testing.T) {
+// HandleListByZoneSuccessfully configures the test server to respond to a ListByZone request.
+func HandleListByZoneSuccessfully(t *testing.T) {
 	th.Mux.HandleFunc("/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets",
 		func(w http.ResponseWriter, r *http.Request) {
 			th.TestMethod(t, r, "GET")
 			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 			w.Header().Add("Content-Type", "application/json")
-			fmt.Fprintf(w, ListOutput)
+			fmt.Fprintf(w, ListByZoneOutput)
 		})
 }
 
-// HandleGetSuccessfully configures the test server to respond to a List request.
+// HandleGetSuccessfully configures the test server to respond to a Get request.
 func HandleGetSuccessfully(t *testing.T) {
 	th.Mux.HandleFunc("/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets/f7b10e9b-0cae-4a91-b162-562bc6096648",
 		func(w http.ResponseWriter, r *http.Request) {

--- a/openstack/dns/v2/recordsets/testing/fixtures.go
+++ b/openstack/dns/v2/recordsets/testing/fixtures.go
@@ -40,7 +40,7 @@ const ListByZoneOutput = `
         {
             "description": "This is another example record set.",
             "links": {
-                "self": "https://127.0.0.1:9001/v2/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets/f7b10e9b-0cae-4a91-b162-562bc6096648"
+                "self": "https://127.0.0.1:9001/v2/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets/7423aeaf-b354-4bd7-8aba-2e831567b478"
             },
             "updated_at": "2017-03-04T14:29:07.000000",
             "records": [
@@ -76,7 +76,7 @@ const ListByZoneOutputLimited = `
         {
             "description": "This is another example record set.",
             "links": {
-                "self": "https://127.0.0.1:9001/v2/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets/f7b10e9b-0cae-4a91-b162-562bc6096648"
+                "self": "https://127.0.0.1:9001/v2/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets/7423aeaf-b354-4bd7-8aba-2e831567b478"
             },
             "updated_at": "2017-03-04T14:29:07.000000",
             "records": [
@@ -157,8 +157,11 @@ var FirstRecordSet = recordsets.RecordSet{
 	Type:        "A",
 	Status:      "PENDING",
 	Action:      "CREATE",
-	Links: map[string]interface{}{
-		"self": "https://127.0.0.1:9001/v2/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets/f7b10e9b-0cae-4a91-b162-562bc6096648",
+	Links: []gophercloud.Link{
+		{
+			Rel:  "self",
+			Href: "https://127.0.0.1:9001/v2/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets/f7b10e9b-0cae-4a91-b162-562bc6096648",
+		},
 	},
 }
 
@@ -180,8 +183,11 @@ var SecondRecordSet = recordsets.RecordSet{
 	Type:        "A",
 	Status:      "PENDING",
 	Action:      "CREATE",
-	Links: map[string]interface{}{
-		"self": "https://127.0.0.1:9001/v2/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets/f7b10e9b-0cae-4a91-b162-562bc6096648",
+	Links: []gophercloud.Link{
+		{
+			Rel:  "self",
+			Href: "https://127.0.0.1:9001/v2/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets/7423aeaf-b354-4bd7-8aba-2e831567b478",
+		},
 	},
 }
 

--- a/openstack/dns/v2/recordsets/testing/fixtures.go
+++ b/openstack/dns/v2/recordsets/testing/fixtures.go
@@ -1,0 +1,168 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/dns/v2/recordsets"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+// ListOutput is a sample response to a List call.
+const ListOutput = `
+{
+    "recordsets": [
+        {
+            "description": "This is an example record set.",
+            "links": {
+                "self": "https://127.0.0.1:9001/v2/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets/f7b10e9b-0cae-4a91-b162-562bc6096648"
+            },
+            "updated_at": null,
+            "records": [
+                "10.1.0.2"
+            ],
+            "ttl": 3600,
+            "id": "f7b10e9b-0cae-4a91-b162-562bc6096648",
+            "name": "example.org.",
+            "project_id": "4335d1f0-f793-11e2-b778-0800200c9a66",
+            "zone_id": "2150b1bf-dee2-4221-9d85-11f7886fb15f",
+            "zone_name": "example.com.",
+            "created_at": "2014-10-24T19:59:44.000000",
+            "version": 1,
+            "type": "A",
+            "status": "PENDING",
+            "action": "CREATE"
+        },
+        {
+            "description": "This is another example record set.",
+            "links": {
+                "self": "https://127.0.0.1:9001/v2/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets/f7b10e9b-0cae-4a91-b162-562bc6096648"
+            },
+            "updated_at": "2017-03-04T14:29:07.000000",
+            "records": [
+                "10.1.0.3",
+                "10.1.0.4"
+            ],
+            "ttl": 3600,
+            "id": "7423aeaf-b354-4bd7-8aba-2e831567b478",
+            "name": "foo.example.org.",
+            "project_id": "4335d1f0-f793-11e2-b778-0800200c9a66",
+            "zone_id": "2150b1bf-dee2-4221-9d85-11f7886fb15f",
+            "zone_name": "example.com.",
+            "created_at": "2014-10-24T19:59:44.000000",
+            "version": 1,
+            "type": "A",
+            "status": "PENDING",
+            "action": "CREATE"
+        }
+    ],
+    "links": {
+        "self": "http://127.0.0.1:9001/v2/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets?limit=1"
+    },
+    "metadata": {
+        "total_count": 2
+    }
+}
+`
+
+// GetOutput is a sample response to a Get call.
+const GetOutput = `
+{
+		"description": "This is an example record set.",
+		"links": {
+				"self": "https://127.0.0.1:9001/v2/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets/f7b10e9b-0cae-4a91-b162-562bc6096648"
+		},
+		"updated_at": null,
+		"records": [
+				"10.1.0.2"
+		],
+		"ttl": 3600,
+		"id": "f7b10e9b-0cae-4a91-b162-562bc6096648",
+		"name": "example.org.",
+		"project_id": "4335d1f0-f793-11e2-b778-0800200c9a66",
+		"zone_id": "2150b1bf-dee2-4221-9d85-11f7886fb15f",
+		"zone_name": "example.com.",
+		"created_at": "2014-10-24T19:59:44.000000",
+		"version": 1,
+		"type": "A",
+		"status": "PENDING",
+		"action": "CREATE"
+}
+`
+
+// FirstRecordSet is the first result in ListOutput
+var FirstRecordSetCreatedAt, _ = time.Parse(gophercloud.RFC3339MilliNoZ, "2014-10-24T19:59:44.000000")
+var FirstRecordSet = recordsets.RecordSet{
+	ID:          "f7b10e9b-0cae-4a91-b162-562bc6096648",
+	Description: "This is an example record set.",
+	UpdatedAt:   time.Time{},
+	Records:     []string{"10.1.0.2"},
+	TTL:         3600,
+	Name:        "example.org.",
+	ProjectID:   "4335d1f0-f793-11e2-b778-0800200c9a66",
+	ZoneID:      "2150b1bf-dee2-4221-9d85-11f7886fb15f",
+	ZoneName:    "example.com.",
+	CreatedAt:   FirstRecordSetCreatedAt,
+	Version:     1,
+	Type:        "A",
+	Status:      "PENDING",
+	Action:      "CREATE",
+	Links: map[string]interface{}{
+		"self": "https://127.0.0.1:9001/v2/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets/f7b10e9b-0cae-4a91-b162-562bc6096648",
+	},
+}
+
+// SecondRecordSet is the first result in ListOutput
+var SecondRecordSetCreatedAt, _ = time.Parse(gophercloud.RFC3339MilliNoZ, "2014-10-24T19:59:44.000000")
+var SecondRecordSetUpdatedAt, _ = time.Parse(gophercloud.RFC3339MilliNoZ, "2017-03-04T14:29:07.000000")
+var SecondRecordSet = recordsets.RecordSet{
+	ID:          "7423aeaf-b354-4bd7-8aba-2e831567b478",
+	Description: "This is another example record set.",
+	UpdatedAt:   SecondRecordSetUpdatedAt,
+	Records:     []string{"10.1.0.3", "10.1.0.4"},
+	TTL:         3600,
+	Name:        "foo.example.org.",
+	ProjectID:   "4335d1f0-f793-11e2-b778-0800200c9a66",
+	ZoneID:      "2150b1bf-dee2-4221-9d85-11f7886fb15f",
+	ZoneName:    "example.com.",
+	CreatedAt:   SecondRecordSetCreatedAt,
+	Version:     1,
+	Type:        "A",
+	Status:      "PENDING",
+	Action:      "CREATE",
+	Links: map[string]interface{}{
+		"self": "https://127.0.0.1:9001/v2/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets/f7b10e9b-0cae-4a91-b162-562bc6096648",
+	},
+}
+
+// ExpectedRecordSetSlice is the slice of results that should be parsed
+// from ListOutput, in the expected order.
+var ExpectedRecordSetSlice = []recordsets.RecordSet{FirstRecordSet, SecondRecordSet}
+
+// HandleListSuccessfully configures the test server to respond to a List request.
+func HandleListSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "GET")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+			w.Header().Add("Content-Type", "application/json")
+			fmt.Fprintf(w, ListOutput)
+		})
+}
+
+// HandleGetSuccessfully configures the test server to respond to a List request.
+func HandleGetSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets/f7b10e9b-0cae-4a91-b162-562bc6096648",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "GET")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+			w.Header().Add("Content-Type", "application/json")
+			fmt.Fprintf(w, GetOutput)
+		})
+}

--- a/openstack/dns/v2/recordsets/testing/requests_test.go
+++ b/openstack/dns/v2/recordsets/testing/requests_test.go
@@ -9,13 +9,13 @@ import (
 	"github.com/gophercloud/gophercloud/testhelper/client"
 )
 
-func TestList(t *testing.T) {
+func TestListByZone(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
-	HandleListSuccessfully(t)
+	HandleListByZoneSuccessfully(t)
 
 	count := 0
-	err := recordsets.List(client.ServiceClient(), "2150b1bf-dee2-4221-9d85-11f7886fb15f", nil).EachPage(func(page pagination.Page) (bool, error) {
+	err := recordsets.ListByZone(client.ServiceClient(), "2150b1bf-dee2-4221-9d85-11f7886fb15f", nil).EachPage(func(page pagination.Page) (bool, error) {
 		count++
 		actual, err := recordsets.ExtractRecordSets(page)
 		th.AssertNoErr(t, err)
@@ -27,12 +27,12 @@ func TestList(t *testing.T) {
 	th.CheckEquals(t, 1, count)
 }
 
-func TestListAllPages(t *testing.T) {
+func TestListByZoneAllPages(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
-	HandleListSuccessfully(t)
+	HandleListByZoneSuccessfully(t)
 
-	allPages, err := recordsets.List(client.ServiceClient(), "2150b1bf-dee2-4221-9d85-11f7886fb15f", nil).AllPages()
+	allPages, err := recordsets.ListByZone(client.ServiceClient(), "2150b1bf-dee2-4221-9d85-11f7886fb15f", nil).AllPages()
 	th.AssertNoErr(t, err)
 	allRecordSets, err := recordsets.ExtractRecordSets(allPages)
 	th.AssertNoErr(t, err)

--- a/openstack/dns/v2/recordsets/testing/requests_test.go
+++ b/openstack/dns/v2/recordsets/testing/requests_test.go
@@ -1,0 +1,50 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/dns/v2/recordsets"
+	"github.com/gophercloud/gophercloud/pagination"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func TestList(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleListSuccessfully(t)
+
+	count := 0
+	err := recordsets.List(client.ServiceClient(), "2150b1bf-dee2-4221-9d85-11f7886fb15f", nil).EachPage(func(page pagination.Page) (bool, error) {
+		count++
+		actual, err := recordsets.ExtractRecordSets(page)
+		th.AssertNoErr(t, err)
+		th.CheckDeepEquals(t, ExpectedRecordSetSlice, actual)
+
+		return true, nil
+	})
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, 1, count)
+}
+
+func TestListAllPages(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleListSuccessfully(t)
+
+	allPages, err := recordsets.List(client.ServiceClient(), "2150b1bf-dee2-4221-9d85-11f7886fb15f", nil).AllPages()
+	th.AssertNoErr(t, err)
+	allRecordSets, err := recordsets.ExtractRecordSets(allPages)
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, 2, len(allRecordSets))
+}
+
+func TestGet(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleGetSuccessfully(t)
+
+	actual, err := recordsets.Get(client.ServiceClient(), "2150b1bf-dee2-4221-9d85-11f7886fb15f", "f7b10e9b-0cae-4a91-b162-562bc6096648").Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, &FirstRecordSet, actual)
+}

--- a/openstack/dns/v2/recordsets/urls.go
+++ b/openstack/dns/v2/recordsets/urls.go
@@ -1,0 +1,11 @@
+package recordsets
+
+import "github.com/gophercloud/gophercloud"
+
+func listURL(c *gophercloud.ServiceClient, zoneID string) string {
+	return c.ServiceURL("v2/zones", zoneID, "recordsets")
+}
+
+func rrsetURL(c *gophercloud.ServiceClient, zoneID string, rrsetID string) string {
+	return c.ServiceURL("v2/zones", zoneID, "recordsets", rrsetID)
+}

--- a/openstack/dns/v2/recordsets/urls.go
+++ b/openstack/dns/v2/recordsets/urls.go
@@ -2,10 +2,10 @@ package recordsets
 
 import "github.com/gophercloud/gophercloud"
 
-func listURL(c *gophercloud.ServiceClient, zoneID string) string {
-	return c.ServiceURL("v2/zones", zoneID, "recordsets")
+func baseURL(c *gophercloud.ServiceClient, zoneID string) string {
+	return c.ServiceURL("zones", zoneID, "recordsets")
 }
 
 func rrsetURL(c *gophercloud.ServiceClient, zoneID string, rrsetID string) string {
-	return c.ServiceURL("v2/zones", zoneID, "recordsets", rrsetID)
+	return c.ServiceURL("zones", zoneID, "recordsets", rrsetID)
 }


### PR DESCRIPTION
For #57 
Supersedes #175 

URLs:

https://github.com/openstack/designate/blob/master/designate/api/v2/controllers/recordsets.py
https://github.com/openstack/designate/blob/master/designate/api/v2/controllers/common.py
https://github.com/openstack/designate/blob/master/designate/objects/recordset.py
https://github.com/openstack/designate/blob/master/designate/objects/adapters/api_v2/recordset.py
https://github.com/openstack/designate/tree/stable/newton/api-ref/source/samples/recordsets
