### PR TITLE
Update some docs for some nits found

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ import (
 
 // Option 1: Pass in the values yourself
 opts := gophercloud.AuthOptions{
-  IdentityEndpoint: "https://my-openstack.com:5000/v2.0",
+  IdentityEndpoint: "https://openstack.example.com:5000/v2.0",
   Username: "{username}",
   Password: "{password}",
 }

--- a/auth_options.go
+++ b/auth_options.go
@@ -1,7 +1,7 @@
 package gophercloud
 
 /*
-AuthOptions stores information needed to authenticate to an OpenStack cluster.
+AuthOptions stores information needed to authenticate to an OpenStack Cloud.
 You can populate one manually, or use a provider's AuthOptionsFromEnv() function
 to read relevant information from the standard environment variables. Pass one
 to a provider's AuthenticatedClient function to authenticate and obtain a

--- a/auth_options.go
+++ b/auth_options.go
@@ -31,7 +31,7 @@ type AuthOptions struct {
 	DomainName string `json:"name,omitempty"`
 
 	// The TenantID and TenantName fields are optional for the Identity V2 API.
-	// The same fields are knows as project id and project name in the Identity
+	// The same fields are known as project_id and project_name in the Identity
 	// V3 API, but are collected as TenantID and TenantName here in both cases.
 	// Some providers allow you to specify a TenantName instead of the TenantId.
 	// Some require both. Your provider's authentication policies will determine

--- a/auth_options.go
+++ b/auth_options.go
@@ -31,9 +31,16 @@ type AuthOptions struct {
 	DomainName string `json:"name,omitempty"`
 
 	// The TenantID and TenantName fields are optional for the Identity V2 API.
+	// The same fields are knows as project id and project name in the Identity
+	// V3 API, but are collected as TenantID and TenantName here in both cases.
 	// Some providers allow you to specify a TenantName instead of the TenantId.
 	// Some require both. Your provider's authentication policies will determine
 	// how these fields influence authentication.
+	// If DomainID or DomainName are provided, they will also apply to TenantName.
+	// It is not currently possible to authenticate with Username and a Domain
+	// and scope to a Project in a different Domain by using TenantName. To
+	// accomplish that, the ProjectID will need to be provided to the TenantID
+	// option.
 	TenantID   string `json:"tenantId,omitempty"`
 	TenantName string `json:"tenantName,omitempty"`
 

--- a/doc.go
+++ b/doc.go
@@ -4,8 +4,13 @@ clouds. The library has a three-level hierarchy: providers, services, and
 resources.
 
 Provider structs represent the service providers that offer and manage a
-collection of services. Examples of providers include: OpenStack, Rackspace,
-HP. These are defined like so:
+collection of services. Examples of public OpenStack cloud providers include:
+Rackspace, Dreamhost, Internap, Vexxhost, OVH, CityCloud, Datacentred and
+Enter Cloud Suite, or else the OpenStack cloud may be a local/private cloud.
+The IdentityEndpoint is typically refered to as "auth_url" in information
+provided by the cloud operator. Additionally, the cloud may refer to
+TenantID or TenantName as project_id and project_name.
+These are defined like so:
 
   opts := gophercloud.AuthOptions{
     IdentityEndpoint: "https://my-openstack.com:5000/v2.0",

--- a/doc.go
+++ b/doc.go
@@ -13,7 +13,7 @@ TenantID or TenantName as project_id and project_name.
 These are defined like so:
 
   opts := gophercloud.AuthOptions{
-    IdentityEndpoint: "https://my-openstack.com:5000/v2.0",
+    IdentityEndpoint: "https://openstack.example.com:5000/v2.0",
     Username: "{username}",
     Password: "{password}",
     TenantID: "{tenant_id}",

--- a/doc.go
+++ b/doc.go
@@ -4,12 +4,9 @@ clouds. The library has a three-level hierarchy: providers, services, and
 resources.
 
 Provider structs represent the service providers that offer and manage a
-collection of services. Examples of public OpenStack cloud providers include:
-Rackspace, Dreamhost, Internap, Vexxhost, OVH, CityCloud, Datacentred and
-Enter Cloud Suite, or else the OpenStack cloud may be a local/private cloud.
-The IdentityEndpoint is typically refered to as "auth_url" in information
-provided by the cloud operator. Additionally, the cloud may refer to
-TenantID or TenantName as project_id and project_name.
+collection of services. The IdentityEndpoint is typically refered to as
+"auth_url" in information provided by the cloud operator. Additionally,
+the cloud may refer to TenantID or TenantName as project_id and project_name.
 These are defined like so:
 
   opts := gophercloud.AuthOptions{

--- a/openstack/compute/v2/extensions/keypairs/results.go
+++ b/openstack/compute/v2/extensions/keypairs/results.go
@@ -5,7 +5,7 @@ import (
 	"github.com/gophercloud/gophercloud/pagination"
 )
 
-// KeyPair is an SSH key known to the OpenStack cluster that is available to be injected into
+// KeyPair is an SSH key known to the OpenStack Cloud that is available to be injected into
 // servers.
 type KeyPair struct {
 	// Name is used to refer to this keypair from other services within this region.

--- a/openstack/db/v1/instances/testing/fixtures.go
+++ b/openstack/db/v1/instances/testing/fixtures.go
@@ -27,22 +27,22 @@ var instance = `
     "id": "1",
     "links": [
       {
-        "href": "https://my-openstack.com/v1.0/1234/flavors/1",
+        "href": "https://openstack.example.com/v1.0/1234/flavors/1",
         "rel": "self"
       },
       {
-        "href": "https://my-openstack.com/v1.0/1234/flavors/1",
+        "href": "https://openstack.example.com/v1.0/1234/flavors/1",
         "rel": "bookmark"
       }
     ]
   },
   "links": [
     {
-      "href": "https://my-openstack.com/v1.0/1234/instances/1",
+      "href": "https://openstack.example.com/v1.0/1234/instances/1",
       "rel": "self"
     }
   ],
-  "hostname": "e09ad9a3f73309469cf1f43d11e79549caf9acf2.my-openstack.com",
+  "hostname": "e09ad9a3f73309469cf1f43d11e79549caf9acf2.openstack.example.com",
   "id": "{instanceID}",
   "name": "json_rack_instance",
   "status": "BUILD",
@@ -114,14 +114,14 @@ var expectedInstance = instances.Instance{
 	Flavor: instances.Flavor{
 		ID: "1",
 		Links: []gophercloud.Link{
-			{Href: "https://my-openstack.com/v1.0/1234/flavors/1", Rel: "self"},
-			{Href: "https://my-openstack.com/v1.0/1234/flavors/1", Rel: "bookmark"},
+			{Href: "https://openstack.example.com/v1.0/1234/flavors/1", Rel: "self"},
+			{Href: "https://openstack.example.com/v1.0/1234/flavors/1", Rel: "bookmark"},
 		},
 	},
-	Hostname: "e09ad9a3f73309469cf1f43d11e79549caf9acf2.my-openstack.com",
+	Hostname: "e09ad9a3f73309469cf1f43d11e79549caf9acf2.openstack.example.com",
 	ID:       instanceID,
 	Links: []gophercloud.Link{
-		{Href: "https://my-openstack.com/v1.0/1234/instances/1", Rel: "self"},
+		{Href: "https://openstack.example.com/v1.0/1234/instances/1", Rel: "self"},
 	},
 	Name:   "json_rack_instance",
 	Status: "BUILD",


### PR DESCRIPTION
For #252

I was reading through some of the docs and just noticed a few things. Most of them are trivial, but I figured I'd make a PR anyway. It's possible that some of the words in this might help with the situation described in 252 (cross-domain scoping should work fine if projects are specified by ID. specifying domain information is only useful if the user wants to specify both user and project by name - but since both can be specified by id, then it's really not an actual issue)