### PR TITLE
use $GOPATH in the readme of acceptance tests

### DIFF
--- a/acceptance/README.md
+++ b/acceptance/README.md
@@ -63,7 +63,7 @@ Alternatively, add the following to your `.bashrc`:
 ```bash
 gophercloudtest() {
   if [[ -n $1 ]] && [[ -n $2 ]]; then
-    pushd  ~/go/src/github.com/gophercloud/gophercloud
+    pushd  $GOPATH/src/github.com/gophercloud/gophercloud
     go test -v -tags "fixtures acceptance" -run "$1" github.com/gophercloud/gophercloud/acceptance/openstack/$2 | tee ~/gophercloud.log
     popd
 fi


### PR DESCRIPTION
Enforce `$GOPATH` instead of `~/go` in `gophercloudest()` bash function. Everyone should have `$GOPATH` set, but it may not point to ~/go.

For #296