### PR TITLE
ObjectStorage v1: recognize X-Account-Meta-Quota-Bytes header in accounts.GetHeader

### DIFF
--- a/openstack/objectstorage/v1/accounts/testing/fixtures.go
+++ b/openstack/objectstorage/v1/accounts/testing/fixtures.go
@@ -17,6 +17,7 @@ func HandleGetAccountSuccessfully(t *testing.T) {
 
 		w.Header().Set("X-Account-Container-Count", "2")
 		w.Header().Set("X-Account-Object-Count", "5")
+		w.Header().Set("X-Account-Meta-Quota-Bytes", "42")
 		w.Header().Set("X-Account-Bytes-Used", "14")
 		w.Header().Set("X-Account-Meta-Subject", "books")
 		w.Header().Set("Date", "Fri, 17 Jan 2014 16:09:56 GMT")

--- a/openstack/objectstorage/v1/accounts/testing/requests_test.go
+++ b/openstack/objectstorage/v1/accounts/testing/requests_test.go
@@ -35,7 +35,7 @@ func TestGetAccount(t *testing.T) {
 	defer th.TeardownHTTP()
 	HandleGetAccountSuccessfully(t)
 
-	expectedMetadata := map[string]string{"Subject": "books"}
+	expectedMetadata := map[string]string{"Subject": "books", "Quota-Bytes": "42"}
 	res := accounts.Get(fake.ServiceClient(), &accounts.GetOpts{})
 	th.AssertNoErr(t, res.Err)
 	actualMetadata, _ := res.ExtractMetadata()
@@ -44,6 +44,7 @@ func TestGetAccount(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	expected := &accounts.GetHeader{
+		QuotaBytes:     42,
 		ContainerCount: 2,
 		ObjectCount:    5,
 		BytesUsed:      14,


### PR DESCRIPTION
For #312

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/swift/blob/stable/newton/swift/common/middleware/account_quotas.py

The only part that might be controversial is the usage of `-1` to encode "no quota". I'm being consistent with other OpenStack services' quota handling here. Swift is a special snowflake because it does not report JSONs, but stuffs everything in headers. If you don't like `quota == -1`, I can also change the type of `GetHeader.Quota` to `*int64`, so that `nil` would indicate absence of a quota.