### PR TITLE
Remove checks for TenantId

### DIFF
--- a/auth_options.go
+++ b/auth_options.go
@@ -139,14 +139,6 @@ func (opts *AuthOptions) ToTokenV3CreateMap(scope map[string]interface{}) (map[s
 	// if insufficient or incompatible information is present.
 	var req request
 
-	// Test first for unrecognized arguments.
-	if opts.TenantID != "" {
-		return nil, ErrTenantIDProvided{}
-	}
-	if opts.TenantName != "" {
-		return nil, ErrTenantNameProvided{}
-	}
-
 	if opts.Password == "" {
 		if opts.TokenID != "" {
 			// Because we aren't using password authentication, it's an error to also provide any of the user-based authentication
@@ -259,8 +251,6 @@ func (opts *AuthOptions) ToTokenV3ScopeMap() (map[string]interface{}, error) {
 
 	if opts.TenantID != "" {
 		scope.ProjectID = opts.TenantID
-		opts.TenantID = ""
-		opts.TenantName = ""
 	} else {
 		if opts.TenantName != "" {
 			scope.ProjectName = opts.TenantName


### PR DESCRIPTION
For #255 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR: Um, not sure.

I am unable to reauth in my project. The issue is that the scope is not generated correctly after the first auth. All subsequent auth lose access to the TenantId because it is mutated and set to `""`.

```golang
                scope.ProjectID = opts.TenantID
-               opts.TenantID = ""
-               opts.TenantName = ""
```

to support that change I also comment out a sanity check. I'm not sure if that sanity check is necessary for other environments but my standalone script works fine without it.