### PR TITLE
Add arbitrary key/value scheduler hints ( was add reservation in scheduler hints)

### DIFF
--- a/openstack/compute/v2/extensions/schedulerhints/requests.go
+++ b/openstack/compute/v2/extensions/schedulerhints/requests.go
@@ -27,8 +27,8 @@ type SchedulerHints struct {
 	TargetCell string `json:"target_cell,omitempty"`
 	// BuildNearHostIP specifies a subnet of compute nodes to host the instance.
 	BuildNearHostIP string
-	// Reservation specifies the id of a reservation obtained in blazar
-	Reservation string
+	// AdditionalProperies are arbitrary key/values that are not validated by nova.
+	AdditionalProperties map[string]interface{}
 }
 
 // CreateOptsBuilder builds the scheduler hints into a serializable format.
@@ -118,15 +118,10 @@ func (opts SchedulerHints) ToServerSchedulerHintsCreateMap() (map[string]interfa
 		sh["cidr"] = "/" + ipParts[1]
 	}
 
-	if opts.Reservation != "" {
-		if !uuidRegex.MatchString(opts.Reservation) {
-			err := gophercloud.ErrInvalidInput{}
-			err.Argument = "schedulerhints.SchedulerHints.Reservation"
-			err.Value = opts.Reservation
-			err.Info = "The reservation_id must be in UUID format."
-			return nil, err
+	if opts.AdditionalProperties != nil {
+		for k, v := range opts.AdditionalProperties {
+			sh[k] = v
 		}
-		sh["reservation"] = opts.Reservation
 	}
 
 	return sh, nil

--- a/openstack/compute/v2/extensions/schedulerhints/requests.go
+++ b/openstack/compute/v2/extensions/schedulerhints/requests.go
@@ -27,6 +27,8 @@ type SchedulerHints struct {
 	TargetCell string `json:"target_cell,omitempty"`
 	// BuildNearHostIP specifies a subnet of compute nodes to host the instance.
 	BuildNearHostIP string
+	// Reservation specifies the id of a reservation obtained in blazar
+	Reservation string
 }
 
 // CreateOptsBuilder builds the scheduler hints into a serializable format.
@@ -114,6 +116,17 @@ func (opts SchedulerHints) ToServerSchedulerHintsCreateMap() (map[string]interfa
 		ipParts := strings.Split(opts.BuildNearHostIP, "/")
 		sh["build_near_host_ip"] = ipParts[0]
 		sh["cidr"] = "/" + ipParts[1]
+	}
+
+	if opts.Reservation != "" {
+		if !uuidRegex.MatchString(opts.Reservation) {
+			err := gophercloud.ErrInvalidInput{}
+			err.Argument = "schedulerhints.SchedulerHints.Reservation"
+			err.Value = opts.Reservation
+			err.Info = "The reservation_id must be in UUID format."
+			return nil, err
+		}
+		sh["reservation"] = opts.Reservation
 	}
 
 	return sh, nil

--- a/openstack/compute/v2/extensions/schedulerhints/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/schedulerhints/testing/requests_test.go
@@ -28,6 +28,7 @@ func TestCreateOpts(t *testing.T) {
 		Query:           []interface{}{">=", "$free_ram_mb", "1024"},
 		TargetCell:      "foobar",
 		BuildNearHostIP: "192.168.1.1/24",
+		Reservation:     "a0cf03a5-d921-4877-bb5c-86d26cf818e1",
 	}
 
 	ext := schedulerhints.CreateOptsExt{
@@ -57,7 +58,8 @@ func TestCreateOpts(t *testing.T) {
 				],
 				"target_cell": "foobar",
 				"build_near_host_ip": "192.168.1.1",
-				"cidr": "/24"
+				"cidr": "/24",
+				"reservation": "a0cf03a5-d921-4877-bb5c-86d26cf818e1"
 			}
 		}
 	`
@@ -86,6 +88,7 @@ func TestCreateOptsWithComplexQuery(t *testing.T) {
 		Query:           []interface{}{"and", []string{">=", "$free_ram_mb", "1024"}, []string{">=", "$free_disk_mb", "204800"}},
 		TargetCell:      "foobar",
 		BuildNearHostIP: "192.168.1.1/24",
+		Reservation:     "a0cf03a5-d921-4877-bb5c-86d26cf818e1",
 	}
 
 	ext := schedulerhints.CreateOptsExt{
@@ -117,7 +120,8 @@ func TestCreateOptsWithComplexQuery(t *testing.T) {
 				],
 				"target_cell": "foobar",
 				"build_near_host_ip": "192.168.1.1",
-				"cidr": "/24"
+				"cidr": "/24",
+				"reservation": "a0cf03a5-d921-4877-bb5c-86d26cf818e1"
 			}
 		}
 	`

--- a/openstack/compute/v2/extensions/schedulerhints/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/schedulerhints/testing/requests_test.go
@@ -28,7 +28,7 @@ func TestCreateOpts(t *testing.T) {
 		Query:           []interface{}{">=", "$free_ram_mb", "1024"},
 		TargetCell:      "foobar",
 		BuildNearHostIP: "192.168.1.1/24",
-		Reservation:     "a0cf03a5-d921-4877-bb5c-86d26cf818e1",
+		AdditionalProperties: map[string]interface{}{"reservation": "a0cf03a5-d921-4877-bb5c-86d26cf818e1"},
 	}
 
 	ext := schedulerhints.CreateOptsExt{
@@ -88,7 +88,7 @@ func TestCreateOptsWithComplexQuery(t *testing.T) {
 		Query:           []interface{}{"and", []string{">=", "$free_ram_mb", "1024"}, []string{">=", "$free_disk_mb", "204800"}},
 		TargetCell:      "foobar",
 		BuildNearHostIP: "192.168.1.1/24",
-		Reservation:     "a0cf03a5-d921-4877-bb5c-86d26cf818e1",
+		AdditionalProperties: map[string]interface{}{"reservation": "a0cf03a5-d921-4877-bb5c-86d26cf818e1"},
 	}
 
 	ext := schedulerhints.CreateOptsExt{


### PR DESCRIPTION
Some OpenStack installation[[1](https://www.chameleoncloud.org/
)] use a lease system.  Leases are usually
provided by blazar[[2](https://wiki.openstack.org/wiki/Blazar
)] and each lease is composed of a list of
reservations. When creating servers, one must pass a valid reservation
id in order to indicate to the system which reservation will be used by
the future resource.

For #317