### PR TITLE
add missing doc files to support autogenerated on godoc

### DIFF
--- a/openstack/compute/v2/extensions/bootfromvolume/doc.go
+++ b/openstack/compute/v2/extensions/bootfromvolume/doc.go
@@ -1,0 +1,1 @@
+package bootfromvolume

--- a/openstack/compute/v2/extensions/defsecrules/doc.go
+++ b/openstack/compute/v2/extensions/defsecrules/doc.go
@@ -1,1 +1,2 @@
+// compute_extensions_defsecrules_v2
 package defsecrules

--- a/openstack/compute/v2/extensions/limits/doc.go
+++ b/openstack/compute/v2/extensions/limits/doc.go
@@ -1,0 +1,1 @@
+package limits

--- a/openstack/compute/v2/extensions/limits/testing/doc.go
+++ b/openstack/compute/v2/extensions/limits/testing/doc.go
@@ -1,0 +1,1 @@
+package testing

--- a/openstack/doc.go
+++ b/openstack/doc.go
@@ -1,0 +1,1 @@
+package openstack

--- a/openstack/identity/v3/projects/doc.go
+++ b/openstack/identity/v3/projects/doc.go
@@ -1,0 +1,1 @@
+package projects

--- a/openstack/identity/v3/projects/testing/doc.go
+++ b/openstack/identity/v3/projects/testing/doc.go
@@ -1,0 +1,1 @@
+package testing

--- a/openstack/imageservice/v2/imagedata/doc.go
+++ b/openstack/imageservice/v2/imagedata/doc.go
@@ -1,0 +1,1 @@
+package imagedata

--- a/openstack/imageservice/v2/imagedata/testing/doc.go
+++ b/openstack/imageservice/v2/imagedata/testing/doc.go
@@ -1,0 +1,1 @@
+package testing

--- a/openstack/imageservice/v2/images/doc.go
+++ b/openstack/imageservice/v2/images/doc.go
@@ -1,0 +1,1 @@
+package images

--- a/openstack/imageservice/v2/images/testing/doc.go
+++ b/openstack/imageservice/v2/images/testing/doc.go
@@ -1,0 +1,1 @@
+package testing

--- a/openstack/imageservice/v2/members/doc.go
+++ b/openstack/imageservice/v2/members/doc.go
@@ -1,0 +1,1 @@
+package members

--- a/openstack/imageservice/v2/members/testing/doc.go
+++ b/openstack/imageservice/v2/members/testing/doc.go
@@ -1,0 +1,1 @@
+package testing

--- a/openstack/networking/v2/extensions/doc.go
+++ b/openstack/networking/v2/extensions/doc.go
@@ -1,0 +1,1 @@
+package extensions

--- a/openstack/networking/v2/extensions/fwaas/firewalls/doc.go
+++ b/openstack/networking/v2/extensions/fwaas/firewalls/doc.go
@@ -1,0 +1,2 @@
+// networking_extensions_fwaas_firewalls_v2
+package firewalls

--- a/openstack/networking/v2/extensions/fwaas/policies/doc.go
+++ b/openstack/networking/v2/extensions/fwaas/policies/doc.go
@@ -1,0 +1,2 @@
+// networking_extensions_fwaas_policies_v2
+package policies

--- a/openstack/networking/v2/extensions/fwaas/rules/doc.go
+++ b/openstack/networking/v2/extensions/fwaas/rules/doc.go
@@ -1,0 +1,2 @@
+// networking_extensions_fwaas_rules_v2
+package rules

--- a/openstack/networking/v2/extensions/layer3/floatingips/doc.go
+++ b/openstack/networking/v2/extensions/layer3/floatingips/doc.go
@@ -1,0 +1,2 @@
+// networking_extensions_layer3_floatingips_v2
+package floatingips

--- a/openstack/networking/v2/extensions/layer3/routers/doc.go
+++ b/openstack/networking/v2/extensions/layer3/routers/doc.go
@@ -1,0 +1,2 @@
+// networking_extensions_layer3_routers_v2
+package routers

--- a/openstack/networking/v2/extensions/lbaas/members/doc.go
+++ b/openstack/networking/v2/extensions/lbaas/members/doc.go
@@ -1,0 +1,2 @@
+// networking_extensions_lbaas_members_v2
+package members

--- a/openstack/networking/v2/extensions/lbaas/monitors/doc.go
+++ b/openstack/networking/v2/extensions/lbaas/monitors/doc.go
@@ -1,0 +1,2 @@
+// networking_extensions_lbaas_monitors_v2
+package monitors

--- a/openstack/networking/v2/extensions/lbaas/pools/doc.go
+++ b/openstack/networking/v2/extensions/lbaas/pools/doc.go
@@ -1,0 +1,2 @@
+// networking_extensions_lbaas_pools_v2
+package pools

--- a/openstack/networking/v2/extensions/lbaas/vips/doc.go
+++ b/openstack/networking/v2/extensions/lbaas/vips/doc.go
@@ -1,0 +1,2 @@
+// networking_extensions_lbaas_vips_v2
+package vips

--- a/openstack/networking/v2/extensions/lbaas_v2/listeners/doc.go
+++ b/openstack/networking/v2/extensions/lbaas_v2/listeners/doc.go
@@ -1,0 +1,2 @@
+// networking_extensions_lbaas_v2_listeners_v2
+package listeners

--- a/openstack/networking/v2/extensions/lbaas_v2/loadbalancers/doc.go
+++ b/openstack/networking/v2/extensions/lbaas_v2/loadbalancers/doc.go
@@ -1,0 +1,2 @@
+// networking_extensions_lbaas_v2_loadbalancers_v2
+package loadbalancers

--- a/openstack/networking/v2/extensions/lbaas_v2/monitors/doc.go
+++ b/openstack/networking/v2/extensions/lbaas_v2/monitors/doc.go
@@ -1,0 +1,2 @@
+// networking_extensions_lbaas_v2_monitors_v2
+package monitors

--- a/openstack/networking/v2/extensions/lbaas_v2/pools/doc.go
+++ b/openstack/networking/v2/extensions/lbaas_v2/pools/doc.go
@@ -1,0 +1,2 @@
+// networking_extensions_lbaas_v2_pools_v2
+package pools

--- a/openstack/networking/v2/extensions/security/groups/doc.go
+++ b/openstack/networking/v2/extensions/security/groups/doc.go
@@ -1,0 +1,2 @@
+// networking_extensions_security_groups_v2
+package groups

--- a/openstack/networking/v2/extensions/security/rules/doc.go
+++ b/openstack/networking/v2/extensions/security/rules/doc.go
@@ -1,0 +1,2 @@
+// networking_extensions_security_rules_v2
+package rules

--- a/openstack/objectstorage/v1/swauth/doc.go
+++ b/openstack/objectstorage/v1/swauth/doc.go
@@ -1,0 +1,2 @@
+// objectstorage_swauth_v1
+package swauth

--- a/openstack/sharedfilesystems/v2/availabilityzones/doc.go
+++ b/openstack/sharedfilesystems/v2/availabilityzones/doc.go
@@ -1,0 +1,2 @@
+// sharedfilesystems_v2_availabilityzones
+package availabilityzones

--- a/openstack/sharedfilesystems/v2/availabilityzones/testing/doc.go
+++ b/openstack/sharedfilesystems/v2/availabilityzones/testing/doc.go
@@ -1,0 +1,2 @@
+// sharedfilesystems_v2_availabilityzones
+package testing

--- a/openstack/sharedfilesystems/v2/securityservices/doc.go
+++ b/openstack/sharedfilesystems/v2/securityservices/doc.go
@@ -1,0 +1,2 @@
+// sharedfilesystems_v2_securityservices
+package securityservices

--- a/openstack/sharedfilesystems/v2/securityservices/testing/doc.go
+++ b/openstack/sharedfilesystems/v2/securityservices/testing/doc.go
@@ -1,0 +1,2 @@
+// sharedfilesystems_v2_securityservices
+package testing

--- a/openstack/sharedfilesystems/v2/sharenetworks/doc.go
+++ b/openstack/sharedfilesystems/v2/sharenetworks/doc.go
@@ -1,0 +1,2 @@
+// sharedfilesystems_v2_sharenetworks
+package sharenetworks

--- a/openstack/sharedfilesystems/v2/sharenetworks/testing/doc.go
+++ b/openstack/sharedfilesystems/v2/sharenetworks/testing/doc.go
@@ -1,0 +1,2 @@
+// sharedfilesystems_v2_sharenetworks
+package testing

--- a/openstack/sharedfilesystems/v2/shares/doc.go
+++ b/openstack/sharedfilesystems/v2/shares/doc.go
@@ -1,0 +1,2 @@
+// sharedfilesystems_v2_shares
+package shares

--- a/openstack/sharedfilesystems/v2/shares/testing/doc.go
+++ b/openstack/sharedfilesystems/v2/shares/testing/doc.go
@@ -1,0 +1,2 @@
+// sharedfilesystems_v2_shares
+package testing

--- a/openstack/sharedfilesystems/v2/sharetypes/doc.go
+++ b/openstack/sharedfilesystems/v2/sharetypes/doc.go
@@ -1,0 +1,2 @@
+// sharedfilesystems_v2_sharetypes
+package sharetypes

--- a/openstack/sharedfilesystems/v2/sharetypes/testing/doc.go
+++ b/openstack/sharedfilesystems/v2/sharetypes/testing/doc.go
@@ -1,0 +1,2 @@
+// sharedfilesystems_v2_sharetypes
+package testing

--- a/openstack/utils/doc.go
+++ b/openstack/utils/doc.go
@@ -1,0 +1,2 @@
+//utils
+package utils

--- a/pagination/doc.go
+++ b/pagination/doc.go
@@ -1,0 +1,2 @@
+// pagination
+package pagination

--- a/testhelper/client/doc.go
+++ b/testhelper/client/doc.go
@@ -1,0 +1,4 @@
+/*
+Package testhelper container methods that are useful for writing unit tests.
+*/
+package client

--- a/testhelper/fixture/doc.go
+++ b/testhelper/fixture/doc.go
@@ -1,0 +1,4 @@
+/*
+Package testhelper container methods that are useful for writing unit tests.
+*/
+package fixture


### PR DESCRIPTION
* add missing doc files;
* some new apis are not shown/autogenerated on [GoDoc](https://godoc.org/github.com/gophercloud/gophercloud), e.g. *availability zones* (#320) 

