### PR TITLE
fix availability zones url in shared file system

### DIFF
--- a/openstack/sharedfilesystems/v2/availabilityzones/testing/fixtures.go
+++ b/openstack/sharedfilesystems/v2/availabilityzones/testing/fixtures.go
@@ -10,14 +10,7 @@ import (
 )
 
 func MockListResponse(t *testing.T) {
-	th.Mux.HandleFunc("/os-availability-zone", func(w http.ResponseWriter, r *http.Request) {
-		th.TestMethod(t, r, "GET")
-		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
-
-		w.Header().Add("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-
-		fmt.Fprintf(w, `
+	response := `
         {
             "availability_zones": [
                 {
@@ -27,6 +20,15 @@ func MockListResponse(t *testing.T) {
                     "id": "388c983d-258e-4a0e-b1ba-10da37d766db"
                 }
             ]
-        }`)
+        }`
+
+	th.Mux.HandleFunc("/availability-zones", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, response)
 	})
 }

--- a/openstack/sharedfilesystems/v2/availabilityzones/urls.go
+++ b/openstack/sharedfilesystems/v2/availabilityzones/urls.go
@@ -3,5 +3,5 @@ package availabilityzones
 import "github.com/gophercloud/gophercloud"
 
 func listURL(c *gophercloud.ServiceClient) string {
-	return c.ServiceURL("os-availability-zone")
+	return c.ServiceURL("availability-zones")
 }


### PR DESCRIPTION
@jtopjian fix the url as we discussed in #323

Reference: [shared-file-systems list-availability-zones](https://developer.openstack.org/api-ref/shared-file-systems/index.html?expanded=list-security-services-detail,list-all-major-versions-detail,show-details-of-specific-api-version-detail#list-availability-zones)