### PR TITLE
get the raw console output from the server instance

### DIFF
--- a/openstack/compute/v2/servers/requests.go
+++ b/openstack/compute/v2/servers/requests.go
@@ -739,3 +739,36 @@ func GetPassword(client *gophercloud.ServiceClient, serverId string) (r GetPassw
 	_, r.Err = client.Get(passwordURL(client, serverId), &r.Body, nil)
 	return
 }
+
+// ShowConsoleOutputOptsBuilder is the interface types must satisfy in order to be
+// used as ShowConsoleOutput options
+type ShowConsoleOutputOptsBuilder interface {
+	ToServerShowConsoleOutputMap() (map[string]interface{}, error)
+}
+
+// ShowConsoleOutputOpts satisfies the ShowConsoleOutputOptsBuilder
+type ShowConsoleOutputOpts struct {
+	// The number of lines to fetch from the end of console log.
+	// All lines will be returned if this is not specified.
+	Length string `json:"length,omitempty"`
+}
+
+// ToServerShowConsoleOutputMap formats a ShowConsoleOutputOpts structure into a request body.
+func (opts ShowConsoleOutputOpts) ToServerShowConsoleOutputMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "os-getConsoleOutput")
+}
+
+// ShowConsoleOutput makes a request against the nova API to get console log from the server
+func ShowConsoleOutput(client *gophercloud.ServiceClient, id string, opts ShowConsoleOutputOptsBuilder) (r ShowConsoleOutputResult) {
+	b, err := opts.ToServerShowConsoleOutputMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := client.Post(actionURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	r.Err = err
+	r.Header = resp.Header
+	return r
+}

--- a/openstack/compute/v2/servers/testing/fixtures.go
+++ b/openstack/compute/v2/servers/testing/fixtures.go
@@ -304,6 +304,21 @@ const ServerPasswordBody = `
 }
 `
 
+const HostKeyConsoleOutput = `
+FAKE CONSOLE OUTPUT\r
+-----BEGIN SSH HOST KEY KEYS-----\r
+ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBDciNMyzj0osyPOM+1OyseTWgkzw+M43zp5H2CchG8daRDHel7V3OHETVdI6WofNnSdBJAwIoisRFPxyroNGiVw= root@my-name
+ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDU854+fNdcKMZTLCUejMOZllQmmphr6V5Aaz1F2+x2jXql5rqKQd5/h6OdFszcp+gdTeVtfgG++/298qodTemVVrvqwjp4eN87iHvhPxH6GDEevAKlEed2ckdAmgvzI9rcOYgR/46G9xIea0IdgNjMvN1baj6WPtv+HfcfH/ZV58G306lSJfbz/GVxNTIxW+Wg7ZQCAe6jWgm4oQ+66sco+7Fub24EPue3kO8jqufqq3mY5+MFlzEHSX5B04ioG5Alw/JuqVx5+7zHt9I2wA3nzsyUdKtCTrw8V4fYEhWDm53WLOpW+8CeYCXuv+yL7EjwLqhIH/TUuzGQiWmFGvyz root@my-name
+-----END SSH HOST KEY KEYS-----\r
+LAST LINE
+`
+
+const HostKey = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDU854+fNdcKMZTLCUejMOZllQmmphr6V5Aaz1F2+x2jXql5rqKQd5/h6OdFszcp+gdTeVtfgG++/298qodTemVVrvqwjp4eN87iHvhPxH6GDEevAKlEed2ckdAmgvzI9rcOYgR/46G9xIea0IdgNjMvN1baj6WPtv+HfcfH/ZV58G306lSJfbz/GVxNTIxW+Wg7ZQCAe6jWgm4oQ+66sco+7Fub24EPue3kO8jqufqq3mY5+MFlzEHSX5B04ioG5Alw/JuqVx5+7zHt9I2wA3nzsyUdKtCTrw8V4fYEhWDm53WLOpW+8CeYCXuv+yL7EjwLqhIH/TUuzGQiWmFGvyz root@my-name"
+
+const ConsoleOutputBody = `{
+	"output": "abc"
+}`
+
 var (
 	herpTimeCreated, _ = time.Parse(time.RFC3339, "2014-09-25T13:10:02Z")
 	herpTimeUpdated, _ = time.Parse(time.RFC3339, "2014-09-25T13:10:10Z")
@@ -420,6 +435,8 @@ var (
 			},
 		},
 	}
+
+	ConsoleOutput = "abc"
 
 	merpTimeCreated, _ = time.Parse(time.RFC3339, "2014-09-25T13:04:41Z")
 	merpTimeUpdated, _ = time.Parse(time.RFC3339, "2014-09-25T13:04:49Z")
@@ -740,6 +757,19 @@ func HandleRebootSuccessfully(t *testing.T) {
 		th.TestJSONRequest(t, r, `{ "reboot": { "type": "SOFT" } }`)
 
 		w.WriteHeader(http.StatusAccepted)
+	})
+}
+
+// HandleShowConsoleOutputSuccessfully sets up the test server to respond to a os-getConsoleOutput request with success.
+func HandleShowConsoleOutputSuccessfully(t *testing.T, response string) {
+	th.Mux.HandleFunc("/servers/1234asdf/action", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, `{ "os-getConsoleOutput": { "length": "50" } }`)
+
+		w.WriteHeader(http.StatusOK)
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprintf(w, response)
 	})
 }
 

--- a/openstack/compute/v2/servers/testing/requests_test.go
+++ b/openstack/compute/v2/servers/testing/requests_test.go
@@ -253,6 +253,24 @@ func TestChangeServerAdminPassword(t *testing.T) {
 	th.AssertNoErr(t, res.Err)
 }
 
+func TestShowConsoleOutput(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleShowConsoleOutputSuccessfully(t, ConsoleOutputBody)
+
+	Actual, err := servers.ShowConsoleOutput(client.ServiceClient(), "1234asdf", &servers.ShowConsoleOutputOpts{
+		Length: "50"}).ExtractConsoleOutput()
+
+	th.AssertNoErr(t, err)
+	th.AssertByteArrayEquals(t, []byte(ConsoleOutput), []byte(Actual))
+}
+
+func TestHostKeyFromConsoleOutput(t *testing.T) {
+	hostkey, err := servers.GetHostKeyFromConsole(HostKeyConsoleOutput)
+	th.AssertNoErr(t, err)
+	th.AssertByteArrayEquals(t, []byte(HostKey), []byte(hostkey))
+}
+
 func TestGetPassword(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()


### PR DESCRIPTION
For #319 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

* [openstack compute api doc on `os-getConsoleOutput`](https://developer.openstack.org/api-ref/compute/?expanded=show-console-output-os-getconsoleoutput-action-detail#show-console-output-os-getconsoleoutput-action)
* [novaclient/v2/servers.py `get_console_output`](https://github.com/openstack/python-novaclient/blob/master/novaclient/v2/servers.py#L1680-L1693)