### PR TITLE
Continue reauth fixes

### DIFF
--- a/acceptance/openstack/client_test.go
+++ b/acceptance/openstack/client_test.go
@@ -5,6 +5,7 @@ package openstack
 import (
 	"os"
 	"testing"
+	"time"
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack"
@@ -36,5 +37,50 @@ func TestAuthenticatedClient(t *testing.T) {
 		t.Errorf("Unable to locate a storage service: %v", err)
 	} else {
 		t.Logf("Located a storage service at endpoint: [%s]", storage.Endpoint)
+	}
+}
+
+func TestReauth(t *testing.T) {
+	ao, err := openstack.AuthOptionsFromEnv()
+	if err != nil {
+		t.Fatalf("Unable to obtain environment auth options: %v", err)
+	}
+
+	// Allow reauth
+	ao.AllowReauth = true
+
+	provider, err := openstack.NewClient(ao.IdentityEndpoint)
+	if err != nil {
+		t.Fatalf("Unable to create provider: %v", err)
+	}
+
+	err = openstack.Authenticate(provider, ao)
+	if err != nil {
+		t.Fatalf("Unable to authenticate: %v", err)
+	}
+
+	t.Logf("Creating a compute client")
+	_, err = openstack.NewComputeV2(provider, gophercloud.EndpointOpts{
+		Region: os.Getenv("OS_REGION_NAME"),
+	})
+	if err != nil {
+		t.Fatalf("Unable to create compute client: %v", err)
+	}
+
+	t.Logf("Sleeping for 1 second")
+	time.Sleep(1 * time.Second)
+	t.Logf("Attempting to reauthenticate")
+
+	err = provider.ReauthFunc()
+	if err != nil {
+		t.Fatalf("Unable to reauthenticate: %v", err)
+	}
+
+	t.Logf("Creating a compute client")
+	_, err = openstack.NewComputeV2(provider, gophercloud.EndpointOpts{
+		Region: os.Getenv("OS_REGION_NAME"),
+	})
+	if err != nil {
+		t.Fatalf("Unable to create compute client: %v", err)
 	}
 }

--- a/auth_options.go
+++ b/auth_options.go
@@ -257,7 +257,6 @@ func (opts *AuthOptions) ToTokenV3ScopeMap() (map[string]interface{}, error) {
 			scope.DomainID = opts.DomainID
 			scope.DomainName = opts.DomainName
 		}
-		opts.TenantName = ""
 	}
 
 	if scope.ProjectName != "" {


### PR DESCRIPTION
This commit stops auth_options.go from clearing the TenantName.
It also adds an acceptance test for reauthentication.

For #255 