### PR TITLE
Added Type into ServiceClient to Distinguish Different Services

### DIFF
--- a/service_client.go
+++ b/service_client.go
@@ -21,7 +21,31 @@ type ServiceClient struct {
 	// as-is, instead.
 	ResourceBase string
 
+	// Type of service, e.g. Nova, Manila, etc.
+	Type serviceType
+
 	Microversion string
+}
+
+type serviceType string
+
+const (
+	novaServiceType   serviceType = "Nova"
+	manilaServiceType serviceType = "Manila"
+)
+
+const (
+	novaHTTPMicroversionHeader   = "X-OpenStack-Nova-API-Version"
+	manilaHTTPMicroversionHeader = "X-Openstack-Manila-Api-Version"
+)
+
+type httpMicroversionHeaderMap map[serviceType]string
+
+var getHTTPMicroversionHeader = httpMicroversionHeaderMap{
+	novaServiceType:   novaHTTPMicroversionHeader,
+	manilaServiceType: manilaHTTPMicroversionHeader,
+	// default
+	"": novaHTTPMicroversionHeader,
 }
 
 // ResourceBaseURL returns the base URL of any resources used by this service. It MUST end with a /.
@@ -49,7 +73,7 @@ func (client *ServiceClient) Get(url string, JSONResponse interface{}, opts *Req
 	if opts.MoreHeaders == nil {
 		opts.MoreHeaders = make(map[string]string)
 	}
-	opts.MoreHeaders["X-OpenStack-Nova-API-Version"] = client.Microversion
+	opts.MoreHeaders[getHTTPMicroversionHeader[client.Type]] = client.Microversion
 
 	return client.Request("GET", url, opts)
 }
@@ -73,7 +97,7 @@ func (client *ServiceClient) Post(url string, JSONBody interface{}, JSONResponse
 	if opts.MoreHeaders == nil {
 		opts.MoreHeaders = make(map[string]string)
 	}
-	opts.MoreHeaders["X-OpenStack-Nova-API-Version"] = client.Microversion
+	opts.MoreHeaders[getHTTPMicroversionHeader[client.Type]] = client.Microversion
 
 	return client.Request("POST", url, opts)
 }
@@ -97,7 +121,7 @@ func (client *ServiceClient) Put(url string, JSONBody interface{}, JSONResponse 
 	if opts.MoreHeaders == nil {
 		opts.MoreHeaders = make(map[string]string)
 	}
-	opts.MoreHeaders["X-OpenStack-Nova-API-Version"] = client.Microversion
+	opts.MoreHeaders[getHTTPMicroversionHeader[client.Type]] = client.Microversion
 
 	return client.Request("PUT", url, opts)
 }
@@ -121,7 +145,7 @@ func (client *ServiceClient) Patch(url string, JSONBody interface{}, JSONRespons
 	if opts.MoreHeaders == nil {
 		opts.MoreHeaders = make(map[string]string)
 	}
-	opts.MoreHeaders["X-OpenStack-Nova-API-Version"] = client.Microversion
+	opts.MoreHeaders[getHTTPMicroversionHeader[client.Type]] = client.Microversion
 
 	return client.Request("PATCH", url, opts)
 }
@@ -135,7 +159,7 @@ func (client *ServiceClient) Delete(url string, opts *RequestOpts) (*http.Respon
 	if opts.MoreHeaders == nil {
 		opts.MoreHeaders = make(map[string]string)
 	}
-	opts.MoreHeaders["X-OpenStack-Nova-API-Version"] = client.Microversion
+	opts.MoreHeaders[getHTTPMicroversionHeader[client.Type]] = client.Microversion
 
 	return client.Request("DELETE", url, opts)
 }


### PR DESCRIPTION
All ServiceClient methods insert the OpenStack Nova HTTP Microversion header ("X-OpenStack-Nova-API-Version") into HTTP requests even though the request may be to a different service than Nova. This is incorrect.

That's why a mapping of serviceType to HTTPMicroversionHeader is added. Default value (empty string) is mapped to OpenStack Nova HTTP Microversion header because of backward compatibility.

The serviceType constants will be made public as soon as it will be needed.

Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

For #53 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR: N/A


