### PR TITLE
Get manila api microversion

### DIFF
--- a/openstack/sharedfilesystems/v2/shares/requests.go
+++ b/openstack/sharedfilesystems/v2/shares/requests.go
@@ -1,8 +1,6 @@
 package shares
 
-import (
-	"github.com/gophercloud/gophercloud"
-)
+import "github.com/gophercloud/gophercloud"
 
 // CreateOptsBuilder allows extensions to add additional parameters to the
 // Create request.
@@ -77,5 +75,11 @@ func Delete(client *gophercloud.ServiceClient, id string) (r DeleteResult) {
 // Get will get a single share with given UUID
 func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {
 	_, r.Err = client.Get(getURL(client, id), &r.Body, nil)
+	return
+}
+
+// GetMicroversion will get Microversion of Manila API
+func GetMicroversion(client *gophercloud.ServiceClient) (r GetResult) {
+	_, r.Err = client.Get(getMicroversionsURL(client), &r.Body, nil)
 	return
 }

--- a/openstack/sharedfilesystems/v2/shares/results.go
+++ b/openstack/sharedfilesystems/v2/shares/results.go
@@ -110,3 +110,53 @@ type DeleteResult struct {
 type GetResult struct {
 	commonResult
 }
+
+// Link contains links to OpenStack documentation, self (this Manila API).
+type Link struct {
+	// link
+	HRef string `json:"href"`
+	// link type
+	Type string `json:"type, omitempty"`
+	// link relationship
+	Rel string `json:"rel"`
+}
+
+// MediaType is a media type supported by the API
+type MediaType struct {
+	// Base of the media type
+	Base string `json:"base, omitempty"`
+	// Type of the media type
+	Type string `json:"type, omitempty"`
+}
+
+// Version contains all information associated with an OpenStack Manila specific API (micro)version
+type Version struct {
+	// The status of this API version. This can be one of: CURRENT, SUPPORTED, DEPRECATED
+	Status string `json:"status"`
+	// Timestamp
+	Updated time.Time `json:"updated, omitempty"`
+	// Shared filesystem API links
+	Links []Link `json:"links"`
+	// If this version of the API supports microversions, the minimum microversion that is supported. This will be the empty string if microversions are not supported.
+	MinVersion string `json:"min_version, omitempty"`
+	// If this version of the API supports microversions, the maximum microversion that is supported. This will be the empty string if microversions are not supported.
+	Version string `json:"version, omitempty"`
+	// Media types supported by the API
+	MediaTypes []MediaType `json:"media-types, omitempty"`
+	// A common name for the version in question. Informative only, it has no real semantic meaning.
+	ID string `json:"id"`
+}
+
+// ExtractMicroversion will get the Specific API Version object from the commonResult
+func (r commonResult) ExtractMicroversion() (*[]Version, error) {
+	var s struct {
+		GetMicroversionRes *[]Version `json:"versions"`
+	}
+	err := r.ExtractInto(&s)
+	return s.GetMicroversionRes, err
+}
+
+// GetMicroversionResult contains the result.
+type GetMicroversionResult struct {
+	commonResult
+}

--- a/openstack/sharedfilesystems/v2/shares/testing/fixtures.go
+++ b/openstack/sharedfilesystems/v2/shares/testing/fixtures.go
@@ -12,6 +12,7 @@ import (
 const (
 	shareEndpoint = "/shares"
 	shareID       = "011d21e2-fbc3-4e4a-9993-9ea223f73264"
+	projectID     = "16e1ab15c35a457e9c2b2aa189f544e1"
 )
 
 var createRequest = `{
@@ -139,5 +140,44 @@ func MockGetResponse(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprintf(w, getResponse)
+	})
+}
+
+var getMicroversionResponse = `{
+    "versions": [
+        {
+		"status": "CURRENT",
+		"updated": "2015-08-27T11:33:21Z",
+        	"links": [
+            		{
+                		"href": "http://172.18.198.54:8786/v2/16e1ab15c35a457e9c2b2aa189f544e1/shares/011d21e2-fbc3-4e4a-9993-9ea223f73264",
+                		"rel": "self"
+            		},
+            		{
+                		"href": "http://docs.openstack.org/",
+				"type": "text/html",
+                		"rel": "describedby"
+            		}
+        	],
+        	"min_version": "2.0",
+		"version": "2.15",
+		"media-types": [
+			{
+				"base": "application/json",
+				"type": "application/vnd.openstack.share+json;version=1"
+			}
+			],
+        	"id": "v2.0"
+	}
+    ]
+}`
+
+// MockGetMicroversionResponse creates a mock get microversion response
+func MockGetMicroversionResponse(t *testing.T) {
+	th.Mux.HandleFunc("/v2/", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, getMicroversionResponse)
 	})
 }

--- a/openstack/sharedfilesystems/v2/shares/testing/request_test.go
+++ b/openstack/sharedfilesystems/v2/shares/testing/request_test.go
@@ -52,7 +52,7 @@ func TestGet(t *testing.T) {
 		ShareType:          "25747776-08e5-494f-ab40-a64b9d20d8f7",
 		ShareTypeName:      "default",
 		ConsistencyGroupID: "9397c191-8427-4661-a2e8-b23820dc01d4",
-		ProjectID:          "16e1ab15c35a457e9c2b2aa189f544e1",
+		ProjectID:          projectID,
 		Metadata: map[string]string{
 			"project": "my_app",
 			"aim":     "doc",
@@ -79,6 +79,48 @@ func TestGet(t *testing.T) {
 				"href": "http://172.18.198.54:8786/16e1ab15c35a457e9c2b2aa189f544e1/shares/011d21e2-fbc3-4e4a-9993-9ea223f73264",
 				"rel":  "bookmark",
 			},
+		},
+	})
+}
+
+func TestGetMicroversion(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockGetMicroversionResponse(t)
+
+	c := client.ServiceClient()
+	// Adding a pattern
+	c.Endpoint += "v2/"
+	// Adding projectID that is removed by getMicroversionsURL
+	c.Endpoint += projectID
+
+	s, err := shares.GetMicroversion(c).ExtractMicroversion()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, s, &[]shares.Version{
+		{
+			Status:  "CURRENT",
+			Updated: time.Date(2015, time.August, 27, 11, 33, 21, 0, time.UTC),
+			Links: []shares.Link{
+				{
+					HRef: "http://172.18.198.54:8786/v2/16e1ab15c35a457e9c2b2aa189f544e1/shares/011d21e2-fbc3-4e4a-9993-9ea223f73264",
+					Rel:  "self",
+				},
+				{
+					HRef: "http://docs.openstack.org/",
+					Type: "text/html",
+					Rel:  "describedby",
+				},
+			},
+			MinVersion: "2.0",
+			Version:    "2.15",
+			MediaTypes: []shares.MediaType{
+				{
+					Base: "application/json",
+					Type: "application/vnd.openstack.share+json;version=1",
+				},
+			},
+			ID: "v2.0",
 		},
 	})
 }

--- a/openstack/sharedfilesystems/v2/shares/urls.go
+++ b/openstack/sharedfilesystems/v2/shares/urls.go
@@ -1,6 +1,10 @@
 package shares
 
-import "github.com/gophercloud/gophercloud"
+import (
+	"strings"
+
+	"github.com/gophercloud/gophercloud"
+)
 
 func createURL(c *gophercloud.ServiceClient) string {
 	return c.ServiceURL("shares")
@@ -12,4 +16,10 @@ func deleteURL(c *gophercloud.ServiceClient, id string) string {
 
 func getURL(c *gophercloud.ServiceClient, id string) string {
 	return c.ServiceURL("shares", id)
+}
+
+func getMicroversionsURL(c *gophercloud.ServiceClient) string {
+	baseURLWithoutEndingSlashes := strings.TrimRight(c.ResourceBaseURL(), "/")
+	slashIndexBeforeProjectID := strings.LastIndex(baseURLWithoutEndingSlashes, "/")
+	return baseURLWithoutEndingSlashes[:slashIndexBeforeProjectID] + "/"
 }


### PR DESCRIPTION
For https://github.com/gophercloud/gophercloud/issues/340

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/manila/blob/stable/newton/manila/api/versions.py#L88
