### PR TITLE
Networking v2: Security Group Update Fix

### DIFF
--- a/acceptance/openstack/networking/v2/extensions/security_test.go
+++ b/acceptance/openstack/networking/v2/extensions/security_test.go
@@ -33,7 +33,7 @@ func TestSecurityGroupsList(t *testing.T) {
 	}
 }
 
-func TestSecurityGroupsCreateDelete(t *testing.T) {
+func TestSecurityGroupsCreateUpdateDelete(t *testing.T) {
 	client, err := clients.NewNetworkV2Client()
 	if err != nil {
 		t.Fatalf("Unable to create a network client: %v", err)
@@ -52,6 +52,17 @@ func TestSecurityGroupsCreateDelete(t *testing.T) {
 	defer DeleteSecurityGroupRule(t, client, rule.ID)
 
 	tools.PrintResource(t, group)
+
+	updateOpts := groups.UpdateOpts{
+		Description: "A security group",
+	}
+
+	newGroup, err := groups.Update(client, group.ID, updateOpts).Extract()
+	if err != nil {
+		t.Fatalf("Unable to update security group: %v", err)
+	}
+
+	tools.PrintResource(t, newGroup)
 }
 
 func TestSecurityGroupsPort(t *testing.T) {

--- a/openstack/networking/v2/extensions/security/groups/requests.go
+++ b/openstack/networking/v2/extensions/security/groups/requests.go
@@ -81,13 +81,16 @@ func (opts UpdateOpts) ToSecGroupUpdateMap() (map[string]interface{}, error) {
 }
 
 // Update is an operation which updates an existing security group.
-func Update(c *gophercloud.ServiceClient, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(c *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToSecGroupUpdateMap()
 	if err != nil {
 		r.Err = err
 		return
 	}
-	_, r.Err = c.Put(rootURL(c), b, &r.Body, nil)
+
+	_, r.Err = c.Put(resourceURL(c, id), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
 	return
 }
 

--- a/openstack/networking/v2/extensions/security/groups/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/security/groups/testing/requests_test.go
@@ -72,21 +72,22 @@ func TestUpdate(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 
-	th.Mux.HandleFunc("/v2.0/security-groups", func(w http.ResponseWriter, r *http.Request) {
-		th.TestMethod(t, r, "PUT")
-		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
-		th.TestHeader(t, r, "Content-Type", "application/json")
-		th.TestHeader(t, r, "Accept", "application/json")
-		th.TestJSONRequest(t, r, SecurityGroupUpdateRequest)
+	th.Mux.HandleFunc("/v2.0/security-groups/2076db17-a522-4506-91de-c6dd8e837028",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "PUT")
+			th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+			th.TestHeader(t, r, "Content-Type", "application/json")
+			th.TestHeader(t, r, "Accept", "application/json")
+			th.TestJSONRequest(t, r, SecurityGroupUpdateRequest)
 
-		w.Header().Add("Content-Type", "application/json")
-		w.WriteHeader(http.StatusCreated)
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, SecurityGroupUpdateResponse)
-	})
+			fmt.Fprintf(w, SecurityGroupUpdateResponse)
+		})
 
 	opts := groups.UpdateOpts{Name: "newer-webservers"}
-	sg, err := groups.Update(fake.ServiceClient(), opts).Extract()
+	sg, err := groups.Update(fake.ServiceClient(), "2076db17-a522-4506-91de-c6dd8e837028", opts).Extract()
 	th.AssertNoErr(t, err)
 
 	th.AssertEquals(t, "newer-webservers", sg.Name)


### PR DESCRIPTION
Fixes incorrect implementation of security group update.

For #347

200 response code is defined [here](https://github.com/openstack/neutron/blob/19a069d99f7249854fab9ff2706a38fe8b66bb1e/neutron/wsgi.py#L689). Since there's a result returned, the code is 200.