### PR TITLE
internal: Add RemainingKeys function

### DIFF
--- a/internal/testing/util_test.go
+++ b/internal/testing/util_test.go
@@ -1,0 +1,36 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/internal"
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestRemainingKeys(t *testing.T) {
+	type User struct {
+		FirstName string `json:"first_name"`
+		LastName  string `json:"last_name"`
+		City      string
+	}
+
+	userStruct := User{
+		FirstName: "John",
+		LastName:  "Doe",
+	}
+
+	userMap := map[string]interface{}{
+		"first_name": "John",
+		"last_name":  "Doe",
+		"city":       "Honolulu",
+		"state":      "Hawaii",
+	}
+
+	expected := map[string]interface{}{
+		"city":  "Honolulu",
+		"state": "Hawaii",
+	}
+
+	actual := internal.RemainingKeys(userStruct, userMap)
+	th.AssertDeepEquals(t, expected, actual)
+}

--- a/internal/util.go
+++ b/internal/util.go
@@ -1,0 +1,25 @@
+package internal
+
+import (
+	"reflect"
+)
+
+// RemainingKeys will inspect a struct and compare it to a map. Any key that
+// is defined in a JSON tag of the struct will be removed from the map. The
+// remaining map and keys are then returned.
+//
+// This is useful for determining the extra fields returned in response bodies
+// for resources that can contain an arbitrary or dynamic number of fields.
+func RemainingKeys(s interface{}, m map[string]interface{}) map[string]interface{} {
+	valueOf := reflect.ValueOf(s)
+	typeOf := reflect.TypeOf(s)
+	for i := 0; i < valueOf.NumField(); i++ {
+		field := typeOf.Field(i)
+		tagValue := field.Tag.Get("json")
+		if _, ok := m[tagValue]; ok {
+			delete(m, tagValue)
+		}
+	}
+
+	return m
+}

--- a/internal/util.go
+++ b/internal/util.go
@@ -5,21 +5,22 @@ import (
 )
 
 // RemainingKeys will inspect a struct and compare it to a map. Any key that
-// is defined in a JSON tag of the struct will be removed from the map. The
-// remaining map and keys are then returned.
+// is not defined in a JSON tag of the struct will be added to the extras map
+// and returned.
 //
 // This is useful for determining the extra fields returned in response bodies
 // for resources that can contain an arbitrary or dynamic number of fields.
-func RemainingKeys(s interface{}, m map[string]interface{}) map[string]interface{} {
+func RemainingKeys(s interface{}, m map[string]interface{}) (extras map[string]interface{}) {
+	extras = make(map[string]interface{})
 	valueOf := reflect.ValueOf(s)
 	typeOf := reflect.TypeOf(s)
 	for i := 0; i < valueOf.NumField(); i++ {
 		field := typeOf.Field(i)
 		tagValue := field.Tag.Get("json")
-		if _, ok := m[tagValue]; ok {
-			delete(m, tagValue)
+		if _, ok := m[tagValue]; !ok {
+			extras[tagValue] = m[tagValue]
 		}
 	}
 
-	return m
+	return
 }


### PR DESCRIPTION
This commit adds the RemainingKeys function which can be used to
detect fields returned in response bodies but are not defined in
the resource's result struct.

For #350 