### PR TITLE
Add Cinder V2 Snapshot support

### DIFF
--- a/acceptance/openstack/blockstorage/v2/blockstorage.go
+++ b/acceptance/openstack/blockstorage/v2/blockstorage.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/acceptance/clients"
 	"github.com/gophercloud/gophercloud/acceptance/tools"
+	"github.com/gophercloud/gophercloud/openstack/blockstorage/v2/snapshots"
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v2/volumes"
 )
 
@@ -83,4 +84,59 @@ func DeleteVolume(t *testing.T, client *gophercloud.ServiceClient, volume *volum
 	}
 
 	t.Logf("Deleted volume: %s", volume.ID)
+}
+
+// CreateSnapshot will create a snapshot of the specified volume.
+// Snapshot will be assigned a random name and description.
+func CreateSnapshot(t *testing.T, client *gophercloud.ServiceClient, volume *volumes.Volume) (*snapshots.Snapshot, error) {
+	if testing.Short() {
+		t.Skip("Skipping test that requires snapshot creation in short mode.")
+	}
+
+	snapshotName := tools.RandomString("ACPTTEST", 16)
+	snapshotDescription := tools.RandomString("ACPTTEST", 16)
+	t.Logf("Attempting to create snapshot: %s", snapshotName)
+
+	createOpts := snapshots.CreateOpts{
+		VolumeID:    volume.ID,
+		Name:        snapshotName,
+		Description: snapshotDescription,
+	}
+
+	snapshot, err := snapshots.Create(client, createOpts).Extract()
+	if err != nil {
+		return snapshot, err
+	}
+
+	err = snapshots.WaitForStatus(client, snapshot.ID, "available", 60)
+	if err != nil {
+		return snapshot, err
+	}
+
+	return snapshot, nil
+}
+
+// DeleteSnapshot will delete a snapshot. A fatal error will occur if the
+// snapshot failed to be deleted.
+func DeleteSnapshot(t *testing.T, client *gophercloud.ServiceClient, snapshot *snapshots.Snapshot) {
+	err := snapshots.Delete(client, snapshot.ID).ExtractErr()
+	if err != nil {
+		t.Fatalf("Unable to delete snapshot %s: %+v", snapshot.ID, err)
+	}
+
+	// Volumes can't be deleted until their snapshots have been,
+	// so block up to 120 seconds for the snapshot to delete.
+	err = gophercloud.WaitFor(120, func() (bool, error) {
+		_, err := snapshots.Get(client, snapshot.ID).Extract()
+		if err != nil {
+			return true, nil
+		}
+
+		return false, nil
+	})
+	if err != nil {
+		t.Fatalf("Error waiting for snapshot to delete: %v", err)
+	}
+
+	t.Logf("Deleted snapshot: %s", snapshot.ID)
 }

--- a/acceptance/openstack/blockstorage/v2/snapshots_test.go
+++ b/acceptance/openstack/blockstorage/v2/snapshots_test.go
@@ -1,0 +1,58 @@
+// +build acceptance blockstorage
+
+package v2
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/acceptance/clients"
+	"github.com/gophercloud/gophercloud/acceptance/tools"
+	"github.com/gophercloud/gophercloud/openstack/blockstorage/v2/snapshots"
+)
+
+func TestSnapshotsList(t *testing.T) {
+	client, err := clients.NewBlockStorageV2Client()
+	if err != nil {
+		t.Fatalf("Unable to create a blockstorage client: %v", err)
+	}
+
+	allPages, err := snapshots.List(client, snapshots.ListOpts{}).AllPages()
+	if err != nil {
+		t.Fatalf("Unable to retrieve snapshots: %v", err)
+	}
+
+	allSnapshots, err := snapshots.ExtractSnapshots(allPages)
+	if err != nil {
+		t.Fatalf("Unable to extract snapshots: %v", err)
+	}
+
+	for _, snapshot := range allSnapshots {
+		tools.PrintResource(t, snapshot)
+	}
+}
+
+func TestSnapshotsCreateDelete(t *testing.T) {
+	client, err := clients.NewBlockStorageV2Client()
+	if err != nil {
+		t.Fatalf("Unable to create a blockstorage client: %v", err)
+	}
+
+	volume, err := CreateVolume(t, client)
+	if err != nil {
+		t.Fatalf("Unable to create volume: %v", err)
+	}
+	defer DeleteVolume(t, client, volume)
+
+	snapshot, err := CreateSnapshot(t, client, volume)
+	if err != nil {
+		t.Fatalf("Unable to create snapshot: %v", err)
+	}
+	defer DeleteSnapshot(t, client, snapshot)
+
+	newSnapshot, err := snapshots.Get(client, snapshot.ID).Extract()
+	if err != nil {
+		t.Errorf("Unable to retrieve snapshot: %v", err)
+	}
+
+	tools.PrintResource(t, newSnapshot)
+}

--- a/openstack/blockstorage/v2/snapshots/doc.go
+++ b/openstack/blockstorage/v2/snapshots/doc.go
@@ -1,0 +1,5 @@
+// Package snapshots provides information and interaction with snapshots in the
+// OpenStack Block Storage service. A snapshot is a point in time copy of the
+// data contained in an external storage volume, and can be controlled
+// programmatically.
+package snapshots

--- a/openstack/blockstorage/v2/snapshots/requests.go
+++ b/openstack/blockstorage/v2/snapshots/requests.go
@@ -1,0 +1,158 @@
+package snapshots
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToSnapshotCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts contains options for creating a Snapshot. This object is passed to
+// the snapshots.Create function. For more information about these parameters,
+// see the Snapshot object.
+type CreateOpts struct {
+	VolumeID    string                 `json:"volume_id" required:"true"`
+	Force       bool                   `json:"force,omitempty"`
+	Name        string                 `json:"name,omitempty"`
+	Description string                 `json:"description,omitempty"`
+	Metadata    map[string]interface{} `json:"metadata,omitempty"`
+}
+
+// ToSnapshotCreateMap assembles a request body based on the contents of a
+// CreateOpts.
+func (opts CreateOpts) ToSnapshotCreateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "snapshot")
+}
+
+// Create will create a new Snapshot based on the values in CreateOpts. To
+// extract the Snapshot object from the response, call the Extract method on the
+// CreateResult.
+func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToSnapshotCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(createURL(client), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+	})
+	return
+}
+
+// Delete will delete the existing Snapshot with the provided ID.
+func Delete(client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+	_, r.Err = client.Delete(deleteURL(client, id), nil)
+	return
+}
+
+// Get retrieves the Snapshot with the provided ID. To extract the Snapshot
+// object from the response, call the Extract method on the GetResult.
+func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {
+	_, r.Err = client.Get(getURL(client, id), &r.Body, nil)
+	return
+}
+
+// ListOptsBuilder allows extensions to add additional parameters to the List
+// request.
+type ListOptsBuilder interface {
+	ToSnapshotListQuery() (string, error)
+}
+
+// ListOpts hold options for listing Snapshots. It is passed to the
+// snapshots.List function.
+type ListOpts struct {
+	Name     string `q:"name"`
+	Status   string `q:"status"`
+	VolumeID string `q:"volume_id"`
+}
+
+// ToSnapshotListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToSnapshotListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List returns Snapshots optionally limited by the conditions provided in
+// ListOpts.
+func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(client)
+	if opts != nil {
+		query, err := opts.ToSnapshotListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return SnapshotPage{pagination.SinglePageBase(r)}
+	})
+}
+
+// UpdateMetadataOptsBuilder allows extensions to add additional parameters to
+// the Update request.
+type UpdateMetadataOptsBuilder interface {
+	ToSnapshotUpdateMetadataMap() (map[string]interface{}, error)
+}
+
+// UpdateMetadataOpts contain options for updating an existing Snapshot. This
+// object is passed to the snapshots.Update function. For more information
+// about the parameters, see the Snapshot object.
+type UpdateMetadataOpts struct {
+	Metadata map[string]interface{} `json:"metadata,omitempty"`
+}
+
+// ToSnapshotUpdateMetadataMap assembles a request body based on the contents of
+// an UpdateMetadataOpts.
+func (opts UpdateMetadataOpts) ToSnapshotUpdateMetadataMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "")
+}
+
+// UpdateMetadata will update the Snapshot with provided information. To
+// extract the updated Snapshot from the response, call the ExtractMetadata
+// method on the UpdateMetadataResult.
+func UpdateMetadata(client *gophercloud.ServiceClient, id string, opts UpdateMetadataOptsBuilder) (r UpdateMetadataResult) {
+	b, err := opts.ToSnapshotUpdateMetadataMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Put(updateMetadataURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// IDFromName is a convienience function that returns a snapshot's ID given its name.
+func IDFromName(client *gophercloud.ServiceClient, name string) (string, error) {
+	count := 0
+	id := ""
+	pages, err := List(client, nil).AllPages()
+	if err != nil {
+		return "", err
+	}
+
+	all, err := ExtractSnapshots(pages)
+	if err != nil {
+		return "", err
+	}
+
+	for _, s := range all {
+		if s.Name == name {
+			count++
+			id = s.ID
+		}
+	}
+
+	switch count {
+	case 0:
+		return "", gophercloud.ErrResourceNotFound{Name: name, ResourceType: "snapshot"}
+	case 1:
+		return id, nil
+	default:
+		return "", gophercloud.ErrMultipleResourcesFound{Name: name, Count: count, ResourceType: "snapshot"}
+	}
+}

--- a/openstack/blockstorage/v2/snapshots/results.go
+++ b/openstack/blockstorage/v2/snapshots/results.go
@@ -1,0 +1,120 @@
+package snapshots
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// Snapshot contains all the information associated with a Cinder Snapshot.
+type Snapshot struct {
+	// Unique identifier.
+	ID string `json:"id"`
+
+	// Date created.
+	CreatedAt time.Time `json:"-"`
+
+	// Date updated.
+	UpdatedAt time.Time `json:"-"`
+
+	// Display name.
+	Name string `json:"name"`
+
+	// Display description.
+	Description string `json:"description"`
+
+	// ID of the Volume from which this Snapshot was created.
+	VolumeID string `json:"volume_id"`
+
+	// Currect status of the Snapshot.
+	Status string `json:"status"`
+
+	// Size of the Snapshot, in GB.
+	Size int `json:"size"`
+
+	// User-defined key-value pairs.
+	Metadata map[string]string `json:"metadata"`
+}
+
+// CreateResult contains the response body and error from a Create request.
+type CreateResult struct {
+	commonResult
+}
+
+// GetResult contains the response body and error from a Get request.
+type GetResult struct {
+	commonResult
+}
+
+// DeleteResult contains the response body and error from a Delete request.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
+// SnapshotPage is a pagination.Pager that is returned from a call to the List function.
+type SnapshotPage struct {
+	pagination.SinglePageBase
+}
+
+func (r *Snapshot) UnmarshalJSON(b []byte) error {
+	type tmp Snapshot
+	var s struct {
+		tmp
+		CreatedAt gophercloud.JSONRFC3339MilliNoZ `json:"created_at"`
+		UpdatedAt gophercloud.JSONRFC3339MilliNoZ `json:"updated_at"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	*r = Snapshot(s.tmp)
+
+	r.CreatedAt = time.Time(s.CreatedAt)
+	r.UpdatedAt = time.Time(s.UpdatedAt)
+
+	return err
+}
+
+// IsEmpty returns true if a SnapshotPage contains no Snapshots.
+func (r SnapshotPage) IsEmpty() (bool, error) {
+	volumes, err := ExtractSnapshots(r)
+	return len(volumes) == 0, err
+}
+
+// ExtractSnapshots extracts and returns Snapshots. It is used while iterating over a snapshots.List call.
+func ExtractSnapshots(r pagination.Page) ([]Snapshot, error) {
+	var s struct {
+		Snapshots []Snapshot `json:"snapshots"`
+	}
+	err := (r.(SnapshotPage)).ExtractInto(&s)
+	return s.Snapshots, err
+}
+
+// UpdateMetadataResult contains the response body and error from an UpdateMetadata request.
+type UpdateMetadataResult struct {
+	commonResult
+}
+
+// ExtractMetadata returns the metadata from a response from snapshots.UpdateMetadata.
+func (r UpdateMetadataResult) ExtractMetadata() (map[string]interface{}, error) {
+	if r.Err != nil {
+		return nil, r.Err
+	}
+	m := r.Body.(map[string]interface{})["metadata"]
+	return m.(map[string]interface{}), nil
+}
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// Extract will get the Snapshot object out of the commonResult object.
+func (r commonResult) Extract() (*Snapshot, error) {
+	var s struct {
+		Snapshot *Snapshot `json:"snapshot"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Snapshot, err
+}

--- a/openstack/blockstorage/v2/snapshots/testing/doc.go
+++ b/openstack/blockstorage/v2/snapshots/testing/doc.go
@@ -1,0 +1,2 @@
+// snapshots_v2
+package testing

--- a/openstack/blockstorage/v2/snapshots/testing/fixtures.go
+++ b/openstack/blockstorage/v2/snapshots/testing/fixtures.go
@@ -1,0 +1,134 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	th "github.com/gophercloud/gophercloud/testhelper"
+	fake "github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func MockListResponse(t *testing.T) {
+	th.Mux.HandleFunc("/snapshots", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, `
+    {
+      "snapshots": [
+        {
+          "id": "289da7f8-6440-407c-9fb4-7db01ec49164",
+          "name": "snapshot-001",
+          "volume_id": "521752a6-acf6-4b2d-bc7a-119f9148cd8c",
+          "description": "Daily Backup",
+          "status": "available",
+          "size": 30,
+		  "created_at": "2017-05-30T03:35:03.000000"
+        },
+        {
+          "id": "96c3bda7-c82a-4f50-be73-ca7621794835",
+          "name": "snapshot-002",
+          "volume_id": "76b8950a-8594-4e5b-8dce-0dfa9c696358",
+          "description": "Weekly Backup",
+          "status": "available",
+          "size": 25,
+		  "created_at": "2017-05-30T03:35:03.000000"
+        }
+      ]
+    }
+    `)
+	})
+}
+
+func MockGetResponse(t *testing.T) {
+	th.Mux.HandleFunc("/snapshots/d32019d3-bc6e-4319-9c1d-6722fc136a22", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, `
+{
+    "snapshot": {
+        "id": "d32019d3-bc6e-4319-9c1d-6722fc136a22",
+        "name": "snapshot-001",
+        "description": "Daily backup",
+        "volume_id": "521752a6-acf6-4b2d-bc7a-119f9148cd8c",
+        "status": "available",
+        "size": 30,
+		"created_at": "2017-05-30T03:35:03.000000"
+    }
+}
+      `)
+	})
+}
+
+func MockCreateResponse(t *testing.T) {
+	th.Mux.HandleFunc("/snapshots", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, `
+{
+    "snapshot": {
+        "volume_id": "1234",
+        "name": "snapshot-001"
+    }
+}
+      `)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+
+		fmt.Fprintf(w, `
+{
+    "snapshot": {
+        "volume_id": "1234",
+        "name": "snapshot-001",
+        "id": "d32019d3-bc6e-4319-9c1d-6722fc136a22",
+        "description": "Daily backup",
+        "volume_id": "1234",
+        "status": "available",
+        "size": 30,
+		"created_at": "2017-05-30T03:35:03.000000"
+  }
+}
+    `)
+	})
+}
+
+func MockUpdateMetadataResponse(t *testing.T) {
+	th.Mux.HandleFunc("/snapshots/123/metadata", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestJSONRequest(t, r, `
+    {
+      "metadata": {
+        "key": "v1"
+      }
+    }
+    `)
+
+		fmt.Fprintf(w, `
+      {
+        "metadata": {
+          "key": "v1"
+        }
+      }
+    `)
+	})
+}
+
+func MockDeleteResponse(t *testing.T) {
+	th.Mux.HandleFunc("/snapshots/d32019d3-bc6e-4319-9c1d-6722fc136a22", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.WriteHeader(http.StatusNoContent)
+	})
+}

--- a/openstack/blockstorage/v2/snapshots/testing/requests_test.go
+++ b/openstack/blockstorage/v2/snapshots/testing/requests_test.go
@@ -1,0 +1,116 @@
+package testing
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gophercloud/gophercloud/openstack/blockstorage/v2/snapshots"
+	"github.com/gophercloud/gophercloud/pagination"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func TestList(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockListResponse(t)
+
+	count := 0
+
+	snapshots.List(client.ServiceClient(), &snapshots.ListOpts{}).EachPage(func(page pagination.Page) (bool, error) {
+		count++
+		actual, err := snapshots.ExtractSnapshots(page)
+		if err != nil {
+			t.Errorf("Failed to extract snapshots: %v", err)
+			return false, err
+		}
+
+		expected := []snapshots.Snapshot{
+			{
+				ID:          "289da7f8-6440-407c-9fb4-7db01ec49164",
+				Name:        "snapshot-001",
+				VolumeID:    "521752a6-acf6-4b2d-bc7a-119f9148cd8c",
+				Status:      "available",
+				Size:        30,
+				CreatedAt:   time.Date(2017, 5, 30, 3, 35, 3, 0, time.UTC),
+				Description: "Daily Backup",
+			},
+			{
+				ID:          "96c3bda7-c82a-4f50-be73-ca7621794835",
+				Name:        "snapshot-002",
+				VolumeID:    "76b8950a-8594-4e5b-8dce-0dfa9c696358",
+				Status:      "available",
+				Size:        25,
+				CreatedAt:   time.Date(2017, 5, 30, 3, 35, 3, 0, time.UTC),
+				Description: "Weekly Backup",
+			},
+		}
+
+		th.CheckDeepEquals(t, expected, actual)
+
+		return true, nil
+	})
+
+	if count != 1 {
+		t.Errorf("Expected 1 page, got %d", count)
+	}
+}
+
+func TestGet(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockGetResponse(t)
+
+	v, err := snapshots.Get(client.ServiceClient(), "d32019d3-bc6e-4319-9c1d-6722fc136a22").Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, v.Name, "snapshot-001")
+	th.AssertEquals(t, v.ID, "d32019d3-bc6e-4319-9c1d-6722fc136a22")
+}
+
+func TestCreate(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockCreateResponse(t)
+
+	options := snapshots.CreateOpts{VolumeID: "1234", Name: "snapshot-001"}
+	n, err := snapshots.Create(client.ServiceClient(), options).Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, n.VolumeID, "1234")
+	th.AssertEquals(t, n.Name, "snapshot-001")
+	th.AssertEquals(t, n.ID, "d32019d3-bc6e-4319-9c1d-6722fc136a22")
+}
+
+func TestUpdateMetadata(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockUpdateMetadataResponse(t)
+
+	expected := map[string]interface{}{"key": "v1"}
+
+	options := &snapshots.UpdateMetadataOpts{
+		Metadata: map[string]interface{}{
+			"key": "v1",
+		},
+	}
+
+	actual, err := snapshots.UpdateMetadata(client.ServiceClient(), "123", options).ExtractMetadata()
+
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, actual, expected)
+}
+
+func TestDelete(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockDeleteResponse(t)
+
+	res := snapshots.Delete(client.ServiceClient(), "d32019d3-bc6e-4319-9c1d-6722fc136a22")
+	th.AssertNoErr(t, res.Err)
+}

--- a/openstack/blockstorage/v2/snapshots/urls.go
+++ b/openstack/blockstorage/v2/snapshots/urls.go
@@ -1,0 +1,27 @@
+package snapshots
+
+import "github.com/gophercloud/gophercloud"
+
+func createURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("snapshots")
+}
+
+func deleteURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("snapshots", id)
+}
+
+func getURL(c *gophercloud.ServiceClient, id string) string {
+	return deleteURL(c, id)
+}
+
+func listURL(c *gophercloud.ServiceClient) string {
+	return createURL(c)
+}
+
+func metadataURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("snapshots", id, "metadata")
+}
+
+func updateMetadataURL(c *gophercloud.ServiceClient, id string) string {
+	return metadataURL(c, id)
+}

--- a/openstack/blockstorage/v2/snapshots/util.go
+++ b/openstack/blockstorage/v2/snapshots/util.go
@@ -1,0 +1,22 @@
+package snapshots
+
+import (
+	"github.com/gophercloud/gophercloud"
+)
+
+// WaitForStatus will continually poll the resource, checking for a particular
+// status. It will do this for the amount of seconds defined.
+func WaitForStatus(c *gophercloud.ServiceClient, id, status string, secs int) error {
+	return gophercloud.WaitFor(secs, func() (bool, error) {
+		current, err := Get(c, id).Extract()
+		if err != nil {
+			return false, err
+		}
+
+		if current.Status == status {
+			return true, nil
+		}
+
+		return false, nil
+	})
+}


### PR DESCRIPTION
Note that there is little difference between V1 and V2, and
subsequently even V3.

For #349

Links to source code regarding the API additions that include params:
  * Create
    https://github.com/openstack/cinder/blob/master/cinder/api/v2/snapshots.py#L135

  * ViewBuilder for snapshots (API Snapshot object from Cinder)
    https://github.com/openstack/cinder/blob/master/cinder/api/views/snapshots.py#L45

  * Snapshot Metadata controller
    https://github.com/openstack/cinder/blob/master/cinder/api/v2/snapshot_metadata.py

Example usage from the cinderclient to show options and url's used (note
the client does hacky things like import other version objects,
fortunately there's no delta between base V3.0 and v2):
  * Create
    https://github.com/openstack/python-cinderclient/blob/master/cinderclient/v3/volume_snapshots.py#L82
