### PR TITLE
Use map[string]string for snapshot createopt

### DIFF
--- a/openstack/blockstorage/v2/snapshots/requests.go
+++ b/openstack/blockstorage/v2/snapshots/requests.go
@@ -15,11 +15,11 @@ type CreateOptsBuilder interface {
 // the snapshots.Create function. For more information about these parameters,
 // see the Snapshot object.
 type CreateOpts struct {
-	VolumeID    string                 `json:"volume_id" required:"true"`
-	Force       bool                   `json:"force,omitempty"`
-	Name        string                 `json:"name,omitempty"`
-	Description string                 `json:"description,omitempty"`
-	Metadata    map[string]interface{} `json:"metadata,omitempty"`
+	VolumeID    string            `json:"volume_id" required:"true"`
+	Force       bool              `json:"force,omitempty"`
+	Name        string            `json:"name,omitempty"`
+	Description string            `json:"description,omitempty"`
+	Metadata    map[string]string `json:"metadata,omitempty"`
 }
 
 // ToSnapshotCreateMap assembles a request body based on the contents of a


### PR DESCRIPTION
Snapshot create opts are using map[string]interface{} for the
metadata opt.  This is doable, but we should be consistent with
other objects/resources and use map[string]string.

I missed this on the initial commit, so this patch just modifies
the CreateOption struct to make it match the types we use in Volumes.

For #367 