### PR TITLE
ImageService v2: Collect all properties of images

### DIFF
--- a/acceptance/openstack/imageservice/v2/images_test.go
+++ b/acceptance/openstack/imageservice/v2/images_test.go
@@ -30,6 +30,7 @@ func TestImagesListEachPage(t *testing.T) {
 
 		for _, image := range images {
 			tools.PrintResource(t, image)
+			tools.PrintResource(t, image.Properties)
 		}
 
 		return true, nil
@@ -58,6 +59,7 @@ func TestImagesListAllPages(t *testing.T) {
 
 	for _, image := range allImages {
 		tools.PrintResource(t, image)
+		tools.PrintResource(t, image.Properties)
 	}
 }
 

--- a/openstack/imageservice/v2/images/results.go
+++ b/openstack/imageservice/v2/images/results.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/internal"
 	"github.com/gophercloud/gophercloud/pagination"
 )
 
@@ -63,7 +64,7 @@ type Image struct {
 	Metadata map[string]string `json:"metadata"`
 
 	// Properties is a set of key-value pairs, if any, that are associated with the image.
-	Properties map[string]string `json:"properties"`
+	Properties map[string]interface{} `json:"-"`
 
 	// CreatedAt is the date when the image has been created.
 	CreatedAt time.Time `json:"created_at"`
@@ -103,6 +104,17 @@ func (r *Image) UnmarshalJSON(b []byte) error {
 		r.SizeBytes = int64(t)
 	default:
 		return fmt.Errorf("Unknown type for SizeBytes: %v (value: %v)", reflect.TypeOf(t), t)
+	}
+
+	// Bundle all other fields into Properties
+	var result interface{}
+	err = json.Unmarshal(b, &result)
+	if err != nil {
+		return err
+	}
+	if resultMap, ok := result.(map[string]interface{}); ok {
+		delete(resultMap, "self")
+		r.Properties = internal.RemainingKeys(Image{}, resultMap)
 	}
 
 	return err

--- a/openstack/imageservice/v2/images/results.go
+++ b/openstack/imageservice/v2/images/results.go
@@ -77,6 +77,9 @@ type Image struct {
 
 	// Schema is the path to the JSON-schema that represent the image or image entity.
 	Schema string `json:"schema"`
+
+	// VirtualSize is the virtual size of the image
+	VirtualSize int64 `json:"virtual_size"`
 }
 
 func (r *Image) UnmarshalJSON(b []byte) error {

--- a/openstack/imageservice/v2/images/testing/fixtures.go
+++ b/openstack/imageservice/v2/images/testing/fixtures.go
@@ -261,7 +261,7 @@ func HandleImageGetSuccessfully(t *testing.T) {
 			"size": 13167616,
 			"min_ram": 0,
 			"schema": "/v2/schemas/image",
-			"virtual_size": "None"
+			"virtual_size": null
 		}`)
 	})
 }

--- a/openstack/imageservice/v2/images/testing/fixtures.go
+++ b/openstack/imageservice/v2/images/testing/fixtures.go
@@ -43,7 +43,10 @@ func HandleImageListSuccessfully(t *testing.T) {
             "owner": "cba624273b8344e59dd1fd18685183b0",
             "virtual_size": null,
             "min_ram": 0,
-            "schema": "/v2/schemas/image"
+            "schema": "/v2/schemas/image",
+            "hw_disk_bus": "scsi",
+            "hw_disk_bus_model": "virtio-scsi",
+            "hw_scsi_model": "virtio-scsi"
         }`}
 	images[1] = imageEntry{"cirros-0.3.4-x86_64-uec-ramdisk",
 		`{
@@ -65,7 +68,10 @@ func HandleImageListSuccessfully(t *testing.T) {
             "owner": "cba624273b8344e59dd1fd18685183b0",
             "virtual_size": null,
             "min_ram": 0,
-            "schema": "/v2/schemas/image"
+            "schema": "/v2/schemas/image",
+            "hw_disk_bus": "scsi",
+            "hw_disk_bus_model": "virtio-scsi",
+            "hw_scsi_model": "virtio-scsi"
         }`}
 	images[2] = imageEntry{"cirros-0.3.4-x86_64-uec-kernel",
 		`{
@@ -87,7 +93,10 @@ func HandleImageListSuccessfully(t *testing.T) {
             "owner": "cba624273b8344e59dd1fd18685183b0",
             "virtual_size": null,
             "min_ram": 0,
-            "schema": "/v2/schemas/image"
+            "schema": "/v2/schemas/image",
+            "hw_disk_bus": "scsi",
+            "hw_disk_bus_model": "virtio-scsi",
+            "hw_scsi_model": "virtio-scsi"
         }`}
 
 	th.Mux.HandleFunc("/images", func(w http.ResponseWriter, r *http.Request) {
@@ -187,7 +196,10 @@ func HandleImageCreationSuccessfully(t *testing.T) {
 			"schema": "/v2/schemas/image",
 			"size": 0,
 			"checksum": "",
-			"virtual_size": 0
+			"virtual_size": 0,
+			"hw_disk_bus": "scsi",
+			"hw_disk_bus_model": "virtio-scsi",
+			"hw_scsi_model": "virtio-scsi"
 		}`)
 	})
 }
@@ -261,7 +273,10 @@ func HandleImageGetSuccessfully(t *testing.T) {
 			"size": 13167616,
 			"min_ram": 0,
 			"schema": "/v2/schemas/image",
-			"virtual_size": null
+			"virtual_size": null,
+			"hw_disk_bus": "scsi",
+			"hw_disk_bus_model": "virtio-scsi",
+			"hw_scsi_model": "virtio-scsi"
 		}`)
 	})
 }
@@ -323,7 +338,10 @@ func HandleImageUpdateSuccessfully(t *testing.T) {
 			"min_disk": 0,
 			"disk_format": "",
 			"virtual_size": 0,
-			"container_format": ""
+			"container_format": "",
+			"hw_disk_bus": "scsi",
+			"hw_disk_bus_model": "virtio-scsi",
+			"hw_scsi_model": "virtio-scsi"
 		}`)
 	})
 }

--- a/openstack/imageservice/v2/images/testing/requests_test.go
+++ b/openstack/imageservice/v2/images/testing/requests_test.go
@@ -102,11 +102,12 @@ func TestCreateImage(t *testing.T) {
 
 		Owner: owner,
 
-		Visibility: images.ImageVisibilityPrivate,
-		File:       file,
-		CreatedAt:  createdDate,
-		UpdatedAt:  lastUpdate,
-		Schema:     schema,
+		Visibility:  images.ImageVisibilityPrivate,
+		File:        file,
+		CreatedAt:   createdDate,
+		UpdatedAt:   lastUpdate,
+		Schema:      schema,
+		VirtualSize: 0,
 	}
 
 	th.AssertDeepEquals(t, &expectedImage, actualImage)
@@ -204,12 +205,13 @@ func TestGetImage(t *testing.T) {
 		Protected:  false,
 		Visibility: images.ImageVisibilityPublic,
 
-		Checksum:  checksum,
-		SizeBytes: sizeBytes,
-		File:      file,
-		CreatedAt: createdDate,
-		UpdatedAt: lastUpdate,
-		Schema:    schema,
+		Checksum:    checksum,
+		SizeBytes:   sizeBytes,
+		File:        file,
+		CreatedAt:   createdDate,
+		UpdatedAt:   lastUpdate,
+		Schema:      schema,
+		VirtualSize: 0,
 	}
 
 	th.AssertDeepEquals(t, &expectedImage, actualImage)
@@ -269,6 +271,7 @@ func TestUpdateImage(t *testing.T) {
 		CreatedAt:       createdDate,
 		UpdatedAt:       lastUpdate,
 		Schema:          schema,
+		VirtualSize:     0,
 	}
 
 	th.AssertDeepEquals(t, &expectedImage, actualImage)

--- a/openstack/imageservice/v2/images/testing/requests_test.go
+++ b/openstack/imageservice/v2/images/testing/requests_test.go
@@ -108,6 +108,11 @@ func TestCreateImage(t *testing.T) {
 		UpdatedAt:   lastUpdate,
 		Schema:      schema,
 		VirtualSize: 0,
+		Properties: map[string]interface{}{
+			"hw_disk_bus":       "scsi",
+			"hw_disk_bus_model": "virtio-scsi",
+			"hw_scsi_model":     "virtio-scsi",
+		},
 	}
 
 	th.AssertDeepEquals(t, &expectedImage, actualImage)
@@ -212,6 +217,11 @@ func TestGetImage(t *testing.T) {
 		UpdatedAt:   lastUpdate,
 		Schema:      schema,
 		VirtualSize: 0,
+		Properties: map[string]interface{}{
+			"hw_disk_bus":       "scsi",
+			"hw_disk_bus_model": "virtio-scsi",
+			"hw_scsi_model":     "virtio-scsi",
+		},
 	}
 
 	th.AssertDeepEquals(t, &expectedImage, actualImage)
@@ -272,6 +282,11 @@ func TestUpdateImage(t *testing.T) {
 		UpdatedAt:       lastUpdate,
 		Schema:          schema,
 		VirtualSize:     0,
+		Properties: map[string]interface{}{
+			"hw_disk_bus":       "scsi",
+			"hw_disk_bus_model": "virtio-scsi",
+			"hw_scsi_model":     "virtio-scsi",
+		},
 	}
 
 	th.AssertDeepEquals(t, &expectedImage, actualImage)


### PR DESCRIPTION
For #260 

While investigating this, I discovered that `virtual_size` was a first-class field:

* https://github.com/openstack/glance/blob/48ee8ef4793ed40397613193f09872f474c11abe/glance/db/sqlalchemy/migrate_repo/versions/034_add_virtual_size.py
* https://github.com/openstack/glance/blob/61046c8f247d52d5cd506ad465dcd0e70b2cb4b2/glance/domain/__init__.py#L51

`self` is being deleted from the JSON response since it's included in every response and part of the pagination system of Glance.