### PR TITLE
Identity v3: Remove GetOpts/GetOptsBuilder from Projects

### DIFF
--- a/acceptance/openstack/identity/v3/projects_test.go
+++ b/acceptance/openstack/identity/v3/projects_test.go
@@ -53,7 +53,7 @@ func TestProjectsGet(t *testing.T) {
 	}
 
 	project := allProjects[0]
-	p, err := projects.Get(client, project.ID, nil).Extract()
+	p, err := projects.Get(client, project.ID).Extract()
 	if err != nil {
 		t.Fatalf("Unable to get project: %v", err)
 	}

--- a/openstack/identity/v3/projects/requests.go
+++ b/openstack/identity/v3/projects/requests.go
@@ -51,36 +51,9 @@ func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pa
 	})
 }
 
-// GetOptsBuilder allows extensions to add additional parameters to
-// the Get request.
-type GetOptsBuilder interface {
-	ToProjectGetQuery() (string, error)
-}
-
-// GetOpts allows you to modify the details included in the Get request.
-type GetOpts struct{}
-
-// ToProjectGetQuery formats a GetOpts into a query string.
-func (opts GetOpts) ToProjectGetQuery() (string, error) {
-	q, err := gophercloud.BuildQueryString(opts)
-	return q.String(), err
-}
-
 // Get retrieves details on a single project, by ID.
-func Get(client *gophercloud.ServiceClient, id string, opts GetOptsBuilder) (r GetResult) {
-	url := getURL(client, id)
-	if opts != nil {
-		query, err := opts.ToProjectGetQuery()
-		if err != nil {
-			r.Err = err
-			return
-		}
-		url += query
-	}
-
-	_, r.Err = client.Get(url, &r.Body, &gophercloud.RequestOpts{
-		OkCodes: []int{200},
-	})
+func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {
+	_, r.Err = client.Get(getURL(client, id), &r.Body, nil)
 	return
 }
 

--- a/openstack/identity/v3/projects/testing/requests_test.go
+++ b/openstack/identity/v3/projects/testing/requests_test.go
@@ -34,7 +34,7 @@ func TestGetProject(t *testing.T) {
 	defer th.TeardownHTTP()
 	HandleGetProjectSuccessfully(t)
 
-	actual, err := projects.Get(client.ServiceClient(), "1234", nil).Extract()
+	actual, err := projects.Get(client.ServiceClient(), "1234").Extract()
 	th.AssertNoErr(t, err)
 	th.CheckDeepEquals(t, RedTeam, *actual)
 }


### PR DESCRIPTION
For #377 