### PR TITLE
Shared Filesystems: Share Export Locations

### DIFF
--- a/openstack/sharedfilesystems/v2/shares/requests.go
+++ b/openstack/sharedfilesystems/v2/shares/requests.go
@@ -79,3 +79,9 @@ func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {
 	_, r.Err = client.Get(getURL(client, id), &r.Body, nil)
 	return
 }
+
+// GetExportLocations will get shareID's export locations
+func GetExportLocations(client *gophercloud.ServiceClient, id string) (r GetExportLocationsResult) {
+	_, r.Err = client.Get(getExportLocationsURL(client, id), &r.Body, nil)
+	return
+}

--- a/openstack/sharedfilesystems/v2/shares/results.go
+++ b/openstack/sharedfilesystems/v2/shares/results.go
@@ -117,21 +117,26 @@ type ExportLocation struct {
 	Path string `json:"path"`
 	// The UUID of the share instance that this export location belongs to.
 	ShareInstanceID string `json:"share_instance_id"`
-	// Defines purpose of an export location. If set to true, then it is expected to be used for service needs and by administrators only. If it is set to false, then this export location can be used by end users.
+	// Defines purpose of an export location.
+	// If set to true, then it is expected to be used for service needs
+	// and by administrators only.
+	// If it is set to false, then this export location can be used by end users.
 	IsAdminOnly bool `json:"is_admin_only"`
 	// The share export location UUID.
 	ID string `json:"id"`
-	// Drivers may use this field to identify which export locations are most efficient and should be used preferentially by clients. By default it is set to false value. New in version 2.14
+	// Drivers may use this field to identify which export locations are
+	// most efficient and should be used preferentially by clients.
+	// By default it is set to false value. New in version 2.14
 	Preferred bool `json:"preferred"`
 }
 
 // ExtractExportLocations will get the Export Locations from the commonResult
 func (r commonResult) ExtractExportLocations() ([]ExportLocation, error) {
 	var s struct {
-		GetExportLocationsRes []ExportLocation `json:"export_locations"`
+		ExportLocations []ExportLocation `json:"export_locations"`
 	}
 	err := r.ExtractInto(&s)
-	return s.GetExportLocationsRes, err
+	return s.ExportLocations, err
 }
 
 // GetExportLocationsResult contains the result.

--- a/openstack/sharedfilesystems/v2/shares/results.go
+++ b/openstack/sharedfilesystems/v2/shares/results.go
@@ -110,3 +110,31 @@ type DeleteResult struct {
 type GetResult struct {
 	commonResult
 }
+
+// ExportLocation contains all information associated with a share export location
+type ExportLocation struct {
+	// The export location path that should be used for mount operation.
+	Path string `json:"path"`
+	// The UUID of the share instance that this export location belongs to.
+	ShareInstanceID string `json:"share_instance_id"`
+	// Defines purpose of an export location. If set to true, then it is expected to be used for service needs and by administrators only. If it is set to false, then this export location can be used by end users.
+	IsAdminOnly bool `json:"is_admin_only"`
+	// The share export location UUID.
+	ID string `json:"id"`
+	// Drivers may use this field to identify which export locations are most efficient and should be used preferentially by clients. By default it is set to false value. New in version 2.14
+	Preferred bool `json:"preferred"`
+}
+
+// ExtractExportLocations will get the Export Locations from the commonResult
+func (r commonResult) ExtractExportLocations() ([]ExportLocation, error) {
+	var s struct {
+		GetExportLocationsRes []ExportLocation `json:"export_locations"`
+	}
+	err := r.ExtractInto(&s)
+	return s.GetExportLocationsRes, err
+}
+
+// GetExportLocationsResult contains the result.
+type GetExportLocationsResult struct {
+	commonResult
+}

--- a/openstack/sharedfilesystems/v2/shares/testing/fixtures.go
+++ b/openstack/sharedfilesystems/v2/shares/testing/fixtures.go
@@ -141,3 +141,25 @@ func MockGetResponse(t *testing.T) {
 		fmt.Fprintf(w, getResponse)
 	})
 }
+
+var getExportLocationsResponse = `{
+    "export_locations": [
+        {
+		"path": "127.0.0.1:/var/lib/manila/mnt/share-9a922036-ad26-4d27-b955-7a1e285fa74d",
+        	"share_instance_id": "011d21e2-fbc3-4e4a-9993-9ea223f73264",
+		"is_admin_only": false,
+        	"id": "80ed63fc-83bc-4afc-b881-da4a345ac83d",
+		"preferred": false
+	}
+    ]
+}`
+
+// MockGetExportLocationsResponse creates a mock get export locations response
+func MockGetExportLocationsResponse(t *testing.T) {
+	th.Mux.HandleFunc(shareEndpoint+"/"+shareID+"/export_locations", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, getExportLocationsResponse)
+	})
+}

--- a/openstack/sharedfilesystems/v2/shares/testing/request_test.go
+++ b/openstack/sharedfilesystems/v2/shares/testing/request_test.go
@@ -82,3 +82,27 @@ func TestGet(t *testing.T) {
 		},
 	})
 }
+
+func TestGetExportLocationsSuccess(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockGetExportLocationsResponse(t)
+
+	c := client.ServiceClient()
+	// Client c must have Microversion set; minimum supported microversion for Get Export Locations is 2.14
+	c.Microversion = "2.14"
+
+	s, err := shares.GetExportLocations(c, shareID).ExtractExportLocations()
+
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, s, []shares.ExportLocation{
+		{
+			Path:            "127.0.0.1:/var/lib/manila/mnt/share-9a922036-ad26-4d27-b955-7a1e285fa74d",
+			ShareInstanceID: "011d21e2-fbc3-4e4a-9993-9ea223f73264",
+			IsAdminOnly:     false,
+			ID:              "80ed63fc-83bc-4afc-b881-da4a345ac83d",
+			Preferred:       false,
+		},
+	})
+}

--- a/openstack/sharedfilesystems/v2/shares/urls.go
+++ b/openstack/sharedfilesystems/v2/shares/urls.go
@@ -13,3 +13,7 @@ func deleteURL(c *gophercloud.ServiceClient, id string) string {
 func getURL(c *gophercloud.ServiceClient, id string) string {
 	return c.ServiceURL("shares", id)
 }
+
+func getExportLocationsURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("shares", id, "export_locations")
+}


### PR DESCRIPTION
For #380

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/manila/blob/master/manila/api/v2/share_export_locations.py#L25