### PR TITLE
support HTTP status 300 in pagination

### DIFF
--- a/pagination/http.go
+++ b/pagination/http.go
@@ -55,6 +55,6 @@ func PageResultFromParsed(resp *http.Response, body interface{}) PageResult {
 func Request(client *gophercloud.ServiceClient, headers map[string]string, url string) (*http.Response, error) {
 	return client.Get(url, nil, &gophercloud.RequestOpts{
 		MoreHeaders: headers,
-		OkCodes:     []int{200, 204},
+		OkCodes:     []int{200, 204, 300},
 	})
 }


### PR DESCRIPTION
FIX #384

According to [this line](https://github.com/openstack/cinder/blob/master/api-ref/source/v1/volumes-v1-versions.inc#list-api-versions-v1) in Cinder, HTTP status 300 could return when blockstorage list API versions.
