### PR TITLE
Add ListGroups method to Retrieve groups user belongs to

### DIFF
--- a/acceptance/openstack/identity/v3/users_test.go
+++ b/acceptance/openstack/identity/v3/users_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gophercloud/gophercloud/acceptance/clients"
 	"github.com/gophercloud/gophercloud/acceptance/tools"
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/groups"
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/users"
 )
 
@@ -119,5 +120,37 @@ func TestUserCRUD(t *testing.T) {
 
 	tools.PrintResource(t, newUser)
 	tools.PrintResource(t, newUser.Extra)
+}
 
+func TestUsersListGroups(t *testing.T) {
+	client, err := clients.NewIdentityV3Client()
+	if err != nil {
+		t.Fatalf("Unable to obtain an identity client: %v", err)
+	}
+	allUserPages, err := users.List(client, nil).AllPages()
+	if err != nil {
+		t.Fatalf("Unable to list users: %v", err)
+	}
+
+	allUsers, err := users.ExtractUsers(allUserPages)
+	if err != nil {
+		t.Fatalf("Unable to extract users: %v", err)
+	}
+
+	user := allUsers[0]
+
+	allGroupPages, err := users.ListGroups(client, user.ID).AllPages()
+	if err != nil {
+		t.Fatalf("Unable to list groups: %v", err)
+	}
+
+	allGroups, err := groups.ExtractGroups(allGroupPages)
+	if err != nil {
+		t.Fatalf("Unable to extract groups: %v", err)
+	}
+
+	for _, group := range allGroups {
+		tools.PrintResource(t, group)
+		tools.PrintResource(t, group.Extra)
+	}
 }

--- a/openstack/identity/v3/groups/results.go
+++ b/openstack/identity/v3/groups/results.go
@@ -1,0 +1,108 @@
+package groups
+
+import (
+	"encoding/json"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/internal"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// Group helps manage related users.
+type Group struct {
+	// Description describes the group purpose.
+	Description string `json:"description"`
+
+	// DomainID is the domain ID the group belongs to.
+	DomainID string `json:"domain_id"`
+
+	// ID is the unique ID of the group.
+	ID string `json:"id"`
+
+	// Extra is a collection of miscellaneous key/values.
+	Extra map[string]interface{} `json:"-"`
+
+	// Links contains referencing links to the group.
+	Links map[string]interface{} `json:"links"`
+
+	// Name is the name of the group.
+	Name string `json:"name"`
+}
+
+func (r *Group) UnmarshalJSON(b []byte) error {
+	type tmp Group
+	var s struct {
+		tmp
+		Extra map[string]interface{} `json:"extra"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	*r = Group(s.tmp)
+
+	// Collect other fields and bundle them into Extra
+	// but only if a field titled "extra" wasn't sent.
+	if s.Extra != nil {
+		r.Extra = s.Extra
+	} else {
+		var result interface{}
+		err := json.Unmarshal(b, &result)
+		if err != nil {
+			return err
+		}
+		if resultMap, ok := result.(map[string]interface{}); ok {
+			r.Extra = internal.RemainingKeys(Group{}, resultMap)
+		}
+	}
+
+	return err
+}
+
+type groupResult struct {
+	gophercloud.Result
+}
+
+// GroupPage is a single page of Group results.
+type GroupPage struct {
+	pagination.LinkedPageBase
+}
+
+// IsEmpty determines whether or not a page of Groups contains any results.
+func (r GroupPage) IsEmpty() (bool, error) {
+	groups, err := ExtractGroups(r)
+	return len(groups) == 0, err
+}
+
+// NextPageURL extracts the "next" link from the links section of the result.
+func (r GroupPage) NextPageURL() (string, error) {
+	var s struct {
+		Links struct {
+			Next     string `json:"next"`
+			Previous string `json:"previous"`
+		} `json:"links"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return s.Links.Next, err
+}
+
+// ExtractGroups returns a slice of Groups contained in a single page of results.
+func ExtractGroups(r pagination.Page) ([]Group, error) {
+	var s struct {
+		Groups []Group `json:"groups"`
+	}
+	err := (r.(GroupPage)).ExtractInto(&s)
+	return s.Groups, err
+}
+
+// Extract interprets any group results as a Group.
+func (r groupResult) Extract() (*Group, error) {
+	var s struct {
+		Group *Group `json:"group"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Group, err
+}

--- a/openstack/identity/v3/users/requests.go
+++ b/openstack/identity/v3/users/requests.go
@@ -2,6 +2,7 @@ package users
 
 import (
 	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/groups"
 	"github.com/gophercloud/gophercloud/pagination"
 )
 
@@ -206,4 +207,12 @@ func Update(client *gophercloud.ServiceClient, userID string, opts UpdateOptsBui
 func Delete(client *gophercloud.ServiceClient, userID string) (r DeleteResult) {
 	_, r.Err = client.Delete(deleteURL(client, userID), nil)
 	return
+}
+
+// ListGroups enumerates groups user belongs to.
+func ListGroups(client *gophercloud.ServiceClient, userID string) pagination.Pager {
+	url := listGroupsURL(client, userID)
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return groups.GroupPage{pagination.LinkedPageBase{PageResult: r}}
+	})
 }

--- a/openstack/identity/v3/users/testing/requests_test.go
+++ b/openstack/identity/v3/users/testing/requests_test.go
@@ -3,6 +3,7 @@ package testing
 import (
 	"testing"
 
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/groups"
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/users"
 	"github.com/gophercloud/gophercloud/pagination"
 	th "github.com/gophercloud/gophercloud/testhelper"
@@ -133,4 +134,15 @@ func TestDeleteUser(t *testing.T) {
 
 	res := users.Delete(client.ServiceClient(), "9fe1d3")
 	th.AssertNoErr(t, res.Err)
+}
+
+func TestListUserGroups(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleListUserGroupsSuccessfully(t)
+	allPages, err := users.ListGroups(client.ServiceClient(), "9fe1d3").AllPages()
+	th.AssertNoErr(t, err)
+	actual, err := groups.ExtractGroups(allPages)
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, ExpectedGroupsSlice, actual)
 }

--- a/openstack/identity/v3/users/urls.go
+++ b/openstack/identity/v3/users/urls.go
@@ -21,3 +21,7 @@ func updateURL(client *gophercloud.ServiceClient, userID string) string {
 func deleteURL(client *gophercloud.ServiceClient, userID string) string {
 	return client.ServiceURL("users", userID)
 }
+
+func listGroupsURL(client *gophercloud.ServiceClient, userID string) string {
+	return client.ServiceURL("users", userID, "groups")
+}


### PR DESCRIPTION
Adds a method to v3 bindings to retrieve groups user belongs to,
based on his/her ID.

For #382 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

groups resource definition in keystone request router: https://github.com/openstack/keystone/blob/a3aee6ccb52d85eac1deedec31724a955d47fa96/keystone/identity/routers.py#L77-L84

list_group_for_users general implementation https://github.com/openstack/keystone/blob/16f6ed14df136eb9c283a5415b9f18fcb0834350/keystone/identity/core.py#L1281

list_group_for_users SQL driver implementation https://github.com/openstack/keystone/blob/7754f170aa0eb42bea356e7f912bc241832eb1f3/keystone/identity/backends/sql.py#L312


Based on: https://developer.openstack.org/api-ref/identity/v3/?expanded=list-groups-to-which-a-user-belongs-detail,list-users-detail#list-groups-to-which-a-user-belongs
