### PR TITLE
Add tenants V2 create support

### DIFF
--- a/openstack/identity/v2/tenants/requests.go
+++ b/openstack/identity/v2/tenants/requests.go
@@ -27,3 +27,36 @@ func List(client *gophercloud.ServiceClient, opts *ListOpts) pagination.Pager {
 		return TenantPage{pagination.LinkedPageBase{PageResult: r}}
 	})
 }
+
+// CreateOpts represents the options needed when creating new tenant.
+type CreateOpts struct {
+	// Name is the name of the tenant.
+	Name string `json:"name,required"`
+	// Description is the description of the tenant.
+	Description string `json:"description,omitempty"`
+	// Enabled sets the tenant status to enabled or disabled.
+	Enabled *bool `json:"enabled,omitempty"`
+}
+
+// CreateOptsBuilder describes struct types that can be accepted by the Create call.
+type CreateOptsBuilder interface {
+	ToTenantCreateMap() (map[string]interface{}, error)
+}
+
+// ToTenantCreateMap assembles a request body based on the contents of a CreateOpts.
+func (opts CreateOpts) ToTenantCreateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "tenant")
+}
+
+// Create is the operation responsible for creating new tenant.
+func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToTenantCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(createURL(client), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200, 201},
+	})
+	return
+}

--- a/openstack/identity/v2/tenants/results.go
+++ b/openstack/identity/v2/tenants/results.go
@@ -51,3 +51,21 @@ func ExtractTenants(r pagination.Page) ([]Tenant, error) {
 	err := (r.(TenantPage)).ExtractInto(&s)
 	return s.Tenants, err
 }
+
+type tenantResult struct {
+	gophercloud.Result
+}
+
+// Extract interprets any tenantResults as a tenant.
+func (r tenantResult) Extract() (*Tenant, error) {
+	var s struct {
+		Tenant *Tenant `json:"tenant"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Tenant, err
+}
+
+// CreateResult temporarily contains the reponse from the Create call.
+type CreateResult struct {
+	tenantResult
+}

--- a/openstack/identity/v2/tenants/testing/fixtures.go
+++ b/openstack/identity/v2/tenants/testing/fixtures.go
@@ -62,3 +62,34 @@ func HandleListTenantsSuccessfully(t *testing.T) {
 		fmt.Fprintf(w, ListOutput)
 	})
 }
+
+func mockCreateTenantResponse(t *testing.T) {
+	th.Mux.HandleFunc("/tenants", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		th.TestJSONRequest(t, r, `
+{
+    "tenant": {
+		    "name": "new_tenant",
+		    "description": "This is new tenant",
+		    "enabled": true
+    }
+}
+	`)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, `
+{
+    "tenant": {
+        "name": "new_tenant",
+        "description": "This is new tenant",
+        "enabled": true,
+        "id": "5c62ef576dc7444cbb73b1fe84b97648"
+    }
+}
+`)
+	})
+}

--- a/openstack/identity/v2/tenants/testing/requests_test.go
+++ b/openstack/identity/v2/tenants/testing/requests_test.go
@@ -3,6 +3,7 @@ package testing
 import (
 	"testing"
 
+	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/identity/v2/tenants"
 	"github.com/gophercloud/gophercloud/pagination"
 	th "github.com/gophercloud/gophercloud/testhelper"
@@ -27,4 +28,30 @@ func TestListTenants(t *testing.T) {
 	})
 	th.AssertNoErr(t, err)
 	th.CheckEquals(t, count, 1)
+}
+
+func TestCreateTenant(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	mockCreateTenantResponse(t)
+
+	opts := tenants.CreateOpts{
+		Name:        "new_tenant",
+		Description: "This is new tenant",
+		Enabled:     gophercloud.Enabled,
+	}
+
+	tenant, err := tenants.Create(client.ServiceClient(), opts).Extract()
+
+	th.AssertNoErr(t, err)
+
+	expected := &tenants.Tenant{
+		Name:        "new_tenant",
+		Description: "This is new tenant",
+		Enabled:     true,
+		ID:          "5c62ef576dc7444cbb73b1fe84b97648",
+	}
+
+	th.AssertDeepEquals(t, expected, tenant)
 }

--- a/openstack/identity/v2/tenants/urls.go
+++ b/openstack/identity/v2/tenants/urls.go
@@ -5,3 +5,7 @@ import "github.com/gophercloud/gophercloud"
 func listURL(client *gophercloud.ServiceClient) string {
 	return client.ServiceURL("tenants")
 }
+
+func createURL(client *gophercloud.ServiceClient) string {
+	return client.ServiceURL("tenants")
+}


### PR DESCRIPTION
For #397

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

create_tenant general implementation 
https://github.com/openstack/keystone/blob/5c8dcd2f2f1a7645f93f39c3f5784920e2099998/keystone/identity/core.py#L293

create_tenant sql driver implementation 
https://github.com/openstack/keystone/blob/5c8dcd2f2f1a7645f93f39c3f5784920e2099998/keystone/identity/backends/sql.py#L331
