### PR TITLE
Add tenants V2 get support

### DIFF
--- a/openstack/identity/v2/tenants/requests.go
+++ b/openstack/identity/v2/tenants/requests.go
@@ -61,6 +61,12 @@ func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r Create
 	return
 }
 
+// Get requests details on a single tenant by ID.
+func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {
+	_, r.Err = client.Get(getURL(client, id), &r.Body, nil)
+	return
+}
+
 // UpdateOptsBuilder allows extensions to add additional attributes to the Update request.
 type UpdateOptsBuilder interface {
 	ToTenantUpdateMap() (map[string]interface{}, error)

--- a/openstack/identity/v2/tenants/results.go
+++ b/openstack/identity/v2/tenants/results.go
@@ -65,6 +65,11 @@ func (r tenantResult) Extract() (*Tenant, error) {
 	return s.Tenant, err
 }
 
+// GetResult temporarily contains the response from the Get call.
+type GetResult struct {
+	tenantResult
+}
+
 // CreateResult temporarily contains the reponse from the Create call.
 type CreateResult struct {
 	tenantResult

--- a/openstack/identity/v2/tenants/testing/fixtures.go
+++ b/openstack/identity/v2/tenants/testing/fixtures.go
@@ -132,3 +132,24 @@ func mockUpdateTenantResponse(t *testing.T) {
 `)
 	})
 }
+
+func mockGetTenantResponse(t *testing.T) {
+	th.Mux.HandleFunc("/tenants/5c62ef576dc7444cbb73b1fe84b97648", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, `
+{
+		"tenant": {
+				"name": "new_tenant",
+				"description": "This is new tenant",
+				"enabled": true,
+				"id": "5c62ef576dc7444cbb73b1fe84b97648"
+		}
+}
+`)
+	})
+}

--- a/openstack/identity/v2/tenants/testing/requests_test.go
+++ b/openstack/identity/v2/tenants/testing/requests_test.go
@@ -92,3 +92,22 @@ func TestUpdateTenant(t *testing.T) {
 
 	th.AssertDeepEquals(t, expected, tenant)
 }
+
+func TestGetTenant(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	mockGetTenantResponse(t)
+
+	tenant, err := tenants.Get(client.ServiceClient(), "5c62ef576dc7444cbb73b1fe84b97648").Extract()
+	th.AssertNoErr(t, err)
+
+	expected := &tenants.Tenant{
+		Name:        "new_tenant",
+		ID:          "5c62ef576dc7444cbb73b1fe84b97648",
+		Description: "This is new tenant",
+		Enabled:     true,
+	}
+
+	th.AssertDeepEquals(t, expected, tenant)
+}

--- a/openstack/identity/v2/tenants/urls.go
+++ b/openstack/identity/v2/tenants/urls.go
@@ -6,6 +6,10 @@ func listURL(client *gophercloud.ServiceClient) string {
 	return client.ServiceURL("tenants")
 }
 
+func getURL(client *gophercloud.ServiceClient, tenantID string) string {
+	return client.ServiceURL("tenants", tenantID)
+}
+
 func createURL(client *gophercloud.ServiceClient) string {
 	return client.ServiceURL("tenants")
 }


### PR DESCRIPTION
For #397

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

get_tenant general implementation
https://github.com/openstack/keystone/blob/5c8dcd2f2f1a7645f93f39c3f5784920e2099998/keystone/identity/core.py#L283

get_tenant sql driver implementation
https://github.com/openstack/keystone/blob/5c8dcd2f2f1a7645f93f39c3f5784920e2099998/keystone/identity/backends/sql.py#L161