### PR TITLE
SharedFileSystems: apiversions package

### DIFF
--- a/openstack/sharedfilesystems/apiversions/doc.go
+++ b/openstack/sharedfilesystems/apiversions/doc.go
@@ -1,0 +1,3 @@
+// Package apiversions provides information and interaction with the different
+// API versions for the Shared File System service, code-named Manila.
+package apiversions

--- a/openstack/sharedfilesystems/apiversions/errors.go
+++ b/openstack/sharedfilesystems/apiversions/errors.go
@@ -1,0 +1,23 @@
+package apiversions
+
+import (
+	"fmt"
+)
+
+// ErrVersionNotFound is the error when the requested API version
+// could not be found.
+type ErrVersionNotFound struct{}
+
+func (e ErrVersionNotFound) Error() string {
+	return fmt.Sprintf("Unable to find requested API version")
+}
+
+// ErrMultipleVersionsFound is the error when a request for an API
+// version returns multiple results.
+type ErrMultipleVersionsFound struct {
+	Count int
+}
+
+func (e ErrMultipleVersionsFound) Error() string {
+	return fmt.Sprintf("Found %d API versions", e.Count)
+}

--- a/openstack/sharedfilesystems/apiversions/requests.go
+++ b/openstack/sharedfilesystems/apiversions/requests.go
@@ -1,0 +1,19 @@
+package apiversions
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// List lists all the API versions available to end-users.
+func List(c *gophercloud.ServiceClient) pagination.Pager {
+	return pagination.NewPager(c, listURL(c), func(r pagination.PageResult) pagination.Page {
+		return APIVersionPage{pagination.SinglePageBase(r)}
+	})
+}
+
+// Get will get a specific API version, specified by major ID.
+func Get(client *gophercloud.ServiceClient, v string) (r GetResult) {
+	_, r.Err = client.Get(getURL(client, v), &r.Body, nil)
+	return
+}

--- a/openstack/sharedfilesystems/apiversions/results.go
+++ b/openstack/sharedfilesystems/apiversions/results.go
@@ -1,0 +1,74 @@
+package apiversions
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// APIVersion represents an API version for the Shared File System service.
+type APIVersion struct {
+	// ID is the unique identifier of the API version.
+	ID string `json:"id"`
+
+	// MinVersion is the minimum microversion supported.
+	MinVersion string `json:"min_version"`
+
+	// Status is the API versions status.
+	Status string `json:"status"`
+
+	// Updated is the date when the API was last updated.
+	Updated time.Time `json:"updated"`
+
+	// Version is the maximum microversion supported.
+	Version string `json:"version"`
+}
+
+// APIVersionPage is the page returned by a pager when traversing over a
+// collection of API versions.
+type APIVersionPage struct {
+	pagination.SinglePageBase
+}
+
+// IsEmpty checks whether an APIVersionPage struct is empty.
+func (r APIVersionPage) IsEmpty() (bool, error) {
+	is, err := ExtractAPIVersions(r)
+	return len(is) == 0, err
+}
+
+// ExtractAPIVersions takes a collection page, extracts all of the elements,
+// and returns them a slice of APIVersion structs. It is effectively a cast.
+func ExtractAPIVersions(r pagination.Page) ([]APIVersion, error) {
+	var s struct {
+		Versions []APIVersion `json:"versions"`
+	}
+	err := (r.(APIVersionPage)).ExtractInto(&s)
+	return s.Versions, err
+}
+
+// GetResult represents the result of a get operation.
+type GetResult struct {
+	gophercloud.Result
+}
+
+// Extract is a function that accepts a result and extracts an API version resource.
+func (r GetResult) Extract() (*APIVersion, error) {
+	var s struct {
+		Versions []APIVersion `json:"versions"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return nil, err
+	}
+
+	switch len(s.Versions) {
+	case 0:
+		return nil, fmt.Errorf("Version not found")
+	case 1:
+		return &s.Versions[0], nil
+	default:
+		return nil, fmt.Errorf("Multiple results found")
+	}
+}

--- a/openstack/sharedfilesystems/apiversions/results.go
+++ b/openstack/sharedfilesystems/apiversions/results.go
@@ -1,7 +1,6 @@
 package apiversions
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/gophercloud/gophercloud"
@@ -65,10 +64,10 @@ func (r GetResult) Extract() (*APIVersion, error) {
 
 	switch len(s.Versions) {
 	case 0:
-		return nil, fmt.Errorf("Version not found")
+		return nil, ErrVersionNotFound{}
 	case 1:
 		return &s.Versions[0], nil
 	default:
-		return nil, fmt.Errorf("Multiple results found")
+		return nil, ErrMultipleVersionsFound{Count: len(s.Versions)}
 	}
 }

--- a/openstack/sharedfilesystems/apiversions/testing/doc.go
+++ b/openstack/sharedfilesystems/apiversions/testing/doc.go
@@ -1,0 +1,2 @@
+// apiversions_v1
+package testing

--- a/openstack/sharedfilesystems/apiversions/testing/fixtures.go
+++ b/openstack/sharedfilesystems/apiversions/testing/fixtures.go
@@ -1,0 +1,140 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gophercloud/gophercloud/openstack/sharedfilesystems/apiversions"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+const ManilaAPIVersionResponse = `
+{
+    "versions": [
+        {
+            "id": "v2.0",
+            "links": [
+                {
+                    "href": "http://docs.openstack.org/",
+                    "rel": "describedby",
+                    "type": "text/html"
+                },
+                {
+                    "href": "http://localhost:8786/v2/",
+                    "rel": "self"
+                }
+            ],
+            "media-types": [
+                {
+                    "base": "application/json",
+                    "type": "application/vnd.openstack.share+json;version=1"
+                }
+            ],
+            "min_version": "2.0",
+            "status": "CURRENT",
+            "updated": "2015-08-27T11:33:21Z",
+            "version": "2.32"
+        }
+    ]
+}
+`
+const ManilaAllAPIVersionsResponse = `
+{
+    "versions": [
+        {
+            "id": "v1.0",
+            "links": [
+                {
+                    "href": "http://docs.openstack.org/",
+                    "rel": "describedby",
+                    "type": "text/html"
+                },
+                {
+                    "href": "http://localhost:8786/v1/",
+                    "rel": "self"
+                }
+            ],
+            "media-types": [
+                {
+                    "base": "application/json",
+                    "type": "application/vnd.openstack.share+json;version=1"
+                }
+            ],
+            "min_version": "",
+            "status": "DEPRECATED",
+            "updated": "2015-08-27T11:33:21Z",
+            "version": ""
+        },
+        {
+            "id": "v2.0",
+            "links": [
+                {
+                    "href": "http://docs.openstack.org/",
+                    "rel": "describedby",
+                    "type": "text/html"
+                },
+                {
+                    "href": "http://localhost:8786/v2/",
+                    "rel": "self"
+                }
+            ],
+            "media-types": [
+                {
+                    "base": "application/json",
+                    "type": "application/vnd.openstack.share+json;version=1"
+                }
+            ],
+            "min_version": "2.0",
+            "status": "CURRENT",
+            "updated": "2015-08-27T11:33:21Z",
+            "version": "2.32"
+        }
+    ]
+}
+`
+
+var ManilaAPIVersion1Result = apiversions.APIVersion{
+	ID:      "v1.0",
+	Status:  "DEPRECATED",
+	Updated: time.Date(2015, 8, 27, 11, 33, 21, 0, time.UTC),
+}
+
+var ManilaAPIVersion2Result = apiversions.APIVersion{
+	ID:         "v2.0",
+	Status:     "CURRENT",
+	Updated:    time.Date(2015, 8, 27, 11, 33, 21, 0, time.UTC),
+	MinVersion: "2.0",
+	Version:    "2.32",
+}
+
+var ManilaAllAPIVersionResults = []apiversions.APIVersion{
+	ManilaAPIVersion1Result,
+	ManilaAPIVersion2Result,
+}
+
+func MockListResponse(t *testing.T) {
+	th.Mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, ManilaAllAPIVersionsResponse)
+	})
+}
+
+func MockGetResponse(t *testing.T) {
+	th.Mux.HandleFunc("/v2/", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, ManilaAPIVersionResponse)
+	})
+}

--- a/openstack/sharedfilesystems/apiversions/testing/fixtures.go
+++ b/openstack/sharedfilesystems/apiversions/testing/fixtures.go
@@ -41,6 +41,69 @@ const ManilaAPIVersionResponse = `
     ]
 }
 `
+
+const ManilaAPIInvalidVersionResponse_1 = `
+{
+    "versions": [
+    ]
+}
+`
+
+const ManilaAPIInvalidVersionResponse_2 = `
+{
+    "versions": [
+        {
+            "id": "v2.0",
+            "links": [
+                {
+                    "href": "http://docs.openstack.org/",
+                    "rel": "describedby",
+                    "type": "text/html"
+                },
+                {
+                    "href": "http://localhost:8786/v2/",
+                    "rel": "self"
+                }
+            ],
+            "media-types": [
+                {
+                    "base": "application/json",
+                    "type": "application/vnd.openstack.share+json;version=1"
+                }
+            ],
+            "min_version": "2.0",
+            "status": "CURRENT",
+            "updated": "2015-08-27T11:33:21Z",
+            "version": "2.32"
+        },
+        {
+            "id": "v2.9",
+            "links": [
+                {
+                    "href": "http://docs.openstack.org/",
+                    "rel": "describedby",
+                    "type": "text/html"
+                },
+                {
+                    "href": "http://localhost:8786/v2/",
+                    "rel": "self"
+                }
+            ],
+            "media-types": [
+                {
+                    "base": "application/json",
+                    "type": "application/vnd.openstack.share+json;version=1"
+                }
+            ],
+            "min_version": "2.9",
+            "status": "CURRENT",
+            "updated": "2015-08-27T11:33:21Z",
+            "version": "2.99"
+        }
+    ]
+}
+`
+
 const ManilaAllAPIVersionsResponse = `
 {
     "versions": [
@@ -136,5 +199,29 @@ func MockGetResponse(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 
 		fmt.Fprintf(w, ManilaAPIVersionResponse)
+	})
+}
+
+func MockGetNoResponse(t *testing.T) {
+	th.Mux.HandleFunc("/v2/", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, ManilaAPIInvalidVersionResponse_1)
+	})
+}
+
+func MockGetMultipleResponses(t *testing.T) {
+	th.Mux.HandleFunc("/v2/", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, ManilaAPIInvalidVersionResponse_2)
 	})
 }

--- a/openstack/sharedfilesystems/apiversions/testing/requests_test.go
+++ b/openstack/sharedfilesystems/apiversions/testing/requests_test.go
@@ -1,0 +1,36 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/sharedfilesystems/apiversions"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func TestListAPIVersions(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockListResponse(t)
+
+	allVersions, err := apiversions.List(client.ServiceClient()).AllPages()
+	th.AssertNoErr(t, err)
+
+	actual, err := apiversions.ExtractAPIVersions(allVersions)
+	th.AssertNoErr(t, err)
+
+	th.AssertDeepEquals(t, ManilaAllAPIVersionResults, actual)
+}
+
+func TestGetAPIVersion(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockGetResponse(t)
+
+	actual, err := apiversions.Get(client.ServiceClient(), "v2").Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertDeepEquals(t, ManilaAPIVersion2Result, *actual)
+}

--- a/openstack/sharedfilesystems/apiversions/testing/requests_test.go
+++ b/openstack/sharedfilesystems/apiversions/testing/requests_test.go
@@ -34,3 +34,23 @@ func TestGetAPIVersion(t *testing.T) {
 
 	th.AssertDeepEquals(t, ManilaAPIVersion2Result, *actual)
 }
+
+func TestGetNoAPIVersion(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockGetNoResponse(t)
+
+	_, err := apiversions.Get(client.ServiceClient(), "v2").Extract()
+	th.AssertEquals(t, err.Error(), "Unable to find requested API version")
+}
+
+func TestGetMultipleAPIVersion(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockGetMultipleResponses(t)
+
+	_, err := apiversions.Get(client.ServiceClient(), "v2").Extract()
+	th.AssertEquals(t, err.Error(), "Found 2 API versions")
+}

--- a/openstack/sharedfilesystems/apiversions/urls.go
+++ b/openstack/sharedfilesystems/apiversions/urls.go
@@ -1,0 +1,20 @@
+package apiversions
+
+import (
+	"net/url"
+	"strings"
+
+	"github.com/gophercloud/gophercloud"
+)
+
+func getURL(c *gophercloud.ServiceClient, version string) string {
+	u, _ := url.Parse(c.ServiceURL(""))
+	u.Path = "/" + strings.TrimRight(version, "/") + "/"
+	return u.String()
+}
+
+func listURL(c *gophercloud.ServiceClient) string {
+	u, _ := url.Parse(c.ServiceURL(""))
+	u.Path = "/"
+	return u.String()
+}


### PR DESCRIPTION
For #408 

@jrperritt There's some discussion here:

https://github.com/jtopjian/gophercloud/commit/5bf58ab1beb18b3220bd0b63f74104a56e1f273e
https://github.com/jtopjian/gophercloud/commit/7f48e23cca311be0fb1796e61bbded54cfefb7d6

This implementation could definitely use some critique when you have time.

Should proper error types be created?

The most notable oddity is that when retrieving a major version, an array is returned. I can't see why more than one result would be returned, but is that a safe assumption?

If it's best to handle multiple results, then this gets a little weird. The way I see it, a Get should be treated like a List and there should then be some convenience functions to extract the best result (or specify the type of result). But since there's no example of what multiple results would look like, it's really hard to think ahead.

/cc @pospispa