### PR TITLE
Allows a user with privilege to list servers for any particular tenant

### DIFF
--- a/openstack/compute/v2/servers/requests.go
+++ b/openstack/compute/v2/servers/requests.go
@@ -50,6 +50,9 @@ type ListOpts struct {
 
 	// Bool to show all tenants
 	AllTenants bool `q:"all_tenants"`
+
+	// List servers for a particular tenant. Setting "AllTenants = true" is required.
+	TenantID string `q:"tenant_id"`
 }
 
 // ToServerListQuery formats a ListOpts into a query string.


### PR DESCRIPTION
A very simple change that allows listing of servers for any particular tenant.

Issue #410

Here is how the server listing would work:
```
serverOpts := servers.ListOpts{AllTenants: true, TenantID: <tenant-id>}
pager := servers.List(client, serverOpts)
```

