### PR TITLE
Add Cinder V3 and MicroVersion Support

### DIFF
--- a/acceptance/clients/clients.go
+++ b/acceptance/clients/clients.go
@@ -147,6 +147,25 @@ func NewBlockStorageV2Client() (*gophercloud.ServiceClient, error) {
 	})
 }
 
+// NewBlockStorageV3Client returns a *ServiceClient for making calls
+// to the OpenStack Block Storage v3 API. An error will be returned
+// if authentication or client creation was not possible.
+func NewBlockStorageV3Client() (*gophercloud.ServiceClient, error) {
+	ao, err := openstack.AuthOptionsFromEnv()
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := openstack.AuthenticatedClient(ao)
+	if err != nil {
+		return nil, err
+	}
+
+	return openstack.NewBlockStorageV3(client, gophercloud.EndpointOpts{
+		Region: os.Getenv("OS_REGION_NAME"),
+	})
+}
+
 // NewBlockStorageV2NoAuthClient returns a noauth *ServiceClient for
 // making calls to the OpenStack Block Storage v2 API. An error will be
 // returned if client creation was not possible.
@@ -159,7 +178,24 @@ func NewBlockStorageV2NoAuthClient() (*gophercloud.ServiceClient, error) {
 		return nil, err
 	}
 
-	return noauth.NewBlockStorageV2(client, noauth.EndpointOpts{
+	return noauth.NewBlockStorageNoAuth(client, noauth.EndpointOpts{
+		CinderEndpoint: os.Getenv("CINDER_ENDPOINT"),
+	})
+}
+
+// NewBlockStorageV3NoAuthClient returns a noauth *ServiceClient for
+// making calls to the OpenStack Block Storage v2 API. An error will be
+// returned if client creation was not possible.
+func NewBlockStorageV3NoAuthClient() (*gophercloud.ServiceClient, error) {
+	client, err := noauth.NewClient(gophercloud.AuthOptions{
+		Username:   os.Getenv("OS_USERNAME"),
+		TenantName: os.Getenv("OS_TENANT_NAME"),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return noauth.NewBlockStorageNoAuth(client, noauth.EndpointOpts{
 		CinderEndpoint: os.Getenv("CINDER_ENDPOINT"),
 	})
 }

--- a/openstack/blockstorage/noauth/doc.go
+++ b/openstack/blockstorage/noauth/doc.go
@@ -8,7 +8,7 @@ Example of Creating a noauth Service Client
 		Username:   os.Getenv("OS_USERNAME"),
 		TenantName: os.Getenv("OS_TENANT_NAME"),
 	})
-	client, err := noauth.NewBlockStorageV2(provider, noauth.EndpointOpts{
+	client, err := noauth.NewBlockStorageNoAuth(provider, noauth.EndpointOpts{
 		CinderEndpoint: os.Getenv("CINDER_ENDPOINT"),
 	})
 

--- a/openstack/blockstorage/noauth/requests.go
+++ b/openstack/blockstorage/noauth/requests.go
@@ -48,8 +48,8 @@ func initClientOpts(client *gophercloud.ProviderClient, eo EndpointOpts) (*gophe
 	return sc, nil
 }
 
-// NewBlockStorageV2 creates a ServiceClient that may be used to access a
-// "noauth" block storage service.
-func NewBlockStorageV2(client *gophercloud.ProviderClient, eo EndpointOpts) (*gophercloud.ServiceClient, error) {
+// NewBlockStorageNoAuth creates a ServiceClient that may be used to access a
+// "noauth" block storage service (V2 or V3 Cinder API).
+func NewBlockStorageNoAuth(client *gophercloud.ProviderClient, eo EndpointOpts) (*gophercloud.ServiceClient, error) {
 	return initClientOpts(client, eo)
 }

--- a/openstack/blockstorage/noauth/testing/requests_test.go
+++ b/openstack/blockstorage/noauth/testing/requests_test.go
@@ -15,7 +15,7 @@ func TestNoAuth(t *testing.T) {
 	}
 	provider, err := noauth.NewClient(ao)
 	th.AssertNoErr(t, err)
-	noauthClient, err := noauth.NewBlockStorageV2(provider, noauth.EndpointOpts{
+	noauthClient, err := noauth.NewBlockStorageNoAuth(provider, noauth.EndpointOpts{
 		CinderEndpoint: "http://cinder:8776/v2",
 	})
 	th.AssertNoErr(t, err)
@@ -25,14 +25,14 @@ func TestNoAuth(t *testing.T) {
 	ao2 := gophercloud.AuthOptions{}
 	provider2, err := noauth.NewClient(ao2)
 	th.AssertNoErr(t, err)
-	noauthClient2, err := noauth.NewBlockStorageV2(provider2, noauth.EndpointOpts{
+	noauthClient2, err := noauth.NewBlockStorageNoAuth(provider2, noauth.EndpointOpts{
 		CinderEndpoint: "http://cinder:8776/v2/",
 	})
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, naResult.Endpoint, noauthClient2.Endpoint)
 	th.AssertEquals(t, naResult.TokenID, noauthClient2.TokenID)
 
-	errTest, err := noauth.NewBlockStorageV2(provider2, noauth.EndpointOpts{})
+	errTest, err := noauth.NewBlockStorageNoAuth(provider2, noauth.EndpointOpts{})
 	_ = errTest
 	th.AssertEquals(t, errorResult, err.Error())
 }

--- a/openstack/blockstorage/v3/snapshots/doc.go
+++ b/openstack/blockstorage/v3/snapshots/doc.go
@@ -1,0 +1,5 @@
+// Package snapshots provides information and interaction with snapshots in the
+// OpenStack Block Storage service. A snapshot is a point in time copy of the
+// data contained in an external storage volume, and can be controlled
+// programmatically.
+package snapshots

--- a/openstack/blockstorage/v3/snapshots/requests.go
+++ b/openstack/blockstorage/v3/snapshots/requests.go
@@ -1,0 +1,158 @@
+package snapshots
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToSnapshotCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts contains options for creating a Snapshot. This object is passed to
+// the snapshots.Create function. For more information about these parameters,
+// see the Snapshot object.
+type CreateOpts struct {
+	VolumeID    string            `json:"volume_id" required:"true"`
+	Force       bool              `json:"force,omitempty"`
+	Name        string            `json:"name,omitempty"`
+	Description string            `json:"description,omitempty"`
+	Metadata    map[string]string `json:"metadata,omitempty"`
+}
+
+// ToSnapshotCreateMap assembles a request body based on the contents of a
+// CreateOpts.
+func (opts CreateOpts) ToSnapshotCreateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "snapshot")
+}
+
+// Create will create a new Snapshot based on the values in CreateOpts. To
+// extract the Snapshot object from the response, call the Extract method on the
+// CreateResult.
+func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToSnapshotCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(createURL(client), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+	})
+	return
+}
+
+// Delete will delete the existing Snapshot with the provided ID.
+func Delete(client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+	_, r.Err = client.Delete(deleteURL(client, id), nil)
+	return
+}
+
+// Get retrieves the Snapshot with the provided ID. To extract the Snapshot
+// object from the response, call the Extract method on the GetResult.
+func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {
+	_, r.Err = client.Get(getURL(client, id), &r.Body, nil)
+	return
+}
+
+// ListOptsBuilder allows extensions to add additional parameters to the List
+// request.
+type ListOptsBuilder interface {
+	ToSnapshotListQuery() (string, error)
+}
+
+// ListOpts hold options for listing Snapshots. It is passed to the
+// snapshots.List function.
+type ListOpts struct {
+	Name     string `q:"name"`
+	Status   string `q:"status"`
+	VolumeID string `q:"volume_id"`
+}
+
+// ToSnapshotListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToSnapshotListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List returns Snapshots optionally limited by the conditions provided in
+// ListOpts.
+func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(client)
+	if opts != nil {
+		query, err := opts.ToSnapshotListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return SnapshotPage{pagination.SinglePageBase(r)}
+	})
+}
+
+// UpdateMetadataOptsBuilder allows extensions to add additional parameters to
+// the Update request.
+type UpdateMetadataOptsBuilder interface {
+	ToSnapshotUpdateMetadataMap() (map[string]interface{}, error)
+}
+
+// UpdateMetadataOpts contain options for updating an existing Snapshot. This
+// object is passed to the snapshots.Update function. For more information
+// about the parameters, see the Snapshot object.
+type UpdateMetadataOpts struct {
+	Metadata map[string]interface{} `json:"metadata,omitempty"`
+}
+
+// ToSnapshotUpdateMetadataMap assembles a request body based on the contents of
+// an UpdateMetadataOpts.
+func (opts UpdateMetadataOpts) ToSnapshotUpdateMetadataMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "")
+}
+
+// UpdateMetadata will update the Snapshot with provided information. To
+// extract the updated Snapshot from the response, call the ExtractMetadata
+// method on the UpdateMetadataResult.
+func UpdateMetadata(client *gophercloud.ServiceClient, id string, opts UpdateMetadataOptsBuilder) (r UpdateMetadataResult) {
+	b, err := opts.ToSnapshotUpdateMetadataMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Put(updateMetadataURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// IDFromName is a convienience function that returns a snapshot's ID given its name.
+func IDFromName(client *gophercloud.ServiceClient, name string) (string, error) {
+	count := 0
+	id := ""
+	pages, err := List(client, nil).AllPages()
+	if err != nil {
+		return "", err
+	}
+
+	all, err := ExtractSnapshots(pages)
+	if err != nil {
+		return "", err
+	}
+
+	for _, s := range all {
+		if s.Name == name {
+			count++
+			id = s.ID
+		}
+	}
+
+	switch count {
+	case 0:
+		return "", gophercloud.ErrResourceNotFound{Name: name, ResourceType: "snapshot"}
+	case 1:
+		return id, nil
+	default:
+		return "", gophercloud.ErrMultipleResourcesFound{Name: name, Count: count, ResourceType: "snapshot"}
+	}
+}

--- a/openstack/blockstorage/v3/snapshots/results.go
+++ b/openstack/blockstorage/v3/snapshots/results.go
@@ -1,0 +1,121 @@
+package snapshots
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// Snapshot contains all the information associated with a Cinder Snapshot.
+type Snapshot struct {
+	// Unique identifier.
+	ID string `json:"id"`
+
+	// Date created.
+	CreatedAt time.Time `json:"-"`
+
+	// Date updated.
+	UpdatedAt time.Time `json:"-"`
+
+	// Display name.
+	Name string `json:"name"`
+
+	// Display description.
+	Description string `json:"description"`
+
+	// ID of the Volume from which this Snapshot was created.
+	VolumeID string `json:"volume_id"`
+
+	// Currect status of the Snapshot.
+	Status string `json:"status"`
+
+	// Size of the Snapshot, in GB.
+	Size int `json:"size"`
+
+	// User-defined key-value pairs.
+	Metadata map[string]string `json:"metadata"`
+}
+
+// CreateResult contains the response body and error from a Create request.
+type CreateResult struct {
+	commonResult
+}
+
+// GetResult contains the response body and error from a Get request.
+type GetResult struct {
+	commonResult
+}
+
+// DeleteResult contains the response body and error from a Delete request.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
+// SnapshotPage is a pagination.Pager that is returned from a call to the List function.
+type SnapshotPage struct {
+	pagination.SinglePageBase
+}
+
+// UnmarshalJSON converts our JSON API response into our snapshot struct
+func (r *Snapshot) UnmarshalJSON(b []byte) error {
+	type tmp Snapshot
+	var s struct {
+		tmp
+		CreatedAt gophercloud.JSONRFC3339MilliNoZ `json:"created_at"`
+		UpdatedAt gophercloud.JSONRFC3339MilliNoZ `json:"updated_at"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	*r = Snapshot(s.tmp)
+
+	r.CreatedAt = time.Time(s.CreatedAt)
+	r.UpdatedAt = time.Time(s.UpdatedAt)
+
+	return err
+}
+
+// IsEmpty returns true if a SnapshotPage contains no Snapshots.
+func (r SnapshotPage) IsEmpty() (bool, error) {
+	volumes, err := ExtractSnapshots(r)
+	return len(volumes) == 0, err
+}
+
+// ExtractSnapshots extracts and returns Snapshots. It is used while iterating over a snapshots.List call.
+func ExtractSnapshots(r pagination.Page) ([]Snapshot, error) {
+	var s struct {
+		Snapshots []Snapshot `json:"snapshots"`
+	}
+	err := (r.(SnapshotPage)).ExtractInto(&s)
+	return s.Snapshots, err
+}
+
+// UpdateMetadataResult contains the response body and error from an UpdateMetadata request.
+type UpdateMetadataResult struct {
+	commonResult
+}
+
+// ExtractMetadata returns the metadata from a response from snapshots.UpdateMetadata.
+func (r UpdateMetadataResult) ExtractMetadata() (map[string]interface{}, error) {
+	if r.Err != nil {
+		return nil, r.Err
+	}
+	m := r.Body.(map[string]interface{})["metadata"]
+	return m.(map[string]interface{}), nil
+}
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// Extract will get the Snapshot object out of the commonResult object.
+func (r commonResult) Extract() (*Snapshot, error) {
+	var s struct {
+		Snapshot *Snapshot `json:"snapshot"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Snapshot, err
+}

--- a/openstack/blockstorage/v3/snapshots/testing/doc.go
+++ b/openstack/blockstorage/v3/snapshots/testing/doc.go
@@ -1,0 +1,2 @@
+// snapshots_v3
+package testing

--- a/openstack/blockstorage/v3/snapshots/testing/fixtures.go
+++ b/openstack/blockstorage/v3/snapshots/testing/fixtures.go
@@ -1,0 +1,134 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	th "github.com/gophercloud/gophercloud/testhelper"
+	fake "github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func MockListResponse(t *testing.T) {
+	th.Mux.HandleFunc("/snapshots", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, `
+    {
+      "snapshots": [
+        {
+          "id": "289da7f8-6440-407c-9fb4-7db01ec49164",
+          "name": "snapshot-001",
+          "volume_id": "521752a6-acf6-4b2d-bc7a-119f9148cd8c",
+          "description": "Daily Backup",
+          "status": "available",
+          "size": 30,
+		  "created_at": "2017-05-30T03:35:03.000000"
+        },
+        {
+          "id": "96c3bda7-c82a-4f50-be73-ca7621794835",
+          "name": "snapshot-002",
+          "volume_id": "76b8950a-8594-4e5b-8dce-0dfa9c696358",
+          "description": "Weekly Backup",
+          "status": "available",
+          "size": 25,
+		  "created_at": "2017-05-30T03:35:03.000000"
+        }
+      ]
+    }
+    `)
+	})
+}
+
+func MockGetResponse(t *testing.T) {
+	th.Mux.HandleFunc("/snapshots/d32019d3-bc6e-4319-9c1d-6722fc136a22", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, `
+{
+    "snapshot": {
+        "id": "d32019d3-bc6e-4319-9c1d-6722fc136a22",
+        "name": "snapshot-001",
+        "description": "Daily backup",
+        "volume_id": "521752a6-acf6-4b2d-bc7a-119f9148cd8c",
+        "status": "available",
+        "size": 30,
+		"created_at": "2017-05-30T03:35:03.000000"
+    }
+}
+      `)
+	})
+}
+
+func MockCreateResponse(t *testing.T) {
+	th.Mux.HandleFunc("/snapshots", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, `
+{
+    "snapshot": {
+        "volume_id": "1234",
+        "name": "snapshot-001"
+    }
+}
+      `)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+
+		fmt.Fprintf(w, `
+{
+    "snapshot": {
+        "volume_id": "1234",
+        "name": "snapshot-001",
+        "id": "d32019d3-bc6e-4319-9c1d-6722fc136a22",
+        "description": "Daily backup",
+        "volume_id": "1234",
+        "status": "available",
+        "size": 30,
+		"created_at": "2017-05-30T03:35:03.000000"
+  }
+}
+    `)
+	})
+}
+
+func MockUpdateMetadataResponse(t *testing.T) {
+	th.Mux.HandleFunc("/snapshots/123/metadata", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestJSONRequest(t, r, `
+    {
+      "metadata": {
+        "key": "v1"
+      }
+    }
+    `)
+
+		fmt.Fprintf(w, `
+      {
+        "metadata": {
+          "key": "v1"
+        }
+      }
+    `)
+	})
+}
+
+func MockDeleteResponse(t *testing.T) {
+	th.Mux.HandleFunc("/snapshots/d32019d3-bc6e-4319-9c1d-6722fc136a22", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.WriteHeader(http.StatusNoContent)
+	})
+}

--- a/openstack/blockstorage/v3/snapshots/testing/requests_test.go
+++ b/openstack/blockstorage/v3/snapshots/testing/requests_test.go
@@ -1,0 +1,116 @@
+package testing
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/snapshots"
+	"github.com/gophercloud/gophercloud/pagination"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func TestList(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockListResponse(t)
+
+	count := 0
+
+	snapshots.List(client.ServiceClient(), &snapshots.ListOpts{}).EachPage(func(page pagination.Page) (bool, error) {
+		count++
+		actual, err := snapshots.ExtractSnapshots(page)
+		if err != nil {
+			t.Errorf("Failed to extract snapshots: %v", err)
+			return false, err
+		}
+
+		expected := []snapshots.Snapshot{
+			{
+				ID:          "289da7f8-6440-407c-9fb4-7db01ec49164",
+				Name:        "snapshot-001",
+				VolumeID:    "521752a6-acf6-4b2d-bc7a-119f9148cd8c",
+				Status:      "available",
+				Size:        30,
+				CreatedAt:   time.Date(2017, 5, 30, 3, 35, 3, 0, time.UTC),
+				Description: "Daily Backup",
+			},
+			{
+				ID:          "96c3bda7-c82a-4f50-be73-ca7621794835",
+				Name:        "snapshot-002",
+				VolumeID:    "76b8950a-8594-4e5b-8dce-0dfa9c696358",
+				Status:      "available",
+				Size:        25,
+				CreatedAt:   time.Date(2017, 5, 30, 3, 35, 3, 0, time.UTC),
+				Description: "Weekly Backup",
+			},
+		}
+
+		th.CheckDeepEquals(t, expected, actual)
+
+		return true, nil
+	})
+
+	if count != 1 {
+		t.Errorf("Expected 1 page, got %d", count)
+	}
+}
+
+func TestGet(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockGetResponse(t)
+
+	v, err := snapshots.Get(client.ServiceClient(), "d32019d3-bc6e-4319-9c1d-6722fc136a22").Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, v.Name, "snapshot-001")
+	th.AssertEquals(t, v.ID, "d32019d3-bc6e-4319-9c1d-6722fc136a22")
+}
+
+func TestCreate(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockCreateResponse(t)
+
+	options := snapshots.CreateOpts{VolumeID: "1234", Name: "snapshot-001"}
+	n, err := snapshots.Create(client.ServiceClient(), options).Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, n.VolumeID, "1234")
+	th.AssertEquals(t, n.Name, "snapshot-001")
+	th.AssertEquals(t, n.ID, "d32019d3-bc6e-4319-9c1d-6722fc136a22")
+}
+
+func TestUpdateMetadata(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockUpdateMetadataResponse(t)
+
+	expected := map[string]interface{}{"key": "v1"}
+
+	options := &snapshots.UpdateMetadataOpts{
+		Metadata: map[string]interface{}{
+			"key": "v1",
+		},
+	}
+
+	actual, err := snapshots.UpdateMetadata(client.ServiceClient(), "123", options).ExtractMetadata()
+
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, actual, expected)
+}
+
+func TestDelete(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockDeleteResponse(t)
+
+	res := snapshots.Delete(client.ServiceClient(), "d32019d3-bc6e-4319-9c1d-6722fc136a22")
+	th.AssertNoErr(t, res.Err)
+}

--- a/openstack/blockstorage/v3/snapshots/urls.go
+++ b/openstack/blockstorage/v3/snapshots/urls.go
@@ -1,0 +1,27 @@
+package snapshots
+
+import "github.com/gophercloud/gophercloud"
+
+func createURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("snapshots")
+}
+
+func deleteURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("snapshots", id)
+}
+
+func getURL(c *gophercloud.ServiceClient, id string) string {
+	return deleteURL(c, id)
+}
+
+func listURL(c *gophercloud.ServiceClient) string {
+	return createURL(c)
+}
+
+func metadataURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("snapshots", id, "metadata")
+}
+
+func updateMetadataURL(c *gophercloud.ServiceClient, id string) string {
+	return metadataURL(c, id)
+}

--- a/openstack/blockstorage/v3/snapshots/util.go
+++ b/openstack/blockstorage/v3/snapshots/util.go
@@ -1,0 +1,22 @@
+package snapshots
+
+import (
+	"github.com/gophercloud/gophercloud"
+)
+
+// WaitForStatus will continually poll the resource, checking for a particular
+// status. It will do this for the amount of seconds defined.
+func WaitForStatus(c *gophercloud.ServiceClient, id, status string, secs int) error {
+	return gophercloud.WaitFor(secs, func() (bool, error) {
+		current, err := Get(c, id).Extract()
+		if err != nil {
+			return false, err
+		}
+
+		if current.Status == status {
+			return true, nil
+		}
+
+		return false, nil
+	})
+}

--- a/openstack/blockstorage/v3/volumes/doc.go
+++ b/openstack/blockstorage/v3/volumes/doc.go
@@ -1,0 +1,5 @@
+// Package volumes provides information and interaction with volumes in the
+// OpenStack Block Storage service. A volume is a detachable block storage
+// device, akin to a USB hard drive. It can only be attached to one instance at
+// a time.
+package volumes

--- a/openstack/blockstorage/v3/volumes/requests.go
+++ b/openstack/blockstorage/v3/volumes/requests.go
@@ -1,0 +1,182 @@
+package volumes
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToVolumeCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts contains options for creating a Volume. This object is passed to
+// the volumes.Create function. For more information about these parameters,
+// see the Volume object.
+type CreateOpts struct {
+	// The size of the volume, in GB
+	Size int `json:"size" required:"true"`
+	// The availability zone
+	AvailabilityZone string `json:"availability_zone,omitempty"`
+	// ConsistencyGroupID is the ID of a consistency group
+	ConsistencyGroupID string `json:"consistencygroup_id,omitempty"`
+	// The volume description
+	Description string `json:"description,omitempty"`
+	// One or more metadata key and value pairs to associate with the volume
+	Metadata map[string]string `json:"metadata,omitempty"`
+	// The volume name
+	Name string `json:"name,omitempty"`
+	// the ID of the existing volume snapshot
+	SnapshotID string `json:"snapshot_id,omitempty"`
+	// SourceReplica is a UUID of an existing volume to replicate with
+	SourceReplica string `json:"source_replica,omitempty"`
+	// the ID of the existing volume
+	SourceVolID string `json:"source_volid,omitempty"`
+	// The ID of the image from which you want to create the volume.
+	// Required to create a bootable volume.
+	ImageID string `json:"imageRef,omitempty"`
+	// The associated volume type
+	VolumeType string `json:"volume_type,omitempty"`
+}
+
+// ToVolumeCreateMap assembles a request body based on the contents of a
+// CreateOpts.
+func (opts CreateOpts) ToVolumeCreateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "volume")
+}
+
+// Create will create a new Volume based on the values in CreateOpts. To extract
+// the Volume object from the response, call the Extract method on the
+// CreateResult.
+func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToVolumeCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(createURL(client), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+	})
+	return
+}
+
+// Delete will delete the existing Volume with the provided ID.
+func Delete(client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+	_, r.Err = client.Delete(deleteURL(client, id), nil)
+	return
+}
+
+// Get retrieves the Volume with the provided ID. To extract the Volume object
+// from the response, call the Extract method on the GetResult.
+func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {
+	_, r.Err = client.Get(getURL(client, id), &r.Body, nil)
+	return
+}
+
+// ListOptsBuilder allows extensions to add additional parameters to the List
+// request.
+type ListOptsBuilder interface {
+	ToVolumeListQuery() (string, error)
+}
+
+// ListOpts holds options for listing Volumes. It is passed to the volumes.List
+// function.
+type ListOpts struct {
+	// admin-only option. Set it to true to see all tenant volumes.
+	AllTenants bool `q:"all_tenants"`
+	// List only volumes that contain Metadata.
+	Metadata map[string]string `q:"metadata"`
+	// List only volumes that have Name as the display name.
+	Name string `q:"name"`
+	// List only volumes that have a status of Status.
+	Status string `q:"status"`
+}
+
+// ToVolumeListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToVolumeListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List returns Volumes optionally limited by the conditions provided in ListOpts.
+func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(client)
+	if opts != nil {
+		query, err := opts.ToVolumeListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return VolumePage{pagination.SinglePageBase(r)}
+	})
+}
+
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
+type UpdateOptsBuilder interface {
+	ToVolumeUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts contain options for updating an existing Volume. This object is passed
+// to the volumes.Update function. For more information about the parameters, see
+// the Volume object.
+type UpdateOpts struct {
+	Name        string            `json:"name,omitempty"`
+	Description string            `json:"description,omitempty"`
+	Metadata    map[string]string `json:"metadata,omitempty"`
+}
+
+// ToVolumeUpdateMap assembles a request body based on the contents of an
+// UpdateOpts.
+func (opts UpdateOpts) ToVolumeUpdateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "volume")
+}
+
+// Update will update the Volume with provided information. To extract the updated
+// Volume from the response, call the Extract method on the UpdateResult.
+func Update(client *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToVolumeUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Put(updateURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// IDFromName is a convienience function that returns a server's ID given its name.
+func IDFromName(client *gophercloud.ServiceClient, name string) (string, error) {
+	count := 0
+	id := ""
+	pages, err := List(client, nil).AllPages()
+	if err != nil {
+		return "", err
+	}
+
+	all, err := ExtractVolumes(pages)
+	if err != nil {
+		return "", err
+	}
+
+	for _, s := range all {
+		if s.Name == name {
+			count++
+			id = s.ID
+		}
+	}
+
+	switch count {
+	case 0:
+		return "", gophercloud.ErrResourceNotFound{Name: name, ResourceType: "volume"}
+	case 1:
+		return id, nil
+	default:
+		return "", gophercloud.ErrMultipleResourcesFound{Name: name, Count: count, ResourceType: "volume"}
+	}
+}

--- a/openstack/blockstorage/v3/volumes/results.go
+++ b/openstack/blockstorage/v3/volumes/results.go
@@ -1,0 +1,159 @@
+package volumes
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// Attachment represents a Volume Attachment record
+type Attachment struct {
+	AttachedAt   time.Time `json:"-"`
+	AttachmentID string    `json:"attachment_id"`
+	Device       string    `json:"device"`
+	HostName     string    `json:"host_name"`
+	ID           string    `json:"id"`
+	ServerID     string    `json:"server_id"`
+	VolumeID     string    `json:"volume_id"`
+}
+
+// UnmarshalJSON is our unmarshalling helper
+func (r *Attachment) UnmarshalJSON(b []byte) error {
+	type tmp Attachment
+	var s struct {
+		tmp
+		AttachedAt gophercloud.JSONRFC3339MilliNoZ `json:"attached_at"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	*r = Attachment(s.tmp)
+
+	r.AttachedAt = time.Time(s.AttachedAt)
+
+	return err
+}
+
+// Volume contains all the information associated with an OpenStack Volume.
+type Volume struct {
+	// Unique identifier for the volume.
+	ID string `json:"id"`
+	// Current status of the volume.
+	Status string `json:"status"`
+	// Size of the volume in GB.
+	Size int `json:"size"`
+	// AvailabilityZone is which availability zone the volume is in.
+	AvailabilityZone string `json:"availability_zone"`
+	// The date when this volume was created.
+	CreatedAt time.Time `json:"-"`
+	// The date when this volume was last updated
+	UpdatedAt time.Time `json:"-"`
+	// Instances onto which the volume is attached.
+	Attachments []Attachment `json:"attachments"`
+	// Human-readable display name for the volume.
+	Name string `json:"name"`
+	// Human-readable description for the volume.
+	Description string `json:"description"`
+	// The type of volume to create, either SATA or SSD.
+	VolumeType string `json:"volume_type"`
+	// The ID of the snapshot from which the volume was created
+	SnapshotID string `json:"snapshot_id"`
+	// The ID of another block storage volume from which the current volume was created
+	SourceVolID string `json:"source_volid"`
+	// Arbitrary key-value pairs defined by the user.
+	Metadata map[string]string `json:"metadata"`
+	// UserID is the id of the user who created the volume.
+	UserID string `json:"user_id"`
+	// Indicates whether this is a bootable volume.
+	Bootable string `json:"bootable"`
+	// Encrypted denotes if the volume is encrypted.
+	Encrypted bool `json:"encrypted"`
+	// ReplicationStatus is the status of replication.
+	ReplicationStatus string `json:"replication_status"`
+	// ConsistencyGroupID is the consistency group ID.
+	ConsistencyGroupID string `json:"consistencygroup_id"`
+	// Multiattach denotes if the volume is multi-attach capable.
+	Multiattach bool `json:"multiattach"`
+}
+
+// UnmarshalJSON another unmarshalling function
+func (r *Volume) UnmarshalJSON(b []byte) error {
+	type tmp Volume
+	var s struct {
+		tmp
+		CreatedAt gophercloud.JSONRFC3339MilliNoZ `json:"created_at"`
+		UpdatedAt gophercloud.JSONRFC3339MilliNoZ `json:"updated_at"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	*r = Volume(s.tmp)
+
+	r.CreatedAt = time.Time(s.CreatedAt)
+	r.UpdatedAt = time.Time(s.UpdatedAt)
+
+	return err
+}
+
+// VolumePage is a pagination.pager that is returned from a call to the List function.
+type VolumePage struct {
+	pagination.SinglePageBase
+}
+
+// IsEmpty returns true if a ListResult contains no Volumes.
+func (r VolumePage) IsEmpty() (bool, error) {
+	volumes, err := ExtractVolumes(r)
+	return len(volumes) == 0, err
+}
+
+// ExtractVolumes extracts and returns Volumes. It is used while iterating over a volumes.List call.
+func ExtractVolumes(r pagination.Page) ([]Volume, error) {
+	var s []Volume
+	err := ExtractVolumesInto(r, &s)
+	return s, err
+}
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// Extract will get the Volume object out of the commonResult object.
+func (r commonResult) Extract() (*Volume, error) {
+	var s Volume
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+// ExtractInto converts our response data into a volume struct
+func (r commonResult) ExtractInto(v interface{}) error {
+	return r.Result.ExtractIntoStructPtr(v, "volume")
+}
+
+// ExtractVolumesInto similar to ExtractInto but operates on a `list` of volumes
+func ExtractVolumesInto(r pagination.Page, v interface{}) error {
+	return r.(VolumePage).Result.ExtractIntoSlicePtr(v, "volumes")
+}
+
+// CreateResult contains the response body and error from a Create request.
+type CreateResult struct {
+	commonResult
+}
+
+// GetResult contains the response body and error from a Get request.
+type GetResult struct {
+	commonResult
+}
+
+// UpdateResult contains the response body and error from an Update request.
+type UpdateResult struct {
+	commonResult
+}
+
+// DeleteResult contains the response body and error from a Delete request.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}

--- a/openstack/blockstorage/v3/volumes/testing/doc.go
+++ b/openstack/blockstorage/v3/volumes/testing/doc.go
@@ -1,0 +1,2 @@
+// volumes_v3
+package testing

--- a/openstack/blockstorage/v3/volumes/testing/fixtures.go
+++ b/openstack/blockstorage/v3/volumes/testing/fixtures.go
@@ -1,0 +1,203 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	th "github.com/gophercloud/gophercloud/testhelper"
+	fake "github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func MockListResponse(t *testing.T) {
+	th.Mux.HandleFunc("/volumes/detail", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, `
+  {
+  "volumes": [
+    {
+      "volume_type": "lvmdriver-1",
+      "created_at": "2015-09-17T03:35:03.000000",
+      "bootable": "false",
+      "name": "vol-001",
+      "os-vol-mig-status-attr:name_id": null,
+      "consistencygroup_id": null,
+      "source_volid": null,
+      "os-volume-replication:driver_data": null,
+      "multiattach": false,
+      "snapshot_id": null,
+      "replication_status": "disabled",
+      "os-volume-replication:extended_status": null,
+      "encrypted": false,
+      "os-vol-host-attr:host": null,
+      "availability_zone": "nova",
+      "attachments": [{
+        "server_id": "83ec2e3b-4321-422b-8706-a84185f52a0a",
+        "attachment_id": "05551600-a936-4d4a-ba42-79a037c1-c91a",
+        "attached_at": "2016-08-06T14:48:20.000000",
+        "host_name": "foobar",
+        "volume_id": "d6cacb1a-8b59-4c88-ad90-d70ebb82bb75",
+        "device": "/dev/vdc",
+        "id": "d6cacb1a-8b59-4c88-ad90-d70ebb82bb75"
+      }],
+      "id": "289da7f8-6440-407c-9fb4-7db01ec49164",
+      "size": 75,
+      "user_id": "ff1ce52c03ab433aaba9108c2e3ef541",
+      "os-vol-tenant-attr:tenant_id": "304dc00909ac4d0da6c62d816bcb3459",
+      "os-vol-mig-status-attr:migstat": null,
+      "metadata": {"foo": "bar"},
+      "status": "available",
+      "description": null
+    },
+    {
+      "volume_type": "lvmdriver-1",
+      "created_at": "2015-09-17T03:32:29.000000",
+      "bootable": "false",
+      "name": "vol-002",
+      "os-vol-mig-status-attr:name_id": null,
+      "consistencygroup_id": null,
+      "source_volid": null,
+      "os-volume-replication:driver_data": null,
+      "multiattach": false,
+      "snapshot_id": null,
+      "replication_status": "disabled",
+      "os-volume-replication:extended_status": null,
+      "encrypted": false,
+      "os-vol-host-attr:host": null,
+      "availability_zone": "nova",
+      "attachments": [],
+      "id": "96c3bda7-c82a-4f50-be73-ca7621794835",
+      "size": 75,
+      "user_id": "ff1ce52c03ab433aaba9108c2e3ef541",
+      "os-vol-tenant-attr:tenant_id": "304dc00909ac4d0da6c62d816bcb3459",
+      "os-vol-mig-status-attr:migstat": null,
+      "metadata": {},
+      "status": "available",
+      "description": null
+    }
+  ]
+}
+  `)
+	})
+}
+
+func MockGetResponse(t *testing.T) {
+	th.Mux.HandleFunc("/volumes/d32019d3-bc6e-4319-9c1d-6722fc136a22", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, `
+{
+  "volume": {
+    "volume_type": "lvmdriver-1",
+    "created_at": "2015-09-17T03:32:29.000000",
+    "bootable": "false",
+    "name": "vol-001",
+    "os-vol-mig-status-attr:name_id": null,
+    "consistencygroup_id": null,
+    "source_volid": null,
+    "os-volume-replication:driver_data": null,
+    "multiattach": false,
+    "snapshot_id": null,
+    "replication_status": "disabled",
+    "os-volume-replication:extended_status": null,
+    "encrypted": false,
+    "os-vol-host-attr:host": null,
+    "availability_zone": "nova",
+    "attachments": [{
+      "server_id": "83ec2e3b-4321-422b-8706-a84185f52a0a",
+      "attachment_id": "05551600-a936-4d4a-ba42-79a037c1-c91a",
+      "attached_at": "2016-08-06T14:48:20.000000",
+      "host_name": "foobar",
+      "volume_id": "d6cacb1a-8b59-4c88-ad90-d70ebb82bb75",
+      "device": "/dev/vdc",
+      "id": "d6cacb1a-8b59-4c88-ad90-d70ebb82bb75"
+    }],
+    "id": "d32019d3-bc6e-4319-9c1d-6722fc136a22",
+    "size": 75,
+    "user_id": "ff1ce52c03ab433aaba9108c2e3ef541",
+    "os-vol-tenant-attr:tenant_id": "304dc00909ac4d0da6c62d816bcb3459",
+    "os-vol-mig-status-attr:migstat": null,
+    "metadata": {},
+    "status": "available",
+    "description": null
+  }
+}
+      `)
+	})
+}
+
+func MockCreateResponse(t *testing.T) {
+	th.Mux.HandleFunc("/volumes", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, `
+{
+    "volume": {
+    	"name": "vol-001",
+        "size": 75
+    }
+}
+      `)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+
+		fmt.Fprintf(w, `
+{
+  "volume": {
+    "size": 75,
+    "id": "d32019d3-bc6e-4319-9c1d-6722fc136a22",
+    "metadata": {},
+    "created_at": "2015-09-17T03:32:29.044216",
+    "encrypted": false,
+    "bootable": "false",
+    "availability_zone": "nova",
+    "attachments": [],
+    "user_id": "ff1ce52c03ab433aaba9108c2e3ef541",
+    "status": "creating",
+    "description": null,
+    "volume_type": "lvmdriver-1",
+    "name": "vol-001",
+    "replication_status": "disabled",
+    "consistencygroup_id": null,
+    "source_volid": null,
+    "snapshot_id": null,
+    "multiattach": false
+  }
+}
+    `)
+	})
+}
+
+func MockDeleteResponse(t *testing.T) {
+	th.Mux.HandleFunc("/volumes/d32019d3-bc6e-4319-9c1d-6722fc136a22", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.WriteHeader(http.StatusAccepted)
+	})
+}
+
+func MockUpdateResponse(t *testing.T) {
+	th.Mux.HandleFunc("/volumes/d32019d3-bc6e-4319-9c1d-6722fc136a22", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, `
+{
+  "volume": {
+    "name": "vol-002"
+  }
+}
+        `)
+	})
+}

--- a/openstack/blockstorage/v3/volumes/testing/requests_test.go
+++ b/openstack/blockstorage/v3/volumes/testing/requests_test.go
@@ -1,0 +1,257 @@
+package testing
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/volumetenants"
+	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes"
+	"github.com/gophercloud/gophercloud/pagination"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func TestListWithExtensions(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockListResponse(t)
+
+	count := 0
+
+	volumes.List(client.ServiceClient(), &volumes.ListOpts{}).EachPage(func(page pagination.Page) (bool, error) {
+		count++
+		actual, err := volumes.ExtractVolumes(page)
+		if err != nil {
+			t.Errorf("Failed to extract volumes: %v", err)
+			return false, err
+		}
+
+		expected := []volumes.Volume{
+			{
+				ID:   "289da7f8-6440-407c-9fb4-7db01ec49164",
+				Name: "vol-001",
+				Attachments: []volumes.Attachment{{
+					ServerID:     "83ec2e3b-4321-422b-8706-a84185f52a0a",
+					AttachmentID: "05551600-a936-4d4a-ba42-79a037c1-c91a",
+					AttachedAt:   time.Date(2016, 8, 6, 14, 48, 20, 0, time.UTC),
+					HostName:     "foobar",
+					VolumeID:     "d6cacb1a-8b59-4c88-ad90-d70ebb82bb75",
+					Device:       "/dev/vdc",
+					ID:           "d6cacb1a-8b59-4c88-ad90-d70ebb82bb75",
+				}},
+				AvailabilityZone:   "nova",
+				Bootable:           "false",
+				ConsistencyGroupID: "",
+				CreatedAt:          time.Date(2015, 9, 17, 3, 35, 3, 0, time.UTC),
+				Description:        "",
+				Encrypted:          false,
+				Metadata:           map[string]string{"foo": "bar"},
+				Multiattach:        false,
+				//TenantID:                  "304dc00909ac4d0da6c62d816bcb3459",
+				//ReplicationDriverData:     "",
+				//ReplicationExtendedStatus: "",
+				ReplicationStatus: "disabled",
+				Size:              75,
+				SnapshotID:        "",
+				SourceVolID:       "",
+				Status:            "available",
+				UserID:            "ff1ce52c03ab433aaba9108c2e3ef541",
+				VolumeType:        "lvmdriver-1",
+			},
+			{
+				ID:                 "96c3bda7-c82a-4f50-be73-ca7621794835",
+				Name:               "vol-002",
+				Attachments:        []volumes.Attachment{},
+				AvailabilityZone:   "nova",
+				Bootable:           "false",
+				ConsistencyGroupID: "",
+				CreatedAt:          time.Date(2015, 9, 17, 3, 32, 29, 0, time.UTC),
+				Description:        "",
+				Encrypted:          false,
+				Metadata:           map[string]string{},
+				Multiattach:        false,
+				//TenantID:                  "304dc00909ac4d0da6c62d816bcb3459",
+				//ReplicationDriverData:     "",
+				//ReplicationExtendedStatus: "",
+				ReplicationStatus: "disabled",
+				Size:              75,
+				SnapshotID:        "",
+				SourceVolID:       "",
+				Status:            "available",
+				UserID:            "ff1ce52c03ab433aaba9108c2e3ef541",
+				VolumeType:        "lvmdriver-1",
+			},
+		}
+
+		th.CheckDeepEquals(t, expected, actual)
+
+		return true, nil
+	})
+
+	if count != 1 {
+		t.Errorf("Expected 1 page, got %d", count)
+	}
+}
+
+func TestListAllWithExtensions(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockListResponse(t)
+
+	type VolumeWithExt struct {
+		volumes.Volume
+		volumetenants.VolumeTenantExt
+	}
+
+	allPages, err := volumes.List(client.ServiceClient(), &volumes.ListOpts{}).AllPages()
+	th.AssertNoErr(t, err)
+
+	var actual []VolumeWithExt
+	err = volumes.ExtractVolumesInto(allPages, &actual)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, 2, len(actual))
+	th.AssertEquals(t, "304dc00909ac4d0da6c62d816bcb3459", actual[0].TenantID)
+}
+
+func TestListAll(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockListResponse(t)
+
+	allPages, err := volumes.List(client.ServiceClient(), &volumes.ListOpts{}).AllPages()
+	th.AssertNoErr(t, err)
+	actual, err := volumes.ExtractVolumes(allPages)
+	th.AssertNoErr(t, err)
+
+	expected := []volumes.Volume{
+		{
+			ID:   "289da7f8-6440-407c-9fb4-7db01ec49164",
+			Name: "vol-001",
+			Attachments: []volumes.Attachment{{
+				ServerID:     "83ec2e3b-4321-422b-8706-a84185f52a0a",
+				AttachmentID: "05551600-a936-4d4a-ba42-79a037c1-c91a",
+				AttachedAt:   time.Date(2016, 8, 6, 14, 48, 20, 0, time.UTC),
+				HostName:     "foobar",
+				VolumeID:     "d6cacb1a-8b59-4c88-ad90-d70ebb82bb75",
+				Device:       "/dev/vdc",
+				ID:           "d6cacb1a-8b59-4c88-ad90-d70ebb82bb75",
+			}},
+			AvailabilityZone:   "nova",
+			Bootable:           "false",
+			ConsistencyGroupID: "",
+			CreatedAt:          time.Date(2015, 9, 17, 3, 35, 3, 0, time.UTC),
+			Description:        "",
+			Encrypted:          false,
+			Metadata:           map[string]string{"foo": "bar"},
+			Multiattach:        false,
+			//TenantID:                  "304dc00909ac4d0da6c62d816bcb3459",
+			//ReplicationDriverData:     "",
+			//ReplicationExtendedStatus: "",
+			ReplicationStatus: "disabled",
+			Size:              75,
+			SnapshotID:        "",
+			SourceVolID:       "",
+			Status:            "available",
+			UserID:            "ff1ce52c03ab433aaba9108c2e3ef541",
+			VolumeType:        "lvmdriver-1",
+		},
+		{
+			ID:                 "96c3bda7-c82a-4f50-be73-ca7621794835",
+			Name:               "vol-002",
+			Attachments:        []volumes.Attachment{},
+			AvailabilityZone:   "nova",
+			Bootable:           "false",
+			ConsistencyGroupID: "",
+			CreatedAt:          time.Date(2015, 9, 17, 3, 32, 29, 0, time.UTC),
+			Description:        "",
+			Encrypted:          false,
+			Metadata:           map[string]string{},
+			Multiattach:        false,
+			//TenantID:                  "304dc00909ac4d0da6c62d816bcb3459",
+			//ReplicationDriverData:     "",
+			//ReplicationExtendedStatus: "",
+			ReplicationStatus: "disabled",
+			Size:              75,
+			SnapshotID:        "",
+			SourceVolID:       "",
+			Status:            "available",
+			UserID:            "ff1ce52c03ab433aaba9108c2e3ef541",
+			VolumeType:        "lvmdriver-1",
+		},
+	}
+
+	th.CheckDeepEquals(t, expected, actual)
+
+}
+
+func TestGet(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockGetResponse(t)
+
+	v, err := volumes.Get(client.ServiceClient(), "d32019d3-bc6e-4319-9c1d-6722fc136a22").Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, v.Name, "vol-001")
+	th.AssertEquals(t, v.ID, "d32019d3-bc6e-4319-9c1d-6722fc136a22")
+}
+
+func TestCreate(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockCreateResponse(t)
+
+	options := &volumes.CreateOpts{Size: 75, Name: "vol-001"}
+	n, err := volumes.Create(client.ServiceClient(), options).Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, n.Size, 75)
+	th.AssertEquals(t, n.ID, "d32019d3-bc6e-4319-9c1d-6722fc136a22")
+}
+
+func TestDelete(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockDeleteResponse(t)
+
+	res := volumes.Delete(client.ServiceClient(), "d32019d3-bc6e-4319-9c1d-6722fc136a22")
+	th.AssertNoErr(t, res.Err)
+}
+
+func TestUpdate(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockUpdateResponse(t)
+
+	options := volumes.UpdateOpts{Name: "vol-002"}
+	v, err := volumes.Update(client.ServiceClient(), "d32019d3-bc6e-4319-9c1d-6722fc136a22", options).Extract()
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, "vol-002", v.Name)
+}
+
+func TestGetWithExtensions(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockGetResponse(t)
+
+	var s struct {
+		volumes.Volume
+		volumetenants.VolumeTenantExt
+	}
+	err := volumes.Get(client.ServiceClient(), "d32019d3-bc6e-4319-9c1d-6722fc136a22").ExtractInto(&s)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, "304dc00909ac4d0da6c62d816bcb3459", s.TenantID)
+
+	err = volumes.Get(client.ServiceClient(), "d32019d3-bc6e-4319-9c1d-6722fc136a22").ExtractInto(s)
+	if err == nil {
+		t.Errorf("Expected error when providing non-pointer struct")
+	}
+}

--- a/openstack/blockstorage/v3/volumes/urls.go
+++ b/openstack/blockstorage/v3/volumes/urls.go
@@ -1,0 +1,23 @@
+package volumes
+
+import "github.com/gophercloud/gophercloud"
+
+func createURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("volumes")
+}
+
+func listURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("volumes", "detail")
+}
+
+func deleteURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("volumes", id)
+}
+
+func getURL(c *gophercloud.ServiceClient, id string) string {
+	return deleteURL(c, id)
+}
+
+func updateURL(c *gophercloud.ServiceClient, id string) string {
+	return deleteURL(c, id)
+}

--- a/openstack/blockstorage/v3/volumes/util.go
+++ b/openstack/blockstorage/v3/volumes/util.go
@@ -1,0 +1,22 @@
+package volumes
+
+import (
+	"github.com/gophercloud/gophercloud"
+)
+
+// WaitForStatus will continually poll the resource, checking for a particular
+// status. It will do this for the amount of seconds defined.
+func WaitForStatus(c *gophercloud.ServiceClient, id, status string, secs int) error {
+	return gophercloud.WaitFor(secs, func() (bool, error) {
+		current, err := Get(c, id).Extract()
+		if err != nil {
+			return false, err
+		}
+
+		if current.Status == status {
+			return true, nil
+		}
+
+		return false, nil
+	})
+}

--- a/openstack/client.go
+++ b/openstack/client.go
@@ -308,8 +308,12 @@ func NewBlockStorageV2(client *gophercloud.ProviderClient, eo gophercloud.Endpoi
 	return initClientOpts(client, eo, "volumev2")
 }
 
-// NewSharedFileSystemV2 creates a ServiceClient that may be used to access the
-// v2 shared file system service.
+// NewBlockStorageV3 creates a ServiceClient that may be used to access the v3 block storage service.
+func NewBlockStorageV3(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
+	return initClientOpts(client, eo, "volumev3")
+}
+
+// NewSharedFileSystemV2 creates a ServiceClient that may be used to access the v2 shared file system service.
 func NewSharedFileSystemV2(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
 	return initClientOpts(client, eo, "sharev2")
 }

--- a/service_client.go
+++ b/service_client.go
@@ -114,6 +114,8 @@ func (client *ServiceClient) setMicroversionHeader(opts *RequestOpts) {
 		opts.MoreHeaders["X-OpenStack-Nova-API-Version"] = client.Microversion
 	case "sharev2":
 		opts.MoreHeaders["X-OpenStack-Manila-API-Version"] = client.Microversion
+	case "volume":
+		opts.MoreHeaders["X-OpenStack-Volume-API-Version"] = client.Microversion
 	}
 
 	if client.Type != "" {


### PR DESCRIPTION
This change pulls the existing V2 implementations into V3. Note that
the base V3 version (3.0) is a direct map back to V2. As a result to
use the base V3 endpoint for Cinder we can don't need to change anything
other than the URL. Also clean up some simple lint errors in
requests.go

One thing that the base V3 version does buy us here though is
Microversions (for better or worse). So, this change also adds in the
ability to specify MicroVersion in the additional-header of the
ServiceClient. This will be important going forward and so we can now
add things like the new standalone Attachment API.

For #412

Volume V3 just points to V2 unless a microversioned call is issued:
https://github.com/openstack/cinder/blob/master/cinder/api/v3/volumes.py#L25
https://github.com/openstack/cinder/blob/master/cinder/api/v3/volumes.py#L50

An example of a micro versioned call (not implemented in gophercloud):
https://github.com/openstack/cinder/blob/master/cinder/api/v3/volumes.py#L212

Even the base V3 view builder just utilizes V2 (only adding additional
info for specific versions):
https://github.com/openstack/cinder/blob/master/cinder/api/v3/views/volumes.py#L19
https://github.com/openstack/cinder/blob/master/cinder/api/v3/views/snapshots.py#L19