### PR TITLE
Added method to get info from Volume actions volume_upload_image method response

### DIFF
--- a/acceptance/openstack/blockstorage/extensions/extensions.go
+++ b/acceptance/openstack/blockstorage/extensions/extensions.go
@@ -16,7 +16,7 @@ import (
 
 // CreateUploadImage will upload volume it as volume-baked image. An name of new image or err will be
 // returned
-func CreateUploadImage(t *testing.T, client *gophercloud.ServiceClient, volume *volumes.Volume) (string, error) {
+func CreateUploadImage(t *testing.T, client *gophercloud.ServiceClient, volume *volumes.Volume) (volumeactions.VolumeImage, error) {
 	if testing.Short() {
 		t.Skip("Skipping test that requires volume-backed image uploading in short mode.")
 	}
@@ -27,19 +27,20 @@ func CreateUploadImage(t *testing.T, client *gophercloud.ServiceClient, volume *
 		Force:     true,
 	}
 
-	if err := volumeactions.UploadImage(client, volume.ID, uploadImageOpts).ExtractErr(); err != nil {
-		return "", err
+	volumeImage, err := volumeactions.UploadImage(client, volume.ID, uploadImageOpts).Extract()
+	if err != nil {
+		return volumeImage, err
 	}
 
 	t.Logf("Uploading volume %s as volume-backed image %s", volume.ID, imageName)
 
 	if err := volumes.WaitForStatus(client, volume.ID, "available", 60); err != nil {
-		return "", err
+		return volumeImage, err
 	}
 
 	t.Logf("Uploaded volume %s as volume-backed image %s", volume.ID, imageName)
 
-	return imageName, nil
+	return volumeImage, nil
 
 }
 

--- a/acceptance/openstack/blockstorage/extensions/volumeactions_test.go
+++ b/acceptance/openstack/blockstorage/extensions/volumeactions_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/gophercloud/gophercloud/acceptance/clients"
+	"github.com/gophercloud/gophercloud/acceptance/tools"
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v2/volumes"
 
 	blockstorage "github.com/gophercloud/gophercloud/acceptance/openstack/blockstorage/v2"
@@ -28,12 +29,14 @@ func TestVolumeActionsUploadImageDestroy(t *testing.T) {
 	}
 	defer blockstorage.DeleteVolume(t, blockClient, volume)
 
-	imageName, err := CreateUploadImage(t, blockClient, volume)
+	volumeImage, err := CreateUploadImage(t, blockClient, volume)
 	if err != nil {
 		t.Fatalf("Unable to upload volume-backed image: %v", err)
 	}
 
-	err = DeleteUploadedImage(t, computeClient, imageName)
+	tools.PrintResource(t, volumeImage)
+
+	err = DeleteUploadedImage(t, computeClient, volumeImage.ImageName)
 	if err != nil {
 		t.Fatalf("Unable to delete volume-backed image: %v", err)
 	}

--- a/openstack/blockstorage/extensions/volumeactions/requests.go
+++ b/openstack/blockstorage/extensions/volumeactions/requests.go
@@ -246,7 +246,7 @@ func UploadImage(client *gophercloud.ServiceClient, id string, opts UploadImageO
 		r.Err = err
 		return
 	}
-	_, r.Err = client.Post(uploadURL(client, id), b, nil, &gophercloud.RequestOpts{
+	_, r.Err = client.Post(uploadURL(client, id), b,  &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{202},
 	})
 	return

--- a/openstack/blockstorage/extensions/volumeactions/requests.go
+++ b/openstack/blockstorage/extensions/volumeactions/requests.go
@@ -246,7 +246,7 @@ func UploadImage(client *gophercloud.ServiceClient, id string, opts UploadImageO
 		r.Err = err
 		return
 	}
-	_, r.Err = client.Post(uploadURL(client, id), b,  &r.Body, &gophercloud.RequestOpts{
+	_, r.Err = client.Post(uploadURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{202},
 	})
 	return

--- a/openstack/blockstorage/extensions/volumeactions/results.go
+++ b/openstack/blockstorage/extensions/volumeactions/results.go
@@ -1,6 +1,10 @@
 package volumeactions
 
-import "github.com/gophercloud/gophercloud"
+import (
+	"time"
+
+	"github.com/gophercloud/gophercloud"
+)
 
 // AttachResult contains the response body and error from a Get request.
 type AttachResult struct {
@@ -50,10 +54,32 @@ func (r commonResult) Extract() (map[string]interface{}, error) {
 	return s.ConnectionInfo, err
 }
 
+// VolumeImage contains information about volume upload to an image service.
+type VolumeImage struct {
+	// The ID of a volume an image is created from.
+	VolumeId string `json:"id"`
+	// Container format, may be bare, ofv, ova, etc.
+	ContainerFormat string `json:"container_format"`
+	// Disk format, may be raw, qcow2, vhd, vdi, vmdk, etc.
+	DiskFormat string `json:"disk_format"`
+	// Human-readable description for the volume.
+	Description string `json:"display_description"`
+	// The ID of an image being created.
+	ImageId string `json:"image_id"`
+	// Human-readable display name for the image.
+	ImageName string `json:"image_name"`
+	// Size of the volume in GB.
+	Size int `json:"size"`
+	// Current status of the volume.
+	Status string `json:"status"`
+	// The date when this volume was last updated.
+	UpdatedAt time.Time `json:"-"`
+}
+
 // Extract will get an object with info about image being uploaded out of the UploadImageResult object.
-func (r UploadImageResult) Extract() (map[string]interface{}, error) {
+func (r UploadImageResult) Extract() (VolumeImage, error) {
 	var s struct {
-		VolumeUploadImage map[string]interface{} `json:"os-volume_upload_image"`
+		VolumeUploadImage VolumeImage `json:"os-volume_upload_image"`
 	}
 	err := r.ExtractInto(&s)
 	return s.VolumeUploadImage, err

--- a/openstack/blockstorage/extensions/volumeactions/results.go
+++ b/openstack/blockstorage/extensions/volumeactions/results.go
@@ -53,7 +53,7 @@ func (r commonResult) Extract() (map[string]interface{}, error) {
 // Extract will get an object with info about image being uploaded out of the UploadImageResult object.
 func (r UploadImageResult) Extract() (map[string]interface{}, error) {
 	var s struct {
-		VolumeUploadImage   map[string]interface{} `json:"os-volume_upload_image"`
+		VolumeUploadImage map[string]interface{} `json:"os-volume_upload_image"`
 	}
 	err := r.ExtractInto(&s)
 	return s.VolumeUploadImage, err

--- a/openstack/blockstorage/extensions/volumeactions/results.go
+++ b/openstack/blockstorage/extensions/volumeactions/results.go
@@ -69,7 +69,7 @@ type ImageVolumeType struct {
 	ExtraSpecs map[string]interface{} `json:"extra_specs"`
 	// ID of quality of service specs.
 	QosSpecsID string `json:"qos_specs_id"`
-	// Flag for deletion status of volume tpe.
+	// Flag for deletion status of volume type.
 	Deleted bool `json:"deleted"`
 	// The date when volume type was deleted.
 	DeletedAt time.Time `json:"-"`

--- a/openstack/blockstorage/extensions/volumeactions/results.go
+++ b/openstack/blockstorage/extensions/volumeactions/results.go
@@ -55,10 +55,10 @@ func (r commonResult) Extract() (map[string]interface{}, error) {
 	return s.ConnectionInfo, err
 }
 
-// VolumeImage contains information about volume upload to an image service.
-type VolumeImageVolumeType struct {
+// ImageVolumeType contains volume type object obtained from UploadImage action.
+type ImageVolumeType struct {
 	// The ID of a volume type.
-	Id string `json:"id"`
+	ID string `json:"id"`
 	// Human-readable display name for the volume type.
 	Name string `json:"name"`
 	// Human-readable description for the volume type.
@@ -67,8 +67,8 @@ type VolumeImageVolumeType struct {
 	IsPublic bool `json:"is_public"`
 	// Extra specifications for volume type.
 	ExtraSpecs map[string]interface{} `json:"extra_specs"`
-	// Id of quality of service specs.
-	QosSpecsId string `json:"qos_specs_id"`
+	// ID of quality of service specs.
+	QosSpecsID string `json:"qos_specs_id"`
 	// Flag for deletion status of volume tpe.
 	Deleted bool `json:"deleted"`
 	// The date when volume type was deleted.
@@ -79,8 +79,8 @@ type VolumeImageVolumeType struct {
 	UpdatedAt time.Time `json:"-"`
 }
 
-func (r *VolumeImageVolumeType) UnmarshalJSON(b []byte) error {
-	type tmp VolumeImageVolumeType
+func (r *ImageVolumeType) UnmarshalJSON(b []byte) error {
+	type tmp ImageVolumeType
 	var s struct {
 		tmp
 		CreatedAt gophercloud.JSONRFC3339MilliNoZ `json:"created_at"`
@@ -91,7 +91,7 @@ func (r *VolumeImageVolumeType) UnmarshalJSON(b []byte) error {
 	if err != nil {
 		return err
 	}
-	*r = VolumeImageVolumeType(s.tmp)
+	*r = ImageVolumeType(s.tmp)
 
 	r.CreatedAt = time.Time(s.CreatedAt)
 	r.UpdatedAt = time.Time(s.UpdatedAt)
@@ -103,7 +103,7 @@ func (r *VolumeImageVolumeType) UnmarshalJSON(b []byte) error {
 // VolumeImage contains information about volume upload to an image service.
 type VolumeImage struct {
 	// The ID of a volume an image is created from.
-	VolumeId string `json:"id"`
+	VolumeID string `json:"id"`
 	// Container format, may be bare, ofv, ova, etc.
 	ContainerFormat string `json:"container_format"`
 	// Disk format, may be raw, qcow2, vhd, vdi, vmdk, etc.
@@ -111,7 +111,7 @@ type VolumeImage struct {
 	// Human-readable description for the volume.
 	Description string `json:"display_description"`
 	// The ID of an image being created.
-	ImageId string `json:"image_id"`
+	ImageID string `json:"image_id"`
 	// Human-readable display name for the image.
 	ImageName string `json:"image_name"`
 	// Size of the volume in GB.
@@ -121,7 +121,7 @@ type VolumeImage struct {
 	// The date when this volume was last updated.
 	UpdatedAt time.Time `json:"-"`
 	// Volume type object of used volume.
-	VolumeType VolumeImageVolumeType `json:"volume_type"`
+	VolumeType ImageVolumeType `json:"volume_type"`
 }
 
 func (r *VolumeImage) UnmarshalJSON(b []byte) error {
@@ -144,10 +144,10 @@ func (r *VolumeImage) UnmarshalJSON(b []byte) error {
 // Extract will get an object with info about image being uploaded out of the UploadImageResult object.
 func (r UploadImageResult) Extract() (VolumeImage, error) {
 	var s struct {
-		VolumeUploadImage VolumeImage `json:"os-volume_upload_image"`
+		VolumeImage VolumeImage `json:"os-volume_upload_image"`
 	}
 	err := r.ExtractInto(&s)
-	return s.VolumeUploadImage, err
+	return s.VolumeImage, err
 }
 
 // InitializeConnectionResult contains the response body and error from a Get request.

--- a/openstack/blockstorage/extensions/volumeactions/results.go
+++ b/openstack/blockstorage/extensions/volumeactions/results.go
@@ -24,7 +24,7 @@ type DetachResult struct {
 
 // UploadImageResult contains the response body and error from a UploadImage request.
 type UploadImageResult struct {
-	gophercloud.ErrResult
+	gophercloud.Result
 }
 
 // ReserveResult contains the response body and error from a Get request.

--- a/openstack/blockstorage/extensions/volumeactions/results.go
+++ b/openstack/blockstorage/extensions/volumeactions/results.go
@@ -1,6 +1,7 @@
 package volumeactions
 
 import (
+	"encoding/json"
 	"time"
 
 	"github.com/gophercloud/gophercloud"
@@ -78,6 +79,27 @@ type VolumeImageVolumeType struct {
 	UpdatedAt time.Time `json:"-"`
 }
 
+func (r *VolumeImageVolumeType) UnmarshalJSON(b []byte) error {
+	type tmp VolumeImageVolumeType
+	var s struct {
+		tmp
+		CreatedAt gophercloud.JSONRFC3339MilliNoZ `json:"created_at"`
+		UpdatedAt gophercloud.JSONRFC3339MilliNoZ `json:"updated_at"`
+		DeletedAt gophercloud.JSONRFC3339MilliNoZ `json:"deleted_at"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	*r = VolumeImageVolumeType(s.tmp)
+
+	r.CreatedAt = time.Time(s.CreatedAt)
+	r.UpdatedAt = time.Time(s.UpdatedAt)
+	r.DeletedAt = time.Time(s.DeletedAt)
+
+	return err
+}
+
 // VolumeImage contains information about volume upload to an image service.
 type VolumeImage struct {
 	// The ID of a volume an image is created from.
@@ -100,6 +122,23 @@ type VolumeImage struct {
 	UpdatedAt time.Time `json:"-"`
 	// Volume type object of used volume.
 	VolumeType VolumeImageVolumeType `json:"volume_type"`
+}
+
+func (r *VolumeImage) UnmarshalJSON(b []byte) error {
+	type tmp VolumeImage
+	var s struct {
+		tmp
+		UpdatedAt gophercloud.JSONRFC3339MilliNoZ `json:"updated_at"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	*r = VolumeImage(s.tmp)
+
+	r.UpdatedAt = time.Time(s.UpdatedAt)
+
+	return err
 }
 
 // Extract will get an object with info about image being uploaded out of the UploadImageResult object.

--- a/openstack/blockstorage/extensions/volumeactions/results.go
+++ b/openstack/blockstorage/extensions/volumeactions/results.go
@@ -50,6 +50,15 @@ func (r commonResult) Extract() (map[string]interface{}, error) {
 	return s.ConnectionInfo, err
 }
 
+// Extract will get an object with info about image being uploaded out of the UploadImageResult object.
+func (r UploadImageResult) Extract() (map[string]interface{}, error) {
+	var s struct {
+		VolumeUploadImage   map[string]interface{} `json:"os-volume_upload_image"`
+	}
+	err := r.ExtractInto(&s)
+	return s.VolumeUploadImage, err
+}
+
 // InitializeConnectionResult contains the response body and error from a Get request.
 type InitializeConnectionResult struct {
 	commonResult

--- a/openstack/blockstorage/extensions/volumeactions/results.go
+++ b/openstack/blockstorage/extensions/volumeactions/results.go
@@ -55,6 +55,30 @@ func (r commonResult) Extract() (map[string]interface{}, error) {
 }
 
 // VolumeImage contains information about volume upload to an image service.
+type VolumeImageVolumeType struct {
+	// The ID of a volume type.
+	Id string `json:"id"`
+	// Human-readable display name for the volume type.
+	Name string `json:"name"`
+	// Human-readable description for the volume type.
+	Description string `json:"display_description"`
+	// Flag for public access.
+	IsPublic bool `json:"is_public"`
+	// Extra specifications for volume type.
+	ExtraSpecs map[string]interface{} `json:"extra_specs"`
+	// Id of quality of service specs.
+	QosSpecsId string `json:"qos_specs_id"`
+	// Flag for deletion status of volume tpe.
+	Deleted bool `json:"deleted"`
+	// The date when volume type was deleted.
+	DeletedAt time.Time `json:"-"`
+	// The date when volume type was created.
+	CreatedAt time.Time `json:"-"`
+	// The date when this volume was last updated.
+	UpdatedAt time.Time `json:"-"`
+}
+
+// VolumeImage contains information about volume upload to an image service.
 type VolumeImage struct {
 	// The ID of a volume an image is created from.
 	VolumeId string `json:"id"`
@@ -74,6 +98,8 @@ type VolumeImage struct {
 	Status string `json:"status"`
 	// The date when this volume was last updated.
 	UpdatedAt time.Time `json:"-"`
+	// Volume type object of used volume.
+	VolumeType VolumeImageVolumeType `json:"volume_type"`
 }
 
 // Extract will get an object with info about image being uploaded out of the UploadImageResult object.

--- a/openstack/blockstorage/extensions/volumeactions/testing/fixtures.go
+++ b/openstack/blockstorage/extensions/volumeactions/testing/fixtures.go
@@ -95,7 +95,34 @@ func MockUploadImageResponse(t *testing.T) {
 			w.Header().Add("Content-Type", "application/json")
 			w.WriteHeader(http.StatusAccepted)
 
-			fmt.Fprintf(w, `{}`)
+			fmt.Fprintf(w, `
+{
+    "os-volume_upload_image": {
+        "container_format": "bare",
+        "display_description": null,
+        "id": "a3f68aa2-a07b-4c6d-9a5b-ebd5600cfff8",
+        "image_id": "ecb92d98-de08-45db-8235-bbafe317269c",
+        "image_name": "test",
+        "disk_format": "raw",
+        "size": 5,
+        "status": "uploading",
+        "updated_at": "2017-07-17T09:29:22.000000",
+        "volume_type": {
+            "created_at": "2016-05-04T08:54:14.000000",
+            "deleted": false,
+            "deleted_at": null,
+            "description": null,
+            "extra_specs": {
+                "volume_backend_name": "basic.ru-2a"
+            },
+            "id": "b7133444-62f6-4433-8da3-70ac332229b7",
+            "is_public": true,
+            "name": "basic.ru-2a",
+            "updated_at": "2016-05-04T09:15:33.000000"
+        }
+    }
+}
+          `)
 		})
 }
 

--- a/openstack/blockstorage/extensions/volumeactions/testing/fixtures.go
+++ b/openstack/blockstorage/extensions/volumeactions/testing/fixtures.go
@@ -100,7 +100,7 @@ func MockUploadImageResponse(t *testing.T) {
     "os-volume_upload_image": {
         "container_format": "bare",
         "display_description": null,
-        "id": "a3f68aa2-a07b-4c6d-9a5b-ebd5600cfff8",
+        "id": "cd281d77-8217-4830-be95-9528227c105c",
         "image_id": "ecb92d98-de08-45db-8235-bbafe317269c",
         "image_name": "test",
         "disk_format": "raw",

--- a/openstack/blockstorage/extensions/volumeactions/testing/requests_test.go
+++ b/openstack/blockstorage/extensions/volumeactions/testing/requests_test.go
@@ -55,7 +55,7 @@ func TestUploadImage(t *testing.T) {
 		Force:           true,
 	}
 
-	err := volumeactions.UploadImage(client.ServiceClient(), "cd281d77-8217-4830-be95-9528227c105c", options).ExtractErr()
+	_, err := volumeactions.UploadImage(client.ServiceClient(), "cd281d77-8217-4830-be95-9528227c105c", options).Extract()
 	th.AssertNoErr(t, err)
 }
 

--- a/openstack/blockstorage/extensions/volumeactions/testing/requests_test.go
+++ b/openstack/blockstorage/extensions/volumeactions/testing/requests_test.go
@@ -2,6 +2,7 @@ package testing
 
 import (
 	"testing"
+	"time"
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/volumeactions"
@@ -55,8 +56,33 @@ func TestUploadImage(t *testing.T) {
 		Force:           true,
 	}
 
-	_, err := volumeactions.UploadImage(client.ServiceClient(), "cd281d77-8217-4830-be95-9528227c105c", options).Extract()
+	actual, err := volumeactions.UploadImage(client.ServiceClient(), "cd281d77-8217-4830-be95-9528227c105c", options).Extract()
 	th.AssertNoErr(t, err)
+
+	expected := volumeactions.VolumeImage{
+		VolumeID:        "cd281d77-8217-4830-be95-9528227c105c",
+		ContainerFormat: "bare",
+		DiskFormat:      "raw",
+		Description:     "",
+		ImageID:         "ecb92d98-de08-45db-8235-bbafe317269c",
+		ImageName:       "test",
+		Size:            5,
+		Status:          "uploading",
+		UpdatedAt:       time.Date(2017, 7, 17, 9, 29, 22, 0, time.UTC),
+		VolumeType: volumeactions.ImageVolumeType{
+			ID:          "b7133444-62f6-4433-8da3-70ac332229b7",
+			Name:        "basic.ru-2a",
+			Description: "",
+			IsPublic:    true,
+			ExtraSpecs:  map[string]interface{}{"volume_backend_name": "basic.ru-2a"},
+			QosSpecsID:  "",
+			Deleted:     false,
+			DeletedAt:   time.Time{},
+			CreatedAt:   time.Date(2016, 5, 4, 8, 54, 14, 0, time.UTC),
+			UpdatedAt:   time.Date(2016, 5, 4, 9, 15, 33, 0, time.UTC),
+		},
+	}
+	th.AssertDeepEquals(t, expected, actual)
 }
 
 func TestReserve(t *testing.T) {


### PR DESCRIPTION
I've added response body to UploadImageResults and added method Extract to extract the response into an object.

For #416 

https://github.com/openstack/cinder/blob/master/cinder/api/contrib/volume_actions.py#L304
https://github.com/openstack/cinder/blob/master/cinder/api/contrib/volume_actions.py#L290-L293
https://github.com/openstack/cinder/blob/master/cinder/volume/api.py#L1272-L1281