### PR TITLE
floatingips: Add Status field to ListOpts

### DIFF
--- a/openstack/networking/v2/extensions/layer3/floatingips/requests.go
+++ b/openstack/networking/v2/extensions/layer3/floatingips/requests.go
@@ -22,6 +22,7 @@ type ListOpts struct {
 	SortKey           string `q:"sort_key"`
 	SortDir           string `q:"sort_dir"`
 	RouterID          string `q:"router_id"`
+	Status            string `q:"status"`
 }
 
 // List returns a Pager which allows you to iterate over a collection of


### PR DESCRIPTION
It lets `floatingips.List()` filter by `Status` (which can be `ACTIVE`,
`DOWN` or `ERROR`).

Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

For #418

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/neutron-lib/blob/master/neutron_lib/api/definitions/l3.py#L134-L135
