### PR TITLE
Add Nova interface-list support

### DIFF
--- a/acceptance/openstack/compute/v2/servers_test.go
+++ b/acceptance/openstack/compute/v2/servers_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/acceptance/clients"
 	"github.com/gophercloud/gophercloud/acceptance/tools"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/attachinterfaces"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/availabilityzones"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/pauseunpause"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
@@ -72,6 +73,20 @@ func TestServersCreateDestroy(t *testing.T) {
 
 	for network, address := range allAddresses {
 		t.Logf("Addresses on %s: %+v", network, address)
+	}
+
+	allInterfacePages, err := attachinterfaces.List(client, server.ID).AllPages()
+	if err != nil {
+		t.Errorf("Unable to list server Interfaces: %v", err)
+	}
+
+	allInterfaces, err := attachinterfaces.ExtractInterfaces(allInterfacePages)
+	if err != nil {
+		t.Errorf("Unable to extract server Interfaces: %v", err)
+	}
+
+	for _, Interface := range allInterfaces {
+		t.Logf("Interfaces: %+v", Interface)
 	}
 
 	allNetworkAddressPages, err := servers.ListAddressesByNetwork(client, server.ID, choices.NetworkName).AllPages()

--- a/openstack/compute/v2/extensions/attachinterfaces/doc.go
+++ b/openstack/compute/v2/extensions/attachinterfaces/doc.go
@@ -1,0 +1,3 @@
+// Package attachinterfaces provides the ability to manage network interfaces through
+// nova-network
+package attachinterfaces

--- a/openstack/compute/v2/extensions/attachinterfaces/requests.go
+++ b/openstack/compute/v2/extensions/attachinterfaces/requests.go
@@ -1,0 +1,13 @@
+package attachinterfaces
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// List makes a request against the nova API to list the servers interfaces.
+func List(client *gophercloud.ServiceClient, serverID string) pagination.Pager {
+	return pagination.NewPager(client, listInterfaceURL(client, serverID), func(r pagination.PageResult) pagination.Page {
+		return InterfacePage{pagination.SinglePageBase(r)}
+	})
+}

--- a/openstack/compute/v2/extensions/attachinterfaces/results.go
+++ b/openstack/compute/v2/extensions/attachinterfaces/results.go
@@ -1,0 +1,43 @@
+package attachinterfaces
+
+import (
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// FixedIP represents a Fixed IP Address.
+type FixedIP struct {
+	SubnetID  string `json:"subnet_id"`
+	IPAddress string `json:"ip_address"`
+}
+
+// Interface represents a network interface on an instance.
+type Interface struct {
+	PortState string    `json:"port_state"`
+	FixedIPs  []FixedIP `json:"fixed_ips"`
+	PortID    string    `json:"port_id"`
+	NetID     string    `json:"net_id"`
+	MACAddr   string    `json:"mac_addr"`
+}
+
+// InterfacePage abstracts the raw results of making a List() request against the API.
+// As OpenStack extensions may freely alter the response bodies of structures returned
+// to the client, you may only safely access the data provided through the ExtractInterfaces call.
+type InterfacePage struct {
+	pagination.SinglePageBase
+}
+
+// IsEmpty returns true if an InterfacePage contains no interfaces.
+func (r InterfacePage) IsEmpty() (bool, error) {
+	interfaces, err := ExtractInterfaces(r)
+	return len(interfaces) == 0, err
+}
+
+// ExtractInterfaces interprets the results of a single page from a List() call,
+// producing a map of interfaces.
+func ExtractInterfaces(r pagination.Page) ([]Interface, error) {
+	var s struct {
+		Interfaces []Interface `json:"interfaceAttachments"`
+	}
+	err := (r.(InterfacePage)).ExtractInto(&s)
+	return s.Interfaces, err
+}

--- a/openstack/compute/v2/extensions/attachinterfaces/testing/doc.go
+++ b/openstack/compute/v2/extensions/attachinterfaces/testing/doc.go
@@ -1,0 +1,2 @@
+// compute_extensions_attachinterfaces_v2
+package testing

--- a/openstack/compute/v2/extensions/attachinterfaces/testing/fixtures.go
+++ b/openstack/compute/v2/extensions/attachinterfaces/testing/fixtures.go
@@ -1,0 +1,61 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/attachinterfaces"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+// ListInterfacesExpected represents an expected repsonse from a ListInterfaces request.
+var ListInterfacesExpected = []attachinterfaces.Interface{
+	{
+		PortState: "ACTIVE",
+		FixedIPs: []attachinterfaces.FixedIP{
+			{
+				SubnetID:  "d7906db4-a566-4546-b1f4-5c7fa70f0bf3",
+				IPAddress: "10.0.0.7",
+			},
+			{
+				SubnetID:  "45906d64-a548-4276-h1f8-kcffa80fjbnl",
+				IPAddress: "10.0.0.8",
+			},
+		},
+		PortID:  "0dde1598-b374-474e-986f-5b8dd1df1d4e",
+		NetID:   "8a5fe506-7e9f-4091-899b-96336909d93c",
+		MACAddr: "fa:16:3e:38:2d:80",
+	},
+}
+
+// HandleInterfaceListSuccessfully sets up the test server to respond to a ListInterfaces request.
+func HandleInterfaceListSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/servers/b07e7a3b-d951-4efc-a4f9-ac9f001afb7f/os-interface", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprintf(w, `{
+			"interfaceAttachments": [
+				{
+					"port_state":"ACTIVE",
+					"fixed_ips": [
+						{
+							"subnet_id": "d7906db4-a566-4546-b1f4-5c7fa70f0bf3",
+							"ip_address": "10.0.0.7"
+						},
+						{
+							"subnet_id": "45906d64-a548-4276-h1f8-kcffa80fjbnl",
+							"ip_address": "10.0.0.8"
+						}
+					],
+					"port_id": "0dde1598-b374-474e-986f-5b8dd1df1d4e",
+					"net_id": "8a5fe506-7e9f-4091-899b-96336909d93c",
+					"mac_addr": "fa:16:3e:38:2d:80"
+				}
+			]
+		}`)
+	})
+}

--- a/openstack/compute/v2/extensions/attachinterfaces/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/attachinterfaces/testing/requests_test.go
@@ -1,0 +1,45 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/attachinterfaces"
+	"github.com/gophercloud/gophercloud/pagination"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func TestListInterface(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleInterfaceListSuccessfully(t)
+
+	expected := ListInterfacesExpected
+	pages := 0
+	err := attachinterfaces.List(client.ServiceClient(), "b07e7a3b-d951-4efc-a4f9-ac9f001afb7f").EachPage(func(page pagination.Page) (bool, error) {
+		pages++
+
+		actual, err := attachinterfaces.ExtractInterfaces(page)
+		th.AssertNoErr(t, err)
+
+		if len(actual) != 1 {
+			t.Fatalf("Expected 1 interface, got %d", len(actual))
+		}
+		th.CheckDeepEquals(t, expected, actual)
+
+		return true, nil
+	})
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, 1, pages)
+}
+
+func TestListInterfacesAllPages(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleInterfaceListSuccessfully(t)
+
+	allPages, err := attachinterfaces.List(client.ServiceClient(), "b07e7a3b-d951-4efc-a4f9-ac9f001afb7f").AllPages()
+	th.AssertNoErr(t, err)
+	_, err = attachinterfaces.ExtractInterfaces(allPages)
+	th.AssertNoErr(t, err)
+}

--- a/openstack/compute/v2/extensions/attachinterfaces/urls.go
+++ b/openstack/compute/v2/extensions/attachinterfaces/urls.go
@@ -1,0 +1,7 @@
+package attachinterfaces
+
+import "github.com/gophercloud/gophercloud"
+
+func listInterfaceURL(client *gophercloud.ServiceClient, serverID string) string {
+	return client.ServiceURL("servers", serverID, "os-interface")
+}


### PR DESCRIPTION
Add support to list interface for a server
through a GET on: /v2.1/{tenant_id}/servers/{server_id}/os-interface

The same operation with OpenStack CLI is done with:
  nova interface-list <server_id>

Fix gophercloud issue:
https://github.com/gophercloud/gophercloud/issues/431

Fix kubernetes issue: 

   https://github.com/kubernetes/kubernetes/issues/43909