### PR TITLE
Add Microversion support to sharev2 client

### DIFF
--- a/openstack/client.go
+++ b/openstack/client.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gophercloud/gophercloud"
 	tokens2 "github.com/gophercloud/gophercloud/openstack/identity/v2/tokens"
 	tokens3 "github.com/gophercloud/gophercloud/openstack/identity/v3/tokens"
+	sfsapi "github.com/gophercloud/gophercloud/openstack/sharedfilesystems/apiversions"
 	"github.com/gophercloud/gophercloud/openstack/utils"
 )
 
@@ -261,7 +262,19 @@ func NewBlockStorageV2(client *gophercloud.ProviderClient, eo gophercloud.Endpoi
 
 // NewSharedFileSystemV2 creates a ServiceClient that may be used to access the v2 shared file system service.
 func NewSharedFileSystemV2(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
-	return initClientOpts(client, eo, "sharev2")
+	sc, err := initClientOpts(client, eo, "sharev2")
+	if err != nil {
+		return sc, err
+	}
+
+	apiVersion, err := sfsapi.Get(sc, "v2").Extract()
+	if err != nil {
+		return sc, err
+	}
+
+	sc.Microversion = apiVersion.Version
+
+	return sc, nil
 }
 
 // NewCDNV1 creates a ServiceClient that may be used to access the OpenStack v1


### PR DESCRIPTION
For #340

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/manila/blob/stable/newton/manila/api/versions.py#L88
