### PR TITLE
support suspend/resume for compute instance

### DIFF
--- a/openstack/compute/v2/extensions/suspendresume/doc.go
+++ b/openstack/compute/v2/extensions/suspendresume/doc.go
@@ -1,0 +1,5 @@
+/*
+Package suspendresume provides functionality to suspend and resume servers that have
+been provisioned by the OpenStack Compute service.
+*/
+package suspendresume

--- a/openstack/compute/v2/extensions/suspendresume/requests.go
+++ b/openstack/compute/v2/extensions/suspendresume/requests.go
@@ -1,0 +1,19 @@
+package suspendresume
+
+import "github.com/gophercloud/gophercloud"
+
+func actionURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL("servers", id, "action")
+}
+
+// Suspend is the operation responsible for suspending a Compute server.
+func Suspend(client *gophercloud.ServiceClient, id string) (r gophercloud.ErrResult) {
+	_, r.Err = client.Post(actionURL(client, id), map[string]interface{}{"suspend": nil}, nil, nil)
+	return
+}
+
+// Resume is the operation responsible for resuming a Compute server.
+func Resume(client *gophercloud.ServiceClient, id string) (r gophercloud.ErrResult) {
+	_, r.Err = client.Post(actionURL(client, id), map[string]interface{}{"resume": nil}, nil, nil)
+	return
+}

--- a/openstack/compute/v2/extensions/suspendresume/testing/doc.go
+++ b/openstack/compute/v2/extensions/suspendresume/testing/doc.go
@@ -1,0 +1,2 @@
+// compute_extensions_suspendresume_v2
+package testing

--- a/openstack/compute/v2/extensions/suspendresume/testing/fixtures.go
+++ b/openstack/compute/v2/extensions/suspendresume/testing/fixtures.go
@@ -1,0 +1,27 @@
+package testing
+
+import (
+	"net/http"
+	"testing"
+
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func mockSuspendServerResponse(t *testing.T, id string) {
+	th.Mux.HandleFunc("/servers/"+id+"/action", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, `{"suspend": null}`)
+		w.WriteHeader(http.StatusAccepted)
+	})
+}
+
+func mockResumeServerResponse(t *testing.T, id string) {
+	th.Mux.HandleFunc("/servers/"+id+"/action", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, `{"resume": null}`)
+		w.WriteHeader(http.StatusAccepted)
+	})
+}

--- a/openstack/compute/v2/extensions/suspendresume/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/suspendresume/testing/requests_test.go
@@ -1,0 +1,31 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/suspendresume"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+const serverID = "{serverId}"
+
+func TestSuspend(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	mockSuspendServerResponse(t, serverID)
+
+	err := suspendresume.Suspend(client.ServiceClient(), serverID).ExtractErr()
+	th.AssertNoErr(t, err)
+}
+
+func TestResume(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	mockResumeServerResponse(t, serverID)
+
+	err := suspendresume.Resume(client.ServiceClient(), serverID).ExtractErr()
+	th.AssertNoErr(t, err)
+}


### PR DESCRIPTION
Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

For #432

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/nova/blob/stable/ocata/nova/api/openstack/compute/suspend_server.py
https://github.com/openstack/nova/blob/stable/ocata/nova/compute/api.py#L3381

The forked gophercloud repository is missing in #433 , recreate a new PR.