### PR TITLE
Compute v2: Adding Migrate Action

### DIFF
--- a/acceptance/openstack/compute/v2/migrate_test.go
+++ b/acceptance/openstack/compute/v2/migrate_test.go
@@ -1,0 +1,30 @@
+// +build acceptance compute servers
+
+package v2
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/acceptance/clients"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/migrate"
+)
+
+func TestMigrate(t *testing.T) {
+	client, err := clients.NewComputeV2Client()
+	if err != nil {
+		t.Fatalf("Unable to create a compute client: %v", err)
+	}
+
+	server, err := CreateServer(t, client)
+	if err != nil {
+		t.Fatalf("Unable to create server: %v", err)
+	}
+	defer DeleteServer(t, client, server)
+
+	t.Logf("Attempting to migrate server %s", server.ID)
+
+	err = migrate.Migrate(client, server.ID).ExtractErr()
+	if err != nil {
+		t.Fatalf("Error during migration: %v", err)
+	}
+}

--- a/openstack/compute/v2/extensions/migrate/doc.go
+++ b/openstack/compute/v2/extensions/migrate/doc.go
@@ -1,3 +1,13 @@
-// Package migrate provides functionality to migrate servers that have been
-// provisioned by the OpenStack Compute service.
+/*
+Package migrate provides functionality to migrate servers that have been
+provisioned by the OpenStack Compute service.
+
+Example to Migrate a Server
+
+	serverID := "b16ba811-199d-4ffd-8839-ba96c1185a67"
+	err := migrate.Migrate(computeClient, serverID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+*/
 package migrate

--- a/openstack/compute/v2/extensions/migrate/doc.go
+++ b/openstack/compute/v2/extensions/migrate/doc.go
@@ -1,0 +1,3 @@
+// Package migrate provides functionality to migrate servers that have been
+// provisioned by the OpenStack Compute service.
+package migrate

--- a/openstack/compute/v2/extensions/migrate/requests.go
+++ b/openstack/compute/v2/extensions/migrate/requests.go
@@ -1,0 +1,11 @@
+package migrate
+
+import (
+	"github.com/gophercloud/gophercloud"
+)
+
+// Migrate will initiate a migration of the instance to another host.
+func Migrate(client *gophercloud.ServiceClient, id string) (r gophercloud.ErrResult) {
+	_, r.Err = client.Post(actionURL(client, id), map[string]interface{}{"migrate": nil}, nil, nil)
+	return
+}

--- a/openstack/compute/v2/extensions/migrate/requests.go
+++ b/openstack/compute/v2/extensions/migrate/requests.go
@@ -5,7 +5,7 @@ import (
 )
 
 // Migrate will initiate a migration of the instance to another host.
-func Migrate(client *gophercloud.ServiceClient, id string) (r gophercloud.ErrResult) {
+func Migrate(client *gophercloud.ServiceClient, id string) (r MigrateResult) {
 	_, r.Err = client.Post(actionURL(client, id), map[string]interface{}{"migrate": nil}, nil, nil)
 	return
 }

--- a/openstack/compute/v2/extensions/migrate/results.go
+++ b/openstack/compute/v2/extensions/migrate/results.go
@@ -1,0 +1,11 @@
+package migrate
+
+import (
+	"github.com/gophercloud/gophercloud"
+)
+
+// MigrateResult is the response from a Migrate operation. Call its ExtractErr
+// method to determine if the suceeded or failed.
+type MigrateResult struct {
+	gophercloud.ErrResult
+}

--- a/openstack/compute/v2/extensions/migrate/testing/doc.go
+++ b/openstack/compute/v2/extensions/migrate/testing/doc.go
@@ -1,0 +1,2 @@
+// compute_extensions_startstop_v2
+package testing

--- a/openstack/compute/v2/extensions/migrate/testing/fixtures.go
+++ b/openstack/compute/v2/extensions/migrate/testing/fixtures.go
@@ -1,0 +1,18 @@
+package testing
+
+import (
+	"net/http"
+	"testing"
+
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func mockMigrateResponse(t *testing.T, id string) {
+	th.Mux.HandleFunc("/servers/"+id+"/action", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, `{"migrate": null}`)
+		w.WriteHeader(http.StatusAccepted)
+	})
+}

--- a/openstack/compute/v2/extensions/migrate/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/migrate/testing/requests_test.go
@@ -1,0 +1,21 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/migrate"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+const serverID = "b16ba811-199d-4ffd-8839-ba96c1185a67"
+
+func TestMigrate(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	mockMigrateResponse(t, serverID)
+
+	err := migrate.Migrate(client.ServiceClient(), serverID).ExtractErr()
+	th.AssertNoErr(t, err)
+}

--- a/openstack/compute/v2/extensions/migrate/urls.go
+++ b/openstack/compute/v2/extensions/migrate/urls.go
@@ -1,0 +1,9 @@
+package migrate
+
+import (
+	"github.com/gophercloud/gophercloud"
+)
+
+func actionURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL("servers", id, "action")
+}


### PR DESCRIPTION
For #82 

Supersedes #84 

https://github.com/openstack/nova/blob/77b11a9e31e265c338857326418bfe8cd135c1f8/nova/api/openstack/compute/migrate_server.py

Note that this only implements what would be handled in the `_migrate` function, not the `_migrate_live` function. 