### PR TITLE
SharedFileSystems v2: Restrict ExtractExportLocations to only GetExportLocationsResults

### DIFF
--- a/openstack/sharedfilesystems/v2/shares/results.go
+++ b/openstack/sharedfilesystems/v2/shares/results.go
@@ -96,18 +96,24 @@ func (r commonResult) Extract() (*Share, error) {
 	return s.Share, err
 }
 
-// CreateResult contains the result..
+// CreateResult contains the response body and error from a Create request.
 type CreateResult struct {
 	commonResult
 }
 
-// DeleteResult contains the delete results
+// DeleteResult contains the response body and error from a Delete request.
 type DeleteResult struct {
 	gophercloud.ErrResult
 }
 
-// GetResult contains the get result
+// GetResult contains the response body and error from a Get request.
 type GetResult struct {
+	commonResult
+}
+
+// GetExportLocationsResult contains the result body and error from an
+// GetExportLocations request.
+type GetExportLocationsResult struct {
 	commonResult
 }
 
@@ -131,15 +137,10 @@ type ExportLocation struct {
 }
 
 // ExtractExportLocations will get the Export Locations from the commonResult
-func (r commonResult) ExtractExportLocations() ([]ExportLocation, error) {
+func (r GetExportLocationsResult) ExtractExportLocations() ([]ExportLocation, error) {
 	var s struct {
 		ExportLocations []ExportLocation `json:"export_locations"`
 	}
 	err := r.ExtractInto(&s)
 	return s.ExportLocations, err
-}
-
-// GetExportLocationsResult contains the result.
-type GetExportLocationsResult struct {
-	commonResult
 }

--- a/openstack/sharedfilesystems/v2/shares/results.go
+++ b/openstack/sharedfilesystems/v2/shares/results.go
@@ -136,7 +136,7 @@ type ExportLocation struct {
 	Preferred bool `json:"preferred"`
 }
 
-// ExtractExportLocations will get the Export Locations from the commonResult
+// Extract will get the Export Locations from the commonResult
 func (r GetExportLocationsResult) Extract() ([]ExportLocation, error) {
 	var s struct {
 		ExportLocations []ExportLocation `json:"export_locations"`

--- a/openstack/sharedfilesystems/v2/shares/results.go
+++ b/openstack/sharedfilesystems/v2/shares/results.go
@@ -114,7 +114,7 @@ type GetResult struct {
 // GetExportLocationsResult contains the result body and error from an
 // GetExportLocations request.
 type GetExportLocationsResult struct {
-	commonResult
+	gophercloud.Result
 }
 
 // ExportLocation contains all information associated with a share export location
@@ -137,7 +137,7 @@ type ExportLocation struct {
 }
 
 // ExtractExportLocations will get the Export Locations from the commonResult
-func (r GetExportLocationsResult) ExtractExportLocations() ([]ExportLocation, error) {
+func (r GetExportLocationsResult) Extract() ([]ExportLocation, error) {
 	var s struct {
 		ExportLocations []ExportLocation `json:"export_locations"`
 	}

--- a/openstack/sharedfilesystems/v2/shares/testing/request_test.go
+++ b/openstack/sharedfilesystems/v2/shares/testing/request_test.go
@@ -93,7 +93,7 @@ func TestGetExportLocationsSuccess(t *testing.T) {
 	// Client c must have Microversion set; minimum supported microversion for Get Export Locations is 2.14
 	c.Microversion = "2.14"
 
-	s, err := shares.GetExportLocations(c, shareID).ExtractExportLocations()
+	s, err := shares.GetExportLocations(c, shareID).Extract()
 
 	th.AssertNoErr(t, err)
 	th.AssertDeepEquals(t, s, []shares.ExportLocation{


### PR DESCRIPTION
For #448 