### PR TITLE
Docs: Top level doc updates

### DIFF
--- a/auth_options.go
+++ b/auth_options.go
@@ -9,12 +9,32 @@ ProviderClient representing an active session on that provider.
 
 Its fields are the union of those recognized by each identity implementation and
 provider.
+
+An example of manually providing authentication information:
+
+  opts := gophercloud.AuthOptions{
+    IdentityEndpoint: "https://openstack.example.com:5000/v2.0",
+    Username: "{username}",
+    Password: "{password}",
+    TenantID: "{tenant_id}",
+  }
+
+  provider, err := openstack.AuthenticatedClient(opts)
+
+An example of using AuthOptionsFromEnv(), where the environment variables can
+be read from a file, such as a standard openrc file:
+
+  opts, err := openstack.AuthOptionsFromEnv()
+  provider, err := openstack.AuthenticatedClient(opts)
 */
 type AuthOptions struct {
 	// IdentityEndpoint specifies the HTTP endpoint that is required to work with
 	// the Identity API of the appropriate version. While it's ultimately needed by
 	// all of the identity services, it will often be populated by a provider-level
 	// function.
+	//
+	// The IdentityEndpoint is typically referred to as the "auth_url" or
+	// "OS_AUTH_URL" in the information provided by the cloud operator.
 	IdentityEndpoint string `json:"-"`
 
 	// Username is required if using Identity V2 API. Consult with your provider's
@@ -39,7 +59,7 @@ type AuthOptions struct {
 	// If DomainID or DomainName are provided, they will also apply to TenantName.
 	// It is not currently possible to authenticate with Username and a Domain
 	// and scope to a Project in a different Domain by using TenantName. To
-	// accomplish that, the ProjectID will need to be provided to the TenantID
+	// accomplish that, the ProjectID will need to be provided as the TenantID
 	// option.
 	TenantID   string `json:"tenantId,omitempty"`
 	TenantName string `json:"tenantName,omitempty"`
@@ -50,10 +70,12 @@ type AuthOptions struct {
 	// false, it will not cache these settings, but re-authentication will not be
 	// possible.  This setting defaults to false.
 	//
-	// NOTE: The reauth function will try to re-authenticate endlessly if left unchecked.
-	// The way to limit the number of attempts is to provide a custom HTTP client to the provider client
-	// and provide a transport that implements the RoundTripper interface and stores the number of failed retries.
-	// For an example of this, see here: https://github.com/rackspace/rack/blob/1.0.0/auth/clients.go#L311
+	// NOTE: The reauth function will try to re-authenticate endlessly if left
+	// unchecked. The way to limit the number of attempts is to provide a custom
+	// HTTP client to the provider client and provide a transport that implements
+	// the RoundTripper interface and stores the number of failed retries. For an
+	// example of this, see here:
+	// https://github.com/rackspace/rack/blob/1.0.0/auth/clients.go#L311
 	AllowReauth bool `json:"-"`
 
 	// TokenID allows users to authenticate (possibly as another user) with an

--- a/endpoint_search.go
+++ b/endpoint_search.go
@@ -27,7 +27,7 @@ const (
 // unambiguously identify one, and only one, endpoint within the catalog.
 //
 // Usually, these are passed to service client factory functions in a provider
-// package, like "rackspace.NewComputeV2()".
+// package, like "openstack.NewComputeV2()".
 type EndpointOpts struct {
 	// Type [required] is the service type for the client (e.g., "compute",
 	// "object-store"). Generally, this will be supplied by the service client

--- a/params.go
+++ b/params.go
@@ -10,10 +10,28 @@ import (
 	"time"
 )
 
-// BuildRequestBody builds a map[string]interface from the given `struct`. If
-// parent is not the empty string, the final map[string]interface returned will
-// encapsulate the built one
-//
+/*
+BuildRequestBody builds a map[string]interface from the given `struct`. If
+parent is not an empty string, the final map[string]interface returned will
+encapsulate the built one. For example:
+
+  disk := 1
+  createOpts := flavors.CreateOpts{
+    ID:         "1",
+    Name:       "m1.tiny",
+    Disk:       &disk,
+    RAM:        512,
+    VCPUs:      1,
+    RxTxFactor: 1.0,
+  }
+
+  body, err := gophercloud.BuildRequestBody(createOpts, "flavor")
+
+The above example can be run as-is, however it is recommended to look at how
+BuildRequestBody is used within Gophercloud to more fully understand how it
+fits within the request process as a whole rather than use it directly as shown
+above.
+*/
 func BuildRequestBody(opts interface{}, parent string) (map[string]interface{}, error) {
 	optsValue := reflect.ValueOf(opts)
 	if optsValue.Kind() == reflect.Ptr {


### PR DESCRIPTION
For #446 

@jrperritt This was just a quick update to the godoc found in the `gophercloud` top-level directory. The main focus of #446 will be adding documentation for the various services found in `gophercloud/openstack`.