### PR TITLE
BlockStorage v2: Clean-up volumetenants

### DIFF
--- a/openstack/blockstorage/extensions/volumetenants/doc.go
+++ b/openstack/blockstorage/extensions/volumetenants/doc.go
@@ -1,0 +1,26 @@
+/*
+Package volumetenants provides the ability to extend a volume result with
+tenant/project information. Example:
+
+	type VolumeWithTenant struct {
+		volumes.Volume
+		volumetenants.VolumeTenantExt
+	}
+
+	var allVolumes []VolumeWithTenant
+
+	allPages, err := volumes.List(client, nil).AllPages()
+	if err != nil {
+		panic("Unable to retrieve volumes: %s", err)
+	}
+
+	err = volumes.ExtractVolumesInto(allPages, &allVolumes)
+	if err != nil {
+		panic("Unable to extract volumes: %s", err)
+	}
+
+	for _, volume := range allVolumes {
+		fmt.Println(volume.TenantID)
+	}
+*/
+package volumetenants

--- a/openstack/blockstorage/extensions/volumetenants/results.go
+++ b/openstack/blockstorage/extensions/volumetenants/results.go
@@ -1,12 +1,7 @@
 package volumetenants
 
-// VolumeExt is an extension to the base Volume object
-type VolumeExt struct {
+// VolumeTenantExt is an extension to the base Volume object
+type VolumeTenantExt struct {
 	// TenantID is the id of the project that owns the volume.
 	TenantID string `json:"os-vol-tenant-attr:tenant_id"`
-}
-
-// UnmarshalJSON to override default
-func (r *VolumeExt) UnmarshalJSON(b []byte) error {
-	return nil
 }

--- a/openstack/blockstorage/v2/volumes/testing/requests_test.go
+++ b/openstack/blockstorage/v2/volumes/testing/requests_test.go
@@ -102,7 +102,7 @@ func TestListAllWithExtensions(t *testing.T) {
 
 	type VolumeWithExt struct {
 		volumes.Volume
-		volumetenants.VolumeExt
+		volumetenants.VolumeTenantExt
 	}
 
 	allPages, err := volumes.List(client.ServiceClient(), &volumes.ListOpts{}).AllPages()
@@ -244,7 +244,7 @@ func TestGetWithExtensions(t *testing.T) {
 
 	var s struct {
 		volumes.Volume
-		volumetenants.VolumeExt
+		volumetenants.VolumeTenantExt
 	}
 	err := volumes.Get(client.ServiceClient(), "d32019d3-bc6e-4319-9c1d-6722fc136a22").ExtractInto(&s)
 	th.AssertNoErr(t, err)


### PR DESCRIPTION
For #455 
For #446 

`VolumeExt` is renamed to `VolumeTenantExt` since `VolumeExt` is rather generic and having two extensions named `VolumeExt` cannot be used together.

The `UnmarshalJSON` function is not needed, so it has been removed.

Example documentation has also been added.