### PR TITLE
BlockStorage: apiversions

### DIFF
--- a/acceptance/openstack/blockstorage/apiversions_test.go
+++ b/acceptance/openstack/blockstorage/apiversions_test.go
@@ -1,0 +1,46 @@
+// +build acceptance blockstorage
+
+package blockstorage
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/acceptance/clients"
+	"github.com/gophercloud/gophercloud/acceptance/tools"
+	"github.com/gophercloud/gophercloud/openstack/blockstorage/apiversions"
+)
+
+func TestAPIVersionsList(t *testing.T) {
+	client, err := clients.NewBlockStorageV2Client()
+	if err != nil {
+		t.Fatalf("Unable to create a blockstorage client: %v", err)
+	}
+
+	allPages, err := apiversions.List(client).AllPages()
+	if err != nil {
+		t.Fatalf("Unable to retrieve API versions: %v", err)
+	}
+
+	allVersions, err := apiversions.ExtractAPIVersions(allPages)
+	if err != nil {
+		t.Fatalf("Unable to extract API versions: %v", err)
+	}
+
+	for _, v := range allVersions {
+		tools.PrintResource(t, v)
+	}
+}
+
+func TestAPIVersionsGet(t *testing.T) {
+	client, err := clients.NewBlockStorageV2Client()
+	if err != nil {
+		t.Fatalf("Unable to create a blockstorage client: %v", err)
+	}
+
+	v, err := apiversions.Get(client, "v2").Extract()
+	if err != nil {
+		t.Fatalf("Unable to retrieve API version: %v", err)
+	}
+
+	tools.PrintResource(t, v)
+}

--- a/acceptance/openstack/blockstorage/apiversions_test.go
+++ b/acceptance/openstack/blockstorage/apiversions_test.go
@@ -37,9 +37,14 @@ func TestAPIVersionsGet(t *testing.T) {
 		t.Fatalf("Unable to create a blockstorage client: %v", err)
 	}
 
-	v, err := apiversions.Get(client, "v2").Extract()
+	allPages, err := apiversions.List(client).AllPages()
 	if err != nil {
-		t.Fatalf("Unable to retrieve API version: %v", err)
+		t.Fatalf("Unable to retrieve API versions: %v", err)
+	}
+
+	v, err := apiversions.ExtractAPIVersion(allPages, "v3.0")
+	if err != nil {
+		t.Fatalf("Unable to extract API version: %v", err)
 	}
 
 	tools.PrintResource(t, v)

--- a/openstack/blockstorage/apiversions/doc.go
+++ b/openstack/blockstorage/apiversions/doc.go
@@ -1,0 +1,31 @@
+/*
+Package apiversions provides information and interaction with the different
+API versions for the OpenStack Block Storage service, code-named Cinder.
+
+Example of Retrieving all API Versions
+
+	allPages, err := apiversions.List(client).AllPages()
+	if err != nil {
+		panic("Unable to get API versions: %s", err)
+	}
+
+	allVersions, err := apiversions.ExtractAPIVersions(allPages)
+	if err != nil {
+		panic("Unable to extract API versions: %s", err)
+	}
+
+	for _, version := range versions {
+		fmt.Printf("%+v\n", version)
+	}
+
+
+Example of Retrieving an API Version
+
+	version, err := apiversions.Get(client, "v3").Extract()
+	if err != nil {
+		panic("Unable to get API version: %s", err)
+	}
+
+	fmt.Printf("%+v\n", version)
+*/
+package apiversions

--- a/openstack/blockstorage/apiversions/errors.go
+++ b/openstack/blockstorage/apiversions/errors.go
@@ -1,0 +1,23 @@
+package apiversions
+
+import (
+	"fmt"
+)
+
+// ErrVersionNotFound is the error when the requested API version
+// could not be found.
+type ErrVersionNotFound struct{}
+
+func (e ErrVersionNotFound) Error() string {
+	return fmt.Sprintf("Unable to find requested API version")
+}
+
+// ErrMultipleVersionsFound is the error when a request for an API
+// version returns multiple results.
+type ErrMultipleVersionsFound struct {
+	Count int
+}
+
+func (e ErrMultipleVersionsFound) Error() string {
+	return fmt.Sprintf("Found %d API versions", e.Count)
+}

--- a/openstack/blockstorage/apiversions/requests.go
+++ b/openstack/blockstorage/apiversions/requests.go
@@ -11,10 +11,3 @@ func List(c *gophercloud.ServiceClient) pagination.Pager {
 		return APIVersionPage{pagination.SinglePageBase(r)}
 	})
 }
-
-// Get will retrieve a specific API version. To extract the version,
-// call the Extract method on the GetResult.
-func Get(client *gophercloud.ServiceClient, v string) (r GetResult) {
-	_, r.Err = client.Get(getURL(client, v), &r.Body, nil)
-	return
-}

--- a/openstack/blockstorage/apiversions/requests.go
+++ b/openstack/blockstorage/apiversions/requests.go
@@ -1,0 +1,20 @@
+package apiversions
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// List lists all the Cinder API versions available to end-users.
+func List(c *gophercloud.ServiceClient) pagination.Pager {
+	return pagination.NewPager(c, listURL(c), func(r pagination.PageResult) pagination.Page {
+		return APIVersionPage{pagination.SinglePageBase(r)}
+	})
+}
+
+// Get will retrieve a specific API version. To extract the version,
+// call the Extract method on the GetResult.
+func Get(client *gophercloud.ServiceClient, v string) (r GetResult) {
+	_, r.Err = client.Get(getURL(client, v), &r.Body, nil)
+	return
+}

--- a/openstack/blockstorage/apiversions/results.go
+++ b/openstack/blockstorage/apiversions/results.go
@@ -1,0 +1,73 @@
+package apiversions
+
+import (
+	"time"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// APIVersion represents an API version for Cinder.
+type APIVersion struct {
+	// ID is the unique identifier of the API version.
+	ID string `json:"id"`
+
+	// MinVersion is the minimum microversion supported.
+	MinVersion string `json:"min_version"`
+
+	// Status represents the status of the API version.
+	Status string `json:"status"`
+
+	// Updated is the date the API version was updated.
+	Updated time.Time `json:"updated"`
+
+	// Version is the current version and microversion.
+	Version string `json:"version"`
+}
+
+// APIVersionPage is the page returned by a pager when traversing over a
+// collection of API versions.
+type APIVersionPage struct {
+	pagination.SinglePageBase
+}
+
+// IsEmpty checks whether an APIVersionPage struct is empty.
+func (r APIVersionPage) IsEmpty() (bool, error) {
+	is, err := ExtractAPIVersions(r)
+	return len(is) == 0, err
+}
+
+// ExtractAPIVersions takes a collection page, extracts all of the elements,
+// and returns them a slice of APIVersion structs. It is effectively a cast.
+func ExtractAPIVersions(r pagination.Page) ([]APIVersion, error) {
+	var s struct {
+		Versions []APIVersion `json:"versions"`
+	}
+	err := (r.(APIVersionPage)).ExtractInto(&s)
+	return s.Versions, err
+}
+
+// GetResult represents the result of a get operation.
+type GetResult struct {
+	gophercloud.Result
+}
+
+// Extract is a function that accepts a result and extracts an API version resource.
+func (r GetResult) Extract() (*APIVersion, error) {
+	var s struct {
+		Versions []APIVersion `json:"versions"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return nil, err
+	}
+
+	switch len(s.Versions) {
+	case 0:
+		return nil, ErrVersionNotFound{}
+	case 1:
+		return &s.Versions[0], nil
+	default:
+		return nil, ErrMultipleVersionsFound{Count: len(s.Versions)}
+	}
+}

--- a/openstack/blockstorage/apiversions/results.go
+++ b/openstack/blockstorage/apiversions/results.go
@@ -3,7 +3,6 @@ package apiversions
 import (
 	"time"
 
-	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/pagination"
 )
 
@@ -47,27 +46,19 @@ func ExtractAPIVersions(r pagination.Page) ([]APIVersion, error) {
 	return s.Versions, err
 }
 
-// GetResult represents the result of a get operation.
-type GetResult struct {
-	gophercloud.Result
-}
-
-// Extract is a function that accepts a result and extracts an API version resource.
-func (r GetResult) Extract() (*APIVersion, error) {
-	var s struct {
-		Versions []APIVersion `json:"versions"`
-	}
-	err := r.ExtractInto(&s)
+// ExtractAPIVersion takes a List result and extracts a single requested
+// version, which is returned as an APIVersion
+func ExtractAPIVersion(r pagination.Page, v string) (*APIVersion, error) {
+	allVersions, err := ExtractAPIVersions(r)
 	if err != nil {
 		return nil, err
 	}
 
-	switch len(s.Versions) {
-	case 0:
-		return nil, ErrVersionNotFound{}
-	case 1:
-		return &s.Versions[0], nil
-	default:
-		return nil, ErrMultipleVersionsFound{Count: len(s.Versions)}
+	for _, version := range allVersions {
+		if version.ID == v {
+			return &version, nil
+		}
 	}
+
+	return nil, ErrVersionNotFound{}
 }

--- a/openstack/blockstorage/apiversions/testing/doc.go
+++ b/openstack/blockstorage/apiversions/testing/doc.go
@@ -1,0 +1,2 @@
+// apiversions_v1
+package testing

--- a/openstack/blockstorage/apiversions/testing/fixtures.go
+++ b/openstack/blockstorage/apiversions/testing/fixtures.go
@@ -88,36 +88,33 @@ const APIListResponse = `
 }
 `
 
-const APIGetResponse = `
+const APIListOldResponse = `
 {
-    "versions": [
+  "versions": [
+    {
+      "status": "CURRENT",
+      "updated": "2012-01-04T11:33:21Z",
+      "id": "v1.0",
+      "links": [
         {
-            "id": "v3.0",
-            "links": [
-                {
-                    "href": "http://docs.openstack.org/",
-                    "rel": "describedby",
-                    "type": "text/html"
-                },
-                {
-                    "href": "http://localhost:8776/v3/",
-                    "rel": "self"
-                }
-            ],
-            "media-types": [
-                {
-                    "base": "application/json",
-                    "type": "application/vnd.openstack.volume+json;version=1"
-                }
-            ],
-            "min_version": "3.0",
-            "status": "CURRENT",
-            "updated": "2016-02-08T12:20:21Z",
-            "version": "3.27"
+          "href": "http://23.253.228.211:8776/v1/",
+          "rel": "self"
         }
-    ]
-}
-`
+      ]
+      },
+    {
+      "status": "CURRENT",
+      "updated": "2012-11-21T11:33:21Z",
+      "id": "v2.0",
+      "links": [
+        {
+          "href": "http://23.253.228.211:8776/v2/",
+          "rel": "self"
+        }
+      ]
+    }
+  ]
+}`
 
 func MockListResponse(t *testing.T) {
 	th.Mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
@@ -131,14 +128,14 @@ func MockListResponse(t *testing.T) {
 	})
 }
 
-func MockGetResponse(t *testing.T) {
-	th.Mux.HandleFunc("/v3/", func(w http.ResponseWriter, r *http.Request) {
+func MockListOldResponse(t *testing.T) {
+	th.Mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "GET")
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, APIGetResponse)
+		fmt.Fprintf(w, APIListOldResponse)
 	})
 }

--- a/openstack/blockstorage/apiversions/testing/fixtures.go
+++ b/openstack/blockstorage/apiversions/testing/fixtures.go
@@ -1,0 +1,144 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+const APIListResponse = `
+{
+    "versions": [
+        {
+            "id": "v1.0",
+            "links": [
+                {
+                    "href": "http://docs.openstack.org/",
+                    "rel": "describedby",
+                    "type": "text/html"
+                },
+                {
+                    "href": "http://localhost:8776/v1/",
+                    "rel": "self"
+                }
+            ],
+            "media-types": [
+                {
+                    "base": "application/json",
+                    "type": "application/vnd.openstack.volume+json;version=1"
+                }
+            ],
+            "min_version": "",
+            "status": "DEPRECATED",
+            "updated": "2016-05-02T20:25:19Z",
+            "version": ""
+        },
+        {
+            "id": "v2.0",
+            "links": [
+                {
+                    "href": "http://docs.openstack.org/",
+                    "rel": "describedby",
+                    "type": "text/html"
+                },
+                {
+                    "href": "http://localhost:8776/v2/",
+                    "rel": "self"
+                }
+            ],
+            "media-types": [
+                {
+                    "base": "application/json",
+                    "type": "application/vnd.openstack.volume+json;version=1"
+                }
+            ],
+            "min_version": "",
+            "status": "SUPPORTED",
+            "updated": "2014-06-28T12:20:21Z",
+            "version": ""
+        },
+        {
+            "id": "v3.0",
+            "links": [
+                {
+                    "href": "http://docs.openstack.org/",
+                    "rel": "describedby",
+                    "type": "text/html"
+                },
+                {
+                    "href": "http://localhost:8776/v3/",
+                    "rel": "self"
+                }
+            ],
+            "media-types": [
+                {
+                    "base": "application/json",
+                    "type": "application/vnd.openstack.volume+json;version=1"
+                }
+            ],
+            "min_version": "3.0",
+            "status": "CURRENT",
+            "updated": "2016-02-08T12:20:21Z",
+            "version": "3.27"
+        }
+    ]
+}
+`
+
+const APIGetResponse = `
+{
+    "versions": [
+        {
+            "id": "v3.0",
+            "links": [
+                {
+                    "href": "http://docs.openstack.org/",
+                    "rel": "describedby",
+                    "type": "text/html"
+                },
+                {
+                    "href": "http://localhost:8776/v3/",
+                    "rel": "self"
+                }
+            ],
+            "media-types": [
+                {
+                    "base": "application/json",
+                    "type": "application/vnd.openstack.volume+json;version=1"
+                }
+            ],
+            "min_version": "3.0",
+            "status": "CURRENT",
+            "updated": "2016-02-08T12:20:21Z",
+            "version": "3.27"
+        }
+    ]
+}
+`
+
+func MockListResponse(t *testing.T) {
+	th.Mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, APIListResponse)
+	})
+}
+
+func MockGetResponse(t *testing.T) {
+	th.Mux.HandleFunc("/v3/", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, APIGetResponse)
+	})
+}

--- a/openstack/blockstorage/apiversions/testing/requests_test.go
+++ b/openstack/blockstorage/apiversions/testing/requests_test.go
@@ -43,13 +43,42 @@ func TestListVersions(t *testing.T) {
 	th.AssertDeepEquals(t, expected, actual)
 }
 
+func TestListOldVersions(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockListOldResponse(t)
+
+	allVersions, err := apiversions.List(client.ServiceClient()).AllPages()
+	th.AssertNoErr(t, err)
+	actual, err := apiversions.ExtractAPIVersions(allVersions)
+	th.AssertNoErr(t, err)
+
+	expected := []apiversions.APIVersion{
+		{
+			ID:      "v1.0",
+			Status:  "CURRENT",
+			Updated: time.Date(2012, 1, 4, 11, 33, 21, 0, time.UTC),
+		},
+		{
+			ID:      "v2.0",
+			Status:  "CURRENT",
+			Updated: time.Date(2012, 11, 21, 11, 33, 21, 0, time.UTC),
+		},
+	}
+
+	th.AssertDeepEquals(t, expected, actual)
+}
+
 func TestGetVersion(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 
-	MockGetResponse(t)
+	MockListResponse(t)
 
-	actual, err := apiversions.Get(client.ServiceClient(), "v3").Extract()
+	allVersions, err := apiversions.List(client.ServiceClient()).AllPages()
+	th.AssertNoErr(t, err)
+	actual, err := apiversions.ExtractAPIVersion(allVersions, "v3.0")
 	th.AssertNoErr(t, err)
 
 	expected := apiversions.APIVersion{
@@ -58,6 +87,30 @@ func TestGetVersion(t *testing.T) {
 		Status:     "CURRENT",
 		Updated:    time.Date(2016, 2, 8, 12, 20, 21, 0, time.UTC),
 		Version:    "3.27",
+	}
+
+	th.AssertEquals(t, actual.ID, expected.ID)
+	th.AssertEquals(t, actual.Status, expected.Status)
+	th.AssertEquals(t, actual.Updated, expected.Updated)
+}
+
+func TestGetOldVersion(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockListOldResponse(t)
+
+	allVersions, err := apiversions.List(client.ServiceClient()).AllPages()
+	th.AssertNoErr(t, err)
+	actual, err := apiversions.ExtractAPIVersion(allVersions, "v2.0")
+	th.AssertNoErr(t, err)
+
+	expected := apiversions.APIVersion{
+		ID:         "v2.0",
+		MinVersion: "",
+		Status:     "CURRENT",
+		Updated:    time.Date(2012, 11, 21, 11, 33, 21, 0, time.UTC),
+		Version:    "",
 	}
 
 	th.AssertEquals(t, actual.ID, expected.ID)

--- a/openstack/blockstorage/apiversions/testing/requests_test.go
+++ b/openstack/blockstorage/apiversions/testing/requests_test.go
@@ -1,0 +1,66 @@
+package testing
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gophercloud/gophercloud/openstack/blockstorage/apiversions"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func TestListVersions(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockListResponse(t)
+
+	allVersions, err := apiversions.List(client.ServiceClient()).AllPages()
+	th.AssertNoErr(t, err)
+	actual, err := apiversions.ExtractAPIVersions(allVersions)
+	th.AssertNoErr(t, err)
+
+	expected := []apiversions.APIVersion{
+		{
+			ID:      "v1.0",
+			Status:  "DEPRECATED",
+			Updated: time.Date(2016, 5, 2, 20, 25, 19, 0, time.UTC),
+		},
+		{
+			ID:      "v2.0",
+			Status:  "SUPPORTED",
+			Updated: time.Date(2014, 6, 28, 12, 20, 21, 0, time.UTC),
+		},
+		{
+			ID:         "v3.0",
+			MinVersion: "3.0",
+			Status:     "CURRENT",
+			Updated:    time.Date(2016, 2, 8, 12, 20, 21, 0, time.UTC),
+			Version:    "3.27",
+		},
+	}
+
+	th.AssertDeepEquals(t, expected, actual)
+}
+
+func TestGetVersion(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockGetResponse(t)
+
+	actual, err := apiversions.Get(client.ServiceClient(), "v3").Extract()
+	th.AssertNoErr(t, err)
+
+	expected := apiversions.APIVersion{
+		ID:         "v3.0",
+		MinVersion: "3.0",
+		Status:     "CURRENT",
+		Updated:    time.Date(2016, 2, 8, 12, 20, 21, 0, time.UTC),
+		Version:    "3.27",
+	}
+
+	th.AssertEquals(t, actual.ID, expected.ID)
+	th.AssertEquals(t, actual.Status, expected.Status)
+	th.AssertEquals(t, actual.Updated, expected.Updated)
+}

--- a/openstack/blockstorage/apiversions/urls.go
+++ b/openstack/blockstorage/apiversions/urls.go
@@ -1,0 +1,18 @@
+package apiversions
+
+import (
+	"net/url"
+	"strings"
+
+	"github.com/gophercloud/gophercloud"
+)
+
+func getURL(c *gophercloud.ServiceClient, version string) string {
+	return c.ServiceURL(strings.TrimRight(version, "/") + "/")
+}
+
+func listURL(c *gophercloud.ServiceClient) string {
+	u, _ := url.Parse(c.ServiceURL(""))
+	u.Path = "/"
+	return u.String()
+}

--- a/openstack/blockstorage/apiversions/urls.go
+++ b/openstack/blockstorage/apiversions/urls.go
@@ -1,14 +1,16 @@
 package apiversions
 
 import (
+	"fmt"
 	"net/url"
-	"strings"
 
 	"github.com/gophercloud/gophercloud"
 )
 
 func getURL(c *gophercloud.ServiceClient, version string) string {
-	return c.ServiceURL(strings.TrimRight(version, "/") + "/")
+	u, _ := url.Parse(c.ServiceURL(""))
+	u.Path = fmt.Sprintf("/%s/", version)
+	return u.String()
 }
 
 func listURL(c *gophercloud.ServiceClient) string {

--- a/openstack/blockstorage/apiversions/urls.go
+++ b/openstack/blockstorage/apiversions/urls.go
@@ -1,17 +1,10 @@
 package apiversions
 
 import (
-	"fmt"
 	"net/url"
 
 	"github.com/gophercloud/gophercloud"
 )
-
-func getURL(c *gophercloud.ServiceClient, version string) string {
-	u, _ := url.Parse(c.ServiceURL(""))
-	u.Path = fmt.Sprintf("/%s/", version)
-	return u.String()
-}
 
 func listURL(c *gophercloud.ServiceClient) string {
 	u, _ := url.Parse(c.ServiceURL(""))

--- a/openstack/blockstorage/v1/apiversions/doc.go
+++ b/openstack/blockstorage/v1/apiversions/doc.go
@@ -1,3 +1,11 @@
-// Package apiversions provides information and interaction with the different
-// API versions for the OpenStack Block Storage service, code-named Cinder.
+/*
+Package apiversions provides information and interaction with the different
+API versions for the OpenStack Block Storage service, code-named Cinder.
+
+This package is deprecated and should only be used in environments where the
+older API version format is expected.
+
+Consider using the gophercloud/openstack/blockstorage/apiversions package
+instead.
+*/
 package apiversions


### PR DESCRIPTION
For #457 

If there's concern about leaving `v1/apiversions` for backwards compatibility, I can easily drop the deletion of `v1/apiversions` here. I'm on the fence about whether that would be worthwhile or not. The original `apiversions` seems to be expecting an old response format, but I suppose that might be useful for some very old environments.

/cc @j-griffith 