### PR TITLE
Common: Clean up common package

### DIFF
--- a/openstack/common/README.md
+++ b/openstack/common/README.md
@@ -1,3 +1,0 @@
-# Common Resources
-
-This directory is for resources that are shared by multiple services.

--- a/openstack/common/extensions/doc.go
+++ b/openstack/common/extensions/doc.go
@@ -1,15 +1,52 @@
-// Package extensions provides information and interaction with the different extensions available
-// for an OpenStack service.
-//
-// The purpose of OpenStack API extensions is to:
-//
-// - Introduce new features in the API without requiring a version change.
-// - Introduce vendor-specific niche functionality.
-// - Act as a proving ground for experimental functionalities that might be included in a future
-//   version of the API.
-//
-// Extensions usually have tags that prevent conflicts with other extensions that define attributes
-// or resources with the same names, and with core resources and attributes.
-// Because an extension might not be supported by all plug-ins, its availability varies with deployments
-// and the specific plug-in.
+/*
+Package extensions provides information and interaction with the different
+extensions available for an OpenStack service.
+
+The purpose of OpenStack API extensions is to:
+
+- Introduce new features in the API without requiring a version change.
+- Introduce vendor-specific niche functionality.
+- Act as a proving ground for experimental functionalities that might be
+included in a future version of the API.
+
+Extensions usually have tags that prevent conflicts with other extensions that
+define attributes or resources with the same names, and with core resources and
+attributes. Because an extension might not be supported by all plug-ins, its
+availability varies with deployments and the specific plug-in.
+
+The results of this package vary depending on the type of Service Client used.
+In the following examples, note how the only difference is the creation of the
+Service Client.
+
+Example of Retrieving Compute Extensions
+
+	ao, err := openstack.AuthOptionsFromEnv()
+	provider, err := openstack.AuthenticatedClient(ao)
+	computeClient, err := openstack.NewComputeV2(provider, gophercloud.EndpointOpts{
+		Region: os.Getenv("OS_REGION_NAME"),
+	})
+
+	allPages, err := extensions.List(computeClient).Allpages()
+	allExtensions, err := extensions.ExtractExtensions(allPages)
+
+	for _, extension := range allExtensions{
+		fmt.Println("%+v\n", extension)
+	}
+
+
+Example of Retrieving Network Extensions
+
+	ao, err := openstack.AuthOptionsFromEnv()
+	provider, err := openstack.AuthenticatedClient(ao)
+	networkClient, err := openstack.NewNetworkV2(provider, gophercloud.EndpointOpts{
+		Region: os.Getenv("OS_REGION_NAME"),
+	})
+
+	allPages, err := extensions.List(networkClient).Allpages()
+	allExtensions, err := extensions.ExtractExtensions(allPages)
+
+	for _, extension := range allExtensions{
+		fmt.Println("%+v\n", extension)
+	}
+*/
 package extensions

--- a/openstack/common/extensions/errors.go
+++ b/openstack/common/extensions/errors.go
@@ -1,1 +1,0 @@
-package extensions

--- a/openstack/common/extensions/results.go
+++ b/openstack/common/extensions/results.go
@@ -41,8 +41,8 @@ func (r ExtensionPage) IsEmpty() (bool, error) {
 	return len(is) == 0, err
 }
 
-// ExtractExtensions accepts a Page struct, specifically an ExtensionPage struct, and extracts the
-// elements into a slice of Extension structs.
+// ExtractExtensions accepts a Page struct, specifically an ExtensionPage
+// struct, and extracts the elements into a slice of Extension structs.
 // In other words, a generic collection is mapped into a relevant slice.
 func ExtractExtensions(r pagination.Page) ([]Extension, error) {
 	var s struct {


### PR DESCRIPTION
This commit cleans up the common package by removing unused files
as well as adds more detailed documentation.

For #446 