### PR TITLE
Compute v2: Clean up diskconfig package

### DIFF
--- a/openstack/compute/v2/extensions/diskconfig/doc.go
+++ b/openstack/compute/v2/extensions/diskconfig/doc.go
@@ -1,3 +1,46 @@
-// Package diskconfig provides information and interaction with the Disk
-// Config extension that works with the OpenStack Compute service.
+/*
+Package diskconfig provides information and interaction with the Disk Config
+extension that works with the OpenStack Compute service.
+
+Example of Obtaining the Disk Config of a Server
+
+	type ServerWithDiskConfig {
+		servers.Server
+		diskconfig.ServerDiskConfigExt
+	}
+
+	var allServers []ServerWithDiskConfig
+
+	allPages, err := servers.List(client, nil).AllPages()
+	if err != nil {
+		panic("Unable to retrieve servers: %s", err)
+	}
+
+	err = servers.ExtractServersInto(allPages, &allServers)
+	if err != nil {
+		panic("Unable to extract servers: %s", err)
+	}
+
+	for _, server := range allServers {
+		fmt.Println(server.DiskConfig)
+	}
+
+Example of Creating a Server with Disk Config
+
+	serverCreateOpts := servers.CreateOpts{
+		Name:      "server_name",
+		ImageRef:  "image-uuid",
+		FlavorRef: "flavor-uuid",
+	}
+
+	createOpts := diskconfig.CreateOptsExt{
+		CreateOptsBuilder: serverCreateOpts,
+		DiskConfig:        diskconfig.Manual,
+	}
+
+	server, err := servers.Create(computeClient, createOpts).Extract()
+	if err != nil {
+		panic("Unable to create server: %s", err)
+	}
+*/
 package diskconfig

--- a/openstack/compute/v2/extensions/diskconfig/requests.go
+++ b/openstack/compute/v2/extensions/diskconfig/requests.go
@@ -5,20 +5,22 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
 )
 
-// DiskConfig represents one of the two possible settings for the DiskConfig option when creating,
-// rebuilding, or resizing servers: Auto or Manual.
+// DiskConfig represents one of the two possible settings for the DiskConfig
+// option when creating, rebuilding, or resizing servers: Auto or Manual.
 type DiskConfig string
 
 const (
-	// Auto builds a server with a single partition the size of the target flavor disk and
-	// automatically adjusts the filesystem to fit the entire partition. Auto may only be used with
-	// images and servers that use a single EXT3 partition.
+	// Auto builds a server with a single partition the size of the target flavor
+	// disk and automatically adjusts the filesystem to fit the entire partition.
+	// Auto may only be used with images and servers that use a single EXT3
+	// partition.
 	Auto DiskConfig = "AUTO"
 
-	// Manual builds a server using whatever partition scheme and filesystem are present in the source
-	// image. If the target flavor disk is larger, the remaining space is left unpartitioned. This
-	// enables images to have non-EXT3 filesystems, multiple partitions, and so on, and enables you
-	// to manage the disk configuration. It also results in slightly shorter boot times.
+	// Manual builds a server using whatever partition scheme and filesystem are
+	// present in the source image. If the target flavor disk is larger, the
+	// remaining space is left unpartitioned. This enables images to have non-EXT3
+	// filesystems, multiple partitions, and so on, and enables you to manage the
+	// disk configuration. It also results in slightly shorter boot times.
 	Manual DiskConfig = "MANUAL"
 )
 
@@ -50,6 +52,7 @@ func (opts CreateOptsExt) ToServerCreateMap() (map[string]interface{}, error) {
 // RebuildOptsExt adds a DiskConfig option to the base RebuildOpts.
 type RebuildOptsExt struct {
 	servers.RebuildOptsBuilder
+
 	// DiskConfig controls how the rebuilt server's disk is partitioned.
 	DiskConfig DiskConfig `json:"OS-DCF:diskConfig,omitempty"`
 }

--- a/openstack/compute/v2/extensions/diskconfig/results.go
+++ b/openstack/compute/v2/extensions/diskconfig/results.go
@@ -1,17 +1,6 @@
 package diskconfig
 
-import "github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
-
-type ServerWithDiskConfig struct {
-	servers.Server
+type ServerDiskConfigExt struct {
+	// DiskConfig is the disk configuration of the server.
 	DiskConfig DiskConfig `json:"OS-DCF:diskConfig"`
-}
-
-func (s ServerWithDiskConfig) ToServerCreateResult() (m map[string]interface{}) {
-	m["OS-DCF:diskConfig"] = s.DiskConfig
-	return
-}
-
-type CreateServerResultBuilder interface {
-	ToServerCreateResult() map[string]interface{}
 }

--- a/openstack/compute/v2/servers/testing/requests_test.go
+++ b/openstack/compute/v2/servers/testing/requests_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/availabilityzones"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/diskconfig"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
 	"github.com/gophercloud/gophercloud/pagination"
 	th "github.com/gophercloud/gophercloud/testhelper"
@@ -65,6 +66,7 @@ func TestListAllServersWithExtensions(t *testing.T) {
 	type ServerWithExt struct {
 		servers.Server
 		availabilityzones.ServerAvailabilityZoneExt
+		diskconfig.ServerDiskConfigExt
 	}
 
 	allPages, err := servers.List(client.ServiceClient(), servers.ListOpts{}).AllPages()
@@ -75,6 +77,7 @@ func TestListAllServersWithExtensions(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, 3, len(actual))
 	th.AssertEquals(t, "nova", actual[0].AvailabilityZone)
+	th.AssertEquals(t, diskconfig.Manual, actual[0].DiskConfig)
 }
 
 func TestCreateServer(t *testing.T) {
@@ -218,11 +221,13 @@ func TestGetServerWithExtensions(t *testing.T) {
 	var s struct {
 		servers.Server
 		availabilityzones.ServerAvailabilityZoneExt
+		diskconfig.ServerDiskConfigExt
 	}
 
 	err := servers.Get(client.ServiceClient(), "1234asdf").ExtractInto(&s)
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, "nova", s.AvailabilityZone)
+	th.AssertEquals(t, diskconfig.Manual, s.DiskConfig)
 
 	err = servers.Get(client.ServiceClient(), "1234asdf").ExtractInto(s)
 	if err == nil {


### PR DESCRIPTION
For #470 
For #446 

A unit test for the extension can be added after #466 is merged since it modifies the same area of code. I tested it locally and it works as expected.