### PR TITLE
Identity v3 - Add Get Projects by User

### DIFF
--- a/acceptance/openstack/identity/v3/users_test.go
+++ b/acceptance/openstack/identity/v3/users_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gophercloud/gophercloud/acceptance/clients"
 	"github.com/gophercloud/gophercloud/acceptance/tools"
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/groups"
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/projects"
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/users"
 )
 
@@ -152,5 +153,37 @@ func TestUsersListGroups(t *testing.T) {
 	for _, group := range allGroups {
 		tools.PrintResource(t, group)
 		tools.PrintResource(t, group.Extra)
+	}
+}
+
+func TestUsersListProjects(t *testing.T) {
+	client, err := clients.NewIdentityV3Client()
+	if err != nil {
+		t.Fatalf("Unable to obtain an identity client: %v", err)
+	}
+	allUserPages, err := users.List(client, nil).AllPages()
+	if err != nil {
+		t.Fatalf("Unable to list users: %v", err)
+	}
+
+	allUsers, err := users.ExtractUsers(allUserPages)
+	if err != nil {
+		t.Fatalf("Unable to extract users: %v", err)
+	}
+
+	user := allUsers[0]
+
+	allProjectPages, err := users.ListProjects(client, user.ID).AllPages()
+	if err != nil {
+		t.Fatalf("Unable to list projects: %v", err)
+	}
+
+	allProjects, err := projects.ExtractProjects(allProjectPages)
+	if err != nil {
+		t.Fatalf("Unable to extract projects: %v", err)
+	}
+
+	for _, project := range allProjects {
+		tools.PrintResource(t, project)
 	}
 }

--- a/openstack/identity/v3/users/doc.go
+++ b/openstack/identity/v3/users/doc.go
@@ -89,7 +89,7 @@ Example to List Projects a User Belongs To
 		panic(err)
 	}
 
-	allProjects, err := projects.ExtractGroups(allPages)
+	allProjects, err := projects.ExtractProjects(allPages)
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/identity/v3/users/doc.go
+++ b/openstack/identity/v3/users/doc.go
@@ -71,7 +71,7 @@ Example to List Groups a User Belongs To
 		panic(err)
 	}
 
-	allGroups, err := users.ExtractGroups(allPages)
+	allGroups, err := groups.ExtractGroups(allPages)
 	if err != nil {
 		panic(err)
 	}
@@ -79,5 +79,24 @@ Example to List Groups a User Belongs To
 	for _, group := range allGroups {
 		fmt.Printf("%+v\n", group)
 	}
+
+Example to List Projects a User Belongs To
+
+	userID := "0fe36e73809d46aeae6705c39077b1b3"
+
+	allPages, err := users.ListGroups(identityClient, userID).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allProjects, err := projects.ExtractGroups(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, project := range allProjects {
+		fmt.Printf("%+v\n", project)
+	}
+
 */
 package users

--- a/openstack/identity/v3/users/doc.go
+++ b/openstack/identity/v3/users/doc.go
@@ -84,7 +84,7 @@ Example to List Projects a User Belongs To
 
 	userID := "0fe36e73809d46aeae6705c39077b1b3"
 
-	allPages, err := users.ListGroups(identityClient, userID).AllPages()
+	allPages, err := users.ListProjects(identityClient, userID).AllPages()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/identity/v3/users/requests.go
+++ b/openstack/identity/v3/users/requests.go
@@ -3,6 +3,7 @@ package users
 import (
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/groups"
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/projects"
 	"github.com/gophercloud/gophercloud/pagination"
 )
 
@@ -214,5 +215,13 @@ func ListGroups(client *gophercloud.ServiceClient, userID string) pagination.Pag
 	url := listGroupsURL(client, userID)
 	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
 		return groups.GroupPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// ListProjects enumerates groups user belongs to.
+func ListProjects(client *gophercloud.ServiceClient, userID string) pagination.Pager {
+	url := listProjectsURL(client, userID)
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return projects.ProjectPage{pagination.LinkedPageBase{PageResult: r}}
 	})
 }

--- a/openstack/identity/v3/users/testing/fixtures.go
+++ b/openstack/identity/v3/users/testing/fixtures.go
@@ -196,40 +196,38 @@ const ListGroupsOutput = `
 }
 `
 
-// Sample response from "https://developer.openstack.org/api-ref/identity/v3/#list-projects-for-user"
-// by the Openstack Foundation is licensed under CC BY 3.0 (https://creativecommons.org/licenses/by/3.0/)
 // ListProjectsOutput provides a ListProjects result.
 const ListProjectsOutput = `
 {
+    "links": {
+        "next": null,
+        "previous": null,
+        "self": "http://localhost:5000/identity/v3/users/foobar/projects",
+    },
     "projects": [
         {
-            "description": "description of this project",
-            "domain_id": "161718",
+            "description": "my first project",
+            "domain_id": "11111",
             "enabled": true,
-            "id": "456788",
+            "id": "abcde",
             "links": {
-                "self": "http://example.com/identity/v3/projects/456788"
+                "self": "http://localhost:5000/identity/v3/projects/abcde"
             },
-            "name": "a project name",
-            "parent_id": "212223"
+            "name": "project 1",
+            "parent_id": "11111"
         },
         {
-            "description": "description of this project",
-            "domain_id": "161718",
+            "description": "my second project",
+            "domain_id": "22222",
             "enabled": true,
-            "id": "456789",
+            "id": "bcdef",
             "links": {
-                "self": "http://example.com/identity/v3/projects/456789"
+                "self": "http://localhost:5000/identity/v3/projects/bcdef"
             },
-            "name": "another domain",
-            "parent_id": "212223"
+            "name": "project 2",
+            "parent_id": "22222"
         }
-    ],
-    "links": {
-        "self": "http://example.com/identity/v3/users/313233/projects",
-        "previous": null,
-        "next": null
-    }
+    ]
 }
 `
 
@@ -338,24 +336,22 @@ var SecondGroup = groups.Group{
 
 var ExpectedGroupsSlice = []groups.Group{FirstGroup, SecondGroup}
 
-// Parsed response is derivative of "https://developer.openstack.org/api-ref/identity/v3/#list-projects-for-user"
-// by the Openstack Foundation is licensed under CC BY 3.0 (https://creativecommons.org/licenses/by/3.0/)
 var FirstProject = projects.Project{
-	Description: "description of this project",
-	DomainID:    "161718",
+	Description: "my first project",
+	DomainID:    "11111",
 	Enabled:     true,
-	ID:          "456788",
-	Name:        "a project name",
-	ParentID:    "212223",
+	ID:          "abcde",
+	Name:        "project 1",
+	ParentID:    "11111",
 }
 
 var SecondProject = projects.Project{
-	Description: "description of this project",
-	DomainID:    "161718",
+	Description: "my second project",
+	DomainID:    "22222",
 	Enabled:     true,
-	ID:          "456789",
-	Name:        "another domain",
-	ParentID:    "212223",
+	ID:          "bcdef",
+	Name:        "project 2",
+	ParentID:    "22222",
 }
 
 var ExpectedProjectsSlice = []projects.Project{FirstProject, SecondProject}

--- a/openstack/identity/v3/users/testing/fixtures.go
+++ b/openstack/identity/v3/users/testing/fixtures.go
@@ -202,7 +202,7 @@ const ListProjectsOutput = `
     "links": {
         "next": null,
         "previous": null,
-        "self": "http://localhost:5000/identity/v3/users/foobar/projects",
+        "self": "http://localhost:5000/identity/v3/users/foobar/projects"
     },
     "projects": [
         {

--- a/openstack/identity/v3/users/testing/fixtures.go
+++ b/openstack/identity/v3/users/testing/fixtures.go
@@ -196,6 +196,8 @@ const ListGroupsOutput = `
 }
 `
 
+// Sample response from "https://developer.openstack.org/api-ref/identity/v3/#list-projects-for-user"
+// by the Openstack Foundation is licensed under CC BY 3.0 (https://creativecommons.org/licenses/by/3.0/)
 // ListProjectsOutput provides a ListProjects result.
 const ListProjectsOutput = `
 {
@@ -336,6 +338,8 @@ var SecondGroup = groups.Group{
 
 var ExpectedGroupsSlice = []groups.Group{FirstGroup, SecondGroup}
 
+// Parsed response is derivative of "https://developer.openstack.org/api-ref/identity/v3/#list-projects-for-user"
+// by the Openstack Foundation is licensed under CC BY 3.0 (https://creativecommons.org/licenses/by/3.0/)
 var FirstProject = projects.Project{
 	Description: "description of this project",
 	DomainID:    "161718",

--- a/openstack/identity/v3/users/testing/fixtures.go
+++ b/openstack/identity/v3/users/testing/fixtures.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/groups"
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/projects"
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/users"
 	th "github.com/gophercloud/gophercloud/testhelper"
 	"github.com/gophercloud/gophercloud/testhelper/client"
@@ -195,6 +196,41 @@ const ListGroupsOutput = `
 }
 `
 
+// ListProjectsOutput provides a ListProjects result.
+const ListProjectsOutput = `
+{
+    "projects": [
+        {
+            "description": "description of this project",
+            "domain_id": "161718",
+            "enabled": true,
+            "id": "456788",
+            "links": {
+                "self": "http://example.com/identity/v3/projects/456788"
+            },
+            "name": "a project name",
+            "parent_id": "212223"
+        },
+        {
+            "description": "description of this project",
+            "domain_id": "161718",
+            "enabled": true,
+            "id": "456789",
+            "links": {
+                "self": "http://example.com/identity/v3/projects/456789"
+            },
+            "name": "another domain",
+            "parent_id": "212223"
+        }
+    ],
+    "links": {
+        "self": "http://example.com/identity/v3/users/313233/projects",
+        "previous": null,
+        "next": null
+    }
+}
+`
+
 // FirstUser is the first user in the List request.
 var nilTime time.Time
 var FirstUser = users.User{
@@ -300,6 +336,26 @@ var SecondGroup = groups.Group{
 
 var ExpectedGroupsSlice = []groups.Group{FirstGroup, SecondGroup}
 
+var FirstProject = projects.Project{
+	Description: "description of this project",
+	DomainID:    "161718",
+	Enabled:     true,
+	ID:          "456788",
+	Name:        "a project name",
+	ParentID:    "212223",
+}
+
+var SecondProject = projects.Project{
+	Description: "description of this project",
+	DomainID:    "161718",
+	Enabled:     true,
+	ID:          "456789",
+	Name:        "another domain",
+	ParentID:    "212223",
+}
+
+var ExpectedProjectsSlice = []projects.Project{FirstProject, SecondProject}
+
 // HandleListUsersSuccessfully creates an HTTP handler at `/users` on the
 // test handler mux that responds with a list of two users.
 func HandleListUsersSuccessfully(t *testing.T) {
@@ -379,7 +435,7 @@ func HandleDeleteUserSuccessfully(t *testing.T) {
 }
 
 // HandleListUserGroupsSuccessfully creates an HTTP handler at /users/{userID}/groups
-// on the test handler mux that respons wit a list of two groups
+// on the test handler mux that respons with a list of two groups
 func HandleListUserGroupsSuccessfully(t *testing.T) {
 	th.Mux.HandleFunc("/users/9fe1d3/groups", func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "GET")
@@ -389,5 +445,19 @@ func HandleListUserGroupsSuccessfully(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprintf(w, ListGroupsOutput)
+	})
+}
+
+// HandleListUserProjectsSuccessfully creates an HTTP handler at /users/{userID}/projects
+// on the test handler mux that respons wit a list of two projects
+func HandleListUserProjectsSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/users/9fe1d3/projects", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, ListProjectsOutput)
 	})
 }

--- a/openstack/identity/v3/users/testing/requests_test.go
+++ b/openstack/identity/v3/users/testing/requests_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/groups"
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/projects"
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/users"
 	"github.com/gophercloud/gophercloud/pagination"
 	th "github.com/gophercloud/gophercloud/testhelper"
@@ -145,4 +146,15 @@ func TestListUserGroups(t *testing.T) {
 	actual, err := groups.ExtractGroups(allPages)
 	th.AssertNoErr(t, err)
 	th.CheckDeepEquals(t, ExpectedGroupsSlice, actual)
+}
+
+func TestListUserProjects(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleListUserGroupsSuccessfully(t)
+	allPages, err := users.ListProjects(client.ServiceClient(), "9fe1d3").AllPages()
+	th.AssertNoErr(t, err)
+	actual, err := projects.ExtractProjects(allPages)
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, ExpectedProjectsSlice, actual)
 }

--- a/openstack/identity/v3/users/testing/requests_test.go
+++ b/openstack/identity/v3/users/testing/requests_test.go
@@ -151,7 +151,7 @@ func TestListUserGroups(t *testing.T) {
 func TestListUserProjects(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
-	HandleListUserGroupsSuccessfully(t)
+	HandleListUserProjectsSuccessfully(t)
 	allPages, err := users.ListProjects(client.ServiceClient(), "9fe1d3").AllPages()
 	th.AssertNoErr(t, err)
 	actual, err := projects.ExtractProjects(allPages)

--- a/openstack/identity/v3/users/urls.go
+++ b/openstack/identity/v3/users/urls.go
@@ -25,3 +25,7 @@ func deleteURL(client *gophercloud.ServiceClient, userID string) string {
 func listGroupsURL(client *gophercloud.ServiceClient, userID string) string {
 	return client.ServiceURL("users", userID, "groups")
 }
+
+func listProjectsURL(client *gophercloud.ServiceClient, userID string) string {
+	return client.ServiceURL("users", userID, "projects")
+}


### PR DESCRIPTION
For #528

Details: Add ListUsers function for Gophercloud's OpenStack Identity v3 API
- Allows a caller to get the list of projects that a specified user has access to
- Effectively wraps OpenStack Identity v3 API function /v3/users/{user_id}/projects
- Based on implementation of ListGroups

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://developer.openstack.org/api-ref/identity/v3/#list-projects-for-user
https://github.com/openstack/keystone/blob/stable/pike/keystone/common/policies/user.py#L39
https://github.com/openstack/keystone/blob/stable/pike/keystone/auth/controllers.py#L363-L381

**Update** Source link identified by maintainer: https://github.com/openstack/keystone/blob/6b6e1a7322666fb4da871281bb8c58db199c7f49/keystone/assignment/core.py#L227-L240