### PR TITLE
Compute v2: Add Evacuate Action

### DIFF
--- a/openstack/compute/v2/extensions/evacuate/doc.go
+++ b/openstack/compute/v2/extensions/evacuate/doc.go
@@ -1,0 +1,13 @@
+/*
+Package evacuate provides functionality to evacuates servers that have been
+provisioned by the OpenStack Compute service from a failed host to a new host.
+
+Example to Evacuate a Server
+
+	serverID := "b16ba811-199d-4ffd-8839-ba96c1185a67"
+	err := evacuate.Evacuate(computeClient, serverID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+*/
+package evacuate

--- a/openstack/compute/v2/extensions/evacuate/doc.go
+++ b/openstack/compute/v2/extensions/evacuate/doc.go
@@ -2,10 +2,10 @@
 Package evacuate provides functionality to evacuates servers that have been
 provisioned by the OpenStack Compute service from a failed host to a new host.
 
-Example to Evacuate a Server
+Example to Evacuate a Server from a Host
 
 	serverID := "b16ba811-199d-4ffd-8839-ba96c1185a67"
-	err := evacuate.Evacuate(computeClient, serverID).ExtractErr()
+	err := evacuate.Evacuate(computeClient, serverID, nil).ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/compute/v2/extensions/evacuate/doc.go
+++ b/openstack/compute/v2/extensions/evacuate/doc.go
@@ -5,7 +5,7 @@ provisioned by the OpenStack Compute service from a failed host to a new host.
 Example to Evacuate a Server from a Host
 
 	serverID := "b16ba811-199d-4ffd-8839-ba96c1185a67"
-	err := evacuate.Evacuate(computeClient, serverID, nil).ExtractErr()
+	err := evacuate.Evacuate(computeClient, serverID, evacuate.EvacuateOpts{}).ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/compute/v2/extensions/evacuate/requests.go
+++ b/openstack/compute/v2/extensions/evacuate/requests.go
@@ -13,10 +13,10 @@ type EvacuateOptsBuilder interface {
 // EvacuateOpts specifies Evacuate action parameters.
 type EvacuateOpts struct {
 	// The name of the host to which the server is evacuated
-	Host string `json:"host"`
+	Host string `json:"host,omitempty"`
 
 	// Indicates whether server is on shared storage
-	onSharedStorage *bool `json:"onSharedStorage"`
+	OnSharedStorage bool `json:"OnSharedStorage"`
 
 	// An administrative password to access the evacuated server
 	AdminPass string `json:"adminPass,omitempty"`

--- a/openstack/compute/v2/extensions/evacuate/requests.go
+++ b/openstack/compute/v2/extensions/evacuate/requests.go
@@ -13,7 +13,7 @@ type EvacuateOptsBuilder interface {
 // EvacuateOpts specifies Evacuate action parameters.
 type EvacuateOpts struct {
 	// The name of the host to which the server is evacuated
-	Host string 	`json:"host"`
+	Host string `json:"host"`
 
 	// Indicates whether server is on shared storage
 	onSharedStorage *bool `json:"onSharedStorage"`

--- a/openstack/compute/v2/extensions/evacuate/requests.go
+++ b/openstack/compute/v2/extensions/evacuate/requests.go
@@ -4,8 +4,38 @@ import (
 	"github.com/gophercloud/gophercloud"
 )
 
+// EvacuateOptsBuilder allows extensions to add additional parameters to the
+// the Evacuate request.
+type EvacuateOptsBuilder interface {
+	ToEvacuateMap() (map[string]interface{}, error)
+}
+
+// EvacuateOpts specifies Evacuate action parameters.
+type EvacuateOpts struct {
+	// The name of the host to which the server is evacuated
+	Host string 	`json:"host"`
+
+	// Indicates whether server is on shared storage
+	onSharedStorage *bool `json:"onSharedStorage"`
+
+	// An administrative password to access the evacuated server
+	AdminPass string `json:"adminPass,omitempty"`
+}
+
+// ToServerGroupCreateMap constructs a request body from CreateOpts.
+func (opts EvacuateOpts) ToEvacuateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "evacuate")
+}
+
 // Evacuate will Evacuate a failed instance to another host.
-func Evacuate(client *gophercloud.ServiceClient, id string) (r EvacuateResult) {
-	_, r.Err = client.Post(actionURL(client, id), map[string]interface{}{"evacuate": nil}, nil, nil)
+func Evacuate(client *gophercloud.ServiceClient, id string, opts EvacuateOptsBuilder) (r EvacuateResult) {
+	b, err := opts.ToEvacuateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(actionURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+	})
 	return
 }

--- a/openstack/compute/v2/extensions/evacuate/requests.go
+++ b/openstack/compute/v2/extensions/evacuate/requests.go
@@ -39,17 +39,3 @@ func Evacuate(client *gophercloud.ServiceClient, id string, opts EvacuateOptsBui
 	})
 	return
 }
-
-func (r EvacuateResult) ExtractAdminPass() (string, error) {
-	var s struct {
-		AdminPass string `json:"adminPass"`
-	}
-	err := r.ExtractInto(&s)
-	if err != nil && err.Error() == "EOF" {
-		return "", nil
-	}
-	if err != nil && err.Error() != "EOF" {
-		return s.AdminPass, err
-	}
-	return s.AdminPass, err
-}

--- a/openstack/compute/v2/extensions/evacuate/requests.go
+++ b/openstack/compute/v2/extensions/evacuate/requests.go
@@ -45,8 +45,11 @@ func (r EvacuateResult) ExtractAdminPass() (string, error) {
 		AdminPass string `json:"adminPass"`
 	}
 	err := r.ExtractInto(&s)
+	if err != nil && err.Error() == "EOF" {
+	  return "", nil
+	}
 	if err != nil && err.Error() != "EOF" {
 		return s.AdminPass, err
 	}
-	return s.AdminPass, nil
+	return s.AdminPass, err
 }

--- a/openstack/compute/v2/extensions/evacuate/requests.go
+++ b/openstack/compute/v2/extensions/evacuate/requests.go
@@ -1,0 +1,11 @@
+package evacuate
+
+import (
+	"github.com/gophercloud/gophercloud"
+)
+
+// Evacuate will Evacuate a failed instance to another host.
+func Evacuate(client *gophercloud.ServiceClient, id string) (r EvacuateResult) {
+	_, r.Err = client.Post(actionURL(client, id), map[string]interface{}{"evacuate": nil}, nil, nil)
+	return
+}

--- a/openstack/compute/v2/extensions/evacuate/requests.go
+++ b/openstack/compute/v2/extensions/evacuate/requests.go
@@ -16,7 +16,7 @@ type EvacuateOpts struct {
 	Host string `json:"host,omitempty"`
 
 	// Indicates whether server is on shared storage
-	OnSharedStorage bool `json:"OnSharedStorage"`
+	OnSharedStorage bool `json:"onSharedStorage"`
 
 	// An administrative password to access the evacuated server
 	AdminPass string `json:"adminPass,omitempty"`
@@ -35,7 +35,17 @@ func Evacuate(client *gophercloud.ServiceClient, id string, opts EvacuateOptsBui
 		return
 	}
 	_, r.Err = client.Post(actionURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
-		OkCodes: []int{202},
+		OkCodes: []int{200},
 	})
 	return
+}
+
+func (r EvacuateResult) ExtractAdminPass() (string, error) {
+	if r.Err != nil && r.Err.Error() != "EOF" {
+		return "", r.Err
+	}
+	if l, ok := r.Header["adminPass"]; ok && len(l) > 0 {
+		return l[0], nil
+	}
+	return "", nil
 }

--- a/openstack/compute/v2/extensions/evacuate/requests.go
+++ b/openstack/compute/v2/extensions/evacuate/requests.go
@@ -41,11 +41,12 @@ func Evacuate(client *gophercloud.ServiceClient, id string, opts EvacuateOptsBui
 }
 
 func (r EvacuateResult) ExtractAdminPass() (string, error) {
-	if r.Err != nil && r.Err.Error() != "EOF" {
-		return "", r.Err
+	var s struct {
+		AdminPass string `json:"adminPass"`
 	}
-	if l, ok := r.Header["adminPass"]; ok && len(l) > 0 {
-		return l[0], nil
+	err := r.ExtractInto(&s)
+	if err != nil && err.Error() != "EOF" {
+		return s.AdminPass, err
 	}
-	return "", nil
+	return s.AdminPass, nil
 }

--- a/openstack/compute/v2/extensions/evacuate/requests.go
+++ b/openstack/compute/v2/extensions/evacuate/requests.go
@@ -46,7 +46,7 @@ func (r EvacuateResult) ExtractAdminPass() (string, error) {
 	}
 	err := r.ExtractInto(&s)
 	if err != nil && err.Error() == "EOF" {
-	  return "", nil
+		return "", nil
 	}
 	if err != nil && err.Error() != "EOF" {
 		return s.AdminPass, err

--- a/openstack/compute/v2/extensions/evacuate/results.go
+++ b/openstack/compute/v2/extensions/evacuate/results.go
@@ -4,8 +4,20 @@ import (
 	"github.com/gophercloud/gophercloud"
 )
 
-// EvacuateResult is the response from an Evacuate operation. Call its ExtractErr
-// method to determine if the request suceeded or failed.
+// EvacuateResult is the response from an Evacuate operation.
+//Call its ExtractAdminPass method to retrieve the admin password of the instance.
+//The admin password will be an empty string if the cloud is not configured to inject admin passwords..
 type EvacuateResult struct {
 	gophercloud.Result
+}
+
+func (r EvacuateResult) ExtractAdminPass() (string, error) {
+	var s struct {
+		AdminPass string `json:"adminPass"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil && err.Error() == "EOF" {
+		return "", nil
+	}
+	return s.AdminPass, err
 }

--- a/openstack/compute/v2/extensions/evacuate/results.go
+++ b/openstack/compute/v2/extensions/evacuate/results.go
@@ -7,5 +7,5 @@ import (
 // EvacuateResult is the response from an Evacuate operation. Call its ExtractErr
 // method to determine if the request suceeded or failed.
 type EvacuateResult struct {
-	gophercloud.ErrResult
+	gophercloud.Result
 }

--- a/openstack/compute/v2/extensions/evacuate/results.go
+++ b/openstack/compute/v2/extensions/evacuate/results.go
@@ -1,0 +1,11 @@
+package evacuate
+
+import (
+	"github.com/gophercloud/gophercloud"
+)
+
+// EvacuateResult is the response from an Evacuate operation. Call its ExtractErr
+// method to determine if the request suceeded or failed.
+type EvacuateResult struct {
+	gophercloud.ErrResult
+}

--- a/openstack/compute/v2/extensions/evacuate/testing/doc.go
+++ b/openstack/compute/v2/extensions/evacuate/testing/doc.go
@@ -1,0 +1,2 @@
+// compute_extensions_evacuate_v2
+package testing

--- a/openstack/compute/v2/extensions/evacuate/testing/fixtures.go
+++ b/openstack/compute/v2/extensions/evacuate/testing/fixtures.go
@@ -16,9 +16,40 @@ func mockEvacuateResponse(t *testing.T, id string) {
 		{
 		    "evacuate": {
 		    	"OnSharedStorage": false,
-			    "adminPass": "false",
+			    "adminPass": "true",
 			    "host": "derp"
 		    }
+		}
+		      `)
+		w.WriteHeader(http.StatusAccepted)
+	})
+}
+
+func mockEvacuateResponseWithHost(t *testing.T, id string) {
+	th.Mux.HandleFunc("/servers/"+id+"/action", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, `
+		{
+		    "evacuate": {
+		    	"OnSharedStorage": false,
+			    "host": "derp"
+		    }
+		}
+		      `)
+		w.WriteHeader(http.StatusAccepted)
+	})
+}
+
+func mockEvacuateResponseWithNoOpts(t *testing.T, id string) {
+	th.Mux.HandleFunc("/servers/"+id+"/action", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, `
+		{
+		    "evacuate": {
+		    	"OnSharedStorage": false
+		  }
 		}
 		      `)
 		w.WriteHeader(http.StatusAccepted)

--- a/openstack/compute/v2/extensions/evacuate/testing/fixtures.go
+++ b/openstack/compute/v2/extensions/evacuate/testing/fixtures.go
@@ -1,0 +1,18 @@
+package testing
+
+import (
+	"net/http"
+	"testing"
+
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func mockMigrateResponse(t *testing.T, id string) {
+	th.Mux.HandleFunc("/servers/"+id+"/action", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, `{"evacuate": null}`)
+		w.WriteHeader(http.StatusAccepted)
+	})
+}

--- a/openstack/compute/v2/extensions/evacuate/testing/fixtures.go
+++ b/openstack/compute/v2/extensions/evacuate/testing/fixtures.go
@@ -1,6 +1,7 @@
 package testing
 
 import (
+	"fmt"
 	"net/http"
 	"testing"
 
@@ -56,5 +57,27 @@ func mockEvacuateResponseWithNoOpts(t *testing.T, id string) {
 		}
 		      `)
 		w.WriteHeader(http.StatusOK)
+	})
+}
+
+const EvacuateResponse = `
+{
+  "adminPass": "MySecretPass"
+}
+`
+
+func mockEvacuateAdminpassResponse(t *testing.T, id string) {
+	th.Mux.HandleFunc("/servers/"+id+"/action", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, `
+    {
+        "evacuate": {
+          "onSharedStorage": false
+        }
+    }
+          `)
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprintf(w, EvacuateResponse)
 	})
 }

--- a/openstack/compute/v2/extensions/evacuate/testing/fixtures.go
+++ b/openstack/compute/v2/extensions/evacuate/testing/fixtures.go
@@ -15,8 +15,9 @@ func mockEvacuateResponse(t *testing.T, id string) {
 		th.TestJSONRequest(t, r, `
 		{
 		    "evacuate": {
-		    	"host": "derp",
-		        "adminPass": "false"
+		    	"OnSharedStorage": false,
+			    "adminPass": "false",
+			    "host": "derp"
 		    }
 		}
 		      `)

--- a/openstack/compute/v2/extensions/evacuate/testing/fixtures.go
+++ b/openstack/compute/v2/extensions/evacuate/testing/fixtures.go
@@ -8,11 +8,18 @@ import (
 	"github.com/gophercloud/gophercloud/testhelper/client"
 )
 
-func mockMigrateResponse(t *testing.T, id string) {
+func mockEvacuateResponse(t *testing.T, id string) {
 	th.Mux.HandleFunc("/servers/"+id+"/action", func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "POST")
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
-		th.TestJSONRequest(t, r, `{"evacuate": null}`)
+		th.TestJSONRequest(t, r, `
+		{
+		    "evacuate": {
+		    	"host": "derp",
+		        "adminPass": "false"
+		    }
+		}
+		      `)
 		w.WriteHeader(http.StatusAccepted)
 	})
 }

--- a/openstack/compute/v2/extensions/evacuate/testing/fixtures.go
+++ b/openstack/compute/v2/extensions/evacuate/testing/fixtures.go
@@ -22,7 +22,7 @@ func mockEvacuateResponse(t *testing.T, id string) {
 
 		}
 		      `)
-		w.WriteHeader(http.StatusAccepted)
+		w.WriteHeader(http.StatusOK)
 	})
 }
 
@@ -39,7 +39,7 @@ func mockEvacuateResponseWithHost(t *testing.T, id string) {
 
 		}
 		      `)
-		w.WriteHeader(http.StatusAccepted)
+		w.WriteHeader(http.StatusOK)
 	})
 }
 
@@ -55,6 +55,6 @@ func mockEvacuateResponseWithNoOpts(t *testing.T, id string) {
 
 		}
 		      `)
-		w.WriteHeader(http.StatusAccepted)
+		w.WriteHeader(http.StatusOK)
 	})
 }

--- a/openstack/compute/v2/extensions/evacuate/testing/fixtures.go
+++ b/openstack/compute/v2/extensions/evacuate/testing/fixtures.go
@@ -15,10 +15,11 @@ func mockEvacuateResponse(t *testing.T, id string) {
 		th.TestJSONRequest(t, r, `
 		{
 		    "evacuate": {
-		    	"OnSharedStorage": false,
-			    "adminPass": "true",
-			    "host": "derp"
-		    }
+		    "adminPass": "MySecretPass",
+		    "host": "derp",
+		    "onSharedStorage": false
+		  }
+
 		}
 		      `)
 		w.WriteHeader(http.StatusAccepted)
@@ -32,9 +33,10 @@ func mockEvacuateResponseWithHost(t *testing.T, id string) {
 		th.TestJSONRequest(t, r, `
 		{
 		    "evacuate": {
-		    	"OnSharedStorage": false,
-			    "host": "derp"
-		    }
+		    "host": "derp",
+		    "onSharedStorage": false
+		  }
+
 		}
 		      `)
 		w.WriteHeader(http.StatusAccepted)
@@ -48,8 +50,9 @@ func mockEvacuateResponseWithNoOpts(t *testing.T, id string) {
 		th.TestJSONRequest(t, r, `
 		{
 		    "evacuate": {
-		    	"OnSharedStorage": false
+		    "onSharedStorage": false
 		  }
+
 		}
 		      `)
 		w.WriteHeader(http.StatusAccepted)

--- a/openstack/compute/v2/extensions/evacuate/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/evacuate/testing/requests_test.go
@@ -33,7 +33,7 @@ func TestEvacuateWithHost(t *testing.T) {
 	mockEvacuateResponseWithHost(t, serverID)
 
 	err := evacuate.Evacuate(client.ServiceClient(), serverID, evacuate.EvacuateOpts{
-		Host:            "derp",
+		Host: "derp",
 	}).ExtractErr()
 	if err != nil && err.Error() != "EOF" {
 		t.Fatalf("Unable to evacuate to server: %s", err)
@@ -47,8 +47,7 @@ func TestEvacuateWithNoOpts(t *testing.T) {
 
 	mockEvacuateResponseWithNoOpts(t, serverID)
 
-	err := evacuate.Evacuate(client.ServiceClient(), serverID, evacuate.EvacuateOpts{
-	}).ExtractErr()
+	err := evacuate.Evacuate(client.ServiceClient(), serverID, evacuate.EvacuateOpts{}).ExtractErr()
 	if err != nil && err.Error() != "EOF" {
 		t.Fatalf("Unable to evacuate to server: %s", err)
 	}

--- a/openstack/compute/v2/extensions/evacuate/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/evacuate/testing/requests_test.go
@@ -15,12 +15,12 @@ func TestEvacuate(t *testing.T) {
 
 	mockEvacuateResponse(t, serverID)
 
-	err := evacuate.Evacuate(client.ServiceClient(), serverID, evacuate.EvacuateOpts{
+	_, err := evacuate.Evacuate(client.ServiceClient(), serverID, evacuate.EvacuateOpts{
 		Host:            "derp",
-		AdminPass:       "true",
+		AdminPass:       "MySecretPass",
 		OnSharedStorage: false,
-	}).ExtractErr()
-	if err != nil && err.Error() != "EOF" {
+	}).ExtractAdminPass()
+	if err != nil {
 		t.Fatalf("Unable to evacuate to server: %s", err)
 	}
 }
@@ -32,10 +32,10 @@ func TestEvacuateWithHost(t *testing.T) {
 
 	mockEvacuateResponseWithHost(t, serverID)
 
-	err := evacuate.Evacuate(client.ServiceClient(), serverID, evacuate.EvacuateOpts{
+	_, err := evacuate.Evacuate(client.ServiceClient(), serverID, evacuate.EvacuateOpts{
 		Host: "derp",
-	}).ExtractErr()
-	if err != nil && err.Error() != "EOF" {
+	}).ExtractAdminPass()
+	if err != nil {
 		t.Fatalf("Unable to evacuate to server: %s", err)
 	}
 }
@@ -47,8 +47,8 @@ func TestEvacuateWithNoOpts(t *testing.T) {
 
 	mockEvacuateResponseWithNoOpts(t, serverID)
 
-	err := evacuate.Evacuate(client.ServiceClient(), serverID, evacuate.EvacuateOpts{}).ExtractErr()
-	if err != nil && err.Error() != "EOF" {
+	_, err := evacuate.Evacuate(client.ServiceClient(), serverID, evacuate.EvacuateOpts{}).ExtractAdminPass()
+	if err != nil {
 		t.Fatalf("Unable to evacuate to server: %s", err)
 	}
 }

--- a/openstack/compute/v2/extensions/evacuate/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/evacuate/testing/requests_test.go
@@ -8,8 +8,6 @@ import (
 	"github.com/gophercloud/gophercloud/testhelper/client"
 )
 
-
-
 func TestEvacuate(t *testing.T) {
 	const serverID = "b16ba811-199d-4ffd-8839-ba96c1185a67"
 	th.SetupHTTP()
@@ -18,12 +16,11 @@ func TestEvacuate(t *testing.T) {
 	mockEvacuateResponse(t, serverID)
 
 	err := evacuate.Evacuate(client.ServiceClient(), serverID, evacuate.EvacuateOpts{
-		Host:      			"derp",
-		AdminPass: 			"false",
-		OnSharedStorage: 	false,
+		Host:            "derp",
+		AdminPass:       "false",
+		OnSharedStorage: false,
 	}).ExtractErr()
 	if err != nil && err.Error() != "EOF" {
 		t.Fatalf("Unable to evacuate to server: %s", err)
 	}
 }
-

--- a/openstack/compute/v2/extensions/evacuate/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/evacuate/testing/requests_test.go
@@ -52,3 +52,16 @@ func TestEvacuateWithNoOpts(t *testing.T) {
 		t.Fatalf("Unable to evacuate to server: %s", err)
 	}
 }
+
+func TestEvacuateAdminpassResponse(t *testing.T) {
+	const serverID = "b16ba811-199d-4ffd-8839-ba96c1185a67"
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	mockEvacuateAdminpassResponse(t, serverID)
+
+	_, err := evacuate.Evacuate(client.ServiceClient(), serverID, evacuate.EvacuateOpts{}).ExtractAdminPass()
+	if err != nil {
+		t.Fatalf("Unable to evacuate to server: %s", err)
+	}
+}

--- a/openstack/compute/v2/extensions/evacuate/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/evacuate/testing/requests_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/evacuate"
 	th "github.com/gophercloud/gophercloud/testhelper"
 	"github.com/gophercloud/gophercloud/testhelper/client"
-
 )
 
 const serverID = "b16ba811-199d-4ffd-8839-ba96c1185a67"
@@ -18,8 +17,8 @@ func TestEvacuate(t *testing.T) {
 	mockEvacuateResponse(t, serverID)
 
 	err := evacuate.Evacuate(client.ServiceClient(), serverID, evacuate.EvacuateOpts{
-		Host:					"derp",
-		AdminPass: 				"false",
+		Host:      "derp",
+		AdminPass: "false",
 	}).ExtractErr()
 	if err != nil && err.Error() != "EOF" {
 		t.Fatalf("Unable to evacuate to server: %s", err)

--- a/openstack/compute/v2/extensions/evacuate/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/evacuate/testing/requests_test.go
@@ -8,19 +8,22 @@ import (
 	"github.com/gophercloud/gophercloud/testhelper/client"
 )
 
-const serverID = "b16ba811-199d-4ffd-8839-ba96c1185a67"
+
 
 func TestEvacuate(t *testing.T) {
+	const serverID = "b16ba811-199d-4ffd-8839-ba96c1185a67"
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 
 	mockEvacuateResponse(t, serverID)
 
 	err := evacuate.Evacuate(client.ServiceClient(), serverID, evacuate.EvacuateOpts{
-		Host:      "derp",
-		AdminPass: "false",
+		Host:      			"derp",
+		AdminPass: 			"false",
+		OnSharedStorage: 	false,
 	}).ExtractErr()
 	if err != nil && err.Error() != "EOF" {
 		t.Fatalf("Unable to evacuate to server: %s", err)
 	}
 }
+

--- a/openstack/compute/v2/extensions/evacuate/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/evacuate/testing/requests_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/evacuate"
 	th "github.com/gophercloud/gophercloud/testhelper"
 	"github.com/gophercloud/gophercloud/testhelper/client"
+
 )
 
 const serverID = "b16ba811-199d-4ffd-8839-ba96c1185a67"
@@ -14,8 +15,13 @@ func TestEvacuate(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 
-	mockMigrateResponse(t, serverID)
+	mockEvacuateResponse(t, serverID)
 
-	err := evacuate.Evacuate(client.ServiceClient(), serverID).ExtractErr()
-	th.AssertNoErr(t, err)
+	err := evacuate.Evacuate(client.ServiceClient(), serverID, evacuate.EvacuateOpts{
+		Host:					"derp",
+		AdminPass: 				"false",
+	}).ExtractErr()
+	if err != nil && err.Error() != "EOF" {
+		t.Fatalf("Unable to evacuate to server: %s", err)
+	}
 }

--- a/openstack/compute/v2/extensions/evacuate/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/evacuate/testing/requests_test.go
@@ -60,7 +60,8 @@ func TestEvacuateAdminpassResponse(t *testing.T) {
 
 	mockEvacuateAdminpassResponse(t, serverID)
 
-	_, err := evacuate.Evacuate(client.ServiceClient(), serverID, evacuate.EvacuateOpts{}).ExtractAdminPass()
+	actual, err := evacuate.Evacuate(client.ServiceClient(), serverID, evacuate.EvacuateOpts{}).ExtractAdminPass()
+	th.CheckEquals(t, "MySecretPass", actual)
 	if err != nil {
 		t.Fatalf("Unable to evacuate to server: %s", err)
 	}

--- a/openstack/compute/v2/extensions/evacuate/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/evacuate/testing/requests_test.go
@@ -20,9 +20,7 @@ func TestEvacuate(t *testing.T) {
 		AdminPass:       "MySecretPass",
 		OnSharedStorage: false,
 	}).ExtractAdminPass()
-	if err != nil {
-		t.Fatalf("Unable to evacuate to server: %s", err)
-	}
+	th.AssertNoErr(t, err)
 }
 
 func TestEvacuateWithHost(t *testing.T) {
@@ -35,9 +33,7 @@ func TestEvacuateWithHost(t *testing.T) {
 	_, err := evacuate.Evacuate(client.ServiceClient(), serverID, evacuate.EvacuateOpts{
 		Host: "derp",
 	}).ExtractAdminPass()
-	if err != nil {
-		t.Fatalf("Unable to evacuate to server: %s", err)
-	}
+	th.AssertNoErr(t, err)
 }
 
 func TestEvacuateWithNoOpts(t *testing.T) {
@@ -48,9 +44,7 @@ func TestEvacuateWithNoOpts(t *testing.T) {
 	mockEvacuateResponseWithNoOpts(t, serverID)
 
 	_, err := evacuate.Evacuate(client.ServiceClient(), serverID, evacuate.EvacuateOpts{}).ExtractAdminPass()
-	if err != nil {
-		t.Fatalf("Unable to evacuate to server: %s", err)
-	}
+	th.AssertNoErr(t, err)
 }
 
 func TestEvacuateAdminpassResponse(t *testing.T) {
@@ -62,7 +56,5 @@ func TestEvacuateAdminpassResponse(t *testing.T) {
 
 	actual, err := evacuate.Evacuate(client.ServiceClient(), serverID, evacuate.EvacuateOpts{}).ExtractAdminPass()
 	th.CheckEquals(t, "MySecretPass", actual)
-	if err != nil {
-		t.Fatalf("Unable to evacuate to server: %s", err)
-	}
+	th.AssertNoErr(t, err)
 }

--- a/openstack/compute/v2/extensions/evacuate/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/evacuate/testing/requests_test.go
@@ -17,8 +17,37 @@ func TestEvacuate(t *testing.T) {
 
 	err := evacuate.Evacuate(client.ServiceClient(), serverID, evacuate.EvacuateOpts{
 		Host:            "derp",
-		AdminPass:       "false",
+		AdminPass:       "true",
 		OnSharedStorage: false,
+	}).ExtractErr()
+	if err != nil && err.Error() != "EOF" {
+		t.Fatalf("Unable to evacuate to server: %s", err)
+	}
+}
+
+func TestEvacuateWithHost(t *testing.T) {
+	const serverID = "b16ba811-199d-4ffd-8839-ba96c1185a67"
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	mockEvacuateResponseWithHost(t, serverID)
+
+	err := evacuate.Evacuate(client.ServiceClient(), serverID, evacuate.EvacuateOpts{
+		Host:            "derp",
+	}).ExtractErr()
+	if err != nil && err.Error() != "EOF" {
+		t.Fatalf("Unable to evacuate to server: %s", err)
+	}
+}
+
+func TestEvacuateWithNoOpts(t *testing.T) {
+	const serverID = "b16ba811-199d-4ffd-8839-ba96c1185a67"
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	mockEvacuateResponseWithNoOpts(t, serverID)
+
+	err := evacuate.Evacuate(client.ServiceClient(), serverID, evacuate.EvacuateOpts{
 	}).ExtractErr()
 	if err != nil && err.Error() != "EOF" {
 		t.Fatalf("Unable to evacuate to server: %s", err)

--- a/openstack/compute/v2/extensions/evacuate/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/evacuate/testing/requests_test.go
@@ -1,0 +1,21 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/evacuate"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+const serverID = "b16ba811-199d-4ffd-8839-ba96c1185a67"
+
+func TestEvacuate(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	mockMigrateResponse(t, serverID)
+
+	err := evacuate.Evacuate(client.ServiceClient(), serverID).ExtractErr()
+	th.AssertNoErr(t, err)
+}

--- a/openstack/compute/v2/extensions/evacuate/urls.go
+++ b/openstack/compute/v2/extensions/evacuate/urls.go
@@ -1,0 +1,9 @@
+package evacuate
+
+import (
+	"github.com/gophercloud/gophercloud"
+)
+
+func actionURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL("servers", id, "action")
+}


### PR DESCRIPTION
For #519 

Links to the line numbers/files in the OpenStack source code that support the code in this PR:

https://github.com/openstack/nova/blob/stable/ocata/nova/api/openstack/compute/evacuate.py

cc @jtopjian 
