### PR TITLE
Neutron Ports: Add support for extra_dhcp_opts

### DIFF
--- a/acceptance/openstack/networking/v2/networking.go
+++ b/acceptance/openstack/networking/v2/networking.go
@@ -43,6 +43,7 @@ func CreatePort(t *testing.T, client *gophercloud.ServiceClient, networkID, subn
 		Name:         portName,
 		AdminStateUp: gophercloud.Enabled,
 		FixedIPs:     []ports.IP{ports.IP{SubnetID: subnetID}},
+		ExtraDHCPOPTS:[]string{},
 	}
 
 	port, err := ports.Create(client, createOpts).Extract()

--- a/acceptance/openstack/networking/v2/networking.go
+++ b/acceptance/openstack/networking/v2/networking.go
@@ -43,7 +43,7 @@ func CreatePort(t *testing.T, client *gophercloud.ServiceClient, networkID, subn
 		Name:          portName,
 		AdminStateUp:  gophercloud.Enabled,
 		FixedIPs:      []ports.IP{ports.IP{SubnetID: subnetID}},
-		ExtraDHCPOPTS: &[]string{tools.RandomString("TESTACC-", 8)},
+		ExtraDHCPOPTS: []ports.ExtraDHCPOpts{},
 	}
 
 	port, err := ports.Create(client, createOpts).Extract()

--- a/acceptance/openstack/networking/v2/networking.go
+++ b/acceptance/openstack/networking/v2/networking.go
@@ -38,14 +38,12 @@ func CreatePort(t *testing.T, client *gophercloud.ServiceClient, networkID, subn
 
 	t.Logf("Attempting to create port: %s", portName)
 
-	extraPort := []string{}
-	extraPort = append(extraPort, tools.RandomString("TESTACC-", 8))
 	createOpts := ports.CreateOpts{
-		NetworkID:    networkID,
-		Name:         portName,
-		AdminStateUp: gophercloud.Enabled,
-		FixedIPs:     []ports.IP{ports.IP{SubnetID: subnetID}},
-		ExtraDHCPOPTS: extraPort,
+		NetworkID:    	networkID,
+		Name:         	portName,
+		AdminStateUp: 	gophercloud.Enabled,
+		FixedIPs:     	[]ports.IP{ports.IP{SubnetID: subnetID}},
+		ExtraDHCPOPTS:	&[]string{tools.RandomString("TESTACC-", 8)}
 	}
 
 	port, err := ports.Create(client, createOpts).Extract()

--- a/acceptance/openstack/networking/v2/networking.go
+++ b/acceptance/openstack/networking/v2/networking.go
@@ -43,7 +43,7 @@ func CreatePort(t *testing.T, client *gophercloud.ServiceClient, networkID, subn
 		Name:         	portName,
 		AdminStateUp: 	gophercloud.Enabled,
 		FixedIPs:     	[]ports.IP{ports.IP{SubnetID: subnetID}},
-		ExtraDHCPOPTS:	&[]string{tools.RandomString("TESTACC-", 8)}
+		ExtraDHCPOPTS:	&[]string{tools.RandomString("TESTACC-", 8)},
 	}
 
 	port, err := ports.Create(client, createOpts).Extract()

--- a/acceptance/openstack/networking/v2/networking.go
+++ b/acceptance/openstack/networking/v2/networking.go
@@ -38,12 +38,14 @@ func CreatePort(t *testing.T, client *gophercloud.ServiceClient, networkID, subn
 
 	t.Logf("Attempting to create port: %s", portName)
 
+	extraPort := []string{}
+	extraPort = append(extraPort, tools.RandomString("TESTACC-", 8))
 	createOpts := ports.CreateOpts{
 		NetworkID:    networkID,
 		Name:         portName,
 		AdminStateUp: gophercloud.Enabled,
 		FixedIPs:     []ports.IP{ports.IP{SubnetID: subnetID}},
-		ExtraDHCPOPTS:[]string{},
+		ExtraDHCPOPTS: extraPort,
 	}
 
 	port, err := ports.Create(client, createOpts).Extract()

--- a/acceptance/openstack/networking/v2/networking.go
+++ b/acceptance/openstack/networking/v2/networking.go
@@ -39,11 +39,11 @@ func CreatePort(t *testing.T, client *gophercloud.ServiceClient, networkID, subn
 	t.Logf("Attempting to create port: %s", portName)
 
 	createOpts := ports.CreateOpts{
-		NetworkID:    	networkID,
-		Name:         	portName,
-		AdminStateUp: 	gophercloud.Enabled,
-		FixedIPs:     	[]ports.IP{ports.IP{SubnetID: subnetID}},
-		ExtraDHCPOPTS:	&[]string{tools.RandomString("TESTACC-", 8)},
+		NetworkID:     networkID,
+		Name:          portName,
+		AdminStateUp:  gophercloud.Enabled,
+		FixedIPs:      []ports.IP{ports.IP{SubnetID: subnetID}},
+		ExtraDHCPOPTS: &[]string{tools.RandomString("TESTACC-", 8)},
 	}
 
 	port, err := ports.Create(client, createOpts).Extract()

--- a/acceptance/openstack/networking/v2/ports_test.go
+++ b/acceptance/openstack/networking/v2/ports_test.go
@@ -67,9 +67,11 @@ func TestPortsCRUD(t *testing.T) {
 
 	// Update port
 	newPortName := tools.RandomString("TESTACC-", 8)
+	extraPort := []string{}
+	extraPort = append(extraPort, tools.RandomString("TESTACC-", 8))
 	updateOpts := ports.UpdateOpts{
-		Name: newPortName,
-		ExtraDHCPOPTS: []string{},
+		Name:          newPortName,
+		ExtraDHCPOPTS: extraPort,
 	}
 	newPort, err := ports.Update(client, port.ID, updateOpts).Extract()
 	if err != nil {

--- a/acceptance/openstack/networking/v2/ports_test.go
+++ b/acceptance/openstack/networking/v2/ports_test.go
@@ -67,11 +67,9 @@ func TestPortsCRUD(t *testing.T) {
 
 	// Update port
 	newPortName := tools.RandomString("TESTACC-", 8)
-	extraPort := []string{}
-	extraPort = append(extraPort, tools.RandomString("TESTACC-", 8))
 	updateOpts := ports.UpdateOpts{
 		Name:          newPortName,
-		ExtraDHCPOPTS: extraPort,
+		ExtraDHCPOPTS: &[]string{tools.RandomString("TESTACC-", 8)},
 	}
 	newPort, err := ports.Update(client, port.ID, updateOpts).Extract()
 	if err != nil {

--- a/acceptance/openstack/networking/v2/ports_test.go
+++ b/acceptance/openstack/networking/v2/ports_test.go
@@ -69,6 +69,7 @@ func TestPortsCRUD(t *testing.T) {
 	newPortName := tools.RandomString("TESTACC-", 8)
 	updateOpts := ports.UpdateOpts{
 		Name: newPortName,
+		ExtraDHCPOPTS: []string{},
 	}
 	newPort, err := ports.Update(client, port.ID, updateOpts).Extract()
 	if err != nil {

--- a/acceptance/openstack/networking/v2/ports_test.go
+++ b/acceptance/openstack/networking/v2/ports_test.go
@@ -69,7 +69,7 @@ func TestPortsCRUD(t *testing.T) {
 	newPortName := tools.RandomString("TESTACC-", 8)
 	updateOpts := ports.UpdateOpts{
 		Name:          newPortName,
-		ExtraDHCPOPTS: &[]string{tools.RandomString("TESTACC-", 8)},
+		ExtraDHCPOPTS: &[]ports.ExtraDHCPOpts{},
 	}
 	newPort, err := ports.Update(client, port.ID, updateOpts).Extract()
 	if err != nil {

--- a/openstack/networking/v2/ports/requests.go
+++ b/openstack/networking/v2/ports/requests.go
@@ -17,20 +17,20 @@ type ListOptsBuilder interface {
 // by a particular port attribute. SortDir sets the direction, and is either
 // `asc' or `desc'. Marker and Limit are used for pagination.
 type ListOpts struct {
-	Status       		string `q:"status"`
-	Name         		string `q:"name"`
-	AdminStateUp 		*bool  `q:"admin_state_up"`
-	NetworkID    		string `q:"network_id"`
-	TenantID     		string `q:"tenant_id"`
-	DeviceOwner  		string `q:"device_owner"`
-	MACAddress   		string `q:"mac_address"`
-	ID           		string `q:"id"`
-	DeviceID     		string `q:"device_id"`
-	Limit        		int    `q:"limit"`
-	Marker       		string `q:"marker"`
-	SortKey      		string `q:"sort_key"`
-	SortDir      		string `q:"sort_dir"`
-	ExtraDHCPOPTS     	*[]string `q:"extra_dhcp_opts"`
+	Status        string    `q:"status"`
+	Name          string    `q:"name"`
+	AdminStateUp  *bool     `q:"admin_state_up"`
+	NetworkID     string    `q:"network_id"`
+	TenantID      string    `q:"tenant_id"`
+	DeviceOwner   string    `q:"device_owner"`
+	MACAddress    string    `q:"mac_address"`
+	ID            string    `q:"id"`
+	DeviceID      string    `q:"device_id"`
+	Limit         int       `q:"limit"`
+	Marker        string    `q:"marker"`
+	SortKey       string    `q:"sort_key"`
+	SortDir       string    `q:"sort_dir"`
+	ExtraDHCPOPTS *[]string `q:"extra_dhcp_opts"`
 }
 
 // ToPortListQuery formats a ListOpts into a query string.
@@ -84,7 +84,7 @@ type CreateOpts struct {
 	TenantID            string        `json:"tenant_id,omitempty"`
 	SecurityGroups      *[]string     `json:"security_groups,omitempty"`
 	AllowedAddressPairs []AddressPair `json:"allowed_address_pairs,omitempty"`
-	ExtraDHCPOPTS     	*[]string 	  `json:"extra_dhcp_opts,omitempty"`
+	ExtraDHCPOPTS       *[]string     `json:"extra_dhcp_opts,omitempty"`
 }
 
 // ToPortCreateMap builds a request body from CreateOpts.
@@ -119,7 +119,7 @@ type UpdateOpts struct {
 	DeviceOwner         string         `json:"device_owner,omitempty"`
 	SecurityGroups      *[]string      `json:"security_groups,omitempty"`
 	AllowedAddressPairs *[]AddressPair `json:"allowed_address_pairs,omitempty"`
-	ExtraDHCPOPTS     	*[]string 	  `json:"extra_dhcp_opts,omitempty"`
+	ExtraDHCPOPTS       *[]string      `json:"extra_dhcp_opts,omitempty"`
 }
 
 // ToPortUpdateMap builds a request body from UpdateOpts.

--- a/openstack/networking/v2/ports/requests.go
+++ b/openstack/networking/v2/ports/requests.go
@@ -17,20 +17,20 @@ type ListOptsBuilder interface {
 // by a particular port attribute. SortDir sets the direction, and is either
 // `asc' or `desc'. Marker and Limit are used for pagination.
 type ListOpts struct {
-	Status        string    `q:"status"`
-	Name          string    `q:"name"`
-	AdminStateUp  *bool     `q:"admin_state_up"`
-	NetworkID     string    `q:"network_id"`
-	TenantID      string    `q:"tenant_id"`
-	DeviceOwner   string    `q:"device_owner"`
-	MACAddress    string    `q:"mac_address"`
-	ID            string    `q:"id"`
-	DeviceID      string    `q:"device_id"`
-	Limit         int       `q:"limit"`
-	Marker        string    `q:"marker"`
-	SortKey       string    `q:"sort_key"`
-	SortDir       string    `q:"sort_dir"`
-	ExtraDHCPOPTS *[]string `q:"extra_dhcp_opts"`
+	Status        string          `q:"status"`
+	Name          string          `q:"name"`
+	AdminStateUp  *bool           `q:"admin_state_up"`
+	NetworkID     string          `q:"network_id"`
+	TenantID      string          `q:"tenant_id"`
+	DeviceOwner   string          `q:"device_owner"`
+	MACAddress    string          `q:"mac_address"`
+	ID            string          `q:"id"`
+	DeviceID      string          `q:"device_id"`
+	Limit         int             `q:"limit"`
+	Marker        string          `q:"marker"`
+	SortKey       string          `q:"sort_key"`
+	SortDir       string          `q:"sort_dir"`
+	ExtraDHCPOPTS []ExtraDHCPOpts `q:"extra_dhcp_opts"`
 }
 
 // ToPortListQuery formats a ListOpts into a query string.
@@ -74,17 +74,17 @@ type CreateOptsBuilder interface {
 
 // CreateOpts represents the attributes used when creating a new port.
 type CreateOpts struct {
-	NetworkID           string        `json:"network_id" required:"true"`
-	Name                string        `json:"name,omitempty"`
-	AdminStateUp        *bool         `json:"admin_state_up,omitempty"`
-	MACAddress          string        `json:"mac_address,omitempty"`
-	FixedIPs            interface{}   `json:"fixed_ips,omitempty"`
-	DeviceID            string        `json:"device_id,omitempty"`
-	DeviceOwner         string        `json:"device_owner,omitempty"`
-	TenantID            string        `json:"tenant_id,omitempty"`
-	SecurityGroups      *[]string     `json:"security_groups,omitempty"`
-	AllowedAddressPairs []AddressPair `json:"allowed_address_pairs,omitempty"`
-	ExtraDHCPOPTS       *[]string     `json:"extra_dhcp_opts,omitempty"`
+	NetworkID           string          `json:"network_id" required:"true"`
+	Name                string          `json:"name,omitempty"`
+	AdminStateUp        *bool           `json:"admin_state_up,omitempty"`
+	MACAddress          string          `json:"mac_address,omitempty"`
+	FixedIPs            interface{}     `json:"fixed_ips,omitempty"`
+	DeviceID            string          `json:"device_id,omitempty"`
+	DeviceOwner         string          `json:"device_owner,omitempty"`
+	TenantID            string          `json:"tenant_id,omitempty"`
+	SecurityGroups      *[]string       `json:"security_groups,omitempty"`
+	AllowedAddressPairs []AddressPair   `json:"allowed_address_pairs,omitempty"`
+	ExtraDHCPOPTS       []ExtraDHCPOpts `json:"extra_dhcp_opts,omitempty"`
 }
 
 // ToPortCreateMap builds a request body from CreateOpts.
@@ -112,14 +112,14 @@ type UpdateOptsBuilder interface {
 
 // UpdateOpts represents the attributes used when updating an existing port.
 type UpdateOpts struct {
-	Name                string         `json:"name,omitempty"`
-	AdminStateUp        *bool          `json:"admin_state_up,omitempty"`
-	FixedIPs            interface{}    `json:"fixed_ips,omitempty"`
-	DeviceID            string         `json:"device_id,omitempty"`
-	DeviceOwner         string         `json:"device_owner,omitempty"`
-	SecurityGroups      *[]string      `json:"security_groups,omitempty"`
-	AllowedAddressPairs *[]AddressPair `json:"allowed_address_pairs,omitempty"`
-	ExtraDHCPOPTS       *[]string      `json:"extra_dhcp_opts,omitempty"`
+	Name                string           `json:"name,omitempty"`
+	AdminStateUp        *bool            `json:"admin_state_up,omitempty"`
+	FixedIPs            interface{}      `json:"fixed_ips,omitempty"`
+	DeviceID            string           `json:"device_id,omitempty"`
+	DeviceOwner         string           `json:"device_owner,omitempty"`
+	SecurityGroups      *[]string        `json:"security_groups,omitempty"`
+	AllowedAddressPairs *[]AddressPair   `json:"allowed_address_pairs,omitempty"`
+	ExtraDHCPOPTS       *[]ExtraDHCPOpts `json:"extra_dhcp_opts,omitempty"`
 }
 
 // ToPortUpdateMap builds a request body from UpdateOpts.

--- a/openstack/networking/v2/ports/requests.go
+++ b/openstack/networking/v2/ports/requests.go
@@ -17,19 +17,20 @@ type ListOptsBuilder interface {
 // by a particular port attribute. SortDir sets the direction, and is either
 // `asc' or `desc'. Marker and Limit are used for pagination.
 type ListOpts struct {
-	Status       string `q:"status"`
-	Name         string `q:"name"`
-	AdminStateUp *bool  `q:"admin_state_up"`
-	NetworkID    string `q:"network_id"`
-	TenantID     string `q:"tenant_id"`
-	DeviceOwner  string `q:"device_owner"`
-	MACAddress   string `q:"mac_address"`
-	ID           string `q:"id"`
-	DeviceID     string `q:"device_id"`
-	Limit        int    `q:"limit"`
-	Marker       string `q:"marker"`
-	SortKey      string `q:"sort_key"`
-	SortDir      string `q:"sort_dir"`
+	Status       		string `q:"status"`
+	Name         		string `q:"name"`
+	AdminStateUp 		*bool  `q:"admin_state_up"`
+	NetworkID    		string `q:"network_id"`
+	TenantID     		string `q:"tenant_id"`
+	DeviceOwner  		string `q:"device_owner"`
+	MACAddress   		string `q:"mac_address"`
+	ID           		string `q:"id"`
+	DeviceID     		string `q:"device_id"`
+	Limit        		int    `q:"limit"`
+	Marker       		string `q:"marker"`
+	SortKey      		string `q:"sort_key"`
+	SortDir      		string `q:"sort_dir"`
+	ExtraDHCPOPTS     	*[]string `q:"extra_dhcp_opts"`
 }
 
 // ToPortListQuery formats a ListOpts into a query string.
@@ -83,6 +84,7 @@ type CreateOpts struct {
 	TenantID            string        `json:"tenant_id,omitempty"`
 	SecurityGroups      *[]string     `json:"security_groups,omitempty"`
 	AllowedAddressPairs []AddressPair `json:"allowed_address_pairs,omitempty"`
+	ExtraDHCPOPTS     	*[]string 	  `json:"extra_dhcp_opts,omitempty"`
 }
 
 // ToPortCreateMap builds a request body from CreateOpts.
@@ -117,6 +119,7 @@ type UpdateOpts struct {
 	DeviceOwner         string         `json:"device_owner,omitempty"`
 	SecurityGroups      *[]string      `json:"security_groups,omitempty"`
 	AllowedAddressPairs *[]AddressPair `json:"allowed_address_pairs,omitempty"`
+	ExtraDHCPOPTS     	*[]string 	  `json:"extra_dhcp_opts,omitempty"`
 }
 
 // ToPortUpdateMap builds a request body from UpdateOpts.

--- a/openstack/networking/v2/ports/results.go
+++ b/openstack/networking/v2/ports/results.go
@@ -54,6 +54,13 @@ type AddressPair struct {
 	MACAddress string `json:"mac_address,omitempty"`
 }
 
+//This is the sub-struct that represents extra DHCP option pairs
+type ExtraDHCPOpts struct {
+	OptName   string                `json:"opt_name"`
+	OptValue  string                `json:"opt_value"`
+	IPVersion gophercloud.IPVersion `json:"ip_version"`
+}
+
 // Port represents a Neutron port. See package documentation for a top-level
 // description of what this is.
 type Port struct {
@@ -96,6 +103,9 @@ type Port struct {
 
 	// Identifies the list of IP addresses the port will recognize/accept
 	AllowedAddressPairs []AddressPair `json:"allowed_address_pairs"`
+
+	//A set of zero or more extra DHCP option pairs
+	ExtraDHCPOPTS []ExtraDHCPOpts `json:"extra_dhcp_opts"`
 }
 
 // PortPage is the page returned by a pager when traversing over a collection


### PR DESCRIPTION
For #511 

Links to the line files in the OpenStack (Neutron) source code that support the code in this PR:

+ https://github.com/openstack/neutron/blob/e6dc39518ccfef79ecf9beae0b3a2c094b4c220b/neutron/agent/linux/dhcp.py
+ https://github.com/openstack/neutron/blob/7b4ad21cb53c57b31f093ba9f6babb8e0f27e9f6/neutron/db/extradhcpopt_db.py
