### PR TITLE
Adding ability to list users for a group.

### DIFF
--- a/openstack/identity/v3/users/doc.go
+++ b/openstack/identity/v3/users/doc.go
@@ -98,5 +98,26 @@ Example to List Projects a User Belongs To
 		fmt.Printf("%+v\n", project)
 	}
 
+Example to List Users in a Group
+
+	groupID := "bede500ee1124ae9b0006ff859758b3a"
+	listOpts := users.ListOpts{
+		DomainID: "default",
+	}
+
+	allPages, err := users.ListInGroup(identityClient, groupID, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allUsers, err := users.ExtractUsers(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, user := range allUsers {
+		fmt.Printf("%+v\n", user)
+	}
+
 */
 package users

--- a/openstack/identity/v3/users/requests.go
+++ b/openstack/identity/v3/users/requests.go
@@ -225,3 +225,18 @@ func ListProjects(client *gophercloud.ServiceClient, userID string) pagination.P
 		return projects.ProjectPage{pagination.LinkedPageBase{PageResult: r}}
 	})
 }
+
+// ListInGroup enumerates users that belong to a group.
+func ListInGroup(client *gophercloud.ServiceClient, groupID string, opts ListOptsBuilder) pagination.Pager {
+	url := listInGroupURL(client, groupID)
+	if opts != nil {
+		query, err := opts.ToUserListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return UserPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}

--- a/openstack/identity/v3/users/testing/fixtures.go
+++ b/openstack/identity/v3/users/testing/fixtures.go
@@ -461,3 +461,17 @@ func HandleListUserProjectsSuccessfully(t *testing.T) {
 		fmt.Fprintf(w, ListProjectsOutput)
 	})
 }
+
+// HandleListInGroupSuccessfully creates an HTTP handler at /groups/{groupID}/users
+// on the test handler mux that response with a list of two users
+func HandleListInGroupSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/groups/ea167b/users", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, ListOutput)
+	})
+}

--- a/openstack/identity/v3/users/testing/requests_test.go
+++ b/openstack/identity/v3/users/testing/requests_test.go
@@ -158,3 +158,20 @@ func TestListUserProjects(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.CheckDeepEquals(t, ExpectedProjectsSlice, actual)
 }
+
+func TestListInGroup(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleListInGroupSuccessfully(t)
+
+	iTrue := true
+	listOpts := users.ListOpts{
+		Enabled: &iTrue,
+	}
+
+	allPages, err := users.ListInGroup(client.ServiceClient(), "ea167b", listOpts).AllPages()
+	th.AssertNoErr(t, err)
+	actual, err := users.ExtractUsers(allPages)
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, ExpectedUsersSlice, actual)
+}

--- a/openstack/identity/v3/users/urls.go
+++ b/openstack/identity/v3/users/urls.go
@@ -29,3 +29,7 @@ func listGroupsURL(client *gophercloud.ServiceClient, userID string) string {
 func listProjectsURL(client *gophercloud.ServiceClient, userID string) string {
 	return client.ServiceURL("users", userID, "projects")
 }
+
+func listInGroupURL(client *gophercloud.ServiceClient, groupID string) string {
+	return client.ServiceURL("groups", groupID, "users")
+}


### PR DESCRIPTION
Adding ability to list users belonging to a group given the group id.

Although this is logically a group operation, mixing this operation into groups creates a circular dependency between groups and users OR requires adding packages for common components. This approach was deemed the least offensive.

For #385

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

groups resource definition in keystone request router: 
https://github.com/openstack/keystone/blob/stable/pike/keystone/identity/routers.py#L50-L57

list_group_for_users general implementation 
https://github.com/openstack/keystone/blob/16f6ed14df136eb9c283a5415b9f18fcb0834350/keystone/identity/core.py#L1314

list_group_for_users SQL driver implementation 
https://github.com/openstack/keystone/blob/7754f170aa0eb42bea356e7f912bc241832eb1f3/keystone/identity/backends/sql.py#L320-L330

Based on: https://developer.openstack.org/api-ref/identity/v3/#list-users-in-group
