### PR TITLE
Compute v2: Add Reset State Action

### DIFF
--- a/openstack/compute/v2/extensions/resetstate/doc.go
+++ b/openstack/compute/v2/extensions/resetstate/doc.go
@@ -1,0 +1,13 @@
+/*
+Package resetstate provides functionality to reset the state of a server that has
+been provisioned by the OpenStack Compute service.
+
+Example to Reset a Server
+
+	serverID := "47b6b7b7-568d-40e4-868c-d5c41735532e"
+	err := resetstate.ResetState(client, id, resetstate.StateActive).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+*/
+package resetstate

--- a/openstack/compute/v2/extensions/resetstate/requests.go
+++ b/openstack/compute/v2/extensions/resetstate/requests.go
@@ -1,0 +1,23 @@
+package resetstate
+
+import (
+	"github.com/gophercloud/gophercloud"
+)
+
+// ServerState refers to the states usable in ResetState Action
+type ServerState string
+
+const (
+	// StateActive returns the state of the server as active
+	StateActive ServerState = "active"
+
+	// StateError returns the state of the server as error
+	StateError ServerState = "error"
+)
+
+// ResetState will reset the state of a server
+func ResetState(client *gophercloud.ServiceClient, id string, state ServerState) (r ResetResult) {
+	stateMap := map[string]interface{}{"state": state}
+	_, r.Err = client.Post(actionURL(client, id), map[string]interface{}{"os-resetState": stateMap}, nil, nil)
+	return
+}

--- a/openstack/compute/v2/extensions/resetstate/results.go
+++ b/openstack/compute/v2/extensions/resetstate/results.go
@@ -1,0 +1,11 @@
+package resetstate
+
+import (
+	"github.com/gophercloud/gophercloud"
+)
+
+// ResetResult is the response of a ResetState operation. Call its ExtractErr
+// method to determine if the request suceeded or failed.
+type ResetResult struct {
+	gophercloud.ErrResult
+}

--- a/openstack/compute/v2/extensions/resetstate/testing/doc.go
+++ b/openstack/compute/v2/extensions/resetstate/testing/doc.go
@@ -1,0 +1,1 @@
+package testing

--- a/openstack/compute/v2/extensions/resetstate/testing/fixtures.go
+++ b/openstack/compute/v2/extensions/resetstate/testing/fixtures.go
@@ -1,0 +1,19 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func mockResetStateResponse(t *testing.T, id string, state string) {
+	th.Mux.HandleFunc("/servers/"+id+"/action", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, fmt.Sprintf(`{"os-resetState": {"state": "%s"}}`, state))
+		w.WriteHeader(http.StatusAccepted)
+	})
+}

--- a/openstack/compute/v2/extensions/resetstate/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/resetstate/testing/requests_test.go
@@ -1,0 +1,21 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/resetstate"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+const serverID = "b16ba811-199d-4ffd-8839-ba96c1185a67"
+
+func TestResetState(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	mockResetStateResponse(t, serverID, "active")
+
+	err := resetstate.ResetState(client.ServiceClient(), serverID, "active").ExtractErr()
+	th.AssertNoErr(t, err)
+}

--- a/openstack/compute/v2/extensions/resetstate/urls.go
+++ b/openstack/compute/v2/extensions/resetstate/urls.go
@@ -1,0 +1,9 @@
+package resetstate
+
+import (
+	"github.com/gophercloud/gophercloud"
+)
+
+func actionURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL("servers", id, "action")
+}


### PR DESCRIPTION
For #521

Links to the line numbers/files in the OpenStack source code (Nova API service) that support the
code in this PR:
https://github.com/openstack/nova/blob/c2aa30b102808882c85d3d3f53d531c4510218cd/nova/api/openstack/compute/admin_actions.py#L74
https://github.com/openstack/nova/blob/c2aa30b102808882c85d3d3f53d531c4510218cd/nova/api/openstack/compute/admin_actions.py#L29-L32


