### PR TITLE
Identity v3: Add Group create

### DIFF
--- a/acceptance/openstack/identity/v3/identity.go
+++ b/acceptance/openstack/identity/v3/identity.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/acceptance/tools"
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/groups"
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/projects"
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/users"
 )
@@ -36,7 +37,7 @@ func CreateProject(t *testing.T, client *gophercloud.ServiceClient, c *projects.
 	return project, nil
 }
 
-// CreateUser will create a project with a random name.
+// CreateUser will create a user with a random name.
 // It takes an optional createOpts parameter since creating a user
 // has so many options. An error will be returned if the user was
 // unable to be created.
@@ -61,6 +62,33 @@ func CreateUser(t *testing.T, client *gophercloud.ServiceClient, c *users.Create
 	t.Logf("Successfully created user %s with ID %s", name, user.ID)
 
 	return user, nil
+}
+
+// CreateGroup will create a group with a random name.
+// It takes an optional createOpts parameter since creating a group
+// has so many options. An error will be returned if the group was
+// unable to be created.
+func CreateGroup(t *testing.T, client *gophercloud.ServiceClient, c *groups.CreateOpts) (*groups.Group, error) {
+	name := tools.RandomString("ACPTTEST", 8)
+	t.Logf("Attempting to create group: %s", name)
+
+	var createOpts groups.CreateOpts
+	if c != nil {
+		createOpts = *c
+	} else {
+		createOpts = groups.CreateOpts{}
+	}
+
+	createOpts.Name = name
+
+	group, err := groups.Create(client, createOpts).Extract()
+	if err != nil {
+		return group, err
+	}
+
+	t.Logf("Successfully created group %s with ID %s", name, group.ID)
+
+	return group, nil
 }
 
 // DeleteProject will delete a project by ID. A fatal error will occur if

--- a/openstack/identity/v3/groups/doc.go
+++ b/openstack/identity/v3/groups/doc.go
@@ -20,5 +20,20 @@ Example to List Groups
 	for _, group := range allGroups {
 		fmt.Printf("%+v\n", group)
 	}
+
+Example to Create a Group
+
+	createOpts := groups.CreateOpts{
+		Name:             "groupname",
+		DomainID:         "default",
+		Extra: map[string]interface{}{
+			"email": "groupname@example.com",
+		}
+	}
+
+	group, err := groups.Create(identityClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
 */
 package groups

--- a/openstack/identity/v3/groups/requests.go
+++ b/openstack/identity/v3/groups/requests.go
@@ -46,3 +46,55 @@ func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {
 	_, r.Err = client.Get(getURL(client, id), &r.Body, nil)
 	return
 }
+
+// CreateOptsBuilder allows extensions to add additional parameters to
+// the Create request.
+type CreateOptsBuilder interface {
+	ToGroupCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts provides options used to create a group.
+type CreateOpts struct {
+	// Name is the name of the new group.
+	Name string `json:"name" required:"true"`
+
+	// Description is a description of the group.
+	Description string `json:"description,omitempty"`
+
+	// DomainID is the ID of the domain the group belongs to.
+	DomainID string `json:"domain_id,omitempty"`
+
+	// Extra is free-form extra key/value pairs to describe the group.
+	Extra map[string]interface{} `json:"-"`
+}
+
+// ToGroupCreateMap formats a CreateOpts into a create request.
+func (opts CreateOpts) ToGroupCreateMap() (map[string]interface{}, error) {
+	b, err := gophercloud.BuildRequestBody(opts, "group")
+	if err != nil {
+		return nil, err
+	}
+
+	if opts.Extra != nil {
+		if v, ok := b["group"].(map[string]interface{}); ok {
+			for key, value := range opts.Extra {
+				v[key] = value
+			}
+		}
+	}
+
+	return b, nil
+}
+
+// Create creates a new Group.
+func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToGroupCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(createURL(client), &b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{201},
+	})
+	return
+}

--- a/openstack/identity/v3/groups/results.go
+++ b/openstack/identity/v3/groups/results.go
@@ -69,6 +69,12 @@ type GetResult struct {
 	groupResult
 }
 
+// CreateResult is the response from a Create operation. Call its Extract method
+// to interpret it as a Group.
+type CreateResult struct {
+	groupResult
+}
+
 // GroupPage is a single page of Group results.
 type GroupPage struct {
 	pagination.LinkedPageBase

--- a/openstack/identity/v3/groups/testing/fixtures.go
+++ b/openstack/identity/v3/groups/testing/fixtures.go
@@ -65,6 +65,18 @@ const GetOutput = `
 }
 `
 
+// CreateRequest provides the input to a Create request.
+const CreateRequest = `
+{
+    "group": {
+        "domain_id": "1789d1",
+        "name": "support",
+        "description": "group for support users",
+        "email": "support@example.com"
+    }
+}
+`
+
 // FirstGroup is the first group in the List request.
 var FirstGroup = groups.Group{
 	DomainID: "default",
@@ -120,6 +132,19 @@ func HandleGetGroupSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, GetOutput)
+	})
+}
+
+// HandleCreateGroupSuccessfully creates an HTTP handler at `/groups` on the
+// test handler mux that tests group creation.
+func HandleCreateGroupSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/groups", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, CreateRequest)
+
+		w.WriteHeader(http.StatusCreated)
 		fmt.Fprintf(w, GetOutput)
 	})
 }

--- a/openstack/identity/v3/groups/testing/requests_test.go
+++ b/openstack/identity/v3/groups/testing/requests_test.go
@@ -54,3 +54,22 @@ func TestGetGroup(t *testing.T) {
 	th.CheckDeepEquals(t, SecondGroup, *actual)
 	th.AssertEquals(t, SecondGroup.Extra["email"], "support@example.com")
 }
+
+func TestCreateGroup(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleCreateGroupSuccessfully(t)
+
+	createOpts := groups.CreateOpts{
+		Name:        "support",
+		DomainID:    "1789d1",
+		Description: "group for support users",
+		Extra: map[string]interface{}{
+			"email": "support@example.com",
+		},
+	}
+
+	actual, err := groups.Create(client.ServiceClient(), createOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, SecondGroup, *actual)
+}

--- a/openstack/identity/v3/groups/urls.go
+++ b/openstack/identity/v3/groups/urls.go
@@ -9,3 +9,7 @@ func listURL(client *gophercloud.ServiceClient) string {
 func getURL(client *gophercloud.ServiceClient, groupID string) string {
 	return client.ServiceURL("groups", groupID)
 }
+
+func createURL(client *gophercloud.ServiceClient) string {
+	return client.ServiceURL("groups")
+}


### PR DESCRIPTION
Changing group acceptance tests to a CRUD based test now that
create exists. This also reduces the risks of errant test failures
as group existence is not required in an openstack v3 deployment. The
Update and Delete will be added as the functionality is merged.

For #539 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

Create:

https://github.com/openstack/keystone/blob/stable/pike/keystone/identity/controllers.py#L316
https://github.com/openstack/keystone/blob/master/keystone/identity/backends/sql.py#L346
https://github.com/openstack/keystone/blob/stable/pike/keystone/identity/schema.py#L106
