### PR TITLE
Identity v3: group delete

### DIFF
--- a/acceptance/openstack/identity/v3/groups_test.go
+++ b/acceptance/openstack/identity/v3/groups_test.go
@@ -29,6 +29,8 @@ func TestGroupCRUD(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to create group: %v", err)
 	}
+	defer DeleteGroup(t, client, group.ID)
+
 	tools.PrintResource(t, group)
 	tools.PrintResource(t, group.Extra)
 

--- a/acceptance/openstack/identity/v3/identity.go
+++ b/acceptance/openstack/identity/v3/identity.go
@@ -114,3 +114,15 @@ func DeleteUser(t *testing.T, client *gophercloud.ServiceClient, userID string) 
 
 	t.Logf("Deleted user: %s", userID)
 }
+
+// DeleteGroup will delete a group by ID. A fatal error will occur if
+// the group failed to be deleted. This works best when using it as
+// a deferred function.
+func DeleteGroup(t *testing.T, client *gophercloud.ServiceClient, groupID string) {
+	err := groups.Delete(client, groupID).ExtractErr()
+	if err != nil {
+		t.Fatalf("Unable to delete group %s: %v", groupID, err)
+	}
+
+	t.Logf("Deleted group: %s", groupID)
+}

--- a/openstack/identity/v3/groups/doc.go
+++ b/openstack/identity/v3/groups/doc.go
@@ -35,5 +35,13 @@ Example to Create a Group
 	if err != nil {
 		panic(err)
 	}
+
+Example to Delete a Group
+
+	groupID := "0fe36e73809d46aeae6705c39077b1b3"
+	err := groups.Delete(identityClient, groupID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
 */
 package groups

--- a/openstack/identity/v3/groups/requests.go
+++ b/openstack/identity/v3/groups/requests.go
@@ -98,3 +98,9 @@ func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r Create
 	})
 	return
 }
+
+// Delete deletes a group.
+func Delete(client *gophercloud.ServiceClient, groupID string) (r DeleteResult) {
+	_, r.Err = client.Delete(deleteURL(client, groupID), nil)
+	return
+}

--- a/openstack/identity/v3/groups/results.go
+++ b/openstack/identity/v3/groups/results.go
@@ -75,6 +75,12 @@ type CreateResult struct {
 	groupResult
 }
 
+// DeleteResult is the response from a Delete operation. Call its ExtractErr to
+// determine if the request succeeded or failed.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
 // GroupPage is a single page of Group results.
 type GroupPage struct {
 	pagination.LinkedPageBase

--- a/openstack/identity/v3/groups/testing/fixtures.go
+++ b/openstack/identity/v3/groups/testing/fixtures.go
@@ -148,3 +148,14 @@ func HandleCreateGroupSuccessfully(t *testing.T) {
 		fmt.Fprintf(w, GetOutput)
 	})
 }
+
+// HandleDeleteGroupSuccessfully creates an HTTP handler at `/groups` on the
+// test handler mux that tests group deletion.
+func HandleDeleteGroupSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/groups/9fe1d3", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.WriteHeader(http.StatusNoContent)
+	})
+}

--- a/openstack/identity/v3/groups/testing/requests_test.go
+++ b/openstack/identity/v3/groups/testing/requests_test.go
@@ -73,3 +73,12 @@ func TestCreateGroup(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.CheckDeepEquals(t, SecondGroup, *actual)
 }
+
+func TestDeleteGroup(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleDeleteGroupSuccessfully(t)
+
+	res := groups.Delete(client.ServiceClient(), "9fe1d3")
+	th.AssertNoErr(t, res.Err)
+}

--- a/openstack/identity/v3/groups/urls.go
+++ b/openstack/identity/v3/groups/urls.go
@@ -13,3 +13,7 @@ func getURL(client *gophercloud.ServiceClient, groupID string) string {
 func createURL(client *gophercloud.ServiceClient) string {
 	return client.ServiceURL("groups")
 }
+
+func deleteURL(client *gophercloud.ServiceClient, groupID string) string {
+	return client.ServiceURL("groups", groupID)
+}


### PR DESCRIPTION
For #539

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

Delete:

https://github.com/openstack/keystone/blob/stable/pike/keystone/identity/controllers.py#L354
https://github.com/openstack/keystone/blob/stable/pike/keystone/identity/backends/sql.py#L394
