### PR TITLE
Identity v3 domain list / get

### DIFF
--- a/acceptance/openstack/identity/v3/domains_test.go
+++ b/acceptance/openstack/identity/v3/domains_test.go
@@ -1,0 +1,62 @@
+// +build acceptance
+
+package v3
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/acceptance/clients"
+	"github.com/gophercloud/gophercloud/acceptance/tools"
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/domains"
+)
+
+func TestDomainsList(t *testing.T) {
+	client, err := clients.NewIdentityV3Client()
+	if err != nil {
+		t.Fatalf("Unable to obtain an identity client: %v", err)
+	}
+
+	var iTrue bool = true
+	listOpts := domains.ListOpts{
+		Enabled: &iTrue,
+	}
+
+	allPages, err := domains.List(client, listOpts).AllPages()
+	if err != nil {
+		t.Fatalf("Unable to list domains: %v", err)
+	}
+
+	allDomains, err := domains.ExtractDomains(allPages)
+	if err != nil {
+		t.Fatalf("Unable to extract domains: %v", err)
+	}
+
+	for _, domain := range allDomains {
+		tools.PrintResource(t, domain)
+	}
+}
+
+func TestDomainsGet(t *testing.T) {
+	client, err := clients.NewIdentityV3Client()
+	if err != nil {
+		t.Fatalf("Unable to obtain an identity client: %v", err)
+	}
+
+	allPages, err := domains.List(client, nil).AllPages()
+	if err != nil {
+		t.Fatalf("Unable to list domains: %v", err)
+	}
+
+	allDomains, err := domains.ExtractDomains(allPages)
+	if err != nil {
+		t.Fatalf("Unable to extract domains: %v", err)
+	}
+
+	domain := allDomains[0]
+	p, err := domains.Get(client, domain.ID).Extract()
+	if err != nil {
+		t.Fatalf("Unable to get domain: %v", err)
+	}
+
+	tools.PrintResource(t, p)
+}

--- a/openstack/identity/v3/domains/doc.go
+++ b/openstack/identity/v3/domains/doc.go
@@ -1,0 +1,25 @@
+/*
+Package domains manages and retrieves Domains in the OpenStack Identity Service.
+
+Example to List Domains
+
+	var iTrue bool = true
+	listOpts := domains.ListOpts{
+		Enabled: &iTrue,
+	}
+
+	allPages, err := domains.List(identityClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allDomains, err := domains.ExtractDomains(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, domain := range allDomains {
+		fmt.Printf("%+v\n", domain)
+	}
+*/
+package domains

--- a/openstack/identity/v3/domains/requests.go
+++ b/openstack/identity/v3/domains/requests.go
@@ -1,0 +1,48 @@
+package domains
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// ListOptsBuilder allows extensions to add additional parameters to
+// the List request
+type ListOptsBuilder interface {
+	ToDomainListQuery() (string, error)
+}
+
+// ListOpts provides options to filter the List results.
+type ListOpts struct {
+	// Enabled filters the response by enabled domains.
+	Enabled *bool `q:"enabled"`
+
+	// Name filters the response by domain name.
+	Name string `q:"name"`
+}
+
+// ToDomainListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToDomainListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List enumerates the domains to which the current token has access.
+func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(client)
+	if opts != nil {
+		query, err := opts.ToDomainListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return DomainPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// Get retrieves details on a single domain, by ID.
+func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {
+	_, r.Err = client.Get(getURL(client, id), &r.Body, nil)
+	return
+}

--- a/openstack/identity/v3/domains/results.go
+++ b/openstack/identity/v3/domains/results.go
@@ -1,0 +1,79 @@
+package domains
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// A Domain is a collection of projects, users, and roles.
+type Domain struct {
+	// Description is the description of the Domain.
+	Description string `json:"description"`
+
+	// Enabled is whether or not the domain is enabled.
+	Enabled bool `json:"enabled"`
+
+	// ID is the unique ID of the domain.
+	ID string `json:"id"`
+
+	// Links contains referencing links to the domain.
+	Links map[string]interface{} `json:"links"`
+
+	// Name is the name of the domain.
+	Name string `json:"name"`
+}
+
+type domainResult struct {
+	gophercloud.Result
+}
+
+// GetResult is the response from a Get operation. Call its Extract method
+// to interpret it as a Domain.
+type GetResult struct {
+	domainResult
+}
+
+// DomainPage is a single page of Domain results.
+type DomainPage struct {
+	pagination.LinkedPageBase
+}
+
+// IsEmpty determines whether or not a page of Domains contains any results.
+func (r DomainPage) IsEmpty() (bool, error) {
+	domains, err := ExtractDomains(r)
+	return len(domains) == 0, err
+}
+
+// NextPageURL extracts the "next" link from the links section of the result.
+func (r DomainPage) NextPageURL() (string, error) {
+	var s struct {
+		Links struct {
+			Next     string `json:"next"`
+			Previous string `json:"previous"`
+		} `json:"links"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return s.Links.Next, err
+}
+
+// ExtractDomains returns a slice of Domains contained in a single page of
+// results.
+func ExtractDomains(r pagination.Page) ([]Domain, error) {
+	var s struct {
+		Domains []Domain `json:"domains"`
+	}
+	err := (r.(DomainPage)).ExtractInto(&s)
+	return s.Domains, err
+}
+
+// Extract interprets any domainResults as a Domain.
+func (r domainResult) Extract() (*Domain, error) {
+	var s struct {
+		Domain *Domain `json:"domain"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Domain, err
+}

--- a/openstack/identity/v3/domains/testing/fixtures.go
+++ b/openstack/identity/v3/domains/testing/fixtures.go
@@ -1,0 +1,107 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/domains"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+// ListOutput provides a single page of Domain results.
+const ListOutput = `
+{
+    "links": {
+        "next": null,
+        "previous": null,
+        "self": "http://example.com/identity/v3/domains"
+    },
+    "domains": [
+        {
+            "enabled": true,
+            "id": "2844b2a08be147a08ef58317d6471f1f",
+            "links": {
+                "self": "http://example.com/identity/v3/domains/2844b2a08be147a08ef58317d6471f1f"
+            },
+            "name": "domain one",
+            "description": "some description"
+        },
+        {
+            "enabled": true,
+            "id": "9fe1d3",
+            "links": {
+                "self": "https://example.com/identity/v3/domains/9fe1d3"
+            },
+            "name": "domain two"
+        }
+    ]
+}
+`
+
+// GetOutput provides a Get result.
+const GetOutput = `
+{
+    "domain": {
+        "enabled": true,
+        "id": "9fe1d3",
+        "links": {
+            "self": "https://example.com/identity/v3/domains/9fe1d3"
+        },
+        "name": "domain two"
+    }
+}
+`
+
+// FirstDomain is the first domain in the List request.
+var FirstDomain = domains.Domain{
+	Enabled: true,
+	ID:      "2844b2a08be147a08ef58317d6471f1f",
+	Links: map[string]interface{}{
+		"self": "http://example.com/identity/v3/domains/2844b2a08be147a08ef58317d6471f1f",
+	},
+	Name:        "domain one",
+	Description: "some description",
+}
+
+// SecondDomain is the second domain in the List request.
+var SecondDomain = domains.Domain{
+	Enabled: true,
+	ID:      "9fe1d3",
+	Links: map[string]interface{}{
+		"self": "https://example.com/identity/v3/domains/9fe1d3",
+	},
+	Name: "domain two",
+}
+
+// ExpectedDomainsSlice is the slice of domains expected to be returned from ListOutput.
+var ExpectedDomainsSlice = []domains.Domain{FirstDomain, SecondDomain}
+
+// HandleListDomainsSuccessfully creates an HTTP handler at `/domains` on the
+// test handler mux that responds with a list of two domains.
+func HandleListDomainsSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/domains", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, ListOutput)
+	})
+}
+
+// HandleGetDomainSuccessfully creates an HTTP handler at `/domains` on the
+// test handler mux that responds with a single domain.
+func HandleGetDomainSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/domains/9fe1d3", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, GetOutput)
+	})
+}

--- a/openstack/identity/v3/domains/testing/requests_test.go
+++ b/openstack/identity/v3/domains/testing/requests_test.go
@@ -1,0 +1,52 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/domains"
+	"github.com/gophercloud/gophercloud/pagination"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func TestListDomains(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleListDomainsSuccessfully(t)
+
+	count := 0
+	err := domains.List(client.ServiceClient(), nil).EachPage(func(page pagination.Page) (bool, error) {
+		count++
+
+		actual, err := domains.ExtractDomains(page)
+		th.AssertNoErr(t, err)
+
+		th.CheckDeepEquals(t, ExpectedDomainsSlice, actual)
+
+		return true, nil
+	})
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, count, 1)
+}
+
+func TestListDomainsAllPages(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleListDomainsSuccessfully(t)
+
+	allPages, err := domains.List(client.ServiceClient(), nil).AllPages()
+	th.AssertNoErr(t, err)
+	actual, err := domains.ExtractDomains(allPages)
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, ExpectedDomainsSlice, actual)
+}
+
+func TestGetDomain(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleGetDomainSuccessfully(t)
+
+	actual, err := domains.Get(client.ServiceClient(), "9fe1d3").Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, SecondDomain, *actual)
+}

--- a/openstack/identity/v3/domains/urls.go
+++ b/openstack/identity/v3/domains/urls.go
@@ -1,0 +1,11 @@
+package domains
+
+import "github.com/gophercloud/gophercloud"
+
+func listURL(client *gophercloud.ServiceClient) string {
+	return client.ServiceURL("domains")
+}
+
+func getURL(client *gophercloud.ServiceClient, domainID string) string {
+	return client.ServiceURL("domains", domainID)
+}


### PR DESCRIPTION
For #555 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

List:

https://github.com/openstack/keystone/blob/83bd595b22944d38eff1cdef77b4c07a75af0fdc/keystone/resource/controllers.py#L123

Get:

General project model/schema:
https://github.com/openstack/keystone/blob/master/keystone/resource/schema.py#L51

Controller / router:
https://github.com/openstack/keystone/blob/83bd595b22944d38eff1cdef77b4c07a75af0fdc/keystone/resource/controllers.py#L189


