### PR TITLE
Identity v3 role list / get

### DIFF
--- a/acceptance/openstack/identity/v3/roles_test.go
+++ b/acceptance/openstack/identity/v3/roles_test.go
@@ -1,0 +1,61 @@
+// +build acceptance
+
+package v3
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/acceptance/clients"
+	"github.com/gophercloud/gophercloud/acceptance/tools"
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/roles"
+)
+
+func TestRolesList(t *testing.T) {
+	client, err := clients.NewIdentityV3Client()
+	if err != nil {
+		t.Fatalf("Unable to obtain an identity client: %v", err)
+	}
+
+	listOpts := roles.ListOpts{
+		DomainID: "default",
+	}
+
+	allPages, err := roles.List(client, listOpts).AllPages()
+	if err != nil {
+		t.Fatalf("Unable to list roles: %v", err)
+	}
+
+	allRoles, err := roles.ExtractRoles(allPages)
+	if err != nil {
+		t.Fatalf("Unable to extract roles: %v", err)
+	}
+
+	for _, role := range allRoles {
+		tools.PrintResource(t, role)
+	}
+}
+
+func TestRolesGet(t *testing.T) {
+	client, err := clients.NewIdentityV3Client()
+	if err != nil {
+		t.Fatalf("Unable to obtain an identity client: %v", err)
+	}
+
+	allPages, err := roles.List(client, nil).AllPages()
+	if err != nil {
+		t.Fatalf("Unable to list roles: %v", err)
+	}
+
+	allRoles, err := roles.ExtractRoles(allPages)
+	if err != nil {
+		t.Fatalf("Unable to extract roles: %v", err)
+	}
+
+	role := allRoles[0]
+	p, err := roles.Get(client, role.ID).Extract()
+	if err != nil {
+		t.Fatalf("Unable to get role: %v", err)
+	}
+
+	tools.PrintResource(t, p)
+}

--- a/openstack/identity/v3/roles/doc.go
+++ b/openstack/identity/v3/roles/doc.go
@@ -2,6 +2,26 @@
 Package roles provides information and interaction with the roles API
 resource for the OpenStack Identity service.
 
+Example to List Roles
+
+	listOpts := roles.ListOpts{
+		DomainID: "default",
+	}
+
+	allPages, err := roles.List(identityClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allRoles, err := roles.ExtractRoles(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, role := range allRoles {
+		fmt.Printf("%+v\n", role)
+	}
+
 Example to List Role Assignments
 
 	listOpts := roles.ListAssignmentsOpts{

--- a/openstack/identity/v3/roles/requests.go
+++ b/openstack/identity/v3/roles/requests.go
@@ -5,6 +5,49 @@ import (
 	"github.com/gophercloud/gophercloud/pagination"
 )
 
+// ListOptsBuilder allows extensions to add additional parameters to
+// the List request
+type ListOptsBuilder interface {
+	ToRoleListQuery() (string, error)
+}
+
+// ListOpts provides options to filter the List results.
+type ListOpts struct {
+	// DomainID filters the response by a domain ID.
+	DomainID string `q:"domain_id"`
+
+	// Name filters the response by role name.
+	Name string `q:"name"`
+}
+
+// ToRoleListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToRoleListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List enumerates the roles to which the current token has access.
+func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(client)
+	if opts != nil {
+		query, err := opts.ToRoleListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return RolePage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// Get retrieves details on a single role, by ID.
+func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {
+	_, r.Err = client.Get(getURL(client, id), &r.Body, nil)
+	return
+}
+
 // ListAssignmentsOptsBuilder allows extensions to add additional parameters to
 // the ListAssignments request.
 type ListAssignmentsOptsBuilder interface {

--- a/openstack/identity/v3/roles/results.go
+++ b/openstack/identity/v3/roles/results.go
@@ -1,17 +1,90 @@
 package roles
 
-import "github.com/gophercloud/gophercloud/pagination"
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// Role grants permissions to a user.
+type Role struct {
+	// DomainID is the domain ID the role belongs to.
+	DomainID string `json:"domain_id"`
+
+	// ID is the unique ID of the role.
+	ID string `json:"id"`
+
+	// Links contains referencing links to the role.
+	Links map[string]interface{} `json:"links"`
+
+	// Name is the role name
+	Name string `json:"name"`
+}
+
+type roleResult struct {
+	gophercloud.Result
+}
+
+// GetResult is the response from a Get operation. Call its Extract method
+// to interpret it as a Role.
+type GetResult struct {
+	roleResult
+}
+
+// RolePage is a single page of Role results.
+type RolePage struct {
+	pagination.LinkedPageBase
+}
+
+// IsEmpty determines whether or not a page of Roles contains any results.
+func (r RolePage) IsEmpty() (bool, error) {
+	roles, err := ExtractRoles(r)
+	return len(roles) == 0, err
+}
+
+// NextPageURL extracts the "next" link from the links section of the result.
+func (r RolePage) NextPageURL() (string, error) {
+	var s struct {
+		Links struct {
+			Next     string `json:"next"`
+			Previous string `json:"previous"`
+		} `json:"links"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return s.Links.Next, err
+}
+
+// ExtractProjects returns a slice of Roles contained in a single page of
+// results.
+func ExtractRoles(r pagination.Page) ([]Role, error) {
+	var s struct {
+		Roles []Role `json:"roles"`
+	}
+	err := (r.(RolePage)).ExtractInto(&s)
+	return s.Roles, err
+}
+
+// Extract interprets any roleResults as a Role.
+func (r roleResult) Extract() (*Role, error) {
+	var s struct {
+		Role *Role `json:"role"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Role, err
+}
 
 // RoleAssignment is the result of a role assignments query.
 type RoleAssignment struct {
-	Role  Role  `json:"role,omitempty"`
-	Scope Scope `json:"scope,omitempty"`
-	User  User  `json:"user,omitempty"`
-	Group Group `json:"group,omitempty"`
+	Role  AssignedRole `json:"role,omitempty"`
+	Scope Scope        `json:"scope,omitempty"`
+	User  User         `json:"user,omitempty"`
+	Group Group        `json:"group,omitempty"`
 }
 
-// Role represents a Role in an assignment.
-type Role struct {
+// AssignedRole represents a Role in an assignment.
+type AssignedRole struct {
 	ID string `json:"id,omitempty"`
 }
 

--- a/openstack/identity/v3/roles/testing/fixtures.go
+++ b/openstack/identity/v3/roles/testing/fixtures.go
@@ -1,0 +1,105 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/roles"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+// ListOutput provides a single page of Role results.
+const ListOutput = `
+{
+    "links": {
+        "next": null,
+        "previous": null,
+        "self": "http://example.com/identity/v3/roles"
+    },
+    "roles": [
+        {
+            "domain_id": "default",
+            "id": "2844b2a08be147a08ef58317d6471f1f",
+            "links": {
+                "self": "http://example.com/identity/v3/roles/2844b2a08be147a08ef58317d6471f1f"
+            },
+            "name": "admin-read-only"
+        },
+        {
+            "domain_id": "1789d1",
+            "id": "9fe1d3",
+            "links": {
+                "self": "https://example.com/identity/v3/roles/9fe1d3"
+            },
+            "name": "support"
+        }
+    ]
+}
+`
+
+// GetOutput provides a Get result.
+const GetOutput = `
+{
+    "role": {
+        "domain_id": "1789d1",
+        "id": "9fe1d3",
+        "links": {
+            "self": "https://example.com/identity/v3/roles/9fe1d3"
+        },
+        "name": "support"
+    }
+}
+`
+
+// FirstRole is the first role in the List request.
+var FirstRole = roles.Role{
+	DomainID: "default",
+	ID:       "2844b2a08be147a08ef58317d6471f1f",
+	Links: map[string]interface{}{
+		"self": "http://example.com/identity/v3/roles/2844b2a08be147a08ef58317d6471f1f",
+	},
+	Name: "admin-read-only",
+}
+
+// SecondRole is the second role in the List request.
+var SecondRole = roles.Role{
+	DomainID: "1789d1",
+	ID:       "9fe1d3",
+	Links: map[string]interface{}{
+		"self": "https://example.com/identity/v3/roles/9fe1d3",
+	},
+	Name: "support",
+}
+
+// ExpectedRolesSlice is the slice of roles expected to be returned from ListOutput.
+var ExpectedRolesSlice = []roles.Role{FirstRole, SecondRole}
+
+// HandleListRolesSuccessfully creates an HTTP handler at `/roles` on the
+// test handler mux that responds with a list of two roles.
+func HandleListRolesSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/roles", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, ListOutput)
+	})
+}
+
+// HandleGetRoleSuccessfully creates an HTTP handler at `/roles` on the
+// test handler mux that responds with a single role.
+func HandleGetRoleSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/roles/9fe1d3", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, GetOutput)
+	})
+}

--- a/openstack/identity/v3/roles/testing/requests_test.go
+++ b/openstack/identity/v3/roles/testing/requests_test.go
@@ -8,17 +8,60 @@ import (
 
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/roles"
 	"github.com/gophercloud/gophercloud/pagination"
-	"github.com/gophercloud/gophercloud/testhelper"
+	th "github.com/gophercloud/gophercloud/testhelper"
 	"github.com/gophercloud/gophercloud/testhelper/client"
 )
 
-func TestListSinglePage(t *testing.T) {
-	testhelper.SetupHTTP()
-	defer testhelper.TeardownHTTP()
+func TestListRoles(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleListRolesSuccessfully(t)
 
-	testhelper.Mux.HandleFunc("/role_assignments", func(w http.ResponseWriter, r *http.Request) {
-		testhelper.TestMethod(t, r, "GET")
-		testhelper.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+	count := 0
+	err := roles.List(client.ServiceClient(), nil).EachPage(func(page pagination.Page) (bool, error) {
+		count++
+
+		actual, err := roles.ExtractRoles(page)
+		th.AssertNoErr(t, err)
+
+		th.CheckDeepEquals(t, ExpectedRolesSlice, actual)
+
+		return true, nil
+	})
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, count, 1)
+}
+
+func TestListRolesAllPages(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleListRolesSuccessfully(t)
+
+	allPages, err := roles.List(client.ServiceClient(), nil).AllPages()
+	th.AssertNoErr(t, err)
+	actual, err := roles.ExtractRoles(allPages)
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, ExpectedRolesSlice, actual)
+}
+
+func TestGetRole(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleGetRoleSuccessfully(t)
+
+	actual, err := roles.Get(client.ServiceClient(), "9fe1d3").Extract()
+
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, SecondRole, *actual)
+}
+
+func TestListAssignmentsSinglePage(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/role_assignments", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
 		fmt.Fprintf(w, `
@@ -77,13 +120,13 @@ func TestListSinglePage(t *testing.T) {
 
 		expected := []roles.RoleAssignment{
 			{
-				Role:  roles.Role{ID: "123456"},
+				Role:  roles.AssignedRole{ID: "123456"},
 				Scope: roles.Scope{Domain: roles.Domain{ID: "161718"}},
 				User:  roles.User{ID: "313233"},
 				Group: roles.Group{},
 			},
 			{
-				Role:  roles.Role{ID: "123456"},
+				Role:  roles.AssignedRole{ID: "123456"},
 				Scope: roles.Scope{Project: roles.Project{ID: "456789"}},
 				User:  roles.User{ID: "313233"},
 				Group: roles.Group{},

--- a/openstack/identity/v3/roles/urls.go
+++ b/openstack/identity/v3/roles/urls.go
@@ -2,6 +2,14 @@ package roles
 
 import "github.com/gophercloud/gophercloud"
 
+func listURL(client *gophercloud.ServiceClient) string {
+	return client.ServiceURL("roles")
+}
+
+func getURL(client *gophercloud.ServiceClient, roleID string) string {
+	return client.ServiceURL("roles", roleID)
+}
+
 func listAssignmentsURL(client *gophercloud.ServiceClient) string {
 	return client.ServiceURL("role_assignments")
 }


### PR DESCRIPTION
For #550 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

List:

https://github.com/openstack/keystone/blob/83bd595b22944d38eff1cdef77b4c07a75af0fdc/keystone/assignment/controllers.py#L335

Get:
https://github.com/openstack/keystone/blob/83bd595b22944d38eff1cdef77b4c07a75af0fdc/keystone/assignment/controllers.py#L349

Renamed Role struct used in RoleAssignment to AssignedRole as the scope of the Role field in RoleAssignment is a subset of the full v3 role API result. 

Ideally, I would move the previous role_assignment code to a role_assignment package, but as that code has existed for over 2 years, that could break existing users/implementations.

I can also see refactoring the role_assignment tests to match the rest of the identity v3 test structure, but that should be an independent PR.