### PR TITLE
Compute v2 - Add Get Detailed Quota for Tenant (#549)

### DIFF
--- a/openstack/compute/v2/extensions/quotasets/doc.go
+++ b/openstack/compute/v2/extensions/quotasets/doc.go
@@ -10,6 +10,15 @@ Example to Get a Quota Set
 
 	fmt.Printf("%+v\n", quotaset)
 
+Example to Get a Detailed Quota Set
+
+	quotaset, err := quotasets.GetDetail(computeClient, "tenant-id").Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v\n", quotaset)
+
 Example to Update a Quota Set
 
 	updateOpts := quotasets.UpdateOpts{

--- a/openstack/compute/v2/extensions/quotasets/requests.go
+++ b/openstack/compute/v2/extensions/quotasets/requests.go
@@ -9,14 +9,14 @@ import (
 // Get returns public data about a previously created QuotaSet.
 func Get(client *gophercloud.ServiceClient, tenantID string) GetResult {
 	var res GetResult
-	_, res.Err = client.Get(getDetailURL(client, tenantID), &res.Body, nil)
+	_, res.Err = client.Get(getURL(client, tenantID), &res.Body, nil)
 	return res
 }
 
 // GetDetail returns detailed public data about a previously created QuotaSet.
 func GetDetail(client *gophercloud.ServiceClient, tenantID string) GetDetailResult {
 	var res GetDetailResult
-	_, res.Err = client.Get(getDetailURL(client, fmt.Sprintf("%s/detail", tenantID)), &res.Body, nil)
+	_, res.Err = client.Get(getDetailURL(client, tenantID), &res.Body, nil)
 	return res
 }
 

--- a/openstack/compute/v2/extensions/quotasets/requests.go
+++ b/openstack/compute/v2/extensions/quotasets/requests.go
@@ -1,6 +1,8 @@
 package quotasets
 
 import (
+	"fmt"
+
 	"github.com/gophercloud/gophercloud"
 )
 
@@ -8,6 +10,13 @@ import (
 func Get(client *gophercloud.ServiceClient, tenantID string) GetResult {
 	var res GetResult
 	_, res.Err = client.Get(getURL(client, tenantID), &res.Body, nil)
+	return res
+}
+
+// GetDetail returns detailed public data about a previously created QuotaSet.
+func GetDetail(client *gophercloud.ServiceClient, tenantID string) GetResultDetail {
+	var res GetResultDetail
+	_, res.Err = client.Get(getURL(client, fmt.Sprintf("%s/detail", tenantID)), &res.Body, nil)
 	return res
 }
 

--- a/openstack/compute/v2/extensions/quotasets/requests.go
+++ b/openstack/compute/v2/extensions/quotasets/requests.go
@@ -9,14 +9,14 @@ import (
 // Get returns public data about a previously created QuotaSet.
 func Get(client *gophercloud.ServiceClient, tenantID string) GetResult {
 	var res GetResult
-	_, res.Err = client.Get(getURL(client, tenantID), &res.Body, nil)
+	_, res.Err = client.Get(getDetailURL(client, tenantID), &res.Body, nil)
 	return res
 }
 
 // GetDetail returns detailed public data about a previously created QuotaSet.
-func GetDetail(client *gophercloud.ServiceClient, tenantID string) GetResultDetail {
-	var res GetResultDetail
-	_, res.Err = client.Get(getURL(client, fmt.Sprintf("%s/detail", tenantID)), &res.Body, nil)
+func GetDetail(client *gophercloud.ServiceClient, tenantID string) GetDetailResult {
+	var res GetDetailResult
+	_, res.Err = client.Get(getDetailURL(client, fmt.Sprintf("%s/detail", tenantID)), &res.Body, nil)
 	return res
 }
 

--- a/openstack/compute/v2/extensions/quotasets/requests.go
+++ b/openstack/compute/v2/extensions/quotasets/requests.go
@@ -1,8 +1,6 @@
 package quotasets
 
 import (
-	"fmt"
-
 	"github.com/gophercloud/gophercloud"
 )
 

--- a/openstack/compute/v2/extensions/quotasets/results.go
+++ b/openstack/compute/v2/extensions/quotasets/results.go
@@ -55,6 +55,68 @@ type QuotaSet struct {
 	ServerGroupMembers int `json:"server_group_members"`
 }
 
+// QuotaDetailSet is detail on both operational limits that allow for control
+// of compute usage and also currently measured allocation against those limits.
+type QuotaDetailSet struct {
+	// ID is tenant associated with this QuotaDetailSet.
+	ID string `json:"id"`
+
+	// FixedIps is number of fixed ips alloted this QuotaDetailSet.
+	FixedIps QuotaDetail `json:"fixed_ips"`
+
+	// FloatingIps is number of floating ips alloted this QuotaDetailSet.
+	FloatingIps QuotaDetail `json:"floating_ips"`
+
+	// InjectedFileContentBytes is the allowed bytes for each injected file.
+	InjectedFileContentBytes QuotaDetail `json:"injected_file_content_bytes"`
+
+	// InjectedFilePathBytes is allowed bytes for each injected file path.
+	InjectedFilePathBytes QuotaDetail `json:"injected_file_path_bytes"`
+
+	// InjectedFiles is the number of injected files allowed for each project.
+	InjectedFiles QuotaDetail `json:"injected_files"`
+
+	// KeyPairs is number of ssh keypairs.
+	KeyPairs QuotaDetail `json:"key_pairs"`
+
+	// MetadataItems is number of metadata items allowed for each instance.
+	MetadataItems QuotaDetail `json:"metadata_items"`
+
+	// Ram is megabytes allowed for each instance.
+	Ram QuotaDetail `json:"ram"`
+
+	// SecurityGroupRules is number of security group rules allowed for each
+	// security group.
+	SecurityGroupRules QuotaDetail `json:"security_group_rules"`
+
+	// SecurityGroups is the number of security groups allowed for each project.
+	SecurityGroups QuotaDetail `json:"security_groups"`
+
+	// Cores is number of instance cores allowed for each project.
+	Cores QuotaDetail `json:"cores"`
+
+	// Instances is number of instances allowed for each project.
+	Instances QuotaDetail `json:"instances"`
+
+	// ServerGroups is the number of ServerGroups allowed for the project.
+	ServerGroups QuotaDetail `json:"server_groups"`
+
+	// ServerGroupMembers is the number of members for each ServerGroup.
+	ServerGroupMembers QuotaDetail `json:"server_group_members"`
+}
+
+// QuotaDetail is a set of details about a single operational limit that allows for control of compute usage.
+type QuotaDetail struct {
+	// InUse is the current number of provisioned/allocated resources of the given type.
+	InUse int `json:"in_use"`
+
+	// Reserved is a transitional state when a claim against quota has been made but the resource is not yet fully online.
+	Reserved int `json:"reserved"`
+
+	// Limit is the maximum number of a given resource that can be allocated/provisioned.  This is what "quota" usually refers to.
+	Limit int `json:"limit"`
+}
+
 // QuotaSetPage stores a single page of all QuotaSet results from a List call.
 type QuotaSetPage struct {
 	pagination.SinglePageBase
@@ -105,4 +167,24 @@ type UpdateResult struct {
 // to interpret it as a QuotaSet.
 type DeleteResult struct {
 	quotaResult
+}
+
+type quotaResultDetail struct {
+	gophercloud.Result
+}
+
+// GetResult is the response from a Get operation. Call its Extract method to interpret it
+// as a QuotaSet.
+type GetResultDetail struct {
+	quotaResultDetail
+}
+
+// ExtractDetails is a method that attempts to interpret any QuotaDetailSet
+// resource response as an array of QuotaDetailSet structs.
+func (r quotaResultDetail) Extract() (QuotaDetailSet, error) {
+	var s struct {
+		QuotaData QuotaDetailSet `json:"quota_set"`
+	}
+	err := r.ExtractInto(&s)
+	return s.QuotaData, err
 }

--- a/openstack/compute/v2/extensions/quotasets/results.go
+++ b/openstack/compute/v2/extensions/quotasets/results.go
@@ -55,10 +55,10 @@ type QuotaSet struct {
 	ServerGroupMembers int `json:"server_group_members"`
 }
 
-// QuotaDetailSet is detail on both operational limits that allow for control
-// of compute usage and also currently measured allocation against those limits.
+// QuotaDetailSet represents details of both operational limits of compute
+// resources and the current usage of those resources.
 type QuotaDetailSet struct {
-	// ID is tenant associated with this QuotaDetailSet.
+	// ID is the tenant ID associated with this QuotaDetailSet.
 	ID string `json:"id"`
 
 	// FixedIps is number of fixed ips alloted this QuotaDetailSet.
@@ -82,8 +82,8 @@ type QuotaDetailSet struct {
 	// MetadataItems is number of metadata items allowed for each instance.
 	MetadataItems QuotaDetail `json:"metadata_items"`
 
-	// Ram is megabytes allowed for each instance.
-	Ram QuotaDetail `json:"ram"`
+	// RAM is megabytes allowed for each instance.
+	RAM QuotaDetail `json:"ram"`
 
 	// SecurityGroupRules is number of security group rules allowed for each
 	// security group.
@@ -105,7 +105,8 @@ type QuotaDetailSet struct {
 	ServerGroupMembers QuotaDetail `json:"server_group_members"`
 }
 
-// QuotaDetail is a set of details about a single operational limit that allows for control of compute usage.
+// QuotaDetail is a set of details about a single operational limit that allows
+// for control of compute usage.
 type QuotaDetail struct {
 	// InUse is the current number of provisioned/allocated resources of the given type.
 	InUse int `json:"in_use"`
@@ -169,19 +170,19 @@ type DeleteResult struct {
 	quotaResult
 }
 
-type quotaResultDetail struct {
+type quotaDetailResult struct {
 	gophercloud.Result
 }
 
-// GetResult is the response from a Get operation. Call its Extract method to interpret it
+// GetDetailResult is the response from a Get operation. Call its Extract method to interpret it
 // as a QuotaSet.
-type GetResultDetail struct {
-	quotaResultDetail
+type GetDetailResult struct {
+	quotaDetailResult
 }
 
 // ExtractDetails is a method that attempts to interpret any QuotaDetailSet
 // resource response as an array of QuotaDetailSet structs.
-func (r quotaResultDetail) Extract() (QuotaDetailSet, error) {
+func (r quotaDetailResult) Extract() (QuotaDetailSet, error) {
 	var s struct {
 		QuotaData QuotaDetailSet `json:"quota_set"`
 	}

--- a/openstack/compute/v2/extensions/quotasets/testing/fixtures.go
+++ b/openstack/compute/v2/extensions/quotasets/testing/fixtures.go
@@ -2,12 +2,13 @@ package testing
 
 import (
 	"fmt"
-	"github.com/Comcast/gophercloud/openstack/compute/v2/extensions/quotasets"
-	"github.com/gophercloud/gophercloud"
-	th "github.com/gophercloud/gophercloud/testhelper"
-	"github.com/gophercloud/gophercloud/testhelper/client"
 	"net/http"
 	"testing"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/quotasets"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
 )
 
 // GetOutput is a sample response to a Get call.
@@ -126,7 +127,7 @@ var FirstQuotaDetailsSet = quotasets.QuotaDetailSet{
 	InjectedFiles:            quotasets.QuotaDetail{InUse: 0, Reserved: 0, Limit: 5},
 	KeyPairs:                 quotasets.QuotaDetail{InUse: 0, Reserved: 0, Limit: 10},
 	MetadataItems:            quotasets.QuotaDetail{InUse: 0, Reserved: 0, Limit: 128},
-	Ram:                      quotasets.QuotaDetail{InUse: 0, Reserved: 0, Limit: 200000},
+	RAM:                      quotasets.QuotaDetail{InUse: 0, Reserved: 0, Limit: 200000},
 	SecurityGroupRules:       quotasets.QuotaDetail{InUse: 0, Reserved: 0, Limit: 20},
 	SecurityGroups:           quotasets.QuotaDetail{InUse: 0, Reserved: 0, Limit: 10},
 	Cores:                    quotasets.QuotaDetail{InUse: 0, Reserved: 0, Limit: 200},

--- a/openstack/compute/v2/extensions/quotasets/testing/fixtures.go
+++ b/openstack/compute/v2/extensions/quotasets/testing/fixtures.go
@@ -2,13 +2,12 @@ package testing
 
 import (
 	"fmt"
-	"net/http"
-	"testing"
-
+	"github.com/Comcast/gophercloud/openstack/compute/v2/extensions/quotasets"
 	"github.com/gophercloud/gophercloud"
-	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/quotasets"
 	th "github.com/gophercloud/gophercloud/testhelper"
 	"github.com/gophercloud/gophercloud/testhelper/client"
+	"net/http"
+	"testing"
 )
 
 // GetOutput is a sample response to a Get call.
@@ -30,6 +29,75 @@ const GetOutput = `
    }
 }
 `
+
+// GetDetailsOutput is a sample response to a Get call with the detailed option.
+const GetDetailsOutput = `
+{
+   "quota_set" : {
+	  "id": "555544443333222211110000ffffeeee",
+      "instances" : {
+          "in_use": 0,
+          "limit": 25,
+          "reserved": 0
+      },
+      "security_groups" : {
+          "in_use": 0,
+          "limit": 10,
+          "reserved": 0
+      },
+      "security_group_rules" : {
+          "in_use": 0,
+          "limit": 20,
+          "reserved": 0
+      },
+      "cores" : {
+          "in_use": 0,
+          "limit": 200,
+          "reserved": 0
+      },
+      "injected_file_content_bytes" : {
+          "in_use": 0,
+          "limit": 10240,
+          "reserved": 0
+      },
+      "injected_files" : {
+          "in_use": 0,
+          "limit": 5,
+          "reserved": 0
+      },
+      "metadata_items" : {
+          "in_use": 0,
+          "limit": 128,
+          "reserved": 0
+      },
+      "ram" : {
+          "in_use": 0,
+          "limit": 200000,
+          "reserved": 0
+      },
+      "key_pairs" : {
+          "in_use": 0,
+          "limit": 10,
+          "reserved": 0
+      },
+      "injected_file_path_bytes" : {
+          "in_use": 0,
+          "limit": 255,
+          "reserved": 0
+      },
+      "server_groups" : {
+          "in_use": 0,
+          "limit": 2,
+          "reserved": 0
+      },
+      "server_group_members" : {
+          "in_use": 0,
+          "limit": 3,
+          "reserved": 0
+      }
+   }
+}
+`
 const FirstTenantID = "555544443333222211110000ffffeeee"
 
 // FirstQuotaSet is the first result in ListOutput.
@@ -48,6 +116,23 @@ var FirstQuotaSet = quotasets.QuotaSet{
 	Instances:                25,
 	ServerGroups:             2,
 	ServerGroupMembers:       3,
+}
+
+// FirstQuotaDetailsSet is the first result in ListOutput.
+var FirstQuotaDetailsSet = quotasets.QuotaDetailSet{
+	ID: FirstTenantID,
+	InjectedFileContentBytes: quotasets.QuotaDetail{InUse: 0, Reserved: 0, Limit: 10240},
+	InjectedFilePathBytes:    quotasets.QuotaDetail{InUse: 0, Reserved: 0, Limit: 255},
+	InjectedFiles:            quotasets.QuotaDetail{InUse: 0, Reserved: 0, Limit: 5},
+	KeyPairs:                 quotasets.QuotaDetail{InUse: 0, Reserved: 0, Limit: 10},
+	MetadataItems:            quotasets.QuotaDetail{InUse: 0, Reserved: 0, Limit: 128},
+	Ram:                      quotasets.QuotaDetail{InUse: 0, Reserved: 0, Limit: 200000},
+	SecurityGroupRules:       quotasets.QuotaDetail{InUse: 0, Reserved: 0, Limit: 20},
+	SecurityGroups:           quotasets.QuotaDetail{InUse: 0, Reserved: 0, Limit: 10},
+	Cores:                    quotasets.QuotaDetail{InUse: 0, Reserved: 0, Limit: 200},
+	Instances:                quotasets.QuotaDetail{InUse: 0, Reserved: 0, Limit: 25},
+	ServerGroups:             quotasets.QuotaDetail{InUse: 0, Reserved: 0, Limit: 2},
+	ServerGroupMembers:       quotasets.QuotaDetail{InUse: 0, Reserved: 0, Limit: 3},
 }
 
 //The expected update Body. Is also returned by PUT request
@@ -82,6 +167,16 @@ func HandleGetSuccessfully(t *testing.T) {
 
 		w.Header().Add("Content-Type", "application/json")
 		fmt.Fprintf(w, GetOutput)
+	})
+}
+
+// HandleGetDetailSuccessfully configures the test server to respond to a Get Details request for sample tenant
+func HandleGetDetailSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/os-quota-sets/"+FirstTenantID+"/detail", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprintf(w, GetDetailsOutput)
 	})
 }
 

--- a/openstack/compute/v2/extensions/quotasets/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/quotasets/testing/requests_test.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/Comcast/gophercloud/openstack/compute/v2/extensions/quotasets"
 	"github.com/gophercloud/gophercloud"
-	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/quotasets"
 	th "github.com/gophercloud/gophercloud/testhelper"
 	"github.com/gophercloud/gophercloud/testhelper/client"
 )
@@ -17,6 +17,15 @@ func TestGet(t *testing.T) {
 	actual, err := quotasets.Get(client.ServiceClient(), FirstTenantID).Extract()
 	th.AssertNoErr(t, err)
 	th.CheckDeepEquals(t, &FirstQuotaSet, actual)
+}
+
+func TestGetDetail(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleGetDetailSuccessfully(t)
+	actual, err := quotasets.GetDetail(client.ServiceClient(), FirstTenantID).Extract()
+	th.CheckDeepEquals(t, FirstQuotaDetailsSet, actual)
+	th.AssertNoErr(t, err)
 }
 
 func TestUpdate(t *testing.T) {

--- a/openstack/compute/v2/extensions/quotasets/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/quotasets/testing/requests_test.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/Comcast/gophercloud/openstack/compute/v2/extensions/quotasets"
 	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/quotasets"
 	th "github.com/gophercloud/gophercloud/testhelper"
 	"github.com/gophercloud/gophercloud/testhelper/client"
 )

--- a/openstack/compute/v2/extensions/quotasets/urls.go
+++ b/openstack/compute/v2/extensions/quotasets/urls.go
@@ -13,7 +13,7 @@ func getURL(c *gophercloud.ServiceClient, tenantID string) string {
 }
 
 func getDetailURL(c *gophercloud.ServiceClient, tenantID string) string {
-	return c.ServiceURL(resourcePath, tenantID, "details")
+	return c.ServiceURL(resourcePath, tenantID, "detail")
 }
 
 func updateURL(c *gophercloud.ServiceClient, tenantID string) string {

--- a/openstack/compute/v2/extensions/quotasets/urls.go
+++ b/openstack/compute/v2/extensions/quotasets/urls.go
@@ -8,14 +8,18 @@ func resourceURL(c *gophercloud.ServiceClient) string {
 	return c.ServiceURL(resourcePath)
 }
 
-func getDetailURL(c *gophercloud.ServiceClient, tenantID string) string {
+func getURL(c *gophercloud.ServiceClient, tenantID string) string {
 	return c.ServiceURL(resourcePath, tenantID)
 }
 
+func getDetailURL(c *gophercloud.ServiceClient, tenantID string) string {
+	return c.ServiceURL(resourcePath, tenantID, "details")
+}
+
 func updateURL(c *gophercloud.ServiceClient, tenantID string) string {
-	return getDetailURL(c, tenantID)
+	return getURL(c, tenantID)
 }
 
 func deleteURL(c *gophercloud.ServiceClient, tenantID string) string {
-	return getDetailURL(c, tenantID)
+	return getURL(c, tenantID)
 }

--- a/openstack/compute/v2/extensions/quotasets/urls.go
+++ b/openstack/compute/v2/extensions/quotasets/urls.go
@@ -8,14 +8,14 @@ func resourceURL(c *gophercloud.ServiceClient) string {
 	return c.ServiceURL(resourcePath)
 }
 
-func getURL(c *gophercloud.ServiceClient, tenantID string) string {
+func getDetailURL(c *gophercloud.ServiceClient, tenantID string) string {
 	return c.ServiceURL(resourcePath, tenantID)
 }
 
 func updateURL(c *gophercloud.ServiceClient, tenantID string) string {
-	return getURL(c, tenantID)
+	return getDetailURL(c, tenantID)
 }
 
 func deleteURL(c *gophercloud.ServiceClient, tenantID string) string {
-	return getURL(c, tenantID)
+	return getDetailURL(c, tenantID)
 }


### PR DESCRIPTION
* Add GetQuotaDetailed function for the os-quota-sets extension in Gophercloud's OpenStack Compute v2 API

- Allows a caller to get the list of quota types with in_use, reserved, and limit values for each
- Effectively wraps OpenStack Compute v2 API function /v2/os-quota-sets/{tenant_id}/detail
- Based on implementation of GetQuota

Note: In line with "GetQuota" uses sample response body from https://developer.openstack.org/api-ref/compute/#show-the-detail-of-quota for test

Code citation: https://github.com/openstack/nova/blob/stable/pike/nova/api/openstack/compute/quota_sets.py#L119

For #549 