### PR TITLE
Identity v3: Add assigning a role to a user on a project

### DIFF
--- a/acceptance/openstack/identity/v3/identity.go
+++ b/acceptance/openstack/identity/v3/identity.go
@@ -201,9 +201,9 @@ func DeleteDomain(t *testing.T, client *gophercloud.ServiceClient, domainID stri
 func UnassignRole(t *testing.T, client *gophercloud.ServiceClient, roleID string, opts *roles.AssignOpts) {
 	err := roles.Unassign(client, roleID, *opts).ExtractErr()
 	if err != nil {
-		t.Fatalf("Unable to unassign a role %v on context %v: %v", roleID, *opts, err)
+		t.Fatalf("Unable to unassign a role %v on context %+v: %v", roleID, *opts, err)
 	}
-	t.Logf("Unassigned the role %v on context %v", roleID, *opts)
+	t.Logf("Unassigned the role %v on context %+v", roleID, *opts)
 }
 
 // FindRole finds all roles that the current authenticated client has access

--- a/acceptance/openstack/identity/v3/identity.go
+++ b/acceptance/openstack/identity/v3/identity.go
@@ -198,7 +198,7 @@ func DeleteDomain(t *testing.T, client *gophercloud.ServiceClient, domainID stri
 // UnassignRole will delete a role assigned to a user/group on a project/domain
 // A fatal error will occur if it fails to delete the assignment.
 // This works best when using it as a deferred function.
-func UnassignRole(t *testing.T, client *gophercloud.ServiceClient, roleID string, opts *roles.AssignOpts) {
+func UnassignRole(t *testing.T, client *gophercloud.ServiceClient, roleID string, opts *roles.UnassignOpts) {
 	err := roles.Unassign(client, roleID, *opts).ExtractErr()
 	if err != nil {
 		t.Fatalf("Unable to unassign a role %v on context %+v: %v", roleID, *opts, err)

--- a/acceptance/openstack/identity/v3/roles_test.go
+++ b/acceptance/openstack/identity/v3/roles_test.go
@@ -78,16 +78,17 @@ func TestRoleCRUD(t *testing.T) {
 	tools.PrintResource(t, role.Extra)
 }
 
-func TestAssignToUserOnProject(t *testing.T) {
+func TestRoleAssignToUserOnProject(t *testing.T) {
 	client, err := clients.NewIdentityV3Client()
 	if err != nil {
 		t.Fatalf("Unable to obtain an indentity client: %v", err)
 	}
 
-	project, err := FindProject(t, client)
+	project, err := CreateProject(t, client, nil)
 	if err != nil {
-		t.Fatalf("Unable to get a project: %v", err)
+		t.Fatal("Unable to create a project")
 	}
+	defer DeleteProject(t, client, project.ID)
 
 	role, err := FindRole(t, client)
 	if err != nil {
@@ -100,11 +101,19 @@ func TestAssignToUserOnProject(t *testing.T) {
 	}
 	defer DeleteUser(t, client, user.ID)
 
-	err = AssignRoleToUserOnProject(t, client, role, user, project)
+	t.Logf("Attempting to assign a role %s to a user %s on a project %s", role.Name, user.Name, project.Name)
+	err = roles.Assign(client, role.ID, roles.AssignOpts{
+		UserID:    user.ID,
+		ProjectID: project.ID,
+	}).ExtractErr()
 	if err != nil {
 		t.Fatalf("Unable to assign a role to a user on a project: %v", err)
 	}
-	defer UnassignRoleFromUserOnProject(t, client, role, user, project)
+	t.Logf("Successfully assigned a role %s to a user %s on a project %s", role.Name, user.Name, project.Name)
+	defer UnassignRole(t, client, role.ID, &roles.AssignOpts{
+		UserID:    user.ID,
+		ProjectID: project.ID,
+	})
 
 	allPages, err := roles.ListAssignments(client, roles.ListAssignmentsOpts{
 		RoleID:         role.ID,
@@ -121,6 +130,177 @@ func TestAssignToUserOnProject(t *testing.T) {
 	}
 
 	t.Logf("Role assignments of user %s on project %s:", user.Name, project.Name)
+	for _, roleAssignment := range allRoleAssignments {
+		tools.PrintResource(t, roleAssignment)
+	}
+}
+
+func TestRoleAssignToUserOnDomain(t *testing.T) {
+	client, err := clients.NewIdentityV3Client()
+	if err != nil {
+		t.Fatalf("Unable to obtain an indentity client: %v", err)
+	}
+
+	domain, err := CreateDomain(t, client, nil)
+	if err != nil {
+		t.Fatal("Unable to create a domain")
+	}
+	defer DeleteDomain(t, client, domain.ID)
+
+	role, err := FindRole(t, client)
+	if err != nil {
+		t.Fatalf("Unable to get a role: %v", err)
+	}
+
+	user, err := CreateUser(t, client, nil)
+	if err != nil {
+		t.Fatalf("Unable to create user: %v", err)
+	}
+	defer DeleteUser(t, client, user.ID)
+
+	t.Logf("Attempting to assign a role %s to a user %s on a domain %s", role.Name, user.Name, domain.Name)
+	err = roles.Assign(client, role.ID, roles.AssignOpts{
+		UserID:   user.ID,
+		DomainID: domain.ID,
+	}).ExtractErr()
+	if err != nil {
+		t.Fatalf("Unable to assign a role to a user on a domain: %v", err)
+	}
+	t.Logf("Successfully assigned a role %s to a user %s on a domain %s", role.Name, user.Name, domain.Name)
+	defer UnassignRole(t, client, role.ID, &roles.AssignOpts{
+		UserID:   user.ID,
+		DomainID: domain.ID,
+	})
+
+	allPages, err := roles.ListAssignments(client, roles.ListAssignmentsOpts{
+		RoleID:        role.ID,
+		ScopeDomainID: domain.ID,
+		UserID:        user.ID,
+	}).AllPages()
+	if err != nil {
+		t.Fatalf("Unable to list role assignments: %v", err)
+	}
+
+	allRoleAssignments, err := roles.ExtractRoleAssignments(allPages)
+	if err != nil {
+		t.Fatalf("Unable to extract role assignments: %v", err)
+	}
+
+	t.Logf("Role assignments of user %s on domain %s:", user.Name, domain.Name)
+	for _, roleAssignment := range allRoleAssignments {
+		tools.PrintResource(t, roleAssignment)
+	}
+}
+
+func TestRoleAssignToGroupOnDomain(t *testing.T) {
+	client, err := clients.NewIdentityV3Client()
+	if err != nil {
+		t.Fatalf("Unable to obtain an indentity client: %v", err)
+	}
+
+	domain, err := CreateDomain(t, client, nil)
+	if err != nil {
+		t.Fatal("Unable to create a domain")
+	}
+	defer DeleteDomain(t, client, domain.ID)
+
+	role, err := FindRole(t, client)
+	if err != nil {
+		t.Fatalf("Unable to get a role: %v", err)
+	}
+
+	group, err := CreateGroup(t, client, nil)
+	if err != nil {
+		t.Fatalf("Unable to create group: %v", err)
+	}
+	defer DeleteGroup(t, client, group.ID)
+
+	t.Logf("Attempting to assign a role %s to a group %s on a domain %s", role.Name, group.Name, domain.Name)
+	err = roles.Assign(client, role.ID, roles.AssignOpts{
+		GroupID:  group.ID,
+		DomainID: domain.ID,
+	}).ExtractErr()
+	if err != nil {
+		t.Fatalf("Unable to assign a role to a group on a domain: %v", err)
+	}
+	t.Logf("Successfully assigned a role %s to a group %s on a domain %s", role.Name, group.Name, domain.Name)
+	defer UnassignRole(t, client, role.ID, &roles.AssignOpts{
+		GroupID:  group.ID,
+		DomainID: domain.ID,
+	})
+
+	allPages, err := roles.ListAssignments(client, roles.ListAssignmentsOpts{
+		RoleID:        role.ID,
+		ScopeDomainID: domain.ID,
+		GroupID:       group.ID,
+	}).AllPages()
+	if err != nil {
+		t.Fatalf("Unable to list role assignments: %v", err)
+	}
+
+	allRoleAssignments, err := roles.ExtractRoleAssignments(allPages)
+	if err != nil {
+		t.Fatalf("Unable to extract role assignments: %v", err)
+	}
+
+	t.Logf("Role assignments of group %s on domain %s:", group.Name, domain.Name)
+	for _, roleAssignment := range allRoleAssignments {
+		tools.PrintResource(t, roleAssignment)
+	}
+}
+
+func TestRoleAssignToGroupOnProject(t *testing.T) {
+	client, err := clients.NewIdentityV3Client()
+	if err != nil {
+		t.Fatalf("Unable to obtain an indentity client: %v", err)
+	}
+
+	project, err := CreateProject(t, client, nil)
+	if err != nil {
+		t.Fatal("Unable to create a project")
+	}
+	defer DeleteProject(t, client, project.ID)
+
+	role, err := FindRole(t, client)
+	if err != nil {
+		t.Fatalf("Unable to get a role: %v", err)
+	}
+
+	group, err := CreateGroup(t, client, nil)
+	if err != nil {
+		t.Fatalf("Unable to create group: %v", err)
+	}
+	defer DeleteGroup(t, client, group.ID)
+
+	t.Logf("Attempting to assign a role %s to a group %s on a project %s", role.Name, group.Name, project.Name)
+	err = roles.Assign(client, role.ID, roles.AssignOpts{
+		GroupID:   group.ID,
+		ProjectID: project.ID,
+	}).ExtractErr()
+	if err != nil {
+		t.Fatalf("Unable to assign a role to a group on a project: %v", err)
+	}
+	t.Logf("Successfully assigned a role %s to a group %s on a project %s", role.Name, group.Name, project.Name)
+	defer UnassignRole(t, client, role.ID, &roles.AssignOpts{
+		GroupID:   group.ID,
+		ProjectID: project.ID,
+	})
+
+	allPages, err := roles.ListAssignments(client, roles.ListAssignmentsOpts{
+		RoleID:         role.ID,
+		ScopeProjectID: project.ID,
+		GroupID:        group.ID,
+	}).AllPages()
+	if err != nil {
+		t.Fatalf("Unable to list role assignments: %v", err)
+	}
+
+	allRoleAssignments, err := roles.ExtractRoleAssignments(allPages)
+	if err != nil {
+		t.Fatalf("Unable to extract role assignments: %v", err)
+	}
+
+	t.Logf("Role assignments of group %s on project %s:", group.Name, project.Name)
 	for _, roleAssignment := range allRoleAssignments {
 		tools.PrintResource(t, roleAssignment)
 	}

--- a/acceptance/openstack/identity/v3/roles_test.go
+++ b/acceptance/openstack/identity/v3/roles_test.go
@@ -5,11 +5,11 @@ package v3
 import (
 	"testing"
 
+	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/acceptance/clients"
 	"github.com/gophercloud/gophercloud/acceptance/tools"
-	"github.com/gophercloud/gophercloud/openstack/identity/v3/roles"
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/domains"
-	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/roles"
 )
 
 func TestRolesList(t *testing.T) {
@@ -112,7 +112,7 @@ func TestRoleAssignToUserOnProject(t *testing.T) {
 		t.Fatalf("Unable to assign a role to a user on a project: %v", err)
 	}
 	t.Logf("Successfully assigned a role %s to a user %s on a project %s", role.Name, user.Name, project.Name)
-	defer UnassignRole(t, client, role.ID, &roles.AssignOpts{
+	defer UnassignRole(t, client, role.ID, &roles.UnassignOpts{
 		UserID:    user.ID,
 		ProjectID: project.ID,
 	})
@@ -171,7 +171,7 @@ func TestRoleAssignToUserOnDomain(t *testing.T) {
 		t.Fatalf("Unable to assign a role to a user on a domain: %v", err)
 	}
 	t.Logf("Successfully assigned a role %s to a user %s on a domain %s", role.Name, user.Name, domain.Name)
-	defer UnassignRole(t, client, role.ID, &roles.AssignOpts{
+	defer UnassignRole(t, client, role.ID, &roles.UnassignOpts{
 		UserID:   user.ID,
 		DomainID: domain.ID,
 	})
@@ -230,7 +230,7 @@ func TestRoleAssignToGroupOnDomain(t *testing.T) {
 		t.Fatalf("Unable to assign a role to a group on a domain: %v", err)
 	}
 	t.Logf("Successfully assigned a role %s to a group %s on a domain %s", role.Name, group.Name, domain.Name)
-	defer UnassignRole(t, client, role.ID, &roles.AssignOpts{
+	defer UnassignRole(t, client, role.ID, &roles.UnassignOpts{
 		GroupID:  group.ID,
 		DomainID: domain.ID,
 	})
@@ -287,7 +287,7 @@ func TestRoleAssignToGroupOnProject(t *testing.T) {
 		t.Fatalf("Unable to assign a role to a group on a project: %v", err)
 	}
 	t.Logf("Successfully assigned a role %s to a group %s on a project %s", role.Name, group.Name, project.Name)
-	defer UnassignRole(t, client, role.ID, &roles.AssignOpts{
+	defer UnassignRole(t, client, role.ID, &roles.UnassignOpts{
 		GroupID:   group.ID,
 		ProjectID: project.ID,
 	})

--- a/acceptance/openstack/identity/v3/roles_test.go
+++ b/acceptance/openstack/identity/v3/roles_test.go
@@ -41,17 +41,11 @@ func TestRolesGet(t *testing.T) {
 		t.Fatalf("Unable to obtain an identity client: %v", err)
 	}
 
-	allPages, err := roles.List(client, nil).AllPages()
+	role, err := FindRole(t, client)
 	if err != nil {
-		t.Fatalf("Unable to list roles: %v", err)
+		t.Fatalf("Unable to find a role: %v", err)
 	}
 
-	allRoles, err := roles.ExtractRoles(allPages)
-	if err != nil {
-		t.Fatalf("Unable to extract roles: %v", err)
-	}
-
-	role := allRoles[0]
 	p, err := roles.Get(client, role.ID).Extract()
 	if err != nil {
 		t.Fatalf("Unable to get role: %v", err)
@@ -82,4 +76,52 @@ func TestRoleCRUD(t *testing.T) {
 
 	tools.PrintResource(t, role)
 	tools.PrintResource(t, role.Extra)
+}
+
+func TestAssignToUserOnProject(t *testing.T) {
+	client, err := clients.NewIdentityV3Client()
+	if err != nil {
+		t.Fatalf("Unable to obtain an indentity client: %v", err)
+	}
+
+	project, err := FindProject(t, client)
+	if err != nil {
+		t.Fatalf("Unable to get a project: %v", err)
+	}
+
+	role, err := FindRole(t, client)
+	if err != nil {
+		t.Fatalf("Unable to get a role: %v", err)
+	}
+
+	user, err := CreateUser(t, client, nil)
+	if err != nil {
+		t.Fatalf("Unable to create user: %v", err)
+	}
+	defer DeleteUser(t, client, user.ID)
+
+	err = AssignRoleToUserOnProject(t, client, role, user, project)
+	if err != nil {
+		t.Fatalf("Unable to assign a role to a user on a project: %v", err)
+	}
+	defer UnassignRoleFromUserOnProject(t, client, role, user, project)
+
+	allPages, err := roles.ListAssignments(client, roles.ListAssignmentsOpts{
+		RoleID:         role.ID,
+		ScopeProjectID: project.ID,
+		UserID:         user.ID,
+	}).AllPages()
+	if err != nil {
+		t.Fatalf("Unable to list role assignments: %v", err)
+	}
+
+	allRoleAssignments, err := roles.ExtractRoleAssignments(allPages)
+	if err != nil {
+		t.Fatalf("Unable to extract role assignments: %v", err)
+	}
+
+	t.Logf("Role assignments of user %s on project %s:", user.Name, project.Name)
+	for _, roleAssignment := range allRoleAssignments {
+		tools.PrintResource(t, roleAssignment)
+	}
 }

--- a/acceptance/openstack/identity/v3/roles_test.go
+++ b/acceptance/openstack/identity/v3/roles_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/gophercloud/gophercloud/acceptance/clients"
 	"github.com/gophercloud/gophercloud/acceptance/tools"
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/roles"
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/domains"
+	"github.com/gophercloud/gophercloud"
 )
 
 func TestRolesList(t *testing.T) {
@@ -141,7 +143,9 @@ func TestRoleAssignToUserOnDomain(t *testing.T) {
 		t.Fatalf("Unable to obtain an indentity client: %v", err)
 	}
 
-	domain, err := CreateDomain(t, client, nil)
+	domain, err := CreateDomain(t, client, &domains.CreateOpts{
+		Enabled: gophercloud.Disabled,
+	})
 	if err != nil {
 		t.Fatal("Unable to create a domain")
 	}
@@ -198,7 +202,9 @@ func TestRoleAssignToGroupOnDomain(t *testing.T) {
 		t.Fatalf("Unable to obtain an indentity client: %v", err)
 	}
 
-	domain, err := CreateDomain(t, client, nil)
+	domain, err := CreateDomain(t, client, &domains.CreateOpts{
+		Enabled: gophercloud.Disabled,
+	})
 	if err != nil {
 		t.Fatal("Unable to create a domain")
 	}

--- a/openstack/identity/v3/roles/doc.go
+++ b/openstack/identity/v3/roles/doc.go
@@ -65,7 +65,7 @@ Example to Grant a Role
 	userID := "9df1a02f5eb2416a9781e8b0c022d3ae"
 	roleID := "9fe2ff9ee4384b1894a90878d3e92bab"
 
-	err := roles.Assign(cl.identity, roleID, roles.AssignOpts{
+	err := roles.Assign(identityClient, roleID, roles.AssignOpts{
 		UserID:    userID,
 		ProjectID: projectID,
 	}).ExtractErr()
@@ -80,7 +80,7 @@ Example to Remove a Role
 	userID := "9df1a02f5eb2416a9781e8b0c022d3ae"
 	roleID := "9fe2ff9ee4384b1894a90878d3e92bab"
 
-	err := roles.Unassign(cl.identity, roleID, roles.AssignOpts{
+	err := roles.Unassign(identityClient, roleID, roles.AssignOpts{
 		UserID:    userID,
 		ProjectID: projectID,
 	}).ExtractErr()

--- a/openstack/identity/v3/roles/doc.go
+++ b/openstack/identity/v3/roles/doc.go
@@ -59,7 +59,7 @@ Example to List Role Assignments
 		fmt.Printf("%+v\n", role)
 	}
 
-Example to Grant a Role
+Example to Assign a Role to a User in a Project
 
 	projectID := "a99e9b4e620e4db09a2dfb6e42a01e66"
 	userID := "9df1a02f5eb2416a9781e8b0c022d3ae"
@@ -74,7 +74,7 @@ Example to Grant a Role
 		panic(err)
 	}
 
-Example to Remove a Role
+Example to Unassign a Role From a User in a Project
 
 	projectID := "a99e9b4e620e4db09a2dfb6e42a01e66"
 	userID := "9df1a02f5eb2416a9781e8b0c022d3ae"

--- a/openstack/identity/v3/roles/doc.go
+++ b/openstack/identity/v3/roles/doc.go
@@ -59,24 +59,32 @@ Example to List Role Assignments
 		fmt.Printf("%+v\n", role)
 	}
 
-Example to Grant a Role to a User on a Project
+Example to Grant a Role
 
 	projectID := "a99e9b4e620e4db09a2dfb6e42a01e66"
 	userID := "9df1a02f5eb2416a9781e8b0c022d3ae"
 	roleID := "9fe2ff9ee4384b1894a90878d3e92bab"
 
-	err := roles.AssignToUserOnProject(identityClient, roleID, userID, projectID).ExtractErr()
+	err := roles.Assign(cl.identity, roleID, roles.AssignOpts{
+		UserID:    userID,
+		ProjectID: projectID,
+	}).ExtractErr()
+
 	if err != nil {
 		panic(err)
 	}
 
-Example to Remove a Role from a User on a project
+Example to Remove a Role
 
 	projectID := "a99e9b4e620e4db09a2dfb6e42a01e66"
 	userID := "9df1a02f5eb2416a9781e8b0c022d3ae"
 	roleID := "9fe2ff9ee4384b1894a90878d3e92bab"
 
-	err := roles.UnassignFromUserOnProject(identityClient, roleID, userID, projectID).ExtractErr()
+	err := roles.Unassign(cl.identity, roleID, roles.AssignOpts{
+		UserID:    userID,
+		ProjectID: projectID,
+	}).ExtractErr()
+
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/identity/v3/roles/doc.go
+++ b/openstack/identity/v3/roles/doc.go
@@ -58,5 +58,27 @@ Example to List Role Assignments
 	for _, role := range allRoles {
 		fmt.Printf("%+v\n", role)
 	}
+
+Example to Grant a Role to a User on a Project
+
+	projectID := "a99e9b4e620e4db09a2dfb6e42a01e66"
+	userID := "9df1a02f5eb2416a9781e8b0c022d3ae"
+	roleID := "9fe2ff9ee4384b1894a90878d3e92bab"
+
+	err := roles.AssignToUserOnProject(identityClient, roleID, userID, projectID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Remove a Role from a User on a project
+
+	projectID := "a99e9b4e620e4db09a2dfb6e42a01e66"
+	userID := "9df1a02f5eb2416a9781e8b0c022d3ae"
+	roleID := "9fe2ff9ee4384b1894a90878d3e92bab"
+
+	err := roles.UnassignFromUserOnProject(identityClient, roleID, userID, projectID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
 */
 package roles

--- a/openstack/identity/v3/roles/doc.go
+++ b/openstack/identity/v3/roles/doc.go
@@ -80,7 +80,7 @@ Example to Remove a Role
 	userID := "9df1a02f5eb2416a9781e8b0c022d3ae"
 	roleID := "9fe2ff9ee4384b1894a90878d3e92bab"
 
-	err := roles.Unassign(identityClient, roleID, roles.AssignOpts{
+	err := roles.Unassign(identityClient, roleID, roles.UnassignOpts{
 		UserID:    userID,
 		ProjectID: projectID,
 	}).ExtractErr()

--- a/openstack/identity/v3/roles/requests.go
+++ b/openstack/identity/v3/roles/requests.go
@@ -148,3 +148,21 @@ func ListAssignments(client *gophercloud.ServiceClient, opts ListAssignmentsOpts
 		return RoleAssignmentPage{pagination.LinkedPageBase{PageResult: r}}
 	})
 }
+
+// AssignToUserOnProject is the operation responsible for assigning a role
+// to a user on a project.
+func AssignToUserOnProject(client *gophercloud.ServiceClient, roleID, userID, projectID string) (r RoleAssignmentResult) {
+	_, r.Err = client.Put(userOnProjectURL(client, projectID, userID, roleID), nil, nil, &gophercloud.RequestOpts{
+		OkCodes: []int{204},
+	})
+	return
+}
+
+// UnassignFromUserOnProject is the operation responsible for assigning a role
+// to a user on a project.
+func UnassignFromUserOnProject(client *gophercloud.ServiceClient, roleID, userID, projectID string) (r RoleAssignmentResult) {
+	_, r.Err = client.Delete(userOnProjectURL(client, projectID, userID, roleID), &gophercloud.RequestOpts{
+		OkCodes: []int{204},
+	})
+	return
+}

--- a/openstack/identity/v3/roles/requests.go
+++ b/openstack/identity/v3/roles/requests.go
@@ -170,19 +170,19 @@ type AssignOpts struct {
 
 // UnassignOpts provides options to unassign a role
 type UnassignOpts struct {
-	// UserID is the ID of a user to assign a role
+	// UserID is the ID of a user to unassign a role
 	// Note: exactly one of UserID or GroupID must be provided
 	UserID string `xor:"GroupID"`
 
-	// GroupID is the ID of a group to assign a role
+	// GroupID is the ID of a group to unassign a role
 	// Note: exactly one of UserID or GroupID must be provided
 	GroupID string `xor:"UserID"`
 
-	// ProjectID is the ID of a project to assign a role on
+	// ProjectID is the ID of a project to unassign a role on
 	// Note: exactly one of ProjectID or DomainID must be provided
 	ProjectID string `xor:"DomainID"`
 
-	// DomainID is the ID of a domain to assign a role on
+	// DomainID is the ID of a domain to unassign a role on
 	// Note: exactly one of ProjectID or DomainID must be provided
 	DomainID string `xor:"ProjectID"`
 }

--- a/openstack/identity/v3/roles/results.go
+++ b/openstack/identity/v3/roles/results.go
@@ -188,3 +188,9 @@ func ExtractRoleAssignments(r pagination.Page) ([]RoleAssignment, error) {
 	err := (r.(RoleAssignmentPage)).ExtractInto(&s)
 	return s.RoleAssignments, err
 }
+
+// RoleAssignmentResult represents the result of assign or unassign operation.
+// Call ExtractErr method to determine if the request succeeded or failed.
+type RoleAssignmentResult struct {
+	gophercloud.ErrResult
+}

--- a/openstack/identity/v3/roles/results.go
+++ b/openstack/identity/v3/roles/results.go
@@ -189,13 +189,13 @@ func ExtractRoleAssignments(r pagination.Page) ([]RoleAssignment, error) {
 	return s.RoleAssignments, err
 }
 
-// AssignmentResult represents the result of assign operation.
+// AssignmentResult represents the result of an assign operation.
 // Call ExtractErr method to determine if the request succeeded or failed.
 type AssignmentResult struct {
 	gophercloud.ErrResult
 }
 
-// UnassignmentResult represents the result of unassign operation.
+// UnassignmentResult represents the result of an unassign operation.
 // Call ExtractErr method to determine if the request succeeded or failed.
 type UnassignmentResult struct {
 	gophercloud.ErrResult

--- a/openstack/identity/v3/roles/results.go
+++ b/openstack/identity/v3/roles/results.go
@@ -189,8 +189,14 @@ func ExtractRoleAssignments(r pagination.Page) ([]RoleAssignment, error) {
 	return s.RoleAssignments, err
 }
 
-// RoleAssignmentResult represents the result of assign or unassign operation.
+// AssignmentResult represents the result of assign operation.
 // Call ExtractErr method to determine if the request succeeded or failed.
-type RoleAssignmentResult struct {
+type AssignmentResult struct {
+	gophercloud.ErrResult
+}
+
+// UnassignmentResult represents the result of unassign operation.
+// Call ExtractErr method to determine if the request succeeded or failed.
+type UnassignmentResult struct {
 	gophercloud.ErrResult
 }

--- a/openstack/identity/v3/roles/testing/fixtures.go
+++ b/openstack/identity/v3/roles/testing/fixtures.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/roles"
 	th "github.com/gophercloud/gophercloud/testhelper"
-	"github.com/gophercloud/gophercloud/testhelper/client"
+	fake "github.com/gophercloud/gophercloud/testhelper/client"
 )
 
 // ListOutput provides a single page of Role results.
@@ -103,7 +103,7 @@ func HandleListRolesSuccessfully(t *testing.T) {
 	th.Mux.HandleFunc("/roles", func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "GET")
 		th.TestHeader(t, r, "Accept", "application/json")
-		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -117,7 +117,7 @@ func HandleGetRoleSuccessfully(t *testing.T) {
 	th.Mux.HandleFunc("/roles/9fe1d3", func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "GET")
 		th.TestHeader(t, r, "Accept", "application/json")
-		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -130,10 +130,26 @@ func HandleGetRoleSuccessfully(t *testing.T) {
 func HandleCreateRoleSuccessfully(t *testing.T) {
 	th.Mux.HandleFunc("/roles", func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "POST")
-		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 		th.TestJSONRequest(t, r, CreateRequest)
 
 		w.WriteHeader(http.StatusCreated)
 		fmt.Fprintf(w, GetOutput)
+	})
+}
+
+func HandleAssignToUserOnProjectSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/projects/{project_id}/users/{user_id}/roles/{role_id}", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.WriteHeader(http.StatusNoContent)
+	})
+}
+
+func HandleUnassignFromUserOnProjectSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/projects/{project_id}/users/{user_id}/roles/{role_id}", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.WriteHeader(http.StatusNoContent)
 	})
 }

--- a/openstack/identity/v3/roles/testing/fixtures.go
+++ b/openstack/identity/v3/roles/testing/fixtures.go
@@ -138,16 +138,52 @@ func HandleCreateRoleSuccessfully(t *testing.T) {
 	})
 }
 
-func HandleAssignToUserOnProjectSuccessfully(t *testing.T) {
+func HandleAssignSuccessfully(t *testing.T) {
 	th.Mux.HandleFunc("/projects/{project_id}/users/{user_id}/roles/{role_id}", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	th.Mux.HandleFunc("/projects/{project_id}/groups/{group_id}/roles/{role_id}", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	th.Mux.HandleFunc("/domains/{domain_id}/users/{user_id}/roles/{role_id}", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	th.Mux.HandleFunc("/domains/{domain_id}/groups/{group_id}/roles/{role_id}", func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "PUT")
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 		w.WriteHeader(http.StatusNoContent)
 	})
 }
 
-func HandleUnassignFromUserOnProjectSuccessfully(t *testing.T) {
+func HandleUnassignSuccessfully(t *testing.T) {
 	th.Mux.HandleFunc("/projects/{project_id}/users/{user_id}/roles/{role_id}", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	th.Mux.HandleFunc("/projects/{project_id}/groups/{group_id}/roles/{role_id}", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	th.Mux.HandleFunc("/domains/{domain_id}/users/{user_id}/roles/{role_id}", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	th.Mux.HandleFunc("/domains/{domain_id}/groups/{group_id}/roles/{role_id}", func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "DELETE")
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 		w.WriteHeader(http.StatusNoContent)

--- a/openstack/identity/v3/roles/testing/requests_test.go
+++ b/openstack/identity/v3/roles/testing/requests_test.go
@@ -201,25 +201,25 @@ func TestUnassign(t *testing.T) {
 	defer th.TeardownHTTP()
 	HandleUnassignSuccessfully(t)
 
-	err := roles.Unassign(client.ServiceClient(), "{role_id}", roles.AssignOpts{
+	err := roles.Unassign(client.ServiceClient(), "{role_id}", roles.UnassignOpts{
 		UserID:    "{user_id}",
 		ProjectID: "{project_id}",
 	}).ExtractErr()
 	th.AssertNoErr(t, err)
 
-	err = roles.Unassign(client.ServiceClient(), "{role_id}", roles.AssignOpts{
+	err = roles.Unassign(client.ServiceClient(), "{role_id}", roles.UnassignOpts{
 		UserID:   "{user_id}",
 		DomainID: "{domain_id}",
 	}).ExtractErr()
 	th.AssertNoErr(t, err)
 
-	err = roles.Unassign(client.ServiceClient(), "{role_id}", roles.AssignOpts{
+	err = roles.Unassign(client.ServiceClient(), "{role_id}", roles.UnassignOpts{
 		GroupID:   "{group_id}",
 		ProjectID: "{project_id}",
 	}).ExtractErr()
 	th.AssertNoErr(t, err)
 
-	err = roles.Unassign(client.ServiceClient(), "{role_id}", roles.AssignOpts{
+	err = roles.Unassign(client.ServiceClient(), "{role_id}", roles.UnassignOpts{
 		GroupID:  "{group_id}",
 		DomainID: "{domain_id}",
 	}).ExtractErr()

--- a/openstack/identity/v3/roles/testing/requests_test.go
+++ b/openstack/identity/v3/roles/testing/requests_test.go
@@ -166,20 +166,62 @@ func TestListAssignmentsSinglePage(t *testing.T) {
 	}
 }
 
-func TestAssignToUserOnProject(t *testing.T) {
+func TestAssign(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
-	HandleAssignToUserOnProjectSuccessfully(t)
+	HandleAssignSuccessfully(t)
 
-	err := roles.AssignToUserOnProject(client.ServiceClient(), "{role_id}", "{user_id}", "{project_id}").ExtractErr()
+	err := roles.Assign(client.ServiceClient(), "{role_id}", roles.AssignOpts{
+		UserID:    "{user_id}",
+		ProjectID: "{project_id}",
+	}).ExtractErr()
+	th.AssertNoErr(t, err)
+
+	err = roles.Assign(client.ServiceClient(), "{role_id}", roles.AssignOpts{
+		UserID:   "{user_id}",
+		DomainID: "{domain_id}",
+	}).ExtractErr()
+	th.AssertNoErr(t, err)
+
+	err = roles.Assign(client.ServiceClient(), "{role_id}", roles.AssignOpts{
+		GroupID:   "{group_id}",
+		ProjectID: "{project_id}",
+	}).ExtractErr()
+	th.AssertNoErr(t, err)
+
+	err = roles.Assign(client.ServiceClient(), "{role_id}", roles.AssignOpts{
+		GroupID:  "{group_id}",
+		DomainID: "{domain_id}",
+	}).ExtractErr()
 	th.AssertNoErr(t, err)
 }
 
-func TestUnassignToUserOnProject(t *testing.T) {
+func TestUnassign(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
-	HandleUnassignFromUserOnProjectSuccessfully(t)
+	HandleUnassignSuccessfully(t)
 
-	err := roles.UnassignFromUserOnProject(client.ServiceClient(), "{role_id}", "{user_id}", "{project_id}").ExtractErr()
+	err := roles.Unassign(client.ServiceClient(), "{role_id}", roles.AssignOpts{
+		UserID:    "{user_id}",
+		ProjectID: "{project_id}",
+	}).ExtractErr()
+	th.AssertNoErr(t, err)
+
+	err = roles.Unassign(client.ServiceClient(), "{role_id}", roles.AssignOpts{
+		UserID:   "{user_id}",
+		DomainID: "{domain_id}",
+	}).ExtractErr()
+	th.AssertNoErr(t, err)
+
+	err = roles.Unassign(client.ServiceClient(), "{role_id}", roles.AssignOpts{
+		GroupID:   "{group_id}",
+		ProjectID: "{project_id}",
+	}).ExtractErr()
+	th.AssertNoErr(t, err)
+
+	err = roles.Unassign(client.ServiceClient(), "{role_id}", roles.AssignOpts{
+		GroupID:  "{group_id}",
+		DomainID: "{domain_id}",
+	}).ExtractErr()
 	th.AssertNoErr(t, err)
 }

--- a/openstack/identity/v3/roles/testing/requests_test.go
+++ b/openstack/identity/v3/roles/testing/requests_test.go
@@ -165,3 +165,21 @@ func TestListAssignmentsSinglePage(t *testing.T) {
 		t.Errorf("Expected 1 page, got %d", count)
 	}
 }
+
+func TestAssignToUserOnProject(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleAssignToUserOnProjectSuccessfully(t)
+
+	err := roles.AssignToUserOnProject(client.ServiceClient(), "{role_id}", "{user_id}", "{project_id}").ExtractErr()
+	th.AssertNoErr(t, err)
+}
+
+func TestUnassignToUserOnProject(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleUnassignFromUserOnProjectSuccessfully(t)
+
+	err := roles.UnassignFromUserOnProject(client.ServiceClient(), "{role_id}", "{user_id}", "{project_id}").ExtractErr()
+	th.AssertNoErr(t, err)
+}

--- a/openstack/identity/v3/roles/urls.go
+++ b/openstack/identity/v3/roles/urls.go
@@ -3,11 +3,7 @@ package roles
 import "github.com/gophercloud/gophercloud"
 
 const (
-	rolePath    = "roles"
-	userPath    = "users"
-	domainPath  = "domains"
-	groupPath   = "groups"
-	projectPath = "projects"
+	rolePath = "roles"
 )
 
 func listURL(client *gophercloud.ServiceClient) string {
@@ -26,18 +22,6 @@ func listAssignmentsURL(client *gophercloud.ServiceClient) string {
 	return client.ServiceURL("role_assignments")
 }
 
-func groupOnDomainURL(client *gophercloud.ServiceClient, domainID, groupID, roleID string) string {
-	return client.ServiceURL(domainPath, domainID, groupPath, groupID, rolePath, roleID)
-}
-
-func userOnDomainURL(client *gophercloud.ServiceClient, domainID, userID, roleID string) string {
-	return client.ServiceURL(domainPath, domainID, userPath, userID, rolePath, roleID)
-}
-
-func groupOnProjectURL(client *gophercloud.ServiceClient, projectID, groupID, roleID string) string {
-	return client.ServiceURL(projectPath, projectID, groupPath, groupID, rolePath, roleID)
-}
-
-func userOnProjectURL(client *gophercloud.ServiceClient, projectID, userID, roleID string) string {
-	return client.ServiceURL(projectPath, projectID, userPath, userID, rolePath, roleID)
+func assignURL(client *gophercloud.ServiceClient, targetType, targetID, actorType, actorID, roleID string) string {
+	return client.ServiceURL(targetType, targetID, actorType, actorID, rolePath, roleID)
 }

--- a/openstack/identity/v3/roles/urls.go
+++ b/openstack/identity/v3/roles/urls.go
@@ -2,18 +2,28 @@ package roles
 
 import "github.com/gophercloud/gophercloud"
 
+const (
+	rolePath    = "roles"
+	userPath    = "users"
+	projectPath = "projects"
+)
+
 func listURL(client *gophercloud.ServiceClient) string {
-	return client.ServiceURL("roles")
+	return client.ServiceURL(rolePath)
 }
 
 func getURL(client *gophercloud.ServiceClient, roleID string) string {
-	return client.ServiceURL("roles", roleID)
+	return client.ServiceURL(rolePath, roleID)
 }
 
 func createURL(client *gophercloud.ServiceClient) string {
-	return client.ServiceURL("roles")
+	return client.ServiceURL(rolePath)
 }
 
 func listAssignmentsURL(client *gophercloud.ServiceClient) string {
 	return client.ServiceURL("role_assignments")
+}
+
+func userOnProjectURL(client *gophercloud.ServiceClient, projectID, userID, roleID string) string {
+	return client.ServiceURL(projectPath, projectID, userPath, userID, rolePath, roleID)
 }

--- a/openstack/identity/v3/roles/urls.go
+++ b/openstack/identity/v3/roles/urls.go
@@ -5,6 +5,8 @@ import "github.com/gophercloud/gophercloud"
 const (
 	rolePath    = "roles"
 	userPath    = "users"
+	domainPath  = "domains"
+	groupPath   = "groups"
 	projectPath = "projects"
 )
 
@@ -22,6 +24,18 @@ func createURL(client *gophercloud.ServiceClient) string {
 
 func listAssignmentsURL(client *gophercloud.ServiceClient) string {
 	return client.ServiceURL("role_assignments")
+}
+
+func groupOnDomainURL(client *gophercloud.ServiceClient, domainID, groupID, roleID string) string {
+	return client.ServiceURL(domainPath, domainID, groupPath, groupID, rolePath, roleID)
+}
+
+func userOnDomainURL(client *gophercloud.ServiceClient, domainID, userID, roleID string) string {
+	return client.ServiceURL(domainPath, domainID, userPath, userID, rolePath, roleID)
+}
+
+func groupOnProjectURL(client *gophercloud.ServiceClient, projectID, groupID, roleID string) string {
+	return client.ServiceURL(projectPath, projectID, groupPath, groupID, rolePath, roleID)
 }
 
 func userOnProjectURL(client *gophercloud.ServiceClient, projectID, userID, roleID string) string {


### PR DESCRIPTION
This is an implementation for assigning/unassining a role to a user on a project for #566.

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:
* [api doc for assigning](https://developer.openstack.org/api-ref/identity/v3/#assign-role-to-user-on-project)
* [api doc for unassining](https://developer.openstack.org/api-ref/identity/v3/#unassign-role-from-user-on-project)
* https://github.com/openstack/keystone/blob/83bd595b22944d38eff1cdef77b4c07a75af0fdc/keystone/assignment/controllers.py#L638
* https://github.com/openstack/keystone/blob/83bd595b22944d38eff1cdef77b4c07a75af0fdc/keystone/assignment/controllers.py#L677

This is a contribution from [Salesforce](https://www.salesforce.com/)