### PR TITLE
Identity v3: role create

### DIFF
--- a/acceptance/openstack/identity/v3/identity.go
+++ b/acceptance/openstack/identity/v3/identity.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/domains"
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/groups"
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/projects"
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/roles"
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/users"
 )
 
@@ -117,6 +118,33 @@ func CreateDomain(t *testing.T, client *gophercloud.ServiceClient, c *domains.Cr
 	t.Logf("Successfully created domain %s with ID %s", name, domain.ID)
 
 	return domain, nil
+}
+
+// CreateRole will create a role with a random name.
+// It takes an optional createOpts parameter since creating a role
+// has so many options. An error will be returned if the role was
+// unable to be created.
+func CreateRole(t *testing.T, client *gophercloud.ServiceClient, c *roles.CreateOpts) (*roles.Role, error) {
+	name := tools.RandomString("ACPTTEST", 8)
+	t.Logf("Attempting to create role: %s", name)
+
+	var createOpts roles.CreateOpts
+	if c != nil {
+		createOpts = *c
+	} else {
+		createOpts = roles.CreateOpts{}
+	}
+
+	createOpts.Name = name
+
+	role, err := roles.Create(client, createOpts).Extract()
+	if err != nil {
+		return role, err
+	}
+
+	t.Logf("Successfully created role %s with ID %s", name, role.ID)
+
+	return role, nil
 }
 
 // DeleteProject will delete a project by ID. A fatal error will occur if

--- a/acceptance/openstack/identity/v3/roles_test.go
+++ b/acceptance/openstack/identity/v3/roles_test.go
@@ -59,3 +59,27 @@ func TestRolesGet(t *testing.T) {
 
 	tools.PrintResource(t, p)
 }
+
+func TestRoleCRUD(t *testing.T) {
+	client, err := clients.NewIdentityV3Client()
+	if err != nil {
+		t.Fatalf("Unable to obtain an identity client: %v", err)
+	}
+
+	createOpts := roles.CreateOpts{
+		Name:     "testrole",
+		DomainID: "default",
+		Extra: map[string]interface{}{
+			"description": "test role description",
+		},
+	}
+
+	// Create Role in the default domain
+	role, err := CreateRole(t, client, &createOpts)
+	if err != nil {
+		t.Fatalf("Unable to create role: %v", err)
+	}
+
+	tools.PrintResource(t, role)
+	tools.PrintResource(t, role.Extra)
+}

--- a/openstack/identity/v3/roles/doc.go
+++ b/openstack/identity/v3/roles/doc.go
@@ -22,6 +22,22 @@ Example to List Roles
 		fmt.Printf("%+v\n", role)
 	}
 
+Example to Create a Role
+
+	createOpts := roles.CreateOpts{
+		Name:             "read-only-admin",
+		DomainID:         "default",
+		Extra: map[string]interface{}{
+			"description": "this role grants read-only privilege cross tenant",
+		}
+	}
+
+	role, err := roles.Create(identityClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+
 Example to List Role Assignments
 
 	listOpts := roles.ListAssignmentsOpts{

--- a/openstack/identity/v3/roles/testing/fixtures.go
+++ b/openstack/identity/v3/roles/testing/fixtures.go
@@ -33,7 +33,10 @@ const ListOutput = `
             "links": {
                 "self": "https://example.com/identity/v3/roles/9fe1d3"
             },
-            "name": "support"
+            "name": "support",
+            "extra": {
+                "description": "read-only support role"
+            }
         }
     ]
 }
@@ -48,7 +51,21 @@ const GetOutput = `
         "links": {
             "self": "https://example.com/identity/v3/roles/9fe1d3"
         },
-        "name": "support"
+        "name": "support",
+        "extra": {
+            "description": "read-only support role"
+        }
+    }
+}
+`
+
+// CreateRequest provides the input to a Create request.
+const CreateRequest = `
+{
+    "role": {
+        "domain_id": "1789d1",
+        "name": "support",
+        "description": "read-only support role"
     }
 }
 `
@@ -60,7 +77,8 @@ var FirstRole = roles.Role{
 	Links: map[string]interface{}{
 		"self": "http://example.com/identity/v3/roles/2844b2a08be147a08ef58317d6471f1f",
 	},
-	Name: "admin-read-only",
+	Name:  "admin-read-only",
+	Extra: map[string]interface{}{},
 }
 
 // SecondRole is the second role in the List request.
@@ -71,6 +89,9 @@ var SecondRole = roles.Role{
 		"self": "https://example.com/identity/v3/roles/9fe1d3",
 	},
 	Name: "support",
+	Extra: map[string]interface{}{
+		"description": "read-only support role",
+	},
 }
 
 // ExpectedRolesSlice is the slice of roles expected to be returned from ListOutput.
@@ -100,6 +121,19 @@ func HandleGetRoleSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, GetOutput)
+	})
+}
+
+// HandleCreateRoleSuccessfully creates an HTTP handler at `/roles` on the
+// test handler mux that tests role creation.
+func HandleCreateRoleSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/roles", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, CreateRequest)
+
+		w.WriteHeader(http.StatusCreated)
 		fmt.Fprintf(w, GetOutput)
 	})
 }

--- a/openstack/identity/v3/roles/testing/requests_test.go
+++ b/openstack/identity/v3/roles/testing/requests_test.go
@@ -42,6 +42,7 @@ func TestListRolesAllPages(t *testing.T) {
 	actual, err := roles.ExtractRoles(allPages)
 	th.AssertNoErr(t, err)
 	th.CheckDeepEquals(t, ExpectedRolesSlice, actual)
+	th.AssertEquals(t, ExpectedRolesSlice[1].Extra["description"], "read-only support role")
 }
 
 func TestGetRole(t *testing.T) {
@@ -51,6 +52,24 @@ func TestGetRole(t *testing.T) {
 
 	actual, err := roles.Get(client.ServiceClient(), "9fe1d3").Extract()
 
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, SecondRole, *actual)
+}
+
+func TestCreateRole(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleCreateRoleSuccessfully(t)
+
+	createOpts := roles.CreateOpts{
+		Name:     "support",
+		DomainID: "1789d1",
+		Extra: map[string]interface{}{
+			"description": "read-only support role",
+		},
+	}
+
+	actual, err := roles.Create(client.ServiceClient(), createOpts).Extract()
 	th.AssertNoErr(t, err)
 	th.CheckDeepEquals(t, SecondRole, *actual)
 }

--- a/openstack/identity/v3/roles/urls.go
+++ b/openstack/identity/v3/roles/urls.go
@@ -10,6 +10,10 @@ func getURL(client *gophercloud.ServiceClient, roleID string) string {
 	return client.ServiceURL("roles", roleID)
 }
 
+func createURL(client *gophercloud.ServiceClient) string {
+	return client.ServiceURL("roles")
+}
+
 func listAssignmentsURL(client *gophercloud.ServiceClient) string {
 	return client.ServiceURL("role_assignments")
 }


### PR DESCRIPTION
Adding create role. This also updates the result structure of `Role` to add an `Extra` field as this patch allowed testing/validation of support for the `Extra` field.

For #571 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

Schema:
https://github.com/openstack/keystone/blob/stable/pike/keystone/assignment/role_backends/sql.py#L196
https://github.com/openstack/keystone/blob/stable/pike/keystone/assignment/role_backends/sql.py#L201

Create:
https://github.com/openstack/keystone/blob/83bd595b22944d38eff1cdef77b4c07a75af0fdc/keystone/assignment/controllers.py#L319