### PR TITLE
Identity v3 Role update

### DIFF
--- a/acceptance/openstack/identity/v3/identity.go
+++ b/acceptance/openstack/identity/v3/identity.go
@@ -195,6 +195,18 @@ func DeleteDomain(t *testing.T, client *gophercloud.ServiceClient, domainID stri
 	t.Logf("Deleted domain: %s", domainID)
 }
 
+// DeleteRole will delete a role by ID. A fatal error will occur if
+// the role failed to be deleted. This works best when using it as
+// a deferred function.
+func DeleteRole(t *testing.T, client *gophercloud.ServiceClient, roleID string) {
+	err := roles.Delete(client, roleID).ExtractErr()
+	if err != nil {
+		t.Fatalf("Unable to delete role %s: %v", roleID, err)
+	}
+
+	t.Logf("Deleted role: %s", roleID)
+}
+
 // UnassignRole will delete a role assigned to a user/group on a project/domain
 // A fatal error will occur if it fails to delete the assignment.
 // This works best when using it as a deferred function.

--- a/acceptance/openstack/identity/v3/roles_test.go
+++ b/acceptance/openstack/identity/v3/roles_test.go
@@ -75,6 +75,7 @@ func TestRoleCRUD(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to create role: %v", err)
 	}
+	defer DeleteRole(t, client, role.ID)
 
 	tools.PrintResource(t, role)
 	tools.PrintResource(t, role.Extra)

--- a/acceptance/openstack/identity/v3/roles_test.go
+++ b/acceptance/openstack/identity/v3/roles_test.go
@@ -79,6 +79,20 @@ func TestRoleCRUD(t *testing.T) {
 
 	tools.PrintResource(t, role)
 	tools.PrintResource(t, role.Extra)
+
+	updateOpts := roles.UpdateOpts{
+		Extra: map[string]interface{}{
+			"description": "updated test role description",
+		},
+	}
+
+	newRole, err := roles.Update(client, role.ID, updateOpts).Extract()
+	if err != nil {
+		t.Fatalf("Unable to update role: %v", err)
+	}
+
+	tools.PrintResource(t, newRole)
+	tools.PrintResource(t, newRole.Extra)
 }
 
 func TestRoleAssignToUserOnProject(t *testing.T) {

--- a/openstack/identity/v3/roles/doc.go
+++ b/openstack/identity/v3/roles/doc.go
@@ -37,6 +37,19 @@ Example to Create a Role
 		panic(err)
 	}
 
+Example to Update a Role
+
+	roleID := "0fe36e73809d46aeae6705c39077b1b3"
+
+	updateOpts := roles.UpdateOpts{
+		Name: "read only admin",
+	}
+
+	role, err := roles.Update(identityClient, roleID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
 Example to Delete a Role
 
 	roleID := "0fe36e73809d46aeae6705c39077b1b3"

--- a/openstack/identity/v3/roles/doc.go
+++ b/openstack/identity/v3/roles/doc.go
@@ -37,6 +37,13 @@ Example to Create a Role
 		panic(err)
 	}
 
+Example to Delete a Role
+
+	roleID := "0fe36e73809d46aeae6705c39077b1b3"
+	err := roles.Delete(identityClient, roleID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
 
 Example to List Role Assignments
 

--- a/openstack/identity/v3/roles/requests.go
+++ b/openstack/identity/v3/roles/requests.go
@@ -97,6 +97,12 @@ func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r Create
 	return
 }
 
+// Delete deletes a role.
+func Delete(client *gophercloud.ServiceClient, roleID string) (r DeleteResult) {
+	_, r.Err = client.Delete(deleteURL(client, roleID), nil)
+	return
+}
+
 // ListAssignmentsOptsBuilder allows extensions to add additional parameters to
 // the ListAssignments request.
 type ListAssignmentsOptsBuilder interface {

--- a/openstack/identity/v3/roles/results.go
+++ b/openstack/identity/v3/roles/results.go
@@ -72,6 +72,12 @@ type CreateResult struct {
 	roleResult
 }
 
+// DeleteResult is the response from a Delete operation. Call its ExtractErr to
+// determine if the request succeeded or failed.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
 // RolePage is a single page of Role results.
 type RolePage struct {
 	pagination.LinkedPageBase

--- a/openstack/identity/v3/roles/results.go
+++ b/openstack/identity/v3/roles/results.go
@@ -72,6 +72,12 @@ type CreateResult struct {
 	roleResult
 }
 
+// UpdateResult is the response from an Update operation. Call its Extract
+// method to interpret it as a Role.
+type UpdateResult struct {
+	roleResult
+}
+
 // DeleteResult is the response from a Delete operation. Call its ExtractErr to
 // determine if the request succeeded or failed.
 type DeleteResult struct {

--- a/openstack/identity/v3/roles/testing/fixtures.go
+++ b/openstack/identity/v3/roles/testing/fixtures.go
@@ -70,6 +70,32 @@ const CreateRequest = `
 }
 `
 
+// UpdateRequest provides the input to as Update request.
+const UpdateRequest = `
+{
+    "role": {
+        "description": "admin read-only support role"
+    }
+}
+`
+
+// UpdateOutput provides an update result.
+const UpdateOutput = `
+{
+    "role": {
+        "domain_id": "1789d1",
+        "id": "9fe1d3",
+        "links": {
+            "self": "https://example.com/identity/v3/roles/9fe1d3"
+        },
+        "name": "support",
+        "extra": {
+            "description": "admin read-only support role"
+        }
+    }
+}
+`
+
 // FirstRole is the first role in the List request.
 var FirstRole = roles.Role{
 	DomainID: "default",
@@ -91,6 +117,19 @@ var SecondRole = roles.Role{
 	Name: "support",
 	Extra: map[string]interface{}{
 		"description": "read-only support role",
+	},
+}
+
+// SecondRoleUpdated is how SecondRole should look after an Update.
+var SecondRoleUpdated = roles.Role{
+	DomainID: "1789d1",
+	ID:       "9fe1d3",
+	Links: map[string]interface{}{
+		"self": "https://example.com/identity/v3/roles/9fe1d3",
+	},
+	Name: "support",
+	Extra: map[string]interface{}{
+		"description": "admin read-only support role",
 	},
 }
 
@@ -135,6 +174,19 @@ func HandleCreateRoleSuccessfully(t *testing.T) {
 
 		w.WriteHeader(http.StatusCreated)
 		fmt.Fprintf(w, GetOutput)
+	})
+}
+
+// HandleUpdateRoleSuccessfully creates an HTTP handler at `/roles` on the
+// test handler mux that tests role update.
+func HandleUpdateRoleSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/roles/9fe1d3", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PATCH")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestJSONRequest(t, r, UpdateRequest)
+
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, UpdateOutput)
 	})
 }
 

--- a/openstack/identity/v3/roles/testing/fixtures.go
+++ b/openstack/identity/v3/roles/testing/fixtures.go
@@ -138,6 +138,17 @@ func HandleCreateRoleSuccessfully(t *testing.T) {
 	})
 }
 
+// HandleDeleteRoleSuccessfully creates an HTTP handler at `/roles` on the
+// test handler mux that tests role deletion.
+func HandleDeleteRoleSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/roles/9fe1d3", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.WriteHeader(http.StatusNoContent)
+	})
+}
+
 func HandleAssignSuccessfully(t *testing.T) {
 	th.Mux.HandleFunc("/projects/{project_id}/users/{user_id}/roles/{role_id}", func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "PUT")

--- a/openstack/identity/v3/roles/testing/requests_test.go
+++ b/openstack/identity/v3/roles/testing/requests_test.go
@@ -74,6 +74,15 @@ func TestCreateRole(t *testing.T) {
 	th.CheckDeepEquals(t, SecondRole, *actual)
 }
 
+func TestDeleteRole(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleDeleteRoleSuccessfully(t)
+
+	res := roles.Delete(client.ServiceClient(), "9fe1d3")
+	th.AssertNoErr(t, res.Err)
+}
+
 func TestListAssignmentsSinglePage(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()

--- a/openstack/identity/v3/roles/testing/requests_test.go
+++ b/openstack/identity/v3/roles/testing/requests_test.go
@@ -74,6 +74,22 @@ func TestCreateRole(t *testing.T) {
 	th.CheckDeepEquals(t, SecondRole, *actual)
 }
 
+func TestUpdateRole(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleUpdateRoleSuccessfully(t)
+
+	updateOpts := roles.UpdateOpts{
+		Extra: map[string]interface{}{
+			"description": "admin read-only support role",
+		},
+	}
+
+	actual, err := roles.Update(client.ServiceClient(), "9fe1d3", updateOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, SecondRoleUpdated, *actual)
+}
+
 func TestDeleteRole(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()

--- a/openstack/identity/v3/roles/urls.go
+++ b/openstack/identity/v3/roles/urls.go
@@ -18,6 +18,10 @@ func createURL(client *gophercloud.ServiceClient) string {
 	return client.ServiceURL(rolePath)
 }
 
+func deleteURL(client *gophercloud.ServiceClient, roleID string) string {
+	return client.ServiceURL(rolePath, roleID)
+}
+
 func listAssignmentsURL(client *gophercloud.ServiceClient) string {
 	return client.ServiceURL("role_assignments")
 }

--- a/openstack/identity/v3/roles/urls.go
+++ b/openstack/identity/v3/roles/urls.go
@@ -18,6 +18,10 @@ func createURL(client *gophercloud.ServiceClient) string {
 	return client.ServiceURL(rolePath)
 }
 
+func updateURL(client *gophercloud.ServiceClient, roleID string) string {
+	return client.ServiceURL(rolePath, roleID)
+}
+
 func deleteURL(client *gophercloud.ServiceClient, roleID string) string {
 	return client.ServiceURL(rolePath, roleID)
 }


### PR DESCRIPTION
For #571 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

Update:
https://github.com/openstack/keystone/blob/83bd595b22944d38eff1cdef77b4c07a75af0fdc/keystone/assignment/controllers.py#L367

Note that the API for roles does not support updating the domain ID per https://developer.openstack.org/api-ref/identity/v3/#update-role