### PR TITLE
Identity v3: Region list / get

### DIFF
--- a/acceptance/openstack/identity/v3/regions_test.go
+++ b/acceptance/openstack/identity/v3/regions_test.go
@@ -1,0 +1,61 @@
+// +build acceptance
+
+package v3
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/acceptance/clients"
+	"github.com/gophercloud/gophercloud/acceptance/tools"
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/regions"
+)
+
+func TestRegionsList(t *testing.T) {
+	client, err := clients.NewIdentityV3Client()
+	if err != nil {
+		t.Fatalf("Unable to obtain an identity client: %v", err)
+	}
+
+	listOpts := regions.ListOpts{
+		ParentRegionID: "RegionOne",
+	}
+
+	allPages, err := regions.List(client, listOpts).AllPages()
+	if err != nil {
+		t.Fatalf("Unable to list regions: %v", err)
+	}
+
+	allRegions, err := regions.ExtractRegions(allPages)
+	if err != nil {
+		t.Fatalf("Unable to extract regions: %v", err)
+	}
+
+	for _, region := range allRegions {
+		tools.PrintResource(t, region)
+	}
+}
+
+func TestRegionsGet(t *testing.T) {
+	client, err := clients.NewIdentityV3Client()
+	if err != nil {
+		t.Fatalf("Unable to obtain an identity client: %v", err)
+	}
+
+	allPages, err := regions.List(client, nil).AllPages()
+	if err != nil {
+		t.Fatalf("Unable to list regions: %v", err)
+	}
+
+	allRegions, err := regions.ExtractRegions(allPages)
+	if err != nil {
+		t.Fatalf("Unable to extract regions: %v", err)
+	}
+
+	region := allRegions[0]
+	p, err := regions.Get(client, region.ID).Extract()
+	if err != nil {
+		t.Fatalf("Unable to get region: %v", err)
+	}
+
+	tools.PrintResource(t, p)
+}

--- a/openstack/identity/v3/regions/doc.go
+++ b/openstack/identity/v3/regions/doc.go
@@ -1,0 +1,24 @@
+/*
+Package regions manages and retrieves Regions in the OpenStack Identity Service.
+
+Example to List Regions
+
+	listOpts := regions.ListOpts{
+		ParentRegionID: "RegionOne",
+	}
+
+	allPages, err := regions.List(identityClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allRegions, err := regions.ExtractRegions(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, region := range allRegions {
+		fmt.Printf("%+v\n", region)
+	}
+*/
+package regions

--- a/openstack/identity/v3/regions/requests.go
+++ b/openstack/identity/v3/regions/requests.go
@@ -1,0 +1,45 @@
+package regions
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// ListOptsBuilder allows extensions to add additional parameters to
+// the List request
+type ListOptsBuilder interface {
+	ToRegionListQuery() (string, error)
+}
+
+// ListOpts provides options to filter the List results.
+type ListOpts struct {
+	// ParentRegionID filters the response by a parent region ID.
+	ParentRegionID string `q:"parent_region_id"`
+}
+
+// ToRegionListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToRegionListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List enumerates the Regions to which the current token has access.
+func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(client)
+	if opts != nil {
+		query, err := opts.ToRegionListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return RegionPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// Get retrieves details on a single region, by ID.
+func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {
+	_, r.Err = client.Get(getURL(client, id), &r.Body, nil)
+	return
+}

--- a/openstack/identity/v3/regions/results.go
+++ b/openstack/identity/v3/regions/results.go
@@ -1,0 +1,111 @@
+package regions
+
+import (
+	"encoding/json"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/internal"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// Region helps manage related users.
+type Region struct {
+	// Description describes the region purpose.
+	Description string `json:"description"`
+
+	// ID is the unique ID of the region.
+	ID string `json:"id"`
+
+	// Extra is a collection of miscellaneous key/values.
+	Extra map[string]interface{} `json:"-"`
+
+	// Links contains referencing links to the region.
+	Links map[string]interface{} `json:"links"`
+
+	// Name is the ID of the parent region.
+	ParentRegionID string `json:"parent_region_id"`
+}
+
+func (r *Region) UnmarshalJSON(b []byte) error {
+	type tmp Region
+	var s struct {
+		tmp
+		Extra map[string]interface{} `json:"extra"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	*r = Region(s.tmp)
+
+	// Collect other fields and bundle them into Extra
+	// but only if a field titled "extra" wasn't sent.
+	if s.Extra != nil {
+		r.Extra = s.Extra
+	} else {
+		var result interface{}
+		err := json.Unmarshal(b, &result)
+		if err != nil {
+			return err
+		}
+		if resultMap, ok := result.(map[string]interface{}); ok {
+			r.Extra = internal.RemainingKeys(Region{}, resultMap)
+		}
+	}
+
+	return err
+}
+
+type regionResult struct {
+	gophercloud.Result
+}
+
+// GetResult is the response from a Get operation. Call its Extract method
+// to interpret it as a Region.
+type GetResult struct {
+	regionResult
+}
+
+// RegionPage is a single page of Region results.
+type RegionPage struct {
+	pagination.LinkedPageBase
+}
+
+// IsEmpty determines whether or not a page of Regions contains any results.
+func (r RegionPage) IsEmpty() (bool, error) {
+	regions, err := ExtractRegions(r)
+	return len(regions) == 0, err
+}
+
+// NextPageURL extracts the "next" link from the links section of the result.
+func (r RegionPage) NextPageURL() (string, error) {
+	var s struct {
+		Links struct {
+			Next     string `json:"next"`
+			Previous string `json:"previous"`
+		} `json:"links"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return s.Links.Next, err
+}
+
+// ExtractRegions returns a slice of Regions contained in a single page of results.
+func ExtractRegions(r pagination.Page) ([]Region, error) {
+	var s struct {
+		Regions []Region `json:"regions"`
+	}
+	err := (r.(RegionPage)).ExtractInto(&s)
+	return s.Regions, err
+}
+
+// Extract interprets any region results as a Region.
+func (r regionResult) Extract() (*Region, error) {
+	var s struct {
+		Region *Region `json:"region"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Region, err
+}

--- a/openstack/identity/v3/regions/testing/fixtures.go
+++ b/openstack/identity/v3/regions/testing/fixtures.go
@@ -1,0 +1,116 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/regions"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+// ListOutput provides a single page of Region results.
+const ListOutput = `
+{
+    "links": {
+        "next": null,
+        "previous": null,
+        "self": "http://example.com/identity/v3/regions"
+    },
+    "regions": [
+        {
+            "id": "RegionOne-East",
+            "description": "East sub-region of RegionOne",
+            "links": {
+                "self": "http://example.com/identity/v3/regions/RegionOne-East"
+            },
+            "parent_region_id": "RegionOne"
+        },
+        {
+            "id": "RegionOne-West",
+            "description": "West sub-region of RegionOne",
+            "links": {
+                "self": "https://example.com/identity/v3/regions/RegionOne-West"
+            },
+            "extra": {
+                "email": "westsupport@example.com"
+            },
+            "parent_region_id": "RegionOne"
+        }
+    ]
+}
+`
+
+// GetOutput provides a Get result.
+const GetOutput = `
+{
+    "region": {
+        "id": "RegionOne-West",
+        "description": "West sub-region of RegionOne",
+        "links": {
+            "self": "https://example.com/identity/v3/regions/RegionOne-West"
+        },
+        "name": "support",
+        "extra": {
+            "email": "westsupport@example.com"
+        },
+        "parent_region_id": "RegionOne"
+    }
+}
+`
+
+// FirstRegion is the first region in the List request.
+var FirstRegion = regions.Region{
+	ID: "RegionOne-East",
+	Links: map[string]interface{}{
+		"self": "http://example.com/identity/v3/regions/RegionOne-East",
+	},
+	Description:    "East sub-region of RegionOne",
+	Extra:          map[string]interface{}{},
+	ParentRegionID: "RegionOne",
+}
+
+// SecondRegion is the second region in the List request.
+var SecondRegion = regions.Region{
+	ID: "RegionOne-West",
+	Links: map[string]interface{}{
+		"self": "https://example.com/identity/v3/regions/RegionOne-West",
+	},
+	Description: "West sub-region of RegionOne",
+	Extra: map[string]interface{}{
+		"email": "westsupport@example.com",
+	},
+	ParentRegionID: "RegionOne",
+}
+
+// ExpectedRegionsSlice is the slice of regions expected to be returned from ListOutput.
+var ExpectedRegionsSlice = []regions.Region{FirstRegion, SecondRegion}
+
+// HandleListRegionsSuccessfully creates an HTTP handler at `/regions` on the
+// test handler mux that responds with a list of two regions.
+func HandleListRegionsSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/regions", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, ListOutput)
+	})
+}
+
+// HandleGetRegionSuccessfully creates an HTTP handler at `/regions` on the
+// test handler mux that responds with a single region.
+func HandleGetRegionSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/regions/RegionOne-West", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, GetOutput)
+	})
+}

--- a/openstack/identity/v3/regions/testing/requests_test.go
+++ b/openstack/identity/v3/regions/testing/requests_test.go
@@ -1,0 +1,54 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/regions"
+	"github.com/gophercloud/gophercloud/pagination"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func TestListRegions(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleListRegionsSuccessfully(t)
+
+	count := 0
+	err := regions.List(client.ServiceClient(), nil).EachPage(func(page pagination.Page) (bool, error) {
+		count++
+
+		actual, err := regions.ExtractRegions(page)
+		th.AssertNoErr(t, err)
+
+		th.CheckDeepEquals(t, ExpectedRegionsSlice, actual)
+
+		return true, nil
+	})
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, count, 1)
+}
+
+func TestListRegionsAllPages(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleListRegionsSuccessfully(t)
+
+	allPages, err := regions.List(client.ServiceClient(), nil).AllPages()
+	th.AssertNoErr(t, err)
+	actual, err := regions.ExtractRegions(allPages)
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, ExpectedRegionsSlice, actual)
+	th.AssertEquals(t, ExpectedRegionsSlice[1].Extra["email"], "westsupport@example.com")
+}
+
+func TestGetRegion(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleGetRegionSuccessfully(t)
+
+	actual, err := regions.Get(client.ServiceClient(), "RegionOne-West").Extract()
+
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, SecondRegion, *actual)
+}

--- a/openstack/identity/v3/regions/urls.go
+++ b/openstack/identity/v3/regions/urls.go
@@ -1,0 +1,11 @@
+package regions
+
+import "github.com/gophercloud/gophercloud"
+
+func listURL(client *gophercloud.ServiceClient) string {
+	return client.ServiceURL("regions")
+}
+
+func getURL(client *gophercloud.ServiceClient, regionID string) string {
+	return client.ServiceURL("regions", regionID)
+}


### PR DESCRIPTION
For #583

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

API:
https://developer.openstack.org/api-ref/identity/v3/#regions

Schema:
https://github.com/openstack/keystone/blob/2764b49bc209245276da31693ef31f1525cf17d8/keystone/catalog/backends/sql.py#L34
https://github.com/openstack/keystone/blob/2764b49bc209245276da31693ef31f1525cf17d8/keystone/catalog/schema.py#L22

List:
https://github.com/openstack/keystone/blob/2764b49bc209245276da31693ef31f1525cf17d8/keystone/catalog/controllers.py#L70

Get:
https://github.com/openstack/keystone/blob/2764b49bc209245276da31693ef31f1525cf17d8/keystone/catalog/controllers.py#L78