### PR TITLE
Identity v3 region create

### DIFF
--- a/acceptance/openstack/identity/v3/identity.go
+++ b/acceptance/openstack/identity/v3/identity.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/domains"
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/groups"
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/projects"
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/regions"
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/roles"
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/users"
 )
@@ -145,6 +146,33 @@ func CreateRole(t *testing.T, client *gophercloud.ServiceClient, c *roles.Create
 	t.Logf("Successfully created role %s with ID %s", name, role.ID)
 
 	return role, nil
+}
+
+// CreateRegion will create a region with a random name.
+// It takes an optional createOpts parameter since creating a region
+// has so many options. An error will be returned if the region was
+// unable to be created.
+func CreateRegion(t *testing.T, client *gophercloud.ServiceClient, c *regions.CreateOpts) (*regions.Region, error) {
+	id := tools.RandomString("ACPTTEST", 8)
+	t.Logf("Attempting to create region: %s", id)
+
+	var createOpts regions.CreateOpts
+	if c != nil {
+		createOpts = *c
+	} else {
+		createOpts = regions.CreateOpts{}
+	}
+
+	createOpts.ID = id
+
+	region, err := regions.Create(client, createOpts).Extract()
+	if err != nil {
+		return region, err
+	}
+
+	t.Logf("Successfully created region %s", id)
+
+	return region, nil
 }
 
 // DeleteProject will delete a project by ID. A fatal error will occur if

--- a/acceptance/openstack/identity/v3/regions_test.go
+++ b/acceptance/openstack/identity/v3/regions_test.go
@@ -59,3 +59,27 @@ func TestRegionsGet(t *testing.T) {
 
 	tools.PrintResource(t, p)
 }
+
+func TestRegionsCRUD(t *testing.T) {
+	client, err := clients.NewIdentityV3Client()
+	if err != nil {
+		t.Fatalf("Unable to obtain an identity client: %v", err)
+	}
+
+	createOpts := regions.CreateOpts{
+		ID:          "testregion",
+		Description: "Region for testing",
+		Extra: map[string]interface{}{
+			"email": "testregion@example.com",
+		},
+	}
+
+	// Create region in the default domain
+	region, err := CreateRegion(t, client, &createOpts)
+	if err != nil {
+		t.Fatalf("Unable to create region: %v", err)
+	}
+
+	tools.PrintResource(t, region)
+	tools.PrintResource(t, region.Extra)
+}

--- a/openstack/identity/v3/regions/doc.go
+++ b/openstack/identity/v3/regions/doc.go
@@ -20,5 +20,20 @@ Example to List Regions
 	for _, region := range allRegions {
 		fmt.Printf("%+v\n", region)
 	}
+
+Example to Create a Region
+
+	createOpts := regions.CreateOpts{
+		ID:             "TestRegion",
+		Description: "Region for testing"
+		Extra: map[string]interface{}{
+			"email": "testregionsupport@example.com",
+		}
+	}
+
+	region, err := regions.Create(identityClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
 */
 package regions

--- a/openstack/identity/v3/regions/requests.go
+++ b/openstack/identity/v3/regions/requests.go
@@ -43,3 +43,55 @@ func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {
 	_, r.Err = client.Get(getURL(client, id), &r.Body, nil)
 	return
 }
+
+// CreateOptsBuilder allows extensions to add additional parameters to
+// the Create request.
+type CreateOptsBuilder interface {
+	ToRegionCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts provides options used to create a region.
+type CreateOpts struct {
+	// ID is the ID of the new region.
+	ID string `json:"id,omitempty"`
+
+	// Description is a description of the region.
+	Description string `json:"description,omitempty"`
+
+	// ParentRegionID is the ID of the parent the region to add this region under.
+	ParentRegionID string `json:"parent_region_id,omitempty"`
+
+	// Extra is free-form extra key/value pairs to describe the region.
+	Extra map[string]interface{} `json:"-"`
+}
+
+// ToRegionCreateMap formats a CreateOpts into a create request.
+func (opts CreateOpts) ToRegionCreateMap() (map[string]interface{}, error) {
+	b, err := gophercloud.BuildRequestBody(opts, "region")
+	if err != nil {
+		return nil, err
+	}
+
+	if opts.Extra != nil {
+		if v, ok := b["region"].(map[string]interface{}); ok {
+			for key, value := range opts.Extra {
+				v[key] = value
+			}
+		}
+	}
+
+	return b, nil
+}
+
+// Create creates a new Region.
+func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToRegionCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(createURL(client), &b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{201},
+	})
+	return
+}

--- a/openstack/identity/v3/regions/results.go
+++ b/openstack/identity/v3/regions/results.go
@@ -66,6 +66,12 @@ type GetResult struct {
 	regionResult
 }
 
+// CreateResult is the response from a Create operation. Call its Extract method
+// to interpret it as a Region.
+type CreateResult struct {
+	regionResult
+}
+
 // RegionPage is a single page of Region results.
 type RegionPage struct {
 	pagination.LinkedPageBase

--- a/openstack/identity/v3/regions/testing/fixtures.go
+++ b/openstack/identity/v3/regions/testing/fixtures.go
@@ -60,6 +60,18 @@ const GetOutput = `
 }
 `
 
+// CreateRequest provides the input to a Create request.
+const CreateRequest = `
+{
+    "region": {
+        "id": "RegionOne-West",
+        "description": "West sub-region of RegionOne",
+        "email": "westsupport@example.com",
+        "parent_region_id": "RegionOne"
+    }
+}
+`
+
 // FirstRegion is the first region in the List request.
 var FirstRegion = regions.Region{
 	ID: "RegionOne-East",
@@ -111,6 +123,19 @@ func HandleGetRegionSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, GetOutput)
+	})
+}
+
+// HandleCreateRegionSuccessfully creates an HTTP handler at `/regions` on the
+// test handler mux that tests region creation.
+func HandleCreateRegionSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/regions", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, CreateRequest)
+
+		w.WriteHeader(http.StatusCreated)
 		fmt.Fprintf(w, GetOutput)
 	})
 }

--- a/openstack/identity/v3/regions/testing/requests_test.go
+++ b/openstack/identity/v3/regions/testing/requests_test.go
@@ -52,3 +52,22 @@ func TestGetRegion(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.CheckDeepEquals(t, SecondRegion, *actual)
 }
+
+func TestCreateRegion(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleCreateRegionSuccessfully(t)
+
+	createOpts := regions.CreateOpts{
+		ID:          "RegionOne-West",
+		Description: "West sub-region of RegionOne",
+		Extra: map[string]interface{}{
+			"email": "westsupport@example.com",
+		},
+		ParentRegionID: "RegionOne",
+	}
+
+	actual, err := regions.Create(client.ServiceClient(), createOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, SecondRegion, *actual)
+}

--- a/openstack/identity/v3/regions/urls.go
+++ b/openstack/identity/v3/regions/urls.go
@@ -9,3 +9,7 @@ func listURL(client *gophercloud.ServiceClient) string {
 func getURL(client *gophercloud.ServiceClient, regionID string) string {
 	return client.ServiceURL("regions", regionID)
 }
+
+func createURL(client *gophercloud.ServiceClient) string {
+	return client.ServiceURL("regions")
+}


### PR DESCRIPTION
For #583 

Note region create is unique from most of the rest of the identity resources in that you can directly specify the ID, but providing the ID string is optional.

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

API:
https://developer.openstack.org/api-ref/identity/v3/#create-region

Schema:
https://github.com/openstack/keystone/blob/2764b49bc209245276da31693ef31f1525cf17d8/keystone/catalog/backends/sql.py#L161
https://github.com/openstack/keystone/blob/2764b49bc209245276da31693ef31f1525cf17d8/keystone/catalog/schema.py#L36
https://github.com/openstack/keystone/blob/2764b49bc209245276da31693ef31f1525cf17d8/keystone/catalog/schema.py#L22

Create:
https://github.com/openstack/keystone/blob/2764b49bc209245276da31693ef31f1525cf17d8/keystone/catalog/controllers.py#L54
