### PR TITLE
Request integrating a new CI system to Gophercloud

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -1,0 +1,12 @@
+- project:
+    name: gophercloud/gophercloud
+    check:
+      jobs:
+        - gophercloud-unittest
+        - gophercloud-acceptance-test
+    recheck-mitaka:
+      jobs:
+        - gophercloud-acceptance-test-mitaka
+    recheck-pike:
+      jobs:
+        - gophercloud-acceptance-test-pike


### PR DESCRIPTION
I'd like to request to integrate a new CI system which built based on
zuul[1] and nodepool[2] tools to Gophercloud repo. It is for running
Gophercloud tests(both unit tests and acceptance tests) based on a
devstack[3] environment. For now, my colleagues and I have basicially
finish the CI system building, and have tested with Gophercloud, it can
work OK, please see[4]. We will long-term maintain the CI system and would
like to propose to intergrate with Gophercloud official repo.

FYI, the zuul jobs definition can be found in [5], the zuul jobs status web
page is [6], the test jobs log server is [7].

[1] https://docs.openstack.org/infra/zuul/
[2] https://docs.openstack.org/infra/nodepool/
[3] https://docs.openstack.org/devstack/latest/
[4] https://github.com/theopenlab/gophercloud/pull/5
[5] https://github.com/theopenlab/openlab-zuul-jobs
[6] http://80.158.20.68/
[7] http://80.158.20.68/logs/

For #592
