### PR TITLE
Identity v3 Region update

### DIFF
--- a/acceptance/openstack/identity/v3/regions_test.go
+++ b/acceptance/openstack/identity/v3/regions_test.go
@@ -83,4 +83,19 @@ func TestRegionsCRUD(t *testing.T) {
 
 	tools.PrintResource(t, region)
 	tools.PrintResource(t, region.Extra)
+
+	updateOpts := regions.UpdateOpts{
+		Description: "Region A for testing",
+		Extra: map[string]interface{}{
+			"email": "testregionA@example.com",
+		},
+	}
+
+	newRegion, err := regions.Update(client, region.ID, updateOpts).Extract()
+	if err != nil {
+		t.Fatalf("Unable to update region: %v", err)
+	}
+
+	tools.PrintResource(t, newRegion)
+	tools.PrintResource(t, newRegion.Extra)
 }

--- a/acceptance/openstack/identity/v3/regions_test.go
+++ b/acceptance/openstack/identity/v3/regions_test.go
@@ -86,9 +86,15 @@ func TestRegionsCRUD(t *testing.T) {
 
 	updateOpts := regions.UpdateOpts{
 		Description: "Region A for testing",
-		Extra: map[string]interface{}{
-			"email": "testregionA@example.com",
-		},
+		/*
+			// Due to a bug in Keystone, the Extra column of the Region table
+			// is not updatable, see: https://bugs.launchpad.net/keystone/+bug/1729933
+			// The following lines should be uncommented once the fix is merged.
+
+			Extra: map[string]interface{}{
+				"email": "testregionA@example.com",
+			},
+		*/
 	}
 
 	newRegion, err := regions.Update(client, region.ID, updateOpts).Extract()

--- a/openstack/identity/v3/regions/doc.go
+++ b/openstack/identity/v3/regions/doc.go
@@ -35,6 +35,19 @@ Example to Create a Region
 	if err != nil {
 		panic(err)
 
+Example to Update a Region
+
+	regionID := "TestRegion"
+
+	updateOpts := regions.UpdateOpts{
+		Description: "Updated Description for region",
+	}
+
+	region, err := regions.Update(identityClient, regionID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
 Example to Delete a Region
 
 	regionID := "TestRegion"

--- a/openstack/identity/v3/regions/doc.go
+++ b/openstack/identity/v3/regions/doc.go
@@ -34,11 +34,15 @@ Example to Create a Region
 	region, err := regions.Create(identityClient, createOpts).Extract()
 	if err != nil {
 		panic(err)
+	}
 
 Example to Update a Region
 
 	regionID := "TestRegion"
 
+	// There is currently a bug in Keystone where updating the optional Extras
+	// attributes set in regions.Create is not supported, see:
+	// https://bugs.launchpad.net/keystone/+bug/1729933
 	updateOpts := regions.UpdateOpts{
 		Description: "Updated Description for region",
 	}
@@ -53,6 +57,7 @@ Example to Delete a Region
 	regionID := "TestRegion"
 	err := regions.Delete(identityClient, regionID).ExtractErr()
 	if err != nil {
+		panic(err)
 	}
 */
 package regions

--- a/openstack/identity/v3/regions/requests.go
+++ b/openstack/identity/v3/regions/requests.go
@@ -110,8 +110,14 @@ type UpdateOpts struct {
 	// ParentRegionID is the ID of the parent region.
 	ParentRegionID string `json:"parent_region_id,omitempty"`
 
-	// Extra is free-form extra key/value pairs to describe the region.
-	Extra map[string]interface{} `json:"-"`
+	/*
+		// Due to a bug in Keystone, the Extra column of the Region table
+		// is not updatable, see: https://bugs.launchpad.net/keystone/+bug/1729933
+		// The following lines should be uncommented once the fix is merged.
+
+		// Extra is free-form extra key/value pairs to describe the region.
+		Extra map[string]interface{} `json:"-"`
+	*/
 }
 
 // ToRegionUpdateMap formats a UpdateOpts into an update request.
@@ -121,13 +127,19 @@ func (opts UpdateOpts) ToRegionUpdateMap() (map[string]interface{}, error) {
 		return nil, err
 	}
 
-	if opts.Extra != nil {
-		if v, ok := b["region"].(map[string]interface{}); ok {
-			for key, value := range opts.Extra {
-				v[key] = value
+	/*
+		// Due to a bug in Keystone, the Extra column of the Region table
+		// is not updatable, see: https://bugs.launchpad.net/keystone/+bug/1729933
+		// The following lines should be uncommented once the fix is merged.
+
+		if opts.Extra != nil {
+			if v, ok := b["region"].(map[string]interface{}); ok {
+				for key, value := range opts.Extra {
+					v[key] = value
+				}
 			}
 		}
-	}
+	*/
 
 	return b, nil
 }

--- a/openstack/identity/v3/regions/requests.go
+++ b/openstack/identity/v3/regions/requests.go
@@ -96,6 +96,55 @@ func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r Create
 	return
 }
 
+// UpdateOptsBuilder allows extensions to add additional parameters to
+// the Update request.
+type UpdateOptsBuilder interface {
+	ToRegionUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts provides options for updating a region.
+type UpdateOpts struct {
+	// Description is a description of the region.
+	Description string `json:"description,omitempty"`
+
+	// ParentRegionID is the ID of the parent region.
+	ParentRegionID string `json:"parent_region_id,omitempty"`
+
+	// Extra is free-form extra key/value pairs to describe the region.
+	Extra map[string]interface{} `json:"-"`
+}
+
+// ToRegionUpdateMap formats a UpdateOpts into an update request.
+func (opts UpdateOpts) ToRegionUpdateMap() (map[string]interface{}, error) {
+	b, err := gophercloud.BuildRequestBody(opts, "region")
+	if err != nil {
+		return nil, err
+	}
+
+	if opts.Extra != nil {
+		if v, ok := b["region"].(map[string]interface{}); ok {
+			for key, value := range opts.Extra {
+				v[key] = value
+			}
+		}
+	}
+
+	return b, nil
+}
+
+// Update updates an existing Region.
+func Update(client *gophercloud.ServiceClient, regionID string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToRegionUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Patch(updateURL(client, regionID), &b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
 // Delete deletes a region.
 func Delete(client *gophercloud.ServiceClient, regionID string) (r DeleteResult) {
 	_, r.Err = client.Delete(deleteURL(client, regionID), nil)

--- a/openstack/identity/v3/regions/results.go
+++ b/openstack/identity/v3/regions/results.go
@@ -22,7 +22,7 @@ type Region struct {
 	// Links contains referencing links to the region.
 	Links map[string]interface{} `json:"links"`
 
-	// Name is the ID of the parent region.
+	// ParentRegionID is the ID of the parent region.
 	ParentRegionID string `json:"parent_region_id"`
 }
 
@@ -69,6 +69,12 @@ type GetResult struct {
 // CreateResult is the response from a Create operation. Call its Extract method
 // to interpret it as a Region.
 type CreateResult struct {
+	regionResult
+}
+
+// UpdateResult is the response from an Update operation. Call its Extract
+// method to interpret it as a Region.
+type UpdateResult struct {
 	regionResult
 }
 

--- a/openstack/identity/v3/regions/testing/fixtures.go
+++ b/openstack/identity/v3/regions/testing/fixtures.go
@@ -72,16 +72,31 @@ const CreateRequest = `
 }
 `
 
+/*
+	// Due to a bug in Keystone, the Extra column of the Region table
+	// is not updatable, see: https://bugs.launchpad.net/keystone/+bug/1729933
+	// The following line should be added to region in UpdateRequest once the
+	// fix is merged.
+
+	"email": "1stwestsupport@example.com"
+*/
 // UpdateRequest provides the input to as Update request.
 const UpdateRequest = `
 {
     "region": {
-        "description": "First West sub-region of RegionOne",
-        "email": "1stwestsupport@example.com"
+        "description": "First West sub-region of RegionOne"
     }
 }
 `
 
+/*
+	// Due to a bug in Keystone, the Extra column of the Region table
+	// is not updatable, see: https://bugs.launchpad.net/keystone/+bug/1729933
+	// This following line should replace the email in UpdateOutput.extra once
+	// the fix is merged.
+
+	"email": "1stwestsupport@example.com"
+*/
 // UpdateOutput provides an update result.
 const UpdateOutput = `
 {
@@ -92,7 +107,7 @@ const UpdateOutput = `
         },
         "description": "First West sub-region of RegionOne",
         "extra": {
-            "email": "1stwestsupport@example.com"
+            "email": "westsupport@example.com"
         },
         "parent_region_id": "RegionOne"
     }
@@ -123,6 +138,14 @@ var SecondRegion = regions.Region{
 	ParentRegionID: "RegionOne",
 }
 
+/*
+	// Due to a bug in Keystone, the Extra column of the Region table
+	// is not updatable, see: https://bugs.launchpad.net/keystone/+bug/1729933
+	// This should replace the email in SecondRegionUpdated.Extra once the fix
+	// is merged.
+
+	"email": "1stwestsupport@example.com"
+*/
 // SecondRegionUpdated is the second region in the List request.
 var SecondRegionUpdated = regions.Region{
 	ID: "RegionOne-West",
@@ -131,7 +154,7 @@ var SecondRegionUpdated = regions.Region{
 	},
 	Description: "First West sub-region of RegionOne",
 	Extra: map[string]interface{}{
-		"email": "1stwestsupport@example.com",
+		"email": "westsupport@example.com",
 	},
 	ParentRegionID: "RegionOne",
 }

--- a/openstack/identity/v3/regions/testing/fixtures.go
+++ b/openstack/identity/v3/regions/testing/fixtures.go
@@ -72,6 +72,33 @@ const CreateRequest = `
 }
 `
 
+// UpdateRequest provides the input to as Update request.
+const UpdateRequest = `
+{
+    "region": {
+        "description": "First West sub-region of RegionOne",
+        "email": "1stwestsupport@example.com"
+    }
+}
+`
+
+// UpdateOutput provides an update result.
+const UpdateOutput = `
+{
+    "region": {
+        "id": "RegionOne-West",
+        "links": {
+            "self": "https://example.com/identity/v3/regions/RegionOne-West"
+        },
+        "description": "First West sub-region of RegionOne",
+        "extra": {
+            "email": "1stwestsupport@example.com"
+        },
+        "parent_region_id": "RegionOne"
+    }
+}
+`
+
 // FirstRegion is the first region in the List request.
 var FirstRegion = regions.Region{
 	ID: "RegionOne-East",
@@ -92,6 +119,19 @@ var SecondRegion = regions.Region{
 	Description: "West sub-region of RegionOne",
 	Extra: map[string]interface{}{
 		"email": "westsupport@example.com",
+	},
+	ParentRegionID: "RegionOne",
+}
+
+// SecondRegionUpdated is the second region in the List request.
+var SecondRegionUpdated = regions.Region{
+	ID: "RegionOne-West",
+	Links: map[string]interface{}{
+		"self": "https://example.com/identity/v3/regions/RegionOne-West",
+	},
+	Description: "First West sub-region of RegionOne",
+	Extra: map[string]interface{}{
+		"email": "1stwestsupport@example.com",
 	},
 	ParentRegionID: "RegionOne",
 }
@@ -137,6 +177,19 @@ func HandleCreateRegionSuccessfully(t *testing.T) {
 
 		w.WriteHeader(http.StatusCreated)
 		fmt.Fprintf(w, GetOutput)
+	})
+}
+
+// HandleUpdateRegionSuccessfully creates an HTTP handler at `/regions` on the
+// test handler mux that tests region update.
+func HandleUpdateRegionSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/regions/RegionOne-West", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PATCH")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, UpdateRequest)
+
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, UpdateOutput)
 	})
 }
 

--- a/openstack/identity/v3/regions/testing/requests_test.go
+++ b/openstack/identity/v3/regions/testing/requests_test.go
@@ -72,6 +72,23 @@ func TestCreateRegion(t *testing.T) {
 	th.CheckDeepEquals(t, SecondRegion, *actual)
 }
 
+func TestUpdateRegion(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleUpdateRegionSuccessfully(t)
+
+	updateOpts := regions.UpdateOpts{
+		Description: "First West sub-region of RegionOne",
+		Extra: map[string]interface{}{
+			"email": "1stwestsupport@example.com",
+		},
+	}
+
+	actual, err := regions.Update(client.ServiceClient(), "RegionOne-West", updateOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, SecondRegionUpdated, *actual)
+}
+
 func TestDeleteRegion(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()

--- a/openstack/identity/v3/regions/testing/requests_test.go
+++ b/openstack/identity/v3/regions/testing/requests_test.go
@@ -79,9 +79,15 @@ func TestUpdateRegion(t *testing.T) {
 
 	updateOpts := regions.UpdateOpts{
 		Description: "First West sub-region of RegionOne",
-		Extra: map[string]interface{}{
-			"email": "1stwestsupport@example.com",
-		},
+		/*
+			// Due to a bug in Keystone, the Extra column of the Region table
+			// is not updatable, see: https://bugs.launchpad.net/keystone/+bug/1729933
+			// The following lines should be uncommented once the fix is merged.
+
+			Extra: map[string]interface{}{
+				"email": "1stwestsupport@example.com",
+			},
+		*/
 	}
 
 	actual, err := regions.Update(client.ServiceClient(), "RegionOne-West", updateOpts).Extract()

--- a/openstack/identity/v3/regions/urls.go
+++ b/openstack/identity/v3/regions/urls.go
@@ -14,6 +14,10 @@ func createURL(client *gophercloud.ServiceClient) string {
 	return client.ServiceURL("regions")
 }
 
+func updateURL(client *gophercloud.ServiceClient, regionID string) string {
+	return client.ServiceURL("regions", regionID)
+}
+
 func deleteURL(client *gophercloud.ServiceClient, regionID string) string {
 	return client.ServiceURL("regions", regionID)
 }


### PR DESCRIPTION
Note that ID cannot be updated even though it is settable on create.

There is also currently an issue with updating the Extra field. This I believe is
a bug in keystone. I have posted a bug and patch to fix. https://bugs.launchpad.net/keystone/+bug/1729933

For #583
Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

API:
https://developer.openstack.org/api-ref/identity/v3/#update-region

Schema:
https://github.com/openstack/keystone/blob/2764b49bc209245276da31693ef31f1525cf17d8/keystone/catalog/backends/sql.py#L175

Update:
https://github.com/openstack/keystone/blob/2764b49bc209245276da31693ef31f1525cf17d8/keystone/catalog/controllers.py#L83
