### PR TITLE
Remove autocomputed etag value

### DIFF
--- a/openstack/objectstorage/v1/objects/requests.go
+++ b/openstack/objectstorage/v1/objects/requests.go
@@ -185,8 +185,6 @@ func (opts CreateOpts) ToObjectCreateParams() (io.Reader, map[string]string, str
 	if err != nil {
 		return nil, nil, "", err
 	}
-	localChecksum := fmt.Sprintf("%x", hash.Sum(nil))
-	h["ETag"] = localChecksum
 
 	return buf, h, q.String(), nil
 }


### PR DESCRIPTION
The autocomputed etag value should be optionnally set by the end user, not the lib. 
The computed value based on the content of the body is wrong in some usecases

e.g.: for multipart manifests, if set, the value must contain the MD5 checksum of the concatenated ETag values of the object segments.

Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

For #[PUT ISSUE NUMBER HERE]

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

[PUT URLS HERE]
