### PR TITLE
fix token issue which results in endless loop on reauth

### DIFF
--- a/provider_client.go
+++ b/provider_client.go
@@ -145,10 +145,6 @@ func (client *ProviderClient) Request(method, url string, options *RequestOpts) 
 	}
 	req.Header.Set("Accept", applicationJSON)
 
-	for k, v := range client.AuthenticatedHeaders() {
-		req.Header.Add(k, v)
-	}
-
 	// Set the User-Agent header
 	req.Header.Set("User-Agent", client.UserAgent.Join())
 
@@ -160,6 +156,11 @@ func (client *ProviderClient) Request(method, url string, options *RequestOpts) 
 				req.Header.Del(k)
 			}
 		}
+	}
+
+	// get latest token from client
+	for k, v := range client.AuthenticatedHeaders() {
+		req.Header.Set(k, v)
 	}
 
 	// Set connection parameter to close the connection immediately when we've got the response


### PR DESCRIPTION
For #232 

```go
        // get client latest token and add to header
	for k, v := range client.AuthenticatedHeaders() {
		req.Header.Add(k, v)
	}

	// Set the User-Agent header
	req.Header.Set("User-Agent", client.UserAgent.Join())

	if options.MoreHeaders != nil {
                // MoreHeaders holds one old token which is set by caller
		for k, v := range options.MoreHeaders {
			if v != "" {
				req.Header.Set(k, v) // override the latest token which is refreshed by re-auth
			} else {
				req.Header.Del(k)
			}
		}
	}
```