### PR TITLE
Identity v3: Services update

### DIFF
--- a/acceptance/openstack/identity/v3/identity.go
+++ b/acceptance/openstack/identity/v3/identity.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/projects"
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/regions"
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/roles"
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/services"
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/users"
 )
 
@@ -175,6 +176,33 @@ func CreateRegion(t *testing.T, client *gophercloud.ServiceClient, c *regions.Cr
 	return region, nil
 }
 
+// CreateService will create a service with a random name.
+// It takes an optional createOpts parameter since creating a service
+// has so many options. An error will be returned if the service was
+// unable to be created.
+func CreateService(t *testing.T, client *gophercloud.ServiceClient, c *services.CreateOpts) (*services.Service, error) {
+	name := tools.RandomString("ACPTTEST", 8)
+	t.Logf("Attempting to create service: %s", name)
+
+	var createOpts services.CreateOpts
+	if c != nil {
+		createOpts = *c
+	} else {
+		createOpts = services.CreateOpts{}
+	}
+
+	createOpts.Extra["name"] = name
+
+	service, err := services.Create(client, createOpts).Extract()
+	if err != nil {
+		return service, err
+	}
+
+	t.Logf("Successfully created service %s", service.ID)
+
+	return service, nil
+}
+
 // DeleteProject will delete a project by ID. A fatal error will occur if
 // the project ID failed to be deleted. This works best when using it as
 // a deferred function.
@@ -236,7 +264,7 @@ func DeleteRole(t *testing.T, client *gophercloud.ServiceClient, roleID string) 
 }
 
 // DeleteRegion will delete a reg by ID. A fatal error will occur if
-// the role failed to be deleted. This works best when using it as
+// the region failed to be deleted. This works best when using it as
 // a deferred function.
 func DeleteRegion(t *testing.T, client *gophercloud.ServiceClient, regionID string) {
 	err := regions.Delete(client, regionID).ExtractErr()
@@ -245,6 +273,18 @@ func DeleteRegion(t *testing.T, client *gophercloud.ServiceClient, regionID stri
 	}
 
 	t.Logf("Deleted region: %s", regionID)
+}
+
+// DeleteService will delete a reg by ID. A fatal error will occur if
+// the service failed to be deleted. This works best when using it as
+// a deferred function.
+func DeleteService(t *testing.T, client *gophercloud.ServiceClient, serviceID string) {
+	err := services.Delete(client, serviceID).ExtractErr()
+	if err != nil {
+		t.Fatalf("Unable to delete service %s: %v", serviceID, err)
+	}
+
+	t.Logf("Deleted service: %s", serviceID)
 }
 
 // UnassignRole will delete a role assigned to a user/group on a project/domain

--- a/acceptance/openstack/identity/v3/service_test.go
+++ b/acceptance/openstack/identity/v3/service_test.go
@@ -54,4 +54,20 @@ func TestServicesCRUD(t *testing.T) {
 
 	tools.PrintResource(t, service)
 	tools.PrintResource(t, service.Extra)
+
+	updateOpts := services.UpdateOpts{
+		Type: "testing2",
+		Extra: map[string]interface{}{
+			"description": "Test Users",
+			"email":       "thetestservice@example.com",
+		},
+	}
+
+	newService, err := services.Update(client, service.ID, updateOpts).Extract()
+	if err != nil {
+		t.Fatalf("Unable to update service: %v", err)
+	}
+
+	tools.PrintResource(t, newService)
+	tools.PrintResource(t, newService.Extra)
 }

--- a/acceptance/openstack/identity/v3/service_test.go
+++ b/acceptance/openstack/identity/v3/service_test.go
@@ -31,3 +31,27 @@ func TestServicesList(t *testing.T) {
 	}
 
 }
+
+func TestServicesCRUD(t *testing.T) {
+	client, err := clients.NewIdentityV3Client()
+	if err != nil {
+		t.Fatalf("Unable to obtain an identity client: %v", err)
+	}
+
+	createOpts := services.CreateOpts{
+		Type: "testing",
+		Extra: map[string]interface{}{
+			"email": "testservice@example.com",
+		},
+	}
+
+	// Create service in the default domain
+	service, err := CreateService(t, client, &createOpts)
+	if err != nil {
+		t.Fatalf("Unable to create service: %v", err)
+	}
+	defer DeleteService(t, client, service.ID)
+
+	tools.PrintResource(t, service)
+	tools.PrintResource(t, service.Extra)
+}

--- a/openstack/identity/v3/services/doc.go
+++ b/openstack/identity/v3/services/doc.go
@@ -24,7 +24,15 @@ Example to List Services
 
 Example to Create a Service
 
-	service, err := services.Create(identityClient, "compute").Extract()
+	createOpts := services.CreateOpts{
+		Type: "compute",
+		Extra: map[string]interface{}{
+			"name": "compute-service",
+			"description": "Compute Service",
+		},
+	}
+
+	service, err := services.Create(identityClient, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/identity/v3/services/doc.go
+++ b/openstack/identity/v3/services/doc.go
@@ -37,6 +37,23 @@ Example to Create a Service
 		panic(err)
 	}
 
+Example to Update a Service
+
+	serviceID :=  "3c7bbe9a6ecb453ca1789586291380ed"
+
+	var iFalse bool = false
+	updateOpts := services.UpdateOpts{
+		Enabled: &iFalse,
+		Extra: map[string]interface{}{
+			"description": "Disabled Compute Service"
+		},
+	}
+
+	service, err := services.Update(identityClient, serviceID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
 Example to Delete a Service
 
 	serviceID := "3c7bbe9a6ecb453ca1789586291380ed"
@@ -44,5 +61,6 @@ Example to Delete a Service
 	if err != nil {
 		panic(err)
 	}
+
 */
 package services

--- a/openstack/identity/v3/services/results.go
+++ b/openstack/identity/v3/services/results.go
@@ -1,17 +1,20 @@
 package services
 
 import (
+	"encoding/json"
+
 	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/internal"
 	"github.com/gophercloud/gophercloud/pagination"
 )
 
-type commonResult struct {
+type serviceResult struct {
 	gophercloud.Result
 }
 
 // Extract interprets a GetResult, CreateResult or UpdateResult as a concrete
 // Service. An error is returned if the original call or the extraction failed.
-func (r commonResult) Extract() (*Service, error) {
+func (r serviceResult) Extract() (*Service, error) {
 	var s struct {
 		Service *Service `json:"service"`
 	}
@@ -22,19 +25,19 @@ func (r commonResult) Extract() (*Service, error) {
 // CreateResult is the response from a Create request. Call its Extract method
 // to interpret it as a Service.
 type CreateResult struct {
-	commonResult
+	serviceResult
 }
 
 // GetResult is the response from a Get request. Call its Extract method
 // to interpret it as a Service.
 type GetResult struct {
-	commonResult
+	serviceResult
 }
 
 // UpdateResult is the response from an Update request. Call its Extract method
 // to interpret it as a Service.
 type UpdateResult struct {
-	commonResult
+	serviceResult
 }
 
 // DeleteResult is the response from a Delete request. Call its ExtractErr
@@ -45,17 +48,50 @@ type DeleteResult struct {
 
 // Service represents an OpenStack Service.
 type Service struct {
-	// Description is a description of the service.
-	Description string `json:"description"`
-
 	// ID is the unique ID of the service.
 	ID string `json:"id"`
 
-	// Name is the name of the service.
-	Name string `json:"name"`
-
 	// Type is the type of the service.
 	Type string `json:"type"`
+
+	// Enabled is whether or not the service is enabled.
+	Enabled bool `json:"enabled"`
+
+	// Links contains referencing links to the service.
+	Links map[string]interface{} `json:"links"`
+
+	// Extra is a collection of miscellaneous key/values.
+	Extra map[string]interface{} `json:"-"`
+}
+
+func (r *Service) UnmarshalJSON(b []byte) error {
+	type tmp Service
+	var s struct {
+		tmp
+		Extra map[string]interface{} `json:"extra"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	*r = Service(s.tmp)
+
+	// Collect other fields and bundle them into Extra
+	// but only if a field titled "extra" wasn't sent.
+	if s.Extra != nil {
+		r.Extra = s.Extra
+	} else {
+		var result interface{}
+		err := json.Unmarshal(b, &result)
+		if err != nil {
+			return err
+		}
+		if resultMap, ok := result.(map[string]interface{}); ok {
+			r.Extra = internal.RemainingKeys(Service{}, resultMap)
+		}
+	}
+
+	return err
 }
 
 // ServicePage is a single page of Service results.
@@ -67,6 +103,21 @@ type ServicePage struct {
 func (p ServicePage) IsEmpty() (bool, error) {
 	services, err := ExtractServices(p)
 	return len(services) == 0, err
+}
+
+// NextPageURL extracts the "next" link from the links section of the result.
+func (r ServicePage) NextPageURL() (string, error) {
+	var s struct {
+		Links struct {
+			Next     string `json:"next"`
+			Previous string `json:"previous"`
+		} `json:"links"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return s.Links.Next, err
 }
 
 // ExtractServices extracts a slice of Services from a Collection acquired

--- a/openstack/identity/v3/services/testing/fixtures.go
+++ b/openstack/identity/v3/services/testing/fixtures.go
@@ -81,7 +81,10 @@ const CreateRequest = `
 // UpdateRequest provides the input to as Update request.
 const UpdateRequest = `
 {
-    "type": "compute2"
+    "service": {
+        "type": "compute2",
+        "description": "Service Two Updated"
+    }
 }
 `
 
@@ -97,7 +100,7 @@ const UpdateOutput = `
         "enabled": false,
         "extra": {
             "name": "service-two",
-            "description": "Service Two",
+            "description": "Service Two Updated",
             "email": "service@example.com"
         }
     }
@@ -143,7 +146,7 @@ var SecondServiceUpdated = services.Service{
 	Enabled: false,
 	Extra: map[string]interface{}{
 		"name":        "service-two",
-		"description": "Service Two",
+		"description": "Service Two Updated",
 		"email":       "service@example.com",
 	},
 }

--- a/openstack/identity/v3/services/testing/fixtures.go
+++ b/openstack/identity/v3/services/testing/fixtures.go
@@ -1,0 +1,206 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/services"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+// ListOutput provides a single page of Service results.
+const ListOutput = `
+{
+    "links": {
+        "next": null,
+        "previous": null
+    },
+    "services": [
+        {
+            "id": "1234",
+            "links": {
+                "self": "https://example.com/identity/v3/services/1234"
+            },
+            "type": "identity",
+            "enabled": false,
+            "extra": {
+                "name": "service-one",
+                "description": "Service One"
+            }
+        },
+        {
+            "id": "9876",
+            "links": {
+                "self": "https://example.com/identity/v3/services/9876"
+            },
+            "type": "compute",
+            "enabled": false,
+            "extra": {
+                "name": "service-two",
+                "description": "Service Two",
+                "email": "service@example.com"
+            }
+        }
+    ]
+}
+`
+
+// GetOutput provides a Get result.
+const GetOutput = `
+{
+    "service": {
+        "id": "9876",
+        "links": {
+            "self": "https://example.com/identity/v3/services/9876"
+        },
+        "type": "compute",
+        "enabled": false,
+        "extra": {
+            "name": "service-two",
+            "description": "Service Two",
+            "email": "service@example.com"
+        }
+    }
+}
+`
+
+// CreateRequest provides the input to a Create request.
+const CreateRequest = `
+{
+    "service": {
+        "description": "Service Two",
+        "email": "service@example.com",
+        "name": "service-two",
+        "type": "compute"
+    }
+}
+`
+
+// UpdateRequest provides the input to as Update request.
+const UpdateRequest = `
+{
+    "type": "compute2"
+}
+`
+
+// UpdateOutput provides an update result.
+const UpdateOutput = `
+{
+    "service": {
+        "id": "9876",
+        "links": {
+            "self": "https://example.com/identity/v3/services/9876"
+        },
+        "type": "compute2",
+        "enabled": false,
+        "extra": {
+            "name": "service-two",
+            "description": "Service Two",
+            "email": "service@example.com"
+        }
+    }
+}
+`
+
+// FirstService is the first service in the List request.
+var FirstService = services.Service{
+	ID: "1234",
+	Links: map[string]interface{}{
+		"self": "https://example.com/identity/v3/services/1234",
+	},
+	Type:    "identity",
+	Enabled: false,
+	Extra: map[string]interface{}{
+		"name":        "service-one",
+		"description": "Service One",
+	},
+}
+
+// SecondService is the second service in the List request.
+var SecondService = services.Service{
+	ID: "9876",
+	Links: map[string]interface{}{
+		"self": "https://example.com/identity/v3/services/9876",
+	},
+	Type:    "compute",
+	Enabled: false,
+	Extra: map[string]interface{}{
+		"name":        "service-two",
+		"description": "Service Two",
+		"email":       "service@example.com",
+	},
+}
+
+// SecondServiceUpdated is the SecondService should look after an Update.
+var SecondServiceUpdated = services.Service{
+	ID: "9876",
+	Links: map[string]interface{}{
+		"self": "https://example.com/identity/v3/services/9876",
+	},
+	Type:    "compute2",
+	Enabled: false,
+	Extra: map[string]interface{}{
+		"name":        "service-two",
+		"description": "Service Two",
+		"email":       "service@example.com",
+	},
+}
+
+// ExpectedServicesSlice is the slice of services to be returned from ListOutput.
+var ExpectedServicesSlice = []services.Service{FirstService, SecondService}
+
+// HandleListServicesSuccessfully creates an HTTP handler at `/services` on the
+// test handler mux that responds with a list of two services.
+func HandleListServicesSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/services", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, ListOutput)
+	})
+}
+
+// HandleGetServiceSuccessfully creates an HTTP handler at `/services` on the
+// test handler mux that responds with a single service.
+func HandleGetServiceSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/services/9876", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, GetOutput)
+	})
+}
+
+// HandleCreateServiceSuccessfully creates an HTTP handler at `/services` on the
+// test handler mux that tests service creation.
+func HandleCreateServiceSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/services", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, CreateRequest)
+
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprintf(w, GetOutput)
+	})
+}
+
+// HandleUpdateServiceSuccessfully creates an HTTP handler at `/services` on the
+// test handler mux that tests service update.
+func HandleUpdateServiceSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/services/9876", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PATCH")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, UpdateRequest)
+
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, UpdateOutput)
+	})
+}

--- a/openstack/identity/v3/services/testing/requests_test.go
+++ b/openstack/identity/v3/services/testing/requests_test.go
@@ -1,7 +1,6 @@
 package testing
 
 import (
-	"fmt"
 	"net/http"
 	"testing"
 
@@ -14,162 +13,62 @@ import (
 func TestCreateSuccessful(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
+	HandleCreateServiceSuccessfully(t)
 
-	th.Mux.HandleFunc("/services", func(w http.ResponseWriter, r *http.Request) {
-		th.TestMethod(t, r, "POST")
-		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
-		th.TestJSONRequest(t, r, `{ "type": "compute" }`)
-
-		w.Header().Add("Content-Type", "application/json")
-		w.WriteHeader(http.StatusCreated)
-		fmt.Fprintf(w, `{
-        "service": {
-          "description": "Here's your service",
-          "id": "1234",
-          "name": "InscrutableOpenStackProjectName",
-          "type": "compute"
-        }
-    }`)
-	})
-
-	expected := &services.Service{
-		Description: "Here's your service",
-		ID:          "1234",
-		Name:        "InscrutableOpenStackProjectName",
-		Type:        "compute",
+	createOpts := services.CreateOpts{
+		Type: "compute",
+		Extra: map[string]interface{}{
+			"name":        "service-two",
+			"description": "Service Two",
+			"email":       "service@example.com",
+		},
 	}
 
-	actual, err := services.Create(client.ServiceClient(), "compute").Extract()
-	if err != nil {
-		t.Fatalf("Unexpected error from Create: %v", err)
-	}
-	th.AssertDeepEquals(t, expected, actual)
+	actual, err := services.Create(client.ServiceClient(), createOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, SecondService, *actual)
 }
 
 func TestListSinglePage(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
-
-	th.Mux.HandleFunc("/services", func(w http.ResponseWriter, r *http.Request) {
-		th.TestMethod(t, r, "GET")
-		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
-
-		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, `
-			{
-				"links": {
-					"next": null,
-					"previous": null
-				},
-				"services": [
-					{
-						"description": "Service One",
-						"id": "1234",
-						"name": "service-one",
-						"type": "identity"
-					},
-					{
-						"description": "Service Two",
-						"id": "9876",
-						"name": "service-two",
-						"type": "compute"
-					}
-				]
-			}
-		`)
-	})
+	HandleListServicesSuccessfully(t)
 
 	count := 0
 	err := services.List(client.ServiceClient(), services.ListOpts{}).EachPage(func(page pagination.Page) (bool, error) {
 		count++
-		actual, err := services.ExtractServices(page)
-		if err != nil {
-			return false, err
-		}
 
-		expected := []services.Service{
-			{
-				Description: "Service One",
-				ID:          "1234",
-				Name:        "service-one",
-				Type:        "identity",
-			},
-			{
-				Description: "Service Two",
-				ID:          "9876",
-				Name:        "service-two",
-				Type:        "compute",
-			},
-		}
-		th.AssertDeepEquals(t, expected, actual)
+		actual, err := services.ExtractServices(page)
+		th.AssertNoErr(t, err)
+
+		th.CheckDeepEquals(t, ExpectedServicesSlice, actual)
+
 		return true, nil
 	})
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, 1, count)
+	th.CheckEquals(t, count, 1)
 }
 
 func TestGetSuccessful(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
+	HandleGetServiceSuccessfully(t)
 
-	th.Mux.HandleFunc("/services/12345", func(w http.ResponseWriter, r *http.Request) {
-		th.TestMethod(t, r, "GET")
-		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+	actual, err := services.Get(client.ServiceClient(), "9876").Extract()
 
-		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, `
-			{
-				"service": {
-						"description": "Service One",
-						"id": "12345",
-						"name": "service-one",
-						"type": "identity"
-				}
-			}
-		`)
-	})
-
-	actual, err := services.Get(client.ServiceClient(), "12345").Extract()
 	th.AssertNoErr(t, err)
-
-	expected := &services.Service{
-		ID:          "12345",
-		Description: "Service One",
-		Name:        "service-one",
-		Type:        "identity",
-	}
-
-	th.AssertDeepEquals(t, expected, actual)
+	th.CheckDeepEquals(t, SecondService, *actual)
+	th.AssertEquals(t, SecondService.Extra["email"], "service@example.com")
 }
 
 func TestUpdateSuccessful(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
+	HandleUpdateServiceSuccessfully(t)
 
-	th.Mux.HandleFunc("/services/12345", func(w http.ResponseWriter, r *http.Request) {
-		th.TestMethod(t, r, "PATCH")
-		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
-		th.TestJSONRequest(t, r, `{ "type": "lasermagic" }`)
-
-		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, `
-			{
-				"service": {
-						"id": "12345",
-						"type": "lasermagic"
-				}
-			}
-		`)
-	})
-
-	expected := &services.Service{
-		ID:   "12345",
-		Type: "lasermagic",
-	}
-
-	actual, err := services.Update(client.ServiceClient(), "12345", "lasermagic").Extract()
+	actual, err := services.Update(client.ServiceClient(), "9876", "compute2").Extract()
 	th.AssertNoErr(t, err)
-	th.AssertDeepEquals(t, expected, actual)
+	th.CheckDeepEquals(t, SecondServiceUpdated, *actual)
 }
 
 func TestDeleteSuccessful(t *testing.T) {

--- a/openstack/identity/v3/services/testing/requests_test.go
+++ b/openstack/identity/v3/services/testing/requests_test.go
@@ -66,9 +66,16 @@ func TestUpdateSuccessful(t *testing.T) {
 	defer th.TeardownHTTP()
 	HandleUpdateServiceSuccessfully(t)
 
-	actual, err := services.Update(client.ServiceClient(), "9876", "compute2").Extract()
+	updateOpts := services.UpdateOpts{
+		Type: "compute2",
+		Extra: map[string]interface{}{
+			"description": "Service Two Updated",
+		},
+	}
+	actual, err := services.Update(client.ServiceClient(), "9876", updateOpts).Extract()
 	th.AssertNoErr(t, err)
 	th.CheckDeepEquals(t, SecondServiceUpdated, *actual)
+	th.AssertEquals(t, SecondServiceUpdated.Extra["description"], "Service Two Updated")
 }
 
 func TestDeleteSuccessful(t *testing.T) {

--- a/openstack/identity/v3/services/urls.go
+++ b/openstack/identity/v3/services/urls.go
@@ -6,6 +6,10 @@ func listURL(client *gophercloud.ServiceClient) string {
 	return client.ServiceURL("services")
 }
 
+func createURL(client *gophercloud.ServiceClient) string {
+	return client.ServiceURL("services")
+}
+
 func serviceURL(client *gophercloud.ServiceClient, serviceID string) string {
 	return client.ServiceURL("services", serviceID)
 }

--- a/openstack/identity/v3/services/urls.go
+++ b/openstack/identity/v3/services/urls.go
@@ -13,3 +13,7 @@ func createURL(client *gophercloud.ServiceClient) string {
 func serviceURL(client *gophercloud.ServiceClient, serviceID string) string {
 	return client.ServiceURL("services", serviceID)
 }
+
+func updateURL(client *gophercloud.ServiceClient, serviceID string) string {
+	return client.ServiceURL("services", serviceID)
+}


### PR DESCRIPTION
This updates how service update is done. It is a backward incompatible change.

For #605 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

Schema:

https://github.com/openstack/keystone/blob/master/keystone/catalog/backends/sql.py#L53
https://github.com/openstack/keystone/blob/master/keystone/catalog/schema.py#L52
Note here name is in the schema but not in the backend, as thus it's stored in extra.
https://github.com/openstack/keystone/blob/master/keystone/catalog/schema.py#L65

Update:
- https://github.com/openstack/keystone/blob/master/keystone/catalog/controllers.py#L130
