### PR TITLE
Add 'tenant' support in volume&snapshot API

### DIFF
--- a/openstack/blockstorage/v2/snapshots/requests.go
+++ b/openstack/blockstorage/v2/snapshots/requests.go
@@ -68,6 +68,11 @@ type ListOpts struct {
 	Name     string `q:"name"`
 	Status   string `q:"status"`
 	VolumeID string `q:"volume_id"`
+	// Admin-only option. Set it to true to see all tenant snapshots.
+	AllTenants bool `q:"all_tenants"`
+	// List only snapshots that belongs to one particular tenant.
+	// Setting "AllTenants = true" is required.
+	TenantID string `q:"project_id"`
 }
 
 // ToSnapshotListQuery formats a ListOpts into a query string.

--- a/openstack/blockstorage/v2/volumes/requests.go
+++ b/openstack/blockstorage/v2/volumes/requests.go
@@ -91,6 +91,9 @@ type ListOpts struct {
 	Name string `q:"name"`
 	// List only volumes that have a status of Status.
 	Status string `q:"status"`
+	// List only volumes that belongs to one particular tenant.
+	// Setting "AllTenants = true" is required.
+	TenantID string `q:"project_id"`
 }
 
 // ToVolumeListQuery formats a ListOpts into a query string.

--- a/openstack/blockstorage/v3/snapshots/requests.go
+++ b/openstack/blockstorage/v3/snapshots/requests.go
@@ -68,6 +68,11 @@ type ListOpts struct {
 	Name     string `q:"name"`
 	Status   string `q:"status"`
 	VolumeID string `q:"volume_id"`
+	// Admin-only option. Set it to true to see all tenant snapshots.
+	AllTenants bool `q:"all_tenants"`
+	// List only snapshots that belongs to one particular tenant.
+	// Setting "AllTenants = true" is required.
+	TenantID string `q:"project_id"`
 }
 
 // ToSnapshotListQuery formats a ListOpts into a query string.

--- a/openstack/blockstorage/v3/volumes/requests.go
+++ b/openstack/blockstorage/v3/volumes/requests.go
@@ -91,6 +91,9 @@ type ListOpts struct {
 	Name string `q:"name"`
 	// List only volumes that have a status of Status.
 	Status string `q:"status"`
+	// List only volumes that belongs to one particular tenant.
+	// Setting "AllTenants = true" is required.
+	TenantID string `q:"project_id"`
 }
 
 // ToVolumeListQuery formats a ListOpts into a query string.


### PR DESCRIPTION
Query parameter `tenant` is required in a multi-tenants environment. Add this support
in blockstorage V3 APIs.

For #627

Code in Cinder:
Volumes: https://github.com/openstack/cinder/blob/master/cinder/volume/api.py#L581-L595
Snapshots: https://github.com/openstack/cinder/blob/master/cinder/volume/api.py#L638-L647
