### PR TITLE
Fix wrong status on Resize function comment

### DIFF
--- a/openstack/compute/v2/servers/requests.go
+++ b/openstack/compute/v2/servers/requests.go
@@ -515,7 +515,7 @@ func (opts ResizeOpts) ToServerResizeMap() (map[string]interface{}, error) {
 // Note that this implies rebuilding it.
 //
 // Unfortunately, one cannot pass rebuild parameters to the resize function.
-// When the resize completes, the server will be in RESIZE_VERIFY state.
+// When the resize completes, the server will be in VERIFY_RESIZE state.
 // While in this state, you can explore the use of the new server's
 // configuration. If you like it, call ConfirmResize() to commit the resize
 // permanently. Otherwise, call RevertResize() to restore the old configuration.


### PR DESCRIPTION
This commit changes the VERIFY status for the resize operation.
The correct VERIFY_RESIZE status was gotten from:
https://developer.openstack.org/api-guide/compute/server_concepts.html

Signed-off-by: Obed N Munoz <obed.n.munoz@intel.com>

Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

For #629

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/nova/blob/master/nova/api/openstack/common.py#L76