### PR TITLE
Supprt extend volume in v2/v3 APIs

### DIFF
--- a/openstack/blockstorage/v2/volumes/requests.go
+++ b/openstack/blockstorage/v2/volumes/requests.go
@@ -122,6 +122,36 @@ func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pa
 	})
 }
 
+// ExtendOptsBuilder allows extensions to add additional parameters to the
+// extend action (os-extend) request.
+type ExtendOptsBuilder interface {
+	ToVolumeExtendMap() (map[string]interface{}, error)
+}
+
+// ExtendOpts holds options for extending volumes. It is passed to the volumes.Extend
+// function.
+type ExtendOpts struct {
+	//New size of the volume in GiB
+	NewSize int `json:"new_size" required:"true"`
+}
+
+func (opts ExtendOpts) ToVolumeExtendMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "os-extend")
+}
+
+// Extend will extend the Volume with specified volume size.
+func Extend(client *gophercloud.ServiceClient, id string, opts ExtendOptsBuilder) (r ActionResult) {
+	b, err := opts.ToVolumeExtendMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(actionURL(client, id), b, nil, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+	})
+	return
+}
+
 // UpdateOptsBuilder allows extensions to add additional parameters to the
 // Update request.
 type UpdateOptsBuilder interface {

--- a/openstack/blockstorage/v2/volumes/results.go
+++ b/openstack/blockstorage/v2/volumes/results.go
@@ -152,3 +152,8 @@ type UpdateResult struct {
 type DeleteResult struct {
 	gophercloud.ErrResult
 }
+
+// ActionResult contains the response body and error from a Action request.
+type ActionResult struct {
+	gophercloud.ErrResult
+}

--- a/openstack/blockstorage/v2/volumes/testing/fixtures.go
+++ b/openstack/blockstorage/v2/volumes/testing/fixtures.go
@@ -201,3 +201,12 @@ func MockUpdateResponse(t *testing.T) {
         `)
 	})
 }
+
+func MockExtendResponse(t *testing.T) {
+	th.Mux.HandleFunc("/volumes/d32019d3-bc6e-4319-9c1d-6722fc136a22/action", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestBody(t, r, `{"os-extend":{"new_size":2}}`)
+		w.WriteHeader(http.StatusAccepted)
+	})
+}

--- a/openstack/blockstorage/v2/volumes/testing/requests_test.go
+++ b/openstack/blockstorage/v2/volumes/testing/requests_test.go
@@ -255,3 +255,14 @@ func TestGetWithExtensions(t *testing.T) {
 		t.Errorf("Expected error when providing non-pointer struct")
 	}
 }
+
+func TestExtend(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockExtendResponse(t)
+
+	options := volumes.ExtendOpts{NewSize: 2}
+	err := volumes.Extend(client.ServiceClient(), "d32019d3-bc6e-4319-9c1d-6722fc136a22", options).ExtractErr()
+	th.AssertNoErr(t, err)
+}

--- a/openstack/blockstorage/v2/volumes/urls.go
+++ b/openstack/blockstorage/v2/volumes/urls.go
@@ -21,3 +21,7 @@ func getURL(c *gophercloud.ServiceClient, id string) string {
 func updateURL(c *gophercloud.ServiceClient, id string) string {
 	return deleteURL(c, id)
 }
+
+func actionURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL("volumes", id, "action")
+}

--- a/openstack/blockstorage/v3/volumes/requests.go
+++ b/openstack/blockstorage/v3/volumes/requests.go
@@ -122,6 +122,36 @@ func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pa
 	})
 }
 
+// ExtendOptsBuilder allows extensions to add additional parameters to the
+// extend action (os-extend) request.
+type ExtendOptsBuilder interface {
+	ToVolumeExtendMap() (map[string]interface{}, error)
+}
+
+// ExtendOpts holds options for extending volumes. It is passed to the volumes.Extend
+// function.
+type ExtendOpts struct {
+	//New size of the volume in GiB
+	NewSize int `json:"new_size" required:"true"`
+}
+
+func (opts ExtendOpts) ToVolumeExtendMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "os-extend")
+}
+
+// Extend will extend the Volume with specified volume size.
+func Extend(client *gophercloud.ServiceClient, id string, opts ExtendOptsBuilder) (r ActionResult) {
+	b, err := opts.ToVolumeExtendMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(actionURL(client, id), b, nil, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+	})
+	return
+}
+
 // UpdateOptsBuilder allows extensions to add additional parameters to the
 // Update request.
 type UpdateOptsBuilder interface {

--- a/openstack/blockstorage/v3/volumes/results.go
+++ b/openstack/blockstorage/v3/volumes/results.go
@@ -157,3 +157,8 @@ type UpdateResult struct {
 type DeleteResult struct {
 	gophercloud.ErrResult
 }
+
+// ActionResult contains the response body and error from a Action request.
+type ActionResult struct {
+	gophercloud.ErrResult
+}

--- a/openstack/blockstorage/v3/volumes/testing/fixtures.go
+++ b/openstack/blockstorage/v3/volumes/testing/fixtures.go
@@ -201,3 +201,12 @@ func MockUpdateResponse(t *testing.T) {
         `)
 	})
 }
+
+func MockExtendResponse(t *testing.T) {
+	th.Mux.HandleFunc("/volumes/d32019d3-bc6e-4319-9c1d-6722fc136a22/action", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestBody(t, r, `{"os-extend":{"new_size":2}}`)
+		w.WriteHeader(http.StatusAccepted)
+	})
+}

--- a/openstack/blockstorage/v3/volumes/testing/requests_test.go
+++ b/openstack/blockstorage/v3/volumes/testing/requests_test.go
@@ -255,3 +255,14 @@ func TestGetWithExtensions(t *testing.T) {
 		t.Errorf("Expected error when providing non-pointer struct")
 	}
 }
+
+func TestExtend(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockExtendResponse(t)
+
+	options := volumes.ExtendOpts{NewSize: 2}
+	err := volumes.Extend(client.ServiceClient(), "d32019d3-bc6e-4319-9c1d-6722fc136a22", options).ExtractErr()
+	th.AssertNoErr(t, err)
+}

--- a/openstack/blockstorage/v3/volumes/urls.go
+++ b/openstack/blockstorage/v3/volumes/urls.go
@@ -21,3 +21,7 @@ func getURL(c *gophercloud.ServiceClient, id string) string {
 func updateURL(c *gophercloud.ServiceClient, id string) string {
 	return deleteURL(c, id)
 }
+
+func actionURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL("volumes", id, "action")
+}


### PR DESCRIPTION
Add extend volume support in v2/v3 APIs

For #632

Action [**os-extend**](https://github.com/openstack/cinder/blob/master/cinder/api/contrib/volume_actions.py#L300) in Cinder