### PR TITLE
add UseTokenLock method in ProviderClient to allow safe concurrent access

### DIFF
--- a/openstack/client.go
+++ b/openstack/client.go
@@ -56,11 +56,12 @@ func NewClient(endpoint string) (*gophercloud.ProviderClient, error) {
 	endpoint = gophercloud.NormalizeURL(endpoint)
 	base = gophercloud.NormalizeURL(base)
 
-	return &gophercloud.ProviderClient{
-		IdentityBase:     base,
-		IdentityEndpoint: endpoint,
-	}, nil
+	p := new(gophercloud.ProviderClient)
+	p.IdentityBase = base
+	p.IdentityEndpoint = endpoint
+	p.UseTokenLock()
 
+	return p, nil
 }
 
 /*

--- a/openstack/client.go
+++ b/openstack/client.go
@@ -163,7 +163,7 @@ func v2auth(client *gophercloud.ProviderClient, endpoint string, options gopherc
 			return v2auth(client, endpoint, options, eo)
 		}
 	}
-	client.SetToken(token.ID)
+	client.TokenID = token.ID
 	client.EndpointLocator = func(opts gophercloud.EndpointOpts) (string, error) {
 		return V2EndpointURL(catalog, opts)
 	}
@@ -199,7 +199,7 @@ func v3auth(client *gophercloud.ProviderClient, endpoint string, opts tokens3.Au
 		return err
 	}
 
-	client.SetToken(token.ID)
+	client.TokenID = token.ID
 
 	if opts.CanReauth() {
 		client.ReauthFunc = func() error {

--- a/openstack/client.go
+++ b/openstack/client.go
@@ -163,7 +163,7 @@ func v2auth(client *gophercloud.ProviderClient, endpoint string, options gopherc
 			return v2auth(client, endpoint, options, eo)
 		}
 	}
-	client.TokenID = token.ID
+	client.SetToken(token.ID)
 	client.EndpointLocator = func(opts gophercloud.EndpointOpts) (string, error) {
 		return V2EndpointURL(catalog, opts)
 	}
@@ -199,7 +199,7 @@ func v3auth(client *gophercloud.ProviderClient, endpoint string, opts tokens3.Au
 		return err
 	}
 
-	client.TokenID = token.ID
+	client.SetToken(token.ID)
 
 	if opts.CanReauth() {
 		client.ReauthFunc = func() error {

--- a/provider_client.go
+++ b/provider_client.go
@@ -84,9 +84,9 @@ func (client *ProviderClient) AuthenticatedHeaders() map[string]string {
 	return map[string]string{"X-Auth-Token": t}
 }
 
-// UseSafeReauth creates a mutex that is used to allow safe concurrent re-authentication.
+// UseTokenLock creates a mutex that is used to allow safe concurrent access to the auth token.
 // If the application's ProviderClient is not used concurrently, this doesn't need to be called.
-func (client *ProviderClient) UseSafeReauth() {
+func (client *ProviderClient) UseTokenLock() {
 	client.mut = new(sync.RWMutex)
 }
 

--- a/provider_client.go
+++ b/provider_client.go
@@ -75,20 +75,33 @@ type ProviderClient struct {
 // AuthenticatedHeaders returns a map of HTTP headers that are common for all
 // authenticated service requests.
 func (client *ProviderClient) AuthenticatedHeaders() map[string]string {
-	if client.mut != nil {
-		client.mut.RLock()
-		defer client.mut.RUnlock()
-	}
-	if client.TokenID == "" {
+	t := client.Token()
+	if t == "" {
 		return map[string]string{}
 	}
-	return map[string]string{"X-Auth-Token": client.TokenID}
+	return map[string]string{"X-Auth-Token": t}
 }
 
 // UseSafeReauth creates a mutex that is used to allow safe concurrent re-authentication.
 // If the application's ProviderClient is not used concurrently, this doesn't need to be called.
 func (client *ProviderClient) UseSafeReauth() {
 	client.mut = new(sync.RWMutex)
+}
+
+func (client *ProviderClient) Token() string {
+	if client.mut != nil {
+		client.mut.RLock()
+		defer client.mut.RUnlock()
+	}
+	return client.TokenID
+}
+
+func (client *ProviderClient) SetToken(t string) {
+	if client.mut != nil {
+		client.mut.Lock()
+		defer client.mut.Unlock()
+	}
+	client.TokenID = t
 }
 
 // RequestOpts customizes the behavior of the provider.Request() method.

--- a/provider_client.go
+++ b/provider_client.go
@@ -52,6 +52,8 @@ type ProviderClient struct {
 	IdentityEndpoint string
 
 	// TokenID is the ID of the most recently issued valid token.
+	// NOTE: Aside from within a custom ReauthFunc, this field shouldn't be set by an application.
+	// To safely read or write this value, call `Token` or `SetToken`, respectively
 	TokenID string
 
 	// EndpointLocator describes how this provider discovers the endpoints for
@@ -88,6 +90,8 @@ func (client *ProviderClient) UseSafeReauth() {
 	client.mut = new(sync.RWMutex)
 }
 
+// Token safely reads the value of the auth token from the ProviderClient. Applications should
+// call this method to access the token instead of the TokenID field
 func (client *ProviderClient) Token() string {
 	if client.mut != nil {
 		client.mut.RLock()
@@ -96,6 +100,8 @@ func (client *ProviderClient) Token() string {
 	return client.TokenID
 }
 
+// SetToken safely sets the value of the auth token in the ProviderClient. Applications may
+// use this method in a custom ReauthFunc
 func (client *ProviderClient) SetToken(t string) {
 	if client.mut != nil {
 		client.mut.Lock()

--- a/testing/provider_client_test.go
+++ b/testing/provider_client_test.go
@@ -56,7 +56,7 @@ func TestConcurrentReauth(t *testing.T) {
 	postreauthTok := "12345678"
 
 	p := new(gophercloud.ProviderClient)
-	p.UseSafeReauth()
+	p.UseTokenLock()
 	p.SetToken(prereauthTok)
 	p.ReauthFunc = func() error {
 		time.Sleep(1 * time.Second)

--- a/testing/provider_client_test.go
+++ b/testing/provider_client_test.go
@@ -56,8 +56,8 @@ func TestConcurrentReauth(t *testing.T) {
 	postreauthTok := "12345678"
 
 	p := new(gophercloud.ProviderClient)
-	p.TokenID = prereauthTok
 	p.UseSafeReauth()
+	p.SetToken(prereauthTok)
 	p.ReauthFunc = func() error {
 		time.Sleep(1 * time.Second)
 		info.mut.Lock()
@@ -80,7 +80,7 @@ func TestConcurrentReauth(t *testing.T) {
 		info.mut.RUnlock()
 
 		if hasReauthed {
-			th.CheckEquals(t, p.TokenID, postreauthTok)
+			th.CheckEquals(t, p.Token(), postreauthTok)
 		}
 
 		w.Header().Add("Content-Type", "application/json")

--- a/testing/provider_client_test.go
+++ b/testing/provider_client_test.go
@@ -1,10 +1,16 @@
 package testing
 
 import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/gophercloud/gophercloud"
 	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
 )
 
 func TestAuthenticatedHeaders(t *testing.T) {
@@ -33,4 +39,82 @@ func TestUserAgent(t *testing.T) {
 	expected = "gophercloud/2.0.0"
 	actual = p.UserAgent.Join()
 	th.CheckEquals(t, expected, actual)
+}
+
+func TestConcurrentReauth(t *testing.T) {
+	var info = struct {
+		numreauths int
+		mut        *sync.RWMutex
+	}{
+		0,
+		new(sync.RWMutex),
+	}
+
+	numconc := 20
+
+	prereauthTok := client.TokenID
+	postreauthTok := "12345678"
+
+	p := new(gophercloud.ProviderClient)
+	p.TokenID = prereauthTok
+	p.UseSafeReauth()
+	p.ReauthFunc = func() error {
+		time.Sleep(1 * time.Second)
+		info.mut.Lock()
+		info.numreauths++
+		info.mut.Unlock()
+		p.TokenID = postreauthTok
+		return nil
+	}
+
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/route", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Auth-Token") != postreauthTok {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		info.mut.RLock()
+		hasReauthed := info.numreauths != 0
+		info.mut.RUnlock()
+
+		if hasReauthed {
+			th.CheckEquals(t, p.TokenID, postreauthTok)
+		}
+
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprintf(w, `{}`)
+	})
+
+	wg := new(sync.WaitGroup)
+	reqopts := new(gophercloud.RequestOpts)
+
+	for i := 0; i < numconc; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			resp, err := p.Request("GET", fmt.Sprintf("%s/route", th.Endpoint()), reqopts)
+			th.CheckNoErr(t, err)
+			if resp == nil {
+				t.Errorf("got a nil response")
+				return
+			}
+			if resp.Body == nil {
+				t.Errorf("response body was nil")
+				return
+			}
+			defer resp.Body.Close()
+			actual, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				t.Errorf("error reading response body: %s", err)
+				return
+			}
+			th.CheckByteArrayEquals(t, []byte(`{}`), actual)
+		}()
+	}
+
+	wg.Wait()
+
+	th.AssertEquals(t, 1, info.numreauths)
 }


### PR DESCRIPTION
For #310 

- adds a `mut` field and `UseTokenLock`, `Token`, and `SetToken` methods to `ProviderClient`
- adds a unit test for concurrent reauth
- removes the `Debug` field from `ProviderClient`, which was a relic and isn't used anywhere

Intended to be backwards-compatible (with the exception of the unused and now-removed `Debug` field).