### PR TITLE
Refactor volume actions' action URL method

### DIFF
--- a/openstack/blockstorage/extensions/volumeactions/requests.go
+++ b/openstack/blockstorage/extensions/volumeactions/requests.go
@@ -47,7 +47,7 @@ func Attach(client *gophercloud.ServiceClient, id string, opts AttachOptsBuilder
 		r.Err = err
 		return
 	}
-	_, r.Err = client.Post(attachURL(client, id), b, nil, &gophercloud.RequestOpts{
+	_, r.Err = client.Post(actionURL(client, id), b, nil, &gophercloud.RequestOpts{
 		OkCodes: []int{202},
 	})
 	return
@@ -56,7 +56,7 @@ func Attach(client *gophercloud.ServiceClient, id string, opts AttachOptsBuilder
 // BeginDetach will mark the volume as detaching.
 func BeginDetaching(client *gophercloud.ServiceClient, id string) (r BeginDetachingResult) {
 	b := map[string]interface{}{"os-begin_detaching": make(map[string]interface{})}
-	_, r.Err = client.Post(beginDetachingURL(client, id), b, nil, &gophercloud.RequestOpts{
+	_, r.Err = client.Post(actionURL(client, id), b, nil, &gophercloud.RequestOpts{
 		OkCodes: []int{202},
 	})
 	return
@@ -87,7 +87,7 @@ func Detach(client *gophercloud.ServiceClient, id string, opts DetachOptsBuilder
 		r.Err = err
 		return
 	}
-	_, r.Err = client.Post(detachURL(client, id), b, nil, &gophercloud.RequestOpts{
+	_, r.Err = client.Post(actionURL(client, id), b, nil, &gophercloud.RequestOpts{
 		OkCodes: []int{202},
 	})
 	return
@@ -96,7 +96,7 @@ func Detach(client *gophercloud.ServiceClient, id string, opts DetachOptsBuilder
 // Reserve will reserve a volume based on volume ID.
 func Reserve(client *gophercloud.ServiceClient, id string) (r ReserveResult) {
 	b := map[string]interface{}{"os-reserve": make(map[string]interface{})}
-	_, r.Err = client.Post(reserveURL(client, id), b, nil, &gophercloud.RequestOpts{
+	_, r.Err = client.Post(actionURL(client, id), b, nil, &gophercloud.RequestOpts{
 		OkCodes: []int{200, 201, 202},
 	})
 	return
@@ -105,7 +105,7 @@ func Reserve(client *gophercloud.ServiceClient, id string) (r ReserveResult) {
 // Unreserve will unreserve a volume based on volume ID.
 func Unreserve(client *gophercloud.ServiceClient, id string) (r UnreserveResult) {
 	b := map[string]interface{}{"os-unreserve": make(map[string]interface{})}
-	_, r.Err = client.Post(unreserveURL(client, id), b, nil, &gophercloud.RequestOpts{
+	_, r.Err = client.Post(actionURL(client, id), b, nil, &gophercloud.RequestOpts{
 		OkCodes: []int{200, 201, 202},
 	})
 	return
@@ -145,7 +145,7 @@ func InitializeConnection(client *gophercloud.ServiceClient, id string, opts Ini
 		r.Err = err
 		return
 	}
-	_, r.Err = client.Post(initializeConnectionURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
+	_, r.Err = client.Post(actionURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{200, 201, 202},
 	})
 	return
@@ -183,7 +183,7 @@ func TerminateConnection(client *gophercloud.ServiceClient, id string, opts Term
 		r.Err = err
 		return
 	}
-	_, r.Err = client.Post(teminateConnectionURL(client, id), b, nil, &gophercloud.RequestOpts{
+	_, r.Err = client.Post(actionURL(client, id), b, nil, &gophercloud.RequestOpts{
 		OkCodes: []int{202},
 	})
 	return
@@ -216,7 +216,7 @@ func ExtendSize(client *gophercloud.ServiceClient, id string, opts ExtendSizeOpt
 		r.Err = err
 		return
 	}
-	_, r.Err = client.Post(extendSizeURL(client, id), b, nil, &gophercloud.RequestOpts{
+	_, r.Err = client.Post(actionURL(client, id), b, nil, &gophercloud.RequestOpts{
 		OkCodes: []int{202},
 	})
 	return
@@ -256,7 +256,7 @@ func UploadImage(client *gophercloud.ServiceClient, id string, opts UploadImageO
 		r.Err = err
 		return
 	}
-	_, r.Err = client.Post(uploadURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
+	_, r.Err = client.Post(actionURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{202},
 	})
 	return
@@ -264,6 +264,6 @@ func UploadImage(client *gophercloud.ServiceClient, id string, opts UploadImageO
 
 // ForceDelete will delete the volume regardless of state.
 func ForceDelete(client *gophercloud.ServiceClient, id string) (r ForceDeleteResult) {
-	_, r.Err = client.Post(forceDeleteURL(client, id), map[string]interface{}{"os-force_delete": ""}, nil, nil)
+	_, r.Err = client.Post(actionURL(client, id), map[string]interface{}{"os-force_delete": ""}, nil, nil)
 	return
 }

--- a/openstack/blockstorage/extensions/volumeactions/urls.go
+++ b/openstack/blockstorage/extensions/volumeactions/urls.go
@@ -2,42 +2,6 @@ package volumeactions
 
 import "github.com/gophercloud/gophercloud"
 
-func attachURL(c *gophercloud.ServiceClient, id string) string {
+func actionURL(c *gophercloud.ServiceClient, id string) string {
 	return c.ServiceURL("volumes", id, "action")
-}
-
-func beginDetachingURL(c *gophercloud.ServiceClient, id string) string {
-	return attachURL(c, id)
-}
-
-func detachURL(c *gophercloud.ServiceClient, id string) string {
-	return attachURL(c, id)
-}
-
-func uploadURL(c *gophercloud.ServiceClient, id string) string {
-	return attachURL(c, id)
-}
-
-func reserveURL(c *gophercloud.ServiceClient, id string) string {
-	return attachURL(c, id)
-}
-
-func unreserveURL(c *gophercloud.ServiceClient, id string) string {
-	return attachURL(c, id)
-}
-
-func initializeConnectionURL(c *gophercloud.ServiceClient, id string) string {
-	return attachURL(c, id)
-}
-
-func teminateConnectionURL(c *gophercloud.ServiceClient, id string) string {
-	return attachURL(c, id)
-}
-
-func extendSizeURL(c *gophercloud.ServiceClient, id string) string {
-	return attachURL(c, id)
-}
-
-func forceDeleteURL(c *gophercloud.ServiceClient, id string) string {
-	return attachURL(c, id)
 }


### PR DESCRIPTION
Replace volume action's xxxxURL method with actionURL

Volume actions' url is always in the format of ``/{project}/volumes/{volume_id}/action``, there is no need
to define new xxxxURL individually.

For: #640 
**side node**: This change may be discussable or already been discussed before :smile: 

Cinder API [Document](https://developer.openstack.org/api-ref/block-storage/v3/#volume-actions-volumes-action)