### PR TITLE
Add support to get interface of a server

### DIFF
--- a/openstack/compute/v2/extensions/attachinterfaces/doc.go
+++ b/openstack/compute/v2/extensions/attachinterfaces/doc.go
@@ -18,5 +18,14 @@ Example of Listing a Server's Interfaces
 	for _, interface := range allInterfaces {
 		fmt.Printf("%+v\n", interface)
 	}
+
+Example to Get a Server's Interface
+
+	interfaceID = "0dde1598-b374-474e-986f-5b8dd1df1d4e"
+	serverID := "b07e7a3b-d951-4efc-a4f9-ac9f001afb7f"
+	interface, err := attachinterfaces.Get(computeClient, serverID, interfaceID).Extract()
+	if err != nil {
+		panic(err)
+	}
 */
 package attachinterfaces

--- a/openstack/compute/v2/extensions/attachinterfaces/doc.go
+++ b/openstack/compute/v2/extensions/attachinterfaces/doc.go
@@ -21,9 +21,9 @@ Example of Listing a Server's Interfaces
 
 Example to Get a Server's Interface
 
-	interfaceID = "0dde1598-b374-474e-986f-5b8dd1df1d4e"
+	portID = "0dde1598-b374-474e-986f-5b8dd1df1d4e"
 	serverID := "b07e7a3b-d951-4efc-a4f9-ac9f001afb7f"
-	interface, err := attachinterfaces.Get(computeClient, serverID, interfaceID).Extract()
+	interface, err := attachinterfaces.Get(computeClient, serverID, portID).Extract()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/compute/v2/extensions/attachinterfaces/requests.go
+++ b/openstack/compute/v2/extensions/attachinterfaces/requests.go
@@ -11,3 +11,11 @@ func List(client *gophercloud.ServiceClient, serverID string) pagination.Pager {
 		return InterfacePage{pagination.SinglePageBase(r)}
 	})
 }
+
+// Get requests details on a single interface attachment by the server and port IDs.
+func Get(client *gophercloud.ServiceClient, serverID, portID string) (r GetResult) {
+	_, r.Err = client.Get(getInterfaceURL(client, serverID, portID), &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200, 203},
+	})
+	return
+}

--- a/openstack/compute/v2/extensions/attachinterfaces/requests.go
+++ b/openstack/compute/v2/extensions/attachinterfaces/requests.go
@@ -15,7 +15,7 @@ func List(client *gophercloud.ServiceClient, serverID string) pagination.Pager {
 // Get requests details on a single interface attachment by the server and port IDs.
 func Get(client *gophercloud.ServiceClient, serverID, portID string) (r GetResult) {
 	_, r.Err = client.Get(getInterfaceURL(client, serverID, portID), &r.Body, &gophercloud.RequestOpts{
-		OkCodes: []int{200, 203},
+		OkCodes: []int{200},
 	})
 	return
 }

--- a/openstack/compute/v2/extensions/attachinterfaces/results.go
+++ b/openstack/compute/v2/extensions/attachinterfaces/results.go
@@ -1,8 +1,28 @@
 package attachinterfaces
 
 import (
+	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/pagination"
 )
+
+type attachInterfaceResult struct {
+	gophercloud.Result
+}
+
+// Extract interprets any attachInterfaceResult as an Interface, if possible.
+func (r attachInterfaceResult) Extract() (*Interface, error) {
+	var s struct {
+		Interface *Interface `json:"interfaceAttachment"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Interface, err
+}
+
+// GetResult is the response from a Get operation. Call its Extract
+// method to interpret it as a Interface.
+type GetResult struct {
+	attachInterfaceResult
+}
 
 // FixedIP represents a Fixed IP Address.
 type FixedIP struct {

--- a/openstack/compute/v2/extensions/attachinterfaces/testing/fixtures.go
+++ b/openstack/compute/v2/extensions/attachinterfaces/testing/fixtures.go
@@ -30,6 +30,24 @@ var ListInterfacesExpected = []attachinterfaces.Interface{
 	},
 }
 
+// GetInterfaceExpected represents an expected repsonse from a GetInterface request.
+var GetInterfaceExpected = attachinterfaces.Interface{
+	PortState: "ACTIVE",
+	FixedIPs: []attachinterfaces.FixedIP{
+		{
+			SubnetID:  "d7906db4-a566-4546-b1f4-5c7fa70f0bf3",
+			IPAddress: "10.0.0.7",
+		},
+		{
+			SubnetID:  "45906d64-a548-4276-h1f8-kcffa80fjbnl",
+			IPAddress: "10.0.0.8",
+		},
+	},
+	PortID:  "0dde1598-b374-474e-986f-5b8dd1df1d4e",
+	NetID:   "8a5fe506-7e9f-4091-899b-96336909d93c",
+	MACAddr: "fa:16:3e:38:2d:80",
+}
+
 // HandleInterfaceListSuccessfully sets up the test server to respond to a ListInterfaces request.
 func HandleInterfaceListSuccessfully(t *testing.T) {
 	th.Mux.HandleFunc("/servers/b07e7a3b-d951-4efc-a4f9-ac9f001afb7f/os-interface", func(w http.ResponseWriter, r *http.Request) {
@@ -56,6 +74,35 @@ func HandleInterfaceListSuccessfully(t *testing.T) {
 					"mac_addr": "fa:16:3e:38:2d:80"
 				}
 			]
+		}`)
+	})
+}
+
+// HandleInterfaceGetSuccessfully sets up the test server to respond to a GetInterface request.
+func HandleInterfaceGetSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/servers/b07e7a3b-d951-4efc-a4f9-ac9f001afb7f/os-interface/0dde1598-b374-474e-986f-5b8dd1df1d4e", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprintf(w, `{
+			"interfaceAttachment":
+				{
+					"port_state":"ACTIVE",
+					"fixed_ips": [
+						{
+							"subnet_id": "d7906db4-a566-4546-b1f4-5c7fa70f0bf3",
+							"ip_address": "10.0.0.7"
+						},
+						{
+							"subnet_id": "45906d64-a548-4276-h1f8-kcffa80fjbnl",
+							"ip_address": "10.0.0.8"
+						}
+					],
+					"port_id": "0dde1598-b374-474e-986f-5b8dd1df1d4e",
+					"net_id": "8a5fe506-7e9f-4091-899b-96336909d93c",
+					"mac_addr": "fa:16:3e:38:2d:80"
+				}
 		}`)
 	})
 }

--- a/openstack/compute/v2/extensions/attachinterfaces/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/attachinterfaces/testing/requests_test.go
@@ -43,3 +43,18 @@ func TestListInterfacesAllPages(t *testing.T) {
 	_, err = attachinterfaces.ExtractInterfaces(allPages)
 	th.AssertNoErr(t, err)
 }
+
+func TestGetInterface(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleInterfaceGetSuccessfully(t)
+
+	expected := GetInterfaceExpected
+
+	serverID := "b07e7a3b-d951-4efc-a4f9-ac9f001afb7f"
+	interfaceID := "0dde1598-b374-474e-986f-5b8dd1df1d4e"
+
+	actual, err := attachinterfaces.Get(client.ServiceClient(), serverID, interfaceID).Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, &expected, actual)
+}

--- a/openstack/compute/v2/extensions/attachinterfaces/urls.go
+++ b/openstack/compute/v2/extensions/attachinterfaces/urls.go
@@ -5,3 +5,7 @@ import "github.com/gophercloud/gophercloud"
 func listInterfaceURL(client *gophercloud.ServiceClient, serverID string) string {
 	return client.ServiceURL("servers", serverID, "os-interface")
 }
+
+func getInterfaceURL(client *gophercloud.ServiceClient, serverID, portID string) string {
+	return client.ServiceURL("servers", serverID, "os-interface", portID)
+}


### PR DESCRIPTION
Add support to get interface of a server through a GET on: /v2.1/{tenant_id}/servers/{server_id}/os-interface/{port_id}

For #641 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/nova/blob/stable/pike/nova/api/openstack/compute/attach_interfaces.py#L75