### PR TITLE
Add Nova interface-attach support

### DIFF
--- a/openstack/compute/v2/extensions/attachinterfaces/doc.go
+++ b/openstack/compute/v2/extensions/attachinterfaces/doc.go
@@ -27,5 +27,17 @@ Example to Get a Server's Interface
 	if err != nil {
 		panic(err)
 	}
+
+Example to Create a new Interface attachment on the Server
+
+	networkID := "8a5fe506-7e9f-4091-899b-96336909d93c"
+	serverID := "b07e7a3b-d951-4efc-a4f9-ac9f001afb7f"
+	attachOpts := attachinterfaces.CreateOpts{
+		NetworkID: networkID,
+	}
+	interface, err := attachinterfaces.Create(computeClient, serverID, attachOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
 */
 package attachinterfaces

--- a/openstack/compute/v2/extensions/attachinterfaces/results.go
+++ b/openstack/compute/v2/extensions/attachinterfaces/results.go
@@ -9,7 +9,7 @@ type attachInterfaceResult struct {
 	gophercloud.Result
 }
 
-// Extract interprets any attachInterfaceResult as an Interface, if possible.
+// Extract interprets any attachInterfaceResult as a Interface, if possible.
 func (r attachInterfaceResult) Extract() (*Interface, error) {
 	var s struct {
 		Interface *Interface `json:"interfaceAttachment"`
@@ -21,6 +21,12 @@ func (r attachInterfaceResult) Extract() (*Interface, error) {
 // GetResult is the response from a Get operation. Call its Extract
 // method to interpret it as a Interface.
 type GetResult struct {
+	attachInterfaceResult
+}
+
+// CreateResult is the response from a Create operation. Call its Extract
+// method to interpret it as a Interface.
+type CreateResult struct {
 	attachInterfaceResult
 }
 

--- a/openstack/compute/v2/extensions/attachinterfaces/results.go
+++ b/openstack/compute/v2/extensions/attachinterfaces/results.go
@@ -9,7 +9,7 @@ type attachInterfaceResult struct {
 	gophercloud.Result
 }
 
-// Extract interprets any attachInterfaceResult as a Interface, if possible.
+// Extract interprets any attachInterfaceResult as an Interface, if possible.
 func (r attachInterfaceResult) Extract() (*Interface, error) {
 	var s struct {
 		Interface *Interface `json:"interfaceAttachment"`
@@ -19,13 +19,13 @@ func (r attachInterfaceResult) Extract() (*Interface, error) {
 }
 
 // GetResult is the response from a Get operation. Call its Extract
-// method to interpret it as a Interface.
+// method to interpret it as an Interface.
 type GetResult struct {
 	attachInterfaceResult
 }
 
 // CreateResult is the response from a Create operation. Call its Extract
-// method to interpret it as a Interface.
+// method to interpret it as an Interface.
 type CreateResult struct {
 	attachInterfaceResult
 }

--- a/openstack/compute/v2/extensions/attachinterfaces/testing/fixtures.go
+++ b/openstack/compute/v2/extensions/attachinterfaces/testing/fixtures.go
@@ -48,6 +48,20 @@ var GetInterfaceExpected = attachinterfaces.Interface{
 	MACAddr: "fa:16:3e:38:2d:80",
 }
 
+// CreateInterfacesExpected represents an expected repsonse from a CreateInterface request.
+var CreateInterfacesExpected = attachinterfaces.Interface{
+	PortState: "ACTIVE",
+	FixedIPs: []attachinterfaces.FixedIP{
+		{
+			SubnetID:  "d7906db4-a566-4546-b1f4-5c7fa70f0bf3",
+			IPAddress: "10.0.0.7",
+		},
+	},
+	PortID:  "0dde1598-b374-474e-986f-5b8dd1df1d4e",
+	NetID:   "8a5fe506-7e9f-4091-899b-96336909d93c",
+	MACAddr: "fa:16:3e:38:2d:80",
+}
+
 // HandleInterfaceListSuccessfully sets up the test server to respond to a ListInterfaces request.
 func HandleInterfaceListSuccessfully(t *testing.T) {
 	th.Mux.HandleFunc("/servers/b07e7a3b-d951-4efc-a4f9-ac9f001afb7f/os-interface", func(w http.ResponseWriter, r *http.Request) {
@@ -97,6 +111,36 @@ func HandleInterfaceGetSuccessfully(t *testing.T) {
 						{
 							"subnet_id": "45906d64-a548-4276-h1f8-kcffa80fjbnl",
 							"ip_address": "10.0.0.8"
+						}
+					],
+					"port_id": "0dde1598-b374-474e-986f-5b8dd1df1d4e",
+					"net_id": "8a5fe506-7e9f-4091-899b-96336909d93c",
+					"mac_addr": "fa:16:3e:38:2d:80"
+				}
+		}`)
+	})
+}
+
+// HandleInterfaceCreateSuccessfully sets up the test server to respond to a CreateInterface request.
+func HandleInterfaceCreateSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/servers/b07e7a3b-d951-4efc-a4f9-ac9f001afb7f/os-interface", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, `{
+			  "interfaceAttachment": {
+				"net_id": "8a5fe506-7e9f-4091-899b-96336909d93c"
+			  }
+		}`)
+
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprintf(w, `{
+			"interfaceAttachment":
+				{
+					"port_state":"ACTIVE",
+					"fixed_ips": [
+						{
+							"subnet_id": "d7906db4-a566-4546-b1f4-5c7fa70f0bf3",
+							"ip_address": "10.0.0.7"
 						}
 					],
 					"port_id": "0dde1598-b374-474e-986f-5b8dd1df1d4e",

--- a/openstack/compute/v2/extensions/attachinterfaces/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/attachinterfaces/testing/requests_test.go
@@ -58,3 +58,20 @@ func TestGetInterface(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.CheckDeepEquals(t, &expected, actual)
 }
+
+func TestCreateInterface(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleInterfaceCreateSuccessfully(t)
+
+	expected := CreateInterfacesExpected
+
+	serverID := "b07e7a3b-d951-4efc-a4f9-ac9f001afb7f"
+	networkID := "8a5fe506-7e9f-4091-899b-96336909d93c"
+
+	actual, err := attachinterfaces.Create(client.ServiceClient(), serverID, attachinterfaces.CreateOpts{
+		NetworkID: networkID,
+	}).Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, &expected, actual)
+}

--- a/openstack/compute/v2/extensions/attachinterfaces/urls.go
+++ b/openstack/compute/v2/extensions/attachinterfaces/urls.go
@@ -9,3 +9,7 @@ func listInterfaceURL(client *gophercloud.ServiceClient, serverID string) string
 func getInterfaceURL(client *gophercloud.ServiceClient, serverID, portID string) string {
 	return client.ServiceURL("servers", serverID, "os-interface", portID)
 }
+
+func createInterfaceURL(client *gophercloud.ServiceClient, serverID string) string {
+	return client.ServiceURL("servers", serverID, "os-interface")
+}


### PR DESCRIPTION
Add support to attach interface to a server through a POST on: /v2.1/{tenant_id}/servers/{server_id}/os-interface

The same operation with the OpenStack CLI is done with:
  nova interface-attach <server>

For #641 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/nova/blob/stable/pike/nova/api/openstack/compute/attach_interfaces.py#L104