### PR TITLE
Add Nova interface-detach support

### DIFF
--- a/openstack/compute/v2/extensions/attachinterfaces/doc.go
+++ b/openstack/compute/v2/extensions/attachinterfaces/doc.go
@@ -39,5 +39,14 @@ Example to Create a new Interface attachment on the Server
 	if err != nil {
 		panic(err)
 	}
+
+Example to Delete an Interface attachment from the Server
+
+	interfaceID = "0dde1598-b374-474e-986f-5b8dd1df1d4e"
+	serverID := "b07e7a3b-d951-4efc-a4f9-ac9f001afb7f"
+	err := attachinterfaces.Delete(computeClient, serverID, interfaceID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
 */
 package attachinterfaces

--- a/openstack/compute/v2/extensions/attachinterfaces/doc.go
+++ b/openstack/compute/v2/extensions/attachinterfaces/doc.go
@@ -42,9 +42,9 @@ Example to Create a new Interface attachment on the Server
 
 Example to Delete an Interface attachment from the Server
 
-	interfaceID = "0dde1598-b374-474e-986f-5b8dd1df1d4e"
+	portID = "0dde1598-b374-474e-986f-5b8dd1df1d4e"
 	serverID := "b07e7a3b-d951-4efc-a4f9-ac9f001afb7f"
-	err := attachinterfaces.Delete(computeClient, serverID, interfaceID).ExtractErr()
+	err := attachinterfaces.Delete(computeClient, serverID, portID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/compute/v2/extensions/attachinterfaces/requests.go
+++ b/openstack/compute/v2/extensions/attachinterfaces/requests.go
@@ -63,3 +63,10 @@ func Create(client *gophercloud.ServiceClient, serverID string, opts CreateOptsB
 	})
 	return
 }
+
+// Delete makes a request against the nova API to detach a single interface from the server.
+// It needs server and port IDs to make a such request.
+func Delete(client *gophercloud.ServiceClient, serverID, portID string) (r DeleteResult) {
+	_, r.Err = client.Delete(deleteInterfaceURL(client, serverID, portID), nil)
+	return
+}

--- a/openstack/compute/v2/extensions/attachinterfaces/results.go
+++ b/openstack/compute/v2/extensions/attachinterfaces/results.go
@@ -30,6 +30,12 @@ type CreateResult struct {
 	attachInterfaceResult
 }
 
+// DeleteResult is the response from a Delete operation. Call its ExtractErr
+// method to determine if the call succeeded or failed.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
 // FixedIP represents a Fixed IP Address.
 type FixedIP struct {
 	SubnetID  string `json:"subnet_id"`

--- a/openstack/compute/v2/extensions/attachinterfaces/testing/fixtures.go
+++ b/openstack/compute/v2/extensions/attachinterfaces/testing/fixtures.go
@@ -150,3 +150,13 @@ func HandleInterfaceCreateSuccessfully(t *testing.T) {
 		}`)
 	})
 }
+
+// HandleInterfaceDeleteSuccessfully sets up the test server to respond to a DeleteInterface request.
+func HandleInterfaceDeleteSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/servers/b07e7a3b-d951-4efc-a4f9-ac9f001afb7f/os-interface/0dde1598-b374-474e-986f-5b8dd1df1d4e", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.WriteHeader(http.StatusAccepted)
+	})
+}

--- a/openstack/compute/v2/extensions/attachinterfaces/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/attachinterfaces/testing/requests_test.go
@@ -82,8 +82,8 @@ func TestDeleteInterface(t *testing.T) {
 	HandleInterfaceDeleteSuccessfully(t)
 
 	serverID := "b07e7a3b-d951-4efc-a4f9-ac9f001afb7f"
-	interfaceID := "0dde1598-b374-474e-986f-5b8dd1df1d4e"
+	portID := "0dde1598-b374-474e-986f-5b8dd1df1d4e"
 
-	err := attachinterfaces.Delete(client.ServiceClient(), serverID, interfaceID).ExtractErr()
+	err := attachinterfaces.Delete(client.ServiceClient(), serverID, portID).ExtractErr()
 	th.AssertNoErr(t, err)
 }

--- a/openstack/compute/v2/extensions/attachinterfaces/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/attachinterfaces/testing/requests_test.go
@@ -75,3 +75,15 @@ func TestCreateInterface(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.CheckDeepEquals(t, &expected, actual)
 }
+
+func TestDeleteInterface(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleInterfaceDeleteSuccessfully(t)
+
+	serverID := "b07e7a3b-d951-4efc-a4f9-ac9f001afb7f"
+	interfaceID := "0dde1598-b374-474e-986f-5b8dd1df1d4e"
+
+	err := attachinterfaces.Delete(client.ServiceClient(), serverID, interfaceID).ExtractErr()
+	th.AssertNoErr(t, err)
+}

--- a/openstack/compute/v2/extensions/attachinterfaces/urls.go
+++ b/openstack/compute/v2/extensions/attachinterfaces/urls.go
@@ -13,3 +13,6 @@ func getInterfaceURL(client *gophercloud.ServiceClient, serverID, portID string)
 func createInterfaceURL(client *gophercloud.ServiceClient, serverID string) string {
 	return client.ServiceURL("servers", serverID, "os-interface")
 }
+func deleteInterfaceURL(client *gophercloud.ServiceClient, serverID, portID string) string {
+	return client.ServiceURL("servers", serverID, "os-interface", portID)
+}


### PR DESCRIPTION
Add support to detach interface from a server through a DELETE on: /v2.1/{tenant_id}/servers/{server_id}/os-interface/{port_id}

The same operation with the OpenStack CLI is done with:
  nova interface-detach <server_id> <port_id>

For #641 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/nova/blob/stable/pike/nova/api/openstack/compute/attach_interfaces.py#L161