### PR TITLE
fix reauth deadlock by not calling Token() during reauth

### DIFF
--- a/provider_client.go
+++ b/provider_client.go
@@ -73,14 +73,24 @@ type ProviderClient struct {
 
 	mut *sync.RWMutex
 
-	isreauthing bool
+	reauthmut *reauthlock
+}
+
+type reauthlock struct {
+	sync.RWMutex
+	reauthing bool
 }
 
 // AuthenticatedHeaders returns a map of HTTP headers that are common for all
 // authenticated service requests.
 func (client *ProviderClient) AuthenticatedHeaders() (m map[string]string) {
-	if client.isreauthing {
-		return
+	if client.reauthmut != nil {
+		client.reauthmut.RLock()
+		if client.reauthmut.reauthing {
+			client.reauthmut.RUnlock()
+			return
+		}
+		client.reauthmut.RUnlock()
 	}
 	t := client.Token()
 	if t == "" {
@@ -93,6 +103,7 @@ func (client *ProviderClient) AuthenticatedHeaders() (m map[string]string) {
 // If the application's ProviderClient is not used concurrently, this doesn't need to be called.
 func (client *ProviderClient) UseTokenLock() {
 	client.mut = new(sync.RWMutex)
+	client.reauthmut = new(reauthlock)
 }
 
 // Token safely reads the value of the auth token from the ProviderClient. Applications should
@@ -245,11 +256,15 @@ func (client *ProviderClient) Request(method, url string, options *RequestOpts) 
 			if client.ReauthFunc != nil {
 				if client.mut != nil {
 					client.mut.Lock()
-					client.isreauthing = true
+					client.reauthmut.Lock()
+					client.reauthmut.reauthing = true
+					client.reauthmut.Unlock()
 					if curtok := client.TokenID; curtok == prereqtok {
 						err = client.ReauthFunc()
 					}
-					client.isreauthing = false
+					client.reauthmut.Lock()
+					client.reauthmut.reauthing = false
+					client.reauthmut.Unlock()
 					client.mut.Unlock()
 				} else {
 					err = client.ReauthFunc()

--- a/testing/provider_client_test.go
+++ b/testing/provider_client_test.go
@@ -60,6 +60,7 @@ func TestConcurrentReauth(t *testing.T) {
 	p.SetToken(prereauthTok)
 	p.ReauthFunc = func() error {
 		time.Sleep(1 * time.Second)
+		p.AuthenticatedHeaders()
 		info.mut.Lock()
 		info.numreauths++
 		info.mut.Unlock()


### PR DESCRIPTION
For #645 
