### PR TITLE
Add basic CRUD support in V3 volume types

### DIFF
--- a/openstack/blockstorage/v3/volumetypes/doc.go
+++ b/openstack/blockstorage/v3/volumetypes/doc.go
@@ -1,0 +1,4 @@
+// Package volumetypes provides information and interaction with volume types in the
+// OpenStack Block Storage service. A volume type is a collection of specs used to
+// define the volume capabilities.
+package volumetypes

--- a/openstack/blockstorage/v3/volumetypes/requests.go
+++ b/openstack/blockstorage/v3/volumetypes/requests.go
@@ -1,0 +1,102 @@
+package volumetypes
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToVolumeTypeCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts contains options for creating a Volume Type. This object is passed to
+// the volumetypes.Create function. For more information about these parameters,
+// see the Volume Type object.
+type CreateOpts struct {
+	// The name of the volume type
+	Name string `json:"name" required:"true"`
+	// The volume type description
+	Description string `json:"description,omitempty"`
+	// the ID of the existing volume snapshot
+	IsPublic bool `json:"is_public"`
+}
+
+// ToVolumeTypeCreateMap assembles a request body based on the contents of a
+// CreateOpts.
+func (opts CreateOpts) ToVolumeTypeCreateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "volume_type")
+}
+
+// Create will create a new Volume Type based on the values in CreateOpts. To extract
+// the Volume Type object from the response, call the Extract method on the
+// CreateResult.
+func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToVolumeTypeCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(createURL(client), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// Delete will delete the existing Volume Type with the provided ID.
+func Delete(client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+	_, r.Err = client.Delete(deleteURL(client, id), nil)
+	return
+}
+
+// Get retrieves the Volume Type with the provided ID. To extract the Volume Type object
+// from the response, call the Extract method on the GetResult.
+func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {
+	_, r.Err = client.Get(getURL(client, id), &r.Body, nil)
+	return
+}
+
+// List returns Volume types.
+func List(client *gophercloud.ServiceClient) pagination.Pager {
+	url := listURL(client)
+
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return VolumeTypePage{pagination.SinglePageBase(r)}
+	})
+}
+
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
+type UpdateOptsBuilder interface {
+	ToVolumeTypeUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts contain options for updating an existing Volume Type. This object is passed
+// to the volumetypes.Update function. For more information about the parameters, see
+// the Volume Type object.
+type UpdateOpts struct {
+	Name        string `json:"name,omitempty"`
+	Description string `json:"description,omitempty"`
+	IsPublic    bool   `json:"is_public"`
+}
+
+// ToVolumeUpdateMap assembles a request body based on the contents of an
+// UpdateOpts.
+func (opts UpdateOpts) ToVolumeTypeUpdateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "volume_type")
+}
+
+// Update will update the Volume Type with provided information. To extract the updated
+// Volume Type from the response, call the Extract method on the UpdateResult.
+func Update(client *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToVolumeTypeUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Put(updateURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}

--- a/openstack/blockstorage/v3/volumetypes/results.go
+++ b/openstack/blockstorage/v3/volumetypes/results.go
@@ -1,0 +1,96 @@
+package volumetypes
+
+import (
+	"encoding/json"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// Volume Type contains all the information associated with an OpenStack Volume Type.
+type VolumeType struct {
+	// Unique identifier for the volume type.
+	ID string `json:"id"`
+	// Human-readable display name for the volume type.
+	Name string `json:"name"`
+	// Human-readable description for the volume type.
+	Description string `json:"description"`
+	// Arbitrary key-value pairs defined by the user.
+	ExtraSpecs map[string]string `json:"extra_specs"`
+	// Whether the volume type is publicly visible.
+	IsPublic bool `json:"is_public"`
+}
+
+// UnmarshalJSON another unmarshalling function
+func (r *VolumeType) UnmarshalJSON(b []byte) error {
+	type tmp VolumeType
+	var s struct {
+		tmp
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+
+	*r = VolumeType(s.tmp)
+	return nil
+}
+
+// VolumeTypePage is a pagination.pager that is returned from a call to the List function.
+type VolumeTypePage struct {
+	pagination.SinglePageBase
+}
+
+// IsEmpty returns true if a ListResult contains no Volume Types.
+func (r VolumeTypePage) IsEmpty() (bool, error) {
+	volumes, err := ExtractVolumeTypes(r)
+	return len(volumes) == 0, err
+}
+
+// ExtractVolumeTypes extracts and returns Volumes. It is used while iterating over a volumetypes.List call.
+func ExtractVolumeTypes(r pagination.Page) ([]VolumeType, error) {
+	var s []VolumeType
+	err := ExtractVolumeTypesInto(r, &s)
+	return s, err
+}
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// Extract will get the Volume Type object out of the commonResult object.
+func (r commonResult) Extract() (*VolumeType, error) {
+	var s VolumeType
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+// ExtractInto converts our response data into a volume type struct
+func (r commonResult) ExtractInto(v interface{}) error {
+	return r.Result.ExtractIntoStructPtr(v, "volume_type")
+}
+
+// ExtractVolumesInto similar to ExtractInto but operates on a `list` of volume types
+func ExtractVolumeTypesInto(r pagination.Page, v interface{}) error {
+	return r.(VolumeTypePage).Result.ExtractIntoSlicePtr(v, "volume_types")
+}
+
+// CreateResult contains the response body and error from a Create request.
+type CreateResult struct {
+	commonResult
+}
+
+// GetResult contains the response body and error from a Get request.
+type GetResult struct {
+	commonResult
+}
+
+// UpdateResult contains the response body and error from an Update request.
+type UpdateResult struct {
+	commonResult
+}
+
+// DeleteResult contains the response body and error from a Delete request.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}

--- a/openstack/blockstorage/v3/volumetypes/testing/doc.go
+++ b/openstack/blockstorage/v3/volumetypes/testing/doc.go
@@ -1,0 +1,2 @@
+// volume_types
+package testing

--- a/openstack/blockstorage/v3/volumetypes/testing/fixtures.go
+++ b/openstack/blockstorage/v3/volumetypes/testing/fixtures.go
@@ -1,0 +1,128 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	th "github.com/gophercloud/gophercloud/testhelper"
+	fake "github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func MockListResponse(t *testing.T) {
+	th.Mux.HandleFunc("/types", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, `
+{
+    "volume_types": [
+        {
+            "name": "SSD",
+            "qos_specs_id": null,
+            "extra_specs": {
+                "volume_backend_name": "lvmdriver-1"
+            },
+            "is_public": true,
+            "id": "6685584b-1eac-4da6-b5c3-555430cf68ff",
+            "description": null
+        },
+        {
+            "name": "SATA",
+            "qos_specs_id": null,
+            "extra_specs": {
+                "volume_backend_name": "lvmdriver-1"
+            },
+            "is_public": true,
+            "id": "8eb69a46-df97-4e41-9586-9a40a7533803",
+            "description": null
+        }
+    ]
+}
+  `)
+	})
+}
+
+func MockGetResponse(t *testing.T) {
+	th.Mux.HandleFunc("/types/d32019d3-bc6e-4319-9c1d-6722fc136a22", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, `
+{
+    "volume_type": {
+        "id": "d32019d3-bc6e-4319-9c1d-6722fc136a22",
+        "name": "vol-type-001",
+        "description": "volume type 001",
+        "is_public": true,
+        "extra_specs": {
+            "capabilities": "gpu"
+        }
+    }
+}
+`)
+	})
+}
+
+func MockCreateResponse(t *testing.T) {
+	th.Mux.HandleFunc("/types", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, `
+{
+    "volume_type": {
+        "name": "test_type",
+        "is_public": true,
+        "description": "test_type_desc"
+    }
+}
+      `)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, `
+{
+    "volume_type": {
+        "name": "test_type",
+        "extra_specs": {},
+        "is_public": true,
+        "id": "6d0ff92a-0007-4780-9ece-acfe5876966a",
+        "description": "test_type_desc"
+    }
+}
+    `)
+	})
+}
+
+func MockDeleteResponse(t *testing.T) {
+	th.Mux.HandleFunc("/types/d32019d3-bc6e-4319-9c1d-6722fc136a22", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.WriteHeader(http.StatusAccepted)
+	})
+}
+
+func MockUpdateResponse(t *testing.T) {
+	th.Mux.HandleFunc("/types/d32019d3-bc6e-4319-9c1d-6722fc136a22", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, `
+{
+    "volume_type": {
+        "name": "vol-type-002",
+        "description": "volume type 0001",
+        "is_public": true,
+		"id": "d32019d3-bc6e-4319-9c1d-6722fc136a22"
+    }
+}`)
+	})
+}

--- a/openstack/blockstorage/v3/volumetypes/testing/requests_test.go
+++ b/openstack/blockstorage/v3/volumetypes/testing/requests_test.go
@@ -1,0 +1,90 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumetypes"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func TestListAll(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockListResponse(t)
+
+	allPages, err := volumetypes.List(client.ServiceClient()).AllPages()
+	th.AssertNoErr(t, err)
+	actual, err := volumetypes.ExtractVolumeTypes(allPages)
+	th.AssertNoErr(t, err)
+
+	expected := []volumetypes.VolumeType{
+		{
+			ID:          "6685584b-1eac-4da6-b5c3-555430cf68ff",
+			Name:        "SSD",
+			ExtraSpecs:  map[string]string{"volume_backend_name": "lvmdriver-1"},
+			IsPublic:    true,
+			Description: "",
+		}, {
+			ID:          "8eb69a46-df97-4e41-9586-9a40a7533803",
+			Name:        "SATA",
+			ExtraSpecs:  map[string]string{"volume_backend_name": "lvmdriver-1"},
+			IsPublic:    true,
+			Description: "",
+		},
+	}
+	th.CheckDeepEquals(t, expected, actual)
+}
+
+func TestGet(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockGetResponse(t)
+
+	v, err := volumetypes.Get(client.ServiceClient(), "d32019d3-bc6e-4319-9c1d-6722fc136a22").Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, v.Name, "vol-type-001")
+	th.AssertEquals(t, v.ID, "d32019d3-bc6e-4319-9c1d-6722fc136a22")
+	th.AssertEquals(t, v.ExtraSpecs["capabilities"], "gpu")
+}
+
+func TestCreate(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockCreateResponse(t)
+
+	options := &volumetypes.CreateOpts{Name: "test_type", IsPublic: true, Description: "test_type_desc"}
+	n, err := volumetypes.Create(client.ServiceClient(), options).Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, n.Name, "test_type")
+	th.AssertEquals(t, n.Description, "test_type_desc")
+	th.AssertEquals(t, n.IsPublic, true)
+	th.AssertEquals(t, n.ID, "6d0ff92a-0007-4780-9ece-acfe5876966a")
+}
+
+func TestDelete(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockDeleteResponse(t)
+
+	res := volumetypes.Delete(client.ServiceClient(), "d32019d3-bc6e-4319-9c1d-6722fc136a22")
+	th.AssertNoErr(t, res.Err)
+}
+
+func TestUpdate(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockUpdateResponse(t)
+
+	options := volumetypes.UpdateOpts{Name: "vol-type-002"}
+	v, err := volumetypes.Update(client.ServiceClient(), "d32019d3-bc6e-4319-9c1d-6722fc136a22", options).Extract()
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, "vol-type-002", v.Name)
+}

--- a/openstack/blockstorage/v3/volumetypes/urls.go
+++ b/openstack/blockstorage/v3/volumetypes/urls.go
@@ -1,0 +1,23 @@
+package volumetypes
+
+import "github.com/gophercloud/gophercloud"
+
+func createURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("types")
+}
+
+func listURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("types")
+}
+
+func deleteURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("types", id)
+}
+
+func getURL(c *gophercloud.ServiceClient, id string) string {
+	return deleteURL(c, id)
+}
+
+func updateURL(c *gophercloud.ServiceClient, id string) string {
+	return deleteURL(c, id)
+}


### PR DESCRIPTION
Add Create/Delete/List/Update/Get support for volume type in volume V3.

For #649 

Volume types in [V3](https://developer.openstack.org/api-ref/block-storage/v3/#volume-types-types)
