### PR TITLE
Add CREATE support in V3 volume types

### DIFF
--- a/acceptance/openstack/blockstorage/v3/volumetypes_test.go
+++ b/acceptance/openstack/blockstorage/v3/volumetypes_test.go
@@ -44,3 +44,24 @@ func TestVolumeTypesList(t *testing.T) {
 		tools.PrintResource(t, vt)
 	}
 }
+
+func TestVolumeTypesCreate(t *testing.T) {
+	client, err := clients.NewBlockStorageV3Client()
+	if err != nil {
+		t.Fatalf("Unable to create a blockstorage client: %v", err)
+	}
+
+	createOpts := volumetypes.CreateOpts{
+		Name:         "create_from_gophercloud",
+		PublicAccess: true,
+		ExtraSpecs:   map[string]string{"volume_backend_name": "fake_backend_name"},
+		Description:  "create_from_gophercloud",
+	}
+
+	vt, err := volumetypes.Create(client, createOpts).Extract()
+	if err != nil {
+		t.Fatalf("Unable to create volumetype: %v", err)
+	}
+
+	tools.PrintResource(t, vt)
+}

--- a/openstack/blockstorage/v3/volumetypes/doc.go
+++ b/openstack/blockstorage/v3/volumetypes/doc.go
@@ -25,6 +25,18 @@ Example to show a Volume Type
 		panic(err)
 	}
 	fmt.Println(volumeType)
+
+Example to create a Volume Type
+
+	volumeType, err := volumetypes.Create(client, volumetypes.CreateOpts{
+		Name:"volume_type_001",
+		IsPublic:true,
+		Description:"description_001",
+	}).Extract()
+	if err != nil{
+		panic(err)
+	}
+	fmt.Println(volumeType)
 */
 
 package volumetypes

--- a/openstack/blockstorage/v3/volumetypes/requests.go
+++ b/openstack/blockstorage/v3/volumetypes/requests.go
@@ -20,7 +20,9 @@ type CreateOpts struct {
 	// The volume type description
 	Description string `json:"description,omitempty"`
 	// the ID of the existing volume snapshot
-	IsPublic bool `json:"is_public"`
+	PublicAccess bool `json:"os-volume-type-access:is_public"`
+	// Extra spec key-value pairs defined by the user.
+	ExtraSpecs map[string]string `json:"extra_specs"`
 }
 
 // ToVolumeTypeCreateMap assembles a request body based on the contents of a

--- a/openstack/blockstorage/v3/volumetypes/requests.go
+++ b/openstack/blockstorage/v3/volumetypes/requests.go
@@ -5,6 +5,45 @@ import (
 	"github.com/gophercloud/gophercloud/pagination"
 )
 
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToVolumeTypeCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts contains options for creating a Volume Type. This object is passed to
+// the volumetypes.Create function. For more information about these parameters,
+// see the Volume Type object.
+type CreateOpts struct {
+	// The name of the volume type
+	Name string `json:"name" required:"true"`
+	// The volume type description
+	Description string `json:"description,omitempty"`
+	// the ID of the existing volume snapshot
+	IsPublic bool `json:"is_public"`
+}
+
+// ToVolumeTypeCreateMap assembles a request body based on the contents of a
+// CreateOpts.
+func (opts CreateOpts) ToVolumeTypeCreateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "volume_type")
+}
+
+// Create will create a new Volume Type based on the values in CreateOpts. To extract
+// the Volume Type object from the response, call the Extract method on the
+// CreateResult.
+func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToVolumeTypeCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(createURL(client), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
 // Get retrieves the Volume Type with the provided ID. To extract the Volume Type object
 // from the response, call the Extract method on the GetResult.
 func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {

--- a/openstack/blockstorage/v3/volumetypes/results.go
+++ b/openstack/blockstorage/v3/volumetypes/results.go
@@ -77,3 +77,8 @@ func ExtractVolumeTypesInto(r pagination.Page, v interface{}) error {
 type GetResult struct {
 	commonResult
 }
+
+// CreateResult contains the response body and error from a Create request.
+type CreateResult struct {
+	commonResult
+}

--- a/openstack/blockstorage/v3/volumetypes/testing/fixtures.go
+++ b/openstack/blockstorage/v3/volumetypes/testing/fixtures.go
@@ -87,3 +87,36 @@ func MockGetResponse(t *testing.T) {
 `)
 	})
 }
+
+func MockCreateResponse(t *testing.T) {
+	th.Mux.HandleFunc("/types", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, `
+{
+    "volume_type": {
+        "name": "test_type",
+        "is_public": true,
+        "description": "test_type_desc"
+    }
+}
+      `)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, `
+{
+    "volume_type": {
+        "name": "test_type",
+        "extra_specs": {},
+        "is_public": true,
+        "id": "6d0ff92a-0007-4780-9ece-acfe5876966a",
+        "description": "test_type_desc"
+    }
+}
+    `)
+	})
+}

--- a/openstack/blockstorage/v3/volumetypes/testing/fixtures.go
+++ b/openstack/blockstorage/v3/volumetypes/testing/fixtures.go
@@ -98,8 +98,11 @@ func MockCreateResponse(t *testing.T) {
 {
     "volume_type": {
         "name": "test_type",
-        "is_public": true,
-        "description": "test_type_desc"
+        "os-volume-type-access:is_public": true,
+        "description": "test_type_desc",
+		"extra_specs": {
+            "capabilities": "gpu"
+        }
     }
 }
       `)
@@ -113,8 +116,12 @@ func MockCreateResponse(t *testing.T) {
         "name": "test_type",
         "extra_specs": {},
         "is_public": true,
+        "os-volume-type-access:is_public": true,
         "id": "6d0ff92a-0007-4780-9ece-acfe5876966a",
-        "description": "test_type_desc"
+        "description": "test_type_desc",
+		"extra_specs": {
+            "capabilities": "gpu"
+        }
     }
 }
     `)

--- a/openstack/blockstorage/v3/volumetypes/testing/requests_test.go
+++ b/openstack/blockstorage/v3/volumetypes/testing/requests_test.go
@@ -63,3 +63,19 @@ func TestGet(t *testing.T) {
 	th.AssertEquals(t, v.QosSpecID, "d32019d3-bc6e-4319-9c1d-6722fc136a22")
 	th.AssertEquals(t, v.PublicAccess, true)
 }
+
+func TestCreate(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockCreateResponse(t)
+
+	options := &volumetypes.CreateOpts{Name: "test_type", IsPublic: true, Description: "test_type_desc"}
+	n, err := volumetypes.Create(client.ServiceClient(), options).Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, n.Name, "test_type")
+	th.AssertEquals(t, n.Description, "test_type_desc")
+	th.AssertEquals(t, n.IsPublic, true)
+	th.AssertEquals(t, n.ID, "6d0ff92a-0007-4780-9ece-acfe5876966a")
+}

--- a/openstack/blockstorage/v3/volumetypes/testing/requests_test.go
+++ b/openstack/blockstorage/v3/volumetypes/testing/requests_test.go
@@ -70,12 +70,14 @@ func TestCreate(t *testing.T) {
 
 	MockCreateResponse(t)
 
-	options := &volumetypes.CreateOpts{Name: "test_type", IsPublic: true, Description: "test_type_desc"}
+	options := &volumetypes.CreateOpts{Name: "test_type", PublicAccess: true, Description: "test_type_desc", ExtraSpecs: map[string]string{"capabilities": "gpu"}}
 	n, err := volumetypes.Create(client.ServiceClient(), options).Extract()
 	th.AssertNoErr(t, err)
 
 	th.AssertEquals(t, n.Name, "test_type")
 	th.AssertEquals(t, n.Description, "test_type_desc")
 	th.AssertEquals(t, n.IsPublic, true)
+	th.AssertEquals(t, n.PublicAccess, true)
 	th.AssertEquals(t, n.ID, "6d0ff92a-0007-4780-9ece-acfe5876966a")
+	th.AssertEquals(t, n.ExtraSpecs["capabilities"], "gpu")
 }

--- a/openstack/blockstorage/v3/volumetypes/urls.go
+++ b/openstack/blockstorage/v3/volumetypes/urls.go
@@ -9,3 +9,7 @@ func listURL(c *gophercloud.ServiceClient) string {
 func getURL(c *gophercloud.ServiceClient, id string) string {
 	return c.ServiceURL("types", id)
 }
+
+func createURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("types")
+}


### PR DESCRIPTION
Add Create support for volume type in volume V3.

For #649 

**Document:**
Volume type create [V3](https://developer.openstack.org/api-ref/block-storage/v3/#create-a-volume-type)

**Code:**
Volume type create [V3](https://github.com/openstack/cinder/blob/master/cinder/api/contrib/types_manage.py#L51)

**Model:**
[Link](https://github.com/openstack/cinder/blob/master/cinder/db/sqlalchemy/models.py#L378)
