### PR TITLE
Add DELETE support in V3 volume types

### DIFF
--- a/acceptance/openstack/blockstorage/v3/volumetypes_test.go
+++ b/acceptance/openstack/blockstorage/v3/volumetypes_test.go
@@ -45,7 +45,7 @@ func TestVolumeTypesList(t *testing.T) {
 	}
 }
 
-func TestVolumeTypesCreate(t *testing.T) {
+func TestVolumeTypesCreateDestroy(t *testing.T) {
 	client, err := clients.NewBlockStorageV3Client()
 	if err != nil {
 		t.Fatalf("Unable to create a blockstorage client: %v", err)
@@ -64,4 +64,6 @@ func TestVolumeTypesCreate(t *testing.T) {
 	}
 
 	tools.PrintResource(t, vt)
+
+	defer volumetypes.Delete(client, vt.ID)
 }

--- a/openstack/blockstorage/v3/volumetypes/doc.go
+++ b/openstack/blockstorage/v3/volumetypes/doc.go
@@ -37,6 +37,14 @@ Example to create a Volume Type
 		panic(err)
 	}
 	fmt.Println(volumeType)
+
+Example to delete a Volume TYpe
+
+	typeID := "0fe36e73809d46aeae6705c39077b1b3"
+	err := volumetypes.Delete(client, typeID).ExtractErr()
+	if err != nil{
+		panic(err)
+	}
 */
 
 package volumetypes

--- a/openstack/blockstorage/v3/volumetypes/requests.go
+++ b/openstack/blockstorage/v3/volumetypes/requests.go
@@ -46,6 +46,12 @@ func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r Create
 	return
 }
 
+// Delete will delete the existing Volume Type with the provided ID.
+func Delete(client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+	_, r.Err = client.Delete(deleteURL(client, id), nil)
+	return
+}
+
 // Get retrieves the Volume Type with the provided ID. To extract the Volume Type object
 // from the response, call the Extract method on the GetResult.
 func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {

--- a/openstack/blockstorage/v3/volumetypes/results.go
+++ b/openstack/blockstorage/v3/volumetypes/results.go
@@ -82,3 +82,8 @@ type GetResult struct {
 type CreateResult struct {
 	commonResult
 }
+
+// DeleteResult contains the response body and error from a Delete request.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}

--- a/openstack/blockstorage/v3/volumetypes/testing/fixtures.go
+++ b/openstack/blockstorage/v3/volumetypes/testing/fixtures.go
@@ -127,3 +127,11 @@ func MockCreateResponse(t *testing.T) {
     `)
 	})
 }
+
+func MockDeleteResponse(t *testing.T) {
+	th.Mux.HandleFunc("/types/d32019d3-bc6e-4319-9c1d-6722fc136a22", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.WriteHeader(http.StatusAccepted)
+	})
+}

--- a/openstack/blockstorage/v3/volumetypes/testing/requests_test.go
+++ b/openstack/blockstorage/v3/volumetypes/testing/requests_test.go
@@ -80,4 +80,15 @@ func TestCreate(t *testing.T) {
 	th.AssertEquals(t, n.PublicAccess, true)
 	th.AssertEquals(t, n.ID, "6d0ff92a-0007-4780-9ece-acfe5876966a")
 	th.AssertEquals(t, n.ExtraSpecs["capabilities"], "gpu")
+	th.AssertEquals(t, n.ID, "6d0ff92a-0007-4780-9ece-acfe5876966a")
+}
+
+func TestDelete(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockDeleteResponse(t)
+
+	res := volumetypes.Delete(client.ServiceClient(), "d32019d3-bc6e-4319-9c1d-6722fc136a22")
+	th.AssertNoErr(t, res.Err)
 }

--- a/openstack/blockstorage/v3/volumetypes/testing/requests_test.go
+++ b/openstack/blockstorage/v3/volumetypes/testing/requests_test.go
@@ -80,7 +80,6 @@ func TestCreate(t *testing.T) {
 	th.AssertEquals(t, n.PublicAccess, true)
 	th.AssertEquals(t, n.ID, "6d0ff92a-0007-4780-9ece-acfe5876966a")
 	th.AssertEquals(t, n.ExtraSpecs["capabilities"], "gpu")
-	th.AssertEquals(t, n.ID, "6d0ff92a-0007-4780-9ece-acfe5876966a")
 }
 
 func TestDelete(t *testing.T) {

--- a/openstack/blockstorage/v3/volumetypes/urls.go
+++ b/openstack/blockstorage/v3/volumetypes/urls.go
@@ -17,4 +17,3 @@ func createURL(c *gophercloud.ServiceClient) string {
 func deleteURL(c *gophercloud.ServiceClient, id string) string {
 	return c.ServiceURL("types", id)
 }
-

--- a/openstack/blockstorage/v3/volumetypes/urls.go
+++ b/openstack/blockstorage/v3/volumetypes/urls.go
@@ -13,3 +13,8 @@ func getURL(c *gophercloud.ServiceClient, id string) string {
 func createURL(c *gophercloud.ServiceClient) string {
 	return c.ServiceURL("types")
 }
+
+func deleteURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("types", id)
+}
+


### PR DESCRIPTION
Add Delete support for volume type in volume V3.

For #649 

Volume type delete [V3](https://developer.openstack.org/api-ref/block-storage/v3/#delete-a-volume-type)