### PR TITLE
Add UPDATE support in V3 volume types

### DIFF
--- a/acceptance/openstack/blockstorage/v3/volumetypes_test.go
+++ b/acceptance/openstack/blockstorage/v3/volumetypes_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gophercloud/gophercloud/acceptance/clients"
 	"github.com/gophercloud/gophercloud/acceptance/tools"
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumetypes"
+	th "github.com/gophercloud/gophercloud/testhelper"
 )
 
 func TestVolumeTypesList(t *testing.T) {
@@ -45,7 +46,7 @@ func TestVolumeTypesList(t *testing.T) {
 	}
 }
 
-func TestVolumeTypesCreateDestroy(t *testing.T) {
+func TestVolumeTypesCRUD(t *testing.T) {
 	client, err := clients.NewBlockStorageV3Client()
 	if err != nil {
 		t.Fatalf("Unable to create a blockstorage client: %v", err)
@@ -66,4 +67,14 @@ func TestVolumeTypesCreateDestroy(t *testing.T) {
 	tools.PrintResource(t, vt)
 
 	defer volumetypes.Delete(client, vt.ID)
+
+	var isPublic = false
+
+	newVT, err := volumetypes.Update(client, vt.ID, volumetypes.UpdateOpts{
+		Name:     "updated_volume_type",
+		IsPublic: &isPublic,
+	}).Extract()
+	th.AssertEquals(t, "updated_volume_type", newVT.Name)
+
+	th.AssertEquals(t, false, newVT.IsPublic)
 }

--- a/openstack/blockstorage/v3/volumetypes/doc.go
+++ b/openstack/blockstorage/v3/volumetypes/doc.go
@@ -19,7 +19,7 @@ Example to list Volume Types
 
 Example to show a Volume Type
 
-	typeID := "0fe36e73809d46aeae6705c39077b1b3"
+	typeID := "7ffaca22-f646-41d4-b79d-d7e4452ef8cc"
 	volumeType, err := volumetypes.Get(client, typeID).Extract()
 	if err != nil{
 		panic(err)
@@ -38,13 +38,26 @@ Example to create a Volume Type
 	}
 	fmt.Println(volumeType)
 
-Example to delete a Volume TYpe
+Example to delete a Volume Type
 
-	typeID := "0fe36e73809d46aeae6705c39077b1b3"
+	typeID := "7ffaca22-f646-41d4-b79d-d7e4452ef8cc"
 	err := volumetypes.Delete(client, typeID).ExtractErr()
 	if err != nil{
 		panic(err)
 	}
+
+Example to update a Volume Type
+
+	typeID := "7ffaca22-f646-41d4-b79d-d7e4452ef8cc"
+	volumetype, err = volumetypes.Update(client, typeID, volumetypes.UpdateOpts{
+		Name: "volume_type_002",
+		Description:"description_002",
+		IsPublic:false,
+	}).Extract()
+	if err != nil{
+		panic(err)
+	}
+	fmt.Println(volumetype)
 */
 
 package volumetypes

--- a/openstack/blockstorage/v3/volumetypes/requests.go
+++ b/openstack/blockstorage/v3/volumetypes/requests.go
@@ -101,3 +101,38 @@ func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pa
 		return VolumeTypePage{pagination.LinkedPageBase{PageResult: r}}
 	})
 }
+
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
+type UpdateOptsBuilder interface {
+	ToVolumeTypeUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts contain options for updating an existing Volume Type. This object is passed
+// to the volumetypes.Update function. For more information about the parameters, see
+// the Volume Type object.
+type UpdateOpts struct {
+	Name        string `json:"name,omitempty"`
+	Description string `json:"description,omitempty"`
+	IsPublic    *bool  `json:"is_public,omitempty"`
+}
+
+// ToVolumeUpdateMap assembles a request body based on the contents of an
+// UpdateOpts.
+func (opts UpdateOpts) ToVolumeTypeUpdateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "volume_type")
+}
+
+// Update will update the Volume Type with provided information. To extract the updated
+// Volume Type from the response, call the Extract method on the UpdateResult.
+func Update(client *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToVolumeTypeUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Put(updateURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}

--- a/openstack/blockstorage/v3/volumetypes/results.go
+++ b/openstack/blockstorage/v3/volumetypes/results.go
@@ -87,3 +87,9 @@ type CreateResult struct {
 type DeleteResult struct {
 	gophercloud.ErrResult
 }
+
+// UpdateResult contains the response body and error from an Update request.
+type UpdateResult struct {
+	commonResult
+}
+

--- a/openstack/blockstorage/v3/volumetypes/results.go
+++ b/openstack/blockstorage/v3/volumetypes/results.go
@@ -92,4 +92,3 @@ type DeleteResult struct {
 type UpdateResult struct {
 	commonResult
 }
-

--- a/openstack/blockstorage/v3/volumetypes/testing/fixtures.go
+++ b/openstack/blockstorage/v3/volumetypes/testing/fixtures.go
@@ -135,3 +135,20 @@ func MockDeleteResponse(t *testing.T) {
 		w.WriteHeader(http.StatusAccepted)
 	})
 }
+
+func MockUpdateResponse(t *testing.T) {
+	th.Mux.HandleFunc("/types/d32019d3-bc6e-4319-9c1d-6722fc136a22", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, `
+{
+    "volume_type": {
+        "name": "vol-type-002",
+        "description": "volume type 0001",
+        "is_public": true,
+		"id": "d32019d3-bc6e-4319-9c1d-6722fc136a22"
+    }
+}`)
+	})
+}

--- a/openstack/blockstorage/v3/volumetypes/testing/requests_test.go
+++ b/openstack/blockstorage/v3/volumetypes/testing/requests_test.go
@@ -91,3 +91,15 @@ func TestDelete(t *testing.T) {
 	res := volumetypes.Delete(client.ServiceClient(), "d32019d3-bc6e-4319-9c1d-6722fc136a22")
 	th.AssertNoErr(t, res.Err)
 }
+
+func TestUpdate(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockUpdateResponse(t)
+
+	options := volumetypes.UpdateOpts{Name: "vol-type-002"}
+	v, err := volumetypes.Update(client.ServiceClient(), "d32019d3-bc6e-4319-9c1d-6722fc136a22", options).Extract()
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, "vol-type-002", v.Name)
+}

--- a/openstack/blockstorage/v3/volumetypes/testing/requests_test.go
+++ b/openstack/blockstorage/v3/volumetypes/testing/requests_test.go
@@ -98,8 +98,10 @@ func TestUpdate(t *testing.T) {
 
 	MockUpdateResponse(t)
 
-	options := volumetypes.UpdateOpts{Name: "vol-type-002"}
+	var isPublic = true
+	options := volumetypes.UpdateOpts{Name: "vol-type-002", IsPublic: &isPublic}
 	v, err := volumetypes.Update(client.ServiceClient(), "d32019d3-bc6e-4319-9c1d-6722fc136a22", options).Extract()
 	th.AssertNoErr(t, err)
 	th.CheckEquals(t, "vol-type-002", v.Name)
+	th.CheckEquals(t, true, v.IsPublic)
 }

--- a/openstack/blockstorage/v3/volumetypes/urls.go
+++ b/openstack/blockstorage/v3/volumetypes/urls.go
@@ -19,5 +19,5 @@ func deleteURL(c *gophercloud.ServiceClient, id string) string {
 }
 
 func updateURL(c *gophercloud.ServiceClient, id string) string {
-	return c.ServiceURL("types")
+	return c.ServiceURL("types", id)
 }

--- a/openstack/blockstorage/v3/volumetypes/urls.go
+++ b/openstack/blockstorage/v3/volumetypes/urls.go
@@ -17,3 +17,7 @@ func createURL(c *gophercloud.ServiceClient) string {
 func deleteURL(c *gophercloud.ServiceClient, id string) string {
 	return c.ServiceURL("types", id)
 }
+
+func updateURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("types")
+}


### PR DESCRIPTION
Add Update support for volume type in volume V3.

For #649 

Volume type update in [V3](https://developer.openstack.org/api-ref/block-storage/v3/#update-a-volume-type)

Volume type update [Code](https://github.com/openstack/cinder/blob/master/cinder/api/contrib/types_manage.py#L101)