### PR TITLE
Add List/Get support for volume type in volume V3

### DIFF
--- a/openstack/blockstorage/v3/volumetypes/doc.go
+++ b/openstack/blockstorage/v3/volumetypes/doc.go
@@ -1,4 +1,30 @@
-// Package volumetypes provides information and interaction with volume types in the
-// OpenStack Block Storage service. A volume type is a collection of specs used to
-// define the volume capabilities.
+/*
+Package volumetypes provides information and interaction with volume types in the
+OpenStack Block Storage service. A volume type is a collection of specs used to
+define the volume capabilities.
+
+Example to list Volume Types
+
+	allPages, err := volumetypes.List(client, volumetypes.ListOpts{}).AllPages()
+	if err != nil{
+		panic(err)
+	}
+	volumeTypes, err := volumetypes.ExtractVolumeTypes(allPages)
+	if err != nil{
+		panic(err)
+	}
+	for _,vt := range volumeTypes{
+		fmt.Println(vt)
+	}
+
+Example to show a Volume Type
+
+	typeID := "0fe36e73809d46aeae6705c39077b1b3"
+	volumeType, err := volumetypes.Get(client, typeID).Extract()
+	if err != nil{
+		panic(err)
+	}
+	fmt.Println(volumeType)
+*/
+
 package volumetypes

--- a/openstack/blockstorage/v3/volumetypes/doc.go
+++ b/openstack/blockstorage/v3/volumetypes/doc.go
@@ -1,0 +1,4 @@
+// Package volumetypes provides information and interaction with volume types in the
+// OpenStack Block Storage service. A volume type is a collection of specs used to
+// define the volume capabilities.
+package volumetypes

--- a/openstack/blockstorage/v3/volumetypes/requests.go
+++ b/openstack/blockstorage/v3/volumetypes/requests.go
@@ -1,0 +1,102 @@
+package volumetypes
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToVolumeTypeCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts contains options for creating a Volume Type. This object is passed to
+// the volumetypes.Create function. For more information about these parameters,
+// see the Volume Type object.
+type CreateOpts struct {
+	// The name of the volume type
+	Name string `json:"name" required:"true"`
+	// The volume type description
+	Description string `json:"description,omitempty"`
+	// the ID of the existing volume snapshot
+	IsPublic bool `json:"is_public"`
+}
+
+// ToVolumeTypeCreateMap assembles a request body based on the contents of a
+// CreateOpts.
+func (opts CreateOpts) ToVolumeTypeCreateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "volume_type")
+}
+
+// Create will create a new Volume Type based on the values in CreateOpts. To extract
+// the Volume Type object from the response, call the Extract method on the
+// CreateResult.
+func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToVolumeTypeCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(createURL(client), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// Delete will delete the existing Volume Type with the provided ID.
+func Delete(client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+	_, r.Err = client.Delete(deleteURL(client, id), nil)
+	return
+}
+
+// Get retrieves the Volume Type with the provided ID. To extract the Volume Type object
+// from the response, call the Extract method on the GetResult.
+func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {
+	_, r.Err = client.Get(getURL(client, id), &r.Body, nil)
+	return
+}
+
+// List returns Volume types.
+func List(client *gophercloud.ServiceClient) pagination.Pager {
+	url := listURL(client)
+
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return VolumeTypePage{pagination.SinglePageBase(r)}
+	})
+}
+
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
+type UpdateOptsBuilder interface {
+	ToVolumeTypeUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts contain options for updating an existing Volume Type. This object is passed
+// to the volumetypes.Update function. For more information about the parameters, see
+// the Volume Type object.
+type UpdateOpts struct {
+	Name        string `json:"name,omitempty"`
+	Description string `json:"description,omitempty"`
+	IsPublic    bool   `json:"is_public"`
+}
+
+// ToVolumeUpdateMap assembles a request body based on the contents of an
+// UpdateOpts.
+func (opts UpdateOpts) ToVolumeTypeUpdateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "volume_type")
+}
+
+// Update will update the Volume Type with provided information. To extract the updated
+// Volume Type from the response, call the Extract method on the UpdateResult.
+func Update(client *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToVolumeTypeUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Put(updateURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}

--- a/openstack/blockstorage/v3/volumetypes/requests.go
+++ b/openstack/blockstorage/v3/volumetypes/requests.go
@@ -5,51 +5,6 @@ import (
 	"github.com/gophercloud/gophercloud/pagination"
 )
 
-// CreateOptsBuilder allows extensions to add additional parameters to the
-// Create request.
-type CreateOptsBuilder interface {
-	ToVolumeTypeCreateMap() (map[string]interface{}, error)
-}
-
-// CreateOpts contains options for creating a Volume Type. This object is passed to
-// the volumetypes.Create function. For more information about these parameters,
-// see the Volume Type object.
-type CreateOpts struct {
-	// The name of the volume type
-	Name string `json:"name" required:"true"`
-	// The volume type description
-	Description string `json:"description,omitempty"`
-	// the ID of the existing volume snapshot
-	IsPublic bool `json:"is_public"`
-}
-
-// ToVolumeTypeCreateMap assembles a request body based on the contents of a
-// CreateOpts.
-func (opts CreateOpts) ToVolumeTypeCreateMap() (map[string]interface{}, error) {
-	return gophercloud.BuildRequestBody(opts, "volume_type")
-}
-
-// Create will create a new Volume Type based on the values in CreateOpts. To extract
-// the Volume Type object from the response, call the Extract method on the
-// CreateResult.
-func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
-	b, err := opts.ToVolumeTypeCreateMap()
-	if err != nil {
-		r.Err = err
-		return
-	}
-	_, r.Err = client.Post(createURL(client), b, &r.Body, &gophercloud.RequestOpts{
-		OkCodes: []int{200},
-	})
-	return
-}
-
-// Delete will delete the existing Volume Type with the provided ID.
-func Delete(client *gophercloud.ServiceClient, id string) (r DeleteResult) {
-	_, r.Err = client.Delete(deleteURL(client, id), nil)
-	return
-}
-
 // Get retrieves the Volume Type with the provided ID. To extract the Volume Type object
 // from the response, call the Extract method on the GetResult.
 func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {
@@ -57,46 +12,45 @@ func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {
 	return
 }
 
+// ListOptsBuilder allows extensions to add additional parameters to the List
+// request.
+type ListOptsBuilder interface {
+	ToVolumeTypeListQuery() (string, error)
+}
+
+// ListOpts holds options for listing Volume Types. It is passed to the volumetypes.List
+// function.
+type ListOpts struct {
+	// Comma-separated list of sort keys and optional sort directions in the
+	// form of <key>[:<direction>].
+	Sort string `q:"sort"`
+	// Requests a page size of items.
+	Limit int `q:"limit"`
+	// Used in conjunction with limit to return a slice of items.
+	Offset int `q:"offset"`
+	// The ID of the last-seen item.
+	Marker string `q:"marker"`
+}
+
+// ToVolumeTypeListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToVolumeTypeListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
 // List returns Volume types.
-func List(client *gophercloud.ServiceClient) pagination.Pager {
+func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(client)
 
-	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
-		return VolumeTypePage{pagination.SinglePageBase(r)}
-	})
-}
-
-// UpdateOptsBuilder allows extensions to add additional parameters to the
-// Update request.
-type UpdateOptsBuilder interface {
-	ToVolumeTypeUpdateMap() (map[string]interface{}, error)
-}
-
-// UpdateOpts contain options for updating an existing Volume Type. This object is passed
-// to the volumetypes.Update function. For more information about the parameters, see
-// the Volume Type object.
-type UpdateOpts struct {
-	Name        string `json:"name,omitempty"`
-	Description string `json:"description,omitempty"`
-	IsPublic    bool   `json:"is_public"`
-}
-
-// ToVolumeUpdateMap assembles a request body based on the contents of an
-// UpdateOpts.
-func (opts UpdateOpts) ToVolumeTypeUpdateMap() (map[string]interface{}, error) {
-	return gophercloud.BuildRequestBody(opts, "volume_type")
-}
-
-// Update will update the Volume Type with provided information. To extract the updated
-// Volume Type from the response, call the Extract method on the UpdateResult.
-func Update(client *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
-	b, err := opts.ToVolumeTypeUpdateMap()
-	if err != nil {
-		r.Err = err
-		return
+	if opts != nil {
+		query, err := opts.ToVolumeTypeListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
 	}
-	_, r.Err = client.Put(updateURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
-		OkCodes: []int{200},
+
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return VolumeTypePage{pagination.LinkedPageBase{PageResult: r}}
 	})
-	return
 }

--- a/openstack/blockstorage/v3/volumetypes/results.go
+++ b/openstack/blockstorage/v3/volumetypes/results.go
@@ -1,0 +1,96 @@
+package volumetypes
+
+import (
+	"encoding/json"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// Volume Type contains all the information associated with an OpenStack Volume Type.
+type VolumeType struct {
+	// Unique identifier for the volume type.
+	ID string `json:"id"`
+	// Human-readable display name for the volume type.
+	Name string `json:"name"`
+	// Human-readable description for the volume type.
+	Description string `json:"description"`
+	// Arbitrary key-value pairs defined by the user.
+	ExtraSpecs map[string]string `json:"extra_specs"`
+	// Whether the volume type is publicly visible.
+	IsPublic bool `json:"is_public"`
+}
+
+// UnmarshalJSON another unmarshalling function
+func (r *VolumeType) UnmarshalJSON(b []byte) error {
+	type tmp VolumeType
+	var s struct {
+		tmp
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+
+	*r = VolumeType(s.tmp)
+	return nil
+}
+
+// VolumeTypePage is a pagination.pager that is returned from a call to the List function.
+type VolumeTypePage struct {
+	pagination.SinglePageBase
+}
+
+// IsEmpty returns true if a ListResult contains no Volume Types.
+func (r VolumeTypePage) IsEmpty() (bool, error) {
+	volumes, err := ExtractVolumeTypes(r)
+	return len(volumes) == 0, err
+}
+
+// ExtractVolumeTypes extracts and returns Volumes. It is used while iterating over a volumetypes.List call.
+func ExtractVolumeTypes(r pagination.Page) ([]VolumeType, error) {
+	var s []VolumeType
+	err := ExtractVolumeTypesInto(r, &s)
+	return s, err
+}
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// Extract will get the Volume Type object out of the commonResult object.
+func (r commonResult) Extract() (*VolumeType, error) {
+	var s VolumeType
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+// ExtractInto converts our response data into a volume type struct
+func (r commonResult) ExtractInto(v interface{}) error {
+	return r.Result.ExtractIntoStructPtr(v, "volume_type")
+}
+
+// ExtractVolumesInto similar to ExtractInto but operates on a `list` of volume types
+func ExtractVolumeTypesInto(r pagination.Page, v interface{}) error {
+	return r.(VolumeTypePage).Result.ExtractIntoSlicePtr(v, "volume_types")
+}
+
+// CreateResult contains the response body and error from a Create request.
+type CreateResult struct {
+	commonResult
+}
+
+// GetResult contains the response body and error from a Get request.
+type GetResult struct {
+	commonResult
+}
+
+// UpdateResult contains the response body and error from an Update request.
+type UpdateResult struct {
+	commonResult
+}
+
+// DeleteResult contains the response body and error from a Delete request.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}

--- a/openstack/blockstorage/v3/volumetypes/results.go
+++ b/openstack/blockstorage/v3/volumetypes/results.go
@@ -1,8 +1,6 @@
 package volumetypes
 
 import (
-	"encoding/json"
-
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/pagination"
 )
@@ -19,32 +17,32 @@ type VolumeType struct {
 	ExtraSpecs map[string]string `json:"extra_specs"`
 	// Whether the volume type is publicly visible.
 	IsPublic bool `json:"is_public"`
-}
-
-// UnmarshalJSON another unmarshalling function
-func (r *VolumeType) UnmarshalJSON(b []byte) error {
-	type tmp VolumeType
-	var s struct {
-		tmp
-	}
-	err := json.Unmarshal(b, &s)
-	if err != nil {
-		return err
-	}
-
-	*r = VolumeType(s.tmp)
-	return nil
+	// Qos Spec ID
+	QosSpecID string `json:"qos_specs_id"`
+	// Volume Type access public attribute
+	PublicAccess bool `json:"os-volume-type-access:is_public"`
 }
 
 // VolumeTypePage is a pagination.pager that is returned from a call to the List function.
 type VolumeTypePage struct {
-	pagination.SinglePageBase
+	pagination.LinkedPageBase
 }
 
 // IsEmpty returns true if a ListResult contains no Volume Types.
 func (r VolumeTypePage) IsEmpty() (bool, error) {
-	volumes, err := ExtractVolumeTypes(r)
-	return len(volumes) == 0, err
+	volumetypes, err := ExtractVolumeTypes(r)
+	return len(volumetypes) == 0, err
+}
+
+func (page VolumeTypePage) NextPageURL() (string, error) {
+	var s struct {
+		Links []gophercloud.Link `json:"volume_type_links"`
+	}
+	err := page.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return gophercloud.ExtractNextURL(s.Links)
 }
 
 // ExtractVolumeTypes extracts and returns Volumes. It is used while iterating over a volumetypes.List call.
@@ -75,22 +73,7 @@ func ExtractVolumeTypesInto(r pagination.Page, v interface{}) error {
 	return r.(VolumeTypePage).Result.ExtractIntoSlicePtr(v, "volume_types")
 }
 
-// CreateResult contains the response body and error from a Create request.
-type CreateResult struct {
-	commonResult
-}
-
 // GetResult contains the response body and error from a Get request.
 type GetResult struct {
 	commonResult
-}
-
-// UpdateResult contains the response body and error from an Update request.
-type UpdateResult struct {
-	commonResult
-}
-
-// DeleteResult contains the response body and error from a Delete request.
-type DeleteResult struct {
-	gophercloud.ErrResult
 }

--- a/openstack/blockstorage/v3/volumetypes/testing/doc.go
+++ b/openstack/blockstorage/v3/volumetypes/testing/doc.go
@@ -1,0 +1,2 @@
+// volume_types
+package testing

--- a/openstack/blockstorage/v3/volumetypes/testing/fixtures.go
+++ b/openstack/blockstorage/v3/volumetypes/testing/fixtures.go
@@ -1,0 +1,128 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	th "github.com/gophercloud/gophercloud/testhelper"
+	fake "github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func MockListResponse(t *testing.T) {
+	th.Mux.HandleFunc("/types", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, `
+{
+    "volume_types": [
+        {
+            "name": "SSD",
+            "qos_specs_id": null,
+            "extra_specs": {
+                "volume_backend_name": "lvmdriver-1"
+            },
+            "is_public": true,
+            "id": "6685584b-1eac-4da6-b5c3-555430cf68ff",
+            "description": null
+        },
+        {
+            "name": "SATA",
+            "qos_specs_id": null,
+            "extra_specs": {
+                "volume_backend_name": "lvmdriver-1"
+            },
+            "is_public": true,
+            "id": "8eb69a46-df97-4e41-9586-9a40a7533803",
+            "description": null
+        }
+    ]
+}
+  `)
+	})
+}
+
+func MockGetResponse(t *testing.T) {
+	th.Mux.HandleFunc("/types/d32019d3-bc6e-4319-9c1d-6722fc136a22", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, `
+{
+    "volume_type": {
+        "id": "d32019d3-bc6e-4319-9c1d-6722fc136a22",
+        "name": "vol-type-001",
+        "description": "volume type 001",
+        "is_public": true,
+        "extra_specs": {
+            "capabilities": "gpu"
+        }
+    }
+}
+`)
+	})
+}
+
+func MockCreateResponse(t *testing.T) {
+	th.Mux.HandleFunc("/types", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, `
+{
+    "volume_type": {
+        "name": "test_type",
+        "is_public": true,
+        "description": "test_type_desc"
+    }
+}
+      `)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, `
+{
+    "volume_type": {
+        "name": "test_type",
+        "extra_specs": {},
+        "is_public": true,
+        "id": "6d0ff92a-0007-4780-9ece-acfe5876966a",
+        "description": "test_type_desc"
+    }
+}
+    `)
+	})
+}
+
+func MockDeleteResponse(t *testing.T) {
+	th.Mux.HandleFunc("/types/d32019d3-bc6e-4319-9c1d-6722fc136a22", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.WriteHeader(http.StatusAccepted)
+	})
+}
+
+func MockUpdateResponse(t *testing.T) {
+	th.Mux.HandleFunc("/types/d32019d3-bc6e-4319-9c1d-6722fc136a22", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, `
+{
+    "volume_type": {
+        "name": "vol-type-002",
+        "description": "volume type 0001",
+        "is_public": true,
+		"id": "d32019d3-bc6e-4319-9c1d-6722fc136a22"
+    }
+}`)
+	})
+}

--- a/openstack/blockstorage/v3/volumetypes/testing/requests_test.go
+++ b/openstack/blockstorage/v3/volumetypes/testing/requests_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumetypes"
+	"github.com/gophercloud/gophercloud/pagination"
 	th "github.com/gophercloud/gophercloud/testhelper"
 	"github.com/gophercloud/gophercloud/testhelper/client"
 )
@@ -13,28 +14,38 @@ func TestListAll(t *testing.T) {
 	defer th.TeardownHTTP()
 
 	MockListResponse(t)
-
-	allPages, err := volumetypes.List(client.ServiceClient()).AllPages()
+	pages := 0
+	err := volumetypes.List(client.ServiceClient(), nil).EachPage(func(page pagination.Page) (bool, error) {
+		pages++
+		actual, err := volumetypes.ExtractVolumeTypes(page)
+		if err != nil {
+			return false, err
+		}
+		expected := []volumetypes.VolumeType{
+			{
+				ID:           "6685584b-1eac-4da6-b5c3-555430cf68ff",
+				Name:         "SSD",
+				ExtraSpecs:   map[string]string{"volume_backend_name": "lvmdriver-1"},
+				IsPublic:     true,
+				Description:  "",
+				QosSpecID:    "",
+				PublicAccess: true,
+			}, {
+				ID:           "8eb69a46-df97-4e41-9586-9a40a7533803",
+				Name:         "SATA",
+				ExtraSpecs:   map[string]string{"volume_backend_name": "lvmdriver-1"},
+				IsPublic:     true,
+				Description:  "",
+				QosSpecID:    "",
+				PublicAccess: true,
+			},
+		}
+		th.CheckDeepEquals(t, expected, actual)
+		return true, nil
+	})
 	th.AssertNoErr(t, err)
-	actual, err := volumetypes.ExtractVolumeTypes(allPages)
-	th.AssertNoErr(t, err)
+	th.AssertEquals(t, pages, 1)
 
-	expected := []volumetypes.VolumeType{
-		{
-			ID:          "6685584b-1eac-4da6-b5c3-555430cf68ff",
-			Name:        "SSD",
-			ExtraSpecs:  map[string]string{"volume_backend_name": "lvmdriver-1"},
-			IsPublic:    true,
-			Description: "",
-		}, {
-			ID:          "8eb69a46-df97-4e41-9586-9a40a7533803",
-			Name:        "SATA",
-			ExtraSpecs:  map[string]string{"volume_backend_name": "lvmdriver-1"},
-			IsPublic:    true,
-			Description: "",
-		},
-	}
-	th.CheckDeepEquals(t, expected, actual)
 }
 
 func TestGet(t *testing.T) {
@@ -49,42 +60,6 @@ func TestGet(t *testing.T) {
 	th.AssertEquals(t, v.Name, "vol-type-001")
 	th.AssertEquals(t, v.ID, "d32019d3-bc6e-4319-9c1d-6722fc136a22")
 	th.AssertEquals(t, v.ExtraSpecs["capabilities"], "gpu")
-}
-
-func TestCreate(t *testing.T) {
-	th.SetupHTTP()
-	defer th.TeardownHTTP()
-
-	MockCreateResponse(t)
-
-	options := &volumetypes.CreateOpts{Name: "test_type", IsPublic: true, Description: "test_type_desc"}
-	n, err := volumetypes.Create(client.ServiceClient(), options).Extract()
-	th.AssertNoErr(t, err)
-
-	th.AssertEquals(t, n.Name, "test_type")
-	th.AssertEquals(t, n.Description, "test_type_desc")
-	th.AssertEquals(t, n.IsPublic, true)
-	th.AssertEquals(t, n.ID, "6d0ff92a-0007-4780-9ece-acfe5876966a")
-}
-
-func TestDelete(t *testing.T) {
-	th.SetupHTTP()
-	defer th.TeardownHTTP()
-
-	MockDeleteResponse(t)
-
-	res := volumetypes.Delete(client.ServiceClient(), "d32019d3-bc6e-4319-9c1d-6722fc136a22")
-	th.AssertNoErr(t, res.Err)
-}
-
-func TestUpdate(t *testing.T) {
-	th.SetupHTTP()
-	defer th.TeardownHTTP()
-
-	MockUpdateResponse(t)
-
-	options := volumetypes.UpdateOpts{Name: "vol-type-002"}
-	v, err := volumetypes.Update(client.ServiceClient(), "d32019d3-bc6e-4319-9c1d-6722fc136a22", options).Extract()
-	th.AssertNoErr(t, err)
-	th.CheckEquals(t, "vol-type-002", v.Name)
+	th.AssertEquals(t, v.QosSpecID, "d32019d3-bc6e-4319-9c1d-6722fc136a22")
+	th.AssertEquals(t, v.PublicAccess, true)
 }

--- a/openstack/blockstorage/v3/volumetypes/testing/requests_test.go
+++ b/openstack/blockstorage/v3/volumetypes/testing/requests_test.go
@@ -1,0 +1,90 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumetypes"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func TestListAll(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockListResponse(t)
+
+	allPages, err := volumetypes.List(client.ServiceClient()).AllPages()
+	th.AssertNoErr(t, err)
+	actual, err := volumetypes.ExtractVolumeTypes(allPages)
+	th.AssertNoErr(t, err)
+
+	expected := []volumetypes.VolumeType{
+		{
+			ID:          "6685584b-1eac-4da6-b5c3-555430cf68ff",
+			Name:        "SSD",
+			ExtraSpecs:  map[string]string{"volume_backend_name": "lvmdriver-1"},
+			IsPublic:    true,
+			Description: "",
+		}, {
+			ID:          "8eb69a46-df97-4e41-9586-9a40a7533803",
+			Name:        "SATA",
+			ExtraSpecs:  map[string]string{"volume_backend_name": "lvmdriver-1"},
+			IsPublic:    true,
+			Description: "",
+		},
+	}
+	th.CheckDeepEquals(t, expected, actual)
+}
+
+func TestGet(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockGetResponse(t)
+
+	v, err := volumetypes.Get(client.ServiceClient(), "d32019d3-bc6e-4319-9c1d-6722fc136a22").Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, v.Name, "vol-type-001")
+	th.AssertEquals(t, v.ID, "d32019d3-bc6e-4319-9c1d-6722fc136a22")
+	th.AssertEquals(t, v.ExtraSpecs["capabilities"], "gpu")
+}
+
+func TestCreate(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockCreateResponse(t)
+
+	options := &volumetypes.CreateOpts{Name: "test_type", IsPublic: true, Description: "test_type_desc"}
+	n, err := volumetypes.Create(client.ServiceClient(), options).Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, n.Name, "test_type")
+	th.AssertEquals(t, n.Description, "test_type_desc")
+	th.AssertEquals(t, n.IsPublic, true)
+	th.AssertEquals(t, n.ID, "6d0ff92a-0007-4780-9ece-acfe5876966a")
+}
+
+func TestDelete(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockDeleteResponse(t)
+
+	res := volumetypes.Delete(client.ServiceClient(), "d32019d3-bc6e-4319-9c1d-6722fc136a22")
+	th.AssertNoErr(t, res.Err)
+}
+
+func TestUpdate(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockUpdateResponse(t)
+
+	options := volumetypes.UpdateOpts{Name: "vol-type-002"}
+	v, err := volumetypes.Update(client.ServiceClient(), "d32019d3-bc6e-4319-9c1d-6722fc136a22", options).Extract()
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, "vol-type-002", v.Name)
+}

--- a/openstack/blockstorage/v3/volumetypes/urls.go
+++ b/openstack/blockstorage/v3/volumetypes/urls.go
@@ -2,22 +2,10 @@ package volumetypes
 
 import "github.com/gophercloud/gophercloud"
 
-func createURL(c *gophercloud.ServiceClient) string {
-	return c.ServiceURL("types")
-}
-
 func listURL(c *gophercloud.ServiceClient) string {
 	return c.ServiceURL("types")
 }
 
-func deleteURL(c *gophercloud.ServiceClient, id string) string {
-	return c.ServiceURL("types", id)
-}
-
 func getURL(c *gophercloud.ServiceClient, id string) string {
-	return deleteURL(c, id)
-}
-
-func updateURL(c *gophercloud.ServiceClient, id string) string {
-	return deleteURL(c, id)
+	return c.ServiceURL("types", id)
 }

--- a/openstack/blockstorage/v3/volumetypes/urls.go
+++ b/openstack/blockstorage/v3/volumetypes/urls.go
@@ -1,0 +1,23 @@
+package volumetypes
+
+import "github.com/gophercloud/gophercloud"
+
+func createURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("types")
+}
+
+func listURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("types")
+}
+
+func deleteURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("types", id)
+}
+
+func getURL(c *gophercloud.ServiceClient, id string) string {
+	return deleteURL(c, id)
+}
+
+func updateURL(c *gophercloud.ServiceClient, id string) string {
+	return deleteURL(c, id)
+}


### PR DESCRIPTION
Add List/Get support for volume type in volume V3.

For #649 

**Document:**
Volume type get [V3](https://developer.openstack.org/api-ref/block-storage/v3/#show-volume-type-detail)
Volume type list [V3](https://developer.openstack.org/api-ref/block-storage/v3/#list-all-volume-types)

**Code:**
Volume type get [V3](https://github.com/openstack/cinder/blob/master/cinder/api/v2/types.py#L41)
Volume type list [V3](https://github.com/openstack/cinder/blob/master/cinder/api/v2/types.py#L35)

**Model:**
[Link](https://github.com/openstack/cinder/blob/master/cinder/db/sqlalchemy/models.py#L378)