### PR TITLE
Compute v2: Add the extended status information API

### DIFF
--- a/acceptance/openstack/compute/v2/servers_test.go
+++ b/acceptance/openstack/compute/v2/servers_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gophercloud/gophercloud/acceptance/tools"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/attachinterfaces"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/availabilityzones"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/extendedstatus"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/lockunlock"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/pauseunpause"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/suspendresume"
@@ -111,6 +112,7 @@ func TestServersCreateDestroyWithExtensions(t *testing.T) {
 	var extendedServer struct {
 		servers.Server
 		availabilityzones.ServerAvailabilityZoneExt
+		extendedstatus.ServerExtendedStatusExt
 	}
 
 	client, err := clients.NewComputeV2Client()
@@ -131,6 +133,9 @@ func TestServersCreateDestroyWithExtensions(t *testing.T) {
 	tools.PrintResource(t, extendedServer)
 
 	t.Logf("Availability Zone: %s\n", extendedServer.AvailabilityZone)
+	t.Logf("Power State: %s\n", extendedServer.PowerState)
+	t.Logf("Task State: %s\n", extendedServer.TaskState)
+	t.Logf("VM State: %s\n", extendedServer.VmState)
 }
 
 func TestServersWithoutImageRef(t *testing.T) {

--- a/openstack/compute/v2/extensions/extendedstatus/doc.go
+++ b/openstack/compute/v2/extensions/extendedstatus/doc.go
@@ -1,0 +1,28 @@
+/*
+Package extendedstatus provides the ability to extend a server result with
+the extended status information. Example:
+
+	type ServerWithExt struct {
+		servers.Server
+		extendedstatus.ServerExtendedStatusExt
+	}
+
+	var allServers []ServerWithExt
+
+	allPages, err := servers.List(client, nil).AllPages()
+	if err != nil {
+		panic("Unable to retrieve servers: %s", err)
+	}
+
+	err = servers.ExtractServersInto(allPages, &allServers)
+	if err != nil {
+		panic("Unable to extract servers: %s", err)
+	}
+
+	for _, server := range allServers {
+		fmt.Println(server.TaskState)
+		fmt.Println(server.VmState)
+		fmt.Println(server.PowerState)
+	}
+*/
+package extendedstatus

--- a/openstack/compute/v2/extensions/extendedstatus/results.go
+++ b/openstack/compute/v2/extensions/extendedstatus/results.go
@@ -19,8 +19,8 @@ const (
 	SUSPENDED
 )
 
-func (ps PowerState) String() string {
-	switch ps {
+func (r PowerState) String() string {
+	switch r {
 	case NOSTATE:
 		return "NOSTATE"
 	case RUNNING:

--- a/openstack/compute/v2/extensions/extendedstatus/results.go
+++ b/openstack/compute/v2/extensions/extendedstatus/results.go
@@ -11,8 +11,10 @@ type ServerExtendedStatusExt struct {
 const (
 	NOSTATE = iota
 	RUNNING
+	_UNUSED1
 	PAUSED
 	SHUTDOWN
+	_UNUSED2
 	CRASHED
 	SUSPENDED
 )
@@ -31,6 +33,8 @@ func (ps PowerState) String() string {
 		return "CRASHED"
 	case SUSPENDED:
 		return "SUSPENDED"
+	case _UNUSED1, _UNUSED2:
+		return "_UNUSED"
 	default:
 		return "N/A"
 	}

--- a/openstack/compute/v2/extensions/extendedstatus/results.go
+++ b/openstack/compute/v2/extensions/extendedstatus/results.go
@@ -1,0 +1,37 @@
+package extendedstatus
+
+type PowerState int
+
+type ServerExtendedStatusExt struct {
+	TaskState  string     `json:"OS-EXT-STS:task_state"`
+	VmState    string     `json:"OS-EXT-STS:vm_state"`
+	PowerState PowerState `json:"OS-EXT-STS:power_state"`
+}
+
+const (
+	NOSTATE = iota
+	RUNNING
+	PAUSED
+	SHUTDOWN
+	CRASHED
+	SUSPENDED
+)
+
+func (ps PowerState) String() string {
+	switch ps {
+	case NOSTATE:
+		return "NOSTATE"
+	case RUNNING:
+		return "RUNNING"
+	case PAUSED:
+		return "PAUSED"
+	case SHUTDOWN:
+		return "SHUTDOWN"
+	case CRASHED:
+		return "CRASHED"
+	case SUSPENDED:
+		return "SUSPENDED"
+	default:
+		return "N/A"
+	}
+}

--- a/openstack/compute/v2/servers/testing/requests_test.go
+++ b/openstack/compute/v2/servers/testing/requests_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/availabilityzones"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/diskconfig"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/extendedstatus"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
 	"github.com/gophercloud/gophercloud/pagination"
 	th "github.com/gophercloud/gophercloud/testhelper"
@@ -66,6 +67,7 @@ func TestListAllServersWithExtensions(t *testing.T) {
 	type ServerWithExt struct {
 		servers.Server
 		availabilityzones.ServerAvailabilityZoneExt
+		extendedstatus.ServerExtendedStatusExt
 		diskconfig.ServerDiskConfigExt
 	}
 
@@ -77,6 +79,9 @@ func TestListAllServersWithExtensions(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, 3, len(actual))
 	th.AssertEquals(t, "nova", actual[0].AvailabilityZone)
+	th.AssertEquals(t, "RUNNING", actual[0].PowerState.String())
+	th.AssertEquals(t, "", actual[0].TaskState)
+	th.AssertEquals(t, "active", actual[0].VmState)
 	th.AssertEquals(t, diskconfig.Manual, actual[0].DiskConfig)
 }
 
@@ -237,12 +242,16 @@ func TestGetServerWithExtensions(t *testing.T) {
 	var s struct {
 		servers.Server
 		availabilityzones.ServerAvailabilityZoneExt
+		extendedstatus.ServerExtendedStatusExt
 		diskconfig.ServerDiskConfigExt
 	}
 
 	err := servers.Get(client.ServiceClient(), "1234asdf").ExtractInto(&s)
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, "nova", s.AvailabilityZone)
+	th.AssertEquals(t, "RUNNING", s.PowerState.String())
+	th.AssertEquals(t, "", s.TaskState)
+	th.AssertEquals(t, "active", s.VmState)
 	th.AssertEquals(t, diskconfig.Manual, s.DiskConfig)
 
 	err = servers.Get(client.ServiceClient(), "1234asdf").ExtractInto(s)


### PR DESCRIPTION
I added the extended status information API as ServerExtendedStatusExt result extension.

For #658 

Links to the line numbers/files in the OpenStack source code that support the code in this PR:
 * [/nova/api/openstack/compute/extended_status.py](https://github.com/openstack/nova/blob/master/nova/api/openstack/compute/extended_status.py)
 * OpenStack compute API doc
   * [List Server Details](https://developer.openstack.org/api-ref/compute/#list-servers-detailed)
   * [Show Server Details](https://developer.openstack.org/api-ref/compute/#show-server-details)
