### PR TITLE
Fix a small syntax error of TestShareTypeExtraSpecs test

### DIFF
--- a/acceptance/openstack/sharedfilesystems/v2/sharetypes_test.go
+++ b/acceptance/openstack/sharedfilesystems/v2/sharetypes_test.go
@@ -70,7 +70,7 @@ func TestShareTypeExtraSpecs(t *testing.T) {
 	}
 
 	options := sharetypes.SetExtraSpecsOpts{
-		Specs: map[string]interface{}{"my_new_key": "my_value"},
+		ExtraSpecs: map[string]interface{}{"my_new_key": "my_value"},
 	}
 
 	_, err = sharetypes.SetExtraSpecs(client, shareType.ID, options).Extract()


### PR DESCRIPTION
This test try to init a sharetypes.SetExtraSpecsOpts object with a wrong
field name, this change fix it.

For #670
