### PR TITLE
Support pagination in snapshot resources 

### DIFF
--- a/openstack/blockstorage/v3/snapshots/requests.go
+++ b/openstack/blockstorage/v3/snapshots/requests.go
@@ -78,6 +78,19 @@ type ListOpts struct {
 
 	// VolumeID will filter by a specified volume ID.
 	VolumeID string `q:"volume_id"`
+
+	// Comma-separated list of sort keys and optional sort directions in the
+	// form of <key>[:<direction>].
+	Sort string `q:"sort"`
+
+	// Requests a page size of items.
+	Limit int `q:"limit"`
+
+	// Used in conjunction with limit to return a slice of items.
+	Offset int `q:"offset"`
+
+	// The ID of the last-seen item.
+	Marker string `q:"marker"`
 }
 
 // ToSnapshotListQuery formats a ListOpts into a query string.
@@ -98,7 +111,7 @@ func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pa
 		url += query
 	}
 	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
-		return SnapshotPage{pagination.SinglePageBase(r)}
+		return SnapshotPage{pagination.LinkedPageBase{PageResult: r}}
 	})
 }
 

--- a/openstack/blockstorage/v3/snapshots/results.go
+++ b/openstack/blockstorage/v3/snapshots/results.go
@@ -55,7 +55,7 @@ type DeleteResult struct {
 
 // SnapshotPage is a pagination.Pager that is returned from a call to the List function.
 type SnapshotPage struct {
-	pagination.SinglePageBase
+	pagination.LinkedPageBase
 }
 
 // UnmarshalJSON converts our JSON API response into our snapshot struct
@@ -82,6 +82,17 @@ func (r *Snapshot) UnmarshalJSON(b []byte) error {
 func (r SnapshotPage) IsEmpty() (bool, error) {
 	volumes, err := ExtractSnapshots(r)
 	return len(volumes) == 0, err
+}
+
+func (page SnapshotPage) NextPageURL() (string, error) {
+	var s struct {
+		Links []gophercloud.Link `json:"snapshots_links"`
+	}
+	err := page.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return gophercloud.ExtractNextURL(s.Links)
 }
 
 // ExtractSnapshots extracts and returns Snapshots. It is used while iterating over a snapshots.List call.

--- a/openstack/blockstorage/v3/snapshots/testing/fixtures.go
+++ b/openstack/blockstorage/v3/snapshots/testing/fixtures.go
@@ -17,7 +17,11 @@ func MockListResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		r.ParseForm()
+		marker := r.Form.Get("marker")
+		switch marker {
+		case "":
+			fmt.Fprintf(w, `
     {
       "snapshots": [
         {
@@ -38,9 +42,19 @@ func MockListResponse(t *testing.T) {
           "size": 25,
 		  "created_at": "2017-05-30T03:35:03.000000"
         }
-      ]
+      ],
+      "snapshots_links": [
+        {
+            "href": "%s/snapshots?marker=1",
+            "rel": "next"
+        }]
     }
-    `)
+    `, th.Server.URL)
+		case "1":
+			fmt.Fprintf(w, `{"snapshots": []}`)
+		default:
+			t.Fatalf("Unexpected marker: [%s]", marker)
+		}
 	})
 }
 


### PR DESCRIPTION
Pagniation is supported in blockstorage's [snapshot ](https://developer.openstack.org/api-ref/block-storage/v3/#list-snapshots-and-details) resource.

Code: [Snapshot](https://github.com/openstack/cinder/blob/master/cinder/api/v3/snapshots.py#L78)
For #676 