### PR TITLE
Support pagination in volume resources

### DIFF
--- a/openstack/blockstorage/v3/volumes/requests.go
+++ b/openstack/blockstorage/v3/volumes/requests.go
@@ -98,6 +98,19 @@ type ListOpts struct {
 	// TenantID will filter by a specific tenant/project ID.
 	// Setting AllTenants is required for this.
 	TenantID string `q:"project_id"`
+
+	// Comma-separated list of sort keys and optional sort directions in the
+	// form of <key>[:<direction>].
+	Sort string `q:"sort"`
+
+	// Requests a page size of items.
+	Limit int `q:"limit"`
+
+	// Used in conjunction with limit to return a slice of items.
+	Offset int `q:"offset"`
+
+	// The ID of the last-seen item.
+	Marker string `q:"marker"`
 }
 
 // ToVolumeListQuery formats a ListOpts into a query string.
@@ -118,7 +131,7 @@ func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pa
 	}
 
 	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
-		return VolumePage{pagination.SinglePageBase(r)}
+		return VolumePage{pagination.LinkedPageBase{PageResult: r}}
 	})
 }
 

--- a/openstack/blockstorage/v3/volumes/results.go
+++ b/openstack/blockstorage/v3/volumes/results.go
@@ -101,13 +101,24 @@ func (r *Volume) UnmarshalJSON(b []byte) error {
 
 // VolumePage is a pagination.pager that is returned from a call to the List function.
 type VolumePage struct {
-	pagination.SinglePageBase
+	pagination.LinkedPageBase
 }
 
 // IsEmpty returns true if a ListResult contains no Volumes.
 func (r VolumePage) IsEmpty() (bool, error) {
 	volumes, err := ExtractVolumes(r)
 	return len(volumes) == 0, err
+}
+
+func (page VolumePage) NextPageURL() (string, error) {
+	var s struct {
+		Links []gophercloud.Link `json:"volumes_links"`
+	}
+	err := page.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return gophercloud.ExtractNextURL(s.Links)
 }
 
 // ExtractVolumes extracts and returns Volumes. It is used while iterating over a volumes.List call.

--- a/openstack/blockstorage/v3/volumes/testing/fixtures.go
+++ b/openstack/blockstorage/v3/volumes/testing/fixtures.go
@@ -17,7 +17,11 @@ func MockListResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		r.ParseForm()
+		marker := r.Form.Get("marker")
+		switch marker {
+		case "":
+			fmt.Fprintf(w, `
   {
   "volumes": [
     {
@@ -80,9 +84,19 @@ func MockListResponse(t *testing.T) {
       "status": "available",
       "description": null
     }
-  ]
+  ],
+	"volumes_links": [
+	{
+		"href": "%s/volumes/detail?marker=1",
+		"rel": "next"
+	}]
 }
-  `)
+  `, th.Server.URL)
+		case "1":
+			fmt.Fprintf(w, `{"volumes": []}`)
+		default:
+			t.Fatalf("Unexpected marker: [%s]", marker)
+		}
 	})
 }
 


### PR DESCRIPTION
Pagniation is supported in blockstorage's [volume ](https://developer.openstack.org/api-ref/block-storage/v3/#list-accessible-volumes-with-details) resource.

Code: [Volume](https://github.com/openstack/cinder/blob/master/cinder/api/v3/volumes.py#L99)
For #676 