### PR TITLE
Flavor Extra Specs: List / Get

### DIFF
--- a/acceptance/openstack/compute/v2/flavors_test.go
+++ b/acceptance/openstack/compute/v2/flavors_test.go
@@ -153,3 +153,23 @@ func TestFlavorAccessCRUD(t *testing.T) {
 		tools.PrintResource(t, access)
 	}
 }
+
+func TestFlavorExtraSpecs(t *testing.T) {
+	client, err := clients.NewComputeV2Client()
+	if err != nil {
+		t.Fatalf("Unable to create a compute client: %v", err)
+	}
+
+	flavor, err := CreatePrivateFlavor(t, client)
+	if err != nil {
+		t.Fatalf("Unable to create flavor: %v", err)
+	}
+	defer DeleteFlavor(t, client, flavor)
+
+	allExtraSpecs, err := flavors.ListExtraSpecs(client, flavor.ID).Extract()
+	if err != nil {
+		t.Fatalf("Unable to get flavor extra_specs: %v", err)
+	}
+
+	tools.PrintResource(t, allExtraSpecs)
+}

--- a/openstack/compute/v2/flavors/doc.go
+++ b/openstack/compute/v2/flavors/doc.go
@@ -72,5 +72,15 @@ Example to Grant Access to a Flavor
 	if err != nil {
 		panic(err)
 	}
+
+Example to Get Extra Specs for a Flavor
+	flavorID := "e91758d6-a54a-4778-ad72-0c73a1cb695b"
+
+	extraSpecs, err := flavors.ListExtraSpecs(computeClient, flavorID).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v", extraSpecs)
 */
 package flavors

--- a/openstack/compute/v2/flavors/requests.go
+++ b/openstack/compute/v2/flavors/requests.go
@@ -230,3 +230,14 @@ func IDFromName(client *gophercloud.ServiceClient, name string) (string, error) 
 		return "", err
 	}
 }
+
+// ExtraSpecs requests all the extra-specs for the given flavor ID.
+func ListExtraSpecs(client *gophercloud.ServiceClient, flavorID string) (r ListExtraSpecsResult) {
+	_, r.Err = client.Get(extraSpecsListURL(client, flavorID), &r.Body, nil)
+	return
+}
+
+func GetExtraSpec(client *gophercloud.ServiceClient, flavorID string, key string) (r GetExtraSpecResult) {
+	_, r.Err = client.Get(extraSpecsGetURL(client, flavorID, key), &r.Body, nil)
+	return
+}

--- a/openstack/compute/v2/flavors/results.go
+++ b/openstack/compute/v2/flavors/results.go
@@ -182,3 +182,44 @@ type FlavorAccess struct {
 	// TenantID is the unique ID of the tenant.
 	TenantID string `json:"tenant_id"`
 }
+
+// Extract interprets any extraSpecsResult as ExtraSpecs, if possible.
+func (r extraSpecsResult) Extract() (map[string]string, error) {
+	var s struct {
+		ExtraSpecs map[string]string `json:"extra_specs"`
+	}
+	err := r.ExtractInto(&s)
+	return s.ExtraSpecs, err
+}
+
+// extraSpecsResult contains the result of a call for (potentially) multiple
+// key-value pairs. Call its Extract method to interpret it as a
+// map[string]interface.
+type extraSpecsResult struct {
+	gophercloud.Result
+}
+
+// ListExtraSpecsResult contains the result of a Get operation. Call its Extract
+// method to interpret it as a map[string]interface.
+type ListExtraSpecsResult struct {
+	extraSpecsResult
+}
+
+// extraSpecResult contains the result of a call for individual a single
+// key-value pair.
+type extraSpecResult struct {
+	gophercloud.Result
+}
+
+// GetExtraSpecResult contains the result of a Get operation. Call its Extract
+// method to interpret it as a map[string]interface.
+type GetExtraSpecResult struct {
+	extraSpecResult
+}
+
+// Extract interprets any extraSpecResult as an ExtraSpec, if possible.
+func (r extraSpecResult) Extract() (map[string]string, error) {
+	var s map[string]string
+	err := r.ExtractInto(&s)
+	return s, err
+}

--- a/openstack/compute/v2/flavors/testing/fixtures.go
+++ b/openstack/compute/v2/flavors/testing/fixtures.go
@@ -1,0 +1,62 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	th "github.com/gophercloud/gophercloud/testhelper"
+	fake "github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+// ExtraSpecsGetBody provides a GET result of the extra_specs for a flavor
+const ExtraSpecsGetBody = `
+{
+    "extra_specs" : {
+        "hw:cpu_policy": "CPU-POLICY",
+        "hw:cpu_thread_policy": "CPU-THREAD-POLICY"
+    }
+}
+`
+
+// ExtraSpecGetBody provides a GET result of a particular extra_spec for a flavor
+const GetExtraSpecBody = `
+{
+    "hw:cpu_policy": "CPU-POLICY"
+}
+`
+
+// ExtraSpecs is the expected extra_specs returned from GET on a flavor's extra_specs
+var ExtraSpecs = map[string]string{
+	"hw:cpu_policy":        "CPU-POLICY",
+	"hw:cpu_thread_policy": "CPU-THREAD-POLICY",
+}
+
+// ExtraSpec is the expected extra_spec returned from GET on a flavor's extra_specs
+var ExtraSpec = map[string]string{
+	"hw:cpu_policy": "CPU-POLICY",
+}
+
+func HandleExtraSpecsListSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/flavors/1/os-extra_specs", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, ExtraSpecsGetBody)
+	})
+}
+
+func HandleExtraSpecGetSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/flavors/1/os-extra_specs/hw:cpu_policy", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, GetExtraSpecBody)
+	})
+}

--- a/openstack/compute/v2/flavors/testing/requests_test.go
+++ b/openstack/compute/v2/flavors/testing/requests_test.go
@@ -299,3 +299,25 @@ func TestFlavorAccessAdd(t *testing.T) {
 		t.Errorf("Expected %#v, but was %#v", expected, actual)
 	}
 }
+
+func TestFlavorExtraSpecsList(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleExtraSpecsListSuccessfully(t)
+
+	expected := ExtraSpecs
+	actual, err := flavors.ListExtraSpecs(fake.ServiceClient(), "1").Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, expected, actual)
+}
+
+func TestFlavorExtraSpecGet(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleExtraSpecGetSuccessfully(t)
+
+	expected := ExtraSpec
+	actual, err := flavors.GetExtraSpec(fake.ServiceClient(), "1", "hw:cpu_policy").Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, expected, actual)
+}

--- a/openstack/compute/v2/flavors/urls.go
+++ b/openstack/compute/v2/flavors/urls.go
@@ -27,3 +27,11 @@ func accessURL(client *gophercloud.ServiceClient, id string) string {
 func accessActionURL(client *gophercloud.ServiceClient, id string) string {
 	return client.ServiceURL("flavors", id, "action")
 }
+
+func extraSpecsListURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL("flavors", id, "os-extra_specs")
+}
+
+func extraSpecsGetURL(client *gophercloud.ServiceClient, id, key string) string {
+	return client.ServiceURL("flavors", id, "os-extra_specs", key)
+}


### PR DESCRIPTION
For #540

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

API reference:
* List
https://developer.openstack.org/api-ref/compute/#list-extra-specs-for-a-flavor

* Get
https://developer.openstack.org/api-ref/compute/#show-an-extra-spec-for-a-flavor

Nova implementation:
* List
https://github.com/openstack/nova/blob/stable/pike/nova/api/openstack/compute/flavors_extraspecs.py#L50
* Get
https://github.com/openstack/nova/blob/stable/pike/nova/api/openstack/compute/flavors_extraspecs.py#L98

Schema:
https://github.com/openstack/nova/blob/stable/pike/nova/api/openstack/compute/schemas/flavors_extraspecs.py
https://github.com/openstack/nova/blob/stable/pike/nova/api/validation/parameter_types.py#L363-L371