### PR TITLE
Flavor Extra Specs Create 

### DIFF
--- a/acceptance/openstack/compute/v2/flavors_test.go
+++ b/acceptance/openstack/compute/v2/flavors_test.go
@@ -154,7 +154,7 @@ func TestFlavorAccessCRUD(t *testing.T) {
 	}
 }
 
-func TestFlavorExtraSpecs(t *testing.T) {
+func TestFlavorExtraSpecsCRUD(t *testing.T) {
 	client, err := clients.NewComputeV2Client()
 	if err != nil {
 		t.Fatalf("Unable to create a compute client: %v", err)
@@ -166,10 +166,27 @@ func TestFlavorExtraSpecs(t *testing.T) {
 	}
 	defer DeleteFlavor(t, client, flavor)
 
+	createOpts := flavors.ExtraSpecsOpts{
+		"hw:cpu_policy":        "CPU-POLICY",
+		"hw:cpu_thread_policy": "CPU-THREAD-POLICY",
+	}
+	createdExtraSpecs, err := flavors.CreateExtraSpecs(client, flavor.ID, createOpts).Extract()
+	if err != nil {
+		t.Fatalf("Unable to create flavor extra_specs: %v", err)
+	}
+	tools.PrintResource(t, createdExtraSpecs)
+
 	allExtraSpecs, err := flavors.ListExtraSpecs(client, flavor.ID).Extract()
 	if err != nil {
 		t.Fatalf("Unable to get flavor extra_specs: %v", err)
 	}
-
 	tools.PrintResource(t, allExtraSpecs)
+
+	for key, _ := range allExtraSpecs {
+		spec, err := flavors.GetExtraSpec(client, flavor.ID, key).Extract()
+		if err != nil {
+			t.Fatalf("Unable to get flavor extra spec: %v", err)
+		}
+		tools.PrintResource(t, spec)
+	}
 }

--- a/openstack/compute/v2/flavors/doc.go
+++ b/openstack/compute/v2/flavors/doc.go
@@ -73,7 +73,23 @@ Example to Grant Access to a Flavor
 		panic(err)
 	}
 
+Example to Create Extra Specs for a Flavor
+
+	flavorID := "e91758d6-a54a-4778-ad72-0c73a1cb695b"
+
+	createOpts := flavors.ExtraSpecsOpts{
+		"hw:cpu_policy":        "CPU-POLICY",
+		"hw:cpu_thread_policy": "CPU-THREAD-POLICY",
+	}
+	createdExtraSpecs, err := flavors.CreateExtraSpecs(computeClient, flavorID, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v", createdExtraSpecs)
+
 Example to Get Extra Specs for a Flavor
+
 	flavorID := "e91758d6-a54a-4778-ad72-0c73a1cb695b"
 
 	extraSpecs, err := flavors.ListExtraSpecs(computeClient, flavorID).Extract()
@@ -82,5 +98,6 @@ Example to Get Extra Specs for a Flavor
 	}
 
 	fmt.Printf("%+v", extraSpecs)
+
 */
 package flavors

--- a/openstack/compute/v2/flavors/requests.go
+++ b/openstack/compute/v2/flavors/requests.go
@@ -192,6 +192,45 @@ func AddAccess(client *gophercloud.ServiceClient, id string, opts AddAccessOptsB
 	return
 }
 
+// ExtraSpecs requests all the extra-specs for the given flavor ID.
+func ListExtraSpecs(client *gophercloud.ServiceClient, flavorID string) (r ListExtraSpecsResult) {
+	_, r.Err = client.Get(extraSpecsListURL(client, flavorID), &r.Body, nil)
+	return
+}
+
+func GetExtraSpec(client *gophercloud.ServiceClient, flavorID string, key string) (r GetExtraSpecResult) {
+	_, r.Err = client.Get(extraSpecsGetURL(client, flavorID, key), &r.Body, nil)
+	return
+}
+
+// CreateExtraSpecsOptsBuilder allows extensions to add additional parameters to the
+// CreateExtraSpecs requests.
+type CreateExtraSpecsOptsBuilder interface {
+	ToExtraSpecsCreateMap() (map[string]interface{}, error)
+}
+
+// ExtraSpecsOpts is a map that contains key-value pairs.
+type ExtraSpecsOpts map[string]string
+
+// ToExtraSpecsCreateMap assembles a body for a Create request based on the
+// contents of a ExtraSpecsOpts
+func (opts ExtraSpecsOpts) ToExtraSpecsCreateMap() (map[string]interface{}, error) {
+	return map[string]interface{}{"extra_specs": opts}, nil
+}
+
+// CreateExtraSpecs will create or update the extra-specs key-value pairs for the specified Flavor
+func CreateExtraSpecs(client *gophercloud.ServiceClient, flavorID string, opts CreateExtraSpecsOptsBuilder) (r CreateExtraSpecsResult) {
+	b, err := opts.ToExtraSpecsCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(extraSpecsCreateURL(client, flavorID), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
 // IDFromName is a convienience function that returns a flavor's ID given its
 // name.
 func IDFromName(client *gophercloud.ServiceClient, name string) (string, error) {
@@ -229,15 +268,4 @@ func IDFromName(client *gophercloud.ServiceClient, name string) (string, error) 
 		err.Count = count
 		return "", err
 	}
-}
-
-// ExtraSpecs requests all the extra-specs for the given flavor ID.
-func ListExtraSpecs(client *gophercloud.ServiceClient, flavorID string) (r ListExtraSpecsResult) {
-	_, r.Err = client.Get(extraSpecsListURL(client, flavorID), &r.Body, nil)
-	return
-}
-
-func GetExtraSpec(client *gophercloud.ServiceClient, flavorID string, key string) (r GetExtraSpecResult) {
-	_, r.Err = client.Get(extraSpecsGetURL(client, flavorID, key), &r.Body, nil)
-	return
 }

--- a/openstack/compute/v2/flavors/results.go
+++ b/openstack/compute/v2/flavors/results.go
@@ -205,6 +205,12 @@ type ListExtraSpecsResult struct {
 	extraSpecsResult
 }
 
+// CreateExtraSpecResult contains the result of a Create operation. Call its
+// Extract method to interpret it as a map[string]interface.
+type CreateExtraSpecsResult struct {
+	extraSpecsResult
+}
+
 // extraSpecResult contains the result of a call for individual a single
 // key-value pair.
 type extraSpecResult struct {

--- a/openstack/compute/v2/flavors/testing/fixtures.go
+++ b/openstack/compute/v2/flavors/testing/fixtures.go
@@ -60,3 +60,21 @@ func HandleExtraSpecGetSuccessfully(t *testing.T) {
 		fmt.Fprintf(w, GetExtraSpecBody)
 	})
 }
+
+func HandleExtraSpecsCreateSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/flavors/1/os-extra_specs", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, `{
+				"extra_specs": {
+					"hw:cpu_policy":        "CPU-POLICY",
+					"hw:cpu_thread_policy": "CPU-THREAD-POLICY"
+				}
+			}`)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, ExtraSpecsGetBody)
+	})
+}

--- a/openstack/compute/v2/flavors/testing/requests_test.go
+++ b/openstack/compute/v2/flavors/testing/requests_test.go
@@ -321,3 +321,18 @@ func TestFlavorExtraSpecGet(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.CheckDeepEquals(t, expected, actual)
 }
+
+func TestFlavorExtraSpecsCreate(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleExtraSpecsCreateSuccessfully(t)
+
+	createOpts := flavors.ExtraSpecsOpts{
+		"hw:cpu_policy":        "CPU-POLICY",
+		"hw:cpu_thread_policy": "CPU-THREAD-POLICY",
+	}
+	expected := ExtraSpecs
+	actual, err := flavors.CreateExtraSpecs(fake.ServiceClient(), "1", createOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, expected, actual)
+}

--- a/openstack/compute/v2/flavors/urls.go
+++ b/openstack/compute/v2/flavors/urls.go
@@ -35,3 +35,7 @@ func extraSpecsListURL(client *gophercloud.ServiceClient, id string) string {
 func extraSpecsGetURL(client *gophercloud.ServiceClient, id, key string) string {
 	return client.ServiceURL("flavors", id, "os-extra_specs", key)
 }
+
+func extraSpecsCreateURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL("flavors", id, "os-extra_specs")
+}


### PR DESCRIPTION
For #540 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

API reference:
https://developer.openstack.org/api-ref/compute/#create-extra-specs-for-a-flavor

Nova implementation:
https://github.com/openstack/nova/blob/stable/pike/nova/api/openstack/compute/flavors_extraspecs.py#L61

Schema:
https://github.com/openstack/nova/blob/stable/pike/nova/api/openstack/compute/schemas/flavors_extraspecs.py#L24
https://github.com/openstack/nova/blob/stable/pike/nova/api/validation/parameter_types.py#L363-L371
