### PR TITLE
Add os-aggregates support

### DIFF
--- a/acceptance/openstack/compute/v2/aggregates_test.go
+++ b/acceptance/openstack/compute/v2/aggregates_test.go
@@ -1,0 +1,32 @@
+// +build acceptance compute aggregates
+
+package v2
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/acceptance/clients"
+	"github.com/gophercloud/gophercloud/acceptance/tools"
+	"github.com/ildarsv/gophercloud/openstack/compute/v2/extensions/aggregates"
+)
+
+func TestAggregatesList(t *testing.T) {
+	client, err := clients.NewComputeV2Client()
+	if err != nil {
+		t.Fatalf("Unable to create a compute client: %v", err)
+	}
+
+	allPages, err := aggregates.List(client).AllPages()
+	if err != nil {
+		t.Fatalf("Unable to list aggregates: %v", err)
+	}
+
+	allAggregates, err := aggregates.ExtractAggregates(allPages)
+	if err != nil {
+		t.Fatalf("Unable to extract aggregates")
+	}
+
+	for _, h := range allAggregates {
+		tools.PrintResource(t, h)
+	}
+}

--- a/acceptance/openstack/compute/v2/aggregates_test.go
+++ b/acceptance/openstack/compute/v2/aggregates_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/gophercloud/gophercloud/acceptance/clients"
 	"github.com/gophercloud/gophercloud/acceptance/tools"
-	"github.com/ildarsv/gophercloud/openstack/compute/v2/extensions/aggregates"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/aggregates"
 )
 
 func TestAggregatesList(t *testing.T) {

--- a/openstack/compute/v2/extensions/aggregates/doc.go
+++ b/openstack/compute/v2/extensions/aggregates/doc.go
@@ -1,0 +1,21 @@
+/*
+Package aggregates returns information about the host aggregates in the
+OpenStack cloud.
+
+Example of Retrieving list of all aggregates
+
+	allPages, err := aggregates.List(computeClient).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allAggregates, err := aggregates.ExtractAggregates(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, aggregate := range allAggregates {
+		fmt.Printf("%+v\n", aggregate)
+	}
+*/
+package aggregates

--- a/openstack/compute/v2/extensions/aggregates/requests.go
+++ b/openstack/compute/v2/extensions/aggregates/requests.go
@@ -1,0 +1,13 @@
+package aggregates
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// List makes a request against the API to list aggregates.
+func List(client *gophercloud.ServiceClient) pagination.Pager {
+	return pagination.NewPager(client, aggregatesListURL(client), func(r pagination.PageResult) pagination.Page {
+		return AggregatesPage{pagination.SinglePageBase(r)}
+	})
+}

--- a/openstack/compute/v2/extensions/aggregates/results.go
+++ b/openstack/compute/v2/extensions/aggregates/results.go
@@ -1,0 +1,39 @@
+package aggregates
+
+import "github.com/gophercloud/gophercloud/pagination"
+
+// Aggregate represents a host aggregate in the OpenStack cloud.
+type Aggregate struct {
+	// The availability zone of the host aggregate.
+	AvailabilityZone string `json:"availability_zone"`
+
+	// A list of host ids in this aggregate.
+	Hosts []string `json:hosts`
+
+	// The ID of the host aggregate.
+	ID int `json:"id"`
+
+	// Name of the aggregate.
+	Name string `json:"name"`
+}
+
+// AggregatesPage represents a single page of all Aggregates from a List
+// request.
+type AggregatesPage struct {
+	pagination.SinglePageBase
+}
+
+// IsEmpty determines whether or not a page of Aggregates contains any results.
+func (page AggregatesPage) IsEmpty() (bool, error) {
+	aggregates, err := ExtractAggregates(page)
+	return len(aggregates) == 0, err
+}
+
+// ExtractAggregates interprets a page of results as a slice of Aggregates.
+func ExtractAggregates(p pagination.Page) ([]Aggregate, error) {
+	var a struct {
+		Aggregates []Aggregate `json:"aggregates"`
+	}
+	err := (p.(AggregatesPage)).ExtractInto(&a)
+	return a.Aggregates, err
+}

--- a/openstack/compute/v2/extensions/aggregates/results.go
+++ b/openstack/compute/v2/extensions/aggregates/results.go
@@ -8,7 +8,7 @@ type Aggregate struct {
 	AvailabilityZone string `json:"availability_zone"`
 
 	// A list of host ids in this aggregate.
-	Hosts []string `json:hosts`
+	Hosts []string `json:"hosts"`
 
 	// The ID of the host aggregate.
 	ID int `json:"id"`

--- a/openstack/compute/v2/extensions/aggregates/results.go
+++ b/openstack/compute/v2/extensions/aggregates/results.go
@@ -13,6 +13,9 @@ type Aggregate struct {
 	// The ID of the host aggregate.
 	ID int `json:"id"`
 
+	// Metadata key and value pairs associate with the aggregate.
+	Metadata map[string]string `json:"metadata"`
+
 	// Name of the aggregate.
 	Name string `json:"name"`
 }

--- a/openstack/compute/v2/extensions/aggregates/testing/fixtures.go
+++ b/openstack/compute/v2/extensions/aggregates/testing/fixtures.go
@@ -49,6 +49,7 @@ var FirstFakeAggregate = aggregates.Aggregate{
 	AvailabilityZone: "",
 	Hosts:            []string{},
 	ID:               1,
+	Metadata:         map[string]string{},
 	Name:             "test-aggregate1",
 }
 
@@ -57,6 +58,7 @@ var SecondFakeAggregate = aggregates.Aggregate{
 	AvailabilityZone: "test-az",
 	Hosts:            []string{"cmp0"},
 	ID:               4,
+	Metadata:         map[string]string{"availability_zone": "test-az"},
 	Name:             "test-aggregate2",
 }
 

--- a/openstack/compute/v2/extensions/aggregates/testing/fixtures.go
+++ b/openstack/compute/v2/extensions/aggregates/testing/fixtures.go
@@ -1,0 +1,72 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/aggregates"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+// AggregateListBody is sample response to the List call
+const AggregateListBody = `
+{
+    "aggregates": [
+        {
+            "name": "test-aggregate1",
+            "availability_zone": null,
+            "deleted": false,
+            "created_at": "2017-12-22T10:12:06.000000",
+            "updated_at": null,
+            "hosts": [],
+            "deleted_at": null,
+            "id": 1,
+            "metadata": {}
+        },
+        {
+            "name": "test-aggregate2",
+            "availability_zone": "test-az",
+            "deleted": false,
+            "created_at": "2017-12-22T10:16:07.000000",
+            "updated_at": null,
+            "hosts": [
+                "cmp0"
+            ],
+            "deleted_at": null,
+            "id": 4,
+            "metadata": {
+                "availability_zone": "test-az"
+            }
+        }
+    ]
+}
+`
+
+// First aggregate from the AggregateListBody
+var FirstFakeAggregate = aggregates.Aggregate{
+	AvailabilityZone: "",
+	Hosts:            []string{},
+	ID:               1,
+	Name:             "test-aggregate1",
+}
+
+// Second aggregate from the AggregateListBody
+var SecondFakeAggregate = aggregates.Aggregate{
+	AvailabilityZone: "test-az",
+	Hosts:            []string{"cmp0"},
+	ID:               4,
+	Name:             "test-aggregate2",
+}
+
+// HandleListSuccessfully configures the test server to respond to a List request.
+func HandleListSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/os-aggregates", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprintf(w, AggregateListBody)
+	})
+}

--- a/openstack/compute/v2/extensions/aggregates/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/aggregates/testing/requests_test.go
@@ -1,0 +1,40 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/aggregates"
+	"github.com/gophercloud/gophercloud/pagination"
+	"github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func TestListAggregates(t *testing.T) {
+	testhelper.SetupHTTP()
+	defer testhelper.TeardownHTTP()
+	HandleListSuccessfully(t)
+
+	pages := 0
+	err := aggregates.List(client.ServiceClient()).EachPage(func(page pagination.Page) (bool, error) {
+		pages++
+
+		actual, err := aggregates.ExtractAggregates(page)
+		if err != nil {
+			return false, err
+		}
+
+		if len(actual) != 2 {
+			t.Fatalf("Expected 2 aggregates, got %d", len(actual))
+		}
+		testhelper.CheckDeepEquals(t, FirstFakeAggregate, actual[0])
+		testhelper.CheckDeepEquals(t, SecondFakeAggregate, actual[1])
+
+		return true, nil
+	})
+
+	testhelper.AssertNoErr(t, err)
+
+	if pages != 1 {
+		t.Errorf("Expected 1 page, saw %d", pages)
+	}
+}

--- a/openstack/compute/v2/extensions/aggregates/urls.go
+++ b/openstack/compute/v2/extensions/aggregates/urls.go
@@ -1,0 +1,7 @@
+package aggregates
+
+import "github.com/gophercloud/gophercloud"
+
+func aggregatesListURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("os-aggregates")
+}


### PR DESCRIPTION
For #690 

Add support for the Nova host aggregates to list host aggregates.

API reference:
https://developer.openstack.org/api-ref/compute/#list-aggregates

Implementation:
https://github.com/openstack/nova/blob/stable/pike/nova/api/openstack/compute/aggregates.py#L44