### PR TITLE
Fix the acceptance tests of Orchestration service

### DIFF
--- a/acceptance/openstack/orchestration/v1/stackevents_test.go
+++ b/acceptance/openstack/orchestration/v1/stackevents_test.go
@@ -20,11 +20,13 @@ func TestStackEvents(t *testing.T) {
 	stackName := "postman_stack_2"
 	resourceName := "hello_world"
 	var eventID string
+	var templateOpts = new(stacks.Template)
+	templateOpts.Bin = []byte(template)
 
 	createOpts := stacks.CreateOpts{
-		Name:     stackName,
-		Template: template,
-		Timeout:  5,
+		Name:         stackName,
+		TemplateOpts: templateOpts,
+		Timeout:      5,
 	}
 	stack, err := stacks.Create(client, createOpts).Extract()
 	th.AssertNoErr(t, err)

--- a/acceptance/openstack/orchestration/v1/stackresources_test.go
+++ b/acceptance/openstack/orchestration/v1/stackresources_test.go
@@ -18,11 +18,13 @@ func TestStackResources(t *testing.T) {
 	client := newClient(t)
 
 	stackName := "postman_stack_2"
+	var templateOpts = new(stacks.Template)
+	templateOpts.Bin = []byte(template)
 
 	createOpts := stacks.CreateOpts{
-		Name:     stackName,
-		Template: template,
-		Timeout:  5,
+		Name:         stackName,
+		TemplateOpts: templateOpts,
+		Timeout:      5,
 	}
 	stack, err := stacks.Create(client, createOpts).Extract()
 	th.AssertNoErr(t, err)

--- a/acceptance/openstack/orchestration/v1/stacks_test.go
+++ b/acceptance/openstack/orchestration/v1/stacks_test.go
@@ -17,10 +17,13 @@ func TestStacks(t *testing.T) {
 	client := newClient(t)
 
 	stackName1 := "gophercloud-test-stack-2"
+	var templateOpts = new(stacks.Template)
+	templateOpts.Bin = []byte(template)
+
 	createOpts := stacks.CreateOpts{
-		Name:     stackName1,
-		Template: template,
-		Timeout:  5,
+		Name:         stackName1,
+		TemplateOpts: templateOpts,
+		Timeout:      5,
 	}
 	stack, err := stacks.Create(client, createOpts).Extract()
 	th.AssertNoErr(t, err)
@@ -42,8 +45,8 @@ func TestStacks(t *testing.T) {
 	})
 
 	updateOpts := stacks.UpdateOpts{
-		Template: template,
-		Timeout:  20,
+		TemplateOpts: templateOpts,
+		Timeout:      20,
 	}
 	err = stacks.Update(client, stackName1, stack.ID, updateOpts).ExtractErr()
 	th.AssertNoErr(t, err)
@@ -87,9 +90,9 @@ func TestStacksNewTemplateFormat(t *testing.T) {
 	client := newClient(t)
 
 	stackName1 := "gophercloud-test-stack-2"
-	templateOpts := new(osStacks.Template)
+	templateOpts := new(stacks.Template)
 	templateOpts.Bin = []byte(template)
-	createOpts := osStacks.CreateOpts{
+	createOpts := stacks.CreateOpts{
 		Name:         stackName1,
 		TemplateOpts: templateOpts,
 		Timeout:      5,
@@ -113,7 +116,7 @@ func TestStacksNewTemplateFormat(t *testing.T) {
 		return false, nil
 	})
 
-	updateOpts := osStacks.UpdateOpts{
+	updateOpts := stacks.UpdateOpts{
 		TemplateOpts: templateOpts,
 		Timeout:      20,
 	}
@@ -133,7 +136,7 @@ func TestStacksNewTemplateFormat(t *testing.T) {
 	t.Logf("Updated stack")
 
 	err = stacks.List(client, nil).EachPage(func(page pagination.Page) (bool, error) {
-		stackList, err := osStacks.ExtractStacks(page)
+		stackList, err := stacks.ExtractStacks(page)
 		th.AssertNoErr(t, err)
 
 		t.Logf("Got stack list: %+v\n", stackList)

--- a/acceptance/openstack/orchestration/v1/stacktemplates_test.go
+++ b/acceptance/openstack/orchestration/v1/stacktemplates_test.go
@@ -17,11 +17,13 @@ func TestStackTemplates(t *testing.T) {
 	client := newClient(t)
 
 	stackName := "postman_stack_2"
+	var templateOpts = new(stacks.Template)
+	templateOpts.Bin = []byte(template)
 
 	createOpts := stacks.CreateOpts{
-		Name:     stackName,
-		Template: template,
-		Timeout:  5,
+		Name:         stackName,
+		TemplateOpts: templateOpts,
+		Timeout:      5,
 	}
 	stack, err := stacks.Create(client, createOpts).Extract()
 	th.AssertNoErr(t, err)
@@ -46,7 +48,7 @@ func TestStackTemplates(t *testing.T) {
 	th.AssertNoErr(t, err)
 	t.Logf("retrieved template: %+v\n", tmpl)
 
-	validateOpts := osStacktemplates.ValidateOpts{
+	validateOpts := stacktemplates.ValidateOpts{
 		Template: `{"heat_template_version": "2013-05-23",
 			"description": "Simple template to test heat commands",
 			"parameters": {
@@ -68,7 +70,8 @@ func TestStackTemplates(t *testing.T) {
 					},
 				},
 			},
-		}`}
+		}`,
+	}
 	validatedTemplate, err := stacktemplates.Validate(client, validateOpts).Extract()
 	th.AssertNoErr(t, err)
 	t.Logf("validated template: %+v\n", validatedTemplate)


### PR DESCRIPTION
There are some syntax error when try to run the acceptance tests of
Orchestration service, this change try to fix.

For #692
