### PR TITLE
Add Neutron subnetpool list support.

### DIFF
--- a/acceptance/openstack/networking/v2/extensions/subnetpools/subnetpools_test.go
+++ b/acceptance/openstack/networking/v2/extensions/subnetpools/subnetpools_test.go
@@ -1,4 +1,4 @@
-// +build acceptance networking
+// +build acceptance networking subnetpools
 
 package v2
 

--- a/acceptance/openstack/networking/v2/extensions/subnetpools/subnetpools_test.go
+++ b/acceptance/openstack/networking/v2/extensions/subnetpools/subnetpools_test.go
@@ -1,0 +1,32 @@
+// +build acceptance networking
+
+package v2
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/acceptance/clients"
+	"github.com/gophercloud/gophercloud/acceptance/tools"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/subnetpools"
+)
+
+func TestSubnetPoolsList(t *testing.T) {
+	client, err := clients.NewNetworkV2Client()
+	if err != nil {
+		t.Fatalf("Unable to create a network client: %v", err)
+	}
+
+	allPages, err := subnetpools.List(client, nil).AllPages()
+	if err != nil {
+		t.Fatalf("Unable to list subnetpools: %v", err)
+	}
+
+	allSubnetPools, err := subnetpools.ExtractSubnetPools(allPages)
+	if err != nil {
+		t.Fatalf("Unable to extract subnetpools: %v", err)
+	}
+
+	for _, subnetpool := range allSubnetPools {
+		tools.PrintResource(t, subnetpool)
+	}
+}

--- a/openstack/networking/v2/extensions/subnetpools/doc.go
+++ b/openstack/networking/v2/extensions/subnetpools/doc.go
@@ -1,0 +1,24 @@
+/*
+Package subnetpools provides the ability to retrieve and manage subnetpools through the Neutron API.
+
+Example of Listing Subnetpools.
+
+	listOpts := subnets.ListOpts{
+		IPVersion: 6,
+	}
+
+	allPages, err := subnetpools.List(networkClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allSubnetpools, err := subnetpools.ExtractSubnetPools(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, subnetpools := range allSubnetpools {
+		fmt.Printf("%+v\n", subnetpools)
+	}
+*/
+package subnetpools

--- a/openstack/networking/v2/extensions/subnetpools/requests.go
+++ b/openstack/networking/v2/extensions/subnetpools/requests.go
@@ -1,0 +1,68 @@
+package subnetpools
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// ListOptsBuilder allows extensions to add additional parameters to the
+// List request.
+type ListOptsBuilder interface {
+	ToSubnetPoolListQuery() (string, error)
+}
+
+// ListOpts allows the filtering and sorting of paginated collections through
+// the Neutron API. Filtering is achieved by passing in struct field values
+// that map to the subnetpool attributes you want to see returned.
+// SortKey allows you to sort by a particular subnetpool attribute.
+// SortDir sets the direction, and is either `asc' or `desc'.
+// Marker and Limit are used for the pagination.
+type ListOpts struct {
+	ID               string   `q:"id"`
+	Name             string   `q:"name"`
+	DefaultQuota     int      `q:"default_quota"`
+	TenantID         string   `q:"tenant_id"`
+	ProjectID        string   `q:"project_id"`
+	CreatedAt        string   `q:"created_at"`
+	UpdatedAt        string   `q:"updated_at"`
+	Prefixes         []string `q:"prefixes"`
+	DefaultPrefixLen int      `q:"default_prefixlen"`
+	MinPrefixLen     int      `q:"min_prefixlen"`
+	MaxPrefixLen     int      `q:"max_prefixlen"`
+	AddressScopeID   string   `q:"address_scope_id"`
+	IPversion        int      `q:"ip_version"`
+	Shared           bool     `q:"shared"`
+	Description      string   `q:"description"`
+	IsDefault        bool     `q:"is_default"`
+	RevisionNumber   int      `q:"revision_number"`
+	Limit            int      `q:"limit"`
+	Marker           string   `q:"marker"`
+	SortKey          string   `q:"sort_key"`
+	SortDir          string   `q:"sort_dir"`
+}
+
+// ToSubnetPoolListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToSubnetPoolListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List returns a Pager which allows you to iterate over a collection of
+// subnetpools. It accepts a ListOpts struct, which allows you to filter and sort
+// the returned collection for greater efficiency.
+//
+// Default policy settings return only the subnetpools owned by the project
+// of the user submitting the request, unless the user has the administrative role.
+func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(c)
+	if opts != nil {
+		query, err := opts.ToSubnetPoolListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		return SubnetPoolPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}

--- a/openstack/networking/v2/extensions/subnetpools/results.go
+++ b/openstack/networking/v2/extensions/subnetpools/results.go
@@ -1,0 +1,107 @@
+package subnetpools
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// SubnetPool represents a Neutron subnetpool.
+// A subnetpool is a pool of addresses from which subnets can be allocated.
+type SubnetPool struct {
+	// ID is the id of the subnetpool.
+	ID string `json:"id"`
+
+	// Name is the human-readable name of the subnetpool.
+	Name string `json:"name"`
+
+	// DefaultQuota is the per-project quota on the prefix space
+	// that can be allocated from the subnetpool for project subnets.
+	DefaultQuota int `json:"default_quota"`
+
+	// TenantID is the id of the Identity project.
+	TenantID string `json:"tenant_id"`
+
+	// ProjectID is the id of the Identity project.
+	ProjectID string `json:"project_id"`
+
+	// CreatedAt is the time at which subnetpool has been created.
+	CreatedAt string `json:"created_at"`
+
+	// UpdatedAt is the time at which subnetpool has been created.
+	UpdatedAt string `json:"updated_at"`
+
+	// Prefixes is the list of subnet prefixes to assign to the subnetpool.
+	// Neutron API merges adjacent prefixes and treats them as a single prefix.
+	// Each subnet prefix must be unique among all subnet prefixes in all subnetpools
+	// that are associated with the address scope.
+	Prefixes []string `json:"prefixes"`
+
+	// DefaultPrefixLen is yhe size of the prefix to allocate when the cidr
+	// or prefixlen attributes are omitted when you create the subnet.
+	// Defaults to the MinPrefixLen.
+	DefaultPrefixLen int `json:"default_prefixlen"`
+
+	// MinPrefixLen is the smallest prefix that can be allocated from a subnetpool.
+	// For IPv4 subnetpools, default is 8.
+	// For IPv6 subnetpools, default is 64.
+	MinPrefixLen int `json:"min_prefixlen"`
+
+	// MaxPrefixLen is the maximum prefix size that can be allocated from the subnetpool.
+	// For IPv4 subnetpools, default is 32.
+	// For IPv6 subnetpools, default is 128.
+	MaxPrefixLen int `json:"max_prefixlen"`
+
+	// AddressScopeID is the Neutron address scope to assign to the subnetpool.
+	AddressScopeID string `json:"address_scope_id"`
+
+	// IPversion is the IP protocol version.
+	// Valid value is 4 or 6. Default is 4.
+	IPversion int `json:"ip_version"`
+
+	// Shared indicates whether this network is shared across all projects.
+	Shared bool `json:"shared"`
+
+	// Description is thehuman-readable description for the resource.
+	Description string `json:"description"`
+
+	// IsDefault indicates if the subnetpool is default pool or not.
+	IsDefault bool `json:"is_default"`
+
+	// RevisionNumber is the revision number of the subnetpool.
+	RevisionNumber int `json:"revision_number"`
+}
+
+// SubnetPoolPage stores a single page of SubnetPools from a List() API call.
+type SubnetPoolPage struct {
+	pagination.LinkedPageBase
+}
+
+// NextPageURL is invoked when a paginated collection of subnetpools has reached
+// the end of a page and the pager seeks to traverse over a new one.
+// In order to do this, it needs to construct the next page's URL.
+func (r SubnetPoolPage) NextPageURL() (string, error) {
+	var s struct {
+		Links []gophercloud.Link `json:"subnetpools_links"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return gophercloud.ExtractNextURL(s.Links)
+}
+
+// IsEmpty determines whether or not a SubnetPoolPage is empty.
+func (r SubnetPoolPage) IsEmpty() (bool, error) {
+	subnetpools, err := ExtractSubnetPools(r)
+	return len(subnetpools) == 0, err
+}
+
+// ExtractSubnetPools interprets the results of a single page from a List() API call,
+// producing a slice of SubnetPools structs.
+func ExtractSubnetPools(r pagination.Page) ([]SubnetPool, error) {
+	var s struct {
+		SubnetPools []SubnetPool `json:"subnetpools"`
+	}
+	err := (r.(SubnetPoolPage)).ExtractInto(&s)
+	return s.SubnetPools, err
+}

--- a/openstack/networking/v2/extensions/subnetpools/testing/doc.go
+++ b/openstack/networking/v2/extensions/subnetpools/testing/doc.go
@@ -1,0 +1,2 @@
+// subnetpools unit tests
+package testing

--- a/openstack/networking/v2/extensions/subnetpools/testing/fixtures.go
+++ b/openstack/networking/v2/extensions/subnetpools/testing/fixtures.go
@@ -6,73 +6,73 @@ import (
 
 const SubnetPoolsListResult = `
 {
-	  "subnetpools": [
-	  		{
-	  				"address_scope_id": null,
-	  				"created_at": "2017-12-28T07:21:41Z",
-	  				"default_prefixlen": "8",
-	  				"default_quota": null,
-	  				"description": "IPv4",
-	  				"id": "d43a57fe-3390-4608-b437-b1307b0adb40",
-	  				"ip_version": 4,
-	  				"is_default": false,
-	  				"max_prefixlen": "32",
-	  				"min_prefixlen": "8",
-	  				"name": "MyPoolIpv4",
-	  				"prefixes": [
-	  						"10.10.10.0/24",
-	  						"10.11.11.0/24"
-	  				],
-	  				"project_id": "1e2b9857295a4a3e841809ef492812c5",
-	  				"revision_number": 1,
-	  				"shared": false,
-	  				"tenant_id": "1e2b9857295a4a3e841809ef492812c5",
-	  				"updated_at": "2017-12-28T07:21:41Z"
-	  		},
-	  		{
-	  				"address_scope_id": "0bc38e22-be49-4e67-969e-fec3f36508bd",
-	  				"created_at": "2017-12-28T07:21:34Z",
-	  				"default_prefixlen": "64",
-	  				"default_quota": null,
-	  				"description": "IPv6",
-	  				"id": "832cb7f3-59fe-40cf-8f64-8350ffc03272",
-	  				"ip_version": 6,
-	  				"is_default": true,
-	  				"max_prefixlen": "128",
-	  				"min_prefixlen": "64",
-	  				"name": "MyPoolIpv6",
-	  				"prefixes": [
-	  						"fdf7:b13d:dead:beef::/64",
-	  						"fd65:86cc:a334:39b7::/64"
-	  				],
-	  				"project_id": "1e2b9857295a4a3e841809ef492812c5",
-	  				"revision_number": 1,
-	  				"shared": false,
-	  				"tenant_id": "1e2b9857295a4a3e841809ef492812c5",
-	  				"updated_at": "2017-12-28T07:21:34Z"
-	  		},
-	  		{
-	  				"address_scope_id": null,
-	  				"created_at": "2017-12-28T07:21:27Z",
-	  				"default_prefixlen": "64",
-	  				"default_quota": 4,
-	  				"description": "PublicPool",
-	  				"id": "2fe18ae6-58c2-4a85-8bfb-566d6426749b",
-	  				"ip_version": 6,
-	  				"is_default": false,
-	  				"max_prefixlen": "128",
-	  				"min_prefixlen": "64",
-	  				"name": "PublicIPv6",
-	  				"prefixes": [
-	  						"2001:db8::a3/64"
-	  				],
-	  				"project_id": "ceb366d50ad54fe39717df3af60f9945",
-	  				"revision_number": 1,
-	  				"shared": true,
-	  				"tenant_id": "ceb366d50ad54fe39717df3af60f9945",
-	  				"updated_at": "2017-12-28T07:21:27Z"
-	  		}
-	  ]
+    "subnetpools": [
+        {
+            "address_scope_id": null,
+            "created_at": "2017-12-28T07:21:41Z",
+            "default_prefixlen": "8",
+            "default_quota": null,
+            "description": "IPv4",
+            "id": "d43a57fe-3390-4608-b437-b1307b0adb40",
+            "ip_version": 4,
+            "is_default": false,
+            "max_prefixlen": "32",
+            "min_prefixlen": "8",
+            "name": "MyPoolIpv4",
+            "prefixes": [
+                "10.10.10.0/24",
+                "10.11.11.0/24"
+            ],
+            "project_id": "1e2b9857295a4a3e841809ef492812c5",
+            "revision_number": 1,
+            "shared": false,
+            "tenant_id": "1e2b9857295a4a3e841809ef492812c5",
+            "updated_at": "2017-12-28T07:21:41Z"
+        },
+        {
+            "address_scope_id": "0bc38e22-be49-4e67-969e-fec3f36508bd",
+            "created_at": "2017-12-28T07:21:34Z",
+            "default_prefixlen": "64",
+            "default_quota": null,
+            "description": "IPv6",
+            "id": "832cb7f3-59fe-40cf-8f64-8350ffc03272",
+            "ip_version": 6,
+            "is_default": true,
+            "max_prefixlen": "128",
+            "min_prefixlen": "64",
+            "name": "MyPoolIpv6",
+            "prefixes": [
+                "fdf7:b13d:dead:beef::/64",
+                "fd65:86cc:a334:39b7::/64"
+            ],
+            "project_id": "1e2b9857295a4a3e841809ef492812c5",
+            "revision_number": 1,
+            "shared": false,
+            "tenant_id": "1e2b9857295a4a3e841809ef492812c5",
+            "updated_at": "2017-12-28T07:21:34Z"
+        },
+        {
+            "address_scope_id": null,
+            "created_at": "2017-12-28T07:21:27Z",
+            "default_prefixlen": "64",
+            "default_quota": 4,
+            "description": "PublicPool",
+            "id": "2fe18ae6-58c2-4a85-8bfb-566d6426749b",
+            "ip_version": 6,
+            "is_default": false,
+            "max_prefixlen": "128",
+            "min_prefixlen": "64",
+            "name": "PublicIPv6",
+            "prefixes": [
+                "2001:db8::a3/64"
+            ],
+            "project_id": "ceb366d50ad54fe39717df3af60f9945",
+            "revision_number": 1,
+            "shared": true,
+            "tenant_id": "ceb366d50ad54fe39717df3af60f9945",
+            "updated_at": "2017-12-28T07:21:27Z"
+        }
+    ]
 }
 `
 

--- a/openstack/networking/v2/extensions/subnetpools/testing/fixtures.go
+++ b/openstack/networking/v2/extensions/subnetpools/testing/fixtures.go
@@ -1,0 +1,145 @@
+package testing
+
+import (
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/subnetpools"
+)
+
+const SubnetPoolsListResult = `
+{
+	  "subnetpools": [
+	  		{
+	  				"address_scope_id": null,
+	  				"created_at": "2017-12-28T07:21:41Z",
+	  				"default_prefixlen": 8,
+	  				"default_quota": null,
+	  				"description": "IPv4",
+	  				"id": "d43a57fe-3390-4608-b437-b1307b0adb40",
+	  				"ip_version": 4,
+	  				"is_default": false,
+	  				"max_prefixlen": 32,
+	  				"min_prefixlen": 8,
+	  				"name": "MyPoolIpv4",
+	  				"prefixes": [
+	  						"10.10.10.0/24",
+	  						"10.11.11.0/24"
+	  				],
+	  				"project_id": "1e2b9857295a4a3e841809ef492812c5",
+	  				"revision_number": 1,
+	  				"shared": false,
+	  				"tenant_id": "1e2b9857295a4a3e841809ef492812c5",
+	  				"updated_at": "2017-12-28T07:21:41Z"
+	  		},
+	  		{
+	  				"address_scope_id": "0bc38e22-be49-4e67-969e-fec3f36508bd",
+	  				"created_at": "2017-12-28T07:21:34Z",
+	  				"default_prefixlen": 64,
+	  				"default_quota": null,
+	  				"description": "IPv6",
+	  				"id": "832cb7f3-59fe-40cf-8f64-8350ffc03272",
+	  				"ip_version": 6,
+	  				"is_default": true,
+	  				"max_prefixlen": 128,
+	  				"min_prefixlen": 64,
+	  				"name": "MyPoolIpv6",
+	  				"prefixes": [
+	  						"fdf7:b13d:dead:beef::/64",
+	  						"fd65:86cc:a334:39b7::/64"
+	  				],
+	  				"project_id": "1e2b9857295a4a3e841809ef492812c5",
+	  				"revision_number": 1,
+	  				"shared": false,
+	  				"tenant_id": "1e2b9857295a4a3e841809ef492812c5",
+	  				"updated_at": "2017-12-28T07:21:34Z"
+	  		},
+	  		{
+	  				"address_scope_id": null,
+	  				"created_at": "2017-12-28T07:21:27Z",
+	  				"default_prefixlen": 64,
+	  				"default_quota": 4,
+	  				"description": "PublicPool",
+	  				"id": "2fe18ae6-58c2-4a85-8bfb-566d6426749b",
+	  				"ip_version": 6,
+	  				"is_default": false,
+	  				"max_prefixlen": 128,
+	  				"min_prefixlen": 64,
+	  				"name": "PublicIPv6",
+	  				"prefixes": [
+	  						"2001:db8::a3/64"
+	  				],
+	  				"project_id": "ceb366d50ad54fe39717df3af60f9945",
+	  				"revision_number": 1,
+	  				"shared": true,
+	  				"tenant_id": "ceb366d50ad54fe39717df3af60f9945",
+	  				"updated_at": "2017-12-28T07:21:27Z"
+	  		}
+	  ]
+}
+`
+
+var SubnetPool1 = subnetpools.SubnetPool{
+	AddressScopeID:   "",
+	CreatedAt:        "2017-12-28T07:21:41Z",
+	DefaultPrefixLen: 8,
+	DefaultQuota:     0,
+	Description:      "IPv4",
+	ID:               "d43a57fe-3390-4608-b437-b1307b0adb40",
+	IPversion:        4,
+	IsDefault:        false,
+	MaxPrefixLen:     32,
+	MinPrefixLen:     8,
+	Name:             "MyPoolIpv4",
+	Prefixes: []string{
+		"10.10.10.0/24",
+		"10.11.11.0/24",
+	},
+	ProjectID:      "1e2b9857295a4a3e841809ef492812c5",
+	TenantID:       "1e2b9857295a4a3e841809ef492812c5",
+	RevisionNumber: 1,
+	Shared:         false,
+	UpdatedAt:      "2017-12-28T07:21:41Z",
+}
+
+var SubnetPool2 = subnetpools.SubnetPool{
+	AddressScopeID:   "0bc38e22-be49-4e67-969e-fec3f36508bd",
+	CreatedAt:        "2017-12-28T07:21:34Z",
+	DefaultPrefixLen: 64,
+	DefaultQuota:     0,
+	Description:      "IPv6",
+	ID:               "832cb7f3-59fe-40cf-8f64-8350ffc03272",
+	IPversion:        6,
+	IsDefault:        true,
+	MaxPrefixLen:     128,
+	MinPrefixLen:     64,
+	Name:             "MyPoolIpv6",
+	Prefixes: []string{
+		"fdf7:b13d:dead:beef::/64",
+		"fd65:86cc:a334:39b7::/64",
+	},
+	ProjectID:      "1e2b9857295a4a3e841809ef492812c5",
+	TenantID:       "1e2b9857295a4a3e841809ef492812c5",
+	RevisionNumber: 1,
+	Shared:         false,
+	UpdatedAt:      "2017-12-28T07:21:34Z",
+}
+
+var SubnetPool3 = subnetpools.SubnetPool{
+	AddressScopeID:   "",
+	CreatedAt:        "2017-12-28T07:21:27Z",
+	DefaultPrefixLen: 64,
+	DefaultQuota:     4,
+	Description:      "PublicPool",
+	ID:               "2fe18ae6-58c2-4a85-8bfb-566d6426749b",
+	IPversion:        6,
+	IsDefault:        false,
+	MaxPrefixLen:     128,
+	MinPrefixLen:     64,
+	Name:             "PublicIPv6",
+	Prefixes: []string{
+		"2001:db8::a3/64",
+	},
+	ProjectID:      "ceb366d50ad54fe39717df3af60f9945",
+	TenantID:       "ceb366d50ad54fe39717df3af60f9945",
+	RevisionNumber: 1,
+	Shared:         true,
+	UpdatedAt:      "2017-12-28T07:21:27Z",
+}

--- a/openstack/networking/v2/extensions/subnetpools/testing/fixtures.go
+++ b/openstack/networking/v2/extensions/subnetpools/testing/fixtures.go
@@ -10,14 +10,14 @@ const SubnetPoolsListResult = `
 	  		{
 	  				"address_scope_id": null,
 	  				"created_at": "2017-12-28T07:21:41Z",
-	  				"default_prefixlen": 8,
+	  				"default_prefixlen": "8",
 	  				"default_quota": null,
 	  				"description": "IPv4",
 	  				"id": "d43a57fe-3390-4608-b437-b1307b0adb40",
 	  				"ip_version": 4,
 	  				"is_default": false,
-	  				"max_prefixlen": 32,
-	  				"min_prefixlen": 8,
+	  				"max_prefixlen": "32",
+	  				"min_prefixlen": "8",
 	  				"name": "MyPoolIpv4",
 	  				"prefixes": [
 	  						"10.10.10.0/24",
@@ -32,14 +32,14 @@ const SubnetPoolsListResult = `
 	  		{
 	  				"address_scope_id": "0bc38e22-be49-4e67-969e-fec3f36508bd",
 	  				"created_at": "2017-12-28T07:21:34Z",
-	  				"default_prefixlen": 64,
+	  				"default_prefixlen": "64",
 	  				"default_quota": null,
 	  				"description": "IPv6",
 	  				"id": "832cb7f3-59fe-40cf-8f64-8350ffc03272",
 	  				"ip_version": 6,
 	  				"is_default": true,
-	  				"max_prefixlen": 128,
-	  				"min_prefixlen": 64,
+	  				"max_prefixlen": "128",
+	  				"min_prefixlen": "64",
 	  				"name": "MyPoolIpv6",
 	  				"prefixes": [
 	  						"fdf7:b13d:dead:beef::/64",
@@ -54,14 +54,14 @@ const SubnetPoolsListResult = `
 	  		{
 	  				"address_scope_id": null,
 	  				"created_at": "2017-12-28T07:21:27Z",
-	  				"default_prefixlen": 64,
+	  				"default_prefixlen": "64",
 	  				"default_quota": 4,
 	  				"description": "PublicPool",
 	  				"id": "2fe18ae6-58c2-4a85-8bfb-566d6426749b",
 	  				"ip_version": 6,
 	  				"is_default": false,
-	  				"max_prefixlen": 128,
-	  				"min_prefixlen": 64,
+	  				"max_prefixlen": "128",
+	  				"min_prefixlen": "64",
 	  				"name": "PublicIPv6",
 	  				"prefixes": [
 	  						"2001:db8::a3/64"

--- a/openstack/networking/v2/extensions/subnetpools/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/subnetpools/testing/requests_test.go
@@ -1,0 +1,52 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	fake "github.com/gophercloud/gophercloud/openstack/networking/v2/common"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/subnetpools"
+	"github.com/gophercloud/gophercloud/pagination"
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestList(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/subnetpools", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, SubnetPoolsListResult)
+	})
+
+	count := 0
+
+	subnetpools.List(fake.ServiceClient(), subnetpools.ListOpts{}).EachPage(func(page pagination.Page) (bool, error) {
+		count++
+		actual, err := subnetpools.ExtractSubnetPools(page)
+		if err != nil {
+			t.Errorf("Failed to extract subnetpools: %v", err)
+			return false, nil
+		}
+
+		expected := []subnetpools.SubnetPool{
+			SubnetPool1,
+			SubnetPool2,
+			SubnetPool3,
+		}
+
+		th.CheckDeepEquals(t, expected, actual)
+
+		return true, nil
+	})
+
+	if count != 1 {
+		t.Errorf("Expected 1 page, got %d", count)
+	}
+}

--- a/openstack/networking/v2/extensions/subnetpools/urls.go
+++ b/openstack/networking/v2/extensions/subnetpools/urls.go
@@ -1,0 +1,13 @@
+package subnetpools
+
+import "github.com/gophercloud/gophercloud"
+
+const resourcePath = "subnetpools"
+
+func rootURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL(resourcePath)
+}
+
+func listURL(c *gophercloud.ServiceClient) string {
+	return rootURL(c)
+}


### PR DESCRIPTION
Add support to list Neutron subnetpools through a GET request on `/v2.0/subnetpools`

The same command with OpenStack CLI is done with:
`openstack subnet pool list`
or
`neutron subnetpool-list`

For #672 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/neutron/blob/stable/pike/neutron/db/db_base_plugin_v2.py#L707
https://github.com/openstack/neutron/blob/stable/pike/neutron/api/v2/attributes.py#L214
https://github.com/openstack/neutron/blob/stable/pike/neutron/ipam/subnet_alloc.py#L244