### PR TITLE
BlockStorage v3: Rename VolumeType PublicAccess to IsPublic

### DIFF
--- a/acceptance/openstack/blockstorage/v3/volumetypes_test.go
+++ b/acceptance/openstack/blockstorage/v3/volumetypes_test.go
@@ -53,16 +53,17 @@ func TestVolumeTypesCRUD(t *testing.T) {
 	}
 
 	createOpts := volumetypes.CreateOpts{
-		Name:         "create_from_gophercloud",
-		PublicAccess: true,
-		ExtraSpecs:   map[string]string{"volume_backend_name": "fake_backend_name"},
-		Description:  "create_from_gophercloud",
+		Name:        "create_from_gophercloud",
+		ExtraSpecs:  map[string]string{"volume_backend_name": "fake_backend_name"},
+		Description: "create_from_gophercloud",
 	}
 
 	vt, err := volumetypes.Create(client, createOpts).Extract()
 	if err != nil {
 		t.Fatalf("Unable to create volumetype: %v", err)
 	}
+
+	th.AssertEquals(t, true, vt.IsPublic)
 
 	tools.PrintResource(t, vt)
 
@@ -74,7 +75,9 @@ func TestVolumeTypesCRUD(t *testing.T) {
 		Name:     "updated_volume_type",
 		IsPublic: &isPublic,
 	}).Extract()
-	th.AssertEquals(t, "updated_volume_type", newVT.Name)
 
+	th.AssertEquals(t, "updated_volume_type", newVT.Name)
 	th.AssertEquals(t, false, newVT.IsPublic)
+
+	tools.PrintResource(t, newVT)
 }

--- a/openstack/blockstorage/v3/volumetypes/requests.go
+++ b/openstack/blockstorage/v3/volumetypes/requests.go
@@ -20,7 +20,7 @@ type CreateOpts struct {
 	// The volume type description
 	Description string `json:"description,omitempty"`
 	// the ID of the existing volume snapshot
-	PublicAccess bool `json:"os-volume-type-access:is_public"`
+	IsPublic *bool `json:"os-volume-type-access:is_public,omitempty"`
 	// Extra spec key-value pairs defined by the user.
 	ExtraSpecs map[string]string `json:"extra_specs"`
 }

--- a/openstack/blockstorage/v3/volumetypes/testing/fixtures.go
+++ b/openstack/blockstorage/v3/volumetypes/testing/fixtures.go
@@ -27,9 +27,9 @@ func MockListResponse(t *testing.T) {
         {
             "name": "SSD",
             "qos_specs_id": null,
- 			"os-volume-type-access:is_public": true,
+            "os-volume-type-access:is_public": true,
             "extra_specs": {
-                "volume_backend_name": "lvmdriver-1"
+              "volume_backend_name": "lvmdriver-1"
             },
             "is_public": true,
             "id": "6685584b-1eac-4da6-b5c3-555430cf68ff",
@@ -38,7 +38,7 @@ func MockListResponse(t *testing.T) {
         {
             "name": "SATA",
             "qos_specs_id": null,
-			"os-volume-type-access:is_public": true,
+            "os-volume-type-access:is_public": true,
             "extra_specs": {
                 "volume_backend_name": "lvmdriver-1"
             },
@@ -75,8 +75,8 @@ func MockGetResponse(t *testing.T) {
     "volume_type": {
         "id": "d32019d3-bc6e-4319-9c1d-6722fc136a22",
         "name": "vol-type-001",
-		"os-volume-type-access:is_public": true,
-		"qos_specs_id": "d32019d3-bc6e-4319-9c1d-6722fc136a22",
+        "os-volume-type-access:is_public": true,
+        "qos_specs_id": "d32019d3-bc6e-4319-9c1d-6722fc136a22",
         "description": "volume type 001",
         "is_public": true,
         "extra_specs": {
@@ -100,7 +100,7 @@ func MockCreateResponse(t *testing.T) {
         "name": "test_type",
         "os-volume-type-access:is_public": true,
         "description": "test_type_desc",
-		"extra_specs": {
+        "extra_specs": {
             "capabilities": "gpu"
         }
     }
@@ -119,7 +119,7 @@ func MockCreateResponse(t *testing.T) {
         "os-volume-type-access:is_public": true,
         "id": "6d0ff92a-0007-4780-9ece-acfe5876966a",
         "description": "test_type_desc",
-		"extra_specs": {
+        "extra_specs": {
             "capabilities": "gpu"
         }
     }
@@ -147,7 +147,7 @@ func MockUpdateResponse(t *testing.T) {
         "name": "vol-type-002",
         "description": "volume type 0001",
         "is_public": true,
-		"id": "d32019d3-bc6e-4319-9c1d-6722fc136a22"
+        "id": "d32019d3-bc6e-4319-9c1d-6722fc136a22"
     }
 }`)
 	})

--- a/openstack/blockstorage/v3/volumetypes/testing/requests_test.go
+++ b/openstack/blockstorage/v3/volumetypes/testing/requests_test.go
@@ -45,7 +45,6 @@ func TestListAll(t *testing.T) {
 	})
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, pages, 1)
-
 }
 
 func TestGet(t *testing.T) {
@@ -70,7 +69,15 @@ func TestCreate(t *testing.T) {
 
 	MockCreateResponse(t)
 
-	options := &volumetypes.CreateOpts{Name: "test_type", PublicAccess: true, Description: "test_type_desc", ExtraSpecs: map[string]string{"capabilities": "gpu"}}
+	var isPublic = true
+
+	options := &volumetypes.CreateOpts{
+		Name:        "test_type",
+		IsPublic:    &isPublic,
+		Description: "test_type_desc",
+		ExtraSpecs:  map[string]string{"capabilities": "gpu"},
+	}
+
 	n, err := volumetypes.Create(client.ServiceClient(), options).Extract()
 	th.AssertNoErr(t, err)
 
@@ -99,7 +106,11 @@ func TestUpdate(t *testing.T) {
 	MockUpdateResponse(t)
 
 	var isPublic = true
-	options := volumetypes.UpdateOpts{Name: "vol-type-002", IsPublic: &isPublic}
+	options := volumetypes.UpdateOpts{
+		Name:     "vol-type-002",
+		IsPublic: &isPublic,
+	}
+
 	v, err := volumetypes.Update(client.ServiceClient(), "d32019d3-bc6e-4319-9c1d-6722fc136a22", options).Extract()
 	th.AssertNoErr(t, err)
 	th.CheckEquals(t, "vol-type-002", v.Name)


### PR DESCRIPTION
This commit renames the VolumeType CreateOpts PublicAccess field
to IsPublic.

For #649 

https://github.com/openstack/cinder/blob/master/cinder/api/contrib/types_manage.py#L63-L64