### PR TITLE
Add Neutron subnetpool get support

### DIFF
--- a/openstack/networking/v2/extensions/subnetpools/doc.go
+++ b/openstack/networking/v2/extensions/subnetpools/doc.go
@@ -20,5 +20,13 @@ Example of Listing Subnetpools.
 	for _, subnetpools := range allSubnetpools {
 		fmt.Printf("%+v\n", subnetpools)
 	}
+
+Example to Get a Subnetpool
+
+	subnetPoolID = "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55"
+	subnetPool, err := subnetpools.Get(networkClient, subnetPoolID).Extract()
+	if err != nil {
+		panic(err)
+	}
 */
 package subnetpools

--- a/openstack/networking/v2/extensions/subnetpools/requests.go
+++ b/openstack/networking/v2/extensions/subnetpools/requests.go
@@ -66,3 +66,9 @@ func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 		return SubnetPoolPage{pagination.LinkedPageBase{PageResult: r}}
 	})
 }
+
+// Get retrieves a specific subnetpool based on its ID.
+func Get(c *gophercloud.ServiceClient, id string) (r GetResult) {
+	_, r.Err = c.Get(getURL(c, id), &r.Body, nil)
+	return
+}

--- a/openstack/networking/v2/extensions/subnetpools/results.go
+++ b/openstack/networking/v2/extensions/subnetpools/results.go
@@ -9,6 +9,25 @@ import (
 	"github.com/gophercloud/gophercloud/pagination"
 )
 
+type commonResult struct {
+	gophercloud.Result
+}
+
+// Extract is a function that accepts a result and extracts a subnetpool resource.
+func (r commonResult) Extract() (*SubnetPool, error) {
+	var s struct {
+		SubnetPool *SubnetPool `json:"subnetpool"`
+	}
+	err := r.ExtractInto(&s)
+	return s.SubnetPool, err
+}
+
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a SubnetPool.
+type GetResult struct {
+	commonResult
+}
+
 // SubnetPool represents a Neutron subnetpool.
 // A subnetpool is a pool of addresses from which subnets can be allocated.
 type SubnetPool struct {

--- a/openstack/networking/v2/extensions/subnetpools/testing/fixtures.go
+++ b/openstack/networking/v2/extensions/subnetpools/testing/fixtures.go
@@ -143,3 +143,29 @@ var SubnetPool3 = subnetpools.SubnetPool{
 	Shared:         true,
 	UpdatedAt:      "2017-12-28T07:21:27Z",
 }
+
+const SubnetPoolGetResult = `
+{
+    "subnetpool": {
+        "min_prefixlen": "64",
+        "address_scope_id": null,
+        "default_prefixlen": "64",
+        "id": "0a738452-8057-4ad3-89c2-92f6a74afa76",
+        "max_prefixlen": "128",
+        "name": "my-ipv6-pool",
+        "default_quota": 2,
+        "is_default": true,
+        "project_id": "1e2b9857295a4a3e841809ef492812c5",
+        "tenant_id": "1e2b9857295a4a3e841809ef492812c5",
+        "created_at": "2018-01-01T00:00:01",
+        "prefixes": [
+            "2001:db8::a3/64"
+        ],
+        "updated_at": "2018-01-01T00:10:10",
+        "ip_version": 6,
+        "shared": false,
+        "description": "ipv6 prefixes",
+        "revision_number": 2
+    }
+}
+`

--- a/openstack/networking/v2/extensions/subnetpools/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/subnetpools/testing/requests_test.go
@@ -50,3 +50,41 @@ func TestList(t *testing.T) {
 		t.Errorf("Expected 1 page, got %d", count)
 	}
 }
+
+func TestGet(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/subnetpools/0a738452-8057-4ad3-89c2-92f6a74afa76", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, SubnetPoolGetResult)
+	})
+
+	s, err := subnetpools.Get(fake.ServiceClient(), "0a738452-8057-4ad3-89c2-92f6a74afa76").Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, s.ID, "0a738452-8057-4ad3-89c2-92f6a74afa76")
+	th.AssertEquals(t, s.Name, "my-ipv6-pool")
+	th.AssertEquals(t, s.DefaultQuota, 2)
+	th.AssertEquals(t, s.TenantID, "1e2b9857295a4a3e841809ef492812c5")
+	th.AssertEquals(t, s.ProjectID, "1e2b9857295a4a3e841809ef492812c5")
+	th.AssertEquals(t, s.CreatedAt, "2018-01-01T00:00:01")
+	th.AssertEquals(t, s.UpdatedAt, "2018-01-01T00:10:10")
+	th.AssertDeepEquals(t, s.Prefixes, []string{
+		"2001:db8::a3/64",
+	})
+	th.AssertEquals(t, s.DefaultPrefixLen, 64)
+	th.AssertEquals(t, s.MinPrefixLen, 64)
+	th.AssertEquals(t, s.MaxPrefixLen, 128)
+	th.AssertEquals(t, s.AddressScopeID, "")
+	th.AssertEquals(t, s.IPversion, 6)
+	th.AssertEquals(t, s.Shared, false)
+	th.AssertEquals(t, s.Description, "ipv6 prefixes")
+	th.AssertEquals(t, s.IsDefault, true)
+	th.AssertEquals(t, s.RevisionNumber, 2)
+}

--- a/openstack/networking/v2/extensions/subnetpools/urls.go
+++ b/openstack/networking/v2/extensions/subnetpools/urls.go
@@ -4,10 +4,18 @@ import "github.com/gophercloud/gophercloud"
 
 const resourcePath = "subnetpools"
 
+func resourceURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL(resourcePath, id)
+}
+
 func rootURL(c *gophercloud.ServiceClient) string {
 	return c.ServiceURL(resourcePath)
 }
 
 func listURL(c *gophercloud.ServiceClient) string {
 	return rootURL(c)
+}
+
+func getURL(c *gophercloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
 }


### PR DESCRIPTION
Add support to show a Neutron subnetpool through a GET request on
/v2.0/subnetpools/{subnetpool_id}.
The same command with OpenStack CLI is done with:
`openstack subnet pool show`
or
`neutron subnetpool-show`

For #672 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/neutron/blob/stable/pike/neutron/db/db_base_plugin_v2.py#L707
https://github.com/openstack/neutron/blob/stable/pike/neutron/api/v2/attributes.py#L214
https://github.com/openstack/neutron/blob/stable/pike/neutron/ipam/subnet_alloc.py#L244