### PR TITLE
Add Neutron subnetpool creation support

### DIFF
--- a/acceptance/openstack/networking/v2/extensions/subnetpools/subnetpools.go
+++ b/acceptance/openstack/networking/v2/extensions/subnetpools/subnetpools.go
@@ -1,0 +1,32 @@
+package v2
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/acceptance/tools"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/subnetpools"
+)
+
+// CreateSubnetPool will create a subnetpool. An error will be returned if the
+// subnetpool could not be created.
+func CreateSubnetPool(t *testing.T, client *gophercloud.ServiceClient) (*subnetpools.SubnetPool, error) {
+	subnetPoolName := tools.RandomString("TESTACC-", 8)
+	subnetPoolPrefixes := []string{
+		"10.0.0.0/8",
+	}
+	createOpts := subnetpools.CreateOpts{
+		Name:     subnetPoolName,
+		Prefixes: subnetPoolPrefixes,
+	}
+
+	t.Logf("Attempting to create a subnetpool: %s", subnetPoolName)
+
+	subnetPool, err := subnetpools.Create(client, createOpts).Extract()
+	if err != nil {
+		return nil, err
+	}
+
+	t.Logf("Successfully created the subnetpool.")
+	return subnetPool, nil
+}

--- a/acceptance/openstack/networking/v2/extensions/subnetpools/subnetpools_test.go
+++ b/acceptance/openstack/networking/v2/extensions/subnetpools/subnetpools_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/subnetpools"
 )
 
-func TestCreateSubnetPool(t *testing.T) {
+func TestSubnetPoolsCRUD(t *testing.T) {
 	client, err := clients.NewNetworkV2Client()
 	if err != nil {
 		t.Fatalf("Unable to create a network client: %v", err)

--- a/acceptance/openstack/networking/v2/extensions/subnetpools/subnetpools_test.go
+++ b/acceptance/openstack/networking/v2/extensions/subnetpools/subnetpools_test.go
@@ -10,6 +10,21 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/subnetpools"
 )
 
+func TestCreateSubnetPool(t *testing.T) {
+	client, err := clients.NewNetworkV2Client()
+	if err != nil {
+		t.Fatalf("Unable to create a network client: %v", err)
+	}
+
+	// Create a subnetpool
+	subnetPool, err := CreateSubnetPool(t, client)
+	if err != nil {
+		t.Fatalf("Unable to create a subnetpool: %v", err)
+	}
+
+	tools.PrintResource(t, subnetPool)
+}
+
 func TestSubnetPoolsList(t *testing.T) {
 	client, err := clients.NewNetworkV2Client()
 	if err != nil {

--- a/openstack/networking/v2/extensions/subnetpools/doc.go
+++ b/openstack/networking/v2/extensions/subnetpools/doc.go
@@ -28,5 +28,22 @@ Example to Get a Subnetpool
 	if err != nil {
 		panic(err)
 	}
+
+Example to Create a new Subnetpool.
+
+	subnetPoolName := "private_pool"
+	subnetPoolPrefixes := []string{
+		"10.0.0.0/8",
+		"172.16.0.0/12",
+		"192.168.0.0/16",
+	}
+	subnetPoolOpts := subnetpools.CreateOpts{
+		Name: subnetPoolName,
+		Prefixes: subnetPoolPrefixes,
+	}
+	subnetPool, err := subnetpools.Create(networkClient, subnetPoolOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
 */
 package subnetpools

--- a/openstack/networking/v2/extensions/subnetpools/requests.go
+++ b/openstack/networking/v2/extensions/subnetpools/requests.go
@@ -81,7 +81,6 @@ type CreateOptsBuilder interface {
 
 // CreateOpts specifies parameters of a new subnetpool.
 type CreateOpts struct {
-
 	// Name is the human-readable name of the subnetpool.
 	Name string `json:"name"`
 
@@ -101,7 +100,7 @@ type CreateOpts struct {
 	// that are associated with the address scope.
 	Prefixes []string `json:"prefixes"`
 
-	// DefaultPrefixLen is yhe size of the prefix to allocate when the cidr
+	// DefaultPrefixLen is the size of the prefix to allocate when the cidr
 	// or prefixlen attributes are omitted when you create the subnet.
 	// Defaults to the MinPrefixLen.
 	DefaultPrefixLen int `json:"default_prefixlen,omitempty"`

--- a/openstack/networking/v2/extensions/subnetpools/requests.go
+++ b/openstack/networking/v2/extensions/subnetpools/requests.go
@@ -72,3 +72,77 @@ func Get(c *gophercloud.ServiceClient, id string) (r GetResult) {
 	_, r.Err = c.Get(getURL(c, id), &r.Body, nil)
 	return
 }
+
+// CreateOptsBuilder allows to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToSubnetPoolCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts specifies parameters of a new subnetpool.
+type CreateOpts struct {
+
+	// Name is the human-readable name of the subnetpool.
+	Name string `json:"name"`
+
+	// DefaultQuota is the per-project quota on the prefix space
+	// that can be allocated from the subnetpool for project subnets.
+	DefaultQuota int `json:"default_quota,omitempty"`
+
+	// TenantID is the id of the Identity project.
+	TenantID string `json:"tenant_id,omitempty"`
+
+	// ProjectID is the id of the Identity project.
+	ProjectID string `json:"project_id,omitempty"`
+
+	// Prefixes is the list of subnet prefixes to assign to the subnetpool.
+	// Neutron API merges adjacent prefixes and treats them as a single prefix.
+	// Each subnet prefix must be unique among all subnet prefixes in all subnetpools
+	// that are associated with the address scope.
+	Prefixes []string `json:"prefixes"`
+
+	// DefaultPrefixLen is yhe size of the prefix to allocate when the cidr
+	// or prefixlen attributes are omitted when you create the subnet.
+	// Defaults to the MinPrefixLen.
+	DefaultPrefixLen int `json:"default_prefixlen,omitempty"`
+
+	// MinPrefixLen is the smallest prefix that can be allocated from a subnetpool.
+	// For IPv4 subnetpools, default is 8.
+	// For IPv6 subnetpools, default is 64.
+	MinPrefixLen int `json:"min_prefixlen,omitempty"`
+
+	// MaxPrefixLen is the maximum prefix size that can be allocated from the subnetpool.
+	// For IPv4 subnetpools, default is 32.
+	// For IPv6 subnetpools, default is 128.
+	MaxPrefixLen int `json:"max_prefixlen,omitempty"`
+
+	// AddressScopeID is the Neutron address scope to assign to the subnetpool.
+	AddressScopeID string `json:"address_scope_id,omitempty"`
+
+	// Shared indicates whether this network is shared across all projects.
+	Shared bool `json:"shared,omitempty"`
+
+	// Description is the human-readable description for the resource.
+	Description string `json:"description,omitempty"`
+
+	// IsDefault indicates if the subnetpool is default pool or not.
+	IsDefault bool `json:"is_default,omitempty"`
+}
+
+// ToSubnetPoolCreateMap constructs a request body from CreateOpts.
+func (opts CreateOpts) ToSubnetPoolCreateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "subnetpool")
+}
+
+// Create requests the creation of a new subnetpool on the server.
+func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToSubnetPoolCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(createURL(client), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{201},
+	})
+	return
+}

--- a/openstack/networking/v2/extensions/subnetpools/results.go
+++ b/openstack/networking/v2/extensions/subnetpools/results.go
@@ -28,6 +28,12 @@ type GetResult struct {
 	commonResult
 }
 
+// CreateResult represents the result of a create operation. Call its Extract
+// method to interpret it as a SubnetPool.
+type CreateResult struct {
+	commonResult
+}
+
 // SubnetPool represents a Neutron subnetpool.
 // A subnetpool is a pool of addresses from which subnets can be allocated.
 type SubnetPool struct {

--- a/openstack/networking/v2/extensions/subnetpools/testing/fixtures.go
+++ b/openstack/networking/v2/extensions/subnetpools/testing/fixtures.go
@@ -169,3 +169,46 @@ const SubnetPoolGetResult = `
     }
 }
 `
+
+const SubnetPoolCreateRequest = `
+{
+    "subnetpool": {
+        "name": "my_ipv4_pool",
+        "prefixes": [
+            "10.10.0.0/16",
+            "10.11.11.0/24"
+        ],
+        "address_scope_id": "3d4e2e2a-552b-42ad-a16d-820bbf3edaf3",
+        "min_prefixlen": 25,
+        "max_prefixlen": 30,
+        "description": "ipv4 prefixes"
+    }
+}
+`
+
+const SubnetPoolCreateResult = `
+{
+    "subnetpool": {
+        "address_scope_id": "3d4e2e2a-552b-42ad-a16d-820bbf3edaf3",
+        "created_at": "2018-01-01T00:00:15Z",
+        "default_prefixlen": "25",
+        "default_quota": null,
+        "description": "ipv4 prefixes",
+        "id": "55b5999c-c2fe-42cd-bce0-961a551b80f5",
+        "ip_version": 4,
+        "is_default": false,
+        "max_prefixlen": "30",
+        "min_prefixlen": "25",
+        "name": "my_ipv4_pool",
+        "prefixes": [
+            "10.10.0.0/16",
+            "10.11.11.0/24"
+        ],
+        "project_id": "1e2b9857295a4a3e841809ef492812c5",
+        "revision_number": 1,
+        "shared": false,
+        "tenant_id": "1e2b9857295a4a3e841809ef492812c5",
+        "updated_at": "2018-01-01T00:00:15Z"
+    }
+}
+`

--- a/openstack/networking/v2/extensions/subnetpools/urls.go
+++ b/openstack/networking/v2/extensions/subnetpools/urls.go
@@ -19,3 +19,7 @@ func listURL(c *gophercloud.ServiceClient) string {
 func getURL(c *gophercloud.ServiceClient, id string) string {
 	return resourceURL(c, id)
 }
+
+func createURL(c *gophercloud.ServiceClient) string {
+	return rootURL(c)
+}


### PR DESCRIPTION
Add support to create a Neutron subnetpool through a POST request on
/v2.0/subnetpools.
The same command with OpenStack CLI is done with:
`openstack subnet pool create`
or
`neutron subnetpool-create`

For #672 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/neutron/blob/stable/pike/neutron/db/db_base_plugin_v2.py#L1117
https://github.com/openstack/neutron/blob/stable/pike/neutron/api/v2/attributes.py#L214