### PR TITLE
Expose the real error message of BadRequest error

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -103,7 +103,11 @@ type ErrDefault503 struct {
 }
 
 func (e ErrDefault400) Error() string {
-	return "Invalid request due to incorrect syntax or missing required parameters."
+	e.DefaultErrString = fmt.Sprintf(
+		"Bad request with: [%s %s], error message: %s",
+		e.Method, e.URL, e.Body,
+	)
+	return e.choseErrString()
 }
 func (e ErrDefault401) Error() string {
 	return "Authentication failed"


### PR DESCRIPTION
This change expose the error message of BadRequest error from openstack
API, this is helpful to find out the reason of request failure.

For #243 
  