### PR TITLE
Flavor Extra Spec Delete

### DIFF
--- a/acceptance/openstack/compute/v2/flavors_test.go
+++ b/acceptance/openstack/compute/v2/flavors_test.go
@@ -176,6 +176,11 @@ func TestFlavorExtraSpecsCRUD(t *testing.T) {
 	}
 	tools.PrintResource(t, createdExtraSpecs)
 
+	err = flavors.DeleteExtraSpec(client, flavor.ID, "hw:cpu_policy").ExtractErr()
+	if err != nil {
+		t.Fatalf("Unable to delete ExtraSpec: %v\n", err)
+	}
+
 	allExtraSpecs, err := flavors.ListExtraSpecs(client, flavor.ID).Extract()
 	if err != nil {
 		t.Fatalf("Unable to get flavor extra_specs: %v", err)
@@ -189,4 +194,5 @@ func TestFlavorExtraSpecsCRUD(t *testing.T) {
 		}
 		tools.PrintResource(t, spec)
 	}
+
 }

--- a/openstack/compute/v2/flavors/doc.go
+++ b/openstack/compute/v2/flavors/doc.go
@@ -99,5 +99,12 @@ Example to Get Extra Specs for a Flavor
 
 	fmt.Printf("%+v", extraSpecs)
 
+Example to Delete an Extra Spec for a Flavor
+
+	flavorID := "e91758d6-a54a-4778-ad72-0c73a1cb695b"
+	err := flavors.DeleteExtraSpec(computeClient, flavorID, "hw:cpu_thread_policy").ExtractErr()
+	if err != nil {
+		panic(err)
+	}
 */
 package flavors

--- a/openstack/compute/v2/flavors/requests.go
+++ b/openstack/compute/v2/flavors/requests.go
@@ -231,6 +231,15 @@ func CreateExtraSpecs(client *gophercloud.ServiceClient, flavorID string, opts C
 	return
 }
 
+// DeleteExtraSpec will delete the key-value pair with the given key for the given
+// flavor ID.
+func DeleteExtraSpec(client *gophercloud.ServiceClient, flavorID, key string) (r DeleteExtraSpecResult) {
+	_, r.Err = client.Delete(extraSpecDeleteURL(client, flavorID, key), &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
 // IDFromName is a convienience function that returns a flavor's ID given its
 // name.
 func IDFromName(client *gophercloud.ServiceClient, name string) (string, error) {

--- a/openstack/compute/v2/flavors/results.go
+++ b/openstack/compute/v2/flavors/results.go
@@ -223,6 +223,12 @@ type GetExtraSpecResult struct {
 	extraSpecResult
 }
 
+// DeleteExtraSpecResult contains the result of a Delete operation. Call its
+// ExtractErr method to determine if the call succeeded or failed.
+type DeleteExtraSpecResult struct {
+	gophercloud.ErrResult
+}
+
 // Extract interprets any extraSpecResult as an ExtraSpec, if possible.
 func (r extraSpecResult) Extract() (map[string]string, error) {
 	var s map[string]string

--- a/openstack/compute/v2/flavors/testing/fixtures.go
+++ b/openstack/compute/v2/flavors/testing/fixtures.go
@@ -78,3 +78,12 @@ func HandleExtraSpecsCreateSuccessfully(t *testing.T) {
 		fmt.Fprintf(w, ExtraSpecsGetBody)
 	})
 }
+
+func HandleExtraSpecDeleteSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/flavors/1/os-extra_specs/hw:cpu_policy", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.WriteHeader(http.StatusOK)
+	})
+}

--- a/openstack/compute/v2/flavors/testing/requests_test.go
+++ b/openstack/compute/v2/flavors/testing/requests_test.go
@@ -336,3 +336,12 @@ func TestFlavorExtraSpecsCreate(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.CheckDeepEquals(t, expected, actual)
 }
+
+func TestFlavorExtraSpecDelete(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleExtraSpecDeleteSuccessfully(t)
+
+	res := flavors.DeleteExtraSpec(fake.ServiceClient(), "1", "hw:cpu_policy")
+	th.AssertNoErr(t, res.Err)
+}

--- a/openstack/compute/v2/flavors/urls.go
+++ b/openstack/compute/v2/flavors/urls.go
@@ -39,3 +39,7 @@ func extraSpecsGetURL(client *gophercloud.ServiceClient, id, key string) string 
 func extraSpecsCreateURL(client *gophercloud.ServiceClient, id string) string {
 	return client.ServiceURL("flavors", id, "os-extra_specs")
 }
+
+func extraSpecDeleteURL(client *gophercloud.ServiceClient, id, key string) string {
+	return client.ServiceURL("flavors", id, "os-extra_specs", key)
+}


### PR DESCRIPTION
For #540

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

API reference:

https://developer.openstack.org/api-ref/compute/#delete-an-extra-spec-for-a-flavor

Nova implementation:

https://github.com/openstack/nova/blob/stable/pike/nova/api/openstack/compute/flavors_extraspecs.py#L111

There is a note in the above that the error _should_ be 204, rather than the 200 that is returned. The value in the API spec is also 200. Testing proved that the return code is 200 rather than 204.