### PR TITLE
Add Neutron subnetpool update support

### DIFF
--- a/acceptance/openstack/networking/v2/extensions/subnetpools/subnetpools_test.go
+++ b/acceptance/openstack/networking/v2/extensions/subnetpools/subnetpools_test.go
@@ -29,7 +29,7 @@ func TestSubnetPoolsCRUD(t *testing.T) {
 		Name: newName,
 	}
 
-	newSubnetPool, err = subnetpools.Update(client, subnetPool.ID, updateOpts).Extract()
+	newSubnetPool, err := subnetpools.Update(client, subnetPool.ID, updateOpts).Extract()
 	if err != nil {
 		t.Fatalf("Unable to update the subnetpool: %v", err)
 	}

--- a/acceptance/openstack/networking/v2/extensions/subnetpools/subnetpools_test.go
+++ b/acceptance/openstack/networking/v2/extensions/subnetpools/subnetpools_test.go
@@ -23,6 +23,18 @@ func TestSubnetPoolsCRUD(t *testing.T) {
 	}
 
 	tools.PrintResource(t, subnetPool)
+
+	newName := tools.RandomString("TESTACC-", 8)
+	updateOpts := &subnetpools.UpdateOpts{
+		Name: newName,
+	}
+
+	newSubnetPool, err = subnetpools.Update(client, subnetPool.ID, updateOpts).Extract()
+	if err != nil {
+		t.Fatalf("Unable to update the subnetpool: %v", err)
+	}
+
+	tools.PrintResource(t, newSubnetPool)
 }
 
 func TestSubnetPoolsList(t *testing.T) {

--- a/openstack/networking/v2/extensions/subnetpools/doc.go
+++ b/openstack/networking/v2/extensions/subnetpools/doc.go
@@ -1,7 +1,7 @@
 /*
 Package subnetpools provides the ability to retrieve and manage subnetpools through the Neutron API.
 
-Example of Listing Subnetpools.
+Example of Listing Subnetpools
 
 	listOpts := subnets.ListOpts{
 		IPVersion: 6,
@@ -29,7 +29,7 @@ Example to Get a Subnetpool
 		panic(err)
 	}
 
-Example to Create a new Subnetpool.
+Example to Create a new Subnetpool
 
 	subnetPoolName := "private_pool"
 	subnetPoolPrefixes := []string{

--- a/openstack/networking/v2/extensions/subnetpools/doc.go
+++ b/openstack/networking/v2/extensions/subnetpools/doc.go
@@ -45,5 +45,20 @@ Example to Create a new Subnetpool.
 	if err != nil {
 		panic(err)
 	}
+
+Example to Update a Subnetpool
+
+	subnetPoolID := "099546ca-788d-41e5-a76d-17d8cd282d3e"
+	updateOpts := networks.UpdateOpts{
+		Prefixes: []string{
+		  "fdf7:b13d:dead:beef::/64",
+	  },
+		MaxPrefixLen: 72,
+	}
+
+	subnetPool, err := subnetpools.Update(networkClient, subnetPoolID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
 */
 package subnetpools

--- a/openstack/networking/v2/extensions/subnetpools/requests.go
+++ b/openstack/networking/v2/extensions/subnetpools/requests.go
@@ -159,7 +159,7 @@ type UpdateOpts struct {
 
 	// DefaultQuota is the per-project quota on the prefix space
 	// that can be allocated from the subnetpool for project subnets.
-	DefaultQuota int `json:"default_quota,omitempty"`
+	DefaultQuota *int `json:"default_quota,omitempty"`
 
 	// TenantID is the id of the Identity project.
 	TenantID string `json:"tenant_id,omitempty"`
@@ -189,13 +189,13 @@ type UpdateOpts struct {
 	MaxPrefixLen int `json:"max_prefixlen,omitempty"`
 
 	// AddressScopeID is the Neutron address scope to assign to the subnetpool.
-	AddressScopeID string `json:"address_scope_id,omitempty"`
+	AddressScopeID *string `json:"address_scope_id,omitempty"`
 
 	// Description is thehuman-readable description for the resource.
-	Description string `json:"description,omitempty"`
+	Description *string `json:"description,omitempty"`
 
 	// IsDefault indicates if the subnetpool is default pool or not.
-	IsDefault bool `json:"is_default,omitempty"`
+	IsDefault *bool `json:"is_default,omitempty"`
 }
 
 // ToSubnetPoolUpdateMap builds a request body from UpdateOpts.

--- a/openstack/networking/v2/extensions/subnetpools/requests.go
+++ b/openstack/networking/v2/extensions/subnetpools/requests.go
@@ -145,3 +145,74 @@ func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r Create
 	})
 	return
 }
+
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
+type UpdateOptsBuilder interface {
+	ToSubnetPoolUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts represents options used to update a network.
+type UpdateOpts struct {
+	// Name is the human-readable name of the subnetpool.
+	Name string `json:"name,omitempty"`
+
+	// DefaultQuota is the per-project quota on the prefix space
+	// that can be allocated from the subnetpool for project subnets.
+	DefaultQuota int `json:"default_quota,omitempty"`
+
+	// TenantID is the id of the Identity project.
+	TenantID string `json:"tenant_id,omitempty"`
+
+	// ProjectID is the id of the Identity project.
+	ProjectID string `json:"project_id,omitempty"`
+
+	// Prefixes is the list of subnet prefixes to assign to the subnetpool.
+	// Neutron API merges adjacent prefixes and treats them as a single prefix.
+	// Each subnet prefix must be unique among all subnet prefixes in all subnetpools
+	// that are associated with the address scope.
+	Prefixes []string `json:"prefixes,omitempty"`
+
+	// DefaultPrefixLen is yhe size of the prefix to allocate when the cidr
+	// or prefixlen attributes are omitted when you create the subnet.
+	// Defaults to the MinPrefixLen.
+	DefaultPrefixLen int `json:"default_prefixlen,omitempty"`
+
+	// MinPrefixLen is the smallest prefix that can be allocated from a subnetpool.
+	// For IPv4 subnetpools, default is 8.
+	// For IPv6 subnetpools, default is 64.
+	MinPrefixLen int `json:"min_prefixlen,omitempty"`
+
+	// MaxPrefixLen is the maximum prefix size that can be allocated from the subnetpool.
+	// For IPv4 subnetpools, default is 32.
+	// For IPv6 subnetpools, default is 128.
+	MaxPrefixLen int `json:"max_prefixlen,omitempty"`
+
+	// AddressScopeID is the Neutron address scope to assign to the subnetpool.
+	AddressScopeID string `json:"address_scope_id,omitempty"`
+
+	// Description is thehuman-readable description for the resource.
+	Description string `json:"description,omitempty"`
+
+	// IsDefault indicates if the subnetpool is default pool or not.
+	IsDefault bool `json:"is_default,omitempty"`
+}
+
+// ToSubnetPoolUpdateMap builds a request body from UpdateOpts.
+func (opts UpdateOpts) ToSubnetPoolUpdateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "subnetpool")
+}
+
+// Update accepts a UpdateOpts struct and updates an existing subnetpool using the
+// values provided.
+func Update(c *gophercloud.ServiceClient, subnetPoolID string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToSubnetPoolUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Put(updateURL(c, subnetPoolID), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}

--- a/openstack/networking/v2/extensions/subnetpools/results.go
+++ b/openstack/networking/v2/extensions/subnetpools/results.go
@@ -34,6 +34,12 @@ type CreateResult struct {
 	commonResult
 }
 
+// UpdateResult represents the result of an update operation. Call its Extract
+// method to interpret it as a SubnetPool.
+type UpdateResult struct {
+	commonResult
+}
+
 // SubnetPool represents a Neutron subnetpool.
 // A subnetpool is a pool of addresses from which subnets can be allocated.
 type SubnetPool struct {

--- a/openstack/networking/v2/extensions/subnetpools/testing/fixtures.go
+++ b/openstack/networking/v2/extensions/subnetpools/testing/fixtures.go
@@ -212,3 +212,43 @@ const SubnetPoolCreateResult = `
     }
 }
 `
+
+const SubnetPoolUpdateRequest = `
+{
+    "subnetpool": {
+        "name": "new_subnetpool_name",
+        "prefixes": [
+            "10.11.12.0/24",
+            "10.24.0.0/16"
+        ],
+        "max_prefixlen": 16
+    }
+}
+`
+
+const SubnetPoolUpdateResponse = `
+{
+    "subnetpool": {
+        "address_scope_id": null,
+        "created_at": "2018-01-03T07:21:34Z",
+        "default_prefixlen": 8,
+        "default_quota": null,
+        "description": "private pool",
+        "id": "099546ca-788d-41e5-a76d-17d8cd282d3e",
+        "ip_version": 4,
+        "is_default": true,
+        "max_prefixlen": 16,
+        "min_prefixlen": 8,
+        "name": "new_subnetpool_name",
+        "prefixes": [
+            "10.8.0.0/16",
+            "10.11.12.0/24",
+            "10.24.0.0/16"
+        ],
+        "revision_number": 2,
+        "shared": false,
+        "tenant_id": "1e2b9857295a4a3e841809ef492812c5",
+        "updated_at": "2018-01-05T09:56:56Z"
+    }
+}
+`

--- a/openstack/networking/v2/extensions/subnetpools/testing/fixtures.go
+++ b/openstack/networking/v2/extensions/subnetpools/testing/fixtures.go
@@ -221,7 +221,10 @@ const SubnetPoolUpdateRequest = `
             "10.11.12.0/24",
             "10.24.0.0/16"
         ],
-        "max_prefixlen": 16
+        "max_prefixlen": 16,
+        "address_scope_id": "",
+        "default_quota": 0,
+        "description": ""
     }
 }
 `
@@ -233,7 +236,7 @@ const SubnetPoolUpdateResponse = `
         "created_at": "2018-01-03T07:21:34Z",
         "default_prefixlen": 8,
         "default_quota": null,
-        "description": "private pool",
+        "description": null,
         "id": "099546ca-788d-41e5-a76d-17d8cd282d3e",
         "ip_version": 4,
         "is_default": true,

--- a/openstack/networking/v2/extensions/subnetpools/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/subnetpools/testing/requests_test.go
@@ -147,13 +147,18 @@ func TestUpdate(t *testing.T) {
 		fmt.Fprintf(w, SubnetPoolUpdateResponse)
 	})
 
+	nullString := ""
+	nullInt := 0
 	updateOpts := subnetpools.UpdateOpts{
 		Name: "new_subnetpool_name",
 		Prefixes: []string{
 			"10.11.12.0/24",
 			"10.24.0.0/16",
 		},
-		MaxPrefixLen: 16,
+		MaxPrefixLen:   16,
+		AddressScopeID: &nullString,
+		DefaultQuota:   &nullInt,
+		Description:    &nullString,
 	}
 	n, err := subnetpools.Update(fake.ServiceClient(), "099546ca-788d-41e5-a76d-17d8cd282d3e", updateOpts).Extract()
 	th.AssertNoErr(t, err)
@@ -166,4 +171,7 @@ func TestUpdate(t *testing.T) {
 	})
 	th.AssertEquals(t, n.MaxPrefixLen, 16)
 	th.AssertEquals(t, n.ID, "099546ca-788d-41e5-a76d-17d8cd282d3e")
+	th.AssertEquals(t, n.AddressScopeID, "")
+	th.AssertEquals(t, n.DefaultQuota, 0)
+	th.AssertEquals(t, n.Description, "")
 }

--- a/openstack/networking/v2/extensions/subnetpools/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/subnetpools/testing/requests_test.go
@@ -129,3 +129,41 @@ func TestCreate(t *testing.T) {
 	th.AssertEquals(t, s.AddressScopeID, "3d4e2e2a-552b-42ad-a16d-820bbf3edaf3")
 	th.AssertEquals(t, s.Description, "ipv4 prefixes")
 }
+
+func TestUpdate(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/subnetpools/099546ca-788d-41e5-a76d-17d8cd282d3e", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, SubnetPoolUpdateRequest)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, SubnetPoolUpdateResponse)
+	})
+
+	updateOpts := subnetpools.UpdateOpts{
+		Name: "new_subnetpool_name",
+		Prefixes: []string{
+			"10.11.12.0/24",
+			"10.24.0.0/16",
+		},
+		MaxPrefixLen: 16,
+	}
+	n, err := subnetpools.Update(fake.ServiceClient(), "099546ca-788d-41e5-a76d-17d8cd282d3e", updateOpts).Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, n.Name, "new_subnetpool_name")
+	th.AssertDeepEquals(t, n.Prefixes, []string{
+		"10.8.0.0/16",
+		"10.11.12.0/24",
+		"10.24.0.0/16",
+	})
+	th.AssertEquals(t, n.MaxPrefixLen, 16)
+	th.AssertEquals(t, n.ID, "099546ca-788d-41e5-a76d-17d8cd282d3e")
+}

--- a/openstack/networking/v2/extensions/subnetpools/urls.go
+++ b/openstack/networking/v2/extensions/subnetpools/urls.go
@@ -23,3 +23,7 @@ func getURL(c *gophercloud.ServiceClient, id string) string {
 func createURL(c *gophercloud.ServiceClient) string {
 	return rootURL(c)
 }
+
+func updateURL(c *gophercloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
+}


### PR DESCRIPTION
Add support to update a Neutron subnetpool through a PUT request on /v2.0/subnetpools.
The same command with OpenStack CLI is done with:
`openstack subnet pool set`
 or
`neutron subnetpool-update`

For [#672](https://github.com/gophercloud/gophercloud/issues/672)

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/neutron/blob/stable/pike/neutron/db/db_base_plugin_v2.py#L1146
https://github.com/openstack/neutron/blob/stable/pike/neutron/api/v2/attributes.py#L214