### PR TITLE
Fix Orchestration TestTemplateParsing

### DIFF
--- a/openstack/orchestration/v1/stacks/fixtures.go
+++ b/openstack/orchestration/v1/stacks/fixtures.go
@@ -6,7 +6,7 @@ const ValidJSONTemplate = `
   "heat_template_version": "2014-10-16",
   "parameters": {
     "flavor": {
-      "default": 4353,
+      "default": "debian2G",
       "description": "Flavor for the server to be created",
       "hidden": true,
       "type": "string"
@@ -32,7 +32,7 @@ parameters:
   flavor:
     type: string
     description: Flavor for the server to be created
-    default: 4353
+    default: debian2G
     hidden: true
 resources:
   test_server:
@@ -49,7 +49,7 @@ parameters:
   flavor:
     type: string
     description: Flavor for the server to be created
-    default: 4353
+    default: debian2G
     hidden: true
 resources:
   test_server:
@@ -128,7 +128,7 @@ parameters:
 	flavor:
 		type: string
 		description: Flavor for the server to be created
-		default: 4353
+		default: debian2G
 		hidden: true
 resources:
 	test_server:
@@ -180,7 +180,7 @@ var ValidJSONTemplateParsed = map[string]interface{}{
 	"heat_template_version": "2014-10-16",
 	"parameters": map[string]interface{}{
 		"flavor": map[string]interface{}{
-			"default":     4353,
+			"default":     "debian2G",
 			"description": "Flavor for the server to be created",
 			"hidden":      true,
 			"type":        "string",

--- a/openstack/orchestration/v1/stacks/template_test.go
+++ b/openstack/orchestration/v1/stacks/template_test.go
@@ -99,7 +99,7 @@ resources:
       - {uuid: 11111111-1111-1111-1111-111111111111}`
 	th.Mux.HandleFunc(urlparsed.Path, func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "GET")
-		w.Header().Set("Content-Type", "application/jason")
+		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprintf(w, myNovaContent)
 	})


### PR DESCRIPTION
Fix "Content-Type" in orchestration templates unit tests ("application/jason" -> "application/json").

Set "default" field to be a string in "ValidJSONTemplate", "ValidYAMLTemplate", "InvalidTemplateNoVersion", "InvalidEnvironment", "ValidJSONTemplateParsed" orchestration templates test fixtures.

That automatically fixes the TestTemplateParsing unit test.

For #707 
 
Default field in the flavor is a reference to the default flavor that will be used in the template. It can't be an `int` as it represents the name (or maybe ID) of the flavor.
There are some examples in the official [heat-templates](https://github.com/openstack/heat-templates) repo: [autohealing_group.yaml#L17](https://github.com/openstack/heat-templates/blob/master/hot/autohealing/autohealing_group.yaml#L17).