### PR TITLE
Flavor Extra Spec Update

### DIFF
--- a/acceptance/openstack/compute/v2/flavors_test.go
+++ b/acceptance/openstack/compute/v2/flavors_test.go
@@ -181,6 +181,15 @@ func TestFlavorExtraSpecsCRUD(t *testing.T) {
 		t.Fatalf("Unable to delete ExtraSpec: %v\n", err)
 	}
 
+	updateOpts := flavors.ExtraSpecsOpts{
+		"hw:cpu_thread_policy": "CPU-THREAD-POLICY-BETTER",
+	}
+	updatedExtraSpec, err := flavors.UpdateExtraSpec(client, flavor.ID, updateOpts).Extract()
+	if err != nil {
+		t.Fatalf("Unable to update flavor extra_specs: %v", err)
+	}
+	tools.PrintResource(t, updatedExtraSpec)
+
 	allExtraSpecs, err := flavors.ListExtraSpecs(client, flavor.ID).Extract()
 	if err != nil {
 		t.Fatalf("Unable to get flavor extra_specs: %v", err)

--- a/openstack/compute/v2/flavors/doc.go
+++ b/openstack/compute/v2/flavors/doc.go
@@ -99,6 +99,20 @@ Example to Get Extra Specs for a Flavor
 
 	fmt.Printf("%+v", extraSpecs)
 
+Example to Update Extra Specs for a Flavor
+
+	flavorID := "e91758d6-a54a-4778-ad72-0c73a1cb695b"
+
+	updateOpts := flavors.ExtraSpecsOpts{
+		"hw:cpu_thread_policy": "CPU-THREAD-POLICY-UPDATED",
+	}
+	updatedExtraSpec, err := flavors.UpdateExtraSpec(computeClient, flavorID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v", updatedExtraSpec)
+
 Example to Delete an Extra Spec for a Flavor
 
 	flavorID := "e91758d6-a54a-4778-ad72-0c73a1cb695b"

--- a/openstack/compute/v2/flavors/requests.go
+++ b/openstack/compute/v2/flavors/requests.go
@@ -231,6 +231,43 @@ func CreateExtraSpecs(client *gophercloud.ServiceClient, flavorID string, opts C
 	return
 }
 
+// UpdateExtraSpecOptsBuilder allows extensions to add additional parameters to the
+// Update request.
+type UpdateExtraSpecOptsBuilder interface {
+	ToExtraSpecUpdateMap() (map[string]string, string, error)
+}
+
+// ToExtraSpecUpdateMap assembles a body for an Update request based on the
+// contents of a ExtraSpecOpts.
+func (opts ExtraSpecsOpts) ToExtraSpecUpdateMap() (map[string]string, string, error) {
+	if len(opts) != 1 {
+		err := gophercloud.ErrInvalidInput{}
+		err.Argument = "flavors.ExtraSpecOpts"
+		err.Info = "Must have 1 and only one key-value pair"
+		return nil, "", err
+	}
+
+	var key string
+	for k := range opts {
+		key = k
+	}
+
+	return opts, key, nil
+}
+
+// UpdateExtraSpec will updates the value of the specified flavor's extra spec for the key in opts.
+func UpdateExtraSpec(client *gophercloud.ServiceClient, flavorID string, opts UpdateExtraSpecOptsBuilder) (r UpdateExtraSpecResult) {
+	b, key, err := opts.ToExtraSpecUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Put(extraSpecUpdateURL(client, flavorID, key), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
 // DeleteExtraSpec will delete the key-value pair with the given key for the given
 // flavor ID.
 func DeleteExtraSpec(client *gophercloud.ServiceClient, flavorID, key string) (r DeleteExtraSpecResult) {

--- a/openstack/compute/v2/flavors/results.go
+++ b/openstack/compute/v2/flavors/results.go
@@ -223,6 +223,12 @@ type GetExtraSpecResult struct {
 	extraSpecResult
 }
 
+// UpdateExtraSpecResult contains the result of an Update operation. Call its
+// Extract method to interpret it as a map[string]interface.
+type UpdateExtraSpecResult struct {
+	extraSpecResult
+}
+
 // DeleteExtraSpecResult contains the result of a Delete operation. Call its
 // ExtractErr method to determine if the call succeeded or failed.
 type DeleteExtraSpecResult struct {

--- a/openstack/compute/v2/flavors/testing/fixtures.go
+++ b/openstack/compute/v2/flavors/testing/fixtures.go
@@ -19,10 +19,17 @@ const ExtraSpecsGetBody = `
 }
 `
 
-// ExtraSpecGetBody provides a GET result of a particular extra_spec for a flavor
+// GetExtraSpecBody provides a GET result of a particular extra_spec for a flavor
 const GetExtraSpecBody = `
 {
     "hw:cpu_policy": "CPU-POLICY"
+}
+`
+
+// UpdatedExtraSpecBody provides an PUT result of a particular updated extra_spec for a flavor
+const UpdatedExtraSpecBody = `
+{
+    "hw:cpu_policy": "CPU-POLICY-2"
 }
 `
 
@@ -35,6 +42,11 @@ var ExtraSpecs = map[string]string{
 // ExtraSpec is the expected extra_spec returned from GET on a flavor's extra_specs
 var ExtraSpec = map[string]string{
 	"hw:cpu_policy": "CPU-POLICY",
+}
+
+// UpdatedExtraSpec is the expected extra_spec returned from PUT on a flavor's extra_specs
+var UpdatedExtraSpec = map[string]string{
+	"hw:cpu_policy": "CPU-POLICY-2",
 }
 
 func HandleExtraSpecsListSuccessfully(t *testing.T) {
@@ -76,6 +88,21 @@ func HandleExtraSpecsCreateSuccessfully(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprintf(w, ExtraSpecsGetBody)
+	})
+}
+
+func HandleExtraSpecUpdateSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/flavors/1/os-extra_specs/hw:cpu_policy", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, `{
+				"hw:cpu_policy":        "CPU-POLICY-2"
+			}`)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, UpdatedExtraSpecBody)
 	})
 }
 

--- a/openstack/compute/v2/flavors/testing/requests_test.go
+++ b/openstack/compute/v2/flavors/testing/requests_test.go
@@ -337,6 +337,20 @@ func TestFlavorExtraSpecsCreate(t *testing.T) {
 	th.CheckDeepEquals(t, expected, actual)
 }
 
+func TestFlavorExtraSpecUpdate(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleExtraSpecUpdateSuccessfully(t)
+
+	updateOpts := flavors.ExtraSpecsOpts{
+		"hw:cpu_policy": "CPU-POLICY-2",
+	}
+	expected := UpdatedExtraSpec
+	actual, err := flavors.UpdateExtraSpec(fake.ServiceClient(), "1", updateOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, expected, actual)
+}
+
 func TestFlavorExtraSpecDelete(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()

--- a/openstack/compute/v2/flavors/urls.go
+++ b/openstack/compute/v2/flavors/urls.go
@@ -40,6 +40,10 @@ func extraSpecsCreateURL(client *gophercloud.ServiceClient, id string) string {
 	return client.ServiceURL("flavors", id, "os-extra_specs")
 }
 
+func extraSpecUpdateURL(client *gophercloud.ServiceClient, id, key string) string {
+	return client.ServiceURL("flavors", id, "os-extra_specs", key)
+}
+
 func extraSpecDeleteURL(client *gophercloud.ServiceClient, id, key string) string {
 	return client.ServiceURL("flavors", id, "os-extra_specs", key)
 }


### PR DESCRIPTION
For #540

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

API reference:
https://developer.openstack.org/api-ref/compute/#update-an-extra-spec-for-a-flavor

Nova implementation:
https://github.com/openstack/nova/blob/stable/pike/nova/api/openstack/compute/flavors_extraspecs.py#L79

Schema:
https://github.com/openstack/nova/blob/stable/pike/nova/api/openstack/compute/schemas/flavors_extraspecs.py#L24
https://github.com/openstack/nova/blob/stable/pike/nova/api/validation/parameter_types.py#L363-L371

The API will return an error if more than one key-value pair is passed and also if the key differs from the key parameter on the URL. As the API accepts more than one key-value pair and then properly returns an error, per the discussion on #689, the API is left to do the error handling.