### PR TITLE
Compute service list support

### DIFF
--- a/acceptance/openstack/compute/v2/services_test.go
+++ b/acceptance/openstack/compute/v2/services_test.go
@@ -1,0 +1,32 @@
+// +build acceptance compute services
+
+package v2
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/acceptance/clients"
+	"github.com/gophercloud/gophercloud/acceptance/tools"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/services"
+)
+
+func TestServicesList(t *testing.T) {
+	client, err := clients.NewComputeV2Client()
+	if err != nil {
+		t.Fatalf("Unable to create a compute client: %v", err)
+	}
+
+	allPages, err := services.List(client).AllPages()
+	if err != nil {
+		t.Fatalf("Unable to list services: %v", err)
+	}
+
+	allServices, err := services.ExtractServices(allPages)
+	if err != nil {
+		t.Fatalf("Unable to extract services")
+	}
+
+	for _, service := range allServices {
+		tools.PrintResource(t, service)
+	}
+}

--- a/openstack/compute/v2/extensions/services/doc.go
+++ b/openstack/compute/v2/extensions/services/doc.go
@@ -1,0 +1,22 @@
+/*
+Package services returns information about the compute services in the OpenStack
+cloud.
+
+Example of Retrieving list of all services
+
+	allPages, err := services.List(computeClient).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allServices, err := services.ExtractServices(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, service := range allServices {
+		fmt.Printf("%+v\n", service)
+	}
+*/
+
+package services

--- a/openstack/compute/v2/extensions/services/requests.go
+++ b/openstack/compute/v2/extensions/services/requests.go
@@ -1,0 +1,13 @@
+package services
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// List makes a request against the API to list services.
+func List(client *gophercloud.ServiceClient) pagination.Pager {
+	return pagination.NewPager(client, listURL(client), func(r pagination.PageResult) pagination.Page {
+		return ServicePage{pagination.SinglePageBase(r)}
+	})
+}

--- a/openstack/compute/v2/extensions/services/results.go
+++ b/openstack/compute/v2/extensions/services/results.go
@@ -1,6 +1,12 @@
 package services
 
-import "github.com/gophercloud/gophercloud/pagination"
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
 
 // Service represents a Compute service in the OpenStack cloud.
 type Service struct {
@@ -9,9 +15,6 @@ type Service struct {
 
 	// The reason for disabling a service.
 	DisabledReason string `json:"disabled_reason"`
-
-	// Whether or not this service was forced down manually by an administrator.
-	ForcedDown bool `json:"forced_down"`
 
 	// The name of the host.
 	Host string `json:"host"`
@@ -25,8 +28,29 @@ type Service struct {
 	// The status of the service. One of enabled or disabled.
 	Status string `json:"status"`
 
+	// The date and time when the resource was updated.
+	UpdatedAt time.Time `json:"-"`
+
 	// The availability zone name.
 	Zone string `json:"zone"`
+}
+
+// UnmarshalJSON to override default
+func (r *Service) UnmarshalJSON(b []byte) error {
+	type tmp Service
+	var s struct {
+		tmp
+		UpdatedAt gophercloud.JSONRFC3339MilliNoZ `json:"updated_at"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	*r = Service(s.tmp)
+
+	r.UpdatedAt = time.Time(s.UpdatedAt)
+
+	return nil
 }
 
 // ServicePage represents a single page of all Services from a List request.

--- a/openstack/compute/v2/extensions/services/results.go
+++ b/openstack/compute/v2/extensions/services/results.go
@@ -1,0 +1,49 @@
+package services
+
+import "github.com/gophercloud/gophercloud/pagination"
+
+// Service represents a Compute service in the OpenStack cloud.
+type Service struct {
+	// The binary name of the service.
+	Binary string `json:"binary"`
+
+	// The reason for disabling a service.
+	DisabledReason string `json:"disabled_reason"`
+
+	// Whether or not this service was forced down manually by an administrator.
+	ForcedDown bool `json:"forced_down"`
+
+	// The name of the host.
+	Host string `json:"host"`
+
+	// The id of the service.
+	ID int `json:"id"`
+
+	// The state of the service. One of up or down.
+	State string `json:"state"`
+
+	// The status of the service. One of enabled or disabled.
+	Status string `json:"status"`
+
+	// The availability zone name.
+	Zone string `json:"zone"`
+}
+
+// ServicePage represents a single page of all Services from a List request.
+type ServicePage struct {
+	pagination.SinglePageBase
+}
+
+// IsEmpty determines whether or not a page of Services contains any results.
+func (page ServicePage) IsEmpty() (bool, error) {
+	services, err := ExtractServices(page)
+	return len(services) == 0, err
+}
+
+func ExtractServices(r pagination.Page) ([]Service, error) {
+	var s struct {
+		Service []Service `json:"services"`
+	}
+	err := (r.(ServicePage)).ExtractInto(&s)
+	return s.Service, err
+}

--- a/openstack/compute/v2/extensions/services/testing/fixtures.go
+++ b/openstack/compute/v2/extensions/services/testing/fixtures.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/services"
 	th "github.com/gophercloud/gophercloud/testhelper"
@@ -66,11 +67,11 @@ const ServiceListBody = `
 var FirstFakeService = services.Service{
 	Binary:         "nova-scheduler",
 	DisabledReason: "test1",
-	ForcedDown:     false,
 	Host:           "host1",
 	ID:             1,
 	State:          "up",
 	Status:         "disabled",
+	UpdatedAt:      time.Date(2012, 10, 29, 13, 42, 2, 0, time.UTC),
 	Zone:           "internal",
 }
 
@@ -78,11 +79,11 @@ var FirstFakeService = services.Service{
 var SecondFakeService = services.Service{
 	Binary:         "nova-compute",
 	DisabledReason: "test2",
-	ForcedDown:     false,
 	Host:           "host1",
 	ID:             2,
 	State:          "up",
 	Status:         "disabled",
+	UpdatedAt:      time.Date(2012, 10, 29, 13, 42, 5, 0, time.UTC),
 	Zone:           "nova",
 }
 
@@ -90,11 +91,11 @@ var SecondFakeService = services.Service{
 var ThirdFakeService = services.Service{
 	Binary:         "nova-scheduler",
 	DisabledReason: "",
-	ForcedDown:     false,
 	Host:           "host2",
 	ID:             3,
 	State:          "down",
 	Status:         "enabled",
+	UpdatedAt:      time.Date(2012, 9, 19, 6, 55, 34, 0, time.UTC),
 	Zone:           "internal",
 }
 
@@ -102,11 +103,11 @@ var ThirdFakeService = services.Service{
 var FourthFakeService = services.Service{
 	Binary:         "nova-compute",
 	DisabledReason: "test4",
-	ForcedDown:     false,
 	Host:           "host2",
 	ID:             4,
 	State:          "down",
 	Status:         "disabled",
+	UpdatedAt:      time.Date(2012, 9, 18, 8, 3, 38, 0, time.UTC),
 	Zone:           "nova",
 }
 

--- a/openstack/compute/v2/extensions/services/testing/fixtures.go
+++ b/openstack/compute/v2/extensions/services/testing/fixtures.go
@@ -1,0 +1,122 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/services"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+// ServiceListBody is sample response to the List call
+const ServiceListBody = `
+{
+    "services": [
+        {
+            "id": 1,
+            "binary": "nova-scheduler",
+            "disabled_reason": "test1",
+            "host": "host1",
+            "state": "up",
+            "status": "disabled",
+            "updated_at": "2012-10-29T13:42:02.000000",
+            "forced_down": false,
+            "zone": "internal"
+        },
+        {
+            "id": 2,
+            "binary": "nova-compute",
+            "disabled_reason": "test2",
+            "host": "host1",
+            "state": "up",
+            "status": "disabled",
+            "updated_at": "2012-10-29T13:42:05.000000",
+            "forced_down": false,
+            "zone": "nova"
+        },
+        {
+            "id": 3,
+            "binary": "nova-scheduler",
+            "disabled_reason": null,
+            "host": "host2",
+            "state": "down",
+            "status": "enabled",
+            "updated_at": "2012-09-19T06:55:34.000000",
+            "forced_down": false,
+            "zone": "internal"
+        },
+        {
+            "id": 4,
+            "binary": "nova-compute",
+            "disabled_reason": "test4",
+            "host": "host2",
+            "state": "down",
+            "status": "disabled",
+            "updated_at": "2012-09-18T08:03:38.000000",
+            "forced_down": false,
+            "zone": "nova"
+        }
+    ]
+}
+`
+
+// First service from the ServiceListBody
+var FirstFakeService = services.Service{
+	Binary:         "nova-scheduler",
+	DisabledReason: "test1",
+	ForcedDown:     false,
+	Host:           "host1",
+	ID:             1,
+	State:          "up",
+	Status:         "disabled",
+	Zone:           "internal",
+}
+
+// Second service from the ServiceListBody
+var SecondFakeService = services.Service{
+	Binary:         "nova-compute",
+	DisabledReason: "test2",
+	ForcedDown:     false,
+	Host:           "host1",
+	ID:             2,
+	State:          "up",
+	Status:         "disabled",
+	Zone:           "nova",
+}
+
+// Third service from the ServiceListBody
+var ThirdFakeService = services.Service{
+	Binary:         "nova-scheduler",
+	DisabledReason: "",
+	ForcedDown:     false,
+	Host:           "host2",
+	ID:             3,
+	State:          "down",
+	Status:         "enabled",
+	Zone:           "internal",
+}
+
+// Fourth service from the ServiceListBody
+var FourthFakeService = services.Service{
+	Binary:         "nova-compute",
+	DisabledReason: "test4",
+	ForcedDown:     false,
+	Host:           "host2",
+	ID:             4,
+	State:          "down",
+	Status:         "disabled",
+	Zone:           "nova",
+}
+
+// HandleListSuccessfully configures the test server to respond to a List request.
+func HandleListSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/os-services", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprintf(w, ServiceListBody)
+	})
+}

--- a/openstack/compute/v2/extensions/services/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/services/testing/requests_test.go
@@ -1,0 +1,42 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/services"
+	"github.com/gophercloud/gophercloud/pagination"
+	"github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func TestListServices(t *testing.T) {
+	testhelper.SetupHTTP()
+	defer testhelper.TeardownHTTP()
+	HandleListSuccessfully(t)
+
+	pages := 0
+	err := services.List(client.ServiceClient()).EachPage(func(page pagination.Page) (bool, error) {
+		pages++
+
+		actual, err := services.ExtractServices(page)
+		if err != nil {
+			return false, err
+		}
+
+		if len(actual) != 4 {
+			t.Fatalf("Expected 4 services, got %d", len(actual))
+		}
+		testhelper.CheckDeepEquals(t, FirstFakeService, actual[0])
+		testhelper.CheckDeepEquals(t, SecondFakeService, actual[1])
+		testhelper.CheckDeepEquals(t, ThirdFakeService, actual[2])
+		testhelper.CheckDeepEquals(t, FourthFakeService, actual[3])
+
+		return true, nil
+	})
+
+	testhelper.AssertNoErr(t, err)
+
+	if pages != 1 {
+		t.Errorf("Expected 1 page, saw %d", pages)
+	}
+}

--- a/openstack/compute/v2/extensions/services/urls.go
+++ b/openstack/compute/v2/extensions/services/urls.go
@@ -1,0 +1,7 @@
+package services
+
+import "github.com/gophercloud/gophercloud"
+
+func listURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("os-services")
+}


### PR DESCRIPTION
For #715 

Add support for the running Compute service list.

API reference:
https://developer.openstack.org/api-ref/compute/#list-compute-services

Implementation:
https://github.com/openstack/nova/blob/stable/ocata/nova/api/openstack/compute/services.py#L200
