### PR TITLE
Add get request in subnetpools acceptance tests

### DIFF
--- a/acceptance/openstack/networking/v2/extensions/subnetpools/subnetpools_test.go
+++ b/acceptance/openstack/networking/v2/extensions/subnetpools/subnetpools_test.go
@@ -29,9 +29,14 @@ func TestSubnetPoolsCRUD(t *testing.T) {
 		Name: newName,
 	}
 
-	newSubnetPool, err := subnetpools.Update(client, subnetPool.ID, updateOpts).Extract()
+	_, err = subnetpools.Update(client, subnetPool.ID, updateOpts).Extract()
 	if err != nil {
 		t.Fatalf("Unable to update the subnetpool: %v", err)
+	}
+
+	newSubnetPool, err := subnetpools.Get(client, subnetPool.ID).Extract()
+	if err != nil {
+		t.Fatalf("Unable to get subnetpool: %v", err)
 	}
 
 	tools.PrintResource(t, newSubnetPool)


### PR DESCRIPTION
It would be better if we will test the `GET` request inside the `TestSubnetPoolsCRUD` acceptance test.

For #672 

Support for `Get` was implemented in PR [#701](https://github.com/gophercloud/gophercloud/pull/701) and for `Update` in [#706](https://github.com/gophercloud/gophercloud/pull/706).