### PR TITLE
Add Neutron subnetpool delete support

### DIFF
--- a/acceptance/openstack/networking/v2/extensions/subnetpools/subnetpools.go
+++ b/acceptance/openstack/networking/v2/extensions/subnetpools/subnetpools.go
@@ -30,3 +30,16 @@ func CreateSubnetPool(t *testing.T, client *gophercloud.ServiceClient) (*subnetp
 	t.Logf("Successfully created the subnetpool.")
 	return subnetPool, nil
 }
+
+// DeleteSubnetPool will delete a subnetpool with a specified ID.
+// A fatal error will occur if the delete was not successful.
+func DeleteSubnetPool(t *testing.T, client *gophercloud.ServiceClient, subnetPoolID string) {
+	t.Logf("Attempting to delete the subnetpool: %s", subnetPoolID)
+
+	err := subnetpools.Delete(client, subnetPoolID).ExtractErr()
+	if err != nil {
+		t.Fatalf("Unable to delete subnetpool %s: %v", subnetPoolID, err)
+	}
+
+	t.Logf("Deleted subnetpool: %s", subnetPoolID)
+}

--- a/acceptance/openstack/networking/v2/extensions/subnetpools/subnetpools_test.go
+++ b/acceptance/openstack/networking/v2/extensions/subnetpools/subnetpools_test.go
@@ -21,6 +21,7 @@ func TestSubnetPoolsCRUD(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to create a subnetpool: %v", err)
 	}
+	defer DeleteSubnetPool(t, client, subnetPool.ID)
 
 	tools.PrintResource(t, subnetPool)
 

--- a/openstack/networking/v2/extensions/subnetpools/doc.go
+++ b/openstack/networking/v2/extensions/subnetpools/doc.go
@@ -60,5 +60,13 @@ Example to Update a Subnetpool
 	if err != nil {
 		panic(err)
 	}
+
+Example to Delete a Subnetpool
+
+	subnetPoolID := "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55"
+	err := subnetpools.Delete(networkClient, subnetPoolID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
 */
 package subnetpools

--- a/openstack/networking/v2/extensions/subnetpools/requests.go
+++ b/openstack/networking/v2/extensions/subnetpools/requests.go
@@ -216,3 +216,9 @@ func Update(c *gophercloud.ServiceClient, subnetPoolID string, opts UpdateOptsBu
 	})
 	return
 }
+
+// Delete accepts a unique ID and deletes the subnetpool associated with it.
+func Delete(c *gophercloud.ServiceClient, id string) (r DeleteResult) {
+	_, r.Err = c.Delete(deleteURL(c, id), nil)
+	return
+}

--- a/openstack/networking/v2/extensions/subnetpools/results.go
+++ b/openstack/networking/v2/extensions/subnetpools/results.go
@@ -40,6 +40,12 @@ type UpdateResult struct {
 	commonResult
 }
 
+// DeleteResult represents the result of a delete operation. Call its
+// ExtractErr method to determine if the request succeeded or failed.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
 // SubnetPool represents a Neutron subnetpool.
 // A subnetpool is a pool of addresses from which subnets can be allocated.
 type SubnetPool struct {

--- a/openstack/networking/v2/extensions/subnetpools/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/subnetpools/testing/requests_test.go
@@ -175,3 +175,17 @@ func TestUpdate(t *testing.T) {
 	th.AssertEquals(t, n.DefaultQuota, 0)
 	th.AssertEquals(t, n.Description, "")
 }
+
+func TestDelete(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/subnetpools/099546ca-788d-41e5-a76d-17d8cd282d3e", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	res := subnetpools.Delete(fake.ServiceClient(), "099546ca-788d-41e5-a76d-17d8cd282d3e")
+	th.AssertNoErr(t, res.Err)
+}

--- a/openstack/networking/v2/extensions/subnetpools/urls.go
+++ b/openstack/networking/v2/extensions/subnetpools/urls.go
@@ -27,3 +27,7 @@ func createURL(c *gophercloud.ServiceClient) string {
 func updateURL(c *gophercloud.ServiceClient, id string) string {
 	return resourceURL(c, id)
 }
+
+func deleteURL(c *gophercloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
+}


### PR DESCRIPTION
Add a Delete request, unit test and acceptance tests with acceptance
reusable "DeleteSubnetPool" function.

The same command with OpenStack CLI is done with:
`openstack subnet pool delete`
or
`neutron subnetpool-delete`

For #672 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/neutron/blob/stable/pike/neutron/db/db_base_plugin_v2.py#L1211
https://github.com/openstack/neutron/blob/stable/pike/neutron/api/v2/attributes.py#L214
