### PR TITLE
Compute v2: Get Hypervisor Details

### DIFF
--- a/acceptance/openstack/compute/v2/hypervisors_test.go
+++ b/acceptance/openstack/compute/v2/hypervisors_test.go
@@ -3,8 +3,10 @@
 package v2
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/acceptance/clients"
 	"github.com/gophercloud/gophercloud/acceptance/tools"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/hypervisors"
@@ -31,6 +33,25 @@ func TestHypervisorsList(t *testing.T) {
 	}
 }
 
+func TestHypervisorsGet(t *testing.T) {
+	client, err := clients.NewComputeV2Client()
+	if err != nil {
+		t.Fatalf("Unable to create a compute client: %v", err)
+	}
+
+	hypervisorID, err := getHypervisorID(t, client)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	hypervisor, err := hypervisors.Get(client, hypervisorID).Extract()
+	if err != nil {
+		t.Fatalf("Unable to get hypervisor: %v", err)
+	}
+
+	tools.PrintResource(t, hypervisor)
+}
+
 func TestHypervisorsStatistics(t *testing.T) {
 	client, err := clients.NewComputeV2Client()
 	if err != nil {
@@ -43,4 +64,22 @@ func TestHypervisorsStatistics(t *testing.T) {
 	}
 
 	tools.PrintResource(t, hypervisorsStats)
+}
+
+func getHypervisorID(t *testing.T, client *gophercloud.ServiceClient) (int, error) {
+	allPages, err := hypervisors.List(client).AllPages()
+	if err != nil {
+		t.Fatalf("Unable to list hypervisors: %v", err)
+	}
+
+	allHypervisors, err := hypervisors.ExtractHypervisors(allPages)
+	if err != nil {
+		t.Fatalf("Unable to extract hypervisors")
+	}
+
+	for _, h := range allHypervisors {
+		return h.ID, nil
+	}
+
+	return 0, fmt.Errorf("Unable to get hypervisor ID")
 }

--- a/openstack/compute/v2/extensions/hypervisors/doc.go
+++ b/openstack/compute/v2/extensions/hypervisors/doc.go
@@ -1,6 +1,16 @@
 /*
-Package hypervisors returns details about the hypervisors and shows
-summary statistics for all hypervisors over all compute nodes in the OpenStack cloud.
+Package hypervisors returns details about list of hypervisors, shows details for a hypervisor
+and shows summary statistics for all hypervisors over all compute nodes in the OpenStack cloud.
+
+Example of Show Hypervisor Details
+
+	hypervisorID := 42
+	hypervisor, err := hypervisors.Get(computeClient, 42).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v\n", hypervisor)
 
 Example of Retrieving Details of All Hypervisors
 

--- a/openstack/compute/v2/extensions/hypervisors/requests.go
+++ b/openstack/compute/v2/extensions/hypervisors/requests.go
@@ -1,6 +1,8 @@
 package hypervisors
 
 import (
+	"strconv"
+
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/pagination"
 )
@@ -22,7 +24,8 @@ func GetStatistics(client *gophercloud.ServiceClient) (r StatisticsResult) {
 
 // Get makes a request against the API to get details for specific hypervisor.
 func Get(client *gophercloud.ServiceClient, hypervisorID int) (r HypervisorResult) {
-	_, r.Err = client.Get(hypervisorsGetURL(client, hypervisorID), &r.Body, &gophercloud.RequestOpts{
+	v := strconv.Itoa(hypervisorID)
+	_, r.Err = client.Get(hypervisorsGetURL(client, v), &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{200},
 	})
 	return

--- a/openstack/compute/v2/extensions/hypervisors/requests.go
+++ b/openstack/compute/v2/extensions/hypervisors/requests.go
@@ -19,3 +19,11 @@ func GetStatistics(client *gophercloud.ServiceClient) (r StatisticsResult) {
 	})
 	return
 }
+
+// Get makes a request against the API to get details for specific hypervisor.
+func Get(client *gophercloud.ServiceClient, hypervisorID int) (r HypervisorResult) {
+	_, r.Err = client.Get(hypervisorsGetURL(client, hypervisorID), &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}

--- a/openstack/compute/v2/extensions/hypervisors/results.go
+++ b/openstack/compute/v2/extensions/hypervisors/results.go
@@ -191,6 +191,19 @@ func ExtractHypervisors(p pagination.Page) ([]Hypervisor, error) {
 	return h.Hypervisors, err
 }
 
+type HypervisorResult struct {
+	gophercloud.Result
+}
+
+// Extract interprets any HypervisorResult as a Hypervisor, if possible.
+func (r HypervisorResult) Extract() (*Hypervisor, error) {
+	var s struct {
+		Hypervisor Hypervisor `json:"hypervisor"`
+	}
+	err := r.ExtractInto(&s)
+	return &s.Hypervisor, err
+}
+
 // Statistics represents a summary statistics for all enabled
 // hypervisors over all compute nodes in the OpenStack cloud.
 type Statistics struct {

--- a/openstack/compute/v2/extensions/hypervisors/testing/fixtures.go
+++ b/openstack/compute/v2/extensions/hypervisors/testing/fixtures.go
@@ -3,6 +3,7 @@ package testing
 import (
 	"fmt"
 	"net/http"
+	"strconv"
 	"testing"
 
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/hypervisors"
@@ -223,7 +224,8 @@ func HandleHypervisorListSuccessfully(t *testing.T) {
 }
 
 func HandleHypervisorGetSuccessfully(t *testing.T) {
-	testhelper.Mux.HandleFunc("/os-hypervisors/"+string(HypervisorFake.ID), func(w http.ResponseWriter, r *http.Request) {
+	v := strconv.Itoa(HypervisorFake.ID)
+	testhelper.Mux.HandleFunc("/os-hypervisors/"+v, func(w http.ResponseWriter, r *http.Request) {
 		testhelper.TestMethod(t, r, "GET")
 		testhelper.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 

--- a/openstack/compute/v2/extensions/hypervisors/testing/fixtures.go
+++ b/openstack/compute/v2/extensions/hypervisors/testing/fixtures.go
@@ -102,6 +102,50 @@ const HypervisorsStatisticsBody = `
 }
 `
 
+const HypervisorGetBody = `
+{
+    "hypervisor":{
+        "cpu_info":{
+            "arch":"x86_64",
+            "model":"Nehalem",
+            "vendor":"Intel",
+            "features":[
+                "pge",
+                "clflush"
+            ],
+            "topology":{
+                "cores":1,
+                "threads":1,
+                "sockets":4
+            }
+        },
+        "current_workload":0,
+        "status":"enabled",
+        "state":"up",
+        "disk_available_least":0,
+        "host_ip":"1.1.1.1",
+        "free_disk_gb":1028,
+        "free_ram_mb":7680,
+        "hypervisor_hostname":"fake-mini",
+        "hypervisor_type":"fake",
+        "hypervisor_version":2002000,
+        "id":1,
+        "local_gb":1028,
+        "local_gb_used":0,
+        "memory_mb":8192,
+        "memory_mb_used":512,
+        "running_vms":0,
+        "service":{
+            "host":"e6a37ee802d74863ab8b91ade8f12a67",
+            "id":2,
+            "disabled_reason":null
+        },
+        "vcpus":1,
+        "vcpus_used":0
+    }
+}
+`
+
 var (
 	HypervisorFake = hypervisors.Hypervisor{
 		CPUInfo: hypervisors.CPUInfo{
@@ -175,5 +219,15 @@ func HandleHypervisorListSuccessfully(t *testing.T) {
 
 		w.Header().Add("Content-Type", "application/json")
 		fmt.Fprintf(w, HypervisorListBody)
+	})
+}
+
+func HandleHypervisorGetSuccessfully(t *testing.T) {
+	testhelper.Mux.HandleFunc("/os-hypervisors/"+string(HypervisorFake.ID), func(w http.ResponseWriter, r *http.Request) {
+		testhelper.TestMethod(t, r, "GET")
+		testhelper.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprintf(w, HypervisorGetBody)
 	})
 }

--- a/openstack/compute/v2/extensions/hypervisors/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/hypervisors/testing/requests_test.go
@@ -63,3 +63,15 @@ func TestHypervisorsStatistics(t *testing.T) {
 	testhelper.AssertNoErr(t, err)
 	testhelper.CheckDeepEquals(t, &expected, actual)
 }
+
+func TestGetHypervisor(t *testing.T) {
+	testhelper.SetupHTTP()
+	defer testhelper.TeardownHTTP()
+	HandleHypervisorGetSuccessfully(t)
+
+	expected := HypervisorFake
+
+	actual, err := hypervisors.Get(client.ServiceClient(), expected.ID).Extract()
+	testhelper.AssertNoErr(t, err)
+	testhelper.CheckDeepEquals(t, &expected, actual)
+}

--- a/openstack/compute/v2/extensions/hypervisors/urls.go
+++ b/openstack/compute/v2/extensions/hypervisors/urls.go
@@ -9,3 +9,7 @@ func hypervisorsListDetailURL(c *gophercloud.ServiceClient) string {
 func hypervisorsStatisticsURL(c *gophercloud.ServiceClient) string {
 	return c.ServiceURL("os-hypervisors", "statistics")
 }
+
+func hypervisorsGetURL(c *gophercloud.ServiceClient, hypervisorID int) string {
+	return c.ServiceURL("os-hypervisors", string(hypervisorID))
+}

--- a/openstack/compute/v2/extensions/hypervisors/urls.go
+++ b/openstack/compute/v2/extensions/hypervisors/urls.go
@@ -10,6 +10,6 @@ func hypervisorsStatisticsURL(c *gophercloud.ServiceClient) string {
 	return c.ServiceURL("os-hypervisors", "statistics")
 }
 
-func hypervisorsGetURL(c *gophercloud.ServiceClient, hypervisorID int) string {
-	return c.ServiceURL("os-hypervisors", string(hypervisorID))
+func hypervisorsGetURL(c *gophercloud.ServiceClient, hypervisorID string) string {
+	return c.ServiceURL("os-hypervisors", hypervisorID)
 }


### PR DESCRIPTION
For #721

The same for Openstack CLI:

- `openstack hypervisor show <hypervisor-id>`
- `nova hypervisor-show hypervisor-show <hypervisor-id>` 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

API doc:
- [https://developer.openstack.org/api-ref/compute/#show-hypervisor-details](https://developer.openstack.org/api-ref/compute/#show-hypervisor-details)

Source code:
- [https://github.com/openstack/nova/blob/master/nova/api/openstack/compute/hypervisors.py#L302](https://github.com/openstack/nova/blob/master/nova/api/openstack/compute/hypervisors.py#L302)