### PR TITLE
Update provider_client.go

### DIFF
--- a/provider_client.go
+++ b/provider_client.go
@@ -193,6 +193,9 @@ func (client *ProviderClient) Request(method, url string, options *RequestOpts) 
 
 	// Set the User-Agent header
 	req.Header.Set("User-Agent", client.UserAgent.Join())
+	
+	//Avoid caching of responses; you could wait forever for resources being created...
+	req.Header.Set("Cache-Control", "no-cache")
 
 	if options.MoreHeaders != nil {
 		for k, v := range options.MoreHeaders {

--- a/provider_client.go
+++ b/provider_client.go
@@ -193,8 +193,8 @@ func (client *ProviderClient) Request(method, url string, options *RequestOpts) 
 
 	// Set the User-Agent header
 	req.Header.Set("User-Agent", client.UserAgent.Join())
-	
-	//Avoid caching of responses; you could wait forever for resources being created...
+
+	// Avoid caching of responses; you could wait forever for resources being created...
 	req.Header.Set("Cache-Control", "no-cache")
 
 	if options.MoreHeaders != nil {


### PR DESCRIPTION
I ran into an issue where I was using terraform-openstack-provider (which uses gophercloud) through an HTTP proxy. Terraform was creating resources in an openstack cloud. Since creating the resources took some time, the initial response from openstack was "still creating...". Further polling of the resource status resulted in receiving cached copies of "still creating..." until time-out.

One could argue this is an openstack issue not including proper cache-control headers in the response, but being explit on the request shouldn't hurt... Especially because gophercloud is meant to query API's which responses are volatile in nature.

Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

For #727 
