### PR TITLE
Prevent Recursive BuildRequestBody

### DIFF
--- a/params.go
+++ b/params.go
@@ -115,10 +115,15 @@ func BuildRequestBody(opts interface{}, parent string) (map[string]interface{}, 
 				}
 			}
 
+			jsonTag := f.Tag.Get("json")
+			if jsonTag == "-" {
+				continue
+			}
+
 			if v.Kind() == reflect.Struct || (v.Kind() == reflect.Ptr && v.Elem().Kind() == reflect.Struct) {
 				if zero {
 					//fmt.Printf("value before change: %+v\n", optsValue.Field(i))
-					if jsonTag := f.Tag.Get("json"); jsonTag != "" {
+					if jsonTag != "" {
 						jsonTagPieces := strings.Split(jsonTag, ",")
 						if len(jsonTagPieces) > 1 && jsonTagPieces[1] == "omitempty" {
 							if v.CanSet() {

--- a/testing/params_test.go
+++ b/testing/params_test.go
@@ -4,6 +4,7 @@ import (
 	"net/url"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/gophercloud/gophercloud"
 	th "github.com/gophercloud/gophercloud/testhelper"
@@ -254,4 +255,22 @@ func TestBuildRequestBody(t *testing.T) {
 		_, err := gophercloud.BuildRequestBody(failCase.opts, "auth")
 		th.AssertDeepEquals(t, reflect.TypeOf(failCase.expected), reflect.TypeOf(err))
 	}
+
+	createdAt := time.Date(2018, 1, 4, 10, 00, 12, 0, time.UTC)
+	var complexFields = struct {
+		Username  string     `json:"username" required:"true"`
+		CreatedAt *time.Time `json:"-"`
+	}{
+		Username:  "jdoe",
+		CreatedAt: &createdAt,
+	}
+
+	expectedComplexFields := map[string]interface{}{
+		"username": "jdoe",
+	}
+
+	actual, err := gophercloud.BuildRequestBody(complexFields, "")
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expectedComplexFields, actual)
+
 }


### PR DESCRIPTION
For #729 

@jrperritt I felt more comfortable adding the check for `"-"` after all of the other validation field checks were done. I wasn't sure if there are cases of something like this floating around:

```go
Username username `json:"-" required:"true"`
```