### PR TITLE
Blockstorage service list support

### DIFF
--- a/acceptance/openstack/blockstorage/extensions/services_test.go
+++ b/acceptance/openstack/blockstorage/extensions/services_test.go
@@ -16,7 +16,7 @@ func TestServicesList(t *testing.T) {
 		t.Fatalf("Unable to create a blockstorage client: %v", err)
 	}
 
-	allPages, err := services.List(blockClient).AllPages()
+	allPages, err := services.List(blockClient, services.ListOpts{}).AllPages()
 	if err != nil {
 		t.Fatalf("Unable to list services: %v", err)
 	}

--- a/acceptance/openstack/blockstorage/extensions/services_test.go
+++ b/acceptance/openstack/blockstorage/extensions/services_test.go
@@ -1,0 +1,32 @@
+// +build acceptance blockstorage
+
+package extensions
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/acceptance/clients"
+	"github.com/gophercloud/gophercloud/acceptance/tools"
+	"github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/services"
+)
+
+func TestServicesList(t *testing.T) {
+	blockClient, err := clients.NewBlockStorageV3Client()
+	if err != nil {
+		t.Fatalf("Unable to create a blockstorage client: %v", err)
+	}
+
+	allPages, err := services.List(blockClient).AllPages()
+	if err != nil {
+		t.Fatalf("Unable to list services: %v", err)
+	}
+
+	allServices, err := services.ExtractServices(allPages)
+	if err != nil {
+		t.Fatalf("Unable to extract services")
+	}
+
+	for _, service := range allServices {
+		tools.PrintResource(t, service)
+	}
+}

--- a/openstack/blockstorage/extensions/services/doc.go
+++ b/openstack/blockstorage/extensions/services/doc.go
@@ -1,0 +1,22 @@
+/*
+Package services returns information about the blockstorage services in the
+OpenStack cloud.
+
+Example of Retrieving list of all services
+
+	allPages, err := services.List(blockstorageClient).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allServices, err := services.ExtractServices(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, service := range allServices {
+		fmt.Printf("%+v\n", service)
+	}
+*/
+
+package services

--- a/openstack/blockstorage/extensions/services/doc.go
+++ b/openstack/blockstorage/extensions/services/doc.go
@@ -4,7 +4,7 @@ OpenStack cloud.
 
 Example of Retrieving list of all services
 
-	allPages, err := services.List(blockstorageClient).AllPages()
+	allPages, err := services.List(blockstorageClient, services.ListOpts{}).AllPages()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/blockstorage/extensions/services/requests.go
+++ b/openstack/blockstorage/extensions/services/requests.go
@@ -1,0 +1,13 @@
+package services
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// List makes a request against the API to list services.
+func List(client *gophercloud.ServiceClient) pagination.Pager {
+	return pagination.NewPager(client, listURL(client), func(r pagination.PageResult) pagination.Page {
+		return ServicePage{pagination.SinglePageBase(r)}
+	})
+}

--- a/openstack/blockstorage/extensions/services/requests.go
+++ b/openstack/blockstorage/extensions/services/requests.go
@@ -5,9 +5,38 @@ import (
 	"github.com/gophercloud/gophercloud/pagination"
 )
 
+// ListOptsBuilder allows extensions to add additional parameters to the List
+// request.
+type ListOptsBuilder interface {
+	ToServiceListQuery() (string, error)
+}
+
+// ListOpts holds options for listing Services.
+type ListOpts struct {
+	// Filter the service list result by binary name of the service.
+	Binary string `q:"binary"`
+
+	// Filter the service list result by host name of the service.
+	Host string `q:"host"`
+}
+
+// ToServiceListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToServiceListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
 // List makes a request against the API to list services.
-func List(client *gophercloud.ServiceClient) pagination.Pager {
-	return pagination.NewPager(client, listURL(client), func(r pagination.PageResult) pagination.Page {
+func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(client)
+	if opts != nil {
+		query, err := opts.ToServiceListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
 		return ServicePage{pagination.SinglePageBase(r)}
 	})
 }

--- a/openstack/blockstorage/extensions/services/results.go
+++ b/openstack/blockstorage/extensions/services/results.go
@@ -1,0 +1,84 @@
+package services
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// Service represents a Blockstorage service in the OpenStack cloud.
+type Service struct {
+	// The binary name of the service.
+	Binary string `json:"binary"`
+
+	// The reason for disabling a service.
+	DisabledReason string `json:"disabled_reason"`
+
+	// The name of the host.
+	Host string `json:"host"`
+
+	// The state of the service. One of up or down.
+	State string `json:"state"`
+
+	// The status of the service. One of available or unavailable.
+	Status string `json:"status"`
+
+	// The date and time stamp when the extension was last updated.
+	UpdatedAt time.Time `json:"-"`
+
+	// The availability zone name.
+	Zone string `json:"zone"`
+
+	// The following fields are optional
+
+	// The host is frozen or not. Only in cinder-volume service.
+	Frozen bool `json:"frozen"`
+
+	// The cluster name. Only in cinder-volume service.
+	Cluster string `json:"cluster"`
+
+	// The volume service replication status. Only in cinder-volume service.
+	ReplicationStatus string `json:"replication_status"`
+
+	// The ID of active storage backend. Only in cinder-volume service.
+	ActiveBackendID string `json:"active_backend_id"`
+}
+
+// UnmarshalJSON to override default
+func (r *Service) UnmarshalJSON(b []byte) error {
+	type tmp Service
+	var s struct {
+		tmp
+		UpdatedAt gophercloud.JSONRFC3339MilliNoZ `json:"updated_at"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	*r = Service(s.tmp)
+
+	r.UpdatedAt = time.Time(s.UpdatedAt)
+
+	return nil
+}
+
+// ServicePage represents a single page of all Services from a List request.
+type ServicePage struct {
+	pagination.SinglePageBase
+}
+
+// IsEmpty determines whether or not a page of Services contains any results.
+func (page ServicePage) IsEmpty() (bool, error) {
+	services, err := ExtractServices(page)
+	return len(services) == 0, err
+}
+
+func ExtractServices(r pagination.Page) ([]Service, error) {
+	var s struct {
+		Service []Service `json:"services"`
+	}
+	err := (r.(ServicePage)).ExtractInto(&s)
+	return s.Service, err
+}

--- a/openstack/blockstorage/extensions/services/testing/fixtures.go
+++ b/openstack/blockstorage/extensions/services/testing/fixtures.go
@@ -1,0 +1,97 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/services"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+// ServiceListBody is sample response to the List call
+const ServiceListBody = `
+{
+    "services": [{
+        "status": "enabled",
+        "binary": "cinder-scheduler",
+        "zone": "nova",
+        "state": "up",
+        "updated_at": "2017-06-29T05:50:35.000000",
+        "host": "devstack",
+        "disabled_reason": null
+    },
+    {
+        "status": "enabled",
+        "binary": "cinder-backup",
+        "zone": "nova",
+        "state": "up",
+        "updated_at": "2017-06-29T05:50:42.000000",
+        "host": "devstack",
+        "disabled_reason": null
+    },
+    {
+        "status": "enabled",
+        "binary": "cinder-volume",
+        "zone": "nova",
+        "frozen": false,
+        "state": "up",
+        "updated_at": "2017-06-29T05:50:39.000000",
+        "cluster": null,
+        "host": "devstack@lvmdriver-1",
+        "replication_status": "disabled",
+        "active_backend_id": null,
+        "disabled_reason": null
+    }]
+}
+`
+
+// First service from the ServiceListBody
+var FirstFakeService = services.Service{
+	Binary:         "cinder-scheduler",
+	DisabledReason: "",
+	Host:           "devstack",
+	State:          "up",
+	Status:         "enabled",
+	UpdatedAt:      time.Date(2017, 6, 29, 5, 50, 35, 0, time.UTC),
+	Zone:           "nova",
+}
+
+// Second service from the ServiceListBody
+var SecondFakeService = services.Service{
+	Binary:         "cinder-backup",
+	DisabledReason: "",
+	Host:           "devstack",
+	State:          "up",
+	Status:         "enabled",
+	UpdatedAt:      time.Date(2017, 6, 29, 5, 50, 42, 0, time.UTC),
+	Zone:           "nova",
+}
+
+// Third service from the ServiceListBody
+var ThirdFakeService = services.Service{
+	ActiveBackendID:   "",
+	Binary:            "cinder-volume",
+	Cluster:           "",
+	DisabledReason:    "",
+	Frozen:            false,
+	Host:              "devstack@lvmdriver-1",
+	ReplicationStatus: "disabled",
+	State:             "up",
+	Status:            "enabled",
+	UpdatedAt:         time.Date(2017, 6, 29, 5, 50, 39, 0, time.UTC),
+	Zone:              "nova",
+}
+
+// HandleListSuccessfully configures the test server to respond to a List request.
+func HandleListSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/os-services", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprintf(w, ServiceListBody)
+	})
+}

--- a/openstack/blockstorage/extensions/services/testing/requests_test.go
+++ b/openstack/blockstorage/extensions/services/testing/requests_test.go
@@ -1,0 +1,41 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/services"
+	"github.com/gophercloud/gophercloud/pagination"
+	"github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func TestListServices(t *testing.T) {
+	testhelper.SetupHTTP()
+	defer testhelper.TeardownHTTP()
+	HandleListSuccessfully(t)
+
+	pages := 0
+	err := services.List(client.ServiceClient()).EachPage(func(page pagination.Page) (bool, error) {
+		pages++
+
+		actual, err := services.ExtractServices(page)
+		if err != nil {
+			return false, err
+		}
+
+		if len(actual) != 3 {
+			t.Fatalf("Expected 3 services, got %d", len(actual))
+		}
+		testhelper.CheckDeepEquals(t, FirstFakeService, actual[0])
+		testhelper.CheckDeepEquals(t, SecondFakeService, actual[1])
+		testhelper.CheckDeepEquals(t, ThirdFakeService, actual[2])
+
+		return true, nil
+	})
+
+	testhelper.AssertNoErr(t, err)
+
+	if pages != 1 {
+		t.Errorf("Expected 1 page, saw %d", pages)
+	}
+}

--- a/openstack/blockstorage/extensions/services/testing/requests_test.go
+++ b/openstack/blockstorage/extensions/services/testing/requests_test.go
@@ -15,7 +15,7 @@ func TestListServices(t *testing.T) {
 	HandleListSuccessfully(t)
 
 	pages := 0
-	err := services.List(client.ServiceClient()).EachPage(func(page pagination.Page) (bool, error) {
+	err := services.List(client.ServiceClient(), services.ListOpts{}).EachPage(func(page pagination.Page) (bool, error) {
 		pages++
 
 		actual, err := services.ExtractServices(page)

--- a/openstack/blockstorage/extensions/services/urls.go
+++ b/openstack/blockstorage/extensions/services/urls.go
@@ -1,0 +1,7 @@
+package services
+
+import "github.com/gophercloud/gophercloud"
+
+func listURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("os-services")
+}


### PR DESCRIPTION
For #732 

API reference:
https://developer.openstack.org/api-ref/block-storage/v3/index.html#list-all-cinder-services

Implementation:
https://github.com/openstack/cinder/blob/stable/ocata/cinder/api/contrib/services.py#L46-L102