### PR TITLE
Add Ephemeral attribute to Flavor struct

### DIFF
--- a/openstack/compute/v2/flavors/results.go
+++ b/openstack/compute/v2/flavors/results.go
@@ -66,6 +66,9 @@ type Flavor struct {
 
 	// IsPublic indicates whether the flavor is public.
 	IsPublic bool `json:"os-flavor-access:is_public"`
+
+	// Ephemeral is the amount of ephemeral disk space, measured in GB.
+	Ephemeral int `json:"OS-FLV-EXT-DATA:ephemeral"`
 }
 
 func (r *Flavor) UnmarshalJSON(b []byte) error {


### PR DESCRIPTION
Nova returns the amount of ephemeral storage (in GB) associated with a
flavor as `OS-FLV-EXT-DATA:ephemeral`. Return it as `Flavor.Ephemeral`.

For #736.

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

- https://github.com/openstack/nova/blob/master/nova/api/openstack/compute/schemas/flavor_manage.py#L37-L38
