### PR TITLE
Compute v2: Delete aggregate

### DIFF
--- a/openstack/compute/v2/extensions/aggregates/doc.go
+++ b/openstack/compute/v2/extensions/aggregates/doc.go
@@ -13,8 +13,15 @@ Example of Create an aggregate
 	if err != nil {
 		panic(err)
 	}
-
 	fmt.Printf("%+v\n", aggregate)
+
+Example of Delete an aggregate
+
+	aggregateID := 32
+	err := aggregates.Delete(computeClient, aggregateID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
 
 Example of Retrieving list of all aggregates
 

--- a/openstack/compute/v2/extensions/aggregates/requests.go
+++ b/openstack/compute/v2/extensions/aggregates/requests.go
@@ -46,6 +46,7 @@ func Create(client *gophercloud.ServiceClient, opts CreateOpts) (r CreateResult)
 func Delete(client *gophercloud.ServiceClient, aggregateID int) (r DeleteResult) {
 	v := strconv.Itoa(aggregateID)
 	_, r.Err = client.Delete(aggregatesDeleteURL(client, v), &gophercloud.RequestOpts{
-		OkCodes: []int{200}})
+		OkCodes: []int{200},
+	})
 	return
 }

--- a/openstack/compute/v2/extensions/aggregates/requests.go
+++ b/openstack/compute/v2/extensions/aggregates/requests.go
@@ -45,6 +45,7 @@ func Create(client *gophercloud.ServiceClient, opts CreateOpts) (r CreateResult)
 // Delete makes a request against the API to delete an aggregate.
 func Delete(client *gophercloud.ServiceClient, aggregateID int) (r DeleteResult) {
 	v := strconv.Itoa(aggregateID)
-	_, r.Err = client.Delete(aggregatesDeleteURL(client, v), nil)
+	_, r.Err = client.Delete(aggregatesDeleteURL(client, v), &gophercloud.RequestOpts{
+		OkCodes: []int{200}})
 	return
 }

--- a/openstack/compute/v2/extensions/aggregates/requests.go
+++ b/openstack/compute/v2/extensions/aggregates/requests.go
@@ -1,6 +1,8 @@
 package aggregates
 
 import (
+	"strconv"
+
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/pagination"
 )
@@ -37,5 +39,12 @@ func Create(client *gophercloud.ServiceClient, opts CreateOpts) (r CreateResult)
 	_, r.Err = client.Post(aggregatesCreateURL(client), b, &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{200},
 	})
+	return
+}
+
+// Delete makes a request against the API to delete an aggregate.
+func Delete(client *gophercloud.ServiceClient, aggregateID int) (r DeleteResult) {
+	v := strconv.Itoa(aggregateID)
+	_, r.Err = client.Delete(aggregatesDeleteURL(client, v), nil)
 	return
 }

--- a/openstack/compute/v2/extensions/aggregates/results.go
+++ b/openstack/compute/v2/extensions/aggregates/results.go
@@ -89,3 +89,7 @@ func (r CreateResult) Extract() (*Aggregate, error) {
 	err := r.ExtractInto(&s)
 	return s.Aggregate, err
 }
+
+type DeleteResult struct {
+	gophercloud.ErrResult
+}

--- a/openstack/compute/v2/extensions/aggregates/testing/fixtures.go
+++ b/openstack/compute/v2/extensions/aggregates/testing/fixtures.go
@@ -3,6 +3,7 @@ package testing
 import (
 	"fmt"
 	"net/http"
+	"strconv"
 	"testing"
 	"time"
 
@@ -91,6 +92,8 @@ var CreatedAggregate = aggregates.Aggregate{
 	UpdatedAt:        time.Time{},
 }
 
+var AggregateIDtoDelete = 1
+
 // HandleListSuccessfully configures the test server to respond to a List request.
 func HandleListSuccessfully(t *testing.T) {
 	th.Mux.HandleFunc("/os-aggregates", func(w http.ResponseWriter, r *http.Request) {
@@ -109,5 +112,15 @@ func HandleCreateSuccessfully(t *testing.T) {
 
 		w.Header().Add("Content-Type", "application/json")
 		fmt.Fprintf(w, AggregateCreateBody)
+	})
+}
+
+func HandleDeleteSuccessfully(t *testing.T) {
+	v := strconv.Itoa(AggregateIDtoDelete)
+	th.Mux.HandleFunc("/os-aggregates/"+v, func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.WriteHeader(http.StatusAccepted)
 	})
 }

--- a/openstack/compute/v2/extensions/aggregates/testing/fixtures.go
+++ b/openstack/compute/v2/extensions/aggregates/testing/fixtures.go
@@ -121,6 +121,6 @@ func HandleDeleteSuccessfully(t *testing.T) {
 		th.TestMethod(t, r, "DELETE")
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
-		w.WriteHeader(http.StatusAccepted)
+		w.WriteHeader(http.StatusOK)
 	})
 }

--- a/openstack/compute/v2/extensions/aggregates/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/aggregates/testing/requests_test.go
@@ -56,3 +56,12 @@ func TestCreateAggregates(t *testing.T) {
 
 	th.AssertDeepEquals(t, &expected, actual)
 }
+
+func TestDeleteAggregates(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleDeleteSuccessfully(t)
+
+	err := aggregates.Delete(client.ServiceClient(), AggregateIDtoDelete).ExtractErr()
+	th.AssertNoErr(t, err)
+}

--- a/openstack/compute/v2/extensions/aggregates/urls.go
+++ b/openstack/compute/v2/extensions/aggregates/urls.go
@@ -9,3 +9,7 @@ func aggregatesListURL(c *gophercloud.ServiceClient) string {
 func aggregatesCreateURL(c *gophercloud.ServiceClient) string {
 	return c.ServiceURL("os-aggregates")
 }
+
+func aggregatesDeleteURL(c *gophercloud.ServiceClient, aggregateID string) string {
+	return c.ServiceURL("os-aggregates", aggregateID)
+}


### PR DESCRIPTION
For #738 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

API doc: 
- https://developer.openstack.org/api-ref/compute/#delete-aggregate

Source code: 
- https://github.com/openstack/nova/blob/master/nova/api/openstack/compute/aggregates.py#L124