### PR TITLE
Compute v2: Add host to aggregate

### DIFF
--- a/acceptance/openstack/compute/v2/aggregates_test.go
+++ b/acceptance/openstack/compute/v2/aggregates_test.go
@@ -90,3 +90,27 @@ func TestAggregatesUpdate(t *testing.T) {
 
 	tools.PrintResource(t, updatedAggregate)
 }
+
+func TestAggregatesAddHost(t *testing.T) {
+	client, err := clients.NewComputeV2Client()
+	if err != nil {
+		t.Fatalf("Unable to create a compute client: %v", err)
+	}
+
+	createdAggregate, err := CreateAggregate(t, client)
+	if err != nil {
+		t.Fatalf("Unable to create an aggregate: %v", err)
+	}
+	defer DeleteAggregate(t, client, createdAggregate)
+
+	addHostOpts := aggregates.AddHostOpts{
+		Host: "new-cmp",
+	}
+
+	aggregateWithNewHost, err := aggregates.AddHost(client, createdAggregate.ID, addHostOpts).Extract()
+	if err != nil {
+		t.Fatalf("Unable to add host to aggregate: %v", err)
+	}
+
+	tools.PrintResource(t, aggregateWithNewHost)
+}

--- a/acceptance/openstack/compute/v2/aggregates_test.go
+++ b/acceptance/openstack/compute/v2/aggregates_test.go
@@ -3,11 +3,14 @@
 package v2
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/acceptance/clients"
 	"github.com/gophercloud/gophercloud/acceptance/tools"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/aggregates"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/hypervisors"
 )
 
 func TestAggregatesList(t *testing.T) {
@@ -97,6 +100,11 @@ func TestAggregatesAddHost(t *testing.T) {
 		t.Fatalf("Unable to create a compute client: %v", err)
 	}
 
+	hostToAdd, err := getHypervisor(t, client)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	createdAggregate, err := CreateAggregate(t, client)
 	if err != nil {
 		t.Fatalf("Unable to create an aggregate: %v", err)
@@ -104,7 +112,7 @@ func TestAggregatesAddHost(t *testing.T) {
 	defer DeleteAggregate(t, client, createdAggregate)
 
 	addHostOpts := aggregates.AddHostOpts{
-		Host: "new-cmp",
+		Host: hostToAdd.HypervisorHostname,
 	}
 
 	aggregateWithNewHost, err := aggregates.AddHost(client, createdAggregate.ID, addHostOpts).Extract()
@@ -113,4 +121,22 @@ func TestAggregatesAddHost(t *testing.T) {
 	}
 
 	tools.PrintResource(t, aggregateWithNewHost)
+}
+
+func getHypervisor(t *testing.T, client *gophercloud.ServiceClient) (*hypervisors.Hypervisor, error) {
+	allPages, err := hypervisors.List(client).AllPages()
+	if err != nil {
+		t.Fatalf("Unable to list hypervisors: %v", err)
+	}
+
+	allHypervisors, err := hypervisors.ExtractHypervisors(allPages)
+	if err != nil {
+		t.Fatal("Unable to extract hypervisors")
+	}
+
+	for _, h := range allHypervisors {
+		return &h, nil
+	}
+
+	return nil, fmt.Errorf("Unable to get hypervisor")
 }

--- a/openstack/compute/v2/extensions/aggregates/doc.go
+++ b/openstack/compute/v2/extensions/aggregates/doc.go
@@ -61,5 +61,19 @@ Example of Retrieving list of all aggregates
 	for _, aggregate := range allAggregates {
 		fmt.Printf("%+v\n", aggregate)
 	}
+
+Example of Add Host
+
+	aggregateID := 22
+	opts := aggregates.AddHostOpts{
+		Host: "newhost-cmp1"
+	}
+
+	aggregate, err := aggregates.AddHost(computeClient, aggregateID, opts).Extract()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("%+v\n", aggregate)
+
 */
 package aggregates

--- a/openstack/compute/v2/extensions/aggregates/requests.go
+++ b/openstack/compute/v2/extensions/aggregates/requests.go
@@ -92,7 +92,7 @@ func Update(client *gophercloud.ServiceClient, aggregateID int, opts UpdateOpts)
 
 type AddHostOpts struct {
 	// The name of the host.
-	Host string `json:"host"`
+	Host string `json:"host" required:"true"`
 }
 
 func (opts AddHostOpts) ToAggregatesAddHostMap() (map[string]interface{}, error) {

--- a/openstack/compute/v2/extensions/aggregates/requests.go
+++ b/openstack/compute/v2/extensions/aggregates/requests.go
@@ -51,7 +51,7 @@ func Delete(client *gophercloud.ServiceClient, aggregateID int) (r DeleteResult)
 	return
 }
 
-// Get makes a request against the API to get details for an specific aggregate.
+// Get makes a request against the API to get details for a specific aggregate.
 func Get(client *gophercloud.ServiceClient, aggregateID int) (r GetResult) {
 	v := strconv.Itoa(aggregateID)
 	_, r.Err = client.Get(aggregatesGetURL(client, v), &r.Body, &gophercloud.RequestOpts{
@@ -75,6 +75,7 @@ func (opts UpdateOpts) ToAggregatesUpdateMap() (map[string]interface{}, error) {
 	return gophercloud.BuildRequestBody(opts, "aggregate")
 }
 
+// Update makes a request against the API to update a specific aggregate.
 func Update(client *gophercloud.ServiceClient, aggregateID int, opts UpdateOpts) (r UpdateResult) {
 	v := strconv.Itoa(aggregateID)
 
@@ -84,6 +85,30 @@ func Update(client *gophercloud.ServiceClient, aggregateID int, opts UpdateOpts)
 		return
 	}
 	_, r.Err = client.Put(aggregatesUpdateURL(client, v), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+type AddHostOpts struct {
+	// The name of the host.
+	Host string `json:"host"`
+}
+
+func (opts AddHostOpts) ToAggregatesAddHostMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "add_host")
+}
+
+// AddHost makes a request against the API to add host to a specific aggregate.
+func AddHost(client *gophercloud.ServiceClient, aggregateID int, opts AddHostOpts) (r ActionResult) {
+	v := strconv.Itoa(aggregateID)
+
+	b, err := opts.ToAggregatesAddHostMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(aggregatesAddHostURL(client, v), b, &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{200},
 	})
 	return

--- a/openstack/compute/v2/extensions/aggregates/results.go
+++ b/openstack/compute/v2/extensions/aggregates/results.go
@@ -111,3 +111,7 @@ type DeleteResult struct {
 type UpdateResult struct {
 	aggregatesResult
 }
+
+type ActionResult struct {
+	aggregatesResult
+}

--- a/openstack/compute/v2/extensions/aggregates/testing/fixtures.go
+++ b/openstack/compute/v2/extensions/aggregates/testing/fixtures.go
@@ -98,6 +98,27 @@ const AggregateUpdateBody = `
 }
 `
 
+const AggregateAddHostBody = `
+{
+    "aggregate": {
+            "name": "test-aggregate2",
+            "availability_zone": "test-az",
+            "deleted": false,
+            "created_at": "2017-12-22T10:16:07.000000",
+            "updated_at": null,
+            "hosts": [
+                "cmp0",
+				"cmp1"
+            ],
+            "deleted_at": null,
+            "id": 4,
+            "metadata": {
+                "availability_zone": "test-az"
+            }
+        }
+}
+`
+
 var (
 	// First aggregate from the AggregateListBody
 	FirstFakeAggregate = aggregates.Aggregate{
@@ -159,6 +180,18 @@ var (
 		DeletedAt:        time.Time{},
 		Deleted:          false,
 	}
+
+	AggregateWithAddedHost = aggregates.Aggregate{
+		AvailabilityZone: "test-az",
+		Hosts:            []string{"cmp0", "cmp1"},
+		ID:               4,
+		Metadata:         map[string]string{"availability_zone": "test-az"},
+		Name:             "test-aggregate2",
+		CreatedAt:        time.Date(2017, 12, 22, 10, 16, 7, 0, time.UTC),
+		UpdatedAt:        time.Time{},
+		DeletedAt:        time.Time{},
+		Deleted:          false,
+	}
 )
 
 // HandleListSuccessfully configures the test server to respond to a List request.
@@ -211,5 +244,16 @@ func HandleUpdateSuccessfully(t *testing.T) {
 
 		w.Header().Add("Content-Type", "application/json")
 		fmt.Fprintf(w, AggregateUpdateBody)
+	})
+}
+
+func HandleAddHostSuccessfully(t *testing.T) {
+	v := strconv.Itoa(AggregateWithAddedHost.ID)
+	th.Mux.HandleFunc("/os-aggregates/"+v+"/action", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprintf(w, AggregateAddHostBody)
 	})
 }

--- a/openstack/compute/v2/extensions/aggregates/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/aggregates/testing/requests_test.go
@@ -96,3 +96,20 @@ func TestUpdateAggregate(t *testing.T) {
 
 	th.AssertDeepEquals(t, &expected, actual)
 }
+
+func TestAddHostAggregate(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleAddHostSuccessfully(t)
+
+	expected := AggregateWithAddedHost
+
+	opts := aggregates.AddHostOpts{
+		Host: "cmp1",
+	}
+
+	actual, err := aggregates.AddHost(client.ServiceClient(), expected.ID, opts).Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertDeepEquals(t, &expected, actual)
+}

--- a/openstack/compute/v2/extensions/aggregates/urls.go
+++ b/openstack/compute/v2/extensions/aggregates/urls.go
@@ -21,3 +21,7 @@ func aggregatesGetURL(c *gophercloud.ServiceClient, aggregateID string) string {
 func aggregatesUpdateURL(c *gophercloud.ServiceClient, aggregateID string) string {
 	return c.ServiceURL("os-aggregates", aggregateID)
 }
+
+func aggregatesAddHostURL(c *gophercloud.ServiceClient, aggregateID string) string {
+	return c.ServiceURL("os-aggregates", aggregateID, "action")
+}


### PR DESCRIPTION
For #738 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

API doc: 

- https://developer.openstack.org/api-ref/compute/#add-host

Source code:

- https://github.com/openstack/nova/blob/master/nova/api/openstack/compute/aggregates.py#L141