### PR TITLE
Compute v2: Remove host

### DIFF
--- a/acceptance/openstack/compute/v2/aggregates_test.go
+++ b/acceptance/openstack/compute/v2/aggregates_test.go
@@ -94,7 +94,7 @@ func TestAggregatesUpdate(t *testing.T) {
 	tools.PrintResource(t, updatedAggregate)
 }
 
-func TestAggregatesAddHost(t *testing.T) {
+func TestAggregatesAddRemoveHost(t *testing.T) {
 	client, err := clients.NewComputeV2Client()
 	if err != nil {
 		t.Fatalf("Unable to create a compute client: %v", err)
@@ -121,6 +121,17 @@ func TestAggregatesAddHost(t *testing.T) {
 	}
 
 	tools.PrintResource(t, aggregateWithNewHost)
+
+	removeHostOpts := aggregates.RemoveHostOpts{
+		Host: hostToAdd.HypervisorHostname,
+	}
+
+	aggregateWithRemovedHost, err := aggregates.RemoveHost(client, createdAggregate.ID, removeHostOpts).Extract()
+	if err != nil {
+		t.Fatalf("Unable to remove host from aggregate: %v", err)
+	}
+
+	tools.PrintResource(t, aggregateWithRemovedHost)
 }
 
 func getHypervisor(t *testing.T, client *gophercloud.ServiceClient) (*hypervisors.Hypervisor, error) {

--- a/openstack/compute/v2/extensions/aggregates/doc.go
+++ b/openstack/compute/v2/extensions/aggregates/doc.go
@@ -75,5 +75,18 @@ Example of Add Host
 	}
 	fmt.Printf("%+v\n", aggregate)
 
+Example of Remove Host
+
+	aggregateID := 22
+	opts := aggregates.RemoveHostOpts{
+		Host: "newhost-cmp1"
+	}
+
+	aggregate, err := aggregates.RemoveHost(computeClient, aggregateID, opts).Extract()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("%+v\n", aggregate)
+
 */
 package aggregates

--- a/openstack/compute/v2/extensions/aggregates/requests.go
+++ b/openstack/compute/v2/extensions/aggregates/requests.go
@@ -113,3 +113,27 @@ func AddHost(client *gophercloud.ServiceClient, aggregateID int, opts AddHostOpt
 	})
 	return
 }
+
+type RemoveHostOpts struct {
+	// The name of the host.
+	Host string `json:"host" required:"true"`
+}
+
+func (opts RemoveHostOpts) ToAggregatesRemoveHostMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "remove_host")
+}
+
+// RemoveHost makes a request against the API to remove host from a specific aggregate.
+func RemoveHost(client *gophercloud.ServiceClient, aggregateID int, opts RemoveHostOpts) (r ActionResult) {
+	v := strconv.Itoa(aggregateID)
+
+	b, err := opts.ToAggregatesRemoveHostMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(aggregatesRemoveHostURL(client, v), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}

--- a/openstack/compute/v2/extensions/aggregates/testing/fixtures.go
+++ b/openstack/compute/v2/extensions/aggregates/testing/fixtures.go
@@ -119,6 +119,24 @@ const AggregateAddHostBody = `
 }
 `
 
+const AggregateRemoveHostBody = `
+{
+    "aggregate": {
+            "name": "test-aggregate2",
+            "availability_zone": "nova2",
+            "deleted": false,
+            "created_at": "2017-12-22T10:12:06.000000",
+            "updated_at": "2017-12-23T10:18:00.000000",
+            "hosts": [],
+            "deleted_at": null,
+            "id": 1,
+            "metadata": {
+                "availability_zone": "nova2"
+            }
+        }
+}
+`
+
 var (
 	// First aggregate from the AggregateListBody
 	FirstFakeAggregate = aggregates.Aggregate{
@@ -192,6 +210,18 @@ var (
 		DeletedAt:        time.Time{},
 		Deleted:          false,
 	}
+
+	AggregateWithRemovedHost = aggregates.Aggregate{
+		AvailabilityZone: "nova2",
+		Hosts:            []string{},
+		ID:               1,
+		Metadata:         map[string]string{"availability_zone": "nova2"},
+		Name:             "test-aggregate2",
+		CreatedAt:        time.Date(2017, 12, 22, 10, 12, 6, 0, time.UTC),
+		UpdatedAt:        time.Date(2017, 12, 23, 10, 18, 0, 0, time.UTC),
+		DeletedAt:        time.Time{},
+		Deleted:          false,
+	}
 )
 
 // HandleListSuccessfully configures the test server to respond to a List request.
@@ -255,5 +285,16 @@ func HandleAddHostSuccessfully(t *testing.T) {
 
 		w.Header().Add("Content-Type", "application/json")
 		fmt.Fprintf(w, AggregateAddHostBody)
+	})
+}
+
+func HandleRemoveHostSuccessfully(t *testing.T) {
+	v := strconv.Itoa(AggregateWithRemovedHost.ID)
+	th.Mux.HandleFunc("/os-aggregates/"+v+"/action", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprintf(w, AggregateRemoveHostBody)
 	})
 }

--- a/openstack/compute/v2/extensions/aggregates/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/aggregates/testing/requests_test.go
@@ -113,3 +113,20 @@ func TestAddHostAggregate(t *testing.T) {
 
 	th.AssertDeepEquals(t, &expected, actual)
 }
+
+func TestRemoveHostAggregate(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleAddHostSuccessfully(t)
+
+	expected := AggregateWithAddedHost
+
+	opts := aggregates.RemoveHostOpts{
+		Host: "cmp1",
+	}
+
+	actual, err := aggregates.RemoveHost(client.ServiceClient(), expected.ID, opts).Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertDeepEquals(t, &expected, actual)
+}

--- a/openstack/compute/v2/extensions/aggregates/urls.go
+++ b/openstack/compute/v2/extensions/aggregates/urls.go
@@ -25,3 +25,7 @@ func aggregatesUpdateURL(c *gophercloud.ServiceClient, aggregateID string) strin
 func aggregatesAddHostURL(c *gophercloud.ServiceClient, aggregateID string) string {
 	return c.ServiceURL("os-aggregates", aggregateID, "action")
 }
+
+func aggregatesRemoveHostURL(c *gophercloud.ServiceClient, aggregateID string) string {
+	return c.ServiceURL("os-aggregates", aggregateID, "action")
+}


### PR DESCRIPTION
For #738 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

API doc: 
- https://developer.openstack.org/api-ref/compute/#remove-host

Source code: 
- https://github.com/openstack/nova/blob/master/nova/api/openstack/compute/aggregates.py#L164