### PR TITLE
Compute v2: Create Or Update Aggregate Metadata

### DIFF
--- a/acceptance/openstack/compute/v2/aggregates_test.go
+++ b/acceptance/openstack/compute/v2/aggregates_test.go
@@ -147,7 +147,7 @@ func TestAggregatesSetMetadata(t *testing.T) {
 	defer DeleteAggregate(t, client, createdAggregate)
 
 	opts := aggregates.SetMetadataOpts{
-		Metadata: map[string]string{"key": "value"},
+		Metadata: map[string]interface{}{"key": "value"},
 	}
 
 	aggregateWithMetadata, err := aggregates.SetMetadata(client, createdAggregate.ID, opts).Extract()

--- a/acceptance/openstack/compute/v2/aggregates_test.go
+++ b/acceptance/openstack/compute/v2/aggregates_test.go
@@ -134,6 +134,30 @@ func TestAggregatesAddRemoveHost(t *testing.T) {
 	tools.PrintResource(t, aggregateWithRemovedHost)
 }
 
+func TestAggregatesSetMetadata(t *testing.T) {
+	client, err := clients.NewComputeV2Client()
+	if err != nil {
+		t.Fatalf("Unable to create a compute client: %v", err)
+	}
+
+	createdAggregate, err := CreateAggregate(t, client)
+	if err != nil {
+		t.Fatalf("Unable to create an aggregate: %v", err)
+	}
+	defer DeleteAggregate(t, client, createdAggregate)
+
+	opts := aggregates.SetMetadataOpts{
+		Metadata: map[string]string{"key": "value"},
+	}
+
+	aggregateWithMetadata, err := aggregates.SetMetadata(client, createdAggregate.ID, opts).Extract()
+	if err != nil {
+		t.Fatalf("Unable to set metadata to aggregate: %v", err)
+	}
+
+	tools.PrintResource(t, aggregateWithMetadata)
+}
+
 func getHypervisor(t *testing.T, client *gophercloud.ServiceClient) (*hypervisors.Hypervisor, error) {
 	allPages, err := hypervisors.List(client).AllPages()
 	if err != nil {

--- a/acceptance/openstack/compute/v2/aggregates_test.go
+++ b/acceptance/openstack/compute/v2/aggregates_test.go
@@ -134,7 +134,7 @@ func TestAggregatesAddRemoveHost(t *testing.T) {
 	tools.PrintResource(t, aggregateWithRemovedHost)
 }
 
-func TestAggregatesSetMetadata(t *testing.T) {
+func TestAggregatesSetRemoveMetadata(t *testing.T) {
 	client, err := clients.NewComputeV2Client()
 	if err != nil {
 		t.Fatalf("Unable to create a compute client: %v", err)
@@ -156,6 +156,17 @@ func TestAggregatesSetMetadata(t *testing.T) {
 	}
 
 	tools.PrintResource(t, aggregateWithMetadata)
+
+	optsToRemove := aggregates.SetMetadataOpts{
+		Metadata: map[string]interface{}{"key": nil},
+	}
+
+	aggregateWithRemovedKey, err := aggregates.SetMetadata(client, createdAggregate.ID, optsToRemove).Extract()
+	if err != nil {
+		t.Fatalf("Unable to set metadata to aggregate: %v", err)
+	}
+
+	tools.PrintResource(t, aggregateWithRemovedKey)
 }
 
 func getHypervisor(t *testing.T, client *gophercloud.ServiceClient) (*hypervisors.Hypervisor, error) {

--- a/openstack/compute/v2/extensions/aggregates/doc.go
+++ b/openstack/compute/v2/extensions/aggregates/doc.go
@@ -88,5 +88,18 @@ Example of Remove Host
 	}
 	fmt.Printf("%+v\n", aggregate)
 
+Example of Create or Update Metadata
+
+	aggregateID := 22
+	opts := aggregates.SetMetadata{
+		Metadata: map[string]string{"key": "value"}
+	}
+
+	aggregate, err := aggregates.SetMetadata(computeClient, aggregateID, opts).Extract()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("%+v\n", aggregate)
+
 */
 package aggregates

--- a/openstack/compute/v2/extensions/aggregates/doc.go
+++ b/openstack/compute/v2/extensions/aggregates/doc.go
@@ -66,7 +66,7 @@ Example of Add Host
 
 	aggregateID := 22
 	opts := aggregates.AddHostOpts{
-		Host: "newhost-cmp1"
+		Host: "newhost-cmp1",
 	}
 
 	aggregate, err := aggregates.AddHost(computeClient, aggregateID, opts).Extract()
@@ -79,7 +79,7 @@ Example of Remove Host
 
 	aggregateID := 22
 	opts := aggregates.RemoveHostOpts{
-		Host: "newhost-cmp1"
+		Host: "newhost-cmp1",
 	}
 
 	aggregate, err := aggregates.RemoveHost(computeClient, aggregateID, opts).Extract()
@@ -92,7 +92,7 @@ Example of Create or Update Metadata
 
 	aggregateID := 22
 	opts := aggregates.SetMetadata{
-		Metadata: map[string]string{"key": "value"}
+		Metadata: map[string]string{"key": "value"},
 	}
 
 	aggregate, err := aggregates.SetMetadata(computeClient, aggregateID, opts).Extract()

--- a/openstack/compute/v2/extensions/aggregates/requests.go
+++ b/openstack/compute/v2/extensions/aggregates/requests.go
@@ -137,3 +137,26 @@ func RemoveHost(client *gophercloud.ServiceClient, aggregateID int, opts RemoveH
 	})
 	return
 }
+
+type SetMetadataOpts struct {
+	Metadata map[string]string `json:"metadata" required:"true"`
+}
+
+func (opts SetMetadataOpts) ToSetMetadataMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "set_metadata")
+}
+
+// SetMetadata makes a request against the API to set metadata to a specific aggregate.
+func SetMetadata(client *gophercloud.ServiceClient, aggregateID int, opts SetMetadataOpts) (r ActionResult) {
+	v := strconv.Itoa(aggregateID)
+
+	b, err := opts.ToSetMetadataMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(aggregatesSetMetadataURL(client, v), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}

--- a/openstack/compute/v2/extensions/aggregates/requests.go
+++ b/openstack/compute/v2/extensions/aggregates/requests.go
@@ -139,7 +139,7 @@ func RemoveHost(client *gophercloud.ServiceClient, aggregateID int, opts RemoveH
 }
 
 type SetMetadataOpts struct {
-	Metadata map[string]string `json:"metadata" required:"true"`
+	Metadata map[string]interface{} `json:"metadata" required:"true"`
 }
 
 func (opts SetMetadataOpts) ToSetMetadataMap() (map[string]interface{}, error) {

--- a/openstack/compute/v2/extensions/aggregates/testing/fixtures.go
+++ b/openstack/compute/v2/extensions/aggregates/testing/fixtures.go
@@ -137,6 +137,27 @@ const AggregateRemoveHostBody = `
 }
 `
 
+const AggregateSetMetadataBody = `
+{
+    "aggregate": {
+            "name": "test-aggregate2",
+            "availability_zone": "test-az",
+            "deleted": false,
+            "created_at": "2017-12-22T10:16:07.000000",
+            "updated_at": "2017-12-23T10:18:00.000000",
+            "hosts": [
+                "cmp0"
+            ],
+            "deleted_at": null,
+            "id": 4,
+            "metadata": {
+                "availability_zone": "test-az",
+				"key": "value"
+            }
+        }
+}
+`
+
 var (
 	// First aggregate from the AggregateListBody
 	FirstFakeAggregate = aggregates.Aggregate{
@@ -222,6 +243,18 @@ var (
 		DeletedAt:        time.Time{},
 		Deleted:          false,
 	}
+
+	AggregateWithUpdatedMetadata = aggregates.Aggregate{
+		AvailabilityZone: "test-az",
+		Hosts:            []string{"cmp0"},
+		ID:               4,
+		Metadata:         map[string]string{"availability_zone": "test-az", "key": "value"},
+		Name:             "test-aggregate2",
+		CreatedAt:        time.Date(2017, 12, 22, 10, 16, 7, 0, time.UTC),
+		UpdatedAt:        time.Date(2017, 12, 23, 10, 18, 0, 0, time.UTC),
+		DeletedAt:        time.Time{},
+		Deleted:          false,
+	}
 )
 
 // HandleListSuccessfully configures the test server to respond to a List request.
@@ -296,5 +329,16 @@ func HandleRemoveHostSuccessfully(t *testing.T) {
 
 		w.Header().Add("Content-Type", "application/json")
 		fmt.Fprintf(w, AggregateRemoveHostBody)
+	})
+}
+
+func HandleSetMetadataSuccessfully(t *testing.T) {
+	v := strconv.Itoa(AggregateWithUpdatedMetadata.ID)
+	th.Mux.HandleFunc("/os-aggregates/"+v+"/action", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprintf(w, AggregateSetMetadataBody)
 	})
 }

--- a/openstack/compute/v2/extensions/aggregates/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/aggregates/testing/requests_test.go
@@ -117,15 +117,32 @@ func TestAddHostAggregate(t *testing.T) {
 func TestRemoveHostAggregate(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
-	HandleAddHostSuccessfully(t)
+	HandleRemoveHostSuccessfully(t)
 
-	expected := AggregateWithAddedHost
+	expected := AggregateWithRemovedHost
 
 	opts := aggregates.RemoveHostOpts{
 		Host: "cmp1",
 	}
 
 	actual, err := aggregates.RemoveHost(client.ServiceClient(), expected.ID, opts).Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertDeepEquals(t, &expected, actual)
+}
+
+func TestSetMetadataAggregate(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleSetMetadataSuccessfully(t)
+
+	expected := AggregateWithUpdatedMetadata
+
+	opts := aggregates.SetMetadataOpts{
+		Metadata: map[string]string{"key": "value"},
+	}
+
+	actual, err := aggregates.SetMetadata(client.ServiceClient(), expected.ID, opts).Extract()
 	th.AssertNoErr(t, err)
 
 	th.AssertDeepEquals(t, &expected, actual)

--- a/openstack/compute/v2/extensions/aggregates/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/aggregates/testing/requests_test.go
@@ -139,7 +139,7 @@ func TestSetMetadataAggregate(t *testing.T) {
 	expected := AggregateWithUpdatedMetadata
 
 	opts := aggregates.SetMetadataOpts{
-		Metadata: map[string]string{"key": "value"},
+		Metadata: map[string]interface{}{"key": "value"},
 	}
 
 	actual, err := aggregates.SetMetadata(client.ServiceClient(), expected.ID, opts).Extract()

--- a/openstack/compute/v2/extensions/aggregates/urls.go
+++ b/openstack/compute/v2/extensions/aggregates/urls.go
@@ -29,3 +29,7 @@ func aggregatesAddHostURL(c *gophercloud.ServiceClient, aggregateID string) stri
 func aggregatesRemoveHostURL(c *gophercloud.ServiceClient, aggregateID string) string {
 	return c.ServiceURL("os-aggregates", aggregateID, "action")
 }
+
+func aggregatesSetMetadataURL(c *gophercloud.ServiceClient, aggregateID string) string {
+	return c.ServiceURL("os-aggregates", aggregateID, "action")
+}


### PR DESCRIPTION
For #738 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

API doc:

- https://developer.openstack.org/api-ref/compute/#create-or-update-aggregate-metadata

Source code: 

- https://github.com/openstack/nova/blob/master/nova/api/openstack/compute/aggregates.py#L186

