### PR TITLE
Add SubnetPoolID into the Subnet struct and GET requests

### DIFF
--- a/openstack/networking/v2/subnets/requests.go
+++ b/openstack/networking/v2/subnets/requests.go
@@ -27,6 +27,7 @@ type ListOpts struct {
 	IPv6AddressMode string `q:"ipv6_address_mode"`
 	IPv6RAMode      string `q:"ipv6_ra_mode"`
 	ID              string `q:"id"`
+	SubnetPoolID    string `q:"subnetpool_id"`
 	Limit           int    `q:"limit"`
 	Marker          string `q:"marker"`
 	SortKey         string `q:"sort_key"`

--- a/openstack/networking/v2/subnets/results.go
+++ b/openstack/networking/v2/subnets/results.go
@@ -100,6 +100,9 @@ type Subnet struct {
 	// The IPv6 router advertisement specifies whether the networking service
 	// should transmit ICMPv6 packets.
 	IPv6RAMode string `json:"ipv6_ra_mode"`
+
+	// SubnetPoolID is the id of the subnet pool associated with the subnet.
+	SubnetPoolID string `json:"subnetpool_id"`
 }
 
 // SubnetPage is the page returned by a pager when traversing over a collection

--- a/openstack/networking/v2/subnets/testing/fixtures.go
+++ b/openstack/networking/v2/subnets/testing/fixtures.go
@@ -60,6 +60,25 @@ const SubnetListResult = `
             "gateway_ip": null,
             "cidr": "192.168.1.0/24",
             "id": "54d6f61d-db07-451c-9ab3-b9609b6b6f0c"
+        },
+        {
+            "name": "my_subnet_with_subnetpool",
+            "enable_dhcp": false,
+            "network_id": "d32019d3-bc6e-4319-9c1d-6722fc136a23",
+            "tenant_id": "4fd44f30292945e481c7b8a0c8908869",
+            "dns_nameservers": [],
+            "allocation_pools": [
+                {
+                    "start": "10.11.12.2",
+                    "end": "10.11.12.254"
+                }
+            ],
+            "host_routes": [],
+            "ip_version": 4,
+            "gateway_ip": null,
+            "cidr": "10.11.12.0/24",
+            "id": "38186a51-f373-4bbc-838b-6eaa1aa13eac",
+            "subnetpool_id": "b80340c7-9960-4f67-a99c-02501656284b"
         }
     ]
 }
@@ -122,6 +141,26 @@ var Subnet3 = subnets.Subnet{
 	ID:         "54d6f61d-db07-451c-9ab3-b9609b6b6f0c",
 }
 
+var Subnet4 = subnets.Subnet{
+	Name:           "my_subnet_with_subnetpool",
+	EnableDHCP:     false,
+	NetworkID:      "d32019d3-bc6e-4319-9c1d-6722fc136a23",
+	TenantID:       "4fd44f30292945e481c7b8a0c8908869",
+	DNSNameservers: []string{},
+	AllocationPools: []subnets.AllocationPool{
+		{
+			Start: "10.11.12.2",
+			End:   "10.11.12.254",
+		},
+	},
+	HostRoutes:   []subnets.HostRoute{},
+	IPVersion:    4,
+	GatewayIP:    "",
+	CIDR:         "10.11.12.0/24",
+	ID:           "38186a51-f373-4bbc-838b-6eaa1aa13eac",
+	SubnetPoolID: "b80340c7-9960-4f67-a99c-02501656284b",
+}
+
 const SubnetGetResult = `
 {
     "subnet": {
@@ -140,7 +179,8 @@ const SubnetGetResult = `
         "ip_version": 4,
         "gateway_ip": "192.0.0.1",
         "cidr": "192.0.0.0/8",
-        "id": "54d6f61d-db07-451c-9ab3-b9609b6b6f0b"
+        "id": "54d6f61d-db07-451c-9ab3-b9609b6b6f0b",
+        "subnetpool_id": "b80340c7-9960-4f67-a99c-02501656284b"
     }
 }
 `

--- a/openstack/networking/v2/subnets/testing/requests_test.go
+++ b/openstack/networking/v2/subnets/testing/requests_test.go
@@ -39,6 +39,7 @@ func TestList(t *testing.T) {
 			Subnet1,
 			Subnet2,
 			Subnet3,
+			Subnet4,
 		}
 
 		th.CheckDeepEquals(t, expected, actual)
@@ -84,6 +85,7 @@ func TestGet(t *testing.T) {
 	th.AssertEquals(t, s.GatewayIP, "192.0.0.1")
 	th.AssertEquals(t, s.CIDR, "192.0.0.0/8")
 	th.AssertEquals(t, s.ID, "54d6f61d-db07-451c-9ab3-b9609b6b6f0b")
+	th.AssertEquals(t, s.SubnetPoolID, "b80340c7-9960-4f67-a99c-02501656284b")
 }
 
 func TestCreate(t *testing.T) {


### PR DESCRIPTION
Add ability to populate subnet's subnetpool_id field from GET requests.
Also add this field to GET and LIST unit tests.

For #763 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/neutron/blob/stable/pike/neutron/objects/subnet.py#L179