### PR TITLE
Add the SubnetPoolID to the Subnet Create request

### DIFF
--- a/acceptance/openstack/networking/v2/networking.go
+++ b/acceptance/openstack/networking/v2/networking.go
@@ -188,6 +188,32 @@ func CreateSubnetWithNoGateway(t *testing.T, client *gophercloud.ServiceClient, 
 	return subnet, nil
 }
 
+// CreateSubnetWithSubnetPool will create a subnet associated with the provided subnetpool on the specified Network ID.
+// An error will be returned if the subnet or the subnetpool could not be created.
+func CreateSubnetWithSubnetPool(t *testing.T, client *gophercloud.ServiceClient, networkID string, subnetPoolID string) (*subnets.Subnet, error) {
+	subnetName := tools.RandomString("TESTACC-", 8)
+	subnetOctet := tools.RandomInt(1, 250)
+	subnetCIDR := fmt.Sprintf("10.%d.0.0/24", subnetOctet)
+	createOpts := subnets.CreateOpts{
+		NetworkID:    networkID,
+		CIDR:         subnetCIDR,
+		IPVersion:    4,
+		Name:         subnetName,
+		EnableDHCP:   gophercloud.Disabled,
+		SubnetPoolID: subnetPoolID,
+	}
+
+	t.Logf("Attempting to create subnet: %s", subnetName)
+
+	subnet, err := subnets.Create(client, createOpts).Extract()
+	if err != nil {
+		return subnet, err
+	}
+
+	t.Logf("Successfully created subnet.")
+	return subnet, nil
+}
+
 // DeleteNetwork will delete a network with a specified ID. A fatal error will
 // occur if the delete was not successful. This works best when used as a
 // deferred function.

--- a/openstack/networking/v2/subnets/requests.go
+++ b/openstack/networking/v2/subnets/requests.go
@@ -115,6 +115,9 @@ type CreateOpts struct {
 	// The IPv6 router advertisement specifies whether the networking service
 	// should transmit ICMPv6 packets.
 	IPv6RAMode string `json:"ipv6_ra_mode,omitempty"`
+
+	// SubnetPoolID is the id of the subnet pool that subnet should be associated to.
+	SubnetPoolID string `json:"subnetpool_id,omitempty"`
 }
 
 // ToSubnetCreateMap builds a request body from CreateOpts.

--- a/openstack/networking/v2/subnets/testing/fixtures.go
+++ b/openstack/networking/v2/subnets/testing/fixtures.go
@@ -199,7 +199,8 @@ const SubnetCreateRequest = `
                 "end": "192.168.199.254"
             }
         ],
-        "host_routes": [{"destination":"","nexthop": "bar"}]
+        "host_routes": [{"destination":"","nexthop": "bar"}],
+        "subnetpool_id": "b80340c7-9960-4f67-a99c-02501656284b"
     }
 }
 `
@@ -222,7 +223,8 @@ const SubnetCreateResult = `
         "ip_version": 4,
         "gateway_ip": "192.168.199.1",
         "cidr": "192.168.199.0/24",
-        "id": "3b80198d-4f7b-4f77-9ef5-774d54e17126"
+        "id": "3b80198d-4f7b-4f77-9ef5-774d54e17126",
+        "subnetpool_id": "b80340c7-9960-4f67-a99c-02501656284b"
     }
 }
 `

--- a/openstack/networking/v2/subnets/testing/requests_test.go
+++ b/openstack/networking/v2/subnets/testing/requests_test.go
@@ -121,6 +121,7 @@ func TestCreate(t *testing.T) {
 		HostRoutes: []subnets.HostRoute{
 			{NextHop: "bar"},
 		},
+		SubnetPoolID: "b80340c7-9960-4f67-a99c-02501656284b",
 	}
 	s, err := subnets.Create(fake.ServiceClient(), opts).Extract()
 	th.AssertNoErr(t, err)
@@ -141,6 +142,7 @@ func TestCreate(t *testing.T) {
 	th.AssertEquals(t, s.GatewayIP, "192.168.199.1")
 	th.AssertEquals(t, s.CIDR, "192.168.199.0/24")
 	th.AssertEquals(t, s.ID, "3b80198d-4f7b-4f77-9ef5-774d54e17126")
+	th.AssertEquals(t, s.SubnetPoolID, "b80340c7-9960-4f67-a99c-02501656284b")
 }
 
 func TestCreateNoGateway(t *testing.T) {


### PR DESCRIPTION
Add the "subnetpool_id" field to the subnet creation request with an acceptance test.
Also update the unit test.

For #763 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

Here you can see a subnetpool_id in the subnet collection of a resource map:
https://github.com/openstack/neutron/blob/stable/pike/neutron/api/v2/attributes.py#L149
it's provided into this method:
https://github.com/openstack/neutron/blob/master/neutron/neutron_plugin_base_v2.py#L33

