### PR TITLE
Use pointers to some subnetpools CreateOpts fields

### DIFF
--- a/openstack/networking/v2/extensions/subnetpools/requests.go
+++ b/openstack/networking/v2/extensions/subnetpools/requests.go
@@ -118,14 +118,14 @@ type CreateOpts struct {
 	// AddressScopeID is the Neutron address scope to assign to the subnetpool.
 	AddressScopeID string `json:"address_scope_id,omitempty"`
 
-	// Shared indicates whether this network is shared across all projects.
-	Shared bool `json:"shared,omitempty"`
+	// Shared indicates whether the subnetpool is shared across all projects.
+	Shared *bool `json:"shared,omitempty"`
 
 	// Description is the human-readable description for the resource.
 	Description string `json:"description,omitempty"`
 
 	// IsDefault indicates if the subnetpool is default pool or not.
-	IsDefault bool `json:"is_default,omitempty"`
+	IsDefault *bool `json:"is_default,omitempty"`
 }
 
 // ToSubnetPoolCreateMap constructs a request body from CreateOpts.

--- a/openstack/networking/v2/extensions/subnetpools/testing/fixtures.go
+++ b/openstack/networking/v2/extensions/subnetpools/testing/fixtures.go
@@ -181,7 +181,8 @@ const SubnetPoolCreateRequest = `
         "address_scope_id": "3d4e2e2a-552b-42ad-a16d-820bbf3edaf3",
         "min_prefixlen": 25,
         "max_prefixlen": 30,
-        "description": "ipv4 prefixes"
+        "description": "ipv4 prefixes",
+        "shared": true
     }
 }
 `
@@ -206,7 +207,7 @@ const SubnetPoolCreateResult = `
         ],
         "project_id": "1e2b9857295a4a3e841809ef492812c5",
         "revision_number": 1,
-        "shared": false,
+        "shared": true,
         "tenant_id": "1e2b9857295a4a3e841809ef492812c5",
         "updated_at": "2018-01-01T00:00:15Z"
     }

--- a/openstack/networking/v2/extensions/subnetpools/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/subnetpools/testing/requests_test.go
@@ -88,6 +88,7 @@ func TestGet(t *testing.T) {
 	th.AssertEquals(t, s.IsDefault, true)
 	th.AssertEquals(t, s.RevisionNumber, 2)
 }
+
 func TestCreate(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
@@ -105,6 +106,7 @@ func TestCreate(t *testing.T) {
 		fmt.Fprintf(w, SubnetPoolCreateResult)
 	})
 
+	shared := true
 	opts := subnetpools.CreateOpts{
 		Name: "my_ipv4_pool",
 		Prefixes: []string{
@@ -115,6 +117,7 @@ func TestCreate(t *testing.T) {
 		MaxPrefixLen:   30,
 		AddressScopeID: "3d4e2e2a-552b-42ad-a16d-820bbf3edaf3",
 		Description:    "ipv4 prefixes",
+		Shared:         &shared,
 	}
 	s, err := subnetpools.Create(fake.ServiceClient(), opts).Extract()
 	th.AssertNoErr(t, err)
@@ -128,6 +131,7 @@ func TestCreate(t *testing.T) {
 	th.AssertEquals(t, s.MaxPrefixLen, 30)
 	th.AssertEquals(t, s.AddressScopeID, "3d4e2e2a-552b-42ad-a16d-820bbf3edaf3")
 	th.AssertEquals(t, s.Description, "ipv4 prefixes")
+	th.AssertEquals(t, s.Shared, true)
 }
 
 func TestUpdate(t *testing.T) {


### PR DESCRIPTION
We need to use pointers to optional "Shared" and "IsDefault" fields of
the CreateOpts structure.

For #766 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/neutron/blob/stable/pike/neutron/db/db_base_plugin_v2.py#L1117
https://github.com/openstack/neutron/blob/stable/pike/neutron/api/v2/attributes.py#L214