### PR TITLE
Allow dns_name and dns_domain to be set on networking resources

### DIFF
--- a/openstack/networking/v2/extensions/layer3/floatingips/requests.go
+++ b/openstack/networking/v2/extensions/layer3/floatingips/requests.go
@@ -23,6 +23,8 @@ type ListOpts struct {
 	SortDir           string `q:"sort_dir"`
 	RouterID          string `q:"router_id"`
 	Status            string `q:"status"`
+	DNSDomain         string `q:"dns_domain"`
+	DNSName           string `q:"dns_name"`
 }
 
 // List returns a Pager which allows you to iterate over a collection of
@@ -55,6 +57,8 @@ type CreateOpts struct {
 	FixedIP           string `json:"fixed_ip_address,omitempty"`
 	SubnetID          string `json:"subnet_id,omitempty"`
 	TenantID          string `json:"tenant_id,omitempty"`
+	DNSDomain         string `json:"dns_domain,omitempty"`
+	DNSName           string `json:"dns_name,omitempty"`
 }
 
 // ToFloatingIPCreateMap allows CreateOpts to satisfy the CreateOptsBuilder
@@ -114,7 +118,9 @@ type UpdateOptsBuilder interface {
 // linked to. To associate the floating IP with a new internal port, provide its
 // ID. To disassociate the floating IP from all ports, provide an empty string.
 type UpdateOpts struct {
-	PortID *string `json:"port_id"`
+	PortID    *string `json:"port_id"`
+	DNSDomain string  `json:"dns_domain,omitempty"`
+	DNSName   string  `json:"dns_name,omitempty"`
 }
 
 // ToFloatingIPUpdateMap allows UpdateOpts to satisfy the UpdateOptsBuilder

--- a/openstack/networking/v2/extensions/layer3/floatingips/results.go
+++ b/openstack/networking/v2/extensions/layer3/floatingips/results.go
@@ -39,6 +39,12 @@ type FloatingIP struct {
 
 	// RouterID is the ID of the router used for this floating IP.
 	RouterID string `json:"router_id"`
+
+	// Specifies the DNS domain used for autocreating public DNS entries for this floating IP (overrides port and network DNSDomain settings)
+	DNSDomain string `json:"dns_domain,omitempty"`
+
+	// Specifies the DNS Name used as the first label of autocreated public DNS entries for this floating IP (overrides port DNSName setting)
+	DNSName string `json:"dns_name,omitempty"`
 }
 
 type commonResult struct {

--- a/openstack/networking/v2/networks/requests.go
+++ b/openstack/networking/v2/networks/requests.go
@@ -27,6 +27,7 @@ type ListOpts struct {
 	Limit        int    `q:"limit"`
 	SortKey      string `q:"sort_key"`
 	SortDir      string `q:"sort_dir"`
+	DNSDomain    string `q:"dns_domain"`
 }
 
 // ToNetworkListQuery formats a ListOpts into a query string.
@@ -71,6 +72,7 @@ type CreateOpts struct {
 	Shared                *bool    `json:"shared,omitempty"`
 	TenantID              string   `json:"tenant_id,omitempty"`
 	AvailabilityZoneHints []string `json:"availability_zone_hints,omitempty"`
+	DNSDomain             string   `json:"dns_domain,omitempty"`
 }
 
 // ToNetworkCreateMap builds a request body from CreateOpts.
@@ -106,6 +108,7 @@ type UpdateOpts struct {
 	AdminStateUp *bool  `json:"admin_state_up,omitempty"`
 	Name         string `json:"name,omitempty"`
 	Shared       *bool  `json:"shared,omitempty"`
+	DNSDomain    string `json:"dns_domain,omitempty"`
 }
 
 // ToNetworkUpdateMap builds a request body from UpdateOpts.

--- a/openstack/networking/v2/networks/results.go
+++ b/openstack/networking/v2/networks/results.go
@@ -73,6 +73,9 @@ type Network struct {
 	// Availability zone hints groups network nodes that run services like DHCP, L3, FW, and others.
 	// Used to make network resources highly available.
 	AvailabilityZoneHints []string `json:"availability_zone_hints"`
+
+	// Specifies the DNS Domain used as the local DNS Search Domain, and the domain used for autocreating public DNS entries
+	DNSDomain string `json:"dns_domain,omitempty"`
 }
 
 // NetworkPage is the page returned by a pager when traversing over a

--- a/openstack/networking/v2/ports/requests.go
+++ b/openstack/networking/v2/ports/requests.go
@@ -30,6 +30,8 @@ type ListOpts struct {
 	Marker       string `q:"marker"`
 	SortKey      string `q:"sort_key"`
 	SortDir      string `q:"sort_dir"`
+	DNSDomain    string `q:"dns_domain"`
+	DNSName      string `q:"dns_name"`
 }
 
 // ToPortListQuery formats a ListOpts into a query string.
@@ -83,6 +85,8 @@ type CreateOpts struct {
 	TenantID            string        `json:"tenant_id,omitempty"`
 	SecurityGroups      *[]string     `json:"security_groups,omitempty"`
 	AllowedAddressPairs []AddressPair `json:"allowed_address_pairs,omitempty"`
+	DNSDomain           string        `json:"dns_domain,omitempty"`
+	DNSName             string        `json:"dns_name,omitempty"`
 }
 
 // ToPortCreateMap builds a request body from CreateOpts.
@@ -117,6 +121,8 @@ type UpdateOpts struct {
 	DeviceOwner         string         `json:"device_owner,omitempty"`
 	SecurityGroups      *[]string      `json:"security_groups,omitempty"`
 	AllowedAddressPairs *[]AddressPair `json:"allowed_address_pairs,omitempty"`
+	DNSDomain           string         `json:"dns_domain,omitempty"`
+	DNSName             string         `json:"dns_name,omitempty"`
 }
 
 // ToPortUpdateMap builds a request body from UpdateOpts.

--- a/openstack/networking/v2/ports/results.go
+++ b/openstack/networking/v2/ports/results.go
@@ -98,6 +98,12 @@ type Port struct {
 
 	// Identifies the list of IP addresses the port will recognize/accept
 	AllowedAddressPairs []AddressPair `json:"allowed_address_pairs"`
+
+	// Specifies the DNS Domain used as the local DNS Search Domain, and the domain used for autocreating public DNS entries for this port
+	DNSDomain string `json:"dns_domain,omitempty"`
+
+	// Specifies the DNS Name used as the first label of the DNS entry, and the name used for autocreating public DNS entries for this port
+	DNSName string `json:"dns_name,omitempty"`
 }
 
 // PortPage is the page returned by a pager when traversing over a collection


### PR DESCRIPTION
For ##776

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

Network `dns_domain` : https://github.com/openstack/neutron/blob/master/neutron/objects/network.py#L216

Port `dns_domain` and `dns_name` : https://github.com/openstack/neutron/blob/master/neutron/objects/ports.py#L286 which links to https://github.com/openstack/neutron/blob/master/neutron/objects/ports.py#L207

Floating IP `dns_domain` and `dns_name` : https://github.com/openstack/neutron/blob/master/neutron/objects/floatingip.py#L33-L34
