### PR TITLE
Image Service v2: Add Missing Fields to ListOpts

### DIFF
--- a/acceptance/openstack/imageservice/v2/images_test.go
+++ b/acceptance/openstack/imageservice/v2/images_test.go
@@ -134,7 +134,7 @@ func TestImagesListByDate(t *testing.T) {
 	}
 }
 
-func TestImagesFilterByTags(t *testing.T) {
+func TestImagesFilter(t *testing.T) {
 	client, err := clients.NewImageServiceV2Client()
 	if err != nil {
 		t.Fatalf("Unable to create an image service client: %v", err)
@@ -148,7 +148,9 @@ func TestImagesFilterByTags(t *testing.T) {
 	defer DeleteImage(t, client, image)
 
 	listOpts := images.ListOpts{
-		Tags: []string{"foo", "bar"},
+		Tags:            []string{"foo", "bar"},
+		ContainerFormat: "bare",
+		DiskFormat:      "qcow2",
 	}
 
 	allPages, err := images.List(client, listOpts).AllPages()

--- a/acceptance/openstack/imageservice/v2/images_test.go
+++ b/acceptance/openstack/imageservice/v2/images_test.go
@@ -133,3 +133,35 @@ func TestImagesListByDate(t *testing.T) {
 		t.Fatalf("Expected 0 images, got %d", len(allImages))
 	}
 }
+
+func TestImagesFilterByTags(t *testing.T) {
+	client, err := clients.NewImageServiceV2Client()
+	if err != nil {
+		t.Fatalf("Unable to create an image service client: %v", err)
+	}
+
+	image, err := CreateEmptyImage(t, client)
+	if err != nil {
+		t.Fatalf("Unable to create empty image: %v", err)
+	}
+
+	defer DeleteImage(t, client, image)
+
+	listOpts := images.ListOpts{
+		Tags: []string{"foo", "bar"},
+	}
+
+	allPages, err := images.List(client, listOpts).AllPages()
+	if err != nil {
+		t.Fatalf("Unable to retrieve all images: %v", err)
+	}
+
+	allImages, err := images.ExtractImages(allPages)
+	if err != nil {
+		t.Fatalf("Unable to extract images: %v", err)
+	}
+
+	if len(allImages) == 0 {
+		t.Fatalf("Query resulted in no results")
+	}
+}

--- a/acceptance/openstack/imageservice/v2/images_test.go
+++ b/acceptance/openstack/imageservice/v2/images_test.go
@@ -4,6 +4,7 @@ package v2
 
 import (
 	"testing"
+	"time"
 
 	"github.com/gophercloud/gophercloud/acceptance/clients"
 	"github.com/gophercloud/gophercloud/acceptance/tools"
@@ -77,4 +78,58 @@ func TestImagesCreateDestroyEmptyImage(t *testing.T) {
 	defer DeleteImage(t, client, image)
 
 	tools.PrintResource(t, image)
+}
+
+func TestImagesListByDate(t *testing.T) {
+	client, err := clients.NewImageServiceV2Client()
+	if err != nil {
+		t.Fatalf("Unable to create an image service client: %v", err)
+	}
+
+	date := time.Date(2014, 1, 1, 1, 1, 1, 0, time.UTC)
+	listOpts := images.ListOpts{
+		Limit: 1,
+		CreatedAt: &images.ImageDateQuery{
+			Date:   date,
+			Filter: images.FilterGTE,
+		},
+	}
+
+	allPages, err := images.List(client, listOpts).AllPages()
+	if err != nil {
+		t.Fatalf("Unable to retrieve all images: %v", err)
+	}
+
+	allImages, err := images.ExtractImages(allPages)
+	if err != nil {
+		t.Fatalf("Unable to extract images: %v", err)
+	}
+
+	for _, image := range allImages {
+		tools.PrintResource(t, image)
+		tools.PrintResource(t, image.Properties)
+	}
+
+	date = time.Date(2049, 1, 1, 1, 1, 1, 0, time.UTC)
+	listOpts = images.ListOpts{
+		Limit: 1,
+		CreatedAt: &images.ImageDateQuery{
+			Date:   date,
+			Filter: images.FilterGTE,
+		},
+	}
+
+	allPages, err = images.List(client, listOpts).AllPages()
+	if err != nil {
+		t.Fatalf("Unable to retrieve all images: %v", err)
+	}
+
+	allImages, err = images.ExtractImages(allPages)
+	if err != nil {
+		t.Fatalf("Unable to extract images: %v", err)
+	}
+
+	if len(allImages) > 0 {
+		t.Fatalf("Expected 0 images, got %d", len(allImages))
+	}
 }

--- a/acceptance/openstack/imageservice/v2/imageservice.go
+++ b/acceptance/openstack/imageservice/v2/imageservice.go
@@ -31,6 +31,7 @@ func CreateEmptyImage(t *testing.T, client *gophercloud.ServiceClient) (*images.
 		Properties: map[string]string{
 			"architecture": "x86_64",
 		},
+		Tags: []string{"foo", "bar", "baz"},
 	}
 
 	image, err := images.Create(client, createOpts).Extract()

--- a/openstack/imageservice/v2/images/requests.go
+++ b/openstack/imageservice/v2/images/requests.go
@@ -44,7 +44,7 @@ type ListOpts struct {
 	Owner string `q:"owner"`
 
 	// Status filters on the status of the image.
-	Status ImageStatus `q:"status"`
+	Status string `q:"status"`
 
 	// SizeMin filters on the size_min image property.
 	SizeMin int64 `q:"size_min"`

--- a/openstack/imageservice/v2/images/requests.go
+++ b/openstack/imageservice/v2/images/requests.go
@@ -61,8 +61,8 @@ type ListOpts struct {
 	// SortDir will sort the list results either ascending or decending.
 	SortDir string `q:"sort_dir"`
 
-	// Tag filters on a specific image tag.
-	Tag string `q:"tag"`
+	// Tags filters on specific image tags.
+	Tags []string `q:"tag"`
 
 	// CreatedAt filters images based on their creation date.
 	CreatedAt *ImageDateQuery

--- a/openstack/imageservice/v2/images/requests.go
+++ b/openstack/imageservice/v2/images/requests.go
@@ -23,6 +23,8 @@ type ListOptsBuilder interface {
 // http://developer.openstack.org/api-ref-image-v2.html
 type ListOpts struct {
 	// ID is the ID of the image.
+	// Multiple IDs can be specified by constructing a string
+	// such as "in:uuid1,uuid2,uuid3".
 	ID string `q:"id"`
 
 	// Integer value for the limit of values to return.
@@ -32,6 +34,8 @@ type ListOpts struct {
 	Marker string `q:"marker"`
 
 	// Name filters on the name of the image.
+	// Multiple names can be specified by constructing a string
+	// such as "in:name1,name2,name3".
 	Name string `q:"name"`
 
 	// Visibility filters on the visibility of the image.
@@ -44,6 +48,8 @@ type ListOpts struct {
 	Owner string `q:"owner"`
 
 	// Status filters on the status of the image.
+	// Multiple statuses can be specified by constructing a string
+	// such as "in:saving,queued".
 	Status string `q:"status"`
 
 	// SizeMin filters on the size_min image property.
@@ -74,9 +80,13 @@ type ListOpts struct {
 	UpdatedAt *ImageDateQuery
 
 	// ContainerFormat filters images based on the container_format.
+	// Multiple container formats can be specified by constructing a
+	// string such as "in:bare,ami".
 	ContainerFormat string `q:"container_format"`
 
 	// DiskFormat filters images based on the disk_format.
+	// Multiple disk formats can be specified by constructing a string
+	// such as "in:qcow2,iso".
 	DiskFormat string `q:"disk_format"`
 }
 

--- a/openstack/imageservice/v2/images/requests.go
+++ b/openstack/imageservice/v2/images/requests.go
@@ -22,6 +22,9 @@ type ListOptsBuilder interface {
 //
 // http://developer.openstack.org/api-ref-image-v2.html
 type ListOpts struct {
+	// ID is the ID of the image.
+	ID string `q:"id"`
+
 	// Integer value for the limit of values to return.
 	Limit int `q:"limit"`
 

--- a/openstack/imageservice/v2/images/requests.go
+++ b/openstack/imageservice/v2/images/requests.go
@@ -50,7 +50,7 @@ type ListOpts struct {
 	// Status filters on the status of the image.
 	// Multiple statuses can be specified by constructing a string
 	// such as "in:saving,queued".
-	Status string `q:"status"`
+	Status ImageStatus `q:"status"`
 
 	// SizeMin filters on the size_min image property.
 	SizeMin int64 `q:"size_min"`
@@ -73,11 +73,11 @@ type ListOpts struct {
 	// Tags filters on specific image tags.
 	Tags []string `q:"tag"`
 
-	// CreatedAt filters images based on their creation date.
-	CreatedAt *ImageDateQuery
+	// CreatedAtQuery filters images based on their creation date.
+	CreatedAtQuery *ImageDateQuery
 
-	// UpdatedAt filters images based on their updated date.
-	UpdatedAt *ImageDateQuery
+	// UpdatedAtQuery filters images based on their updated date.
+	UpdatedAtQuery *ImageDateQuery
 
 	// ContainerFormat filters images based on the container_format.
 	// Multiple container formats can be specified by constructing a
@@ -95,18 +95,18 @@ func (opts ListOpts) ToImageListQuery() (string, error) {
 	q, err := gophercloud.BuildQueryString(opts)
 	params := q.Query()
 
-	if opts.CreatedAt != nil {
-		createdAt := opts.CreatedAt.Date.Format(time.RFC3339)
-		if v := opts.CreatedAt.Filter; v != "" {
+	if opts.CreatedAtQuery != nil {
+		createdAt := opts.CreatedAtQuery.Date.Format(time.RFC3339)
+		if v := opts.CreatedAtQuery.Filter; v != "" {
 			createdAt = fmt.Sprintf("%s:%s", v, createdAt)
 		}
 
 		params.Add("created_at", createdAt)
 	}
 
-	if opts.UpdatedAt != nil {
-		updatedAt := opts.UpdatedAt.Date.Format(time.RFC3339)
-		if v := opts.UpdatedAt.Filter; v != "" {
+	if opts.UpdatedAtQuery != nil {
+		updatedAt := opts.UpdatedAtQuery.Date.Format(time.RFC3339)
+		if v := opts.UpdatedAtQuery.Filter; v != "" {
 			updatedAt = fmt.Sprintf("%s:%s", v, updatedAt)
 		}
 

--- a/openstack/imageservice/v2/images/requests.go
+++ b/openstack/imageservice/v2/images/requests.go
@@ -69,6 +69,12 @@ type ListOpts struct {
 
 	// UpdatedAt filters images based on their updated date.
 	UpdatedAt *ImageDateQuery
+
+	// ContainerFormat filters images based on the container_format.
+	ContainerFormat string `q:"container_format"`
+
+	// DiskFormat filters images based on the disk_format.
+	DiskFormat string `q:"disk_format"`
 }
 
 // ToImageListQuery formats a ListOpts into a query string.

--- a/openstack/imageservice/v2/images/testing/fixtures.go
+++ b/openstack/imageservice/v2/images/testing/fixtures.go
@@ -345,3 +345,44 @@ func HandleImageUpdateSuccessfully(t *testing.T) {
 		}`)
 	})
 }
+
+// HandleImageListByTagsSuccessfully tests a list operation with tags.
+func HandleImageListByTagsSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/images", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fakeclient.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, `{
+    "images": [
+        {
+          "status": "active",
+          "name": "cirros-0.3.2-x86_64-disk",
+          "tags": ["foo", "bar"],
+          "container_format": "bare",
+          "created_at": "2014-05-05T17:15:10Z",
+          "disk_format": "qcow2",
+          "updated_at": "2014-05-05T17:15:11Z",
+          "visibility": "public",
+          "self": "/v2/images/1bea47ed-f6a9-463b-b423-14b9cca9ad27",
+          "min_disk": 0,
+          "protected": false,
+          "id": "1bea47ed-f6a9-463b-b423-14b9cca9ad27",
+          "file": "/v2/images/1bea47ed-f6a9-463b-b423-14b9cca9ad27/file",
+          "checksum": "64d7c1cd2b6f60c92c14662941cb7913",
+          "owner": "5ef70662f8b34079a6eddb8da9d75fe8",
+          "size": 13167616,
+          "min_ram": 0,
+          "schema": "/v2/schemas/image",
+          "virtual_size": null,
+          "hw_disk_bus": "scsi",
+          "hw_disk_bus_model": "virtio-scsi",
+          "hw_scsi_model": "virtio-scsi"
+        }
+    ]
+	}`)
+	})
+}

--- a/openstack/imageservice/v2/images/testing/requests_test.go
+++ b/openstack/imageservice/v2/images/testing/requests_test.go
@@ -311,3 +311,71 @@ func TestImageDateQuery(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, expectedQueryString, actualQueryString)
 }
+
+func TestImageListByTags(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	HandleImageListByTagsSuccessfully(t)
+
+	listOpts := images.ListOpts{
+		Tags: []string{"foo", "bar"},
+	}
+
+	expectedQueryString := "?tag=foo&tag=bar"
+	actualQueryString, err := listOpts.ToImageListQuery()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, expectedQueryString, actualQueryString)
+
+	pages, err := images.List(fakeclient.ServiceClient(), listOpts).AllPages()
+	th.AssertNoErr(t, err)
+	allImages, err := images.ExtractImages(pages)
+	th.AssertNoErr(t, err)
+
+	checksum := "64d7c1cd2b6f60c92c14662941cb7913"
+	sizeBytes := int64(13167616)
+	containerFormat := "bare"
+	diskFormat := "qcow2"
+	minDiskGigabytes := 0
+	minRAMMegabytes := 0
+	owner := "5ef70662f8b34079a6eddb8da9d75fe8"
+	file := allImages[0].File
+	createdDate := allImages[0].CreatedAt
+	lastUpdate := allImages[0].UpdatedAt
+	schema := "/v2/schemas/image"
+	tags := []string{"foo", "bar"}
+
+	expectedImage := images.Image{
+		ID:   "1bea47ed-f6a9-463b-b423-14b9cca9ad27",
+		Name: "cirros-0.3.2-x86_64-disk",
+		Tags: tags,
+
+		Status: images.ImageStatusActive,
+
+		ContainerFormat: containerFormat,
+		DiskFormat:      diskFormat,
+
+		MinDiskGigabytes: minDiskGigabytes,
+		MinRAMMegabytes:  minRAMMegabytes,
+
+		Owner: owner,
+
+		Protected:  false,
+		Visibility: images.ImageVisibilityPublic,
+
+		Checksum:    checksum,
+		SizeBytes:   sizeBytes,
+		File:        file,
+		CreatedAt:   createdDate,
+		UpdatedAt:   lastUpdate,
+		Schema:      schema,
+		VirtualSize: 0,
+		Properties: map[string]interface{}{
+			"hw_disk_bus":       "scsi",
+			"hw_disk_bus_model": "virtio-scsi",
+			"hw_scsi_model":     "virtio-scsi",
+		},
+	}
+
+	th.AssertDeepEquals(t, expectedImage, allImages[0])
+}

--- a/openstack/imageservice/v2/images/testing/requests_test.go
+++ b/openstack/imageservice/v2/images/testing/requests_test.go
@@ -297,11 +297,11 @@ func TestImageDateQuery(t *testing.T) {
 	date := time.Date(2014, 1, 1, 1, 1, 1, 0, time.UTC)
 
 	listOpts := images.ListOpts{
-		CreatedAt: &images.ImageDateQuery{
+		CreatedAtQuery: &images.ImageDateQuery{
 			Date:   date,
 			Filter: images.FilterGTE,
 		},
-		UpdatedAt: &images.ImageDateQuery{
+		UpdatedAtQuery: &images.ImageDateQuery{
 			Date: date,
 		},
 	}

--- a/openstack/imageservice/v2/images/testing/requests_test.go
+++ b/openstack/imageservice/v2/images/testing/requests_test.go
@@ -2,6 +2,7 @@ package testing
 
 import (
 	"testing"
+	"time"
 
 	"github.com/gophercloud/gophercloud/openstack/imageservice/v2/images"
 	"github.com/gophercloud/gophercloud/pagination"
@@ -290,4 +291,23 @@ func TestUpdateImage(t *testing.T) {
 	}
 
 	th.AssertDeepEquals(t, &expectedImage, actualImage)
+}
+
+func TestImageDateQuery(t *testing.T) {
+	date := time.Date(2014, 1, 1, 1, 1, 1, 0, time.UTC)
+
+	listOpts := images.ListOpts{
+		CreatedAt: &images.ImageDateQuery{
+			Date:   date,
+			Filter: images.FilterGTE,
+		},
+		UpdatedAt: &images.ImageDateQuery{
+			Date: date,
+		},
+	}
+
+	expectedQueryString := "?created_at=gte%3A2014-01-01T01%3A01%3A01Z&updated_at=2014-01-01T01%3A01%3A01Z"
+	actualQueryString, err := listOpts.ToImageListQuery()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, expectedQueryString, actualQueryString)
 }

--- a/openstack/imageservice/v2/images/types.go
+++ b/openstack/imageservice/v2/images/types.go
@@ -1,5 +1,9 @@
 package images
 
+import (
+	"time"
+)
+
 // ImageStatus image statuses
 // http://docs.openstack.org/developer/glance/statuses.html
 type ImageStatus string
@@ -77,3 +81,22 @@ const (
 	// ImageMemberStatusAll
 	ImageMemberStatusAll ImageMemberStatus = "all"
 )
+
+// ImageDateFilter represents a valid filter to use for filtering
+// images by their date during a List.
+type ImageDateFilter string
+
+const (
+	FilterGT  ImageDateFilter = "gt"
+	FilterGTE ImageDateFilter = "gte"
+	FilterLT  ImageDateFilter = "lt"
+	FilterLTE ImageDateFilter = "lte"
+	FilterNEQ ImageDateFilter = "neq"
+	FilterNE  ImageDateFilter = "eq"
+)
+
+// ImageDateQuery represents a date field to be used for listing images.
+type ImageDateQuery struct {
+	Date   time.Time
+	Filter ImageDateFilter
+}

--- a/openstack/imageservice/v2/images/types.go
+++ b/openstack/imageservice/v2/images/types.go
@@ -92,7 +92,7 @@ const (
 	FilterLT  ImageDateFilter = "lt"
 	FilterLTE ImageDateFilter = "lte"
 	FilterNEQ ImageDateFilter = "neq"
-	FilterNE  ImageDateFilter = "eq"
+	FilterEQ  ImageDateFilter = "eq"
 )
 
 // ImageDateQuery represents a date field to be used for listing images.

--- a/openstack/imageservice/v2/images/types.go
+++ b/openstack/imageservice/v2/images/types.go
@@ -83,7 +83,6 @@ const (
 )
 
 // ImageDateFilter represents a valid filter to use for filtering
-// images by their date during a List.
 type ImageDateFilter string
 
 const (
@@ -96,6 +95,8 @@ const (
 )
 
 // ImageDateQuery represents a date field to be used for listing images.
+// If no filter is specified, the query will act as though FilterEQ was
+// set.
 type ImageDateQuery struct {
 	Date   time.Time
 	Filter ImageDateFilter

--- a/openstack/imageservice/v2/images/types.go
+++ b/openstack/imageservice/v2/images/types.go
@@ -83,6 +83,7 @@ const (
 )
 
 // ImageDateFilter represents a valid filter to use for filtering
+// images by their date during a List.
 type ImageDateFilter string
 
 const (


### PR DESCRIPTION
For #779 

The first commit is the most notable and deserves a good review. I don't mind changing the names of the new types or consts:

https://github.com/gophercloud/gophercloud/commit/b364a87bb579aa578e8ae95721546e3acaba191e

The second commit, changing `Tag` to `Tags` will be a breaking change for some. I thought about keeping `Tag` for backwards compatibility, but that felt awkward.

The third commit is pretty standard.

/cc @dklyle 