### PR TITLE
Network v2: RBAC-Delete

### DIFF
--- a/acceptance/openstack/networking/v2/extensions/rbacpolicies/rbacpolicies.go
+++ b/acceptance/openstack/networking/v2/extensions/rbacpolicies/rbacpolicies.go
@@ -27,3 +27,17 @@ func CreateRBACPolicy(t *testing.T, client *gophercloud.ServiceClient, tenantID,
 	t.Logf("Successfully created rbac_policy")
 	return rbacPolicy, nil
 }
+
+// DeleteRBACPolicy will delete a rbac-policy with a specified ID. A fatal error will
+// occur if the delete was not successful. This works best when used as a
+// deferred function.
+func DeleteRBACPolicy(t *testing.T, client *gophercloud.ServiceClient, rbacPolicyID string) {
+	t.Logf("Trying to delete rbac_policy: %s", rbacPolicyID)
+
+	err := rbacpolicies.Delete(client, rbacPolicyID).ExtractErr()
+	if err != nil {
+		t.Fatalf("Unable to delete rbac_policy %s: %v", rbacPolicyID, err)
+	}
+
+	t.Logf("Deleted rbac_policy: %s", rbacPolicyID)
+}

--- a/acceptance/openstack/networking/v2/extensions/rbacpolicies/rbacpolicies_test.go
+++ b/acceptance/openstack/networking/v2/extensions/rbacpolicies/rbacpolicies_test.go
@@ -52,6 +52,7 @@ func TestRBACPolicyCreate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to create rbac-policy: %v", err)
 	}
+	defer DeleteRBACPolicy(t, client, rbacPolicy.ID)
 
 	tools.PrintResource(t, rbacPolicy)
 

--- a/openstack/networking/v2/extensions/rbacpolicies/doc.go
+++ b/openstack/networking/v2/extensions/rbacpolicies/doc.go
@@ -27,5 +27,13 @@ Example to Create a RBAC Policy
 		panic(err)
 	}
 
+Example to Delete a RBAC Policy
+
+        rbacPolicyID := "94fe107f-da78-4d92-a9d7-5611b06dad8d"
+        err := rbacpolicies.Delete(rbacClient, rbacPolicyID).ExtractErr()
+        if err != nil {
+                panic(err)
+        }
+
 */
 package rbacpolicies

--- a/openstack/networking/v2/extensions/rbacpolicies/requests.go
+++ b/openstack/networking/v2/extensions/rbacpolicies/requests.go
@@ -55,3 +55,9 @@ func Create(c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResul
 	_, r.Err = c.Post(createURL(c), b, &r.Body, nil)
 	return
 }
+
+// Delete accepts a unique ID and deletes the rbac-policy associated with it.
+func Delete(c *gophercloud.ServiceClient, rbacPolicyID string) (r DeleteResult) {
+	_, r.Err = c.Delete(deleteURL(c, rbacPolicyID), nil)
+	return
+}

--- a/openstack/networking/v2/extensions/rbacpolicies/results.go
+++ b/openstack/networking/v2/extensions/rbacpolicies/results.go
@@ -31,6 +31,12 @@ type GetResult struct {
 	commonResult
 }
 
+// DeleteResult represents the result of a delete operation. Call its
+// ExtractErr method to determine if the request succeeded or failed.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
 // RBACPolicy represents a RBAC policy.
 type RBACPolicy struct {
 	// UUID of the RBAC policy.

--- a/openstack/networking/v2/extensions/rbacpolicies/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/rbacpolicies/testing/requests_test.go
@@ -56,3 +56,17 @@ func TestGet(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.CheckDeepEquals(t, &rbacPolicy1, n)
 }
+
+func TestDelete(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/rbac-policies/71d55b18-d2f8-4c76-a5e6-e0a3dd114361", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	res := rbacpolicies.Delete(fake.ServiceClient(), "71d55b18-d2f8-4c76-a5e6-e0a3dd114361").ExtractErr()
+	th.AssertNoErr(t, res)
+}

--- a/openstack/networking/v2/extensions/rbacpolicies/urls.go
+++ b/openstack/networking/v2/extensions/rbacpolicies/urls.go
@@ -17,3 +17,7 @@ func createURL(c *gophercloud.ServiceClient) string {
 func getURL(c *gophercloud.ServiceClient, id string) string {
 	return resourceURL(c, id)
 }
+
+func deleteURL(c *gophercloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
+}


### PR DESCRIPTION
For #731

Delete RBAC policy by ID.

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

API:
https://developer.openstack.org/api-ref/network/v2/#delete-rbac-policy

Schema:
https://github.com/openstack/neutron/blob/8f79a92e45c84819cfc4d1cda99c9320ae78bbaf/neutron/db/rbac_db_models.py

Delete:
https://github.com/openstack/neutron/blob/59e2c40f14157e0f2f64c340070cf46758d522e1/neutron/db/rbac_db_mixin.py#L85
