### PR TITLE
Network v2: RBAC-Update

### DIFF
--- a/openstack/networking/v2/extensions/rbacpolicies/doc.go
+++ b/openstack/networking/v2/extensions/rbacpolicies/doc.go
@@ -64,5 +64,16 @@ Example to Get RBAC Policy by ID
 	}
 	fmt.Printf("%+v", rbacpolicy)
 
+Example to Update a RBAC Policy
+
+	rbacPolicyID := "570b0306-afb5-4d3b-ab47-458fdc16baaa"
+	updateOpts := rbacpolicies.UpdateOpts{
+		TargetTenant: "9d766060b6354c9e8e2da44cab0e8f38",
+	}
+	rbacPolicy, err := rbacpolicies.Update(rbacClient, rbacPolicyID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
 */
 package rbacpolicies

--- a/openstack/networking/v2/extensions/rbacpolicies/requests.go
+++ b/openstack/networking/v2/extensions/rbacpolicies/requests.go
@@ -109,3 +109,33 @@ func Delete(c *gophercloud.ServiceClient, rbacPolicyID string) (r DeleteResult) 
 	_, r.Err = c.Delete(deleteURL(c, rbacPolicyID), nil)
 	return
 }
+
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
+type UpdateOptsBuilder interface {
+	ToRBACPolicyUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts represents options used to update a rbac-policy.
+type UpdateOpts struct {
+	TargetTenant string `json:"target_tenant" required:"true"`
+}
+
+// ToRBACPolicyUpdateMap builds a request body from UpdateOpts.
+func (opts UpdateOpts) ToRBACPolicyUpdateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "rbac_policy")
+}
+
+// Update accepts a UpdateOpts struct and updates an existing rbac-policy using the
+// values provided.
+func Update(c *gophercloud.ServiceClient, rbacPolicyID string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToRBACPolicyUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Put(updateURL(c, rbacPolicyID), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200, 201},
+	})
+	return
+}

--- a/openstack/networking/v2/extensions/rbacpolicies/results.go
+++ b/openstack/networking/v2/extensions/rbacpolicies/results.go
@@ -38,6 +38,12 @@ type DeleteResult struct {
 	gophercloud.ErrResult
 }
 
+// UpdateResult represents the result of an update operation. Call its Extract
+// method to interpret it as a RBAC Policy.
+type UpdateResult struct {
+	commonResult
+}
+
 // RBACPolicy represents a RBAC policy.
 type RBACPolicy struct {
 	// UUID of the RBAC policy.

--- a/openstack/networking/v2/extensions/rbacpolicies/testing/fixtures.go
+++ b/openstack/networking/v2/extensions/rbacpolicies/testing/fixtures.go
@@ -67,6 +67,28 @@ const GetResponse = `
         }
 }`
 
+// UpdateRequest is the structure of request body to update rbac-policy.
+const UpdateRequest = `
+{
+    "rbac_policy": {
+        "target_tenant": "9d766060b6354c9e8e2da44cab0e8f38"
+    }
+}`
+
+// UpdateResponse is the structure of response body of rbac-policy update.
+const UpdateResponse = `
+{
+    "rbac_policy": {
+        "target_tenant": "9d766060b6354c9e8e2da44cab0e8f38",
+        "tenant_id": "3de27ce0a2a54cc6ae06dc62dd0ec832",
+        "object_type": "network",
+        "object_id": "240d22bf-bd17-4238-9758-25f72610ecdc",
+        "action": "access_as_shared",
+        "project_id": "3de27ce0a2a54cc6ae06dc62dd0ec832",
+        "id": "2cf7523a-93b5-4e69-9360-6c6bf986bb7c"
+    }
+}`
+
 var rbacPolicy1 = rbacpolicies.RBACPolicy{
 	ID:           "2cf7523a-93b5-4e69-9360-6c6bf986bb7c",
 	Action:       rbacpolicies.ActionAccessShared,

--- a/openstack/networking/v2/extensions/rbacpolicies/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/rbacpolicies/testing/requests_test.go
@@ -142,3 +142,28 @@ func TestDelete(t *testing.T) {
 	res := rbacpolicies.Delete(fake.ServiceClient(), "71d55b18-d2f8-4c76-a5e6-e0a3dd114361").ExtractErr()
 	th.AssertNoErr(t, res)
 }
+
+func TestUpdate(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/rbac-policies/2cf7523a-93b5-4e69-9360-6c6bf986bb7c", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, UpdateRequest)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, UpdateResponse)
+	})
+
+	options := rbacpolicies.UpdateOpts{TargetTenant: "9d766060b6354c9e8e2da44cab0e8f38"}
+	rbacResult, err := rbacpolicies.Update(fake.ServiceClient(), "2cf7523a-93b5-4e69-9360-6c6bf986bb7c", options).Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, rbacResult.TargetTenant, "9d766060b6354c9e8e2da44cab0e8f38")
+	th.AssertEquals(t, rbacResult.ID, "2cf7523a-93b5-4e69-9360-6c6bf986bb7c")
+}

--- a/openstack/networking/v2/extensions/rbacpolicies/urls.go
+++ b/openstack/networking/v2/extensions/rbacpolicies/urls.go
@@ -25,3 +25,7 @@ func getURL(c *gophercloud.ServiceClient, id string) string {
 func deleteURL(c *gophercloud.ServiceClient, id string) string {
 	return resourceURL(c, id)
 }
+
+func updateURL(c *gophercloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
+}


### PR DESCRIPTION
For #731

Update RBAC policy by ID.

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

API:
https://developer.openstack.org/api-ref/network/v2/#update-rbac-policy

Schema:
https://github.com/openstack/neutron/blob/8f79a92e45c84819cfc4d1cda99c9320ae78bbaf/neutron/db/rbac_db_models.py

Update:
https://github.com/openstack/neutron/blob/59e2c40f14157e0f2f64c340070cf46758d522e1/neutron/db/rbac_db_mixin.py#L69

Code reference for update fields:
https://github.com/openstack/neutron/blob/master/neutron/extensions/rbac.py