### PR TITLE
Identity v3: Add support for RegionID in token catalog endpoints

### DIFF
--- a/openstack/endpoint_location.go
+++ b/openstack/endpoint_location.go
@@ -84,7 +84,7 @@ func V3EndpointURL(catalog *tokens3.ServiceCatalog, opts gophercloud.EndpointOpt
 					return "", err
 				}
 				if (opts.Availability == gophercloud.Availability(endpoint.Interface)) &&
-					(opts.Region == "" || endpoint.Region == opts.Region) {
+					(opts.Region == "" || endpoint.Region == opts.Region || endpoint.RegionID == opts.Region) {
 					endpoints = append(endpoints, endpoint)
 				}
 			}

--- a/openstack/identity/v3/tokens/results.go
+++ b/openstack/identity/v3/tokens/results.go
@@ -13,6 +13,7 @@ import (
 type Endpoint struct {
 	ID        string `json:"id"`
 	Region    string `json:"region"`
+	RegionID  string `json:"region_id"`
 	Interface string `json:"interface"`
 	URL       string `json:"url"`
 }

--- a/openstack/identity/v3/tokens/testing/fixtures.go
+++ b/openstack/identity/v3/tokens/testing/fixtures.go
@@ -125,18 +125,21 @@ var catalogEntry1 = tokens.CatalogEntry{
 		tokens.Endpoint{
 			ID:        "3eac9e7588eb4eb2a4650cf5e079505f",
 			Region:    "RegionOne",
+			RegionID:  "RegionOne",
 			Interface: "admin",
 			URL:       "http://127.0.0.1:8774/v2.1/a99e9b4e620e4db09a2dfb6e42a01e66",
 		},
 		tokens.Endpoint{
 			ID:        "6b33fabc69c34ea782a3f6282582b59f",
 			Region:    "RegionOne",
+			RegionID:  "RegionOne",
 			Interface: "internal",
 			URL:       "http://127.0.0.1:8774/v2.1/a99e9b4e620e4db09a2dfb6e42a01e66",
 		},
 		tokens.Endpoint{
 			ID:        "dae63c71bee24070a71f5425e7a916b5",
 			Region:    "RegionOne",
+			RegionID:  "RegionOne",
 			Interface: "public",
 			URL:       "http://127.0.0.1:8774/v2.1/a99e9b4e620e4db09a2dfb6e42a01e66",
 		},
@@ -150,18 +153,21 @@ var catalogEntry2 = tokens.CatalogEntry{
 		tokens.Endpoint{
 			ID:        "0539aeff80954a0bb756cec496768d3d",
 			Region:    "RegionOne",
+			RegionID:  "RegionOne",
 			Interface: "admin",
 			URL:       "http://127.0.0.1:35357/v3",
 		},
 		tokens.Endpoint{
 			ID:        "15bdf2d0853e4c939993d29548b1b56f",
 			Region:    "RegionOne",
+			RegionID:  "RegionOne",
 			Interface: "public",
 			URL:       "http://127.0.0.1:5000/v3",
 		},
 		tokens.Endpoint{
 			ID:        "3b4423c54ba343c58226bc424cb11c4b",
 			Region:    "RegionOne",
+			RegionID:  "RegionOne",
 			Interface: "internal",
 			URL:       "http://127.0.0.1:5000/v3",
 		},

--- a/openstack/testing/endpoint_location_test.go
+++ b/openstack/testing/endpoint_location_test.go
@@ -178,6 +178,30 @@ var catalog3 = tokens3.ServiceCatalog{
 				},
 			},
 		},
+		tokens3.CatalogEntry{
+			Type: "someother",
+			Name: "someother",
+			Endpoints: []tokens3.Endpoint{
+				tokens3.Endpoint{
+					ID:        "1",
+					Region:    "someother",
+					Interface: "public",
+					URL:       "https://public.correct.com/",
+				},
+				tokens3.Endpoint{
+					ID:        "2",
+					RegionID:  "someother",
+					Interface: "admin",
+					URL:       "https://admin.correct.com/",
+				},
+				tokens3.Endpoint{
+					ID:        "3",
+					RegionID:  "someother",
+					Interface: "internal",
+					URL:       "https://internal.correct.com/",
+				},
+			},
+		},
 	},
 }
 
@@ -228,4 +252,23 @@ func TestV3EndpointBadAvailability(t *testing.T) {
 		Availability: "wat",
 	})
 	th.CheckEquals(t, "Unexpected availability in endpoint query: wat", err.Error())
+}
+
+func TestV3EndpointWithRegionID(t *testing.T) {
+	expectedURLs := map[gophercloud.Availability]string{
+		gophercloud.AvailabilityPublic:   "https://public.correct.com/",
+		gophercloud.AvailabilityAdmin:    "https://admin.correct.com/",
+		gophercloud.AvailabilityInternal: "https://internal.correct.com/",
+	}
+
+	for availability, expected := range expectedURLs {
+		actual, err := openstack.V3EndpointURL(&catalog3, gophercloud.EndpointOpts{
+			Type:         "someother",
+			Name:         "someother",
+			Region:       "someother",
+			Availability: availability,
+		})
+		th.AssertNoErr(t, err)
+		th.CheckEquals(t, expected, actual)
+	}
 }


### PR DESCRIPTION
For #343 

I was looking at older issues and came across #343. After digging around in the Keystone code, I determined two things:

1. The catalog endpoints in a token contain _both_ region and region_id:

   https://github.com/openstack/keystone/blob/master/keystone/catalog/backends/sql.py#L360
   
   I double confirmed this by modifying the above line to read `regionnnn` and, sure enough, the token response contained the malformed name. Secondly, our test fixtures already had both `region` and `region_id`.

2. "region" is still properly handled as of the current Keystone master branch. #343 mentions that OVH has dropped the `region` parameter. If this is true, then:
   
   a. Perhaps it was only temporary or else I think we would have heard from more users by now.
   b. They are deviating from "vanilla" openstack which means the problem isn't Gophercloud's to solve.

_However_, I've patched the endpoint search code to account for a missing region field. I figured it was easy to do, future-proofs a possible removal of `region` (there are comments in the Keystone code which mention `region` is for backwards compatibility), and it would be a pain for apps which want to support multiple clouds where one cloud is using `region_id` exclusively and it's only a few extra characters for Gophercloud core to enable this.

/cc @dklyle 

marking as `[wip]` until openlab clears this change.