### PR TITLE
Networking v2: Port Security Create

### DIFF
--- a/acceptance/openstack/networking/v2/networks_test.go
+++ b/acceptance/openstack/networking/v2/networks_test.go
@@ -71,3 +71,29 @@ func TestNetworksCRUD(t *testing.T) {
 
 	tools.PrintResource(t, newNetwork)
 }
+
+func TestNetworksPortSecurityCRUD(t *testing.T) {
+	client, err := clients.NewNetworkV2Client()
+	if err != nil {
+		t.Fatalf("Unable to create a network client: %v", err)
+	}
+
+	// Create a network without port security
+	network, err := CreateNetworkWithoutPortSecurity(t, client)
+	if err != nil {
+		t.Fatalf("Unable to create network: %v", err)
+	}
+	defer DeleteNetwork(t, client, network.ID)
+
+	var networkWithExtensions struct {
+		networks.Network
+		portsecurity.PortSecurityExt
+	}
+
+	err = networks.Get(client, network.ID).ExtractInto(&networkWithExtensions)
+	if err != nil {
+		t.Fatalf("Unable to retrieve network: %v", err)
+	}
+
+	tools.PrintResource(t, networkWithExtensions)
+}

--- a/openstack/networking/v2/extensions/portsecurity/requests.go
+++ b/openstack/networking/v2/extensions/portsecurity/requests.go
@@ -1,0 +1,55 @@
+package portsecurity
+
+import (
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
+)
+
+// PortCreateOptsExt adds port security options to the base ports.CreateOpts.
+type PortCreateOptsExt struct {
+	ports.CreateOptsBuilder
+
+	// PortSecurityEnabled toggles port security on a port.
+	PortSecurityEnabled *bool `json:"port_security_enabled,omitempty"`
+}
+
+// ToPortCreateMap casts a CreateOpts struct to a map.
+func (opts PortCreateOptsExt) ToPortCreateMap() (map[string]interface{}, error) {
+	base, err := opts.CreateOptsBuilder.ToPortCreateMap()
+	if err != nil {
+		return nil, err
+	}
+
+	port := base["port"].(map[string]interface{})
+
+	if opts.PortSecurityEnabled != nil {
+		port["port_security_enabled"] = &opts.PortSecurityEnabled
+	}
+
+	return base, nil
+}
+
+// NetworkCreateOptsExt adds port security options to the base
+// networks.CreateOpts.
+type NetworkCreateOptsExt struct {
+	networks.CreateOptsBuilder
+
+	// PortSecurityEnabled toggles port security on a port.
+	PortSecurityEnabled *bool `json:"port_security_enabled,omitempty"`
+}
+
+// ToNetworkCreateMap casts a CreateOpts struct to a map.
+func (opts NetworkCreateOptsExt) ToNetworkCreateMap() (map[string]interface{}, error) {
+	base, err := opts.CreateOptsBuilder.ToNetworkCreateMap()
+	if err != nil {
+		return nil, err
+	}
+
+	network := base["network"].(map[string]interface{})
+
+	if opts.PortSecurityEnabled != nil {
+		network["port_security_enabled"] = &opts.PortSecurityEnabled
+	}
+
+	return base, nil
+}

--- a/openstack/networking/v2/networks/testing/fixtures.go
+++ b/openstack/networking/v2/networks/testing/fixtures.go
@@ -86,6 +86,32 @@ const CreateResponse = `
     }
 }`
 
+const CreatePortSecurityRequest = `
+{
+    "network": {
+        "name": "private",
+        "admin_state_up": true,
+        "port_security_enabled": false
+    }
+}`
+
+const CreatePortSecurityResponse = `
+{
+    "network": {
+        "status": "ACTIVE",
+        "subnets": ["08eae331-0402-425a-923c-34f7cfe39c1b"],
+        "name": "private",
+        "admin_state_up": true,
+        "tenant_id": "26a7980765d0414dbc1fc1f88cdb7e6e",
+        "shared": false,
+        "id": "db193ab3-96e3-4cb3-8fc5-05f4296d0324",
+        "provider:segmentation_id": 9876543210,
+        "provider:physical_network": null,
+        "provider:network_type": "local",
+        "port_security_enabled": false
+    }
+}`
+
 const CreateOptionalFieldsRequest = `
 {
   "network": {

--- a/openstack/networking/v2/networks/testing/requests_test.go
+++ b/openstack/networking/v2/networks/testing/requests_test.go
@@ -218,3 +218,39 @@ func TestDelete(t *testing.T) {
 	res := networks.Delete(fake.ServiceClient(), "4e8e5957-649f-477b-9e5b-f1f75b21c03c")
 	th.AssertNoErr(t, res.Err)
 }
+
+func TestCreatePortSecurity(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/networks", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, CreatePortSecurityRequest)
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+
+		fmt.Fprintf(w, CreatePortSecurityResponse)
+	})
+
+	var networkWithExtensions struct {
+		networks.Network
+		portsecurity.PortSecurityExt
+	}
+
+	iTrue := true
+	iFalse := false
+	networkCreateOpts := networks.CreateOpts{Name: "private", AdminStateUp: &iTrue}
+	createOpts := portsecurity.NetworkCreateOptsExt{
+		CreateOptsBuilder:   networkCreateOpts,
+		PortSecurityEnabled: &iFalse,
+	}
+
+	err := networks.Create(fake.ServiceClient(), createOpts).ExtractInto(&networkWithExtensions)
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, networkWithExtensions.Status, "ACTIVE")
+	th.AssertEquals(t, networkWithExtensions.PortSecurityEnabled, false)
+}

--- a/openstack/networking/v2/ports/testing/fixtures.go
+++ b/openstack/networking/v2/ports/testing/fixtures.go
@@ -220,6 +220,62 @@ const CreateOmitSecurityGroupsResponse = `
 }
 `
 
+const CreatePortSecurityRequest = `
+{
+    "port": {
+        "network_id": "a87cc70a-3e15-4acf-8205-9b711a3531b7",
+        "name": "private-port",
+        "admin_state_up": true,
+        "fixed_ips": [
+            {
+                "subnet_id": "a0304c3a-4f08-4c43-88af-d796509c97d2",
+                "ip_address": "10.0.0.2"
+            }
+        ],
+        "security_groups": ["foo"],
+        "allowed_address_pairs": [
+          {
+            "ip_address": "10.0.0.4",
+            "mac_address": "fa:16:3e:c9:cb:f0"
+          }
+        ],
+        "port_security_enabled": false
+    }
+}
+`
+
+const CreatePortSecurityResponse = `
+{
+    "port": {
+        "status": "DOWN",
+        "name": "private-port",
+        "admin_state_up": true,
+        "network_id": "a87cc70a-3e15-4acf-8205-9b711a3531b7",
+        "tenant_id": "d6700c0c9ffa4f1cb322cd4a1f3906fa",
+        "device_owner": "",
+        "mac_address": "fa:16:3e:c9:cb:f0",
+        "fixed_ips": [
+            {
+                "subnet_id": "a0304c3a-4f08-4c43-88af-d796509c97d2",
+                "ip_address": "10.0.0.2"
+            }
+        ],
+        "id": "65c0ee9f-d634-4522-8954-51021b570b0d",
+        "security_groups": [
+            "f0ac4394-7e4a-4409-9701-ba8be283dbc3"
+        ],
+        "allowed_address_pairs": [
+          {
+            "ip_address": "10.0.0.4",
+            "mac_address": "fa:16:3e:c9:cb:f0"
+          }
+        ],
+        "device_id": "",
+        "port_security_enabled": false
+    }
+}
+`
+
 const UpdateRequest = `
 {
     "port": {


### PR DESCRIPTION
For #298 

Continuing with catching up on old work.

This is a rather large PR since it handles Create for both networks and ports, but since they're identical in implementation, I added them both here. The bulk of the additions are tests, though.

One thing to confirm with @jrperritt is the name `PortCreateOptsExt` and `NetworkCreateOptsExt`. I waffled on using either that form or `CreatePortOptsExt` and `CreateNetworkOptsExt`. This is the first occurrence of an extension being able to support extending multiple `CreateOpts`, so the name is new.

/cc @dklyle 