### PR TITLE
Networking v2: Fix subnetpools

### DIFF
--- a/openstack/networking/v2/extensions/subnetpools/requests.go
+++ b/openstack/networking/v2/extensions/subnetpools/requests.go
@@ -18,27 +18,24 @@ type ListOptsBuilder interface {
 // SortDir sets the direction, and is either `asc' or `desc'.
 // Marker and Limit are used for the pagination.
 type ListOpts struct {
-	ID               string   `q:"id"`
-	Name             string   `q:"name"`
-	DefaultQuota     int      `q:"default_quota"`
-	TenantID         string   `q:"tenant_id"`
-	ProjectID        string   `q:"project_id"`
-	CreatedAt        string   `q:"created_at"`
-	UpdatedAt        string   `q:"updated_at"`
-	Prefixes         []string `q:"prefixes"`
-	DefaultPrefixLen int      `q:"default_prefixlen"`
-	MinPrefixLen     int      `q:"min_prefixlen"`
-	MaxPrefixLen     int      `q:"max_prefixlen"`
-	AddressScopeID   string   `q:"address_scope_id"`
-	IPversion        int      `q:"ip_version"`
-	Shared           bool     `q:"shared"`
-	Description      string   `q:"description"`
-	IsDefault        bool     `q:"is_default"`
-	RevisionNumber   int      `q:"revision_number"`
-	Limit            int      `q:"limit"`
-	Marker           string   `q:"marker"`
-	SortKey          string   `q:"sort_key"`
-	SortDir          string   `q:"sort_dir"`
+	ID               string `q:"id"`
+	Name             string `q:"name"`
+	DefaultQuota     int    `q:"default_quota"`
+	TenantID         string `q:"tenant_id"`
+	ProjectID        string `q:"project_id"`
+	DefaultPrefixLen int    `q:"default_prefixlen"`
+	MinPrefixLen     int    `q:"min_prefixlen"`
+	MaxPrefixLen     int    `q:"max_prefixlen"`
+	AddressScopeID   string `q:"address_scope_id"`
+	IPVersion        int    `q:"ip_version"`
+	Shared           *bool  `q:"shared"`
+	Description      string `q:"description"`
+	IsDefault        *bool  `q:"is_default"`
+	RevisionNumber   int    `q:"revision_number"`
+	Limit            int    `q:"limit"`
+	Marker           string `q:"marker"`
+	SortKey          string `q:"sort_key"`
+	SortDir          string `q:"sort_dir"`
 }
 
 // ToSubnetPoolListQuery formats a ListOpts into a query string.

--- a/openstack/networking/v2/extensions/subnetpools/results.go
+++ b/openstack/networking/v2/extensions/subnetpools/results.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"time"
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/pagination"
@@ -66,10 +67,10 @@ type SubnetPool struct {
 	ProjectID string `json:"project_id"`
 
 	// CreatedAt is the time at which subnetpool has been created.
-	CreatedAt string `json:"created_at"`
+	CreatedAt time.Time `json:"created_at"`
 
 	// UpdatedAt is the time at which subnetpool has been created.
-	UpdatedAt string `json:"updated_at"`
+	UpdatedAt time.Time `json:"updated_at"`
 
 	// Prefixes is the list of subnet prefixes to assign to the subnetpool.
 	// Neutron API merges adjacent prefixes and treats them as a single prefix.

--- a/openstack/networking/v2/extensions/subnetpools/testing/fixtures.go
+++ b/openstack/networking/v2/extensions/subnetpools/testing/fixtures.go
@@ -1,6 +1,8 @@
 package testing
 
 import (
+	"time"
+
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/subnetpools"
 )
 
@@ -78,7 +80,7 @@ const SubnetPoolsListResult = `
 
 var SubnetPool1 = subnetpools.SubnetPool{
 	AddressScopeID:   "",
-	CreatedAt:        "2017-12-28T07:21:41Z",
+	CreatedAt:        time.Date(2017, 12, 28, 7, 21, 41, 0, time.UTC),
 	DefaultPrefixLen: 8,
 	DefaultQuota:     0,
 	Description:      "IPv4",
@@ -96,12 +98,12 @@ var SubnetPool1 = subnetpools.SubnetPool{
 	TenantID:       "1e2b9857295a4a3e841809ef492812c5",
 	RevisionNumber: 1,
 	Shared:         false,
-	UpdatedAt:      "2017-12-28T07:21:41Z",
+	UpdatedAt:      time.Date(2017, 12, 28, 7, 21, 41, 0, time.UTC),
 }
 
 var SubnetPool2 = subnetpools.SubnetPool{
 	AddressScopeID:   "0bc38e22-be49-4e67-969e-fec3f36508bd",
-	CreatedAt:        "2017-12-28T07:21:34Z",
+	CreatedAt:        time.Date(2017, 12, 28, 7, 21, 34, 0, time.UTC),
 	DefaultPrefixLen: 64,
 	DefaultQuota:     0,
 	Description:      "IPv6",
@@ -119,12 +121,12 @@ var SubnetPool2 = subnetpools.SubnetPool{
 	TenantID:       "1e2b9857295a4a3e841809ef492812c5",
 	RevisionNumber: 1,
 	Shared:         false,
-	UpdatedAt:      "2017-12-28T07:21:34Z",
+	UpdatedAt:      time.Date(2017, 12, 28, 7, 21, 34, 0, time.UTC),
 }
 
 var SubnetPool3 = subnetpools.SubnetPool{
 	AddressScopeID:   "",
-	CreatedAt:        "2017-12-28T07:21:27Z",
+	CreatedAt:        time.Date(2017, 12, 28, 7, 21, 27, 0, time.UTC),
 	DefaultPrefixLen: 64,
 	DefaultQuota:     4,
 	Description:      "PublicPool",
@@ -141,7 +143,7 @@ var SubnetPool3 = subnetpools.SubnetPool{
 	TenantID:       "ceb366d50ad54fe39717df3af60f9945",
 	RevisionNumber: 1,
 	Shared:         true,
-	UpdatedAt:      "2017-12-28T07:21:27Z",
+	UpdatedAt:      time.Date(2017, 12, 28, 7, 21, 27, 0, time.UTC),
 }
 
 const SubnetPoolGetResult = `
@@ -157,11 +159,11 @@ const SubnetPoolGetResult = `
         "is_default": true,
         "project_id": "1e2b9857295a4a3e841809ef492812c5",
         "tenant_id": "1e2b9857295a4a3e841809ef492812c5",
-        "created_at": "2018-01-01T00:00:01",
+        "created_at": "2018-01-01T00:00:01Z",
         "prefixes": [
             "2001:db8::a3/64"
         ],
-        "updated_at": "2018-01-01T00:10:10",
+        "updated_at": "2018-01-01T00:10:10Z",
         "ip_version": 6,
         "shared": false,
         "description": "ipv6 prefixes",

--- a/openstack/networking/v2/extensions/subnetpools/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/subnetpools/testing/requests_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	fake "github.com/gophercloud/gophercloud/openstack/networking/v2/common"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/subnetpools"
@@ -73,8 +74,8 @@ func TestGet(t *testing.T) {
 	th.AssertEquals(t, s.DefaultQuota, 2)
 	th.AssertEquals(t, s.TenantID, "1e2b9857295a4a3e841809ef492812c5")
 	th.AssertEquals(t, s.ProjectID, "1e2b9857295a4a3e841809ef492812c5")
-	th.AssertEquals(t, s.CreatedAt, "2018-01-01T00:00:01")
-	th.AssertEquals(t, s.UpdatedAt, "2018-01-01T00:10:10")
+	th.AssertEquals(t, s.CreatedAt, time.Date(2018, 1, 1, 0, 0, 1, 0, time.UTC))
+	th.AssertEquals(t, s.UpdatedAt, time.Date(2018, 1, 1, 0, 10, 10, 0, time.UTC))
 	th.AssertDeepEquals(t, s.Prefixes, []string{
 		"2001:db8::a3/64",
 	})


### PR DESCRIPTION
For #788 

The following fixes have been applied:

* Removal of Prefixes from ListOpts
* Changing ListOpts Shared to *bool
* Changing ListOpts IsDefault to *bool
* Changing the result CreatedAt to time.Time
* Changing the result UpdatedAt to time.Time

/cc @dklyle 

I've tested these fixes pretty extensively to make sure they're correct. 

I'm not a fan of including `ID` and `tenant_id` in `ListOpts`, but since they were already merged and since they _do_ work, I'm going to leave them.

If someone has time to do a review of this, it would help move the Terraform PRs along.