### PR TITLE
Corrects example to create a server with a key pair

### DIFF
--- a/openstack/compute/v2/extensions/keypairs/doc.go
+++ b/openstack/compute/v2/extensions/keypairs/doc.go
@@ -58,7 +58,7 @@ Example to Create a Server With a Key Pair
 		FlavorRef: "flavor-uuid",
 	}
 
-	createOpts := keypairs.CreateOpts{
+	createOpts := keypairs.CreateOptsExt{
 		CreateOptsBuilder: serverCreateOpts,
 		KeyName:           "keypair-name",
 	}


### PR DESCRIPTION
Minor documentation fix.

For #800 