### PR TITLE
Networking v2: Support both TenantID and ProjectID where applicable

### DIFF
--- a/openstack/networking/v2/extensions/fwaas/firewalls/requests.go
+++ b/openstack/networking/v2/extensions/fwaas/firewalls/requests.go
@@ -18,6 +18,7 @@ type ListOptsBuilder interface {
 // `asc' or `desc'. Marker and Limit are used for pagination.
 type ListOpts struct {
 	TenantID     string `q:"tenant_id"`
+	ProjectID    string `q:"project_id"`
 	Name         string `q:"name"`
 	Description  string `q:"description"`
 	AdminStateUp bool   `q:"admin_state_up"`
@@ -69,6 +70,7 @@ type CreateOpts struct {
 	// an admin role in order to set this. Otherwise, this field is left unset
 	// and the caller will be the owner.
 	TenantID     string `json:"tenant_id,omitempty"`
+	ProjectID    string `json:"project_id,omitempty"`
 	Name         string `json:"name,omitempty"`
 	Description  string `json:"description,omitempty"`
 	AdminStateUp *bool  `json:"admin_state_up,omitempty"`

--- a/openstack/networking/v2/extensions/fwaas/firewalls/results.go
+++ b/openstack/networking/v2/extensions/fwaas/firewalls/results.go
@@ -14,6 +14,7 @@ type Firewall struct {
 	Status       string `json:"status"`
 	PolicyID     string `json:"firewall_policy_id"`
 	TenantID     string `json:"tenant_id"`
+	ProjectID    string `json:"project_id"`
 }
 
 type commonResult struct {

--- a/openstack/networking/v2/extensions/fwaas/policies/requests.go
+++ b/openstack/networking/v2/extensions/fwaas/policies/requests.go
@@ -18,6 +18,7 @@ type ListOptsBuilder interface {
 // and is either `asc' or `desc'. Marker and Limit are used for pagination.
 type ListOpts struct {
 	TenantID    string `q:"tenant_id"`
+	ProjectID   string `q:"project_id"`
 	Name        string `q:"name"`
 	Description string `q:"description"`
 	Shared      *bool  `q:"shared"`
@@ -67,6 +68,7 @@ type CreateOpts struct {
 	// an admin role in order to set this. Otherwise, this field is left unset
 	// and the caller will be the owner.
 	TenantID    string   `json:"tenant_id,omitempty"`
+	ProjectID   string   `json:"project_id,omitempty"`
 	Name        string   `json:"name,omitempty"`
 	Description string   `json:"description,omitempty"`
 	Shared      *bool    `json:"shared,omitempty"`

--- a/openstack/networking/v2/extensions/fwaas/policies/results.go
+++ b/openstack/networking/v2/extensions/fwaas/policies/results.go
@@ -11,6 +11,7 @@ type Policy struct {
 	Name        string   `json:"name"`
 	Description string   `json:"description"`
 	TenantID    string   `json:"tenant_id"`
+	ProjectID   string   `json:"project_id"`
 	Audited     bool     `json:"audited"`
 	Shared      bool     `json:"shared"`
 	Rules       []string `json:"firewall_rules,omitempty"`

--- a/openstack/networking/v2/extensions/fwaas/rules/requests.go
+++ b/openstack/networking/v2/extensions/fwaas/rules/requests.go
@@ -37,6 +37,7 @@ type ListOptsBuilder interface {
 // is either `asc' or `desc'. Marker and Limit are used for pagination.
 type ListOpts struct {
 	TenantID             string `q:"tenant_id"`
+	ProjectID            string `q:"project_id"`
 	Name                 string `q:"name"`
 	Description          string `q:"description"`
 	Protocol             string `q:"protocol"`
@@ -96,6 +97,7 @@ type CreateOpts struct {
 	Protocol             Protocol              `json:"protocol" required:"true"`
 	Action               string                `json:"action" required:"true"`
 	TenantID             string                `json:"tenant_id,omitempty"`
+	ProjectID            string                `json:"project_id,omitempty"`
 	Name                 string                `json:"name,omitempty"`
 	Description          string                `json:"description,omitempty"`
 	IPVersion            gophercloud.IPVersion `json:"ip_version,omitempty"`

--- a/openstack/networking/v2/extensions/fwaas/rules/results.go
+++ b/openstack/networking/v2/extensions/fwaas/rules/results.go
@@ -22,6 +22,7 @@ type Rule struct {
 	PolicyID             string `json:"firewall_policy_id"`
 	Position             int    `json:"position"`
 	TenantID             string `json:"tenant_id"`
+	ProjectID            string `json:"project_id"`
 }
 
 // RulePage is the page returned by a pager when traversing over a

--- a/openstack/networking/v2/extensions/layer3/floatingips/requests.go
+++ b/openstack/networking/v2/extensions/layer3/floatingips/requests.go
@@ -17,6 +17,7 @@ type ListOpts struct {
 	FixedIP           string `q:"fixed_ip_address"`
 	FloatingIP        string `q:"floating_ip_address"`
 	TenantID          string `q:"tenant_id"`
+	ProjectID         string `q:"project_id"`
 	Limit             int    `q:"limit"`
 	Marker            string `q:"marker"`
 	SortKey           string `q:"sort_key"`
@@ -55,6 +56,7 @@ type CreateOpts struct {
 	FixedIP           string `json:"fixed_ip_address,omitempty"`
 	SubnetID          string `json:"subnet_id,omitempty"`
 	TenantID          string `json:"tenant_id,omitempty"`
+	ProjectID         string `json:"project_id,omitempty"`
 }
 
 // ToFloatingIPCreateMap allows CreateOpts to satisfy the CreateOptsBuilder

--- a/openstack/networking/v2/extensions/layer3/floatingips/results.go
+++ b/openstack/networking/v2/extensions/layer3/floatingips/results.go
@@ -30,9 +30,12 @@ type FloatingIP struct {
 	// associated with the floating IP.
 	FixedIP string `json:"fixed_ip_address"`
 
-	// TenantID is the Owner of the floating IP. Only admin users can specify a
-	// tenant identifier other than its own.
+	// TenantID is the project owner of the floating IP. Only admin users can
+	// specify a project identifier other than its own.
 	TenantID string `json:"tenant_id"`
+
+	// ProjectID is the project owner of the floating IP.
+	ProjectID string `json:"project_id"`
 
 	// Status is the condition of the API resource.
 	Status string `json:"status"`

--- a/openstack/networking/v2/extensions/layer3/routers/requests.go
+++ b/openstack/networking/v2/extensions/layer3/routers/requests.go
@@ -17,6 +17,7 @@ type ListOpts struct {
 	Distributed  *bool  `q:"distributed"`
 	Status       string `q:"status"`
 	TenantID     string `q:"tenant_id"`
+	ProjectID    string `q:"project_id"`
 	Limit        int    `q:"limit"`
 	Marker       string `q:"marker"`
 	SortKey      string `q:"sort_key"`
@@ -53,6 +54,7 @@ type CreateOpts struct {
 	AdminStateUp          *bool        `json:"admin_state_up,omitempty"`
 	Distributed           *bool        `json:"distributed,omitempty"`
 	TenantID              string       `json:"tenant_id,omitempty"`
+	ProjectID             string       `json:"project_id,omitempty"`
 	GatewayInfo           *GatewayInfo `json:"external_gateway_info,omitempty"`
 	AvailabilityZoneHints []string     `json:"availability_zone_hints,omitempty"`
 }

--- a/openstack/networking/v2/extensions/layer3/routers/results.go
+++ b/openstack/networking/v2/extensions/layer3/routers/results.go
@@ -54,9 +54,12 @@ type Router struct {
 	// ID is the unique identifier for the router.
 	ID string `json:"id"`
 
-	// TenantID is the owner of the router. Only admin users can specify a tenant
-	// identifier other than its own.
+	// TenantID is the project owner of the router. Only admin users can
+	// specify a project identifier other than its own.
 	TenantID string `json:"tenant_id"`
+
+	// ProjectID is the project owner of the router.
+	ProjectID string `json:"project_id"`
 
 	// Routes are a collection of static routes that the router will host.
 	Routes []Route `json:"routes"`

--- a/openstack/networking/v2/extensions/lbaas_v2/listeners/requests.go
+++ b/openstack/networking/v2/extensions/lbaas_v2/listeners/requests.go
@@ -31,6 +31,7 @@ type ListOpts struct {
 	Name            string `q:"name"`
 	AdminStateUp    *bool  `q:"admin_state_up"`
 	TenantID        string `q:"tenant_id"`
+	ProjectID       string `q:"project_id"`
 	LoadbalancerID  string `q:"loadbalancer_id"`
 	DefaultPoolID   string `q:"default_pool_id"`
 	Protocol        string `q:"protocol"`
@@ -86,8 +87,12 @@ type CreateOpts struct {
 	ProtocolPort int `json:"protocol_port" required:"true"`
 
 	// TenantID is only required if the caller has an admin role and wants
-	// to create a pool for another tenant.
+	// to create a pool for another project.
 	TenantID string `json:"tenant_id,omitempty"`
+
+	// ProjectID is only required if the caller has an admin role and wants
+	// to create a pool for another project.
+	ProjectID string `json:"project_id,omitempty"`
 
 	// Human-readable name for the Listener. Does not have to be unique.
 	Name string `json:"name,omitempty"`

--- a/openstack/networking/v2/extensions/lbaas_v2/loadbalancers/requests.go
+++ b/openstack/networking/v2/extensions/lbaas_v2/loadbalancers/requests.go
@@ -20,6 +20,7 @@ type ListOpts struct {
 	Description        string `q:"description"`
 	AdminStateUp       *bool  `q:"admin_state_up"`
 	TenantID           string `q:"tenant_id"`
+	ProjectID          string `q:"project_id"`
 	ProvisioningStatus string `q:"provisioning_status"`
 	VipAddress         string `q:"vip_address"`
 	VipPortID          string `q:"vip_port_id"`
@@ -81,9 +82,13 @@ type CreateOpts struct {
 	// that belong to them or networks that are shared).
 	VipSubnetID string `json:"vip_subnet_id" required:"true"`
 
-	// The UUID of the tenant who owns the Loadbalancer. Only administrative users
-	// can specify a tenant UUID other than their own.
+	// TenantID is the UUID of the project who owns the Loadbalancer.
+	// Only administrative users can specify a project UUID other than their own.
 	TenantID string `json:"tenant_id,omitempty"`
+
+	// ProjectID is the UUID of the project who owns the Loadbalancer.
+	// Only administrative users can specify a project UUID other than their own.
+	ProjectID string `json:"project_id,omitempty"`
 
 	// The IP address of the Loadbalancer.
 	VipAddress string `json:"vip_address,omitempty"`

--- a/openstack/networking/v2/extensions/lbaas_v2/monitors/requests.go
+++ b/openstack/networking/v2/extensions/lbaas_v2/monitors/requests.go
@@ -22,6 +22,7 @@ type ListOpts struct {
 	ID            string `q:"id"`
 	Name          string `q:"name"`
 	TenantID      string `q:"tenant_id"`
+	ProjectID     string `q:"project_id"`
 	PoolID        string `q:"pool_id"`
 	Type          string `q:"type"`
 	Delay         int    `q:"delay"`
@@ -119,9 +120,13 @@ type CreateOpts struct {
 	// types.
 	ExpectedCodes string `json:"expected_codes,omitempty"`
 
-	// The UUID of the tenant who owns the Monitor. Only administrative users
-	// can specify a tenant UUID other than their own.
+	// TenantID is the UUID of the project who owns the Monitor.
+	// Only administrative users can specify a project UUID other than their own.
 	TenantID string `json:"tenant_id,omitempty"`
+
+	// ProjectID is the UUID of the project who owns the Monitor.
+	// Only administrative users can specify a project UUID other than their own.
+	ProjectID string `json:"project_id,omitempty"`
 
 	// The Name of the Monitor.
 	Name string `json:"name,omitempty"`

--- a/openstack/networking/v2/extensions/lbaas_v2/pools/requests.go
+++ b/openstack/networking/v2/extensions/lbaas_v2/pools/requests.go
@@ -20,6 +20,7 @@ type ListOpts struct {
 	LBMethod       string `q:"lb_algorithm"`
 	Protocol       string `q:"protocol"`
 	TenantID       string `q:"tenant_id"`
+	ProjectID      string `q:"project_id"`
 	AdminStateUp   *bool  `q:"admin_state_up"`
 	Name           string `q:"name"`
 	ID             string `q:"id"`
@@ -97,9 +98,13 @@ type CreateOpts struct {
 	// Note: one of LoadbalancerID or ListenerID must be provided.
 	ListenerID string `json:"listener_id,omitempty" xor:"LoadbalancerID"`
 
-	// The UUID of the tenant who owns the Pool. Only administrative users
-	// can specify a tenant UUID other than their own.
+	// TenantID is the UUID of the project who owns the Pool.
+	// Only administrative users can specify a project UUID other than their own.
 	TenantID string `json:"tenant_id,omitempty"`
+
+	// ProjectID is the UUID of the project who owns the Pool.
+	// Only administrative users can specify a project UUID other than their own.
+	ProjectID string `json:"project_id,omitempty"`
 
 	// Name of the pool.
 	Name string `json:"name,omitempty"`
@@ -257,9 +262,13 @@ type CreateMemberOpts struct {
 	// Name of the Member.
 	Name string `json:"name,omitempty"`
 
-	// The UUID of the tenant who owns the Member. Only administrative users
-	// can specify a tenant UUID other than their own.
+	// TenantID is the UUID of the project who owns the Member.
+	// Only administrative users can specify a project UUID other than their own.
 	TenantID string `json:"tenant_id,omitempty"`
+
+	// ProjectID is the UUID of the project who owns the Member.
+	// Only administrative users can specify a project UUID other than their own.
+	ProjectID string `json:"project_id,omitempty"`
 
 	// A positive integer value that indicates the relative portion of traffic
 	// that  this member should receive from the pool. For example, a member with

--- a/openstack/networking/v2/extensions/rbacpolicies/requests.go
+++ b/openstack/networking/v2/extensions/rbacpolicies/requests.go
@@ -21,6 +21,7 @@ type ListOpts struct {
 	ObjectType   string       `q:"object_type"`
 	ObjectID     string       `q:"object_id"`
 	Action       PolicyAction `q:"action"`
+	TenantID     string       `q:"tenant_id"`
 	ProjectID    string       `q:"project_id"`
 	Marker       string       `q:"marker"`
 	Limit        int          `q:"limit"`

--- a/openstack/networking/v2/extensions/security/groups/requests.go
+++ b/openstack/networking/v2/extensions/security/groups/requests.go
@@ -11,13 +11,14 @@ import (
 // sort by a particular network attribute. SortDir sets the direction, and is
 // either `asc' or `desc'. Marker and Limit are used for pagination.
 type ListOpts struct {
-	ID       string `q:"id"`
-	Name     string `q:"name"`
-	TenantID string `q:"tenant_id"`
-	Limit    int    `q:"limit"`
-	Marker   string `q:"marker"`
-	SortKey  string `q:"sort_key"`
-	SortDir  string `q:"sort_dir"`
+	ID        string `q:"id"`
+	Name      string `q:"name"`
+	TenantID  string `q:"tenant_id"`
+	ProjectID string `q:"project_id"`
+	Limit     int    `q:"limit"`
+	Marker    string `q:"marker"`
+	SortKey   string `q:"sort_key"`
+	SortDir   string `q:"sort_dir"`
 }
 
 // List returns a Pager which allows you to iterate over a collection of
@@ -45,9 +46,13 @@ type CreateOpts struct {
 	// Human-readable name for the Security Group. Does not have to be unique.
 	Name string `json:"name" required:"true"`
 
-	// The UUID of the tenant who owns the Group. Only administrative users
-	// can specify a tenant UUID other than their own.
+	// TenantID is the UUID of the project who owns the Group.
+	// Only administrative users can specify a tenant UUID other than their own.
 	TenantID string `json:"tenant_id,omitempty"`
+
+	// ProjectID is the UUID of the project who owns the Group.
+	// Only administrative users can specify a tenant UUID other than their own.
+	ProjectID string `json:"project_id,omitempty"`
 
 	// Describes the security group.
 	Description string `json:"description,omitempty"`

--- a/openstack/networking/v2/extensions/security/groups/results.go
+++ b/openstack/networking/v2/extensions/security/groups/results.go
@@ -22,8 +22,11 @@ type SecGroup struct {
 	// traffic entering and leaving the group.
 	Rules []rules.SecGroupRule `json:"security_group_rules"`
 
-	// Owner of the security group.
+	// TenantID is the project owner of the security group.
 	TenantID string `json:"tenant_id"`
+
+	// ProjectID is the project owner of the security group.
+	ProjectID string `json:"project_id"`
 }
 
 // SecGroupPage is the page returned by a pager when traversing over a

--- a/openstack/networking/v2/extensions/security/rules/requests.go
+++ b/openstack/networking/v2/extensions/security/rules/requests.go
@@ -21,6 +21,7 @@ type ListOpts struct {
 	RemoteIPPrefix string `q:"remote_ip_prefix"`
 	SecGroupID     string `q:"security_group_id"`
 	TenantID       string `q:"tenant_id"`
+	ProjectID      string `q:"project_id"`
 	Limit          int    `q:"limit"`
 	Marker         string `q:"marker"`
 	SortKey        string `q:"sort_key"`
@@ -118,9 +119,9 @@ type CreateOpts struct {
 	// specified IP prefix as the source IP address of the IP packet.
 	RemoteIPPrefix string `json:"remote_ip_prefix,omitempty"`
 
-	// The UUID of the tenant who owns the Rule. Only administrative users
-	// can specify a tenant UUID other than their own.
-	TenantID string `json:"tenant_id,omitempty"`
+	// TenantID is the UUID of the project who owns the Rule.
+	// Only administrative users can specify a project UUID other than their own.
+	ProjectID string `json:"project_id,omitempty"`
 }
 
 // ToSecGroupRuleCreateMap builds a request body from CreateOpts.

--- a/openstack/networking/v2/extensions/security/rules/results.go
+++ b/openstack/networking/v2/extensions/security/rules/results.go
@@ -48,8 +48,11 @@ type SecGroupRule struct {
 	// matches the specified IP prefix as the source IP address of the IP packet.
 	RemoteIPPrefix string `json:"remote_ip_prefix"`
 
-	// The owner of this security group rule.
+	// TenantID is the project owner of this security group rule.
 	TenantID string `json:"tenant_id"`
+
+	// ProjectID is the project owner of this security group rule.
+	ProjectID string `json:"project_id"`
 }
 
 // SecGroupRulePage is the page returned by a pager when traversing over a

--- a/openstack/networking/v2/networks/requests.go
+++ b/openstack/networking/v2/networks/requests.go
@@ -21,6 +21,7 @@ type ListOpts struct {
 	Name         string `q:"name"`
 	AdminStateUp *bool  `q:"admin_state_up"`
 	TenantID     string `q:"tenant_id"`
+	ProjectID    string `q:"project_id"`
 	Shared       *bool  `q:"shared"`
 	ID           string `q:"id"`
 	Marker       string `q:"marker"`
@@ -70,6 +71,7 @@ type CreateOpts struct {
 	Name                  string   `json:"name,omitempty"`
 	Shared                *bool    `json:"shared,omitempty"`
 	TenantID              string   `json:"tenant_id,omitempty"`
+	ProjectID             string   `json:"project_id,omitempty"`
 	AvailabilityZoneHints []string `json:"availability_zone_hints,omitempty"`
 }
 

--- a/openstack/networking/v2/networks/results.go
+++ b/openstack/networking/v2/networks/results.go
@@ -64,8 +64,11 @@ type Network struct {
 	// Subnets associated with this network.
 	Subnets []string `json:"subnets"`
 
-	// Owner of network.
+	// TenantID is the project owner of the network.
 	TenantID string `json:"tenant_id"`
+
+	// ProjectID is the project owner of the network.
+	ProjectID string `json:"project_id"`
 
 	// Specifies whether the network resource can be accessed by any tenant.
 	Shared bool `json:"shared"`

--- a/openstack/networking/v2/ports/requests.go
+++ b/openstack/networking/v2/ports/requests.go
@@ -22,6 +22,7 @@ type ListOpts struct {
 	AdminStateUp *bool  `q:"admin_state_up"`
 	NetworkID    string `q:"network_id"`
 	TenantID     string `q:"tenant_id"`
+	ProjectID    string `q:"project_id"`
 	DeviceOwner  string `q:"device_owner"`
 	MACAddress   string `q:"mac_address"`
 	ID           string `q:"id"`
@@ -81,6 +82,7 @@ type CreateOpts struct {
 	DeviceID            string        `json:"device_id,omitempty"`
 	DeviceOwner         string        `json:"device_owner,omitempty"`
 	TenantID            string        `json:"tenant_id,omitempty"`
+	ProjectID           string        `json:"project_id,omitempty"`
 	SecurityGroups      *[]string     `json:"security_groups,omitempty"`
 	AllowedAddressPairs []AddressPair `json:"allowed_address_pairs,omitempty"`
 }

--- a/openstack/networking/v2/ports/results.go
+++ b/openstack/networking/v2/ports/results.go
@@ -84,8 +84,11 @@ type Port struct {
 	// the subnets where the IP addresses are picked from
 	FixedIPs []IP `json:"fixed_ips"`
 
-	// Owner of network.
+	// TenantID is the project owner of the port.
 	TenantID string `json:"tenant_id"`
+
+	// ProjectID is the project owner of the port.
+	ProjectID string `json:"project_id"`
 
 	// Identifies the entity (e.g.: dhcp agent) using this port.
 	DeviceOwner string `json:"device_owner"`

--- a/openstack/networking/v2/subnets/requests.go
+++ b/openstack/networking/v2/subnets/requests.go
@@ -21,6 +21,7 @@ type ListOpts struct {
 	EnableDHCP      *bool  `q:"enable_dhcp"`
 	NetworkID       string `q:"network_id"`
 	TenantID        string `q:"tenant_id"`
+	ProjectID       string `q:"project_id"`
 	IPVersion       int    `q:"ip_version"`
 	GatewayIP       string `q:"gateway_ip"`
 	CIDR            string `q:"cidr"`
@@ -84,9 +85,13 @@ type CreateOpts struct {
 	// Name is a human-readable name of the subnet.
 	Name string `json:"name,omitempty"`
 
-	// The UUID of the tenant who owns the Subnet. Only administrative users
-	// can specify a tenant UUID other than their own.
+	// The UUID of the project who owns the Subnet. Only administrative users
+	// can specify a project UUID other than their own.
 	TenantID string `json:"tenant_id,omitempty"`
+
+	// The UUID of the project who owns the Subnet. Only administrative users
+	// can specify a project UUID other than their own.
+	ProjectID string `json:"project_id,omitempty"`
 
 	// AllocationPools are IP Address pools that will be available for DHCP.
 	AllocationPools []AllocationPool `json:"allocation_pools,omitempty"`

--- a/openstack/networking/v2/subnets/results.go
+++ b/openstack/networking/v2/subnets/results.go
@@ -91,8 +91,11 @@ type Subnet struct {
 	// Specifies whether DHCP is enabled for this subnet or not.
 	EnableDHCP bool `json:"enable_dhcp"`
 
-	// Owner of network.
+	// TenantID is the project owner of the subnet.
 	TenantID string `json:"tenant_id"`
+
+	// ProjectID is the project owner of the subnet.
+	ProjectID string `json:"project_id"`
 
 	// The IPv6 address modes specifies mechanisms for assigning IPv6 IP addresses.
 	IPv6AddressMode string `json:"ipv6_address_mode"`


### PR DESCRIPTION
For #790 

Per discussion in #790, this PR adds `ProjectID` support to the network resources which support it.

I've updated the inline documentation where applicable, notably rewording `TenantID` to be described as a "project". My intention was to imply that tenant and project are the same without having a paragraph in each resource explicitly laying that out.

This has been tested to the best of my ability. There's always a chance _something_ slipped by me.

/cc @dklyle 

_edit_: In #790 I mentioned that LBaaS does not send `project_id`. To amend that statement, LBaaS will gladly accept `ProjectID` in other calls. It just does not set it in the response.