### PR TITLE
Networking v2: Port Extra DHCP Options fixes

### DIFF
--- a/acceptance/openstack/networking/v2/networking.go
+++ b/acceptance/openstack/networking/v2/networking.go
@@ -338,15 +338,15 @@ func WaitForPortToCreate(client *gophercloud.ServiceClient, portID string, secs 
 	})
 }
 
-// PortWithDHCPOpts represents a port with extra DHCP options configuration.
-type PortWithDHCPOpts struct {
+// PortWithExtraDHCPOpts represents a port with extra DHCP options configuration.
+type PortWithExtraDHCPOpts struct {
 	ports.Port
 	extradhcpopts.ExtraDHCPOptsExt
 }
 
-// CreatePortWithDHCPOpts will create a port with DHCP options on the specified subnet.
-// An error will be returned if the port could not be created.
-func CreatePortWithDHCPOpts(t *testing.T, client *gophercloud.ServiceClient, networkID, subnetID string) (*PortWithDHCPOpts, error) {
+// CreatePortWithExtraDHCPOpts will create a port with DHCP options on the
+// specified subnet. An error will be returned if the port could not be created.
+func CreatePortWithExtraDHCPOpts(t *testing.T, client *gophercloud.ServiceClient, networkID, subnetID string) (*PortWithExtraDHCPOpts, error) {
 	portName := tools.RandomString("TESTACC-", 8)
 
 	t.Logf("Attempting to create port: %s", portName)
@@ -359,14 +359,14 @@ func CreatePortWithDHCPOpts(t *testing.T, client *gophercloud.ServiceClient, net
 	}
 	createOpts := extradhcpopts.CreateOptsExt{
 		CreateOptsBuilder: portCreateOpts,
-		ExtraDHCPOpts: []extradhcpopts.ExtraDHCPOpts{
+		ExtraDHCPOpts: []extradhcpopts.ExtraDHCPOpt{
 			{
 				OptName:  "test_option_1",
 				OptValue: "test_value_1",
 			},
 		},
 	}
-	port := &PortWithDHCPOpts{}
+	port := &PortWithExtraDHCPOpts{}
 
 	err := ports.Create(client, createOpts).ExtractInto(port)
 	if err != nil {

--- a/acceptance/openstack/networking/v2/ports_test.go
+++ b/acceptance/openstack/networking/v2/ports_test.go
@@ -390,7 +390,7 @@ func TestPortsPortSecurityCRUD(t *testing.T) {
 	tools.PrintResource(t, portWithExt)
 }
 
-func TestPortsWithDHCPOptsCRUD(t *testing.T) {
+func TestPortsWithExtraDHCPOptsCRUD(t *testing.T) {
 	client, err := clients.NewNetworkV2Client()
 	if err != nil {
 		t.Fatalf("Unable to create a network client: %v", err)
@@ -411,7 +411,7 @@ func TestPortsWithDHCPOptsCRUD(t *testing.T) {
 	defer DeleteSubnet(t, client, subnet.ID)
 
 	// Create a port with extra DHCP options.
-	port, err := CreatePortWithDHCPOpts(t, client, network.ID, subnet.ID)
+	port, err := CreatePortWithExtraDHCPOpts(t, client, network.ID, subnet.ID)
 	if err != nil {
 		t.Fatalf("Unable to create a port: %v", err)
 	}
@@ -426,7 +426,7 @@ func TestPortsWithDHCPOptsCRUD(t *testing.T) {
 	}
 	updateOpts := extradhcpopts.UpdateOptsExt{
 		UpdateOptsBuilder: portUpdateOpts,
-		ExtraDHCPOpts: []extradhcpopts.ExtraDHCPOpts{
+		ExtraDHCPOpts: []extradhcpopts.ExtraDHCPOpt{
 			{
 				OptName:  "test_option_2",
 				OptValue: "test_value_2",
@@ -434,7 +434,7 @@ func TestPortsWithDHCPOptsCRUD(t *testing.T) {
 		},
 	}
 
-	newPort := &PortWithDHCPOpts{}
+	newPort := &PortWithExtraDHCPOpts{}
 	err = ports.Update(client, port.ID, updateOpts).ExtractInto(newPort)
 	if err != nil {
 		t.Fatalf("Could not update port: %v", err)

--- a/openstack/networking/v2/extensions/extradhcpopts/doc.go
+++ b/openstack/networking/v2/extensions/extradhcpopts/doc.go
@@ -1,7 +1,7 @@
 /*
 Package extradhcpopts allow to work with extra DHCP functionality of Neutron ports.
 
-Example to Get a Port with DHCP opts
+Example to Get a Port with Extra DHCP Options
 
 	portID := "46d4bfb9-b26e-41f3-bd2e-e6dcc1ccedb2"
 	var s struct {
@@ -14,7 +14,7 @@ Example to Get a Port with DHCP opts
 		panic(err)
 	}
 
-Example to Create a Port with DHCP opts
+Example to Create a Port with Extra DHCP Options
 
 	adminStateUp := true
 	portCreateOpts := ports.CreateOpts{
@@ -27,7 +27,7 @@ Example to Create a Port with DHCP opts
 	}
 	createOpts := extradhcpopts.CreateOptsExt{
 		CreateOptsBuilder: portCreateOpts,
-		ExtraDHCPOpts: []extradhcpopts.ExtraDHCPOpts{
+		ExtraDHCPOpts: []extradhcpopts.ExtraDHCPOpt{
 			{
 				OptName:  "optionA",
 				OptValue: "valueA",
@@ -44,7 +44,7 @@ Example to Create a Port with DHCP opts
 		panic(err)
 	}
 
-Example to Update a Port with DHCP opts
+Example to Update a Port with Extra DHCP Options
 
 	portUpdateOpts := ports.UpdateOpts{
 		Name: "updated-dhcp-conf-port",
@@ -54,7 +54,7 @@ Example to Update a Port with DHCP opts
 	}
 	updateOpts := extradhcpopts.UpdateOptsExt{
 		UpdateOptsBuilder: portUpdateOpts,
-		ExtraDHCPOpts: []extradhcpopts.ExtraDHCPOpts{
+		ExtraDHCPOpts: []extradhcpopts.ExtraDHCPOpt{
 			{
 				OptName:  "optionB",
 				OptValue: "valueB",

--- a/openstack/networking/v2/extensions/extradhcpopts/requests.go
+++ b/openstack/networking/v2/extensions/extradhcpopts/requests.go
@@ -4,14 +4,14 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
 )
 
-// CreateOptsExt adds port DHCP options to the base ports.CreateOpts.
+// CreateOptsExt adds extra DHCP options to the base ports.CreateOpts.
 type CreateOptsExt struct {
 	// CreateOptsBuilder is the interface options structs have to satisfy in order
 	// to be used in the main Create operation in this package.
 	ports.CreateOptsBuilder
 
 	// ExtraDHCPOpts field is a set of DHCP options for a single port.
-	ExtraDHCPOpts []ExtraDHCPOpts `json:"extra_dhcp_opts,omitempty"`
+	ExtraDHCPOpts []ExtraDHCPOpt `json:"extra_dhcp_opts,omitempty"`
 }
 
 // ToPortCreateMap casts a CreateOptsExt struct to a map.
@@ -23,7 +23,7 @@ func (opts CreateOptsExt) ToPortCreateMap() (map[string]interface{}, error) {
 
 	port := base["port"].(map[string]interface{})
 
-	// Convert opts.DHCPOpts to a slice of maps.
+	// Convert opts.ExtraDHCPOpts to a slice of maps.
 	if opts.ExtraDHCPOpts != nil {
 		extraDHCPOpts := make([]map[string]interface{}, len(opts.ExtraDHCPOpts))
 		for i, opt := range opts.ExtraDHCPOpts {
@@ -39,14 +39,14 @@ func (opts CreateOptsExt) ToPortCreateMap() (map[string]interface{}, error) {
 	return base, nil
 }
 
-// UpdateOptsExt adds port DHCP options to the base ports.UpdateOpts
+// UpdateOptsExt adds extra DHCP options to the base ports.UpdateOpts.
 type UpdateOptsExt struct {
 	// UpdateOptsBuilder is the interface options structs have to satisfy in order
 	// to be used in the main Update operation in this package.
 	ports.UpdateOptsBuilder
 
 	// ExtraDHCPOpts field is a set of DHCP options for a single port.
-	ExtraDHCPOpts []ExtraDHCPOpts `json:"extra_dhcp_opts,omitempty"`
+	ExtraDHCPOpts []ExtraDHCPOpt `json:"extra_dhcp_opts,omitempty"`
 }
 
 // ToPortUpdateMap casts an UpdateOpts struct to a map.

--- a/openstack/networking/v2/extensions/extradhcpopts/results.go
+++ b/openstack/networking/v2/extensions/extradhcpopts/results.go
@@ -2,13 +2,14 @@ package extradhcpopts
 
 import "github.com/gophercloud/gophercloud"
 
-// ExtraDHCPOptsExt is a struct that contains different DHCP options for a single port.
+// ExtraDHCPOptsExt is a struct that contains different DHCP options for a
+// single port.
 type ExtraDHCPOptsExt struct {
-	ExtraDHCPOpts []ExtraDHCPOpts `json:"extra_dhcp_opts"`
+	ExtraDHCPOpts []ExtraDHCPOpt `json:"extra_dhcp_opts"`
 }
 
-// ExtraDHCPOpts represents a single set of extra DHCP options for a single port.
-type ExtraDHCPOpts struct {
+// ExtraDHCPOpt represents a single set of extra DHCP options for a single port.
+type ExtraDHCPOpt struct {
 	// Name is the name of a single DHCP option.
 	OptName string `json:"opt_name"`
 
@@ -20,9 +21,9 @@ type ExtraDHCPOpts struct {
 	IPVersion int `json:"ip_version,omitempty"`
 }
 
-// ToMap is a helper function to convert an individual DHCPOpts structure
+// ToMap is a helper function to convert an individual ExtraDHCPOpt structure
 // into a sub-map.
-func (opts ExtraDHCPOpts) ToMap() (map[string]interface{}, error) {
+func (opts ExtraDHCPOpt) ToMap() (map[string]interface{}, error) {
 	b, err := gophercloud.BuildRequestBody(opts, "")
 	if err != nil {
 		return nil, err

--- a/openstack/networking/v2/ports/testing/fixtures.go
+++ b/openstack/networking/v2/ports/testing/fixtures.go
@@ -521,8 +521,9 @@ const DontUpdateAllowedAddressPairsResponse = `
 }
 `
 
-// GetWithDHCPOptsResponse represents a raw port response with extra DHCP options.
-const GetWithDHCPOptsResponse = `
+// GetWithExtraDHCPOptsResponse represents a raw port response with extra
+// DHCP options.
+const GetWithExtraDHCPOptsResponse = `
 {
     "port": {
         "status": "ACTIVE",
@@ -556,8 +557,9 @@ const GetWithDHCPOptsResponse = `
 }
 `
 
-// CreateWithDHCPOptsRequest represents a raw port creation request with extra DHCP options.
-const CreateWithDHCPOptsRequest = `
+// CreateWithExtraDHCPOptsRequest represents a raw port creation request
+// with extra DHCP options.
+const CreateWithExtraDHCPOptsRequest = `
 {
     "port": {
         "network_id": "a87cc70a-3e15-4acf-8205-9b711a3531b7",
@@ -579,8 +581,9 @@ const CreateWithDHCPOptsRequest = `
 }
 `
 
-// CreateWithDHCPOptsResponse represents a raw port creation response with extra DHCP options.
-const CreateWithDHCPOptsResponse = `
+// CreateWithExtraDHCPOptsResponse represents a raw port creation response
+// with extra DHCP options.
+const CreateWithExtraDHCPOptsResponse = `
 {
     "port": {
         "status": "DOWN",
@@ -609,8 +612,9 @@ const CreateWithDHCPOptsResponse = `
 }
 `
 
-// UpdateWithDHCPOptsRequest represents a raw port update request with extra DHCP options.
-const UpdateWithDHCPOptsRequest = `
+// UpdateWithExtraDHCPOptsRequest represents a raw port update request with
+// extra DHCP options.
+const UpdateWithExtraDHCPOptsRequest = `
 {
     "port": {
         "name": "updated-port-with-dhcp-opts",
@@ -630,8 +634,9 @@ const UpdateWithDHCPOptsRequest = `
 }
 `
 
-// UpdateWithDHCPOptsResponse represents a raw port update response with extra DHCP options.
-const UpdateWithDHCPOptsResponse = `
+// UpdateWithExtraDHCPOptsResponse represents a raw port update response with
+// extra DHCP options.
+const UpdateWithExtraDHCPOptsResponse = `
 {
     "port": {
         "status": "DOWN",

--- a/openstack/networking/v2/ports/testing/requests_test.go
+++ b/openstack/networking/v2/ports/testing/requests_test.go
@@ -571,7 +571,7 @@ func TestDelete(t *testing.T) {
 	th.AssertNoErr(t, res.Err)
 }
 
-func TestGetWithDHCPOpts(t *testing.T) {
+func TestGetWithExtraDHCPOpts(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 
@@ -582,7 +582,7 @@ func TestGetWithDHCPOpts(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, GetWithDHCPOptsResponse)
+		fmt.Fprintf(w, GetWithExtraDHCPOptsResponse)
 	})
 
 	var s struct {
@@ -597,7 +597,7 @@ func TestGetWithDHCPOpts(t *testing.T) {
 	th.AssertEquals(t, s.NetworkID, "a87cc70a-3e15-4acf-8205-9b711a3531b7")
 	th.AssertEquals(t, s.TenantID, "d6700c0c9ffa4f1cb322cd4a1f3906fa")
 	th.AssertDeepEquals(t, s.ExtraDHCPOptsExt, extradhcpopts.ExtraDHCPOptsExt{
-		ExtraDHCPOpts: []extradhcpopts.ExtraDHCPOpts{
+		ExtraDHCPOpts: []extradhcpopts.ExtraDHCPOpt{
 			{OptName: "option1", OptValue: "value1", IPVersion: 4},
 			{OptName: "option2", OptValue: "value2", IPVersion: 4},
 		},
@@ -613,7 +613,7 @@ func TestGetWithDHCPOpts(t *testing.T) {
 	th.AssertEquals(t, s.DeviceID, "")
 }
 
-func TestCreateWithDHCPOpts(t *testing.T) {
+func TestCreateWithExtraDHCPOpts(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 
@@ -622,12 +622,12 @@ func TestCreateWithDHCPOpts(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 		th.TestHeader(t, r, "Content-Type", "application/json")
 		th.TestHeader(t, r, "Accept", "application/json")
-		th.TestJSONRequest(t, r, CreateWithDHCPOptsRequest)
+		th.TestJSONRequest(t, r, CreateWithExtraDHCPOptsRequest)
 
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		fmt.Fprintf(w, CreateWithDHCPOptsResponse)
+		fmt.Fprintf(w, CreateWithExtraDHCPOptsResponse)
 	})
 
 	adminStateUp := true
@@ -642,7 +642,7 @@ func TestCreateWithDHCPOpts(t *testing.T) {
 
 	createOpts := extradhcpopts.CreateOptsExt{
 		CreateOptsBuilder: portCreateOpts,
-		ExtraDHCPOpts: []extradhcpopts.ExtraDHCPOpts{
+		ExtraDHCPOpts: []extradhcpopts.ExtraDHCPOpt{
 			{
 				OptName:  "option1",
 				OptValue: "value1",
@@ -662,7 +662,7 @@ func TestCreateWithDHCPOpts(t *testing.T) {
 	th.AssertEquals(t, s.NetworkID, "a87cc70a-3e15-4acf-8205-9b711a3531b7")
 	th.AssertEquals(t, s.TenantID, "d6700c0c9ffa4f1cb322cd4a1f3906fa")
 	th.AssertDeepEquals(t, s.ExtraDHCPOptsExt, extradhcpopts.ExtraDHCPOptsExt{
-		ExtraDHCPOpts: []extradhcpopts.ExtraDHCPOpts{
+		ExtraDHCPOpts: []extradhcpopts.ExtraDHCPOpt{
 			{OptName: "option1", OptValue: "value1", IPVersion: 4},
 		},
 	})
@@ -677,7 +677,7 @@ func TestCreateWithDHCPOpts(t *testing.T) {
 	th.AssertEquals(t, s.DeviceID, "")
 }
 
-func TestUpdateWithDHCPOpts(t *testing.T) {
+func TestUpdateWithExtraDHCPOpts(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 
@@ -686,12 +686,12 @@ func TestUpdateWithDHCPOpts(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 		th.TestHeader(t, r, "Content-Type", "application/json")
 		th.TestHeader(t, r, "Accept", "application/json")
-		th.TestJSONRequest(t, r, UpdateWithDHCPOptsRequest)
+		th.TestJSONRequest(t, r, UpdateWithExtraDHCPOptsRequest)
 
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, UpdateWithDHCPOptsResponse)
+		fmt.Fprintf(w, UpdateWithExtraDHCPOptsResponse)
 	})
 
 	portUpdateOpts := ports.UpdateOpts{
@@ -703,7 +703,7 @@ func TestUpdateWithDHCPOpts(t *testing.T) {
 
 	updateOpts := extradhcpopts.UpdateOptsExt{
 		UpdateOptsBuilder: portUpdateOpts,
-		ExtraDHCPOpts: []extradhcpopts.ExtraDHCPOpts{
+		ExtraDHCPOpts: []extradhcpopts.ExtraDHCPOpt{
 			{
 				OptName:  "option2",
 				OptValue: "value2",
@@ -723,7 +723,7 @@ func TestUpdateWithDHCPOpts(t *testing.T) {
 	th.AssertEquals(t, s.NetworkID, "a87cc70a-3e15-4acf-8205-9b711a3531b7")
 	th.AssertEquals(t, s.TenantID, "d6700c0c9ffa4f1cb322cd4a1f3906fa")
 	th.AssertDeepEquals(t, s.ExtraDHCPOptsExt, extradhcpopts.ExtraDHCPOptsExt{
-		ExtraDHCPOpts: []extradhcpopts.ExtraDHCPOpts{
+		ExtraDHCPOpts: []extradhcpopts.ExtraDHCPOpt{
 			{OptName: "option2", OptValue: "value2", IPVersion: 4},
 		},
 	})


### PR DESCRIPTION
For #511 

This commit renames the `ExtraDHCPOpts` struct to `ExtraDHCPOpt`. It also makes some minor doc changes.