### PR TITLE
Compute v2: Fix EOF errors in compute secgroups

### DIFF
--- a/acceptance/openstack/compute/v2/compute.go
+++ b/acceptance/openstack/compute/v2/compute.go
@@ -681,7 +681,15 @@ func DeleteServer(t *testing.T, client *gophercloud.ServiceClient, server *serve
 		t.Fatalf("Unable to delete server %s: %s", server.ID, err)
 	}
 
-	t.Logf("Deleted server: %s", server.ID)
+	if err := WaitForComputeStatus(client, server, "DELETED"); err != nil {
+		if _, ok := err.(gophercloud.ErrDefault404); ok {
+			t.Logf("Deleted server: %s", server.ID)
+			return
+		}
+		t.Fatalf("Error deleting server %s: %s", server.ID, err)
+	}
+
+	t.Fatalf("Could not delete server: %s", server.ID)
 }
 
 // DeleteServerGroup will delete a server group. A fatal error will occur if

--- a/openstack/compute/v2/extensions/secgroups/requests.go
+++ b/openstack/compute/v2/extensions/secgroups/requests.go
@@ -172,12 +172,12 @@ func actionMap(prefix, groupName string) map[string]map[string]string {
 // AddServer will associate a server and a security group, enforcing the
 // rules of the group on the server.
 func AddServer(client *gophercloud.ServiceClient, serverID, groupName string) (r AddServerResult) {
-	_, r.Err = client.Post(serverActionURL(client, serverID), actionMap("add", groupName), &r.Body, nil)
+	_, r.Err = client.Post(serverActionURL(client, serverID), actionMap("add", groupName), nil, nil)
 	return
 }
 
 // RemoveServer will disassociate a server from a security group.
 func RemoveServer(client *gophercloud.ServiceClient, serverID, groupName string) (r RemoveServerResult) {
-	_, r.Err = client.Post(serverActionURL(client, serverID), actionMap("remove", groupName), &r.Body, nil)
+	_, r.Err = client.Post(serverActionURL(client, serverID), actionMap("remove", groupName), nil, nil)
 	return
 }

--- a/openstack/compute/v2/extensions/secgroups/testing/fixtures.go
+++ b/openstack/compute/v2/extensions/secgroups/testing/fixtures.go
@@ -303,7 +303,6 @@ func mockAddServerToGroupResponse(t *testing.T, serverID string) {
 
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusAccepted)
-		fmt.Fprintf(w, `{}`)
 	})
 }
 
@@ -323,6 +322,5 @@ func mockRemoveServerFromGroupResponse(t *testing.T, serverID string) {
 
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusAccepted)
-		fmt.Fprintf(w, `{}`)
 	})
 }


### PR DESCRIPTION
For #206 

This commit modifies the `AddServer` and `RemoveServer` actions so a response body is not parsed.

I'll admit I haven't done an exhaustive review of the code, but from what I can tell, the lack of a return statement here:

https://github.com/openstack/nova/blob/master/nova/api/openstack/compute/security_groups.py#L441-L456

Is probably good enough.

Note how other functions are returning some object, such as here:

https://github.com/openstack/nova/blob/master/nova/api/openstack/compute/security_groups.py#L340

Also note that the explicit EOF check in the acceptance test was added by me (which I'm removing in this PR). This is because I _swear_ I was seeing intermittent EOFs and not steady ones. But it's been so long since I was working on that, I can't be sure if my testing was correct.

/cc @dklyle 