### PR TITLE
Networking v2: Fix Extra DHCP Options Updates

### DIFF
--- a/acceptance/openstack/networking/v2/networking.go
+++ b/acceptance/openstack/networking/v2/networking.go
@@ -357,9 +357,10 @@ func CreatePortWithExtraDHCPOpts(t *testing.T, client *gophercloud.ServiceClient
 		AdminStateUp: gophercloud.Enabled,
 		FixedIPs:     []ports.IP{ports.IP{SubnetID: subnetID}},
 	}
+
 	createOpts := extradhcpopts.CreateOptsExt{
 		CreateOptsBuilder: portCreateOpts,
-		ExtraDHCPOpts: []extradhcpopts.ExtraDHCPOpt{
+		ExtraDHCPOpts: []extradhcpopts.CreateExtraDHCPOpt{
 			{
 				OptName:  "test_option_1",
 				OptValue: "test_value_1",

--- a/acceptance/openstack/networking/v2/ports_test.go
+++ b/acceptance/openstack/networking/v2/ports_test.go
@@ -424,12 +424,20 @@ func TestPortsWithExtraDHCPOptsCRUD(t *testing.T) {
 	portUpdateOpts := ports.UpdateOpts{
 		Name: newPortName,
 	}
+
+	existingOpt := port.ExtraDHCPOpts[0]
+	newOptValue := "test_value_2"
+
 	updateOpts := extradhcpopts.UpdateOptsExt{
 		UpdateOptsBuilder: portUpdateOpts,
-		ExtraDHCPOpts: []extradhcpopts.ExtraDHCPOpt{
+		ExtraDHCPOpts: []extradhcpopts.UpdateExtraDHCPOpt{
+			{
+				OptName:  existingOpt.OptName,
+				OptValue: nil,
+			},
 			{
 				OptName:  "test_option_2",
-				OptValue: "test_value_2",
+				OptValue: &newOptValue,
 			},
 		},
 	}

--- a/openstack/networking/v2/extensions/extradhcpopts/doc.go
+++ b/openstack/networking/v2/extensions/extradhcpopts/doc.go
@@ -16,6 +16,11 @@ Example to Get a Port with Extra DHCP Options
 
 Example to Create a Port with Extra DHCP Options
 
+	var s struct {
+		ports.Port
+		extradhcpopts.ExtraDHCPOptsExt
+	}
+
 	adminStateUp := true
 	portCreateOpts := ports.CreateOpts{
 		Name:         "dhcp-conf-port",
@@ -25,18 +30,15 @@ Example to Create a Port with Extra DHCP Options
 			{SubnetID: "a0304c3a-4f08-4c43-88af-d796509c97d2", IPAddress: "10.0.0.2"},
 		},
 	}
+
 	createOpts := extradhcpopts.CreateOptsExt{
 		CreateOptsBuilder: portCreateOpts,
-		ExtraDHCPOpts: []extradhcpopts.ExtraDHCPOpt{
+		ExtraDHCPOpts: []extradhcpopts.CreateExtraDHCPOpt{
 			{
 				OptName:  "optionA",
 				OptValue: "valueA",
 			},
 		},
-	}
-	var s struct {
-		ports.Port
-		extradhcpopts.ExtraDHCPOptsExt
 	}
 
 	err := ports.Create(networkClient, createOpts).ExtractInto(&s)
@@ -46,27 +48,30 @@ Example to Create a Port with Extra DHCP Options
 
 Example to Update a Port with Extra DHCP Options
 
+	var s struct {
+		ports.Port
+		extradhcpopts.ExtraDHCPOptsExt
+	}
+
 	portUpdateOpts := ports.UpdateOpts{
 		Name: "updated-dhcp-conf-port",
 		FixedIPs: []ports.IP{
 			{SubnetID: "a0304c3a-4f08-4c43-88af-d796509c97d2", IPAddress: "10.0.0.3"},
 		},
 	}
+
+	value := "valueB"
 	updateOpts := extradhcpopts.UpdateOptsExt{
 		UpdateOptsBuilder: portUpdateOpts,
-		ExtraDHCPOpts: []extradhcpopts.ExtraDHCPOpt{
+		ExtraDHCPOpts: []extradhcpopts.UpdateExtraDHCPOpt{
 			{
 				OptName:  "optionB",
-				OptValue: "valueB",
+				OptValue: &value,
 			},
 		},
 	}
-	var s struct {
-		ports.Port
-		extradhcpopts.ExtraDHCPOptsExt
-	}
-	portID := "46d4bfb9-b26e-41f3-bd2e-e6dcc1ccedb2"
 
+	portID := "46d4bfb9-b26e-41f3-bd2e-e6dcc1ccedb2"
 	err := ports.Update(networkClient, portID, updateOpts).ExtractInto(&s)
 	if err != nil {
 		panic(err)

--- a/openstack/networking/v2/extensions/extradhcpopts/requests.go
+++ b/openstack/networking/v2/extensions/extradhcpopts/requests.go
@@ -1,6 +1,7 @@
 package extradhcpopts
 
 import (
+	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
 )
 
@@ -11,7 +12,20 @@ type CreateOptsExt struct {
 	ports.CreateOptsBuilder
 
 	// ExtraDHCPOpts field is a set of DHCP options for a single port.
-	ExtraDHCPOpts []ExtraDHCPOpt `json:"extra_dhcp_opts,omitempty"`
+	ExtraDHCPOpts []CreateExtraDHCPOpt `json:"extra_dhcp_opts,omitempty"`
+}
+
+// CreateExtraDHCPOpt represents the options required to create an extra DHCP
+// option on a port.
+type CreateExtraDHCPOpt struct {
+	// OptName is the name of a DHCP option.
+	OptName string `json:"opt_name" required:"true"`
+
+	// OptValue is the value of the DHCP option.
+	OptValue string `json:"opt_value" required:"true"`
+
+	// IPVersion is the IP protocol version of a DHCP option.
+	IPVersion gophercloud.IPVersion `json:"ip_version,omitempty"`
 }
 
 // ToPortCreateMap casts a CreateOptsExt struct to a map.
@@ -27,11 +41,11 @@ func (opts CreateOptsExt) ToPortCreateMap() (map[string]interface{}, error) {
 	if opts.ExtraDHCPOpts != nil {
 		extraDHCPOpts := make([]map[string]interface{}, len(opts.ExtraDHCPOpts))
 		for i, opt := range opts.ExtraDHCPOpts {
-			extraDHCPOptMap, err := opt.ToMap()
+			b, err := gophercloud.BuildRequestBody(opt, "")
 			if err != nil {
 				return nil, err
 			}
-			extraDHCPOpts[i] = extraDHCPOptMap
+			extraDHCPOpts[i] = b
 		}
 		port["extra_dhcp_opts"] = extraDHCPOpts
 	}
@@ -46,7 +60,20 @@ type UpdateOptsExt struct {
 	ports.UpdateOptsBuilder
 
 	// ExtraDHCPOpts field is a set of DHCP options for a single port.
-	ExtraDHCPOpts []ExtraDHCPOpt `json:"extra_dhcp_opts,omitempty"`
+	ExtraDHCPOpts []UpdateExtraDHCPOpt `json:"extra_dhcp_opts,omitempty"`
+}
+
+// UpdateExtraDHCPOpt represents the options required to update an extra DHCP
+// option on a port.
+type UpdateExtraDHCPOpt struct {
+	// OptName is the name of a DHCP option.
+	OptName string `json:"opt_name" required:"true"`
+
+	// OptValue is the value of the DHCP option.
+	OptValue *string `json:"opt_value"`
+
+	// IPVersion is the IP protocol version of a DHCP option.
+	IPVersion gophercloud.IPVersion `json:"ip_version,omitempty"`
 }
 
 // ToPortUpdateMap casts an UpdateOpts struct to a map.
@@ -62,11 +89,11 @@ func (opts UpdateOptsExt) ToPortUpdateMap() (map[string]interface{}, error) {
 	if opts.ExtraDHCPOpts != nil {
 		extraDHCPOpts := make([]map[string]interface{}, len(opts.ExtraDHCPOpts))
 		for i, opt := range opts.ExtraDHCPOpts {
-			extraDHCPOptMap, err := opt.ToMap()
+			b, err := gophercloud.BuildRequestBody(opt, "")
 			if err != nil {
 				return nil, err
 			}
-			extraDHCPOpts[i] = extraDHCPOptMap
+			extraDHCPOpts[i] = b
 		}
 		port["extra_dhcp_opts"] = extraDHCPOpts
 	}

--- a/openstack/networking/v2/extensions/extradhcpopts/results.go
+++ b/openstack/networking/v2/extensions/extradhcpopts/results.go
@@ -1,7 +1,5 @@
 package extradhcpopts
 
-import "github.com/gophercloud/gophercloud"
-
 // ExtraDHCPOptsExt is a struct that contains different DHCP options for a
 // single port.
 type ExtraDHCPOptsExt struct {
@@ -10,24 +8,13 @@ type ExtraDHCPOptsExt struct {
 
 // ExtraDHCPOpt represents a single set of extra DHCP options for a single port.
 type ExtraDHCPOpt struct {
-	// Name is the name of a single DHCP option.
+	// OptName is the name of a single DHCP option.
 	OptName string `json:"opt_name"`
 
-	// Value is the value of a single DHCP option.
+	// OptValue is the value of a single DHCP option.
 	OptValue string `json:"opt_value"`
 
 	// IPVersion is the IP protocol version of a single DHCP option.
 	// Valid value is 4 or 6. Default is 4.
-	IPVersion int `json:"ip_version,omitempty"`
-}
-
-// ToMap is a helper function to convert an individual ExtraDHCPOpt structure
-// into a sub-map.
-func (opts ExtraDHCPOpt) ToMap() (map[string]interface{}, error) {
-	b, err := gophercloud.BuildRequestBody(opts, "")
-	if err != nil {
-		return nil, err
-	}
-
-	return b, nil
+	IPVersion int `json:"ip_version"`
 }

--- a/openstack/networking/v2/ports/testing/fixtures.go
+++ b/openstack/networking/v2/ports/testing/fixtures.go
@@ -626,6 +626,10 @@ const UpdateWithExtraDHCPOptsRequest = `
         ],
         "extra_dhcp_opts": [
             {
+                "opt_name": "option1",
+                "opt_value": null
+            },
+            {
                 "opt_name": "option2",
                 "opt_value": "value2"
             }

--- a/openstack/networking/v2/ports/testing/requests_test.go
+++ b/openstack/networking/v2/ports/testing/requests_test.go
@@ -596,12 +596,6 @@ func TestGetWithExtraDHCPOpts(t *testing.T) {
 	th.AssertEquals(t, s.Status, "ACTIVE")
 	th.AssertEquals(t, s.NetworkID, "a87cc70a-3e15-4acf-8205-9b711a3531b7")
 	th.AssertEquals(t, s.TenantID, "d6700c0c9ffa4f1cb322cd4a1f3906fa")
-	th.AssertDeepEquals(t, s.ExtraDHCPOptsExt, extradhcpopts.ExtraDHCPOptsExt{
-		ExtraDHCPOpts: []extradhcpopts.ExtraDHCPOpt{
-			{OptName: "option1", OptValue: "value1", IPVersion: 4},
-			{OptName: "option2", OptValue: "value2", IPVersion: 4},
-		},
-	})
 	th.AssertEquals(t, s.AdminStateUp, true)
 	th.AssertEquals(t, s.Name, "port-with-extra-dhcp-opts")
 	th.AssertEquals(t, s.DeviceOwner, "")
@@ -611,6 +605,13 @@ func TestGetWithExtraDHCPOpts(t *testing.T) {
 	})
 	th.AssertEquals(t, s.ID, "65c0ee9f-d634-4522-8954-51021b570b0d")
 	th.AssertEquals(t, s.DeviceID, "")
+
+	th.AssertDeepEquals(t, s.ExtraDHCPOpts[0].OptName, "option1")
+	th.AssertDeepEquals(t, s.ExtraDHCPOpts[0].OptValue, "value1")
+	th.AssertDeepEquals(t, s.ExtraDHCPOpts[0].IPVersion, 4)
+	th.AssertDeepEquals(t, s.ExtraDHCPOpts[1].OptName, "option2")
+	th.AssertDeepEquals(t, s.ExtraDHCPOpts[1].OptValue, "value2")
+	th.AssertDeepEquals(t, s.ExtraDHCPOpts[1].IPVersion, 4)
 }
 
 func TestCreateWithExtraDHCPOpts(t *testing.T) {
@@ -642,7 +643,7 @@ func TestCreateWithExtraDHCPOpts(t *testing.T) {
 
 	createOpts := extradhcpopts.CreateOptsExt{
 		CreateOptsBuilder: portCreateOpts,
-		ExtraDHCPOpts: []extradhcpopts.ExtraDHCPOpt{
+		ExtraDHCPOpts: []extradhcpopts.CreateExtraDHCPOpt{
 			{
 				OptName:  "option1",
 				OptValue: "value1",
@@ -661,11 +662,6 @@ func TestCreateWithExtraDHCPOpts(t *testing.T) {
 	th.AssertEquals(t, s.Status, "DOWN")
 	th.AssertEquals(t, s.NetworkID, "a87cc70a-3e15-4acf-8205-9b711a3531b7")
 	th.AssertEquals(t, s.TenantID, "d6700c0c9ffa4f1cb322cd4a1f3906fa")
-	th.AssertDeepEquals(t, s.ExtraDHCPOptsExt, extradhcpopts.ExtraDHCPOptsExt{
-		ExtraDHCPOpts: []extradhcpopts.ExtraDHCPOpt{
-			{OptName: "option1", OptValue: "value1", IPVersion: 4},
-		},
-	})
 	th.AssertEquals(t, s.AdminStateUp, true)
 	th.AssertEquals(t, s.Name, "port-with-extra-dhcp-opts")
 	th.AssertEquals(t, s.DeviceOwner, "")
@@ -675,6 +671,10 @@ func TestCreateWithExtraDHCPOpts(t *testing.T) {
 	})
 	th.AssertEquals(t, s.ID, "65c0ee9f-d634-4522-8954-51021b570b0d")
 	th.AssertEquals(t, s.DeviceID, "")
+
+	th.AssertDeepEquals(t, s.ExtraDHCPOpts[0].OptName, "option1")
+	th.AssertDeepEquals(t, s.ExtraDHCPOpts[0].OptValue, "value1")
+	th.AssertDeepEquals(t, s.ExtraDHCPOpts[0].IPVersion, 4)
 }
 
 func TestUpdateWithExtraDHCPOpts(t *testing.T) {
@@ -701,12 +701,16 @@ func TestUpdateWithExtraDHCPOpts(t *testing.T) {
 		},
 	}
 
+	edoValue2 := "value2"
 	updateOpts := extradhcpopts.UpdateOptsExt{
 		UpdateOptsBuilder: portUpdateOpts,
-		ExtraDHCPOpts: []extradhcpopts.ExtraDHCPOpt{
+		ExtraDHCPOpts: []extradhcpopts.UpdateExtraDHCPOpt{
+			{
+				OptName: "option1",
+			},
 			{
 				OptName:  "option2",
-				OptValue: "value2",
+				OptValue: &edoValue2,
 			},
 		},
 	}
@@ -722,11 +726,6 @@ func TestUpdateWithExtraDHCPOpts(t *testing.T) {
 	th.AssertEquals(t, s.Status, "DOWN")
 	th.AssertEquals(t, s.NetworkID, "a87cc70a-3e15-4acf-8205-9b711a3531b7")
 	th.AssertEquals(t, s.TenantID, "d6700c0c9ffa4f1cb322cd4a1f3906fa")
-	th.AssertDeepEquals(t, s.ExtraDHCPOptsExt, extradhcpopts.ExtraDHCPOptsExt{
-		ExtraDHCPOpts: []extradhcpopts.ExtraDHCPOpt{
-			{OptName: "option2", OptValue: "value2", IPVersion: 4},
-		},
-	})
 	th.AssertEquals(t, s.AdminStateUp, true)
 	th.AssertEquals(t, s.Name, "updated-port-with-dhcp-opts")
 	th.AssertEquals(t, s.DeviceOwner, "")
@@ -736,4 +735,8 @@ func TestUpdateWithExtraDHCPOpts(t *testing.T) {
 	})
 	th.AssertEquals(t, s.ID, "65c0ee9f-d634-4522-8954-51021b570b0d")
 	th.AssertEquals(t, s.DeviceID, "")
+
+	th.AssertDeepEquals(t, s.ExtraDHCPOpts[0].OptName, "option2")
+	th.AssertDeepEquals(t, s.ExtraDHCPOpts[0].OptValue, "value2")
+	th.AssertDeepEquals(t, s.ExtraDHCPOpts[0].IPVersion, 4)
 }


### PR DESCRIPTION
This commit fixes updating of extra DHCP options on a Networking
port. The fix entails creating two new structs: one for create
and one for update. The update struct is able to take a string
pointer as a dhcp value so a nil/null string can be provided.
This nil/null value will cause a dhcp option to be remove if
requested.

For #816 

/cc @dklyle 