### PR TITLE
Vpnaas: Show IPSec site connection details

### DIFF
--- a/acceptance/openstack/networking/v2/extensions/vpnaas/siteconnection_test.go
+++ b/acceptance/openstack/networking/v2/extensions/vpnaas/siteconnection_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers"
 
 	"github.com/gophercloud/gophercloud/acceptance/tools"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/vpnaas/siteconnections"
 )
 
 func TestConnectionCRUD(t *testing.T) {
@@ -92,6 +93,12 @@ func TestConnectionCRUD(t *testing.T) {
 	}
 	defer DeleteSiteConnection(t, client, conn.ID)
 
+	newConnection, err := siteconnections.Get(client, conn.ID).Extract()
+	if err != nil {
+		t.Fatalf("Unable to get connection: %v", err)
+	}
+
 	tools.PrintResource(t, conn)
+	tools.PrintResource(t, newConnection)
 
 }

--- a/openstack/networking/v2/extensions/vpnaas/ikepolicies/doc.go
+++ b/openstack/networking/v2/extensions/vpnaas/ikepolicies/doc.go
@@ -42,7 +42,7 @@ Example to Update an IKE policy
 	}
 	updatedPolicy, err := ikepolicies.Update(client, "5c561d9d-eaea-45f6-ae3e-08d1a7080828", updateOpts).Extract()
 	if err != nil {
-		t.Fatalf("Unable to update IKE policy: %v", err)
+		panic(err)
 	}
 
 

--- a/openstack/networking/v2/extensions/vpnaas/ipsecpolicies/doc.go
+++ b/openstack/networking/v2/extensions/vpnaas/ipsecpolicies/doc.go
@@ -20,6 +20,24 @@ Example to Delete a Policy
 		panic(err)
 	}
 
+Example to Show the details of a specific IPSec policy by ID
+
+	policy, err := ipsecpolicies.Get(client, "f2b08c1e-aa81-4668-8ae1-1401bcb0576c").Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Update an IPSec policy
+
+	updateOpts := ipsecpolicies.UpdateOpts{
+		Name:        "updatedname",
+		Description: "updated policy",
+	}
+	updatedPolicy, err := ipsecpolicies.Update(client, "5c561d9d-eaea-45f6-ae3e-08d1a7080828", updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
 Example to List IPSec policies
 
 	allPages, err := ipsecpolicies.List(client, nil).AllPages()

--- a/openstack/networking/v2/extensions/vpnaas/services/doc.go
+++ b/openstack/networking/v2/extensions/vpnaas/services/doc.go
@@ -44,5 +44,12 @@ Example to Delete a Service
 		panic(err)
 	}
 
+Example to Show the details of a specific Service by ID
+
+	service, err := services.Get(client, "f2b08c1e-aa81-4668-8ae1-1401bcb0576c").Extract()
+	if err != nil {
+		panic(err)
+	}
+
 */
 package services

--- a/openstack/networking/v2/extensions/vpnaas/siteconnections/doc.go
+++ b/openstack/networking/v2/extensions/vpnaas/siteconnections/doc.go
@@ -23,5 +23,20 @@ createOpts := siteconnections.CreateOpts{
 	if err != nil {
 		panic(err)
 	}
+
+Example to Show the details of a specific IPSec site connection by ID
+
+	conn, err := siteconnections.Get(client, "f2b08c1e-aa81-4668-8ae1-1401bcb0576c").Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete a site connection
+
+	connID := "38aee955-6283-4279-b091-8b9c828000ec"
+	err := siteconnections.Delete(networkClient, serviceID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
 */
 package siteconnections

--- a/openstack/networking/v2/extensions/vpnaas/siteconnections/requests.go
+++ b/openstack/networking/v2/extensions/vpnaas/siteconnections/requests.go
@@ -134,3 +134,9 @@ func Delete(c *gophercloud.ServiceClient, id string) (r DeleteResult) {
 	_, r.Err = c.Delete(resourceURL(c, id), nil)
 	return
 }
+
+// Get retrieves a particular IPSec site connection based on its unique ID.
+func Get(c *gophercloud.ServiceClient, id string) (r GetResult) {
+	_, r.Err = c.Get(resourceURL(c, id), &r.Body, nil)
+	return
+}

--- a/openstack/networking/v2/extensions/vpnaas/siteconnections/results.go
+++ b/openstack/networking/v2/extensions/vpnaas/siteconnections/results.go
@@ -111,3 +111,9 @@ type CreateResult struct {
 type DeleteResult struct {
 	gophercloud.ErrResult
 }
+
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a Connection.
+type GetResult struct {
+	commonResult
+}

--- a/openstack/networking/v2/extensions/vpnaas/siteconnections/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/vpnaas/siteconnections/testing/requests_test.go
@@ -136,3 +136,80 @@ func TestDelete(t *testing.T) {
 	res := siteconnections.Delete(fake.ServiceClient(), "5c561d9d-eaea-45f6-ae3e-08d1a7080828")
 	th.AssertNoErr(t, res.Err)
 }
+
+func TestGet(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/vpn/ipsec-site-connections/5c561d9d-eaea-45f6-ae3e-08d1a7080828", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, `
+{
+    "ipsec_site_connection": {
+        "status": "PENDING_CREATE",
+        "psk": "secret",
+        "initiator": "bi-directional",
+        "name": "vpnconnection1",
+        "admin_state_up": true,
+        "project_id": "10039663455a446d8ba2cbb058b0f578",
+        "tenant_id": "10039663455a446d8ba2cbb058b0f578",
+        "auth_mode": "psk",
+        "peer_cidrs": [],
+        "mtu": 1500,
+        "peer_ep_group_id": "9ad5a7e0-6dac-41b4-b20d-a7b8645fddf1",
+        "ikepolicy_id": "9b00d6b0-6c93-4ca5-9747-b8ade7bb514f",
+        "vpnservice_id": "5c561d9d-eaea-45f6-ae3e-08d1a7080828",
+        "dpd": {
+            "action": "hold",
+            "interval": 30,
+            "timeout": 120
+        },
+        "route_mode": "static",
+        "ipsecpolicy_id": "e6e23d0c-9519-4d52-8ea4-5b1f96d857b1",
+        "local_ep_group_id": "3e1815dd-e212-43d0-8f13-b494fa553e68",
+        "peer_address": "172.24.4.233",
+        "peer_id": "172.24.4.233",
+        "id": "851f280f-5639-4ea3-81aa-e298525ab74b",
+        "description": ""
+    }
+}
+        `)
+	})
+
+	actual, err := siteconnections.Get(fake.ServiceClient(), "5c561d9d-eaea-45f6-ae3e-08d1a7080828").Extract()
+	th.AssertNoErr(t, err)
+	expectedDPD := siteconnections.DPD{
+		Action:   "hold",
+		Interval: 30,
+		Timeout:  120,
+	}
+	expected := siteconnections.Connection{
+		TenantID:       "10039663455a446d8ba2cbb058b0f578",
+		Name:           "vpnconnection1",
+		AdminStateUp:   true,
+		PSK:            "secret",
+		Initiator:      "bi-directional",
+		IPSecPolicyID:  "e6e23d0c-9519-4d52-8ea4-5b1f96d857b1",
+		MTU:            1500,
+		PeerEPGroupID:  "9ad5a7e0-6dac-41b4-b20d-a7b8645fddf1",
+		IKEPolicyID:    "9b00d6b0-6c93-4ca5-9747-b8ade7bb514f",
+		VPNServiceID:   "5c561d9d-eaea-45f6-ae3e-08d1a7080828",
+		LocalEPGroupID: "3e1815dd-e212-43d0-8f13-b494fa553e68",
+		PeerAddress:    "172.24.4.233",
+		PeerID:         "172.24.4.233",
+		Status:         "PENDING_CREATE",
+		ProjectID:      "10039663455a446d8ba2cbb058b0f578",
+		AuthMode:       "psk",
+		PeerCIDRs:      []string{},
+		DPD:            expectedDPD,
+		RouteMode:      "static",
+		ID:             "851f280f-5639-4ea3-81aa-e298525ab74b",
+		Description:    "",
+	}
+	th.AssertDeepEquals(t, expected, *actual)
+}


### PR DESCRIPTION

For #723 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/neutron-vpnaas/blob/058469e1b99b647537a5228c6a384d93df5484df/neutron_vpnaas/db/vpn/vpn_db.py#L263

I also added some documentation fixes into this PR, let me know if I should open a separate PR for this @jtopjian 
