### PR TITLE
Senlin: Webhook Trigger

### DIFF
--- a/acceptance/clients/clients.go
+++ b/acceptance/clients/clients.go
@@ -493,25 +493,6 @@ func NewLoadBalancerV2Client() (*gophercloud.ServiceClient, error) {
 	})
 }
 
-// NewClusteringV1Client returns a *ServiceClient for making calls to the
-// OpenStack Clustering v1 API. An error will be returned if authentication
-// or client creation was not possible.
-func NewClusteringV1Client() (*gophercloud.ServiceClient, error) {
-	ao, err := openstack.AuthOptionsFromEnv()
-	if err != nil {
-		return nil, err
-	}
-
-	client, err := openstack.AuthenticatedClient(ao)
-	if err != nil {
-		return nil, err
-	}
-
-	return openstack.NewClusteringV1(client, gophercloud.EndpointOpts{
-		Region: os.Getenv("OS_REGION_NAME"),
-	})
-}
-
 // NewClusteringV1Client returns a *ServiceClient for making calls
 // to the OpenStack Clustering v1 API. An error will be returned
 // if authentication or client creation was not possible.
@@ -530,4 +511,3 @@ func NewClusteringV1Client() (*gophercloud.ServiceClient, error) {
 		Region: os.Getenv("OS_REGION_NAME"),
 	})
 }
-

--- a/acceptance/clients/clients.go
+++ b/acceptance/clients/clients.go
@@ -511,3 +511,23 @@ func NewClusteringV1Client() (*gophercloud.ServiceClient, error) {
 		Region: os.Getenv("OS_REGION_NAME"),
 	})
 }
+
+// NewClusteringV1Client returns a *ServiceClient for making calls
+// to the OpenStack Clustering v1 API. An error will be returned
+// if authentication or client creation was not possible.
+func NewClusteringV1Client() (*gophercloud.ServiceClient, error) {
+	ao, err := openstack.AuthOptionsFromEnv()
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := openstack.AuthenticatedClient(ao)
+	if err != nil {
+		return nil, err
+	}
+
+	return openstack.NewClusteringV1(client, gophercloud.EndpointOpts{
+		Region: os.Getenv("OS_REGION_NAME"),
+	})
+}
+

--- a/acceptance/openstack/clustering/v1/webhooktrigger_test.go
+++ b/acceptance/openstack/clustering/v1/webhooktrigger_test.go
@@ -27,6 +27,6 @@ func TestClusteringWebhookTrigger(t *testing.T) {
 		t.Logf("Webhook trigger action id %s", actionID)
 	}
 
-	// TODO: Need to compare make sure action ID exists
+	// TODO: Need to compare to make sure action ID exists
 	th.AssertEquals(t, true, true)
 }

--- a/acceptance/openstack/clustering/v1/webhooktrigger_test.go
+++ b/acceptance/openstack/clustering/v1/webhooktrigger_test.go
@@ -1,0 +1,32 @@
+package v1
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/acceptance/clients"
+	"github.com/gophercloud/gophercloud/openstack/clustering/v1/webhooks"
+
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestClusteringWebhookTrigger(t *testing.T) {
+
+	client, err := clients.NewClusteringV1Client()
+	if err != nil {
+		t.Fatalf("Unable to create clustering client: %v", err)
+	}
+
+	// TODO: need to have cluster receiver created
+	receiverUUID := "f93f83f6-762b-41b6-b757-80507834d394"
+	actionID, err := webhooks.Trigger(client, receiverUUID, nil).Extract()
+	if err != nil {
+		// TODO: Uncomment next line once using real receiver
+		//t.Fatalf("Unable to extract webhooks trigger: %v", err)
+		t.Logf("TODO: Need to implement webhook trigger once PR receiver")
+	} else {
+		t.Logf("Webhook trigger action id %s", actionID)
+	}
+
+	// TODO: Need to compare make sure action ID exists
+	th.AssertEquals(t, true, true)
+}

--- a/openstack/clustering/v1/webhooks/doc.go
+++ b/openstack/clustering/v1/webhooks/doc.go
@@ -1,0 +1,11 @@
+/*
+Package webhooks enables triggers an action represented by a webhook from the OpenStack
+Clustering Service.
+
+Example to Trigger webhook action
+	result := webhooks.Trigger(webhookClient, "my-webhook")
+	if result.Err != nil {
+		panic(result.Err)
+	}
+*/
+package webhooks

--- a/openstack/clustering/v1/webhooks/doc.go
+++ b/openstack/clustering/v1/webhooks/doc.go
@@ -1,11 +1,12 @@
 /*
-Package webhooks enables triggers an action represented by a webhook from the OpenStack
-Clustering Service.
+Package webhooks provides the ability to trigger an action represented by a webhook from the OpenStack Clustering
+Service.
 
 Example to Trigger webhook action
-	result := webhooks.Trigger(webhookClient, "my-webhook")
-	if result.Err != nil {
-		panic(result.Err)
+
+	result, err := webhooks.Trigger(webhookClient, "f93f83f6-762b-41b6-b757-80507834d394", nil).Extract()
+	if err != nil {
+		panic(err)
 	}
 */
 package webhooks

--- a/openstack/clustering/v1/webhooks/doc.go
+++ b/openstack/clustering/v1/webhooks/doc.go
@@ -4,11 +4,12 @@ Service.
 
 Example to Trigger webhook action
 
-	result, err := webhooks.Trigger(webhookClient,
-									"f93f83f6-762b-41b6-b757-80507834d394",
-									webhooks.TriggerOpts{V: "1"}).Extract()
+	result, err := webhooks.Trigger(serviceClient(), "f93f83f6-762b-41b6-b757-80507834d394", webhooks.TriggerOpts{V: "1"}).Extract()
 	if err != nil {
 		panic(err)
 	}
+
+	fmt.Println("result", result)
+
 */
 package webhooks

--- a/openstack/clustering/v1/webhooks/doc.go
+++ b/openstack/clustering/v1/webhooks/doc.go
@@ -4,7 +4,9 @@ Service.
 
 Example to Trigger webhook action
 
-	result, err := webhooks.Trigger(webhookClient, "f93f83f6-762b-41b6-b757-80507834d394", nil).Extract()
+	result, err := webhooks.Trigger(webhookClient,
+									"f93f83f6-762b-41b6-b757-80507834d394",
+									webhooks.TriggerOpts{V: "1"}).Extract()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/clustering/v1/webhooks/requests.go
+++ b/openstack/clustering/v1/webhooks/requests.go
@@ -1,0 +1,43 @@
+package webhooks
+
+import (
+	"github.com/gophercloud/gophercloud"
+)
+
+// TriggerOpts Webhooks request parameters
+type TriggerOpts struct {
+	// V (Optional)	query	string	The webhook implementation version requested.
+	V string `q:"V, omitempty"`
+
+	// params (Optional)	query	object	The query string that forms the inputs to use for the targeted action.
+	Params string `q:"params, omitempty"`
+}
+
+// TriggerOptsBuilder Query string builder interface for webhooks
+type TriggerOptsBuilder interface {
+	ToTriggerQuery() (string, error)
+}
+
+// Query string builder for webhooks
+func (opts TriggerOpts) ToTriggerQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// Trigger an action represented by a webhook.
+func Trigger(client *gophercloud.ServiceClient, id string, opts TriggerOptsBuilder) (r TriggerResult) {
+	url := triggerURL(client, id)
+	if opts != nil {
+		query, err := opts.ToTriggerQuery()
+		if err != nil {
+			r.Err = err
+			return
+		}
+		url += query
+	}
+
+	_, r.Err = client.Post(url, nil, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200, 201, 202},
+	})
+	return
+}

--- a/openstack/clustering/v1/webhooks/requests.go
+++ b/openstack/clustering/v1/webhooks/requests.go
@@ -1,23 +1,33 @@
 package webhooks
 
 import (
+	"net/url"
+
 	"github.com/gophercloud/gophercloud"
+	"golang.org/x/crypto/openpgp/errors"
 )
 
 // TriggerOpts represents options used for triggering an action
 type TriggerOpts struct {
-	V      string `q:"V"`
-	Params string `q:"params, omitempty"`
+	V      string `q:"V,required"`
+	Params map[string]string
 }
 
 // TriggerOptsBuilder Query string builder interface for webhooks
 type TriggerOptsBuilder interface {
-	ToTriggerQuery() (string, error)
+	ToWebhookTriggerQuery() (string, error)
 }
 
 // Query string builder for webhooks
-func (opts TriggerOpts) ToTriggerQuery() (string, error) {
+func (opts TriggerOpts) ToWebhookTriggerQuery() (string, error) {
 	q, err := gophercloud.BuildQueryString(opts)
+	params := q.Query()
+
+	for k, v := range opts.Params {
+		params.Add(k, v)
+	}
+
+	q = &url.URL{RawQuery: params.Encode()}
 	return q.String(), err
 }
 
@@ -25,12 +35,15 @@ func (opts TriggerOpts) ToTriggerQuery() (string, error) {
 func Trigger(client *gophercloud.ServiceClient, id string, opts TriggerOptsBuilder) (r TriggerResult) {
 	url := triggerURL(client, id)
 	if opts != nil {
-		query, err := opts.ToTriggerQuery()
+		query, err := opts.ToWebhookTriggerQuery()
 		if err != nil {
 			r.Err = err
 			return
 		}
 		url += query
+	} else {
+		r.Err = errors.InvalidArgumentError("Must contain V for TriggerOpt")
+		return
 	}
 
 	_, r.Err = client.Post(url, nil, &r.Body, &gophercloud.RequestOpts{

--- a/openstack/clustering/v1/webhooks/requests.go
+++ b/openstack/clustering/v1/webhooks/requests.go
@@ -4,12 +4,9 @@ import (
 	"github.com/gophercloud/gophercloud"
 )
 
-// TriggerOpts Webhooks request parameters
+// TriggerOpts represents options used for triggering an action
 type TriggerOpts struct {
-	// V (Optional)	query	string	The webhook implementation version requested.
-	V string `q:"V, omitempty"`
-
-	// params (Optional)	query	object	The query string that forms the inputs to use for the targeted action.
+	V      string `q:"V"`
 	Params string `q:"params, omitempty"`
 }
 

--- a/openstack/clustering/v1/webhooks/results.go
+++ b/openstack/clustering/v1/webhooks/results.go
@@ -8,24 +8,15 @@ type commonResult struct {
 	gophercloud.Result
 }
 
-// GetResult is the response of a Get operations. Call its Extract method to
-// interpret it as a Version.
-type GetResult struct {
-	commonResult
-}
-
 type TriggerResult struct {
 	commonResult
 }
 
-// Webhook represents a detailed webhook
-type Webhook struct {
-	Action string `json:"action"`
-}
-
 // Extract retrieves the response action
 func (r commonResult) Extract() (string, error) {
-	var s *Webhook
+	var s struct {
+		Action string `json:"action"`
+	}
 	err := r.ExtractInto(&s)
 	return s.Action, err
 }

--- a/openstack/clustering/v1/webhooks/results.go
+++ b/openstack/clustering/v1/webhooks/results.go
@@ -1,0 +1,31 @@
+package webhooks
+
+import (
+	"github.com/gophercloud/gophercloud"
+)
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// GetResult is the response of a Get operations. Call its Extract method to
+// interpret it as a Version.
+type GetResult struct {
+	commonResult
+}
+
+type TriggerResult struct {
+	commonResult
+}
+
+// Webhook represents a detailed webhook
+type Webhook struct {
+	Action string `json:"action"`
+}
+
+// Extract retrieves the response action
+func (r commonResult) Extract() (string, error) {
+	var s *Webhook
+	err := r.ExtractInto(&s)
+	return s.Action, err
+}

--- a/openstack/clustering/v1/webhooks/testing/doc.go
+++ b/openstack/clustering/v1/webhooks/testing/doc.go
@@ -1,0 +1,2 @@
+// clustering_webhooks_v1
+package testing

--- a/openstack/clustering/v1/webhooks/testing/requests_test.go
+++ b/openstack/clustering/v1/webhooks/testing/requests_test.go
@@ -29,25 +29,29 @@ func TestWebhookTrigger(t *testing.T) {
 			}`)
 	})
 
-	result, err := webhooks.Trigger(fake.ServiceClient(),
-		"f93f83f6-762b-41b6-b757-80507834d394",
-		webhooks.TriggerOpts{V: "1", Params: map[string]string{"foo": "bar", "bar": "baz"}}).Extract()
-	th.AssertNoErr(t, err)
-	th.AssertEquals(t, result, "290c44fa-c60f-4d75-a0eb-87433ba982a3")
-}
-
-// Test webhook with params that generates query strings
-func TestWebhookParams(t *testing.T) {
-	to := webhooks.TriggerOpts{
+	triggerOpts := webhooks.TriggerOpts{
 		V: "1",
 		Params: map[string]string{
 			"foo": "bar",
 			"bar": "baz",
 		},
 	}
+	result, err := webhooks.Trigger(fake.ServiceClient(), "f93f83f6-762b-41b6-b757-80507834d394", triggerOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, result, "290c44fa-c60f-4d75-a0eb-87433ba982a3")
+}
 
+// Test webhook with params that generates query strings
+func TestWebhookParams(t *testing.T) {
+	triggerOpts := webhooks.TriggerOpts{
+		V: "1",
+		Params: map[string]string{
+			"foo": "bar",
+			"bar": "baz",
+		},
+	}
 	expected := "?V=1&bar=baz&foo=bar"
-	actual, err := to.ToWebhookTriggerQuery()
+	actual, err := triggerOpts.ToWebhookTriggerQuery()
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, actual, expected)
 }
@@ -70,9 +74,14 @@ func TestWebhooksInvalidAction(t *testing.T) {
 			}`)
 	})
 
-	_, err := webhooks.Trigger(fake.ServiceClient(),
-		"f93f83f6-762b-41b6-b757-80507834d394",
-		webhooks.TriggerOpts{V: "1"}).Extract()
+	triggerOpts := webhooks.TriggerOpts{
+		V: "1",
+		Params: map[string]string{
+			"foo": "bar",
+			"bar": "baz",
+		},
+	}
+	_, err := webhooks.Trigger(fake.ServiceClient(), "f93f83f6-762b-41b6-b757-80507834d394", triggerOpts).Extract()
 	isValid := err.(*json.UnmarshalTypeError) == nil
 	th.AssertEquals(t, false, isValid)
 }
@@ -95,9 +104,7 @@ func TestWebhookTriggerInvalidEmptyOpt(t *testing.T) {
 			}`)
 	})
 
-	_, err := webhooks.Trigger(fake.ServiceClient(),
-		"f93f83f6-762b-41b6-b757-80507834d394",
-		webhooks.TriggerOpts{}).Extract()
+	_, err := webhooks.Trigger(fake.ServiceClient(), "f93f83f6-762b-41b6-b757-80507834d394", webhooks.TriggerOpts{}).Extract()
 	if err == nil {
 		t.Errorf("Expected error without V param")
 	}

--- a/openstack/clustering/v1/webhooks/testing/requests_test.go
+++ b/openstack/clustering/v1/webhooks/testing/requests_test.go
@@ -34,7 +34,7 @@ func TestWebhooks(t *testing.T) {
 	th.AssertEquals(t, result, "290c44fa-c60f-4d75-a0eb-87433ba982a3")
 }
 
-// Return an invalid type of integer as action id
+// Returns invalid type (integer) for action id
 func TestWebhooksInvalidAction(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()

--- a/openstack/clustering/v1/webhooks/testing/requests_test.go
+++ b/openstack/clustering/v1/webhooks/testing/requests_test.go
@@ -1,0 +1,58 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"encoding/json"
+
+	"github.com/gophercloud/gophercloud/openstack/clustering/v1/webhooks"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	fake "github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func TestWebhooks(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, `
+			{
+				"action": "290c44fa-c60f-4d75-a0eb-87433ba982a3"
+			}`)
+	})
+
+	result, err := webhooks.Trigger(fake.ServiceClient(), "f93f83f6-762b-41b6-b757-80507834d394", webhooks.TriggerOpts{}).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, result, "290c44fa-c60f-4d75-a0eb-87433ba982a3")
+}
+
+// Return an invalid type of integer as action id
+func TestWebhooksInvalidAction(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, `
+			{
+				"action": 123
+			}`)
+	})
+
+	_, err := webhooks.Trigger(fake.ServiceClient(), "f93f83f6-762b-41b6-b757-80507834d394", webhooks.TriggerOpts{}).Extract()
+	isValid := err.(*json.UnmarshalTypeError) == nil
+	th.AssertEquals(t, false, isValid)
+}

--- a/openstack/clustering/v1/webhooks/testing/requests_test.go
+++ b/openstack/clustering/v1/webhooks/testing/requests_test.go
@@ -12,7 +12,7 @@ import (
 	fake "github.com/gophercloud/gophercloud/testhelper/client"
 )
 
-func TestWebhooks(t *testing.T) {
+func TestWebhookTrigger(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 
@@ -29,12 +29,30 @@ func TestWebhooks(t *testing.T) {
 			}`)
 	})
 
-	result, err := webhooks.Trigger(fake.ServiceClient(), "f93f83f6-762b-41b6-b757-80507834d394", webhooks.TriggerOpts{}).Extract()
+	result, err := webhooks.Trigger(fake.ServiceClient(),
+		"f93f83f6-762b-41b6-b757-80507834d394",
+		webhooks.TriggerOpts{V: "1", Params: map[string]string{"foo": "bar", "bar": "baz"}}).Extract()
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, result, "290c44fa-c60f-4d75-a0eb-87433ba982a3")
 }
 
-// Returns invalid type (integer) for action id
+// Test webhook with params that generates query strings
+func TestWebhookParams(t *testing.T) {
+	to := webhooks.TriggerOpts{
+		V: "1",
+		Params: map[string]string{
+			"foo": "bar",
+			"bar": "baz",
+		},
+	}
+
+	expected := "?V=1&bar=baz&foo=bar"
+	actual, err := to.ToWebhookTriggerQuery()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, actual, expected)
+}
+
+// Nagative test case for returning invalid type (integer) for action id
 func TestWebhooksInvalidAction(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
@@ -52,7 +70,60 @@ func TestWebhooksInvalidAction(t *testing.T) {
 			}`)
 	})
 
-	_, err := webhooks.Trigger(fake.ServiceClient(), "f93f83f6-762b-41b6-b757-80507834d394", webhooks.TriggerOpts{}).Extract()
+	_, err := webhooks.Trigger(fake.ServiceClient(),
+		"f93f83f6-762b-41b6-b757-80507834d394",
+		webhooks.TriggerOpts{V: "1"}).Extract()
 	isValid := err.(*json.UnmarshalTypeError) == nil
 	th.AssertEquals(t, false, isValid)
+}
+
+// Negative test case for passing empty TriggerOpt
+func TestWebhookTriggerInvalidEmptyOpt(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, `
+			{
+				"action": "290c44fa-c60f-4d75-a0eb-87433ba982a3"
+			}`)
+	})
+
+	_, err := webhooks.Trigger(fake.ServiceClient(),
+		"f93f83f6-762b-41b6-b757-80507834d394",
+		webhooks.TriggerOpts{}).Extract()
+	if err == nil {
+		t.Errorf("Expected error without V param")
+	}
+}
+
+// Negative test case for passing in nil for TriggerOpt
+func TestWebhookTriggerInvalidNilOpt(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, `
+			{
+				"action": "290c44fa-c60f-4d75-a0eb-87433ba982a3"
+			}`)
+	})
+
+	_, err := webhooks.Trigger(fake.ServiceClient(), "f93f83f6-762b-41b6-b757-80507834d394", nil).Extract()
+
+	if err == nil {
+		t.Errorf("Expected error with nil param")
+	}
 }

--- a/openstack/clustering/v1/webhooks/urls.go
+++ b/openstack/clustering/v1/webhooks/urls.go
@@ -1,0 +1,7 @@
+package webhooks
+
+import "github.com/gophercloud/gophercloud"
+
+func triggerURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL("v1", "webhooks", id, "trigger")
+}


### PR DESCRIPTION
Add webhooks trigger for senlin clustering

Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

For #[823 [Add support for Senlin clustering]](https://github.com/gophercloud/gophercloud/issues/823)

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

[[webhooks:trigger]](https://github.com/openstack/senlin/blob/e5bc16b3fea2f10dead365f983c5a937f23d72b0/senlin/api/openstack/v1/webhooks.py#L28)
