### PR TITLE
add 'OS-SCH-HNT:scheduler_hints' to volume CreateOpts

### DIFF
--- a/openstack/blockstorage/v2/volumes/requests.go
+++ b/openstack/blockstorage/v2/volumes/requests.go
@@ -38,12 +38,18 @@ type CreateOpts struct {
 	ImageID string `json:"imageRef,omitempty"`
 	// The associated volume type
 	VolumeType string `json:"volume_type,omitempty"`
+	// The scheduler hints
+	SchedulerHints map[string]interface{} `json:"-"`
 }
 
 // ToVolumeCreateMap assembles a request body based on the contents of a
 // CreateOpts.
 func (opts CreateOpts) ToVolumeCreateMap() (map[string]interface{}, error) {
-	return gophercloud.BuildRequestBody(opts, "volume")
+	m, err := gophercloud.BuildRequestBody(opts, "volume")
+	if err == nil && opts.SchedulerHints != nil {
+		m["OS-SCH-HNT:scheduler_hints"] = opts.SchedulerHints
+	}
+	return m, err
 }
 
 // Create will create a new Volume based on the values in CreateOpts. To extract

--- a/openstack/blockstorage/v2/volumes/testing/fixtures.go
+++ b/openstack/blockstorage/v2/volumes/testing/fixtures.go
@@ -145,6 +145,13 @@ func MockCreateResponse(t *testing.T) {
     "volume": {
     	"name": "vol-001",
         "size": 75
+    },
+    "OS-SCH-HNT:scheduler_hints": {
+         "local_to_instance": "8c19174f-4220-44f0-824a-cd1eeef102ff",
+         "same_host": [
+             "a0cf03a5-d921-4877-bb5c-86d26cf818e1",
+             "8c19174f-4220-44f0-824a-cd1eeef10287"
+         ]
     }
 }
       `)

--- a/openstack/blockstorage/v2/volumes/testing/requests_test.go
+++ b/openstack/blockstorage/v2/volumes/testing/requests_test.go
@@ -206,7 +206,18 @@ func TestCreate(t *testing.T) {
 
 	MockCreateResponse(t)
 
-	options := &volumes.CreateOpts{Size: 75, Name: "vol-001"}
+	h := map[string]interface{}{
+		"same_host": []string{
+			"a0cf03a5-d921-4877-bb5c-86d26cf818e1",
+			"8c19174f-4220-44f0-824a-cd1eeef10287",
+		},
+		"local_to_instance": "8c19174f-4220-44f0-824a-cd1eeef102ff",
+	}
+	options := &volumes.CreateOpts{
+		Size:           75,
+		Name:           "vol-001",
+		SchedulerHints: h,
+	}
 	n, err := volumes.Create(client.ServiceClient(), options).Extract()
 	th.AssertNoErr(t, err)
 

--- a/openstack/blockstorage/v3/volumes/requests.go
+++ b/openstack/blockstorage/v3/volumes/requests.go
@@ -38,12 +38,18 @@ type CreateOpts struct {
 	ImageID string `json:"imageRef,omitempty"`
 	// The associated volume type
 	VolumeType string `json:"volume_type,omitempty"`
+	// The scheduler hints
+	SchedulerHints map[string]interface{} `json:"-"`
 }
 
 // ToVolumeCreateMap assembles a request body based on the contents of a
 // CreateOpts.
 func (opts CreateOpts) ToVolumeCreateMap() (map[string]interface{}, error) {
-	return gophercloud.BuildRequestBody(opts, "volume")
+	m, err := gophercloud.BuildRequestBody(opts, "volume")
+	if err == nil && opts.SchedulerHints != nil {
+		m["OS-SCH-HNT:scheduler_hints"] = opts.SchedulerHints
+	}
+	return m, err
 }
 
 // Create will create a new Volume based on the values in CreateOpts. To extract

--- a/openstack/blockstorage/v3/volumes/testing/fixtures.go
+++ b/openstack/blockstorage/v3/volumes/testing/fixtures.go
@@ -159,6 +159,13 @@ func MockCreateResponse(t *testing.T) {
     "volume": {
     	"name": "vol-001",
         "size": 75
+    },
+    "OS-SCH-HNT:scheduler_hints": {
+         "local_to_instance": "8c19174f-4220-44f0-824a-cd1eeef102ff",
+         "same_host": [
+             "a0cf03a5-d921-4877-bb5c-86d26cf818e1",
+             "8c19174f-4220-44f0-824a-cd1eeef10287"
+         ]
     }
 }
       `)

--- a/openstack/blockstorage/v3/volumes/testing/requests_test.go
+++ b/openstack/blockstorage/v3/volumes/testing/requests_test.go
@@ -206,7 +206,18 @@ func TestCreate(t *testing.T) {
 
 	MockCreateResponse(t)
 
-	options := &volumes.CreateOpts{Size: 75, Name: "vol-001"}
+	h := map[string]interface{}{
+		"same_host": []string{
+			"a0cf03a5-d921-4877-bb5c-86d26cf818e1",
+			"8c19174f-4220-44f0-824a-cd1eeef10287",
+		},
+		"local_to_instance": "8c19174f-4220-44f0-824a-cd1eeef102ff",
+	}
+	options := &volumes.CreateOpts{
+		Size:           75,
+		Name:           "vol-001",
+		SchedulerHints: h,
+	}
 	n, err := volumes.Create(client.ServiceClient(), options).Extract()
 	th.AssertNoErr(t, err)
 


### PR DESCRIPTION
For #827 

The relevant codes in Openstack/Cinder
https://github.com/openstack/cinder/blob/master/cinder/scheduler/filters/affinity_filter.py#L39-L67

https://github.com/openstack/cinder/blob/master/cinder/scheduler/filters/affinity_filter.py#L75-L101

https://github.com/openstack/cinder/blob/master/cinder/scheduler/filters/instance_locality_filter.py#L76-L120
