### PR TITLE
LBaaS v2 l7 policy support - part 4: delete l7policy

### DIFF
--- a/acceptance/openstack/loadbalancer/v2/loadbalancer.go
+++ b/acceptance/openstack/loadbalancer/v2/loadbalancer.go
@@ -202,6 +202,23 @@ func CreateL7Policy(t *testing.T, client *gophercloud.ServiceClient, listener *l
 	return policy, nil
 }
 
+// DeleteL7Policy will delete a specified l7 policy. A fatal error will occur if
+// the l7 policy could not be deleted. This works best when used as a deferred
+// function.
+func DeleteL7Policy(t *testing.T, client *gophercloud.ServiceClient, lbID, policyID string) {
+	t.Logf("Attempting to delete l7 policy %s", policyID)
+
+	if err := l7policies.Delete(client, policyID).ExtractErr(); err != nil {
+		t.Fatalf("Unable to delete l7 policy: %v", err)
+	}
+
+	if err := WaitForLoadBalancerState(client, lbID, "ACTIVE", loadbalancerActiveTimeoutSeconds); err != nil {
+		t.Fatalf("Timed out waiting for loadbalancer to become active")
+	}
+
+	t.Logf("Successfully deleted l7 policy %s", policyID)
+}
+
 // DeleteListener will delete a specified listener. A fatal error will occur if
 // the listener could not be deleted. This works best when used as a deferred
 // function.

--- a/acceptance/openstack/loadbalancer/v2/loadbalancers_test.go
+++ b/acceptance/openstack/loadbalancer/v2/loadbalancers_test.go
@@ -106,6 +106,7 @@ func TestLoadbalancersCRUD(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to create l7 policy: %v", err)
 	}
+	defer DeleteL7Policy(t, lbClient, policy.ID)
 
 	newPolicy, err := l7policies.Get(lbClient, policy.ID).Extract()
 	if err != nil {

--- a/acceptance/openstack/loadbalancer/v2/loadbalancers_test.go
+++ b/acceptance/openstack/loadbalancer/v2/loadbalancers_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gophercloud/gophercloud/acceptance/clients"
 	networking "github.com/gophercloud/gophercloud/acceptance/openstack/networking/v2"
 	"github.com/gophercloud/gophercloud/acceptance/tools"
+	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/l7policies"
 	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/listeners"
 	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/loadbalancers"
 	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/monitors"
@@ -101,10 +102,17 @@ func TestLoadbalancersCRUD(t *testing.T) {
 	tools.PrintResource(t, newListener)
 
 	// L7 policy
-	_, err = CreateL7Policy(t, lbClient, listener, lb)
+	policy, err := CreateL7Policy(t, lbClient, listener, lb)
 	if err != nil {
 		t.Fatalf("Unable to create l7 policy: %v", err)
 	}
+
+	newPolicy, err := l7policies.Get(lbClient, policy.ID).Extract()
+	if err != nil {
+		t.Fatalf("Unable to get l7 policy: %v", err)
+	}
+
+	tools.PrintResource(t, newPolicy)
 
 	// Pool
 	pool, err := CreatePool(t, lbClient, lb)

--- a/acceptance/openstack/loadbalancer/v2/loadbalancers_test.go
+++ b/acceptance/openstack/loadbalancer/v2/loadbalancers_test.go
@@ -106,7 +106,7 @@ func TestLoadbalancersCRUD(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to create l7 policy: %v", err)
 	}
-	defer DeleteL7Policy(t, lbClient, policy.ID)
+	defer DeleteL7Policy(t, lbClient, lb.ID, policy.ID)
 
 	newPolicy, err := l7policies.Get(lbClient, policy.ID).Extract()
 	if err != nil {

--- a/openstack/loadbalancer/v2/l7policies/doc.go
+++ b/openstack/loadbalancer/v2/l7policies/doc.go
@@ -38,5 +38,13 @@ Example to Get a L7Policy
 	if err != nil {
 		panic(err)
 	}
+
+Example to Delete a L7Policy
+
+	l7policyID := "d67d56a6-4a86-4688-a282-f46444705c64"
+	err := l7policies.Delete(lbClient, l7policyID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
 */
 package l7policies

--- a/openstack/loadbalancer/v2/l7policies/doc.go
+++ b/openstack/loadbalancer/v2/l7policies/doc.go
@@ -1,23 +1,26 @@
 /*
 Package l7policies provides information and interaction with L7Policies and
 Rules of the LBaaS v2 extension for the OpenStack Networking service.
+
 Example to Create a L7Policy
+
 	createOpts := l7policies.CreateOpts{
 		Name:        "redirect-example.com",
 		ListenerID:  "023f2e34-7806-443b-bfae-16c324569a3d",
 		Action:      l7policies.ActionRedirectToURL,
 		RedirectURL: "http://www.example.com",
 	}
-	l7policy, err := l7policies.Create(networkClient, createOpts).Extract()
+	l7policy, err := l7policies.Create(lbClient, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
 
 Example to List L7Policies
+
 	listOpts := l7policies.ListOpts{
 		ListenerID: "c79a4468-d788-410c-bf79-9a8ef6354852",
 	}
-	allPages, err := l7policies.List(networkClient, listOpts).AllPages()
+	allPages, err := l7policies.List(lbClient, listOpts).AllPages()
 	if err != nil {
 		panic(err)
 	}
@@ -27,6 +30,13 @@ Example to List L7Policies
 	}
 	for _, l7policy := range allL7Policies {
 		fmt.Printf("%+v\n", l7policy)
+	}
+
+Example to Get a L7Policy
+
+	l7policy, err := l7policies.Get(lbClient, "023f2e34-7806-443b-bfae-16c324569a3d").Extract()
+	if err != nil {
+		panic(err)
 	}
 */
 package l7policies

--- a/openstack/loadbalancer/v2/l7policies/requests.go
+++ b/openstack/loadbalancer/v2/l7policies/requests.go
@@ -131,3 +131,9 @@ func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 		return L7PolicyPage{pagination.LinkedPageBase{PageResult: r}}
 	})
 }
+
+// Get retrieves a particular l7policy based on its unique ID.
+func Get(c *gophercloud.ServiceClient, id string) (r GetResult) {
+	_, r.Err = c.Get(resourceURL(c, id), &r.Body, nil)
+	return
+}

--- a/openstack/loadbalancer/v2/l7policies/requests.go
+++ b/openstack/loadbalancer/v2/l7policies/requests.go
@@ -137,3 +137,9 @@ func Get(c *gophercloud.ServiceClient, id string) (r GetResult) {
 	_, r.Err = c.Get(resourceURL(c, id), &r.Body, nil)
 	return
 }
+
+// Delete will permanently delete a particular l7policy based on its unique ID.
+func Delete(c *gophercloud.ServiceClient, id string) (r DeleteResult) {
+	_, r.Err = c.Delete(resourceURL(c, id), nil)
+	return
+}

--- a/openstack/loadbalancer/v2/l7policies/results.go
+++ b/openstack/loadbalancer/v2/l7policies/results.go
@@ -129,3 +129,9 @@ func ExtractL7Policies(r pagination.Page) ([]L7Policy, error) {
 	err := (r.(L7PolicyPage)).ExtractInto(&s)
 	return s.L7Policies, err
 }
+
+// GetResult represents the result of a Get operation. Call its Extract
+// method to interpret the result as a L7Policy.
+type GetResult struct {
+	commonResult
+}

--- a/openstack/loadbalancer/v2/l7policies/results.go
+++ b/openstack/loadbalancer/v2/l7policies/results.go
@@ -135,3 +135,9 @@ func ExtractL7Policies(r pagination.Page) ([]L7Policy, error) {
 type GetResult struct {
 	commonResult
 }
+
+// DeleteResult represents the result of a Delete operation. Call its
+// ExtractErr method to determine if the request succeeded or failed.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}

--- a/openstack/loadbalancer/v2/l7policies/testing/fixtures.go
+++ b/openstack/loadbalancer/v2/l7policies/testing/fixtures.go
@@ -131,3 +131,14 @@ func HandleL7PolicyListSuccessfully(t *testing.T) {
 		}
 	})
 }
+
+// HandleL7PolicyGetSuccessfully sets up the test server to respond to a l7policy Get request.
+func HandleL7PolicyGetSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/v2.0/lbaas/l7policies/8a1412f0-4c32-4257-8b07-af4770b604fd", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+
+		fmt.Fprintf(w, SingleL7PolicyBody)
+	})
+}

--- a/openstack/loadbalancer/v2/l7policies/testing/fixtures.go
+++ b/openstack/loadbalancer/v2/l7policies/testing/fixtures.go
@@ -142,3 +142,13 @@ func HandleL7PolicyGetSuccessfully(t *testing.T) {
 		fmt.Fprintf(w, SingleL7PolicyBody)
 	})
 }
+
+// HandleL7PolicyDeletionSuccessfully sets up the test server to respond to a l7policy deletion request.
+func HandleL7PolicyDeletionSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/v2.0/lbaas/l7policies/8a1412f0-4c32-4257-8b07-af4770b604fd", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.WriteHeader(http.StatusNoContent)
+	})
+}

--- a/openstack/loadbalancer/v2/l7policies/testing/requests_test.go
+++ b/openstack/loadbalancer/v2/l7policies/testing/requests_test.go
@@ -84,3 +84,17 @@ func TestListAllL7Policies(t *testing.T) {
 	th.CheckDeepEquals(t, L7PolicyToURL, actual[0])
 	th.CheckDeepEquals(t, L7PolicyToPool, actual[1])
 }
+
+func TestGetL7Policy(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleL7PolicyGetSuccessfully(t)
+
+	client := fake.ServiceClient()
+	actual, err := l7policies.Get(client, "8a1412f0-4c32-4257-8b07-af4770b604fd").Extract()
+	if err != nil {
+		t.Fatalf("Unexpected Get error: %v", err)
+	}
+
+	th.CheckDeepEquals(t, L7PolicyToURL, *actual)
+}

--- a/openstack/loadbalancer/v2/l7policies/testing/requests_test.go
+++ b/openstack/loadbalancer/v2/l7policies/testing/requests_test.go
@@ -98,3 +98,12 @@ func TestGetL7Policy(t *testing.T) {
 
 	th.CheckDeepEquals(t, L7PolicyToURL, *actual)
 }
+
+func TestDeleteL7Policy(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleL7PolicyDeletionSuccessfully(t)
+
+	res := l7policies.Delete(fake.ServiceClient(), "8a1412f0-4c32-4257-8b07-af4770b604fd")
+	th.AssertNoErr(t, res.Err)
+}

--- a/openstack/loadbalancer/v2/l7policies/urls.go
+++ b/openstack/loadbalancer/v2/l7policies/urls.go
@@ -10,3 +10,7 @@ const (
 func rootURL(c *gophercloud.ServiceClient) string {
 	return c.ServiceURL(rootPath, resourcePath)
 }
+
+func resourceURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL(rootPath, resourcePath, id)
+}


### PR DESCRIPTION
For #832

Neutron-LBaaS l7 policy delete API implementation:
https://github.com/openstack/neutron-lbaas/blob/8e8a6c47c7d38fa7b61850ff9ea2cf130718ded3/neutron_lbaas/services/loadbalancer/plugin.py#L954

Octavia l7 policy delete API implementation:
https://github.com/openstack/octavia/blob/54a4cf00cf304b108013ca4487c138c13f30983d/octavia/api/v2/controllers/l7policy.py#L253