### PR TITLE
Identity V3: Change user password

### DIFF
--- a/openstack/identity/v3/users/doc.go
+++ b/openstack/identity/v3/users/doc.go
@@ -65,7 +65,7 @@ Example to Change Password of a User
 		Password:         password,
 	}
 
-	user, err := users.ChangePassword(identityClient, userID, changePasswordOpts).ExtractErr()
+	err := users.ChangePassword(identityClient, userID, changePasswordOpts).ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/identity/v3/users/doc.go
+++ b/openstack/identity/v3/users/doc.go
@@ -60,12 +60,12 @@ Example to Change Password of a User
 	originalPassword := "secretsecret"
 	password := "new_secretsecret"
 
-	chpwdOpts := users.ChpwdOpts{
+	changePasswordOpts := users.ChangePasswordOpts{
 		OriginalPassword: originalPassword,
 		Password:         password,
 	}
 
-	user, err := users.ChangePassword(identityClient, userID, chpwdOpts).ExtractErr()
+	user, err := users.ChangePassword(identityClient, userID, changePasswordOpts).ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/identity/v3/users/doc.go
+++ b/openstack/identity/v3/users/doc.go
@@ -54,6 +54,22 @@ Example to Update a User
 		panic(err)
 	}
 
+Example to Change Password of a User
+
+	userID := "0fe36e73809d46aeae6705c39077b1b3"
+	originalPassword := "secretsecret"
+	password := "new_secretsecret"
+
+	chpwdOpts := users.ChpwdOpts{
+		OriginalPassword: originalPassword,
+		Password:         password,
+	}
+
+	user, err := users.ChangePassword(identityClient, userID, chpwdOpts).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+
 Example to Delete a User
 
 	userID := "0fe36e73809d46aeae6705c39077b1b3"

--- a/openstack/identity/v3/users/requests.go
+++ b/openstack/identity/v3/users/requests.go
@@ -204,14 +204,14 @@ func Update(client *gophercloud.ServiceClient, userID string, opts UpdateOptsBui
 	return
 }
 
-// ChpwdOptsBuilder allows extensions to add additional parameters to
+// ChangePasswordOptsBuilder allows extensions to add additional parameters to
 // the ChangePassword request.
-type ChpwdOptsBuilder interface {
-	ToUserChpwdMap() (map[string]interface{}, error)
+type ChangePasswordOptsBuilder interface {
+	ToUserChangePasswordMap() (map[string]interface{}, error)
 }
 
-// ChpwdOpts provides options for changing password for a user.
-type ChpwdOpts struct {
+// ChangePasswordOpts provides options for changing password for a user.
+type ChangePasswordOpts struct {
 	// OriginalPassword is the original password of the user.
 	OriginalPassword string `json:"original_password,omitempty"`
 
@@ -219,8 +219,8 @@ type ChpwdOpts struct {
 	Password string `json:"password,omitempty"`
 }
 
-// ToUserChpwdMap formats a ChpwdOpts into a ChangePassword request.
-func (opts ChpwdOpts) ToUserChpwdMap() (map[string]interface{}, error) {
+// ToUserChangePasswordMap formats a ChangePasswordOpts into a ChangePassword request.
+func (opts ChangePasswordOpts) ToUserChangePasswordMap() (map[string]interface{}, error) {
 	b, err := gophercloud.BuildRequestBody(opts, "user")
 	if err != nil {
 		return nil, err
@@ -230,8 +230,8 @@ func (opts ChpwdOpts) ToUserChpwdMap() (map[string]interface{}, error) {
 }
 
 // ChangePassword changes password for a user.
-func ChangePassword(client *gophercloud.ServiceClient, userID string, opts ChpwdOptsBuilder) (r ChpwdResult) {
-	b, err := opts.ToUserChpwdMap()
+func ChangePassword(client *gophercloud.ServiceClient, userID string, opts ChangePasswordOptsBuilder) (r ChangePasswordResult) {
+	b, err := opts.ToUserChangePasswordMap()
 	if err != nil {
 		r.Err = err
 		return

--- a/openstack/identity/v3/users/requests.go
+++ b/openstack/identity/v3/users/requests.go
@@ -213,10 +213,10 @@ type ChangePasswordOptsBuilder interface {
 // ChangePasswordOpts provides options for changing password for a user.
 type ChangePasswordOpts struct {
 	// OriginalPassword is the original password of the user.
-	OriginalPassword string `json:"original_password,omitempty"`
+	OriginalPassword string `json:"original_password"`
 
 	// Password is the new password of the user.
-	Password string `json:"password,omitempty"`
+	Password string `json:"password"`
 }
 
 // ToUserChangePasswordMap formats a ChangePasswordOpts into a ChangePassword request.

--- a/openstack/identity/v3/users/requests.go
+++ b/openstack/identity/v3/users/requests.go
@@ -204,6 +204,45 @@ func Update(client *gophercloud.ServiceClient, userID string, opts UpdateOptsBui
 	return
 }
 
+// ChpwdOptsBuilder allows extensions to add additional parameters to
+// the ChangePassword request.
+type ChpwdOptsBuilder interface {
+	ToUserChpwdMap() (map[string]interface{}, error)
+}
+
+// ChpwdOpts provides options for changing password for a user.
+type ChpwdOpts struct {
+	// OriginalPassword is the original password of the user.
+	OriginalPassword string `json:"original_password,omitempty"`
+
+	// Password is the new password of the user.
+	Password string `json:"password,omitempty"`
+}
+
+// ToUserChpwdMap formats a ChpwdOpts into a ChangePassword request.
+func (opts ChpwdOpts) ToUserChpwdMap() (map[string]interface{}, error) {
+	b, err := gophercloud.BuildRequestBody(opts, "user")
+	if err != nil {
+		return nil, err
+	}
+
+	return b, nil
+}
+
+// ChangePassword changes password for a user.
+func ChangePassword(client *gophercloud.ServiceClient, userID string, opts ChpwdOptsBuilder) (r ChpwdResult) {
+	b, err := opts.ToUserChpwdMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = client.Post(changePasswordURL(client, userID), &b, nil, &gophercloud.RequestOpts{
+		OkCodes: []int{204},
+	})
+	return
+}
+
 // Delete deletes a user.
 func Delete(client *gophercloud.ServiceClient, userID string) (r DeleteResult) {
 	_, r.Err = client.Delete(deleteURL(client, userID), nil)

--- a/openstack/identity/v3/users/results.go
+++ b/openstack/identity/v3/users/results.go
@@ -98,9 +98,9 @@ type UpdateResult struct {
 	userResult
 }
 
-// ChpwdResult is the response from a ChangePassword operation. Call its
+// ChangePasswordResult is the response from a ChangePassword operation. Call its
 // ExtractErr method to determine if the request succeeded or failed.
-type ChpwdResult struct {
+type ChangePasswordResult struct {
 	gophercloud.ErrResult
 }
 

--- a/openstack/identity/v3/users/results.go
+++ b/openstack/identity/v3/users/results.go
@@ -98,6 +98,12 @@ type UpdateResult struct {
 	userResult
 }
 
+// ChpwdResult is the response from a ChangePassword operation. Call its
+// ExtractErr method to determine if the request succeeded or failed.
+type ChpwdResult struct {
+	gophercloud.ErrResult
+}
+
 // DeleteResult is the response from a Delete operation. Call its ExtractErr to
 // determine if the request succeeded or failed.
 type DeleteResult struct {

--- a/openstack/identity/v3/users/testing/fixtures.go
+++ b/openstack/identity/v3/users/testing/fixtures.go
@@ -129,7 +129,7 @@ const CreateNoOptionsRequest = `
 }
 `
 
-// UpdateRequest provides the input to as Update request.
+// UpdateRequest provides the input to an Update request.
 const UpdateRequest = `
 {
     "user": {
@@ -160,6 +160,16 @@ const UpdateOutput = `
         "options": {
             "ignore_password_expiry": true
         }
+    }
+}
+`
+
+// ChangePasswordRequest provides the input to a ChangePassword request.
+const ChangePasswordRequest = `
+{
+    "user": {
+        "password": "new_secretsecret",
+        "original_password": "secretsecret"
     }
 }
 `
@@ -420,6 +430,18 @@ func HandleUpdateUserSuccessfully(t *testing.T) {
 
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprintf(w, UpdateOutput)
+	})
+}
+
+// HandleChangeUserPasswordSuccessfully creates an HTTP handler at `/users` on the
+// test handler mux that tests change user password.
+func HandleChangeUserPasswordSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/users/9fe1d3/password", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, ChangePasswordRequest)
+
+		w.WriteHeader(http.StatusNoContent)
 	})
 }
 

--- a/openstack/identity/v3/users/testing/requests_test.go
+++ b/openstack/identity/v3/users/testing/requests_test.go
@@ -128,6 +128,20 @@ func TestUpdateUser(t *testing.T) {
 	th.CheckDeepEquals(t, SecondUserUpdated, *actual)
 }
 
+func TestChangeUserPassword(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleChangeUserPasswordSuccessfully(t)
+
+	chpwdOpts := users.ChpwdOpts{
+		OriginalPassword: "secretsecret",
+		Password:         "new_secretsecret",
+	}
+
+	res := users.ChangePassword(client.ServiceClient(), "9fe1d3", chpwdOpts)
+	th.AssertNoErr(t, res.Err)
+}
+
 func TestDeleteUser(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()

--- a/openstack/identity/v3/users/testing/requests_test.go
+++ b/openstack/identity/v3/users/testing/requests_test.go
@@ -133,12 +133,12 @@ func TestChangeUserPassword(t *testing.T) {
 	defer th.TeardownHTTP()
 	HandleChangeUserPasswordSuccessfully(t)
 
-	chpwdOpts := users.ChpwdOpts{
+	changePasswordOpts := users.ChangePasswordOpts{
 		OriginalPassword: "secretsecret",
 		Password:         "new_secretsecret",
 	}
 
-	res := users.ChangePassword(client.ServiceClient(), "9fe1d3", chpwdOpts)
+	res := users.ChangePassword(client.ServiceClient(), "9fe1d3", changePasswordOpts)
 	th.AssertNoErr(t, res.Err)
 }
 

--- a/openstack/identity/v3/users/urls.go
+++ b/openstack/identity/v3/users/urls.go
@@ -18,6 +18,10 @@ func updateURL(client *gophercloud.ServiceClient, userID string) string {
 	return client.ServiceURL("users", userID)
 }
 
+func changePasswordURL(client *gophercloud.ServiceClient, userID string) string {
+	return client.ServiceURL("users", userID, "password")
+}
+
 func deleteURL(client *gophercloud.ServiceClient, userID string) string {
 	return client.ServiceURL("users", userID)
 }


### PR DESCRIPTION
For #862

API reference:
[Identity API v3 - Change password for user](https://developer.openstack.org/api-ref/identity/v3/index.html#change-password-for-user)

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:
https://github.com/openstack/keystone/blob/a6adc72e3e7ff4ff0bff0702e69ebd8f697d6261/keystone/identity/routers.py#L31
https://github.com/openstack/keystone/blob/a6adc72e3e7ff4ff0bff0702e69ebd8f697d6261/keystone/identity/core.py#L1381
https://github.com/openstack/python-keystoneclient/blob/40642d597deecce4dd81428449353bbd0c2ad5be/keystoneclient/v3/users.py#L203
