### PR TITLE
Identity V3: add user to group

### DIFF
--- a/acceptance/openstack/identity/v3/users_test.go
+++ b/acceptance/openstack/identity/v3/users_test.go
@@ -186,17 +186,23 @@ func TestUserAddToGroup(t *testing.T) {
 	tools.PrintResource(t, user)
 	tools.PrintResource(t, user.Extra)
 
-	allGroupPages, err := groups.List(client, nil).AllPages()
-	if err != nil {
-		t.Fatalf("Unable to list groups: %v", err)
+	createGroupOpts := groups.CreateOpts{
+		Name:     "testgroup",
+		DomainID: "default",
+		Extra: map[string]interface{}{
+			"email": "testgroup@example.com",
+		},
 	}
 
-	allGroups, err := groups.ExtractGroups(allGroupPages)
+	// Create Group in the default domain
+	group, err := CreateGroup(t, client, &createGroupOpts)
 	if err != nil {
-		t.Fatalf("Unable to extract groups: %v", err)
+		t.Fatalf("Unable to create group: %v", err)
 	}
+	defer DeleteGroup(t, client, group.ID)
 
-	group := allGroups[0]
+	tools.PrintResource(t, group)
+	tools.PrintResource(t, group.Extra)
 
 	err = users.AddToGroup(client, group.ID, user.ID).ExtractErr()
 	if err != nil {

--- a/openstack/identity/v3/users/doc.go
+++ b/openstack/identity/v3/users/doc.go
@@ -80,6 +80,16 @@ Example to List Groups a User Belongs To
 		fmt.Printf("%+v\n", group)
 	}
 
+Example to Add a User to a Group
+
+	groupID := "bede500ee1124ae9b0006ff859758b3a"
+	userID := "0fe36e73809d46aeae6705c39077b1b3"
+	err := users.AddToGroup(identityClient, groupID, userID).ExtractErr()
+
+	if err != nil {
+		panic(err)
+	}
+
 Example to List Projects a User Belongs To
 
 	userID := "0fe36e73809d46aeae6705c39077b1b3"

--- a/openstack/identity/v3/users/requests.go
+++ b/openstack/identity/v3/users/requests.go
@@ -218,6 +218,15 @@ func ListGroups(client *gophercloud.ServiceClient, userID string) pagination.Pag
 	})
 }
 
+// AddToGroup adds a user to a group.
+func AddToGroup(client *gophercloud.ServiceClient, groupID, userID string) (r AddToGroupResult) {
+	url := addToGroupURL(client, groupID, userID)
+	_, r.Err = client.Put(url, nil, nil, &gophercloud.RequestOpts{
+		OkCodes: []int{204},
+	})
+	return
+}
+
 // ListProjects enumerates groups user belongs to.
 func ListProjects(client *gophercloud.ServiceClient, userID string) pagination.Pager {
 	url := listProjectsURL(client, userID)

--- a/openstack/identity/v3/users/results.go
+++ b/openstack/identity/v3/users/results.go
@@ -104,6 +104,12 @@ type DeleteResult struct {
 	gophercloud.ErrResult
 }
 
+// AddToGroupResult is the response from a AddToGroup operation. Call its
+// ExtractErr method to determine if the request succeeded or failed.
+type AddToGroupResult struct {
+	gophercloud.ErrResult
+}
+
 // UserPage is a single page of User results.
 type UserPage struct {
 	pagination.LinkedPageBase

--- a/openstack/identity/v3/users/testing/fixtures.go
+++ b/openstack/identity/v3/users/testing/fixtures.go
@@ -448,6 +448,17 @@ func HandleListUserGroupsSuccessfully(t *testing.T) {
 	})
 }
 
+// HandleAddToGroupSuccessfully creates an HTTP handler at /groups/{groupID}/users/{userID}
+// on the test handler mux that tests adding user to group.
+func HandleAddToGroupSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/groups/ea167b/users/9fe1d3", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.WriteHeader(http.StatusNoContent)
+	})
+}
+
 // HandleListUserProjectsSuccessfully creates an HTTP handler at /users/{userID}/projects
 // on the test handler mux that respons wit a list of two projects
 func HandleListUserProjectsSuccessfully(t *testing.T) {

--- a/openstack/identity/v3/users/testing/requests_test.go
+++ b/openstack/identity/v3/users/testing/requests_test.go
@@ -148,6 +148,14 @@ func TestListUserGroups(t *testing.T) {
 	th.CheckDeepEquals(t, ExpectedGroupsSlice, actual)
 }
 
+func TestAddToGroup(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleAddToGroupSuccessfully(t)
+	res := users.AddToGroup(client.ServiceClient(), "ea167b", "9fe1d3")
+	th.AssertNoErr(t, res.Err)
+}
+
 func TestListUserProjects(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()

--- a/openstack/identity/v3/users/urls.go
+++ b/openstack/identity/v3/users/urls.go
@@ -26,6 +26,10 @@ func listGroupsURL(client *gophercloud.ServiceClient, userID string) string {
 	return client.ServiceURL("users", userID, "groups")
 }
 
+func addToGroupURL(client *gophercloud.ServiceClient, groupID, userID string) string {
+	return client.ServiceURL("groups", groupID, "users", userID)
+}
+
 func listProjectsURL(client *gophercloud.ServiceClient, userID string) string {
 	return client.ServiceURL("users", userID, "projects")
 }


### PR DESCRIPTION
For #866

API reference:
[Identity API v3 - Add user to group](https://developer.openstack.org/api-ref/identity/v3/#add-user-to-group)

Python source code:
https://github.com/openstack/keystone/blob/a6adc72e3e7ff4ff0bff0702e69ebd8f697d6261/keystone/identity/routers.py#L49
https://github.com/openstack/keystone/blob/a6adc72e3e7ff4ff0bff0702e69ebd8f697d6261/keystone/identity/core.py#L1248
https://github.com/openstack/python-keystoneclient/blob/40642d597deecce4dd81428449353bbd0c2ad5be/keystoneclient/v3/users.py#L228

