### PR TITLE
Support acceptance test against OpenStack Queens release in OpenLab

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -7,6 +7,15 @@
     recheck-mitaka:
       jobs:
         - gophercloud-acceptance-test-mitaka
+    recheck-newton:
+      jobs:
+        - gophercloud-acceptance-test-newton
+    recheck-ocata:
+      jobs:
+        - gophercloud-acceptance-test-ocata
     recheck-pike:
       jobs:
         - gophercloud-acceptance-test-pike
+    recheck-queens:
+      jobs:
+        - gophercloud-acceptance-test-queens


### PR DESCRIPTION
Input comment "recheck stable/queens" in pull request comments, that
will trigger acceptance tests against OpenStack Queens release. OpenLab
will report test result in followint comments automatically.

And add support for Newton and Ocata release
- "recheck stable/newton" -> test against OpenStack Newton release
- "recheck stable/ocata" -> test against OpenStack Ocata release

Related-Bug: theopenlab/openlab#38