### PR TITLE
Senlin: Profiles Create

### DIFF
--- a/acceptance/openstack/clustering/v1/autoscaling_test.go
+++ b/acceptance/openstack/clustering/v1/autoscaling_test.go
@@ -51,7 +51,13 @@ func profileCreate(t *testing.T) {
 		},
 	}
 
-	profile, err := profiles.Create(client, optsProfile).Extract()
+	createResult := profiles.Create(client, optsProfile)
+	th.AssertNoErr(t, createResult.Err)
+
+	requestID := createResult.Header.Get("X-OpenStack-Request-Id")
+	th.AssertEquals(t, true, requestID != "")
+
+	profile, err := createResult.Extract()
 	if err != nil {
 		t.Fatalf("Unable to create profile %s: %v", profileName, err)
 	} else {

--- a/acceptance/openstack/clustering/v1/autoscaling_test.go
+++ b/acceptance/openstack/clustering/v1/autoscaling_test.go
@@ -29,7 +29,7 @@ func profileCreate(t *testing.T) {
 		{"network": "sandbox-internal-net"},
 	}
 
-	props := &map[string]interface{}{
+	props := map[string]interface{}{
 		"name":            "centos-server",
 		"flavor":          "t2.micro",
 		"image":           "centos7.3-latest",
@@ -44,10 +44,10 @@ func profileCreate(t *testing.T) {
 			"test": "123",
 		},
 		Name: profileName,
-		Spec: map[string]interface{}{
-			"type":       "os.nova.server",
-			"version":    "1.0",
-			"properties": props,
+		Spec: profiles.Spec{
+			Type:       "os.nova.server",
+			Version:    "1.0",
+			Properties: props,
 		},
 	}
 
@@ -59,6 +59,6 @@ func profileCreate(t *testing.T) {
 	}
 
 	th.AssertEquals(t, profileName, profile.Name)
-	th.AssertEquals(t, "os.nova.server", (map[string]interface{})(profile.Spec)["type"])
-	th.AssertEquals(t, "1.0", (map[string]interface{})(profile.Spec)["version"])
+	th.AssertEquals(t, "os.nova.server", profile.Spec.Type)
+	th.AssertEquals(t, "1.0", profile.Spec.Version)
 }

--- a/acceptance/openstack/clustering/v1/autoscaling_test.go
+++ b/acceptance/openstack/clustering/v1/autoscaling_test.go
@@ -1,0 +1,62 @@
+package v1
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/acceptance/clients"
+	"github.com/gophercloud/gophercloud/openstack/clustering/v1/profiles"
+
+	"github.com/gophercloud/gophercloud/acceptance/tools"
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+var testName string
+
+func TestAutoScaling(t *testing.T) {
+	testName = tools.RandomString("TESTACC-", 8)
+	profileCreate(t)
+}
+
+func profileCreate(t *testing.T) {
+	client, err := clients.NewClusteringV1Client()
+	if err != nil {
+		t.Fatalf("Unable to create clustering client: %v", err)
+	}
+
+	networks := []map[string]interface{}{
+		{"network": "sandbox-internal-net"},
+	}
+
+	props := &map[string]interface{}{
+		"name":            "centos-server",
+		"flavor":          "t2.micro",
+		"image":           "centos7.3-latest",
+		"networks":        networks,
+		"security_groups": "",
+	}
+
+	profileName := testName
+	optsProfile := &profiles.CreateOpts{
+		Metadata: map[string]interface{}{
+			"foo":  "bar",
+			"test": "123",
+		},
+		Name: profileName,
+		Spec: map[string]interface{}{
+			"type":       "os.nova.server",
+			"version":    "1.0",
+			"properties": props,
+		},
+	}
+
+	profile, err := profiles.Create(client, optsProfile).Extract()
+	if err != nil {
+		t.Fatalf("Unable to create profile %s: %v", profileName, err)
+	} else {
+		t.Logf("Profile created %v", profile)
+	}
+
+	th.AssertEquals(t, profileName, profile.Name)
+	th.AssertEquals(t, "os.nova.server", (map[string]interface{})(profile.Spec)["type"])
+	th.AssertEquals(t, "1.0", (map[string]interface{})(profile.Spec)["version"])
+}

--- a/acceptance/openstack/clustering/v1/autoscaling_test.go
+++ b/acceptance/openstack/clustering/v1/autoscaling_test.go
@@ -1,3 +1,5 @@
+// +build acceptance clustering autoscaling profiles
+
 package v1
 
 import (

--- a/openstack/clustering/v1/profiles/doc.go
+++ b/openstack/clustering/v1/profiles/doc.go
@@ -1,0 +1,32 @@
+/*
+Example to Create a profile
+
+	networks := []map[string]interface{} {
+		{"network": "test-network"},
+	}
+
+	props := &map[string]interface{}{
+		"name":            "test_gophercloud_profile",
+		"flavor":          "t2.micro",
+		"image":           "centos7.3-latest",
+		"networks":        networks,
+		"security_groups": "",
+	}
+
+	createOpts := profiles.CreateOpts {
+		Name: "test_profile",
+		Spec: map[string]interface{}{
+			"type":       "os.nova.server",
+			"version":    "1.0",
+			"properties": props,
+		},
+	}
+
+	profile, err := profiles.Create(serviceClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("Profile", profile)
+*/
+package profiles

--- a/openstack/clustering/v1/profiles/doc.go
+++ b/openstack/clustering/v1/profiles/doc.go
@@ -5,7 +5,7 @@ Example to Create a profile
 		{"network": "test-network"},
 	}
 
-	props := &map[string]interface{}{
+	props := map[string]interface{}{
 		"name":            "test_gophercloud_profile",
 		"flavor":          "t2.micro",
 		"image":           "centos7.3-latest",
@@ -15,10 +15,10 @@ Example to Create a profile
 
 	createOpts := profiles.CreateOpts {
 		Name: "test_profile",
-		Spec: map[string]interface{}{
-			"type":       "os.nova.server",
-			"version":    "1.0",
-			"properties": props,
+		Spec: profiles.Spec{
+			Type:       "os.nova.server",
+			Version:    "1.0",
+			Properties: props,
 		},
 	}
 

--- a/openstack/clustering/v1/profiles/requests.go
+++ b/openstack/clustering/v1/profiles/requests.go
@@ -15,7 +15,7 @@ type CreateOptsBuilder interface {
 type CreateOpts struct {
 	Name     string                 `json:"name" required:"true"`
 	Metadata map[string]interface{} `json:"metadata,omitempty"`
-	Spec     map[string]interface{} `json:"spec" required:"true"`
+	Spec     Spec                   `json:"spec" required:"true"`
 }
 
 // ToProfileCreateMap constructs a request body from CreateOpts.

--- a/openstack/clustering/v1/profiles/requests.go
+++ b/openstack/clustering/v1/profiles/requests.go
@@ -1,0 +1,42 @@
+package profiles
+
+import (
+	"net/http"
+
+	"github.com/gophercloud/gophercloud"
+)
+
+// CreateOptsBuilder for options used for creating a profile.
+type CreateOptsBuilder interface {
+	ToProfileCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts represents options used for creating a profile
+type CreateOpts struct {
+	Name     string                 `json:"name" required:"true"`
+	Metadata map[string]interface{} `json:"metadata,omitempty"`
+	Spec     map[string]interface{} `json:"spec" required:"true"`
+}
+
+// ToProfileCreateMap constructs a request body from CreateOpts.
+func (opts CreateOpts) ToProfileCreateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "profile")
+}
+
+// Create requests the creation of a new profile on the server.
+func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToProfileCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	var result *http.Response
+	result, r.Err = client.Post(createURL(client), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200, 201},
+	})
+
+	if r.Err == nil {
+		r.Header = result.Header
+	}
+	return
+}

--- a/openstack/clustering/v1/profiles/results.go
+++ b/openstack/clustering/v1/profiles/results.go
@@ -1,0 +1,89 @@
+package profiles
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"reflect"
+
+	"github.com/gophercloud/gophercloud"
+)
+
+// commonResult is the response of a base result.
+type commonResult struct {
+	gophercloud.Result
+}
+
+// CreateResult is the response of a Create operation.
+type CreateResult struct {
+	commonResult
+}
+
+// Extract provides access to Profile returned by the Get and Create functions.
+func (r commonResult) Extract() (*Profile, error) {
+	var s struct {
+		Profile *Profile `json:"profile"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Profile, err
+}
+
+// Profile represent a detailed profile
+type Profile struct {
+	CreatedAt time.Time              `json:"-"`
+	Domain    string                 `json:"domain"`
+	ID        string                 `json:"id"`
+	Metadata  map[string]interface{} `json:"metadata"`
+	Name      string                 `json:"name"`
+	Project   string                 `json:"project"`
+	Spec      map[string]interface{} `json:"spec"`
+	Type      string                 `json:"type"`
+	UpdatedAt time.Time              `json:"-"`
+	User      string                 `json:"user"`
+}
+
+func (r *Profile) UnmarshalJSON(b []byte) error {
+	type tmp Profile
+	var s struct {
+		tmp
+		CreatedAt interface{} `json:"created_at"`
+		UpdatedAt interface{} `json:"updated_at"`
+	}
+
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	*r = Profile(s.tmp)
+
+	switch t := s.CreatedAt.(type) {
+	case string:
+		if t != "" {
+			r.CreatedAt, err = time.Parse(gophercloud.RFC3339Milli, t)
+			if err != nil {
+				return err
+			}
+		}
+	case nil:
+		r.CreatedAt = time.Time{}
+	default:
+		return fmt.Errorf("Invalid type for time. type=%v", reflect.TypeOf(s.CreatedAt))
+	}
+
+	switch t := s.UpdatedAt.(type) {
+	case string:
+		if t != "" {
+			r.UpdatedAt, err = time.Parse(gophercloud.RFC3339Milli, t)
+			if err != nil {
+				return err
+			}
+		}
+	case nil:
+		r.UpdatedAt = time.Time{}
+	default:
+		return fmt.Errorf("Invalid type for time. type=%v", reflect.TypeOf(s.UpdatedAt))
+	}
+
+	return nil
+}

--- a/openstack/clustering/v1/profiles/results.go
+++ b/openstack/clustering/v1/profiles/results.go
@@ -29,6 +29,12 @@ func (r commonResult) Extract() (*Profile, error) {
 	return s.Profile, err
 }
 
+type Spec struct {
+	Type       string                 `json:"type"`
+	Version    string                 `json:"version"`
+	Properties map[string]interface{} `json:"properties"`
+}
+
 // Profile represent a detailed profile
 type Profile struct {
 	CreatedAt time.Time              `json:"-"`
@@ -37,7 +43,7 @@ type Profile struct {
 	Metadata  map[string]interface{} `json:"metadata"`
 	Name      string                 `json:"name"`
 	Project   string                 `json:"project"`
-	Spec      map[string]interface{} `json:"spec"`
+	Spec      Spec                   `json:"spec"`
 	Type      string                 `json:"type"`
 	UpdatedAt time.Time              `json:"-"`
 	User      string                 `json:"user"`

--- a/openstack/clustering/v1/profiles/testing/doc.go
+++ b/openstack/clustering/v1/profiles/testing/doc.go
@@ -1,0 +1,2 @@
+// clustering_profiles_v1
+package testing

--- a/openstack/clustering/v1/profiles/testing/requests_test.go
+++ b/openstack/clustering/v1/profiles/testing/requests_test.go
@@ -43,7 +43,7 @@ func TestCreateProfile(t *testing.T) {
 						]
 					},
 					"type": "os.nova.server",
-					"version": 1.0
+					"version": "1.0"
 				},
 				"type": "os.nova.server-1.0",
 				"updated_at": "2016-01-03T17:22:23Z",
@@ -56,7 +56,7 @@ func TestCreateProfile(t *testing.T) {
 		{"network": "private-network"},
 	}
 
-	props := &map[string]interface{}{
+	props := map[string]interface{}{
 		"name":            "test_gopher_cloud_profile",
 		"flavor":          "t2.small",
 		"image":           "centos7.3-latest",
@@ -66,10 +66,10 @@ func TestCreateProfile(t *testing.T) {
 
 	optsProfile := &profiles.CreateOpts{
 		Name: "TestProfile",
-		Spec: map[string]interface{}{
-			"type":       "os.nova.server",
-			"version":    "1.0",
-			"properties": props,
+		Spec: profiles.Spec{
+			Type:       "os.nova.server",
+			Version:    "1.0",
+			Properties: props,
 		},
 	}
 
@@ -88,8 +88,8 @@ func TestCreateProfile(t *testing.T) {
 		Metadata:  map[string]interface{}{},
 		Name:      "test-profile",
 		Project:   "42d9e9663331431f97b75e25136307ff",
-		Spec: map[string]interface{}{
-			"properties": map[string]interface{}{
+		Spec: profiles.Spec{
+			Properties: map[string]interface{}{
 				"flavor": "t2.small",
 				"image":  "centos7.3-latest",
 				"name":   "centos_server",
@@ -97,8 +97,8 @@ func TestCreateProfile(t *testing.T) {
 					map[string]interface{}{"network": "private-network"},
 				},
 			},
-			"type":    "os.nova.server",
-			"version": 1.0,
+			Type:    "os.nova.server",
+			Version: "1.0",
 		},
 		Type:      "os.nova.server-1.0",
 		UpdatedAt: updatedAt,

--- a/openstack/clustering/v1/profiles/testing/requests_test.go
+++ b/openstack/clustering/v1/profiles/testing/requests_test.go
@@ -107,3 +107,111 @@ func TestCreateProfile(t *testing.T) {
 
 	th.AssertDeepEquals(t, expected, *profile)
 }
+
+func TestCreateProfileInvalidTimeFloat(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v1/profiles", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, `
+		{
+			"profile": {
+				"created_at": 123456789.0,
+				"domain": null,
+				"id": "9e1c6f42-acf5-4688-be2c-8ce954ef0f23",
+				"metadata": {},
+				"name": "test-profile",
+				"project": "42d9e9663331431f97b75e25136307ff",
+				"spec": {
+					"properties": {
+						"flavor": "t2.small",
+						"image": "centos7.3-latest",
+						"name": "centos_server",
+						"networks": [
+								{
+									"network": "private-network"
+								}
+						]
+					},
+					"type": "os.nova.server",
+					"version": "1.0"
+				},
+				"type": "os.nova.server-1.0",
+				"updated_at": 123456789.0,
+				"user": "5e5bf8027826429c96af157f68dc9072"
+			}
+		}`)
+	})
+
+	optsProfile := &profiles.CreateOpts{
+		Name: "TestProfile",
+		Spec: profiles.Spec{
+			Type:       "os.nova.server",
+			Version:    "1.0",
+			Properties: map[string]interface{}{},
+		},
+	}
+
+	_, err := profiles.Create(fake.ServiceClient(), optsProfile).Extract()
+	th.AssertEquals(t, false, err == nil)
+}
+
+func TestCreateProfileInvalidTimeString(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v1/profiles", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, `
+		{
+			"profile": {
+				"created_at": "invalid_time",
+				"domain": null,
+				"id": "9e1c6f42-acf5-4688-be2c-8ce954ef0f23",
+				"metadata": {},
+				"name": "test-profile",
+				"project": "42d9e9663331431f97b75e25136307ff",
+				"spec": {
+					"properties": {
+						"flavor": "t2.small",
+						"image": "centos7.3-latest",
+						"name": "centos_server",
+						"networks": [
+								{
+									"network": "private-network"
+								}
+						]
+					},
+					"type": "os.nova.server",
+					"version": "1.0"
+				},
+				"type": "os.nova.server-1.0",
+				"updated_at": "invalid_time",
+				"user": "5e5bf8027826429c96af157f68dc9072"
+			}
+		}`)
+	})
+
+	optsProfile := &profiles.CreateOpts{
+		Name: "TestProfile",
+		Spec: profiles.Spec{
+			Type:       "os.nova.server",
+			Version:    "1.0",
+			Properties: map[string]interface{}{},
+		},
+	}
+
+	_, err := profiles.Create(fake.ServiceClient(), optsProfile).Extract()
+	th.AssertEquals(t, false, err == nil)
+}

--- a/openstack/clustering/v1/profiles/testing/requests_test.go
+++ b/openstack/clustering/v1/profiles/testing/requests_test.go
@@ -1,0 +1,109 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gophercloud/gophercloud/openstack/clustering/v1/profiles"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	fake "github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func TestCreateProfile(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v1/profiles", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, `
+		{
+			"profile": {
+				"created_at": "2016-01-03T16:22:23Z",
+				"domain": null,
+				"id": "9e1c6f42-acf5-4688-be2c-8ce954ef0f23",
+				"metadata": {},
+				"name": "test-profile",
+				"project": "42d9e9663331431f97b75e25136307ff",
+				"spec": {
+					"properties": {
+						"flavor": "t2.small",
+						"image": "centos7.3-latest",
+						"name": "centos_server",
+						"networks": [
+								{
+									"network": "private-network"
+								}
+						]
+					},
+					"type": "os.nova.server",
+					"version": 1.0
+				},
+				"type": "os.nova.server-1.0",
+				"updated_at": "2016-01-03T17:22:23Z",
+				"user": "5e5bf8027826429c96af157f68dc9072"
+			}
+		}`)
+	})
+
+	networks := []map[string]interface{}{
+		{"network": "private-network"},
+	}
+
+	props := &map[string]interface{}{
+		"name":            "test_gopher_cloud_profile",
+		"flavor":          "t2.small",
+		"image":           "centos7.3-latest",
+		"networks":        networks,
+		"security_groups": "",
+	}
+
+	optsProfile := &profiles.CreateOpts{
+		Name: "TestProfile",
+		Spec: map[string]interface{}{
+			"type":       "os.nova.server",
+			"version":    "1.0",
+			"properties": props,
+		},
+	}
+
+	profile, err := profiles.Create(fake.ServiceClient(), optsProfile).Extract()
+	if err != nil {
+		t.Errorf("Failed to extract profile: %v", err)
+	}
+
+	createdAt, _ := time.Parse(time.RFC3339, "2016-01-03T16:22:23Z")
+	updatedAt, _ := time.Parse(time.RFC3339, "2016-01-03T17:22:23Z")
+
+	expected := profiles.Profile{
+		CreatedAt: createdAt,
+		Domain:    "",
+		ID:        "9e1c6f42-acf5-4688-be2c-8ce954ef0f23",
+		Metadata:  map[string]interface{}{},
+		Name:      "test-profile",
+		Project:   "42d9e9663331431f97b75e25136307ff",
+		Spec: map[string]interface{}{
+			"properties": map[string]interface{}{
+				"flavor": "t2.small",
+				"image":  "centos7.3-latest",
+				"name":   "centos_server",
+				"networks": []interface{}{
+					map[string]interface{}{"network": "private-network"},
+				},
+			},
+			"type":    "os.nova.server",
+			"version": 1.0,
+		},
+		Type:      "os.nova.server-1.0",
+		UpdatedAt: updatedAt,
+		User:      "5e5bf8027826429c96af157f68dc9072",
+	}
+
+	th.AssertDeepEquals(t, expected, *profile)
+}

--- a/openstack/clustering/v1/profiles/urls.go
+++ b/openstack/clustering/v1/profiles/urls.go
@@ -1,0 +1,14 @@
+package profiles
+
+import "github.com/gophercloud/gophercloud"
+
+var apiVersion = "v1"
+var apiName = "profiles"
+
+func commonURL(client *gophercloud.ServiceClient) string {
+	return client.ServiceURL(apiVersion, apiName)
+}
+
+func createURL(client *gophercloud.ServiceClient) string {
+	return commonURL(client)
+}


### PR DESCRIPTION
Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

For #[823 [Add support for Senlin clustering]](https://github.com/gophercloud/gophercloud/issues/823)

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

[[profiles:create]](https://github.com/openstack/senlin/blob/e5bc16b3fea2f10dead365f983c5a937f23d72b0/senlin/api/openstack/v1/profiles.py#L59)
