### PR TITLE
Blockstorage v3 quota-set support - part 2, Get Defaults

### DIFF
--- a/acceptance/openstack/blockstorage/v3/quotaset_test.go
+++ b/acceptance/openstack/blockstorage/v3/quotaset_test.go
@@ -22,6 +22,15 @@ func TestQuotasetGet(t *testing.T) {
 	tools.PrintResource(t, quotaSet)
 }
 
+func TestQuotasetGetDefaults(t *testing.T) {
+	client, projectID := getClientAndProject(t)
+
+	quotaSet, err := quotasets.GetDefaults(client, projectID).Extract()
+	th.AssertNoErr(t, err)
+
+	tools.PrintResource(t, quotaSet)
+}
+
 // getClientAndProject reduces boilerplate by returning a new blockstorage v3
 // ServiceClient and a project ID obtained from the OS_PROJECT_NAME envvar.
 func getClientAndProject(t *testing.T) (*gophercloud.ServiceClient, string) {

--- a/openstack/blockstorage/extensions/quotasets/requests.go
+++ b/openstack/blockstorage/extensions/quotasets/requests.go
@@ -9,3 +9,10 @@ func Get(client *gophercloud.ServiceClient, projectID string) (r GetResult) {
 	_, r.Err = client.Get(getURL(client, projectID), &r.Body, nil)
 	return
 }
+
+// Get returns public data about the project's default block storage quotas.
+func GetDefaults(client *gophercloud.ServiceClient, projectID string) GetResult {
+	var res GetResult
+	_, res.Err = client.Get(getDefaultsURL(client, projectID), &res.Body, nil)
+	return res
+}

--- a/openstack/blockstorage/extensions/quotasets/requests.go
+++ b/openstack/blockstorage/extensions/quotasets/requests.go
@@ -10,7 +10,7 @@ func Get(client *gophercloud.ServiceClient, projectID string) (r GetResult) {
 	return
 }
 
-// Get returns public data about the project's default block storage quotas.
+// GetDefaults returns public data about the project's default block storage quotas.
 func GetDefaults(client *gophercloud.ServiceClient, projectID string) (r GetResult) {
 	_, r.Err = client.Get(getDefaultsURL(client, projectID), &r.Body, nil)
 	return

--- a/openstack/blockstorage/extensions/quotasets/requests.go
+++ b/openstack/blockstorage/extensions/quotasets/requests.go
@@ -11,8 +11,7 @@ func Get(client *gophercloud.ServiceClient, projectID string) (r GetResult) {
 }
 
 // Get returns public data about the project's default block storage quotas.
-func GetDefaults(client *gophercloud.ServiceClient, projectID string) GetResult {
-	var res GetResult
-	_, res.Err = client.Get(getDefaultsURL(client, projectID), &res.Body, nil)
-	return res
+func GetDefaults(client *gophercloud.ServiceClient, projectID string) (r GetResult) {
+	_, r.Err = client.Get(getDefaultsURL(client, projectID), &r.Body, nil)
+	return
 }

--- a/openstack/blockstorage/extensions/quotasets/urls.go
+++ b/openstack/blockstorage/extensions/quotasets/urls.go
@@ -7,3 +7,7 @@ const resourcePath = "os-quota-sets"
 func getURL(c *gophercloud.ServiceClient, projectID string) string {
 	return c.ServiceURL(resourcePath, projectID)
 }
+
+func getDefaultsURL(c *gophercloud.ServiceClient, projectID string) string {
+	return c.ServiceURL(resourcePath, projectID, "defaults")
+}


### PR DESCRIPTION
For #234
Pending #877 

\## API:
https://developer.openstack.org/api-ref/block-storage/v3/index.html#quota-sets-extension-os-quota-sets

\## Schema:
I'm not showing the actual DB schema here because it makes more sense from a
request parameter validation standpoint to show the chain of calls and data
structures involved in validating a request.

Here is an example of [PUT/update request parameter validation](https://github.com/openstack/cinder/blob/master/cinder/api/contrib/quotas.py#L218-L219).

So the data structure that ultimately specifies the correct parameter names is [cinder.quotas.QUOTAS](https://github.com/openstack/cinder/blob/master/cinder/quota.py#L1234) which is a module constant initialized with [cinder.quotas.VolumeTypeQuotaEngine](https://github.com/openstack/cinder/blob/master/cinder/quota.py#L1127) which in turn:
* is a [cinder.quotas.QuotaEngine](https://github.com/openstack/cinder/blob/master/cinder/quota.py#L1127), which implements `__contains__` as
```
    def __contains__(self, resource):
        return resource in self.resources
```
* overrides `cinder.quotas.QuotaEngine.resources` and returns a dict whose keys are valid volume quota types.

So regardless of what the db schema looks like, this is the correct chain of
calls and underlying data structure that determines what keys are accepted in
the HTTP request body. The GET api uses the same data structure to retrieve a
list of quotas.

\## Get:
https://github.com/openstack/cinder/blob/master/cinder/api/contrib/quotas.py#L156

\## Update:
https://github.com/openstack/cinder/blob/master/cinder/api/contrib/quotas.py#L193

\## Delete:
https://github.com/openstack/cinder/blob/master/cinder/api/contrib/quotas.py#L337