### PR TITLE
Blockstorage v3 quota-set support - part 3, Get Details

### DIFF
--- a/acceptance/openstack/blockstorage/v3/quotaset_test.go
+++ b/acceptance/openstack/blockstorage/v3/quotaset_test.go
@@ -31,6 +31,15 @@ func TestQuotasetGetDefaults(t *testing.T) {
 	tools.PrintResource(t, quotaSet)
 }
 
+func TestQuotasetGetDetailed(t *testing.T) {
+	client, projectID := getClientAndProject(t)
+
+	detailedQuotaSet, err := quotasets.GetDetail(client, projectID).Extract()
+	th.AssertNoErr(t, err)
+
+	tools.PrintResource(t, detailedQuotaSet)
+}
+
 // getClientAndProject reduces boilerplate by returning a new blockstorage v3
 // ServiceClient and a project ID obtained from the OS_PROJECT_NAME envvar.
 func getClientAndProject(t *testing.T) (*gophercloud.ServiceClient, string) {

--- a/acceptance/openstack/blockstorage/v3/quotaset_test.go
+++ b/acceptance/openstack/blockstorage/v3/quotaset_test.go
@@ -31,13 +31,13 @@ func TestQuotasetGetDefaults(t *testing.T) {
 	tools.PrintResource(t, quotaSet)
 }
 
-func TestQuotasetGetDetailed(t *testing.T) {
+func TestQuotasetGetUsage(t *testing.T) {
 	client, projectID := getClientAndProject(t)
 
-	detailedQuotaSet, err := quotasets.GetDetail(client, projectID).Extract()
+	quotaSetUsage, err := quotasets.GetUsage(client, projectID).Extract()
 	th.AssertNoErr(t, err)
 
-	tools.PrintResource(t, detailedQuotaSet)
+	tools.PrintResource(t, quotaSetUsage)
 }
 
 // getClientAndProject reduces boilerplate by returning a new blockstorage v3

--- a/openstack/blockstorage/extensions/quotasets/doc.go
+++ b/openstack/blockstorage/extensions/quotasets/doc.go
@@ -10,5 +10,13 @@ Example to Get a Quota Set
 
 	fmt.Printf("%+v\n", quotaset)
 
+Example to Get a Detailed Quota Set
+
+	quotaset, err := quotasets.GetDetail(blockStorageClient, "project-id").Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v\n", quotaset)
 */
 package quotasets

--- a/openstack/blockstorage/extensions/quotasets/doc.go
+++ b/openstack/blockstorage/extensions/quotasets/doc.go
@@ -10,9 +10,9 @@ Example to Get a Quota Set
 
 	fmt.Printf("%+v\n", quotaset)
 
-Example to Get a Detailed Quota Set
+Example to Get Quota Set Usage
 
-	quotaset, err := quotasets.GetDetail(blockStorageClient, "project-id").Extract()
+	quotaset, err := quotasets.GetUsage(blockStorageClient, "project-id").Extract()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/blockstorage/extensions/quotasets/requests.go
+++ b/openstack/blockstorage/extensions/quotasets/requests.go
@@ -1,6 +1,8 @@
 package quotasets
 
 import (
+	"fmt"
+
 	"github.com/gophercloud/gophercloud"
 )
 
@@ -18,6 +20,7 @@ func GetDefaults(client *gophercloud.ServiceClient, projectID string) (r GetResu
 
 // GetUsage returns detailed public data about a previously created QuotaSet.
 func GetUsage(client *gophercloud.ServiceClient, projectID string) (r GetUsageResult) {
-	_, r.Err = client.Get(getUsageURL(client, projectID), &r.Body, nil)
+	u := fmt.Sprintf("%s?usage=true", getURL(client, projectID))
+	_, r.Err = client.Get(u, &r.Body, nil)
 	return
 }

--- a/openstack/blockstorage/extensions/quotasets/requests.go
+++ b/openstack/blockstorage/extensions/quotasets/requests.go
@@ -15,3 +15,9 @@ func GetDefaults(client *gophercloud.ServiceClient, projectID string) (r GetResu
 	_, r.Err = client.Get(getDefaultsURL(client, projectID), &r.Body, nil)
 	return
 }
+
+// GetDetail returns detailed public data about a previously created QuotaSet.
+func GetDetail(client *gophercloud.ServiceClient, projectID string) (r GetDetailResult) {
+	_, r.Err = client.Get(getDetailURL(client, projectID), &r.Body, nil)
+	return
+}

--- a/openstack/blockstorage/extensions/quotasets/requests.go
+++ b/openstack/blockstorage/extensions/quotasets/requests.go
@@ -16,8 +16,8 @@ func GetDefaults(client *gophercloud.ServiceClient, projectID string) (r GetResu
 	return
 }
 
-// GetDetail returns detailed public data about a previously created QuotaSet.
-func GetDetail(client *gophercloud.ServiceClient, projectID string) (r GetDetailResult) {
-	_, r.Err = client.Get(getDetailURL(client, projectID), &r.Body, nil)
+// GetUsage returns detailed public data about a previously created QuotaSet.
+func GetUsage(client *gophercloud.ServiceClient, projectID string) (r GetUsageResult) {
+	_, r.Err = client.Get(getUsageURL(client, projectID), &r.Body, nil)
 	return
 }

--- a/openstack/blockstorage/extensions/quotasets/results.go
+++ b/openstack/blockstorage/extensions/quotasets/results.go
@@ -33,55 +33,54 @@ type QuotaSet struct {
 	BackupGigabytes int `json:"backup_gigabytes"`
 }
 
-// QuotaDetailSet represents details of both operational limits of block
+// QuotaUsageSet represents details of both operational limits of block
 // storage resources and the current usage of those resources.
-type QuotaDetailSet struct {
-	// ID is the project ID associated with this QuotaDetailSet.
+type QuotaUsageSet struct {
+	// ID is the project ID associated with this QuotaUsageSet.
 	ID string `json:"id"`
 
 	// Volumes is the volume usage information for this project, including
 	// in_use, limit, reserved and allocated attributes. Note: allocated
 	// attribute is available only when nested quota is enabled.
-	Volumes QuotaDetail `json:"volumes"`
+	Volumes QuotaUsage `json:"volumes"`
 
 	// Snapshots is the snapshot usage information for this project, including
 	// in_use, limit, reserved and allocated attributes. Note: allocated
 	// attribute is available only when nested quota is enabled.
-	Snapshots QuotaDetail `json:"snapshots"`
+	Snapshots QuotaUsage `json:"snapshots"`
 
 	// Gigabytes is the size (GB) usage information of volumes and snapshots
 	// for this project, including in_use, limit, reserved and allocated
 	// attributes. Note: allocated attribute is available only when nested
 	// quota is enabled.
-	Gigabytes QuotaDetail `json:"gigabytes"`
+	Gigabytes QuotaUsage `json:"gigabytes"`
 
 	// PerVolumeGigabytes is the size (GB) usage information for each volume,
 	// including in_use, limit, reserved and allocated attributes. Note:
 	// allocated attribute is available only when nested quota is enabled and
 	// only limit is meaningful here.
-	PerVolumeGigabytes QuotaDetail `json:"per_volume_gigabytes"`
+	PerVolumeGigabytes QuotaUsage `json:"per_volume_gigabytes"`
 
 	// Backups is the backup usage information for this project, including
 	// in_use, limit, reserved and allocated attributes. Note: allocated
 	// attribute is available only when nested quota is enabled.
-	Backups QuotaDetail `json:"backups"`
+	Backups QuotaUsage `json:"backups"`
 
 	// BackupGigabytes is the size (GB) usage information of backup for this
 	// project, including in_use, limit, reserved and allocated attributes.
 	// Note: allocated attribute is available only when nested quota is
 	// enabled.
-	BackupGigabytes QuotaDetail `json:"backup_gigabytes"`
+	BackupGigabytes QuotaUsage `json:"backup_gigabytes"`
 }
 
-// QuotaDetail is a set of details about a single operational limit that allows
+// QuotaUsage is a set of details about a single operational limit that allows
 // for control of block storage usage.
-type QuotaDetail struct {
+type QuotaUsage struct {
 	// InUse is the current number of provisioned resources of the given type.
 	InUse int `json:"in_use"`
 
 	// Allocated is the current number of resources of a given type allocated
-	// for use.  It is only available when nested quota is enabled. It tells
-	// how
+	// for use.  It is only available when nested quota is enabled.
 	Allocated int `json:"allocated"`
 
 	// Reserved is a transitional state when a claim against quota has been made
@@ -133,21 +132,21 @@ type GetResult struct {
 	quotaResult
 }
 
-type quotaDetailResult struct {
+type quotaUsageResult struct {
 	gophercloud.Result
 }
 
-// GetDetailResult is the response from a Get operation. Call its Extract
+// GetUsageResult is the response from a Get operation. Call its Extract
 // method to interpret it as a QuotaSet.
-type GetDetailResult struct {
-	quotaDetailResult
+type GetUsageResult struct {
+	quotaUsageResult
 }
 
-// Extract is a method that attempts to interpret any QuotaDetailSet
-// resource response as a set of QuotaDetailSet structs.
-func (r quotaDetailResult) Extract() (QuotaDetailSet, error) {
+// Extract is a method that attempts to interpret any QuotaUsageSet resource
+// response as a set of QuotaUsageSet structs.
+func (r quotaUsageResult) Extract() (QuotaUsageSet, error) {
 	var s struct {
-		QuotaData QuotaDetailSet `json:"quota_set"`
+		QuotaData QuotaUsageSet `json:"quota_set"`
 	}
 	err := r.ExtractInto(&s)
 	return s.QuotaData, err

--- a/openstack/blockstorage/extensions/quotasets/results.go
+++ b/openstack/blockstorage/extensions/quotasets/results.go
@@ -33,6 +33,66 @@ type QuotaSet struct {
 	BackupGigabytes int `json:"backup_gigabytes"`
 }
 
+// QuotaDetailSet represents details of both operational limits of block
+// storage resources and the current usage of those resources.
+type QuotaDetailSet struct {
+	// ID is the project ID associated with this QuotaDetailSet.
+	ID string `json:"id"`
+
+	// Volumes is the volume usage information for this project, including
+	// in_use, limit, reserved and allocated attributes. Note: allocated
+	// attribute is available only when nested quota is enabled.
+	Volumes QuotaDetail `json:"volumes"`
+
+	// Snapshots is the snapshot usage information for this project, including
+	// in_use, limit, reserved and allocated attributes. Note: allocated
+	// attribute is available only when nested quota is enabled.
+	Snapshots QuotaDetail `json:"snapshots"`
+
+	// Gigabytes is the size (GB) usage information of volumes and snapshots
+	// for this project, including in_use, limit, reserved and allocated
+	// attributes. Note: allocated attribute is available only when nested
+	// quota is enabled.
+	Gigabytes QuotaDetail `json:"gigabytes"`
+
+	// PerVolumeGigabytes is the size (GB) usage information for each volume,
+	// including in_use, limit, reserved and allocated attributes. Note:
+	// allocated attribute is available only when nested quota is enabled and
+	// only limit is meaningful here.
+	PerVolumeGigabytes QuotaDetail `json:"per_volume_gigabytes"`
+
+	// Backups is the backup usage information for this project, including
+	// in_use, limit, reserved and allocated attributes. Note: allocated
+	// attribute is available only when nested quota is enabled.
+	Backups QuotaDetail `json:"backups"`
+
+	// BackupGigabytes is the size (GB) usage information of backup for this
+	// project, including in_use, limit, reserved and allocated attributes.
+	// Note: allocated attribute is available only when nested quota is
+	// enabled.
+	BackupGigabytes QuotaDetail `json:"backup_gigabytes"`
+}
+
+// QuotaDetail is a set of details about a single operational limit that allows
+// for control of block storage usage.
+type QuotaDetail struct {
+	// InUse is the current number of provisioned resources of the given type.
+	InUse int `json:"in_use"`
+
+	// Allocated is the current number of resources of a given type allocated
+	// for use.  It is only available when nested quota is enabled. It tells
+	// how
+	Allocated int `json:"allocated"`
+
+	// Reserved is a transitional state when a claim against quota has been made
+	// but the resource is not yet fully online.
+	Reserved int `json:"reserved"`
+
+	// Limit is the maximum number of a given resource that can be
+	// allocated/provisioned.  This is what "quota" usually refers to.
+	Limit int `json:"limit"`
+}
+
 // QuotaSetPage stores a single page of all QuotaSet results from a List call.
 type QuotaSetPage struct {
 	pagination.SinglePageBase
@@ -71,4 +131,24 @@ func (r quotaResult) Extract() (*QuotaSet, error) {
 // interpret it as a QuotaSet.
 type GetResult struct {
 	quotaResult
+}
+
+type quotaDetailResult struct {
+	gophercloud.Result
+}
+
+// GetDetailResult is the response from a Get operation. Call its Extract
+// method to interpret it as a QuotaSet.
+type GetDetailResult struct {
+	quotaDetailResult
+}
+
+// Extract is a method that attempts to interpret any QuotaDetailSet
+// resource response as a set of QuotaDetailSet structs.
+func (r quotaDetailResult) Extract() (QuotaDetailSet, error) {
+	var s struct {
+		QuotaData QuotaDetailSet `json:"quota_set"`
+	}
+	err := r.ExtractInto(&s)
+	return s.QuotaData, err
 }

--- a/openstack/blockstorage/extensions/quotasets/results.go
+++ b/openstack/blockstorage/extensions/quotasets/results.go
@@ -146,8 +146,8 @@ type GetUsageResult struct {
 // response as a set of QuotaUsageSet structs.
 func (r quotaUsageResult) Extract() (QuotaUsageSet, error) {
 	var s struct {
-		QuotaData QuotaUsageSet `json:"quota_set"`
+		QuotaUsageSet QuotaUsageSet `json:"quota_set"`
 	}
 	err := r.ExtractInto(&s)
-	return s.QuotaData, err
+	return s.QuotaUsageSet, err
 }

--- a/openstack/blockstorage/extensions/quotasets/testing/fixtures.go
+++ b/openstack/blockstorage/extensions/quotasets/testing/fixtures.go
@@ -13,13 +13,13 @@ import (
 const FirstTenantID = "555544443333222211110000ffffeeee"
 
 var successTestCases = []struct {
-	name                   string
-	httpMethod             string
-	jsonBody               string
-	uriPath                string
-	uriQueryParams         map[string]string
-	expectedQuotaSet       quotasets.QuotaSet
-	expectedQuotaDetailSet quotasets.QuotaDetailSet
+	name                  string
+	httpMethod            string
+	jsonBody              string
+	uriPath               string
+	uriQueryParams        map[string]string
+	expectedQuotaSet      quotasets.QuotaSet
+	expectedQuotaUsageSet quotasets.QuotaUsageSet
 }{
 	{
 		name: "simple GET request",
@@ -85,14 +85,14 @@ var successTestCases = []struct {
 		}
 	}
 }`,
-		expectedQuotaDetailSet: quotasets.QuotaDetailSet{
+		expectedQuotaUsageSet: quotasets.QuotaUsageSet{
 			ID:                 FirstTenantID,
-			Volumes:            quotasets.QuotaDetail{InUse: 15, Limit: 16, Reserved: 17},
-			Snapshots:          quotasets.QuotaDetail{InUse: 18, Limit: 19, Reserved: 20},
-			Gigabytes:          quotasets.QuotaDetail{InUse: 21, Limit: 22, Reserved: 23},
-			PerVolumeGigabytes: quotasets.QuotaDetail{InUse: 24, Limit: 25, Reserved: 26},
-			Backups:            quotasets.QuotaDetail{InUse: 27, Limit: 28, Reserved: 29},
-			BackupGigabytes:    quotasets.QuotaDetail{InUse: 30, Limit: 31, Reserved: 32},
+			Volumes:            quotasets.QuotaUsage{InUse: 15, Limit: 16, Reserved: 17},
+			Snapshots:          quotasets.QuotaUsage{InUse: 18, Limit: 19, Reserved: 20},
+			Gigabytes:          quotasets.QuotaUsage{InUse: 21, Limit: 22, Reserved: 23},
+			PerVolumeGigabytes: quotasets.QuotaUsage{InUse: 24, Limit: 25, Reserved: 26},
+			Backups:            quotasets.QuotaUsage{InUse: 27, Limit: 28, Reserved: 29},
+			BackupGigabytes:    quotasets.QuotaUsage{InUse: 30, Limit: 31, Reserved: 32},
 		},
 		uriPath:        "/os-quota-sets/" + FirstTenantID,
 		uriQueryParams: map[string]string{"usage": "true"},

--- a/openstack/blockstorage/extensions/quotasets/testing/fixtures.go
+++ b/openstack/blockstorage/extensions/quotasets/testing/fixtures.go
@@ -13,12 +13,13 @@ import (
 const FirstTenantID = "555544443333222211110000ffffeeee"
 
 var successTestCases = []struct {
-	name             string
-	httpMethod       string
-	jsonBody         string
-	uriPath          string
-	uriQueryParams   map[string]string
-	expectedQuotaSet quotasets.QuotaSet
+	name                   string
+	httpMethod             string
+	jsonBody               string
+	uriPath                string
+	uriQueryParams         map[string]string
+	expectedQuotaSet       quotasets.QuotaSet
+	expectedQuotaDetailSet quotasets.QuotaDetailSet
 }{
 	{
 		name: "simple GET request",
@@ -44,15 +45,72 @@ var successTestCases = []struct {
 		uriPath:    "/os-quota-sets/" + FirstTenantID,
 		httpMethod: "GET",
 	},
+
+	{
+		name: "GET details request",
+		jsonBody: `
+{
+	"quota_set" : {
+		"id": "555544443333222211110000ffffeeee",
+		"volumes" : {
+			"in_use": 15,
+			"limit": 16,
+			"reserved": 17
+		},
+		"snapshots" : {
+			"in_use": 18,
+			"limit": 19,
+			"reserved": 20
+		},
+		"gigabytes" : {
+			"in_use": 21,
+			"limit": 22,
+			"reserved": 23
+		},
+		"per_volume_gigabytes" : {
+			"in_use": 24,
+			"limit": 25,
+			"reserved": 26
+		},
+		"backups" : {
+			"in_use": 27,
+			"limit": 28,
+			"reserved": 29
+		},
+		"backup_gigabytes" : {
+			"in_use": 30,
+			"limit": 31,
+			"reserved": 32
+		}
+		}
+	}
+}`,
+		expectedQuotaDetailSet: quotasets.QuotaDetailSet{
+			ID:                 FirstTenantID,
+			Volumes:            quotasets.QuotaDetail{InUse: 15, Limit: 16, Reserved: 17},
+			Snapshots:          quotasets.QuotaDetail{InUse: 18, Limit: 19, Reserved: 20},
+			Gigabytes:          quotasets.QuotaDetail{InUse: 21, Limit: 22, Reserved: 23},
+			PerVolumeGigabytes: quotasets.QuotaDetail{InUse: 24, Limit: 25, Reserved: 26},
+			Backups:            quotasets.QuotaDetail{InUse: 27, Limit: 28, Reserved: 29},
+			BackupGigabytes:    quotasets.QuotaDetail{InUse: 30, Limit: 31, Reserved: 32},
+		},
+		uriPath:        "/os-quota-sets/" + FirstTenantID,
+		uriQueryParams: map[string]string{"usage": "true"},
+		httpMethod:     "GET",
+	},
 }
 
 // HandleSuccessfulRequest configures the test server to respond to an HTTP request.
-func HandleSuccessfulRequest(t *testing.T, httpMethod, uriPath, jsonOutput string) {
+func HandleSuccessfulRequest(t *testing.T, httpMethod, uriPath, jsonOutput string, uriQueryParams map[string]string) {
 
 	th.Mux.HandleFunc(uriPath, func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, httpMethod)
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		w.Header().Add("Content-Type", "application/json")
+
+		if uriQueryParams != nil {
+			th.TestFormValues(t, r, uriQueryParams)
+		}
 
 		fmt.Fprintf(w, jsonOutput)
 	})

--- a/openstack/blockstorage/extensions/quotasets/testing/requests_test.go
+++ b/openstack/blockstorage/extensions/quotasets/testing/requests_test.go
@@ -9,9 +9,9 @@ import (
 )
 
 var emptyQuotaSet = quotasets.QuotaSet{}
-var emptyQuotaDetailSet = quotasets.QuotaDetailSet{}
+var emptyQuotaUsageSet = quotasets.QuotaUsageSet{}
 
-func testSuccessTestCase(t *testing.T, httpMethod, uriPath, jsonBody string, uriQueryParams map[string]string, expectedQuotaSet quotasets.QuotaSet, expectedQuotaDetailSet quotasets.QuotaDetailSet) error {
+func testSuccessTestCase(t *testing.T, httpMethod, uriPath, jsonBody string, uriQueryParams map[string]string, expectedQuotaSet quotasets.QuotaSet, expectedQuotaUsageSet quotasets.QuotaUsageSet) error {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 	HandleSuccessfulRequest(t, httpMethod, uriPath, jsonBody, uriQueryParams)
@@ -22,19 +22,19 @@ func testSuccessTestCase(t *testing.T, httpMethod, uriPath, jsonBody string, uri
 			return err
 		}
 		th.CheckDeepEquals(t, &expectedQuotaSet, actual)
-	} else if expectedQuotaDetailSet != emptyQuotaDetailSet {
-		actual, err := quotasets.GetDetail(client.ServiceClient(), FirstTenantID).Extract()
+	} else if expectedQuotaUsageSet != emptyQuotaUsageSet {
+		actual, err := quotasets.GetUsage(client.ServiceClient(), FirstTenantID).Extract()
 		if err != nil {
 			return err
 		}
-		th.CheckDeepEquals(t, expectedQuotaDetailSet, actual)
+		th.CheckDeepEquals(t, expectedQuotaUsageSet, actual)
 	}
 	return nil
 }
 
 func TestSuccessTestCases(t *testing.T) {
 	for _, tt := range successTestCases {
-		err := testSuccessTestCase(t, tt.httpMethod, tt.uriPath, tt.jsonBody, tt.uriQueryParams, tt.expectedQuotaSet, tt.expectedQuotaDetailSet)
+		err := testSuccessTestCase(t, tt.httpMethod, tt.uriPath, tt.jsonBody, tt.uriQueryParams, tt.expectedQuotaSet, tt.expectedQuotaUsageSet)
 		if err != nil {
 			t.Fatalf("Test case '%s' failed with error:\n%s", tt.name, err)
 		}

--- a/openstack/blockstorage/extensions/quotasets/testing/requests_test.go
+++ b/openstack/blockstorage/extensions/quotasets/testing/requests_test.go
@@ -11,7 +11,7 @@ import (
 var emptyQuotaSet = quotasets.QuotaSet{}
 var emptyQuotaDetailSet = quotasets.QuotaDetailSet{}
 
-func testSuccessTestCase(t *testing.T, httpMethod, uriPath, jsonBody string, uriQueryParams map[string]string, expectedQuotaSet quotasets.QuotaSet, expectedQuotaDetailSet quotasets.QuotaDetailSet,) error {
+func testSuccessTestCase(t *testing.T, httpMethod, uriPath, jsonBody string, uriQueryParams map[string]string, expectedQuotaSet quotasets.QuotaSet, expectedQuotaDetailSet quotasets.QuotaDetailSet) error {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 	HandleSuccessfulRequest(t, httpMethod, uriPath, jsonBody, uriQueryParams)
@@ -34,7 +34,7 @@ func testSuccessTestCase(t *testing.T, httpMethod, uriPath, jsonBody string, uri
 
 func TestSuccessTestCases(t *testing.T) {
 	for _, tt := range successTestCases {
-		err := testSuccessTestCase(t, tt.httpMethod, tt.uriPath, tt.jsonBody, tt.uriQueryParams, tt.expectedQuotaSet, tt.expectedQuotaDetailSet,)
+		err := testSuccessTestCase(t, tt.httpMethod, tt.uriPath, tt.jsonBody, tt.uriQueryParams, tt.expectedQuotaSet, tt.expectedQuotaDetailSet)
 		if err != nil {
 			t.Fatalf("Test case '%s' failed with error:\n%s", tt.name, err)
 		}

--- a/openstack/blockstorage/extensions/quotasets/testing/requests_test.go
+++ b/openstack/blockstorage/extensions/quotasets/testing/requests_test.go
@@ -9,23 +9,32 @@ import (
 )
 
 var emptyQuotaSet = quotasets.QuotaSet{}
+var emptyQuotaDetailSet = quotasets.QuotaDetailSet{}
 
-func testSuccessTestCase(t *testing.T, httpMethod, uriPath, jsonBody string, expectedQuotaSet quotasets.QuotaSet) error {
+func testSuccessTestCase(t *testing.T, httpMethod, uriPath, jsonBody string, uriQueryParams map[string]string, expectedQuotaSet quotasets.QuotaSet, expectedQuotaDetailSet quotasets.QuotaDetailSet,) error {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
-	HandleSuccessfulRequest(t, httpMethod, uriPath, jsonBody)
+	HandleSuccessfulRequest(t, httpMethod, uriPath, jsonBody, uriQueryParams)
 
-	actual, err := quotasets.Get(client.ServiceClient(), FirstTenantID).Extract()
-	if err != nil {
-		return err
+	if expectedQuotaSet != emptyQuotaSet {
+		actual, err := quotasets.Get(client.ServiceClient(), FirstTenantID).Extract()
+		if err != nil {
+			return err
+		}
+		th.CheckDeepEquals(t, &expectedQuotaSet, actual)
+	} else if expectedQuotaDetailSet != emptyQuotaDetailSet {
+		actual, err := quotasets.GetDetail(client.ServiceClient(), FirstTenantID).Extract()
+		if err != nil {
+			return err
+		}
+		th.CheckDeepEquals(t, expectedQuotaDetailSet, actual)
 	}
-	th.CheckDeepEquals(t, &expectedQuotaSet, actual)
 	return nil
 }
 
 func TestSuccessTestCases(t *testing.T) {
 	for _, tt := range successTestCases {
-		err := testSuccessTestCase(t, tt.httpMethod, tt.uriPath, tt.jsonBody, tt.expectedQuotaSet)
+		err := testSuccessTestCase(t, tt.httpMethod, tt.uriPath, tt.jsonBody, tt.uriQueryParams, tt.expectedQuotaSet, tt.expectedQuotaDetailSet,)
 		if err != nil {
 			t.Fatalf("Test case '%s' failed with error:\n%s", tt.name, err)
 		}

--- a/openstack/blockstorage/extensions/quotasets/urls.go
+++ b/openstack/blockstorage/extensions/quotasets/urls.go
@@ -11,3 +11,7 @@ func getURL(c *gophercloud.ServiceClient, projectID string) string {
 func getDefaultsURL(c *gophercloud.ServiceClient, projectID string) string {
 	return c.ServiceURL(resourcePath, projectID, "defaults")
 }
+
+func getDetailURL(c *gophercloud.ServiceClient, projectID string) string {
+	return c.ServiceURL(resourcePath, projectID+"?usage=true")
+}

--- a/openstack/blockstorage/extensions/quotasets/urls.go
+++ b/openstack/blockstorage/extensions/quotasets/urls.go
@@ -12,6 +12,6 @@ func getDefaultsURL(c *gophercloud.ServiceClient, projectID string) string {
 	return c.ServiceURL(resourcePath, projectID, "defaults")
 }
 
-func getDetailURL(c *gophercloud.ServiceClient, projectID string) string {
+func getUsageURL(c *gophercloud.ServiceClient, projectID string) string {
 	return c.ServiceURL(resourcePath, projectID+"?usage=true")
 }

--- a/openstack/blockstorage/extensions/quotasets/urls.go
+++ b/openstack/blockstorage/extensions/quotasets/urls.go
@@ -11,7 +11,3 @@ func getURL(c *gophercloud.ServiceClient, projectID string) string {
 func getDefaultsURL(c *gophercloud.ServiceClient, projectID string) string {
 	return c.ServiceURL(resourcePath, projectID, "defaults")
 }
-
-func getUsageURL(c *gophercloud.ServiceClient, projectID string) string {
-	return c.ServiceURL(resourcePath, projectID+"?usage=true")
-}


### PR DESCRIPTION
For #234
Pending #878

\## API:
https://developer.openstack.org/api-ref/block-storage/v3/index.html#quota-sets-extension-os-quota-sets

\## Schema:
I'm not showing the actual DB schema here because it makes more sense from a
request parameter validation standpoint to show the chain of calls and data
structures involved in validating a request.

Here is an example of [PUT/update request parameter validation](https://github.com/openstack/cinder/blob/master/cinder/api/contrib/quotas.py#L218-L219).

So the data structure that ultimately specifies the correct parameter names is [cinder.quotas.QUOTAS](https://github.com/openstack/cinder/blob/master/cinder/quota.py#L1234) which is a module constant initialized with [cinder.quotas.VolumeTypeQuotaEngine](https://github.com/openstack/cinder/blob/master/cinder/quota.py#L1127) which in turn:
* is a [cinder.quotas.QuotaEngine](https://github.com/openstack/cinder/blob/master/cinder/quota.py#L1127), which implements `__contains__` as
```
    def __contains__(self, resource):
        return resource in self.resources
```
* overrides `cinder.quotas.QuotaEngine.resources` and returns a dict whose keys are valid volume quota types.

So regardless of what the db schema looks like, this is the correct chain of
calls and underlying data structure that determines what keys are accepted in
the HTTP request body. The GET api uses the same data structure to retrieve a
list of quotas.

https://github.com/openstack/cinder/blob/master/cinder/api/contrib/quotas.py#L156

\## Update:
https://github.com/openstack/cinder/blob/master/cinder/api/contrib/quotas.py#L193

\## Delete:
https://github.com/openstack/cinder/blob/master/cinder/api/contrib/quotas.py#L337