### PR TITLE
Blockstorage v3 quota-set support - part 4, Update

### DIFF
--- a/openstack/blockstorage/extensions/quotasets/doc.go
+++ b/openstack/blockstorage/extensions/quotasets/doc.go
@@ -18,5 +18,18 @@ Example to Get Quota Set Usage
 	}
 
 	fmt.Printf("%+v\n", quotaset)
+
+Example to Update a Quota Set
+
+	updateOpts := quotasets.UpdateOpts{
+		Volumes: gophercloud.IntToPointer(100),
+	}
+
+	quotaset, err := quotasets.Update(blockStorageClient, "project-id", updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v\n", quotaset)
 */
 package quotasets

--- a/openstack/blockstorage/extensions/quotasets/requests.go
+++ b/openstack/blockstorage/extensions/quotasets/requests.go
@@ -24,3 +24,61 @@ func GetUsage(client *gophercloud.ServiceClient, projectID string) (r GetUsageRe
 	_, r.Err = client.Get(u, &r.Body, nil)
 	return
 }
+
+// Updates the quotas for the given projectID and returns the new QuotaSet.
+func Update(client *gophercloud.ServiceClient, projectID string, opts UpdateOptsBuilder) (r UpdateResult) {
+	reqBody, err := opts.ToBlockStorageQuotaUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = client.Put(updateURL(client, projectID), reqBody, &r.Body, &gophercloud.RequestOpts{OkCodes: []int{200}})
+	return r
+}
+
+// Options for Updating the quotas of a Tenant.
+// All int-values are pointers so they can be nil if they are not needed.
+// You can use gopercloud.IntToPointer() for convenience
+type UpdateOpts struct {
+	// Volumes is the number of volumes that are allowed for each project.
+	Volumes *int `json:"volumes,omitempty"`
+
+	// Snapshots is the number of snapshots that are allowed for each project.
+	Snapshots *int `json:"snapshots,omitempty"`
+
+	// Gigabytes is the size (GB) of volumes and snapshots that are allowed for
+	// each project.
+	Gigabytes *int `json:"gigabytes,omitempty"`
+
+	// PerVolumeGigabytes is the size (GB) of volumes and snapshots that are
+	// allowed for each project and the specifed volume type.
+	PerVolumeGigabytes *int `json:"per_volume_gigabytes,omitempty"`
+
+	// Backups is the number of backups that are allowed for each project.
+	Backups *int `json:"backups,omitempty"`
+
+	// BackupGigabytes is the size (GB) of backups that are allowed for each
+	// project.
+	BackupGigabytes *int `json:"backup_gigabytes,omitempty"`
+
+	// Groups is the number of groups that are allowed for each project.
+	Groups *int `json:"groups,omitempty"`
+
+	// Force will update the quotaset even if the quota has already been used
+	// and the reserved quota exceeds the new quota.
+	Force bool `json:"force,omitempty"`
+}
+
+// UpdateOptsBuilder enables extensins to add parameters to the update request.
+type UpdateOptsBuilder interface {
+	// Extra specific name to prevent collisions with interfaces for other quotas
+	// (e.g. neutron)
+	ToBlockStorageQuotaUpdateMap() (map[string]interface{}, error)
+}
+
+// ToBlockStorageQuotaUpdateMap builds the update options into a serializable
+// format.
+func (opts UpdateOpts) ToBlockStorageQuotaUpdateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "quota_set")
+}

--- a/openstack/blockstorage/extensions/quotasets/results.go
+++ b/openstack/blockstorage/extensions/quotasets/results.go
@@ -132,6 +132,12 @@ type GetResult struct {
 	quotaResult
 }
 
+// UpdateResult is the response from a Update operation. Call its Extract method
+// to interpret it as a QuotaSet.
+type UpdateResult struct {
+	quotaResult
+}
+
 type quotaUsageResult struct {
 	gophercloud.Result
 }

--- a/openstack/blockstorage/extensions/quotasets/urls.go
+++ b/openstack/blockstorage/extensions/quotasets/urls.go
@@ -11,3 +11,7 @@ func getURL(c *gophercloud.ServiceClient, projectID string) string {
 func getDefaultsURL(c *gophercloud.ServiceClient, projectID string) string {
 	return c.ServiceURL(resourcePath, projectID, "defaults")
 }
+
+func updateURL(c *gophercloud.ServiceClient, projectID string) string {
+	return getURL(c, projectID)
+}


### PR DESCRIPTION
For #234
Pending #879

\## API:
https://developer.openstack.org/api-ref/block-storage/v3/index.html#quota-sets-extension-os-quota-sets

\## Schema:
I'm not showing the actual DB schema here because it makes more sense from a
request parameter validation standpoint to show the chain of calls and data
structures involved in validating a request.

Here is an example of [PUT/update request parameter validation](https://github.com/openstack/cinder/blob/master/cinder/api/contrib/quotas.py#L218-L219).

So the data structure that ultimately specifies the correct parameter names is [cinder.quotas.QUOTAS](https://github.com/openstack/cinder/blob/master/cinder/quota.py#L1234) which is a module constant initialized with [cinder.quotas.VolumeTypeQuotaEngine](https://github.com/openstack/cinder/blob/master/cinder/quota.py#L1127) which in turn:
* is a [cinder.quotas.QuotaEngine](https://github.com/openstack/cinder/blob/master/cinder/quota.py#L1127), which implements `__contains__` as
```
    def __contains__(self, resource):
        return resource in self.resources
```
* overrides `cinder.quotas.QuotaEngine.resources` and returns a dict whose keys are valid volume quota types.

So regardless of what the db schema looks like, this is the correct chain of
calls and underlying data structure that determines what keys are accepted in
the HTTP request body. The GET api uses the same data structure to retrieve a
list of quotas.

https://github.com/openstack/cinder/blob/master/cinder/api/contrib/quotas.py#L156

\## Update:
https://github.com/openstack/cinder/blob/master/cinder/api/contrib/quotas.py#L193

\## Delete:
https://github.com/openstack/cinder/blob/master/cinder/api/contrib/quotas.py#L337