### PR TITLE
Identity V3: list role assignments for user on project

### DIFF
--- a/openstack/identity/v3/roles/doc.go
+++ b/openstack/identity/v3/roles/doc.go
@@ -79,6 +79,25 @@ Example to List Role Assignments
 		fmt.Printf("%+v\n", role)
 	}
 
+Example to List Role Assignments for a User on a Project
+
+	projectID := "a99e9b4e620e4db09a2dfb6e42a01e66"
+	userID := "9df1a02f5eb2416a9781e8b0c022d3ae"
+
+	allPages, err := roles.ListAssignmentsForUserOnProject(identityClient, projectID, userID).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allRoles, err := roles.ExtractRoles(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, role := range allRoles {
+		fmt.Printf("%+v\n", role)
+	}
+
 Example to Assign a Role to a User in a Project
 
 	projectID := "a99e9b4e620e4db09a2dfb6e42a01e66"

--- a/openstack/identity/v3/roles/requests.go
+++ b/openstack/identity/v3/roles/requests.go
@@ -201,6 +201,14 @@ func ListAssignments(client *gophercloud.ServiceClient, opts ListAssignmentsOpts
 	})
 }
 
+// ListAssignmentsForUserOnProject enumerates the roles assigned to a user on a project.
+func ListAssignmentsForUserOnProject(client *gophercloud.ServiceClient, projectID, userID string) pagination.Pager {
+	url := listAssignmentsForUserOnProjectURL(client, projectID, userID)
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return roles.RolePage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
 // AssignOpts provides options to assign a role
 type AssignOpts struct {
 	// UserID is the ID of a user to assign a role

--- a/openstack/identity/v3/roles/testing/fixtures.go
+++ b/openstack/identity/v3/roles/testing/fixtures.go
@@ -141,6 +141,29 @@ const ListAssignmentOutput = `
 }
 `
 
+// ListAssignmentsForUserOnProjectOutput provides a result of ListAssignmentsForUserOnProject request.
+const ListAssignmentsForUserOnProjectOutput = `
+{
+    "links": {
+        "next": null,
+        "previous": null,
+		"self": "http://example.com/identity/v3/projects/9e5a15/users/b964a9/roles",
+    },
+    "roles": [
+        {
+            "id": "9fe1d3",
+            "links": {
+                "self": "https://example.com/identity/v3/roles/9fe1d3"
+            },
+            "name": "support",
+            "extra": {
+                "description": "read-only support role"
+            }
+        }
+    ]
+}
+`
+
 // FirstRole is the first role in the List request.
 var FirstRole = roles.Role{
 	DomainID: "default",
@@ -329,5 +352,36 @@ func HandleListRoleAssignmentsSuccessfully(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprintf(w, ListAssignmentOutput)
+	})
+}
+
+// RoleForUserOnProject is the role for user on project in the ListAssignmentsForUserOnProject request.
+var RoleForUserOnProject = roles.Role{
+	ID: "9fe1d3",
+	Links: map[string]interface{}{
+		"self": "https://example.com/identity/v3/roles/9fe1d3",
+	},
+	Name: "support",
+	Extra: map[string]interface{}{
+		"description": "read-only support role",
+	},
+}
+
+// ExpectedRolesForUserOnProjectSlice is the slice of roles expected to be returned
+// from ListAssignmentsForUserOnProjectOutput.
+var ExpectedRolesForUserOnProjectSlice = []roles.Role{RoleForUserOnProject}
+
+// HandleListAssignmentsForUserOnProjectSuccessfully creates an HTTP handler at
+// `/projects/9e5a15/users/b964a9/roles` on the test handler mux that tests listing
+// role assignments for user on project.
+func HandleListAssignmentsForUserOnProjectSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/projects/9e5a15/users/b964a9/roles", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, ListAssignmentsForUserOnProjectOutput)
 	})
 }

--- a/openstack/identity/v3/roles/testing/requests_test.go
+++ b/openstack/identity/v3/roles/testing/requests_test.go
@@ -115,6 +115,25 @@ func TestListAssignmentsSinglePage(t *testing.T) {
 	th.CheckEquals(t, count, 1)
 }
 
+func TestListAssignmentsForUserOnProject(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleListAssignmentsForUserOnProjectSuccessfully(t)
+
+	count := 0
+	err := roles.ListAssignmentsForUserOnProject(client.ServiceClient(), "9e5a15", "b964a9").EachPage(func(page pagination.Page) (bool, error) {
+		count++
+
+		actual, err := roles.ExtractRoles(page)
+		th.AssertNoErr(t, err)
+		th.CheckDeepEquals(t, ExpectedRolesForUserOnProjectSlice, actual)
+
+		return true, nil
+	})
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, count, 1)
+}
+
 func TestAssign(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()

--- a/openstack/identity/v3/roles/urls.go
+++ b/openstack/identity/v3/roles/urls.go
@@ -30,6 +30,10 @@ func listAssignmentsURL(client *gophercloud.ServiceClient) string {
 	return client.ServiceURL("role_assignments")
 }
 
+func listAssignmentsForUserOnProjectURL(client *gophercloud.ServiceClient, projectID, userID string) string {
+	return client.ServiceURL("projects", projectID, "users", userID, rolePath)
+}
+
 func assignURL(client *gophercloud.ServiceClient, targetType, targetID, actorType, actorID, roleID string) string {
 	return client.ServiceURL(targetType, targetID, actorType, actorID, rolePath, roleID)
 }


### PR DESCRIPTION
A new one for PR #884 .

For issue #883 .

API reference:
[Identity API v3 - List role assignments for user on project](https://developer.openstack.org/api-ref/identity/v3/#list-role-assignments-for-user-on-project)

Python source code:
https://github.com/openstack/keystone/blob/a6adc72e3e7ff4ff0bff0702e69ebd8f697d6261/keystone/assignment/routers.py#L92
https://github.com/openstack/keystone/blob/a6adc72e3e7ff4ff0bff0702e69ebd8f697d6261/keystone/assignment/core.py#L113
https://github.com/openstack/python-keystoneclient/blob/40642d597deecce4dd81428449353bbd0c2ad5be/keystoneclient/v3/roles.py#L158
