### PR TITLE
Identity V3: Check Whether User Belongs to Group

### DIFF
--- a/acceptance/openstack/identity/v3/users_test.go
+++ b/acceptance/openstack/identity/v3/users_test.go
@@ -196,7 +196,7 @@ func TestUsersListGroups(t *testing.T) {
 	}
 }
 
-func TestUserAddToGroup(t *testing.T) {
+func TestUsersAddToGroup(t *testing.T) {
 	client, err := clients.NewIdentityV3Client()
 	if err != nil {
 		t.Fatalf("Unable to obtain an identity client: %v", err)
@@ -247,6 +247,65 @@ func TestUserAddToGroup(t *testing.T) {
 	err = users.AddToGroup(client, group.ID, user.ID).ExtractErr()
 	if err != nil {
 		t.Fatalf("Unable to add user to group: %v", err)
+	}
+}
+
+func TestUsersRemoveFromGroup(t *testing.T) {
+	client, err := clients.NewIdentityV3Client()
+	if err != nil {
+		t.Fatalf("Unable to obtain an identity client: %v", err)
+	}
+
+	createOpts := users.CreateOpts{
+		Password: "foobar",
+		DomainID: "default",
+		Options: map[users.Option]interface{}{
+			users.IgnorePasswordExpiry: true,
+			users.MultiFactorAuthRules: []interface{}{
+				[]string{"password", "totp"},
+				[]string{"password", "custom-auth-method"},
+			},
+		},
+		Extra: map[string]interface{}{
+			"email": "jsmith@example.com",
+		},
+	}
+
+	user, err := CreateUser(t, client, &createOpts)
+	if err != nil {
+		t.Fatalf("Unable to create user: %v", err)
+	}
+	defer DeleteUser(t, client, user.ID)
+
+	tools.PrintResource(t, user)
+	tools.PrintResource(t, user.Extra)
+
+	createGroupOpts := groups.CreateOpts{
+		Name:     "testgroup",
+		DomainID: "default",
+		Extra: map[string]interface{}{
+			"email": "testgroup@example.com",
+		},
+	}
+
+	// Create Group in the default domain
+	group, err := CreateGroup(t, client, &createGroupOpts)
+	if err != nil {
+		t.Fatalf("Unable to create group: %v", err)
+	}
+	defer DeleteGroup(t, client, group.ID)
+
+	tools.PrintResource(t, group)
+	tools.PrintResource(t, group.Extra)
+
+	err = users.AddToGroup(client, group.ID, user.ID).ExtractErr()
+	if err != nil {
+		t.Fatalf("Unable to add user to group: %v", err)
+	}
+
+	err = users.RemoveFromGroup(client, group.ID, user.ID).ExtractErr()
+	if err != nil {
+		t.Fatalf("Unable to remove user from group: %v", err)
 	}
 }
 

--- a/acceptance/openstack/identity/v3/users_test.go
+++ b/acceptance/openstack/identity/v3/users_test.go
@@ -303,9 +303,12 @@ func TestUsersCheckInGroup(t *testing.T) {
 		t.Fatalf("Unable to add user to group: %v", err)
 	}
 
-	err = users.CheckInGroup(client, group.ID, user.ID).ExtractErr()
+	ok, err := users.IsMemberOfGroup(client, group.ID, user.ID).Extract()
 	if err != nil {
-		t.Fatalf("Unable to check whether user belongs to group correctly: %v", err)
+		t.Fatalf("Unable to check whether user belongs to group: %v", err)
+	}
+	if !ok {
+		t.Fatalf("User %s is expected to be a member of group %s", user.ID, group.ID)
 	}
 }
 

--- a/acceptance/openstack/identity/v3/users_test.go
+++ b/acceptance/openstack/identity/v3/users_test.go
@@ -250,7 +250,7 @@ func TestUsersAddToGroup(t *testing.T) {
 	}
 }
 
-func TestUsersCheckInGroup(t *testing.T) {
+func TestUsersIsMemberOfGroup(t *testing.T) {
 	client, err := clients.NewIdentityV3Client()
 	if err != nil {
 		t.Fatalf("Unable to obtain an identity client: %v", err)

--- a/openstack/identity/v3/users/doc.go
+++ b/openstack/identity/v3/users/doc.go
@@ -110,10 +110,13 @@ Example to Check Whether a User Belongs to a Group
 
 	groupID := "bede500ee1124ae9b0006ff859758b3a"
 	userID := "0fe36e73809d46aeae6705c39077b1b3"
-	err := users.CheckInGroup(identityClient, groupID, userID).ExtractErr()
+	ok, err := users.IsMemberOfGroup(identityClient, groupID, userID).Extract()
+	if err != nil {
+		panic(err)
+	}
 
-	if err == nil {
-		fmt.Printf("user with ID %s belongs to group with ID %s\n", userID, groupID)
+	if ok {
+		fmt.Printf("user %s is a member of group %s\n", userID, groupID)
 	}
 
 Example to Remove a User from a Group

--- a/openstack/identity/v3/users/doc.go
+++ b/openstack/identity/v3/users/doc.go
@@ -106,6 +106,16 @@ Example to Add a User to a Group
 		panic(err)
 	}
 
+Example to Remove a User from a Group
+
+	groupID := "bede500ee1124ae9b0006ff859758b3a"
+	userID := "0fe36e73809d46aeae6705c39077b1b3"
+	err := users.RemoveFromGroup(identityClient, groupID, userID).ExtractErr()
+
+	if err != nil {
+		panic(err)
+	}
+
 Example to List Projects a User Belongs To
 
 	userID := "0fe36e73809d46aeae6705c39077b1b3"

--- a/openstack/identity/v3/users/doc.go
+++ b/openstack/identity/v3/users/doc.go
@@ -106,6 +106,16 @@ Example to Add a User to a Group
 		panic(err)
 	}
 
+Example to Check Whether a User Belongs to a Group
+
+	groupID := "bede500ee1124ae9b0006ff859758b3a"
+	userID := "0fe36e73809d46aeae6705c39077b1b3"
+	err := users.CheckInGroup(identityClient, groupID, userID).ExtractErr()
+
+	if err == nil {
+		fmt.Printf("user with ID %s belongs to group with ID %s\n", userID, groupID)
+	}
+
 Example to Remove a User from a Group
 
 	groupID := "bede500ee1124ae9b0006ff859758b3a"

--- a/openstack/identity/v3/users/requests.go
+++ b/openstack/identity/v3/users/requests.go
@@ -1,6 +1,8 @@
 package users
 
 import (
+	"net/http"
+
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/groups"
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/projects"
@@ -266,12 +268,19 @@ func AddToGroup(client *gophercloud.ServiceClient, groupID, userID string) (r Ad
 	return
 }
 
-// CheckInGroup checks whether a user belongs to a group.
-func CheckInGroup(client *gophercloud.ServiceClient, groupID, userID string) (r CheckInGroupResult) {
-	url := checkInGroupURL(client, groupID, userID)
-	_, r.Err = client.Request("HEAD", url, &gophercloud.RequestOpts{
-		OkCodes: []int{204},
+// IsMemberOfGroup checks whether a user belongs to a group.
+func IsMemberOfGroup(client *gophercloud.ServiceClient, groupID, userID string) (r IsMemberOfGroupResult) {
+	url := isMemberOfGroupURL(client, groupID, userID)
+	var response *http.Response
+	response, r.Err = client.Request("HEAD", url, &gophercloud.RequestOpts{
+		OkCodes: []int{204, 404},
 	})
+	if r.Err == nil {
+		if (*response).StatusCode == 204 {
+			r.IsMember = true
+		}
+	}
+
 	return
 }
 

--- a/openstack/identity/v3/users/requests.go
+++ b/openstack/identity/v3/users/requests.go
@@ -266,6 +266,15 @@ func AddToGroup(client *gophercloud.ServiceClient, groupID, userID string) (r Ad
 	return
 }
 
+// RemoveFromGroup removes a user from a group.
+func RemoveFromGroup(client *gophercloud.ServiceClient, groupID, userID string) (r RemoveFromGroupResult) {
+	url := removeFromGroupURL(client, groupID, userID)
+	_, r.Err = client.Delete(url, &gophercloud.RequestOpts{
+		OkCodes: []int{204},
+	})
+	return
+}
+
 // ListProjects enumerates groups user belongs to.
 func ListProjects(client *gophercloud.ServiceClient, userID string) pagination.Pager {
 	url := listProjectsURL(client, userID)

--- a/openstack/identity/v3/users/requests.go
+++ b/openstack/identity/v3/users/requests.go
@@ -266,6 +266,15 @@ func AddToGroup(client *gophercloud.ServiceClient, groupID, userID string) (r Ad
 	return
 }
 
+// CheckInGroup checks whether a user belongs to a group.
+func CheckInGroup(client *gophercloud.ServiceClient, groupID, userID string) (r CheckInGroupResult) {
+	url := checkInGroupURL(client, groupID, userID)
+	_, r.Err = client.Request("HEAD", url, &gophercloud.RequestOpts{
+		OkCodes: []int{204},
+	})
+	return
+}
+
 // RemoveFromGroup removes a user from a group.
 func RemoveFromGroup(client *gophercloud.ServiceClient, groupID, userID string) (r RemoveFromGroupResult) {
 	url := removeFromGroupURL(client, groupID, userID)

--- a/openstack/identity/v3/users/requests.go
+++ b/openstack/identity/v3/users/requests.go
@@ -275,9 +275,9 @@ func IsMemberOfGroup(client *gophercloud.ServiceClient, groupID, userID string) 
 	response, r.Err = client.Request("HEAD", url, &gophercloud.RequestOpts{
 		OkCodes: []int{204, 404},
 	})
-	if r.Err == nil {
+	if r.Err == nil && response != nil {
 		if (*response).StatusCode == 204 {
-			r.IsMember = true
+			r.isMember = true
 		}
 	}
 

--- a/openstack/identity/v3/users/results.go
+++ b/openstack/identity/v3/users/results.go
@@ -116,6 +116,12 @@ type AddToGroupResult struct {
 	gophercloud.ErrResult
 }
 
+// CheckInGroupResult is the response from a CheckInGroup operation. Call its
+// ExtractErr method to determine if the request succeeded or failed.
+type CheckInGroupResult struct {
+	gophercloud.ErrResult
+}
+
 // RemoveFromGroupResult is the response from a RemoveFromGroup operation. Call its
 // ExtractErr method to determine if the request succeeded or failed.
 type RemoveFromGroupResult struct {

--- a/openstack/identity/v3/users/results.go
+++ b/openstack/identity/v3/users/results.go
@@ -116,6 +116,12 @@ type AddToGroupResult struct {
 	gophercloud.ErrResult
 }
 
+// RemoveFromGroupResult is the response from a RemoveFromGroup operation. Call its
+// ExtractErr method to determine if the request succeeded or failed.
+type RemoveFromGroupResult struct {
+	gophercloud.ErrResult
+}
+
 // UserPage is a single page of User results.
 type UserPage struct {
 	pagination.LinkedPageBase

--- a/openstack/identity/v3/users/results.go
+++ b/openstack/identity/v3/users/results.go
@@ -116,9 +116,10 @@ type AddToGroupResult struct {
 	gophercloud.ErrResult
 }
 
-// CheckInGroupResult is the response from a CheckInGroup operation. Call its
+// IsMemberOfGroupResult is the response from a IsMemberOfGroup operation. Call its
 // ExtractErr method to determine if the request succeeded or failed.
-type CheckInGroupResult struct {
+type IsMemberOfGroupResult struct {
+	IsMember bool
 	gophercloud.ErrResult
 }
 
@@ -170,4 +171,9 @@ func (r userResult) Extract() (*User, error) {
 	}
 	err := r.ExtractInto(&s)
 	return s.User, err
+}
+
+// Extract extracts IsMemberOfGroupResult as bool and error values
+func (r IsMemberOfGroupResult) Extract() (bool, error) {
+	return r.IsMember, r.Err
 }

--- a/openstack/identity/v3/users/results.go
+++ b/openstack/identity/v3/users/results.go
@@ -117,10 +117,10 @@ type AddToGroupResult struct {
 }
 
 // IsMemberOfGroupResult is the response from a IsMemberOfGroup operation. Call its
-// ExtractErr method to determine if the request succeeded or failed.
+// Extract method to determine if the request succeeded or failed.
 type IsMemberOfGroupResult struct {
 	IsMember bool
-	gophercloud.ErrResult
+	gophercloud.Result
 }
 
 // RemoveFromGroupResult is the response from a RemoveFromGroup operation. Call its

--- a/openstack/identity/v3/users/results.go
+++ b/openstack/identity/v3/users/results.go
@@ -119,7 +119,7 @@ type AddToGroupResult struct {
 // IsMemberOfGroupResult is the response from a IsMemberOfGroup operation. Call its
 // Extract method to determine if the request succeeded or failed.
 type IsMemberOfGroupResult struct {
-	IsMember bool
+	isMember bool
 	gophercloud.Result
 }
 
@@ -175,5 +175,5 @@ func (r userResult) Extract() (*User, error) {
 
 // Extract extracts IsMemberOfGroupResult as bool and error values
 func (r IsMemberOfGroupResult) Extract() (bool, error) {
-	return r.IsMember, r.Err
+	return r.isMember, r.Err
 }

--- a/openstack/identity/v3/users/testing/fixtures.go
+++ b/openstack/identity/v3/users/testing/fixtures.go
@@ -481,9 +481,9 @@ func HandleAddToGroupSuccessfully(t *testing.T) {
 	})
 }
 
-// HandleCheckInGroupSuccessfully creates an HTTP handler at /groups/{groupID}/users/{userID}
+// HandleIsMemberOfGroupSuccessfully creates an HTTP handler at /groups/{groupID}/users/{userID}
 // on the test handler mux that tests checking whether user belongs to group.
-func HandleCheckInGroupSuccessfully(t *testing.T) {
+func HandleIsMemberOfGroupSuccessfully(t *testing.T) {
 	th.Mux.HandleFunc("/groups/ea167b/users/9fe1d3", func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "HEAD")
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)

--- a/openstack/identity/v3/users/testing/fixtures.go
+++ b/openstack/identity/v3/users/testing/fixtures.go
@@ -481,6 +481,17 @@ func HandleAddToGroupSuccessfully(t *testing.T) {
 	})
 }
 
+// HandleCheckInGroupSuccessfully creates an HTTP handler at /groups/{groupID}/users/{userID}
+// on the test handler mux that tests checking whether user belongs to group.
+func HandleCheckInGroupSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/groups/ea167b/users/9fe1d3", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "HEAD")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.WriteHeader(http.StatusNoContent)
+	})
+}
+
 // HandleRemoveFromGroupSuccessfully creates an HTTP handler at /groups/{groupID}/users/{userID}
 // on the test handler mux that tests removing user from group.
 func HandleRemoveFromGroupSuccessfully(t *testing.T) {

--- a/openstack/identity/v3/users/testing/fixtures.go
+++ b/openstack/identity/v3/users/testing/fixtures.go
@@ -481,6 +481,17 @@ func HandleAddToGroupSuccessfully(t *testing.T) {
 	})
 }
 
+// HandleRemoveFromGroupSuccessfully creates an HTTP handler at /groups/{groupID}/users/{userID}
+// on the test handler mux that tests removing user from group.
+func HandleRemoveFromGroupSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/groups/ea167b/users/9fe1d3", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.WriteHeader(http.StatusNoContent)
+	})
+}
+
 // HandleListUserProjectsSuccessfully creates an HTTP handler at /users/{userID}/projects
 // on the test handler mux that respons wit a list of two projects
 func HandleListUserProjectsSuccessfully(t *testing.T) {

--- a/openstack/identity/v3/users/testing/requests_test.go
+++ b/openstack/identity/v3/users/testing/requests_test.go
@@ -170,6 +170,14 @@ func TestAddToGroup(t *testing.T) {
 	th.AssertNoErr(t, res.Err)
 }
 
+func TestRemoveFromGroup(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleRemoveFromGroupSuccessfully(t)
+	res := users.RemoveFromGroup(client.ServiceClient(), "ea167b", "9fe1d3")
+	th.AssertNoErr(t, res.Err)
+}
+
 func TestListUserProjects(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()

--- a/openstack/identity/v3/users/testing/requests_test.go
+++ b/openstack/identity/v3/users/testing/requests_test.go
@@ -170,6 +170,14 @@ func TestAddToGroup(t *testing.T) {
 	th.AssertNoErr(t, res.Err)
 }
 
+func TestCheckInGroup(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleCheckInGroupSuccessfully(t)
+	res := users.CheckInGroup(client.ServiceClient(), "ea167b", "9fe1d3")
+	th.AssertNoErr(t, res.Err)
+}
+
 func TestRemoveFromGroup(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()

--- a/openstack/identity/v3/users/testing/requests_test.go
+++ b/openstack/identity/v3/users/testing/requests_test.go
@@ -170,12 +170,13 @@ func TestAddToGroup(t *testing.T) {
 	th.AssertNoErr(t, res.Err)
 }
 
-func TestCheckInGroup(t *testing.T) {
+func TestIsMemberOfGroup(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
-	HandleCheckInGroupSuccessfully(t)
-	res := users.CheckInGroup(client.ServiceClient(), "ea167b", "9fe1d3")
-	th.AssertNoErr(t, res.Err)
+	HandleIsMemberOfGroupSuccessfully(t)
+	ok, err := users.IsMemberOfGroup(client.ServiceClient(), "ea167b", "9fe1d3").Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, true, ok)
 }
 
 func TestRemoveFromGroup(t *testing.T) {

--- a/openstack/identity/v3/users/urls.go
+++ b/openstack/identity/v3/users/urls.go
@@ -34,6 +34,10 @@ func addToGroupURL(client *gophercloud.ServiceClient, groupID, userID string) st
 	return client.ServiceURL("groups", groupID, "users", userID)
 }
 
+func removeFromGroupURL(client *gophercloud.ServiceClient, groupID, userID string) string {
+	return client.ServiceURL("groups", groupID, "users", userID)
+}
+
 func listProjectsURL(client *gophercloud.ServiceClient, userID string) string {
 	return client.ServiceURL("users", userID, "projects")
 }

--- a/openstack/identity/v3/users/urls.go
+++ b/openstack/identity/v3/users/urls.go
@@ -34,7 +34,7 @@ func addToGroupURL(client *gophercloud.ServiceClient, groupID, userID string) st
 	return client.ServiceURL("groups", groupID, "users", userID)
 }
 
-func checkInGroupURL(client *gophercloud.ServiceClient, groupID, userID string) string {
+func isMemberOfGroupURL(client *gophercloud.ServiceClient, groupID, userID string) string {
 	return client.ServiceURL("groups", groupID, "users", userID)
 }
 

--- a/openstack/identity/v3/users/urls.go
+++ b/openstack/identity/v3/users/urls.go
@@ -34,6 +34,10 @@ func addToGroupURL(client *gophercloud.ServiceClient, groupID, userID string) st
 	return client.ServiceURL("groups", groupID, "users", userID)
 }
 
+func checkInGroupURL(client *gophercloud.ServiceClient, groupID, userID string) string {
+	return client.ServiceURL("groups", groupID, "users", userID)
+}
+
 func removeFromGroupURL(client *gophercloud.ServiceClient, groupID, userID string) string {
 	return client.ServiceURL("groups", groupID, "users", userID)
 }


### PR DESCRIPTION
For #886

API reference:
[Identity API v3 - Check whether user belongs to group](https://developer.openstack.org/api-ref/identity/v3/#check-whether-user-belongs-to-group)

Python source code:
https://github.com/openstack/keystone/blob/a6adc72e3e7ff4ff0bff0702e69ebd8f697d6261/keystone/identity/routers.py#L49
https://github.com/openstack/keystone/blob/a6adc72e3e7ff4ff0bff0702e69ebd8f697d6261/keystone/identity/core.py#L1361
https://github.com/openstack/python-keystoneclient/blob/40642d597deecce4dd81428449353bbd0c2ad5be/keystoneclient/v3/users.py#L247

