### PR TITLE
Add Scope to AuthOptions

### DIFF
--- a/auth_options.go
+++ b/auth_options.go
@@ -81,6 +81,17 @@ type AuthOptions struct {
 	// TokenID allows users to authenticate (possibly as another user) with an
 	// authentication token ID.
 	TokenID string `json:"-"`
+
+	// Scope determines the scoping of the authentication request.
+	Scope *AuthScope `json:"-"`
+}
+
+// AuthScope allows a created token to be limited to a specific domain or project.
+type AuthScope struct {
+	ProjectID   string
+	ProjectName string
+	DomainID    string
+	DomainName  string
 }
 
 // ToTokenV2CreateMap allows AuthOptions to satisfy the AuthOptionsBuilder
@@ -263,85 +274,83 @@ func (opts *AuthOptions) ToTokenV3CreateMap(scope map[string]interface{}) (map[s
 }
 
 func (opts *AuthOptions) ToTokenV3ScopeMap() (map[string]interface{}, error) {
-
-	var scope struct {
-		ProjectID   string
-		ProjectName string
-		DomainID    string
-		DomainName  string
-	}
-
-	if opts.TenantID != "" {
-		scope.ProjectID = opts.TenantID
-	} else {
-		if opts.TenantName != "" {
-			scope.ProjectName = opts.TenantName
-			scope.DomainID = opts.DomainID
-			scope.DomainName = opts.DomainName
+	// For backwards compatibility.
+	// If AuthOptions.Scope was not set, try to determine it.
+	// This works well for common scenarios.
+	if opts.Scope == nil {
+		opts.Scope = &AuthScope{}
+		if opts.TenantID != "" {
+			opts.Scope.ProjectID = opts.TenantID
+		} else {
+			if opts.TenantName != "" {
+				opts.Scope.ProjectName = opts.TenantName
+				opts.Scope.DomainID = opts.DomainID
+				opts.Scope.DomainName = opts.DomainName
+			}
 		}
 	}
 
-	if scope.ProjectName != "" {
+	if opts.Scope.ProjectName != "" {
 		// ProjectName provided: either DomainID or DomainName must also be supplied.
 		// ProjectID may not be supplied.
-		if scope.DomainID == "" && scope.DomainName == "" {
+		if opts.Scope.DomainID == "" && opts.Scope.DomainName == "" {
 			return nil, ErrScopeDomainIDOrDomainName{}
 		}
-		if scope.ProjectID != "" {
+		if opts.Scope.ProjectID != "" {
 			return nil, ErrScopeProjectIDOrProjectName{}
 		}
 
-		if scope.DomainID != "" {
+		if opts.Scope.DomainID != "" {
 			// ProjectName + DomainID
 			return map[string]interface{}{
 				"project": map[string]interface{}{
-					"name":   &scope.ProjectName,
-					"domain": map[string]interface{}{"id": &scope.DomainID},
+					"name":   &opts.Scope.ProjectName,
+					"domain": map[string]interface{}{"id": &opts.Scope.DomainID},
 				},
 			}, nil
 		}
 
-		if scope.DomainName != "" {
+		if opts.Scope.DomainName != "" {
 			// ProjectName + DomainName
 			return map[string]interface{}{
 				"project": map[string]interface{}{
-					"name":   &scope.ProjectName,
-					"domain": map[string]interface{}{"name": &scope.DomainName},
+					"name":   &opts.Scope.ProjectName,
+					"domain": map[string]interface{}{"name": &opts.Scope.DomainName},
 				},
 			}, nil
 		}
-	} else if scope.ProjectID != "" {
+	} else if opts.Scope.ProjectID != "" {
 		// ProjectID provided. ProjectName, DomainID, and DomainName may not be provided.
-		if scope.DomainID != "" {
+		if opts.Scope.DomainID != "" {
 			return nil, ErrScopeProjectIDAlone{}
 		}
-		if scope.DomainName != "" {
+		if opts.Scope.DomainName != "" {
 			return nil, ErrScopeProjectIDAlone{}
 		}
 
 		// ProjectID
 		return map[string]interface{}{
 			"project": map[string]interface{}{
-				"id": &scope.ProjectID,
+				"id": &opts.Scope.ProjectID,
 			},
 		}, nil
-	} else if scope.DomainID != "" {
+	} else if opts.Scope.DomainID != "" {
 		// DomainID provided. ProjectID, ProjectName, and DomainName may not be provided.
-		if scope.DomainName != "" {
+		if opts.Scope.DomainName != "" {
 			return nil, ErrScopeDomainIDOrDomainName{}
 		}
 
 		// DomainID
 		return map[string]interface{}{
 			"domain": map[string]interface{}{
-				"id": &scope.DomainID,
+				"id": &opts.Scope.DomainID,
 			},
 		}, nil
-	} else if scope.DomainName != "" {
+	} else if opts.Scope.DomainName != "" {
 		// DomainName
 		return map[string]interface{}{
 			"domain": map[string]interface{}{
-				"name": &scope.DomainName,
+				"name": &opts.Scope.DomainName,
 			},
 		}, nil
 	}

--- a/auth_options.go
+++ b/auth_options.go
@@ -278,7 +278,7 @@ func (opts *AuthOptions) ToTokenV3ScopeMap() (map[string]interface{}, error) {
 	// If AuthOptions.Scope was not set, try to determine it.
 	// This works well for common scenarios.
 	if opts.Scope == nil {
-		opts.Scope = &AuthScope{}
+		opts.Scope = new(AuthScope)
 		if opts.TenantID != "" {
 			opts.Scope.ProjectID = opts.TenantID
 		} else {

--- a/openstack/identity/v3/tokens/requests.go
+++ b/openstack/identity/v3/tokens/requests.go
@@ -72,72 +72,15 @@ func (opts *AuthOptions) ToTokenV3CreateMap(scope map[string]interface{}) (map[s
 
 // ToTokenV3CreateMap builds a scope request body from AuthOptions.
 func (opts *AuthOptions) ToTokenV3ScopeMap() (map[string]interface{}, error) {
-	if opts.Scope.ProjectName != "" {
-		// ProjectName provided: either DomainID or DomainName must also be supplied.
-		// ProjectID may not be supplied.
-		if opts.Scope.DomainID == "" && opts.Scope.DomainName == "" {
-			return nil, gophercloud.ErrScopeDomainIDOrDomainName{}
-		}
-		if opts.Scope.ProjectID != "" {
-			return nil, gophercloud.ErrScopeProjectIDOrProjectName{}
-		}
+	scope := gophercloud.AuthScope(opts.Scope)
 
-		if opts.Scope.DomainID != "" {
-			// ProjectName + DomainID
-			return map[string]interface{}{
-				"project": map[string]interface{}{
-					"name":   &opts.Scope.ProjectName,
-					"domain": map[string]interface{}{"id": &opts.Scope.DomainID},
-				},
-			}, nil
-		}
-
-		if opts.Scope.DomainName != "" {
-			// ProjectName + DomainName
-			return map[string]interface{}{
-				"project": map[string]interface{}{
-					"name":   &opts.Scope.ProjectName,
-					"domain": map[string]interface{}{"name": &opts.Scope.DomainName},
-				},
-			}, nil
-		}
-	} else if opts.Scope.ProjectID != "" {
-		// ProjectID provided. ProjectName, DomainID, and DomainName may not be provided.
-		if opts.Scope.DomainID != "" {
-			return nil, gophercloud.ErrScopeProjectIDAlone{}
-		}
-		if opts.Scope.DomainName != "" {
-			return nil, gophercloud.ErrScopeProjectIDAlone{}
-		}
-
-		// ProjectID
-		return map[string]interface{}{
-			"project": map[string]interface{}{
-				"id": &opts.Scope.ProjectID,
-			},
-		}, nil
-	} else if opts.Scope.DomainID != "" {
-		// DomainID provided. ProjectID, ProjectName, and DomainName may not be provided.
-		if opts.Scope.DomainName != "" {
-			return nil, gophercloud.ErrScopeDomainIDOrDomainName{}
-		}
-
-		// DomainID
-		return map[string]interface{}{
-			"domain": map[string]interface{}{
-				"id": &opts.Scope.DomainID,
-			},
-		}, nil
-	} else if opts.Scope.DomainName != "" {
-		// DomainName
-		return map[string]interface{}{
-			"domain": map[string]interface{}{
-				"name": &opts.Scope.DomainName,
-			},
-		}, nil
+	gophercloudAuthOpts := gophercloud.AuthOptions{
+		Scope:      &scope,
+		DomainID:   opts.DomainID,
+		DomainName: opts.DomainName,
 	}
 
-	return nil, nil
+	return gophercloudAuthOpts.ToTokenV3ScopeMap()
 }
 
 func (opts *AuthOptions) CanReauth() bool {


### PR DESCRIPTION
This commit adds a Scope field to the base AuthOptions struct. This
allows an explicit scope to be passed to AuthOptions which will
enable detailed scoping configurations.

For #252 