### PR TITLE
simulate previous token existing in reauth test

### DIFF
--- a/testing/provider_client_test.go
+++ b/testing/provider_client_test.go
@@ -90,6 +90,9 @@ func TestConcurrentReauth(t *testing.T) {
 
 	wg := new(sync.WaitGroup)
 	reqopts := new(gophercloud.RequestOpts)
+	reqopts.MoreHeaders = map[string]string{
+		"X-Auth-Token": prereauthTok,
+	}
 
 	for i := 0; i < numconc; i++ {
 		wg.Add(1)


### PR DESCRIPTION
For #855 

This [I think] turned out not to be a race condition, but instead just a product of adding the `Reauthenticate` method. The previous token wasn't getting set, causing a non-deterministic number of goroutines to think they needed to reauthenticate.