### PR TITLE
Senlin: Profiles Delete

### DIFF
--- a/openstack/clustering/v1/profiles/doc.go
+++ b/openstack/clustering/v1/profiles/doc.go
@@ -62,5 +62,13 @@ Example to Update profile
 
     fmt.Print("profile", profile)
 
+Example to Delete profile
+
+	profileID := "6dc6d336e3fc4c0a951b5698cd1236ee"
+	err := profiles.Delete(serviceClient, profileID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+
 */
 package profiles

--- a/openstack/clustering/v1/profiles/requests.go
+++ b/openstack/clustering/v1/profiles/requests.go
@@ -129,3 +129,13 @@ func Update(client *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder
 	}
 	return
 }
+
+// Delete deletes the specified profile via profile id.
+func Delete(client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+	var result *http.Response
+	result, r.Err = client.Delete(deleteURL(client, id), nil)
+	if r.Err == nil {
+		r.Header = result.Header
+	}
+	return
+}

--- a/openstack/clustering/v1/profiles/results.go
+++ b/openstack/clustering/v1/profiles/results.go
@@ -154,3 +154,9 @@ func (r *Profile) UnmarshalJSON(b []byte) error {
 
 	return nil
 }
+
+// DeleteResult is the result from a Delete operation. Call its ExtractErr
+// method to determine if the call succeeded or failed.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}

--- a/openstack/clustering/v1/profiles/testing/requests_test.go
+++ b/openstack/clustering/v1/profiles/testing/requests_test.go
@@ -865,3 +865,19 @@ func TestUpdateProfilesInvalidTimeString(t *testing.T) {
 	_, err := profiles.Update(fake.ServiceClient(), "9e1c6f42-acf5-4688-be2c-8ce954ef0f23", profiles.UpdateOpts{Name: "pserver"}).Extract()
 	th.AssertEquals(t, false, err == nil)
 }
+
+func TestDeleteProfile(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v1/profiles/6dc6d336e3fc4c0a951b5698cd1236ee", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	deleteResult := profiles.Delete(fake.ServiceClient(), "6dc6d336e3fc4c0a951b5698cd1236ee")
+	th.AssertNoErr(t, deleteResult.ExtractErr())
+}

--- a/openstack/clustering/v1/profiles/urls.go
+++ b/openstack/clustering/v1/profiles/urls.go
@@ -28,3 +28,7 @@ func listURL(client *gophercloud.ServiceClient) string {
 func updateURL(client *gophercloud.ServiceClient, id string) string {
 	return idURL(client, id)
 }
+
+func deleteURL(client *gophercloud.ServiceClient, id string) string {
+	return idURL(client, id)
+}


### PR DESCRIPTION
Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

For #[823 [Add support for Senlin clustering]](https://github.com/gophercloud/gophercloud/issues/823)

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

[[profiles:delete]](https://github.com/openstack/senlin/blob/e5bc16b3fea2f10dead365f983c5a937f23d72b0/senlin/api/openstack/v1/profiles.py#L99)

