### PR TITLE
Senlin: Clusters Delete

### DIFF
--- a/acceptance/openstack/clustering/v1/autoscaling_test.go
+++ b/acceptance/openstack/clustering/v1/autoscaling_test.go
@@ -25,6 +25,7 @@ func TestAutoScaling(t *testing.T) {
 	profileGet(t)
 	profileList(t)
 	clusterCreate(t)
+	defer clustersDelete(t)
 	clusterGet(t)
 	clusterList(t)
 	clusterUpdate(t)
@@ -322,4 +323,17 @@ func WaitForClusterToUpdate(client *gophercloud.ServiceClient, actionID string, 
 			return false, fmt.Errorf("Error WaitFor ActionID=%s. Received status=%v", actionID, action.Status)
 		}
 	})
+}
+
+func clustersDelete(t *testing.T) {
+
+	client, err := clients.NewClusteringV1Client()
+	if err != nil {
+		t.Fatalf("Unable to create clustering client: %v", err)
+	}
+
+	clusterName := testName
+	err = clusters.Delete(client, clusterName).ExtractErr()
+	th.AssertNoErr(t, err)
+	t.Logf("Cluster deleted: %s", clusterName)
 }

--- a/openstack/clustering/v1/clusters/doc.go
+++ b/openstack/clustering/v1/clusters/doc.go
@@ -58,5 +58,13 @@ Example to Update a cluster
 	}
 	fmt.Printf("%+v\n", cluster)
 
+Example to Delete a cluster
+
+	clusterID := "dc6d336e3fc4c0a951b5698cd1236ee"
+	err := clusters.Delete(serviceClient, clusterID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+
 */
 package clusters

--- a/openstack/clustering/v1/clusters/requests.go
+++ b/openstack/clustering/v1/clusters/requests.go
@@ -140,3 +140,13 @@ func Update(client *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder
 	}
 	return
 }
+
+// Delete deletes the specified cluster ID.
+func Delete(client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+	var result *http.Response
+	result, r.Err = client.Delete(deleteURL(client, id), nil)
+	if r.Err == nil {
+		r.Header = result.Header
+	}
+	return
+}

--- a/openstack/clustering/v1/clusters/results.go
+++ b/openstack/clustering/v1/clusters/results.go
@@ -145,3 +145,9 @@ func (r *Cluster) UnmarshalJSON(b []byte) error {
 
 	return nil
 }
+
+// DeleteResult is the result from a Delete operation. Call its ExtractErr
+// method to determine if the call succeeded or failed.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}

--- a/openstack/clustering/v1/clusters/testing/requests_test.go
+++ b/openstack/clustering/v1/clusters/testing/requests_test.go
@@ -1182,3 +1182,19 @@ func TestUpdateClusterInvalidTimeString(t *testing.T) {
 	_, err := clusters.Update(fake.ServiceClient(), id, updateOpts).Extract()
 	th.AssertEquals(t, false, err == nil)
 }
+
+func TestDeleteCluster(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v1/clusters/6dc6d336e3fc4c0a951b5698cd1236ee", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	err := clusters.Delete(fake.ServiceClient(), "6dc6d336e3fc4c0a951b5698cd1236ee").ExtractErr()
+	th.AssertNoErr(t, err)
+}

--- a/openstack/clustering/v1/clusters/urls.go
+++ b/openstack/clustering/v1/clusters/urls.go
@@ -28,3 +28,7 @@ func listURL(client *gophercloud.ServiceClient) string {
 func updateURL(client *gophercloud.ServiceClient, id string) string {
 	return idURL(client, id)
 }
+
+func deleteURL(client *gophercloud.ServiceClient, id string) string {
+	return idURL(client, id)
+}


### PR DESCRIPTION
Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

For #[823 [Add support for Senlin clustering]](https://github.com/gophercloud/gophercloud/issues/823)

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

[[clusters:delete]](https://github.com/openstack/senlin/blob/e5bc16b3fea2f10dead365f983c5a937f23d72b0/senlin/api/openstack/v1/clusters.py#L315)

