### PR TITLE
Senlin: Nodes Delete

### DIFF
--- a/acceptance/openstack/clustering/v1/autoscaling_test.go
+++ b/acceptance/openstack/clustering/v1/autoscaling_test.go
@@ -1,0 +1,30 @@
+package v1
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/acceptance/clients"
+	"github.com/gophercloud/gophercloud/openstack/clustering/v1/nodes"
+
+	"github.com/gophercloud/gophercloud/acceptance/tools"
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+var testName string
+
+func TestAutoScaling(t *testing.T) {
+	testName = tools.RandomString("TESTACC-", 8)
+	nodeDelete(t)
+}
+
+func nodeDelete(t *testing.T) {
+
+	client, err := clients.NewClusteringV1Client()
+	if err != nil {
+		t.Fatalf("Unable to create clustering client: %v", err)
+	}
+
+	nodeName := testName
+	err = nodes.Delete(client, nodeName).ExtractErr()
+	th.AssertNoErr(t, err)
+}

--- a/openstack/clustering/v1/nodes/doc.go
+++ b/openstack/clustering/v1/nodes/doc.go
@@ -1,0 +1,16 @@
+/*
+Package nodes provides information and interaction with the nodes through
+the OpenStack Clustering service.
+
+Lists all nodes, and creates, shows information for, updates, deletes a node.
+
+Example to Delete Node
+
+	nodeID := "6dc6d336e3fc4c0a951b5698cd1236ee"
+	err := nodes.Delete(serviceClient, nodeID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+
+*/
+package nodes

--- a/openstack/clustering/v1/nodes/requests.go
+++ b/openstack/clustering/v1/nodes/requests.go
@@ -1,0 +1,17 @@
+package nodes
+
+import (
+	"net/http"
+
+	"github.com/gophercloud/gophercloud"
+)
+
+// Delete deletes the specified node ID.
+func Delete(client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+	var result *http.Response
+	result, r.Err = client.Delete(deleteURL(client, id), nil)
+	if r.Err == nil {
+		r.Header = result.Header
+	}
+	return
+}

--- a/openstack/clustering/v1/nodes/results.go
+++ b/openstack/clustering/v1/nodes/results.go
@@ -1,0 +1,11 @@
+package nodes
+
+import (
+	"github.com/gophercloud/gophercloud"
+)
+
+// DeleteResult is the result from a Delete operation. Call ExtractErr
+// method to determine if the call succeeded or failed.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}

--- a/openstack/clustering/v1/nodes/testing/doc.go
+++ b/openstack/clustering/v1/nodes/testing/doc.go
@@ -1,0 +1,2 @@
+// clustering_nodes_v1
+package testing

--- a/openstack/clustering/v1/nodes/testing/requests_test.go
+++ b/openstack/clustering/v1/nodes/testing/requests_test.go
@@ -1,0 +1,26 @@
+package testing
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/clustering/v1/nodes"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	fake "github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func TestDeleteNode(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v1/nodes/6dc6d336e3fc4c0a951b5698cd1236ee", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	deleteResult := nodes.Delete(fake.ServiceClient(), "6dc6d336e3fc4c0a951b5698cd1236ee")
+	th.AssertNoErr(t, deleteResult.ExtractErr())
+}

--- a/openstack/clustering/v1/nodes/urls.go
+++ b/openstack/clustering/v1/nodes/urls.go
@@ -1,0 +1,14 @@
+package nodes
+
+import "github.com/gophercloud/gophercloud"
+
+var apiVersion = "v1"
+var apiName = "nodes"
+
+func idURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL(apiVersion, apiName, id)
+}
+
+func deleteURL(client *gophercloud.ServiceClient, id string) string {
+	return idURL(client, id)
+}


### PR DESCRIPTION
Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

For #[823 [Add support for Senlin clustering]](https://github.com/gophercloud/gophercloud/issues/823)

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

[[nodes:delete]](https://github.com/openstack/senlin/blob/e5bc16b3fea2f10dead365f983c5a937f23d72b0/senlin/api/openstack/v1/nodes.py#L122)
