### PR TITLE
Fix required tag for queries and headers

### DIFF
--- a/openstack/objectstorage/v1/swauth/testing/requests_test.go
+++ b/openstack/objectstorage/v1/swauth/testing/requests_test.go
@@ -25,3 +25,11 @@ func TestAuth(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, swiftClient.TokenID, AuthResult.Token)
 }
+
+func TestBadAuth(t *testing.T) {
+	authOpts := swauth.AuthOpts{}
+	_, err := authOpts.ToAuthOptsMap()
+	if err == nil {
+		t.Fatalf("Expected an error due to missing auth options")
+	}
+}

--- a/params.go
+++ b/params.go
@@ -363,9 +363,8 @@ func BuildQueryString(opts interface{}) (*url.URL, error) {
 						}
 					}
 				} else {
-					// Otherwise, the field is not set.
-					if len(tags) == 2 && tags[1] == "required" {
-						// And the field is required. Return an error.
+					// if the field has a 'required' tag, it can't have a zero-value
+					if requiredTag := f.Tag.Get("required"); requiredTag == "true" {
 						return &url.URL{}, fmt.Errorf("Required query parameter [%s] not set.", f.Name)
 					}
 				}
@@ -439,10 +438,9 @@ func BuildHeaders(opts interface{}) (map[string]string, error) {
 						optsMap[tags[0]] = strconv.FormatBool(v.Bool())
 					}
 				} else {
-					// Otherwise, the field is not set.
-					if len(tags) == 2 && tags[1] == "required" {
-						// And the field is required. Return an error.
-						return optsMap, fmt.Errorf("Required header not set.")
+					// if the field has a 'required' tag, it can't have a zero-value
+					if requiredTag := f.Tag.Get("required"); requiredTag == "true" {
+						return optsMap, fmt.Errorf("Required header [%s] not set.", f.Name)
 					}
 				}
 			}

--- a/testing/params_test.go
+++ b/testing/params_test.go
@@ -39,7 +39,7 @@ func TestBuildQueryString(t *testing.T) {
 	iFalse := false
 	opts := struct {
 		J  int               `q:"j"`
-		R  string            `q:"r,required"`
+		R  string            `q:"r" required:"true"`
 		C  bool              `q:"c"`
 		S  []string          `q:"s"`
 		TS []testVar         `q:"ts"`
@@ -65,7 +65,7 @@ func TestBuildQueryString(t *testing.T) {
 
 	opts = struct {
 		J  int               `q:"j"`
-		R  string            `q:"r,required"`
+		R  string            `q:"r" required:"true"`
 		C  bool              `q:"c"`
 		S  []string          `q:"s"`
 		TS []testVar         `q:"ts"`
@@ -91,7 +91,7 @@ func TestBuildQueryString(t *testing.T) {
 func TestBuildHeaders(t *testing.T) {
 	testStruct := struct {
 		Accept string `h:"Accept"`
-		Num    int    `h:"Number,required"`
+		Num    int    `h:"Number" required:"true"`
 		Style  bool   `h:"Style"`
 	}{
 		Accept: "application/json",


### PR DESCRIPTION
This commit fixes how the required tag is set for query and header
parameters. Instead of using

x:"name,required"

as before, it now uses

x:"name" required:"true"

For #910 