### PR TITLE
Senlin: Profiles Update

### DIFF
--- a/acceptance/openstack/clustering/v1/autoscaling_test.go
+++ b/acceptance/openstack/clustering/v1/autoscaling_test.go
@@ -24,6 +24,7 @@ func TestAutoScaling(t *testing.T) {
 	profileCreate(t)
 	profileGet(t)
 	profileList(t)
+	profileUpdate(t)
 	clusterCreate(t)
 	defer clustersDelete(t)
 	clusterGet(t)
@@ -127,6 +128,30 @@ func profileList(t *testing.T) {
 	})
 
 	th.AssertEquals(t, true, testProfileFound)
+}
+
+func profileUpdate(t *testing.T) {
+	client, err := clients.NewClusteringV1Client()
+	if err != nil {
+		t.Fatalf("Unable to create clustering client: %v", err)
+	}
+
+	profileName := testName
+	newProfileName := profileName + "-TEST-PROFILE_UPDATE"
+
+	// Use new name
+	profile, err := profiles.Update(client, profileName, profiles.UpdateOpts{Name: newProfileName}).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, newProfileName, profile.Name)
+
+	tools.PrintResource(t, profile)
+
+	// Revert back to original name
+	profile, err = profiles.Update(client, newProfileName, profiles.UpdateOpts{Name: profileName}).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, profileName, profile.Name)
+
+	tools.PrintResource(t, profile)
 }
 
 func clusterCreate(t *testing.T) {

--- a/openstack/clustering/v1/profiles/doc.go
+++ b/openstack/clustering/v1/profiles/doc.go
@@ -53,5 +53,14 @@ Example to List profiles
 		return true, nil
 	})
 
+Example to Update profile
+
+	profile, err := profiles.Update(serviceClient, profileName, profiles.UpdateOpts{Name: newProfileName}).Extract()
+    if err != nil {
+		panic(err)
+    }
+
+    fmt.Print("profile", profile)
+
 */
 package profiles

--- a/openstack/clustering/v1/profiles/results.go
+++ b/openstack/clustering/v1/profiles/results.go
@@ -27,6 +27,11 @@ type GetResult struct {
 	commonResult
 }
 
+// UpdateResult is the response of a Update operations.
+type UpdateResult struct {
+	commonResult
+}
+
 // Extract provides access to Profile returned by the Get and Create functions.
 func (r commonResult) Extract() (*Profile, error) {
 	var s struct {

--- a/openstack/clustering/v1/profiles/urls.go
+++ b/openstack/clustering/v1/profiles/urls.go
@@ -24,3 +24,7 @@ func getURL(client *gophercloud.ServiceClient, id string) string {
 func listURL(client *gophercloud.ServiceClient) string {
 	return commonURL(client)
 }
+
+func updateURL(client *gophercloud.ServiceClient, id string) string {
+	return idURL(client, id)
+}


### PR DESCRIPTION
Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

For #[823 [Add support for Senlin clustering]](https://github.com/gophercloud/gophercloud/issues/823)

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

[[profiles:update]](https://github.com/openstack/senlin/blob/e5bc16b3fea2f10dead365f983c5a937f23d72b0/senlin/api/openstack/v1/profiles.py#L83)
