### PR TITLE
Senlin: Clusters Update

### DIFF
--- a/openstack/clustering/v1/clusters/doc.go
+++ b/openstack/clustering/v1/clusters/doc.go
@@ -44,5 +44,19 @@ Example to List Clusters
 		fmt.Printf("%+v\n", cluster)
 	}
 
+Example to Update a cluster
+
+	updateOpts := clusters.UpdateOpts{
+		Name:       "testcluster",
+		ProfileID:  "b7b870ee-d3c5-4a93-b9d7-846c53b2c2da",
+	}
+
+	clusterID := "7d85f602-a948-4a30-afd4-e84f47471c15"
+	cluster, err := clusters.Update(serviceClient, clusterName, clusters.UpdateOpts{Name: newClusterName}).Extract()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("%+v\n", cluster)
+
 */
 package clusters

--- a/openstack/clustering/v1/clusters/requests.go
+++ b/openstack/clustering/v1/clusters/requests.go
@@ -101,7 +101,7 @@ type UpdateOpts struct {
 	Config      string                 `json:"config,omitempty"`
 	Name        string                 `json:"name,omitempty"`
 	ProfileID   string                 `json:"profile_id,omitempty"`
-	Timeout     int                    `json:"timeout,omitempty"`
+	Timeout     *int                   `json:"timeout,omitempty"`
 	Metadata    map[string]interface{} `json:"metadata,omitempty"`
 	ProfileOnly *bool                  `json:"profile_only,omitempty"`
 }

--- a/openstack/clustering/v1/clusters/requests.go
+++ b/openstack/clustering/v1/clusters/requests.go
@@ -95,3 +95,48 @@ func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pa
 		return ClusterPage{pagination.LinkedPageBase{PageResult: r}}
 	})
 }
+
+// UpdateOpts implements UpdateOpts
+type UpdateOpts struct {
+	Config      string                 `json:"config,omitempty"`
+	Name        string                 `json:"name,omitempty"`
+	ProfileID   string                 `json:"profile_id,omitempty"`
+	Timeout     int                    `json:"timeout,omitempty"`
+	Metadata    map[string]interface{} `json:"metadata,omitempty"`
+	ProfileOnly *bool                  `json:"profile_only,omitempty"`
+}
+
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
+type UpdateOptsBuilder interface {
+	ToClusterUpdateMap() (map[string]interface{}, error)
+}
+
+// ToClusterUpdateMap assembles a request body based on the contents of
+// UpdateOpts.
+func (opts UpdateOpts) ToClusterUpdateMap() (map[string]interface{}, error) {
+	b, err := gophercloud.BuildRequestBody(opts, "cluster")
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+// Update implements profile updated request.
+func Update(client *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToClusterUpdateMap()
+	if err != nil {
+		r.Err = err
+		return r
+	}
+
+	var result *http.Response
+	result, r.Err = client.Patch(updateURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200, 202},
+	})
+
+	if r.Err == nil {
+		r.Header = result.Header
+	}
+	return
+}

--- a/openstack/clustering/v1/clusters/results.go
+++ b/openstack/clustering/v1/clusters/results.go
@@ -25,6 +25,11 @@ type GetResult struct {
 	commonResult
 }
 
+// UpdateResult is the response of a Update operations.
+type UpdateResult struct {
+	commonResult
+}
+
 type Cluster struct {
 	Config          map[string]interface{} `json:"config"`
 	CreatedAt       time.Time              `json:"-"`

--- a/openstack/clustering/v1/clusters/testing/requests_test.go
+++ b/openstack/clustering/v1/clusters/testing/requests_test.go
@@ -887,3 +887,298 @@ func TestListClusters(t *testing.T) {
 		t.Errorf("Expected 1 page, got %d", count)
 	}
 }
+
+func TestUpdateCluster(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	id := "7d85f602-a948-4a30-afd4-e84f47471c15"
+	clusterName := "cluster1"
+	profileID := "edc63d0a-2ca4-48fa-9854-27926da76a4a"
+	profileName := "profile1"
+
+	th.Mux.HandleFunc("/v1/clusters/"+id, func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PATCH")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, `
+		{
+			"cluster": {
+				"config": {},
+				"created_at": "2015-02-10T14:26:14Z",
+				"data": {},
+				"dependents": {},
+				"desired_capacity": 4,
+				"domain": null,
+				"id": "%s",
+				"init_at": "2015-02-10T15:26:14Z",
+				"max_size": -1,
+				"metadata": {},
+				"min_size": 0,
+				"name": "%s",
+				"nodes": [
+					"b07c57c8-7ab2-47bf-bdf8-e894c0c601b9",
+					"ecc23d3e-bb68-48f8-8260-c9cf6bcb6e61",
+					"da1e9c87-e584-4626-a120-022da5062dac"
+				],
+				"policies": [],
+				"profile_id": "%s",
+				"profile_name": "%s",
+				"project": "6e18cc2bdbeb48a5b3cad2dc499f6804",
+				"status": "ACTIVE",
+				"status_reason": "Cluster scale-in succeeded",
+				"timeout": 3600,
+				"updated_at": "2015-02-10T16:26:14Z",
+				"user": "5e5bf8027826429c96af157f68dc9072"
+			}
+		}`, id, clusterName, profileID, profileName)
+	})
+
+	createdAt, _ := time.Parse(time.RFC3339, "2015-02-10T14:26:14Z")
+	initAt, _ := time.Parse(time.RFC3339, "2015-02-10T15:26:14Z")
+	updatedAt, _ := time.Parse(time.RFC3339, "2015-02-10T16:26:14Z")
+	expected := clusters.Cluster{
+		Config:          map[string]interface{}{},
+		CreatedAt:       createdAt,
+		Data:            map[string]interface{}{},
+		Dependents:      map[string]interface{}{},
+		DesiredCapacity: 4,
+		Domain:          "",
+		ID:              id,
+		InitAt:          initAt,
+		MaxSize:         -1,
+		Metadata:        map[string]interface{}{},
+		MinSize:         0,
+		Name:            clusterName,
+		Nodes: []string{
+			"b07c57c8-7ab2-47bf-bdf8-e894c0c601b9",
+			"ecc23d3e-bb68-48f8-8260-c9cf6bcb6e61",
+			"da1e9c87-e584-4626-a120-022da5062dac",
+		},
+		Policies:     []string{},
+		ProfileID:    profileID,
+		ProfileName:  profileName,
+		Project:      "6e18cc2bdbeb48a5b3cad2dc499f6804",
+		Status:       "ACTIVE",
+		StatusReason: "Cluster scale-in succeeded",
+		Timeout:      3600,
+		UpdatedAt:    updatedAt,
+		User:         "5e5bf8027826429c96af157f68dc9072",
+	}
+
+	updateOpts := clusters.UpdateOpts{
+		Name:      clusterName,
+		ProfileID: profileID,
+	}
+
+	actual, err := clusters.Update(fake.ServiceClient(), id, updateOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expected, *actual)
+}
+
+func TestUpdateClusterEmptyTime(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	id := "7d85f602-a948-4a30-afd4-e84f47471c15"
+	clusterName := "cluster1"
+	profileID := "edc63d0a-2ca4-48fa-9854-27926da76a4a"
+	profileName := "profile1"
+
+	th.Mux.HandleFunc("/v1/clusters/"+id, func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PATCH")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, `
+		{
+			"cluster": {
+				"config": {},
+				"created_at": null,
+				"data": {},
+				"dependents": {},
+				"desired_capacity": 4,
+				"domain": null,
+				"id": "%s",
+				"init_at": null,
+				"max_size": -1,
+				"metadata": {},
+				"min_size": 0,
+				"name": "%s",
+				"nodes": [
+					"b07c57c8-7ab2-47bf-bdf8-e894c0c601b9",
+					"ecc23d3e-bb68-48f8-8260-c9cf6bcb6e61",
+					"da1e9c87-e584-4626-a120-022da5062dac"
+				],
+				"policies": [],
+				"profile_id": "%s",
+				"profile_name": "%s",
+				"project": "6e18cc2bdbeb48a5b3cad2dc499f6804",
+				"status": "ACTIVE",
+				"status_reason": "Cluster scale-in succeeded",
+				"timeout": 3600,
+				"updated_at": null,
+				"user": "5e5bf8027826429c96af157f68dc9072"
+			}
+		}`, id, clusterName, profileID, profileName)
+	})
+
+	expected := clusters.Cluster{
+		Config:          map[string]interface{}{},
+		CreatedAt:       time.Time{},
+		Data:            map[string]interface{}{},
+		Dependents:      map[string]interface{}{},
+		DesiredCapacity: 4,
+		Domain:          "",
+		ID:              id,
+		InitAt:          time.Time{},
+		MaxSize:         -1,
+		Metadata:        map[string]interface{}{},
+		MinSize:         0,
+		Name:            clusterName,
+		Nodes: []string{
+			"b07c57c8-7ab2-47bf-bdf8-e894c0c601b9",
+			"ecc23d3e-bb68-48f8-8260-c9cf6bcb6e61",
+			"da1e9c87-e584-4626-a120-022da5062dac",
+		},
+		Policies:     []string{},
+		ProfileID:    profileID,
+		ProfileName:  profileName,
+		Project:      "6e18cc2bdbeb48a5b3cad2dc499f6804",
+		Status:       "ACTIVE",
+		StatusReason: "Cluster scale-in succeeded",
+		Timeout:      3600,
+		UpdatedAt:    time.Time{},
+		User:         "5e5bf8027826429c96af157f68dc9072",
+	}
+
+	updateOpts := clusters.UpdateOpts{
+		Name:      clusterName,
+		ProfileID: profileID,
+	}
+
+	actual, err := clusters.Update(fake.ServiceClient(), id, updateOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expected, *actual)
+}
+
+func TestUpdateClusterInvalidTimeFloat(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	id := "7d85f602-a948-4a30-afd4-e84f47471c15"
+	clusterName := "cluster1"
+	profileID := "edc63d0a-2ca4-48fa-9854-27926da76a4a"
+	profileName := "profile1"
+
+	th.Mux.HandleFunc("/v1/clusters/"+id, func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PATCH")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, `
+		{
+			"cluster": {
+				"config": {},
+				"created_at": 123456789.0,
+				"data": {},
+				"dependents": {},
+				"desired_capacity": 4,
+				"domain": null,
+				"id": "%s",
+				"init_at": 123456789.0,
+				"max_size": -1,
+				"metadata": {},
+				"min_size": 0,
+				"name": "%s",
+				"nodes": [
+					"b07c57c8-7ab2-47bf-bdf8-e894c0c601b9",
+					"ecc23d3e-bb68-48f8-8260-c9cf6bcb6e61",
+					"da1e9c87-e584-4626-a120-022da5062dac"
+				],
+				"policies": [],
+				"profile_id": "%s",
+				"profile_name": "%s",
+				"project": "6e18cc2bdbeb48a5b3cad2dc499f6804",
+				"status": "ACTIVE",
+				"status_reason": "Cluster scale-in succeeded",
+				"timeout": 3600,
+				"updated_at": 123456789.0,
+				"user": "5e5bf8027826429c96af157f68dc9072"
+			}
+		}`, id, clusterName, profileID, profileName)
+	})
+
+	updateOpts := clusters.UpdateOpts{
+		Name:      clusterName,
+		ProfileID: profileID,
+	}
+
+	_, err := clusters.Update(fake.ServiceClient(), id, updateOpts).Extract()
+	th.AssertEquals(t, false, err == nil)
+}
+
+func TestUpdateClusterInvalidTimeString(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	id := "7d85f602-a948-4a30-afd4-e84f47471c15"
+	clusterName := "cluster1"
+	profileID := "edc63d0a-2ca4-48fa-9854-27926da76a4a"
+	profileName := "profile1"
+
+	th.Mux.HandleFunc("/v1/clusters/"+id, func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PATCH")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, `
+		{
+			"cluster": {
+				"config": {},
+				"created_at": "invalid",
+				"data": {},
+				"dependents": {},
+				"desired_capacity": 4,
+				"domain": null,
+				"id": "%s",
+				"init_at": "invalid",
+				"max_size": -1,
+				"metadata": {},
+				"min_size": 0,
+				"name": "%s",
+				"nodes": [
+					"b07c57c8-7ab2-47bf-bdf8-e894c0c601b9",
+					"ecc23d3e-bb68-48f8-8260-c9cf6bcb6e61",
+					"da1e9c87-e584-4626-a120-022da5062dac"
+				],
+				"policies": [],
+				"profile_id": "%s",
+				"profile_name": "%s",
+				"project": "6e18cc2bdbeb48a5b3cad2dc499f6804",
+				"status": "ACTIVE",
+				"status_reason": "Cluster scale-in succeeded",
+				"timeout": 3600,
+				"updated_at": "invalid",
+				"user": "5e5bf8027826429c96af157f68dc9072"
+			}
+		}`, id, clusterName, profileID, profileName)
+	})
+
+	updateOpts := clusters.UpdateOpts{
+		Name:      clusterName,
+		ProfileID: profileID,
+	}
+
+	_, err := clusters.Update(fake.ServiceClient(), id, updateOpts).Extract()
+	th.AssertEquals(t, false, err == nil)
+}

--- a/openstack/clustering/v1/clusters/urls.go
+++ b/openstack/clustering/v1/clusters/urls.go
@@ -24,3 +24,7 @@ func getURL(client *gophercloud.ServiceClient, id string) string {
 func listURL(client *gophercloud.ServiceClient) string {
 	return commonURL(client)
 }
+
+func updateURL(client *gophercloud.ServiceClient, id string) string {
+	return idURL(client, id)
+}


### PR DESCRIPTION
Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

For #[823 [Add support for Senlin clustering]](https://github.com/gophercloud/gophercloud/issues/823)

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

[[clusters:update]](https://github.com/openstack/senlin/blob/e5bc16b3fea2f10dead365f983c5a937f23d72b0/senlin/api/openstack/v1/clusters.py#L90)

