### PR TITLE
Acc Tests: Fix Server Delete

### DIFF
--- a/acceptance/openstack/compute/v2/compute.go
+++ b/acceptance/openstack/compute/v2/compute.go
@@ -775,7 +775,9 @@ func DeleteServer(t *testing.T, client *gophercloud.ServiceClient, server *serve
 		t.Fatalf("Error deleting server %s: %s", server.ID, err)
 	}
 
-	t.Fatalf("Could not delete server: %s", server.ID)
+	// If we reach this point, the API returned an actual DELETED status
+	// which is a very short window of time, but happens occasionally.
+	t.Logf("Deleted server: %s", server.ID)
 }
 
 // DeleteServerGroup will delete a server group. A fatal error will occur if


### PR DESCRIPTION
There might be occasions when the API will return an actual
DELETED status. This is a short window of time, but it
could happen.

The `TestSecGroupsAddGroupToServer` is still flapping from time to time. This is the only reason I can think of for it to still be failing.

For #818 