### PR TITLE
Senlin: Profiles Get

### DIFF
--- a/acceptance/openstack/clustering/v1/autoscaling_test.go
+++ b/acceptance/openstack/clustering/v1/autoscaling_test.go
@@ -7,10 +7,9 @@ import (
 	"testing"
 
 	"github.com/gophercloud/gophercloud/acceptance/clients"
+	"github.com/gophercloud/gophercloud/acceptance/tools"
 	"github.com/gophercloud/gophercloud/openstack/clustering/v1/clusters"
 	"github.com/gophercloud/gophercloud/openstack/clustering/v1/profiles"
-
-	"github.com/gophercloud/gophercloud/acceptance/tools"
 	th "github.com/gophercloud/gophercloud/testhelper"
 )
 
@@ -19,6 +18,7 @@ var testName string
 func TestAutoScaling(t *testing.T) {
 	testName = tools.RandomString("TESTACC-", 8)
 	profileCreate(t)
+	profileGet(t)
 	clusterCreate(t)
 }
 
@@ -130,4 +130,18 @@ func clusterCreate(t *testing.T) {
 	th.AssertEquals(t, optsCluster.Timeout, cluster.Timeout)
 	th.CheckDeepEquals(t, optsCluster.Metadata, cluster.Metadata)
 	th.CheckDeepEquals(t, optsCluster.Config, cluster.Config)
+}
+
+func profileGet(t *testing.T) {
+	client, err := clients.NewClusteringV1Client()
+	if err != nil {
+		t.Fatalf("Unable to create clustering client: %v", err)
+	}
+
+	profileName := testName
+	profile, err := profiles.Get(client, profileName).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, profileName, profile.Name)
+
+	tools.PrintResource(t, profile)
 }

--- a/openstack/clustering/v1/profiles/doc.go
+++ b/openstack/clustering/v1/profiles/doc.go
@@ -28,5 +28,15 @@ Example to Create a profile
 	}
 
 	fmt.Println("Profile", profile)
+
+Example to Get profile
+
+	profile, err := profiles.Get(serviceClient, "profile-name").Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Print("profile", profile)
+
 */
 package profiles

--- a/openstack/clustering/v1/profiles/requests.go
+++ b/openstack/clustering/v1/profiles/requests.go
@@ -40,3 +40,15 @@ func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r Create
 	}
 	return
 }
+
+// Get retrieves detail of a single profile. Use Extract to convert its
+// result into a Profile.
+func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {
+	var result *http.Response
+	result, r.Err = client.Get(getURL(client, id), &r.Body, &gophercloud.RequestOpts{OkCodes: []int{200}})
+
+	if r.Err == nil {
+		r.Header = result.Header
+	}
+	return
+}

--- a/openstack/clustering/v1/profiles/results.go
+++ b/openstack/clustering/v1/profiles/results.go
@@ -3,9 +3,8 @@ package profiles
 import (
 	"encoding/json"
 	"fmt"
-	"time"
-
 	"reflect"
+	"time"
 
 	"github.com/gophercloud/gophercloud"
 )
@@ -17,6 +16,11 @@ type commonResult struct {
 
 // CreateResult is the response of a Create operation.
 type CreateResult struct {
+	commonResult
+}
+
+// GetResult is the response of a Get operations.
+type GetResult struct {
 	commonResult
 }
 

--- a/openstack/clustering/v1/profiles/testing/requests_test.go
+++ b/openstack/clustering/v1/profiles/testing/requests_test.go
@@ -215,3 +215,172 @@ func TestCreateProfileInvalidTimeString(t *testing.T) {
 	_, err := profiles.Create(fake.ServiceClient(), optsProfile).Extract()
 	th.AssertEquals(t, false, err == nil)
 }
+
+func TestGetProfile(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v1/profiles/9e1c6f42-acf5-4688-be2c-8ce954ef0f23", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, `
+		{
+			"profile": {
+				"created_at": "2016-01-03T16:22:23Z",
+				"domain": null,
+				"id": "9e1c6f42-acf5-4688-be2c-8ce954ef0f23",
+				"metadata": {},
+				"name": "pserver",
+				"project": "42d9e9663331431f97b75e25136307ff",
+				"spec": {
+					"properties": {
+						"flavor": 1,
+						"image": "cirros-0.3.4-x86_64-uec",
+						"key_name": "oskey",
+						"name": "cirros_server",
+						"networks": [
+							{
+								"network": "private"
+							}
+						]
+					},
+					"type": "os.nova.server",
+					"version": "1.0"
+				},
+				"type": "os.nova.server-1.0",
+				"updated_at": null,
+				"user": "5e5bf8027826429c96af157f68dc9072"
+			}
+		}`)
+	})
+
+	actual, err := profiles.Get(fake.ServiceClient(), "9e1c6f42-acf5-4688-be2c-8ce954ef0f23").Extract()
+	if err != nil {
+		t.Errorf("Failed to get profile. %v", err)
+	} else {
+		createdAt, _ := time.Parse(time.RFC3339, "2016-01-03T16:22:23Z")
+		updatedAt := time.Time{}
+		expected := profiles.Profile{
+			CreatedAt: createdAt,
+			Domain:    "",
+			ID:        "9e1c6f42-acf5-4688-be2c-8ce954ef0f23",
+			Metadata:  map[string]interface{}{},
+			Name:      "pserver",
+			Project:   "42d9e9663331431f97b75e25136307ff",
+			Spec: profiles.Spec{
+				Properties: map[string]interface{}{
+					"flavor":   float64(1),
+					"image":    "cirros-0.3.4-x86_64-uec",
+					"key_name": "oskey",
+					"name":     "cirros_server",
+					"networks": []interface{}{
+						map[string]interface{}{"network": "private"},
+					},
+				},
+				Type:    "os.nova.server",
+				Version: "1.0",
+			},
+			Type:      "os.nova.server-1.0",
+			UpdatedAt: updatedAt,
+			User:      "5e5bf8027826429c96af157f68dc9072",
+		}
+
+		th.AssertDeepEquals(t, expected, *actual)
+	}
+}
+
+func TestGetProfileInvalidCreatedAtTime(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v1/profiles/9e1c6f42-acf5-4688-be2c-8ce954ef0f23", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, `
+		{
+			"profile": {
+				"created_at": 1234567890.0,
+				"domain": null,
+				"id": "9e1c6f42-acf5-4688-be2c-8ce954ef0f23",
+				"metadata": {},
+				"name": "pserver",
+				"project": "42d9e9663331431f97b75e25136307ff",
+				"spec": {
+					"properties": {
+						"flavor": 1,
+						"image": "cirros-0.3.4-x86_64-uec",
+						"key_name": "oskey",
+						"name": "cirros_server",
+						"networks": [
+							{
+								"network": "private"
+							}
+						]
+					},
+					"type": "os.nova.server",
+					"version": "1.0"
+				},
+				"type": "os.nova.server-1.0",
+				"updated_at": "",
+				"user": "5e5bf8027826429c96af157f68dc9072"
+			}
+		}`)
+	})
+
+	_, err := profiles.Get(fake.ServiceClient(), "9e1c6f42-acf5-4688-be2c-8ce954ef0f23").Extract()
+	th.AssertEquals(t, false, err == nil)
+}
+
+func TestGetProfileInvalidUpdatedAtTime(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v1/profiles/9e1c6f42-acf5-4688-be2c-8ce954ef0f23", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, `
+		{
+			"profile": {
+				"created_at": null,
+				"domain": null,
+				"id": "9e1c6f42-acf5-4688-be2c-8ce954ef0f23",
+				"metadata": {},
+				"name": "pserver",
+				"project": "42d9e9663331431f97b75e25136307ff",
+				"spec": {
+					"properties": {
+						"flavor": 1,
+						"image": "cirros-0.3.4-x86_64-uec",
+						"key_name": "oskey",
+						"name": "cirros_server",
+						"networks": [
+							{
+								"network": "private"
+							}
+						]
+					},
+					"type": "os.nova.server",
+					"version": "1.0"
+				},
+				"type": "os.nova.server-1.0",
+				"updated_at": 1234567890.0,
+				"user": "5e5bf8027826429c96af157f68dc9072"
+			}
+		}`)
+	})
+
+	_, err := profiles.Get(fake.ServiceClient(), "9e1c6f42-acf5-4688-be2c-8ce954ef0f23").Extract()
+	th.AssertEquals(t, false, err == nil)
+}

--- a/openstack/clustering/v1/profiles/urls.go
+++ b/openstack/clustering/v1/profiles/urls.go
@@ -12,3 +12,11 @@ func commonURL(client *gophercloud.ServiceClient) string {
 func createURL(client *gophercloud.ServiceClient) string {
 	return commonURL(client)
 }
+
+func idURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL(apiVersion, apiName, id)
+}
+
+func getURL(client *gophercloud.ServiceClient, id string) string {
+	return idURL(client, id)
+}


### PR DESCRIPTION
Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

For #[823 [Add support for Senlin clustering]](https://github.com/gophercloud/gophercloud/issues/823)

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

[[profiles:get]](https://github.com/openstack/senlin/blob/e5bc16b3fea2f10dead365f983c5a937f23d72b0/senlin/api/openstack/v1/profiles.py#L75)
