### PR TITLE
Senlin: Clusters Get

### DIFF
--- a/acceptance/openstack/clustering/v1/autoscaling_test.go
+++ b/acceptance/openstack/clustering/v1/autoscaling_test.go
@@ -22,6 +22,7 @@ func TestAutoScaling(t *testing.T) {
 	profileGet(t)
 	profileList(t)
 	clusterCreate(t)
+	clusterGet(t)
 }
 
 func profileCreate(t *testing.T) {
@@ -180,4 +181,18 @@ func clusterCreate(t *testing.T) {
 	th.AssertEquals(t, optsCluster.Timeout, cluster.Timeout)
 	th.CheckDeepEquals(t, optsCluster.Metadata, cluster.Metadata)
 	th.CheckDeepEquals(t, optsCluster.Config, cluster.Config)
+}
+
+func clusterGet(t *testing.T) {
+	client, err := clients.NewClusteringV1Client()
+	if err != nil {
+		t.Fatalf("Unable to create clustering client: %v", err)
+	}
+
+	clusterName := testName
+	cluster, err := clusters.Get(client, clusterName).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, clusterName, cluster.Name)
+
+	tools.PrintResource(t, cluster)
 }

--- a/openstack/clustering/v1/clusters/doc.go
+++ b/openstack/clustering/v1/clusters/doc.go
@@ -15,5 +15,14 @@ Example to Create a cluster
 		panic(err)
 	}
 
+Example to Get Clusters
+
+	clusterName := "cluster123"
+	cluster, err := clusters.Get(serviceClient, clusterName).Extract()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("%+v\n", cluster)
+
 */
 package clusters

--- a/openstack/clustering/v1/clusters/requests.go
+++ b/openstack/clustering/v1/clusters/requests.go
@@ -46,3 +46,14 @@ func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r Create
 
 	return
 }
+
+// Get retrieves details of a single cluster. Use Extract to convert its
+// result into a Cluster.
+func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {
+	var result *http.Response
+	result, r.Err = client.Get(getURL(client, id), &r.Body, &gophercloud.RequestOpts{OkCodes: []int{200}})
+	if r.Err == nil {
+		r.Header = result.Header
+	}
+	return
+}

--- a/openstack/clustering/v1/clusters/results.go
+++ b/openstack/clustering/v1/clusters/results.go
@@ -19,6 +19,11 @@ type CreateResult struct {
 	commonResult
 }
 
+// GetResult is the response of a Get operations.
+type GetResult struct {
+	commonResult
+}
+
 type Cluster struct {
 	Config          map[string]interface{} `json:"config"`
 	CreatedAt       time.Time              `json:"-"`

--- a/openstack/clustering/v1/clusters/testing/requests_test.go
+++ b/openstack/clustering/v1/clusters/testing/requests_test.go
@@ -412,3 +412,264 @@ func TestCreateClusterMetadata(t *testing.T) {
 	_, err := clusters.Create(fake.ServiceClient(), opts).Extract()
 	th.AssertEquals(t, false, err == nil)
 }
+
+func TestGetCluster(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v1/clusters/7d85f602-a948-4a30-afd4-e84f47471c15", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, `
+		{
+			"cluster": {
+				"config": {},
+				"created_at": "2015-02-10T14:26:14Z",
+				"data": {},
+				"dependents": {},
+				"desired_capacity": 4,
+				"domain": null,
+				"id": "7d85f602-a948-4a30-afd4-e84f47471c15",
+				"init_at": "2015-02-10T15:26:14Z",
+				"max_size": -1,
+				"metadata": {},
+				"min_size": 0,
+				"name": "cluster1",
+				"nodes": [
+					"b07c57c8-7ab2-47bf-bdf8-e894c0c601b9",
+					"ecc23d3e-bb68-48f8-8260-c9cf6bcb6e61",
+					"da1e9c87-e584-4626-a120-022da5062dac"
+				],
+				"policies": [],
+				"profile_id": "edc63d0a-2ca4-48fa-9854-27926da76a4a",
+				"profile_name": "mystack",
+				"project": "6e18cc2bdbeb48a5b3cad2dc499f6804",
+				"status": "ACTIVE",
+				"status_reason": "Cluster scale-in succeeded",
+				"timeout": 3600,
+				"updated_at": "2015-02-10T16:26:14Z",
+				"user": "5e5bf8027826429c96af157f68dc9072"
+			}
+		}`)
+	})
+
+	createdAt, _ := time.Parse(time.RFC3339, "2015-02-10T14:26:14Z")
+	initAt, _ := time.Parse(time.RFC3339, "2015-02-10T15:26:14Z")
+	updatedAt, _ := time.Parse(time.RFC3339, "2015-02-10T16:26:14Z")
+	expected := clusters.Cluster{
+		Config:          map[string]interface{}{},
+		CreatedAt:       createdAt,
+		Data:            map[string]interface{}{},
+		Dependents:      map[string]interface{}{},
+		DesiredCapacity: 4,
+		Domain:          "",
+		ID:              "7d85f602-a948-4a30-afd4-e84f47471c15",
+		InitAt:          initAt,
+		MaxSize:         -1,
+		Metadata:        map[string]interface{}{},
+		MinSize:         0,
+		Name:            "cluster1",
+		Nodes: []string{
+			"b07c57c8-7ab2-47bf-bdf8-e894c0c601b9",
+			"ecc23d3e-bb68-48f8-8260-c9cf6bcb6e61",
+			"da1e9c87-e584-4626-a120-022da5062dac",
+		},
+		Policies:     []string{},
+		ProfileID:    "edc63d0a-2ca4-48fa-9854-27926da76a4a",
+		ProfileName:  "mystack",
+		Project:      "6e18cc2bdbeb48a5b3cad2dc499f6804",
+		Status:       "ACTIVE",
+		StatusReason: "Cluster scale-in succeeded",
+		Timeout:      3600,
+		UpdatedAt:    updatedAt,
+		User:         "5e5bf8027826429c96af157f68dc9072",
+	}
+
+	actual, err := clusters.Get(fake.ServiceClient(), "7d85f602-a948-4a30-afd4-e84f47471c15").Extract()
+	if err != nil {
+		t.Errorf("Failed Get cluster. %v", err)
+	} else {
+		th.AssertDeepEquals(t, expected, *actual)
+	}
+}
+
+func TestGetClusterEmptyTime(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v1/clusters/7d85f602-a948-4a30-afd4-e84f47471c15", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, `
+		{
+			"cluster": {
+				"config": {},
+				"created_at": null,
+				"data": {},
+				"dependents": {},
+				"desired_capacity": 4,
+				"domain": null,
+				"id": "7d85f602-a948-4a30-afd4-e84f47471c15",
+				"init_at": null,
+				"max_size": -1,
+				"metadata": {},
+				"min_size": 0,
+				"name": "cluster1",
+				"nodes": [
+					"b07c57c8-7ab2-47bf-bdf8-e894c0c601b9",
+					"ecc23d3e-bb68-48f8-8260-c9cf6bcb6e61",
+					"da1e9c87-e584-4626-a120-022da5062dac"
+				],
+				"policies": [],
+				"profile_id": "edc63d0a-2ca4-48fa-9854-27926da76a4a",
+				"profile_name": "mystack",
+				"project": "6e18cc2bdbeb48a5b3cad2dc499f6804",
+				"status": "ACTIVE",
+				"status_reason": "Cluster scale-in succeeded",
+				"timeout": 3600,
+				"updated_at": null,
+				"user": "5e5bf8027826429c96af157f68dc9072"
+			}
+		}`)
+	})
+
+	expected := clusters.Cluster{
+		Config:          map[string]interface{}{},
+		CreatedAt:       time.Time{},
+		Data:            map[string]interface{}{},
+		Dependents:      map[string]interface{}{},
+		DesiredCapacity: 4,
+		Domain:          "",
+		ID:              "7d85f602-a948-4a30-afd4-e84f47471c15",
+		InitAt:          time.Time{},
+		MaxSize:         -1,
+		Metadata:        map[string]interface{}{},
+		MinSize:         0,
+		Name:            "cluster1",
+		Nodes: []string{
+			"b07c57c8-7ab2-47bf-bdf8-e894c0c601b9",
+			"ecc23d3e-bb68-48f8-8260-c9cf6bcb6e61",
+			"da1e9c87-e584-4626-a120-022da5062dac",
+		},
+		Policies:     []string{},
+		ProfileID:    "edc63d0a-2ca4-48fa-9854-27926da76a4a",
+		ProfileName:  "mystack",
+		Project:      "6e18cc2bdbeb48a5b3cad2dc499f6804",
+		Status:       "ACTIVE",
+		StatusReason: "Cluster scale-in succeeded",
+		Timeout:      3600,
+		UpdatedAt:    time.Time{},
+		User:         "5e5bf8027826429c96af157f68dc9072",
+	}
+
+	actual, err := clusters.Get(fake.ServiceClient(), "7d85f602-a948-4a30-afd4-e84f47471c15").Extract()
+	if err != nil {
+		t.Errorf("Failed Get cluster. %v", err)
+	} else {
+		th.AssertDeepEquals(t, expected, *actual)
+	}
+}
+
+func TestGetClusterInvalidTimeFloat(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v1/clusters/7d85f602-a948-4a30-afd4-e84f47471c15", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, `
+		{
+			"cluster": {
+				"config": {},
+				"created_at": 123456789.0,
+				"data": {},
+				"dependents": {},
+				"desired_capacity": 4,
+				"domain": null,
+				"id": "7d85f602-a948-4a30-afd4-e84f47471c15",
+				"init_at": 123456789.0,
+				"max_size": -1,
+				"metadata": {},
+				"min_size": 0,
+				"name": "cluster1",
+				"nodes": [
+					"b07c57c8-7ab2-47bf-bdf8-e894c0c601b9",
+					"ecc23d3e-bb68-48f8-8260-c9cf6bcb6e61",
+					"da1e9c87-e584-4626-a120-022da5062dac"
+				],
+				"policies": [],
+				"profile_id": "edc63d0a-2ca4-48fa-9854-27926da76a4a",
+				"profile_name": "mystack",
+				"project": "6e18cc2bdbeb48a5b3cad2dc499f6804",
+				"status": "ACTIVE",
+				"status_reason": "Cluster scale-in succeeded",
+				"timeout": 3600,
+				"updated_at": 123456789.0,
+				"user": "5e5bf8027826429c96af157f68dc9072"
+			}
+		}`)
+	})
+
+	_, err := clusters.Get(fake.ServiceClient(), "7d85f602-a948-4a30-afd4-e84f47471c15").Extract()
+	th.AssertEquals(t, false, err == nil)
+}
+
+func TestGetClusterInvalidTimeString(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v1/clusters/7d85f602-a948-4a30-afd4-e84f47471c15", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, `
+		{
+			"cluster": {
+				"config": {},
+				"created_at": "invalid",
+				"data": {},
+				"dependents": {},
+				"desired_capacity": 4,
+				"domain": null,
+				"id": "7d85f602-a948-4a30-afd4-e84f47471c15",
+				"init_at": "invalid",
+				"max_size": -1,
+				"metadata": {},
+				"min_size": 0,
+				"name": "cluster1",
+				"nodes": [
+					"b07c57c8-7ab2-47bf-bdf8-e894c0c601b9",
+					"ecc23d3e-bb68-48f8-8260-c9cf6bcb6e61",
+					"da1e9c87-e584-4626-a120-022da5062dac"
+				],
+				"policies": [],
+				"profile_id": "edc63d0a-2ca4-48fa-9854-27926da76a4a",
+				"profile_name": "mystack",
+				"project": "6e18cc2bdbeb48a5b3cad2dc499f6804",
+				"status": "ACTIVE",
+				"status_reason": "Cluster scale-in succeeded",
+				"timeout": 3600,
+				"updated_at": "invalid",
+				"user": "5e5bf8027826429c96af157f68dc9072"
+			}
+		}`)
+	})
+
+	_, err := clusters.Get(fake.ServiceClient(), "7d85f602-a948-4a30-afd4-e84f47471c15").Extract()
+	th.AssertEquals(t, false, err == nil)
+}

--- a/openstack/clustering/v1/clusters/urls.go
+++ b/openstack/clustering/v1/clusters/urls.go
@@ -9,6 +9,14 @@ func commonURL(client *gophercloud.ServiceClient) string {
 	return client.ServiceURL(apiVersion, apiName)
 }
 
+func idURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL(apiVersion, apiName, id)
+}
+
 func createURL(client *gophercloud.ServiceClient) string {
 	return commonURL(client)
+}
+
+func getURL(client *gophercloud.ServiceClient, id string) string {
+	return idURL(client, id)
 }


### PR DESCRIPTION
Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

For #[823 [Add support for Senlin clustering]](https://github.com/gophercloud/gophercloud/issues/823)

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

[[clusters:get]](https://github.com/openstack/senlin/blob/e5bc16b3fea2f10dead365f983c5a937f23d72b0/senlin/api/openstack/v1/clusters.py#L81)

