### PR TITLE
Octavia l7 rule support - part 2: list

### DIFF
--- a/acceptance/openstack/loadbalancer/v2/l7policies_test.go
+++ b/acceptance/openstack/loadbalancer/v2/l7policies_test.go
@@ -13,7 +13,7 @@ import (
 func TestL7PoliciesList(t *testing.T) {
 	client, err := clients.NewLoadBalancerV2Client()
 	if err != nil {
-		t.Fatalf("Unable to create a network client: %v", err)
+		t.Fatalf("Unable to create a loadbalancer client: %v", err)
 	}
 
 	allPages, err := l7policies.List(client, nil).AllPages()

--- a/acceptance/openstack/loadbalancer/v2/loadbalancers_test.go
+++ b/acceptance/openstack/loadbalancer/v2/loadbalancers_test.go
@@ -134,6 +134,18 @@ func TestLoadbalancersCRUD(t *testing.T) {
 		t.Fatalf("Unable to create l7 rule: %v", err)
 	}
 
+	allPages, err = l7policies.ListRules(lbClient, policy.ID, l7policies.ListRulesOpts{}).AllPages()
+	if err != nil {
+		t.Fatalf("Unable to get l7 rules: %v", err)
+	}
+	allRules, err = l7policies.ExtractRules(allPages)
+	if err != nil {
+		t.Fatalf("Unable to extract l7 rules: %v", err)
+	}
+	for _, rule := range allRules {
+		tools.PrintResource(t, rule)
+	}
+
 	// Pool
 	pool, err := CreatePool(t, lbClient, lb)
 	if err != nil {

--- a/openstack/loadbalancer/v2/l7policies/doc.go
+++ b/openstack/loadbalancer/v2/l7policies/doc.go
@@ -71,5 +71,23 @@ Example to Create a Rule
 	if err != nil {
 		panic(err)
 	}
+
+Example to List L7 Rules
+
+	l7policyID := "d67d56a6-4a86-4688-a282-f46444705c64"
+	listOpts := l7policies.ListRulesOpts{
+		RuleType: l7policies.TypePath,
+	}
+	allPages, err := l7policies.ListRules(lbClient, l7policyID, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+	allRules, err := l7policies.ExtractRules(allPages)
+	if err != nil {
+		panic(err)
+	}
+	for _, rule := allRules {
+		fmt.Printf("%+v\n", rule)
+	}
 */
 package l7policies

--- a/openstack/loadbalancer/v2/l7policies/results.go
+++ b/openstack/loadbalancer/v2/l7policies/results.go
@@ -166,3 +166,40 @@ func (r commonRuleResult) Extract() (*Rule, error) {
 type CreateRuleResult struct {
 	commonRuleResult
 }
+
+// RulePage is the page returned by a pager when traversing over a
+// collection of Rules in a L7Policy.
+type RulePage struct {
+	pagination.LinkedPageBase
+}
+
+// NextPageURL is invoked when a paginated collection of rules has reached
+// the end of a page and the pager seeks to traverse over a new one. In order
+// to do this, it needs to construct the next page's URL.
+func (r RulePage) NextPageURL() (string, error) {
+	var s struct {
+		Links []gophercloud.Link `json:"rules_links"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return gophercloud.ExtractNextURL(s.Links)
+}
+
+// IsEmpty checks whether a RulePage struct is empty.
+func (r RulePage) IsEmpty() (bool, error) {
+	is, err := ExtractRules(r)
+	return len(is) == 0, err
+}
+
+// ExtractRules accepts a Page struct, specifically a RulePage struct,
+// and extracts the elements into a slice of Rules structs. In other words,
+// a generic collection is mapped into a relevant slice.
+func ExtractRules(r pagination.Page) ([]Rule, error) {
+	var s struct {
+		Rules []Rule `json:"rules"`
+	}
+	err := (r.(RulePage)).ExtractInto(&s)
+	return s.Rules, err
+}

--- a/openstack/loadbalancer/v2/l7policies/testing/fixtures.go
+++ b/openstack/loadbalancer/v2/l7policies/testing/fixtures.go
@@ -79,6 +79,16 @@ var (
 		Invert:       false,
 		AdminStateUp: true,
 	}
+	RuleHostName = l7policies.Rule{
+		ID:           "d24521a0-df84-4468-861a-a531af116d1e",
+		RuleType:     "HOST_NAME",
+		CompareType:  "EQUAL_TO",
+		Value:        "www.example.com",
+		ProjectID:    "e3cd678b11784734bc366148aa37580e",
+		Key:          "",
+		Invert:       false,
+		AdminStateUp: true,
+	}
 )
 
 // HandleL7PolicyCreationSuccessfully sets up the test server to respond to a l7policy creation request
@@ -247,5 +257,53 @@ func HandleRuleCreationSuccessfully(t *testing.T, response string) {
 		w.WriteHeader(http.StatusAccepted)
 		w.Header().Add("Content-Type", "application/json")
 		fmt.Fprintf(w, response)
+	})
+}
+
+// RulesListBody contains the canned body of a rule list response.
+const RulesListBody = `
+{
+	"rules":[
+		{
+            "compare_type": "REGEX",
+            "invert": false,
+            "admin_state_up": true,
+            "value": "/images*",
+            "key": null,
+            "project_id": "e3cd678b11784734bc366148aa37580e",
+            "type": "PATH",
+            "id": "16621dbb-a736-4888-a57a-3ecd53df784c"
+		},
+		{
+            "compare_type": "EQUAL_TO",
+            "invert": false,
+            "admin_state_up": true,
+            "value": "www.example.com",
+            "key": null,
+            "project_id": "e3cd678b11784734bc366148aa37580e",
+            "type": "HOST_NAME",
+            "id": "d24521a0-df84-4468-861a-a531af116d1e"
+		}
+	]
+}
+`
+
+// HandleRuleListSuccessfully sets up the test server to respond to a rule List request.
+func HandleRuleListSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/v2.0/lbaas/l7policies/8a1412f0-4c32-4257-8b07-af4770b604fd/rules", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		r.ParseForm()
+		marker := r.Form.Get("marker")
+		switch marker {
+		case "":
+			fmt.Fprintf(w, RulesListBody)
+		case "45e08a3e-a78f-4b40-a229-1e7e23eee1ab":
+			fmt.Fprintf(w, `{ "rules": [] }`)
+		default:
+			t.Fatalf("/v2.0/lbaas/l7policies/8a1412f0-4c32-4257-8b07-af4770b604fd/rules invoked with unexpected marker=[%s]", marker)
+		}
 	})
 }


### PR DESCRIPTION
For #832

Octavia l7 rule list API implementation:

- https://github.com/openstack/octavia/blob/69a45c254be854dbdbff946dbe2564711cdecec3/octavia/api/v2/controllers/l7rule.py#L59
- https://github.com/openstack/octavia/blob/69a45c254be854dbdbff946dbe2564711cdecec3/octavia/api/v2/types/l7rule.py#L26
