### PR TITLE
Zun: fix Fatalf(): format %v reads arg #1, but call has only 0 args

### DIFF
--- a/acceptance/openstack/identity/v3/endpoint_test.go
+++ b/acceptance/openstack/identity/v3/endpoint_test.go
@@ -15,7 +15,7 @@ import (
 func TestEndpointsList(t *testing.T) {
 	client, err := clients.NewIdentityV3Client()
 	if err != nil {
-		t.Fatalf("Unable to obtain an identity client: %v")
+		t.Fatalf("Unable to obtain an identity client: %v", err)
 	}
 
 	allPages, err := endpoints.List(client, nil).AllPages()
@@ -36,7 +36,7 @@ func TestEndpointsList(t *testing.T) {
 func TestEndpointsNavigateCatalog(t *testing.T) {
 	client, err := clients.NewIdentityV3Client()
 	if err != nil {
-		t.Fatalf("Unable to obtain an identity client: %v")
+		t.Fatalf("Unable to obtain an identity client: %v", err)
 	}
 
 	// Discover the service we're interested in.
@@ -51,7 +51,7 @@ func TestEndpointsNavigateCatalog(t *testing.T) {
 
 	allServices, err := services.ExtractServices(allPages)
 	if err != nil {
-		t.Fatalf("Unable to extract service: %v")
+		t.Fatalf("Unable to extract service: %v", err)
 	}
 
 	if len(allServices) != 1 {
@@ -74,7 +74,7 @@ func TestEndpointsNavigateCatalog(t *testing.T) {
 
 	allEndpoints, err := endpoints.ExtractEndpoints(allPages)
 	if err != nil {
-		t.Fatalf("Unable to extract endpoint: %v")
+		t.Fatalf("Unable to extract endpoint: %v", err)
 	}
 
 	if len(allEndpoints) != 1 {

--- a/acceptance/openstack/identity/v3/projects_test.go
+++ b/acceptance/openstack/identity/v3/projects_test.go
@@ -64,7 +64,7 @@ func TestProjectsGet(t *testing.T) {
 func TestProjectsCRUD(t *testing.T) {
 	client, err := clients.NewIdentityV3Client()
 	if err != nil {
-		t.Fatalf("Unable to obtain an identity client: %v")
+		t.Fatalf("Unable to obtain an identity client: %v", err)
 	}
 
 	project, err := CreateProject(t, client, nil)
@@ -91,7 +91,7 @@ func TestProjectsCRUD(t *testing.T) {
 func TestProjectsDomain(t *testing.T) {
 	client, err := clients.NewIdentityV3Client()
 	if err != nil {
-		t.Fatalf("Unable to obtain an identity client: %v")
+		t.Fatalf("Unable to obtain an identity client: %v", err)
 	}
 
 	var iTrue = true
@@ -126,14 +126,14 @@ func TestProjectsDomain(t *testing.T) {
 
 	_, err = projects.Update(client, projectDomain.ID, updateOpts).Extract()
 	if err != nil {
-		t.Fatalf("Unable to disable domain: %v")
+		t.Fatalf("Unable to disable domain: %v", err)
 	}
 }
 
 func TestProjectsNested(t *testing.T) {
 	client, err := clients.NewIdentityV3Client()
 	if err != nil {
-		t.Fatalf("Unable to obtain an identity client: %v")
+		t.Fatalf("Unable to obtain an identity client: %v", err)
 	}
 
 	projectMain, err := CreateProject(t, client, nil)

--- a/acceptance/openstack/identity/v3/service_test.go
+++ b/acceptance/openstack/identity/v3/service_test.go
@@ -13,7 +13,7 @@ import (
 func TestServicesList(t *testing.T) {
 	client, err := clients.NewIdentityV3Client()
 	if err != nil {
-		t.Fatalf("Unable to obtain an identity client: %v")
+		t.Fatalf("Unable to obtain an identity client: %v", err)
 	}
 
 	listOpts := services.ListOpts{

--- a/acceptance/openstack/identity/v3/token_test.go
+++ b/acceptance/openstack/identity/v3/token_test.go
@@ -14,7 +14,7 @@ import (
 func TestGetToken(t *testing.T) {
 	client, err := clients.NewIdentityV3Client()
 	if err != nil {
-		t.Fatalf("Unable to obtain an identity client: %v")
+		t.Fatalf("Unable to obtain an identity client: %v", err)
 	}
 
 	ao, err := openstack.AuthOptionsFromEnv()


### PR DESCRIPTION
For #700 