### PR TITLE
Octavia l7 rule support - part 3: get

### DIFF
--- a/openstack/loadbalancer/v2/l7policies/doc.go
+++ b/openstack/loadbalancer/v2/l7policies/doc.go
@@ -89,5 +89,12 @@ Example to List L7 Rules
 	for _, rule := allRules {
 		fmt.Printf("%+v\n", rule)
 	}
+
+Example to Get a l7 rule
+
+	l7rule, err := l7policies.GetRule(lbClient, "023f2e34-7806-443b-bfae-16c324569a3d", "53ad8ab8-40fa-11e8-a508-00224d6b7bc1").Extract()
+	if err != nil {
+		panic(err)
+	}
 */
 package l7policies

--- a/openstack/loadbalancer/v2/l7policies/requests.go
+++ b/openstack/loadbalancer/v2/l7policies/requests.go
@@ -267,3 +267,9 @@ func ListRules(c *gophercloud.ServiceClient, policyID string, opts ListRulesOpts
 		return RulePage{pagination.LinkedPageBase{PageResult: r}}
 	})
 }
+
+// GetRule retrieves a particular L7Policy Rule based on its unique ID.
+func GetRule(c *gophercloud.ServiceClient, policyID string, ruleID string) (r GetRuleResult) {
+	_, r.Err = c.Get(ruleResourceURL(c, policyID, ruleID), &r.Body, nil)
+	return
+}

--- a/openstack/loadbalancer/v2/l7policies/results.go
+++ b/openstack/loadbalancer/v2/l7policies/results.go
@@ -203,3 +203,9 @@ func ExtractRules(r pagination.Page) ([]Rule, error) {
 	err := (r.(RulePage)).ExtractInto(&s)
 	return s.Rules, err
 }
+
+// GetRuleResult represents the result of a GetRule operation.
+// Call its Extract method to interpret it as a Rule.
+type GetRuleResult struct {
+	commonRuleResult
+}

--- a/openstack/loadbalancer/v2/l7policies/testing/fixtures.go
+++ b/openstack/loadbalancer/v2/l7policies/testing/fixtures.go
@@ -307,3 +307,14 @@ func HandleRuleListSuccessfully(t *testing.T) {
 		}
 	})
 }
+
+// HandleRuleGetSuccessfully sets up the test server to respond to a rule Get request.
+func HandleRuleGetSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/v2.0/lbaas/l7policies/8a1412f0-4c32-4257-8b07-af4770b604fd/rules/16621dbb-a736-4888-a57a-3ecd53df784c", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+
+		fmt.Fprintf(w, SingleRuleBody)
+	})
+}

--- a/openstack/loadbalancer/v2/l7policies/testing/requests_test.go
+++ b/openstack/loadbalancer/v2/l7policies/testing/requests_test.go
@@ -218,3 +218,17 @@ func TestListAllRules(t *testing.T) {
 	th.CheckDeepEquals(t, RulePath, actual[0])
 	th.CheckDeepEquals(t, RuleHostName, actual[1])
 }
+
+func TestGetRule(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleRuleGetSuccessfully(t)
+
+	client := fake.ServiceClient()
+	actual, err := l7policies.GetRule(client, "8a1412f0-4c32-4257-8b07-af4770b604fd", "16621dbb-a736-4888-a57a-3ecd53df784c").Extract()
+	if err != nil {
+		t.Fatalf("Unexpected Get error: %v", err)
+	}
+
+	th.CheckDeepEquals(t, RulePath, *actual)
+}

--- a/openstack/loadbalancer/v2/l7policies/urls.go
+++ b/openstack/loadbalancer/v2/l7policies/urls.go
@@ -19,3 +19,7 @@ func resourceURL(c *gophercloud.ServiceClient, id string) string {
 func ruleRootURL(c *gophercloud.ServiceClient, policyID string) string {
 	return c.ServiceURL(rootPath, resourcePath, policyID, rulePath)
 }
+
+func ruleResourceURL(c *gophercloud.ServiceClient, policyID string, ruleID string) string {
+	return c.ServiceURL(rootPath, resourcePath, policyID, rulePath, ruleID)
+}


### PR DESCRIPTION
For #832

Octavia l7 rule Get API implementation:

- https://github.com/openstack/octavia/blob/69a45c254be854dbdbff946dbe2564711cdecec3/octavia/api/v2/controllers/l7rule.py#L45
- https://github.com/openstack/octavia/blob/69a45c254be854dbdbff946dbe2564711cdecec3/octavia/api/v2/types/l7rule.py#L26
