### PR TITLE
Octavia l7 rule support - part 4: delete

### DIFF
--- a/acceptance/openstack/loadbalancer/v2/loadbalancer.go
+++ b/acceptance/openstack/loadbalancer/v2/loadbalancer.go
@@ -243,6 +243,23 @@ func DeleteL7Policy(t *testing.T, client *gophercloud.ServiceClient, lbID, polic
 	t.Logf("Successfully deleted l7 policy %s", policyID)
 }
 
+// DeleteL7Rule will delete a specified l7 rule. A fatal error will occur if
+// the l7 rule could not be deleted. This works best when used as a deferred
+// function.
+func DeleteL7Rule(t *testing.T, client *gophercloud.ServiceClient, lbID, policyID, ruleID string) {
+	t.Logf("Attempting to delete l7 rule %s", ruleID)
+
+	if err := l7policies.DeleteRule(client, policyID, ruleID).ExtractErr(); err != nil {
+		t.Fatalf("Unable to delete l7 rule: %v", err)
+	}
+
+	if err := WaitForLoadBalancerState(client, lbID, "ACTIVE", loadbalancerActiveTimeoutSeconds); err != nil {
+		t.Fatalf("Timed out waiting for loadbalancer to become active")
+	}
+
+	t.Logf("Successfully deleted l7 rule %s", ruleID)
+}
+
 // DeleteListener will delete a specified listener. A fatal error will occur if
 // the listener could not be deleted. This works best when used as a deferred
 // function.

--- a/acceptance/openstack/loadbalancer/v2/loadbalancers_test.go
+++ b/acceptance/openstack/loadbalancer/v2/loadbalancers_test.go
@@ -133,6 +133,7 @@ func TestLoadbalancersCRUD(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to create l7 rule: %v", err)
 	}
+	defer DeleteL7Rule(t, lbClient, lb.ID, policy.ID, rule.ID)
 
 	allPages, err := l7policies.ListRules(lbClient, policy.ID, l7policies.ListRulesOpts{}).AllPages()
 	if err != nil {

--- a/openstack/loadbalancer/v2/l7policies/doc.go
+++ b/openstack/loadbalancer/v2/l7policies/doc.go
@@ -96,5 +96,14 @@ Example to Get a l7 rule
 	if err != nil {
 		panic(err)
 	}
+
+Example to Delete a l7 rule
+
+	l7policyID := "d67d56a6-4a86-4688-a282-f46444705c64"
+	ruleID := "64dba99f-8af8-4200-8882-e32a0660f23e"
+	err := l7policies.DeleteRule(lbClient, l7policyID, ruleID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
 */
 package l7policies

--- a/openstack/loadbalancer/v2/l7policies/requests.go
+++ b/openstack/loadbalancer/v2/l7policies/requests.go
@@ -273,3 +273,9 @@ func GetRule(c *gophercloud.ServiceClient, policyID string, ruleID string) (r Ge
 	_, r.Err = c.Get(ruleResourceURL(c, policyID, ruleID), &r.Body, nil)
 	return
 }
+
+// DeleteRule will remove a Rule from a particular L7Policy.
+func DeleteRule(c *gophercloud.ServiceClient, policyID string, ruleID string) (r DeleteRuleResult) {
+	_, r.Err = c.Delete(ruleResourceURL(c, policyID, ruleID), nil)
+	return
+}

--- a/openstack/loadbalancer/v2/l7policies/results.go
+++ b/openstack/loadbalancer/v2/l7policies/results.go
@@ -209,3 +209,9 @@ func ExtractRules(r pagination.Page) ([]Rule, error) {
 type GetRuleResult struct {
 	commonRuleResult
 }
+
+// DeleteRuleResult represents the result of a DeleteRule operation.
+// Call its ExtractErr method to determine if the request succeeded or failed.
+type DeleteRuleResult struct {
+	gophercloud.ErrResult
+}

--- a/openstack/loadbalancer/v2/l7policies/testing/fixtures.go
+++ b/openstack/loadbalancer/v2/l7policies/testing/fixtures.go
@@ -318,3 +318,13 @@ func HandleRuleGetSuccessfully(t *testing.T) {
 		fmt.Fprintf(w, SingleRuleBody)
 	})
 }
+
+// HandleRuleDeletionSuccessfully sets up the test server to respond to a rule deletion request.
+func HandleRuleDeletionSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/v2.0/lbaas/l7policies/8a1412f0-4c32-4257-8b07-af4770b604fd/rules/16621dbb-a736-4888-a57a-3ecd53df784c", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.WriteHeader(http.StatusNoContent)
+	})
+}

--- a/openstack/loadbalancer/v2/l7policies/testing/requests_test.go
+++ b/openstack/loadbalancer/v2/l7policies/testing/requests_test.go
@@ -232,3 +232,12 @@ func TestGetRule(t *testing.T) {
 
 	th.CheckDeepEquals(t, RulePath, *actual)
 }
+
+func TestDeleteRule(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleRuleDeletionSuccessfully(t)
+
+	res := l7policies.DeleteRule(fake.ServiceClient(), "8a1412f0-4c32-4257-8b07-af4770b604fd", "16621dbb-a736-4888-a57a-3ecd53df784c")
+	th.AssertNoErr(t, res.Err)
+}


### PR DESCRIPTION
For #832

Octavia l7 rule Delete API implementation:

- https://github.com/openstack/octavia/blob/69a45c254be854dbdbff946dbe2564711cdecec3/octavia/api/v2/controllers/l7rule.py#L228
