### PR TITLE
Octavia l7 rule support - part 5(final): update

### DIFF
--- a/acceptance/openstack/loadbalancer/v2/loadbalancers_test.go
+++ b/acceptance/openstack/loadbalancer/v2/loadbalancers_test.go
@@ -147,13 +147,23 @@ func TestLoadbalancersCRUD(t *testing.T) {
 		tools.PrintResource(t, rule)
 	}
 
-	newRule, err := l7policies.GetRule(lbClient, newPolicy.ID, rule.ID).Extract()
+	updateL7ruleOpts := l7policies.UpdateRuleOpts{
+		RuleType:    l7policies.TypePath,
+		CompareType: l7policies.CompareTypeRegex,
+		Value:       "/images/special*",
+	}
+	_, err = l7policies.UpdateRule(lbClient, policy.ID, rule.ID, updateL7ruleOpts).Extract()
 	if err != nil {
-		t.Fatalf("Unable to get l7 rule: %v", err)
+		t.Fatalf("Unable to update l7 rule: %v", err)
 	}
 
 	if err := WaitForLoadBalancerState(lbClient, lb.ID, "ACTIVE", loadbalancerActiveTimeoutSeconds); err != nil {
 		t.Fatalf("Timed out waiting for loadbalancer to become active")
+	}
+
+	newRule, err := l7policies.GetRule(lbClient, newPolicy.ID, rule.ID).Extract()
+	if err != nil {
+		t.Fatalf("Unable to get l7 rule: %v", err)
 	}
 
 	tools.PrintResource(t, newRule)

--- a/openstack/loadbalancer/v2/l7policies/doc.go
+++ b/openstack/loadbalancer/v2/l7policies/doc.go
@@ -105,5 +105,19 @@ Example to Delete a l7 rule
 	if err != nil {
 		panic(err)
 	}
+
+Example to Update a Rule
+
+	l7policyID := "d67d56a6-4a86-4688-a282-f46444705c64"
+	ruleID := "64dba99f-8af8-4200-8882-e32a0660f23e"
+	updateOpts := l7policies.UpdateRuleOpts{
+		RuleType:    l7policies.TypePath,
+		CompareType: l7policies.CompareTypeRegex,
+		Value:       "/images/special*",
+	}
+	rule, err := l7policies.UpdateRule(lbClient, l7policyID, ruleID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
 */
 package l7policies

--- a/openstack/loadbalancer/v2/l7policies/requests.go
+++ b/openstack/loadbalancer/v2/l7policies/requests.go
@@ -279,3 +279,42 @@ func DeleteRule(c *gophercloud.ServiceClient, policyID string, ruleID string) (r
 	_, r.Err = c.Delete(ruleResourceURL(c, policyID, ruleID), nil)
 	return
 }
+
+// UpdateRuleOptsBuilder allows to add additional parameters to the PUT request.
+type UpdateRuleOptsBuilder interface {
+	ToRuleUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateRuleOpts is the common options struct used in this package's Update
+// operation.
+type UpdateRuleOpts struct {
+	// The L7 rule type. One of COOKIE, FILE_TYPE, HEADER, HOST_NAME, or PATH.
+	RuleType RuleType `json:"type,omitempty"`
+
+	// The comparison type for the L7 rule. One of CONTAINS, ENDS_WITH, EQUAL_TO, REGEX, or STARTS_WITH.
+	CompareType CompareType `json:"compare_type,omitempty"`
+
+	// The value to use for the comparison. For example, the file type to compare.
+	Value string `json:"value,omitempty"`
+
+	// The key to use for the comparison. For example, the name of the cookie to evaluate.
+	Key string `json:"key,omitempty"`
+
+	// When true the logic of the rule is inverted. For example, with invert true,
+	// equal to would become not equal to. Default is false.
+	Invert bool `json:"invert,omitempty"`
+}
+
+// ToRuleUpdateMap builds a request body from UpdateRuleOpts.
+func (opts UpdateRuleOpts) ToRuleUpdateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "rule")
+}
+
+// UpdateRule allows Rule to be updated.
+func UpdateRule(c *gophercloud.ServiceClient, policyID string, ruleID string, opts UpdateRuleOptsBuilder) (r UpdateRuleResult) {
+	b, _ := opts.ToRuleUpdateMap()
+	_, r.Err = c.Put(ruleResourceURL(c, policyID, ruleID), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200, 201, 202},
+	})
+	return
+}

--- a/openstack/loadbalancer/v2/l7policies/requests.go
+++ b/openstack/loadbalancer/v2/l7policies/requests.go
@@ -177,7 +177,11 @@ func (opts UpdateOpts) ToL7PolicyUpdateMap() (map[string]interface{}, error) {
 
 // Update allows l7policy to be updated.
 func Update(c *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
-	b, _ := opts.ToL7PolicyUpdateMap()
+	b, err := opts.ToL7PolicyUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
 	_, r.Err = c.Put(resourceURL(c, id), b, &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{200},
 	})
@@ -312,7 +316,11 @@ func (opts UpdateRuleOpts) ToRuleUpdateMap() (map[string]interface{}, error) {
 
 // UpdateRule allows Rule to be updated.
 func UpdateRule(c *gophercloud.ServiceClient, policyID string, ruleID string, opts UpdateRuleOptsBuilder) (r UpdateRuleResult) {
-	b, _ := opts.ToRuleUpdateMap()
+	b, err := opts.ToRuleUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
 	_, r.Err = c.Put(ruleResourceURL(c, policyID, ruleID), b, &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{200, 201, 202},
 	})

--- a/openstack/loadbalancer/v2/l7policies/results.go
+++ b/openstack/loadbalancer/v2/l7policies/results.go
@@ -215,3 +215,9 @@ type GetRuleResult struct {
 type DeleteRuleResult struct {
 	gophercloud.ErrResult
 }
+
+// UpdateRuleResult represents the result of an UpdateRule operation.
+// Call its Extract method to interpret it as a Rule.
+type UpdateRuleResult struct {
+	commonRuleResult
+}

--- a/openstack/loadbalancer/v2/l7policies/testing/fixtures.go
+++ b/openstack/loadbalancer/v2/l7policies/testing/fixtures.go
@@ -89,6 +89,16 @@ var (
 		Invert:       false,
 		AdminStateUp: true,
 	}
+	RuleUpdated = l7policies.Rule{
+		ID:           "16621dbb-a736-4888-a57a-3ecd53df784c",
+		RuleType:     "PATH",
+		CompareType:  "REGEX",
+		Value:        "/images/special*",
+		ProjectID:    "e3cd678b11784734bc366148aa37580e",
+		Key:          "",
+		Invert:       false,
+		AdminStateUp: true,
+	}
 )
 
 // HandleL7PolicyCreationSuccessfully sets up the test server to respond to a l7policy creation request
@@ -326,5 +336,40 @@ func HandleRuleDeletionSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.WriteHeader(http.StatusNoContent)
+	})
+}
+
+// PostUpdateRuleBody is the canned response body of a Update request on an existing rule.
+const PostUpdateRuleBody = `
+{
+	"rule": {
+		"compare_type": "REGEX",
+		"invert": false,
+		"admin_state_up": true,
+		"value": "/images/special*",
+		"key": null,
+		"project_id": "e3cd678b11784734bc366148aa37580e",
+		"type": "PATH",
+		"id": "16621dbb-a736-4888-a57a-3ecd53df784c"
+	}
+}
+`
+
+// HandleRuleUpdateSuccessfully sets up the test server to respond to a rule Update request.
+func HandleRuleUpdateSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/v2.0/lbaas/l7policies/8a1412f0-4c32-4257-8b07-af4770b604fd/rules/16621dbb-a736-4888-a57a-3ecd53df784c", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestJSONRequest(t, r, `{
+			"rule": {
+				"compare_type": "REGEX",
+				"type": "PATH",
+				"value": "/images/special*"
+			}
+		}`)
+
+		fmt.Fprintf(w, PostUpdateRuleBody)
 	})
 }

--- a/openstack/loadbalancer/v2/l7policies/testing/requests_test.go
+++ b/openstack/loadbalancer/v2/l7policies/testing/requests_test.go
@@ -241,3 +241,21 @@ func TestDeleteRule(t *testing.T) {
 	res := l7policies.DeleteRule(fake.ServiceClient(), "8a1412f0-4c32-4257-8b07-af4770b604fd", "16621dbb-a736-4888-a57a-3ecd53df784c")
 	th.AssertNoErr(t, res.Err)
 }
+
+func TestUpdateRule(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleRuleUpdateSuccessfully(t)
+
+	client := fake.ServiceClient()
+	actual, err := l7policies.UpdateRule(client, "8a1412f0-4c32-4257-8b07-af4770b604fd", "16621dbb-a736-4888-a57a-3ecd53df784c", l7policies.UpdateRuleOpts{
+		RuleType:    l7policies.TypePath,
+		CompareType: l7policies.CompareTypeRegex,
+		Value:       "/images/special*",
+	}).Extract()
+	if err != nil {
+		t.Fatalf("Unexpected Update error: %v", err)
+	}
+
+	th.CheckDeepEquals(t, RuleUpdated, *actual)
+}

--- a/openstack/loadbalancer/v2/l7policies/testing/requests_test.go
+++ b/openstack/loadbalancer/v2/l7policies/testing/requests_test.go
@@ -128,6 +128,18 @@ func TestUpdateL7Policy(t *testing.T) {
 	th.CheckDeepEquals(t, L7PolicyUpdated, *actual)
 }
 
+func TestUpdateL7PolicyWithInvalidOpts(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	res := l7policies.Update(fake.ServiceClient(), "8a1412f0-4c32-4257-8b07-af4770b604fd", l7policies.UpdateOpts{
+		Action: l7policies.Action("invalid"),
+	})
+	if res.Err == nil {
+		t.Fatalf("Expected error, got none")
+	}
+}
+
 func TestCreateRule(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
@@ -258,4 +270,23 @@ func TestUpdateRule(t *testing.T) {
 	}
 
 	th.CheckDeepEquals(t, RuleUpdated, *actual)
+}
+
+func TestUpdateRuleWithInvalidOpts(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	res := l7policies.UpdateRule(fake.ServiceClient(), "", "", l7policies.UpdateRuleOpts{
+		RuleType: l7policies.RuleType("invalid"),
+	})
+	if res.Err == nil {
+		t.Fatalf("Expected error, got none")
+	}
+
+	res = l7policies.UpdateRule(fake.ServiceClient(), "", "", l7policies.UpdateRuleOpts{
+		CompareType: l7policies.CompareType("invalid"),
+	})
+	if res.Err == nil {
+		t.Fatalf("Expected error, got none")
+	}
 }


### PR DESCRIPTION
For #832

Octavia l7 rule PUT API implementation:

- https://github.com/openstack/octavia/blob/69a45c254be854dbdbff946dbe2564711cdecec3/octavia/api/v2/controllers/l7rule.py#L189
