### PR TITLE
Remove 'listener_id' from Pool ListOpts

### DIFF
--- a/openstack/loadbalancer/v2/pools/requests.go
+++ b/openstack/loadbalancer/v2/pools/requests.go
@@ -25,7 +25,6 @@ type ListOpts struct {
 	Name           string `q:"name"`
 	ID             string `q:"id"`
 	LoadbalancerID string `q:"loadbalancer_id"`
-	ListenerID     string `q:"listener_id"`
 	Limit          int    `q:"limit"`
 	Marker         string `q:"marker"`
 	SortKey        string `q:"sort_key"`


### PR DESCRIPTION
For #937

Octavia does not support to filter pools by listener_id.

Pool database model definiation in Octavia:
https://github.com/openstack/octavia/blob/be505cdfba0543dc6d9722f5c8779e34de84fe57/octavia/db/models.py#L260
