### PR TITLE
Networking v2: CIDR is not required for subnets

### DIFF
--- a/openstack/networking/v2/subnets/requests.go
+++ b/openstack/networking/v2/subnets/requests.go
@@ -80,7 +80,7 @@ type CreateOpts struct {
 	NetworkID string `json:"network_id" required:"true"`
 
 	// CIDR is the address CIDR of the subnet.
-	CIDR string `json:"cidr" required:"true"`
+	CIDR string `json:"cidr"`
 
 	// Name is a human-readable name of the subnet.
 	Name string `json:"name,omitempty"`


### PR DESCRIPTION
For #931 

https://github.com/openstack/neutron-lib/blob/3ee0386c314b409c3f5969fdf0b463efa6cca660/neutron_lib/api/definitions/subnet.py#L58-L63