### PR TITLE
Networking v2: omitempty when CIDR not specified

### DIFF
--- a/acceptance/openstack/networking/v2/networking.go
+++ b/acceptance/openstack/networking/v2/networking.go
@@ -281,6 +281,30 @@ func CreateSubnetWithSubnetPool(t *testing.T, client *gophercloud.ServiceClient,
 	return subnet, nil
 }
 
+// CreateSubnetWithSubnetPoolNoCIDR will create a subnet associated with the
+// provided subnetpool on the specified Network ID.
+// An error will be returned if the subnet or the subnetpool could not be created.
+func CreateSubnetWithSubnetPoolNoCIDR(t *testing.T, client *gophercloud.ServiceClient, networkID string, subnetPoolID string) (*subnets.Subnet, error) {
+	subnetName := tools.RandomString("TESTACC-", 8)
+	createOpts := subnets.CreateOpts{
+		NetworkID:    networkID,
+		IPVersion:    4,
+		Name:         subnetName,
+		EnableDHCP:   gophercloud.Disabled,
+		SubnetPoolID: subnetPoolID,
+	}
+
+	t.Logf("Attempting to create subnet: %s", subnetName)
+
+	subnet, err := subnets.Create(client, createOpts).Extract()
+	if err != nil {
+		return subnet, err
+	}
+
+	t.Logf("Successfully created subnet.")
+	return subnet, nil
+}
+
 // DeleteNetwork will delete a network with a specified ID. A fatal error will
 // occur if the delete was not successful. This works best when used as a
 // deferred function.

--- a/acceptance/openstack/networking/v2/subnets_test.go
+++ b/acceptance/openstack/networking/v2/subnets_test.go
@@ -191,3 +191,37 @@ func TestSubnetsWithSubnetPool(t *testing.T) {
 		t.Fatalf("A subnet pool was not associated.")
 	}
 }
+
+func TestSubnetsWithSubnetPoolNoCIDR(t *testing.T) {
+	client, err := clients.NewNetworkV2Client()
+	if err != nil {
+		t.Fatalf("Unable to create a network client: %v", err)
+	}
+
+	// Create Network
+	network, err := CreateNetwork(t, client)
+	if err != nil {
+		t.Fatalf("Unable to create network: %v", err)
+	}
+	defer DeleteNetwork(t, client, network.ID)
+
+	// Create SubnetPool
+	subnetPool, err := subnetpools.CreateSubnetPool(t, client)
+	if err != nil {
+		t.Fatalf("Unable to create subnet pool: %v", err)
+	}
+	defer subnetpools.DeleteSubnetPool(t, client, subnetPool.ID)
+
+	// Create Subnet
+	subnet, err := CreateSubnetWithSubnetPoolNoCIDR(t, client, network.ID, subnetPool.ID)
+	if err != nil {
+		t.Fatalf("Unable to create subnet: %v", err)
+	}
+	defer DeleteSubnet(t, client, subnet.ID)
+
+	tools.PrintResource(t, subnet)
+
+	if subnet.GatewayIP == "" {
+		t.Fatalf("A subnet pool was not associated.")
+	}
+}

--- a/openstack/networking/v2/subnets/requests.go
+++ b/openstack/networking/v2/subnets/requests.go
@@ -80,7 +80,7 @@ type CreateOpts struct {
 	NetworkID string `json:"network_id" required:"true"`
 
 	// CIDR is the address CIDR of the subnet.
-	CIDR string `json:"cidr"`
+	CIDR string `json:"cidr,omitempty"`
 
 	// Name is a human-readable name of the subnet.
 	Name string `json:"name,omitempty"`

--- a/openstack/networking/v2/subnets/testing/fixtures.go
+++ b/openstack/networking/v2/subnets/testing/fixtures.go
@@ -336,6 +336,18 @@ const SubnetCreateWithIPv6RaAddressModeResponse = `
 }
 `
 
+const SubnetCreateRequestWithNoCIDR = `
+{
+    "subnet": {
+        "network_id": "d32019d3-bc6e-4319-9c1d-6722fc136a22",
+        "ip_version": 4,
+        "dns_nameservers": ["foo"],
+        "host_routes": [{"destination":"","nexthop": "bar"}],
+        "subnetpool_id": "b80340c7-9960-4f67-a99c-02501656284b"
+    }
+}
+`
+
 const SubnetUpdateRequest = `
 {
     "subnet": {

--- a/openstack/networking/v2/subnets/testing/requests_test.go
+++ b/openstack/networking/v2/subnets/testing/requests_test.go
@@ -286,6 +286,54 @@ func TestCreateIPv6RaAddressMode(t *testing.T) {
 	th.AssertEquals(t, s.IPv6RAMode, "slaac")
 }
 
+func TestCreateWithNoCIDR(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/subnets", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, SubnetCreateRequestWithNoCIDR)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+
+		fmt.Fprintf(w, SubnetCreateResult)
+	})
+
+	opts := subnets.CreateOpts{
+		NetworkID:      "d32019d3-bc6e-4319-9c1d-6722fc136a22",
+		IPVersion:      4,
+		DNSNameservers: []string{"foo"},
+		HostRoutes: []subnets.HostRoute{
+			{NextHop: "bar"},
+		},
+		SubnetPoolID: "b80340c7-9960-4f67-a99c-02501656284b",
+	}
+	s, err := subnets.Create(fake.ServiceClient(), opts).Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, s.Name, "")
+	th.AssertEquals(t, s.EnableDHCP, true)
+	th.AssertEquals(t, s.NetworkID, "d32019d3-bc6e-4319-9c1d-6722fc136a22")
+	th.AssertEquals(t, s.TenantID, "4fd44f30292945e481c7b8a0c8908869")
+	th.AssertDeepEquals(t, s.DNSNameservers, []string{})
+	th.AssertDeepEquals(t, s.AllocationPools, []subnets.AllocationPool{
+		{
+			Start: "192.168.199.2",
+			End:   "192.168.199.254",
+		},
+	})
+	th.AssertDeepEquals(t, s.HostRoutes, []subnets.HostRoute{})
+	th.AssertEquals(t, s.IPVersion, 4)
+	th.AssertEquals(t, s.GatewayIP, "192.168.199.1")
+	th.AssertEquals(t, s.CIDR, "192.168.199.0/24")
+	th.AssertEquals(t, s.ID, "3b80198d-4f7b-4f77-9ef5-774d54e17126")
+	th.AssertEquals(t, s.SubnetPoolID, "b80340c7-9960-4f67-a99c-02501656284b")
+}
+
 func TestRequiredCreateOpts(t *testing.T) {
 	res := subnets.Create(fake.ServiceClient(), subnets.CreateOpts{})
 	if res.Err == nil {


### PR DESCRIPTION
For #931 

Of course I should learn that there are no easy fixes :)

The only notable change here is:

https://github.com/gophercloud/gophercloud/compare/master...jtopjian:networkingv2-subnet-cidr-omitempty?expand=1#diff-204ba5cafb491fe49ec624dbd245dce3

The rest of the changes are supporting tests.