### PR TITLE
Object Storage v1: Support string results for X-Static-Large-Object

### DIFF
--- a/openstack/objectstorage/v1/objects/results.go
+++ b/openstack/objectstorage/v1/objects/results.go
@@ -134,7 +134,7 @@ type DownloadHeader struct {
 	ETag               string    `json:"Etag"`
 	LastModified       time.Time `json:"-"`
 	ObjectManifest     string    `json:"X-Object-Manifest"`
-	StaticLargeObject  bool      `json:"X-Static-Large-Object"`
+	StaticLargeObject  bool      `json:"-"`
 	TransID            string    `json:"X-Trans-Id"`
 }
 
@@ -142,10 +142,11 @@ func (r *DownloadHeader) UnmarshalJSON(b []byte) error {
 	type tmp DownloadHeader
 	var s struct {
 		tmp
-		ContentLength string                  `json:"Content-Length"`
-		Date          gophercloud.JSONRFC1123 `json:"Date"`
-		DeleteAt      gophercloud.JSONUnix    `json:"X-Delete-At"`
-		LastModified  gophercloud.JSONRFC1123 `json:"Last-Modified"`
+		ContentLength     string                  `json:"Content-Length"`
+		Date              gophercloud.JSONRFC1123 `json:"Date"`
+		DeleteAt          gophercloud.JSONUnix    `json:"X-Delete-At"`
+		LastModified      gophercloud.JSONRFC1123 `json:"Last-Modified"`
+		StaticLargeObject interface{}             `json:"X-Static-Large-Object"`
 	}
 	err := json.Unmarshal(b, &s)
 	if err != nil {
@@ -162,6 +163,15 @@ func (r *DownloadHeader) UnmarshalJSON(b []byte) error {
 		if err != nil {
 			return err
 		}
+	}
+
+	switch t := s.StaticLargeObject.(type) {
+	case string:
+		if t == "True" || t == "true" {
+			r.StaticLargeObject = true
+		}
+	case bool:
+		r.StaticLargeObject = t
 	}
 
 	r.Date = time.Time(s.Date)
@@ -214,7 +224,7 @@ type GetHeader struct {
 	ETag               string    `json:"Etag"`
 	LastModified       time.Time `json:"-"`
 	ObjectManifest     string    `json:"X-Object-Manifest"`
-	StaticLargeObject  bool      `json:"X-Static-Large-Object"`
+	StaticLargeObject  bool      `json:"-"`
 	TransID            string    `json:"X-Trans-Id"`
 }
 
@@ -222,10 +232,11 @@ func (r *GetHeader) UnmarshalJSON(b []byte) error {
 	type tmp GetHeader
 	var s struct {
 		tmp
-		ContentLength string                  `json:"Content-Length"`
-		Date          gophercloud.JSONRFC1123 `json:"Date"`
-		DeleteAt      gophercloud.JSONUnix    `json:"X-Delete-At"`
-		LastModified  gophercloud.JSONRFC1123 `json:"Last-Modified"`
+		ContentLength     string                  `json:"Content-Length"`
+		Date              gophercloud.JSONRFC1123 `json:"Date"`
+		DeleteAt          gophercloud.JSONUnix    `json:"X-Delete-At"`
+		LastModified      gophercloud.JSONRFC1123 `json:"Last-Modified"`
+		StaticLargeObject interface{}             `json:"X-Static-Large-Object"`
 	}
 	err := json.Unmarshal(b, &s)
 	if err != nil {
@@ -242,6 +253,15 @@ func (r *GetHeader) UnmarshalJSON(b []byte) error {
 		if err != nil {
 			return err
 		}
+	}
+
+	switch t := s.StaticLargeObject.(type) {
+	case string:
+		if t == "True" || t == "true" {
+			r.StaticLargeObject = true
+		}
+	case bool:
+		r.StaticLargeObject = t
 	}
 
 	r.Date = time.Time(s.Date)

--- a/openstack/objectstorage/v1/objects/testing/fixtures.go
+++ b/openstack/objectstorage/v1/objects/testing/fixtures.go
@@ -21,6 +21,7 @@ func HandleDownloadObjectSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 		th.TestHeader(t, r, "Accept", "application/json")
 		w.Header().Set("Date", "Wed, 10 Nov 2009 23:00:00 GMT")
+		w.Header().Set("X-Static-Large-Object", "True")
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprintf(w, "Successful download with Gophercloud")
 	})
@@ -243,6 +244,7 @@ func HandleGetObjectSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 		th.TestHeader(t, r, "Accept", "application/json")
 		w.Header().Add("X-Object-Meta-Gophercloud-Test", "objects")
+		w.Header().Add("X-Static-Large-Object", "true")
 		w.WriteHeader(http.StatusNoContent)
 	})
 }

--- a/openstack/objectstorage/v1/objects/testing/requests_test.go
+++ b/openstack/objectstorage/v1/objects/testing/requests_test.go
@@ -44,9 +44,10 @@ func TestDownloadExtraction(t *testing.T) {
 	th.CheckEquals(t, "Successful download with Gophercloud", string(bytes))
 
 	expected := &objects.DownloadHeader{
-		ContentLength: 36,
-		ContentType:   "text/plain; charset=utf-8",
-		Date:          time.Date(2009, time.November, 10, 23, 0, 0, 0, loc),
+		ContentLength:     36,
+		ContentType:       "text/plain; charset=utf-8",
+		Date:              time.Date(2009, time.November, 10, 23, 0, 0, 0, loc),
+		StaticLargeObject: true,
 	}
 	actual, err := response.Extract()
 	th.AssertNoErr(t, err)
@@ -232,4 +233,8 @@ func TestGetObject(t *testing.T) {
 	actual, err := objects.Get(fake.ServiceClient(), "testContainer", "testObject", nil).ExtractMetadata()
 	th.AssertNoErr(t, err)
 	th.CheckDeepEquals(t, expected, actual)
+
+	actualHeaders, err := objects.Get(fake.ServiceClient(), "testContainer", "testObject", nil).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, actualHeaders.StaticLargeObject, true)
 }


### PR DESCRIPTION
For #599 

https://github.com/openstack/swift/blob/2596b3ca9dbde65fc5f117ea375ae56994be18c8/swift/common/middleware/slo.py#L1135

Additionally, I don't think it's possible for a header to contain a non-string value in general. However, I've still supported the possibility.

There's no acceptance test to this because I'm planning on doing some investigation into SLO and DLO. Those changes will contain acceptance tests. The tests here are standard unit tests to exercise the unmarshalling.