### PR TITLE
Ensure IdentityV3 clients have the right endpoint

### DIFF
--- a/openstack/utils/base_endpoint.go
+++ b/openstack/utils/base_endpoint.go
@@ -1,0 +1,29 @@
+package utils
+
+import (
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+// BaseEndpoint will return a URL without the /vX.Y
+// portion of the URL.
+func BaseEndpoint(endpoint string) (string, error) {
+	var base string
+
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return base, err
+	}
+
+	u.RawQuery, u.Fragment = "", ""
+
+	versionRe := regexp.MustCompile("v[0-9.]+/?")
+	if version := versionRe.FindString(u.Path); version != "" {
+		base = strings.Replace(u.String(), version, "", -1)
+	} else {
+		base = u.String()
+	}
+
+	return base, nil
+}

--- a/openstack/utils/testing/base_endpoint_test.go
+++ b/openstack/utils/testing/base_endpoint_test.go
@@ -1,0 +1,60 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/utils"
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+type endpointTestCases struct {
+	Endpoint     string
+	BaseEndpoint string
+}
+
+func TestBaseEndpoint(t *testing.T) {
+	tests := []endpointTestCases{
+		{
+			Endpoint:     "http://example.com:5000/v3",
+			BaseEndpoint: "http://example.com:5000/",
+		},
+		{
+			Endpoint:     "http://example.com:5000/v3.6",
+			BaseEndpoint: "http://example.com:5000/",
+		},
+		{
+			Endpoint:     "http://example.com:5000/v2.0",
+			BaseEndpoint: "http://example.com:5000/",
+		},
+		{
+			Endpoint:     "http://example.com:5000/",
+			BaseEndpoint: "http://example.com:5000/",
+		},
+		{
+			Endpoint:     "http://example.com:5000",
+			BaseEndpoint: "http://example.com:5000",
+		},
+		{
+			Endpoint:     "http://example.com/identity/v3",
+			BaseEndpoint: "http://example.com/identity/",
+		},
+		{
+			Endpoint:     "http://example.com/identity/v3.6",
+			BaseEndpoint: "http://example.com/identity/",
+		},
+		{
+			Endpoint:     "http://example.com/identity/v2.0",
+			BaseEndpoint: "http://example.com/identity/",
+		},
+		{
+			Endpoint:     "http://example.com/identity/",
+			BaseEndpoint: "http://example.com/identity/",
+		},
+	}
+
+	for _, test := range tests {
+		actual, err := utils.BaseEndpoint(test.Endpoint)
+		th.AssertNoErr(t, err)
+		th.AssertEquals(t, test.BaseEndpoint, actual)
+	}
+}


### PR DESCRIPTION
This commit ensures IdentityV3 clients have the right endpoint
upon creation. This handles both versionless endpoints and
v2.0 endpoints being returned when doing an endpoint search.

For #947 