### PR TITLE
Clustering Policy Update Implementation

### DIFF
--- a/acceptance/openstack/clustering/v1/policies_test.go
+++ b/acceptance/openstack/clustering/v1/policies_test.go
@@ -78,6 +78,24 @@ func TestPolicyCreateUpdateValidateDelete(t *testing.T) {
 		t.Log("CreatePolicy updated at: " + createdPolicy.UpdatedAt.String())
 	}
 
+	updateOpts := policies.UpdateOpts{
+		Name: testName + "-UPDATE",
+	}
+
+	updatePolicy, err := policies.Update(client, createdPolicy.ID, updateOpts).Extract()
+	th.AssertNoErr(t, err)
+
+	tools.PrintResource(t, updatePolicy)
+
+	if updatePolicy.CreatedAt.IsZero() {
+		t.Fatalf("UpdatePolicy's CreatedAt value should not be zero")
+	}
+	t.Log("UpdatePolicy created at: " + updatePolicy.CreatedAt.String())
+
+	if !updatePolicy.UpdatedAt.IsZero() {
+		t.Log("UpdatePolicy updated at: " + updatePolicy.UpdatedAt.String())
+	}
+
 	validateOpts := policies.ValidateOpts{
 		Spec: createOpts.Spec,
 	}

--- a/openstack/clustering/v1/policies/doc.go
+++ b/openstack/clustering/v1/policies/doc.go
@@ -48,6 +48,17 @@ Example to Create a policy
 		panic(err)
 	}
 
+Example to Update a policy
+
+	opts := policies.UpdateOpts{
+		Name: "update_policy",
+	}
+
+	updatePolicy, err := policies.Update(client, opts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
 Example to Validate a policy
 
 	opts := policies.ValidateOpts{

--- a/openstack/clustering/v1/policies/requests.go
+++ b/openstack/clustering/v1/policies/requests.go
@@ -90,13 +90,52 @@ func Create(client *gophercloud.ServiceClient, opts CreateOpts) (r CreateResult)
 	return
 }
 
-// Create makes a request against the API to delete a policy
+// Delete makes a request against the API to delete a policy
 func Delete(client *gophercloud.ServiceClient, policyID string) (r DeleteResult) {
 	var result *http.Response
 	result, r.Err = client.Delete(policyDeleteURL(client, policyID), &gophercloud.RequestOpts{
 		OkCodes: []int{204},
 	})
-	r.Header = result.Header
+	if r.Err == nil {
+		r.Header = result.Header
+	}
+	return
+}
+
+// UpdateOptsBuilder builder
+type UpdateOptsBuilder interface {
+	ToPolicyUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts params
+type UpdateOpts struct {
+	Policy map[string]interface{} `json:"-"`
+	Name   string                 `json:"name,omitempty"`
+}
+
+// ToPolicyUpdateMap formats a UpdateOpts into a body map.
+func (opts UpdateOpts) ToPolicyUpdateMap() (map[string]interface{}, error) {
+	b, err := gophercloud.BuildRequestBody(opts, "policy")
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+// Update implements profile updated request.
+func Update(client *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToPolicyUpdateMap()
+	if err != nil {
+		r.Err = err
+		return r
+	}
+	var result *http.Response
+	result, r.Err = client.Patch(updateURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	if r.Err == nil {
+		r.Header = result.Header
+	}
 	return
 }
 

--- a/openstack/clustering/v1/policies/requests.go
+++ b/openstack/clustering/v1/policies/requests.go
@@ -109,8 +109,7 @@ type UpdateOptsBuilder interface {
 
 // UpdateOpts params
 type UpdateOpts struct {
-	Policy map[string]interface{} `json:"-"`
-	Name   string                 `json:"name,omitempty"`
+	Name string `json:"name,omitempty"`
 }
 
 // ToPolicyUpdateMap formats a UpdateOpts into a body map.

--- a/openstack/clustering/v1/policies/results.go
+++ b/openstack/clustering/v1/policies/results.go
@@ -148,6 +148,11 @@ type DeleteResult struct {
 	gophercloud.HeaderResult
 }
 
+// UpdateResult is the response of a Update operations.
+type UpdateResult struct {
+	policyResult
+}
+
 type ValidateResult struct {
 	policyResult
 }

--- a/openstack/clustering/v1/policies/testing/fixtures.go
+++ b/openstack/clustering/v1/policies/testing/fixtures.go
@@ -99,6 +99,66 @@ const PolicyCreateBody = `
 }
 `
 
+const PolicyUpdateBody = `
+{
+  "policy": {
+    "created_at": "2018-04-02T21:43:30.000000",
+    "data": {},
+    "domain": null,
+    "id": "b99b3ab4-3aa6-4fba-b827-69b88b9c544a",
+    "name": "delpol4",
+    "project": "018cd0909fb44cd5bc9b7a3cd664920e",
+    "spec": {
+      "description": "A policy for choosing victim node(s) from a cluster for deletion.",
+      "properties": {
+        "hooks": {
+          "params": {
+            "queue": "zaqar_queue_name"
+          },
+          "timeout": 180,
+          "type": "zaqar"
+        }
+      },
+      "type": "senlin.policy.deletion",
+      "version": 1.1
+    },
+    "type": "senlin.policy.deletion-1.1",
+    "updated_at": null,
+    "user": "fe43e41739154b72818565e0d2580819"
+  }
+}
+`
+
+const PolicyBadUpdateBody = `
+{
+  "policy": {
+    "created_at": "invalid",
+    "data": {},
+    "domain": null,
+    "id": "b99b3ab4-3aa6-4fba-b827-69b88b9c544a",
+    "name": "delpol4",
+    "project": "018cd0909fb44cd5bc9b7a3cd664920e",
+    "spec": {
+      "description": "A policy for choosing victim node(s) from a cluster for deletion.",
+      "properties": {
+        "hooks": {
+          "params": {
+            "queue": "zaqar_queue_name"
+          },
+          "timeout": 180,
+          "type": "zaqar"
+        }
+      },
+      "type": "senlin.policy.deletion",
+      "version": 1.1
+    },
+    "type": "invalid",
+    "updated_at": null,
+    "user": "fe43e41739154b72818565e0d2580819"
+  }
+}
+`
+
 const PolicyValidateBody = `
 {
   "policy": {
@@ -172,6 +232,9 @@ var (
 	// Policy ID to delete
 	PolicyIDtoDelete = "1"
 
+	// Policy ID to update
+	PolicyIDtoUpdate = "b99b3ab4-3aa6-4fba-b827-69b88b9c544a"
+
 	ExpectedPolicies = [][]policies.Policy{
 		{
 			{
@@ -227,6 +290,33 @@ var (
 
 	ExpectedCreatePolicy = policies.Policy{
 		CreatedAt: ExpectedCreatePolicyCreatedAt,
+		Data:      map[string]interface{}{},
+		Domain:    "",
+		ID:        "b99b3ab4-3aa6-4fba-b827-69b88b9c544a",
+		Name:      "delpol4",
+		Project:   "018cd0909fb44cd5bc9b7a3cd664920e",
+
+		Spec: policies.Spec{
+			Description: "A policy for choosing victim node(s) from a cluster for deletion.",
+			Properties: map[string]interface{}{
+				"hooks": map[string]interface{}{
+					"params": map[string]interface{}{
+						"queue": "zaqar_queue_name",
+					},
+					"timeout": float64(180),
+					"type":    "zaqar",
+				},
+			},
+			Type:    "senlin.policy.deletion",
+			Version: "1.1",
+		},
+		Type:      "senlin.policy.deletion-1.1",
+		User:      "fe43e41739154b72818565e0d2580819",
+		UpdatedAt: ZeroTime,
+	}
+
+	ExpectedUpdatePolicy = policies.Policy{
+		CreatedAt: ExpectedPolicyCreatedAt1,
 		Data:      map[string]interface{}{},
 		Domain:    "",
 		ID:        "b99b3ab4-3aa6-4fba-b827-69b88b9c544a",
@@ -322,6 +412,30 @@ func HandlePolicyDelete(t *testing.T) {
 
 		w.Header().Add("X-OpenStack-Request-ID", PolicyDeleteRequestID)
 		w.WriteHeader(http.StatusNoContent)
+	})
+}
+
+func HandlePolicyUpdate(t *testing.T) {
+	th.Mux.HandleFunc("/v1/policies/"+PolicyIDtoUpdate, func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PATCH")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, PolicyUpdateBody)
+	})
+}
+
+func HandleBadPolicyUpdate(t *testing.T) {
+	th.Mux.HandleFunc("/v1/policies/"+PolicyIDtoUpdate, func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PATCH")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, PolicyBadUpdateBody)
 	})
 }
 

--- a/openstack/clustering/v1/policies/testing/requests_test.go
+++ b/openstack/clustering/v1/policies/testing/requests_test.go
@@ -71,6 +71,38 @@ func TestDeletePolicy(t *testing.T) {
 	th.AssertEquals(t, PolicyDeleteRequestID, actual.RequestID)
 }
 
+func TestUpdatePolicy(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	HandlePolicyUpdate(t)
+
+	expected := ExpectedUpdatePolicy
+
+	opts := policies.UpdateOpts{
+		Name: ExpectedUpdatePolicy.Name,
+	}
+
+	actual, err := policies.Update(fake.ServiceClient(), PolicyIDtoUpdate, opts).Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertDeepEquals(t, &expected, actual)
+}
+
+func TestBadUpdatePolicy(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	HandleBadPolicyUpdate(t)
+
+	opts := policies.UpdateOpts{
+		Name: ExpectedUpdatePolicy.Name,
+	}
+
+	_, err := policies.Update(fake.ServiceClient(), PolicyIDtoUpdate, opts).Extract()
+	th.AssertEquals(t, false, err == nil)
+}
+
 func TestValidatePolicy(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()

--- a/openstack/clustering/v1/policies/urls.go
+++ b/openstack/clustering/v1/policies/urls.go
@@ -19,6 +19,10 @@ func policyDeleteURL(client *gophercloud.ServiceClient, policyID string) string 
 	return client.ServiceURL(apiVersion, apiName, policyID)
 }
 
+func updateURL(client *gophercloud.ServiceClient, policyID string) string {
+	return client.ServiceURL(apiVersion, apiName, policyID)
+}
+
 func validateURL(client *gophercloud.ServiceClient) string {
 	return client.ServiceURL(apiVersion, apiName, "validate")
 }


### PR DESCRIPTION
Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

For #[823 [Add support for Senlin clustering]](https://github.com/gophercloud/gophercloud/issues/823)

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

[[policies:update]](https://github.com/openstack/senlin/blob/e5bc16b3fea2f10dead365f983c5a937f23d72b0/senlin/api/openstack/v1/policies.py#L74)
