### PR TITLE
[Pending #945] Object Storage v1: Allow ETag to be specified and omitted

### DIFF
--- a/acceptance/clients/http.go
+++ b/acceptance/clients/http.go
@@ -73,8 +73,6 @@ func (lrt *LogRoundTripper) logRequest(original io.ReadCloser, contentType strin
 	if strings.HasPrefix(contentType, "application/json") {
 		debugInfo := lrt.formatJSON(bs.Bytes())
 		log.Printf("[DEBUG] OpenStack Request Body: %s", debugInfo)
-	} else {
-		log.Printf("[DEBUG] OpenStack Request Body: %s", bs.String())
 	}
 
 	return ioutil.NopCloser(strings.NewReader(bs.String())), nil

--- a/openstack/objectstorage/v1/objects/requests.go
+++ b/openstack/objectstorage/v1/objects/requests.go
@@ -145,6 +145,7 @@ type CreateOptsBuilder interface {
 type CreateOpts struct {
 	Content            io.Reader
 	Metadata           map[string]string
+	NoETag             bool
 	CacheControl       string `h:"Cache-Control"`
 	ContentDisposition string `h:"Content-Disposition"`
 	ContentEncoding    string `h:"Content-Encoding"`
@@ -177,6 +178,15 @@ func (opts CreateOpts) ToObjectCreateParams() (io.Reader, map[string]string, str
 
 	for k, v := range opts.Metadata {
 		h["X-Object-Meta-"+k] = v
+	}
+
+	if opts.NoETag {
+		delete(h, "etag")
+		return opts.Content, h, q.String(), nil
+	}
+
+	if h["ETag"] != "" {
+		return opts.Content, h, q.String(), nil
 	}
 
 	hash := md5.New()

--- a/openstack/objectstorage/v1/objects/results.go
+++ b/openstack/objectstorage/v1/objects/results.go
@@ -134,7 +134,7 @@ type DownloadHeader struct {
 	ETag               string    `json:"Etag"`
 	LastModified       time.Time `json:"-"`
 	ObjectManifest     string    `json:"X-Object-Manifest"`
-	StaticLargeObject  bool      `json:"X-Static-Large-Object"`
+	StaticLargeObject  bool      `json:"-"`
 	TransID            string    `json:"X-Trans-Id"`
 }
 
@@ -142,10 +142,11 @@ func (r *DownloadHeader) UnmarshalJSON(b []byte) error {
 	type tmp DownloadHeader
 	var s struct {
 		tmp
-		ContentLength string                  `json:"Content-Length"`
-		Date          gophercloud.JSONRFC1123 `json:"Date"`
-		DeleteAt      gophercloud.JSONUnix    `json:"X-Delete-At"`
-		LastModified  gophercloud.JSONRFC1123 `json:"Last-Modified"`
+		ContentLength     string                  `json:"Content-Length"`
+		Date              gophercloud.JSONRFC1123 `json:"Date"`
+		DeleteAt          gophercloud.JSONUnix    `json:"X-Delete-At"`
+		LastModified      gophercloud.JSONRFC1123 `json:"Last-Modified"`
+		StaticLargeObject interface{}             `json:"X-Static-Large-Object"`
 	}
 	err := json.Unmarshal(b, &s)
 	if err != nil {
@@ -162,6 +163,15 @@ func (r *DownloadHeader) UnmarshalJSON(b []byte) error {
 		if err != nil {
 			return err
 		}
+	}
+
+	switch t := s.StaticLargeObject.(type) {
+	case string:
+		if t == "True" || t == "true" {
+			r.StaticLargeObject = true
+		}
+	case bool:
+		r.StaticLargeObject = t
 	}
 
 	r.Date = time.Time(s.Date)
@@ -214,7 +224,7 @@ type GetHeader struct {
 	ETag               string    `json:"Etag"`
 	LastModified       time.Time `json:"-"`
 	ObjectManifest     string    `json:"X-Object-Manifest"`
-	StaticLargeObject  bool      `json:"X-Static-Large-Object"`
+	StaticLargeObject  bool      `json:"-"`
 	TransID            string    `json:"X-Trans-Id"`
 }
 
@@ -222,10 +232,11 @@ func (r *GetHeader) UnmarshalJSON(b []byte) error {
 	type tmp GetHeader
 	var s struct {
 		tmp
-		ContentLength string                  `json:"Content-Length"`
-		Date          gophercloud.JSONRFC1123 `json:"Date"`
-		DeleteAt      gophercloud.JSONUnix    `json:"X-Delete-At"`
-		LastModified  gophercloud.JSONRFC1123 `json:"Last-Modified"`
+		ContentLength     string                  `json:"Content-Length"`
+		Date              gophercloud.JSONRFC1123 `json:"Date"`
+		DeleteAt          gophercloud.JSONUnix    `json:"X-Delete-At"`
+		LastModified      gophercloud.JSONRFC1123 `json:"Last-Modified"`
+		StaticLargeObject interface{}             `json:"X-Static-Large-Object"`
 	}
 	err := json.Unmarshal(b, &s)
 	if err != nil {
@@ -242,6 +253,15 @@ func (r *GetHeader) UnmarshalJSON(b []byte) error {
 		if err != nil {
 			return err
 		}
+	}
+
+	switch t := s.StaticLargeObject.(type) {
+	case string:
+		if t == "True" || t == "true" {
+			r.StaticLargeObject = true
+		}
+	case bool:
+		r.StaticLargeObject = t
 	}
 
 	r.Date = time.Time(s.Date)

--- a/openstack/objectstorage/v1/objects/testing/fixtures.go
+++ b/openstack/objectstorage/v1/objects/testing/fixtures.go
@@ -21,6 +21,7 @@ func HandleDownloadObjectSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 		th.TestHeader(t, r, "Accept", "application/json")
 		w.Header().Set("Date", "Wed, 10 Nov 2009 23:00:00 GMT")
+		w.Header().Set("X-Static-Large-Object", "True")
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprintf(w, "Successful download with Gophercloud")
 	})
@@ -243,6 +244,7 @@ func HandleGetObjectSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 		th.TestHeader(t, r, "Accept", "application/json")
 		w.Header().Add("X-Object-Meta-Gophercloud-Test", "objects")
+		w.Header().Add("X-Static-Large-Object", "true")
 		w.WriteHeader(http.StatusNoContent)
 	})
 }

--- a/openstack/objectstorage/v1/objects/testing/requests_test.go
+++ b/openstack/objectstorage/v1/objects/testing/requests_test.go
@@ -44,9 +44,10 @@ func TestDownloadExtraction(t *testing.T) {
 	th.CheckEquals(t, "Successful download with Gophercloud", string(bytes))
 
 	expected := &objects.DownloadHeader{
-		ContentLength: 36,
-		ContentType:   "text/plain; charset=utf-8",
-		Date:          time.Date(2009, time.November, 10, 23, 0, 0, 0, loc),
+		ContentLength:     36,
+		ContentType:       "text/plain; charset=utf-8",
+		Date:              time.Date(2009, time.November, 10, 23, 0, 0, 0, loc),
+		StaticLargeObject: true,
 	}
 	actual, err := response.Extract()
 	th.AssertNoErr(t, err)
@@ -232,4 +233,8 @@ func TestGetObject(t *testing.T) {
 	actual, err := objects.Get(fake.ServiceClient(), "testContainer", "testObject", nil).ExtractMetadata()
 	th.AssertNoErr(t, err)
 	th.CheckDeepEquals(t, expected, actual)
+
+	actualHeaders, err := objects.Get(fake.ServiceClient(), "testContainer", "testObject", nil).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, actualHeaders.StaticLargeObject, true)
 }


### PR DESCRIPTION
For #805 

Supersedes #597 
Supersedes #806 

As described in the above issue and PRs, there are valid use-cases when etag calculation should be omitted or could be supplied outside of Gophercloud. As also discussed above, it is possible to use a custom `CreateOptsBuilder` interface to get around this, but IMO, Gophercloud should support these options.

One reason is because every application which wants to implement Dynamic Large Objects must create a custom `ToObjectCreateParams` function which omits etag calculation.

Another reason is because etag support can be used for upload verification. Gophercloud's current implementation doesn't give access to the generated etag so the user must therefore calculate it outside of Gophercloud, send the request (which then generates it again), and then compare the return etag. 

Again, a custom `ToObjectCreateParams` would get around this, but the valid use-cases can keep adding up :)

I fully agree that in most cases having the etag calculated is beneficial, but I also think toggling and supplying will save users a lot of work for other cases.