### PR TITLE
[wip] cinder backups

### DIFF
--- a/openstack/blockstorage/v2/backups/doc.go
+++ b/openstack/blockstorage/v2/backups/doc.go
@@ -1,0 +1,5 @@
+// Package snapshots provides information and interaction with snapshots in the
+// OpenStack Block Storage service. A snapshot is a point in time copy of the
+// data contained in an external storage volume, and can be controlled
+// programmatically.
+package snapshots

--- a/openstack/blockstorage/v2/backups/doc.go
+++ b/openstack/blockstorage/v2/backups/doc.go
@@ -1,5 +1,5 @@
-// Package snapshots provides information and interaction with snapshots in the
-// OpenStack Block Storage service. A snapshot is a point in time copy of the
+// Package backups provides information and interaction with backups in the
+// OpenStack Block Storage service. A backup is a point in time copy of the
 // data contained in an external storage volume, and can be controlled
 // programmatically.
-package snapshots
+package backups

--- a/openstack/blockstorage/v2/backups/requests.go
+++ b/openstack/blockstorage/v2/backups/requests.go
@@ -1,0 +1,170 @@
+package snapshots
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToSnapshotCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts contains options for creating a Snapshot. This object is passed to
+// the snapshots.Create function. For more information about these parameters,
+// see the Snapshot object.
+type CreateOpts struct {
+	VolumeID    string            `json:"volume_id" required:"true"`
+	Force       bool              `json:"force,omitempty"`
+	Name        string            `json:"name,omitempty"`
+	Description string            `json:"description,omitempty"`
+	Metadata    map[string]string `json:"metadata,omitempty"`
+}
+
+// ToSnapshotCreateMap assembles a request body based on the contents of a
+// CreateOpts.
+func (opts CreateOpts) ToSnapshotCreateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "snapshot")
+}
+
+// Create will create a new Snapshot based on the values in CreateOpts. To
+// extract the Snapshot object from the response, call the Extract method on the
+// CreateResult.
+func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToSnapshotCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(createURL(client), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+	})
+	return
+}
+
+// Delete will delete the existing Snapshot with the provided ID.
+func Delete(client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+	_, r.Err = client.Delete(deleteURL(client, id), nil)
+	return
+}
+
+// Get retrieves the Snapshot with the provided ID. To extract the Snapshot
+// object from the response, call the Extract method on the GetResult.
+func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {
+	_, r.Err = client.Get(getURL(client, id), &r.Body, nil)
+	return
+}
+
+// ListOptsBuilder allows extensions to add additional parameters to the List
+// request.
+type ListOptsBuilder interface {
+	ToSnapshotListQuery() (string, error)
+}
+
+// ListOpts hold options for listing Snapshots. It is passed to the
+// snapshots.List function.
+type ListOpts struct {
+	// AllTenants will retrieve snapshots of all tenants/projects.
+	AllTenants bool `q:"all_tenants"`
+
+	// Name will filter by the specified snapshot name.
+	Name string `q:"name"`
+
+	// Status will filter by the specified status.
+	Status string `q:"status"`
+
+	// TenantID will filter by a specific tenant/project ID.
+	// Setting AllTenants is required to use this.
+	TenantID string `q:"project_id"`
+
+	// VolumeID will filter by a specified volume ID.
+	VolumeID string `q:"volume_id"`
+}
+
+// ToSnapshotListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToSnapshotListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List returns Snapshots optionally limited by the conditions provided in
+// ListOpts.
+func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(client)
+	if opts != nil {
+		query, err := opts.ToSnapshotListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return SnapshotPage{pagination.SinglePageBase(r)}
+	})
+}
+
+// UpdateMetadataOptsBuilder allows extensions to add additional parameters to
+// the Update request.
+type UpdateMetadataOptsBuilder interface {
+	ToSnapshotUpdateMetadataMap() (map[string]interface{}, error)
+}
+
+// UpdateMetadataOpts contain options for updating an existing Snapshot. This
+// object is passed to the snapshots.Update function. For more information
+// about the parameters, see the Snapshot object.
+type UpdateMetadataOpts struct {
+	Metadata map[string]interface{} `json:"metadata,omitempty"`
+}
+
+// ToSnapshotUpdateMetadataMap assembles a request body based on the contents of
+// an UpdateMetadataOpts.
+func (opts UpdateMetadataOpts) ToSnapshotUpdateMetadataMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "")
+}
+
+// UpdateMetadata will update the Snapshot with provided information. To
+// extract the updated Snapshot from the response, call the ExtractMetadata
+// method on the UpdateMetadataResult.
+func UpdateMetadata(client *gophercloud.ServiceClient, id string, opts UpdateMetadataOptsBuilder) (r UpdateMetadataResult) {
+	b, err := opts.ToSnapshotUpdateMetadataMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Put(updateMetadataURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// IDFromName is a convienience function that returns a snapshot's ID given its name.
+func IDFromName(client *gophercloud.ServiceClient, name string) (string, error) {
+	count := 0
+	id := ""
+	pages, err := List(client, nil).AllPages()
+	if err != nil {
+		return "", err
+	}
+
+	all, err := ExtractSnapshots(pages)
+	if err != nil {
+		return "", err
+	}
+
+	for _, s := range all {
+		if s.Name == name {
+			count++
+			id = s.ID
+		}
+	}
+
+	switch count {
+	case 0:
+		return "", gophercloud.ErrResourceNotFound{Name: name, ResourceType: "snapshot"}
+	case 1:
+		return id, nil
+	default:
+		return "", gophercloud.ErrMultipleResourcesFound{Name: name, Count: count, ResourceType: "snapshot"}
+	}
+}

--- a/openstack/blockstorage/v2/backups/requests.go
+++ b/openstack/blockstorage/v2/backups/requests.go
@@ -1,4 +1,4 @@
-package snapshots
+package backups
 
 import (
 	"github.com/gophercloud/gophercloud"
@@ -8,12 +8,12 @@ import (
 // CreateOptsBuilder allows extensions to add additional parameters to the
 // Create request.
 type CreateOptsBuilder interface {
-	ToSnapshotCreateMap() (map[string]interface{}, error)
+	ToBackupCreateMap() (map[string]interface{}, error)
 }
 
-// CreateOpts contains options for creating a Snapshot. This object is passed to
-// the snapshots.Create function. For more information about these parameters,
-// see the Snapshot object.
+// CreateOpts contains options for creating a Backup. This object is passed to
+// the backups.Create function. For more information about these parameters,
+// see the Backup object.
 type CreateOpts struct {
 	VolumeID    string            `json:"volume_id" required:"true"`
 	Force       bool              `json:"force,omitempty"`
@@ -22,17 +22,17 @@ type CreateOpts struct {
 	Metadata    map[string]string `json:"metadata,omitempty"`
 }
 
-// ToSnapshotCreateMap assembles a request body based on the contents of a
+// ToBackupCreateMap assembles a request body based on the contents of a
 // CreateOpts.
-func (opts CreateOpts) ToSnapshotCreateMap() (map[string]interface{}, error) {
-	return gophercloud.BuildRequestBody(opts, "snapshot")
+func (opts CreateOpts) ToBackupCreateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "backup")
 }
 
-// Create will create a new Snapshot based on the values in CreateOpts. To
-// extract the Snapshot object from the response, call the Extract method on the
+// Create will create a new Backup based on the values in CreateOpts. To
+// extract the Backup object from the response, call the Extract method on the
 // CreateResult.
 func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
-	b, err := opts.ToSnapshotCreateMap()
+	b, err := opts.ToBackupCreateMap()
 	if err != nil {
 		r.Err = err
 		return
@@ -43,13 +43,13 @@ func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r Create
 	return
 }
 
-// Delete will delete the existing Snapshot with the provided ID.
+// Delete will delete the existing Backup with the provided ID.
 func Delete(client *gophercloud.ServiceClient, id string) (r DeleteResult) {
 	_, r.Err = client.Delete(deleteURL(client, id), nil)
 	return
 }
 
-// Get retrieves the Snapshot with the provided ID. To extract the Snapshot
+// Get retrieves the Backup with the provided ID. To extract the Backup
 // object from the response, call the Extract method on the GetResult.
 func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {
 	_, r.Err = client.Get(getURL(client, id), &r.Body, nil)
@@ -59,16 +59,16 @@ func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {
 // ListOptsBuilder allows extensions to add additional parameters to the List
 // request.
 type ListOptsBuilder interface {
-	ToSnapshotListQuery() (string, error)
+	ToBackupListQuery() (string, error)
 }
 
-// ListOpts hold options for listing Snapshots. It is passed to the
-// snapshots.List function.
+// ListOpts hold options for listing Backups. It is passed to the
+// backups.List function.
 type ListOpts struct {
-	// AllTenants will retrieve snapshots of all tenants/projects.
+	// AllTenants will retrieve backups of all tenants/projects.
 	AllTenants bool `q:"all_tenants"`
 
-	// Name will filter by the specified snapshot name.
+	// Name will filter by the specified backup name.
 	Name string `q:"name"`
 
 	// Status will filter by the specified status.
@@ -82,52 +82,52 @@ type ListOpts struct {
 	VolumeID string `q:"volume_id"`
 }
 
-// ToSnapshotListQuery formats a ListOpts into a query string.
-func (opts ListOpts) ToSnapshotListQuery() (string, error) {
+// ToBackupListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToBackupListQuery() (string, error) {
 	q, err := gophercloud.BuildQueryString(opts)
 	return q.String(), err
 }
 
-// List returns Snapshots optionally limited by the conditions provided in
+// List returns Backups optionally limited by the conditions provided in
 // ListOpts.
 func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(client)
 	if opts != nil {
-		query, err := opts.ToSnapshotListQuery()
+		query, err := opts.ToBackupListQuery()
 		if err != nil {
 			return pagination.Pager{Err: err}
 		}
 		url += query
 	}
 	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
-		return SnapshotPage{pagination.SinglePageBase(r)}
+		return BackupPage{pagination.SinglePageBase(r)}
 	})
 }
 
 // UpdateMetadataOptsBuilder allows extensions to add additional parameters to
 // the Update request.
 type UpdateMetadataOptsBuilder interface {
-	ToSnapshotUpdateMetadataMap() (map[string]interface{}, error)
+	ToBackupUpdateMetadataMap() (map[string]interface{}, error)
 }
 
-// UpdateMetadataOpts contain options for updating an existing Snapshot. This
-// object is passed to the snapshots.Update function. For more information
-// about the parameters, see the Snapshot object.
+// UpdateMetadataOpts contain options for updating an existing Backup. This
+// object is passed to the backups.Update function. For more information
+// about the parameters, see the Backup object.
 type UpdateMetadataOpts struct {
 	Metadata map[string]interface{} `json:"metadata,omitempty"`
 }
 
-// ToSnapshotUpdateMetadataMap assembles a request body based on the contents of
+// ToBackupUpdateMetadataMap assembles a request body based on the contents of
 // an UpdateMetadataOpts.
-func (opts UpdateMetadataOpts) ToSnapshotUpdateMetadataMap() (map[string]interface{}, error) {
+func (opts UpdateMetadataOpts) ToBackupUpdateMetadataMap() (map[string]interface{}, error) {
 	return gophercloud.BuildRequestBody(opts, "")
 }
 
-// UpdateMetadata will update the Snapshot with provided information. To
-// extract the updated Snapshot from the response, call the ExtractMetadata
+// UpdateMetadata will update the Backup with provided information. To
+// extract the updated Backup from the response, call the ExtractMetadata
 // method on the UpdateMetadataResult.
 func UpdateMetadata(client *gophercloud.ServiceClient, id string, opts UpdateMetadataOptsBuilder) (r UpdateMetadataResult) {
-	b, err := opts.ToSnapshotUpdateMetadataMap()
+	b, err := opts.ToBackupUpdateMetadataMap()
 	if err != nil {
 		r.Err = err
 		return
@@ -138,7 +138,7 @@ func UpdateMetadata(client *gophercloud.ServiceClient, id string, opts UpdateMet
 	return
 }
 
-// IDFromName is a convienience function that returns a snapshot's ID given its name.
+// IDFromName is a convienience function that returns a backup's ID given its name.
 func IDFromName(client *gophercloud.ServiceClient, name string) (string, error) {
 	count := 0
 	id := ""
@@ -147,7 +147,7 @@ func IDFromName(client *gophercloud.ServiceClient, name string) (string, error) 
 		return "", err
 	}
 
-	all, err := ExtractSnapshots(pages)
+	all, err := ExtractBackups(pages)
 	if err != nil {
 		return "", err
 	}
@@ -161,10 +161,10 @@ func IDFromName(client *gophercloud.ServiceClient, name string) (string, error) 
 
 	switch count {
 	case 0:
-		return "", gophercloud.ErrResourceNotFound{Name: name, ResourceType: "snapshot"}
+		return "", gophercloud.ErrResourceNotFound{Name: name, ResourceType: "backup"}
 	case 1:
 		return id, nil
 	default:
-		return "", gophercloud.ErrMultipleResourcesFound{Name: name, Count: count, ResourceType: "snapshot"}
+		return "", gophercloud.ErrMultipleResourcesFound{Name: name, Count: count, ResourceType: "backup"}
 	}
 }

--- a/openstack/blockstorage/v2/backups/requests.go
+++ b/openstack/blockstorage/v2/backups/requests.go
@@ -20,6 +20,9 @@ type CreateOpts struct {
 	Name        string            `json:"name,omitempty"`
 	Description string            `json:"description,omitempty"`
 	Metadata    map[string]string `json:"metadata,omitempty"`
+	Container   string            `json:"container,omitempty"`
+	Incremental bool              `json:"incremental,omitempty"`
+	SnapshotID  string            `json:"snapshot_id,omitempty"`
 }
 
 // ToBackupCreateMap assembles a request body based on the contents of a

--- a/openstack/blockstorage/v2/backups/results.go
+++ b/openstack/blockstorage/v2/backups/results.go
@@ -1,0 +1,120 @@
+package snapshots
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// Snapshot contains all the information associated with a Cinder Snapshot.
+type Snapshot struct {
+	// Unique identifier.
+	ID string `json:"id"`
+
+	// Date created.
+	CreatedAt time.Time `json:"-"`
+
+	// Date updated.
+	UpdatedAt time.Time `json:"-"`
+
+	// Display name.
+	Name string `json:"name"`
+
+	// Display description.
+	Description string `json:"description"`
+
+	// ID of the Volume from which this Snapshot was created.
+	VolumeID string `json:"volume_id"`
+
+	// Currect status of the Snapshot.
+	Status string `json:"status"`
+
+	// Size of the Snapshot, in GB.
+	Size int `json:"size"`
+
+	// User-defined key-value pairs.
+	Metadata map[string]string `json:"metadata"`
+}
+
+// CreateResult contains the response body and error from a Create request.
+type CreateResult struct {
+	commonResult
+}
+
+// GetResult contains the response body and error from a Get request.
+type GetResult struct {
+	commonResult
+}
+
+// DeleteResult contains the response body and error from a Delete request.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
+// SnapshotPage is a pagination.Pager that is returned from a call to the List function.
+type SnapshotPage struct {
+	pagination.SinglePageBase
+}
+
+func (r *Snapshot) UnmarshalJSON(b []byte) error {
+	type tmp Snapshot
+	var s struct {
+		tmp
+		CreatedAt gophercloud.JSONRFC3339MilliNoZ `json:"created_at"`
+		UpdatedAt gophercloud.JSONRFC3339MilliNoZ `json:"updated_at"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	*r = Snapshot(s.tmp)
+
+	r.CreatedAt = time.Time(s.CreatedAt)
+	r.UpdatedAt = time.Time(s.UpdatedAt)
+
+	return err
+}
+
+// IsEmpty returns true if a SnapshotPage contains no Snapshots.
+func (r SnapshotPage) IsEmpty() (bool, error) {
+	volumes, err := ExtractSnapshots(r)
+	return len(volumes) == 0, err
+}
+
+// ExtractSnapshots extracts and returns Snapshots. It is used while iterating over a snapshots.List call.
+func ExtractSnapshots(r pagination.Page) ([]Snapshot, error) {
+	var s struct {
+		Snapshots []Snapshot `json:"snapshots"`
+	}
+	err := (r.(SnapshotPage)).ExtractInto(&s)
+	return s.Snapshots, err
+}
+
+// UpdateMetadataResult contains the response body and error from an UpdateMetadata request.
+type UpdateMetadataResult struct {
+	commonResult
+}
+
+// ExtractMetadata returns the metadata from a response from snapshots.UpdateMetadata.
+func (r UpdateMetadataResult) ExtractMetadata() (map[string]interface{}, error) {
+	if r.Err != nil {
+		return nil, r.Err
+	}
+	m := r.Body.(map[string]interface{})["metadata"]
+	return m.(map[string]interface{}), nil
+}
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// Extract will get the Snapshot object out of the commonResult object.
+func (r commonResult) Extract() (*Snapshot, error) {
+	var s struct {
+		Snapshot *Snapshot `json:"snapshot"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Snapshot, err
+}

--- a/openstack/blockstorage/v2/backups/results.go
+++ b/openstack/blockstorage/v2/backups/results.go
@@ -1,4 +1,4 @@
-package snapshots
+package backups
 
 import (
 	"encoding/json"
@@ -8,8 +8,8 @@ import (
 	"github.com/gophercloud/gophercloud/pagination"
 )
 
-// Snapshot contains all the information associated with a Cinder Snapshot.
-type Snapshot struct {
+// Backup contains all the information associated with a Cinder Backup.
+type Backup struct {
 	// Unique identifier.
 	ID string `json:"id"`
 
@@ -25,13 +25,13 @@ type Snapshot struct {
 	// Display description.
 	Description string `json:"description"`
 
-	// ID of the Volume from which this Snapshot was created.
+	// ID of the Volume from which this Backup was created.
 	VolumeID string `json:"volume_id"`
 
-	// Currect status of the Snapshot.
+	// Currect status of the Backup.
 	Status string `json:"status"`
 
-	// Size of the Snapshot, in GB.
+	// Size of the Backup, in GB.
 	Size int `json:"size"`
 
 	// User-defined key-value pairs.
@@ -53,13 +53,13 @@ type DeleteResult struct {
 	gophercloud.ErrResult
 }
 
-// SnapshotPage is a pagination.Pager that is returned from a call to the List function.
-type SnapshotPage struct {
+// BackupPage is a pagination.Pager that is returned from a call to the List function.
+type BackupPage struct {
 	pagination.SinglePageBase
 }
 
-func (r *Snapshot) UnmarshalJSON(b []byte) error {
-	type tmp Snapshot
+func (r *Backup) UnmarshalJSON(b []byte) error {
+	type tmp Backup
 	var s struct {
 		tmp
 		CreatedAt gophercloud.JSONRFC3339MilliNoZ `json:"created_at"`
@@ -69,7 +69,7 @@ func (r *Snapshot) UnmarshalJSON(b []byte) error {
 	if err != nil {
 		return err
 	}
-	*r = Snapshot(s.tmp)
+	*r = Backup(s.tmp)
 
 	r.CreatedAt = time.Time(s.CreatedAt)
 	r.UpdatedAt = time.Time(s.UpdatedAt)
@@ -77,19 +77,19 @@ func (r *Snapshot) UnmarshalJSON(b []byte) error {
 	return err
 }
 
-// IsEmpty returns true if a SnapshotPage contains no Snapshots.
-func (r SnapshotPage) IsEmpty() (bool, error) {
-	volumes, err := ExtractSnapshots(r)
+// IsEmpty returns true if a BackupPage contains no Backups.
+func (r BackupPage) IsEmpty() (bool, error) {
+	volumes, err := ExtractBackups(r)
 	return len(volumes) == 0, err
 }
 
-// ExtractSnapshots extracts and returns Snapshots. It is used while iterating over a snapshots.List call.
-func ExtractSnapshots(r pagination.Page) ([]Snapshot, error) {
+// ExtractBackups extracts and returns Backups. It is used while iterating over a backups.List call.
+func ExtractBackups(r pagination.Page) ([]Backup, error) {
 	var s struct {
-		Snapshots []Snapshot `json:"snapshots"`
+		Backups []Backup `json:"backups"`
 	}
-	err := (r.(SnapshotPage)).ExtractInto(&s)
-	return s.Snapshots, err
+	err := (r.(BackupPage)).ExtractInto(&s)
+	return s.Backups, err
 }
 
 // UpdateMetadataResult contains the response body and error from an UpdateMetadata request.
@@ -97,7 +97,7 @@ type UpdateMetadataResult struct {
 	commonResult
 }
 
-// ExtractMetadata returns the metadata from a response from snapshots.UpdateMetadata.
+// ExtractMetadata returns the metadata from a response from backups.UpdateMetadata.
 func (r UpdateMetadataResult) ExtractMetadata() (map[string]interface{}, error) {
 	if r.Err != nil {
 		return nil, r.Err
@@ -110,11 +110,11 @@ type commonResult struct {
 	gophercloud.Result
 }
 
-// Extract will get the Snapshot object out of the commonResult object.
-func (r commonResult) Extract() (*Snapshot, error) {
+// Extract will get the Backup object out of the commonResult object.
+func (r commonResult) Extract() (*Backup, error) {
 	var s struct {
-		Snapshot *Snapshot `json:"snapshot"`
+		Backup *Backup `json:"backup"`
 	}
 	err := r.ExtractInto(&s)
-	return s.Snapshot, err
+	return s.Backup, err
 }

--- a/openstack/blockstorage/v2/backups/testing/doc.go
+++ b/openstack/blockstorage/v2/backups/testing/doc.go
@@ -1,0 +1,2 @@
+// snapshots_v2
+package testing

--- a/openstack/blockstorage/v2/backups/testing/doc.go
+++ b/openstack/blockstorage/v2/backups/testing/doc.go
@@ -1,2 +1,2 @@
-// snapshots_v2
+// backups_v2
 package testing

--- a/openstack/blockstorage/v2/backups/testing/fixtures.go
+++ b/openstack/blockstorage/v2/backups/testing/fixtures.go
@@ -1,0 +1,134 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	th "github.com/gophercloud/gophercloud/testhelper"
+	fake "github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func MockListResponse(t *testing.T) {
+	th.Mux.HandleFunc("/snapshots", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, `
+    {
+      "snapshots": [
+        {
+          "id": "289da7f8-6440-407c-9fb4-7db01ec49164",
+          "name": "snapshot-001",
+          "volume_id": "521752a6-acf6-4b2d-bc7a-119f9148cd8c",
+          "description": "Daily Backup",
+          "status": "available",
+          "size": 30,
+		  "created_at": "2017-05-30T03:35:03.000000"
+        },
+        {
+          "id": "96c3bda7-c82a-4f50-be73-ca7621794835",
+          "name": "snapshot-002",
+          "volume_id": "76b8950a-8594-4e5b-8dce-0dfa9c696358",
+          "description": "Weekly Backup",
+          "status": "available",
+          "size": 25,
+		  "created_at": "2017-05-30T03:35:03.000000"
+        }
+      ]
+    }
+    `)
+	})
+}
+
+func MockGetResponse(t *testing.T) {
+	th.Mux.HandleFunc("/snapshots/d32019d3-bc6e-4319-9c1d-6722fc136a22", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, `
+{
+    "snapshot": {
+        "id": "d32019d3-bc6e-4319-9c1d-6722fc136a22",
+        "name": "snapshot-001",
+        "description": "Daily backup",
+        "volume_id": "521752a6-acf6-4b2d-bc7a-119f9148cd8c",
+        "status": "available",
+        "size": 30,
+		"created_at": "2017-05-30T03:35:03.000000"
+    }
+}
+      `)
+	})
+}
+
+func MockCreateResponse(t *testing.T) {
+	th.Mux.HandleFunc("/snapshots", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, `
+{
+    "snapshot": {
+        "volume_id": "1234",
+        "name": "snapshot-001"
+    }
+}
+      `)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+
+		fmt.Fprintf(w, `
+{
+    "snapshot": {
+        "volume_id": "1234",
+        "name": "snapshot-001",
+        "id": "d32019d3-bc6e-4319-9c1d-6722fc136a22",
+        "description": "Daily backup",
+        "volume_id": "1234",
+        "status": "available",
+        "size": 30,
+		"created_at": "2017-05-30T03:35:03.000000"
+  }
+}
+    `)
+	})
+}
+
+func MockUpdateMetadataResponse(t *testing.T) {
+	th.Mux.HandleFunc("/snapshots/123/metadata", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestJSONRequest(t, r, `
+    {
+      "metadata": {
+        "key": "v1"
+      }
+    }
+    `)
+
+		fmt.Fprintf(w, `
+      {
+        "metadata": {
+          "key": "v1"
+        }
+      }
+    `)
+	})
+}
+
+func MockDeleteResponse(t *testing.T) {
+	th.Mux.HandleFunc("/snapshots/d32019d3-bc6e-4319-9c1d-6722fc136a22", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.WriteHeader(http.StatusNoContent)
+	})
+}

--- a/openstack/blockstorage/v2/backups/testing/fixtures.go
+++ b/openstack/blockstorage/v2/backups/testing/fixtures.go
@@ -10,7 +10,7 @@ import (
 )
 
 func MockListResponse(t *testing.T) {
-	th.Mux.HandleFunc("/snapshots", func(w http.ResponseWriter, r *http.Request) {
+	th.Mux.HandleFunc("/backups", func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "GET")
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 
@@ -19,10 +19,10 @@ func MockListResponse(t *testing.T) {
 
 		fmt.Fprintf(w, `
     {
-      "snapshots": [
+      "backups": [
         {
           "id": "289da7f8-6440-407c-9fb4-7db01ec49164",
-          "name": "snapshot-001",
+          "name": "backup-001",
           "volume_id": "521752a6-acf6-4b2d-bc7a-119f9148cd8c",
           "description": "Daily Backup",
           "status": "available",
@@ -31,7 +31,7 @@ func MockListResponse(t *testing.T) {
         },
         {
           "id": "96c3bda7-c82a-4f50-be73-ca7621794835",
-          "name": "snapshot-002",
+          "name": "backup-002",
           "volume_id": "76b8950a-8594-4e5b-8dce-0dfa9c696358",
           "description": "Weekly Backup",
           "status": "available",
@@ -45,7 +45,7 @@ func MockListResponse(t *testing.T) {
 }
 
 func MockGetResponse(t *testing.T) {
-	th.Mux.HandleFunc("/snapshots/d32019d3-bc6e-4319-9c1d-6722fc136a22", func(w http.ResponseWriter, r *http.Request) {
+	th.Mux.HandleFunc("/backups/d32019d3-bc6e-4319-9c1d-6722fc136a22", func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "GET")
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 
@@ -53,9 +53,9 @@ func MockGetResponse(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprintf(w, `
 {
-    "snapshot": {
+    "backup": {
         "id": "d32019d3-bc6e-4319-9c1d-6722fc136a22",
-        "name": "snapshot-001",
+        "name": "backup-001",
         "description": "Daily backup",
         "volume_id": "521752a6-acf6-4b2d-bc7a-119f9148cd8c",
         "status": "available",
@@ -68,16 +68,16 @@ func MockGetResponse(t *testing.T) {
 }
 
 func MockCreateResponse(t *testing.T) {
-	th.Mux.HandleFunc("/snapshots", func(w http.ResponseWriter, r *http.Request) {
+	th.Mux.HandleFunc("/backups", func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "POST")
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 		th.TestHeader(t, r, "Content-Type", "application/json")
 		th.TestHeader(t, r, "Accept", "application/json")
 		th.TestJSONRequest(t, r, `
 {
-    "snapshot": {
+    "backup": {
         "volume_id": "1234",
-        "name": "snapshot-001"
+        "name": "backup-001"
     }
 }
       `)
@@ -87,9 +87,9 @@ func MockCreateResponse(t *testing.T) {
 
 		fmt.Fprintf(w, `
 {
-    "snapshot": {
+    "backup": {
         "volume_id": "1234",
-        "name": "snapshot-001",
+        "name": "backup-001",
         "id": "d32019d3-bc6e-4319-9c1d-6722fc136a22",
         "description": "Daily backup",
         "volume_id": "1234",
@@ -103,7 +103,7 @@ func MockCreateResponse(t *testing.T) {
 }
 
 func MockUpdateMetadataResponse(t *testing.T) {
-	th.Mux.HandleFunc("/snapshots/123/metadata", func(w http.ResponseWriter, r *http.Request) {
+	th.Mux.HandleFunc("/backups/123/metadata", func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "PUT")
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 		th.TestHeader(t, r, "Content-Type", "application/json")
@@ -126,7 +126,7 @@ func MockUpdateMetadataResponse(t *testing.T) {
 }
 
 func MockDeleteResponse(t *testing.T) {
-	th.Mux.HandleFunc("/snapshots/d32019d3-bc6e-4319-9c1d-6722fc136a22", func(w http.ResponseWriter, r *http.Request) {
+	th.Mux.HandleFunc("/backups/d32019d3-bc6e-4319-9c1d-6722fc136a22", func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "DELETE")
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 		w.WriteHeader(http.StatusNoContent)

--- a/openstack/blockstorage/v2/backups/testing/requests_test.go
+++ b/openstack/blockstorage/v2/backups/testing/requests_test.go
@@ -1,0 +1,116 @@
+package testing
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gophercloud/gophercloud/openstack/blockstorage/v2/snapshots"
+	"github.com/gophercloud/gophercloud/pagination"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func TestList(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockListResponse(t)
+
+	count := 0
+
+	snapshots.List(client.ServiceClient(), &snapshots.ListOpts{}).EachPage(func(page pagination.Page) (bool, error) {
+		count++
+		actual, err := snapshots.ExtractSnapshots(page)
+		if err != nil {
+			t.Errorf("Failed to extract snapshots: %v", err)
+			return false, err
+		}
+
+		expected := []snapshots.Snapshot{
+			{
+				ID:          "289da7f8-6440-407c-9fb4-7db01ec49164",
+				Name:        "snapshot-001",
+				VolumeID:    "521752a6-acf6-4b2d-bc7a-119f9148cd8c",
+				Status:      "available",
+				Size:        30,
+				CreatedAt:   time.Date(2017, 5, 30, 3, 35, 3, 0, time.UTC),
+				Description: "Daily Backup",
+			},
+			{
+				ID:          "96c3bda7-c82a-4f50-be73-ca7621794835",
+				Name:        "snapshot-002",
+				VolumeID:    "76b8950a-8594-4e5b-8dce-0dfa9c696358",
+				Status:      "available",
+				Size:        25,
+				CreatedAt:   time.Date(2017, 5, 30, 3, 35, 3, 0, time.UTC),
+				Description: "Weekly Backup",
+			},
+		}
+
+		th.CheckDeepEquals(t, expected, actual)
+
+		return true, nil
+	})
+
+	if count != 1 {
+		t.Errorf("Expected 1 page, got %d", count)
+	}
+}
+
+func TestGet(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockGetResponse(t)
+
+	v, err := snapshots.Get(client.ServiceClient(), "d32019d3-bc6e-4319-9c1d-6722fc136a22").Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, v.Name, "snapshot-001")
+	th.AssertEquals(t, v.ID, "d32019d3-bc6e-4319-9c1d-6722fc136a22")
+}
+
+func TestCreate(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockCreateResponse(t)
+
+	options := snapshots.CreateOpts{VolumeID: "1234", Name: "snapshot-001"}
+	n, err := snapshots.Create(client.ServiceClient(), options).Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, n.VolumeID, "1234")
+	th.AssertEquals(t, n.Name, "snapshot-001")
+	th.AssertEquals(t, n.ID, "d32019d3-bc6e-4319-9c1d-6722fc136a22")
+}
+
+func TestUpdateMetadata(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockUpdateMetadataResponse(t)
+
+	expected := map[string]interface{}{"key": "v1"}
+
+	options := &snapshots.UpdateMetadataOpts{
+		Metadata: map[string]interface{}{
+			"key": "v1",
+		},
+	}
+
+	actual, err := snapshots.UpdateMetadata(client.ServiceClient(), "123", options).ExtractMetadata()
+
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, actual, expected)
+}
+
+func TestDelete(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockDeleteResponse(t)
+
+	res := snapshots.Delete(client.ServiceClient(), "d32019d3-bc6e-4319-9c1d-6722fc136a22")
+	th.AssertNoErr(t, res.Err)
+}

--- a/openstack/blockstorage/v2/backups/testing/requests_test.go
+++ b/openstack/blockstorage/v2/backups/testing/requests_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gophercloud/gophercloud/openstack/blockstorage/v2/snapshots"
+	"github.com/gophercloud/gophercloud/openstack/blockstorage/v2/backups"
 	"github.com/gophercloud/gophercloud/pagination"
 	th "github.com/gophercloud/gophercloud/testhelper"
 	"github.com/gophercloud/gophercloud/testhelper/client"
@@ -18,18 +18,18 @@ func TestList(t *testing.T) {
 
 	count := 0
 
-	snapshots.List(client.ServiceClient(), &snapshots.ListOpts{}).EachPage(func(page pagination.Page) (bool, error) {
+	backups.List(client.ServiceClient(), &backups.ListOpts{}).EachPage(func(page pagination.Page) (bool, error) {
 		count++
-		actual, err := snapshots.ExtractSnapshots(page)
+		actual, err := backups.ExtractBackups(page)
 		if err != nil {
-			t.Errorf("Failed to extract snapshots: %v", err)
+			t.Errorf("Failed to extract backups: %v", err)
 			return false, err
 		}
 
-		expected := []snapshots.Snapshot{
+		expected := []backups.Backup{
 			{
 				ID:          "289da7f8-6440-407c-9fb4-7db01ec49164",
-				Name:        "snapshot-001",
+				Name:        "backup-001",
 				VolumeID:    "521752a6-acf6-4b2d-bc7a-119f9148cd8c",
 				Status:      "available",
 				Size:        30,
@@ -38,7 +38,7 @@ func TestList(t *testing.T) {
 			},
 			{
 				ID:          "96c3bda7-c82a-4f50-be73-ca7621794835",
-				Name:        "snapshot-002",
+				Name:        "backup-002",
 				VolumeID:    "76b8950a-8594-4e5b-8dce-0dfa9c696358",
 				Status:      "available",
 				Size:        25,
@@ -63,10 +63,10 @@ func TestGet(t *testing.T) {
 
 	MockGetResponse(t)
 
-	v, err := snapshots.Get(client.ServiceClient(), "d32019d3-bc6e-4319-9c1d-6722fc136a22").Extract()
+	v, err := backups.Get(client.ServiceClient(), "d32019d3-bc6e-4319-9c1d-6722fc136a22").Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, v.Name, "snapshot-001")
+	th.AssertEquals(t, v.Name, "backup-001")
 	th.AssertEquals(t, v.ID, "d32019d3-bc6e-4319-9c1d-6722fc136a22")
 }
 
@@ -76,12 +76,12 @@ func TestCreate(t *testing.T) {
 
 	MockCreateResponse(t)
 
-	options := snapshots.CreateOpts{VolumeID: "1234", Name: "snapshot-001"}
-	n, err := snapshots.Create(client.ServiceClient(), options).Extract()
+	options := backups.CreateOpts{VolumeID: "1234", Name: "backup-001"}
+	n, err := backups.Create(client.ServiceClient(), options).Extract()
 	th.AssertNoErr(t, err)
 
 	th.AssertEquals(t, n.VolumeID, "1234")
-	th.AssertEquals(t, n.Name, "snapshot-001")
+	th.AssertEquals(t, n.Name, "backup-001")
 	th.AssertEquals(t, n.ID, "d32019d3-bc6e-4319-9c1d-6722fc136a22")
 }
 
@@ -93,13 +93,13 @@ func TestUpdateMetadata(t *testing.T) {
 
 	expected := map[string]interface{}{"key": "v1"}
 
-	options := &snapshots.UpdateMetadataOpts{
+	options := &backups.UpdateMetadataOpts{
 		Metadata: map[string]interface{}{
 			"key": "v1",
 		},
 	}
 
-	actual, err := snapshots.UpdateMetadata(client.ServiceClient(), "123", options).ExtractMetadata()
+	actual, err := backups.UpdateMetadata(client.ServiceClient(), "123", options).ExtractMetadata()
 
 	th.AssertNoErr(t, err)
 	th.AssertDeepEquals(t, actual, expected)
@@ -111,6 +111,6 @@ func TestDelete(t *testing.T) {
 
 	MockDeleteResponse(t)
 
-	res := snapshots.Delete(client.ServiceClient(), "d32019d3-bc6e-4319-9c1d-6722fc136a22")
+	res := backups.Delete(client.ServiceClient(), "d32019d3-bc6e-4319-9c1d-6722fc136a22")
 	th.AssertNoErr(t, res.Err)
 }

--- a/openstack/blockstorage/v2/backups/urls.go
+++ b/openstack/blockstorage/v2/backups/urls.go
@@ -1,0 +1,27 @@
+package snapshots
+
+import "github.com/gophercloud/gophercloud"
+
+func createURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("snapshots")
+}
+
+func deleteURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("snapshots", id)
+}
+
+func getURL(c *gophercloud.ServiceClient, id string) string {
+	return deleteURL(c, id)
+}
+
+func listURL(c *gophercloud.ServiceClient) string {
+	return createURL(c)
+}
+
+func metadataURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("snapshots", id, "metadata")
+}
+
+func updateMetadataURL(c *gophercloud.ServiceClient, id string) string {
+	return metadataURL(c, id)
+}

--- a/openstack/blockstorage/v2/backups/urls.go
+++ b/openstack/blockstorage/v2/backups/urls.go
@@ -1,13 +1,13 @@
-package snapshots
+package backups
 
 import "github.com/gophercloud/gophercloud"
 
 func createURL(c *gophercloud.ServiceClient) string {
-	return c.ServiceURL("snapshots")
+	return c.ServiceURL("backups")
 }
 
 func deleteURL(c *gophercloud.ServiceClient, id string) string {
-	return c.ServiceURL("snapshots", id)
+	return c.ServiceURL("backups", id)
 }
 
 func getURL(c *gophercloud.ServiceClient, id string) string {
@@ -19,7 +19,7 @@ func listURL(c *gophercloud.ServiceClient) string {
 }
 
 func metadataURL(c *gophercloud.ServiceClient, id string) string {
-	return c.ServiceURL("snapshots", id, "metadata")
+	return c.ServiceURL("backups", id, "metadata")
 }
 
 func updateMetadataURL(c *gophercloud.ServiceClient, id string) string {

--- a/openstack/blockstorage/v2/backups/util.go
+++ b/openstack/blockstorage/v2/backups/util.go
@@ -1,0 +1,22 @@
+package snapshots
+
+import (
+	"github.com/gophercloud/gophercloud"
+)
+
+// WaitForStatus will continually poll the resource, checking for a particular
+// status. It will do this for the amount of seconds defined.
+func WaitForStatus(c *gophercloud.ServiceClient, id, status string, secs int) error {
+	return gophercloud.WaitFor(secs, func() (bool, error) {
+		current, err := Get(c, id).Extract()
+		if err != nil {
+			return false, err
+		}
+
+		if current.Status == status {
+			return true, nil
+		}
+
+		return false, nil
+	})
+}

--- a/openstack/blockstorage/v2/backups/util.go
+++ b/openstack/blockstorage/v2/backups/util.go
@@ -1,4 +1,4 @@
-package snapshots
+package backups
 
 import (
 	"github.com/gophercloud/gophercloud"

--- a/openstack/blockstorage/v3/backups/doc.go
+++ b/openstack/blockstorage/v3/backups/doc.go
@@ -1,0 +1,5 @@
+// Package backups provides information and interaction with backups in the
+// OpenStack Block Storage service. A backup is a point in time copy of the
+// data contained in an external storage volume, and can be controlled
+// programmatically.
+package backups

--- a/openstack/blockstorage/v3/backups/requests.go
+++ b/openstack/blockstorage/v3/backups/requests.go
@@ -20,6 +20,9 @@ type CreateOpts struct {
 	Name        string            `json:"name,omitempty"`
 	Description string            `json:"description,omitempty"`
 	Metadata    map[string]string `json:"metadata,omitempty"`
+	Container   string            `json:"container,omitempty"`
+	Incremental bool              `json:"incremental,omitempty"`
+	SnapshotID  string            `json:"snapshot_id,omitempty"`
 }
 
 // ToBackupCreateMap assembles a request body based on the contents of a

--- a/openstack/blockstorage/v3/backups/requests.go
+++ b/openstack/blockstorage/v3/backups/requests.go
@@ -1,0 +1,181 @@
+package backups
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToBackupCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts contains options for creating a Backup. This object is passed to
+// the backups.Create function. For more information about these parameters,
+// see the Backup object.
+type CreateOpts struct {
+	VolumeID    string            `json:"volume_id" required:"true"`
+	Force       bool              `json:"force,omitempty"`
+	Name        string            `json:"name,omitempty"`
+	Description string            `json:"description,omitempty"`
+	Metadata    map[string]string `json:"metadata,omitempty"`
+}
+
+// ToBackupCreateMap assembles a request body based on the contents of a
+// CreateOpts.
+func (opts CreateOpts) ToBackupCreateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "backup")
+}
+
+// Create will create a new Backup based on the values in CreateOpts. To
+// extract the Backup object from the response, call the Extract method on the
+// CreateResult.
+func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToBackupCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(createURL(client), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+	})
+	return
+}
+
+// Delete will delete the existing Backup with the provided ID.
+func Delete(client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+	_, r.Err = client.Delete(deleteURL(client, id), nil)
+	return
+}
+
+// Get retrieves the Backup with the provided ID. To extract the Backup
+// object from the response, call the Extract method on the GetResult.
+func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {
+	_, r.Err = client.Get(getURL(client, id), &r.Body, nil)
+	return
+}
+
+// ListOptsBuilder allows extensions to add additional parameters to the List
+// request.
+type ListOptsBuilder interface {
+	ToBackupListQuery() (string, error)
+}
+
+type ListOpts struct {
+	// AllTenants will retrieve backups of all tenants/projects.
+	AllTenants bool `q:"all_tenants"`
+
+	// Name will filter by the specified backup name.
+	Name string `q:"name"`
+
+	// Status will filter by the specified status.
+	Status string `q:"status"`
+
+	// TenantID will filter by a specific tenant/project ID.
+	// Setting AllTenants is required to use this.
+	TenantID string `q:"project_id"`
+
+	// VolumeID will filter by a specified volume ID.
+	VolumeID string `q:"volume_id"`
+
+	// Comma-separated list of sort keys and optional sort directions in the
+	// form of <key>[:<direction>].
+	Sort string `q:"sort"`
+
+	// Requests a page size of items.
+	Limit int `q:"limit"`
+
+	// Used in conjunction with limit to return a slice of items.
+	Offset int `q:"offset"`
+
+	// The ID of the last-seen item.
+	Marker string `q:"marker"`
+}
+
+// ToBackupListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToBackupListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List returns Backups optionally limited by the conditions provided in
+// ListOpts.
+func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(client)
+	if opts != nil {
+		query, err := opts.ToBackupListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return BackupPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// UpdateMetadataOptsBuilder allows extensions to add additional parameters to
+// the Update request.
+type UpdateMetadataOptsBuilder interface {
+	ToBackupUpdateMetadataMap() (map[string]interface{}, error)
+}
+
+// UpdateMetadataOpts contain options for updating an existing Backup. This
+// object is passed to the backups.Update function. For more information
+// about the parameters, see the Backup object.
+type UpdateMetadataOpts struct {
+	Metadata map[string]interface{} `json:"metadata,omitempty"`
+}
+
+// ToBackupUpdateMetadataMap assembles a request body based on the contents of
+// an UpdateMetadataOpts.
+func (opts UpdateMetadataOpts) ToBackupUpdateMetadataMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "")
+}
+
+// UpdateMetadata will update the Backup with provided information. To
+// extract the updated Backup from the response, call the ExtractMetadata
+// method on the UpdateMetadataResult.
+func UpdateMetadata(client *gophercloud.ServiceClient, id string, opts UpdateMetadataOptsBuilder) (r UpdateMetadataResult) {
+	b, err := opts.ToBackupUpdateMetadataMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Put(updateMetadataURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// IDFromName is a convienience function that returns a backup's ID given its name.
+func IDFromName(client *gophercloud.ServiceClient, name string) (string, error) {
+	count := 0
+	id := ""
+	pages, err := List(client, nil).AllPages()
+	if err != nil {
+		return "", err
+	}
+
+	all, err := ExtractBackups(pages)
+	if err != nil {
+		return "", err
+	}
+
+	for _, s := range all {
+		if s.Name == name {
+			count++
+			id = s.ID
+		}
+	}
+
+	switch count {
+	case 0:
+		return "", gophercloud.ErrResourceNotFound{Name: name, ResourceType: "backup"}
+	case 1:
+		return id, nil
+	default:
+		return "", gophercloud.ErrMultipleResourcesFound{Name: name, Count: count, ResourceType: "backup"}
+	}
+}

--- a/openstack/blockstorage/v3/backups/results.go
+++ b/openstack/blockstorage/v3/backups/results.go
@@ -1,0 +1,132 @@
+package backups
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// Backup contains all the information associated with a Cinder Backup.
+type Backup struct {
+	// Unique identifier.
+	ID string `json:"id"`
+
+	// Date created.
+	CreatedAt time.Time `json:"-"`
+
+	// Date updated.
+	UpdatedAt time.Time `json:"-"`
+
+	// Display name.
+	Name string `json:"name"`
+
+	// Display description.
+	Description string `json:"description"`
+
+	// ID of the Volume from which this Backup was created.
+	VolumeID string `json:"volume_id"`
+
+	// Currect status of the Backup.
+	Status string `json:"status"`
+
+	// Size of the Backup, in GB.
+	Size int `json:"size"`
+
+	// User-defined key-value pairs.
+	Metadata map[string]string `json:"metadata"`
+}
+
+// CreateResult contains the response body and error from a Create request.
+type CreateResult struct {
+	commonResult
+}
+
+// GetResult contains the response body and error from a Get request.
+type GetResult struct {
+	commonResult
+}
+
+// DeleteResult contains the response body and error from a Delete request.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
+// BackupPage is a pagination.Pager that is returned from a call to the List function.
+type BackupPage struct {
+	pagination.LinkedPageBase
+}
+
+// UnmarshalJSON converts our JSON API response into our backup struct
+func (r *Backup) UnmarshalJSON(b []byte) error {
+	type tmp Backup
+	var s struct {
+		tmp
+		CreatedAt gophercloud.JSONRFC3339MilliNoZ `json:"created_at"`
+		UpdatedAt gophercloud.JSONRFC3339MilliNoZ `json:"updated_at"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	*r = Backup(s.tmp)
+
+	r.CreatedAt = time.Time(s.CreatedAt)
+	r.UpdatedAt = time.Time(s.UpdatedAt)
+
+	return err
+}
+
+// IsEmpty returns true if a BackupPage contains no Backups.
+func (r BackupPage) IsEmpty() (bool, error) {
+	volumes, err := ExtractBackups(r)
+	return len(volumes) == 0, err
+}
+
+func (page BackupPage) NextPageURL() (string, error) {
+	var s struct {
+		Links []gophercloud.Link `json:"backups_links"`
+	}
+	err := page.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return gophercloud.ExtractNextURL(s.Links)
+}
+
+// ExtractBackups extracts and returns Backups. It is used while iterating over a backups.List call.
+func ExtractBackups(r pagination.Page) ([]Backup, error) {
+	var s struct {
+		Backups []Backup `json:"backups"`
+	}
+	err := (r.(BackupPage)).ExtractInto(&s)
+	return s.Backups, err
+}
+
+// UpdateMetadataResult contains the response body and error from an UpdateMetadata request.
+type UpdateMetadataResult struct {
+	commonResult
+}
+
+// ExtractMetadata returns the metadata from a response from backups.UpdateMetadata.
+func (r UpdateMetadataResult) ExtractMetadata() (map[string]interface{}, error) {
+	if r.Err != nil {
+		return nil, r.Err
+	}
+	m := r.Body.(map[string]interface{})["metadata"]
+	return m.(map[string]interface{}), nil
+}
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// Extract will get the Backup object out of the commonResult object.
+func (r commonResult) Extract() (*Backup, error) {
+	var s struct {
+		Backup *Backup `json:"backup"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Backup, err
+}

--- a/openstack/blockstorage/v3/backups/testing/doc.go
+++ b/openstack/blockstorage/v3/backups/testing/doc.go
@@ -1,0 +1,2 @@
+// backups_v3
+package testing

--- a/openstack/blockstorage/v3/backups/testing/fixtures.go
+++ b/openstack/blockstorage/v3/backups/testing/fixtures.go
@@ -1,0 +1,148 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	th "github.com/gophercloud/gophercloud/testhelper"
+	fake "github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func MockListResponse(t *testing.T) {
+	th.Mux.HandleFunc("/backups", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		r.ParseForm()
+		marker := r.Form.Get("marker")
+		switch marker {
+		case "":
+			fmt.Fprintf(w, `
+    {
+      "backups": [
+        {
+          "id": "289da7f8-6440-407c-9fb4-7db01ec49164",
+          "name": "backup-001",
+          "volume_id": "521752a6-acf6-4b2d-bc7a-119f9148cd8c",
+          "description": "Daily Backup",
+          "status": "available",
+          "size": 30,
+		  "created_at": "2017-05-30T03:35:03.000000"
+        },
+        {
+          "id": "96c3bda7-c82a-4f50-be73-ca7621794835",
+          "name": "backup-002",
+          "volume_id": "76b8950a-8594-4e5b-8dce-0dfa9c696358",
+          "description": "Weekly Backup",
+          "status": "available",
+          "size": 25,
+		  "created_at": "2017-05-30T03:35:03.000000"
+        }
+      ],
+      "backups_links": [
+        {
+            "href": "%s/backups?marker=1",
+            "rel": "next"
+        }]
+    }
+    `, th.Server.URL)
+		case "1":
+			fmt.Fprintf(w, `{"backups": []}`)
+		default:
+			t.Fatalf("Unexpected marker: [%s]", marker)
+		}
+	})
+}
+
+func MockGetResponse(t *testing.T) {
+	th.Mux.HandleFunc("/backups/d32019d3-bc6e-4319-9c1d-6722fc136a22", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, `
+{
+    "backup": {
+        "id": "d32019d3-bc6e-4319-9c1d-6722fc136a22",
+        "name": "backup-001",
+        "description": "Daily backup",
+        "volume_id": "521752a6-acf6-4b2d-bc7a-119f9148cd8c",
+        "status": "available",
+        "size": 30,
+		"created_at": "2017-05-30T03:35:03.000000"
+    }
+}
+      `)
+	})
+}
+
+func MockCreateResponse(t *testing.T) {
+	th.Mux.HandleFunc("/backups", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, `
+{
+    "backup": {
+        "volume_id": "1234",
+        "name": "backup-001"
+    }
+}
+      `)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+
+		fmt.Fprintf(w, `
+{
+    "backup": {
+        "volume_id": "1234",
+        "name": "backup-001",
+        "id": "d32019d3-bc6e-4319-9c1d-6722fc136a22",
+        "description": "Daily backup",
+        "volume_id": "1234",
+        "status": "available",
+        "size": 30,
+		"created_at": "2017-05-30T03:35:03.000000"
+  }
+}
+    `)
+	})
+}
+
+func MockUpdateMetadataResponse(t *testing.T) {
+	th.Mux.HandleFunc("/backups/123/metadata", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestJSONRequest(t, r, `
+    {
+      "metadata": {
+        "key": "v1"
+      }
+    }
+    `)
+
+		fmt.Fprintf(w, `
+      {
+        "metadata": {
+          "key": "v1"
+        }
+      }
+    `)
+	})
+}
+
+func MockDeleteResponse(t *testing.T) {
+	th.Mux.HandleFunc("/backups/d32019d3-bc6e-4319-9c1d-6722fc136a22", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.WriteHeader(http.StatusNoContent)
+	})
+}

--- a/openstack/blockstorage/v3/backups/testing/requests_test.go
+++ b/openstack/blockstorage/v3/backups/testing/requests_test.go
@@ -1,0 +1,116 @@
+package testing
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/backups"
+	"github.com/gophercloud/gophercloud/pagination"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func TestList(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockListResponse(t)
+
+	count := 0
+
+	backups.List(client.ServiceClient(), &backups.ListOpts{}).EachPage(func(page pagination.Page) (bool, error) {
+		count++
+		actual, err := backups.ExtractBackups(page)
+		if err != nil {
+			t.Errorf("Failed to extract backups: %v", err)
+			return false, err
+		}
+
+		expected := []backups.Backup{
+			{
+				ID:          "289da7f8-6440-407c-9fb4-7db01ec49164",
+				Name:        "backup-001",
+				VolumeID:    "521752a6-acf6-4b2d-bc7a-119f9148cd8c",
+				Status:      "available",
+				Size:        30,
+				CreatedAt:   time.Date(2017, 5, 30, 3, 35, 3, 0, time.UTC),
+				Description: "Daily Backup",
+			},
+			{
+				ID:          "96c3bda7-c82a-4f50-be73-ca7621794835",
+				Name:        "backup-002",
+				VolumeID:    "76b8950a-8594-4e5b-8dce-0dfa9c696358",
+				Status:      "available",
+				Size:        25,
+				CreatedAt:   time.Date(2017, 5, 30, 3, 35, 3, 0, time.UTC),
+				Description: "Weekly Backup",
+			},
+		}
+
+		th.CheckDeepEquals(t, expected, actual)
+
+		return true, nil
+	})
+
+	if count != 1 {
+		t.Errorf("Expected 1 page, got %d", count)
+	}
+}
+
+func TestGet(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockGetResponse(t)
+
+	v, err := backups.Get(client.ServiceClient(), "d32019d3-bc6e-4319-9c1d-6722fc136a22").Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, v.Name, "backup-001")
+	th.AssertEquals(t, v.ID, "d32019d3-bc6e-4319-9c1d-6722fc136a22")
+}
+
+func TestCreate(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockCreateResponse(t)
+
+	options := backups.CreateOpts{VolumeID: "1234", Name: "backup-001"}
+	n, err := backups.Create(client.ServiceClient(), options).Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, n.VolumeID, "1234")
+	th.AssertEquals(t, n.Name, "backup-001")
+	th.AssertEquals(t, n.ID, "d32019d3-bc6e-4319-9c1d-6722fc136a22")
+}
+
+func TestUpdateMetadata(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockUpdateMetadataResponse(t)
+
+	expected := map[string]interface{}{"key": "v1"}
+
+	options := &backups.UpdateMetadataOpts{
+		Metadata: map[string]interface{}{
+			"key": "v1",
+		},
+	}
+
+	actual, err := backups.UpdateMetadata(client.ServiceClient(), "123", options).ExtractMetadata()
+
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, actual, expected)
+}
+
+func TestDelete(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockDeleteResponse(t)
+
+	res := backups.Delete(client.ServiceClient(), "d32019d3-bc6e-4319-9c1d-6722fc136a22")
+	th.AssertNoErr(t, res.Err)
+}

--- a/openstack/blockstorage/v3/backups/urls.go
+++ b/openstack/blockstorage/v3/backups/urls.go
@@ -1,0 +1,27 @@
+package backups
+
+import "github.com/gophercloud/gophercloud"
+
+func createURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("backups")
+}
+
+func deleteURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("backups", id)
+}
+
+func getURL(c *gophercloud.ServiceClient, id string) string {
+	return deleteURL(c, id)
+}
+
+func listURL(c *gophercloud.ServiceClient) string {
+	return createURL(c)
+}
+
+func metadataURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("backups", id, "metadata")
+}
+
+func updateMetadataURL(c *gophercloud.ServiceClient, id string) string {
+	return metadataURL(c, id)
+}

--- a/openstack/blockstorage/v3/backups/util.go
+++ b/openstack/blockstorage/v3/backups/util.go
@@ -1,0 +1,22 @@
+package backups
+
+import (
+	"github.com/gophercloud/gophercloud"
+)
+
+// WaitForStatus will continually poll the resource, checking for a particular
+// status. It will do this for the amount of seconds defined.
+func WaitForStatus(c *gophercloud.ServiceClient, id, status string, secs int) error {
+	return gophercloud.WaitFor(secs, func() (bool, error) {
+		current, err := Get(c, id).Extract()
+		if err != nil {
+			return false, err
+		}
+
+		if current.Status == status {
+			return true, nil
+		}
+
+		return false, nil
+	})
+}


### PR DESCRIPTION
For #903 

Supporting OpenStack Code:
https://github.com/openstack/cinder/tree/master/cinder/backup
create: https://github.com/openstack/cinder/blob/master/cinder/backup/api.py#L199
list: https://github.com/openstack/cinder/blob/master/cinder/backup/api.py#L112

This is an initial request for pull. I've managed to list existing backups and create one via the new v2 and v3 clients / services.

Of note: the HTTP 400 I was receiving ( mentioned in commit message for 7e01987 ) was because cinder-backup returns a 400 when attempting to make a backup of an "in-use" volume without "force: true". The error message returned direct from Cinder in the response is: `"{"badRequest": {"message": "Invalid volume: Backing up an in-use volume must use the force flag.", "code": 400}}"`