### PR TITLE
Use 'project_id' for octavia resources

### DIFF
--- a/openstack/loadbalancer/v2/l7policies/requests.go
+++ b/openstack/loadbalancer/v2/l7policies/requests.go
@@ -113,7 +113,7 @@ func (opts ListOpts) ToL7PolicyListQuery() (string, error) {
 // the returned collection for greater efficiency.
 //
 // Default policy settings return only those l7policies that are owned by the
-// tenant who submits the request, unless an admin user submits the request.
+// project who submits the request, unless an admin user submits the request.
 func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 	url := rootURL(c)
 	if opts != nil {
@@ -257,7 +257,7 @@ func (opts ListRulesOpts) ToRulesListQuery() (string, error) {
 // sort the returned collection for greater efficiency.
 //
 // Default policy settings return only those rules that are owned by the
-// tenant who submits the request, unless an admin user submits the request.
+// project who submits the request, unless an admin user submits the request.
 func ListRules(c *gophercloud.ServiceClient, policyID string, opts ListRulesOptsBuilder) pagination.Pager {
 	url := ruleRootURL(c, policyID)
 	if opts != nil {

--- a/openstack/loadbalancer/v2/listeners/requests.go
+++ b/openstack/loadbalancer/v2/listeners/requests.go
@@ -30,7 +30,6 @@ type ListOpts struct {
 	ID              string `q:"id"`
 	Name            string `q:"name"`
 	AdminStateUp    *bool  `q:"admin_state_up"`
-	TenantID        string `q:"tenant_id"`
 	ProjectID       string `q:"project_id"`
 	LoadbalancerID  string `q:"loadbalancer_id"`
 	DefaultPoolID   string `q:"default_pool_id"`
@@ -54,7 +53,7 @@ func (opts ListOpts) ToListenerListQuery() (string, error) {
 // the returned collection for greater efficiency.
 //
 // Default policy settings return only those listeners that are owned by the
-// tenant who submits the request, unless an admin user submits the request.
+// project who submits the request, unless an admin user submits the request.
 func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 	url := rootURL(c)
 	if opts != nil {
@@ -85,10 +84,6 @@ type CreateOpts struct {
 
 	// The port on which to listen for client traffic.
 	ProtocolPort int `json:"protocol_port" required:"true"`
-
-	// TenantID is only required if the caller has an admin role and wants
-	// to create a pool for another project.
-	TenantID string `json:"tenant_id,omitempty"`
 
 	// ProjectID is only required if the caller has an admin role and wants
 	// to create a pool for another project.
@@ -127,8 +122,8 @@ func (opts CreateOpts) ToListenerCreateMap() (map[string]interface{}, error) {
 // validated and progress has started on the provisioning process, a
 // CreateResult will be returned.
 //
-// Users with an admin role can create Listeners on behalf of other tenants by
-// specifying a TenantID attribute different than their own.
+// Users with an admin role can create Listeners on behalf of other projects by
+// specifying a ProjectID attribute different than their own.
 func Create(c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToListenerCreateMap()
 	if err != nil {

--- a/openstack/loadbalancer/v2/listeners/results.go
+++ b/openstack/loadbalancer/v2/listeners/results.go
@@ -18,7 +18,7 @@ type Listener struct {
 	ID string `json:"id"`
 
 	// Owner of the Listener.
-	TenantID string `json:"tenant_id"`
+	ProjectID string `json:"project_id"`
 
 	// Human-readable name for the Listener. Does not have to be unique.
 	Name string `json:"name"`

--- a/openstack/loadbalancer/v2/listeners/testing/fixtures.go
+++ b/openstack/loadbalancer/v2/listeners/testing/fixtures.go
@@ -16,7 +16,7 @@ const ListenersListBody = `
 	"listeners":[
 		{
 			"id": "db902c0c-d5ff-4753-b465-668ad9656918",
-			"tenant_id": "310df60f-2a10-4ee5-9554-98393092194c",
+			"project_id": "310df60f-2a10-4ee5-9554-98393092194c",
 			"name": "web",
 			"description": "listener config for the web tier",
 			"loadbalancers": [{"id": "53306cda-815d-4354-9444-59e09da9c3c5"}],
@@ -29,7 +29,7 @@ const ListenersListBody = `
 		},
 		{
 			"id": "36e08a3e-a78f-4b40-a229-1e7e23eee1ab",
-			"tenant_id": "310df60f-2a10-4ee5-9554-98393092194c",
+			"project_id": "310df60f-2a10-4ee5-9554-98393092194c",
 			"name": "db",
 			"description": "listener config for the db tier",
 			"loadbalancers": [{"id": "79e05663-7f03-45d2-a092-8b94062f22ab"}],
@@ -50,7 +50,7 @@ const SingleListenerBody = `
 {
 	"listener": {
 		"id": "36e08a3e-a78f-4b40-a229-1e7e23eee1ab",
-		"tenant_id": "310df60f-2a10-4ee5-9554-98393092194c",
+		"project_id": "310df60f-2a10-4ee5-9554-98393092194c",
 		"name": "db",
 		"description": "listener config for the db tier",
 		"loadbalancers": [{"id": "79e05663-7f03-45d2-a092-8b94062f22ab"}],
@@ -70,7 +70,7 @@ const PostUpdateListenerBody = `
 {
 	"listener": {
 		"id": "36e08a3e-a78f-4b40-a229-1e7e23eee1ab",
-		"tenant_id": "310df60f-2a10-4ee5-9554-98393092194c",
+		"project_id": "310df60f-2a10-4ee5-9554-98393092194c",
 		"name": "NewListenerName",
 		"description": "listener config for the db tier",
 		"loadbalancers": [{"id": "79e05663-7f03-45d2-a092-8b94062f22ab"}],
@@ -88,7 +88,7 @@ const PostUpdateListenerBody = `
 var (
 	ListenerWeb = listeners.Listener{
 		ID:                     "db902c0c-d5ff-4753-b465-668ad9656918",
-		TenantID:               "310df60f-2a10-4ee5-9554-98393092194c",
+		ProjectID:              "310df60f-2a10-4ee5-9554-98393092194c",
 		Name:                   "web",
 		Description:            "listener config for the web tier",
 		Loadbalancers:          []listeners.LoadBalancerID{{ID: "53306cda-815d-4354-9444-59e09da9c3c5"}},
@@ -101,7 +101,7 @@ var (
 	}
 	ListenerDb = listeners.Listener{
 		ID:                     "36e08a3e-a78f-4b40-a229-1e7e23eee1ab",
-		TenantID:               "310df60f-2a10-4ee5-9554-98393092194c",
+		ProjectID:              "310df60f-2a10-4ee5-9554-98393092194c",
 		Name:                   "db",
 		Description:            "listener config for the db tier",
 		Loadbalancers:          []listeners.LoadBalancerID{{ID: "79e05663-7f03-45d2-a092-8b94062f22ab"}},
@@ -115,7 +115,7 @@ var (
 	}
 	ListenerUpdated = listeners.Listener{
 		ID:                     "36e08a3e-a78f-4b40-a229-1e7e23eee1ab",
-		TenantID:               "310df60f-2a10-4ee5-9554-98393092194c",
+		ProjectID:              "310df60f-2a10-4ee5-9554-98393092194c",
 		Name:                   "NewListenerName",
 		Description:            "listener config for the db tier",
 		Loadbalancers:          []listeners.LoadBalancerID{{ID: "79e05663-7f03-45d2-a092-8b94062f22ab"}},

--- a/openstack/loadbalancer/v2/listeners/testing/requests_test.go
+++ b/openstack/loadbalancer/v2/listeners/testing/requests_test.go
@@ -81,15 +81,15 @@ func TestRequiredCreateOpts(t *testing.T) {
 	if res.Err == nil {
 		t.Fatalf("Expected error, got none")
 	}
-	res = listeners.Create(fake.ServiceClient(), listeners.CreateOpts{Name: "foo", TenantID: "bar"})
+	res = listeners.Create(fake.ServiceClient(), listeners.CreateOpts{Name: "foo", ProjectID: "bar"})
 	if res.Err == nil {
 		t.Fatalf("Expected error, got none")
 	}
-	res = listeners.Create(fake.ServiceClient(), listeners.CreateOpts{Name: "foo", TenantID: "bar", Protocol: "bar"})
+	res = listeners.Create(fake.ServiceClient(), listeners.CreateOpts{Name: "foo", ProjectID: "bar", Protocol: "bar"})
 	if res.Err == nil {
 		t.Fatalf("Expected error, got none")
 	}
-	res = listeners.Create(fake.ServiceClient(), listeners.CreateOpts{Name: "foo", TenantID: "bar", Protocol: "bar", ProtocolPort: 80})
+	res = listeners.Create(fake.ServiceClient(), listeners.CreateOpts{Name: "foo", ProjectID: "bar", Protocol: "bar", ProtocolPort: 80})
 	if res.Err == nil {
 		t.Fatalf("Expected error, got none")
 	}

--- a/openstack/loadbalancer/v2/loadbalancers/requests.go
+++ b/openstack/loadbalancer/v2/loadbalancers/requests.go
@@ -19,7 +19,6 @@ type ListOptsBuilder interface {
 type ListOpts struct {
 	Description        string `q:"description"`
 	AdminStateUp       *bool  `q:"admin_state_up"`
-	TenantID           string `q:"tenant_id"`
 	ProjectID          string `q:"project_id"`
 	ProvisioningStatus string `q:"provisioning_status"`
 	VipAddress         string `q:"vip_address"`
@@ -47,7 +46,7 @@ func (opts ListOpts) ToLoadBalancerListQuery() (string, error) {
 // and sort the returned collection for greater efficiency.
 //
 // Default policy settings return only those load balancers that are owned by
-// the tenant who submits the request, unless an admin user submits the request.
+// the project who submits the request, unless an admin user submits the request.
 func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 	url := rootURL(c)
 	if opts != nil {
@@ -77,14 +76,10 @@ type CreateOpts struct {
 	// Human-readable description for the Loadbalancer.
 	Description string `json:"description,omitempty"`
 
-	// The network on which to allocate the Loadbalancer's address. A tenant can
+	// The network on which to allocate the Loadbalancer's address. A project can
 	// only create Loadbalancers on networks authorized by policy (e.g. networks
 	// that belong to them or networks that are shared).
 	VipSubnetID string `json:"vip_subnet_id" required:"true"`
-
-	// TenantID is the UUID of the project who owns the Loadbalancer.
-	// Only administrative users can specify a project UUID other than their own.
-	TenantID string `json:"tenant_id,omitempty"`
 
 	// ProjectID is the UUID of the project who owns the Loadbalancer.
 	// Only administrative users can specify a project UUID other than their own.

--- a/openstack/loadbalancer/v2/loadbalancers/results.go
+++ b/openstack/loadbalancer/v2/loadbalancers/results.go
@@ -18,7 +18,7 @@ type LoadBalancer struct {
 	AdminStateUp bool `json:"admin_state_up"`
 
 	// Owner of the LoadBalancer.
-	TenantID string `json:"tenant_id"`
+	ProjectID string `json:"project_id"`
 
 	// The provisioning status of the LoadBalancer.
 	// This value is ACTIVE, PENDING_CREATE or ERROR.

--- a/openstack/loadbalancer/v2/loadbalancers/testing/fixtures.go
+++ b/openstack/loadbalancer/v2/loadbalancers/testing/fixtures.go
@@ -20,7 +20,7 @@ const LoadbalancersListBody = `
 	"loadbalancers":[
 	         {
 			"id": "c331058c-6a40-4144-948e-b9fb1df9db4b",
-			"tenant_id": "54030507-44f7-473c-9342-b4d14a95f692",
+			"project_id": "54030507-44f7-473c-9342-b4d14a95f692",
 			"name": "web_lb",
 			"description": "lb config for the web tier",
 			"vip_subnet_id": "8a49c438-848f-467b-9655-ea1548708154",
@@ -34,7 +34,7 @@ const LoadbalancersListBody = `
 		},
 		{
 			"id": "36e08a3e-a78f-4b40-a229-1e7e23eee1ab",
-			"tenant_id": "54030507-44f7-473c-9342-b4d14a95f692",
+			"project_id": "54030507-44f7-473c-9342-b4d14a95f692",
 			"name": "db_lb",
 			"description": "lb config for the db tier",
 			"vip_subnet_id": "9cedb85d-0759-4898-8a4b-fa5a5ea10086",
@@ -55,7 +55,7 @@ const SingleLoadbalancerBody = `
 {
 	"loadbalancer": {
 		"id": "36e08a3e-a78f-4b40-a229-1e7e23eee1ab",
-		"tenant_id": "54030507-44f7-473c-9342-b4d14a95f692",
+		"project_id": "54030507-44f7-473c-9342-b4d14a95f692",
 		"name": "db_lb",
 		"description": "lb config for the db tier",
 		"vip_subnet_id": "9cedb85d-0759-4898-8a4b-fa5a5ea10086",
@@ -75,7 +75,7 @@ const PostUpdateLoadbalancerBody = `
 {
 	"loadbalancer": {
 		"id": "36e08a3e-a78f-4b40-a229-1e7e23eee1ab",
-		"tenant_id": "54030507-44f7-473c-9342-b4d14a95f692",
+		"project_id": "54030507-44f7-473c-9342-b4d14a95f692",
 		"name": "NewLoadbalancerName",
 		"description": "lb config for the db tier",
 		"vip_subnet_id": "9cedb85d-0759-4898-8a4b-fa5a5ea10086",
@@ -125,7 +125,7 @@ const LoadbalancerStatuesesTree = `
 var (
 	LoadbalancerWeb = loadbalancers.LoadBalancer{
 		ID:                 "c331058c-6a40-4144-948e-b9fb1df9db4b",
-		TenantID:           "54030507-44f7-473c-9342-b4d14a95f692",
+		ProjectID:          "54030507-44f7-473c-9342-b4d14a95f692",
 		Name:               "web_lb",
 		Description:        "lb config for the web tier",
 		VipSubnetID:        "8a49c438-848f-467b-9655-ea1548708154",
@@ -139,7 +139,7 @@ var (
 	}
 	LoadbalancerDb = loadbalancers.LoadBalancer{
 		ID:                 "36e08a3e-a78f-4b40-a229-1e7e23eee1ab",
-		TenantID:           "54030507-44f7-473c-9342-b4d14a95f692",
+		ProjectID:          "54030507-44f7-473c-9342-b4d14a95f692",
 		Name:               "db_lb",
 		Description:        "lb config for the db tier",
 		VipSubnetID:        "9cedb85d-0759-4898-8a4b-fa5a5ea10086",
@@ -153,7 +153,7 @@ var (
 	}
 	LoadbalancerUpdated = loadbalancers.LoadBalancer{
 		ID:                 "36e08a3e-a78f-4b40-a229-1e7e23eee1ab",
-		TenantID:           "54030507-44f7-473c-9342-b4d14a95f692",
+		ProjectID:          "54030507-44f7-473c-9342-b4d14a95f692",
 		Name:               "NewLoadbalancerName",
 		Description:        "lb config for the db tier",
 		VipSubnetID:        "9cedb85d-0759-4898-8a4b-fa5a5ea10086",

--- a/openstack/loadbalancer/v2/monitors/results.go
+++ b/openstack/loadbalancer/v2/monitors/results.go
@@ -31,8 +31,8 @@ type Monitor struct {
 	// The Name of the Monitor.
 	Name string `json:"name"`
 
-	// TenantID is the owner of the Monitor.
-	TenantID string `json:"tenant_id"`
+	// The owner of the Monitor.
+	ProjectID string `json:"project_id"`
 
 	// The type of probe sent by the load balancer to verify the member state,
 	// which is PING, TCP, HTTP, or HTTPS.

--- a/openstack/loadbalancer/v2/monitors/testing/fixtures.go
+++ b/openstack/loadbalancer/v2/monitors/testing/fixtures.go
@@ -16,7 +16,7 @@ const HealthmonitorsListBody = `
 	"healthmonitors":[
 		{
 			"admin_state_up":true,
-			"tenant_id":"83657cfcdfe44cd5920adaf26c48ceea",
+			"project_id":"83657cfcdfe44cd5920adaf26c48ceea",
 			"delay":10,
 			"name":"web",
 			"max_retries":1,
@@ -27,7 +27,7 @@ const HealthmonitorsListBody = `
 		},
 		{
 			"admin_state_up":true,
-			"tenant_id":"83657cfcdfe44cd5920adaf26c48ceea",
+			"project_id":"83657cfcdfe44cd5920adaf26c48ceea",
 			"delay":5,
 			"name":"db",
 			"expected_codes":"200",
@@ -48,7 +48,7 @@ const SingleHealthmonitorBody = `
 {
 	"healthmonitor": {
 		"admin_state_up":true,
-		"tenant_id":"83657cfcdfe44cd5920adaf26c48ceea",
+		"project_id":"83657cfcdfe44cd5920adaf26c48ceea",
 		"delay":5,
 		"name":"db",
 		"expected_codes":"200",
@@ -68,7 +68,7 @@ const PostUpdateHealthmonitorBody = `
 {
 	"healthmonitor": {
 		"admin_state_up":true,
-		"tenant_id":"83657cfcdfe44cd5920adaf26c48ceea",
+		"project_id":"83657cfcdfe44cd5920adaf26c48ceea",
 		"delay":3,
 		"name":"NewHealthmonitorName",
 		"expected_codes":"301",
@@ -87,7 +87,7 @@ var (
 	HealthmonitorWeb = monitors.Monitor{
 		AdminStateUp: true,
 		Name:         "web",
-		TenantID:     "83657cfcdfe44cd5920adaf26c48ceea",
+		ProjectID:    "83657cfcdfe44cd5920adaf26c48ceea",
 		Delay:        10,
 		MaxRetries:   1,
 		Timeout:      1,
@@ -98,7 +98,7 @@ var (
 	HealthmonitorDb = monitors.Monitor{
 		AdminStateUp:  true,
 		Name:          "db",
-		TenantID:      "83657cfcdfe44cd5920adaf26c48ceea",
+		ProjectID:     "83657cfcdfe44cd5920adaf26c48ceea",
 		Delay:         5,
 		ExpectedCodes: "200",
 		MaxRetries:    2,
@@ -112,7 +112,7 @@ var (
 	HealthmonitorUpdated = monitors.Monitor{
 		AdminStateUp:  true,
 		Name:          "NewHealthmonitorName",
-		TenantID:      "83657cfcdfe44cd5920adaf26c48ceea",
+		ProjectID:     "83657cfcdfe44cd5920adaf26c48ceea",
 		Delay:         3,
 		ExpectedCodes: "301",
 		MaxRetries:    10,
@@ -155,7 +155,7 @@ func HandleHealthmonitorCreationSuccessfully(t *testing.T, response string) {
 			"healthmonitor": {
 				"type":"HTTP",
 				"pool_id":"84f1b61f-58c4-45bf-a8a9-2dafb9e5214d",
-				"tenant_id":"453105b9-1754-413f-aab1-55f1af620750",
+				"project_id":"453105b9-1754-413f-aab1-55f1af620750",
 				"delay":20,
 				"name":"db",
 				"timeout":10,

--- a/openstack/loadbalancer/v2/monitors/testing/requests_test.go
+++ b/openstack/loadbalancer/v2/monitors/testing/requests_test.go
@@ -61,7 +61,7 @@ func TestCreateHealthmonitor(t *testing.T) {
 		Type:          "HTTP",
 		Name:          "db",
 		PoolID:        "84f1b61f-58c4-45bf-a8a9-2dafb9e5214d",
-		TenantID:      "453105b9-1754-413f-aab1-55f1af620750",
+		ProjectID:     "453105b9-1754-413f-aab1-55f1af620750",
 		Delay:         20,
 		Timeout:       10,
 		MaxRetries:    5,

--- a/openstack/loadbalancer/v2/pools/requests.go
+++ b/openstack/loadbalancer/v2/pools/requests.go
@@ -19,7 +19,6 @@ type ListOptsBuilder interface {
 type ListOpts struct {
 	LBMethod       string `q:"lb_algorithm"`
 	Protocol       string `q:"protocol"`
-	TenantID       string `q:"tenant_id"`
 	ProjectID      string `q:"project_id"`
 	AdminStateUp   *bool  `q:"admin_state_up"`
 	Name           string `q:"name"`
@@ -42,7 +41,7 @@ func (opts ListOpts) ToPoolListQuery() (string, error) {
 // the returned collection for greater efficiency.
 //
 // Default policy settings return only those pools that are owned by the
-// tenant who submits the request, unless an admin user submits the request.
+// project who submits the request, unless an admin user submits the request.
 func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 	url := rootURL(c)
 	if opts != nil {
@@ -96,10 +95,6 @@ type CreateOpts struct {
 	// The Listener on which the members of the pool will be associated with.
 	// Note: one of LoadbalancerID or ListenerID must be provided.
 	ListenerID string `json:"listener_id,omitempty" xor:"LoadbalancerID"`
-
-	// TenantID is the UUID of the project who owns the Pool.
-	// Only administrative users can specify a project UUID other than their own.
-	TenantID string `json:"tenant_id,omitempty"`
 
 	// ProjectID is the UUID of the project who owns the Pool.
 	// Only administrative users can specify a project UUID other than their own.
@@ -207,7 +202,7 @@ type ListMembersOpts struct {
 	Name         string `q:"name"`
 	Weight       int    `q:"weight"`
 	AdminStateUp *bool  `q:"admin_state_up"`
-	TenantID     string `q:"tenant_id"`
+	ProjectID    string `q:"project_id"`
 	Address      string `q:"address"`
 	ProtocolPort int    `q:"protocol_port"`
 	ID           string `q:"id"`
@@ -228,7 +223,7 @@ func (opts ListMembersOpts) ToMembersListQuery() (string, error) {
 // sort the returned collection for greater efficiency.
 //
 // Default policy settings return only those members that are owned by the
-// tenant who submits the request, unless an admin user submits the request.
+// project who submits the request, unless an admin user submits the request.
 func ListMembers(c *gophercloud.ServiceClient, poolID string, opts ListMembersOptsBuilder) pagination.Pager {
 	url := memberRootURL(c, poolID)
 	if opts != nil {
@@ -260,10 +255,6 @@ type CreateMemberOpts struct {
 
 	// Name of the Member.
 	Name string `json:"name,omitempty"`
-
-	// TenantID is the UUID of the project who owns the Member.
-	// Only administrative users can specify a project UUID other than their own.
-	TenantID string `json:"tenant_id,omitempty"`
 
 	// ProjectID is the UUID of the project who owns the Member.
 	// Only administrative users can specify a project UUID other than their own.

--- a/openstack/loadbalancer/v2/pools/results.go
+++ b/openstack/loadbalancer/v2/pools/results.go
@@ -69,7 +69,7 @@ type Pool struct {
 	SubnetID string `json:"subnet_id"`
 
 	// Owner of the Pool.
-	TenantID string `json:"tenant_id"`
+	ProjectID string `json:"project_id"`
 
 	// The administrative state of the Pool, which is up (true) or down (false).
 	AdminStateUp bool `json:"admin_state_up"`
@@ -180,7 +180,7 @@ type Member struct {
 	AdminStateUp bool `json:"admin_state_up"`
 
 	// Owner of the Member.
-	TenantID string `json:"tenant_id"`
+	ProjectID string `json:"project_id"`
 
 	// Parameter value for the subnet UUID.
 	SubnetID string `json:"subnet_id"`

--- a/openstack/loadbalancer/v2/pools/testing/fixtures.go
+++ b/openstack/loadbalancer/v2/pools/testing/fixtures.go
@@ -25,7 +25,7 @@ const PoolsListBody = `
 			"id":"72741b06-df4d-4715-b142-276b6bce75ab",
 			"name":"web",
 			"admin_state_up":true,
-			"tenant_id":"83657cfcdfe44cd5920adaf26c48ceea",
+			"project_id":"83657cfcdfe44cd5920adaf26c48ceea",
 			"provider": "haproxy"
 		},
 		{
@@ -39,7 +39,7 @@ const PoolsListBody = `
 			"id":"c3741b06-df4d-4715-b142-276b6bce75ab",
 			"name":"db",
 			"admin_state_up":true,
-			"tenant_id":"83657cfcdfe44cd5920adaf26c48ceea",
+			"project_id":"83657cfcdfe44cd5920adaf26c48ceea",
 			"provider": "haproxy"
 		}
 	]
@@ -60,7 +60,7 @@ const SinglePoolBody = `
 		"id":"c3741b06-df4d-4715-b142-276b6bce75ab",
 		"name":"db",
 		"admin_state_up":true,
-		"tenant_id":"83657cfcdfe44cd5920adaf26c48ceea",
+		"project_id":"83657cfcdfe44cd5920adaf26c48ceea",
 		"provider": "haproxy"
 	}
 }
@@ -80,7 +80,7 @@ const PostUpdatePoolBody = `
 		"id":"c3741b06-df4d-4715-b142-276b6bce75ab",
 		"name":"db",
 		"admin_state_up":true,
-		"tenant_id":"83657cfcdfe44cd5920adaf26c48ceea",
+		"project_id":"83657cfcdfe44cd5920adaf26c48ceea",
 		"provider": "haproxy"
 	}
 }
@@ -92,7 +92,7 @@ var (
 		Protocol:      "HTTP",
 		Description:   "",
 		MonitorID:     "466c8345-28d8-4f84-a246-e04380b0461d",
-		TenantID:      "83657cfcdfe44cd5920adaf26c48ceea",
+		ProjectID:     "83657cfcdfe44cd5920adaf26c48ceea",
 		AdminStateUp:  true,
 		Name:          "web",
 		Members:       []pools.Member{{ID: "53306cda-815d-4354-9fe4-59e09da9c3c5"}},
@@ -106,7 +106,7 @@ var (
 		Protocol:      "HTTP",
 		Description:   "",
 		MonitorID:     "5f6c8345-28d8-4f84-a246-e04380b0461d",
-		TenantID:      "83657cfcdfe44cd5920adaf26c48ceea",
+		ProjectID:     "83657cfcdfe44cd5920adaf26c48ceea",
 		AdminStateUp:  true,
 		Name:          "db",
 		Members:       []pools.Member{{ID: "67306cda-815d-4354-9fe4-59e09da9c3c5"}},
@@ -120,7 +120,7 @@ var (
 		Protocol:      "HTTP",
 		Description:   "",
 		MonitorID:     "5f6c8345-28d8-4f84-a246-e04380b0461d",
-		TenantID:      "83657cfcdfe44cd5920adaf26c48ceea",
+		ProjectID:     "83657cfcdfe44cd5920adaf26c48ceea",
 		AdminStateUp:  true,
 		Name:          "db",
 		Members:       []pools.Member{{ID: "67306cda-815d-4354-9fe4-59e09da9c3c5"}},
@@ -162,7 +162,7 @@ func HandlePoolCreationSuccessfully(t *testing.T, response string) {
 			        "lb_algorithm": "ROUND_ROBIN",
 			        "protocol": "HTTP",
 			        "name": "Example pool",
-			        "tenant_id": "2ffc6e22aae24e4795f87155d24c896f",
+			        "project_id": "2ffc6e22aae24e4795f87155d24c896f",
 			        "loadbalancer_id": "79e05663-7f03-45d2-a092-8b94062f22ab"
 			}
 		}`)
@@ -222,7 +222,7 @@ const MembersListBody = `
 			"weight": 5,
 			"name": "web",
 			"subnet_id": "1981f108-3c48-48d2-b908-30f7d28532c9",
-			"tenant_id": "2ffc6e22aae24e4795f87155d24c896f",
+			"project_id": "2ffc6e22aae24e4795f87155d24c896f",
 			"admin_state_up":true,
 			"protocol_port": 80
 		},
@@ -232,7 +232,7 @@ const MembersListBody = `
 			"weight": 10,
 			"name": "db",
 			"subnet_id": "1981f108-3c48-48d2-b908-30f7d28532c9",
-			"tenant_id": "2ffc6e22aae24e4795f87155d24c896f",
+			"project_id": "2ffc6e22aae24e4795f87155d24c896f",
 			"admin_state_up":false,
 			"protocol_port": 80
 		}
@@ -249,7 +249,7 @@ const SingleMemberBody = `
 		"weight": 10,
 		"name": "db",
 		"subnet_id": "1981f108-3c48-48d2-b908-30f7d28532c9",
-		"tenant_id": "2ffc6e22aae24e4795f87155d24c896f",
+		"project_id": "2ffc6e22aae24e4795f87155d24c896f",
 		"admin_state_up":false,
 		"protocol_port": 80
 	}
@@ -265,7 +265,7 @@ const PostUpdateMemberBody = `
 		"weight": 10,
 		"name": "db",
 		"subnet_id": "1981f108-3c48-48d2-b908-30f7d28532c9",
-		"tenant_id": "2ffc6e22aae24e4795f87155d24c896f",
+		"project_id": "2ffc6e22aae24e4795f87155d24c896f",
 		"admin_state_up":false,
 		"protocol_port": 80
 	}
@@ -275,7 +275,7 @@ const PostUpdateMemberBody = `
 var (
 	MemberWeb = pools.Member{
 		SubnetID:     "1981f108-3c48-48d2-b908-30f7d28532c9",
-		TenantID:     "2ffc6e22aae24e4795f87155d24c896f",
+		ProjectID:    "2ffc6e22aae24e4795f87155d24c896f",
 		AdminStateUp: true,
 		Name:         "web",
 		ID:           "2a280670-c202-4b0b-a562-34077415aabf",
@@ -285,7 +285,7 @@ var (
 	}
 	MemberDb = pools.Member{
 		SubnetID:     "1981f108-3c48-48d2-b908-30f7d28532c9",
-		TenantID:     "2ffc6e22aae24e4795f87155d24c896f",
+		ProjectID:    "2ffc6e22aae24e4795f87155d24c896f",
 		AdminStateUp: false,
 		Name:         "db",
 		ID:           "fad389a3-9a4a-4762-a365-8c7038508b5d",
@@ -295,7 +295,7 @@ var (
 	}
 	MemberUpdated = pools.Member{
 		SubnetID:     "1981f108-3c48-48d2-b908-30f7d28532c9",
-		TenantID:     "2ffc6e22aae24e4795f87155d24c896f",
+		ProjectID:    "2ffc6e22aae24e4795f87155d24c896f",
 		AdminStateUp: false,
 		Name:         "db",
 		ID:           "fad389a3-9a4a-4762-a365-8c7038508b5d",
@@ -337,7 +337,7 @@ func HandleMemberCreationSuccessfully(t *testing.T, response string) {
 			        "weight": 10,
 			        "name": "db",
 			        "subnet_id": "1981f108-3c48-48d2-b908-30f7d28532c9",
-			        "tenant_id": "2ffc6e22aae24e4795f87155d24c896f",
+			        "project_id": "2ffc6e22aae24e4795f87155d24c896f",
 			        "protocol_port": 80
 			}
 		}`)

--- a/openstack/loadbalancer/v2/pools/testing/requests_test.go
+++ b/openstack/loadbalancer/v2/pools/testing/requests_test.go
@@ -61,7 +61,7 @@ func TestCreatePool(t *testing.T) {
 		LBMethod:       pools.LBMethodRoundRobin,
 		Protocol:       "HTTP",
 		Name:           "Example pool",
-		TenantID:       "2ffc6e22aae24e4795f87155d24c896f",
+		ProjectID:      "2ffc6e22aae24e4795f87155d24c896f",
 		LoadbalancerID: "79e05663-7f03-45d2-a092-8b94062f22ab",
 	}).Extract()
 	th.AssertNoErr(t, err)
@@ -192,7 +192,7 @@ func TestCreateMember(t *testing.T) {
 	actual, err := pools.CreateMember(fake.ServiceClient(), "332abe93-f488-41ba-870b-2ac66be7f853", pools.CreateMemberOpts{
 		Name:         "db",
 		SubnetID:     "1981f108-3c48-48d2-b908-30f7d28532c9",
-		TenantID:     "2ffc6e22aae24e4795f87155d24c896f",
+		ProjectID:    "2ffc6e22aae24e4795f87155d24c896f",
 		Address:      "10.0.2.11",
 		ProtocolPort: 80,
 		Weight:       10,


### PR DESCRIPTION
For #963

According to Octavia API document
https://developer.openstack.org/api-ref/load-balancer/v2/index.html
'tenant_id' is no longer supported.
