### PR TITLE
Senlin: Policy Create. Returns headers for senlin's policy create

### DIFF
--- a/acceptance/openstack/clustering/v1/policies_test.go
+++ b/acceptance/openstack/clustering/v1/policies_test.go
@@ -52,11 +52,17 @@ func TestPolicyCreateUpdateValidateDelete(t *testing.T) {
 				"criteria":                "OLDEST_FIRST",
 			},
 			Type:    "senlin.policy.deletion",
-			Version: "1.0",
+			Version: "1.1",
 		},
 	}
 
-	createdPolicy, err := policies.Create(client, createOpts).Extract()
+	createResult := policies.Create(client, createOpts)
+	th.AssertNoErr(t, createResult.Err)
+
+	requestID := createResult.Header.Get("X-Openstack-Request-ID")
+	th.AssertEquals(t, true, requestID != "")
+
+	createdPolicy, err := createResult.Extract()
 	th.AssertNoErr(t, err)
 
 	defer policies.Delete(client, createdPolicy.ID)

--- a/openstack/clustering/v1/policies/requests.go
+++ b/openstack/clustering/v1/policies/requests.go
@@ -80,9 +80,13 @@ func Create(client *gophercloud.ServiceClient, opts CreateOpts) (r CreateResult)
 		r.Err = err
 		return
 	}
-	_, r.Err = client.Post(policyCreateURL(client), b, &r.Body, &gophercloud.RequestOpts{
+	var result *http.Response
+	result, r.Err = client.Post(policyCreateURL(client), b, &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{201},
 	})
+	if r.Err == nil {
+		r.Header = result.Header
+	}
 	return
 }
 


### PR DESCRIPTION
Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

For #[823 [Add support for Senlin clustering]](https://github.com/gophercloud/gophercloud/issues/823)

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

[[policies:create]](https://github.com/openstack/senlin/blob/e5bc16b3fea2f10dead365f983c5a937f23d72b0/senlin/api/openstack/v1/policies.py#L57)

