### PR TITLE
Identity V3: List Policies

### DIFF
--- a/acceptance/openstack/identity/v3/policies_test.go
+++ b/acceptance/openstack/identity/v3/policies_test.go
@@ -1,0 +1,29 @@
+// +build acceptance
+
+package v3
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/acceptance/clients"
+	"github.com/gophercloud/gophercloud/acceptance/tools"
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/policies"
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestPoliciesList(t *testing.T) {
+	clients.RequireAdmin(t)
+
+	client, err := clients.NewIdentityV3Client()
+	th.AssertNoErr(t, err)
+
+	allPages, err := policies.List(client, policies.ListOpts{}).AllPages()
+	th.AssertNoErr(t, err)
+
+	allPolicies, err := policies.ExtractPolicies(allPages)
+	th.AssertNoErr(t, err)
+
+	for _, policy := range allPolicies {
+		tools.PrintResource(t, policy)
+	}
+}

--- a/openstack/identity/v3/policies/doc.go
+++ b/openstack/identity/v3/policies/doc.go
@@ -1,0 +1,25 @@
+/*
+Package policies provides information and interaction with the policies API
+resource for the OpenStack Identity service.
+
+Example to List Policies
+
+	listOpts := policies.ListOpts{
+		Type: "application/json",
+	}
+
+	allPages, err := policies.List(identityClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allPolicies, err := policies.ExtractPolicies(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, policy := range allPolicies {
+		fmt.Printf("%+v\n", policy)
+	}
+*/
+package policies

--- a/openstack/identity/v3/policies/requests.go
+++ b/openstack/identity/v3/policies/requests.go
@@ -1,0 +1,41 @@
+package policies
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// ListOptsBuilder allows extensions to add additional parameters to
+// the List request
+type ListOptsBuilder interface {
+	ToPolicyListQuery() (string, error)
+}
+
+// ListOpts provides options to filter the List results.
+type ListOpts struct {
+	// Type filters the response by MIME media type
+	// of the serialized policy blob.
+	Type string `q:"type"`
+}
+
+// ToPolicyListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToPolicyListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List enumerates the roles to which the current token has access.
+func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(client)
+	if opts != nil {
+		query, err := opts.ToPolicyListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return PolicyPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}

--- a/openstack/identity/v3/policies/results.go
+++ b/openstack/identity/v3/policies/results.go
@@ -1,0 +1,93 @@
+package policies
+
+import (
+	"encoding/json"
+
+	"github.com/gophercloud/gophercloud/internal"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// Policy is an arbitrarily serialized policy engine rule
+// set to be consumed by a remote service.
+type Policy struct {
+	// ID is the unique ID of the policy.
+	ID string `json:"id"`
+
+	// Blob is the policy rule as a serialized blob.
+	Blob string `json:"blob"`
+
+	// Type is the MIME media type of the serialized policy blob.
+	Type string `json:"type"`
+
+	// Links contains referencing links to the policy.
+	Links map[string]interface{} `json:"links"`
+
+	// Extra is a collection of miscellaneous key/values.
+	Extra map[string]interface{} `json:"-"`
+}
+
+func (r *Policy) UnmarshalJSON(b []byte) error {
+	type tmp Policy
+	var s struct {
+		tmp
+		Extra map[string]interface{} `json:"extra"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	*r = Policy(s.tmp)
+
+	// Collect other fields and bundle them into Extra
+	// but only if a field titled "extra" wasn't sent.
+	if s.Extra != nil {
+		r.Extra = s.Extra
+	} else {
+		var result interface{}
+		err := json.Unmarshal(b, &result)
+		if err != nil {
+			return err
+		}
+		if resultMap, ok := result.(map[string]interface{}); ok {
+			r.Extra = internal.RemainingKeys(Policy{}, resultMap)
+		}
+	}
+
+	return err
+}
+
+// PolicyPage is a single page of Policy results.
+type PolicyPage struct {
+	pagination.LinkedPageBase
+}
+
+// IsEmpty determines whether or not a page of Policies contains any results.
+func (r PolicyPage) IsEmpty() (bool, error) {
+	policies, err := ExtractPolicies(r)
+	return len(policies) == 0, err
+}
+
+// NextPageURL extracts the "next" link from the links section of the result.
+func (r PolicyPage) NextPageURL() (string, error) {
+	var s struct {
+		Links struct {
+			Next     string `json:"next"`
+			Previous string `json:"previous"`
+		} `json:"links"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return s.Links.Next, err
+}
+
+// ExtractPolicies returns a slice of Policies
+// contained in a single page of results.
+func ExtractPolicies(r pagination.Page) ([]Policy, error) {
+	var s struct {
+		Policies []Policy `json:"policies"`
+	}
+	err := (r.(PolicyPage)).ExtractInto(&s)
+	return s.Policies, err
+}

--- a/openstack/identity/v3/policies/testing/doc.go
+++ b/openstack/identity/v3/policies/testing/doc.go
@@ -1,0 +1,2 @@
+// Package testing contains policies unit tests
+package testing

--- a/openstack/identity/v3/policies/testing/fixtures.go
+++ b/openstack/identity/v3/policies/testing/fixtures.go
@@ -1,0 +1,111 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/policies"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	fake "github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+// ListOutput provides a single page of Policy results.
+const ListOutput = `
+{
+    "links": {
+        "next": null,
+        "previous": null,
+        "self": "http://example.com/identity/v3/policies"
+    },
+    "policies": [
+        {
+            "type": "text/plain",
+            "id": "2844b2a08be147a08ef58317d6471f1f",
+            "links": {
+                "self": "http://example.com/identity/v3/policies/2844b2a08be147a08ef58317d6471f1f"
+            },
+            "blob": "'foo_user': 'role:compute-user'"
+        },
+        {
+            "type": "application/json",
+            "id": "b49884da9d31494ea02aff38d4b4e701",
+            "links": {
+                "self": "http://example.com/identity/v3/policies/b49884da9d31494ea02aff38d4b4e701"
+            },
+            "blob": "{'bar_user': 'role:network-user'}",
+            "description": "policy for bar_user"
+        }
+    ]
+}
+`
+
+// ListWithFilterOutput provides a single page of filtered Policy results.
+const ListWithFilterOutput = `
+{
+    "links": {
+        "next": null,
+        "previous": null,
+        "self": "http://example.com/identity/v3/policies"
+    },
+    "policies": [
+        {
+            "type": "application/json",
+            "id": "b49884da9d31494ea02aff38d4b4e701",
+            "links": {
+                "self": "http://example.com/identity/v3/policies/b49884da9d31494ea02aff38d4b4e701"
+            },
+            "blob": "{'bar_user': 'role:network-user'}",
+            "description": "policy for bar_user"
+        }
+    ]
+}
+`
+
+// FirstPolicy is the first policy in the List request.
+var FirstPolicy = policies.Policy{
+	ID:   "2844b2a08be147a08ef58317d6471f1f",
+	Blob: "'foo_user': 'role:compute-user'",
+	Type: "text/plain",
+	Links: map[string]interface{}{
+		"self": "http://example.com/identity/v3/policies/2844b2a08be147a08ef58317d6471f1f",
+	},
+	Extra: map[string]interface{}{},
+}
+
+// SecondPolicy is the second policy in the List request.
+var SecondPolicy = policies.Policy{
+	ID:   "b49884da9d31494ea02aff38d4b4e701",
+	Blob: "{'bar_user': 'role:network-user'}",
+	Type: "application/json",
+	Links: map[string]interface{}{
+		"self": "http://example.com/identity/v3/policies/b49884da9d31494ea02aff38d4b4e701",
+	},
+	Extra: map[string]interface{}{
+		"description": "policy for bar_user",
+	},
+}
+
+// ExpectedPoliciesSlice is the slice of policies expected to be returned from ListOutput.
+var ExpectedPoliciesSlice = []policies.Policy{FirstPolicy, SecondPolicy}
+
+// HandleListPoliciesSuccessfully creates an HTTP handler at `/policies` on the
+// test handler mux that responds with a list of two policies.
+func HandleListPoliciesSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/policies", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		switch r.URL.Query().Get("type") {
+		case "":
+			fmt.Fprintf(w, ListOutput)
+		case "application/json":
+			fmt.Fprintf(w, ListWithFilterOutput)
+		default:
+			w.WriteHeader(http.StatusBadRequest)
+		}
+	})
+}

--- a/openstack/identity/v3/policies/testing/requests_test.go
+++ b/openstack/identity/v3/policies/testing/requests_test.go
@@ -1,0 +1,57 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/policies"
+	"github.com/gophercloud/gophercloud/pagination"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func TestListPolicies(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleListPoliciesSuccessfully(t)
+
+	count := 0
+	err := policies.List(client.ServiceClient(), nil).EachPage(func(page pagination.Page) (bool, error) {
+		count++
+
+		actual, err := policies.ExtractPolicies(page)
+		th.AssertNoErr(t, err)
+
+		th.CheckDeepEquals(t, ExpectedPoliciesSlice, actual)
+
+		return true, nil
+	})
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, count, 1)
+}
+
+func TestListPoliciesAllPages(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleListPoliciesSuccessfully(t)
+
+	allPages, err := policies.List(client.ServiceClient(), nil).AllPages()
+	th.AssertNoErr(t, err)
+	actual, err := policies.ExtractPolicies(allPages)
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, ExpectedPoliciesSlice, actual)
+}
+
+func TestListPoliciesWithFilter(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleListPoliciesSuccessfully(t)
+
+	listOpts := policies.ListOpts{
+		Type: "application/json",
+	}
+	allPages, err := policies.List(client.ServiceClient(), listOpts).AllPages()
+	th.AssertNoErr(t, err)
+	actual, err := policies.ExtractPolicies(allPages)
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, []policies.Policy{SecondPolicy}, actual)
+}

--- a/openstack/identity/v3/policies/urls.go
+++ b/openstack/identity/v3/policies/urls.go
@@ -1,0 +1,9 @@
+package policies
+
+import "github.com/gophercloud/gophercloud"
+
+const policyPath = "policies"
+
+func listURL(client *gophercloud.ServiceClient) string {
+	return client.ServiceURL(policyPath)
+}


### PR DESCRIPTION
For #972 

API reference:
[Identity API v3 - List Policies](https://developer.openstack.org/api-ref/identity/v3/#list-policies)

Python source code:
https://github.com/openstack/keystone/blob/master/keystone/policy/routers.py#L21
https://github.com/openstack/keystone/blob/master/keystone/policy/controllers.py#L51
https://github.com/openstack/keystone/blob/master/keystone/policy/core.py#L57
https://github.com/openstack/python-keystoneclient/blob/master/keystoneclient/v3/policies.py#L82

Acceptance testing will be added after other policy APIs are supported.
