### PR TITLE
openstack shares: add ListAccessRights

### DIFF
--- a/acceptance/openstack/sharedfilesystems/v2/shares.go
+++ b/acceptance/openstack/sharedfilesystems/v2/shares.go
@@ -43,6 +43,22 @@ func CreateShare(t *testing.T, client *gophercloud.ServiceClient) (*shares.Share
 	return share, nil
 }
 
+// GrantAccess will grant access to an existing share. A fatal error will occur if
+// this operation fails.
+func GrantAccess(t *testing.T, client *gophercloud.ServiceClient, share *shares.Share) (*shares.AccessRight, error) {
+	return shares.GrantAccess(client, share.ID, shares.GrantAccessOpts{
+		AccessType:  "ip",
+		AccessTo:    "0.0.0.0/32",
+		AccessLevel: "r",
+	}).Extract()
+}
+
+// GetAccessRightsSlice will retrieve all access rules assigned to a share.
+// A fatal error will occur if this operation fails.
+func GetAccessRightsSlice(t *testing.T, client *gophercloud.ServiceClient, share *shares.Share) ([]shares.AccessRight, error) {
+	return shares.ListAccessRights(client, share.ID).Extract()
+}
+
 // DeleteShare will delete a share. A fatal error will occur if the share
 // failed to be deleted. This works best when used as a deferred function.
 func DeleteShare(t *testing.T, client *gophercloud.ServiceClient, share *shares.Share) {
@@ -62,6 +78,16 @@ func PrintShare(t *testing.T, share *shares.Share) {
 	}
 
 	t.Logf("Share %s", string(asJSON))
+}
+
+// PrintAccessRight prints contents of an access rule
+func PrintAccessRight(t *testing.T, accessRight *shares.AccessRight) {
+	asJSON, err := json.MarshalIndent(accessRight, "", " ")
+	if err != nil {
+		t.Logf("Cannot print access rule")
+	}
+
+	t.Logf("Access rule %s", string(asJSON))
 }
 
 func waitForStatus(c *gophercloud.ServiceClient, id, status string, secs int) error {

--- a/acceptance/openstack/sharedfilesystems/v2/shares_test.go
+++ b/acceptance/openstack/sharedfilesystems/v2/shares_test.go
@@ -26,3 +26,37 @@ func TestShareCreate(t *testing.T) {
 	}
 	PrintShare(t, created)
 }
+
+func TestListAccessRights(t *testing.T) {
+	client, err := clients.NewSharedFileSystemV2Client()
+	if err != nil {
+		t.Fatalf("Unable to create a sharedfs client: %v", err)
+	}
+
+	share, err := CreateShare(t, client)
+	if err != nil {
+		t.Fatalf("Unable to create a share: %v", err)
+	}
+
+	defer DeleteShare(t, client, share)
+
+	_, err = GrantAccess(t, client, share)
+	if err != nil {
+		t.Fatalf("Unable to grant access: %v", err)
+	}
+
+	rs, err := GetAccessRightsSlice(t, client, share)
+	if err != nil {
+		t.Fatalf("Unable to retrieve list of access rules for share %s: %v", share.ID, err)
+	}
+
+	if len(rs) != 1 {
+		t.Fatalf("Unexpected number of access rules for share %s: got %d, expected 1", share.ID, len(rs))
+	}
+
+	t.Logf("Share %s has %d access rule(s):", share.ID, len(rs))
+
+	for _, r := range rs {
+		PrintAccessRight(t, &r)
+	}
+}

--- a/openstack/sharedfilesystems/v2/shares/requests.go
+++ b/openstack/sharedfilesystems/v2/shares/requests.go
@@ -125,7 +125,8 @@ func GrantAccess(client *gophercloud.ServiceClient, id string, opts GrantAccessO
 }
 
 // ListAccessRights lists all access rules assigned to a Share based on its id. To extract
-// the ListAccessRighs
+// the AccessRight slice from the response, call the Extract method on the ListAccessRightsResult.
+// Client must have Microversion set; minimum supported microversion for ListAccessRights is 2.7.
 func ListAccessRights(client *gophercloud.ServiceClient, id string) (r ListAccessRightsResult) {
 	requestBody := map[string]interface{}{"access_list": nil}
 	_, r.Err = client.Post(listAccessRightsURL(client, id), requestBody, &r.Body, &gophercloud.RequestOpts{

--- a/openstack/sharedfilesystems/v2/shares/requests.go
+++ b/openstack/sharedfilesystems/v2/shares/requests.go
@@ -123,3 +123,13 @@ func GrantAccess(client *gophercloud.ServiceClient, id string, opts GrantAccessO
 	})
 	return
 }
+
+// ListAccessRights lists all access rules assigned to a Share based on its id. To extract
+// the ListAccessRighs
+func ListAccessRights(client *gophercloud.ServiceClient, id string) (r ListAccessRightsResult) {
+	requestBody := map[string]interface{}{"access_list": nil}
+	_, r.Err = client.Post(listAccessRightsURL(client, id), requestBody, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}

--- a/openstack/sharedfilesystems/v2/shares/results.go
+++ b/openstack/sharedfilesystems/v2/shares/results.go
@@ -179,9 +179,9 @@ type GrantAccessResult struct {
 }
 
 // Extract will get a slice of AccessRight objects from the commonResult
-func (r ListAccessRightsResult) Extract() ([]*AccessRight, error) {
+func (r ListAccessRightsResult) Extract() ([]AccessRight, error) {
 	var s struct {
-		AccessRights []*AccessRight `json:"access_list"`
+		AccessRights []AccessRight `json:"access_list"`
 	}
 	err := r.ExtractInto(&s)
 	return s.AccessRights, err

--- a/openstack/sharedfilesystems/v2/shares/results.go
+++ b/openstack/sharedfilesystems/v2/shares/results.go
@@ -177,3 +177,17 @@ func (r GrantAccessResult) Extract() (*AccessRight, error) {
 type GrantAccessResult struct {
 	gophercloud.Result
 }
+
+// Extract will get a slice of AccessRight objects from the commonResult
+func (r ListAccessRightsResult) Extract() ([]*AccessRight, error) {
+	var s struct {
+		AccessRights []*AccessRight `json:"access_list"`
+	}
+	err := r.ExtractInto(&s)
+	return s.AccessRights, err
+}
+
+// ListAccessRightsResult contains the result body and error from a ListAccessRights request.
+type ListAccessRightsResult struct {
+	gophercloud.Result
+}

--- a/openstack/sharedfilesystems/v2/shares/testing/fixtures.go
+++ b/openstack/sharedfilesystems/v2/shares/testing/fixtures.go
@@ -197,3 +197,35 @@ func MockGrantAccessResponse(t *testing.T) {
 		fmt.Fprintf(w, grantAccessResponse)
 	})
 }
+
+var listAccessRightsRequest = `{
+		"access_list": null
+	}`
+
+var listAccessRightsResponse = `{
+		"access_list": [
+			{
+				"share_id": "011d21e2-fbc3-4e4a-9993-9ea223f73264",
+				"access_type": "ip",
+				"access_to": "0.0.0.0/0",
+				"access_key": "",
+				"access_level": "rw",
+				"state": "new",
+				"id": "a2f226a5-cee8-430b-8a03-78a59bd84ee8"
+			}
+		]
+	}`
+
+// MockListAccessRightsResponse creates a mock list access response
+func MockListAccessRightsResponse(t *testing.T) {
+	th.Mux.HandleFunc(shareEndpoint+"/"+shareID+"/action", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, listAccessRightsRequest)
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, listAccessRightsResponse)
+	})
+}

--- a/openstack/sharedfilesystems/v2/shares/testing/request_test.go
+++ b/openstack/sharedfilesystems/v2/shares/testing/request_test.go
@@ -135,3 +135,29 @@ func TestGrantAcessSuccess(t *testing.T) {
 		ID:          "a2f226a5-cee8-430b-8a03-78a59bd84ee8",
 	})
 }
+
+func TestListAccessRightsSuccess(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockListAccessRightsResponse(t)
+
+	c := client.ServiceClient()
+	// Client c must have Microversion set; minimum supported microversion for Grant Access is 2.7
+	c.Microversion = "2.7"
+
+	s, err := shares.ListAccessRights(c, shareID).Extract()
+
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, s, []*shares.AccessRight{
+		{
+			ShareID:     "011d21e2-fbc3-4e4a-9993-9ea223f73264",
+			AccessType:  "ip",
+			AccessTo:    "0.0.0.0/0",
+			AccessKey:   "",
+			AccessLevel: "rw",
+			State:       "new",
+			ID:          "a2f226a5-cee8-430b-8a03-78a59bd84ee8",
+		},
+	})
+}

--- a/openstack/sharedfilesystems/v2/shares/testing/request_test.go
+++ b/openstack/sharedfilesystems/v2/shares/testing/request_test.go
@@ -149,7 +149,7 @@ func TestListAccessRightsSuccess(t *testing.T) {
 	s, err := shares.ListAccessRights(c, shareID).Extract()
 
 	th.AssertNoErr(t, err)
-	th.AssertDeepEquals(t, s, []*shares.AccessRight{
+	th.AssertDeepEquals(t, s, []shares.AccessRight{
 		{
 			ShareID:     "011d21e2-fbc3-4e4a-9993-9ea223f73264",
 			AccessType:  "ip",

--- a/openstack/sharedfilesystems/v2/shares/urls.go
+++ b/openstack/sharedfilesystems/v2/shares/urls.go
@@ -21,3 +21,7 @@ func getExportLocationsURL(c *gophercloud.ServiceClient, id string) string {
 func grantAccessURL(c *gophercloud.ServiceClient, id string) string {
 	return c.ServiceURL("shares", id, "action")
 }
+
+func listAccessRightsURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("shares", id, "action")
+}


### PR DESCRIPTION
For #985

This PR implements `ListAccessRights`. According to https://developer.openstack.org/api-ref/shared-file-system/#list-access-rules , it seems `access-list` doesn't support pagination and that's why I didn't use it in the implementation, hope it's ok.