### PR TITLE
Run container tests in gophercloud

### DIFF
--- a/.zuul/playbooks/gophercloud-acceptance-test/run.yaml
+++ b/.zuul/playbooks/gophercloud-acceptance-test/run.yaml
@@ -49,6 +49,7 @@
               go test -v -tags "fixtures acceptance" ./acceptance/openstack/networking/v2/
               go test -v -tags "fixtures acceptance" ./acceptance/openstack/blockstorage/v2/
               go test -v -tags "fixtures acceptance" -run "SecGroup|Flavor" ./acceptance/openstack/compute/v2/
+              go test -v -tags "fixtures acceptance" ./acceptance/openstack/container/v1/
               # To enable more after the fix of https://github.com/gophercloud/gophercloud/issues/608
               # go test -v -tags "fixtures acceptance" ./acceptance/openstack/imageservice/v2/
               # go test -v -tags "fixtures acceptance" ./acceptance/openstack/identity/v2/


### PR DESCRIPTION
The previous PR #976 overwritten the container tests job
theopenlab/openlab-zuul-jobs#190, add it to avoid regression.

Closed #974 
