### PR TITLE
Add BlockStorage Client accepting micro versions

### DIFF
--- a/openstack/client.go
+++ b/openstack/client.go
@@ -342,6 +342,17 @@ func NewBlockStorageV3(client *gophercloud.ProviderClient, eo gophercloud.Endpoi
 	return initClientOpts(client, eo, "volumev3")
 }
 
+// NewBlockStorageMicroVersion creates a ServiceClient that may be used to access the v3 block storage service with microversions.
+func NewBlockStorageMicroVersion(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, mv string) (*gophercloud.ServiceClient, error) {
+	sc, _ := initClientOpts(client, eo, "volumev3")
+	if mv != "" {
+		sc.Microversion = mv
+	}
+	return sc, nil
+}
+
+// NewSharedFileSystemV2 creates a ServiceClient that may be used to access the v2 shared file system service.
+
 // NewSharedFileSystemV2 creates a ServiceClient that may be used to access the v2 shared file system service.
 func NewSharedFileSystemV2(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
 	return initClientOpts(client, eo, "sharev2")


### PR DESCRIPTION
This just adds a NewBlockStorage client setup that accepts and sets
microversions.

Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

This doesn't necessarily solve the issue of micro version support, or expose anything new in the OpenStack API's.  What it does do however is let those that are interested and have a need to utilize a micro version of the Cinder API that isn't formally implemented in Gophercloud to roll their own solution.

An example usage can be found here:  
https://gist.github.com/j-griffith/0dee9a3c871a3e6988d11be530bbd9bb
