### PR TITLE
Networking v2: Add ability to list external networks

### DIFF
--- a/openstack/networking/v2/extensions/external/doc.go
+++ b/openstack/networking/v2/extensions/external/doc.go
@@ -4,6 +4,13 @@ extension for the OpenStack Networking service.
 
 Example to List Networks with External Information
 
+	iTrue := true
+	networkListOpts := networks.ListOpts{}
+	listOpts := external.ListOptsExt{
+		ListOptsBuilder: networkListOpts,
+		External: &iTrue,
+	}
+
 	type NetworkWithExternalExt struct {
 		networks.Network
 		external.NetworkExternalExt
@@ -11,7 +18,7 @@ Example to List Networks with External Information
 
 	var allNetworks []NetworkWithExternalExt
 
-	allPages, err := networks.List(networkClient, nil).AllPages()
+	allPages, err := networks.List(networkClient, listOpts).AllPages()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/networking/v2/extensions/external/requests.go
+++ b/openstack/networking/v2/extensions/external/requests.go
@@ -1,8 +1,36 @@
 package external
 
 import (
+	"net/url"
+	"strconv"
+
+	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
 )
+
+// ListOptsExt adds the external network options to the base ListOpts.
+type ListOptsExt struct {
+	networks.ListOptsBuilder
+	External *bool `q:"router:external"`
+}
+
+// ToNetworkListQuery adds the router:external option to the base network
+// list options.
+func (opts ListOptsExt) ToNetworkListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts.ListOptsBuilder)
+	if err != nil {
+		return "", err
+	}
+
+	params := q.Query()
+	if opts.External != nil {
+		v := strconv.FormatBool(*opts.External)
+		params.Add("router:external", v)
+	}
+
+	q = &url.URL{RawQuery: params.Encode()}
+	return q.String(), err
+}
 
 // CreateOptsExt is the structure used when creating new external network
 // resources. It embeds networks.CreateOpts and so inherits all of its required

--- a/openstack/networking/v2/extensions/external/testing/fixtures.go
+++ b/openstack/networking/v2/extensions/external/testing/fixtures.go
@@ -57,3 +57,5 @@ const UpdateResponse = `
         "router:external": false
     }
 }`
+
+const ExpectedListOpts = "?id=d32019d3-bc6e-4319-9c1d-6722fc136a22&router%3Aexternal=true"

--- a/openstack/networking/v2/extensions/external/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/external/testing/requests_test.go
@@ -1,0 +1,26 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/external"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestListExternal(t *testing.T) {
+	var iTrue bool = true
+
+	networkListOpts := networks.ListOpts{
+		ID: "d32019d3-bc6e-4319-9c1d-6722fc136a22",
+	}
+
+	listOpts := external.ListOptsExt{
+		ListOptsBuilder: networkListOpts,
+		External:        &iTrue,
+	}
+
+	actual, err := listOpts.ToNetworkListQuery()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, ExpectedListOpts, actual)
+}


### PR DESCRIPTION
This commit adds the ability to list external networks. It does this by
way of creating an extention to the networks package's ListOpts struct.

For #1009 
