### PR TITLE
Enable OpenLab periodic check

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -74,3 +74,7 @@
     recheck-queens:
       jobs:
         - gophercloud-acceptance-test-queens
+    periodic:
+      jobs:
+        - gophercloud-unittest
+        - gophercloud-acceptance-test


### PR DESCRIPTION
Periodic check will be triggered at UTC-0 0:00 and 12:00 of everyday
automatically, unit and acceptance tests will be executed, results will
be shown in OpenLab CI dashboard http://status.openlabtesting.org/t/openlab/builds.html

For theopenlab/openlab#63