### PR TITLE
[WIP] Senlin: Clusters Resize

### DIFF
--- a/openstack/clustering/v1/clusters/doc.go
+++ b/openstack/clustering/v1/clusters/doc.go
@@ -66,5 +66,29 @@ Example to Delete a cluster
 		panic(err)
 	}
 
+Example to Resize a cluster
+
+	adjustmentType := "CHANGE_IN_CAPACITY"
+	number := 1
+	maxSize := 5
+	minSize := 1
+	minStep := 1
+	strict := true
+
+	resizeOpts := clusters.ResizeOpts{
+		AdjustmentType: adjustmentType,
+		Number:         number,
+		MaxSize:        &maxSize,
+		MinSize:        &minSize,
+		MinStep:        &minStep,
+		Strict:         &strict,
+	}
+
+	actionID, err := clusters.Resize(client, clusterName, resizeOpts).Extract()
+	if err != nil {
+		t.Fatalf("Unable to resize cluster: %v", err)
+	}
+	fmt.Println("Resize actionID", actionID)
+
 */
 package clusters

--- a/openstack/clustering/v1/clusters/requests.go
+++ b/openstack/clustering/v1/clusters/requests.go
@@ -1,7 +1,9 @@
 package clusters
 
 import (
+	"fmt"
 	"net/http"
+	"reflect"
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/pagination"
@@ -145,6 +147,57 @@ func Update(client *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder
 func Delete(client *gophercloud.ServiceClient, id string) (r DeleteResult) {
 	var result *http.Response
 	result, r.Err = client.Delete(deleteURL(client, id), nil)
+	if r.Err == nil {
+		r.Header = result.Header
+	}
+	return
+}
+
+// ResizeOpts params
+type ResizeOpts struct {
+	AdjustmentType string      `json:"adjustment_type,omitempty"`
+	Number         interface{} `json:"number,omitempty"`
+	MinSize        *int        `json:"min_size,omitempty"`
+	MaxSize        *int        `json:"max_size,omitempty"`
+	MinStep        *int        `json:"min_step,omitempty"`
+	Strict         *bool       `json:"strict,omitempty"`
+}
+
+// ToClusterResizeMap constructs a request body from ResizeOpts.
+func (opts ResizeOpts) ToClusterResizeMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "resize")
+}
+
+func Resize(client *gophercloud.ServiceClient, id string, opts ResizeOpts) (r ResizeResult) {
+	if opts.AdjustmentType != "" && opts.Number == nil {
+		r.Err = fmt.Errorf("Number field MUST NOT be empty when AdjustmentType field used")
+		return
+	}
+
+	switch opts.Number.(type) {
+	case int, int32, int64, *int, *int32, *int64:
+		// Valid type. Always allow
+	case float32, float64, *float32, *float64:
+		if opts.AdjustmentType != "CHANGE_IN_PERCENTAGE" {
+			r.Err = fmt.Errorf("Only AdjustmentType=CHANGE_IN_PERCENTAGE allows float value for Number field"+
+				"AdjustmentType=%s", opts.AdjustmentType)
+			return
+		}
+	default:
+		r.Err = fmt.Errorf("Number field must be either int or float %s", reflect.TypeOf(opts.Number))
+		return
+	}
+
+	b, err := opts.ToClusterResizeMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	var result *http.Response
+	result, r.Err = client.Post(actionURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200, 201, 202},
+	})
 	if r.Err == nil {
 		r.Header = result.Header
 	}

--- a/openstack/clustering/v1/clusters/results.go
+++ b/openstack/clustering/v1/clusters/results.go
@@ -25,6 +25,11 @@ type GetResult struct {
 	commonResult
 }
 
+// ResizeResult is the response of a Get operations.
+type ResizeResult struct {
+	commonResult
+}
+
 // UpdateResult is the response of a Update operations.
 type UpdateResult struct {
 	commonResult
@@ -65,6 +70,20 @@ func (r commonResult) Extract() (*Cluster, error) {
 	}
 
 	return s.Cluster, nil
+}
+
+type Action struct {
+	Action string `json:"action"`
+}
+
+func (r ResizeResult) Extract() (string, error) {
+	var s Action
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return s.Action, err
+	}
+
+	return s.Action, nil
 }
 
 // ClusterPage contains a single page of all clusters from a List call.

--- a/openstack/clustering/v1/clusters/testing/requests_test.go
+++ b/openstack/clustering/v1/clusters/testing/requests_test.go
@@ -1198,3 +1198,142 @@ func TestDeleteCluster(t *testing.T) {
 	err := clusters.Delete(fake.ServiceClient(), "6dc6d336e3fc4c0a951b5698cd1236ee").ExtractErr()
 	th.AssertNoErr(t, err)
 }
+
+func TestResizeCluster(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v1/clusters/7d85f602-a948-4a30-afd4-e84f47471c15/actions", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, `
+		{
+  			"action": "2a0ff107-e789-4660-a122-3816c43af703"
+		}`)
+	})
+
+	maxSize := 5
+	minSize := 1
+	number := -2
+	strict := true
+	opts := clusters.ResizeOpts{
+		AdjustmentType: "CHANGE_IN_CAPACITY",
+		MaxSize:        &maxSize,
+		MinSize:        &minSize,
+		Number:         &number,
+		Strict:         &strict,
+	}
+
+	actionID, err := clusters.Resize(fake.ServiceClient(), "7d85f602-a948-4a30-afd4-e84f47471c15", opts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, actionID, "2a0ff107-e789-4660-a122-3816c43af703")
+}
+
+// Test case for Number field having a float value
+func TestResizeClusterNumberFloat(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v1/clusters/7d85f602-a948-4a30-afd4-e84f47471c15/actions", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, `
+		{
+  			"action": "2a0ff107-e789-4660-a122-3816c43af703"
+		}`)
+	})
+
+	maxSize := 5
+	minSize := 1
+	number := 100.0
+	strict := true
+	opts := clusters.ResizeOpts{
+		AdjustmentType: "CHANGE_IN_PERCENTAGE",
+		MaxSize:        &maxSize,
+		MinSize:        &minSize,
+		Number:         &number,
+		Strict:         &strict,
+	}
+
+	result, err := clusters.Resize(fake.ServiceClient(), "7d85f602-a948-4a30-afd4-e84f47471c15", opts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, result, "2a0ff107-e789-4660-a122-3816c43af703")
+}
+
+// Negative test case for missing Number field which is required when AdjustmentType is specified
+func TestResizeClusterInvalidParamsMissingNumber(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v1/clusters/7d85f602-a948-4a30-afd4-e84f47471c15/actions", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, `
+		{
+  			"action": "2a0ff107-e789-4660-a122-3816c43af703"
+		}`)
+	})
+
+	maxSize := 5
+	minSize := 1
+	strict := true
+	opts := clusters.ResizeOpts{
+		AdjustmentType: "CHANGE_IN_CAPACITY",
+		MaxSize:        &maxSize,
+		MinSize:        &minSize,
+		//Number:       MISSING,
+		Strict: &strict,
+	}
+
+	_, err := clusters.Resize(fake.ServiceClient(), "7d85f602-a948-4a30-afd4-e84f47471c15", opts).Extract()
+	isValid := err == nil
+	th.AssertEquals(t, false, isValid)
+}
+
+// Negative test case for missing Number field which is required when AdjustmentType is specified
+func TestResizeClusterInvalidParamsNumberFloat(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v1/clusters/7d85f602-a948-4a30-afd4-e84f47471c15/actions", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, `
+		{
+  			"action": "2a0ff107-e789-4660-a122-3816c43af703"
+		}`)
+	})
+
+	maxSize := 5
+	minSize := 1
+	number := 100.0
+	strict := true
+	opts := clusters.ResizeOpts{
+		AdjustmentType: "CHANGE_IN_CAPACITY",
+		MaxSize:        &maxSize,
+		MinSize:        &minSize,
+		Number:         &number,
+		Strict:         &strict,
+	}
+
+	_, err := clusters.Resize(fake.ServiceClient(), "7d85f602-a948-4a30-afd4-e84f47471c15", opts).Extract()
+	isValid := err == nil
+	th.AssertEquals(t, false, isValid)
+}

--- a/openstack/clustering/v1/clusters/urls.go
+++ b/openstack/clustering/v1/clusters/urls.go
@@ -5,6 +5,10 @@ import "github.com/gophercloud/gophercloud"
 var apiVersion = "v1"
 var apiName = "clusters"
 
+func actionURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL(apiVersion, apiName, id, "actions")
+}
+
 func commonURL(client *gophercloud.ServiceClient) string {
 	return client.ServiceURL(apiVersion, apiName)
 }


### PR DESCRIPTION
Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

For #[823 [Add support for Senlin clustering]](https://github.com/gophercloud/gophercloud/issues/823)

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

[[clusters:resize]](https://github.com/openstack/senlin/blob/e5bc16b3fea2f10dead365f983c5a937f23d72b0/senlin/api/openstack/v1/clusters.py#L135)

