### PR TITLE
senlin-clusterpolicies-get

### DIFF
--- a/acceptance/openstack/clustering/v1/autoscaling_test.go
+++ b/acceptance/openstack/clustering/v1/autoscaling_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gophercloud/gophercloud/acceptance/clients"
 	"github.com/gophercloud/gophercloud/acceptance/tools"
 	"github.com/gophercloud/gophercloud/openstack/clustering/v1/actions"
+	"github.com/gophercloud/gophercloud/openstack/clustering/v1/clusterpolicies"
 	"github.com/gophercloud/gophercloud/openstack/clustering/v1/clusters"
 	"github.com/gophercloud/gophercloud/openstack/clustering/v1/profiles"
 	"github.com/gophercloud/gophercloud/pagination"
@@ -30,6 +31,7 @@ func TestAutoScaling(t *testing.T) {
 	clusterGet(t)
 	clusterList(t)
 	clusterUpdate(t)
+	clusterPolicyGet(t)
 }
 
 func profileCreate(t *testing.T) {
@@ -361,4 +363,19 @@ func clustersDelete(t *testing.T) {
 	err = clusters.Delete(client, clusterName).ExtractErr()
 	th.AssertNoErr(t, err)
 	t.Logf("Cluster deleted: %s", clusterName)
+}
+
+func clusterPolicyGet(t *testing.T) {
+	client, err := clients.NewClusteringV1Client()
+	if err != nil {
+		t.Fatalf("Unable to create clustering client: %v", err)
+	}
+
+	clusterName := testName
+	policyName := testName
+	clusterPolicy, err := clusterpolicies.Get(client, clusterName, policyName).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, policyName, clusterPolicy.PolicyName)
+	th.AssertEquals(t, clusterName, clusterPolicy.ClusterName)
+	tools.PrintResource(t, clusterPolicy)
 }

--- a/openstack/clustering/v1/clusterpolicies/doc.go
+++ b/openstack/clustering/v1/clusterpolicies/doc.go
@@ -1,0 +1,13 @@
+/*
+Package clusterpolicies Gets and Lists all cluster policies and shows detailed information for a cluster policy from the OpenStack
+Clustering Service.
+
+Example to get cluster-policies
+
+	clusterID := "7d85f602-a948-4a30-afd4-e84f47471c15"
+	profileID := "714fe676-a08f-4196-b7af-61d52eeded15"
+	clusterPolicy, err := clusterpolicies.Get(serviceCLient, clusterID, profileID).Extract()
+	fmt.Println("ClusterPolicy=", clusterPolicy)
+
+*/
+package clusterpolicies

--- a/openstack/clustering/v1/clusterpolicies/requests.go
+++ b/openstack/clustering/v1/clusterpolicies/requests.go
@@ -1,0 +1,12 @@
+package clusterpolicies
+
+import (
+	"github.com/gophercloud/gophercloud"
+)
+
+// Get retrieves details of a single cluster-policy. Use Extract to convert its
+// result into a Node.
+func Get(client *gophercloud.ServiceClient, clusterID string, policyID string) (r GetResult) {
+	_, r.Err = client.Get(getURL(client, clusterID, policyID), &r.Body, nil)
+	return
+}

--- a/openstack/clustering/v1/clusterpolicies/results.go
+++ b/openstack/clustering/v1/clusterpolicies/results.go
@@ -1,0 +1,35 @@
+package clusterpolicies
+
+import (
+	"github.com/gophercloud/gophercloud"
+)
+
+// commonResult is the response of a base result.
+type commonResult struct {
+	gophercloud.Result
+}
+
+// GetResult is the response of a Get operations.
+type GetResult struct {
+	commonResult
+}
+
+// Extract provides access to the individual Policy returned by the Get and
+// Create functions.
+func (r commonResult) Extract() (*ClusterPolicy, error) {
+	var s struct {
+		ClusterPolicy *ClusterPolicy `json:"cluster_policy"`
+	}
+	err := r.ExtractInto(&s)
+	return s.ClusterPolicy, err
+}
+
+type ClusterPolicy struct {
+	ClusterUUID string `json:"cluster_id"`
+	ClusterName string `json:"cluster_name"`
+	Enabled     bool   `json:"enabled"`
+	ID          string `json:"id"`
+	PolicyID    string `json:"policy_id"`
+	PolicyName  string `json:"policy_name"`
+	PolicyType  string `json:"policy_type"`
+}

--- a/openstack/clustering/v1/clusterpolicies/testing/doc.go
+++ b/openstack/clustering/v1/clusterpolicies/testing/doc.go
@@ -1,0 +1,2 @@
+// clustering_cluster_policies_v1
+package testing

--- a/openstack/clustering/v1/clusterpolicies/testing/requests_test.go
+++ b/openstack/clustering/v1/clusterpolicies/testing/requests_test.go
@@ -1,0 +1,55 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/clustering/v1/clusterpolicies"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	fake "github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func TestGetClusterPolicies(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v1/clusters/7d85f602-a948-4a30-afd4-e84f47471c15/policies/714fe676-a08f-4196-b7af-61d52eeded15", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, `
+		{
+			"cluster_policy": 
+			{
+				"cluster_id":   "7d85f602-a948-4a30-afd4-e84f47471c15",
+				"cluster_name": "cluster4",
+				"enabled":      true,
+				"id":           "06be3a1f-b238-4a96-a737-ceec5714087e",
+				"policy_id":    "714fe676-a08f-4196-b7af-61d52eeded15",
+				"policy_name":  "dp01",
+				"policy_type":  "senlin.policy.deletion-1.0"
+			}	
+		}`)
+	})
+
+	expected := clusterpolicies.ClusterPolicy{
+		ClusterUUID: "7d85f602-a948-4a30-afd4-e84f47471c15",
+		ClusterName: "cluster4",
+		Enabled:     true,
+		ID:          "06be3a1f-b238-4a96-a737-ceec5714087e",
+		PolicyID:    "714fe676-a08f-4196-b7af-61d52eeded15",
+		PolicyName:  "dp01",
+		PolicyType:  "senlin.policy.deletion-1.0",
+	}
+
+	actual, err := clusterpolicies.Get(fake.ServiceClient(), "7d85f602-a948-4a30-afd4-e84f47471c15", "714fe676-a08f-4196-b7af-61d52eeded15").Extract()
+	if err != nil {
+		t.Errorf("Failed Get cluster policies. %v", err)
+	} else {
+		th.AssertDeepEquals(t, expected, *actual)
+	}
+}

--- a/openstack/clustering/v1/clusterpolicies/urls.go
+++ b/openstack/clustering/v1/clusterpolicies/urls.go
@@ -1,0 +1,10 @@
+package clusterpolicies
+
+import "github.com/gophercloud/gophercloud"
+
+var apiVersion = "v1"
+var apiName = "clusters"
+
+func getURL(client *gophercloud.ServiceClient, clusterID string, policyID string) string {
+	return client.ServiceURL(apiVersion, apiName, clusterID, "policies", policyID)
+}


### PR DESCRIPTION
Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

For #[823 [Add support for Senlin clustering]](https://github.com/gophercloud/gophercloud/issues/823)

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

[[policytypes-get]](https://github.com/openstack/senlin/blob/e5bc16b3fea2f10dead365f983c5a937f23d72b0/senlin/api/openstack/v1/cluster_policies.py#L57)

