### PR TITLE
WIP: Expose the OS_BRANCH environment variable for acc testing

### DIFF
--- a/.zuul/playbooks/gophercloud-acceptance-test/run.yaml
+++ b/.zuul/playbooks/gophercloud-acceptance-test/run.yaml
@@ -20,4 +20,4 @@
           ./script/acceptancetest -v 2>&1 | tee $TEST_RESULTS_TXT
         executable: /bin/bash
         chdir: '{{ zuul.project.src_dir }}'
-      environment: '{{ golang_env }}'
+      environment: '{{ golang_env | combine({"OS_BRANCH": vars["os_branch"] | default("master") }) }}'


### PR DESCRIPTION
This change expose the OS_BRANCH environment variable for running acceptance tests, that allow specific tests can be skipped according to specific OpenStack branch.

For https://github.com/gophercloud/gophercloud/pull/1013#issuecomment-395633308

