### PR TITLE
[WIP] Senlin: Clusters AttachPolicy

### DIFF
--- a/acceptance/openstack/clustering/v1/autoscaling_test.go
+++ b/acceptance/openstack/clustering/v1/autoscaling_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gophercloud/gophercloud/acceptance/tools"
 	"github.com/gophercloud/gophercloud/openstack/clustering/v1/actions"
 	"github.com/gophercloud/gophercloud/openstack/clustering/v1/clusters"
+	"github.com/gophercloud/gophercloud/openstack/clustering/v1/policies"
 	"github.com/gophercloud/gophercloud/openstack/clustering/v1/profiles"
 	"github.com/gophercloud/gophercloud/pagination"
 	th "github.com/gophercloud/gophercloud/testhelper"
@@ -30,6 +31,7 @@ func TestAutoScaling(t *testing.T) {
 	clusterGet(t)
 	clusterList(t)
 	clusterUpdate(t)
+	clusterAttachPolicy(t)
 }
 
 func profileCreate(t *testing.T) {
@@ -361,4 +363,89 @@ func clustersDelete(t *testing.T) {
 	err = clusters.Delete(client, clusterName).ExtractErr()
 	th.AssertNoErr(t, err)
 	t.Logf("Cluster deleted: %s", clusterName)
+}
+
+func clusterAttachPolicy(t *testing.T) {
+	client, err := clients.NewClusteringV1Client()
+	if err != nil {
+		t.Fatalf("Unable to create clustering client: %v", err)
+	}
+
+	client.Microversion = "1.5"
+
+	createOpts := policies.CreateOpts{
+		Name: testName,
+		Spec: policies.Spec{
+			Description: "new policy description",
+			Properties: map[string]interface{}{
+				"adjustment": map[string]interface{}{
+					"min_step":    1,
+					"cooldown":    60,
+					"best_effort": false,
+					"number":      1,
+					"type":        "CHANGE_IN_CAPACITY",
+				},
+				"event": "CLUSTER_SCALE_IN",
+			},
+			Type:    "senlin.policy.scaling",
+			Version: "1.1",
+		},
+	}
+
+	createResult := policies.Create(client, createOpts)
+	th.AssertNoErr(t, createResult.Err)
+
+	requestID := createResult.Header.Get("X-Openstack-Request-ID")
+	th.AssertEquals(t, true, requestID != "")
+
+	createdPolicy, err := createResult.Extract()
+	th.AssertNoErr(t, err)
+
+	defer policies.Delete(client, createdPolicy.ID)
+
+	clusterName := testName
+	policyName := testName
+	enabled := true
+	policyOpts := clusters.AttachPolicyOpts{
+		PolicyID: policyName,
+		Enabled:  &enabled,
+	}
+	actionID, err := clusters.AttachPolicy(client, clusterName, policyOpts).Extract()
+	if err != nil {
+		t.Fatalf("Unable attach policy to cluster: %v", err)
+	}
+
+	WaitForClusterToAttach(client, actionID, 15)
+
+	// TODO: clusterpolicies need to be approved first
+	/*
+		clusterpolicy, err := clusterpolicies.Get(client, policyName).Extract()
+		if err != nil {
+			t.Fatalf("Unable to get cluster: %v", err)
+		}
+		th.AssertEquals(t, clusterName, clusterpolicy.ClusterName)
+		th.AssertEquals(t, policyName, clusterpolicy.PolicyName)
+		th.AssertEquals(t, enabled, clusterpolicy.Enabled)
+	*/
+}
+
+func WaitForClusterToAttach(client *gophercloud.ServiceClient, actionID string, sleepTimeSecs int) error {
+	return gophercloud.WaitFor(sleepTimeSecs, func() (bool, error) {
+		if actionID == "" {
+			return false, fmt.Errorf("Invalid action id. id=%s", actionID)
+		}
+
+		action, err := actions.Get(client, actionID).Extract()
+		if err != nil {
+			return false, err
+		}
+		switch action.Status {
+		case "SUCCEEDED":
+			return true, nil
+		case "READY", "RUNNING", "WAITING":
+			return false, nil
+		default:
+			return false, fmt.Errorf("Error WaitFor ActionID=%s. Received status=%v", actionID, action.Status)
+		}
+	})
 }

--- a/openstack/clustering/v1/clusters/doc.go
+++ b/openstack/clustering/v1/clusters/doc.go
@@ -66,5 +66,19 @@ Example to Delete a cluster
 		panic(err)
 	}
 
+Example to attach a policy to a cluster
+
+	enabled := true
+	attachPolicyOpts := clusters.AttachPolicyOpts{
+		PolicyID: "policy-123",
+		Enabled:  &enabled,
+	}
+	clusterID := "b7b870e3-d3c5-4a93-b9d7-846c53b2c2da"
+	actionID, err := clusters.AttachPolicy(serviceClient, clusterID, attachPolicyOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("Attach Policy actionID", actionID)
+
 */
 package clusters

--- a/openstack/clustering/v1/clusters/requests.go
+++ b/openstack/clustering/v1/clusters/requests.go
@@ -150,3 +150,31 @@ func Delete(client *gophercloud.ServiceClient, id string) (r DeleteResult) {
 	}
 	return
 }
+
+// PolicyOpts params
+type AttachPolicyOpts struct {
+	PolicyID string `json:"policy_id" required:"true"`
+	Enabled  *bool  `json:"enabled,omitempty"`
+}
+
+// ToClusterPolicyMap constructs a request body from PolicyOpts
+func (opts AttachPolicyOpts) ToClusterAttachPolicyMap(policyAction string) (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, policyAction)
+}
+
+// Attach Policy
+func AttachPolicy(client *gophercloud.ServiceClient, id string, opts AttachPolicyOpts) (r AttachPolicyResult) {
+	b, err := opts.ToClusterAttachPolicyMap("policy_attach")
+	if err != nil {
+		r.Err = err
+		return
+	}
+	var result *http.Response
+	result, r.Err = client.Post(policyURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200, 201, 202},
+	})
+	if r.Err == nil {
+		r.Header = result.Header
+	}
+	return
+}

--- a/openstack/clustering/v1/clusters/results.go
+++ b/openstack/clustering/v1/clusters/results.go
@@ -30,6 +30,11 @@ type UpdateResult struct {
 	commonResult
 }
 
+// AttachPolicy is the response of a Create operations.
+type AttachPolicyResult struct {
+	commonResult
+}
+
 type Cluster struct {
 	Config          map[string]interface{} `json:"config"`
 	CreatedAt       time.Time              `json:"-"`
@@ -65,6 +70,18 @@ func (r commonResult) Extract() (*Cluster, error) {
 	}
 
 	return s.Cluster, nil
+}
+
+func (r AttachPolicyResult) Extract() (string, error) {
+	var s struct {
+		Action string `json:"action"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+
+	return s.Action, nil
 }
 
 // ClusterPage contains a single page of all clusters from a List call.

--- a/openstack/clustering/v1/clusters/testing/requests_test.go
+++ b/openstack/clustering/v1/clusters/testing/requests_test.go
@@ -1198,3 +1198,30 @@ func TestDeleteCluster(t *testing.T) {
 	err := clusters.Delete(fake.ServiceClient(), "6dc6d336e3fc4c0a951b5698cd1236ee").ExtractErr()
 	th.AssertNoErr(t, err)
 }
+
+func TestAttachPolicy(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v1/clusters/7d85f602-a948-4a30-afd4-e84f47471c15/actions", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, `
+		{
+  			"action": "2a0ff107-e789-4660-a122-3816c43af703"
+		}`)
+	})
+
+	enabled := true
+	opts := clusters.AttachPolicyOpts{
+		PolicyID: "policy1",
+		Enabled:  &enabled,
+	}
+	actionID, err := clusters.AttachPolicy(fake.ServiceClient(), "7d85f602-a948-4a30-afd4-e84f47471c15", opts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, actionID, "2a0ff107-e789-4660-a122-3816c43af703")
+}

--- a/openstack/clustering/v1/clusters/urls.go
+++ b/openstack/clustering/v1/clusters/urls.go
@@ -32,3 +32,11 @@ func updateURL(client *gophercloud.ServiceClient, id string) string {
 func deleteURL(client *gophercloud.ServiceClient, id string) string {
 	return idURL(client, id)
 }
+
+func actionURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL(apiVersion, apiName, id, "actions")
+}
+
+func policyURL(client *gophercloud.ServiceClient, id string) string {
+	return actionURL(client, id)
+}


### PR DESCRIPTION
Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

For #[823 [Add support for Senlin clustering]](https://github.com/gophercloud/gophercloud/issues/823)

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

[[clusters:attachpolicy]](https://github.com/openstack/senlin/blob/e5bc16b3fea2f10dead365f983c5a937f23d72b0/senlin/api/openstack/v1/clusters.py#L198)
