### PR TITLE
[WIP] Senlin: Clusters DetachPolicy

### DIFF
--- a/openstack/clustering/v1/clusters/doc.go
+++ b/openstack/clustering/v1/clusters/doc.go
@@ -66,5 +66,17 @@ Example to Delete a cluster
 		panic(err)
 	}
 
+Example to detach a policy to cluster
+
+	detachpolicyOpts := clusters.DetachPolicyOpts{
+		PolicyID: "policy-123",
+	}
+	clusterID :=  "b7b870e3-d3c5-4a93-b9d7-846c53b2c2da"
+	actionID, err := clusters.DetachPolicy(serviceClient, clusterID, detachpolicyOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("DetachPolicy actionID", actionID)
+
 */
 package clusters

--- a/openstack/clustering/v1/clusters/requests.go
+++ b/openstack/clustering/v1/clusters/requests.go
@@ -150,3 +150,28 @@ func Delete(client *gophercloud.ServiceClient, id string) (r DeleteResult) {
 	}
 	return
 }
+
+// DetachPolicyOpts params
+type DetachPolicyOpts struct {
+	PolicyID string `json:"policy_id" required:"true"`
+}
+
+func (opts DetachPolicyOpts) ToClusterDetachPolicyMap(policyAction string) (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, policyAction)
+}
+
+func DetachPolicy(client *gophercloud.ServiceClient, id string, opts DetachPolicyOpts) (r DetachPolicyResult) {
+	b, err := opts.ToClusterDetachPolicyMap("policy_detach")
+	if err != nil {
+		r.Err = err
+		return
+	}
+	var result *http.Response
+	result, r.Err = client.Post(policyURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200, 201, 202},
+	})
+	if r.Err == nil {
+		r.Header = result.Header
+	}
+	return
+}

--- a/openstack/clustering/v1/clusters/results.go
+++ b/openstack/clustering/v1/clusters/results.go
@@ -25,6 +25,11 @@ type GetResult struct {
 	commonResult
 }
 
+// PostResult is the response of a Post operations.
+type PostResult struct {
+	commonResult
+}
+
 // UpdateResult is the response of a Update operations.
 type UpdateResult struct {
 	commonResult
@@ -150,4 +155,22 @@ func (r *Cluster) UnmarshalJSON(b []byte) error {
 // method to determine if the call succeeded or failed.
 type DeleteResult struct {
 	gophercloud.ErrResult
+}
+
+type DetachPolicyResult struct {
+	PostResult
+}
+
+type Action struct {
+	Action string `json:"action"`
+}
+
+// Extract retrieves the response action
+func (r DetachPolicyResult) Extract() (string, error) {
+	var s *Action
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return s.Action, err
 }

--- a/openstack/clustering/v1/clusters/testing/requests_test.go
+++ b/openstack/clustering/v1/clusters/testing/requests_test.go
@@ -1198,3 +1198,28 @@ func TestDeleteCluster(t *testing.T) {
 	err := clusters.Delete(fake.ServiceClient(), "6dc6d336e3fc4c0a951b5698cd1236ee").ExtractErr()
 	th.AssertNoErr(t, err)
 }
+
+func TestAttachPolicy(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v1/clusters/7d85f602-a948-4a30-afd4-e84f47471c15/actions", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, `
+		{
+  			"action": "2a0ff107-e789-4660-a122-3816c43af703"
+		}`)
+	})
+
+	opts := clusters.DetachPolicyOpts{
+		PolicyID: "policy1",
+	}
+	result, err := clusters.DetachPolicy(fake.ServiceClient(), "7d85f602-a948-4a30-afd4-e84f47471c15", opts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, result, "2a0ff107-e789-4660-a122-3816c43af703")
+}

--- a/openstack/clustering/v1/clusters/urls.go
+++ b/openstack/clustering/v1/clusters/urls.go
@@ -32,3 +32,11 @@ func updateURL(client *gophercloud.ServiceClient, id string) string {
 func deleteURL(client *gophercloud.ServiceClient, id string) string {
 	return idURL(client, id)
 }
+
+func actionURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL(apiVersion, apiName, id, "actions")
+}
+
+func policyURL(client *gophercloud.ServiceClient, id string) string {
+	return actionURL(client, id)
+}


### PR DESCRIPTION
Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

For #[823 [Add support for Senlin clustering]](https://github.com/gophercloud/gophercloud/issues/823)

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

[[clusters:detachpolicy]](https://github.com/openstack/senlin/blob/e5bc16b3fea2f10dead365f983c5a937f23d72b0/senlin/api/openstack/v1/clusters.py#L205)
