### PR TITLE
[WIP] Senlin: Clusters ScaleOut

### DIFF
--- a/acceptance/openstack/clustering/v1/autoscaling_test.go
+++ b/acceptance/openstack/clustering/v1/autoscaling_test.go
@@ -30,6 +30,7 @@ func TestAutoScaling(t *testing.T) {
 	clusterGet(t)
 	clusterList(t)
 	clusterUpdate(t)
+	clusterScaleOut(t)
 }
 
 func profileCreate(t *testing.T) {
@@ -361,4 +362,52 @@ func clustersDelete(t *testing.T) {
 	err = clusters.Delete(client, clusterName).ExtractErr()
 	th.AssertNoErr(t, err)
 	t.Logf("Cluster deleted: %s", clusterName)
+}
+
+// TODO: Depended on AttachPolicy
+func clusterScaleOut(t *testing.T) {
+	client, err := clients.NewClusteringV1Client()
+	if err != nil {
+		t.Fatalf("Unable to create clustering client: %v", err)
+	}
+
+	clusterName := testName
+	scaleOutOpts := clusters.ScaleOutOpts{
+		Count: 3,
+	}
+
+	// Update to new cluster size
+	actionID, err := clusters.ScaleOut(client, clusterName, scaleOutOpts).Extract()
+	if err != nil {
+		t.Fatalf("Unable to scale-out cluster: %v", err)
+	}
+
+	WaitForClusterToScaleOut(client, actionID, 15)
+
+	cluster, err := clusters.Get(client, actionID).Extract()
+	if err != nil {
+		t.Fatalf("Unable to get cluster: %v", err)
+	}
+	th.AssertEquals(t, 3, len(cluster.Nodes))
+}
+
+func WaitForClusterToScaleOut(client *gophercloud.ServiceClient, actionID string, sleepTimeSecs int) error {
+	return gophercloud.WaitFor(sleepTimeSecs, func() (bool, error) {
+		if actionID == "" {
+			return false, fmt.Errorf("Invalid action id. id=%s", actionID)
+		}
+
+		action, err := actions.Get(client, actionID).Extract()
+		if err != nil {
+			return false, err
+		}
+		switch action.Status {
+		case "SUCCEEDED":
+			return true, nil
+		case "READY", "RUNNING", "WAITING":
+			return false, nil
+		default:
+			return false, fmt.Errorf("Error WaitFor ActionID=%s. Received status=%v", actionID, action.Status)
+		}
+	})
 }

--- a/openstack/clustering/v1/clusters/doc.go
+++ b/openstack/clustering/v1/clusters/doc.go
@@ -66,5 +66,17 @@ Example to Delete a cluster
 		panic(err)
 	}
 
+Example to ScaleOut a cluster
+
+	scaleOutOpts := clusters.ScaleOutOpts{
+		Count: 2,
+	}
+	clusterID := "b7b870e3-d3c5-4a93-b9d7-846c53b2c2da"
+
+	actionID, err := clusters.ScaleOut(computeClient, clusterID, scaleOutOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
 */
 package clusters

--- a/openstack/clustering/v1/clusters/requests.go
+++ b/openstack/clustering/v1/clusters/requests.go
@@ -150,3 +150,27 @@ func Delete(client *gophercloud.ServiceClient, id string) (r DeleteResult) {
 	}
 	return
 }
+
+type ScaleOutOpts struct {
+	Count int `json:"count,omitempty"`
+}
+
+func (opts ScaleOutOpts) ToClusterScaleOutMap(scaleOutAction string) (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, scaleOutAction)
+}
+
+func ScaleOut(client *gophercloud.ServiceClient, id string, opts ScaleOutOpts) (r ScaleOutResult) {
+	b, err := opts.ToClusterScaleOutMap("scale_out")
+	if err != nil {
+		r.Err = err
+		return
+	}
+	var result *http.Response
+	result, r.Err = client.Post(scaleURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200, 201, 202},
+	})
+	if r.Err == nil {
+		r.Header = result.Header
+	}
+	return
+}

--- a/openstack/clustering/v1/clusters/results.go
+++ b/openstack/clustering/v1/clusters/results.go
@@ -25,6 +25,11 @@ type GetResult struct {
 	commonResult
 }
 
+// PostResult is the response of a Post operations.
+type PostResult struct {
+	commonResult
+}
+
 // UpdateResult is the response of a Update operations.
 type UpdateResult struct {
 	commonResult
@@ -150,4 +155,21 @@ func (r *Cluster) UnmarshalJSON(b []byte) error {
 // method to determine if the call succeeded or failed.
 type DeleteResult struct {
 	gophercloud.ErrResult
+}
+
+type ScaleOutResult struct {
+	PostResult
+}
+
+type Action struct {
+	Action string `json:"action"`
+}
+
+func (r ScaleOutResult) Extract() (string, error) {
+	var s *Action
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return s.Action, err
 }

--- a/openstack/clustering/v1/clusters/testing/requests_test.go
+++ b/openstack/clustering/v1/clusters/testing/requests_test.go
@@ -1198,3 +1198,28 @@ func TestDeleteCluster(t *testing.T) {
 	err := clusters.Delete(fake.ServiceClient(), "6dc6d336e3fc4c0a951b5698cd1236ee").ExtractErr()
 	th.AssertNoErr(t, err)
 }
+
+func TestClusterScaleOut(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v1/clusters/edce3528-864f-41fb-8759-f4707925cc09/actions", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, `
+		{
+			"action": "2a0ff107-e789-4660-a122-3816c43af703"
+		}`)
+	})
+
+	scaleOutOpts := clusters.ScaleOutOpts{
+		Count: 5,
+	}
+	result, err := clusters.ScaleOut(fake.ServiceClient(), "edce3528-864f-41fb-8759-f4707925cc09", scaleOutOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, result, "2a0ff107-e789-4660-a122-3816c43af703")
+}

--- a/openstack/clustering/v1/clusters/urls.go
+++ b/openstack/clustering/v1/clusters/urls.go
@@ -32,3 +32,11 @@ func updateURL(client *gophercloud.ServiceClient, id string) string {
 func deleteURL(client *gophercloud.ServiceClient, id string) string {
 	return idURL(client, id)
 }
+
+func actionURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL(apiVersion, apiName, id, "actions")
+}
+
+func scaleURL(client *gophercloud.ServiceClient, id string) string {
+	return actionURL(client, id)
+}


### PR DESCRIPTION
Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

For #[823 [Add support for Senlin clustering]](https://github.com/gophercloud/gophercloud/issues/823)

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

[[clusters:scale-out]](https://github.com/openstack/senlin/blob/e5bc16b3fea2f10dead365f983c5a937f23d72b0/senlin/api/openstack/v1/clusters.py#L180)
