### PR TITLE
[WIP] Senlin: Receivers Delete

### DIFF
--- a/acceptance/openstack/clustering/v1/autoscaling_test.go
+++ b/acceptance/openstack/clustering/v1/autoscaling_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/clustering/v1/actions"
 	"github.com/gophercloud/gophercloud/openstack/clustering/v1/clusters"
 	"github.com/gophercloud/gophercloud/openstack/clustering/v1/profiles"
+	"github.com/gophercloud/gophercloud/openstack/clustering/v1/receivers"
 	"github.com/gophercloud/gophercloud/pagination"
 	th "github.com/gophercloud/gophercloud/testhelper"
 )
@@ -31,6 +32,7 @@ func TestAutoScaling(t *testing.T) {
 	clusterGet(t)
 	clusterList(t)
 	clusterUpdate(t)
+	defer receiverDelete(t)
 }
 
 func profileCreate(t *testing.T) {
@@ -416,4 +418,15 @@ func WaitForClusterToDelete(client *gophercloud.ServiceClient, actionID string, 
 			return false, fmt.Errorf("Error WaitFor ActionID=%s. Received status=%v", actionID, action.Status)
 		}
 	})
+}
+
+func receiverDelete(t *testing.T) {
+	client, err := clients.NewClusteringV1Client()
+	if err != nil {
+		t.Fatalf("Unable to create clustering client: %v", err)
+	}
+
+	receiverName := testName
+	err = receivers.Delete(client, receiverName).ExtractErr()
+	th.AssertNoErr(t, err)
 }

--- a/openstack/clustering/v1/receivers/doc.go
+++ b/openstack/clustering/v1/receivers/doc.go
@@ -1,0 +1,16 @@
+/*
+Package receivers provides information and interaction with the receivers through
+the OpenStack Compute service.
+
+Lists all receivers and creates, shows information for, and deletes a receiver.
+
+Example to Delete receiver
+
+	receiverID := "6dc6d336e3fc4c0a951b5698cd1236ee"
+	err := receivers.Delete(serviceClient, receiverID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+
+*/
+package receivers

--- a/openstack/clustering/v1/receivers/requests.go
+++ b/openstack/clustering/v1/receivers/requests.go
@@ -1,0 +1,11 @@
+package receivers
+
+import (
+	"github.com/gophercloud/gophercloud"
+)
+
+// Delete deletes the specified receiver ID.
+func Delete(client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+	_, r.Err = client.Delete(deleteURL(client, id), nil)
+	return
+}

--- a/openstack/clustering/v1/receivers/results.go
+++ b/openstack/clustering/v1/receivers/results.go
@@ -1,0 +1,11 @@
+package receivers
+
+import (
+	"github.com/gophercloud/gophercloud"
+)
+
+// DeleteResult is the result from a Delete operation. Call its ExtractErr
+// method to determine if the call succeeded or failed.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}

--- a/openstack/clustering/v1/receivers/testing/doc.go
+++ b/openstack/clustering/v1/receivers/testing/doc.go
@@ -1,0 +1,2 @@
+// clustering_receivers_v1
+package testing

--- a/openstack/clustering/v1/receivers/testing/requests_test.go
+++ b/openstack/clustering/v1/receivers/testing/requests_test.go
@@ -1,0 +1,26 @@
+package testing
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/clustering/v1/receivers"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	fake "github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func TestDeleteReceiver(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v1/receivers/6dc6d336e3fc4c0a951b5698cd1236ee", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	deleteResult := receivers.Delete(fake.ServiceClient(), "6dc6d336e3fc4c0a951b5698cd1236ee")
+	th.AssertNoErr(t, deleteResult.ExtractErr())
+}

--- a/openstack/clustering/v1/receivers/urls.go
+++ b/openstack/clustering/v1/receivers/urls.go
@@ -1,0 +1,14 @@
+package receivers
+
+import "github.com/gophercloud/gophercloud"
+
+var apiVersion = "v1"
+var apiName = "receivers"
+
+func idURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL(apiVersion, apiName, id)
+}
+
+func deleteURL(client *gophercloud.ServiceClient, id string) string {
+	return idURL(client, id)
+}


### PR DESCRIPTION
Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

For #[823 [Add support for Senlin clustering]](https://github.com/gophercloud/gophercloud/issues/823)

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

[[receivers:delete]](https://github.com/openstack/senlin/blob/e5bc16b3fea2f10dead365f983c5a937f23d72b0/senlin/api/openstack/v1/receivers.py#L92)
