### PR TITLE
Expose OS_BRANCH var based on refactors on openlab-zuul-jobs

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -19,7 +19,8 @@
     description: |
       Run gophercloud acceptance test on queens branch
     vars:
-      os_branch: 'stable/queens'
+      global_env:
+        OS_BRANCH: stable/queens
 
 - job:
     name: gophercloud-acceptance-test-pike
@@ -27,14 +28,17 @@
     description: |
       Run gophercloud acceptance test on pike branch
     vars:
-      os_branch: 'stable/pike'
+      global_env:
+        OS_BRANCH: stable/pike
+
 - job:
     name: gophercloud-acceptance-test-ocata
     parent: gophercloud-acceptance-test
     description: |
       Run gophercloud acceptance test on ocata branch
     vars:
-      os_branch: 'stable/ocata'
+      global_env:
+        OS_BRANCH: stable/ocata
 
 - job:
     name: gophercloud-acceptance-test-newton
@@ -42,7 +46,8 @@
     description: |
       Run gophercloud acceptance test on newton branch
     vars:
-      os_branch: 'stable/newton'
+      global_env:
+        OS_BRANCH: stable/newton
 
 - job:
     name: gophercloud-acceptance-test-mitaka
@@ -50,7 +55,8 @@
     description: |
       Run gophercloud acceptance test on mitaka branch
     vars:
-      os_branch: 'stable/mitaka'
+      global_env:
+        OS_BRANCH: stable/mitaka
     nodeset: ubuntu-trusty
 
 - project:

--- a/.zuul/playbooks/gophercloud-acceptance-test/run.yaml
+++ b/.zuul/playbooks/gophercloud-acceptance-test/run.yaml
@@ -1,6 +1,7 @@
 - hosts: all
   become: yes
   roles:
+    - config-golang
     - clone-devstack-gate-to-workspace
     - role: create-devstack-local-conf
       enable_services:
@@ -15,9 +16,10 @@
           set -e
           set -o pipefail
           set -x
-          
+          echo $(export |grep OS_BRANCH)
+
           go get ./... || true
           ./script/acceptancetest -v 2>&1 | tee $TEST_RESULTS_TXT
         executable: /bin/bash
         chdir: '{{ zuul.project.src_dir }}'
-      environment: '{{ golang_env }}'
+      environment: '{{ global_env }}'

--- a/.zuul/playbooks/gophercloud-unittest/run.yaml
+++ b/.zuul/playbooks/gophercloud-unittest/run.yaml
@@ -1,4 +1,5 @@
 - hosts: all
+  become: yes
   roles:
     - config-golang
   tasks:

--- a/.zuul/playbooks/gophercloud-unittest/run.yaml
+++ b/.zuul/playbooks/gophercloud-unittest/run.yaml
@@ -1,4 +1,6 @@
 - hosts: all
+  roles:
+    - config-golang
   tasks:
     - name: Run unit tests with gophercloud
       shell:
@@ -10,4 +12,4 @@
           ./script/unittest -v 2>&1 | tee $TEST_RESULTS_TXT
         executable: /bin/bash
         chdir: '{{ zuul.project.src_dir }}'
-      environment: '{{ golang_env }}'
+      environment: '{{ global_env }}'


### PR DESCRIPTION
This change expose the OS_BRANCH environment variable for running acceptance tests, that allow specific tests can be skipped according to specific OpenStack branch. The `openlab-zuul-jobs` have made some refactors in https://github.com/theopenlab/openlab-zuul-jobs/pull/237, this PR is based on that change.

For https://github.com/gophercloud/gophercloud/pull/1013#issuecomment-395633308
