### PR TITLE
Fix the issue of unmarshal string into Go struct field MaxOverSubscriptionRatio 

### DIFF
--- a/openstack/blockstorage/extensions/schedulerstats/results.go
+++ b/openstack/blockstorage/extensions/schedulerstats/results.go
@@ -23,7 +23,7 @@ type Capabilities struct {
 	LocationInfo             string  `json:"location_info"`
 	QoSSupport               bool    `json:"QoS_support"`
 	ProvisionedCapacityGB    float64 `json:"provisioned_capacity_gb"`
-	MaxOverSubscriptionRatio float64 `json:"max_over_subscription_ratio"`
+	MaxOverSubscriptionRatio string  `json:"max_over_subscription_ratio"`
 	ThinProvisioningSupport  bool    `json:"thin_provisioning_support"`
 	ThickProvisioningSupport bool    `json:"thick_provisioning_support"`
 	TotalVolumes             int64   `json:"total_volumes"`


### PR DESCRIPTION

The MaxOverSubscriptionRatio type should be string because max_over_subscription_ratio returned by cinder is a string, not float.

Fix:  #1046 