### PR TITLE
Senlin: ProfileTypes Get/List

### DIFF
--- a/acceptance/openstack/clustering/v1/profiletypes_test.go
+++ b/acceptance/openstack/clustering/v1/profiletypes_test.go
@@ -1,0 +1,29 @@
+// +build acceptance clustering profiletypes
+
+package v1
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/acceptance/clients"
+	"github.com/gophercloud/gophercloud/acceptance/tools"
+	"github.com/gophercloud/gophercloud/openstack/clustering/v1/profiletypes"
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestProfileTypesList(t *testing.T) {
+	client, err := clients.NewClusteringV1Client()
+	th.AssertNoErr(t, err)
+
+	client.Microversion = "1.5"
+
+	allPages, err := profiletypes.List(client).AllPages()
+	th.AssertNoErr(t, err)
+
+	allProfileTypes, err := profiletypes.ExtractProfileTypes(allPages)
+	th.AssertNoErr(t, err)
+
+	for _, profileType := range allProfileTypes {
+		tools.PrintResource(t, profileType)
+	}
+}

--- a/openstack/clustering/v1/profiletypes/doc.go
+++ b/openstack/clustering/v1/profiletypes/doc.go
@@ -1,0 +1,29 @@
+/*
+Package profiletypes lists all profile types and shows details for a profile type from the OpenStack
+Clustering Service.
+
+Example to List ProfileType
+
+	err = profiletypes.List(serviceClient).EachPage(func(page pagination.Page) (bool, error) {
+		profileTypes, err := profiletypes.ExtractProfileTypes(page)
+		if err != nil {
+			return false, err
+		}
+
+		for _, profileType := range profileTypes {
+			fmt.Println("%+v\n", profileType)
+		}
+		return true, nil
+	})
+
+Example to Get a ProfileType
+
+	profileTypeName := "os.nova.server"
+	profileType, err := profiletypes.Get(clusteringClient, profileTypeName).Extract()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("%+v\n", profileType)
+
+*/
+package profiletypes

--- a/openstack/clustering/v1/profiletypes/requests.go
+++ b/openstack/clustering/v1/profiletypes/requests.go
@@ -1,0 +1,21 @@
+package profiletypes
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {
+	_, r.Err = client.Get(getURL(client, id), &r.Body,
+		&gophercloud.RequestOpts{OkCodes: []int{200}})
+
+	return
+}
+
+// List makes a request against the API to list profile types.
+func List(client *gophercloud.ServiceClient) pagination.Pager {
+	url := listURL(client)
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return ProfileTypePage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}

--- a/openstack/clustering/v1/profiletypes/results.go
+++ b/openstack/clustering/v1/profiletypes/results.go
@@ -15,10 +15,13 @@ type GetResult struct {
 	commonResult
 }
 
+type Schema map[string]interface{}
+type SupportStatus map[string]interface{}
+
 type ProfileType struct {
-	Name          string                 `json:"name"`
-	Schema        map[string]interface{} `json:"schema"`
-	SupportStatus map[string]interface{} `json:"support_status"`
+	Name          string                     `json:"name"`
+	Schema        map[string]Schema          `json:"schema"`
+	SupportStatus map[string][]SupportStatus `json:"support_status"`
 }
 
 func (r commonResult) Extract() (*ProfileType, error) {

--- a/openstack/clustering/v1/profiletypes/results.go
+++ b/openstack/clustering/v1/profiletypes/results.go
@@ -1,0 +1,50 @@
+package profiletypes
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// commonResult is the response of a base result.
+type commonResult struct {
+	gophercloud.Result
+}
+
+// GetResult is the response of a Get operations.
+type GetResult struct {
+	commonResult
+}
+
+type ProfileType struct {
+	Name          string                 `json:"name"`
+	Schema        map[string]interface{} `json:"schema"`
+	SupportStatus map[string]interface{} `json:"support_status"`
+}
+
+func (r commonResult) Extract() (*ProfileType, error) {
+	var s struct {
+		ProfileType *ProfileType `json:"profile_type"`
+	}
+	err := r.ExtractInto(&s)
+	return s.ProfileType, err
+}
+
+// ExtractProfileTypes provides access to the list of profiles in a page acquired from the List operation.
+func ExtractProfileTypes(r pagination.Page) ([]ProfileType, error) {
+	var s struct {
+		ProfileTypes []ProfileType `json:"profile_types"`
+	}
+	err := (r.(ProfileTypePage)).ExtractInto(&s)
+	return s.ProfileTypes, err
+}
+
+// ProfileTypePage contains a single page of all profiles from a ListDetails call.
+type ProfileTypePage struct {
+	pagination.LinkedPageBase
+}
+
+// IsEmpty determines if ExtractProfileTypes contains any results.
+func (page ProfileTypePage) IsEmpty() (bool, error) {
+	profileTypes, err := ExtractProfileTypes(page)
+	return len(profileTypes) == 0, err
+}

--- a/openstack/clustering/v1/profiletypes/testing/doc.go
+++ b/openstack/clustering/v1/profiletypes/testing/doc.go
@@ -1,0 +1,2 @@
+// clustering_profiletypes_v1
+package testing

--- a/openstack/clustering/v1/profiletypes/testing/fixtures.go
+++ b/openstack/clustering/v1/profiletypes/testing/fixtures.go
@@ -146,14 +146,14 @@ const GetResponse15 = `
 
 var ExpectedProfileType1 = profiletypes.ProfileType{
 	Name: "os.nova.server-1.0",
-	Schema: map[string]interface{}{
-		"context": map[string]interface{}{
+	Schema: map[string]profiletypes.Schema{
+		"context": {
 			"description": "Customized security context for operating containers.",
 			"required":    false,
 			"type":        "Map",
 			"updatable":   false,
 		},
-		"name": map[string]interface{}{
+		"name": {
 			"description": "The name of the container.",
 			"required":    false,
 			"type":        "Map",
@@ -164,29 +164,29 @@ var ExpectedProfileType1 = profiletypes.ProfileType{
 
 var ExpectedProfileType15 = profiletypes.ProfileType{
 	Name: "os.heat.stack-1.0",
-	Schema: map[string]interface{}{
-		"context": map[string]interface{}{
+	Schema: map[string]profiletypes.Schema{
+		"context": {
 			"default":     map[string]interface{}{},
 			"description": "A dictionary for specifying the customized context for stack operations",
 			"required":    false,
 			"type":        "Map",
 			"updatable":   false,
 		},
-		"disable_rollback": map[string]interface{}{
+		"disable_rollback": {
 			"default":     true,
 			"description": "A boolean specifying whether a stack operation can be rolled back.",
 			"required":    false,
 			"type":        "Boolean",
 			"updatable":   true,
 		},
-		"environment": map[string]interface{}{
+		"environment": {
 			"default":     map[string]interface{}{},
 			"description": "A map that specifies the environment used for stack operations.",
 			"required":    false,
 			"type":        "Map",
 			"updatable":   true,
 		},
-		"files": map[string]interface{}{
+		"files": {
 			"default":     map[string]interface{}{},
 			"description": "Contents of files referenced by the template, if any.",
 			"required":    false,
@@ -194,8 +194,8 @@ var ExpectedProfileType15 = profiletypes.ProfileType{
 			"updatable":   true,
 		},
 	},
-	SupportStatus: map[string]interface{}{
-		"1.0": []map[string]interface{}{
+	SupportStatus: map[string][]profiletypes.SupportStatus{
+		"1.0": {
 			{
 				"status": "SUPPORTED",
 				"since":  "2016.04",

--- a/openstack/clustering/v1/profiletypes/testing/fixtures.go
+++ b/openstack/clustering/v1/profiletypes/testing/fixtures.go
@@ -1,0 +1,244 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/clustering/v1/profiletypes"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	fake "github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+const ProfileTypeRequestID = "req-7328d1b0-9945-456f-b2cd-5166b77d14a8"
+const ListResponse = `
+{
+	"profile_types": [
+		{
+			"name": "os.nova.server-1.0",
+			"schema": {
+				"context": {
+					"description": "Customized security context for operating containers.",
+					"required": false,
+					"type": "Map",
+					"updatable": false
+				},
+				"name": {
+					"description": "The name of the container.",
+					"required": false,
+					"type": "Map",
+					"updatable": false
+				}
+			}
+		},
+		{
+			"name": "os.heat.stack-1.0",
+			"schema": {
+				"context": {
+					"default": {},
+					"description": "A dictionary for specifying the customized context for stack operations",
+					"required": false,
+					"type": "Map",
+					"updatable": false
+				},
+				"disable_rollback": {
+					"default": true,
+					"description": "A boolean specifying whether a stack operation can be rolled back.",
+					"required": false,
+					"type": "Boolean",
+					"updatable": true
+				},
+				"environment": {
+					"default": {},
+					"description": "A map that specifies the environment used for stack operations.",
+					"required": false,
+					"type": "Map",
+					"updatable": true
+				},
+				"files": {
+					"default": {},
+					"description": "Contents of files referenced by the template, if any.",
+					"required": false,
+					"type": "Map",
+					"updatable": true
+				}
+			},
+			"support_status": {
+				"1.0": [
+					{
+						"status": "SUPPORTED",
+						 "since": "2016.04"
+					}
+				]
+			}
+		}
+	]
+}
+`
+
+const GetResponse1 = `
+{
+	"profile_type": {
+		"name": "os.nova.server-1.0",
+		"schema": {
+			"context": {
+				"description": "Customized security context for operating containers.",
+				"required": false,
+				"type": "Map",
+				"updatable": false
+			},
+			"name": {
+				"description": "The name of the container.",
+				"required": false,
+				"type": "Map",
+				"updatable": false
+			}
+		}
+	}
+}
+`
+
+const GetResponse15 = `
+{
+	"profile_type": {
+		"name": "os.heat.stack-1.0",
+		"schema": {
+			"context": {
+				"default": {},
+				"description": "A dictionary for specifying the customized context for stack operations",
+				"required": false,
+				"type": "Map",
+				"updatable": false
+			},
+			"disable_rollback": {
+				"default": true,
+				"description": "A boolean specifying whether a stack operation can be rolled back.",
+				"required": false,
+				"type": "Boolean",
+				"updatable": true
+			},
+			"environment": {
+				"default": {},
+				"description": "A map that specifies the environment used for stack operations.",
+				"required": false,
+				"type": "Map",
+				"updatable": true
+			},
+			"files": {
+				"default": {},
+				"description": "Contents of files referenced by the template, if any.",
+				"required": false,
+				"type": "Map",
+				"updatable": true
+			}
+		},
+		"support_status": {
+			"1.0": [
+				{
+					"status": "SUPPORTED",
+					"since": "2016.04"
+				}
+			]
+		}
+	}
+}
+`
+
+var ExpectedProfileType1 = profiletypes.ProfileType{
+	Name: "os.nova.server-1.0",
+	Schema: map[string]interface{}{
+		"context": map[string]interface{}{
+			"description": "Customized security context for operating containers.",
+			"required":    false,
+			"type":        "Map",
+			"updatable":   false,
+		},
+		"name": map[string]interface{}{
+			"description": "The name of the container.",
+			"required":    false,
+			"type":        "Map",
+			"updatable":   false,
+		},
+	},
+}
+
+var ExpectedProfileType15 = profiletypes.ProfileType{
+	Name: "os.heat.stack-1.0",
+	Schema: map[string]interface{}{
+		"context": map[string]interface{}{
+			"default":     map[string]interface{}{},
+			"description": "A dictionary for specifying the customized context for stack operations",
+			"required":    false,
+			"type":        "Map",
+			"updatable":   false,
+		},
+		"disable_rollback": map[string]interface{}{
+			"default":     true,
+			"description": "A boolean specifying whether a stack operation can be rolled back.",
+			"required":    false,
+			"type":        "Boolean",
+			"updatable":   true,
+		},
+		"environment": map[string]interface{}{
+			"default":     map[string]interface{}{},
+			"description": "A map that specifies the environment used for stack operations.",
+			"required":    false,
+			"type":        "Map",
+			"updatable":   true,
+		},
+		"files": map[string]interface{}{
+			"default":     map[string]interface{}{},
+			"description": "Contents of files referenced by the template, if any.",
+			"required":    false,
+			"type":        "Map",
+			"updatable":   true,
+		},
+	},
+	SupportStatus: map[string]interface{}{
+		"1.0": []map[string]interface{}{
+			{
+				"status": "SUPPORTED",
+				"since":  "2016.04",
+			},
+		},
+	},
+}
+
+var ExpectedProfileTypes = []profiletypes.ProfileType{ExpectedProfileType1, ExpectedProfileType15}
+
+func HandleList1Successfully(t *testing.T) {
+	th.Mux.HandleFunc("/v1/profile-types", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, ListResponse)
+	})
+}
+
+func HandleGet1Successfully(t *testing.T, id string) {
+	th.Mux.HandleFunc("/v1/profile-types/"+id, func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.Header().Add("X-OpenStack-Request-ID", ProfileTypeRequestID)
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, GetResponse1)
+	})
+}
+
+func HandleGet15Successfully(t *testing.T, id string) {
+	th.Mux.HandleFunc("/v1/profile-types/"+id, func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.Header().Add("X-OpenStack-Request-ID", ProfileTypeRequestID)
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, GetResponse15)
+	})
+}

--- a/openstack/clustering/v1/profiletypes/testing/requests_test.go
+++ b/openstack/clustering/v1/profiletypes/testing/requests_test.go
@@ -1,0 +1,55 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/clustering/v1/profiletypes"
+	"github.com/gophercloud/gophercloud/pagination"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	fake "github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func TestListProfileTypes(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	HandleList1Successfully(t)
+
+	pageCount := 0
+	err := profiletypes.List(fake.ServiceClient()).EachPage(func(page pagination.Page) (bool, error) {
+		pageCount++
+		actual, err := profiletypes.ExtractProfileTypes(page)
+		th.AssertNoErr(t, err)
+
+		th.AssertDeepEquals(t, ExpectedProfileTypes, actual)
+
+		return true, nil
+	})
+	th.AssertNoErr(t, err)
+
+	if pageCount != 1 {
+		t.Errorf("Expected 1 page, got %d", pageCount)
+	}
+}
+
+func TestGetProfileType1(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	HandleGet1Successfully(t, ExpectedProfileType1.Name)
+
+	actual, err := profiletypes.Get(fake.ServiceClient(), ExpectedProfileType1.Name).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, ExpectedProfileType1, *actual)
+}
+
+func TestGetProfileType15(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	HandleGet15Successfully(t, ExpectedProfileType15.Name)
+
+	actual, err := profiletypes.Get(fake.ServiceClient(), ExpectedProfileType15.Name).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, ExpectedProfileType15, *actual)
+}

--- a/openstack/clustering/v1/profiletypes/testing/requests_test.go
+++ b/openstack/clustering/v1/profiletypes/testing/requests_test.go
@@ -32,7 +32,7 @@ func TestListProfileTypes(t *testing.T) {
 	}
 }
 
-func TestGetProfileType1(t *testing.T) {
+func TestGetProfileType10(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 

--- a/openstack/clustering/v1/profiletypes/urls.go
+++ b/openstack/clustering/v1/profiletypes/urls.go
@@ -1,0 +1,24 @@
+package profiletypes
+
+import "github.com/gophercloud/gophercloud"
+
+const (
+	apiVersion = "v1"
+	apiName    = "profile-types"
+)
+
+func commonURL(client *gophercloud.ServiceClient) string {
+	return client.ServiceURL(apiVersion, apiName)
+}
+
+func profileTypeURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL(apiVersion, apiName, id)
+}
+
+func getURL(client *gophercloud.ServiceClient, id string) string {
+	return profileTypeURL(client, id)
+}
+
+func listURL(client *gophercloud.ServiceClient) string {
+	return commonURL(client)
+}


### PR DESCRIPTION
Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

For #[823 [Add support for Senlin clustering]](https://github.com/gophercloud/gophercloud/issues/823)

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

[[profiletypes:get/list]](https://github.com/openstack/senlin/blob/e5bc16b3fea2f10dead365f983c5a937f23d72b0/senlin/api/openstack/v1/profile_types.py#L42)
