### PR TITLE
Senlin: ProfileTypes Ops

### DIFF
--- a/acceptance/openstack/clustering/v1/profiletypes_test.go
+++ b/acceptance/openstack/clustering/v1/profiletypes_test.go
@@ -27,3 +27,21 @@ func TestProfileTypesList(t *testing.T) {
 		tools.PrintResource(t, profileType)
 	}
 }
+func TestProfileTypesOpsList(t *testing.T) {
+	client, err := clients.NewClusteringV1Client()
+	th.AssertNoErr(t, err)
+
+	client.Microversion = "1.5"
+
+	profileTypeName := "os.nova.server-1.0"
+	allPages, err := profiletypes.ListOps(client, profileTypeName).AllPages()
+	th.AssertNoErr(t, err)
+
+	ops, err := profiletypes.ExtractOps(allPages)
+	th.AssertNoErr(t, err)
+
+	for k, v := range ops {
+		tools.PrintResource(t, k)
+		tools.PrintResource(t, v)
+	}
+}

--- a/openstack/clustering/v1/profiletypes/doc.go
+++ b/openstack/clustering/v1/profiletypes/doc.go
@@ -25,5 +25,23 @@ Example to Get a ProfileType
 	}
 	fmt.Printf("%+v\n", profileType)
 
+Example of list operations supported by a profile type
+	serviceClient.Microversion = "1.5"
+
+	profileTypeName := "os.nova.server-1.0"
+	allPages, err := profiletypes.ListOps(serviceClient, profileTypeName).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	ops, err := profiletypes.ExtractOps(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, op := range ops {
+		fmt.Printf("%+v\n", op)
+	}
+
 */
 package profiletypes

--- a/openstack/clustering/v1/profiletypes/requests.go
+++ b/openstack/clustering/v1/profiletypes/requests.go
@@ -19,3 +19,10 @@ func List(client *gophercloud.ServiceClient) pagination.Pager {
 		return ProfileTypePage{pagination.LinkedPageBase{PageResult: r}}
 	})
 }
+
+func ListOps(client *gophercloud.ServiceClient, id string) pagination.Pager {
+	url := listOpsURL(client, id)
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return OperationPage{pagination.SinglePageBase(r)}
+	})
+}

--- a/openstack/clustering/v1/profiletypes/results.go
+++ b/openstack/clustering/v1/profiletypes/results.go
@@ -51,3 +51,17 @@ func (page ProfileTypePage) IsEmpty() (bool, error) {
 	profileTypes, err := ExtractProfileTypes(page)
 	return len(profileTypes) == 0, err
 }
+
+// OperationPage contains a single page of all profile type operations from a ListOps call.
+type OperationPage struct {
+	pagination.SinglePageBase
+}
+
+// ExtractOps provides access to the list of operations in a page acquired from the ListOps operation.
+func ExtractOps(r pagination.Page) (map[string]interface{}, error) {
+	var s struct {
+		Operations map[string]interface{} `json:"operations"`
+	}
+	err := (r.(OperationPage)).ExtractInto(&s)
+	return s.Operations, err
+}

--- a/openstack/clustering/v1/profiletypes/testing/fixtures.go
+++ b/openstack/clustering/v1/profiletypes/testing/fixtures.go
@@ -242,3 +242,55 @@ func HandleGet15Successfully(t *testing.T, id string) {
 		fmt.Fprintf(w, GetResponse15)
 	})
 }
+
+const ProfileTypeName = "os.nova.server-1.0"
+
+const ListOpsResponse = `
+{
+	"operations": {
+		"pause": {
+			"description": "Pause the server from running.",
+			"parameter": null
+		},
+		"change_password": {
+			"description": "Change the administrator password.",
+			"parameters": {
+				"admin_pass": {
+					"description": "New password for the administrator.",
+					"required":    false,
+					"type":        "String"
+				}
+			}
+		}
+	}
+}
+`
+
+var ExpectedOps = map[string]interface{}{
+	"change_password": map[string]interface{}{
+		"description": "Change the administrator password.",
+		"parameters": map[string]interface{}{
+			"admin_pass": map[string]interface{}{
+				"description": "New password for the administrator.",
+				"required":    false,
+				"type":        "String",
+			},
+		},
+	},
+	"pause": map[string]interface{}{
+		"description": "Pause the server from running.",
+		"parameter":   nil,
+	},
+}
+
+func HandleListOpsSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/v1/profile-types/"+ProfileTypeName+"/ops", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.Header().Add("X-OpenStack-Request-ID", ProfileTypeRequestID)
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, ListOpsResponse)
+	})
+}

--- a/openstack/clustering/v1/profiletypes/testing/requests_test.go
+++ b/openstack/clustering/v1/profiletypes/testing/requests_test.go
@@ -3,6 +3,7 @@ package testing
 import (
 	"testing"
 
+	"github.com/gophercloud/gophercloud/acceptance/tools"
 	"github.com/gophercloud/gophercloud/openstack/clustering/v1/profiletypes"
 	"github.com/gophercloud/gophercloud/pagination"
 	th "github.com/gophercloud/gophercloud/testhelper"
@@ -52,4 +53,22 @@ func TestGetProfileType15(t *testing.T) {
 	actual, err := profiletypes.Get(fake.ServiceClient(), ExpectedProfileType15.Name).Extract()
 	th.AssertNoErr(t, err)
 	th.AssertDeepEquals(t, ExpectedProfileType15, *actual)
+}
+
+func TestListProfileTypesOps(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	HandleListOpsSuccessfully(t)
+
+	allPages, err := profiletypes.ListOps(fake.ServiceClient(), ProfileTypeName).AllPages()
+	th.AssertNoErr(t, err)
+
+	allPolicyTypes, err := profiletypes.ExtractOps(allPages)
+	th.AssertNoErr(t, err)
+
+	for k, v := range allPolicyTypes {
+		tools.PrintResource(t, k)
+		tools.PrintResource(t, v)
+	}
 }

--- a/openstack/clustering/v1/profiletypes/urls.go
+++ b/openstack/clustering/v1/profiletypes/urls.go
@@ -22,3 +22,7 @@ func getURL(client *gophercloud.ServiceClient, id string) string {
 func listURL(client *gophercloud.ServiceClient) string {
 	return commonURL(client)
 }
+
+func listOpsURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL(apiVersion, apiName, id, "ops")
+}


### PR DESCRIPTION
Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

For #[823 [Add support for Senlin clustering]](https://github.com/gophercloud/gophercloud/issues/823)

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

[[profiletypes:ops]](https://github.com/openstack/senlin/blob/e5bc16b3fea2f10dead365f983c5a937f23d72b0/senlin/api/openstack/v1/profile_types.py#L57)
