### PR TITLE
Magnum: Manage Cluster Templates Get

### DIFF
--- a/acceptance/openstack/containerinfra/v1/clustertemplates_test.go
+++ b/acceptance/openstack/containerinfra/v1/clustertemplates_test.go
@@ -36,6 +36,10 @@ func TestClusterTemplatesCRUD(t *testing.T) {
 
 	th.AssertEquals(t, found, true)
 
+	template, err := clustertemplates.Get(client, clusterTemplate.UUID).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, clusterTemplate.UUID, template.UUID)
+
 	/*
 		// Test cluster update
 		updateOpts := []clustertemplates.UpdateOptsBuilder{

--- a/openstack/containerinfra/v1/clustertemplates/requests.go
+++ b/openstack/containerinfra/v1/clustertemplates/requests.go
@@ -113,3 +113,13 @@ func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pa
 		return ClusterTemplatePage{pagination.LinkedPageBase{PageResult: r}}
 	})
 }
+
+// Get retrieves a specific cluster-template based on its unique ID.
+func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {
+	var result *http.Response
+	result, r.Err = client.Get(getURL(client, id), &r.Body, &gophercloud.RequestOpts{OkCodes: []int{200}})
+	if r.Err == nil {
+		r.Header = result.Header
+	}
+	return
+}

--- a/openstack/containerinfra/v1/clustertemplates/results.go
+++ b/openstack/containerinfra/v1/clustertemplates/results.go
@@ -22,6 +22,11 @@ type DeleteResult struct {
 	gophercloud.ErrResult
 }
 
+// GetResult is the response of a Get operations.
+type GetResult struct {
+	commonResult
+}
+
 // Extract is a function that accepts a result and extracts a cluster-template resource.
 func (r commonResult) Extract() (*ClusterTemplate, error) {
 	var s *ClusterTemplate

--- a/openstack/containerinfra/v1/clustertemplates/testing/fixtures.go
+++ b/openstack/containerinfra/v1/clustertemplates/testing/fixtures.go
@@ -58,6 +58,49 @@ const ClusterTemplateResponse = `
 	"volume_driver": "cinder"
 }`
 
+const ClusterTemplateResponse_EmptyTime = `
+{
+	"apiserver_port": null,
+	"cluster_distro": "fedora-atomic",
+	"coe": "kubernetes",
+	"created_at": null,
+	"dns_nameserver": "8.8.8.8",
+	"docker_storage_driver": null,
+	"docker_volume_size": 5,
+	"external_network_id": "public",
+	"fixed_network": null,
+	"fixed_subnet": null,
+	"flavor_id": "m1.small",
+	"http_proxy": null,
+	"https_proxy": null,
+	"image_id": "fedora-atomic-latest",
+	"insecure_registry": null,
+	"keypair_id": "testkey",
+	"labels": {},
+	"links": [
+		{
+		  "href": "http://65.61.151.130:9511/clustertemplates/472807c2-f175-4946-9765-149701a5aba7",
+		  "rel": "bookmark"
+		},
+		{
+		  "href": "http://65.61.151.130:9511/v1/clustertemplates/472807c2-f175-4946-9765-149701a5aba7",
+		  "rel": "self"
+		}
+	],
+	"master_flavor_id": null,
+	"master_lb_enabled": false,
+	"name": "kubernetes-dev",
+	"network_driver": "flannel",
+	"no_proxy": null,
+	"public": false,
+	"registry_enabled": false,
+	"server_type": "vm",
+	"tls_disabled": false,
+	"updated_at": null,
+	"uuid": "472807c2-f175-4946-9765-149701a5aba7",
+	"volume_driver": null
+}`
+
 const ClusterTemplateListResponse = `
 {
 	"clustertemplates": [
@@ -265,5 +308,29 @@ func HandleListClusterTemplateSuccessfully(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 
 		fmt.Fprint(w, ClusterTemplateListResponse)
+	})
+}
+
+func HandleGetClusterTemplateSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/v1/clustertemplates/7d85f602-a948-4a30-afd4-e84f47471c15", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprint(w, ClusterTemplateResponse)
+	})
+}
+
+func HandleGetClusterTemplateEmptyTimeSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/v1/clustertemplates/7d85f602-a948-4a30-afd4-e84f47471c15", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprint(w, ClusterTemplateResponse_EmptyTime)
 	})
 }

--- a/openstack/containerinfra/v1/clustertemplates/testing/requests_test.go
+++ b/openstack/containerinfra/v1/clustertemplates/testing/requests_test.go
@@ -99,3 +99,31 @@ func TestListClusterTemplates(t *testing.T) {
 		t.Errorf("Expected 1 page, got %d", count)
 	}
 }
+
+func TestGetClusterTemplate(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	HandleGetClusterTemplateSuccessfully(t)
+
+	sc := fake.ServiceClient()
+	sc.Endpoint = sc.Endpoint + "v1/"
+	actual, err := clustertemplates.Get(sc, "7d85f602-a948-4a30-afd4-e84f47471c15").Extract()
+	th.AssertNoErr(t, err)
+	actual.CreatedAt = actual.CreatedAt.UTC()
+	th.AssertDeepEquals(t, ExpectedClusterTemplate, *actual)
+}
+
+func TestGetClusterTemplateEmptyTime(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	HandleGetClusterTemplateEmptyTimeSuccessfully(t)
+
+	sc := fake.ServiceClient()
+	sc.Endpoint = sc.Endpoint + "v1/"
+	actual, err := clustertemplates.Get(sc, "7d85f602-a948-4a30-afd4-e84f47471c15").Extract()
+	th.AssertNoErr(t, err)
+	actual.CreatedAt = actual.CreatedAt.UTC()
+	th.AssertDeepEquals(t, ExpectedClusterTemplate_EmptyTime, *actual)
+}

--- a/openstack/containerinfra/v1/clustertemplates/urls.go
+++ b/openstack/containerinfra/v1/clustertemplates/urls.go
@@ -25,3 +25,7 @@ func deleteURL(client *gophercloud.ServiceClient, id string) string {
 func listURL(client *gophercloud.ServiceClient) string {
 	return commonURL(client)
 }
+
+func getURL(client *gophercloud.ServiceClient, id string) string {
+	return idURL(client, id)
+}


### PR DESCRIPTION
Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

For #[1062 [Migrate Magnum Branch Onto Master]](https://github.com/gophercloud/gophercloud/issues/1062)

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

[[clustertemplates:get]](https://github.com/openstack/magnum/blob/master/magnum/api/controllers/v1/cluster_template.py#L336)
