### PR TITLE
Fix concurrency issue during reauthenticate

### DIFF
--- a/provider_client.go
+++ b/provider_client.go
@@ -71,7 +71,6 @@ type ProviderClient struct {
 	// authentication functions for different Identity service versions.
 	ReauthFunc func() error
 
-
 	mut *reauthlock
 }
 


### PR DESCRIPTION
For #1074 
if reuse serviceClient in multiple thread, and one thread works in AuthenticatedHeaders method (provider_client.go) method, and another works in Reauthenticate method (provider_client.go), the AuthenticatedHeaders will return an empty tokenId, the 'token is null' error will occur in this thread.

# UT Code
I wrote a unit test case, but it  cann't reproduce at each time since it is a random issue, so I did not commit it. Anyway, you may need it:


```
 func TestConcurrentUserClient(t *testing.T) {
	th.SetupHTTP()
	defer th.TeardownHTTP()
	th.Mux.HandleFunc("/v3/auth/tokens", func(w http.ResponseWriter, r *http.Request) {
		w.Header().Add("Content-Type", "application/json")
		w.Header().Add("X-Subject-Token", "token123")

		respBody := `{"token":{"expires_at":"2018-06-28T03:36:52.568000Z","methods":["password"],"catalog":[{"endpoints":[{"region_id":"*","id":"d42888169608440ea3c14c3b411a3ce1","region":"*","interface":"public","url":"${domain}s"}],"name":"","id":"17e8ce5e88d2427e96d566baeeb8ccc0","type":"dns"}],"roles":[],"project":{"domain":{"name":"ad","id":"0984aafba48049a6b9457b89968eeabf"},"name":"cn-north-1","id":"57e98940a77f4bb988a21a7d0603a626"},"issued_at":"2018-06-27T03:36:52.568000Z","user":{"domain":{"name":"ad","id":"0984aafba48049a6b9457b89968eeabf"},"name":"nxu","id":"78fbe23dc0e84151a048c136fc928186"}}}`

		respBody = strings.Replace(respBody,"${domain}s",th.Endpoint(),1)
		w.WriteHeader(http.StatusCreated)
		fmt.Fprintf(w,respBody)
	})

	th.Mux.HandleFunc("/v2/zones", func(w http.ResponseWriter, r *http.Request) {
		randNum := rand.Int31n(10)

		if randNum < 5{
			t.Logf("Unauthorized \n")
			w.WriteHeader(http.StatusUnauthorized)
			return
		}

		if r.Header.Get("X-Auth-Token") == "" {
			w.WriteHeader(http.StatusExpectationFailed) //417
			return
		}

		w.Header().Add("Content-Type", "application/json")
		fmt.Fprintf(w, `{"zones":[{"id":"ff8080826267d7d90162a9d3c14d4416","name":"www.ba1.com.","description":"test1","email":"atest@hw.com","ttl":300,"serial":1,"masters":[],"status":"ACTIVE","pool_id":"ff8080825ce479fe015ceca527b90001","project_id":"57e98940a77f4bb988a21a7d0603a626","zone_type":"public","created_at":"2018-04-09T09:54:09.860","updated_at":"2018-04-09T09:54:09.889","record_num":4,"links":{"self":"https://dns.myhwclouds.com/v2/zones/ff8080826267d7d90162a9d3c14d4416"}}],"links":{"self":"https://dns.myhwclouds.com/v2/zones"},"metadata":{"total_count":1}}`)
	})

	opts := gophercloud.AuthOptions{
		IdentityEndpoint: th.Endpoint() + "v3/",
		Username:         "xdw",
		Password:         "pwd",
		DomainName:       "zd",
		TenantID:         "17ea8940a77g4gb988a21a7d0603a621",
		AllowReauth:      true,
	}

	provierClient, _ := openstack.AuthenticatedClient(opts)
	numconc := 100

	wg := new(sync.WaitGroup)
	for i := 0; i < numconc; i++ {
		wg.Add(1)
		go func(idx int) {
			defer wg.Done()
			concurrencyReAuthTest(provierClient,th.Endpoint(),t,idx)
		}(i)
	}

	wg.Wait()
}

func concurrencyReAuthTest(provider *gophercloud.ProviderClient,fakeServerDomain string,t *testing.T,count int) {
	client, _ := openstack.NewDNSV2(provider, gophercloud.EndpointOpts{})

	err := zones.List(client, zones.ListOpts{}).EachPage(func(page pagination.Page) (bool, error) {
		t.Logf("Done at %d, %s \n",count,time.Now().Format("2006010215:04:05"))
		return true, nil
	})

	if err != nil {
		t.Errorf("Error at %d：  %s \n", count,err)
	}
}
```