### PR TITLE
Add ProvisioningStatus fields to /v2/loadbalancer

### DIFF
--- a/openstack/loadbalancer/v2/listeners/results.go
+++ b/openstack/loadbalancer/v2/listeners/results.go
@@ -55,7 +55,7 @@ type Listener struct {
 	// Pools are the pools which are part of this listener.
 	Pools []pools.Pool `json:"pools"`
 
-	// The provisioning status of the Listener. Showing the listener detail API does not use this value.
+	// The provisioning status of the Listener.
 	// This value is ACTIVE, PENDING_* or ERROR.
 	ProvisioningStatus string `json:"provisioning_status"`
 }

--- a/openstack/loadbalancer/v2/listeners/results.go
+++ b/openstack/loadbalancer/v2/listeners/results.go
@@ -54,6 +54,10 @@ type Listener struct {
 
 	// Pools are the pools which are part of this listener.
 	Pools []pools.Pool `json:"pools"`
+
+	// The provisioning status of the Listener. Showing the listener detail API does not use this value.
+	// This value is ACTIVE, PENDING_* or ERROR.
+	ProvisioningStatus string `json:"provisioning_status"`
 }
 
 // ListenerPage is the page returned by a pager when traversing over a

--- a/openstack/loadbalancer/v2/loadbalancers/testing/fixtures.go
+++ b/openstack/loadbalancer/v2/loadbalancers/testing/fixtures.go
@@ -102,18 +102,22 @@ const LoadbalancerStatuesesTree = `
 			"listeners": [{
 				"id": "db902c0c-d5ff-4753-b465-668ad9656918",
 				"name": "db",
+				"provisioning_status": "ACTIVE",
 				"pools": [{
 					"id": "fad389a3-9a4a-4762-a365-8c7038508b5d",
 					"name": "db",
+					"provisioning_status": "ACTIVE",
 					"healthmonitor": {
 						"id": "67306cda-815d-4354-9fe4-59e09da9c3c5",
-						"type":"PING"
+						"type":"PING",
+						"provisioning_status": "ACTIVE"
 					},
 					"members":[{
 						"id": "2a280670-c202-4b0b-a562-34077415aabf",
 						"name": "db",
 						"address": "10.0.2.11",
-						"protocol_port": 80
+						"protocol_port": 80,
+						"provisioning_status": "ACTIVE"
 					}]
 				}]
 			}]
@@ -171,20 +175,24 @@ var (
 		ProvisioningStatus: "PENDING_UPDATE",
 		OperatingStatus:    "ACTIVE",
 		Listeners: []listeners.Listener{{
-			ID:   "db902c0c-d5ff-4753-b465-668ad9656918",
-			Name: "db",
+			ID:                 "db902c0c-d5ff-4753-b465-668ad9656918",
+			Name:               "db",
+			ProvisioningStatus: "ACTIVE",
 			Pools: []pools.Pool{{
-				ID:   "fad389a3-9a4a-4762-a365-8c7038508b5d",
-				Name: "db",
+				ID:                 "fad389a3-9a4a-4762-a365-8c7038508b5d",
+				Name:               "db",
+				ProvisioningStatus: "ACTIVE",
 				Monitor: monitors.Monitor{
-					ID:   "67306cda-815d-4354-9fe4-59e09da9c3c5",
-					Type: "PING",
+					ID:                 "67306cda-815d-4354-9fe4-59e09da9c3c5",
+					Type:               "PING",
+					ProvisioningStatus: "ACTIVE",
 				},
 				Members: []pools.Member{{
-					ID:           "2a280670-c202-4b0b-a562-34077415aabf",
-					Name:         "db",
-					Address:      "10.0.2.11",
-					ProtocolPort: 80,
+					ID:                 "2a280670-c202-4b0b-a562-34077415aabf",
+					Name:               "db",
+					Address:            "10.0.2.11",
+					ProtocolPort:       80,
+					ProvisioningStatus: "ACTIVE",
 				}},
 			}},
 		}},

--- a/openstack/loadbalancer/v2/monitors/results.go
+++ b/openstack/loadbalancer/v2/monitors/results.go
@@ -71,7 +71,7 @@ type Monitor struct {
 	// List of pools that are associated with the health monitor.
 	Pools []PoolID `json:"pools"`
 
-	// The provisioning status of the Monitor. Showing the monitor detail API does not use this value.
+	// The provisioning status of the Monitor.
 	// This value is ACTIVE, PENDING_* or ERROR.
 	ProvisioningStatus string `json:"provisioning_status"`
 }

--- a/openstack/loadbalancer/v2/monitors/results.go
+++ b/openstack/loadbalancer/v2/monitors/results.go
@@ -70,6 +70,10 @@ type Monitor struct {
 
 	// List of pools that are associated with the health monitor.
 	Pools []PoolID `json:"pools"`
+
+	// The provisioning status of the Monitor. Showing the monitor detail API does not use this value.
+	// This value is ACTIVE, PENDING_* or ERROR.
+	ProvisioningStatus string `json:"provisioning_status"`
 }
 
 // MonitorPage is the page returned by a pager when traversing over a

--- a/openstack/loadbalancer/v2/pools/results.go
+++ b/openstack/loadbalancer/v2/pools/results.go
@@ -93,7 +93,7 @@ type Pool struct {
 	// The Monitor associated with this Pool.
 	Monitor monitors.Monitor `json:"healthmonitor"`
 
-	// The provisioning status of the pool. Showing the pool detail API does not use this value.
+	// The provisioning status of the pool.
 	// This value is ACTIVE, PENDING_* or ERROR.
 	ProvisioningStatus string `json:"provisioning_status"`
 }
@@ -201,7 +201,7 @@ type Member struct {
 	// The unique ID for the Member.
 	ID string `json:"id"`
 
-	// The provisioning status of the pool. Showing the pool detail API does not use this value.
+	// The provisioning status of the pool.
 	// This value is ACTIVE, PENDING_* or ERROR.
 	ProvisioningStatus string `json:"provisioning_status"`
 }

--- a/openstack/loadbalancer/v2/pools/results.go
+++ b/openstack/loadbalancer/v2/pools/results.go
@@ -92,6 +92,10 @@ type Pool struct {
 
 	// The Monitor associated with this Pool.
 	Monitor monitors.Monitor `json:"healthmonitor"`
+
+	// The provisioning status of the pool. Showing the pool detail API does not use this value.
+	// This value is ACTIVE, PENDING_* or ERROR.
+	ProvisioningStatus string `json:"provisioning_status"`
 }
 
 // PoolPage is the page returned by a pager when traversing over a
@@ -196,6 +200,10 @@ type Member struct {
 
 	// The unique ID for the Member.
 	ID string `json:"id"`
+
+	// The provisioning status of the pool. Showing the pool detail API does not use this value.
+	// This value is ACTIVE, PENDING_* or ERROR.
+	ProvisioningStatus string `json:"provisioning_status"`
 }
 
 // MemberPage is the page returned by a pager when traversing over a


### PR DESCRIPTION
Add missing ProvisioningStatus fields to each model in /v2/loadbalancer

For #1066 

## models
* listener https://github.com/openstack/neutron-lbaas/blob/stable/ocata/neutron_lbaas/services/loadbalancer/data_models.py#L676
* member https://github.com/openstack/neutron-lbaas/blob/stable/ocata/neutron_lbaas/services/loadbalancer/data_models.py#L497
* pool https://github.com/openstack/neutron-lbaas/blob/stable/ocata/neutron_lbaas/services/loadbalancer/data_models.py#L412
* health monitor https://github.com/openstack/neutron-lbaas/blob/stable/ocata/neutron_lbaas/services/loadbalancer/data_models.py#L354