### PR TITLE
Add revoke access to Manila

### DIFF
--- a/acceptance/openstack/sharedfilesystems/v2/shares.go
+++ b/acceptance/openstack/sharedfilesystems/v2/shares.go
@@ -53,6 +53,14 @@ func GrantAccess(t *testing.T, client *gophercloud.ServiceClient, share *shares.
 	}).Extract()
 }
 
+// RevokeAccess will revoke an exisiting access of a share. A fatal error will occur
+// if this operation fails.
+func RevokeAccess(t *testing.T, client *gophercloud.ServiceClient, share *shares.Share, accessRight *shares.AccessRight) error {
+	return shares.RevokeAccess(client, share.ID, shares.RevokeAccessOpts{
+		AccessID: accessRight.ID,
+	}).ExtractErr()
+}
+
 // GetAccessRightsSlice will retrieve all access rules assigned to a share.
 // A fatal error will occur if this operation fails.
 func GetAccessRightsSlice(t *testing.T, client *gophercloud.ServiceClient, share *shares.Share) ([]shares.AccessRight, error) {

--- a/acceptance/openstack/sharedfilesystems/v2/shares_test.go
+++ b/acceptance/openstack/sharedfilesystems/v2/shares_test.go
@@ -27,6 +27,31 @@ func TestShareCreate(t *testing.T) {
 	PrintShare(t, created)
 }
 
+func TestGrantAndRevokeAccess(t *testing.T) {
+	client, err := clients.NewSharedFileSystemV2Client()
+	if err != nil {
+		t.Fatalf("Unable to create a sharedfs client: %v", err)
+	}
+
+	share, err := CreateShare(t, client)
+	if err != nil {
+		t.Fatalf("Unable to create a share: %v", err)
+	}
+
+	defer DeleteShare(t, client, share)
+
+	accessRight, err := GrantAccess(t, client, share)
+	if err != nil {
+		t.Fatalf("Unable to grant access: %v", err)
+	}
+
+	PrintAccessRight(t, accessRight)
+
+	if err = RevokeAccess(t, client, share, accessRight); err != nil {
+		t.Fatalf("Unable to revoke access: %v", err)
+	}
+}
+
 func TestListAccessRights(t *testing.T) {
 	client, err := clients.NewSharedFileSystemV2Client()
 	if err != nil {

--- a/openstack/sharedfilesystems/v2/shares/requests.go
+++ b/openstack/sharedfilesystems/v2/shares/requests.go
@@ -124,6 +124,43 @@ func GrantAccess(client *gophercloud.ServiceClient, id string, opts GrantAccessO
 	return
 }
 
+// RevokeAccessOptsBuilder allows extensions to add additional parameters to the
+// RevokeAccess request.
+type RevokeAccessOptsBuilder interface {
+	ToRevokeAccessMap() (map[string]interface{}, error)
+}
+
+// RevokeAccessOpts contains the options for creation of a RevokeAccess request.
+// For more information about these parameters, please, refer to the shared file systems API v2,
+// Share Actions, Revoke Access documentation
+type RevokeAccessOpts struct {
+	AccessID string `json:"access_id"`
+}
+
+// ToRevokeAccessMap assembles a request body based on the contents of a
+// RevokeAccessOpts.
+func (opts RevokeAccessOpts) ToRevokeAccessMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "deny_access")
+}
+
+// RevokeAccess will revoke an existing access to a Share based on the values in RevokeAccessOpts.
+// RevokeAccessResult contains only the error. To extract it, call the ExtractErr method on
+// the RevokeAccessResult. Client must have Microversion set; minimum supported microversion
+// for RevokeAccess is 2.7.
+func RevokeAccess(client *gophercloud.ServiceClient, id string, opts RevokeAccessOptsBuilder) (r RevokeAccessResult) {
+	b, err := opts.ToRevokeAccessMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = client.Post(revokeAccessURL(client, id), b, nil, &gophercloud.RequestOpts{
+		OkCodes: []int{200, 202},
+	})
+
+	return
+}
+
 // ListAccessRights lists all access rules assigned to a Share based on its id. To extract
 // the AccessRight slice from the response, call the Extract method on the ListAccessRightsResult.
 // Client must have Microversion set; minimum supported microversion for ListAccessRights is 2.7.

--- a/openstack/sharedfilesystems/v2/shares/results.go
+++ b/openstack/sharedfilesystems/v2/shares/results.go
@@ -178,6 +178,11 @@ type GrantAccessResult struct {
 	gophercloud.Result
 }
 
+// RevokeAccessResult contains the response body and error from a Revoke access request.
+type RevokeAccessResult struct {
+	gophercloud.ErrResult
+}
+
 // Extract will get a slice of AccessRight objects from the commonResult
 func (r ListAccessRightsResult) Extract() ([]AccessRight, error) {
 	var s struct {

--- a/openstack/sharedfilesystems/v2/shares/testing/fixtures.go
+++ b/openstack/sharedfilesystems/v2/shares/testing/fixtures.go
@@ -198,6 +198,25 @@ func MockGrantAccessResponse(t *testing.T) {
 	})
 }
 
+var revokeAccessRequest = `{
+	"deny_access": {
+		"access_id": "a2f226a5-cee8-430b-8a03-78a59bd84ee8"
+	}
+}`
+
+func MockRevokeAccessResponse(t *testing.T) {
+	th.Mux.HandleFunc(shareEndpoint+"/"+shareID+"/action", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, revokeAccessRequest)
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, grantAccessResponse)
+	})
+}
+
 var listAccessRightsRequest = `{
 		"access_list": null
 	}`

--- a/openstack/sharedfilesystems/v2/shares/testing/fixtures.go
+++ b/openstack/sharedfilesystems/v2/shares/testing/fixtures.go
@@ -212,8 +212,7 @@ func MockRevokeAccessResponse(t *testing.T) {
 		th.TestHeader(t, r, "Accept", "application/json")
 		th.TestJSONRequest(t, r, revokeAccessRequest)
 		w.Header().Add("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, grantAccessResponse)
+		w.WriteHeader(http.StatusAccepted)
 	})
 }
 

--- a/openstack/sharedfilesystems/v2/shares/testing/request_test.go
+++ b/openstack/sharedfilesystems/v2/shares/testing/request_test.go
@@ -136,6 +136,22 @@ func TestGrantAcessSuccess(t *testing.T) {
 	})
 }
 
+func TestRevokeAccessSuccess(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockRevokeAccessResponse(t)
+
+	c := client.ServiceClient()
+	// Client c must have Microversion set; minimum supported microversion for Revoke Access is 2.7
+	c.Microversion = "2.7"
+
+	options := &shares.RevokeAccessOpts{AccessID: "a2f226a5-cee8-430b-8a03-78a59bd84ee8"}
+
+	err := shares.RevokeAccess(c, shareID, options).ExtractErr()
+	th.AssertNoErr(t, err)
+}
+
 func TestListAccessRightsSuccess(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()

--- a/openstack/sharedfilesystems/v2/shares/urls.go
+++ b/openstack/sharedfilesystems/v2/shares/urls.go
@@ -22,6 +22,10 @@ func grantAccessURL(c *gophercloud.ServiceClient, id string) string {
 	return c.ServiceURL("shares", id, "action")
 }
 
+func revokeAccessURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("shares", id, "action")
+}
+
 func listAccessRightsURL(c *gophercloud.ServiceClient, id string) string {
 	return c.ServiceURL("shares", id, "action")
 }


### PR DESCRIPTION
For #1076

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

- revoke access request https://github.com/openstack/manila/blob/master/api-ref/source/samples/share-actions-revoke-access-request.json
- removing an access rule from DB https://github.com/openstack/manila/blob/master/manila/share/access.py#L224