### PR TITLE
Changed from Cluster to ClusterID

### DIFF
--- a/openstack/clustering/v1/receivers/results.go
+++ b/openstack/clustering/v1/receivers/results.go
@@ -13,7 +13,7 @@ type Receiver struct {
 	Action    string                 `json:"action"`
 	Actor     map[string]interface{} `json:"actor"`
 	Channel   map[string]interface{} `json:"channel"`
-	Cluster   string                 `json:"cluster_id"`
+	ClusterID string                 `json:"cluster_id"`
 	CreatedAt time.Time              `json:"-"`
 	Domain    string                 `json:"domain"`
 	ID        string                 `json:"id"`

--- a/openstack/clustering/v1/receivers/testing/fixtures.go
+++ b/openstack/clustering/v1/receivers/testing/fixtures.go
@@ -48,7 +48,7 @@ var ExpectedReceiver = receivers.Receiver{
 	Channel: map[string]interface{}{
 		"alarm_url": "http://node1:8778/v1/webhooks/e03dd2e5-8f2e-4ec1-8c6a-74ba891e5422/trigger?V=1&count=1",
 	},
-	Cluster:   "ae63a10b-4a90-452c-aef1-113a0b255ee3",
+	ClusterID: "ae63a10b-4a90-452c-aef1-113a0b255ee3",
 	CreatedAt: time.Date(2015, 11, 4, 5, 21, 41, 0, time.UTC),
 	Domain:    "Default",
 	ID:        "573aa1ba-bf45-49fd-907d-6b5d6e6adfd3",
@@ -126,7 +126,7 @@ var ExpectedUpdateReceiver = receivers.Receiver{
 	Channel: map[string]interface{}{
 		"alarm_url": "http://node1:8778/v1/webhooks/e03dd2e5-8f2e-4ec1-8c6a-74ba891e5422/trigger?V=1&count=1",
 	},
-	Cluster:   "ae63a10b-4a90-452c-aef1-113a0b255ee3",
+	ClusterID: "ae63a10b-4a90-452c-aef1-113a0b255ee3",
 	CreatedAt: time.Date(2015, 6, 27, 5, 9, 43, 0, time.UTC),
 	Domain:    "Default",
 	ID:        "573aa1ba-bf45-49fd-907d-6b5d6e6adfd3",


### PR DESCRIPTION
Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

For #[1079 [Senlin: Receiver result should use ClusterID instead of Cluster]](https://github.com/gophercloud/gophercloud/issues/1079)

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

[[receivers]](https://github.com/openstack/senlin/blob/e5bc16b3fea2f10dead365f983c5a937f23d72b0/senlin/api/openstack/v1/receivers.py#L35)
