### PR TITLE
Acc Tests: Disabling Octavia

### DIFF
--- a/script/acceptancetest
+++ b/script/acceptancetest
@@ -46,12 +46,6 @@ if [[ $? != 0 ]]; then
   failed=1
 fi
 
-# LoadBalancer v2
-go test -v -timeout $timeout -tags "fixtures acceptance" ./acceptance/openstack/loadbalancer/v2/
-if [[ $? != 0 ]]; then
-  failed=1
-fi
-
 # If any of the test suites failed, exit 1
 if [[ -n $failed ]]; then
   exit 1


### PR DESCRIPTION
Reverts #1012 
For #818 

@hongbin I'm seeing occasional Octavia/LBaaS failures so I'm going to revert the merge of #1012 

```
2018-07-03 02:52:03.283510 | ubuntu-xenial | === RUN   TestLoadbalancersCRUD
2018-07-03 02:57:16.357985 | ubuntu-xenial | --- FAIL: TestLoadbalancersCRUD (312.86s)
2018-07-03 02:57:16.369474 | ubuntu-xenial | 	networking.go:25: Attempting to create network: TESTACC-x3Qg134f
2018-07-03 02:57:16.378072 | ubuntu-xenial | 	networking.go:32: Successfully created network.
2018-07-03 02:57:16.378183 | ubuntu-xenial | 	networking.go:185: Attempting to create subnet: TESTACC-Zl3jexiL
2018-07-03 02:57:16.378243 | ubuntu-xenial | 	networking.go:192: Successfully created subnet.
2018-07-03 02:57:16.378364 | ubuntu-xenial | 	loadbalancer.go:55: Attempting to create loadbalancer TESTACCT-hba26VuO on subnet a17b2d57-d1f1-4966-b8c6-66bc28d3e3f2
2018-07-03 02:57:16.407883 | ubuntu-xenial | 	loadbalancer.go:68: Successfully created loadbalancer TESTACCT-hba26VuO on subnet a17b2d57-d1f1-4966-b8c6-66bc28d3e3f2
2018-07-03 02:57:16.407997 | ubuntu-xenial | 	loadbalancer.go:69: Waiting for loadbalancer TESTACCT-hba26VuO to become active
2018-07-03 02:57:16.408547 | ubuntu-xenial | 	loadbalancers_test.go:64: Unable to create loadbalancer: A timeout occurred
2018-07-03 02:57:16.408633 | ubuntu-xenial | 	networking.go:340: Attempting to delete subnet: a17b2d57-d1f1-4966-b8c6-66bc28d3e3f2
2018-07-03 02:57:16.435963 | ubuntu-xenial | 	networking.go:344: Unable to delete subnet a17b2d57-d1f1-4966-b8c6-66bc28d3e3f2: Expected HTTP response code [202 204] when accessing [DELETE http://192.168.0.6:9696/v2.0/subnets/a17b2d57-d1f1-4966-b8c6-66bc28d3e3f2], but got 409 instead
2018-07-03 02:57:16.454840 | ubuntu-xenial | 		{"NeutronError": {"message": "Unable to complete operation on subnet a17b2d57-d1f1-4966-b8c6-66bc28d3e3f2: One or more ports have an IP allocation from this subnet.", "type": "SubnetInUse", "detail": ""}}
2018-07-03 02:57:16.461736 | ubuntu-xenial | 	networking.go:312: Attempting to delete network: 550f6e77-1334-458c-ab9b-e8e529201784
2018-07-03 02:57:16.462691 | ubuntu-xenial | 	networking.go:316: Unable to delete network 550f6e77-1334-458c-ab9b-e8e529201784: Expected HTTP response code [202 204] when accessing [DELETE http://192.168.0.6:9696/v2.0/networks/550f6e77-1334-458c-ab9b-e8e529201784], but got 409 instead
2018-07-03 02:57:16.462894 | ubuntu-xenial | 		{"NeutronError": {"message": "Unable to complete operation on network 550f6e77-1334-458c-ab9b-e8e529201784. There are one or more ports still in use on the network.", "type": "NetworkInUse", "detail": ""}}
2018-07-03 02:57:16.462942 | ubuntu-xenial | === RUN   TestLoadbalancersCascadeCRUD
2018-07-03 03:02:35.859525 | ubuntu-xenial | --- FAIL: TestLoadbalancersCascadeCRUD (317.18s)
2018-07-03 03:02:37.282617 | ubuntu-xenial | 	networking.go:25: Attempting to create network: TESTACC-UW4ooCZp
2018-07-03 03:02:37.282767 | ubuntu-xenial | 	networking.go:32: Successfully created network.
2018-07-03 03:02:37.282857 | ubuntu-xenial | 	networking.go:185: Attempting to create subnet: TESTACC-4fLPSui4
2018-07-03 03:02:37.282924 | ubuntu-xenial | 	networking.go:192: Successfully created subnet.
2018-07-03 03:02:37.305935 | ubuntu-xenial | 	loadbalancer.go:55: Attempting to create loadbalancer TESTACCT-D9w9dojp on subnet a73a84f9-ac6d-4e8a-bbc0-ebcfe93a0ff3
2018-07-03 03:02:37.376118 | ubuntu-xenial | 	loadbalancer.go:68: Successfully created loadbalancer TESTACCT-D9w9dojp on subnet a73a84f9-ac6d-4e8a-bbc0-ebcfe93a0ff3
2018-07-03 03:02:37.376289 | ubuntu-xenial | 	loadbalancer.go:69: Waiting for loadbalancer TESTACCT-D9w9dojp to become active
2018-07-03 03:02:37.405381 | ubuntu-xenial | 	loadbalancers_test.go:278: Unable to create loadbalancer: A timeout occurred
2018-07-03 03:02:37.405516 | ubuntu-xenial | 	networking.go:340: Attempting to delete subnet: a73a84f9-ac6d-4e8a-bbc0-ebcfe93a0ff3
2018-07-03 03:02:37.410950 | ubuntu-xenial | 	networking.go:344: Unable to delete subnet a73a84f9-ac6d-4e8a-bbc0-ebcfe93a0ff3: Expected HTTP response code [202 204] when accessing [DELETE http://192.168.0.6:9696/v2.0/subnets/a73a84f9-ac6d-4e8a-bbc0-ebcfe93a0ff3], but got 409 instead
2018-07-03 03:02:37.636303 | ubuntu-xenial | 		{"NeutronError": {"message": "Unable to complete operation on subnet a73a84f9-ac6d-4e8a-bbc0-ebcfe93a0ff3: One or more ports have an IP allocation from this subnet.", "type": "SubnetInUse", "detail": ""}}
2018-07-03 03:02:37.636924 | ubuntu-xenial | 	networking.go:312: Attempting to delete network: af93c0c6-261c-4fef-afcb-ae1be76e1419
2018-07-03 03:02:37.647327 | ubuntu-xenial | 	networking.go:316: Unable to delete network af93c0c6-261c-4fef-afcb-ae1be76e1419: Expected HTTP response code [202 204] when accessing [DELETE http://192.168.0.6:9696/v2.0/networks/af93c0c6-261c-4fef-afcb-ae1be76e1419], but got 409 instead
2018-07-03 03:02:37.647555 | ubuntu-xenial | 		{"NeutronError": {"message": "Unable to complete operation on network af93c0c6-261c-4fef-afcb-ae1be76e1419. There are one or more ports still in use on the network.", "type": "NetworkInUse", "detail": ""}}
```

The notable piece is:

```
loadbalancers_test.go:64: Unable to create loadbalancer: A timeout occurred
```