### PR TITLE
Manila: added ListDetail for detailed Share listing 

### DIFF
--- a/acceptance/openstack/sharedfilesystems/v2/shares.go
+++ b/acceptance/openstack/sharedfilesystems/v2/shares.go
@@ -43,6 +43,17 @@ func CreateShare(t *testing.T, client *gophercloud.ServiceClient) (*shares.Share
 	return share, nil
 }
 
+// ListShares lists all shares that belong to this tenant's project.
+// An error will be returned if the shares could not be listed..
+func ListShares(t *testing.T, client *gophercloud.ServiceClient) ([]shares.Share, error) {
+	r, err := shares.ListDetail(client, &shares.ListOpts{}).AllPages()
+	if err != nil {
+		return nil, err
+	}
+
+	return shares.ExtractShares(r)
+}
+
 // GrantAccess will grant access to an existing share. A fatal error will occur if
 // this operation fails.
 func GrantAccess(t *testing.T, client *gophercloud.ServiceClient, share *shares.Share) (*shares.AccessRight, error) {

--- a/acceptance/openstack/sharedfilesystems/v2/shares_test.go
+++ b/acceptance/openstack/sharedfilesystems/v2/shares_test.go
@@ -27,6 +27,29 @@ func TestShareCreate(t *testing.T) {
 	PrintShare(t, created)
 }
 
+func TestShareListDetail(t *testing.T) {
+	client, err := clients.NewSharedFileSystemV2Client()
+	if err != nil {
+		t.Fatalf("Unable to create a sharedfs client: %v", err)
+	}
+
+	share, err := CreateShare(t, client)
+	if err != nil {
+		t.Fatalf("Unable to create a share: %v", err)
+	}
+
+	defer DeleteShare(t, client, share)
+
+	ss, err := ListShares(t, client)
+	if err != nil {
+		t.Fatalf("Unable to list shares: %v", err)
+	}
+
+	for i := range ss {
+		PrintShare(t, &ss[i])
+	}
+}
+
 func TestGrantAndRevokeAccess(t *testing.T) {
 	client, err := clients.NewSharedFileSystemV2Client()
 	if err != nil {

--- a/openstack/sharedfilesystems/v2/shares/requests.go
+++ b/openstack/sharedfilesystems/v2/shares/requests.go
@@ -27,7 +27,7 @@ type CreateOpts struct {
 	// DisplayName is equivalent to Name. The API supports using both
 	// This is an inherited attribute from the block storage API
 	DisplayName string `json:"display_name,omitempty"`
-	// DisplayDescription is equivalent to Description. The API supports using bot
+	// DisplayDescription is equivalent to Description. The API supports using both
 	// This is an inherited attribute from the block storage API
 	DisplayDescription string `json:"display_description,omitempty"`
 	// ShareType defines the sharetype. If omitted, a default share type is used
@@ -80,6 +80,10 @@ type ListOpts struct {
 	Status string `q:"status"`
 	// The UUID of the share server.
 	ShareServerID string `q:"share_server_id"`
+	// One or more metadata key and value pairs as a dictionary of strings.
+	Metadata map[string]string `q:"metadata"`
+	// The extra specifications for the share type.
+	ExtraSpecs map[string]string `q:"extra_specs"`
 	// The UUID of the share type.
 	ShareTypeID string `q:"share_type_id"`
 	// The maximum number of shares to return.
@@ -112,6 +116,20 @@ type ListOpts struct {
 	DescriptionPattern string `q:"description~"`
 	// Whether to show count in API response or not, default is False.
 	WithCount bool `q:"with_count"`
+	// DisplayName is equivalent to Name. The API supports using both
+	// This is an inherited attribute from the block storage API
+	DisplayName string `q:"display_name"`
+	// Equivalent to NamePattern.
+	DisplayNamePattern string `q:"display_name~"`
+	// VolumeTypeID is deprecated but supported. Either ShareTypeID or VolumeTypeID can be used
+	VolumeTypeID string `q:"volume_type_id"`
+	// The UUID of the share group snapshot.
+	ShareGroupSnapshotID string `q:"share_group_snapshot_id"`
+	// DisplayDescription is equivalent to Description. The API supports using both
+	// This is an inherited attribute from the block storage API
+	DisplayDescription string `q:"display_description"`
+	// Equivalent to DescriptionPattern
+	DisplayDescriptionPattern string `q:"display_description~"`
 }
 
 // ListOptsBuilder allows extensions to add additional parameters to the List

--- a/openstack/sharedfilesystems/v2/shares/results.go
+++ b/openstack/sharedfilesystems/v2/shares/results.go
@@ -8,8 +8,6 @@ import (
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/pagination"
-
-	"spew"
 )
 
 // Share contains all information associated with an OpenStack Share
@@ -180,7 +178,7 @@ func ExtractShares(r pagination.Page) ([]Share, error) {
 	}
 
 	err := (r.(SharePage)).ExtractInto(&s)
-	spew.Dump(err)
+
 	return s.Shares, err
 }
 

--- a/openstack/sharedfilesystems/v2/shares/results.go
+++ b/openstack/sharedfilesystems/v2/shares/results.go
@@ -2,9 +2,14 @@ package shares
 
 import (
 	"encoding/json"
+	"net/url"
+	"strconv"
 	"time"
 
 	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+
+	"spew"
 )
 
 // Share contains all information associated with an OpenStack Share
@@ -99,6 +104,84 @@ func (r commonResult) Extract() (*Share, error) {
 // CreateResult contains the response body and error from a Create request.
 type CreateResult struct {
 	commonResult
+}
+
+// SharePage is a pagination.pager that is returned from a call to the List function.
+type SharePage struct {
+	pagination.MarkerPageBase
+}
+
+// NextPageURL generates the URL for the page of results after this one.
+func (r SharePage) NextPageURL() (string, error) {
+	currentURL := r.URL
+	mark, err := r.Owner.LastMarker()
+	if err != nil {
+		return "", err
+	}
+
+	q := currentURL.Query()
+	q.Set("offset", mark)
+	currentURL.RawQuery = q.Encode()
+	return currentURL.String(), nil
+}
+
+// LastMarker returns the last offset in a ListResult.
+func (r SharePage) LastMarker() (string, error) {
+	maxInt := strconv.Itoa(int(^uint(0) >> 1))
+	shares, err := ExtractShares(r)
+	if err != nil {
+		return maxInt, err
+	}
+	if len(shares) == 0 {
+		return maxInt, nil
+	}
+
+	u, err := url.Parse(r.URL.String())
+	if err != nil {
+		return maxInt, err
+	}
+	queryParams := u.Query()
+	offset := queryParams.Get("offset")
+	limit := queryParams.Get("limit")
+
+	// Limit is not present, only one page required
+	if limit == "" {
+		return maxInt, nil
+	}
+
+	iOffset := 0
+	if offset != "" {
+		iOffset, err = strconv.Atoi(offset)
+		if err != nil {
+			return maxInt, err
+		}
+	}
+	iLimit, err := strconv.Atoi(limit)
+	if err != nil {
+		return maxInt, err
+	}
+	iOffset = iOffset + iLimit
+	offset = strconv.Itoa(iOffset)
+
+	return offset, nil
+}
+
+// IsEmpty satisifies the IsEmpty method of the Page interface
+func (r SharePage) IsEmpty() (bool, error) {
+	shares, err := ExtractShares(r)
+	return len(shares) == 0, err
+}
+
+// ExtractShares extracts and returns a Share slice. It is used while
+// iterating over a shares.List call.
+func ExtractShares(r pagination.Page) ([]Share, error) {
+	var s struct {
+		Shares []Share `json:"shares"`
+	}
+
+	err := (r.(SharePage)).ExtractInto(&s)
+	spew.Dump(err)
+	return s.Shares, err
 }
 
 // DeleteResult contains the response body and error from a Delete request.

--- a/openstack/sharedfilesystems/v2/shares/testing/fixtures.go
+++ b/openstack/sharedfilesystems/v2/shares/testing/fixtures.go
@@ -142,6 +142,73 @@ func MockGetResponse(t *testing.T) {
 	})
 }
 
+var listDetailResponse = `{
+		"shares": [
+			{
+		        "links": [
+		            {
+		                "href": "http://172.18.198.54:8786/v2/16e1ab15c35a457e9c2b2aa189f544e1/shares/011d21e2-fbc3-4e4a-9993-9ea223f73264",
+		                "rel": "self"
+		            },
+		            {
+		                "href": "http://172.18.198.54:8786/16e1ab15c35a457e9c2b2aa189f544e1/shares/011d21e2-fbc3-4e4a-9993-9ea223f73264",
+		                "rel": "bookmark"
+		            }
+		        ],
+		        "availability_zone": "nova",
+		        "share_network_id": "713df749-aac0-4a54-af52-10f6c991e80c",
+		        "share_server_id": "e268f4aa-d571-43dd-9ab3-f49ad06ffaef",
+		        "snapshot_id": null,
+		        "id": "011d21e2-fbc3-4e4a-9993-9ea223f73264",
+		        "size": 1,
+		        "share_type": "25747776-08e5-494f-ab40-a64b9d20d8f7",
+		        "share_type_name": "default",
+		        "consistency_group_id": "9397c191-8427-4661-a2e8-b23820dc01d4",
+		        "project_id": "16e1ab15c35a457e9c2b2aa189f544e1",
+		        "metadata": {
+		            "project": "my_app",
+		            "aim": "doc"
+		        },
+		        "status": "available",
+		        "description": "My custom share London",
+		        "host": "manila2@generic1#GENERIC1",
+		        "has_replicas": false,
+		        "replication_type": null,
+		        "task_state": null,
+		        "is_public": true,
+		        "snapshot_support": true,
+		        "name": "my_test_share",
+		        "created_at": "2015-09-18T10:25:24.000000",
+		        "share_proto": "NFS",
+		        "volume_type": "default",
+		        "source_cgsnapshot_member_id": null
+		    }
+		]
+	}`
+
+var listDetailEmptyResponse = `{"shares": []}`
+
+// MockDeleteResponse creates a mock detailed-list response
+func MockListDetailResponse(t *testing.T) {
+	th.Mux.HandleFunc(shareEndpoint+"/detail", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		r.ParseForm()
+		marker := r.Form.Get("offset")
+
+		switch marker {
+		case "":
+			fmt.Fprint(w, listDetailResponse)
+		default:
+			fmt.Fprint(w, listDetailEmptyResponse)
+		}
+	})
+}
+
 var getExportLocationsResponse = `{
     "export_locations": [
         {
@@ -159,6 +226,7 @@ func MockGetExportLocationsResponse(t *testing.T) {
 	th.Mux.HandleFunc(shareEndpoint+"/"+shareID+"/export_locations", func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "GET")
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprintf(w, getExportLocationsResponse)
 	})

--- a/openstack/sharedfilesystems/v2/shares/testing/request_test.go
+++ b/openstack/sharedfilesystems/v2/shares/testing/request_test.go
@@ -83,6 +83,62 @@ func TestGet(t *testing.T) {
 	})
 }
 
+func TestListDetail(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockListDetailResponse(t)
+
+	allPages, err := shares.ListDetail(client.ServiceClient(), &shares.ListOpts{}).AllPages()
+
+	th.AssertNoErr(t, err)
+
+	actual, err := shares.ExtractShares(allPages)
+	th.AssertNoErr(t, err)
+
+	th.AssertDeepEquals(t, actual, []shares.Share{
+		shares.Share{
+			AvailabilityZone:   "nova",
+			ShareNetworkID:     "713df749-aac0-4a54-af52-10f6c991e80c",
+			ShareServerID:      "e268f4aa-d571-43dd-9ab3-f49ad06ffaef",
+			SnapshotID:         "",
+			ID:                 shareID,
+			Size:               1,
+			ShareType:          "25747776-08e5-494f-ab40-a64b9d20d8f7",
+			ShareTypeName:      "default",
+			ConsistencyGroupID: "9397c191-8427-4661-a2e8-b23820dc01d4",
+			ProjectID:          "16e1ab15c35a457e9c2b2aa189f544e1",
+			Metadata: map[string]string{
+				"project": "my_app",
+				"aim":     "doc",
+			},
+			Status:                   "available",
+			Description:              "My custom share London",
+			Host:                     "manila2@generic1#GENERIC1",
+			HasReplicas:              false,
+			ReplicationType:          "",
+			TaskState:                "",
+			SnapshotSupport:          true,
+			Name:                     "my_test_share",
+			CreatedAt:                time.Date(2015, time.September, 18, 10, 25, 24, 0, time.UTC),
+			ShareProto:               "NFS",
+			VolumeType:               "default",
+			SourceCgsnapshotMemberID: "",
+			IsPublic:                 true,
+			Links: []map[string]string{
+				{
+					"href": "http://172.18.198.54:8786/v2/16e1ab15c35a457e9c2b2aa189f544e1/shares/011d21e2-fbc3-4e4a-9993-9ea223f73264",
+					"rel":  "self",
+				},
+				{
+					"href": "http://172.18.198.54:8786/16e1ab15c35a457e9c2b2aa189f544e1/shares/011d21e2-fbc3-4e4a-9993-9ea223f73264",
+					"rel":  "bookmark",
+				},
+			},
+		},
+	})
+}
+
 func TestGetExportLocationsSuccess(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()

--- a/openstack/sharedfilesystems/v2/shares/urls.go
+++ b/openstack/sharedfilesystems/v2/shares/urls.go
@@ -6,6 +6,10 @@ func createURL(c *gophercloud.ServiceClient) string {
 	return c.ServiceURL("shares")
 }
 
+func listDetailURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("shares", "detail")
+}
+
 func deleteURL(c *gophercloud.ServiceClient, id string) string {
 	return c.ServiceURL("shares", id)
 }


### PR DESCRIPTION
For #1094

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

- example response: https://github.com/openstack/manila/blob/master/api-ref/source/samples/shares-list-detailed-response.json
- `get_all` function: https://github.com/openstack/manila/blob/master/manila/share/api.py#L1469