### PR TITLE
Convert type of 'command' from string to list

### DIFF
--- a/openstack/container/v1/capsules/results.go
+++ b/openstack/container/v1/capsules/results.go
@@ -196,7 +196,7 @@ type Container struct {
 	ImageDriver string `json:"image_driver"`
 
 	// Command for the container
-	Command string `json:"command"`
+	Command []string `json:"command"`
 
 	// Capsule ID for the container
 	CapsuleID int `json:"capsule_id"`

--- a/openstack/container/v1/capsules/testing/fixtures.go
+++ b/openstack/container/v1/capsules/testing/fixtures.go
@@ -266,7 +266,7 @@ const CapsuleGetBody_OldTime = `
       },
       "ports": [80],
       "meta": {"key1": "value1"},
-      "command": "testcmd",
+      "command": ["testcmd"],
       "capsule_id": 1,
       "runtime": "runc",
       "cpu": 1,
@@ -366,7 +366,7 @@ const CapsuleGetBody_NewTime = `
       },
       "ports": [80],
       "meta": {"key1": "value1"},
-      "command": "testcmd",
+      "command": ["testcmd"],
       "capsule_id": 1,
       "runtime": "runc",
       "cpu": 1,
@@ -446,7 +446,9 @@ var ExpectedContainer1 = capsules.Container{
 	WorkDir:     "/root",
 	Disk:        0,
 	ContainerID: "5109ebe2ca595777e994416208bd681b561b25ce493c34a234a1b68457cb53fb",
-	Command:     "testcmd",
+	Command: []string{
+		"testcmd",
+	},
 	Ports: []int{
 		80,
 	},


### PR DESCRIPTION
The field 'command' of container resource is changed from string
to list [1]. This change should not break API consumer if they
pin a specific API version. However, Gophercloud doesn't support
API microversion yet, so the CI is complaining. This patch attempts
to fix it.

[1] https://review.openstack.org/#/c/575709/

Prior to starting a PR, please make sure you have read our
[contributor tutorial](https://github.com/gophercloud/gophercloud/tree/master/docs/contributor-tutorial).

Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

For #[PUT ISSUE NUMBER HERE]

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

[PUT URLS HERE]
