### PR TITLE
Manila: IDFromName for shares

### DIFF
--- a/openstack/sharedfilesystems/v2/shares/results.go
+++ b/openstack/sharedfilesystems/v2/shares/results.go
@@ -198,6 +198,28 @@ type GetResult struct {
 	commonResult
 }
 
+// IDFromName is a convenience function that returns a share's ID given its name.
+func IDFromName(client *gophercloud.ServiceClient, name string) (string, error) {
+	r, err := ListDetail(client, &ListOpts{Name: name}).AllPages()
+	if err != nil {
+		return "", err
+	}
+
+	ss, err := ExtractShares(r)
+	if err != nil {
+		return "", err
+	}
+
+	switch len(ss) {
+	case 0:
+		return "", gophercloud.ErrResourceNotFound{Name: name, ResourceType: "share"}
+	case 1:
+		return ss[0].ID, nil
+	default:
+		return "", gophercloud.ErrMultipleResourcesFound{Name: name, Count: len(ss), ResourceType: "share"}
+	}
+}
+
 // GetExportLocationsResult contains the result body and error from an
 // GetExportLocations request.
 type GetExportLocationsResult struct {


### PR DESCRIPTION
For #1096 

Uses `ListDetail` with the supplied share name in the `ListOpts` for filtering.