### PR TITLE
zun: move 'restart_policy' under 'spec'

### DIFF
--- a/acceptance/openstack/container/v1/capsules_test.go
+++ b/acceptance/openstack/container/v1/capsules_test.go
@@ -26,8 +26,8 @@ func TestCapsule(t *testing.T) {
 			},
 			"name": "template"
 		},
-		"restartPolicy": "Always",
 		"spec": {
+			"restartPolicy": "Always",
 			"containers": [
 				{
 					"command": [

--- a/openstack/container/v1/capsules/testing/fixtures.go
+++ b/openstack/container/v1/capsules/testing/fixtures.go
@@ -22,8 +22,8 @@ const ValidJSONTemplate = `
     },
     "name": "template"
   },
-  "restartPolicy": "Always",
   "spec": {
+    "restartPolicy": "Always",
     "containers": [
       {
         "command": [
@@ -65,8 +65,8 @@ metadata:
   labels:
     app: web
     app1: web1
-restartPolicy: Always
 spec:
+  restartPolicy: Always
   containers:
   - image: ubuntu
     command:
@@ -91,7 +91,6 @@ spec:
 var ValidJSONTemplateParsed = map[string]interface{}{
 	"capsuleVersion": "beta",
 	"kind":           "capsule",
-	"restartPolicy":  "Always",
 	"metadata": map[string]interface{}{
 		"name": "template",
 		"labels": map[string]string{
@@ -100,6 +99,7 @@ var ValidJSONTemplateParsed = map[string]interface{}{
 		},
 	},
 	"spec": map[string]interface{}{
+		"restartPolicy": "Always",
 		"containers": []map[string]interface{}{
 			map[string]interface{}{
 				"image": "ubuntu",
@@ -135,7 +135,6 @@ var ValidJSONTemplateParsed = map[string]interface{}{
 var ValidYAMLTemplateParsed = map[string]interface{}{
 	"capsuleVersion": "beta",
 	"kind":           "capsule",
-	"restartPolicy":  "Always",
 	"metadata": map[string]interface{}{
 		"name": "template",
 		"labels": map[string]string{
@@ -144,6 +143,7 @@ var ValidYAMLTemplateParsed = map[string]interface{}{
 		},
 	},
 	"spec": map[interface{}]interface{}{
+		"restartPolicy": "Always",
 		"containers": []map[interface{}]interface{}{
 			map[interface{}]interface{}{
 				"image": "ubuntu",


### PR DESCRIPTION
Zun has moved 'start_policy' to 'spec' [1]. This is the corresponding
change in gophercloud.

[1] https://review.openstack.org/#/c/571398/

Prior to starting a PR, please make sure you have read our
[contributor tutorial](https://github.com/gophercloud/gophercloud/tree/master/docs/contributor-tutorial).

Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

For #[PUT ISSUE NUMBER HERE]

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

[PUT URLS HERE]
