### PR TITLE
Zun: assert capsule become 'Running' after create

### DIFF
--- a/acceptance/openstack/container/v1/capsules.go
+++ b/acceptance/openstack/container/v1/capsules.go
@@ -1,0 +1,31 @@
+package v1
+
+import (
+	"fmt"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/acceptance/tools"
+	"github.com/gophercloud/gophercloud/openstack/container/v1/capsules"
+)
+
+// WaitForCapsuleStatus will poll a capsule's status until it either matches
+// the specified status or the status becomes Failed.
+func WaitForCapsuleStatus(client *gophercloud.ServiceClient, capsule *capsules.Capsule, status string) error {
+	return tools.WaitFor(func() (bool, error) {
+		latest, err := capsules.Get(client, capsule.UUID).Extract()
+		if err != nil {
+			return false, err
+		}
+
+		if latest.Status == status {
+			// Success!
+			return true, nil
+		}
+
+		if latest.Status == "Failed" {
+			return false, fmt.Errorf("Capsule in FAILED state")
+		}
+
+		return false, nil
+	})
+}

--- a/acceptance/openstack/container/v1/capsules_test.go
+++ b/acceptance/openstack/container/v1/capsules_test.go
@@ -31,7 +31,8 @@ func TestCapsule(t *testing.T) {
 			"containers": [
 				{
 					"command": [
-						"/bin/bash"
+						"sleep",
+						"1000000"
 					],
 					"env": {
 						"ENV1": "/usr/local/bin",
@@ -61,7 +62,9 @@ func TestCapsule(t *testing.T) {
 	createOpts := capsules.CreateOpts{
 		TemplateOpts: template,
 	}
-	err = capsules.Create(client, createOpts).ExtractErr()
+	capsule, err := capsules.Create(client, createOpts).Extract()
+	th.AssertNoErr(t, err)
+	err = WaitForCapsuleStatus(client, capsule, "Running")
 	th.AssertNoErr(t, err)
 	pager := capsules.List(client, nil)
 	err = pager.EachPage(func(page pagination.Page) (bool, error) {

--- a/openstack/container/v1/capsules/requests.go
+++ b/openstack/container/v1/capsules/requests.go
@@ -80,7 +80,7 @@ func (opts ListOpts) ToCapsuleListQuery() (string, error) {
 	return q.String(), err
 }
 
-// List makes a request against the API to list servers accessible to you.
+// List makes a request against the API to list capsules accessible to you.
 func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(client)
 	if opts != nil {

--- a/openstack/container/v1/capsules/results.go
+++ b/openstack/container/v1/capsules/results.go
@@ -25,9 +25,9 @@ type GetResult struct {
 }
 
 // CreateResult is the response from a Create operation. Call its Extract
-// method to interpret it as a Server.
+// method to interpret it as a Capsule.
 type CreateResult struct {
-	gophercloud.ErrResult
+	commonResult
 }
 
 // DeleteResult represents the result of a delete operation.

--- a/openstack/container/v1/capsules/results.go
+++ b/openstack/container/v1/capsules/results.go
@@ -39,7 +39,7 @@ type CapsulePage struct {
 	pagination.LinkedPageBase
 }
 
-// Represents a Container Orchestration Engine Bay, i.e. a cluster
+// Represents a Capsule
 type Capsule struct {
 	// UUID for the capsule
 	UUID string `json:"uuid"`
@@ -75,7 +75,7 @@ type Capsule struct {
 	UpdatedAt time.Time `json:"-"`
 
 	// Links includes HTTP references to the itself, useful for passing along to
-	// other APIs that might want a server reference.
+	// other APIs that might want a capsule reference.
 	Links []interface{} `json:"links"`
 
 	// The capsule version
@@ -144,7 +144,7 @@ type Container struct {
 	Name string `json:"name"`
 
 	// Links includes HTTP references to the itself, useful for passing along to
-	// other APIs that might want a server reference.
+	// other APIs that might want a capsule reference.
 	Links []interface{} `json:"links"`
 
 	// Container ID for the container

--- a/openstack/container/v1/capsules/testing/fixtures.go
+++ b/openstack/container/v1/capsules/testing/fixtures.go
@@ -569,7 +569,7 @@ func HandleCapsuleCreateSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", fakeclient.TokenID)
 		th.TestHeader(t, r, "Accept", "application/json")
 		w.WriteHeader(http.StatusAccepted)
-		fmt.Fprintf(w, `{}`)
+		fmt.Fprintf(w, CapsuleGetBody_NewTime)
 	})
 }
 

--- a/openstack/container/v1/capsules/testing/requests_test.go
+++ b/openstack/container/v1/capsules/testing/requests_test.go
@@ -66,8 +66,10 @@ func TestCreateCapsule(t *testing.T) {
 	createOpts := capsules.CreateOpts{
 		TemplateOpts: template,
 	}
-	err := capsules.Create(fakeclient.ServiceClient(), createOpts).ExtractErr()
+	actualCapsule, err := capsules.Create(fakeclient.ServiceClient(), createOpts).Extract()
 	th.AssertNoErr(t, err)
+
+	th.AssertDeepEquals(t, &ExpectedCapsule, actualCapsule)
 }
 
 func TestListCapsule(t *testing.T) {


### PR DESCRIPTION
In the Zun acceptance test, add a step to wait for the capsule
to become 'Running' after it is created.

Fixes: #1098

Prior to starting a PR, please make sure you have read our
[contributor tutorial](https://github.com/gophercloud/gophercloud/tree/master/docs/contributor-tutorial).

Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

For #[PUT ISSUE NUMBER HERE]

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

[PUT URLS HERE]
