### PR TITLE
Senlin: ClusterPolicies List

### DIFF
--- a/acceptance/openstack/clustering/v1/clustering.go
+++ b/acceptance/openstack/clustering/v1/clustering.go
@@ -431,3 +431,30 @@ func WaitForNodeStatus(client *gophercloud.ServiceClient, id string, status stri
 		return false, nil
 	})
 }
+
+func AttachPolicy(t *testing.T, client *gophercloud.ServiceClient, clusterID string, policyID string) error {
+	t.Logf("Attempting to attach policy: %s to cluster: %s", policyID, clusterID)
+	iTrue := true
+	attachPolicyOpts := clusters.AttachPolicyOpts{
+		PolicyID: policyID,
+		Enabled:  &iTrue,
+	}
+	actionID, err := clusters.AttachPolicy(client, clusterID, attachPolicyOpts).Extract()
+	err = WaitForAction(client, actionID)
+	th.AssertNoErr(t, err)
+	t.Logf("Successfully attach policy: %s to cluster: %s", policyID, clusterID)
+	return nil
+}
+
+func DetachPolicy(t *testing.T, client *gophercloud.ServiceClient, clusterID string, policyID string) error {
+	t.Logf("Attempting to detach policy: %s from cluster: %s", policyID, clusterID)
+	opts := clusters.DetachPolicyOpts{
+		PolicyID: policyID,
+	}
+	actionID, err := clusters.DetachPolicy(client, clusterID, opts).Extract()
+	th.AssertNoErr(t, err)
+	err = WaitForAction(client, actionID)
+	th.AssertNoErr(t, err)
+	t.Logf("Successfully detach policy: %s from cluster: %s", policyID, clusterID)
+	return nil
+}

--- a/acceptance/openstack/clustering/v1/clusterpolicies_test.go
+++ b/acceptance/openstack/clustering/v1/clusterpolicies_test.go
@@ -1,0 +1,54 @@
+// +build acceptance clustering actions
+
+package v1
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/acceptance/clients"
+	"github.com/gophercloud/gophercloud/acceptance/tools"
+	_ "github.com/gophercloud/gophercloud/openstack/clustering/v1/actions"
+	"github.com/gophercloud/gophercloud/openstack/clustering/v1/clusterpolicies"
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestClusterPoliciesList(t *testing.T) {
+	client, err := clients.NewClusteringV1Client()
+	th.AssertNoErr(t, err)
+	client.Microversion = "1.5"
+
+	profile, err := CreateProfile(t, client)
+	th.AssertNoErr(t, err)
+	defer DeleteProfile(t, client, profile.ID)
+
+	cluster, err := CreateCluster(t, client, profile.ID)
+	th.AssertNoErr(t, err)
+	defer DeleteCluster(t, client, cluster.ID)
+
+	policy, err := CreatePolicy(t, client)
+	th.AssertNoErr(t, err)
+	defer DeletePolicy(t, client, policy.ID)
+
+	err = AttachPolicy(t, client, cluster.ID, policy.ID)
+	th.AssertNoErr(t, err)
+	defer DetachPolicy(t, client, cluster.ID, policy.ID)
+
+	opts := clusterpolicies.ListOpts{
+		Sort: "enabled:asc",
+	}
+
+	allPages, err := clusterpolicies.List(client, cluster.ID, opts).AllPages()
+	th.AssertNoErr(t, err)
+
+	allClusterPolicies, err := clusterpolicies.ExtractClusterPolicies(allPages)
+	th.AssertNoErr(t, err)
+
+	found := false
+	for _, clusterpolicies := range allClusterPolicies {
+		tools.PrintResource(t, clusterpolicies)
+		if (clusterpolicies.ClusterID == cluster.ID && clusterpolicies.PolicyID == policy.ID) {
+			found = true
+		}
+	}
+	th.AssertEquals(t, found, true)
+}

--- a/openstack/clustering/v1/clusterpolicies/doc.go
+++ b/openstack/clustering/v1/clusterpolicies/doc.go
@@ -1,0 +1,23 @@
+/*
+Package clusterpolicies enables Lists all cluster policies and shows information for a cluster policy from the OpenStack
+Clustering Service.
+
+Example to list cluster policies for a Senlin deployment
+
+	clusterID := "7d85f602-a948-4a30-afd4-e84f47471c15"
+		allPages, err := clusterpolicies.List(serviceClient, clusterID, clusterpolicies.ListOpts{}).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allClusterPolicies, err := clusterpolicies.ExtractClusterPolicies(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, clusterPolicy := range allClusterPolicies {
+		fmt.Printf("%+v\n", clusterPolicy)
+	}
+
+*/
+package clusterpolicies

--- a/openstack/clustering/v1/clusterpolicies/requests.go
+++ b/openstack/clustering/v1/clusterpolicies/requests.go
@@ -1,0 +1,41 @@
+package clusterpolicies
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// ListOptsBuilder Builder.
+type ListOptsBuilder interface {
+	ToClusterPolicyListQuery() (string, error)
+}
+
+// ListOpts params
+type ListOpts struct {
+	Enabled *bool  `q:"enabled"`
+	Name    string `q:"policy_name"`
+	Type    string `q:"policy_type"`
+	Sort    string `q:"sort"`
+}
+
+// ToPolicyListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToClusterPolicyListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List instructs OpenStack to provide a list of policies.
+func List(client *gophercloud.ServiceClient, clusterID string, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(client, clusterID)
+	if opts != nil {
+		query, err := opts.ToClusterPolicyListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return ClusterPolicyPage{pagination.SinglePageBase(r)}
+	})
+}

--- a/openstack/clustering/v1/clusterpolicies/results.go
+++ b/openstack/clustering/v1/clusterpolicies/results.go
@@ -1,0 +1,56 @@
+package clusterpolicies
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// commonResult is the response of a base result.
+type commonResult struct {
+	gophercloud.Result
+}
+
+// GetResult is the response of a Get operations.
+type GetResult struct {
+	commonResult
+}
+
+// Extract provides access to the individual Policy returned by the Get and
+// Create functions.
+func (r commonResult) Extract() (*ClusterPolicy, error) {
+	var s struct {
+		ClusterPolicy *ClusterPolicy `json:"cluster_policy"`
+	}
+	err := r.ExtractInto(&s)
+	return s.ClusterPolicy, err
+}
+
+type ClusterPolicy struct {
+	ClusterID   string `json:"cluster_id"`
+	ClusterName string `json:"cluster_name"`
+	Enabled     bool   `json:"enabled"`
+	ID          string `json:"id"`
+	PolicyID    string `json:"policy_id"`
+	PolicyName  string `json:"policy_name"`
+	PolicyType  string `json:"policy_type"`
+}
+
+// ExtractClusterPolicies provides access to the list of profiles in a page acquired from the ListDetail operation.
+func ExtractClusterPolicies(r pagination.Page) ([]ClusterPolicy, error) {
+	var s struct {
+		ClusterPolicies []ClusterPolicy `json:"cluster_policies"`
+	}
+	err := (r.(ClusterPolicyPage)).ExtractInto(&s)
+	return s.ClusterPolicies, err
+}
+
+// ClusterPolicyPage contains a single page of all policies from a ListDetails call.
+type ClusterPolicyPage struct {
+	pagination.SinglePageBase
+}
+
+// IsEmpty determines if ClusterPolicyPage contains any results.
+func (page ClusterPolicyPage) IsEmpty() (bool, error) {
+	clusterPolicies, err := ExtractClusterPolicies(page)
+	return len(clusterPolicies) == 0, err
+}

--- a/openstack/clustering/v1/clusterpolicies/testing/doc.go
+++ b/openstack/clustering/v1/clusterpolicies/testing/doc.go
@@ -1,0 +1,2 @@
+// clustering_cluster_policies_v1
+package testing

--- a/openstack/clustering/v1/clusterpolicies/testing/fixtures.go
+++ b/openstack/clustering/v1/clusterpolicies/testing/fixtures.go
@@ -1,0 +1,50 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/clustering/v1/clusterpolicies"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	fake "github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+const ListResponse = `
+{
+	"cluster_policies": [
+		{
+			"cluster_id":   "7d85f602-a948-4a30-afd4-e84f47471c15",
+			"cluster_name": "cluster4",
+			"enabled":      true,
+			"id":           "06be3a1f-b238-4a96-a737-ceec5714087e",
+			"policy_id":    "714fe676-a08f-4196-b7af-61d52eeded15",
+			"policy_name":  "dp01",
+			"policy_type":  "senlin.policy.deletion-1.0"
+		}	
+	]
+}
+`
+
+var ExpectedListClusterPolicy = []clusterpolicies.ClusterPolicy{
+	{
+		ClusterID:   "7d85f602-a948-4a30-afd4-e84f47471c15",
+		ClusterName: "cluster4",
+		Enabled:     true,
+		ID:          "06be3a1f-b238-4a96-a737-ceec5714087e",
+		PolicyID:    "714fe676-a08f-4196-b7af-61d52eeded15",
+		PolicyName:  "dp01",
+		PolicyType:  "senlin.policy.deletion-1.0",
+	},
+}
+
+func HandleListSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/v1/clusters/7d85f602-a948-4a30-afd4-e84f47471c15/policies", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, ListResponse)
+	})
+}

--- a/openstack/clustering/v1/clusterpolicies/testing/requests_test.go
+++ b/openstack/clustering/v1/clusterpolicies/testing/requests_test.go
@@ -1,0 +1,34 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/clustering/v1/clusterpolicies"
+	"github.com/gophercloud/gophercloud/pagination"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	fake "github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func TestListActions(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	HandleListSuccessfully(t)
+
+	pageCount := 0
+	clusterID := "7d85f602-a948-4a30-afd4-e84f47471c15"
+	err := clusterpolicies.List(fake.ServiceClient(), clusterID, clusterpolicies.ListOpts{}).EachPage(func(page pagination.Page) (bool, error) {
+		pageCount++
+		actual, err := clusterpolicies.ExtractClusterPolicies(page)
+		th.AssertNoErr(t, err)
+
+		th.AssertDeepEquals(t, ExpectedListClusterPolicy, actual)
+
+		return true, nil
+	})
+	th.AssertNoErr(t, err)
+
+	if pageCount != 1 {
+		t.Errorf("Expected 1 page, got %d", pageCount)
+	}
+}

--- a/openstack/clustering/v1/clusterpolicies/urls.go
+++ b/openstack/clustering/v1/clusterpolicies/urls.go
@@ -1,0 +1,10 @@
+package clusterpolicies
+
+import "github.com/gophercloud/gophercloud"
+
+var apiVersion = "v1"
+var apiName = "clusters"
+
+func listURL(client *gophercloud.ServiceClient, clusterID string) string {
+	return client.ServiceURL(apiVersion, apiName, clusterID, "policies")
+}


### PR DESCRIPTION
Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

For #[823 [Add support for Senlin clustering]](https://github.com/gophercloud/gophercloud/issues/823)
      #[1109 [Senlin: Missing Clusterpolicies Get/List]](https://github.com/gophercloud/gophercloud/issues/1109)

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

[[clusterpolicies:list]](https://github.com/openstack/senlin/blob/e5bc16b3fea2f10dead365f983c5a937f23d72b0/senlin/api/openstack/v1/cluster_policies.py#L57)

