### PR TITLE
Bug: Senlin- Allow ListPoliciesOpts to be passed into clusters.ListPolic…

### DIFF
--- a/openstack/clustering/v1/clusters/requests.go
+++ b/openstack/clustering/v1/clusters/requests.go
@@ -417,7 +417,7 @@ type ListPoliciesOpts struct {
 }
 
 // ToClusterPoliciesListQuery formats a ListOpts into a query string.
-func (opts ListPoliciesOpts) ToClusterPoliciesListQuery() (string, error) {
+func (opts ListPoliciesOpts) ToClusterListPoliciesQuery() (string, error) {
 	q, err := gophercloud.BuildQueryString(opts)
 	return q.String(), err
 }

--- a/openstack/clustering/v1/clusters/requests.go
+++ b/openstack/clustering/v1/clusters/requests.go
@@ -405,7 +405,7 @@ func DetachPolicy(client *gophercloud.ServiceClient, id string, opts DetachPolic
 // ListPolicyOptsBuilder allows extensions to add additional parameters to the
 // ListPolicies request.
 type ListPoliciesOptsBuilder interface {
-	ToClusterListPoliciesQuery() (string, error)
+	ToClusterPoliciesListQuery() (string, error)
 }
 
 // ListPoliciesOpts represents options to list a cluster's policies.
@@ -417,7 +417,7 @@ type ListPoliciesOpts struct {
 }
 
 // ToClusterPoliciesListQuery formats a ListOpts into a query string.
-func (opts ListPoliciesOpts) ToClusterListPoliciesQuery() (string, error) {
+func (opts ListPoliciesOpts) ToClusterPoliciesListQuery() (string, error) {
 	q, err := gophercloud.BuildQueryString(opts)
 	return q.String(), err
 }
@@ -426,7 +426,7 @@ func (opts ListPoliciesOpts) ToClusterListPoliciesQuery() (string, error) {
 func ListPolicies(client *gophercloud.ServiceClient, clusterID string, opts ListPoliciesOptsBuilder) pagination.Pager {
 	url := listPoliciesURL(client, clusterID)
 	if opts != nil {
-		query, err := opts.ToClusterListPoliciesQuery()
+		query, err := opts.ToClusterPoliciesListQuery()
 		if err != nil {
 			return pagination.Pager{Err: err}
 		}

--- a/openstack/clustering/v1/clusters/testing/requests_test.go
+++ b/openstack/clustering/v1/clusters/testing/requests_test.go
@@ -297,7 +297,7 @@ func TestListClusterPolicies(t *testing.T) {
 	HandleListPoliciesSuccessfully(t)
 
 	pageCount := 0
-	err := clusters.ListPolicies(fake.ServiceClient(), ExpectedClusterPolicy.ClusterID, nil).EachPage(func(page pagination.Page) (bool, error) {
+	err := clusters.ListPolicies(fake.ServiceClient(), ExpectedClusterPolicy.ClusterID, clusters.ListPoliciesOpts{Name: "Test"}).EachPage(func(page pagination.Page) (bool, error) {
 		pageCount++
 		actual, err := clusters.ExtractClusterPolicies(page)
 		th.AssertNoErr(t, err)


### PR DESCRIPTION
…ies(...) (#1113)

Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

For #[1113 [Bug: Can't pass ListPoliciesOpts options to Senlin's cluster ListPolicies]](https://github.com/gophercloud/gophercloud/issues/1113)

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

[[clusters:listpolicies]](https://github.com/openstack/senlin/blob/master/senlin/api/openstack/v1/cluster_policies.py#L57)
