### PR TITLE
Implements heat/orchestration stack update PATCH verb.

### DIFF
--- a/openstack/orchestration/v1/stacks/doc.go
+++ b/openstack/orchestration/v1/stacks/doc.go
@@ -5,4 +5,121 @@
 // application framework or component specified (in the template). A stack is a
 // running instance of a template. The result of creating a stack is a deployment
 // of the application framework or component.
+
+/* Update Stack examples using the different update methods.
+Summary of behavior between the different methods :
+
+Function | Test Case | Result
+
+Update()	| Template AND Parameters WITH Conflict | Parameter takes priority, parameters are set in raw_template.environment overlay
+Update()	| Template ONLY | Template updates, raw_template.environment overlay is removed
+Update()	| Parameters ONLY | No update, template is required
+
+UpdatePatch() 	| Template AND Parameters WITH Conflict | Parameter takes priority, parameters are set in raw_template.environment overlay
+UpdatePatch() 	| Template ONLY | Template updates, but raw_template.environment overlay is not removed, existing parameter values will remain
+UpdatePatch() 	| Parameters ONLY | Parameters (raw_template.environment) is updated, excluded values are unchanged
+
+The PUT Update() function will remove parameters from the raw_template.environment overlay
+if they are excluded from the operation, whereas PATCH Update() will never be destructive to the
+raw_template.environment overlay.  It is not possible to expose the raw_template values with a
+patch update once they have been added to the environment overlay with the PATCH verb, but
+newly added values that do not have a corresponding key in the overlay will display the
+raw_template value.
+*/
+
+// example stack update using the Update() (PUT) method
+
+/*
+t := make(map[string]interface{})
+f, err := ioutil.ReadFile("template.yaml")
+if err != nil {
+	panic(err)
+}
+err = yaml.Unmarshal(f, t)
+if err != nil {
+	panic(err)
+}
+
+template := stacks.Template{}
+template.TE = stacks.TE{
+	Bin: f,
+}
+
+var params = make(map[string]interface{})
+params["number_of_nodes"] = 2
+
+stackName := "my_stack"
+stackId := "d68cc349-ccc5-4b44-a17d-07f068c01e5a"
+
+stackOpts := &stacks.UpdateOpts{
+	Parameters: params,
+	TemplateOpts: &template,
+}
+
+// client is an instance of *gophercloud.ServiceClient
+res := stacks.Update(client, stackName, stackId, stackOpts)
+if res.Err != nil {
+	panic(res.Err)
+}
+
+//example template.yaml of a Heat::ResourceGroup with 3 nodes
+*/
+
+//example stack update using the UpdatePatch()  (PATCH) method
+
+/*
+var params = make(map[string]interface{})
+params["number_of_nodes"] = 2
+
+stackName := "my_stack"
+stackId := "d68cc349-ccc5-4b44-a17d-07f068c01e5a"
+
+stackOpts := &stacks.UpdateOpts{
+	Parameters: params,
+}
+
+res := stacks.UpdatePatch(client, stackName, stackId, stackOpts)
+if res.Err != nil {
+	panic(res.Err)
+}
+
+
+//example template.yaml of a Heat::ResourceGroup with 3 nodes
+*/
+
+/*
+heat_template_version: 2016-04-08
+
+parameters:
+	number_of_nodes:
+		type: number
+		default: 3
+		description: the number of nodes
+	node_flavor:
+		type: string
+		default: m1.small
+		description: node flavor
+	node_image:
+		type: string
+		default: centos7.5-latest
+		description: node os image
+	node_network:
+		type: string
+		default: my-node-network
+		description: node network name
+
+resources:
+	resource_group:
+		type: OS::Heat::ResourceGroup
+		properties:
+		count: { get_param: number_of_nodes }
+		resource_def:
+			type: OS::Nova::Server
+			properties:
+				name: my_nova_server_%index%
+				image: { get_param: node_image }
+				flavor: { get_param: node_flavor }
+				networks:
+					- network: {get_param: node_network}
+*/
 package stacks

--- a/openstack/orchestration/v1/stacks/doc.go
+++ b/openstack/orchestration/v1/stacks/doc.go
@@ -1,13 +1,13 @@
-// Package stacks provides operation for working with Heat stacks. A stack is a
-// group of resources (servers, load balancers, databases, and so forth)
-// combined to fulfill a useful purpose. Based on a template, Heat orchestration
-// engine creates an instantiated set of resources (a stack) to run the
-// application framework or component specified (in the template). A stack is a
-// running instance of a template. The result of creating a stack is a deployment
-// of the application framework or component.
+/*
+Package stacks provides operation for working with Heat stacks. A stack is a
+group of resources (servers, load balancers, databases, and so forth)
+combined to fulfill a useful purpose. Based on a template, Heat orchestration
+engine creates an instantiated set of resources (a stack) to run the
+application framework or component specified (in the template). A stack is a
+running instance of a template. The result of creating a stack is a deployment
+of the application framework or component.
 
-/* Update Stack examples using the different update methods.
-Summary of behavior between the different methods :
+Summary of  Behavior Between Stack Update and UpdatePatch Methods :
 
 Function | Test Case | Result
 
@@ -25,101 +25,91 @@ raw_template.environment overlay.  It is not possible to expose the raw_template
 patch update once they have been added to the environment overlay with the PATCH verb, but
 newly added values that do not have a corresponding key in the overlay will display the
 raw_template value.
-*/
 
-// example stack update using the Update() (PUT) method
+Example to Update a Stack Using the Update (PUT) Method
 
-/*
-t := make(map[string]interface{})
-f, err := ioutil.ReadFile("template.yaml")
-if err != nil {
-	panic(err)
-}
-err = yaml.Unmarshal(f, t)
-if err != nil {
-	panic(err)
-}
+	t := make(map[string]interface{})
+	f, err := ioutil.ReadFile("template.yaml")
+	if err != nil {
+		panic(err)
+	}
+	err = yaml.Unmarshal(f, t)
+	if err != nil {
+		panic(err)
+	}
 
-template := stacks.Template{}
-template.TE = stacks.TE{
-	Bin: f,
-}
+	template := stacks.Template{}
+	template.TE = stacks.TE{
+		Bin: f,
+	}
 
-var params = make(map[string]interface{})
-params["number_of_nodes"] = 2
+	var params = make(map[string]interface{})
+	params["number_of_nodes"] = 2
 
-stackName := "my_stack"
-stackId := "d68cc349-ccc5-4b44-a17d-07f068c01e5a"
+	stackName := "my_stack"
+	stackId := "d68cc349-ccc5-4b44-a17d-07f068c01e5a"
 
-stackOpts := &stacks.UpdateOpts{
-	Parameters: params,
-	TemplateOpts: &template,
-}
+	stackOpts := &stacks.UpdateOpts{
+		Parameters: params,
+		TemplateOpts: &template,
+	}
 
-// client is an instance of *gophercloud.ServiceClient
-res := stacks.Update(client, stackName, stackId, stackOpts)
-if res.Err != nil {
-	panic(res.Err)
-}
+	res := stacks.Update(orchestrationClient, stackName, stackId, stackOpts)
+	if res.Err != nil {
+		panic(res.Err)
+	}
 
-//example template.yaml of a Heat::ResourceGroup with 3 nodes
-*/
+Example to Update a Stack Using the UpdatePatch (PATCH) Method
 
-//example stack update using the UpdatePatch()  (PATCH) method
+	var params = make(map[string]interface{})
+	params["number_of_nodes"] = 2
 
-/*
-var params = make(map[string]interface{})
-params["number_of_nodes"] = 2
+	stackName := "my_stack"
+	stackId := "d68cc349-ccc5-4b44-a17d-07f068c01e5a"
 
-stackName := "my_stack"
-stackId := "d68cc349-ccc5-4b44-a17d-07f068c01e5a"
+	stackOpts := &stacks.UpdateOpts{
+		Parameters: params,
+	}
 
-stackOpts := &stacks.UpdateOpts{
-	Parameters: params,
-}
+	res := stacks.UpdatePatch(orchestrationClient, stackName, stackId, stackOpts)
+	if res.Err != nil {
+		panic(res.Err)
+	}
 
-res := stacks.UpdatePatch(client, stackName, stackId, stackOpts)
-if res.Err != nil {
-	panic(res.Err)
-}
+Example YAML Template Containing a Heat::ResourceGroup With Three Nodes
 
+	heat_template_version: 2016-04-08
 
-//example template.yaml of a Heat::ResourceGroup with 3 nodes
-*/
+	parameters:
+		number_of_nodes:
+			type: number
+			default: 3
+			description: the number of nodes
+		node_flavor:
+			type: string
+			default: m1.small
+			description: node flavor
+		node_image:
+			type: string
+			default: centos7.5-latest
+			description: node os image
+		node_network:
+			type: string
+			default: my-node-network
+			description: node network name
 
-/*
-heat_template_version: 2016-04-08
-
-parameters:
-	number_of_nodes:
-		type: number
-		default: 3
-		description: the number of nodes
-	node_flavor:
-		type: string
-		default: m1.small
-		description: node flavor
-	node_image:
-		type: string
-		default: centos7.5-latest
-		description: node os image
-	node_network:
-		type: string
-		default: my-node-network
-		description: node network name
-
-resources:
-	resource_group:
-		type: OS::Heat::ResourceGroup
-		properties:
-		count: { get_param: number_of_nodes }
-		resource_def:
-			type: OS::Nova::Server
+	resources:
+		resource_group:
+			type: OS::Heat::ResourceGroup
 			properties:
-				name: my_nova_server_%index%
-				image: { get_param: node_image }
-				flavor: { get_param: node_flavor }
-				networks:
-					- network: {get_param: node_network}
+			count: { get_param: number_of_nodes }
+			resource_def:
+				type: OS::Nova::Server
+				properties:
+					name: my_nova_server_%index%
+					image: { get_param: node_image }
+					flavor: { get_param: node_flavor }
+					networks:
+						- network: {get_param: node_network}
 */
 package stacks

--- a/openstack/orchestration/v1/stacks/errors.go
+++ b/openstack/orchestration/v1/stacks/errors.go
@@ -31,3 +31,11 @@ type ErrInvalidTemplateFormatVersion struct {
 func (e ErrInvalidTemplateFormatVersion) Error() string {
 	return fmt.Sprintf("Template format version not found.")
 }
+
+type ErrTemplateRequired struct {
+	gophercloud.BaseError
+}
+
+func (e ErrTemplateRequired) Error() string {
+	return fmt.Sprintf("Template required for this function.")
+}

--- a/openstack/orchestration/v1/stacks/requests.go
+++ b/openstack/orchestration/v1/stacks/requests.go
@@ -265,6 +265,8 @@ type UpdateOptsBuilder interface {
 	ToStackUpdateMap() (map[string]interface{}, error)
 }
 
+// UpdatePatchOptsBuilder is the interface options structs have to satisfy in order
+// to be used in the UpdatePatch operation in this package
 type UpdatePatchOptsBuilder interface {
 	ToStackUpdatePatchMap() (map[string]interface{}, error)
 }
@@ -309,7 +311,6 @@ func toStackUpdateMap(opts UpdateOpts) (map[string]interface{}, error) {
 
 	files := make(map[string]string)
 
-	// Template is only required on PUT update
 	if opts.TemplateOpts != nil {
 		if err := opts.TemplateOpts.Parse(); err != nil {
 			return nil, err
@@ -364,7 +365,7 @@ func Update(c *gophercloud.ServiceClient, stackName, stackID string, opts Update
 }
 
 // Update accepts an UpdateOpts struct and updates an existing stack using the
-//  http PATCH verb with the values provided. opts.TemplateOpts is required.
+//  http PATCH verb with the values provided. opts.TemplateOpts is not required.
 func UpdatePatch(c *gophercloud.ServiceClient, stackName, stackID string, opts UpdatePatchOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToStackUpdatePatchMap()
 	if err != nil {

--- a/openstack/orchestration/v1/stacks/testing/fixtures.go
+++ b/openstack/orchestration/v1/stacks/testing/fixtures.go
@@ -233,6 +233,19 @@ func HandleUpdateSuccessfully(t *testing.T) {
 	})
 }
 
+// HandleUpdatePatchSuccessfully creates an HTTP handler at `/stacks/postman_stack/16ef0584-4458-41eb-87c8-0dc8d5f66c87`
+// on the test handler mux that responds with an `Update` response.
+func HandleUpdatePatchSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/stacks/gophercloud-test-stack-2/db6977b2-27aa-4775-9ae7-6213212d4ada", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PATCH")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+	})
+}
+
 // HandleDeleteSuccessfully creates an HTTP handler at `/stacks/postman_stack/16ef0584-4458-41eb-87c8-0dc8d5f66c87`
 // on the test handler mux that responds with a `Delete` response.
 func HandleDeleteSuccessfully(t *testing.T) {

--- a/openstack/orchestration/v1/stacks/testing/requests_test.go
+++ b/openstack/orchestration/v1/stacks/testing/requests_test.go
@@ -133,10 +133,42 @@ func TestUpdateStack(t *testing.T) {
 				}
 			}
 		}`)
-	updateOpts := stacks.UpdateOpts{
+	updateOpts := &stacks.UpdateOpts{
 		TemplateOpts: template,
 	}
 	err := stacks.Update(fake.ServiceClient(), "gophercloud-test-stack-2", "db6977b2-27aa-4775-9ae7-6213212d4ada", updateOpts).ExtractErr()
+	th.AssertNoErr(t, err)
+}
+
+func TestUpdateStackNoTemplate(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleUpdateSuccessfully(t)
+
+	parameters := make(map[string]interface{})
+	parameters["flavor"] = "m1.tiny"
+
+	updateOpts := &stacks.UpdateOpts{
+		Parameters: parameters,
+	}
+	expected := stacks.ErrTemplateRequired{}
+
+	err := stacks.Update(fake.ServiceClient(), "gophercloud-test-stack-2", "db6977b2-27aa-4775-9ae7-6213212d4ada", updateOpts).ExtractErr()
+	th.AssertEquals(t, expected, err)
+}
+
+func TestUpdatePatchStack(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleUpdatePatchSuccessfully(t)
+
+	parameters := make(map[string]interface{})
+	parameters["flavor"] = "m1.tiny"
+
+	updateOpts := &stacks.UpdateOpts{
+		Parameters: parameters,
+	}
+	err := stacks.UpdatePatch(fake.ServiceClient(), "gophercloud-test-stack-2", "db6977b2-27aa-4775-9ae7-6213212d4ada", updateOpts).ExtractErr()
 	th.AssertNoErr(t, err)
 }
 

--- a/provider_client.go
+++ b/provider_client.go
@@ -378,7 +378,7 @@ func defaultOkCodes(method string) []int {
 	case method == "PUT":
 		return []int{201, 202}
 	case method == "PATCH":
-		return []int{200, 204}
+		return []int{200, 202, 204}
 	case method == "DELETE":
 		return []int{202, 204}
 	}


### PR DESCRIPTION
For #[[1101](https://github.com/gophercloud/gophercloud/issues/1101)]

Related Openstack code:
https://github.com/openstack/heat/blob/master/heat/api/openstack/v1/stacks.py#L494
https://github.com/openstack/heat/blob/master/heat/api/openstack/v1/__init__.py#L218

Some notes on the implementation:
Both PUT and PATCH update verbs are acceptable, but the PATCH verb allows template parameter updates without needing to specify the template to the API call, where as PUT does require the template.  PATCH does accept a template, but does not delete the environment overlay as PUT does.  See `openstack/orchestration/v1/stacks/doc.go` for more information on PUT vs PATCH functionality.

I ran this implementation by my colleagues and gophercloud contributors @problemv, @JackKuei  and @dkt26111 and we had some uncertainty on the most gophercloud appropriate manner to implement the PUT vs PATCH, specifically on both routes usage of` ToStackUpdateMaps()`.

We explored the following options:
- Current method of having the Update functions pass in an "existing" flag to the `ToStackUpdateMap() `to reason if a template is required
- Adding a private member to the `UpdateOpts` struct, "existing", that is set by the Update functions and then checked via new interface method in the `ToStackUpdateMap()` function
- Using completely divergent paths for `Update()` and `UpdatePatch()` functions (new structs, new interfaces, new functions)
- Moving the logic from the `ToStackUpdateMap()` function into the different update functions

Since this feature of distinguishing between PUT and PATCH is somewhat unique to stack updates in GopherCloud,  we are hoping to get some feedback on which implementation fits best with in the language and project paradigms.