### PR TITLE
Imageservice V2: implement tasks Get method

### DIFF
--- a/acceptance/openstack/imageservice/v2/tasks_test.go
+++ b/acceptance/openstack/imageservice/v2/tasks_test.go
@@ -1,0 +1,51 @@
+// +build acceptance imageservice tasks
+
+package v2
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/acceptance/clients"
+	"github.com/gophercloud/gophercloud/acceptance/tools"
+	"github.com/gophercloud/gophercloud/openstack/imageservice/v2/tasks"
+	"github.com/gophercloud/gophercloud/pagination"
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestTasksListEachPage(t *testing.T) {
+	client, err := clients.NewImageServiceV2Client()
+	th.AssertNoErr(t, err)
+
+	listOpts := tasks.ListOpts{
+		Limit: 1,
+	}
+
+	pager := tasks.List(client, listOpts)
+	err = pager.EachPage(func(page pagination.Page) (bool, error) {
+		tasks, err := tasks.ExtractTasks(page)
+		th.AssertNoErr(t, err)
+
+		for _, task := range tasks {
+			tools.PrintResource(t, task)
+		}
+
+		return true, nil
+	})
+}
+
+func TestTasksListAllPages(t *testing.T) {
+	client, err := clients.NewImageServiceV2Client()
+	th.AssertNoErr(t, err)
+
+	listOpts := tasks.ListOpts{}
+
+	allPages, err := tasks.List(client, listOpts).AllPages()
+	th.AssertNoErr(t, err)
+
+	allTasks, err := tasks.ExtractTasks(allPages)
+	th.AssertNoErr(t, err)
+
+	for _, i := range allTasks {
+		tools.PrintResource(t, i)
+	}
+}

--- a/openstack/imageservice/v2/tasks/doc.go
+++ b/openstack/imageservice/v2/tasks/doc.go
@@ -1,0 +1,25 @@
+/*
+Package tasks enables management and retrieval of tasks from the OpenStack
+Imageservice.
+
+Example to List Tasks
+
+  listOpts := tasks.ListOpts{
+    Owner: "424e7cf0243c468ca61732ba45973b3e",
+  }
+
+  allPages, err := tasks.List(imagesClient, listOpts).AllPages()
+  if err != nil {
+    panic(err)
+  }
+
+  allTasks, err := tasks.ExtractTasks(allPages)
+  if err != nil {
+    panic(err)
+  }
+
+  for _, task := range allTasks {
+    fmt.Printf("%+v\n", task)
+  }
+*/
+package tasks

--- a/openstack/imageservice/v2/tasks/doc.go
+++ b/openstack/imageservice/v2/tasks/doc.go
@@ -21,5 +21,14 @@ Example to List Tasks
   for _, task := range allTasks {
     fmt.Printf("%+v\n", task)
   }
+
+Example to Get a Task
+
+  task, err := tasks.Get(imagesClient, "1252f636-1246-4319-bfba-c47cde0efbe0").Extract()
+  if err != nil {
+    panic(err)
+  }
+
+  fmt.Printf("%+v\n", task)
 */
 package tasks

--- a/openstack/imageservice/v2/tasks/requests.go
+++ b/openstack/imageservice/v2/tasks/requests.go
@@ -1,0 +1,70 @@
+package tasks
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// ListOptsBuilder allows extensions to add additional parameters to the
+// List request.
+type ListOptsBuilder interface {
+	ToTaskListQuery() (string, error)
+}
+
+// ListOpts allows the filtering and sorting of paginated collections through
+// the OpenStack Imageservice tasks API.
+type ListOpts struct {
+	// Integer value for the limit of values to return.
+	Limit int `q:"limit"`
+
+	// ID of the task at which you want to set a marker.
+	Marker string `q:"marker"`
+
+	// SortDir allows to select sort direction.
+	// It can be "asc" or "desc" (default).
+	SortDir string `q:"sort_dir"`
+
+	// SortKey allows to sort by one of the following tTask attributes:
+	//  - created_at
+	//  - expires_at
+	//  - status
+	//  - type
+	//  - updated_at
+	// Default is created_at.
+	SortKey string `q:"sort_key"`
+
+	// ID filters on the identifier of the task.
+	ID string `json:"id"`
+
+	// Type filters on the type of the task.
+	Type string `json:"type"`
+
+	// Status filters on the status of the task.
+	Status TaskStatus `q:"status"`
+}
+
+// ToTaskListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToTaskListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List returns a Pager which allows you to iterate over a collection of the tasks.
+func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(c)
+	if opts != nil {
+		query, err := opts.ToTaskListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		taskPage := TaskPage{
+			serviceURL:     c.ServiceURL(),
+			LinkedPageBase: pagination.LinkedPageBase{PageResult: r},
+		}
+
+		return taskPage
+	})
+}

--- a/openstack/imageservice/v2/tasks/requests.go
+++ b/openstack/imageservice/v2/tasks/requests.go
@@ -87,3 +87,9 @@ func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 		return taskPage
 	})
 }
+
+// Get retrieves a specific Imageservice task based on its ID.
+func Get(c *gophercloud.ServiceClient, taskID string) (r GetResult) {
+	_, r.Err = c.Get(getURL(c, taskID), &r.Body, nil)
+	return
+}

--- a/openstack/imageservice/v2/tasks/requests.go
+++ b/openstack/imageservice/v2/tasks/requests.go
@@ -5,6 +5,25 @@ import (
 	"github.com/gophercloud/gophercloud/pagination"
 )
 
+// TaskStatus represents valid task status.
+// You can use this type to compare the actual status of a task to a one of the
+// pre-defined statuses.
+type TaskStatus string
+
+const (
+	// TaskStatusPending represents status of the pending task.
+	TaskStatusPending TaskStatus = "pending"
+
+	// TaskStatusProcessing represents status of the processing task.
+	TaskStatusProcessing TaskStatus = "processing"
+
+	// TaskStatusSuccess represents status of the success task.
+	TaskStatusSuccess TaskStatus = "success"
+
+	// TaskStatusFailure represents status of the failure task.
+	TaskStatusFailure TaskStatus = "failure"
+)
+
 // ListOptsBuilder allows extensions to add additional parameters to the
 // List request.
 type ListOptsBuilder interface {

--- a/openstack/imageservice/v2/tasks/results.go
+++ b/openstack/imageservice/v2/tasks/results.go
@@ -1,0 +1,117 @@
+package tasks
+
+import (
+	"time"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// TaskStatus represents valid task status.
+type TaskStatus string
+
+const (
+	// TaskStatusPending represents status of the pending task.
+	TaskStatusPending TaskStatus = "pending"
+
+	// TaskStatusProcessing represents status of the processing task.
+	TaskStatusProcessing TaskStatus = "processing"
+
+	// TaskStatusSuccess represents status of the success task.
+	TaskStatusSuccess TaskStatus = "success"
+
+	// TaskStatusFailure represents status of the failure task.
+	TaskStatusFailure TaskStatus = "failure"
+)
+
+// Task represents a single task of the OpenStack Image service.
+type Task struct {
+	// ID is a unique identifier of the task.
+	ID string `json:"id"`
+
+	// Type represents the type of the task.
+	Type string `json:"type"`
+
+	// Status represents current status of the task.
+	Status TaskStatus `json:"status"`
+
+	// Input represents different parameters for the task.
+	Input map[string]interface{} `json:"input"`
+
+	// Result represents task result details.
+	Result map[string]interface{} `json:"result"`
+
+	// Owner is a unique identifier of the task owner.
+	Owner string `json:"owner"`
+
+	// Message represents human-readable message that is usually populated
+	// on task failure.
+	Message string `json:"message"`
+
+	// ExpiresAt contains the timestamp of when the task will become a subject of
+	// removal.
+	ExpiresAt time.Time `json:"expires_at"`
+
+	// CreatedAt contains the task creation timestamp.
+	CreatedAt time.Time `json:"created_at"`
+
+	// UpdatedAt contains the latest timestamp of when the task was updated.
+	UpdatedAt time.Time `json:"updated_at"`
+
+	// Self contains URI for the task.
+	Self string `json:"self"`
+
+	// Schema the path to the JSON-schema that represent the task.
+	Schema string `json:"schema"`
+}
+
+// Extract interprets any commonResult as a Task.
+func (r commonResult) Extract() (*Task, error) {
+	var s *Task
+	err := r.ExtractInto(&s)
+	return s, err
+}
+
+// TaskPage represents the results of a List request.
+type TaskPage struct {
+	serviceURL string
+	pagination.LinkedPageBase
+}
+
+// IsEmpty returns true if a TaskPage contains no Tasks results.
+func (r TaskPage) IsEmpty() (bool, error) {
+	tasks, err := ExtractTasks(r)
+	return len(tasks) == 0, err
+}
+
+// NextPageURL uses the response's embedded link reference to navigate to
+// the next page of results.
+func (r TaskPage) NextPageURL() (string, error) {
+	var s struct {
+		Next string `json:"next"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+
+	if s.Next == "" {
+		return "", nil
+	}
+
+	return nextPageURL(r.serviceURL, s.Next)
+}
+
+// ExtractTasks interprets the results of a single page from a List() call,
+// producing a slice of Task entities.
+func ExtractTasks(r pagination.Page) ([]Task, error) {
+	var s struct {
+		Tasks []Task `json:"tasks"`
+	}
+	err := (r.(TaskPage)).ExtractInto(&s)
+	return s.Tasks, err
+}

--- a/openstack/imageservice/v2/tasks/results.go
+++ b/openstack/imageservice/v2/tasks/results.go
@@ -11,6 +11,12 @@ type commonResult struct {
 	gophercloud.Result
 }
 
+// GetResult represents the result of a Get operation. Call its Extract
+// method to interpret it as a Task.
+type GetResult struct {
+	commonResult
+}
+
 // Task represents a single task of the OpenStack Image service.
 type Task struct {
 	// ID is a unique identifier of the task.

--- a/openstack/imageservice/v2/tasks/results.go
+++ b/openstack/imageservice/v2/tasks/results.go
@@ -11,23 +11,6 @@ type commonResult struct {
 	gophercloud.Result
 }
 
-// TaskStatus represents valid task status.
-type TaskStatus string
-
-const (
-	// TaskStatusPending represents status of the pending task.
-	TaskStatusPending TaskStatus = "pending"
-
-	// TaskStatusProcessing represents status of the processing task.
-	TaskStatusProcessing TaskStatus = "processing"
-
-	// TaskStatusSuccess represents status of the success task.
-	TaskStatusSuccess TaskStatus = "success"
-
-	// TaskStatusFailure represents status of the failure task.
-	TaskStatusFailure TaskStatus = "failure"
-)
-
 // Task represents a single task of the OpenStack Image service.
 type Task struct {
 	// ID is a unique identifier of the task.
@@ -37,7 +20,9 @@ type Task struct {
 	Type string `json:"type"`
 
 	// Status represents current status of the task.
-	Status TaskStatus `json:"status"`
+	// You can use the TaskStatus custom type to unmarshal raw JSON response into
+	// the pre-defined valid task status.
+	Status string `json:"status"`
 
 	// Input represents different parameters for the task.
 	Input map[string]interface{} `json:"input"`

--- a/openstack/imageservice/v2/tasks/testing/doc.go
+++ b/openstack/imageservice/v2/tasks/testing/doc.go
@@ -1,0 +1,2 @@
+// tasks unit tests
+package testing

--- a/openstack/imageservice/v2/tasks/testing/fixtures.go
+++ b/openstack/imageservice/v2/tasks/testing/fixtures.go
@@ -39,7 +39,7 @@ const TasksListResult = `
 // Task1 is an expected representation of a first task from the TasksListResult.
 var Task1 = tasks.Task{
 	ID:        "1252f636-1246-4319-bfba-c47cde0efbe0",
-	Status:    tasks.TaskStatusPending,
+	Status:    string(tasks.TaskStatusPending),
 	Type:      "import",
 	Owner:     "424e7cf0243c468ca61732ba45973b3e",
 	CreatedAt: time.Date(2018, 7, 25, 8, 59, 13, 0, time.UTC),
@@ -51,7 +51,7 @@ var Task1 = tasks.Task{
 // Task2 is an expected representation of a first task from the TasksListResult.
 var Task2 = tasks.Task{
 	ID:        "349a51f4-d51d-47b6-82da-4fa516f0ca32",
-	Status:    tasks.TaskStatusProcessing,
+	Status:    string(tasks.TaskStatusProcessing),
 	Type:      "import",
 	Owner:     "fb57277ef2f84a0e85b9018ec2dedbf7",
 	CreatedAt: time.Date(2018, 7, 25, 8, 56, 17, 0, time.UTC),

--- a/openstack/imageservice/v2/tasks/testing/fixtures.go
+++ b/openstack/imageservice/v2/tasks/testing/fixtures.go
@@ -1,0 +1,61 @@
+package testing
+
+import (
+	"time"
+
+	"github.com/gophercloud/gophercloud/openstack/imageservice/v2/tasks"
+)
+
+// TasksListResult represents raw server response from a server to a list call.
+const TasksListResult = `
+{
+    "schema": "/v2/schemas/tasks",
+    "tasks": [
+        {
+            "status": "pending",
+            "self": "/v2/tasks/1252f636-1246-4319-bfba-c47cde0efbe0",
+            "updated_at": "2018-07-25T08:59:14Z",
+            "id": "1252f636-1246-4319-bfba-c47cde0efbe0",
+            "owner": "424e7cf0243c468ca61732ba45973b3e",
+            "type": "import",
+            "created_at": "2018-07-25T08:59:13Z",
+            "schema": "/v2/schemas/task"
+        },
+        {
+            "status": "processing",
+            "self": "/v2/tasks/349a51f4-d51d-47b6-82da-4fa516f0ca32",
+            "updated_at": "2018-07-25T08:56:19Z",
+            "id": "349a51f4-d51d-47b6-82da-4fa516f0ca32",
+            "owner": "fb57277ef2f84a0e85b9018ec2dedbf7",
+            "type": "import",
+            "created_at": "2018-07-25T08:56:17Z",
+            "schema": "/v2/schemas/task"
+        }
+    ],
+    "first": "/v2/tasks?sort_key=status&sort_dir=desc&limit=20"
+}
+`
+
+// Task1 is an expected representation of a first task from the TasksListResult.
+var Task1 = tasks.Task{
+	ID:        "1252f636-1246-4319-bfba-c47cde0efbe0",
+	Status:    tasks.TaskStatusPending,
+	Type:      "import",
+	Owner:     "424e7cf0243c468ca61732ba45973b3e",
+	CreatedAt: time.Date(2018, 7, 25, 8, 59, 13, 0, time.UTC),
+	UpdatedAt: time.Date(2018, 7, 25, 8, 59, 14, 0, time.UTC),
+	Self:      "/v2/tasks/1252f636-1246-4319-bfba-c47cde0efbe0",
+	Schema:    "/v2/schemas/task",
+}
+
+// Task2 is an expected representation of a first task from the TasksListResult.
+var Task2 = tasks.Task{
+	ID:        "349a51f4-d51d-47b6-82da-4fa516f0ca32",
+	Status:    tasks.TaskStatusProcessing,
+	Type:      "import",
+	Owner:     "fb57277ef2f84a0e85b9018ec2dedbf7",
+	CreatedAt: time.Date(2018, 7, 25, 8, 56, 17, 0, time.UTC),
+	UpdatedAt: time.Date(2018, 7, 25, 8, 56, 19, 0, time.UTC),
+	Self:      "/v2/tasks/349a51f4-d51d-47b6-82da-4fa516f0ca32",
+	Schema:    "/v2/schemas/task",
+}

--- a/openstack/imageservice/v2/tasks/testing/fixtures.go
+++ b/openstack/imageservice/v2/tasks/testing/fixtures.go
@@ -59,3 +59,27 @@ var Task2 = tasks.Task{
 	Self:      "/v2/tasks/349a51f4-d51d-47b6-82da-4fa516f0ca32",
 	Schema:    "/v2/schemas/task",
 }
+
+// TasksGetResult represents raw server response from a server to a get call.
+const TasksGetResult = `
+{
+    "status": "pending",
+    "created_at": "2018-07-25T08:59:13Z",
+    "updated_at": "2018-07-25T08:59:14Z",
+    "self": "/v2/tasks/1252f636-1246-4319-bfba-c47cde0efbe0",
+    "result": null,
+    "owner": "424e7cf0243c468ca61732ba45973b3e",
+    "input": {
+        "image_properties": {
+            "container_format": "bare",
+            "disk_format": "raw"
+        },
+        "import_from_format": "raw",
+        "import_from": "http://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img"
+    },
+    "message": "",
+    "type": "import",
+    "id": "1252f636-1246-4319-bfba-c47cde0efbe0",
+    "schema": "/v2/schemas/task"
+}
+`

--- a/openstack/imageservice/v2/tasks/testing/requests_test.go
+++ b/openstack/imageservice/v2/tasks/testing/requests_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/gophercloud/gophercloud/openstack/imageservice/v2/tasks"
 	"github.com/gophercloud/gophercloud/pagination"
@@ -48,4 +49,41 @@ func TestList(t *testing.T) {
 	if count != 1 {
 		t.Errorf("Expected 1 page, got %d", count)
 	}
+}
+
+func TestGet(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/tasks/1252f636-1246-4319-bfba-c47cde0efbe0", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fakeclient.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, TasksGetResult)
+	})
+
+	s, err := tasks.Get(fakeclient.ServiceClient(), "1252f636-1246-4319-bfba-c47cde0efbe0").Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, s.Status, string(tasks.TaskStatusPending))
+	th.AssertEquals(t, s.CreatedAt, time.Date(2018, 7, 25, 8, 59, 13, 0, time.UTC))
+	th.AssertEquals(t, s.UpdatedAt, time.Date(2018, 7, 25, 8, 59, 14, 0, time.UTC))
+	th.AssertEquals(t, s.Self, "/v2/tasks/1252f636-1246-4319-bfba-c47cde0efbe0")
+	th.AssertEquals(t, s.Owner, "424e7cf0243c468ca61732ba45973b3e")
+	th.AssertEquals(t, s.Message, "")
+	th.AssertEquals(t, s.Type, "import")
+	th.AssertEquals(t, s.ID, "1252f636-1246-4319-bfba-c47cde0efbe0")
+	th.AssertEquals(t, s.Schema, "/v2/schemas/task")
+	th.AssertDeepEquals(t, s.Result, map[string]interface{}(nil))
+	th.AssertDeepEquals(t, s.Input, map[string]interface{}{
+		"import_from":        "http://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img",
+		"import_from_format": "raw",
+		"image_properties": map[string]interface{}{
+			"container_format": "bare",
+			"disk_format":      "raw",
+		},
+	})
 }

--- a/openstack/imageservice/v2/tasks/testing/requests_test.go
+++ b/openstack/imageservice/v2/tasks/testing/requests_test.go
@@ -1,0 +1,51 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/imageservice/v2/tasks"
+	"github.com/gophercloud/gophercloud/pagination"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	fakeclient "github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func TestList(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/tasks", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fakeclient.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, TasksListResult)
+	})
+
+	count := 0
+
+	tasks.List(fakeclient.ServiceClient(), tasks.ListOpts{}).EachPage(func(page pagination.Page) (bool, error) {
+		count++
+		actual, err := tasks.ExtractTasks(page)
+		if err != nil {
+			t.Errorf("Failed to extract tasks: %v", err)
+			return false, nil
+		}
+
+		expected := []tasks.Task{
+			Task1,
+			Task2,
+		}
+
+		th.CheckDeepEquals(t, expected, actual)
+
+		return true, nil
+	})
+
+	if count != 1 {
+		t.Errorf("Expected 1 page, got %d", count)
+	}
+}

--- a/openstack/imageservice/v2/tasks/urls.go
+++ b/openstack/imageservice/v2/tasks/urls.go
@@ -1,0 +1,43 @@
+package tasks
+
+import (
+	"net/url"
+	"strings"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/utils"
+)
+
+const resourcePath = "tasks"
+
+func rootURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL(resourcePath)
+}
+
+func listURL(c *gophercloud.ServiceClient) string {
+	return rootURL(c)
+}
+
+func nextPageURL(serviceURL, requestedNext string) (string, error) {
+	base, err := utils.BaseEndpoint(serviceURL)
+	if err != nil {
+		return "", err
+	}
+
+	requestedNextURL, err := url.Parse(requestedNext)
+	if err != nil {
+		return "", err
+	}
+
+	base = gophercloud.NormalizeURL(base)
+	nextPath := base + strings.TrimPrefix(requestedNextURL.Path, "/")
+
+	nextURL, err := url.Parse(nextPath)
+	if err != nil {
+		return "", err
+	}
+
+	nextURL.RawQuery = requestedNextURL.RawQuery
+
+	return nextURL.String(), nil
+}

--- a/openstack/imageservice/v2/tasks/urls.go
+++ b/openstack/imageservice/v2/tasks/urls.go
@@ -14,8 +14,16 @@ func rootURL(c *gophercloud.ServiceClient) string {
 	return c.ServiceURL(resourcePath)
 }
 
+func resourceURL(c *gophercloud.ServiceClient, taskID string) string {
+	return c.ServiceURL(resourcePath, taskID)
+}
+
 func listURL(c *gophercloud.ServiceClient) string {
 	return rootURL(c)
+}
+
+func getURL(c *gophercloud.ServiceClient, taskID string) string {
+	return resourceURL(c, taskID)
 }
 
 func nextPageURL(serviceURL, requestedNext string) (string, error) {


### PR DESCRIPTION
Implement Get method for the Imageservice tasks.
Add unit test with documentation example.

For #1143

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

API
https://github.com/openstack/glance/blob/stable/queens/glance/api/v2/tasks.py#L121
https://github.com/openstack/glance/blob/stable/queens/glance/api/v2/tasks.py#L309

DB
https://github.com/openstack/glance/blob/stable/queens/glance/db/sqlalchemy/api.py#L1559