### PR TITLE
Imageservice V2: implement tasks Create method

### DIFF
--- a/acceptance/openstack/imageservice/v2/tasks_test.go
+++ b/acceptance/openstack/imageservice/v2/tasks_test.go
@@ -49,3 +49,15 @@ func TestTasksListAllPages(t *testing.T) {
 		tools.PrintResource(t, i)
 	}
 }
+
+func TestTaskCreate(t *testing.T) {
+	client, err := clients.NewImageServiceV2Client()
+	th.AssertNoErr(t, err)
+
+	task, err := CreateTask(t, client, ImportImageURL)
+	if err != nil {
+		t.Fatalf("Unable to create an Imageservice task: %v", err)
+	}
+
+	tools.PrintResource(t, task)
+}

--- a/openstack/imageservice/v2/tasks/doc.go
+++ b/openstack/imageservice/v2/tasks/doc.go
@@ -30,5 +30,26 @@ Example to Get a Task
   }
 
   fmt.Printf("%+v\n", task)
+
+Example to Create a Task
+
+  createOpts := tasks.CreateOpts{
+    Type: "import",
+    Input: map[string]interface{}{
+      "image_properties": map[string]interface{}{
+        "container_format": "bare",
+        "disk_format":      "raw",
+      },
+      "import_from_format": "raw",
+      "import_from":        "https://cloud-images.ubuntu.com/bionic/current/bionic-server-cloudimg-amd64.img",
+    },
+  }
+
+  task, err := tasks.Create(imagesClient, createOpts).Extract()
+  if err != nil {
+    panic(err)
+  }
+
+  fmt.Printf("%+v\n", task)
 */
 package tasks

--- a/openstack/imageservice/v2/tasks/requests.go
+++ b/openstack/imageservice/v2/tasks/requests.go
@@ -93,3 +93,36 @@ func Get(c *gophercloud.ServiceClient, taskID string) (r GetResult) {
 	_, r.Err = c.Get(getURL(c, taskID), &r.Body, nil)
 	return
 }
+
+// CreateOptsBuilder allows to add additional parameters to the Create request.
+type CreateOptsBuilder interface {
+	ToTaskCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts specifies parameters of a new Imageservice task.
+type CreateOpts struct {
+	Type  string                 `json:"type" required:"true"`
+	Input map[string]interface{} `json:"input"`
+}
+
+// ToTaskCreateMap constructs a request body from CreateOpts.
+func (opts CreateOpts) ToTaskCreateMap() (map[string]interface{}, error) {
+	b, err := gophercloud.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+// Create requests the creation of a new Imageservice task on the server.
+func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToTaskCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(createURL(client), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{201},
+	})
+	return
+}

--- a/openstack/imageservice/v2/tasks/results.go
+++ b/openstack/imageservice/v2/tasks/results.go
@@ -17,6 +17,12 @@ type GetResult struct {
 	commonResult
 }
 
+// CreateResult represents the result of a Create operation. Call its Extract
+// method to interpret it as a Task.
+type CreateResult struct {
+	commonResult
+}
+
 // Task represents a single task of the OpenStack Image service.
 type Task struct {
 	// ID is a unique identifier of the task.

--- a/openstack/imageservice/v2/tasks/testing/fixtures.go
+++ b/openstack/imageservice/v2/tasks/testing/fixtures.go
@@ -83,3 +83,42 @@ const TasksGetResult = `
     "schema": "/v2/schemas/task"
 }
 `
+
+// TaskCreateRequest represents a request to create a task.
+const TaskCreateRequest = `
+{
+    "input": {
+        "image_properties": {
+            "container_format": "bare",
+            "disk_format": "raw"
+        },
+        "import_from_format": "raw",
+        "import_from": "https://cloud-images.ubuntu.com/bionic/current/bionic-server-cloudimg-amd64.img"
+    },
+    "type": "import"
+}
+`
+
+// TaskCreateResult represents a raw server response to the TaskCreateRequest.
+const TaskCreateResult = `
+{
+    "status": "pending",
+    "created_at": "2018-07-25T11:07:54Z",
+    "updated_at": "2018-07-25T11:07:54Z",
+    "self": "/v2/tasks/d550c87d-86ed-430a-9895-c7a1f5ce87e9",
+    "result": null,
+    "owner": "fb57277ef2f84a0e85b9018ec2dedbf7",
+    "input": {
+        "image_properties": {
+            "container_format": "bare",
+            "disk_format": "raw"
+        },
+        "import_from_format": "raw",
+        "import_from": "https://cloud-images.ubuntu.com/bionic/current/bionic-server-cloudimg-amd64.img"
+    },
+    "message": "",
+    "type": "import",
+    "id": "d550c87d-86ed-430a-9895-c7a1f5ce87e9",
+    "schema": "/v2/schemas/task"
+}
+`

--- a/openstack/imageservice/v2/tasks/testing/fixtures.go
+++ b/openstack/imageservice/v2/tasks/testing/fixtures.go
@@ -39,7 +39,11 @@ const TasksListResult = `
 // Task1 is an expected representation of a first task from the TasksListResult.
 var Task1 = tasks.Task{
 	ID:        "1252f636-1246-4319-bfba-c47cde0efbe0",
+<<<<<<< HEAD
 	Status:    string(tasks.TaskStatusPending),
+=======
+	Status:    tasks.TaskStatusPending,
+>>>>>>> Imageservice V2: implement tasks List method
 	Type:      "import",
 	Owner:     "424e7cf0243c468ca61732ba45973b3e",
 	CreatedAt: time.Date(2018, 7, 25, 8, 59, 13, 0, time.UTC),
@@ -51,7 +55,11 @@ var Task1 = tasks.Task{
 // Task2 is an expected representation of a first task from the TasksListResult.
 var Task2 = tasks.Task{
 	ID:        "349a51f4-d51d-47b6-82da-4fa516f0ca32",
+<<<<<<< HEAD
 	Status:    string(tasks.TaskStatusProcessing),
+=======
+	Status:    tasks.TaskStatusProcessing,
+>>>>>>> Imageservice V2: implement tasks List method
 	Type:      "import",
 	Owner:     "fb57277ef2f84a0e85b9018ec2dedbf7",
 	CreatedAt: time.Date(2018, 7, 25, 8, 56, 17, 0, time.UTC),
@@ -59,6 +67,7 @@ var Task2 = tasks.Task{
 	Self:      "/v2/tasks/349a51f4-d51d-47b6-82da-4fa516f0ca32",
 	Schema:    "/v2/schemas/task",
 }
+<<<<<<< HEAD
 
 // TasksGetResult represents raw server response from a server to a get call.
 const TasksGetResult = `
@@ -83,3 +92,5 @@ const TasksGetResult = `
     "schema": "/v2/schemas/task"
 }
 `
+=======
+>>>>>>> Imageservice V2: implement tasks List method

--- a/openstack/imageservice/v2/tasks/testing/fixtures.go
+++ b/openstack/imageservice/v2/tasks/testing/fixtures.go
@@ -39,11 +39,7 @@ const TasksListResult = `
 // Task1 is an expected representation of a first task from the TasksListResult.
 var Task1 = tasks.Task{
 	ID:        "1252f636-1246-4319-bfba-c47cde0efbe0",
-<<<<<<< HEAD
 	Status:    string(tasks.TaskStatusPending),
-=======
-	Status:    tasks.TaskStatusPending,
->>>>>>> Imageservice V2: implement tasks List method
 	Type:      "import",
 	Owner:     "424e7cf0243c468ca61732ba45973b3e",
 	CreatedAt: time.Date(2018, 7, 25, 8, 59, 13, 0, time.UTC),
@@ -55,11 +51,7 @@ var Task1 = tasks.Task{
 // Task2 is an expected representation of a first task from the TasksListResult.
 var Task2 = tasks.Task{
 	ID:        "349a51f4-d51d-47b6-82da-4fa516f0ca32",
-<<<<<<< HEAD
 	Status:    string(tasks.TaskStatusProcessing),
-=======
-	Status:    tasks.TaskStatusProcessing,
->>>>>>> Imageservice V2: implement tasks List method
 	Type:      "import",
 	Owner:     "fb57277ef2f84a0e85b9018ec2dedbf7",
 	CreatedAt: time.Date(2018, 7, 25, 8, 56, 17, 0, time.UTC),
@@ -67,7 +59,6 @@ var Task2 = tasks.Task{
 	Self:      "/v2/tasks/349a51f4-d51d-47b6-82da-4fa516f0ca32",
 	Schema:    "/v2/schemas/task",
 }
-<<<<<<< HEAD
 
 // TasksGetResult represents raw server response from a server to a get call.
 const TasksGetResult = `
@@ -92,5 +83,3 @@ const TasksGetResult = `
     "schema": "/v2/schemas/task"
 }
 `
-=======
->>>>>>> Imageservice V2: implement tasks List method

--- a/openstack/imageservice/v2/tasks/testing/requests_test.go
+++ b/openstack/imageservice/v2/tasks/testing/requests_test.go
@@ -4,10 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
-<<<<<<< HEAD
 	"time"
-=======
->>>>>>> Imageservice V2: implement tasks List method
 
 	"github.com/gophercloud/gophercloud/openstack/imageservice/v2/tasks"
 	"github.com/gophercloud/gophercloud/pagination"
@@ -53,7 +50,6 @@ func TestList(t *testing.T) {
 		t.Errorf("Expected 1 page, got %d", count)
 	}
 }
-<<<<<<< HEAD
 
 func TestGet(t *testing.T) {
 	th.SetupHTTP()
@@ -91,5 +87,3 @@ func TestGet(t *testing.T) {
 		},
 	})
 }
-=======
->>>>>>> Imageservice V2: implement tasks List method

--- a/openstack/imageservice/v2/tasks/testing/requests_test.go
+++ b/openstack/imageservice/v2/tasks/testing/requests_test.go
@@ -4,7 +4,10 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+<<<<<<< HEAD
 	"time"
+=======
+>>>>>>> Imageservice V2: implement tasks List method
 
 	"github.com/gophercloud/gophercloud/openstack/imageservice/v2/tasks"
 	"github.com/gophercloud/gophercloud/pagination"
@@ -50,6 +53,7 @@ func TestList(t *testing.T) {
 		t.Errorf("Expected 1 page, got %d", count)
 	}
 }
+<<<<<<< HEAD
 
 func TestGet(t *testing.T) {
 	th.SetupHTTP()
@@ -87,3 +91,5 @@ func TestGet(t *testing.T) {
 		},
 	})
 }
+=======
+>>>>>>> Imageservice V2: implement tasks List method

--- a/openstack/imageservice/v2/tasks/urls.go
+++ b/openstack/imageservice/v2/tasks/urls.go
@@ -26,6 +26,10 @@ func getURL(c *gophercloud.ServiceClient, taskID string) string {
 	return resourceURL(c, taskID)
 }
 
+func createURL(c *gophercloud.ServiceClient) string {
+	return rootURL(c)
+}
+
 func nextPageURL(serviceURL, requestedNext string) (string, error) {
 	base, err := utils.BaseEndpoint(serviceURL)
 	if err != nil {


### PR DESCRIPTION
Implement Create method for the Imageservice tasks.
Add unit and acceptance tests with documentation.

For #1143 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

API
https://github.com/openstack/glance/blob/stable/queens/glance/api/v2/tasks.py#L69
https://github.com/openstack/glance/blob/stable/queens/glance/api/v2/tasks.py#L216
https://github.com/openstack/glance/blob/stable/queens/glance/api/v2/tasks.py#L304
https://github.com/openstack/glance/blob/stable/queens/glance/api/v2/tasks.py#L430

DB
https://github.com/openstack/glance/blob/stable/queens/glance/db/sqlalchemy/api.py#L1397