### PR TITLE
Fix ToServerRebootMap() method

### DIFF
--- a/acceptance/openstack/compute/v2/servers_test.go
+++ b/acceptance/openstack/compute/v2/servers_test.go
@@ -271,7 +271,7 @@ func TestServersActionReboot(t *testing.T) {
 	th.AssertNoErr(t, err)
 	defer DeleteServer(t, client, server)
 
-	rebootOpts := &servers.RebootOpts{
+	rebootOpts := servers.RebootOpts{
 		Type: servers.SoftReboot,
 	}
 

--- a/docs/MIGRATING.md
+++ b/docs/MIGRATING.md
@@ -16,7 +16,7 @@
 * `servers.Reboot` now requires a `servers.RebootOpts` struct:
 
   ```golang
-  rebootOpts := &servers.RebootOpts{
+  rebootOpts := servers.RebootOpts{
           Type: servers.SoftReboot,
   }
   res := servers.Reboot(client, server.ID, rebootOpts)

--- a/openstack/compute/v2/servers/requests.go
+++ b/openstack/compute/v2/servers/requests.go
@@ -383,7 +383,7 @@ type RebootOpts struct {
 }
 
 // ToServerRebootMap builds a body for the reboot request.
-func (opts *RebootOpts) ToServerRebootMap() (map[string]interface{}, error) {
+func (opts RebootOpts) ToServerRebootMap() (map[string]interface{}, error) {
 	return gophercloud.BuildRequestBody(opts, "reboot")
 }
 

--- a/openstack/compute/v2/servers/testing/requests_test.go
+++ b/openstack/compute/v2/servers/testing/requests_test.go
@@ -311,7 +311,7 @@ func TestRebootServer(t *testing.T) {
 	defer th.TeardownHTTP()
 	HandleRebootSuccessfully(t)
 
-	res := servers.Reboot(client.ServiceClient(), "1234asdf", &servers.RebootOpts{
+	res := servers.Reboot(client.ServiceClient(), "1234asdf", servers.RebootOpts{
 		Type: servers.SoftReboot,
 	})
 	th.AssertNoErr(t, res.Err)


### PR DESCRIPTION
For #1151 
Documentation: [link](https://godoc.org/github.com/gophercloud/gophercloud/openstack/compute/v2/servers)

Example to Reboot a Server
``` go
rebootOpts := servers.RebootOpts{
	Type: servers.SoftReboot,
}

serverID := "d9072956-1560-487c-97f2-18bdf65ec749"

err := servers.Reboot(computeClient, serverID, rebootOpts).ExtractErr()
if err != nil {
	panic(err)
}
```