### PR TITLE
Networking V2: Implement IP availabilities Get

### DIFF
--- a/acceptance/openstack/networking/v2/extensions/networkipavailabilities/networkipavailabilities_test.go
+++ b/acceptance/openstack/networking/v2/extensions/networkipavailabilities/networkipavailabilities_test.go
@@ -1,0 +1,32 @@
+// +build acceptance networking networkipavailabilities
+
+package networkipavailabilities
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/acceptance/clients"
+	"github.com/gophercloud/gophercloud/acceptance/tools"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/networkipavailabilities"
+)
+
+func TestNetworkIPAvailabilityList(t *testing.T) {
+	client, err := clients.NewNetworkV2Client()
+	if err != nil {
+		t.Fatalf("Unable to create a network client: %v", err)
+	}
+
+	allPages, err := networkipavailabilities.List(client, nil).AllPages()
+	if err != nil {
+		t.Fatalf("Unable to list network IP availabilities: %v", err)
+	}
+
+	allAvailabilities, err := networkipavailabilities.ExtractNetworkIPAvailabilities(allPages)
+	if err != nil {
+		t.Fatalf("Unable to extract network IP availabilities: %v", err)
+	}
+
+	for _, availability := range allAvailabilities {
+		tools.PrintResource(t, availability)
+	}
+}

--- a/acceptance/openstack/networking/v2/extensions/networkipavailabilities/pkg.go
+++ b/acceptance/openstack/networking/v2/extensions/networkipavailabilities/pkg.go
@@ -1,0 +1,1 @@
+package networkipavailabilities

--- a/openstack/networking/v2/extensions/networkipavailabilities/doc.go
+++ b/openstack/networking/v2/extensions/networkipavailabilities/doc.go
@@ -1,0 +1,21 @@
+/*
+Package networkipavailabilities provides the ability to retrieve and manage
+networkipavailabilities through the Neutron API.
+
+Example of Listing NetworkIPAvailabilities
+
+  allPages, err := networkipavailabilities.List(networkClient, networkipavailabilities.ListOpts{}).AllPages()
+  if err != nil {
+    panic(err)
+  }
+
+  allAvailabilities, err := subnetpools.ExtractSubnetPools(allPages)
+  if err != nil {
+    panic(err)
+  }
+
+  for _, availability := range allAvailabilities {
+    fmt.Printf("%+v\n", availability)
+  }
+*/
+package networkipavailabilities

--- a/openstack/networking/v2/extensions/networkipavailabilities/doc.go
+++ b/openstack/networking/v2/extensions/networkipavailabilities/doc.go
@@ -17,5 +17,14 @@ Example of Listing NetworkIPAvailabilities
   for _, availability := range allAvailabilities {
     fmt.Printf("%+v\n", availability)
   }
+
+Example of Getting a single NetworkIPAvailability
+
+  availability, err := networkipavailabilities.Get(networkClient, "cf11ab78-2302-49fa-870f-851a08c7afb8").Extract()
+  if err != nil {
+    panic(err)
+  }
+
+  fmt.Printf("%+v\n", availability)
 */
 package networkipavailabilities

--- a/openstack/networking/v2/extensions/networkipavailabilities/requests.go
+++ b/openstack/networking/v2/extensions/networkipavailabilities/requests.go
@@ -20,6 +20,10 @@ type ListOpts struct {
 	// NetworkName allows to filter on the name of a network.
 	NetworkName string `q:"network_name"`
 
+	// IPVersion allows to filter on the version of the IP protocol.
+	// You can use the well-known IP versions with the gophercloud.IPVersion type.
+	IPVersion string `q:"ip_version"`
+
 	// ProjectID allows to filter on the Identity project field.
 	ProjectID string `q:"project_id"`
 

--- a/openstack/networking/v2/extensions/networkipavailabilities/requests.go
+++ b/openstack/networking/v2/extensions/networkipavailabilities/requests.go
@@ -1,0 +1,51 @@
+package networkipavailabilities
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// ListOptsBuilder allows extensions to add additional parameters to the
+// List request.
+type ListOptsBuilder interface {
+	ToNetworkIPAvailabilityListQuery() (string, error)
+}
+
+// ListOpts allows the filtering and sorting of paginated collections through
+// the Neutron API.
+type ListOpts struct {
+	// NetworkName allows to filter on the identifier of a network.
+	NetworkID string `q:"network_id"`
+
+	// NetworkName allows to filter on the name of a network.
+	NetworkName string `q:"network_name"`
+
+	// ProjectID allows to filter on the Identity project field.
+	ProjectID string `q:"project_id"`
+
+	// TenantID allows to filter on the Identity project field.
+	TenantID string `q:"tenant_id"`
+}
+
+// ToNetworkIPAvailabilityListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToNetworkIPAvailabilityListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List returns a Pager which allows you to iterate over a collection of
+// networkipavailabilities. It accepts a ListOpts struct, which allows you to
+// filter the returned collection for greater efficiency.
+func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(c)
+	if opts != nil {
+		query, err := opts.ToNetworkIPAvailabilityListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		return NetworkIPAvailabilityPage{pagination.SinglePageBase(r)}
+	})
+}

--- a/openstack/networking/v2/extensions/networkipavailabilities/requests.go
+++ b/openstack/networking/v2/extensions/networkipavailabilities/requests.go
@@ -53,3 +53,9 @@ func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 		return NetworkIPAvailabilityPage{pagination.SinglePageBase(r)}
 	})
 }
+
+// Get retrieves a specific NetworkIPAvailability based on its ID.
+func Get(c *gophercloud.ServiceClient, id string) (r GetResult) {
+	_, r.Err = c.Get(getURL(c, id), &r.Body, nil)
+	return
+}

--- a/openstack/networking/v2/extensions/networkipavailabilities/results.go
+++ b/openstack/networking/v2/extensions/networkipavailabilities/results.go
@@ -1,0 +1,90 @@
+package networkipavailabilities
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// Extract is a function that accepts a result and extracts a NetworkIPAvailability.
+func (r commonResult) Extract() (*NetworkIPAvailability, error) {
+	var s struct {
+		NetworkIPAvailability *NetworkIPAvailability `json:"network_ip_availability"`
+	}
+	err := r.ExtractInto(&s)
+	return s.NetworkIPAvailability, err
+}
+
+// NetworkIPAvailability represents availability details for a single network.
+type NetworkIPAvailability struct {
+	// NetworkID contains an unique identifier of the network.
+	NetworkID string `json:"network_id"`
+
+	// NetworkName represents human-readable name of the network.
+	NetworkName string `json:"network_name"`
+
+	// ProjectID is the ID of the Identity project.
+	ProjectID string `json:"project_id"`
+
+	// TenantID is the ID of the Identity project.
+	TenantID string `json:"tenant_id"`
+
+	// SubnetIPAvailabilities contains availability details for every subnet
+	// that is associated to the network.
+	SubnetIPAvailabilities []SubnetIPAvailability `json:"subnet_ip_availability"`
+
+	// TotalIPs represents a number of IP addresses in the network.
+	TotalIPs int `json:"total_ips"`
+
+	// UsedIPs represents a number of used IP addresses in the network.
+	UsedIPs int `json:"used_ips"`
+}
+
+// SubnetIPAvailability represents availability details for a single subnet.
+type SubnetIPAvailability struct {
+	// SubnetID contains an unique identifier of the subnet.
+	SubnetID string `json:"subnet_id"`
+
+	// SubnetName represents human-readable name of the subnet.
+	SubnetName string `json:"subnet_name"`
+
+	// CIDR represents prefix in the CIDR format.
+	CIDR string `json:"cidr"`
+
+	// IPVersion is the IP protocol version.
+	IPVersion int `json:"ip_version"`
+
+	// TotalIPs represents a number of IP addresses in the subnet.
+	TotalIPs int `json:"total_ips"`
+
+	// UsedIPs represents a number of used IP addresses in the subnet.
+	UsedIPs int `json:"used_ips"`
+}
+
+// NetworkIPAvailabilityPage stores a single page of NetworkIPAvailabilities
+// from the List call.
+type NetworkIPAvailabilityPage struct {
+	pagination.SinglePageBase
+}
+
+// IsEmpty determines whether or not a NetworkIPAvailability is empty.
+func (r NetworkIPAvailabilityPage) IsEmpty() (bool, error) {
+	networkipavailabilities, err := ExtractNetworkIPAvailabilities(r)
+	return len(networkipavailabilities) == 0, err
+}
+
+// ExtractNetworkIPAvailabilities interprets the results of a single page from
+// a List() API call, producing a slice of NetworkIPAvailabilities structures.
+func ExtractNetworkIPAvailabilities(r pagination.Page) ([]NetworkIPAvailability, error) {
+	var s struct {
+		NetworkIPAvailabilities []NetworkIPAvailability `json:"network_ip_availabilities"`
+	}
+	err := (r.(NetworkIPAvailabilityPage)).ExtractInto(&s)
+	if err != nil {
+		return nil, err
+	}
+	return s.NetworkIPAvailabilities, nil
+}

--- a/openstack/networking/v2/extensions/networkipavailabilities/results.go
+++ b/openstack/networking/v2/extensions/networkipavailabilities/results.go
@@ -9,6 +9,12 @@ type commonResult struct {
 	gophercloud.Result
 }
 
+// GetResult represents the result of a Get operation. Call its Extract
+// method to interpret it as a NetworkIPAvailability.
+type GetResult struct {
+	commonResult
+}
+
 // Extract is a function that accepts a result and extracts a NetworkIPAvailability.
 func (r commonResult) Extract() (*NetworkIPAvailability, error) {
 	var s struct {

--- a/openstack/networking/v2/extensions/networkipavailabilities/testing/doc.go
+++ b/openstack/networking/v2/extensions/networkipavailabilities/testing/doc.go
@@ -1,0 +1,2 @@
+// networkipavailabilities unit tests
+package testing

--- a/openstack/networking/v2/extensions/networkipavailabilities/testing/fixtures.go
+++ b/openstack/networking/v2/extensions/networkipavailabilities/testing/fixtures.go
@@ -104,3 +104,27 @@ var NetworkIPAvailability2 = networkipavailabilities.NetworkIPAvailability{
 		},
 	},
 }
+
+// NetworkIPAvailabilityGetResult represents raw server response from a server to a get call.
+const NetworkIPAvailabilityGetResult = `
+{
+    "network_ip_availability": {
+        "network_id": "cf11ab78-2302-49fa-870f-851a08c7afb8",
+        "network_name": "public",
+        "project_id": "424e7cf0243c468ca61732ba45973b3e",
+        "subnet_ip_availability": [
+            {
+                "cidr": "203.0.113.0/24",
+                "ip_version": 4,
+                "subnet_id": "4afe6e5f-9649-40db-b18f-64c7ead942bd",
+                "subnet_name": "public-subnet",
+                "total_ips": 253,
+                "used_ips": 3
+            }
+        ],
+        "tenant_id": "424e7cf0243c468ca61732ba45973b3e",
+        "total_ips": 253,
+        "used_ips": 3
+    }
+}
+`

--- a/openstack/networking/v2/extensions/networkipavailabilities/testing/fixtures.go
+++ b/openstack/networking/v2/extensions/networkipavailabilities/testing/fixtures.go
@@ -1,0 +1,106 @@
+package testing
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/networkipavailabilities"
+)
+
+// NetworkIPAvailabilityListResult represents raw server response from a server to a list call.
+const NetworkIPAvailabilityListResult = `
+{
+    "network_ip_availabilities": [
+        {
+            "network_id": "080ee064-036d-405a-a307-3bde4a213a1b",
+            "network_name": "private",
+            "project_id": "fb57277ef2f84a0e85b9018ec2dedbf7",
+            "subnet_ip_availability": [
+                {
+                    "cidr": "10.0.0.64/26",
+                    "ip_version": 4,
+                    "subnet_id": "497ac4d3-0b92-42cf-82de-71302ab2b656",
+                    "subnet_name": "second-private-subnet",
+                    "total_ips": 61,
+                    "used_ips": 12
+                },
+                {
+                    "cidr": "10.0.0.0/26",
+                    "ip_version": 4,
+                    "subnet_id": "521f47e7-c4fb-452c-b71a-851da38cc571",
+                    "subnet_name": "private-subnet",
+                    "total_ips": 61,
+                    "used_ips": 2
+                }
+            ],
+            "tenant_id": "fb57277ef2f84a0e85b9018ec2dedbf7",
+            "total_ips": 122,
+            "used_ips": 14
+        },
+        {
+            "network_id": "cf11ab78-2302-49fa-870f-851a08c7afb8",
+            "network_name": "public",
+            "project_id": "424e7cf0243c468ca61732ba45973b3e",
+            "subnet_ip_availability": [
+                {
+                    "cidr": "203.0.113.0/24",
+                    "ip_version": 4,
+                    "subnet_id": "4afe6e5f-9649-40db-b18f-64c7ead942bd",
+                    "subnet_name": "public-subnet",
+                    "total_ips": 253,
+                    "used_ips": 3
+                }
+            ],
+            "tenant_id": "424e7cf0243c468ca61732ba45973b3e",
+            "total_ips": 253,
+            "used_ips": 3
+        }
+    ]
+}
+`
+
+// NetworkIPAvailability1 is an expected representation of a first object from the ResourceListResult.
+var NetworkIPAvailability1 = networkipavailabilities.NetworkIPAvailability{
+	NetworkID:   "080ee064-036d-405a-a307-3bde4a213a1b",
+	NetworkName: "private",
+	ProjectID:   "fb57277ef2f84a0e85b9018ec2dedbf7",
+	TenantID:    "fb57277ef2f84a0e85b9018ec2dedbf7",
+	TotalIPs:    122,
+	UsedIPs:     14,
+	SubnetIPAvailabilities: []networkipavailabilities.SubnetIPAvailability{
+		{
+			SubnetID:   "497ac4d3-0b92-42cf-82de-71302ab2b656",
+			SubnetName: "second-private-subnet",
+			CIDR:       "10.0.0.64/26",
+			IPVersion:  int(gophercloud.IPv4),
+			TotalIPs:   61,
+			UsedIPs:    12,
+		},
+		{
+			SubnetID:   "521f47e7-c4fb-452c-b71a-851da38cc571",
+			SubnetName: "private-subnet",
+			CIDR:       "10.0.0.0/26",
+			IPVersion:  int(gophercloud.IPv4),
+			TotalIPs:   61,
+			UsedIPs:    2,
+		},
+	},
+}
+
+// NetworkIPAvailability2 is an expected representation of a first object from the ResourceListResult.
+var NetworkIPAvailability2 = networkipavailabilities.NetworkIPAvailability{
+	NetworkID:   "cf11ab78-2302-49fa-870f-851a08c7afb8",
+	NetworkName: "public",
+	ProjectID:   "424e7cf0243c468ca61732ba45973b3e",
+	TenantID:    "424e7cf0243c468ca61732ba45973b3e",
+	TotalIPs:    253,
+	UsedIPs:     3,
+	SubnetIPAvailabilities: []networkipavailabilities.SubnetIPAvailability{
+		{
+			SubnetID:   "4afe6e5f-9649-40db-b18f-64c7ead942bd",
+			SubnetName: "public-subnet",
+			CIDR:       "203.0.113.0/24",
+			IPVersion:  int(gophercloud.IPv4),
+			TotalIPs:   253,
+			UsedIPs:    3,
+		},
+	},
+}

--- a/openstack/networking/v2/extensions/networkipavailabilities/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/networkipavailabilities/testing/requests_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/gophercloud/gophercloud"
 	fake "github.com/gophercloud/gophercloud/openstack/networking/v2/common"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/networkipavailabilities"
 	"github.com/gophercloud/gophercloud/pagination"
@@ -48,4 +49,39 @@ func TestList(t *testing.T) {
 	if count != 1 {
 		t.Errorf("Expected 1 page, got %d", count)
 	}
+}
+
+func TestGet(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/network-ip-availabilities/cf11ab78-2302-49fa-870f-851a08c7afb8", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, NetworkIPAvailabilityGetResult)
+	})
+
+	s, err := networkipavailabilities.Get(fake.ServiceClient(), "cf11ab78-2302-49fa-870f-851a08c7afb8").Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, s.NetworkID, "cf11ab78-2302-49fa-870f-851a08c7afb8")
+	th.AssertEquals(t, s.NetworkName, "public")
+	th.AssertEquals(t, s.ProjectID, "424e7cf0243c468ca61732ba45973b3e")
+	th.AssertEquals(t, s.TenantID, "424e7cf0243c468ca61732ba45973b3e")
+	th.AssertEquals(t, s.TotalIPs, 253)
+	th.AssertEquals(t, s.UsedIPs, 3)
+	th.AssertDeepEquals(t, s.SubnetIPAvailabilities, []networkipavailabilities.SubnetIPAvailability{
+		{
+			SubnetID:   "4afe6e5f-9649-40db-b18f-64c7ead942bd",
+			SubnetName: "public-subnet",
+			CIDR:       "203.0.113.0/24",
+			IPVersion:  int(gophercloud.IPv4),
+			TotalIPs:   253,
+			UsedIPs:    3,
+		},
+	})
 }

--- a/openstack/networking/v2/extensions/networkipavailabilities/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/networkipavailabilities/testing/requests_test.go
@@ -1,0 +1,51 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	fake "github.com/gophercloud/gophercloud/openstack/networking/v2/common"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/networkipavailabilities"
+	"github.com/gophercloud/gophercloud/pagination"
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestList(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/network-ip-availabilities", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, NetworkIPAvailabilityListResult)
+	})
+
+	count := 0
+
+	networkipavailabilities.List(fake.ServiceClient(), networkipavailabilities.ListOpts{}).EachPage(func(page pagination.Page) (bool, error) {
+		count++
+		actual, err := networkipavailabilities.ExtractNetworkIPAvailabilities(page)
+		if err != nil {
+			t.Errorf("Failed to extract network IP availabilities: %v", err)
+			return false, nil
+		}
+
+		expected := []networkipavailabilities.NetworkIPAvailability{
+			NetworkIPAvailability1,
+			NetworkIPAvailability2,
+		}
+
+		th.CheckDeepEquals(t, expected, actual)
+
+		return true, nil
+	})
+
+	if count != 1 {
+		t.Errorf("Expected 1 page, got %d", count)
+	}
+}

--- a/openstack/networking/v2/extensions/networkipavailabilities/urls.go
+++ b/openstack/networking/v2/extensions/networkipavailabilities/urls.go
@@ -8,6 +8,14 @@ func rootURL(c *gophercloud.ServiceClient) string {
 	return c.ServiceURL(resourcePath)
 }
 
+func resourceURL(c *gophercloud.ServiceClient, networkIPAvailabilityID string) string {
+	return c.ServiceURL(resourcePath, networkIPAvailabilityID)
+}
+
 func listURL(c *gophercloud.ServiceClient) string {
 	return rootURL(c)
+}
+
+func getURL(c *gophercloud.ServiceClient, networkIPAvailabilityID string) string {
+	return resourceURL(c, networkIPAvailabilityID)
 }

--- a/openstack/networking/v2/extensions/networkipavailabilities/urls.go
+++ b/openstack/networking/v2/extensions/networkipavailabilities/urls.go
@@ -1,0 +1,13 @@
+package networkipavailabilities
+
+import "github.com/gophercloud/gophercloud"
+
+const resourcePath = "network-ip-availabilities"
+
+func rootURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL(resourcePath)
+}
+
+func listURL(c *gophercloud.ServiceClient) string {
+	return rootURL(c)
+}


### PR DESCRIPTION
Add Get method in the Networking service extensions "networkipavailabilities" package.
Add unit test with documentation.

For #1144

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

API definition:
https://github.com/openstack/neutron-lib/blob/stable/queens/neutron_lib/api/definitions/network_ip_availability.py

DB structs populations (network and subnet availability):
https://github.com/openstack/neutron/blob/stable/pike/neutron/db/network_ip_availability_db.py#L153
https://github.com/openstack/neutron/blob/stable/pike/neutron/db/network_ip_availability_db.py#L170