### PR TITLE
Compute V2: SortDir and SortKey for flavors

### DIFF
--- a/openstack/compute/v2/flavors/requests.go
+++ b/openstack/compute/v2/flavors/requests.go
@@ -52,6 +52,14 @@ type ListOpts struct {
 	MinDisk int `q:"minDisk"`
 	MinRAM  int `q:"minRam"`
 
+	// SortDir allows to select sort direction.
+	// It can be "asc" or "desc" (default).
+	SortDir string `q:"sort_dir"`
+
+	// SortKey allows to sort by one of the flavors attributes.
+	// Default is flavorid.
+	SortKey string `q:"sort_key"`
+
 	// Marker and Limit control paging.
 	// Marker instructs List where to start listing from.
 	Marker string `q:"marker"`


### PR DESCRIPTION
Add SortKey and SortDir fields for the compute/v2/flavors package.

For #1155 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

Parameters `sort_key` and `sort_dir` are parsed in:
https://github.com/openstack/nova/blob/stable/queens/nova/api/openstack/compute/flavors.py#L86
Then they're passed into:
https://github.com/openstack/nova/blob/stable/queens/nova/objects/flavor.py#L647
And finally they're passed into the `sqlalchemy` methods:
https://github.com/openstack/nova/blob/stable/queens/nova/objects/flavor.py#L625