### PR TITLE
Compute V2: implement remoteconsoles Create method

### DIFF
--- a/acceptance/openstack/compute/v2/compute.go
+++ b/acceptance/openstack/compute/v2/compute.go
@@ -20,6 +20,7 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/keypairs"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/networks"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/quotasets"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/remoteconsoles"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/rescueunrescue"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/schedulerhints"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/secgroups"
@@ -1062,4 +1063,21 @@ func UnrescueServer(t *testing.T, client *gophercloud.ServiceClient, server *ser
 	}
 
 	return nil
+}
+
+// CreateRemoteConsole will create a remote noVNC console for the specified server.
+func CreateRemoteConsole(t *testing.T, client *gophercloud.ServiceClient, serverID string) (*remoteconsoles.RemoteConsole, error) {
+	createOpts := remoteconsoles.CreateOpts{
+		Protocol: string(remoteconsoles.RemoteConsoleVNCProtocol),
+		Type:     string(remoteconsoles.RemoteConsoleNoVNCType),
+	}
+
+	t.Logf("Attempting to create a %s console for the server %s", createOpts.Type, serverID)
+	remoteConsole, err := remoteconsoles.Create(client, serverID, createOpts).Extract()
+	if err != nil {
+		return nil, err
+	}
+
+	t.Logf("Successfully created console: %s", remoteConsole.URL)
+	return remoteConsole, nil
 }

--- a/acceptance/openstack/compute/v2/compute.go
+++ b/acceptance/openstack/compute/v2/compute.go
@@ -1068,8 +1068,8 @@ func UnrescueServer(t *testing.T, client *gophercloud.ServiceClient, server *ser
 // CreateRemoteConsole will create a remote noVNC console for the specified server.
 func CreateRemoteConsole(t *testing.T, client *gophercloud.ServiceClient, serverID string) (*remoteconsoles.RemoteConsole, error) {
 	createOpts := remoteconsoles.CreateOpts{
-		Protocol: string(remoteconsoles.RemoteConsoleVNCProtocol),
-		Type:     string(remoteconsoles.RemoteConsoleNoVNCType),
+		Protocol: remoteconsoles.ConsoleProtocolVNC,
+		Type:     remoteconsoles.ConsoleTypeNoVNC,
 	}
 
 	t.Logf("Attempting to create a %s console for the server %s", createOpts.Type, serverID)

--- a/acceptance/openstack/compute/v2/remoteconsoles_test.go
+++ b/acceptance/openstack/compute/v2/remoteconsoles_test.go
@@ -1,0 +1,27 @@
+// +build acceptance compute remoteconsoles
+
+package v2
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/acceptance/clients"
+	"github.com/gophercloud/gophercloud/acceptance/tools"
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestRemoteConsoleCreate(t *testing.T) {
+	clients.RequireLong(t)
+
+	client, err := clients.NewComputeV2Client()
+	th.AssertNoErr(t, err)
+
+	server, err := CreateServer(t, client)
+	th.AssertNoErr(t, err)
+	defer DeleteServer(t, client, server)
+
+	remoteConsole, err := CreateRemoteConsole(t, client, server.ID)
+	th.AssertNoErr(t, err)
+
+	tools.PrintResource(t, remoteConsole)
+}

--- a/acceptance/openstack/compute/v2/remoteconsoles_test.go
+++ b/acceptance/openstack/compute/v2/remoteconsoles_test.go
@@ -16,6 +16,8 @@ func TestRemoteConsoleCreate(t *testing.T) {
 	client, err := clients.NewComputeV2Client()
 	th.AssertNoErr(t, err)
 
+	client.Microversion = "2.6"
+
 	server, err := CreateServer(t, client)
 	th.AssertNoErr(t, err)
 	defer DeleteServer(t, client, server)

--- a/openstack/compute/v2/extensions/remoteconsoles/doc.go
+++ b/openstack/compute/v2/extensions/remoteconsoles/doc.go
@@ -1,14 +1,20 @@
 /*
 Package remoteconsoles provides the ability to create server remote consoles
 through the Compute API.
+You need to specify at least "2.6" microversion for the ComputeClient to use
+that API.
 
 Example of Creating a new RemoteConsole
+
+  computeClient, err := openstack.NewComputeV2(providerClient, endpointOptions)
+  computeClient.Microversion = "2.6"
 
   createOpts := remoteconsoles.CreateOpts{
     Protocol: string(remoteconsoles.RemoteConsoleVNCProtocol),
     Type:     string(remoteconsoles.RemoteConsoleNoVNCType),
 	}
-	serverID := "b16ba811-199d-4ffd-8839-ba96c1185a67"
+  serverID := "b16ba811-199d-4ffd-8839-ba96c1185a67"
+
   remtoteConsole, err := remoteconsoles.Create(computeClient, serverID, createOpts).Extract()
   if err != nil {
     panic(err)

--- a/openstack/compute/v2/extensions/remoteconsoles/doc.go
+++ b/openstack/compute/v2/extensions/remoteconsoles/doc.go
@@ -1,0 +1,19 @@
+/*
+Package remoteconsoles provides the ability to create server remote consoles
+through the Compute API.
+
+Example of Creating a new RemoteConsole
+
+  createOpts := remoteconsoles.CreateOpts{
+    Protocol: string(remoteconsoles.RemoteConsoleVNCProtocol),
+    Type:     string(remoteconsoles.RemoteConsoleNoVNCType),
+	}
+	serverID := "b16ba811-199d-4ffd-8839-ba96c1185a67"
+  remtoteConsole, err := remoteconsoles.Create(computeClient, serverID, createOpts).Extract()
+  if err != nil {
+    panic(err)
+  }
+
+  fmt.Printf("%+v\n", task)
+*/
+package remoteconsoles

--- a/openstack/compute/v2/extensions/remoteconsoles/doc.go
+++ b/openstack/compute/v2/extensions/remoteconsoles/doc.go
@@ -10,9 +10,9 @@ Example of Creating a new RemoteConsole
   computeClient.Microversion = "2.6"
 
   createOpts := remoteconsoles.CreateOpts{
-    Protocol: string(remoteconsoles.RemoteConsoleVNCProtocol),
-    Type:     string(remoteconsoles.RemoteConsoleNoVNCType),
-	}
+    Protocol: remoteconsoles.ConsoleProtocolVNC,
+    Type:     remoteconsoles.ConsoleTypeNoVNC,
+  }
   serverID := "b16ba811-199d-4ffd-8839-ba96c1185a67"
 
   remtoteConsole, err := remoteconsoles.Create(computeClient, serverID, createOpts).Extract()
@@ -20,6 +20,6 @@ Example of Creating a new RemoteConsole
     panic(err)
   }
 
-  fmt.Printf("%+v\n", task)
+  fmt.Printf("Console URL: %s\n", remtoteConsole.URL)
 */
 package remoteconsoles

--- a/openstack/compute/v2/extensions/remoteconsoles/requests.go
+++ b/openstack/compute/v2/extensions/remoteconsoles/requests.go
@@ -4,49 +4,49 @@ import (
 	"github.com/gophercloud/gophercloud"
 )
 
-// RemoteConsoleProtocol represents valid remote console protocol.
+// ConsoleProtocol represents valid remote console protocol.
 // It can be used to create a remote console with one of the pre-defined protocol.
-type RemoteConsoleProtocol string
+type ConsoleProtocol string
 
 const (
-	// RemoteConsoleVNCProtocol represents the VNC console protocol.
-	RemoteConsoleVNCProtocol RemoteConsoleProtocol = "vnc"
+	// ConsoleProtocolVNC represents the VNC console protocol.
+	ConsoleProtocolVNC ConsoleProtocol = "vnc"
 
-	// RemoteConsoleSPICEProtocol represents the SPICE console protocol.
-	RemoteConsoleSPICEProtocol RemoteConsoleProtocol = "spice"
+	// ConsoleProtocolSPICE represents the SPICE console protocol.
+	ConsoleProtocolSPICE ConsoleProtocol = "spice"
 
-	// RemoteConsoleRDPProtocol represents the RDP console protocol.
-	RemoteConsoleRDPProtocol RemoteConsoleProtocol = "rdp"
+	// ConsoleProtocolRDP represents the RDP console protocol.
+	ConsoleProtocolRDP ConsoleProtocol = "rdp"
 
-	// RemoteConsoleSerialProtocol represents the serial console protocol.
-	RemoteConsoleSerialProtocol RemoteConsoleProtocol = "serial"
+	// ConsoleProtocolSerial represents the Serial console protocol.
+	ConsoleProtocolSerial ConsoleProtocol = "serial"
 
-	// RemoteConsoleMKSProtocol represents the MKS console protocol.
-	RemoteConsoleMKSProtocol RemoteConsoleProtocol = "mks"
+	// ConsoleProtocolMKS represents the MKS console protocol.
+	ConsoleProtocolMKS ConsoleProtocol = "mks"
 )
 
-// RemoteConsoleType represents valid remote console type.
+// ConsoleType represents valid remote console type.
 // It can be used to create a remote console with one of the pre-defined type.
-type RemoteConsoleType string
+type ConsoleType string
 
 const (
-	// RemoteConsoleNoVNCType represents the VNC console type.
-	RemoteConsoleNoVNCType RemoteConsoleType = "novnc"
+	// ConsoleTypeNoVNC represents the VNC console type.
+	ConsoleTypeNoVNC ConsoleType = "novnc"
 
-	// RemoteConsoleXVPVNCType represents the XVP VNC console type.
-	RemoteConsoleXVPVNCType RemoteConsoleType = "xvpvnc"
+	// ConsoleTypeXVPVNC represents the XVP VNC console type.
+	ConsoleTypeXVPVNC ConsoleType = "xvpvnc"
 
-	// RemoteConsoleRDPHTML5Type represents the RDP HTML5 console type.
-	RemoteConsoleRDPHTML5Type RemoteConsoleType = "rdp-html5"
+	// ConsoleTypeRDPHTML5 represents the RDP HTML5 console type.
+	ConsoleTypeRDPHTML5 ConsoleType = "rdp-html5"
 
-	// RemoteConsoleSPICEHTML5Type represents the SPICE HTML5 console type.
-	RemoteConsoleSPICEHTML5Type RemoteConsoleType = "spice-html5"
+	// ConsoleTypeSPICEHTML5 represents the SPICE HTML5 console type.
+	ConsoleTypeSPICEHTML5 ConsoleType = "spice-html5"
 
-	// RemoteConsoleSerialType represents the serial console type.
-	RemoteConsoleSerialType RemoteConsoleType = "serial"
+	// ConsoleTypeSerial represents the Serial console type.
+	ConsoleTypeSerial ConsoleType = "serial"
 
-	// RemoteConsoleWebMKSType represents the web MKS console type.
-	RemoteConsoleWebMKSType RemoteConsoleType = "webmks"
+	// ConsoleTypeWebMKS represents the Web MKS console type.
+	ConsoleTypeWebMKS ConsoleType = "webmks"
 )
 
 // CreateOptsBuilder allows to add additional parameters to the Create request.
@@ -57,10 +57,10 @@ type CreateOptsBuilder interface {
 // CreateOpts specifies parameters to the Create request.
 type CreateOpts struct {
 	// Protocol specifies the protocol of a new remote console.
-	Protocol string `json:"protocol" required:"true"`
+	Protocol ConsoleProtocol `json:"protocol" required:"true"`
 
 	// Type specifies the type of a new remote console.
-	Type string `json:"type" required:"true"`
+	Type ConsoleType `json:"type" required:"true"`
 }
 
 // ToRemoteConsoleCreateMap builds a request body from the CreateOpts.

--- a/openstack/compute/v2/extensions/remoteconsoles/requests.go
+++ b/openstack/compute/v2/extensions/remoteconsoles/requests.go
@@ -1,0 +1,83 @@
+package remoteconsoles
+
+import (
+	"github.com/gophercloud/gophercloud"
+)
+
+// RemoteConsoleProtocol represents valid remote console protocol.
+// It can be used to create a remote console with one of the pre-defined protocol.
+type RemoteConsoleProtocol string
+
+const (
+	// RemoteConsoleVNCProtocol represents the VNC console protocol.
+	RemoteConsoleVNCProtocol RemoteConsoleProtocol = "vnc"
+
+	// RemoteConsoleSPICEProtocol represents the SPICE console protocol.
+	RemoteConsoleSPICEProtocol RemoteConsoleProtocol = "spice"
+
+	// RemoteConsoleRDPProtocol represents the RDP console protocol.
+	RemoteConsoleRDPProtocol RemoteConsoleProtocol = "rdp"
+
+	// RemoteConsoleSerialProtocol represents the serial console protocol.
+	RemoteConsoleSerialProtocol RemoteConsoleProtocol = "serial"
+
+	// RemoteConsoleMKSProtocol represents the MKS console protocol.
+	RemoteConsoleMKSProtocol RemoteConsoleProtocol = "mks"
+)
+
+// RemoteConsoleType represents valid remote console type.
+// It can be used to create a remote console with one of the pre-defined type.
+type RemoteConsoleType string
+
+const (
+	// RemoteConsoleNoVNCType represents the VNC console type.
+	RemoteConsoleNoVNCType RemoteConsoleType = "novnc"
+
+	// RemoteConsoleXVPVNCType represents the XVP VNC console type.
+	RemoteConsoleXVPVNCType RemoteConsoleType = "xvpvnc"
+
+	// RemoteConsoleRDPHTML5Type represents the RDP HTML5 console type.
+	RemoteConsoleRDPHTML5Type RemoteConsoleType = "rdp-html5"
+
+	// RemoteConsoleSPICEHTML5Type represents the SPICE HTML5 console type.
+	RemoteConsoleSPICEHTML5Type RemoteConsoleType = "spice-html5"
+
+	// RemoteConsoleSerialType represents the serial console type.
+	RemoteConsoleSerialType RemoteConsoleType = "serial"
+
+	// RemoteConsoleWebMKSType represents the web MKS console type.
+	RemoteConsoleWebMKSType RemoteConsoleType = "webmks"
+)
+
+// CreateOptsBuilder allows to add additional parameters to the Create request.
+type CreateOptsBuilder interface {
+	ToRemoteConsoleCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts specifies parameters to the Create request.
+type CreateOpts struct {
+	// Protocol specifies the protocol of a new remote console.
+	Protocol string `json:"protocol" required:"true"`
+
+	// Type specifies the type of a new remote console.
+	Type string `json:"type" required:"true"`
+}
+
+// ToRemoteConsoleCreateMap builds a request body from the CreateOpts.
+func (opts CreateOpts) ToRemoteConsoleCreateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "remote_console")
+}
+
+// Create requests the creation of a new remote console on the specified server.
+func Create(client *gophercloud.ServiceClient, serverID string, opts CreateOptsBuilder) (r CreateResult) {
+	reqBody, err := opts.ToRemoteConsoleCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = client.Post(createURL(client, serverID), reqBody, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}

--- a/openstack/compute/v2/extensions/remoteconsoles/results.go
+++ b/openstack/compute/v2/extensions/remoteconsoles/results.go
@@ -1,0 +1,38 @@
+package remoteconsoles
+
+import "github.com/gophercloud/gophercloud"
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// CreateResult represents the result of a create operation. Call its Extract
+// method to interpret it as a RemoteConsole.
+type CreateResult struct {
+	commonResult
+}
+
+// RemoteConsole represents the Compute service remote console object.
+type RemoteConsole struct {
+	// Protocol contains remote console protocol.
+	// You can use the RemoteConsoleProtocol custom type to unmarshal raw JSON
+	// response into the pre-defined valid console protocol.
+	Protocol string `json:"protocol"`
+
+	// Type contains remote console type.
+	// You can use the RemoteConsoleType custom type to unmarshal raw JSON
+	// response into the pre-defined valid console type.
+	Type string `json:"type"`
+
+	// URL can be used to connect to the remote console.
+	URL string `json:"url"`
+}
+
+// Extract interprets any commonResult as a RemoteConsole.
+func (r commonResult) Extract() (*RemoteConsole, error) {
+	var s struct {
+		RemoteConsole *RemoteConsole `json:"remote_console"`
+	}
+	err := r.ExtractInto(&s)
+	return s.RemoteConsole, err
+}

--- a/openstack/compute/v2/extensions/remoteconsoles/testing/doc.go
+++ b/openstack/compute/v2/extensions/remoteconsoles/testing/doc.go
@@ -1,0 +1,1 @@
+package testing

--- a/openstack/compute/v2/extensions/remoteconsoles/testing/fixtures.go
+++ b/openstack/compute/v2/extensions/remoteconsoles/testing/fixtures.go
@@ -1,0 +1,22 @@
+package testing
+
+// RemoteConsoleCreateRequest represents a request to create a remote console.
+const RemoteConsoleCreateRequest = `
+{
+    "remote_console": {
+        "protocol": "vnc",
+        "type": "novnc"
+    }
+}
+`
+
+// RemoteConsoleCreateResult represents a raw server responce to the RemoteConsoleCreateRequest.
+const RemoteConsoleCreateResult = `
+{
+    "remote_console": {
+        "protocol": "vnc",
+        "type": "novnc",
+        "url": "http://192.168.0.4:6080/vnc_auto.html?token=9a2372b9-6a0e-4f71-aca1-56020e6bb677"
+    }
+}
+`

--- a/openstack/compute/v2/extensions/remoteconsoles/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/remoteconsoles/testing/requests_test.go
@@ -1,0 +1,40 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/remoteconsoles"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	fake "github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func TestCreate(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/servers/b16ba811-199d-4ffd-8839-ba96c1185a67/remote-consoles", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, RemoteConsoleCreateRequest)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, RemoteConsoleCreateResult)
+	})
+
+	opts := remoteconsoles.CreateOpts{
+		Protocol: string(remoteconsoles.RemoteConsoleVNCProtocol),
+		Type:     string(remoteconsoles.RemoteConsoleNoVNCType),
+	}
+	s, err := remoteconsoles.Create(fake.ServiceClient(), "b16ba811-199d-4ffd-8839-ba96c1185a67", opts).Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, s.Protocol, string(remoteconsoles.RemoteConsoleVNCProtocol))
+	th.AssertEquals(t, s.Type, string(remoteconsoles.RemoteConsoleNoVNCType))
+	th.AssertEquals(t, s.URL, "http://192.168.0.4:6080/vnc_auto.html?token=9a2372b9-6a0e-4f71-aca1-56020e6bb677")
+}

--- a/openstack/compute/v2/extensions/remoteconsoles/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/remoteconsoles/testing/requests_test.go
@@ -28,13 +28,13 @@ func TestCreate(t *testing.T) {
 	})
 
 	opts := remoteconsoles.CreateOpts{
-		Protocol: string(remoteconsoles.RemoteConsoleVNCProtocol),
-		Type:     string(remoteconsoles.RemoteConsoleNoVNCType),
+		Protocol: remoteconsoles.ConsoleProtocolVNC,
+		Type:     remoteconsoles.ConsoleTypeNoVNC,
 	}
 	s, err := remoteconsoles.Create(fake.ServiceClient(), "b16ba811-199d-4ffd-8839-ba96c1185a67", opts).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, s.Protocol, string(remoteconsoles.RemoteConsoleVNCProtocol))
-	th.AssertEquals(t, s.Type, string(remoteconsoles.RemoteConsoleNoVNCType))
+	th.AssertEquals(t, s.Protocol, string(remoteconsoles.ConsoleProtocolVNC))
+	th.AssertEquals(t, s.Type, string(remoteconsoles.ConsoleTypeNoVNC))
 	th.AssertEquals(t, s.URL, "http://192.168.0.4:6080/vnc_auto.html?token=9a2372b9-6a0e-4f71-aca1-56020e6bb677")
 }

--- a/openstack/compute/v2/extensions/remoteconsoles/urls.go
+++ b/openstack/compute/v2/extensions/remoteconsoles/urls.go
@@ -1,0 +1,17 @@
+package remoteconsoles
+
+import "github.com/gophercloud/gophercloud"
+
+const (
+	rootPath = "servers"
+
+	resourcePath = "remote-consoles"
+)
+
+func rootURL(c *gophercloud.ServiceClient, serverID string) string {
+	return c.ServiceURL(rootPath, serverID, resourcePath)
+}
+
+func createURL(c *gophercloud.ServiceClient, serverID string) string {
+	return rootURL(c, serverID)
+}


### PR DESCRIPTION
Add the new "remoteconsoles" Compute extension package with needed
structures and Create method.
Add unit and acceptance test with documentation.

For #1158

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

API create request handler:
https://github.com/openstack/nova/blob/stable/queens/nova/api/openstack/compute/remote_consoles.py#L160

API definitions:
https://github.com/openstack/nova/blob/stable/queens/nova/api/openstack/compute/schemas/remote_consoles.py#L91
https://github.com/openstack/nova/blob/stable/queens/nova/api/openstack/compute/schemas/remote_consoles.py#L115

Allowed protocols and types:
https://github.com/openstack/nova/blob/stable/queens/nova/api/openstack/compute/schemas/remote_consoles.py#L123
https://github.com/openstack/nova/blob/stable/queens/nova/api/openstack/compute/schemas/remote_consoles.py#L127