### PR TITLE
Compute V2: implement server OS-SRV-USG extension

### DIFF
--- a/acceptance/openstack/compute/v2/servers_test.go
+++ b/acceptance/openstack/compute/v2/servers_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/extendedstatus"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/lockunlock"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/pauseunpause"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/serverusage"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/suspendresume"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
 	th "github.com/gophercloud/gophercloud/testhelper"
@@ -88,6 +89,7 @@ func TestServersWithExtensionsCreateDestroy(t *testing.T) {
 		servers.Server
 		availabilityzones.ServerAvailabilityZoneExt
 		extendedstatus.ServerExtendedStatusExt
+		serverusage.UsageExt
 	}
 
 	client, err := clients.NewComputeV2Client()
@@ -105,6 +107,7 @@ func TestServersWithExtensionsCreateDestroy(t *testing.T) {
 	th.AssertEquals(t, int(extendedServer.PowerState), extendedstatus.RUNNING)
 	th.AssertEquals(t, extendedServer.TaskState, "")
 	th.AssertEquals(t, extendedServer.VmState, "active")
+	th.AssertEquals(t, extendedServer.LaunchedAt, extendedServer.Updated)
 }
 
 func TestServersWithoutImageRef(t *testing.T) {

--- a/openstack/compute/v2/extensions/serverusage/doc.go
+++ b/openstack/compute/v2/extensions/serverusage/doc.go
@@ -1,0 +1,20 @@
+/*
+Package serverusage provides the ability the ability to extend a server result
+with the extended usage information.
+
+Example to Get an extended information:
+
+  type serverUsageExt struct {
+    servers.Server
+    serverusage.UsageExt
+  }
+  var serverWithUsageExt serverUsageExt
+
+  err := servers.Get(fake.ServiceClient(), "d650a0ce-17c3-497d-961a-43c4af80998a").ExtractInto(&serverWithUsageExt)
+  if err != nil {
+    panic(err)
+  }
+
+  fmt.Printf("%+v\n", serverWithUsageExt)
+*/
+package serverusage

--- a/openstack/compute/v2/extensions/serverusage/results.go
+++ b/openstack/compute/v2/extensions/serverusage/results.go
@@ -1,0 +1,34 @@
+package serverusage
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/gophercloud/gophercloud"
+)
+
+// UsageExt represents OS-SRV-USG server response fields.
+type UsageExt struct {
+	LaunchedAt   time.Time `json:"-"`
+	TerminatedAt time.Time `json:"-"`
+}
+
+// UnmarshalJSON helps to unmarshal UsageExt fields into needed values.
+func (r *UsageExt) UnmarshalJSON(b []byte) error {
+	type tmp UsageExt
+	var s struct {
+		tmp
+		LaunchedAt   gophercloud.JSONRFC3339MilliNoZ `json:"OS-SRV-USG:launched_at"`
+		TerminatedAt gophercloud.JSONRFC3339MilliNoZ `json:"OS-SRV-USG:terminated_at"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	*r = UsageExt(s.tmp)
+
+	r.LaunchedAt = time.Time(s.LaunchedAt)
+	r.TerminatedAt = time.Time(s.TerminatedAt)
+
+	return nil
+}

--- a/openstack/compute/v2/extensions/serverusage/testing/doc.go
+++ b/openstack/compute/v2/extensions/serverusage/testing/doc.go
@@ -1,0 +1,1 @@
+package testing

--- a/openstack/compute/v2/extensions/serverusage/testing/fixtures.go
+++ b/openstack/compute/v2/extensions/serverusage/testing/fixtures.go
@@ -1,0 +1,20 @@
+package testing
+
+// ServerWithUsageExtResult represents a raw server response from the Compute API
+// with OS-SRV-USG data.
+// Most of the actual fields were deleted from the response.
+const ServerWithUsageExtResult = `
+{
+    "server": {
+        "OS-SRV-USG:launched_at": "2018-07-27T09:15:55.000000",
+        "OS-SRV-USG:terminated_at": null,
+        "created": "2018-07-27T09:15:48Z",
+        "updated": "2018-07-27T09:15:55Z",
+        "id": "d650a0ce-17c3-497d-961a-43c4af80998a",
+        "name": "test_instance",
+        "status": "ACTIVE",
+        "user_id": "0f2f3822679e4b3ea073e5d1c6ed5f02",
+        "tenant_id": "424e7cf0243c468ca61732ba45973b3e"
+    }
+}
+`

--- a/openstack/compute/v2/extensions/serverusage/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/serverusage/testing/requests_test.go
@@ -1,0 +1,44 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/serverusage"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	fake "github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func TestServerWithUsageExt(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/servers/d650a0ce-17c3-497d-961a-43c4af80998a", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+
+		fmt.Fprintf(w, ServerWithUsageExtResult)
+	})
+
+	type serverUsageExt struct {
+		servers.Server
+		serverusage.UsageExt
+	}
+	var serverWithUsageExt serverUsageExt
+	err := servers.Get(fake.ServiceClient(), "d650a0ce-17c3-497d-961a-43c4af80998a").ExtractInto(&serverWithUsageExt)
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, serverWithUsageExt.LaunchedAt, time.Date(2018, 07, 27, 9, 15, 55, 0, time.UTC))
+	th.AssertEquals(t, serverWithUsageExt.TerminatedAt, time.Time{})
+	th.AssertEquals(t, serverWithUsageExt.Created, time.Date(2018, 07, 27, 9, 15, 48, 0, time.UTC))
+	th.AssertEquals(t, serverWithUsageExt.Updated, time.Date(2018, 07, 27, 9, 15, 55, 0, time.UTC))
+	th.AssertEquals(t, serverWithUsageExt.ID, "d650a0ce-17c3-497d-961a-43c4af80998a")
+	th.AssertEquals(t, serverWithUsageExt.Name, "test_instance")
+	th.AssertEquals(t, serverWithUsageExt.Status, "ACTIVE")
+	th.AssertEquals(t, serverWithUsageExt.UserID, "0f2f3822679e4b3ea073e5d1c6ed5f02")
+	th.AssertEquals(t, serverWithUsageExt.TenantID, "424e7cf0243c468ca61732ba45973b3e")
+}


### PR DESCRIPTION
Add the new "serverusage" package with basic structure and UnmarshalJSON
method.
Add unit test and update TestServersWithExtensionsCreateDestroy aceptance
test.
Add documentation example.

For #1160 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

Main class:
https://github.com/openstack/nova/blob/stable/queens/nova/api/openstack/compute/server_usage.py#L22