### PR TITLE
Compute V2: implement server OS-EXT-AZ extension

### DIFF
--- a/openstack/compute/v2/extensions/extendedavailabilityzone/doc.go
+++ b/openstack/compute/v2/extensions/extendedavailabilityzone/doc.go
@@ -1,0 +1,20 @@
+/*
+Package extendedavailabilityzone provides the ability the ability to extend a
+server result with the extended availability zone information.
+
+Example to Get an extended information:
+
+  type serverAvailabilityZoneExt struct {
+    servers.Server
+    extendedavailabilityzone.AvailabilityZoneExt
+  }
+  var serverWithAvailabilityZoneExt serverAvailabilityZoneExt
+
+  err := servers.Get(computeClient, "d650a0ce-17c3-497d-961a-43c4af80998a").ExtractInto(&serverWithAvailabilityZoneExt)
+  if err != nil {
+    panic(err)
+  }
+
+  fmt.Printf("%+v\n", serverWithAvailabilityZoneExt)
+*/
+package extendedavailabilityzone

--- a/openstack/compute/v2/extensions/extendedavailabilityzone/results.go
+++ b/openstack/compute/v2/extensions/extendedavailabilityzone/results.go
@@ -1,0 +1,6 @@
+package extendedavailabilityzone
+
+// AvailabilityZoneExt represents OS-EXT-AZ server response fields.
+type AvailabilityZoneExt struct {
+	AvailabilityZone string `json:"OS-EXT-AZ:availability_zone"`
+}

--- a/openstack/compute/v2/extensions/extendedavailabilityzone/testing/doc.go
+++ b/openstack/compute/v2/extensions/extendedavailabilityzone/testing/doc.go
@@ -1,0 +1,1 @@
+package testing

--- a/openstack/compute/v2/extensions/extendedavailabilityzone/testing/fixtures.go
+++ b/openstack/compute/v2/extensions/extendedavailabilityzone/testing/fixtures.go
@@ -1,0 +1,19 @@
+package testing
+
+// ServerWithAvailabilityZoneExtResult represents a raw server response from
+// the Compute API with OS-EXT-AZ data.
+// Most of the actual fields were deleted from the response.
+const ServerWithAvailabilityZoneExtResult = `
+{
+    "server": {
+        "OS-EXT-AZ:availability_zone": "nova",
+        "created": "2018-07-27T09:15:48Z",
+        "updated": "2018-07-27T09:15:55Z",
+        "id": "d650a0ce-17c3-497d-961a-43c4af80998a",
+        "name": "test_instance",
+        "status": "ACTIVE",
+        "user_id": "0f2f3822679e4b3ea073e5d1c6ed5f02",
+        "tenant_id": "424e7cf0243c468ca61732ba45973b3e"
+    }
+}
+`

--- a/openstack/compute/v2/extensions/extendedavailabilityzone/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/extendedavailabilityzone/testing/requests_test.go
@@ -1,0 +1,43 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/extendedavailabilityzone"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	fake "github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func TestServerServerWithAvailabilityZoneExt(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/servers/d650a0ce-17c3-497d-961a-43c4af80998a", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+
+		fmt.Fprintf(w, ServerWithAvailabilityZoneExtResult)
+	})
+
+	type serverAvailabilityZoneExt struct {
+		servers.Server
+		extendedavailabilityzone.AvailabilityZoneExt
+	}
+	var serverWithAvailabilityZoneExt serverAvailabilityZoneExt
+	err := servers.Get(fake.ServiceClient(), "d650a0ce-17c3-497d-961a-43c4af80998a").ExtractInto(&serverWithAvailabilityZoneExt)
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, serverWithAvailabilityZoneExt.AvailabilityZone, "nova")
+	th.AssertEquals(t, serverWithAvailabilityZoneExt.Created, time.Date(2018, 07, 27, 9, 15, 48, 0, time.UTC))
+	th.AssertEquals(t, serverWithAvailabilityZoneExt.Updated, time.Date(2018, 07, 27, 9, 15, 55, 0, time.UTC))
+	th.AssertEquals(t, serverWithAvailabilityZoneExt.ID, "d650a0ce-17c3-497d-961a-43c4af80998a")
+	th.AssertEquals(t, serverWithAvailabilityZoneExt.Name, "test_instance")
+	th.AssertEquals(t, serverWithAvailabilityZoneExt.Status, "ACTIVE")
+	th.AssertEquals(t, serverWithAvailabilityZoneExt.UserID, "0f2f3822679e4b3ea073e5d1c6ed5f02")
+	th.AssertEquals(t, serverWithAvailabilityZoneExt.TenantID, "424e7cf0243c468ca61732ba45973b3e")
+}


### PR DESCRIPTION
Add the new "extendedavailabilityzone" package with basic structure,
test and documentation.

For #1160

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

Main class:
https://github.com/openstack/nova/blob/stable/queens/nova/api/openstack/compute/extended_availability_zone.py#L25