### PR TITLE
Compute V2: add server OS-EXT-SRV-ATTR extension

### DIFF
--- a/acceptance/openstack/compute/v2/servers_test.go
+++ b/acceptance/openstack/compute/v2/servers_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gophercloud/gophercloud/acceptance/tools"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/attachinterfaces"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/availabilityzones"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/extendedserverattributes"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/extendedstatus"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/lockunlock"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/pauseunpause"
@@ -88,6 +89,7 @@ func TestServersWithExtensionsCreateDestroy(t *testing.T) {
 		servers.Server
 		availabilityzones.ServerAvailabilityZoneExt
 		extendedstatus.ServerExtendedStatusExt
+		extendedserverattributes.ServerAttributesExt
 	}
 
 	client, err := clients.NewComputeV2Client()
@@ -105,6 +107,7 @@ func TestServersWithExtensionsCreateDestroy(t *testing.T) {
 	th.AssertEquals(t, int(extendedServer.PowerState), extendedstatus.RUNNING)
 	th.AssertEquals(t, extendedServer.TaskState, "")
 	th.AssertEquals(t, extendedServer.VmState, "active")
+	th.AssertEquals(t, extendedServer.Hostname, server.Name)
 }
 
 func TestServersWithoutImageRef(t *testing.T) {

--- a/openstack/compute/v2/extensions/extendedserverattributes/doc.go
+++ b/openstack/compute/v2/extensions/extendedserverattributes/doc.go
@@ -1,0 +1,20 @@
+/*
+Package extendedserverattributes provides the ability to extend a
+server result with the extended usage information.
+
+Example to Get an extended information:
+
+  type serverAttributesExt struct {
+    servers.Server
+    extendedserverattributes.ServerAttributesExt
+  }
+  var serverWithAttributesExt serverAttributesExt
+
+  err := servers.Get(computeClient, "d650a0ce-17c3-497d-961a-43c4af80998a").ExtractInto(&serverWithAttributesExt)
+  if err != nil {
+    panic(err)
+  }
+
+  fmt.Printf("%+v\n", serverWithAttributesExt)
+*/
+package extendedserverattributes

--- a/openstack/compute/v2/extensions/extendedserverattributes/results.go
+++ b/openstack/compute/v2/extensions/extendedserverattributes/results.go
@@ -1,0 +1,15 @@
+package extendedserverattributes
+
+// ServerAttributesExt represents OS-EXT-SRV-ATTR server response fields.
+type ServerAttributesExt struct {
+	ReservationID      string `json:"OS-EXT-SRV-ATTR:reservation_id"`
+	LaunchIndex        int    `json:"OS-EXT-SRV-ATTR:launch_index"`
+	Hostname           string `json:"OS-EXT-SRV-ATTR:hostname"`
+	Host               string `json:"OS-EXT-SRV-ATTR:host"`
+	KernelID           string `json:"OS-EXT-SRV-ATTR:kernel_id"`
+	RamdiskID          string `json:"OS-EXT-SRV-ATTR:ramdisk_id"`
+	RootDeviceName     string `json:"OS-EXT-SRV-ATTR:root_device_name"`
+	UserData           string `json:"OS-EXT-SRV-ATTR:user_data"`
+	InstanceName       string `json:"OS-EXT-SRV-ATTR:instance_name"`
+	HypervisorHostname string `json:"OS-EXT-SRV-ATTR:hypervisor_hostname"`
+}

--- a/openstack/compute/v2/extensions/extendedserverattributes/testing/doc.go
+++ b/openstack/compute/v2/extensions/extendedserverattributes/testing/doc.go
@@ -1,0 +1,1 @@
+package testing

--- a/openstack/compute/v2/extensions/extendedserverattributes/testing/fixtures.go
+++ b/openstack/compute/v2/extensions/extendedserverattributes/testing/fixtures.go
@@ -1,0 +1,28 @@
+package testing
+
+// ServerWithAttributesExtResult represents a raw server response from the
+// Compute API with OS-EXT-SRV-ATTR data.
+// Most of the actual fields were deleted from the response.
+const ServerWithAttributesExtResult = `
+{
+    "server": {
+        "OS-EXT-SRV-ATTR:user_data": "",
+        "OS-EXT-SRV-ATTR:instance_name": "instance-00000001",
+        "OS-EXT-SRV-ATTR:root_device_name": "/dev/sda",
+        "OS-EXT-SRV-ATTR:hostname": "test00",
+        "OS-EXT-SRV-ATTR:reservation_id": "r-ky9gim1l",
+        "OS-EXT-SRV-ATTR:ramdisk_id": "",
+        "OS-EXT-SRV-ATTR:host": "compute01",
+        "OS-EXT-SRV-ATTR:kernel_id": "",
+        "OS-EXT-SRV-ATTR:hypervisor_hostname": "compute01",
+        "OS-EXT-SRV-ATTR:launch_index": 0,
+        "created": "2018-07-27T09:15:48Z",
+        "updated": "2018-07-27T09:15:55Z",
+        "id": "d650a0ce-17c3-497d-961a-43c4af80998a",
+        "name": "test_instance",
+        "status": "ACTIVE",
+        "user_id": "0f2f3822679e4b3ea073e5d1c6ed5f02",
+        "tenant_id": "424e7cf0243c468ca61732ba45973b3e"
+    }
+}
+`

--- a/openstack/compute/v2/extensions/extendedserverattributes/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/extendedserverattributes/testing/requests_test.go
@@ -1,0 +1,52 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/extendedserverattributes"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	fake "github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func TestServerWithUsageExt(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/servers/d650a0ce-17c3-497d-961a-43c4af80998a", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+
+		fmt.Fprintf(w, ServerWithAttributesExtResult)
+	})
+
+	type serverAttributesExt struct {
+		servers.Server
+		extendedserverattributes.ServerAttributesExt
+	}
+	var serverWithAttributesExt serverAttributesExt
+	err := servers.Get(fake.ServiceClient(), "d650a0ce-17c3-497d-961a-43c4af80998a").ExtractInto(&serverWithAttributesExt)
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, serverWithAttributesExt.ReservationID, "r-ky9gim1l")
+	th.AssertEquals(t, serverWithAttributesExt.LaunchIndex, 0)
+	th.AssertEquals(t, serverWithAttributesExt.Hostname, "test00")
+	th.AssertEquals(t, serverWithAttributesExt.KernelID, "")
+	th.AssertEquals(t, serverWithAttributesExt.RamdiskID, "")
+	th.AssertEquals(t, serverWithAttributesExt.Host, "compute01")
+	th.AssertEquals(t, serverWithAttributesExt.RootDeviceName, "/dev/sda")
+	th.AssertEquals(t, serverWithAttributesExt.UserData, "")
+	th.AssertEquals(t, serverWithAttributesExt.InstanceName, "instance-00000001")
+	th.AssertEquals(t, serverWithAttributesExt.HypervisorHostname, "compute01")
+	th.AssertEquals(t, serverWithAttributesExt.Created, time.Date(2018, 07, 27, 9, 15, 48, 0, time.UTC))
+	th.AssertEquals(t, serverWithAttributesExt.Updated, time.Date(2018, 07, 27, 9, 15, 55, 0, time.UTC))
+	th.AssertEquals(t, serverWithAttributesExt.ID, "d650a0ce-17c3-497d-961a-43c4af80998a")
+	th.AssertEquals(t, serverWithAttributesExt.Name, "test_instance")
+	th.AssertEquals(t, serverWithAttributesExt.Status, "ACTIVE")
+	th.AssertEquals(t, serverWithAttributesExt.UserID, "0f2f3822679e4b3ea073e5d1c6ed5f02")
+	th.AssertEquals(t, serverWithAttributesExt.TenantID, "424e7cf0243c468ca61732ba45973b3e")
+}


### PR DESCRIPTION
Add the new "extendedserverattributes" package with basic structure.
Add unit test and update TestServersWithExtensionsCreateDestroy aceptance test.
Add documentation example.

For #1160

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

Main class:
https://github.com/openstack/nova/blob/stable/queens/nova/api/openstack/compute/extended_server_attributes.py#L24