### PR TITLE
Imageservice V2: add imageimport Get request

### DIFF
--- a/acceptance/openstack/imageservice/v2/imageimport_test.go
+++ b/acceptance/openstack/imageservice/v2/imageimport_test.go
@@ -1,0 +1,21 @@
+// +build acceptance imageservice imageimport
+
+package v2
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/acceptance/clients"
+	"github.com/gophercloud/gophercloud/acceptance/tools"
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestGetImportInfo(t *testing.T) {
+	client, err := clients.NewImageServiceV2Client()
+	th.AssertNoErr(t, err)
+
+	importInfo, err := GetImportInfo(t, client)
+	th.AssertNoErr(t, err)
+
+	tools.PrintResource(t, importInfo)
+}

--- a/acceptance/openstack/imageservice/v2/imageservice.go
+++ b/acceptance/openstack/imageservice/v2/imageservice.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/acceptance/tools"
+	"github.com/gophercloud/gophercloud/openstack/imageservice/v2/imageimport"
 	"github.com/gophercloud/gophercloud/openstack/imageservice/v2/images"
 	"github.com/gophercloud/gophercloud/openstack/imageservice/v2/tasks"
 	th "github.com/gophercloud/gophercloud/testhelper"
@@ -94,4 +95,15 @@ func CreateTask(t *testing.T, client *gophercloud.ServiceClient, imageURL string
 	}
 
 	return newTask, nil
+}
+
+// GetImportInfo will retrieve Import API information.
+func GetImportInfo(t *testing.T, client *gophercloud.ServiceClient) (*imageimport.ImportInfo, error) {
+	t.Log("Attempting to get the Imageservice Import API information")
+	importInfo, err := imageimport.Get(client).Extract()
+	if err != nil {
+		return nil, err
+	}
+
+	return importInfo, nil
 }

--- a/openstack/imageservice/v2/imageimport/doc.go
+++ b/openstack/imageservice/v2/imageimport/doc.go
@@ -1,0 +1,14 @@
+/*
+Package imageimport enables management of images import and retrieval of the
+Imageservice Import API information.
+
+Example to Get an information about the Import API
+
+	importInfo, err := imageimport.Get(imagesClient).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v\n", importInfo)
+*/
+package imageimport

--- a/openstack/imageservice/v2/imageimport/requests.go
+++ b/openstack/imageservice/v2/imageimport/requests.go
@@ -1,0 +1,20 @@
+package imageimport
+
+import "github.com/gophercloud/gophercloud"
+
+// ImportMethod represents valid Import API method.
+type ImportMethod string
+
+const (
+	// GlanceDirectMethod represents glance-direct Import API method.
+	GlanceDirectMethod ImportMethod = "glance-direct"
+
+	// WebDownloadMethod represents web-download Import API method.
+	WebDownloadMethod ImportMethod = "web-download"
+)
+
+// Get retrieves Import API information data.
+func Get(c *gophercloud.ServiceClient) (r GetResult) {
+	_, r.Err = c.Get(infoURL(c), &r.Body, nil)
+	return
+}

--- a/openstack/imageservice/v2/imageimport/results.go
+++ b/openstack/imageservice/v2/imageimport/results.go
@@ -1,0 +1,32 @@
+package imageimport
+
+import "github.com/gophercloud/gophercloud"
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// GetResult represents the result of a get operation. Call its Extract method
+// to interpret it as ImportInfo.
+type GetResult struct {
+	commonResult
+}
+
+// ImportInfo represents information data for the Import API.
+type ImportInfo struct {
+	ImportMethods ImportMethods `json:"import-methods"`
+}
+
+// ImportMethods contains information about available Import API methods.
+type ImportMethods struct {
+	Description string   `json:"description"`
+	Type        string   `json:"type"`
+	Value       []string `json:"value"`
+}
+
+// Extract is a function that accepts a result and extracts ImportInfo.
+func (r commonResult) Extract() (*ImportInfo, error) {
+	var s *ImportInfo
+	err := r.ExtractInto(&s)
+	return s, err
+}

--- a/openstack/imageservice/v2/imageimport/testing/doc.go
+++ b/openstack/imageservice/v2/imageimport/testing/doc.go
@@ -1,0 +1,1 @@
+package testing

--- a/openstack/imageservice/v2/imageimport/testing/fixtures.go
+++ b/openstack/imageservice/v2/imageimport/testing/fixtures.go
@@ -1,0 +1,15 @@
+package testing
+
+// ImportGetResult represents raw server response on a Get request.
+const ImportGetResult = `
+{
+    "import-methods": {
+        "description": "Import methods available.",
+        "type": "array",
+        "value": [
+            "glance-direct",
+            "web-download"
+        ]
+    }
+}
+`

--- a/openstack/imageservice/v2/imageimport/testing/requests_test.go
+++ b/openstack/imageservice/v2/imageimport/testing/requests_test.go
@@ -1,0 +1,38 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/imageservice/v2/imageimport"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	fakeclient "github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func TestGet(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/info/import", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fakeclient.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, ImportGetResult)
+	})
+
+	validImportMethods := []string{
+		string(imageimport.GlanceDirectMethod),
+		string(imageimport.WebDownloadMethod),
+	}
+
+	s, err := imageimport.Get(fakeclient.ServiceClient()).Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, s.ImportMethods.Description, "Import methods available.")
+	th.AssertEquals(t, s.ImportMethods.Type, "array")
+	th.AssertDeepEquals(t, s.ImportMethods.Value, validImportMethods)
+}

--- a/openstack/imageservice/v2/imageimport/urls.go
+++ b/openstack/imageservice/v2/imageimport/urls.go
@@ -1,0 +1,12 @@
+package imageimport
+
+import "github.com/gophercloud/gophercloud"
+
+const (
+	infoPath     = "info"
+	resourcePath = "import"
+)
+
+func infoURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL(infoPath, resourcePath)
+}


### PR DESCRIPTION
Add the new "imageimport" package and implement Get request to retrieve Import API information.
Add unit and acceptance tests with documentation.

For #1143 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

Main class:
https://github.com/openstack/glance/blob/stable/queens/glance/api/v2/discovery.py#L26

Import methods are populated from configuration file:
https://github.com/openstack/glance/blob/stable/queens/glance/api/v2/discovery.py#L38
https://github.com/openstack/glance/blob/stable/queens/glance/common/config.py#L729