### PR TITLE
Imageservice V2: add Create to imageimport

### DIFF
--- a/acceptance/openstack/imageservice/v2/imageimport_test.go
+++ b/acceptance/openstack/imageservice/v2/imageimport_test.go
@@ -19,3 +19,18 @@ func TestGetImportInfo(t *testing.T) {
 
 	tools.PrintResource(t, importInfo)
 }
+
+func TestCreateImport(t *testing.T) {
+	client, err := clients.NewImageServiceV2Client()
+	th.AssertNoErr(t, err)
+
+	image, err := CreateEmptyImage(t, client)
+	th.AssertNoErr(t, err)
+	defer DeleteImage(t, client, image)
+
+	err = ImportImage(t, client, image.ID)
+	if err.Error() == "EOF" {
+		err = nil
+	}
+	th.AssertNoErr(t, err)
+}

--- a/acceptance/openstack/imageservice/v2/imageimport_test.go
+++ b/acceptance/openstack/imageservice/v2/imageimport_test.go
@@ -29,8 +29,5 @@ func TestCreateImport(t *testing.T) {
 	defer DeleteImage(t, client, image)
 
 	err = ImportImage(t, client, image.ID)
-	if err.Error() == "EOF" {
-		err = nil
-	}
 	th.AssertNoErr(t, err)
 }

--- a/acceptance/openstack/imageservice/v2/imageservice.go
+++ b/acceptance/openstack/imageservice/v2/imageservice.go
@@ -157,3 +157,14 @@ func DeleteImageFile(t *testing.T, filepath string) {
 
 	t.Logf("Successfully deleted image file %s", filepath)
 }
+
+// ImportImage will import image data from the remote source to the Imageservice.
+func ImportImage(t *testing.T, client *gophercloud.ServiceClient, imageID string) error {
+	importOpts := imageimport.CreateOpts{
+		Name: imageimport.WebDownloadMethod,
+		URI:  ImportImageURL,
+	}
+
+	t.Logf("Attempting to import image data for %s from %s", imageID, importOpts.URI)
+	return imageimport.Create(client, imageID, importOpts).ExtractErr()
+}

--- a/openstack/imageservice/v2/imageimport/doc.go
+++ b/openstack/imageservice/v2/imageimport/doc.go
@@ -10,5 +10,21 @@ Example to Get an information about the Import API
 	}
 
 	fmt.Printf("%+v\n", importInfo)
+
+Example to Create a new image import
+
+  opts := imageimport.CreateOpts{
+    Name: imageimport.WebDownloadMethod,
+    URI:  "http://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img",
+  }
+  imageID := "da3b75d9-3f4a-40e7-8a2c-bfab23927dea"
+
+  err := imageimport.Create(imagesClient, imageID, opts).ExtractErr()
+  if err.Error() == "EOF" {
+    err = nil
+  }
+  if err != nil {
+    panic(err)
+  }
 */
 package imageimport

--- a/openstack/imageservice/v2/imageimport/doc.go
+++ b/openstack/imageservice/v2/imageimport/doc.go
@@ -4,12 +4,12 @@ Imageservice Import API information.
 
 Example to Get an information about the Import API
 
-	importInfo, err := imageimport.Get(imagesClient).Extract()
-	if err != nil {
-		panic(err)
-	}
+  importInfo, err := imageimport.Get(imagesClient).Extract()
+  if err != nil {
+    panic(err)
+  }
 
-	fmt.Printf("%+v\n", importInfo)
+  fmt.Printf("%+v\n", importInfo)
 
 Example to Create a new image import
 
@@ -20,9 +20,6 @@ Example to Create a new image import
   imageID := "da3b75d9-3f4a-40e7-8a2c-bfab23927dea"
 
   err := imageimport.Create(imagesClient, imageID, opts).ExtractErr()
-  if err.Error() == "EOF" {
-    err = nil
-  }
   if err != nil {
     panic(err)
   }

--- a/openstack/imageservice/v2/imageimport/requests.go
+++ b/openstack/imageservice/v2/imageimport/requests.go
@@ -18,3 +18,36 @@ func Get(c *gophercloud.ServiceClient) (r GetResult) {
 	_, r.Err = c.Get(infoURL(c), &r.Body, nil)
 	return
 }
+
+// CreateOptsBuilder allows to add additional parameters to the Create request.
+type CreateOptsBuilder interface {
+	ToImportCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts specifies parameters of a new image import.
+type CreateOpts struct {
+	Name ImportMethod `json:"name"`
+	URI  string       `json:"uri"`
+}
+
+// ToImportCreateMap constructs a request body from CreateOpts.
+func (opts CreateOpts) ToImportCreateMap() (map[string]interface{}, error) {
+	b, err := gophercloud.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+	return map[string]interface{}{"method": b}, nil
+}
+
+// Create requests the creation of a new image import on the server.
+func Create(client *gophercloud.ServiceClient, imageID string, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToImportCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(importURL(client, imageID), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+	})
+	return
+}

--- a/openstack/imageservice/v2/imageimport/requests.go
+++ b/openstack/imageservice/v2/imageimport/requests.go
@@ -46,7 +46,7 @@ func Create(client *gophercloud.ServiceClient, imageID string, opts CreateOptsBu
 		r.Err = err
 		return
 	}
-	_, r.Err = client.Post(importURL(client, imageID), b, &r.Body, &gophercloud.RequestOpts{
+	_, r.Err = client.Post(importURL(client, imageID), b, nil, &gophercloud.RequestOpts{
 		OkCodes: []int{202},
 	})
 	return

--- a/openstack/imageservice/v2/imageimport/results.go
+++ b/openstack/imageservice/v2/imageimport/results.go
@@ -12,6 +12,12 @@ type GetResult struct {
 	commonResult
 }
 
+// CreateResult is the result of import Create operation. Call its ExtractErr
+// method to determine if the request succeeded or failed.
+type CreateResult struct {
+	gophercloud.ErrResult
+}
+
 // ImportInfo represents information data for the Import API.
 type ImportInfo struct {
 	ImportMethods ImportMethods `json:"import-methods"`

--- a/openstack/imageservice/v2/imageimport/testing/fixtures.go
+++ b/openstack/imageservice/v2/imageimport/testing/fixtures.go
@@ -13,3 +13,13 @@ const ImportGetResult = `
     }
 }
 `
+
+// ImportCreateRequest represents a request to create image import.
+const ImportCreateRequest = `
+{
+    "method": {
+        "name": "web-download",
+        "uri": "http://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img"
+    }
+}
+`

--- a/openstack/imageservice/v2/imageimport/testing/requests_test.go
+++ b/openstack/imageservice/v2/imageimport/testing/requests_test.go
@@ -36,3 +36,27 @@ func TestGet(t *testing.T) {
 	th.AssertEquals(t, s.ImportMethods.Type, "array")
 	th.AssertDeepEquals(t, s.ImportMethods.Value, validImportMethods)
 }
+
+func TestCreate(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/images/da3b75d9-3f4a-40e7-8a2c-bfab23927dea/import", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fakeclient.TokenID)
+		th.TestJSONRequest(t, r, ImportCreateRequest)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+	})
+
+	opts := imageimport.CreateOpts{
+		Name: imageimport.WebDownloadMethod,
+		URI:  "http://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img",
+	}
+	err := imageimport.Create(fakeclient.ServiceClient(), "da3b75d9-3f4a-40e7-8a2c-bfab23927dea", opts).ExtractErr()
+	if err.Error() == "EOF" {
+		err = nil
+	}
+	th.AssertNoErr(t, err)
+}

--- a/openstack/imageservice/v2/imageimport/testing/requests_test.go
+++ b/openstack/imageservice/v2/imageimport/testing/requests_test.go
@@ -48,6 +48,7 @@ func TestCreate(t *testing.T) {
 
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusAccepted)
+		fmt.Fprintf(w, `{}`)
 	})
 
 	opts := imageimport.CreateOpts{
@@ -55,8 +56,5 @@ func TestCreate(t *testing.T) {
 		URI:  "http://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img",
 	}
 	err := imageimport.Create(fakeclient.ServiceClient(), "da3b75d9-3f4a-40e7-8a2c-bfab23927dea", opts).ExtractErr()
-	if err.Error() == "EOF" {
-		err = nil
-	}
 	th.AssertNoErr(t, err)
 }

--- a/openstack/imageservice/v2/imageimport/urls.go
+++ b/openstack/imageservice/v2/imageimport/urls.go
@@ -3,10 +3,15 @@ package imageimport
 import "github.com/gophercloud/gophercloud"
 
 const (
+	rootPath     = "images"
 	infoPath     = "info"
 	resourcePath = "import"
 )
 
 func infoURL(c *gophercloud.ServiceClient) string {
 	return c.ServiceURL(infoPath, resourcePath)
+}
+
+func importURL(c *gophercloud.ServiceClient, imageID string) string {
+	return c.ServiceURL(rootPath, imageID, resourcePath)
 }


### PR DESCRIPTION
Implement Create method that allows to import image data to the existing image.
Add unit and acceptance tests with documentation.

For #1143

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

API route:
https://github.com/openstack/glance/blob/stable/queens/glance/api/v2/router.py#L428

Main method:
https://github.com/openstack/glance/blob/stable/queens/glance/api/v2/images.py#L92

Response code:
https://github.com/openstack/glance/blob/stable/queens/glance/api/v2/images.py#L976