### PR TITLE
 Compute V2: add Unrescue action

### DIFF
--- a/acceptance/openstack/compute/v2/compute.go
+++ b/acceptance/openstack/compute/v2/compute.go
@@ -989,3 +989,17 @@ func RescueServer(t *testing.T, client *gophercloud.ServiceClient, server *serve
 
 	return nil
 }
+
+// UnrescueServer will return server from rescue mode.
+func UnrescueServer(t *testing.T, client *gophercloud.ServiceClient, server *servers.Server) error {
+	t.Logf("Attempting to return server %s from rescue mode", server.ID)
+	if err := rescueunrescue.Unrescue(client, server.ID).ExtractErr(); err != nil {
+		return err
+	}
+
+	if err := WaitForComputeStatus(client, server, "ACTIVE"); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/acceptance/openstack/compute/v2/compute.go
+++ b/acceptance/openstack/compute/v2/compute.go
@@ -975,7 +975,7 @@ func FillUpdateOptsFromQuotaSet(src quotasets.QuotaSet, dest *quotasets.UpdateOp
 	dest.MetadataItems = &src.MetadataItems
 }
 
-// RescueServer will put the specified server into rescue mode.
+// RescueServer will place the specified server into rescue mode.
 func RescueServer(t *testing.T, client *gophercloud.ServiceClient, server *servers.Server) error {
 	t.Logf("Attempting to put server %s into rescue mode", server.ID)
 	_, err := rescueunrescue.Rescue(client, server.ID, rescueunrescue.RescueOpts{}).Extract()

--- a/acceptance/openstack/compute/v2/compute.go
+++ b/acceptance/openstack/compute/v2/compute.go
@@ -19,6 +19,7 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/keypairs"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/networks"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/quotasets"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/rescueunrescue"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/schedulerhints"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/secgroups"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/servergroups"
@@ -972,4 +973,19 @@ func FillUpdateOptsFromQuotaSet(src quotasets.QuotaSet, dest *quotasets.UpdateOp
 	dest.ServerGroups = &src.ServerGroups
 	dest.ServerGroupMembers = &src.ServerGroupMembers
 	dest.MetadataItems = &src.MetadataItems
+}
+
+// RescueServer will put the specified server into rescue mode.
+func RescueServer(t *testing.T, client *gophercloud.ServiceClient, server *servers.Server) error {
+	t.Logf("Attempting to put server %s into rescue mode", server.ID)
+	_, err := rescueunrescue.Rescue(client, server.ID, rescueunrescue.RescueOpts{}).Extract()
+	if err != nil {
+		return err
+	}
+
+	if err := WaitForComputeStatus(client, server, "RESCUE"); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/acceptance/openstack/compute/v2/rescueunrescue_test.go
+++ b/acceptance/openstack/compute/v2/rescueunrescue_test.go
@@ -20,7 +20,6 @@ func TestServerRescueUnrescue(t *testing.T) {
 	err = RescueServer(t, client, server)
 	th.AssertNoErr(t, err)
 
-	// Enable unrescue call when it will be implemented.
-	// err = UnrescueServer(t, client, server)
-	// th.AssertNoErr(t, err)
+	err = UnrescueServer(t, client, server)
+	th.AssertNoErr(t, err)
 }

--- a/acceptance/openstack/compute/v2/rescueunrescue_test.go
+++ b/acceptance/openstack/compute/v2/rescueunrescue_test.go
@@ -9,7 +9,7 @@ import (
 	th "github.com/gophercloud/gophercloud/testhelper"
 )
 
-func TestServerRescue(t *testing.T) {
+func TestServerRescueUnrescue(t *testing.T) {
 	client, err := clients.NewComputeV2Client()
 	th.AssertNoErr(t, err)
 
@@ -19,4 +19,8 @@ func TestServerRescue(t *testing.T) {
 
 	err = RescueServer(t, client, server)
 	th.AssertNoErr(t, err)
+
+	// Enable unrescue call when it will be implemented.
+	// err = UnrescueServer(t, client, server)
+	// th.AssertNoErr(t, err)
 }

--- a/acceptance/openstack/compute/v2/rescueunrescue_test.go
+++ b/acceptance/openstack/compute/v2/rescueunrescue_test.go
@@ -1,0 +1,22 @@
+// +build acceptance compute rescueunrescue
+
+package v2
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/acceptance/clients"
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestServerRescue(t *testing.T) {
+	client, err := clients.NewComputeV2Client()
+	th.AssertNoErr(t, err)
+
+	server, err := CreateServer(t, client)
+	th.AssertNoErr(t, err)
+	defer DeleteServer(t, client, server)
+
+	err = RescueServer(t, client, server)
+	th.AssertNoErr(t, err)
+}

--- a/openstack/compute/v2/extensions/rescueunrescue/doc.go
+++ b/openstack/compute/v2/extensions/rescueunrescue/doc.go
@@ -1,1 +1,20 @@
+/*
+Package rescueunrescue provides the ability to send server to a rescue mode and
+to return it back.
+
+Example to Rescue a server
+
+  rescueOpts := rescueunrescue.RescueOpts{
+    AdminPass:      "aUPtawPzE9NU",
+    RescueImageRef: "115e5c5b-72f0-4a0a-9067-60706545248c",
+  }
+  serverID := "3f54d05f-3430-4d80-aa07-63e6af9e2488"
+
+  adminPass, err := rescueunrescue.Rescue(computeClient, serverID, rescueOpts).Extract()
+  if err != nil {
+    panic(err)
+  }
+
+  fmt.Printf("adminPass of the rescued server %s: %s\n", serverID, adminPass)
+*/
 package rescueunrescue

--- a/openstack/compute/v2/extensions/rescueunrescue/doc.go
+++ b/openstack/compute/v2/extensions/rescueunrescue/doc.go
@@ -16,5 +16,13 @@ Example to Rescue a server
   }
 
   fmt.Printf("adminPass of the rescued server %s: %s\n", serverID, adminPass)
+
+Example to Unrescue a server
+
+  serverID := "3f54d05f-3430-4d80-aa07-63e6af9e2488"
+
+  if err := rescueunrescue.Unrescue(computeClient, serverID).ExtractErr(); err != nil {
+    panic(err)
+  }
 */
 package rescueunrescue

--- a/openstack/compute/v2/extensions/rescueunrescue/doc.go
+++ b/openstack/compute/v2/extensions/rescueunrescue/doc.go
@@ -1,6 +1,6 @@
 /*
-Package rescueunrescue provides the ability to send server to a rescue mode and
-to return it back.
+Package rescueunrescue provides the ability to place a server into rescue mode
+and to return it back.
 
 Example to Rescue a server
 

--- a/openstack/compute/v2/extensions/rescueunrescue/doc.go
+++ b/openstack/compute/v2/extensions/rescueunrescue/doc.go
@@ -1,0 +1,1 @@
+package rescueunrescue

--- a/openstack/compute/v2/extensions/rescueunrescue/requests.go
+++ b/openstack/compute/v2/extensions/rescueunrescue/requests.go
@@ -1,0 +1,36 @@
+package rescueunrescue
+
+import "github.com/gophercloud/gophercloud"
+
+// RescueOptsBuilder is an interface that allows extensions to override the
+// default structure of a Rescue request.
+type RescueOptsBuilder interface {
+	ToServerRescueMap() (map[string]interface{}, error)
+}
+
+// RescueOpts represents the configuration options used to control a Rescue
+// option.
+type RescueOpts struct {
+	// AdminPass is the desired administrative password for the instance in
+	// RESCUE mode. If it's left blank, the server will generate a password.
+	AdminPass string `json:"adminPass,omitempty"`
+}
+
+// ToServerRescueMap formats a RescueOpts as a map that can be used as a JSON
+// request body for the Rescue request.
+func (opts RescueOpts) ToServerRescueMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "rescue")
+}
+
+// Rescue instructs the provider to place the server into RESCUE mode.
+func Rescue(client *gophercloud.ServiceClient, id string, opts RescueOptsBuilder) (r RescueResult) {
+	b, err := opts.ToServerRescueMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(actionURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}

--- a/openstack/compute/v2/extensions/rescueunrescue/requests.go
+++ b/openstack/compute/v2/extensions/rescueunrescue/requests.go
@@ -40,3 +40,9 @@ func Rescue(client *gophercloud.ServiceClient, id string, opts RescueOptsBuilder
 	})
 	return
 }
+
+// Unrescue instructs the provider to return the server from RESCUE mode.
+func Unrescue(client *gophercloud.ServiceClient, id string) (r UnrescueResult) {
+	_, r.Err = client.Post(actionURL(client, id), map[string]interface{}{"unrescue": nil}, nil, nil)
+	return
+}

--- a/openstack/compute/v2/extensions/rescueunrescue/requests.go
+++ b/openstack/compute/v2/extensions/rescueunrescue/requests.go
@@ -12,8 +12,14 @@ type RescueOptsBuilder interface {
 // option.
 type RescueOpts struct {
 	// AdminPass is the desired administrative password for the instance in
-	// RESCUE mode. If it's left blank, the server will generate a password.
+	// RESCUE mode.
+	// If it's left blank, the server will generate a password.
 	AdminPass string `json:"adminPass,omitempty"`
+
+	// RescueImageRef contains reference on an image that needs to be used as
+	// rescue image.
+	// If it's left blank, the server will be rescued with the default image.
+	RescueImageRef string `json:"rescue_image_ref,omitempty"`
 }
 
 // ToServerRescueMap formats a RescueOpts as a map that can be used as a JSON

--- a/openstack/compute/v2/extensions/rescueunrescue/results.go
+++ b/openstack/compute/v2/extensions/rescueunrescue/results.go
@@ -1,0 +1,18 @@
+package rescueunrescue
+
+import "github.com/gophercloud/gophercloud"
+
+// RescueResult is the response from a Rescue operation. Call its ExtractErr
+// method to determine if the call succeeded or failed.
+type RescueResult struct {
+	gophercloud.ErrResult
+}
+
+// Extract interprets any RescueResult as an AdminPass, if possible.
+func (r RescueResult) Extract() (string, error) {
+	var s struct {
+		AdminPass string `json:"adminPass"`
+	}
+	err := r.ExtractInto(&s)
+	return s.AdminPass, err
+}

--- a/openstack/compute/v2/extensions/rescueunrescue/results.go
+++ b/openstack/compute/v2/extensions/rescueunrescue/results.go
@@ -12,6 +12,12 @@ type RescueResult struct {
 	commonResult
 }
 
+// UnrescueResult is the response from an UnRescue operation. Call its ExtractErr
+// method to determine if the call succeeded or failed.
+type UnrescueResult struct {
+	gophercloud.ErrResult
+}
+
 // Extract interprets any RescueResult as an AdminPass, if possible.
 func (r RescueResult) Extract() (string, error) {
 	var s struct {

--- a/openstack/compute/v2/extensions/rescueunrescue/results.go
+++ b/openstack/compute/v2/extensions/rescueunrescue/results.go
@@ -2,10 +2,14 @@ package rescueunrescue
 
 import "github.com/gophercloud/gophercloud"
 
-// RescueResult is the response from a Rescue operation. Call its ExtractErr
-// method to determine if the call succeeded or failed.
+type commonResult struct {
+	gophercloud.Result
+}
+
+// RescueResult is the response from a Rescue operation. Call its Extract
+// method to retrieve adminPass for a rescued server.
 type RescueResult struct {
-	gophercloud.ErrResult
+	commonResult
 }
 
 // Extract interprets any RescueResult as an AdminPass, if possible.

--- a/openstack/compute/v2/extensions/rescueunrescue/testing/doc.go
+++ b/openstack/compute/v2/extensions/rescueunrescue/testing/doc.go
@@ -1,0 +1,1 @@
+package testing

--- a/openstack/compute/v2/extensions/rescueunrescue/testing/fixtures.go
+++ b/openstack/compute/v2/extensions/rescueunrescue/testing/fixtures.go
@@ -16,3 +16,10 @@ const RescueResult = `
 	"adminPass": "aUPtawPzE9NU"
 }
 `
+
+// UnrescueRequest represents request to unrescue a server.
+const UnrescueRequest = `
+{
+    "unrescue": null
+}
+`

--- a/openstack/compute/v2/extensions/rescueunrescue/testing/fixtures.go
+++ b/openstack/compute/v2/extensions/rescueunrescue/testing/fixtures.go
@@ -1,0 +1,21 @@
+package testing
+
+import (
+	"net/http"
+	"testing"
+
+	th "github.com/gophercloud/gophercloud/testhelper"
+	fake "github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+// HandleServerRescueSuccessfully sets up the test server to respond to a server Rescue request.
+func HandleServerRescueSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/servers/1234asdf/action", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestJSONRequest(t, r, `{ "rescue": { "adminPass": "1234567890" } }`)
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{ "adminPass": "1234567890" }`))
+	})
+}

--- a/openstack/compute/v2/extensions/rescueunrescue/testing/fixtures.go
+++ b/openstack/compute/v2/extensions/rescueunrescue/testing/fixtures.go
@@ -1,21 +1,18 @@
 package testing
 
-import (
-	"net/http"
-	"testing"
-
-	th "github.com/gophercloud/gophercloud/testhelper"
-	fake "github.com/gophercloud/gophercloud/testhelper/client"
-)
-
-// HandleServerRescueSuccessfully sets up the test server to respond to a server Rescue request.
-func HandleServerRescueSuccessfully(t *testing.T) {
-	th.Mux.HandleFunc("/servers/1234asdf/action", func(w http.ResponseWriter, r *http.Request) {
-		th.TestMethod(t, r, "POST")
-		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
-		th.TestJSONRequest(t, r, `{ "rescue": { "adminPass": "1234567890" } }`)
-
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{ "adminPass": "1234567890" }`))
-	})
+// RescueRequest represents request to rescue a server.
+const RescueRequest = `
+{
+    "rescue": {
+        "adminPass": "aUPtawPzE9NU",
+        "rescue_image_ref": "115e5c5b-72f0-4a0a-9067-60706545248c"
+    }
 }
+`
+
+// RescueResult represents a raw server response to a RescueRequest.
+const RescueResult = `
+{
+	"adminPass": "aUPtawPzE9NU"
+}
+`

--- a/openstack/compute/v2/extensions/rescueunrescue/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/rescueunrescue/testing/requests_test.go
@@ -31,3 +31,19 @@ func TestRescue(t *testing.T) {
 
 	th.AssertEquals(t, "aUPtawPzE9NU", s)
 }
+
+func TestUnrescue(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/servers/3f54d05f-3430-4d80-aa07-63e6af9e2488/action", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestJSONRequest(t, r, UnrescueRequest)
+
+		w.WriteHeader(http.StatusAccepted)
+	})
+
+	err := rescueunrescue.Unrescue(fake.ServiceClient(), "3f54d05f-3430-4d80-aa07-63e6af9e2488").ExtractErr()
+	th.AssertNoErr(t, err)
+}

--- a/openstack/compute/v2/extensions/rescueunrescue/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/rescueunrescue/testing/requests_test.go
@@ -1,0 +1,23 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/rescueunrescue"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	fake "github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func TestRescue(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	HandleServerRescueSuccessfully(t)
+
+	res := rescueunrescue.Rescue(fake.ServiceClient(), "1234asdf", rescueunrescue.RescueOpts{
+		AdminPass: "1234567890",
+	})
+	th.AssertNoErr(t, res.Err)
+	adminPass, _ := res.Extract()
+	th.AssertEquals(t, "1234567890", adminPass)
+}

--- a/openstack/compute/v2/extensions/rescueunrescue/urls.go
+++ b/openstack/compute/v2/extensions/rescueunrescue/urls.go
@@ -1,0 +1,7 @@
+package rescueunrescue
+
+import "github.com/gophercloud/gophercloud"
+
+func actionURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL("servers", id, "action")
+}

--- a/openstack/compute/v2/servers/requests.go
+++ b/openstack/compute/v2/servers/requests.go
@@ -545,39 +545,6 @@ func RevertResize(client *gophercloud.ServiceClient, id string) (r ActionResult)
 	return
 }
 
-// RescueOptsBuilder is an interface that allows extensions to override the
-// default structure of a Rescue request.
-type RescueOptsBuilder interface {
-	ToServerRescueMap() (map[string]interface{}, error)
-}
-
-// RescueOpts represents the configuration options used to control a Rescue
-// option.
-type RescueOpts struct {
-	// AdminPass is the desired administrative password for the instance in
-	// RESCUE mode. If it's left blank, the server will generate a password.
-	AdminPass string `json:"adminPass,omitempty"`
-}
-
-// ToServerRescueMap formats a RescueOpts as a map that can be used as a JSON
-// request body for the Rescue request.
-func (opts RescueOpts) ToServerRescueMap() (map[string]interface{}, error) {
-	return gophercloud.BuildRequestBody(opts, "rescue")
-}
-
-// Rescue instructs the provider to place the server into RESCUE mode.
-func Rescue(client *gophercloud.ServiceClient, id string, opts RescueOptsBuilder) (r RescueResult) {
-	b, err := opts.ToServerRescueMap()
-	if err != nil {
-		r.Err = err
-		return
-	}
-	_, r.Err = client.Post(actionURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
-		OkCodes: []int{200},
-	})
-	return
-}
-
 // ResetMetadataOptsBuilder allows extensions to add additional parameters to
 // the Reset request.
 type ResetMetadataOptsBuilder interface {

--- a/openstack/compute/v2/servers/results.go
+++ b/openstack/compute/v2/servers/results.go
@@ -68,12 +68,6 @@ type ActionResult struct {
 	gophercloud.ErrResult
 }
 
-// RescueResult is the response from a Rescue operation. Call its ExtractErr
-// method to determine if the call succeeded or failed.
-type RescueResult struct {
-	ActionResult
-}
-
 // CreateImageResult is the response from a CreateImage operation. Call its
 // ExtractImageID method to retrieve the ID of the newly created image.
 type CreateImageResult struct {
@@ -147,15 +141,6 @@ func (r CreateImageResult) ExtractImageID() (string, error) {
 		return "", fmt.Errorf("Failed to parse the ID of newly created image: %s", u)
 	}
 	return imageID, nil
-}
-
-// Extract interprets any RescueResult as an AdminPass, if possible.
-func (r RescueResult) Extract() (string, error) {
-	var s struct {
-		AdminPass string `json:"adminPass"`
-	}
-	err := r.ExtractInto(&s)
-	return s.AdminPass, err
 }
 
 // Server represents a server/instance in the OpenStack cloud.

--- a/openstack/compute/v2/servers/testing/fixtures.go
+++ b/openstack/compute/v2/servers/testing/fixtures.go
@@ -888,18 +888,6 @@ func HandleRebuildSuccessfully(t *testing.T, response string) {
 	})
 }
 
-// HandleServerRescueSuccessfully sets up the test server to respond to a server Rescue request.
-func HandleServerRescueSuccessfully(t *testing.T) {
-	th.Mux.HandleFunc("/servers/1234asdf/action", func(w http.ResponseWriter, r *http.Request) {
-		th.TestMethod(t, r, "POST")
-		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
-		th.TestJSONRequest(t, r, `{ "rescue": { "adminPass": "1234567890" } }`)
-
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{ "adminPass": "1234567890" }`))
-	})
-}
-
 // HandleMetadatumGetSuccessfully sets up the test server to respond to a metadatum Get request.
 func HandleMetadatumGetSuccessfully(t *testing.T) {
 	th.Mux.HandleFunc("/servers/1234asdf/metadata/foo", func(w http.ResponseWriter, r *http.Request) {

--- a/openstack/compute/v2/servers/testing/requests_test.go
+++ b/openstack/compute/v2/servers/testing/requests_test.go
@@ -383,20 +383,6 @@ func TestRevertResize(t *testing.T) {
 	th.AssertNoErr(t, res.Err)
 }
 
-func TestRescue(t *testing.T) {
-	th.SetupHTTP()
-	defer th.TeardownHTTP()
-
-	HandleServerRescueSuccessfully(t)
-
-	res := servers.Rescue(client.ServiceClient(), "1234asdf", servers.RescueOpts{
-		AdminPass: "1234567890",
-	})
-	th.AssertNoErr(t, res.Err)
-	adminPass, _ := res.Extract()
-	th.AssertEquals(t, "1234567890", adminPass)
-}
-
 func TestGetMetadatum(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()


### PR DESCRIPTION
Add Unrescue request to the "rescueunrescue" package.
Update TestServerRescueUnrescue acceptance test to also run Unrescue call.
Provide documentation and unit test.

For #1164

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/nova/blob/stable/queens/nova/api/openstack/compute/rescue.py#L85