### PR TITLE
Senlin Bug: Policies Delete Should Use ExtractErr Instead Of Extract

### DIFF
--- a/acceptance/openstack/clustering/v1/clustering.go
+++ b/acceptance/openstack/clustering/v1/clustering.go
@@ -337,7 +337,7 @@ func DeleteNode(t *testing.T, client *gophercloud.ServiceClient, id string) {
 func DeletePolicy(t *testing.T, client *gophercloud.ServiceClient, id string) {
 	t.Logf("Attempting to delete policy: %s", id)
 
-	_, err := policies.Delete(client, id).Extract()
+	err := policies.Delete(client, id).ExtractErr()
 	if err != nil {
 		t.Fatalf("Error deleting policy %s: %s:", id, err)
 	}

--- a/openstack/clustering/v1/policies/results.go
+++ b/openstack/clustering/v1/policies/results.go
@@ -136,18 +136,7 @@ type ValidateResult struct {
 // DeleteResult is the result of a Delete operation. Call its Extract
 // method to interpret it as a DeleteHeader.
 type DeleteResult struct {
-	gophercloud.HeaderResult
-}
-
-// DeleteHeader contains the delete information from a delete policy request.
-type DeleteHeader struct {
-	RequestID string `json:"X-OpenStack-Request-ID"`
-}
-
-func (r DeleteResult) Extract() (*DeleteHeader, error) {
-	var s *DeleteHeader
-	err := r.HeaderResult.ExtractInto(&s)
-	return s, err
+	gophercloud.ErrResult
 }
 
 // PolicyPage contains a list page of all policies from a List call.

--- a/openstack/clustering/v1/policies/testing/fixtures.go
+++ b/openstack/clustering/v1/policies/testing/fixtures.go
@@ -446,7 +446,7 @@ func HandlePolicyDelete(t *testing.T) {
 		th.TestMethod(t, r, "DELETE")
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 
-		w.Header().Add("X-OpenStack-Request-ID", PolicyDeleteRequestID)
+		w.Header().Add("X-OpenStack-Request-Id", PolicyDeleteRequestID)
 		w.WriteHeader(http.StatusNoContent)
 	})
 }

--- a/openstack/clustering/v1/policies/testing/requests_test.go
+++ b/openstack/clustering/v1/policies/testing/requests_test.go
@@ -65,10 +65,11 @@ func TestDeletePolicy(t *testing.T) {
 
 	HandlePolicyDelete(t)
 
-	actual, err := policies.Delete(fake.ServiceClient(), PolicyIDtoDelete).Extract()
-	th.AssertNoErr(t, err)
+	res := policies.Delete(fake.ServiceClient(), PolicyIDtoDelete)
+	th.AssertNoErr(t, res.ExtractErr())
 
-	th.AssertEquals(t, PolicyDeleteRequestID, actual.RequestID)
+	requestID := res.Header["X-Openstack-Request-Id"][0]
+	th.AssertEquals(t, PolicyDeleteRequestID, requestID)
 }
 
 func TestUpdatePolicy(t *testing.T) {


### PR DESCRIPTION
Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

For #[1171 [Senlin Bug: Policies Delete Should Use ExtractErr Instead Of Extract]](https://github.com/gophercloud/gophercloud/issues/1171)

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

[[policies::delete]](https://github.com/openstack/senlin/blob/master/senlin/api/openstack/v1/policies.py#L89)
