### PR TITLE
Manila: add extend and shrink share functionality

### DIFF
--- a/acceptance/openstack/sharedfilesystems/v2/shares.go
+++ b/acceptance/openstack/sharedfilesystems/v2/shares.go
@@ -109,6 +109,16 @@ func PrintAccessRight(t *testing.T, accessRight *shares.AccessRight) {
 	t.Logf("Access rule %s", string(asJSON))
 }
 
+// ExtendShare extends the capacity of an existing share
+func ExtendShare(t *testing.T, client *gophercloud.ServiceClient, share *shares.Share, newSize int) error {
+	return shares.Extend(client, share.ID, &shares.ExtendOpts{NewSize: newSize}).ExtractErr()
+}
+
+// ShrinkShare shrinks the capacity of an existing share
+func ShrinkShare(t *testing.T, client *gophercloud.ServiceClient, share *shares.Share, newSize int) error {
+	return shares.Shrink(client, share.ID, &shares.ShrinkOpts{NewSize: newSize}).ExtractErr()
+}
+
 func waitForStatus(c *gophercloud.ServiceClient, id, status string, secs int) error {
 	return gophercloud.WaitFor(secs, func() (bool, error) {
 		current, err := shares.Get(c, id).Extract()

--- a/acceptance/openstack/sharedfilesystems/v2/shares_test.go
+++ b/acceptance/openstack/sharedfilesystems/v2/shares_test.go
@@ -108,3 +108,43 @@ func TestListAccessRights(t *testing.T) {
 		PrintAccessRight(t, &r)
 	}
 }
+
+func TestExtendAndShrink(t *testing.T) {
+	client, err := clients.NewSharedFileSystemV2Client()
+	if err != nil {
+		t.Fatalf("Unable to create a sharedfs client: %v", err)
+	}
+
+	share, err := CreateShare(t, client)
+	if err != nil {
+		t.Fatalf("Unable to create a share: %v", err)
+	}
+
+	defer DeleteShare(t, client, share)
+
+	err = ExtendShare(t, client, share, 2)
+	if err != nil {
+		t.Fatalf("Unable to extend a share: %v", err)
+	}
+
+	// We need to wait till the Extend is done
+	err = waitForStatus(client, share.ID, "available", 120)
+	if err != nil {
+		t.Fatalf("Share status error: %v", err)
+	}
+
+	t.Logf("Share %s successfuly extended", share.ID)
+
+	err = ShrinkShare(t, client, share, 1)
+	if err != nil {
+		t.Fatalf("Unable to shrink a share: %v", err)
+	}
+
+	// We need to wait till the Shrink is done
+	err = waitForStatus(client, share.ID, "available", 120)
+	if err != nil {
+		t.Fatalf("Share status error: %v", err)
+	}
+
+	t.Logf("Share %s successfuly shrunk", share.ID)
+}

--- a/acceptance/openstack/sharedfilesystems/v2/shares_test.go
+++ b/acceptance/openstack/sharedfilesystems/v2/shares_test.go
@@ -127,7 +127,7 @@ func TestExtendAndShrink(t *testing.T) {
 		t.Fatalf("Unable to extend a share: %v", err)
 	}
 
-	// We need to wait till the Extend is done
+	// We need to wait till the Extend operation is done
 	err = waitForStatus(client, share.ID, "available", 120)
 	if err != nil {
 		t.Fatalf("Share status error: %v", err)
@@ -140,7 +140,7 @@ func TestExtendAndShrink(t *testing.T) {
 		t.Fatalf("Unable to shrink a share: %v", err)
 	}
 
-	// We need to wait till the Shrink is done
+	// We need to wait till the Shrink operation is done
 	err = waitForStatus(client, share.ID, "available", 120)
 	if err != nil {
 		t.Fatalf("Share status error: %v", err)

--- a/openstack/sharedfilesystems/v2/shares/requests.go
+++ b/openstack/sharedfilesystems/v2/shares/requests.go
@@ -267,3 +267,77 @@ func ListAccessRights(client *gophercloud.ServiceClient, id string) (r ListAcces
 	})
 	return
 }
+
+// ExtendOptsBuilder allows extensions to add additional parameters to the
+// Extend request.
+type ExtendOptsBuilder interface {
+	ToExtendMap() (map[string]interface{}, error)
+}
+
+// ExtendOpts contains the options for creation of a Extend request.
+// For more information about these parameters, please, refer to the shared file systems API v2,
+// Share Actions, Extend share documentation
+type ExtendOpts struct {
+	// New size in GBs.
+	NewSize int `json:"new_size"`
+}
+
+// ToExtendMap assembles a request body based on the contents of a
+// ExtendOpts.
+func (opts ExtendOpts) ToExtendMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "extend")
+}
+
+// Extend will extend the capacity of an existing share. ExtendResult contains only the error.
+// To extract it, call the ExtractErr method on the ExtendResult.
+// Client must have Microversion set; minimum supported microversion for Extend is 2.7.
+func Extend(client *gophercloud.ServiceClient, id string, opts ExtendOptsBuilder) (r ExtendResult) {
+	b, err := opts.ToExtendMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = client.Post(extendURL(client, id), b, nil, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+	})
+
+	return
+}
+
+// ShrinkOptsBuilder allows extensions to add additional parameters to the
+// Shrink request.
+type ShrinkOptsBuilder interface {
+	ToShrinkMap() (map[string]interface{}, error)
+}
+
+// ShrinkOpts contains the options for creation of a Shrink request.
+// For more information about these parameters, please, refer to the shared file systems API v2,
+// Share Actions, Shrink share documentation
+type ShrinkOpts struct {
+	// New size in GBs.
+	NewSize int `json:"new_size"`
+}
+
+// ToShrinkMap assembles a request body based on the contents of a
+// ShrinkOpts.
+func (opts ShrinkOpts) ToShrinkMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "shrink")
+}
+
+// Shrink will shrink the capacity of an existing share. ShrinkResult contains only the error.
+// To extract it, call the ExtractErr method on the ShrinkResult.
+// Client must have Microversion set; minimum supported microversion for Shrink is 2.7.
+func Shrink(client *gophercloud.ServiceClient, id string, opts ShrinkOptsBuilder) (r ShrinkResult) {
+	b, err := opts.ToShrinkMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = client.Post(shrinkURL(client, id), b, nil, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+	})
+
+	return
+}

--- a/openstack/sharedfilesystems/v2/shares/requests.go
+++ b/openstack/sharedfilesystems/v2/shares/requests.go
@@ -271,10 +271,10 @@ func ListAccessRights(client *gophercloud.ServiceClient, id string) (r ListAcces
 // ExtendOptsBuilder allows extensions to add additional parameters to the
 // Extend request.
 type ExtendOptsBuilder interface {
-	ToExtendMap() (map[string]interface{}, error)
+	ToShareExtendMap() (map[string]interface{}, error)
 }
 
-// ExtendOpts contains the options for creation of a Extend request.
+// ExtendOpts contains options for extending a Share.
 // For more information about these parameters, please, refer to the shared file systems API v2,
 // Share Actions, Extend share documentation
 type ExtendOpts struct {
@@ -282,9 +282,9 @@ type ExtendOpts struct {
 	NewSize int `json:"new_size"`
 }
 
-// ToExtendMap assembles a request body based on the contents of a
+// ToShareExtendMap assembles a request body based on the contents of a
 // ExtendOpts.
-func (opts ExtendOpts) ToExtendMap() (map[string]interface{}, error) {
+func (opts ExtendOpts) ToShareExtendMap() (map[string]interface{}, error) {
 	return gophercloud.BuildRequestBody(opts, "extend")
 }
 
@@ -292,7 +292,7 @@ func (opts ExtendOpts) ToExtendMap() (map[string]interface{}, error) {
 // To extract it, call the ExtractErr method on the ExtendResult.
 // Client must have Microversion set; minimum supported microversion for Extend is 2.7.
 func Extend(client *gophercloud.ServiceClient, id string, opts ExtendOptsBuilder) (r ExtendResult) {
-	b, err := opts.ToExtendMap()
+	b, err := opts.ToShareExtendMap()
 	if err != nil {
 		r.Err = err
 		return
@@ -308,10 +308,10 @@ func Extend(client *gophercloud.ServiceClient, id string, opts ExtendOptsBuilder
 // ShrinkOptsBuilder allows extensions to add additional parameters to the
 // Shrink request.
 type ShrinkOptsBuilder interface {
-	ToShrinkMap() (map[string]interface{}, error)
+	ToShareShrinkMap() (map[string]interface{}, error)
 }
 
-// ShrinkOpts contains the options for creation of a Shrink request.
+// ShrinkOpts contains options for shrinking a Share.
 // For more information about these parameters, please, refer to the shared file systems API v2,
 // Share Actions, Shrink share documentation
 type ShrinkOpts struct {
@@ -319,9 +319,9 @@ type ShrinkOpts struct {
 	NewSize int `json:"new_size"`
 }
 
-// ToShrinkMap assembles a request body based on the contents of a
+// ToShareShrinkMap assembles a request body based on the contents of a
 // ShrinkOpts.
-func (opts ShrinkOpts) ToShrinkMap() (map[string]interface{}, error) {
+func (opts ShrinkOpts) ToShareShrinkMap() (map[string]interface{}, error) {
 	return gophercloud.BuildRequestBody(opts, "shrink")
 }
 
@@ -329,7 +329,7 @@ func (opts ShrinkOpts) ToShrinkMap() (map[string]interface{}, error) {
 // To extract it, call the ExtractErr method on the ShrinkResult.
 // Client must have Microversion set; minimum supported microversion for Shrink is 2.7.
 func Shrink(client *gophercloud.ServiceClient, id string, opts ShrinkOptsBuilder) (r ShrinkResult) {
-	b, err := opts.ToShrinkMap()
+	b, err := opts.ToShareShrinkMap()
 	if err != nil {
 		r.Err = err
 		return

--- a/openstack/sharedfilesystems/v2/shares/results.go
+++ b/openstack/sharedfilesystems/v2/shares/results.go
@@ -305,3 +305,13 @@ func (r ListAccessRightsResult) Extract() ([]AccessRight, error) {
 type ListAccessRightsResult struct {
 	gophercloud.Result
 }
+
+// ExtendResult contains the response body and error from an Extend request.
+type ExtendResult struct {
+	gophercloud.ErrResult
+}
+
+// ShrinkResult contains the response body and error from a Shrink request.
+type ShrinkResult struct {
+	gophercloud.ErrResult
+}

--- a/openstack/sharedfilesystems/v2/shares/testing/fixtures.go
+++ b/openstack/sharedfilesystems/v2/shares/testing/fixtures.go
@@ -188,7 +188,7 @@ var listDetailResponse = `{
 
 var listDetailEmptyResponse = `{"shares": []}`
 
-// MockDeleteResponse creates a mock detailed-list response
+// MockListDetailResponse creates a mock detailed-list response
 func MockListDetailResponse(t *testing.T) {
 	th.Mux.HandleFunc(shareEndpoint+"/detail", func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "GET")
@@ -272,6 +272,7 @@ var revokeAccessRequest = `{
 	}
 }`
 
+// MockRevokeAccessResponse creates a mock revoke access response
 func MockRevokeAccessResponse(t *testing.T) {
 	th.Mux.HandleFunc(shareEndpoint+"/"+shareID+"/action", func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "POST")
@@ -313,5 +314,43 @@ func MockListAccessRightsResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprintf(w, listAccessRightsResponse)
+	})
+}
+
+var extendRequest = `{
+		"extend": {
+			"new_size": 2
+		}
+	}`
+
+// MockExtendResponse creates a mock extend share response
+func MockExtendResponse(t *testing.T) {
+	th.Mux.HandleFunc(shareEndpoint+"/"+shareID+"/action", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, extendRequest)
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+	})
+}
+
+var shrinkRequest = `{
+		"shrink": {
+			"new_size": 1
+		}
+	}`
+
+// MockShrinkResponse creates a mock shrink share response
+func MockShrinkResponse(t *testing.T) {
+	th.Mux.HandleFunc(shareEndpoint+"/"+shareID+"/action", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, shrinkRequest)
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
 	})
 }

--- a/openstack/sharedfilesystems/v2/shares/testing/request_test.go
+++ b/openstack/sharedfilesystems/v2/shares/testing/request_test.go
@@ -233,3 +233,31 @@ func TestListAccessRightsSuccess(t *testing.T) {
 		},
 	})
 }
+
+func TestExtendSuccess(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockExtendResponse(t)
+
+	c := client.ServiceClient()
+	// Client c must have Microversion set; minimum supported microversion for Grant Access is 2.7
+	c.Microversion = "2.7"
+
+	err := shares.Extend(c, shareID, &shares.ExtendOpts{NewSize: 2}).ExtractErr()
+	th.AssertNoErr(t, err)
+}
+
+func TestShrinkSuccess(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockShrinkResponse(t)
+
+	c := client.ServiceClient()
+	// Client c must have Microversion set; minimum supported microversion for Grant Access is 2.7
+	c.Microversion = "2.7"
+
+	err := shares.Shrink(c, shareID, &shares.ShrinkOpts{NewSize: 1}).ExtractErr()
+	th.AssertNoErr(t, err)
+}

--- a/openstack/sharedfilesystems/v2/shares/urls.go
+++ b/openstack/sharedfilesystems/v2/shares/urls.go
@@ -33,3 +33,11 @@ func revokeAccessURL(c *gophercloud.ServiceClient, id string) string {
 func listAccessRightsURL(c *gophercloud.ServiceClient, id string) string {
 	return c.ServiceURL("shares", id, "action")
 }
+
+func extendURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("shares", id, "action")
+}
+
+func shrinkURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("shares", id, "action")
+}


### PR DESCRIPTION
For #1174 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

Extend:
* example request: https://github.com/openstack/manila/blob/master/api-ref/source/samples/share-actions-extend-request.json
* API v2 `extend`: https://github.com/openstack/manila/blob/master/manila/api/v2/shares.py#L385
* `extend` implementation: https://github.com/openstack/manila/blob/master/manila/share/api.py#L1765

Shrink:
* example request: https://github.com/openstack/manila/blob/master/api-ref/source/samples/share-actions-shrink-request.json
* API v2 `shrink`: https://github.com/openstack/manila/blob/master/manila/api/v2/shares.py#L397
* `shrink` implementation: https://github.com/openstack/manila/blob/master/manila/share/api.py#L1823

/cc @jtopjian 

Ready for review