### PR TITLE
Image Service v2: Support Updating Properties

### DIFF
--- a/openstack/imageservice/v2/images/requests.go
+++ b/openstack/imageservice/v2/images/requests.go
@@ -271,11 +271,11 @@ type UpdateVisibility struct {
 }
 
 // ToImagePatchMap assembles a request body based on UpdateVisibility.
-func (u UpdateVisibility) ToImagePatchMap() map[string]interface{} {
+func (r UpdateVisibility) ToImagePatchMap() map[string]interface{} {
 	return map[string]interface{}{
 		"op":    "replace",
 		"path":  "/visibility",
-		"value": u.Visibility,
+		"value": r.Visibility,
 	}
 }
 
@@ -299,11 +299,11 @@ type ReplaceImageChecksum struct {
 }
 
 // ReplaceImageChecksum assembles a request body based on ReplaceImageChecksum.
-func (rc ReplaceImageChecksum) ToImagePatchMap() map[string]interface{} {
+func (r ReplaceImageChecksum) ToImagePatchMap() map[string]interface{} {
 	return map[string]interface{}{
 		"op":    "replace",
 		"path":  "/checksum",
-		"value": rc.Checksum,
+		"value": r.Checksum,
 	}
 }
 
@@ -319,4 +319,34 @@ func (r ReplaceImageTags) ToImagePatchMap() map[string]interface{} {
 		"path":  "/tags",
 		"value": r.NewTags,
 	}
+}
+
+// UpdateOp represents a valid update operation.
+type UpdateOp string
+
+const (
+	AddOp     UpdateOp = "add"
+	ReplaceOp UpdateOp = "replace"
+	RemoveOp  UpdateOp = "remove"
+)
+
+// UpdateImageProperty represents an update property request.
+type UpdateImageProperty struct {
+	Op    UpdateOp
+	Name  string
+	Value string
+}
+
+// ToImagePatchMap assembles a request body based on UpdateImageProperty.
+func (r UpdateImageProperty) ToImagePatchMap() map[string]interface{} {
+	updateMap := map[string]interface{}{
+		"op":   r.Op,
+		"path": fmt.Sprintf("/%s", r.Name),
+	}
+
+	if r.Value != "" {
+		updateMap["value"] = r.Value
+	}
+
+	return updateMap
 }

--- a/openstack/imageservice/v2/images/testing/fixtures.go
+++ b/openstack/imageservice/v2/images/testing/fixtures.go
@@ -388,3 +388,60 @@ func HandleImageListByTagsSuccessfully(t *testing.T) {
 	}`)
 	})
 }
+
+// HandleImageUpdatePropertiesSuccessfully setup
+func HandleImageUpdatePropertiesSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/images/da3b75d9-3f4a-40e7-8a2c-bfab23927dea", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PATCH")
+		th.TestHeader(t, r, "X-Auth-Token", fakeclient.TokenID)
+
+		th.TestJSONRequest(t, r, `[
+			{
+				"op": "add",
+				"path": "/hw_disk_bus",
+				"value": "scsi"
+			},
+			{
+				"op": "add",
+				"path": "/hw_disk_bus_model",
+				"value": "virtio-scsi"
+			},
+			{
+				"op": "add",
+				"path": "/hw_scsi_model",
+				"value": "virtio-scsi"
+			}
+		]`)
+
+		th.AssertEquals(t, "application/openstack-images-v2.1-json-patch", r.Header.Get("Content-Type"))
+
+		w.WriteHeader(http.StatusOK)
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprintf(w, `{
+			"id": "da3b75d9-3f4a-40e7-8a2c-bfab23927dea",
+			"name": "Fedora 17",
+			"status": "active",
+			"visibility": "public",
+			"size": 2254249,
+			"checksum": "2cec138d7dae2aa59038ef8c9aec2390",
+			"tags": [
+				"fedora",
+				"beefy"
+			],
+			"created_at": "2012-08-10T19:23:50Z",
+			"updated_at": "2012-08-12T11:11:33Z",
+			"self": "/v2/images/da3b75d9-3f4a-40e7-8a2c-bfab23927dea",
+			"file": "/v2/images/da3b75d9-3f4a-40e7-8a2c-bfab23927dea/file",
+			"schema": "/v2/schemas/image",
+			"owner": "",
+			"min_ram": 0,
+			"min_disk": 0,
+			"disk_format": "",
+			"virtual_size": 0,
+			"container_format": "",
+			"hw_disk_bus": "scsi",
+			"hw_disk_bus_model": "virtio-scsi",
+			"hw_scsi_model": "virtio-scsi"
+		}`)
+	})
+}

--- a/openstack/imageservice/v2/images/testing/requests_test.go
+++ b/openstack/imageservice/v2/images/testing/requests_test.go
@@ -388,3 +388,71 @@ func TestImageListByTags(t *testing.T) {
 
 	th.AssertDeepEquals(t, expectedImage, allImages[0])
 }
+
+func TestUpdateImageProperties(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	HandleImageUpdatePropertiesSuccessfully(t)
+
+	actualImage, err := images.Update(fakeclient.ServiceClient(), "da3b75d9-3f4a-40e7-8a2c-bfab23927dea", images.UpdateOpts{
+		images.UpdateImageProperty{
+			Op:    images.AddOp,
+			Name:  "hw_disk_bus",
+			Value: "scsi",
+		},
+		images.UpdateImageProperty{
+			Op:    images.AddOp,
+			Name:  "hw_disk_bus_model",
+			Value: "virtio-scsi",
+		},
+		images.UpdateImageProperty{
+			Op:    images.AddOp,
+			Name:  "hw_scsi_model",
+			Value: "virtio-scsi",
+		},
+	}).Extract()
+
+	th.AssertNoErr(t, err)
+
+	sizebytes := int64(2254249)
+	checksum := "2cec138d7dae2aa59038ef8c9aec2390"
+	file := actualImage.File
+	createdDate := actualImage.CreatedAt
+	lastUpdate := actualImage.UpdatedAt
+	schema := "/v2/schemas/image"
+
+	expectedImage := images.Image{
+		ID:         "da3b75d9-3f4a-40e7-8a2c-bfab23927dea",
+		Name:       "Fedora 17",
+		Status:     images.ImageStatusActive,
+		Visibility: images.ImageVisibilityPublic,
+
+		SizeBytes: sizebytes,
+		Checksum:  checksum,
+
+		Tags: []string{
+			"fedora",
+			"beefy",
+		},
+
+		Owner:            "",
+		MinRAMMegabytes:  0,
+		MinDiskGigabytes: 0,
+
+		DiskFormat:      "",
+		ContainerFormat: "",
+		File:            file,
+		CreatedAt:       createdDate,
+		UpdatedAt:       lastUpdate,
+		Schema:          schema,
+		VirtualSize:     0,
+		Properties: map[string]interface{}{
+			"hw_disk_bus":       "scsi",
+			"hw_disk_bus_model": "virtio-scsi",
+			"hw_scsi_model":     "virtio-scsi",
+		},
+	}
+
+	th.AssertDeepEquals(t, &expectedImage, actualImage)
+}


### PR DESCRIPTION
This commit adds support to update image properties. Technically it can
update any image field with a string value, so this duplicates the
functionality of some existing Update calls. However, there's no other
way to implement this since the OpenStack Image Service treats all
properties as first-class fields.

For #1187 