### PR TITLE
Add support to getting statistics for loadbalancer and listener

### DIFF
--- a/acceptance/openstack/loadbalancer/v2/loadbalancers_test.go
+++ b/acceptance/openstack/loadbalancer/v2/loadbalancers_test.go
@@ -72,6 +72,13 @@ func TestLoadbalancersCRUD(t *testing.T) {
 
 	tools.PrintResource(t, newLB)
 
+	lbStats, err := loadbalancers.GetStats(lbClient, lb.ID).Extract()
+	if err != nil {
+		t.Fatalf("Unable to get loadbalancer's statistics: %v", err)
+	}
+
+	tools.PrintResource(t, lbStats)
+
 	// Because of the time it takes to create a loadbalancer,
 	// this test will include some other resources.
 
@@ -100,6 +107,13 @@ func TestLoadbalancersCRUD(t *testing.T) {
 	}
 
 	tools.PrintResource(t, newListener)
+
+	listenerStats, err := listeners.GetStats(lbClient, listener.ID).Extract()
+	if err != nil {
+		t.Fatalf("Unable to get listener's statistics: %v", err)
+	}
+
+	tools.PrintResource(t, listenerStats)
 
 	// L7 policy
 	policy, err := CreateL7Policy(t, lbClient, listener, lb)

--- a/openstack/loadbalancer/v2/listeners/doc.go
+++ b/openstack/loadbalancer/v2/listeners/doc.go
@@ -59,5 +59,13 @@ Example to Delete a Listener
 	if err != nil {
 		panic(err)
 	}
+
+Example to Get the Statistics of a Listener
+
+	listenerID := "d67d56a6-4a86-4688-a282-f46444705c64"
+	stats, err := listeners.GetStats(networkClient, listenerID).Extract()
+	if err != nil {
+		panic(err)
+	}
 */
 package listeners

--- a/openstack/loadbalancer/v2/listeners/requests.go
+++ b/openstack/loadbalancer/v2/listeners/requests.go
@@ -194,7 +194,7 @@ func Delete(c *gophercloud.ServiceClient, id string) (r DeleteResult) {
 }
 
 // GetStats will return the shows the current statistics of a particular Listeners.
-func GetStats(c *gophercloud.ServiceClient, id string) (r GetStatsResult) {
+func GetStats(c *gophercloud.ServiceClient, id string) (r StatsResult) {
 	_, r.Err = c.Get(statisticsRootURL(c, id), &r.Body, nil)
 	return
 }

--- a/openstack/loadbalancer/v2/listeners/requests.go
+++ b/openstack/loadbalancer/v2/listeners/requests.go
@@ -192,3 +192,9 @@ func Delete(c *gophercloud.ServiceClient, id string) (r DeleteResult) {
 	_, r.Err = c.Delete(resourceURL(c, id), nil)
 	return
 }
+
+// GetStats will return the shows the current statistics of a particular Listeners.
+func GetStats(c *gophercloud.ServiceClient, id string) (r GetStatsResult) {
+	_, r.Err = c.Get(statisticsRootURL(c, id), &r.Body, nil)
+	return
+}

--- a/openstack/loadbalancer/v2/listeners/results.go
+++ b/openstack/loadbalancer/v2/listeners/results.go
@@ -60,6 +60,23 @@ type Listener struct {
 	ProvisioningStatus string `json:"provisioning_status"`
 }
 
+type StatsTree struct {
+	// The currently active connections.
+	ActiveConnections int `json:"active_connections"`
+
+	// The total bytes received.
+	BytesIn int `json:"bytes_in"`
+
+	// The total bytes sent.
+	BytesOut int `json:"bytes_out"`
+
+	// The total requests that were unable to be fulfilled.
+	RequestErrors int `json:"request_errors"`
+
+	// The total connections handled.
+	TotalConnections int `json:"total_connections"`
+}
+
 // ListenerPage is the page returned by a pager when traversing over a
 // collection of listeners.
 type ListenerPage struct {
@@ -132,4 +149,20 @@ type UpdateResult struct {
 // ExtractErr method to determine if the request succeeded or failed.
 type DeleteResult struct {
 	gophercloud.ErrResult
+}
+
+// GetStatsResult represents the result of a GetStats operation.
+// Call its Extract method to interpret it as a StatsTree.
+type GetStatsResult struct {
+	gophercloud.Result
+}
+
+// Extract is a function that accepts a result and extracts the status of
+// a Listener.
+func (r GetStatsResult) Extract() (*StatsTree, error) {
+	var s struct {
+		Stats *StatsTree `json:"stats"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Stats, err
 }

--- a/openstack/loadbalancer/v2/listeners/results.go
+++ b/openstack/loadbalancer/v2/listeners/results.go
@@ -60,7 +60,7 @@ type Listener struct {
 	ProvisioningStatus string `json:"provisioning_status"`
 }
 
-type StatsTree struct {
+type Stats struct {
 	// The currently active connections.
 	ActiveConnections int `json:"active_connections"`
 
@@ -151,17 +151,17 @@ type DeleteResult struct {
 	gophercloud.ErrResult
 }
 
-// GetStatsResult represents the result of a GetStats operation.
-// Call its Extract method to interpret it as a StatsTree.
-type GetStatsResult struct {
+// StatsResult represents the result of a GetStats operation.
+// Call its Extract method to interpret it as a Stats.
+type StatsResult struct {
 	gophercloud.Result
 }
 
 // Extract is a function that accepts a result and extracts the status of
 // a Listener.
-func (r GetStatsResult) Extract() (*StatsTree, error) {
+func (r StatsResult) Extract() (*Stats, error) {
 	var s struct {
-		Stats *StatsTree `json:"stats"`
+		Stats *Stats `json:"stats"`
 	}
 	err := r.ExtractInto(&s)
 	return s.Stats, err

--- a/openstack/loadbalancer/v2/listeners/testing/fixtures.go
+++ b/openstack/loadbalancer/v2/listeners/testing/fixtures.go
@@ -140,7 +140,7 @@ var (
 		DefaultTlsContainerRef: "2c433435-20de-4411-84ae-9cc8917def76",
 		SniContainerRefs:       []string{"3d328d82-2547-4921-ac2f-61c3b452b5ff", "b3cfd7e3-8c19-455c-8ebb-d78dfd8f7e7d"},
 	}
-	ListenerStatsTree = listeners.StatsTree{
+	ListenerStatsTree = listeners.Stats{
 		ActiveConnections: 0,
 		BytesIn:           9532,
 		BytesOut:          22033,

--- a/openstack/loadbalancer/v2/listeners/testing/fixtures.go
+++ b/openstack/loadbalancer/v2/listeners/testing/fixtures.go
@@ -85,6 +85,19 @@ const PostUpdateListenerBody = `
 }
 `
 
+// GetListenerStatsBody is the canned request body of a Get request on listener's statistics.
+const GetListenerStatsBody = `
+{
+    "stats": {
+        "active_connections": 0,
+        "bytes_in": 9532,
+        "bytes_out": 22033,
+        "request_errors": 46,
+        "total_connections": 112
+    }
+}
+`
+
 var (
 	ListenerWeb = listeners.Listener{
 		ID:                     "db902c0c-d5ff-4753-b465-668ad9656918",
@@ -126,6 +139,13 @@ var (
 		AdminStateUp:           true,
 		DefaultTlsContainerRef: "2c433435-20de-4411-84ae-9cc8917def76",
 		SniContainerRefs:       []string{"3d328d82-2547-4921-ac2f-61c3b452b5ff", "b3cfd7e3-8c19-455c-8ebb-d78dfd8f7e7d"},
+	}
+	ListenerStatsTree = listeners.StatsTree{
+		ActiveConnections: 0,
+		BytesIn:           9532,
+		BytesOut:          22033,
+		RequestErrors:     46,
+		TotalConnections:  112,
 	}
 )
 
@@ -209,5 +229,16 @@ func HandleListenerUpdateSuccessfully(t *testing.T) {
 		}`)
 
 		fmt.Fprintf(w, PostUpdateListenerBody)
+	})
+}
+
+// HandleListenerGetStatsTree sets up the test server to respond to a listener Get stats tree request.
+func HandleListenerGetStatsTree(t *testing.T) {
+	th.Mux.HandleFunc("/v2.0/lbaas/listeners/4ec89087-d057-4e2c-911f-60a3b47ee304/stats", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+
+		fmt.Fprintf(w, GetListenerStatsBody)
 	})
 }

--- a/openstack/loadbalancer/v2/listeners/testing/requests_test.go
+++ b/openstack/loadbalancer/v2/listeners/testing/requests_test.go
@@ -135,3 +135,17 @@ func TestUpdateListener(t *testing.T) {
 
 	th.CheckDeepEquals(t, ListenerUpdated, *actual)
 }
+
+func TestGetListenerStatsTree(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleListenerGetStatsTree(t)
+
+	client := fake.ServiceClient()
+	actual, err := listeners.GetStats(client, "4ec89087-d057-4e2c-911f-60a3b47ee304").Extract()
+	if err != nil {
+		t.Fatalf("Unexpected Get error: %v", err)
+	}
+
+	th.CheckDeepEquals(t, ListenerStatsTree, *actual)
+}

--- a/openstack/loadbalancer/v2/listeners/urls.go
+++ b/openstack/loadbalancer/v2/listeners/urls.go
@@ -3,8 +3,9 @@ package listeners
 import "github.com/gophercloud/gophercloud"
 
 const (
-	rootPath     = "lbaas"
-	resourcePath = "listeners"
+	rootPath       = "lbaas"
+	resourcePath   = "listeners"
+	statisticsPath = "stats"
 )
 
 func rootURL(c *gophercloud.ServiceClient) string {
@@ -13,4 +14,8 @@ func rootURL(c *gophercloud.ServiceClient) string {
 
 func resourceURL(c *gophercloud.ServiceClient, id string) string {
 	return c.ServiceURL(rootPath, resourcePath, id)
+}
+
+func statisticsRootURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL(rootPath, resourcePath, id, statisticsPath)
 }

--- a/openstack/loadbalancer/v2/loadbalancers/doc.go
+++ b/openstack/loadbalancer/v2/loadbalancers/doc.go
@@ -72,5 +72,13 @@ Example to Get the Status of a Load Balancer
 	if err != nil {
 		panic(err)
 	}
+
+Example to Get the Statistics of a Load Balancer
+
+	lbID := "d67d56a6-4a86-4688-a282-f46444705c64"
+	stats, err := loadbalancers.GetStats(networkClient, LBID).Extract()
+	if err != nil {
+		panic(err)
+	}
 */
 package loadbalancers

--- a/openstack/loadbalancer/v2/loadbalancers/requests.go
+++ b/openstack/loadbalancer/v2/loadbalancers/requests.go
@@ -205,7 +205,7 @@ func GetStatuses(c *gophercloud.ServiceClient, id string) (r GetStatusesResult) 
 }
 
 // GetStats will return the shows the current statistics of a particular LoadBalancer.
-func GetStats(c *gophercloud.ServiceClient, id string) (r GetStatsResult) {
+func GetStats(c *gophercloud.ServiceClient, id string) (r StatsResult) {
 	_, r.Err = c.Get(statisticsRootURL(c, id), &r.Body, nil)
 	return
 }

--- a/openstack/loadbalancer/v2/loadbalancers/requests.go
+++ b/openstack/loadbalancer/v2/loadbalancers/requests.go
@@ -203,3 +203,9 @@ func GetStatuses(c *gophercloud.ServiceClient, id string) (r GetStatusesResult) 
 	_, r.Err = c.Get(statusRootURL(c, id), &r.Body, nil)
 	return
 }
+
+// GetStats will return the shows the current statistics of a particular LoadBalancer.
+func GetStats(c *gophercloud.ServiceClient, id string) (r GetStatsResult) {
+	_, r.Err = c.Get(statisticsRootURL(c, id), &r.Body, nil)
+	return
+}

--- a/openstack/loadbalancer/v2/loadbalancers/results.go
+++ b/openstack/loadbalancer/v2/loadbalancers/results.go
@@ -58,7 +58,7 @@ type StatusTree struct {
 	Loadbalancer *LoadBalancer `json:"loadbalancer"`
 }
 
-type StatsTree struct {
+type Stats struct {
 	// The currently active connections.
 	ActiveConnections int `json:"active_connections"`
 
@@ -141,17 +141,17 @@ func (r GetStatusesResult) Extract() (*StatusTree, error) {
 	return s.Statuses, err
 }
 
-// GetStatsResult represents the result of a GetStats operation.
-// Call its Extract method to interpret it as a StatsTree.
-type GetStatsResult struct {
+// StatsResult represents the result of a GetStats operation.
+// Call its Extract method to interpret it as a Stats.
+type StatsResult struct {
 	gophercloud.Result
 }
 
 // Extract is a function that accepts a result and extracts the status of
 // a Loadbalancer.
-func (r GetStatsResult) Extract() (*StatsTree, error) {
+func (r StatsResult) Extract() (*Stats, error) {
 	var s struct {
-		Stats *StatsTree `json:"stats"`
+		Stats *Stats `json:"stats"`
 	}
 	err := r.ExtractInto(&s)
 	return s.Stats, err

--- a/openstack/loadbalancer/v2/loadbalancers/results.go
+++ b/openstack/loadbalancer/v2/loadbalancers/results.go
@@ -58,6 +58,23 @@ type StatusTree struct {
 	Loadbalancer *LoadBalancer `json:"loadbalancer"`
 }
 
+type StatsTree struct {
+	// The currently active connections.
+	ActiveConnections int `json:"active_connections"`
+
+	// The total bytes received.
+	BytesIn int `json:"bytes_in"`
+
+	// The total bytes sent.
+	BytesOut int `json:"bytes_out"`
+
+	// The total requests that were unable to be fulfilled.
+	RequestErrors int `json:"request_errors"`
+
+	// The total connections handled.
+	TotalConnections int `json:"total_connections"`
+}
+
 // LoadBalancerPage is the page returned by a pager when traversing over a
 // collection of load balancers.
 type LoadBalancerPage struct {
@@ -122,6 +139,22 @@ func (r GetStatusesResult) Extract() (*StatusTree, error) {
 	}
 	err := r.ExtractInto(&s)
 	return s.Statuses, err
+}
+
+// GetStatsResult represents the result of a GetStats operation.
+// Call its Extract method to interpret it as a StatsTree.
+type GetStatsResult struct {
+	gophercloud.Result
+}
+
+// Extract is a function that accepts a result and extracts the status of
+// a Loadbalancer.
+func (r GetStatsResult) Extract() (*StatsTree, error) {
+	var s struct {
+		Stats *StatsTree `json:"stats"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Stats, err
 }
 
 // CreateResult represents the result of a create operation. Call its Extract

--- a/openstack/loadbalancer/v2/loadbalancers/testing/fixtures.go
+++ b/openstack/loadbalancer/v2/loadbalancers/testing/fixtures.go
@@ -212,7 +212,7 @@ var (
 			}},
 		},
 	}
-	LoadbalancerStatsTree = loadbalancers.StatsTree{
+	LoadbalancerStatsTree = loadbalancers.Stats{
 		ActiveConnections: 0,
 		BytesIn:           9532,
 		BytesOut:          22033,

--- a/openstack/loadbalancer/v2/loadbalancers/testing/fixtures.go
+++ b/openstack/loadbalancer/v2/loadbalancers/testing/fixtures.go
@@ -126,6 +126,19 @@ const GetLoadbalancerStatusesBody = `
 }
 `
 
+// LoadbalancerStatsTree is the canned request body of a Get request on loadbalancer's statistics.
+const GetLoadbalancerStatsBody = `
+{
+    "stats": {
+        "active_connections": 0,
+        "bytes_in": 9532,
+        "bytes_out": 22033,
+        "request_errors": 46,
+        "total_connections": 112
+    }
+}
+`
+
 var (
 	LoadbalancerWeb = loadbalancers.LoadBalancer{
 		ID:                 "c331058c-6a40-4144-948e-b9fb1df9db4b",
@@ -198,6 +211,13 @@ var (
 				}},
 			}},
 		},
+	}
+	LoadbalancerStatsTree = loadbalancers.StatsTree{
+		ActiveConnections: 0,
+		BytesIn:           9532,
+		BytesOut:          22033,
+		RequestErrors:     46,
+		TotalConnections:  112,
 	}
 )
 
@@ -290,5 +310,16 @@ func HandleLoadbalancerUpdateSuccessfully(t *testing.T) {
 		}`)
 
 		fmt.Fprintf(w, PostUpdateLoadbalancerBody)
+	})
+}
+
+// HandleLoadbalancerGetStatsTree sets up the test server to respond to a loadbalancer Get stats tree request.
+func HandleLoadbalancerGetStatsTree(t *testing.T) {
+	th.Mux.HandleFunc("/v2.0/lbaas/loadbalancers/36e08a3e-a78f-4b40-a229-1e7e23eee1ab/stats", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+
+		fmt.Fprintf(w, GetLoadbalancerStatsBody)
 	})
 }

--- a/openstack/loadbalancer/v2/loadbalancers/testing/requests_test.go
+++ b/openstack/loadbalancer/v2/loadbalancers/testing/requests_test.go
@@ -160,3 +160,17 @@ func TestCascadingDeleteLoadbalancer(t *testing.T) {
 	err = loadbalancers.Delete(sc, "36e08a3e-a78f-4b40-a229-1e7e23eee1ab", deleteOpts).ExtractErr()
 	th.AssertNoErr(t, err)
 }
+
+func TestGetLoadbalancerStatsTree(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleLoadbalancerGetStatsTree(t)
+
+	client := fake.ServiceClient()
+	actual, err := loadbalancers.GetStats(client, "36e08a3e-a78f-4b40-a229-1e7e23eee1ab").Extract()
+	if err != nil {
+		t.Fatalf("Unexpected Get error: %v", err)
+	}
+
+	th.CheckDeepEquals(t, LoadbalancerStatsTree, *actual)
+}

--- a/openstack/loadbalancer/v2/loadbalancers/urls.go
+++ b/openstack/loadbalancer/v2/loadbalancers/urls.go
@@ -3,9 +3,10 @@ package loadbalancers
 import "github.com/gophercloud/gophercloud"
 
 const (
-	rootPath     = "lbaas"
-	resourcePath = "loadbalancers"
-	statusPath   = "status"
+	rootPath       = "lbaas"
+	resourcePath   = "loadbalancers"
+	statusPath     = "status"
+	statisticsPath = "stats"
 )
 
 func rootURL(c *gophercloud.ServiceClient) string {
@@ -18,4 +19,8 @@ func resourceURL(c *gophercloud.ServiceClient, id string) string {
 
 func statusRootURL(c *gophercloud.ServiceClient, id string) string {
 	return c.ServiceURL(rootPath, resourcePath, id, statusPath)
+}
+
+func statisticsRootURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL(rootPath, resourcePath, id, statisticsPath)
 }


### PR DESCRIPTION
In this PR:

1. Add GetStats method for a loadbalancer. See API guide: https://developer.openstack.org/api-ref/load-balancer/v2/#get-load-balancer-statistics. Data structure defined in https://github.com/openstack/octavia/blob/master/octavia/api/v2/types/load_balancer.py#L176
2. Add GetStats method for a listener. See API guide: https://developer.openstack.org/api-ref/load-balancer/v2/#get-listener-statistics. Data structure defined in https://github.com/openstack/octavia/blob/master/octavia/api/v2/types/listener.py#L230

For #1189 
