### PR TITLE
Fix loadbalancer's status request

### DIFF
--- a/openstack/loadbalancer/v2/loadbalancers/testing/fixtures.go
+++ b/openstack/loadbalancer/v2/loadbalancers/testing/fixtures.go
@@ -255,7 +255,7 @@ func HandleLoadbalancerGetSuccessfully(t *testing.T) {
 
 // HandleLoadbalancerGetStatusesTree sets up the test server to respond to a loadbalancer Get statuses tree request.
 func HandleLoadbalancerGetStatusesTree(t *testing.T) {
-	th.Mux.HandleFunc("/v2.0/lbaas/loadbalancers/36e08a3e-a78f-4b40-a229-1e7e23eee1ab/statuses", func(w http.ResponseWriter, r *http.Request) {
+	th.Mux.HandleFunc("/v2.0/lbaas/loadbalancers/36e08a3e-a78f-4b40-a229-1e7e23eee1ab/status", func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "GET")
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		th.TestHeader(t, r, "Accept", "application/json")

--- a/openstack/loadbalancer/v2/loadbalancers/urls.go
+++ b/openstack/loadbalancer/v2/loadbalancers/urls.go
@@ -5,7 +5,7 @@ import "github.com/gophercloud/gophercloud"
 const (
 	rootPath     = "lbaas"
 	resourcePath = "loadbalancers"
-	statusPath   = "statuses"
+	statusPath   = "status"
 )
 
 func rootURL(c *gophercloud.ServiceClient) string {


### PR DESCRIPTION
Change GetStatuses method to use "/status" instead alias "/statuses" when
get information from Octavia's API (see: https://review.openstack.org/#/c/560179/). Octavia's code with alias: https://github.com/openstack/octavia/blob/master/octavia/api/v2/controllers/load_balancer.py#L547