### PR TITLE
Update objectstorage object unmarshal

### DIFF
--- a/openstack/objectstorage/v1/objects/results.go
+++ b/openstack/objectstorage/v1/objects/results.go
@@ -25,8 +25,7 @@ type Object struct {
 	// Hash represents the MD5 checksum value of the object's content.
 	Hash string `json:"hash"`
 
-	// LastModified is the time the object was last modified, represented
-	// as a string.
+	// LastModified is the time the object was last modified.
 	LastModified time.Time `json:"-"`
 
 	// Name is the unique name for the object.
@@ -40,7 +39,7 @@ func (r *Object) UnmarshalJSON(b []byte) error {
 	type tmp Object
 	var s *struct {
 		tmp
-		LastModified gophercloud.JSONRFC3339MilliNoZ `json:"last_modified"`
+		LastModified string `json:"last_modified"`
 	}
 
 	err := json.Unmarshal(b, &s)
@@ -50,10 +49,18 @@ func (r *Object) UnmarshalJSON(b []byte) error {
 
 	*r = Object(s.tmp)
 
-	r.LastModified = time.Time(s.LastModified)
+	if s.LastModified != "" {
+		t, err := time.Parse(gophercloud.RFC3339MilliNoZ, s.LastModified)
+		if err != nil {
+			t, err = time.Parse(gophercloud.RFC3339Milli, s.LastModified)
+			if err != nil {
+				return err
+			}
+		}
+		r.LastModified = t
+	}
 
 	return nil
-
 }
 
 // ObjectPage is a single page of objects that is returned from a call to the


### PR DESCRIPTION
Recent versions of OpenStack (post Newton) now return a different
timestamp format for the Last-Modified response header. Update
the unmarshal logic to support either format.

For #1150 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

??? - Not sure. Change based on observed values in https://github.com/gophercloud/gophercloud/issues/1150#issuecomment-415929528
