### PR TITLE
Octavia: Failover Loadbalancer

### DIFF
--- a/openstack/loadbalancer/v2/loadbalancers/doc.go
+++ b/openstack/loadbalancer/v2/loadbalancers/doc.go
@@ -80,5 +80,14 @@ Example to Get the Statistics of a Load Balancer
 	if err != nil {
 		panic(err)
 	}
+
+Example to Failover a Load Balancers
+
+	lbID := "d67d56a6-4a86-4688-a282-f46444705c64"
+
+	err := loadbalancers.Failover(networkClient, lbID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
 */
 package loadbalancers

--- a/openstack/loadbalancer/v2/loadbalancers/requests.go
+++ b/openstack/loadbalancer/v2/loadbalancers/requests.go
@@ -209,3 +209,11 @@ func GetStats(c *gophercloud.ServiceClient, id string) (r StatsResult) {
 	_, r.Err = c.Get(statisticsRootURL(c, id), &r.Body, nil)
 	return
 }
+
+// Failover performs a failover of a load balancer.
+func Failover(c *gophercloud.ServiceClient, id string) (r FailoverResult) {
+	_, r.Err = c.Put(failoverRootURL(c, id), nil, nil, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+	})
+	return
+}

--- a/openstack/loadbalancer/v2/loadbalancers/results.go
+++ b/openstack/loadbalancer/v2/loadbalancers/results.go
@@ -180,3 +180,9 @@ type UpdateResult struct {
 type DeleteResult struct {
 	gophercloud.ErrResult
 }
+
+// FailoverResult represents the result of a failover operation. Call its
+// ExtractErr method to determine if the request succeeded or failed.
+type FailoverResult struct {
+	gophercloud.ErrResult
+}

--- a/openstack/loadbalancer/v2/loadbalancers/testing/fixtures.go
+++ b/openstack/loadbalancer/v2/loadbalancers/testing/fixtures.go
@@ -323,3 +323,13 @@ func HandleLoadbalancerGetStatsTree(t *testing.T) {
 		fmt.Fprintf(w, GetLoadbalancerStatsBody)
 	})
 }
+
+// HandleLoadbalancerFailoverSuccessfully sets up the test server to respond to a loadbalancer failover request.
+func HandleLoadbalancerFailoverSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/v2.0/lbaas/loadbalancers/36e08a3e-a78f-4b40-a229-1e7e23eee1ab/failover", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.WriteHeader(http.StatusAccepted)
+	})
+}

--- a/openstack/loadbalancer/v2/loadbalancers/testing/requests_test.go
+++ b/openstack/loadbalancer/v2/loadbalancers/testing/requests_test.go
@@ -174,3 +174,12 @@ func TestGetLoadbalancerStatsTree(t *testing.T) {
 
 	th.CheckDeepEquals(t, LoadbalancerStatsTree, *actual)
 }
+
+func TestFailoverLoadbalancer(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleLoadbalancerFailoverSuccessfully(t)
+
+	res := loadbalancers.Failover(fake.ServiceClient(), "36e08a3e-a78f-4b40-a229-1e7e23eee1ab")
+	th.AssertNoErr(t, res.Err)
+}

--- a/openstack/loadbalancer/v2/loadbalancers/urls.go
+++ b/openstack/loadbalancer/v2/loadbalancers/urls.go
@@ -7,6 +7,7 @@ const (
 	resourcePath   = "loadbalancers"
 	statusPath     = "status"
 	statisticsPath = "stats"
+	failoverPath   = "failover"
 )
 
 func rootURL(c *gophercloud.ServiceClient) string {
@@ -23,4 +24,8 @@ func statusRootURL(c *gophercloud.ServiceClient, id string) string {
 
 func statisticsRootURL(c *gophercloud.ServiceClient, id string) string {
 	return c.ServiceURL(rootPath, resourcePath, id, statisticsPath)
+}
+
+func failoverRootURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL(rootPath, resourcePath, id, failoverPath)
 }


### PR DESCRIPTION
For #1219

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:
- Doc: 
  https://developer.openstack.org/api-ref/load-balancer/v2/index.html#failover-a-load-balancer
- Source Code:
  https://github.com/openstack/octavia/blob/96b9450e6032e65923df9216763b98a1bd2d74c5/octavia/api/v2/controllers/load_balancer.py#L633
