### PR TITLE
add gophercloud.AuthResult

### DIFF
--- a/auth_result.go
+++ b/auth_result.go
@@ -9,10 +9,7 @@ The following types satisfy this interface:
     github.com/gophercloud/gophercloud/openstack/identity/v2/tokens.CreateResult
     github.com/gophercloud/gophercloud/openstack/identity/v3/tokens.CreateResult
 
-Unfortunately, those types do not share any common methods (or rather, none
-with identical type signatures), so this interface contains a bogus method
-implemented by both of them to ensure that other types cannot be used with this
-interface. Usage of this type might look like this:
+    Usage example:
 
   import (
     "github.com/gophercloud/gophercloud"
@@ -44,7 +41,12 @@ interface. Usage of this type might look like this:
       panic(fmt.Sprintf("got unexpected AuthResult type %t", r))
     }
   }
+
+  Both implementing types share a lot of methods by name, like ExtractUser() in
+  this example. But those methods cannot be part of the AuthResult interface
+  because the return types are different (in this case, type tokens2.User vs.
+  type tokens3.User).
 */
 type AuthResult interface {
-	IsAnAuthResult()
+	ExtractTokenID() (string, error)
 }

--- a/auth_result.go
+++ b/auth_result.go
@@ -6,46 +6,46 @@ client's Keystone token. It is returned from ProviderClient.GetAuthResult().
 
 The following types satisfy this interface:
 
-    github.com/gophercloud/gophercloud/openstack/identity/v2/tokens.CreateResult
-    github.com/gophercloud/gophercloud/openstack/identity/v3/tokens.CreateResult
+	github.com/gophercloud/gophercloud/openstack/identity/v2/tokens.CreateResult
+	github.com/gophercloud/gophercloud/openstack/identity/v3/tokens.CreateResult
 
-    Usage example:
+Usage example:
 
-  import (
-    "github.com/gophercloud/gophercloud"
-    tokens2 "github.com/gophercloud/gophercloud/openstack/identity/v2/tokens"
-    tokens3 "github.com/gophercloud/gophercloud/openstack/identity/v3/tokens"
-  )
+	import (
+		"github.com/gophercloud/gophercloud"
+		tokens2 "github.com/gophercloud/gophercloud/openstack/identity/v2/tokens"
+		tokens3 "github.com/gophercloud/gophercloud/openstack/identity/v3/tokens"
+	)
 
-  func GetAuthenticatedUserID(providerClient *gophercloud.ProviderClient) (string, error) {
-    r := providerClient.AuthResult()
-    if r != nil {
-      //ProviderClient did not use openstack.Authenticate(), e.g. because token
-      //was set manually with ProviderClient.SetToken()
-      return "", errors.New("no AuthResult available")
-    }
-    switch r := r.(type) {
-    case *tokens2.CreateResult:
-      u, err := r.ExtractUser()
-      if err != nil {
-        return "", err
-      }
-      return u.ID, nil
-    case *tokens3.CreateResult:
-      u, err := r.ExtractUser()
-      if err != nil {
-        return "", err
-      }
-      return u.ID, nil
-    default:
-      panic(fmt.Sprintf("got unexpected AuthResult type %t", r))
-    }
-  }
+	func GetAuthenticatedUserID(providerClient *gophercloud.ProviderClient) (string, error) {
+		r := providerClient.GetAuthResult()
+		if r == nil {
+			//ProviderClient did not use openstack.Authenticate(), e.g. because token
+			//was set manually with ProviderClient.SetToken()
+			return "", errors.New("no AuthResult available")
+		}
+		switch r := r.(type) {
+		case *tokens2.CreateResult:
+			u, err := r.ExtractUser()
+			if err != nil {
+				return "", err
+			}
+			return u.ID, nil
+		case *tokens3.CreateResult:
+			u, err := r.ExtractUser()
+			if err != nil {
+				return "", err
+			}
+			return u.ID, nil
+		default:
+			panic(fmt.Sprintf("got unexpected AuthResult type %t", r))
+		}
+	}
 
-  Both implementing types share a lot of methods by name, like ExtractUser() in
-  this example. But those methods cannot be part of the AuthResult interface
-  because the return types are different (in this case, type tokens2.User vs.
-  type tokens3.User).
+Both implementing types share a lot of methods by name, like ExtractUser() in
+this example. But those methods cannot be part of the AuthResult interface
+because the return types are different (in this case, type tokens2.User vs.
+type tokens3.User).
 */
 type AuthResult interface {
 	ExtractTokenID() (string, error)

--- a/auth_result.go
+++ b/auth_result.go
@@ -1,0 +1,50 @@
+package gophercloud
+
+/*
+AuthResult is the result from the request that was used to obtain a provider
+client's Keystone token. It is returned from ProviderClient.GetAuthResult().
+
+The following types satisfy this interface:
+
+    github.com/gophercloud/gophercloud/openstack/identity/v2/tokens.CreateResult
+    github.com/gophercloud/gophercloud/openstack/identity/v3/tokens.CreateResult
+
+Unfortunately, those types do not share any common methods (or rather, none
+with identical type signatures), so this interface contains a bogus method
+implemented by both of them to ensure that other types cannot be used with this
+interface. Usage of this type might look like this:
+
+  import (
+    "github.com/gophercloud/gophercloud"
+    tokens2 "github.com/gophercloud/gophercloud/openstack/identity/v2/tokens"
+    tokens3 "github.com/gophercloud/gophercloud/openstack/identity/v3/tokens"
+  )
+
+  func GetAuthenticatedUserID(providerClient *gophercloud.ProviderClient) (string, error) {
+    r := providerClient.AuthResult()
+    if r != nil {
+      //ProviderClient did not use openstack.Authenticate(), e.g. because token
+      //was set manually with ProviderClient.SetToken()
+      return "", errors.New("no AuthResult available")
+    }
+    switch r := r.(type) {
+    case *tokens2.CreateResult:
+      u, err := r.ExtractUser()
+      if err != nil {
+        return "", err
+      }
+      return u.ID, nil
+    case *tokens3.CreateResult:
+      u, err := r.ExtractUser()
+      if err != nil {
+        return "", err
+      }
+      return u.ID, nil
+    default:
+      panic(fmt.Sprintf("got unexpected AuthResult type %t", r))
+    }
+  }
+*/
+type AuthResult interface {
+	IsAnAuthResult()
+}

--- a/openstack/client.go
+++ b/openstack/client.go
@@ -135,7 +135,7 @@ func v2auth(client *gophercloud.ProviderClient, endpoint string, options gopherc
 
 	result := tokens2.Create(v2Client, v2Opts)
 
-	token, err := result.ExtractToken()
+	err = client.SetTokenFromAuthResult(result)
 	if err != nil {
 		return err
 	}
@@ -152,7 +152,7 @@ func v2auth(client *gophercloud.ProviderClient, endpoint string, options gopherc
 		tac := *client
 		tac.IsThrowaway = true
 		tac.ReauthFunc = nil
-		tac.SetTokenAndAuthResult("", nil)
+		tac.SetTokenFromAuthResult(nil)
 		tao := options
 		tao.AllowReauth = false
 		client.ReauthFunc = func() error {
@@ -164,7 +164,6 @@ func v2auth(client *gophercloud.ProviderClient, endpoint string, options gopherc
 			return nil
 		}
 	}
-	client.SetTokenAndAuthResult(token.ID, result)
 	client.EndpointLocator = func(opts gophercloud.EndpointOpts) (string, error) {
 		return V2EndpointURL(catalog, opts)
 	}
@@ -190,7 +189,7 @@ func v3auth(client *gophercloud.ProviderClient, endpoint string, opts tokens3.Au
 
 	result := tokens3.Create(v3Client, opts)
 
-	token, err := result.ExtractToken()
+	err = client.SetTokenFromAuthResult(result)
 	if err != nil {
 		return err
 	}
@@ -200,8 +199,6 @@ func v3auth(client *gophercloud.ProviderClient, endpoint string, opts tokens3.Au
 		return err
 	}
 
-	client.SetTokenAndAuthResult(token.ID, result)
-
 	if opts.CanReauth() {
 		// here we're creating a throw-away client (tac). it's a copy of the user's provider client, but
 		// with the token and reauth func zeroed out. combined with setting `AllowReauth` to `false`,
@@ -209,7 +206,7 @@ func v3auth(client *gophercloud.ProviderClient, endpoint string, opts tokens3.Au
 		tac := *client
 		tac.IsThrowaway = true
 		tac.ReauthFunc = nil
-		tac.SetTokenAndAuthResult("", nil)
+		tac.SetTokenFromAuthResult(nil)
 		var tao tokens3.AuthOptionsBuilder
 		switch ot := opts.(type) {
 		case *gophercloud.AuthOptions:

--- a/openstack/client.go
+++ b/openstack/client.go
@@ -152,7 +152,7 @@ func v2auth(client *gophercloud.ProviderClient, endpoint string, options gopherc
 		tac := *client
 		tac.IsThrowaway = true
 		tac.ReauthFunc = nil
-		tac.TokenID = ""
+		tac.SetTokenAndAuthResult("", nil)
 		tao := options
 		tao.AllowReauth = false
 		client.ReauthFunc = func() error {
@@ -160,11 +160,11 @@ func v2auth(client *gophercloud.ProviderClient, endpoint string, options gopherc
 			if err != nil {
 				return err
 			}
-			client.TokenID = tac.TokenID
+			client.CopyTokenFrom(&tac)
 			return nil
 		}
 	}
-	client.TokenID = token.ID
+	client.SetTokenAndAuthResult(token.ID, result)
 	client.EndpointLocator = func(opts gophercloud.EndpointOpts) (string, error) {
 		return V2EndpointURL(catalog, opts)
 	}
@@ -200,7 +200,7 @@ func v3auth(client *gophercloud.ProviderClient, endpoint string, opts tokens3.Au
 		return err
 	}
 
-	client.TokenID = token.ID
+	client.SetTokenAndAuthResult(token.ID, result)
 
 	if opts.CanReauth() {
 		// here we're creating a throw-away client (tac). it's a copy of the user's provider client, but
@@ -209,7 +209,7 @@ func v3auth(client *gophercloud.ProviderClient, endpoint string, opts tokens3.Au
 		tac := *client
 		tac.IsThrowaway = true
 		tac.ReauthFunc = nil
-		tac.TokenID = ""
+		tac.SetTokenAndAuthResult("", nil)
 		var tao tokens3.AuthOptionsBuilder
 		switch ot := opts.(type) {
 		case *gophercloud.AuthOptions:
@@ -228,7 +228,7 @@ func v3auth(client *gophercloud.ProviderClient, endpoint string, opts tokens3.Au
 			if err != nil {
 				return err
 			}
-			client.TokenID = tac.TokenID
+			client.CopyTokenFrom(&tac)
 			return nil
 		}
 	}

--- a/openstack/client.go
+++ b/openstack/client.go
@@ -135,7 +135,7 @@ func v2auth(client *gophercloud.ProviderClient, endpoint string, options gopherc
 
 	result := tokens2.Create(v2Client, v2Opts)
 
-	err = client.SetTokenFromAuthResult(result)
+	err = client.SetTokenAndAuthResult(result)
 	if err != nil {
 		return err
 	}
@@ -152,7 +152,7 @@ func v2auth(client *gophercloud.ProviderClient, endpoint string, options gopherc
 		tac := *client
 		tac.IsThrowaway = true
 		tac.ReauthFunc = nil
-		tac.SetTokenFromAuthResult(nil)
+		tac.SetTokenAndAuthResult(nil)
 		tao := options
 		tao.AllowReauth = false
 		client.ReauthFunc = func() error {
@@ -189,7 +189,7 @@ func v3auth(client *gophercloud.ProviderClient, endpoint string, opts tokens3.Au
 
 	result := tokens3.Create(v3Client, opts)
 
-	err = client.SetTokenFromAuthResult(result)
+	err = client.SetTokenAndAuthResult(result)
 	if err != nil {
 		return err
 	}
@@ -206,7 +206,7 @@ func v3auth(client *gophercloud.ProviderClient, endpoint string, opts tokens3.Au
 		tac := *client
 		tac.IsThrowaway = true
 		tac.ReauthFunc = nil
-		tac.SetTokenFromAuthResult(nil)
+		tac.SetTokenAndAuthResult(nil)
 		var tao tokens3.AuthOptionsBuilder
 		switch ot := opts.(type) {
 		case *gophercloud.AuthOptions:

--- a/openstack/identity/v2/tokens/results.go
+++ b/openstack/identity/v2/tokens/results.go
@@ -100,12 +100,6 @@ type CreateResult struct {
 	gophercloud.Result
 }
 
-//IsAnAuthResult implements the gophercloud.AuthResult interface. This method
-//does not do anything, see documentation on type gophercloud.AuthResult for
-//details.
-func (CreateResult) IsAnAuthResult() {
-}
-
 // GetResult is the deferred response from a Get call, which is the same with a
 // Created token. Use ExtractUser() to interpret it as a User.
 type GetResult struct {
@@ -139,6 +133,21 @@ func (r CreateResult) ExtractToken() (*Token, error) {
 		ExpiresAt: expiresTs,
 		Tenant:    s.Access.Token.Tenant,
 	}, nil
+}
+
+// ExtractTokenID implements the gophercloud.AuthResult interface. The returned
+// string is the same as the ID field of the Token struct returned from
+// ExtractToken().
+func (r CreateResult) ExtractTokenID() (string, error) {
+	var s struct {
+		Access struct {
+			Token struct {
+				ID string `json:"id"`
+			} `json:"token"`
+		} `json:"access"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Access.Token.ID, err
 }
 
 // ExtractServiceCatalog returns the ServiceCatalog that was generated along

--- a/openstack/identity/v2/tokens/results.go
+++ b/openstack/identity/v2/tokens/results.go
@@ -100,6 +100,12 @@ type CreateResult struct {
 	gophercloud.Result
 }
 
+//IsAnAuthResult implements the gophercloud.AuthResult interface. This method
+//does not do anything, see documentation on type gophercloud.AuthResult for
+//details.
+func (CreateResult) IsAnAuthResult() {
+}
+
 // GetResult is the deferred response from a Get call, which is the same with a
 // Created token. Use ExtractUser() to interpret it as a User.
 type GetResult struct {

--- a/openstack/identity/v3/tokens/results.go
+++ b/openstack/identity/v3/tokens/results.go
@@ -102,6 +102,13 @@ func (r commonResult) ExtractToken() (*Token, error) {
 	return &s, err
 }
 
+// ExtractTokenID implements the gophercloud.AuthResult interface. The returned
+// string is the same as the ID field of the Token struct returned from
+// ExtractToken().
+func (r CreateResult) ExtractTokenID() (string, error) {
+	return r.Header.Get("X-Subject-Token"), r.Err
+}
+
 // ExtractServiceCatalog returns the ServiceCatalog that was generated along
 // with the user's Token.
 func (r commonResult) ExtractServiceCatalog() (*ServiceCatalog, error) {
@@ -142,12 +149,6 @@ func (r commonResult) ExtractProject() (*Project, error) {
 // as a service catalog.
 type CreateResult struct {
 	commonResult
-}
-
-//IsAnAuthResult implements the gophercloud.AuthResult interface. This method
-//does not do anything, see documentation on type gophercloud.AuthResult for
-//details.
-func (CreateResult) IsAnAuthResult() {
 }
 
 // GetResult is the response from a Get request. Use ExtractToken()

--- a/openstack/identity/v3/tokens/results.go
+++ b/openstack/identity/v3/tokens/results.go
@@ -144,6 +144,12 @@ type CreateResult struct {
 	commonResult
 }
 
+//IsAnAuthResult implements the gophercloud.AuthResult interface. This method
+//does not do anything, see documentation on type gophercloud.AuthResult for
+//details.
+func (CreateResult) IsAnAuthResult() {
+}
+
 // GetResult is the response from a Get request. Use ExtractToken()
 // to interpret it as a Token, or ExtractServiceCatalog() to interpret it
 // as a service catalog.

--- a/provider_client.go
+++ b/provider_client.go
@@ -118,7 +118,7 @@ func (client *ProviderClient) UseTokenLock() {
 }
 
 //GetAuthResult returns the result from the request that was used to obtain a provider
-//client's Keystone token. It is returned from ProviderClient.GetAuthResult().
+//client's Keystone token.
 //
 //The result is nil when authentication has not yet taken place, when the token
 //was set manually with SetToken(), or when a ReauthFunc was used that does not
@@ -144,7 +144,7 @@ func (client *ProviderClient) Token() string {
 // SetToken safely sets the value of the auth token in the ProviderClient. Applications may
 // use this method in a custom ReauthFunc.
 //
-// WARNING: This function is deprecated. Use SetTokenAndAuthResult() instead.
+// WARNING: This function is deprecated. Use SetTokenFromAuthResult() instead.
 func (client *ProviderClient) SetToken(t string) {
 	if client.mut != nil {
 		client.mut.Lock()
@@ -154,16 +154,26 @@ func (client *ProviderClient) SetToken(t string) {
 	client.authResult = nil
 }
 
-//SetTokenAndAuthResult safely sets the value of the auth token in the ProviderClient
-//and also returns the AuthResult that was returned from the token creation
+//SetTokenFromAuthResult safely sets the value of the auth token in the ProviderClient
+//and also records the AuthResult that was returned from the token creation
 //request. Applications may use this method in a custom ReauthFunc.
-func (client *ProviderClient) SetTokenAndAuthResult(t string, r AuthResult) {
+func (client *ProviderClient) SetTokenFromAuthResult(r AuthResult) error {
+	tokenID := ""
+	var err error
+	if r != nil {
+		tokenID, err = r.ExtractTokenID()
+		if err != nil {
+			return err
+		}
+	}
+
 	if client.mut != nil {
 		client.mut.Lock()
 		defer client.mut.Unlock()
 	}
-	client.TokenID = t
+	client.TokenID = tokenID
 	client.authResult = r
+	return nil
 }
 
 //CopyTokenFrom safely copies the token from another ProviderClient into the

--- a/provider_client.go
+++ b/provider_client.go
@@ -117,12 +117,12 @@ func (client *ProviderClient) UseTokenLock() {
 	client.reauthmut = new(reauthlock)
 }
 
-//GetAuthResult returns the result from the request that was used to obtain a provider
-//client's Keystone token.
+// GetAuthResult returns the result from the request that was used to obtain a
+// provider client's Keystone token.
 //
-//The result is nil when authentication has not yet taken place, when the token
-//was set manually with SetToken(), or when a ReauthFunc was used that does not
-//record the AuthResult.
+// The result is nil when authentication has not yet taken place, when the token
+// was set manually with SetToken(), or when a ReauthFunc was used that does not
+// record the AuthResult.
 func (client *ProviderClient) GetAuthResult() AuthResult {
 	if client.mut != nil {
 		client.mut.RLock()
@@ -144,7 +144,7 @@ func (client *ProviderClient) Token() string {
 // SetToken safely sets the value of the auth token in the ProviderClient. Applications may
 // use this method in a custom ReauthFunc.
 //
-// WARNING: This function is deprecated. Use SetTokenFromAuthResult() instead.
+// WARNING: This function is deprecated. Use SetTokenAndAuthResult() instead.
 func (client *ProviderClient) SetToken(t string) {
 	if client.mut != nil {
 		client.mut.Lock()
@@ -154,10 +154,10 @@ func (client *ProviderClient) SetToken(t string) {
 	client.authResult = nil
 }
 
-//SetTokenFromAuthResult safely sets the value of the auth token in the ProviderClient
-//and also records the AuthResult that was returned from the token creation
-//request. Applications may use this method in a custom ReauthFunc.
-func (client *ProviderClient) SetTokenFromAuthResult(r AuthResult) error {
+// SetTokenAndAuthResult safely sets the value of the auth token in the
+// ProviderClient and also records the AuthResult that was returned from the
+// token creation request. Applications may call this in a custom ReauthFunc.
+func (client *ProviderClient) SetTokenAndAuthResult(r AuthResult) error {
 	tokenID := ""
 	var err error
 	if r != nil {
@@ -176,8 +176,8 @@ func (client *ProviderClient) SetTokenFromAuthResult(r AuthResult) error {
 	return nil
 }
 
-//CopyTokenFrom safely copies the token from another ProviderClient into the
-//this one.
+// CopyTokenFrom safely copies the token from another ProviderClient into the
+// this one.
 func (client *ProviderClient) CopyTokenFrom(other *ProviderClient) {
 	if client.mut != nil {
 		client.mut.Lock()

--- a/provider_client.go
+++ b/provider_client.go
@@ -79,6 +79,8 @@ type ProviderClient struct {
 	mut *sync.RWMutex
 
 	reauthmut *reauthlock
+
+	authResult AuthResult
 }
 
 type reauthlock struct {
@@ -115,6 +117,20 @@ func (client *ProviderClient) UseTokenLock() {
 	client.reauthmut = new(reauthlock)
 }
 
+//GetAuthResult returns the result from the request that was used to obtain a provider
+//client's Keystone token. It is returned from ProviderClient.GetAuthResult().
+//
+//The result is nil when authentication has not yet taken place, when the token
+//was set manually with SetToken(), or when a ReauthFunc was used that does not
+//record the AuthResult.
+func (client *ProviderClient) GetAuthResult() AuthResult {
+	if client.mut != nil {
+		client.mut.RLock()
+		defer client.mut.RUnlock()
+	}
+	return client.authResult
+}
+
 // Token safely reads the value of the auth token from the ProviderClient. Applications should
 // call this method to access the token instead of the TokenID field
 func (client *ProviderClient) Token() string {
@@ -126,13 +142,43 @@ func (client *ProviderClient) Token() string {
 }
 
 // SetToken safely sets the value of the auth token in the ProviderClient. Applications may
-// use this method in a custom ReauthFunc
+// use this method in a custom ReauthFunc.
+//
+// WARNING: This function is deprecated. Use SetTokenAndAuthResult() instead.
 func (client *ProviderClient) SetToken(t string) {
 	if client.mut != nil {
 		client.mut.Lock()
 		defer client.mut.Unlock()
 	}
 	client.TokenID = t
+	client.authResult = nil
+}
+
+//SetTokenAndAuthResult safely sets the value of the auth token in the ProviderClient
+//and also returns the AuthResult that was returned from the token creation
+//request. Applications may use this method in a custom ReauthFunc.
+func (client *ProviderClient) SetTokenAndAuthResult(t string, r AuthResult) {
+	if client.mut != nil {
+		client.mut.Lock()
+		defer client.mut.Unlock()
+	}
+	client.TokenID = t
+	client.authResult = r
+}
+
+//CopyTokenFrom safely copies the token from another ProviderClient into the
+//this one.
+func (client *ProviderClient) CopyTokenFrom(other *ProviderClient) {
+	if client.mut != nil {
+		client.mut.Lock()
+		defer client.mut.Unlock()
+	}
+	if other.mut != nil && other.mut != client.mut {
+		other.mut.RLock()
+		defer other.mut.RUnlock()
+	}
+	client.TokenID = other.TokenID
+	client.authResult = other.authResult
 }
 
 // Reauthenticate calls client.ReauthFunc in a thread-safe way. If this is


### PR DESCRIPTION
For #1141.

I have not tested this yet since I first want to have some more eyes on the API design. I ended up doing it in a way that differs from all my previous proposals in #1141.

Pros:
- This does not require any new public API in the `openstack` package, and only small changes to packages `openstack/identity/{v2,v3}/tokens`.
- Using `ProviderClient.GetAuthResult` feels natural. There is no excessive casting between different result types.

Cons:
- Keeping the `ProviderClient.authResult` field private requires some additional API surface between `v2auth/v3auth` and ProviderClient, in the form of `CopyTokenFrom`.
- `IsAnAuthResult` is slightly awkward.

The new `SetTokenAndAuthResult` method is strictly required to ensure that the mutex gets used. (It could have been `SetAuthResult` instead, but I figured that since token and AuthResult are always set at the same time, we may as well save ourselves the double locking/unlocking of the mutex that keeping `SetAuthResult` separate from `SetToken` would entail.)