### PR TITLE
Networking v2: Security Group Rule Description

### DIFF
--- a/openstack/networking/v2/extensions/security/rules/requests.go
+++ b/openstack/networking/v2/extensions/security/rules/requests.go
@@ -88,6 +88,9 @@ type CreateOpts struct {
 	// group rule is applied.
 	Direction RuleDirection `json:"direction" required:"true"`
 
+	// String description of each rule, optional
+	Description string `json:"description" required:"false"`
+
 	// Must be "IPv4" or "IPv6", and addresses represented in CIDR must match the
 	// ingress or egress rules.
 	EtherType RuleEtherType `json:"ethertype" required:"true"`

--- a/openstack/networking/v2/extensions/security/rules/results.go
+++ b/openstack/networking/v2/extensions/security/rules/results.go
@@ -17,6 +17,9 @@ type SecGroupRule struct {
 	// instance. An egress rule is applied to traffic leaving the instance.
 	Direction string
 
+	// Descripton of the rule
+	Description string `json:"description"`
+
 	// Must be IPv4 or IPv6, and addresses represented in CIDR must match the
 	// ingress or egress rules.
 	EtherType string `json:"ethertype"`

--- a/openstack/networking/v2/extensions/security/rules/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/security/rules/testing/requests_test.go
@@ -114,7 +114,7 @@ func TestCreate(t *testing.T) {
 		th.TestJSONRequest(t, r, `
 {
     "security_group_rule": {
-		"description": "test description of rule",
+        "description": "test description of rule",
         "direction": "ingress",
         "port_range_min": 80,
         "ethertype": "IPv4",
@@ -132,7 +132,7 @@ func TestCreate(t *testing.T) {
 		fmt.Fprintf(w, `
 {
     "security_group_rule": {
-		"description": "test description of rule",
+        "description": "test description of rule",
         "direction": "ingress",
         "ethertype": "IPv4",
         "id": "2bc0accf-312e-429a-956e-e4407625eb62",

--- a/openstack/networking/v2/extensions/security/rules/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/security/rules/testing/requests_test.go
@@ -66,6 +66,7 @@ func TestList(t *testing.T) {
 
 		expected := []rules.SecGroupRule{
 			{
+				Description:    "",
 				Direction:      "egress",
 				EtherType:      "IPv6",
 				ID:             "3c0e45ff-adaf-4124-b083-bf390e5482ff",
@@ -113,6 +114,7 @@ func TestCreate(t *testing.T) {
 		th.TestJSONRequest(t, r, `
 {
     "security_group_rule": {
+		"description": "test description of rule",
         "direction": "ingress",
         "port_range_min": 80,
         "ethertype": "IPv4",
@@ -130,6 +132,7 @@ func TestCreate(t *testing.T) {
 		fmt.Fprintf(w, `
 {
     "security_group_rule": {
+		"description": "test description of rule",
         "direction": "ingress",
         "ethertype": "IPv4",
         "id": "2bc0accf-312e-429a-956e-e4407625eb62",
@@ -146,6 +149,7 @@ func TestCreate(t *testing.T) {
 	})
 
 	opts := rules.CreateOpts{
+		Description:   "test description of rule",
 		Direction:     "ingress",
 		PortRangeMin:  80,
 		EtherType:     rules.EtherType4,


### PR DESCRIPTION
For #1230 

A security group rule has standard attributes, i.e also a description field: 

see issue [comment](https://github.com/gophercloud/gophercloud/issues/1230#issuecomment-419957244) or below.

URLS for description field of SecurityGroupRule
https://github.com/openstack/neutron/blob/24c8f952b27e3bfaabad7f41edf283145cce7600/neutron/db/standard_attr.py#L56
https://github.com/openstack/neutron/blob/master/doc/source/contributor/internals/api_extensions.rst
https://github.com/openstack/neutron/blob/a388701ddfe628e9a5bd16a78422164799b11ef8/neutron/db/models/securitygroup.py#L68
https://developer.openstack.org/api-ref/network/v2/index.html#create-security-group-rule