### PR TITLE
Fix BuildRequestBody for struct with specific json marshal

### DIFF
--- a/params_test.go
+++ b/params_test.go
@@ -1,0 +1,25 @@
+package gophercloud
+
+import (
+	"testing"
+	"time"
+
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestBuildRequestBody(t *testing.T) {
+	type Params struct {
+		ID   string    `json:"id"`
+		Date time.Time `json:"date"`
+	}
+
+	params := &Params{
+		ID:   "Foo",
+		Date: time.Date(1970, time.January, 1, 0, 0, 0, 0, time.UTC),
+	}
+
+	body, err := BuildRequestBody(params, "params")
+	th.AssertNoErr(t, err)
+
+	th.AssertJSONEquals(t, `{"params": {"id": "Foo", "date": "1970-01-01T00:00:00Z"}}`, body)
+}


### PR DESCRIPTION
For #1233

We avoid to call this part of code

```
	b, err := json.Marshal(opts)
	if err != nil {
		return nil, err
	}

	//fmt.Printf("string(b): %s\n", string(b))

	err = json.Unmarshal(b, &optsMap)
	if err != nil {
		return nil, err
	}
```

For structs that implements a custom JSON Marshaller that does not ends with a ```map[string]interface{}```.

It's the case for ```time.Time```, where JSON Marshaller returns a string ```"1970-01-01T00:00:00Z"```.

I just dissociate the struct checks (required and not zero stuff) with the creation of the map[string]interface{}.
