### PR TITLE
Support acceptance test against OpenStack Rocky release in OpenLab

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -23,6 +23,15 @@
         OS_BRANCH: stable/queens
 
 - job:
+    name: gophercloud-acceptance-test-rocky
+    parent: gophercloud-acceptance-test
+    description: |
+      Run gophercloud acceptance test on rocky branch
+    vars:
+      global_env:
+        OS_BRANCH: stable/rocky
+
+- job:
     name: gophercloud-acceptance-test-pike
     parent: gophercloud-acceptance-test
     description: |
@@ -80,6 +89,9 @@
     recheck-queens:
       jobs:
         - gophercloud-acceptance-test-queens
+    recheck-rocky:
+      jobs:
+        - gophercloud-acceptance-test-rocky
     periodic:
       jobs:
         - gophercloud-unittest

--- a/acceptance/openstack/compute/v2/quotaset_test.go
+++ b/acceptance/openstack/compute/v2/quotaset_test.go
@@ -17,6 +17,8 @@ import (
 
 func TestQuotasetGet(t *testing.T) {
 	clients.SkipRelease(t, "master")
+	clients.SkipRelease(t, "stable/queens")
+	clients.SkipRelease(t, "stable/rocky")
 
 	client, err := clients.NewComputeV2Client()
 	th.AssertNoErr(t, err)
@@ -103,6 +105,8 @@ var UpdatedQuotas = quotasets.QuotaSet{
 
 func TestQuotasetUpdateDelete(t *testing.T) {
 	clients.SkipRelease(t, "master")
+	clients.SkipRelease(t, "stable/queens")
+	clients.SkipRelease(t, "stable/rocky")
 
 	clients.RequireAdmin(t)
 

--- a/acceptance/openstack/identity/v3/roles_test.go
+++ b/acceptance/openstack/identity/v3/roles_test.go
@@ -114,6 +114,8 @@ func TestRolesFilterList(t *testing.T) {
 	// For some reason this is not longer working.
 	// It might be a temporary issue.
 	clients.SkipRelease(t, "master")
+	clients.SkipRelease(t, "stable/queens")
+	clients.SkipRelease(t, "stable/rocky")
 
 	client, err := clients.NewIdentityV3Client()
 	th.AssertNoErr(t, err)

--- a/acceptance/openstack/networking/v2/extensions/layer3/routers_test.go
+++ b/acceptance/openstack/networking/v2/extensions/layer3/routers_test.go
@@ -9,7 +9,6 @@ import (
 	networking "github.com/gophercloud/gophercloud/acceptance/openstack/networking/v2"
 	"github.com/gophercloud/gophercloud/acceptance/tools"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers"
-	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
 	th "github.com/gophercloud/gophercloud/testhelper"
 )
 
@@ -84,19 +83,17 @@ func TestLayer3ExternalRouterCreateDelete(t *testing.T) {
 }
 
 func TestLayer3RouterInterface(t *testing.T) {
-	clients.SkipRelease(t, "master")
 	clients.RequireAdmin(t)
 
 	client, err := clients.NewNetworkV2Client()
 	th.AssertNoErr(t, err)
 
-	choices, err := clients.AcceptanceTestChoicesFromEnv()
+	// Create Network
+	network, err := networking.CreateNetwork(t, client)
 	th.AssertNoErr(t, err)
+	defer networking.DeleteNetwork(t, client, network.ID)
 
-	netid, err := networks.IDFromName(client, choices.NetworkName)
-	th.AssertNoErr(t, err)
-
-	subnet, err := networking.CreateSubnet(t, client, netid)
+	subnet, err := networking.CreateSubnet(t, client, network.ID)
 	th.AssertNoErr(t, err)
 	defer networking.DeleteSubnet(t, client, subnet.ID)
 


### PR DESCRIPTION
Input comment "recheck stable/rocky" in pull request comments, that
will trigger acceptance tests against OpenStack Rocky release. OpenLab
will report test result in followint comments automatically.

Related-Bug: theopenlab/openlab#82
