### PR TITLE
Block Storage: Add additional multiattach support (#1228)

### DIFF
--- a/acceptance/openstack/blockstorage/v3/volumes_test.go
+++ b/acceptance/openstack/blockstorage/v3/volumes_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/gophercloud/gophercloud/acceptance/clients"
+	"github.com/gophercloud/gophercloud/acceptance/tools"
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes"
 	"github.com/gophercloud/gophercloud/pagination"
 	th "github.com/gophercloud/gophercloud/testhelper"
@@ -46,5 +47,32 @@ func TestVolumes(t *testing.T) {
 		return true, nil
 	})
 
+	th.AssertNoErr(t, err)
+}
+
+func TestVolumesMultiAttach(t *testing.T) {
+	clients.RequireLong(t)
+
+	client, err := clients.NewBlockStorageV3Client()
+	th.AssertNoErr(t, err)
+
+	volumeName := tools.RandomString("ACPTTEST", 16)
+
+	volOpts := volumes.CreateOpts{
+		Size:        1,
+		Name:        volumeName,
+		Description: "Testing creation of multiattach enabled volume",
+		Multiattach: true,
+	}
+
+	vol, err := volumes.Create(client, volOpts).Extract()
+	th.AssertNoErr(t, err)
+
+	err = volumes.WaitForStatus(client, vol.ID, "available", 60)
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, vol.Multiattach, true)
+
+	err = volumes.Delete(client, vol.ID).ExtractErr()
 	th.AssertNoErr(t, err)
 }

--- a/openstack/blockstorage/v2/volumes/requests.go
+++ b/openstack/blockstorage/v2/volumes/requests.go
@@ -38,6 +38,8 @@ type CreateOpts struct {
 	ImageID string `json:"imageRef,omitempty"`
 	// The associated volume type
 	VolumeType string `json:"volume_type,omitempty"`
+	// Multiattach denotes if the volume is multi-attach capable.
+	Multiattach bool `json:"multiattach,omitempty"`
 }
 
 // ToVolumeCreateMap assembles a request body based on the contents of a

--- a/openstack/blockstorage/v3/volumes/requests.go
+++ b/openstack/blockstorage/v3/volumes/requests.go
@@ -38,6 +38,8 @@ type CreateOpts struct {
 	ImageID string `json:"imageRef,omitempty"`
 	// The associated volume type
 	VolumeType string `json:"volume_type,omitempty"`
+	// Multiattach denotes if the volume is multi-attach capable.
+	Multiattach bool `json:"multiattach,omitempty"`
 }
 
 // ToVolumeCreateMap assembles a request body based on the contents of a


### PR DESCRIPTION
Add missing fields for multiattach support

Prior to starting a PR, please make sure you have read our
[contributor tutorial](https://github.com/gophercloud/gophercloud/tree/master/docs/contributor-tutorial).

Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

For #1228 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/cinder/blob/master/cinder/objects/volume.py#L111
