### PR TITLE
Senlin: Profiles Validate

### DIFF
--- a/acceptance/openstack/clustering/v1/profiles_test.go
+++ b/acceptance/openstack/clustering/v1/profiles_test.go
@@ -47,3 +47,30 @@ func TestProfilesCRUD(t *testing.T) {
 	tools.PrintResource(t, newProfile)
 	tools.PrintResource(t, newProfile.UpdatedAt)
 }
+
+func TestProfileValidate(t *testing.T) {
+	client, err := clients.NewClusteringV1Client()
+	th.AssertNoErr(t, err)
+	client.Microversion = "1.2"
+
+	profile, err := CreateProfile(t, client)
+	th.AssertNoErr(t, err)
+	defer DeleteProfile(t, client, profile.ID)
+
+	opts := profiles.ValidateOpts{
+		Spec: profile.Spec,
+	}
+	validatedProfile, err := profiles.Validate(client, opts).Extract()
+	th.AssertNoErr(t, err)
+
+	// Do not validate the following fields for AssertDeepEquals() because the actual fields are either missing or hardcoded.
+	profile.CreatedAt = validatedProfile.CreatedAt
+	profile.Domain = validatedProfile.Domain
+	profile.ID = validatedProfile.ID
+	profile.Metadata = validatedProfile.Metadata
+	profile.Name = "validated_profile"
+	profile.UpdatedAt = validatedProfile.UpdatedAt
+
+	th.AssertDeepEquals(t, validatedProfile, profile)
+	tools.PrintResource(t, validatedProfile)
+}

--- a/acceptance/openstack/clustering/v1/webhooktrigger_test.go
+++ b/acceptance/openstack/clustering/v1/webhooktrigger_test.go
@@ -6,9 +6,8 @@ import (
 	"testing"
 
 	"github.com/gophercloud/gophercloud/acceptance/clients"
-	"github.com/gophercloud/gophercloud/openstack/clustering/v1/webhooks"
-
 	"github.com/gophercloud/gophercloud/openstack/clustering/v1/nodes"
+	"github.com/gophercloud/gophercloud/openstack/clustering/v1/webhooks"
 	th "github.com/gophercloud/gophercloud/testhelper"
 )
 

--- a/openstack/clustering/v1/profiles/doc.go
+++ b/openstack/clustering/v1/profiles/doc.go
@@ -81,5 +81,30 @@ Example to Delete a Profile
 		panic(err)
 	}
 
+Example to Validate a profile
+
+	serviceClient.Microversion = "1.2"
+
+	validateOpts := profiles.ValidateOpts{
+		Spec: profiles.Spec{
+			Properties: map[string]interface{}{
+				"flavor":   "t2.micro",
+				"image":    "cirros-0.3.4-x86_64-uec",
+				"key_name": "oskey",
+				"name":     "cirros_server",
+				"networks": []interface{}{
+					map[string]interface{}{"network": "private"},
+				},
+			},
+			Type:    "os.nova.server",
+			Version: "1.0",
+		},
+	}
+
+	profile, err := profiles.Validate(serviceClient, validateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
 */
 package profiles

--- a/openstack/clustering/v1/profiles/requests.go
+++ b/openstack/clustering/v1/profiles/requests.go
@@ -137,3 +137,37 @@ func Delete(client *gophercloud.ServiceClient, id string) (r DeleteResult) {
 	}
 	return
 }
+
+// ValidateOptsBuilder allows extensions to add additional parameters to the
+// Validate request.
+type ValidateOptsBuilder interface {
+	ToProfileValidateMap() (map[string]interface{}, error)
+}
+
+// ValidateOpts params
+type ValidateOpts struct {
+	Spec Spec `json:"spec" required:"true"`
+}
+
+// ToProfileValidateMap formats a CreateOpts into a body map.
+func (opts ValidateOpts) ToProfileValidateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "profile")
+}
+
+// Validate profile.
+func Validate(client *gophercloud.ServiceClient, opts ValidateOpts) (r ValidateResult) {
+	b, err := opts.ToProfileValidateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	var result *http.Response
+	result, r.Err = client.Post(validateURL(client), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	if r.Err == nil {
+		r.Header = result.Header
+	}
+	return
+}

--- a/openstack/clustering/v1/profiles/results.go
+++ b/openstack/clustering/v1/profiles/results.go
@@ -140,6 +140,11 @@ type DeleteResult struct {
 	gophercloud.ErrResult
 }
 
+// ValidateResult is the response of a Validate operations.
+type ValidateResult struct {
+	commonResult
+}
+
 // ProfilePage contains a single page of all profiles from a List operation.
 type ProfilePage struct {
 	pagination.LinkedPageBase

--- a/openstack/clustering/v1/profiles/testing/fixtures.go
+++ b/openstack/clustering/v1/profiles/testing/fixtures.go
@@ -336,6 +336,61 @@ var ExpectedUpdate = profiles.Profile{
 	User:      "5e5bf8027826429c96af157f68dc9072",
 }
 
+const ValidateResponse = `
+{
+	"profile": {
+		"created_at": "2016-01-03T16:22:23Z",
+		"domain": null,
+		"id": "9e1c6f42-acf5-4688-be2c-8ce954ef0f23",
+		"metadata": {},
+		"name": "pserver",
+		"project": "42d9e9663331431f97b75e25136307ff",
+		"spec": {
+			"properties": {
+				"flavor": "t2.micro",
+				"image": "cirros-0.3.4-x86_64-uec",
+				"key_name": "oskey",
+				"name": "cirros_server",
+				"networks": [
+					{
+						"network": "private"
+					}
+				]
+			},
+			"type": "os.nova.server",
+			"version": "1.0"
+		},
+		"type": "os.nova.server-1.0",
+		"updated_at": "2016-01-03T17:22:23Z",
+		"user": "5e5bf8027826429c96af157f68dc9072"
+	}
+}`
+
+var ExpectedValidate = profiles.Profile{
+	CreatedAt: time.Date(2016, 1, 3, 16, 22, 23, 0, time.UTC),
+	Domain:    "",
+	ID:        "9e1c6f42-acf5-4688-be2c-8ce954ef0f23",
+	Metadata:  map[string]interface{}{},
+	Name:      "pserver",
+	Project:   "42d9e9663331431f97b75e25136307ff",
+	Spec: profiles.Spec{
+		Properties: map[string]interface{}{
+			"flavor":   "t2.micro",
+			"image":    "cirros-0.3.4-x86_64-uec",
+			"key_name": "oskey",
+			"name":     "cirros_server",
+			"networks": []interface{}{
+				map[string]interface{}{"network": "private"},
+			},
+		},
+		Type:    "os.nova.server",
+		Version: "1.0",
+	},
+	Type:      "os.nova.server-1.0",
+	UpdatedAt: time.Date(2016, 1, 3, 17, 22, 23, 0, time.UTC),
+	User:      "5e5bf8027826429c96af157f68dc9072",
+}
+
 func HandleCreateSuccessfully(t *testing.T) {
 	th.Mux.HandleFunc("/v1/profiles", func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "POST")
@@ -391,5 +446,18 @@ func HandleDeleteSuccessfully(t *testing.T) {
 
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusNoContent)
+	})
+}
+
+func HandleValidateSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/v1/profiles/validate", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "OpenStack-API-Version", "clustering 1.2")
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprint(w, ValidateResponse)
 	})
 }

--- a/openstack/clustering/v1/profiles/testing/requests_test.go
+++ b/openstack/clustering/v1/profiles/testing/requests_test.go
@@ -107,3 +107,34 @@ func TestDeleteProfile(t *testing.T) {
 	deleteResult := profiles.Delete(fake.ServiceClient(), "6dc6d336e3fc4c0a951b5698cd1236ee")
 	th.AssertNoErr(t, deleteResult.ExtractErr())
 }
+
+func TestValidateProfile(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	HandleValidateSuccessfully(t)
+
+	validateOpts := profiles.ValidateOpts{
+		Spec: profiles.Spec{
+			Properties: map[string]interface{}{
+				"flavor":   "t2.micro",
+				"image":    "cirros-0.3.4-x86_64-uec",
+				"key_name": "oskey",
+				"name":     "cirros_server",
+				"networks": []interface{}{
+					map[string]interface{}{"network": "private"},
+				},
+			},
+			Type:    "os.nova.server",
+			Version: "1.0",
+		},
+	}
+
+	client := fake.ServiceClient()
+	client.Microversion = "1.2"
+	client.Type = "clustering"
+
+	profile, err := profiles.Validate(client, validateOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, ExpectedValidate, *profile)
+}

--- a/openstack/clustering/v1/profiles/urls.go
+++ b/openstack/clustering/v1/profiles/urls.go
@@ -32,3 +32,7 @@ func updateURL(client *gophercloud.ServiceClient, id string) string {
 func deleteURL(client *gophercloud.ServiceClient, id string) string {
 	return idURL(client, id)
 }
+
+func validateURL(client *gophercloud.ServiceClient) string {
+	return client.ServiceURL(apiVersion, apiName, "validate")
+}

--- a/openstack/clustering/v1/webhooks/testing/requests_test.go
+++ b/openstack/clustering/v1/webhooks/testing/requests_test.go
@@ -1,11 +1,10 @@
 package testing
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"testing"
-
-	"encoding/json"
 
 	"github.com/gophercloud/gophercloud/openstack/clustering/v1/webhooks"
 	th "github.com/gophercloud/gophercloud/testhelper"


### PR DESCRIPTION
Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

For #[823 [Add support for Senlin clustering]](https://github.com/gophercloud/gophercloud/issues/823)

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

[[profiles:validate]](https://github.com/openstack/senlin/blob/e5bc16b3fea2f10dead365f983c5a937f23d72b0/senlin/api/openstack/v1/profiles.py#L67)
