### PR TITLE
Fixed where creating profile and policies will send spec "version" in…

### DIFF
--- a/openstack/clustering/v1/policies/results.go
+++ b/openstack/clustering/v1/policies/results.go
@@ -94,6 +94,19 @@ func (r *Spec) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+func (r Spec) MarshalJSON() ([]byte, error) {
+	spec := struct {
+		Type       string                 `json:"type"`
+		Version    string                 `json:"version"`
+		Properties map[string]interface{} `json:"properties"`
+	}{
+		Type:       r.Type,
+		Version:    r.Version,
+		Properties: r.Properties,
+	}
+	return json.Marshal(spec)
+}
+
 // policyResult is the resposne of a base Policy result.
 type policyResult struct {
 	gophercloud.Result

--- a/openstack/clustering/v1/profiles/results.go
+++ b/openstack/clustering/v1/profiles/results.go
@@ -89,6 +89,19 @@ func (r *Spec) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+func (r Spec) MarshalJSON() ([]byte, error) {
+	spec := struct {
+		Type       string                 `json:"type"`
+		Version    string                 `json:"version"`
+		Properties map[string]interface{} `json:"properties"`
+	}{
+		Type:       r.Type,
+		Version:    r.Version,
+		Properties: r.Properties,
+	}
+	return json.Marshal(spec)
+}
+
 // commonResult is the base result of a Profile operation.
 type commonResult struct {
 	gophercloud.Result


### PR DESCRIPTION
Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

For #[1249 [Bug: Senlin profile create is missing "version" field for spec when sending to api backend]](https://github.com/gophercloud/gophercloud/issues/1249)
Ref #[823 [Add support for Senlin clustering]](https://github.com/gophercloud/gophercloud/issues/823)