### PR TITLE
Block Storage v2: Remove multiattach field from volumes

### DIFF
--- a/openstack/blockstorage/v2/volumes/requests.go
+++ b/openstack/blockstorage/v2/volumes/requests.go
@@ -38,8 +38,6 @@ type CreateOpts struct {
 	ImageID string `json:"imageRef,omitempty"`
 	// The associated volume type
 	VolumeType string `json:"volume_type,omitempty"`
-	// Multiattach denotes if the volume is multi-attach capable.
-	Multiattach bool `json:"multiattach,omitempty"`
 }
 
 // ToVolumeCreateMap assembles a request body based on the contents of a


### PR DESCRIPTION
Add missing fields for multiattach support - to avoid support
issues, remove multiattach field from blockstorage v2.
"In Cinder the functionality is available from microversion '3.50' or higher."

Prior to starting a PR, please make sure you have read our
[contributor tutorial](https://github.com/gophercloud/gophercloud/tree/master/docs/contributor-tutorial).

Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

For #1228

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://docs.openstack.org/cinder/latest/admin/blockstorage-volume-multiattach.html
