### PR TITLE
Add ProtocolUDP support for UDP load balancers introduced in Octavia …

### DIFF
--- a/openstack/networking/v2/extensions/lbaas_v2/listeners/requests.go
+++ b/openstack/networking/v2/extensions/lbaas_v2/listeners/requests.go
@@ -11,6 +11,7 @@ type Protocol string
 // Supported attributes for create/update operations.
 const (
 	ProtocolTCP   Protocol = "TCP"
+	ProtocolUDP   Protocol = "UDP"
 	ProtocolHTTP  Protocol = "HTTP"
 	ProtocolHTTPS Protocol = "HTTPS"
 )

--- a/openstack/networking/v2/extensions/lbaas_v2/pools/requests.go
+++ b/openstack/networking/v2/extensions/lbaas_v2/pools/requests.go
@@ -68,6 +68,7 @@ const (
 	LBMethodSourceIp         LBMethod = "SOURCE_IP"
 
 	ProtocolTCP   Protocol = "TCP"
+	ProtocolUDP   Protocol = "UDP"
 	ProtocolHTTP  Protocol = "HTTP"
 	ProtocolHTTPS Protocol = "HTTPS"
 )
@@ -87,7 +88,7 @@ type CreateOpts struct {
 	LBMethod LBMethod `json:"lb_algorithm" required:"true"`
 
 	// The protocol used by the pool members, you can use either
-	// ProtocolTCP, ProtocolHTTP, or ProtocolHTTPS.
+	// ProtocolTCP, ProtocolUDP, ProtocolHTTP, or ProtocolHTTPS.
 	Protocol Protocol `json:"protocol" required:"true"`
 
 	// The Loadbalancer on which the members of the pool will be associated with.


### PR DESCRIPTION
For #1252 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/octavia/blob/stable/rocky/octavia/amphorae/drivers/haproxy/rest_api_driver.py#L92