### PR TITLE
Fix - add X-Auth-Token header on tokens.Validate

### DIFF
--- a/openstack/identity/v3/tokens/requests.go
+++ b/openstack/identity/v3/tokens/requests.go
@@ -99,6 +99,7 @@ func (opts *AuthOptions) CanReauth() bool {
 func subjectTokenHeaders(c *gophercloud.ServiceClient, subjectToken string) map[string]string {
 	return map[string]string{
 		"X-Subject-Token": subjectToken,
+		"X-Auth-Token":    subjectToken,
 	}
 }
 


### PR DESCRIPTION
Under stable/rocky of keystone
`tokens.Validate` with only `X-Subject-Token` won't get correct response but with also `X-Auth-Token`.

```
HEAD /v3/auth/tokens HTTP/1.1
Host: 127.0.0.1:5000
User-Agent: gophercloud/1.0.0
Connection: close
Accept: application/json
X-Subject-Token: gAAAAABbsJ2xgMz0O5ec33rym04sW1o-StKSOTOu7-jh03mevreKuYxwECuJ7l2CLCbE18HkRBjqIBtZz_pb981QuL3Sm30VtR7yPvcY6OYCQdoIxZxnKV0KrmzaQUke--PXPgqWxULQKDjha4CeFjDeY3keA9lh0A

HTTP/1.1 401 Unauthorized
Date: Sun, 30 Sep 2018 09:56:01 GMT
Server: Apache/2.4.34 (Ubuntu)
WWW-Authenticate: Keystone uri="http://127.0.0.1:5000"
Content-Length: 114
Vary: X-Auth-Token
X-Distribution: Ubuntu
x-openstack-request-id: req-f04eabfb-94f3-4740-958a-dbfa330f5234
Connection: close
Content-Type: application/json
```
