### PR TITLE
Networking trunk extension support Create/Delete

### DIFF
--- a/acceptance/openstack/networking/v2/extensions/trunks/trunks.go
+++ b/acceptance/openstack/networking/v2/extensions/trunks/trunks.go
@@ -1,0 +1,36 @@
+package trunks
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/acceptance/tools"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/trunks"
+)
+
+func CreateTrunk(t *testing.T, client *gophercloud.ServiceClient, parentPortID string, subportIDs ...string) (trunk *trunks.Trunk, err error) {
+	trunkName := tools.RandomString("TESTACC-", 8)
+	iTrue := true
+	opts := trunks.CreateOpts{
+		Name:         trunkName,
+		Description:  "Trunk created by gophercloud",
+		AdminStateUp: &iTrue,
+		PortID:       parentPortID,
+	}
+
+	opts.Subports = make([]trunks.Subport, len(subportIDs))
+	for id, subportID := range subportIDs {
+		opts.Subports[id] = trunks.Subport{
+			SegmentationID:   id + 1,
+			SegmentationType: "vlan",
+			PortID:           subportID,
+		}
+	}
+
+	t.Logf("Attempting to create trunk: %s", opts.Name)
+	trunk, err = trunks.Create(client, opts).Extract()
+	if err == nil {
+		t.Logf("Successfully created trunk")
+	}
+	return
+}

--- a/acceptance/openstack/networking/v2/extensions/trunks/trunks_test.go
+++ b/acceptance/openstack/networking/v2/extensions/trunks/trunks_test.go
@@ -1,0 +1,53 @@
+// +build acceptance trunks
+
+package trunks
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/acceptance/clients"
+	"github.com/gophercloud/gophercloud/acceptance/openstack/networking/v2"
+	"github.com/gophercloud/gophercloud/acceptance/tools"
+)
+
+func TestTrunkCRUD(t *testing.T) {
+	client, err := clients.NewNetworkV2Client()
+	if err != nil {
+		t.Fatalf("Unable to create a network client: %v", err)
+	}
+
+	// Create Network
+	network, err := v2.CreateNetwork(t, client)
+	if err != nil {
+		t.Fatalf("Unable to create network: %v", err)
+	}
+
+	// Create Subnet
+	subnet, err := v2.CreateSubnet(t, client, network.ID)
+	if err != nil {
+		t.Fatalf("Unable to create subnet: %v", err)
+	}
+
+	// Create port
+	parentPort, err := v2.CreatePort(t, client, network.ID, subnet.ID)
+	if err != nil {
+		t.Fatalf("Unable to create port: %v", err)
+	}
+
+	subport1, err := v2.CreatePort(t, client, network.ID, subnet.ID)
+	if err != nil {
+		t.Fatalf("Unable to create port: %v", err)
+	}
+
+	subport2, err := v2.CreatePort(t, client, network.ID, subnet.ID)
+	if err != nil {
+		t.Fatalf("Unable to create port: %v", err)
+	}
+
+	trunk, err := CreateTrunk(t, client, parentPort.ID, subport1.ID, subport2.ID)
+	if err != nil {
+		t.Fatalf("Unable to create trunk: %v", err)
+	}
+
+	tools.PrintResource(t, trunk)
+}

--- a/openstack/networking/v2/extensions/trunks/doc.go
+++ b/openstack/networking/v2/extensions/trunks/doc.go
@@ -1,0 +1,51 @@
+/*
+Package trunks provides the ability to retrieve and manage trunks through the Neutron API.
+Trunks allow you to multiplex multiple ports traffic on a single port. For example, you could
+have a compute instance port be the parent port of a trunk and inside the VM run workloads
+using other ports, without the need of plugging those ports.
+
+Example of a new empty Trunk creation
+
+	iTrue := true
+	createOpts := trunks.CreateOpts{
+		Name:         "gophertrunk",
+		Description:  "Trunk created by gophercloud",
+		AdminStateUp: &iTrue,
+		PortID:       "a6f0560c-b7a8-401f-bf6e-d0a5c851ae10",
+	}
+
+	trunk, err := trunks.Create(networkClient, trunkOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("%+v\n", trunk)
+
+Example of a new Trunk creation with 2 subports
+
+	iTrue := true
+	createOpts := trunks.CreateOpts{
+		Name:         "gophertrunk",
+		Description:  "Trunk created by gophercloud",
+		AdminStateUp: &iTrue,
+		PortID:       "a6f0560c-b7a8-401f-bf6e-d0a5c851ae10",
+		Subports: []trunks.Subport{
+			{
+				SegmentationID:   1,
+				SegmentationType: "vlan",
+				PortID:           "bf4efcc0-b1c7-4674-81f0-31f58a33420a",
+			},
+			{
+				SegmentationID:   10,
+				SegmentationType: "vlan",
+				PortID:           "2cf671b9-02b3-4121-9e85-e0af3548d112",
+			},
+		},
+	}
+
+	trunk, err := trunks.Create(client, trunkOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("%+v\n", trunk)
+*/
+package trunks

--- a/openstack/networking/v2/extensions/trunks/requests.go
+++ b/openstack/networking/v2/extensions/trunks/requests.go
@@ -1,0 +1,41 @@
+package trunks
+
+import (
+	"github.com/gophercloud/gophercloud"
+)
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToTrunkCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts represents the attributes used when creating a new trunk.
+type CreateOpts struct {
+	TenantID     string    `json:"tenant_id,omitempty"`
+	ProjectID    string    `json:"project_id,omitempty"`
+	PortID       string    `json:"port_id" required:"true"`
+	Name         string    `json:"name,omitempty"`
+	Description  string    `json:"description,omitempty"`
+	AdminStateUp *bool     `json:"admin_state_up,omitempty"`
+	Subports     []Subport `json:"sub_ports"`
+}
+
+// ToTrunkCreateMap builds a request body from CreateOpts.
+func (opts CreateOpts) ToTrunkCreateMap() (map[string]interface{}, error) {
+	if opts.Subports == nil {
+		opts.Subports = []Subport{}
+	}
+	return gophercloud.BuildRequestBody(opts, "trunk")
+}
+
+func Create(c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	body, err := opts.ToTrunkCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = c.Post(createURL(c), body, &r.Body, nil)
+	return
+}

--- a/openstack/networking/v2/extensions/trunks/results.go
+++ b/openstack/networking/v2/extensions/trunks/results.go
@@ -1,0 +1,74 @@
+package trunks
+
+import (
+	"time"
+
+	"github.com/gophercloud/gophercloud"
+)
+
+type Subport struct {
+	SegmentationID   int    `json:"segmentation_id"`
+	SegmentationType string `json:"segmentation_type"`
+	PortID           string `json:"port_id"`
+}
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// CreateResult is the response from a Create operation. Call its Extract method
+// to interpret it as a Trunk.
+type CreateResult struct {
+	commonResult
+}
+
+type Trunk struct {
+	// Indicates whether the trunk is currently operational. Possible values include
+	// `ACTIVE', `DOWN', `BUILD', 'DEGRADED' or `ERROR'.
+	Status string `json:"status"`
+
+	// A list of ports associated with the trunk
+	Subports []Subport `json:"sub_ports"`
+
+	// Human-readable name for the trunk. Might not be unique.
+	Name string `json:"name,omitempty"`
+
+	// The administrative state of the trunk. If false (down), the trunk does not
+	// forward packets.
+	AdminStateUp bool `json:"admin_state_up,omitempty"`
+
+	// ProjectID is the project owner of the trunk.
+	ProjectID string `json:"project_id"`
+
+	// TenantID is the project owner of the trunk.
+	TenantID string `json:"tenant_id"`
+
+	// The date and time when the resource was created.
+	CreatedAt time.Time `json:"created_at"`
+
+	// The date and time when the resource was updated,
+	// if the resource has not been updated, this field will show as null.
+	UpdatedAt time.Time `json:"updated_at"`
+
+	RevisionNumber int `json:"revision_number"`
+
+	// UUID of the trunk's parent port
+	PortID string `json:"port_id"`
+
+	// UUID for the trunk resource
+	ID string `json:"id"`
+
+	// Display description.
+	Description string `json:"description"`
+
+	// A list of tags associated with the trunk
+	Tags []string `json:"tags,omitempty"`
+}
+
+func (r commonResult) Extract() (*Trunk, error) {
+	var s struct {
+		Trunk *Trunk `json:"trunk"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Trunk, err
+}

--- a/openstack/networking/v2/extensions/trunks/testing/doc.go
+++ b/openstack/networking/v2/extensions/trunks/testing/doc.go
@@ -1,0 +1,2 @@
+// trunks unit tests
+package testing

--- a/openstack/networking/v2/extensions/trunks/testing/fixtures.go
+++ b/openstack/networking/v2/extensions/trunks/testing/fixtures.go
@@ -1,0 +1,162 @@
+package testing
+
+import (
+	"time"
+
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/trunks"
+)
+
+const CreateRequest = `
+{
+  "trunk": {
+    "admin_state_up": true,
+    "description": "Trunk created by gophercloud",
+    "name": "gophertrunk",
+    "port_id": "c373d2fa-3d3b-4492-924c-aff54dea19b6",
+    "sub_ports": [
+      {
+        "port_id": "28e452d7-4f8a-4be4-b1e6-7f3db4c0430b",
+        "segmentation_id": 1,
+        "segmentation_type": "vlan"
+      },
+      {
+        "port_id": "4c8b2bff-9824-4d4c-9b60-b3f6621b2bab",
+        "segmentation_id": 2,
+        "segmentation_type": "vlan"
+      }
+    ]
+  }
+}`
+
+const CreateResponse = `
+{
+  "trunk": {
+    "admin_state_up": true,
+    "created_at": "2018-10-03T13:57:24Z",
+    "description": "Trunk created by gophercloud",
+    "id": "f6a9718c-5a64-43e3-944f-4deccad8e78c",
+    "name": "gophertrunk",
+    "port_id": "c373d2fa-3d3b-4492-924c-aff54dea19b6",
+    "project_id": "e153f3f9082240a5974f667cfe1036e3",
+    "revision_number": 1,
+    "status": "ACTIVE",
+    "sub_ports": [
+      {
+        "port_id": "28e452d7-4f8a-4be4-b1e6-7f3db4c0430b",
+        "segmentation_id": 1,
+        "segmentation_type": "vlan"
+      },
+      {
+        "port_id": "4c8b2bff-9824-4d4c-9b60-b3f6621b2bab",
+        "segmentation_id": 2,
+        "segmentation_type": "vlan"
+      }
+    ],
+    "tags": [],
+    "tenant_id": "e153f3f9082240a5974f667cfe1036e3",
+    "updated_at": "2018-10-03T13:57:26Z"
+  }
+}`
+
+const CreateNoSubportsRequest = `
+{
+  "trunk": {
+    "admin_state_up": true,
+    "description": "Trunk created by gophercloud",
+    "name": "gophertrunk",
+    "port_id": "c373d2fa-3d3b-4492-924c-aff54dea19b6",
+    "sub_ports": []
+  }
+}`
+
+const CreateNoSubportsResponse = `
+{
+  "trunk": {
+    "admin_state_up": true,
+    "created_at": "2018-10-03T13:57:24Z",
+    "description": "Trunk created by gophercloud",
+    "id": "f6a9718c-5a64-43e3-944f-4deccad8e78c",
+    "name": "gophertrunk",
+    "port_id": "c373d2fa-3d3b-4492-924c-aff54dea19b6",
+    "project_id": "e153f3f9082240a5974f667cfe1036e3",
+    "revision_number": 1,
+    "status": "ACTIVE",
+    "sub_ports": [],
+    "tags": [],
+    "tenant_id": "e153f3f9082240a5974f667cfe1036e3",
+    "updated_at": "2018-10-03T13:57:26Z"
+  }
+}`
+
+var ExpectedSubports = []trunks.Subport{
+	{
+		PortID:           "28e452d7-4f8a-4be4-b1e6-7f3db4c0430b",
+		SegmentationID:   1,
+		SegmentationType: "vlan",
+	},
+	{
+		PortID:           "4c8b2bff-9824-4d4c-9b60-b3f6621b2bab",
+		SegmentationID:   2,
+		SegmentationType: "vlan",
+	},
+}
+
+func ExpectedTrunkSlice() (exp []trunks.Trunk, err error) {
+	trunk1CreatedAt, err := time.Parse(time.RFC3339, "2018-10-01T15:29:39Z")
+	if err != nil {
+		return nil, err
+	}
+
+	trunk1UpdatedAt, err := time.Parse(time.RFC3339, "2018-10-01T15:43:04Z")
+	if err != nil {
+		return nil, err
+	}
+	exp = make([]trunks.Trunk, 2)
+	exp[0] = trunks.Trunk{
+		AdminStateUp:   true,
+		Description:    "",
+		ID:             "3e72aa1b-d0da-48f2-831a-fd1c5f3f99c2",
+		Name:           "mytrunk",
+		PortID:         "16c425d3-d7fc-40b8-b94c-cc95da45b270",
+		ProjectID:      "e153f3f9082240a5974f667cfe1036e3",
+		TenantID:       "e153f3f9082240a5974f667cfe1036e3",
+		RevisionNumber: 3,
+		Status:         "ACTIVE",
+		Subports: []trunks.Subport{
+			{
+				PortID:           "424da4b7-7868-4db2-bb71-05155601c6e4",
+				SegmentationID:   11,
+				SegmentationType: "vlan",
+			},
+		},
+		Tags:      []string{},
+		CreatedAt: trunk1CreatedAt,
+		UpdatedAt: trunk1UpdatedAt,
+	}
+
+	trunk2CreatedAt, err := time.Parse(time.RFC3339, "2018-10-03T13:57:24Z")
+	if err != nil {
+		return nil, err
+	}
+
+	trunk2UpdatedAt, err := time.Parse(time.RFC3339, "2018-10-03T13:57:26Z")
+	if err != nil {
+		return nil, err
+	}
+	exp[1] = trunks.Trunk{
+		AdminStateUp:   true,
+		Description:    "Trunk created by gophercloud",
+		ID:             "f6a9718c-5a64-43e3-944f-4deccad8e78c",
+		Name:           "gophertrunk",
+		PortID:         "c373d2fa-3d3b-4492-924c-aff54dea19b6",
+		ProjectID:      "e153f3f9082240a5974f667cfe1036e3",
+		TenantID:       "e153f3f9082240a5974f667cfe1036e3",
+		RevisionNumber: 1,
+		Status:         "ACTIVE",
+		Subports:       ExpectedSubports,
+		Tags:           []string{},
+		CreatedAt:      trunk2CreatedAt,
+		UpdatedAt:      trunk2UpdatedAt,
+	}
+	return
+}

--- a/openstack/networking/v2/extensions/trunks/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/trunks/testing/requests_test.go
@@ -1,0 +1,89 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	fake "github.com/gophercloud/gophercloud/openstack/networking/v2/common"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/trunks"
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestCreate(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/trunks", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, CreateRequest)
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+
+		fmt.Fprintf(w, CreateResponse)
+	})
+
+	iTrue := true
+	options := trunks.CreateOpts{
+		Name:         "gophertrunk",
+		Description:  "Trunk created by gophercloud",
+		AdminStateUp: &iTrue,
+		Subports: []trunks.Subport{
+			{
+				SegmentationID:   1,
+				SegmentationType: "vlan",
+				PortID:           "28e452d7-4f8a-4be4-b1e6-7f3db4c0430b",
+			},
+			{
+				SegmentationID:   2,
+				SegmentationType: "vlan",
+				PortID:           "4c8b2bff-9824-4d4c-9b60-b3f6621b2bab",
+			},
+		},
+	}
+	_, err := trunks.Create(fake.ServiceClient(), options).Extract()
+	if err == nil {
+		t.Fatalf("Failed to detect missing parent PortID field")
+	}
+	options.PortID = "c373d2fa-3d3b-4492-924c-aff54dea19b6"
+	n, err := trunks.Create(fake.ServiceClient(), options).Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, n.Status, "ACTIVE")
+	expectedTrunks, err := ExpectedTrunkSlice()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, &expectedTrunks[1], n)
+}
+
+func TestCreateNoSubports(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/trunks", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, CreateNoSubportsRequest)
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+
+		fmt.Fprintf(w, CreateNoSubportsResponse)
+	})
+
+	iTrue := true
+	options := trunks.CreateOpts{
+		Name:         "gophertrunk",
+		Description:  "Trunk created by gophercloud",
+		AdminStateUp: &iTrue,
+		PortID:       "c373d2fa-3d3b-4492-924c-aff54dea19b6",
+	}
+	n, err := trunks.Create(fake.ServiceClient(), options).Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, n.Status, "ACTIVE")
+	th.AssertEquals(t, 0, len(n.Subports))
+}

--- a/openstack/networking/v2/extensions/trunks/urls.go
+++ b/openstack/networking/v2/extensions/trunks/urls.go
@@ -1,0 +1,13 @@
+package trunks
+
+import "github.com/gophercloud/gophercloud"
+
+const resourcePath = "trunks"
+
+func rootURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL(resourcePath)
+}
+
+func createURL(c *gophercloud.ServiceClient) string {
+	return rootURL(c)
+}


### PR DESCRIPTION
This patch adds the Networking extension trunk support for Create and Delete operations.

The reason for having both create and delete together is because otherwise the acceptance tests can't remove any resources that are added to the trunk (ports, subnet and network).

For #1257 
