### PR TITLE
Neutron Standard Attributes Tag Extension - ReplaceAll support

### DIFF
--- a/acceptance/openstack/networking/v2/extensions/attributestags_test.go
+++ b/acceptance/openstack/networking/v2/extensions/attributestags_test.go
@@ -1,0 +1,32 @@
+// +build acceptance networking tags
+
+package extensions
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/acceptance/clients"
+	networking "github.com/gophercloud/gophercloud/acceptance/openstack/networking/v2"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/attributestags"
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestTags(t *testing.T) {
+	client, err := clients.NewNetworkV2Client()
+	th.AssertNoErr(t, err)
+
+	// Create Network
+	network, err := networking.CreateNetwork(t, client)
+	th.AssertNoErr(t, err)
+	defer networking.DeleteNetwork(t, client, network.ID)
+
+	tagReplaceAllOpts := attributestags.ReplaceAllOpts{
+		Tags: []string{"abc", "123"},
+	}
+	tags, err := attributestags.ReplaceAll(client, "networks", network.ID, tagReplaceAllOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, tags, []string{"abc", "123"})
+
+	// FIXME(shardy) - when the networks Get schema supports tags we should
+	// verify the tags are set in the Get response
+}

--- a/openstack/networking/v2/extensions/attributestags/doc.go
+++ b/openstack/networking/v2/extensions/attributestags/doc.go
@@ -1,0 +1,19 @@
+/*
+Package attributestags manages Tags on Resources created by the OpenStack Neutron Service.
+
+This enables tagging via a standard interface for resources types which support it.
+
+See https://developer.openstack.org/api-ref/network/v2/#standard-attributes-tag-extension for more information on the underlying API.
+
+Example to ReplaceAll Resource Tags
+
+    network, err := networks.Create(conn, createOpts).Extract()
+
+    tagReplaceAllOpts := attributestags.ReplaceAllOpts{
+        Tags:         []string{"abc", "123"},
+    }
+    attributestags.ReplaceAll(conn, "networks", network.ID, tagReplaceAllOpts)
+
+
+*/
+package attributestags

--- a/openstack/networking/v2/extensions/attributestags/requests.go
+++ b/openstack/networking/v2/extensions/attributestags/requests.go
@@ -1,0 +1,36 @@
+package attributestags
+
+import (
+	"github.com/gophercloud/gophercloud"
+)
+
+// ReplaceAllOptsBuilder allows extensions to add additional parameters to
+// the ReplaceAll request.
+type ReplaceAllOptsBuilder interface {
+	ToAttributeTagsReplaceAllMap() (map[string]interface{}, error)
+}
+
+// ReplaceAllOpts provides options used to create Tags on a Resource
+type ReplaceAllOpts struct {
+	Tags []string `json:"tags" required:"true"`
+}
+
+// ToAttributeTagsReplaceAllMap formats a ReplaceAllOpts into the body of the
+// replace request
+func (opts ReplaceAllOpts) ToAttributeTagsReplaceAllMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "")
+}
+
+// ReplaceAll updates all tags on a resource, replacing any existing tags
+func ReplaceAll(client *gophercloud.ServiceClient, resourceType string, resourceID string, opts ReplaceAllOptsBuilder) (r ReplaceAllResult) {
+	b, err := opts.ToAttributeTagsReplaceAllMap()
+	url := replaceURL(client, resourceType, resourceID)
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Put(url, &b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}

--- a/openstack/networking/v2/extensions/attributestags/results.go
+++ b/openstack/networking/v2/extensions/attributestags/results.go
@@ -1,0 +1,24 @@
+package attributestags
+
+import (
+	"github.com/gophercloud/gophercloud"
+)
+
+type tagResult struct {
+	gophercloud.Result
+}
+
+// Extract interprets tagResult to return the list of tags
+func (r tagResult) Extract() ([]string, error) {
+	var s struct {
+		Tags []string `json:"tags"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Tags, err
+}
+
+// ReplaceAllResult represents the result of a replace operation.
+// Call its Extract method to interpret it as a slice of strings.
+type ReplaceAllResult struct {
+	tagResult
+}

--- a/openstack/networking/v2/extensions/attributestags/testing/fixtures.go
+++ b/openstack/networking/v2/extensions/attributestags/testing/fixtures.go
@@ -1,0 +1,13 @@
+package testing
+
+const attributestagsReplaceAllRequest = `
+{
+	"tags": ["abc", "xyz"]
+}
+`
+
+const attributestagsReplaceAllResult = `
+{
+	"tags": ["abc", "xyz"]
+}
+`

--- a/openstack/networking/v2/extensions/attributestags/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/attributestags/testing/requests_test.go
@@ -1,0 +1,37 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	fake "github.com/gophercloud/gophercloud/openstack/networking/v2/common"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/attributestags"
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestReplaceAll(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/networks/fakeid/tags", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, attributestagsReplaceAllRequest)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, attributestagsReplaceAllResult)
+	})
+
+	opts := attributestags.ReplaceAllOpts{
+		Tags: []string{"abc", "xyz"},
+	}
+	res, err := attributestags.ReplaceAll(fake.ServiceClient(), "networks", "fakeid", opts).Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertDeepEquals(t, res, []string{"abc", "xyz"})
+}

--- a/openstack/networking/v2/extensions/attributestags/urls.go
+++ b/openstack/networking/v2/extensions/attributestags/urls.go
@@ -1,0 +1,11 @@
+package attributestags
+
+import "github.com/gophercloud/gophercloud"
+
+const (
+	tagsPath = "tags"
+)
+
+func replaceURL(c *gophercloud.ServiceClient, r_type string, id string) string {
+	return c.ServiceURL(r_type, id, tagsPath)
+}


### PR DESCRIPTION
This initial patch adds only the ability to Replace all tags on
a given resource, as described in the API docs:

https://developer.openstack.org/api-ref/network/v2/#standard-attributes-tag-extension

https://developer.openstack.org/api-ref/network/v2/#replace-all-tags

If this approach is acceptable subsequent PRs can add the other
operations supported by this API.

Prior to starting a PR, please make sure you have read our
[contributor tutorial](https://github.com/gophercloud/gophercloud/tree/master/docs/contributor-tutorial).

Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

For #1260

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

Note this isn't quite a normal CRUD API since it operates on existing resources:

PUT that adds either a single tag (append):
https://github.com/openstack/neutron/blob/master/neutron/extensions/tagging.py#L115

... or replaces all of them with a list:
https://github.com/openstack/neutron/blob/master/neutron/extensions/tagging.py#L127

Delete one tag:
https://github.com/openstack/neutron/blob/master/neutron/extensions/tagging.py#L140

... or delete them all:
https://github.com/openstack/neutron/blob/master/neutron/extensions/tagging.py#L152

When these are implemented it would be good to look at List filtering by tag (which Neutron also supports) but I guess that will be a separate issue - getting the ability to set/unset tags is a prerequisite.
