### PR TITLE
Networking v2 Trunk support - Delete

### DIFF
--- a/acceptance/openstack/networking/v2/extensions/trunks/trunks.go
+++ b/acceptance/openstack/networking/v2/extensions/trunks/trunks.go
@@ -34,3 +34,13 @@ func CreateTrunk(t *testing.T, client *gophercloud.ServiceClient, parentPortID s
 	}
 	return
 }
+
+func DeleteTrunk(t *testing.T, client *gophercloud.ServiceClient, trunkID string) {
+	t.Logf("Attempting to delete trunk: %s", trunkID)
+	err := trunks.Delete(client, trunkID).ExtractErr()
+	if err != nil {
+		t.Fatalf("Unable to delete trunk %s: %v", trunkID, err)
+	}
+
+	t.Logf("Deleted trunk: %s", trunkID)
+}

--- a/acceptance/openstack/networking/v2/extensions/trunks/trunks_test.go
+++ b/acceptance/openstack/networking/v2/extensions/trunks/trunks_test.go
@@ -21,33 +21,39 @@ func TestTrunkCRUD(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to create network: %v", err)
 	}
+	defer v2.DeleteNetwork(t, client, network.ID)
 
 	// Create Subnet
 	subnet, err := v2.CreateSubnet(t, client, network.ID)
 	if err != nil {
 		t.Fatalf("Unable to create subnet: %v", err)
 	}
+	defer v2.DeleteSubnet(t, client, subnet.ID)
 
 	// Create port
 	parentPort, err := v2.CreatePort(t, client, network.ID, subnet.ID)
 	if err != nil {
 		t.Fatalf("Unable to create port: %v", err)
 	}
+	defer v2.DeletePort(t, client, parentPort.ID)
 
 	subport1, err := v2.CreatePort(t, client, network.ID, subnet.ID)
 	if err != nil {
 		t.Fatalf("Unable to create port: %v", err)
 	}
+	defer v2.DeletePort(t, client, subport1.ID)
 
 	subport2, err := v2.CreatePort(t, client, network.ID, subnet.ID)
 	if err != nil {
 		t.Fatalf("Unable to create port: %v", err)
 	}
+	defer v2.DeletePort(t, client, subport2.ID)
 
 	trunk, err := CreateTrunk(t, client, parentPort.ID, subport1.ID, subport2.ID)
 	if err != nil {
 		t.Fatalf("Unable to create trunk: %v", err)
 	}
+	defer DeleteTrunk(t, client, trunk.ID)
 
 	tools.PrintResource(t, trunk)
 }

--- a/openstack/networking/v2/extensions/trunks/doc.go
+++ b/openstack/networking/v2/extensions/trunks/doc.go
@@ -47,5 +47,13 @@ Example of a new Trunk creation with 2 subports
 		panic(err)
 	}
 	fmt.Printf("%+v\n", trunk)
+
+Example of deleting a Trunk
+
+	trunkID := "c36e7f2e-0c53-4742-8696-aee77c9df159"
+	err := trunks.Delete(networkClient, trunkID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
 */
 package trunks

--- a/openstack/networking/v2/extensions/trunks/requests.go
+++ b/openstack/networking/v2/extensions/trunks/requests.go
@@ -39,3 +39,9 @@ func Create(c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResul
 	_, r.Err = c.Post(createURL(c), body, &r.Body, nil)
 	return
 }
+
+// Delete accepts a unique ID and deletes the trunk associated with it.
+func Delete(c *gophercloud.ServiceClient, id string) (r DeleteResult) {
+	_, r.Err = c.Delete(deleteURL(c, id), nil)
+	return
+}

--- a/openstack/networking/v2/extensions/trunks/results.go
+++ b/openstack/networking/v2/extensions/trunks/results.go
@@ -22,6 +22,12 @@ type CreateResult struct {
 	commonResult
 }
 
+// DeleteResult is the response from a Delete operation. Call its ExtractErr to
+// determine if the request succeeded or failed.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
 type Trunk struct {
 	// Indicates whether the trunk is currently operational. Possible values include
 	// `ACTIVE', `DOWN', `BUILD', 'DEGRADED' or `ERROR'.

--- a/openstack/networking/v2/extensions/trunks/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/trunks/testing/requests_test.go
@@ -87,3 +87,17 @@ func TestCreateNoSubports(t *testing.T) {
 	th.AssertEquals(t, n.Status, "ACTIVE")
 	th.AssertEquals(t, 0, len(n.Subports))
 }
+
+func TestDelete(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/trunks/f6a9718c-5a64-43e3-944f-4deccad8e78c", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	res := trunks.Delete(fake.ServiceClient(), "f6a9718c-5a64-43e3-944f-4deccad8e78c")
+	th.AssertNoErr(t, res.Err)
+}

--- a/openstack/networking/v2/extensions/trunks/urls.go
+++ b/openstack/networking/v2/extensions/trunks/urls.go
@@ -8,6 +8,14 @@ func rootURL(c *gophercloud.ServiceClient) string {
 	return c.ServiceURL(resourcePath)
 }
 
+func resourceURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL(resourcePath, id)
+}
+
 func createURL(c *gophercloud.ServiceClient) string {
 	return rootURL(c)
+}
+
+func deleteURL(c *gophercloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
 }


### PR DESCRIPTION
This patch adds the Networking extension trunk support for the Delete
operation.

Signed-off-by: Antoni Segura Puimedon <celebdor@gmail.com>
For #1257

Neutron master code showing the delete operation:
https://github.com/openstack/neutron/blob/master/neutron/services/trunk/plugin.py#L261-L272
