### PR TITLE
Resolve #209 - Always be able to handle large integers in JSON parsing.

### DIFF
--- a/openstack/compute/v2/extensions/quotasets/testing/fixtures.go
+++ b/openstack/compute/v2/extensions/quotasets/testing/fixtures.go
@@ -22,7 +22,7 @@ const GetOutput = `
       "injected_file_content_bytes" : 10240,
       "injected_files" : 5,
       "metadata_items" : 128,
-      "ram" : 200000,
+      "ram" : 9216000,
       "key_pairs" : 10,
       "injected_file_path_bytes" : 255,
 	  "server_groups" : 2,
@@ -73,7 +73,7 @@ const GetDetailsOutput = `
       },
       "ram" : {
           "in_use": 0,
-          "limit": 200000,
+          "limit": 9216000,
           "reserved": 0
       },
       "key_pairs" : {
@@ -110,7 +110,7 @@ var FirstQuotaSet = quotasets.QuotaSet{
 	InjectedFiles:            5,
 	KeyPairs:                 10,
 	MetadataItems:            128,
-	RAM:                      200000,
+	RAM:                      9216000,
 	SecurityGroupRules:       20,
 	SecurityGroups:           10,
 	Cores:                    200,
@@ -127,7 +127,7 @@ var FirstQuotaDetailsSet = quotasets.QuotaDetailSet{
 	InjectedFiles:            quotasets.QuotaDetail{InUse: 0, Reserved: 0, Limit: 5},
 	KeyPairs:                 quotasets.QuotaDetail{InUse: 0, Reserved: 0, Limit: 10},
 	MetadataItems:            quotasets.QuotaDetail{InUse: 0, Reserved: 0, Limit: 128},
-	RAM:                      quotasets.QuotaDetail{InUse: 0, Reserved: 0, Limit: 200000},
+	RAM:                      quotasets.QuotaDetail{InUse: 0, Reserved: 0, Limit: 9216000},
 	SecurityGroupRules:       quotasets.QuotaDetail{InUse: 0, Reserved: 0, Limit: 20},
 	SecurityGroups:           quotasets.QuotaDetail{InUse: 0, Reserved: 0, Limit: 10},
 	Cores:                    quotasets.QuotaDetail{InUse: 0, Reserved: 0, Limit: 200},
@@ -137,7 +137,7 @@ var FirstQuotaDetailsSet = quotasets.QuotaDetailSet{
 }
 
 //The expected update Body. Is also returned by PUT request
-const UpdateOutput = `{"quota_set":{"cores":200,"fixed_ips":0,"floating_ips":0,"injected_file_content_bytes":10240,"injected_file_path_bytes":255,"injected_files":5,"instances":25,"key_pairs":10,"metadata_items":128,"ram":200000,"security_group_rules":20,"security_groups":10,"server_groups":2,"server_group_members":3}}`
+const UpdateOutput = `{"quota_set":{"cores":200,"fixed_ips":0,"floating_ips":0,"injected_file_content_bytes":10240,"injected_file_path_bytes":255,"injected_files":5,"instances":25,"key_pairs":10,"metadata_items":128,"ram":9216000,"security_group_rules":20,"security_groups":10,"server_groups":2,"server_group_members":3}}`
 
 //The expected partialupdate Body. Is also returned by PUT request
 const PartialUpdateBody = `{"quota_set":{"cores":200, "force":true}}`
@@ -151,7 +151,7 @@ var UpdatedQuotaSet = quotasets.UpdateOpts{
 	InjectedFiles:            gophercloud.IntToPointer(5),
 	KeyPairs:                 gophercloud.IntToPointer(10),
 	MetadataItems:            gophercloud.IntToPointer(128),
-	RAM:                      gophercloud.IntToPointer(200000),
+	RAM:                      gophercloud.IntToPointer(9216000),
 	SecurityGroupRules:       gophercloud.IntToPointer(20),
 	SecurityGroups:           gophercloud.IntToPointer(10),
 	Cores:                    gophercloud.IntToPointer(200),

--- a/openstack/compute/v2/flavors/testing/requests_test.go
+++ b/openstack/compute/v2/flavors/testing/requests_test.go
@@ -35,7 +35,7 @@ func TestListFlavors(t *testing.T) {
 								"name": "m1.tiny",
 								"vcpus": 1,
 								"disk": 1,
-								"ram": 512,
+								"ram": 9216000,
 								"swap":"",
 								"os-flavor-access:is_public": true,
 								"OS-FLV-EXT-DATA:ephemeral": 10
@@ -87,7 +87,7 @@ func TestListFlavors(t *testing.T) {
 		}
 
 		expected := []flavors.Flavor{
-			{ID: "1", Name: "m1.tiny", VCPUs: 1, Disk: 1, RAM: 512, Swap: 0, IsPublic: true, Ephemeral: 10},
+			{ID: "1", Name: "m1.tiny", VCPUs: 1, Disk: 1, RAM: 9216000, Swap: 0, IsPublic: true, Ephemeral: 10},
 			{ID: "2", Name: "m1.small", VCPUs: 1, Disk: 20, RAM: 2048, Swap: 1000, IsPublic: true, Ephemeral: 0},
 			{ID: "3", Name: "m1.medium", VCPUs: 2, Disk: 40, RAM: 4096, Swap: 1000, IsPublic: false, Ephemeral: 0},
 		}

--- a/provider_client.go
+++ b/provider_client.go
@@ -365,7 +365,9 @@ func (client *ProviderClient) Request(method, url string, options *RequestOpts) 
 	// Parse the response body as JSON, if requested to do so.
 	if options.JSONResponse != nil {
 		defer resp.Body.Close()
-		if err := json.NewDecoder(resp.Body).Decode(options.JSONResponse); err != nil {
+		dec := json.NewDecoder(resp.Body)
+		dec.UseNumber()
+		if err := dec.Decode(options.JSONResponse); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
For #209

The bug in #209 seems to have fixed itself since being reported. This PR alters some tests to ensure no reversion.

It also implements the (no longer required) fix discussed in #209, in case any other system has to deal large integers.