### PR TITLE
Neutron attributestags List support

### DIFF
--- a/acceptance/openstack/networking/v2/extensions/attributestags_test.go
+++ b/acceptance/openstack/networking/v2/extensions/attributestags_test.go
@@ -21,12 +21,16 @@ func TestTags(t *testing.T) {
 	defer networking.DeleteNetwork(t, client, network.ID)
 
 	tagReplaceAllOpts := attributestags.ReplaceAllOpts{
-		Tags: []string{"abc", "123"},
+		// Note Neutron returns tags sorted, and although the API
+		// docs say list of tags, it's a set e.g no duplicates
+		Tags: []string{"a", "b", "c"},
 	}
 	tags, err := attributestags.ReplaceAll(client, "networks", network.ID, tagReplaceAllOpts).Extract()
 	th.AssertNoErr(t, err)
-	th.AssertDeepEquals(t, tags, []string{"abc", "123"})
+	th.AssertDeepEquals(t, tags, []string{"a", "b", "c"})
 
-	// FIXME(shardy) - when the networks Get schema supports tags we should
-	// verify the tags are set in the Get response
+	// Verify the tags are set in the List response
+	tags, err = attributestags.List(client, "networks", network.ID).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, tags, []string{"a", "b", "c"})
 }

--- a/openstack/networking/v2/extensions/attributestags/doc.go
+++ b/openstack/networking/v2/extensions/attributestags/doc.go
@@ -14,6 +14,8 @@ Example to ReplaceAll Resource Tags
     }
     attributestags.ReplaceAll(conn, "networks", network.ID, tagReplaceAllOpts)
 
+Example to List all Resource Tags
 
+	tags, err = attributestags.List(conn, "networks", network.ID).Extract()
 */
 package attributestags

--- a/openstack/networking/v2/extensions/attributestags/requests.go
+++ b/openstack/networking/v2/extensions/attributestags/requests.go
@@ -34,3 +34,12 @@ func ReplaceAll(client *gophercloud.ServiceClient, resourceType string, resource
 	})
 	return
 }
+
+// List all tags on a resource
+func List(client *gophercloud.ServiceClient, resourceType string, resourceID string) (r ListResult) {
+	url := listURL(client, resourceType, resourceID)
+	_, r.Err = client.Get(url, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}

--- a/openstack/networking/v2/extensions/attributestags/results.go
+++ b/openstack/networking/v2/extensions/attributestags/results.go
@@ -22,3 +22,7 @@ func (r tagResult) Extract() ([]string, error) {
 type ReplaceAllResult struct {
 	tagResult
 }
+
+type ListResult struct {
+	tagResult
+}

--- a/openstack/networking/v2/extensions/attributestags/testing/fixtures.go
+++ b/openstack/networking/v2/extensions/attributestags/testing/fixtures.go
@@ -11,3 +11,9 @@ const attributestagsReplaceAllResult = `
 	"tags": ["abc", "xyz"]
 }
 `
+
+const attributestagsListResult = `
+{
+	"tags": ["abc", "xyz"]
+}
+`

--- a/openstack/networking/v2/extensions/attributestags/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/attributestags/testing/requests_test.go
@@ -35,3 +35,23 @@ func TestReplaceAll(t *testing.T) {
 
 	th.AssertDeepEquals(t, res, []string{"abc", "xyz"})
 }
+
+func TestList(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/networks/fakeid/tags", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, attributestagsListResult)
+	})
+
+	res, err := attributestags.List(fake.ServiceClient(), "networks", "fakeid").Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertDeepEquals(t, res, []string{"abc", "xyz"})
+}

--- a/openstack/networking/v2/extensions/attributestags/urls.go
+++ b/openstack/networking/v2/extensions/attributestags/urls.go
@@ -9,3 +9,7 @@ const (
 func replaceURL(c *gophercloud.ServiceClient, r_type string, id string) string {
 	return c.ServiceURL(r_type, id, tagsPath)
 }
+
+func listURL(c *gophercloud.ServiceClient, r_type string, id string) string {
+	return c.ServiceURL(r_type, id, tagsPath)
+}


### PR DESCRIPTION
This patch adds the ability to List all tags on a given resource.
    
As described in the API docs:
    
https://developer.openstack.org/api-ref/network/v2/#standard-attributes-tag-extension
    
https://developer.openstack.org/api-ref/network/v2/#obtain-tag-list
    
Issue: #1260

Code from neutron related to this PR:

https://github.com/openstack/neutron/blob/master/neutron/extensions/tagging.py#L98
