### PR TITLE
Networking v2 Trunk support - List

### DIFF
--- a/acceptance/openstack/networking/v2/extensions/trunks/trunks_test.go
+++ b/acceptance/openstack/networking/v2/extensions/trunks/trunks_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gophercloud/gophercloud/acceptance/clients"
 	"github.com/gophercloud/gophercloud/acceptance/openstack/networking/v2"
 	"github.com/gophercloud/gophercloud/acceptance/tools"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/trunks"
 )
 
 func TestTrunkCRUD(t *testing.T) {
@@ -56,4 +57,25 @@ func TestTrunkCRUD(t *testing.T) {
 	defer DeleteTrunk(t, client, trunk.ID)
 
 	tools.PrintResource(t, trunk)
+}
+
+func TestTrunkList(t *testing.T) {
+	client, err := clients.NewNetworkV2Client()
+	if err != nil {
+		t.Fatalf("Unable to create a network client: %v", err)
+	}
+
+	allPages, err := trunks.List(client, nil).AllPages()
+	if err != nil {
+		t.Fatalf("Unable to list trunks: %v", err)
+	}
+
+	allTrunks, err := trunks.ExtractTrunks(allPages)
+	if err != nil {
+		t.Fatalf("Unable to extract trunks: %v", err)
+	}
+
+	for _, trunk := range allTrunks {
+		tools.PrintResource(t, trunk)
+	}
 }

--- a/openstack/networking/v2/extensions/trunks/doc.go
+++ b/openstack/networking/v2/extensions/trunks/doc.go
@@ -55,5 +55,22 @@ Example of deleting a Trunk
 	if err != nil {
 		panic(err)
 	}
+
+Example of listing Trunks
+
+	listOpts := trunks.ListOpts{}
+	allPages, err := trunks.List(networkClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+	allTrunks, err := trunks.ExtractTrunks(allPages)
+	if err != nil {
+		panic(err)
+	}
+	for _, trunk := range allTrunks {
+		fmt.Printf("%+v\n", trunk)
+	}
+
+
 */
 package trunks

--- a/openstack/networking/v2/extensions/trunks/requests.go
+++ b/openstack/networking/v2/extensions/trunks/requests.go
@@ -2,6 +2,7 @@ package trunks
 
 import (
 	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
 )
 
 // CreateOptsBuilder allows extensions to add additional parameters to the
@@ -44,4 +45,60 @@ func Create(c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResul
 func Delete(c *gophercloud.ServiceClient, id string) (r DeleteResult) {
 	_, r.Err = c.Delete(deleteURL(c, id), nil)
 	return
+}
+
+// ListOptsBuilder allows extensions to add additional parameters to the
+// List request.
+type ListOptsBuilder interface {
+	ToTrunkListQuery() (string, error)
+}
+
+// ListOpts allows the filtering and sorting of paginated collections through
+// the API. Filtering is achieved by passing in struct field values that map to
+// the trunk attributes you want to see returned. SortKey allows you to sort
+// by a particular trunk attribute. SortDir sets the direction, and is either
+// `asc' or `desc'. Marker and Limit are used for pagination.
+type ListOpts struct {
+	AdminStateUp   *bool  `q:"admin_state_up"`
+	Description    string `q:"description"`
+	ID             string `q:"id"`
+	Name           string `q:"name"`
+	PortID         string `q:"port_id"`
+	RevisionNumber string `q:"revision_number"`
+	Status         string `q:"status"`
+	TenantID       string `q:"tenant_id"`
+	ProjectID      string `q:"project_id"`
+	SortDir        string `q:"sort_dir"`
+	SortKey        string `q:"sort_key"`
+	Tags           string `q:"tags"`
+	TagsAny        string `q:"tags-any"`
+	NotTags        string `q:"not-tags"`
+	NotTagsAny     string `q:"not-tags-any"`
+}
+
+// ToTrunkListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToTrunkListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List returns a Pager which allows you to iterate over a collection of
+// trunks. It accepts a ListOpts struct, which allows you to filter and sort
+// the returned collection for greater efficiency.
+//
+// Default policy settings return only those trunks that are owned by the tenant
+// who submits the request, unless the request is submitted by a user with
+// administrative rights.
+func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(c)
+	if opts != nil {
+		query, err := opts.ToTrunkListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		return TrunkPage{pagination.LinkedPageBase{PageResult: r}}
+	})
 }

--- a/openstack/networking/v2/extensions/trunks/results.go
+++ b/openstack/networking/v2/extensions/trunks/results.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
 )
 
 type Subport struct {
@@ -77,4 +78,23 @@ func (r commonResult) Extract() (*Trunk, error) {
 	}
 	err := r.ExtractInto(&s)
 	return s.Trunk, err
+}
+
+// TrunkPage is the page returned by a pager when traversing a collection of
+// trunk resources.
+type TrunkPage struct {
+	pagination.LinkedPageBase
+}
+
+func (page TrunkPage) IsEmpty() (bool, error) {
+	trunks, err := ExtractTrunks(page)
+	return len(trunks) == 0, err
+}
+
+func ExtractTrunks(page pagination.Page) ([]Trunk, error) {
+	var a struct {
+		Trunks []Trunk `json:"trunks"`
+	}
+	err := (page.(TrunkPage)).ExtractInto(&a)
+	return a.Trunks, err
 }

--- a/openstack/networking/v2/extensions/trunks/testing/fixtures.go
+++ b/openstack/networking/v2/extensions/trunks/testing/fixtures.go
@@ -88,6 +88,59 @@ const CreateNoSubportsResponse = `
   }
 }`
 
+const ListResponse = `
+{
+  "trunks": [
+    {
+      "admin_state_up": true,
+      "created_at": "2018-10-01T15:29:39Z",
+      "description": "",
+      "id": "3e72aa1b-d0da-48f2-831a-fd1c5f3f99c2",
+      "name": "mytrunk",
+      "port_id": "16c425d3-d7fc-40b8-b94c-cc95da45b270",
+      "project_id": "e153f3f9082240a5974f667cfe1036e3",
+      "revision_number": 3,
+      "status": "ACTIVE",
+      "sub_ports": [
+        {
+          "port_id": "424da4b7-7868-4db2-bb71-05155601c6e4",
+          "segmentation_id": 11,
+          "segmentation_type": "vlan"
+        }
+      ],
+      "tags": [],
+      "tenant_id": "e153f3f9082240a5974f667cfe1036e3",
+      "updated_at": "2018-10-01T15:43:04Z"
+    },
+    {
+      "admin_state_up": true,
+      "created_at": "2018-10-03T13:57:24Z",
+      "description": "Trunk created by gophercloud",
+      "id": "f6a9718c-5a64-43e3-944f-4deccad8e78c",
+      "name": "gophertrunk",
+      "port_id": "c373d2fa-3d3b-4492-924c-aff54dea19b6",
+      "project_id": "e153f3f9082240a5974f667cfe1036e3",
+      "revision_number": 1,
+      "status": "ACTIVE",
+      "sub_ports": [
+        {
+          "port_id": "28e452d7-4f8a-4be4-b1e6-7f3db4c0430b",
+          "segmentation_id": 1,
+          "segmentation_type": "vlan"
+        },
+        {
+          "port_id": "4c8b2bff-9824-4d4c-9b60-b3f6621b2bab",
+          "segmentation_id": 2,
+          "segmentation_type": "vlan"
+        }
+      ],
+      "tags": [],
+      "tenant_id": "e153f3f9082240a5974f667cfe1036e3",
+      "updated_at": "2018-10-03T13:57:26Z"
+    }
+  ]
+}`
+
 var ExpectedSubports = []trunks.Subport{
 	{
 		PortID:           "28e452d7-4f8a-4be4-b1e6-7f3db4c0430b",

--- a/openstack/networking/v2/extensions/trunks/urls.go
+++ b/openstack/networking/v2/extensions/trunks/urls.go
@@ -19,3 +19,7 @@ func createURL(c *gophercloud.ServiceClient) string {
 func deleteURL(c *gophercloud.ServiceClient, id string) string {
 	return resourceURL(c, id)
 }
+
+func listURL(c *gophercloud.ServiceClient) string {
+	return rootURL(c)
+}


### PR DESCRIPTION
This patch adds the Networking extension trunk support for List
operations.

Signed-off-by: Antoni Segura Puimedon <celebdor@gmail.com>

For #1257 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/neutron/blob/master/neutron/services/trunk/plugin.py#L189-L196
https://github.com/openstack/neutron/blob/master/neutron/services/trunk/models.py#L26-L49
