### PR TITLE
Network v2: Fix Upper Limit of IPs

### DIFF
--- a/acceptance/openstack/networking/v2/extensions/networkipavailabilities/networkipavailabilities_test.go
+++ b/acceptance/openstack/networking/v2/extensions/networkipavailabilities/networkipavailabilities_test.go
@@ -22,6 +22,10 @@ func TestNetworkIPAvailabilityList(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	for _, availability := range allAvailabilities {
-		tools.PrintResource(t, availability)
+		for _, subnet := range availability.SubnetIPAvailabilities {
+			tools.PrintResource(t, subnet)
+			tools.PrintResource(t, subnet.TotalIPs)
+			tools.PrintResource(t, subnet.UsedIPs)
+		}
 	}
 }

--- a/openstack/networking/v2/extensions/networkipavailabilities/results.go
+++ b/openstack/networking/v2/extensions/networkipavailabilities/results.go
@@ -1,6 +1,8 @@
 package networkipavailabilities
 
 import (
+	"math/big"
+
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/pagination"
 )
@@ -43,10 +45,10 @@ type NetworkIPAvailability struct {
 	SubnetIPAvailabilities []SubnetIPAvailability `json:"subnet_ip_availability"`
 
 	// TotalIPs represents a number of IP addresses in the network.
-	TotalIPs int `json:"total_ips"`
+	TotalIPs big.Int `json:"total_ips"`
 
 	// UsedIPs represents a number of used IP addresses in the network.
-	UsedIPs int `json:"used_ips"`
+	UsedIPs big.Int `json:"used_ips"`
 }
 
 // SubnetIPAvailability represents availability details for a single subnet.
@@ -64,10 +66,10 @@ type SubnetIPAvailability struct {
 	IPVersion int `json:"ip_version"`
 
 	// TotalIPs represents a number of IP addresses in the subnet.
-	TotalIPs int `json:"total_ips"`
+	TotalIPs big.Int `json:"total_ips"`
 
 	// UsedIPs represents a number of used IP addresses in the subnet.
-	UsedIPs int `json:"used_ips"`
+	UsedIPs big.Int `json:"used_ips"`
 }
 
 // NetworkIPAvailabilityPage stores a single page of NetworkIPAvailabilities

--- a/openstack/networking/v2/extensions/networkipavailabilities/results.go
+++ b/openstack/networking/v2/extensions/networkipavailabilities/results.go
@@ -1,6 +1,7 @@
 package networkipavailabilities
 
 import (
+	"encoding/json"
 	"math/big"
 
 	"github.com/gophercloud/gophercloud"
@@ -45,10 +46,30 @@ type NetworkIPAvailability struct {
 	SubnetIPAvailabilities []SubnetIPAvailability `json:"subnet_ip_availability"`
 
 	// TotalIPs represents a number of IP addresses in the network.
-	TotalIPs big.Int `json:"total_ips"`
+	TotalIPs string `json:"-"`
 
 	// UsedIPs represents a number of used IP addresses in the network.
-	UsedIPs big.Int `json:"used_ips"`
+	UsedIPs string `json:"-"`
+}
+
+func (r *NetworkIPAvailability) UnmarshalJSON(b []byte) error {
+	type tmp NetworkIPAvailability
+	var s struct {
+		tmp
+		TotalIPs big.Int `json:"total_ips"`
+		UsedIPs  big.Int `json:"used_ips"`
+	}
+
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	*r = NetworkIPAvailability(s.tmp)
+
+	r.TotalIPs = s.TotalIPs.String()
+	r.UsedIPs = s.UsedIPs.String()
+
+	return err
 }
 
 // SubnetIPAvailability represents availability details for a single subnet.
@@ -66,10 +87,30 @@ type SubnetIPAvailability struct {
 	IPVersion int `json:"ip_version"`
 
 	// TotalIPs represents a number of IP addresses in the subnet.
-	TotalIPs big.Int `json:"total_ips"`
+	TotalIPs string `json:"-"`
 
 	// UsedIPs represents a number of used IP addresses in the subnet.
-	UsedIPs big.Int `json:"used_ips"`
+	UsedIPs string `json:"-"`
+}
+
+func (r *SubnetIPAvailability) UnmarshalJSON(b []byte) error {
+	type tmp SubnetIPAvailability
+	var s struct {
+		tmp
+		TotalIPs big.Int `json:"total_ips"`
+		UsedIPs  big.Int `json:"used_ips"`
+	}
+
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	*r = SubnetIPAvailability(s.tmp)
+
+	r.TotalIPs = s.TotalIPs.String()
+	r.UsedIPs = s.UsedIPs.String()
+
+	return err
 }
 
 // NetworkIPAvailabilityPage stores a single page of NetworkIPAvailabilities

--- a/openstack/networking/v2/extensions/networkipavailabilities/testing/fixtures.go
+++ b/openstack/networking/v2/extensions/networkipavailabilities/testing/fixtures.go
@@ -1,8 +1,6 @@
 package testing
 
 import (
-	"math/big"
-
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/networkipavailabilities"
 )
@@ -17,12 +15,12 @@ const NetworkIPAvailabilityListResult = `
             "project_id": "fb57277ef2f84a0e85b9018ec2dedbf7",
             "subnet_ip_availability": [
                 {
-                    "cidr": "10.0.0.64/26",
-                    "ip_version": 4,
+                    "cidr": "fdbc:bf53:567e::/64",
+                    "ip_version": 6,
                     "subnet_id": "497ac4d3-0b92-42cf-82de-71302ab2b656",
-                    "subnet_name": "second-private-subnet",
-                    "total_ips": 61,
-                    "used_ips": 12
+                    "subnet_name": "ipv6-private-subnet",
+                    "total_ips": 18446744073709552000,
+                    "used_ips": 2
                 },
                 {
                     "cidr": "10.0.0.0/26",
@@ -65,24 +63,24 @@ var NetworkIPAvailability1 = networkipavailabilities.NetworkIPAvailability{
 	NetworkName: "private",
 	ProjectID:   "fb57277ef2f84a0e85b9018ec2dedbf7",
 	TenantID:    "fb57277ef2f84a0e85b9018ec2dedbf7",
-	TotalIPs:    *big.NewInt(122),
-	UsedIPs:     *big.NewInt(14),
+	TotalIPs:    "122",
+	UsedIPs:     "14",
 	SubnetIPAvailabilities: []networkipavailabilities.SubnetIPAvailability{
 		{
 			SubnetID:   "497ac4d3-0b92-42cf-82de-71302ab2b656",
-			SubnetName: "second-private-subnet",
-			CIDR:       "10.0.0.64/26",
-			IPVersion:  int(gophercloud.IPv4),
-			TotalIPs:   *big.NewInt(61),
-			UsedIPs:    *big.NewInt(12),
+			SubnetName: "ipv6-private-subnet",
+			CIDR:       "fdbc:bf53:567e::/64",
+			IPVersion:  int(gophercloud.IPv6),
+			TotalIPs:   "18446744073709552000",
+			UsedIPs:    "2",
 		},
 		{
 			SubnetID:   "521f47e7-c4fb-452c-b71a-851da38cc571",
 			SubnetName: "private-subnet",
 			CIDR:       "10.0.0.0/26",
 			IPVersion:  int(gophercloud.IPv4),
-			TotalIPs:   *big.NewInt(61),
-			UsedIPs:    *big.NewInt(2),
+			TotalIPs:   "61",
+			UsedIPs:    "2",
 		},
 	},
 }
@@ -93,16 +91,16 @@ var NetworkIPAvailability2 = networkipavailabilities.NetworkIPAvailability{
 	NetworkName: "public",
 	ProjectID:   "424e7cf0243c468ca61732ba45973b3e",
 	TenantID:    "424e7cf0243c468ca61732ba45973b3e",
-	TotalIPs:    *big.NewInt(253),
-	UsedIPs:     *big.NewInt(3),
+	TotalIPs:    "253",
+	UsedIPs:     "3",
 	SubnetIPAvailabilities: []networkipavailabilities.SubnetIPAvailability{
 		{
 			SubnetID:   "4afe6e5f-9649-40db-b18f-64c7ead942bd",
 			SubnetName: "public-subnet",
 			CIDR:       "203.0.113.0/24",
 			IPVersion:  int(gophercloud.IPv4),
-			TotalIPs:   *big.NewInt(253),
-			UsedIPs:    *big.NewInt(3),
+			TotalIPs:   "253",
+			UsedIPs:    "3",
 		},
 	},
 }

--- a/openstack/networking/v2/extensions/networkipavailabilities/testing/fixtures.go
+++ b/openstack/networking/v2/extensions/networkipavailabilities/testing/fixtures.go
@@ -1,6 +1,8 @@
 package testing
 
 import (
+	"math/big"
+
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/networkipavailabilities"
 )
@@ -63,24 +65,24 @@ var NetworkIPAvailability1 = networkipavailabilities.NetworkIPAvailability{
 	NetworkName: "private",
 	ProjectID:   "fb57277ef2f84a0e85b9018ec2dedbf7",
 	TenantID:    "fb57277ef2f84a0e85b9018ec2dedbf7",
-	TotalIPs:    122,
-	UsedIPs:     14,
+	TotalIPs:    *big.NewInt(122),
+	UsedIPs:     *big.NewInt(14),
 	SubnetIPAvailabilities: []networkipavailabilities.SubnetIPAvailability{
 		{
 			SubnetID:   "497ac4d3-0b92-42cf-82de-71302ab2b656",
 			SubnetName: "second-private-subnet",
 			CIDR:       "10.0.0.64/26",
 			IPVersion:  int(gophercloud.IPv4),
-			TotalIPs:   61,
-			UsedIPs:    12,
+			TotalIPs:   *big.NewInt(61),
+			UsedIPs:    *big.NewInt(12),
 		},
 		{
 			SubnetID:   "521f47e7-c4fb-452c-b71a-851da38cc571",
 			SubnetName: "private-subnet",
 			CIDR:       "10.0.0.0/26",
 			IPVersion:  int(gophercloud.IPv4),
-			TotalIPs:   61,
-			UsedIPs:    2,
+			TotalIPs:   *big.NewInt(61),
+			UsedIPs:    *big.NewInt(2),
 		},
 	},
 }
@@ -91,16 +93,16 @@ var NetworkIPAvailability2 = networkipavailabilities.NetworkIPAvailability{
 	NetworkName: "public",
 	ProjectID:   "424e7cf0243c468ca61732ba45973b3e",
 	TenantID:    "424e7cf0243c468ca61732ba45973b3e",
-	TotalIPs:    253,
-	UsedIPs:     3,
+	TotalIPs:    *big.NewInt(253),
+	UsedIPs:     *big.NewInt(3),
 	SubnetIPAvailabilities: []networkipavailabilities.SubnetIPAvailability{
 		{
 			SubnetID:   "4afe6e5f-9649-40db-b18f-64c7ead942bd",
 			SubnetName: "public-subnet",
 			CIDR:       "203.0.113.0/24",
 			IPVersion:  int(gophercloud.IPv4),
-			TotalIPs:   253,
-			UsedIPs:    3,
+			TotalIPs:   *big.NewInt(253),
+			UsedIPs:    *big.NewInt(3),
 		},
 	},
 }

--- a/openstack/networking/v2/extensions/networkipavailabilities/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/networkipavailabilities/testing/requests_test.go
@@ -2,7 +2,6 @@ package testing
 
 import (
 	"fmt"
-	"math/big"
 	"net/http"
 	"testing"
 
@@ -29,7 +28,7 @@ func TestList(t *testing.T) {
 
 	count := 0
 
-	networkipavailabilities.List(fake.ServiceClient(), networkipavailabilities.ListOpts{}).EachPage(func(page pagination.Page) (bool, error) {
+	err := networkipavailabilities.List(fake.ServiceClient(), networkipavailabilities.ListOpts{}).EachPage(func(page pagination.Page) (bool, error) {
 		count++
 		actual, err := networkipavailabilities.ExtractNetworkIPAvailabilities(page)
 		if err != nil {
@@ -46,6 +45,8 @@ func TestList(t *testing.T) {
 
 		return true, nil
 	})
+
+	th.AssertNoErr(t, err)
 
 	if count != 1 {
 		t.Errorf("Expected 1 page, got %d", count)
@@ -73,16 +74,16 @@ func TestGet(t *testing.T) {
 	th.AssertEquals(t, s.NetworkName, "public")
 	th.AssertEquals(t, s.ProjectID, "424e7cf0243c468ca61732ba45973b3e")
 	th.AssertEquals(t, s.TenantID, "424e7cf0243c468ca61732ba45973b3e")
-	th.AssertEquals(t, s.TotalIPs.String(), "253")
-	th.AssertEquals(t, s.UsedIPs.String(), "3")
+	th.AssertEquals(t, s.TotalIPs, "253")
+	th.AssertEquals(t, s.UsedIPs, "3")
 	th.AssertDeepEquals(t, s.SubnetIPAvailabilities, []networkipavailabilities.SubnetIPAvailability{
 		{
 			SubnetID:   "4afe6e5f-9649-40db-b18f-64c7ead942bd",
 			SubnetName: "public-subnet",
 			CIDR:       "203.0.113.0/24",
 			IPVersion:  int(gophercloud.IPv4),
-			TotalIPs:   *big.NewInt(253),
-			UsedIPs:    *big.NewInt(3),
+			TotalIPs:   "253",
+			UsedIPs:    "3",
 		},
 	})
 }

--- a/openstack/networking/v2/extensions/networkipavailabilities/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/networkipavailabilities/testing/requests_test.go
@@ -2,6 +2,7 @@ package testing
 
 import (
 	"fmt"
+	"math/big"
 	"net/http"
 	"testing"
 
@@ -72,16 +73,16 @@ func TestGet(t *testing.T) {
 	th.AssertEquals(t, s.NetworkName, "public")
 	th.AssertEquals(t, s.ProjectID, "424e7cf0243c468ca61732ba45973b3e")
 	th.AssertEquals(t, s.TenantID, "424e7cf0243c468ca61732ba45973b3e")
-	th.AssertEquals(t, s.TotalIPs, 253)
-	th.AssertEquals(t, s.UsedIPs, 3)
+	th.AssertEquals(t, s.TotalIPs.String(), "253")
+	th.AssertEquals(t, s.UsedIPs.String(), "3")
 	th.AssertDeepEquals(t, s.SubnetIPAvailabilities, []networkipavailabilities.SubnetIPAvailability{
 		{
 			SubnetID:   "4afe6e5f-9649-40db-b18f-64c7ead942bd",
 			SubnetName: "public-subnet",
 			CIDR:       "203.0.113.0/24",
 			IPVersion:  int(gophercloud.IPv4),
-			TotalIPs:   253,
-			UsedIPs:    3,
+			TotalIPs:   *big.NewInt(253),
+			UsedIPs:    *big.NewInt(3),
 		},
 	})
 }

--- a/script/acceptancetest
+++ b/script/acceptancetest
@@ -30,10 +30,10 @@ fi
 
 # Networking v2 - networkipavailabilities
 # requires bug fix
-#go test -v -timeout $timeout -tags "fixtures acceptance" ./acceptance/openstack/networking/v2/extensions/networkipavailabilities
-#if [[ $? != 0 ]]; then
-#  failed=1
-#fi
+go test -v -timeout $timeout -tags "fixtures acceptance" ./acceptance/openstack/networking/v2/extensions/networkipavailabilities
+if [[ $? != 0 ]]; then
+  failed=1
+fi
 
 # Networking v2 - portsbinding
 go test -v -timeout $timeout -tags "fixtures acceptance" ./acceptance/openstack/networking/v2/extensions/portsbinding


### PR DESCRIPTION
The networkipavailabilities extension requires an increase to the
upper limit for both Total IPs and Used IPs. This is to
accommodate a large amount of IPv6 addresses.

This commit changes the type of these fields from int to big.Int.

For #1242 

With this in place, the acceptance tests now passes:

```
=== RUN   TestNetworkIPAvailabilityList
--- PASS: TestNetworkIPAvailabilityList (0.13s)
        tools.go:72: {
                  "network_id": "a8976812-bbaf-46f0-b534-d672e77b1cf8",
                  "network_name": "private",
                  "project_id": "29b363f3aca74d608757a51c23c36fad",
                  "tenant_id": "29b363f3aca74d608757a51c23c36fad",
                  "subnet_ip_availability": [
                    {
                      "subnet_id": "203ffe15-a1b5-424f-96d8-6dbb0e33d819",
                      "subnet_name": "private-subnet",
                      "cidr": "10.0.0.0/26",
                      "ip_version": 4,
                      "total_ips": 61,
                      "used_ips": 2
                    },
                    {
                      "subnet_id": "510a4389-1a3a-42ae-b564-1a5e0e8a2715",
                      "subnet_name": "ipv6-private-subnet",
                      "cidr": "fdbc:bf53:567e::/64",
                      "ip_version": 6,
                      "total_ips": 18446744073709552000,
                      "used_ips": 2
                    }
                  ],
                  "total_ips": {},
                  "used_ips": {}
                }
```