### PR TITLE
Networking v2 Trunk support - Get

### DIFF
--- a/acceptance/openstack/networking/v2/extensions/trunks/trunks_test.go
+++ b/acceptance/openstack/networking/v2/extensions/trunks/trunks_test.go
@@ -56,6 +56,11 @@ func TestTrunkCRUD(t *testing.T) {
 	}
 	defer DeleteTrunk(t, client, trunk.ID)
 
+	_, err = trunks.Get(client, trunk.ID).Extract()
+	if err != nil {
+		t.Fatalf("Unable to get trunk: %v", err)
+	}
+
 	tools.PrintResource(t, trunk)
 }
 

--- a/openstack/networking/v2/extensions/trunks/doc.go
+++ b/openstack/networking/v2/extensions/trunks/doc.go
@@ -71,6 +71,13 @@ Example of listing Trunks
 		fmt.Printf("%+v\n", trunk)
 	}
 
+Example of getting a Trunk
 
+	trunkID = "52d8d124-3dc9-4563-9fef-bad3187ecf2d"
+	trunk, err := trunks.Get(networkClient, trunkID).Extract()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("%+v\n", trunk)
 */
 package trunks

--- a/openstack/networking/v2/extensions/trunks/requests.go
+++ b/openstack/networking/v2/extensions/trunks/requests.go
@@ -102,3 +102,9 @@ func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 		return TrunkPage{pagination.LinkedPageBase{PageResult: r}}
 	})
 }
+
+// Get retrieves a specific trunk based on its unique ID.
+func Get(c *gophercloud.ServiceClient, id string) (r GetResult) {
+	_, r.Err = c.Get(getURL(c, id), &r.Body, nil)
+	return
+}

--- a/openstack/networking/v2/extensions/trunks/results.go
+++ b/openstack/networking/v2/extensions/trunks/results.go
@@ -29,6 +29,12 @@ type DeleteResult struct {
 	gophercloud.ErrResult
 }
 
+// GetResult is the response from a Get operation. Call its Extract method
+// to interpret it as a Trunk.
+type GetResult struct {
+	commonResult
+}
+
 type Trunk struct {
 	// Indicates whether the trunk is currently operational. Possible values include
 	// `ACTIVE', `DOWN', `BUILD', 'DEGRADED' or `ERROR'.

--- a/openstack/networking/v2/extensions/trunks/testing/fixtures.go
+++ b/openstack/networking/v2/extensions/trunks/testing/fixtures.go
@@ -141,6 +141,36 @@ const ListResponse = `
   ]
 }`
 
+const GetResponse = `
+{
+  "trunk": {
+    "admin_state_up": true,
+    "created_at": "2018-10-03T13:57:24Z",
+    "description": "Trunk created by gophercloud",
+    "id": "f6a9718c-5a64-43e3-944f-4deccad8e78c",
+    "name": "gophertrunk",
+    "port_id": "c373d2fa-3d3b-4492-924c-aff54dea19b6",
+    "project_id": "e153f3f9082240a5974f667cfe1036e3",
+    "revision_number": 1,
+    "status": "ACTIVE",
+    "sub_ports": [
+      {
+        "port_id": "28e452d7-4f8a-4be4-b1e6-7f3db4c0430b",
+        "segmentation_id": 1,
+        "segmentation_type": "vlan"
+      },
+      {
+        "port_id": "4c8b2bff-9824-4d4c-9b60-b3f6621b2bab",
+        "segmentation_id": 2,
+        "segmentation_type": "vlan"
+      }
+    ],
+    "tags": [],
+    "tenant_id": "e153f3f9082240a5974f667cfe1036e3",
+    "updated_at": "2018-10-03T13:57:26Z"
+  }
+}`
+
 var ExpectedSubports = []trunks.Subport{
 	{
 		PortID:           "28e452d7-4f8a-4be4-b1e6-7f3db4c0430b",

--- a/openstack/networking/v2/extensions/trunks/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/trunks/testing/requests_test.go
@@ -139,3 +139,24 @@ func TestList(t *testing.T) {
 		t.Errorf("Expected 1 page, got %d", count)
 	}
 }
+
+func TestGet(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/trunks/f6a9718c-5a64-43e3-944f-4deccad8e78c", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, GetResponse)
+	})
+
+	n, err := trunks.Get(fake.ServiceClient(), "f6a9718c-5a64-43e3-944f-4deccad8e78c").Extract()
+	th.AssertNoErr(t, err)
+	expectedTrunks, err := ExpectedTrunkSlice()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, &expectedTrunks[1], n)
+}

--- a/openstack/networking/v2/extensions/trunks/urls.go
+++ b/openstack/networking/v2/extensions/trunks/urls.go
@@ -23,3 +23,7 @@ func deleteURL(c *gophercloud.ServiceClient, id string) string {
 func listURL(c *gophercloud.ServiceClient) string {
 	return rootURL(c)
 }
+
+func getURL(c *gophercloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
+}


### PR DESCRIPTION
This patch adds the Networking extension trunk support for the Get
operation.

Signed-off-by: Antoni Segura Puimedon <celebdor@gmail.com>

For #1257 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/neutron/blob/master/neutron/services/trunk/plugin.py#L183-L185
https://github.com/openstack/neutron/blob/master/neutron/services/trunk/plugin.py#L393-L399
https://github.com/openstack/neutron/blob/master/neutron/services/trunk/models.py#L26-L49
