### PR TITLE
Neutron attributestags DeleteAll support

### DIFF
--- a/acceptance/openstack/networking/v2/extensions/attributestags_test.go
+++ b/acceptance/openstack/networking/v2/extensions/attributestags_test.go
@@ -33,4 +33,11 @@ func TestTags(t *testing.T) {
 	tags, err = attributestags.List(client, "networks", network.ID).Extract()
 	th.AssertNoErr(t, err)
 	th.AssertDeepEquals(t, tags, []string{"a", "b", "c"})
+
+	// Delete all tags
+	err = attributestags.DeleteAll(client, "networks", network.ID).ExtractErr()
+	th.AssertNoErr(t, err)
+	tags, err = attributestags.List(client, "networks", network.ID).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, tags, []string{})
 }

--- a/openstack/networking/v2/extensions/attributestags/doc.go
+++ b/openstack/networking/v2/extensions/attributestags/doc.go
@@ -17,5 +17,9 @@ Example to ReplaceAll Resource Tags
 Example to List all Resource Tags
 
 	tags, err = attributestags.List(conn, "networks", network.ID).Extract()
+
+Example to Delete all Resource Tags
+
+	err = attributestags.DeleteAll(conn, "networks", network.ID).ExtractErr()
 */
 package attributestags

--- a/openstack/networking/v2/extensions/attributestags/requests.go
+++ b/openstack/networking/v2/extensions/attributestags/requests.go
@@ -43,3 +43,12 @@ func List(client *gophercloud.ServiceClient, resourceType string, resourceID str
 	})
 	return
 }
+
+// DeleteAll deletes all tags on a resource
+func DeleteAll(client *gophercloud.ServiceClient, resourceType string, resourceID string) (r DeleteResult) {
+	url := deleteAllURL(client, resourceType, resourceID)
+	_, r.Err = client.Delete(url, &gophercloud.RequestOpts{
+		OkCodes: []int{204},
+	})
+	return
+}

--- a/openstack/networking/v2/extensions/attributestags/results.go
+++ b/openstack/networking/v2/extensions/attributestags/results.go
@@ -26,3 +26,9 @@ type ReplaceAllResult struct {
 type ListResult struct {
 	tagResult
 }
+
+// DeleteResult is the result from a Delete/DeleteAll operation.
+// Call its ExtractErr method to determine if the call succeeded or failed.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}

--- a/openstack/networking/v2/extensions/attributestags/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/attributestags/testing/requests_test.go
@@ -55,3 +55,19 @@ func TestList(t *testing.T) {
 
 	th.AssertDeepEquals(t, res, []string{"abc", "xyz"})
 }
+
+func TestDeleteAll(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/networks/fakeid/tags", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	err := attributestags.DeleteAll(fake.ServiceClient(), "networks", "fakeid").ExtractErr()
+	th.AssertNoErr(t, err)
+}

--- a/openstack/networking/v2/extensions/attributestags/urls.go
+++ b/openstack/networking/v2/extensions/attributestags/urls.go
@@ -13,3 +13,7 @@ func replaceURL(c *gophercloud.ServiceClient, r_type string, id string) string {
 func listURL(c *gophercloud.ServiceClient, r_type string, id string) string {
 	return c.ServiceURL(r_type, id, tagsPath)
 }
+
+func deleteAllURL(c *gophercloud.ServiceClient, r_type string, id string) string {
+	return c.ServiceURL(r_type, id, tagsPath)
+}


### PR DESCRIPTION
As described in the API docs:

https://developer.openstack.org/api-ref/network/v2/#standard-attributes-tag-extension

https://developer.openstack.org/api-ref/network/v2/#remove-all-tags

Issue: #1260

Code from neutron related to this PR:

https://github.com/openstack/neutron/blob/master/neutron/extensions/tagging.py#L152