### PR TITLE
Neutron std attr tags add

### DIFF
--- a/acceptance/openstack/networking/v2/extensions/attributestags_test.go
+++ b/acceptance/openstack/networking/v2/extensions/attributestags_test.go
@@ -33,4 +33,11 @@ func TestTags(t *testing.T) {
 	tags, err = attributestags.List(client, "networks", network.ID).Extract()
 	th.AssertNoErr(t, err)
 	th.AssertDeepEquals(t, tags, []string{"a", "b", "c"})
+
+	// Delete all tags
+	err = attributestags.DeleteAll(client, "networks", network.ID).ExtractErr()
+	th.AssertNoErr(t, err)
+	tags, err = attributestags.List(client, "networks", network.ID).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, tags, []string{})
 }

--- a/acceptance/openstack/networking/v2/extensions/attributestags_test.go
+++ b/acceptance/openstack/networking/v2/extensions/attributestags_test.go
@@ -29,10 +29,14 @@ func TestTags(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.AssertDeepEquals(t, tags, []string{"a", "b", "c"})
 
+	// Add a tag
+	err = attributestags.Add(client, "networks", network.ID, "d").ExtractErr()
+	th.AssertNoErr(t, err)
+
 	// Verify the tags are set in the List response
 	tags, err = attributestags.List(client, "networks", network.ID).Extract()
 	th.AssertNoErr(t, err)
-	th.AssertDeepEquals(t, tags, []string{"a", "b", "c"})
+	th.AssertDeepEquals(t, tags, []string{"a", "b", "c", "d"})
 
 	// Delete all tags
 	err = attributestags.DeleteAll(client, "networks", network.ID).ExtractErr()

--- a/openstack/networking/v2/extensions/attributestags/doc.go
+++ b/openstack/networking/v2/extensions/attributestags/doc.go
@@ -21,5 +21,10 @@ Example to List all Resource Tags
 Example to Delete all Resource Tags
 
 	err = attributestags.DeleteAll(conn, "networks", network.ID).ExtractErr()
+
+Example to Add a tag to a Resource
+
+    err = attributestags.Add(client, "networks", network.ID, "atag").ExtractErr()
+
 */
 package attributestags

--- a/openstack/networking/v2/extensions/attributestags/doc.go
+++ b/openstack/networking/v2/extensions/attributestags/doc.go
@@ -17,5 +17,9 @@ Example to ReplaceAll Resource Tags
 Example to List all Resource Tags
 
 	tags, err = attributestags.List(conn, "networks", network.ID).Extract()
+
+Example to Delete all Resource Tags
+
+	err = attributestags.DeleteAll(conn, "networks", network.ID).ExtractErr()
 */
 package attributestags

--- a/openstack/networking/v2/extensions/attributestags/requests.go
+++ b/openstack/networking/v2/extensions/attributestags/requests.go
@@ -52,3 +52,12 @@ func DeleteAll(client *gophercloud.ServiceClient, resourceType string, resourceI
 	})
 	return
 }
+
+// Add a tag on a resource
+func Add(client *gophercloud.ServiceClient, resourceType string, resourceID string, tag string) (r AddResult) {
+	url := addURL(client, resourceType, resourceID, tag)
+	_, r.Err = client.Put(url, nil, nil, &gophercloud.RequestOpts{
+		OkCodes: []int{201},
+	})
+	return
+}

--- a/openstack/networking/v2/extensions/attributestags/requests.go
+++ b/openstack/networking/v2/extensions/attributestags/requests.go
@@ -43,3 +43,12 @@ func List(client *gophercloud.ServiceClient, resourceType string, resourceID str
 	})
 	return
 }
+
+// DeleteAll deletes all tags on a resource
+func DeleteAll(client *gophercloud.ServiceClient, resourceType string, resourceID string) (r DeleteResult) {
+	url := deleteAllURL(client, resourceType, resourceID)
+	_, r.Err = client.Delete(url, &gophercloud.RequestOpts{
+		OkCodes: []int{204},
+	})
+	return
+}

--- a/openstack/networking/v2/extensions/attributestags/results.go
+++ b/openstack/networking/v2/extensions/attributestags/results.go
@@ -26,3 +26,9 @@ type ReplaceAllResult struct {
 type ListResult struct {
 	tagResult
 }
+
+// DeleteResult is the result from a Delete/DeleteAll operation.
+// Call its ExtractErr method to determine if the call succeeded or failed.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}

--- a/openstack/networking/v2/extensions/attributestags/results.go
+++ b/openstack/networking/v2/extensions/attributestags/results.go
@@ -32,3 +32,9 @@ type ListResult struct {
 type DeleteResult struct {
 	gophercloud.ErrResult
 }
+
+// AddResult is the result from an Add operation.
+// Call its ExtractErr method to determine if the call succeeded or failed.
+type AddResult struct {
+	gophercloud.ErrResult
+}

--- a/openstack/networking/v2/extensions/attributestags/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/attributestags/testing/requests_test.go
@@ -55,3 +55,19 @@ func TestList(t *testing.T) {
 
 	th.AssertDeepEquals(t, res, []string{"abc", "xyz"})
 }
+
+func TestDeleteAll(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/networks/fakeid/tags", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	err := attributestags.DeleteAll(fake.ServiceClient(), "networks", "fakeid").ExtractErr()
+	th.AssertNoErr(t, err)
+}

--- a/openstack/networking/v2/extensions/attributestags/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/attributestags/testing/requests_test.go
@@ -71,3 +71,19 @@ func TestDeleteAll(t *testing.T) {
 	err := attributestags.DeleteAll(fake.ServiceClient(), "networks", "fakeid").ExtractErr()
 	th.AssertNoErr(t, err)
 }
+
+func TestAdd(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/networks/fakeid/tags/atag", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+	})
+
+	err := attributestags.Add(fake.ServiceClient(), "networks", "fakeid", "atag").ExtractErr()
+	th.AssertNoErr(t, err)
+}

--- a/openstack/networking/v2/extensions/attributestags/urls.go
+++ b/openstack/networking/v2/extensions/attributestags/urls.go
@@ -13,3 +13,7 @@ func replaceURL(c *gophercloud.ServiceClient, r_type string, id string) string {
 func listURL(c *gophercloud.ServiceClient, r_type string, id string) string {
 	return c.ServiceURL(r_type, id, tagsPath)
 }
+
+func deleteAllURL(c *gophercloud.ServiceClient, r_type string, id string) string {
+	return c.ServiceURL(r_type, id, tagsPath)
+}

--- a/openstack/networking/v2/extensions/attributestags/urls.go
+++ b/openstack/networking/v2/extensions/attributestags/urls.go
@@ -17,3 +17,7 @@ func listURL(c *gophercloud.ServiceClient, r_type string, id string) string {
 func deleteAllURL(c *gophercloud.ServiceClient, r_type string, id string) string {
 	return c.ServiceURL(r_type, id, tagsPath)
 }
+
+func addURL(c *gophercloud.ServiceClient, r_type string, id string, tag string) string {
+	return c.ServiceURL(r_type, id, tagsPath, tag)
+}


### PR DESCRIPTION
As described in the API docs:
    
https://developer.openstack.org/api-ref/network/v2/#standard-attributes-tag-
    
https://developer.openstack.org/api-ref/network/v2/#add-a-tag
    
Issue: #1260

Code from neutron related to this PR: https://github.com/openstack/neutron/blob/master/neutron/extensions/tagging.py#L115

Note this PR depends on https://github.com/gophercloud/gophercloud/pull/1276
--


