### PR TITLE
Networking v2 Trunk support - Update

### DIFF
--- a/acceptance/openstack/networking/v2/extensions/trunks/trunks_test.go
+++ b/acceptance/openstack/networking/v2/extensions/trunks/trunks_test.go
@@ -61,6 +61,19 @@ func TestTrunkCRUD(t *testing.T) {
 		t.Fatalf("Unable to get trunk: %v", err)
 	}
 
+	// Update Trunk
+	updateOpts := trunks.UpdateOpts{
+		Name: "updated_gophertrunk",
+	}
+	updatedTrunk, err := trunks.Update(client, trunk.ID, updateOpts).Extract()
+	if err != nil {
+		t.Fatalf("Unable to update trunk: %v", err)
+	}
+
+	if trunk.Name == updatedTrunk.Name {
+		t.Fatalf("Trunk name was not updated correctly")
+	}
+
 	tools.PrintResource(t, trunk)
 }
 

--- a/openstack/networking/v2/extensions/trunks/doc.go
+++ b/openstack/networking/v2/extensions/trunks/doc.go
@@ -79,5 +79,21 @@ Example of getting a Trunk
 		panic(err)
 	}
 	fmt.Printf("%+v\n", trunk)
+
+Example of updating a Trunk
+
+	trunkID := "c36e7f2e-0c53-4742-8696-aee77c9df159"
+	subports, err := trunks.GetSubports(client, trunkID).Extract()
+	iFalse := false
+	updateOpts := trunks.UpdateOpts{
+		AdminStateUp: &iFalse,
+		Name:         "updated_gophertrunk",
+		Description:  "trunk updated by gophercloud",
+	}
+	trunk, err = trunks.Update(networkClient, trunkID, updateOpts).Extract()
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("%+v\n", trunk)
 */
 package trunks

--- a/openstack/networking/v2/extensions/trunks/requests.go
+++ b/openstack/networking/v2/extensions/trunks/requests.go
@@ -108,3 +108,29 @@ func Get(c *gophercloud.ServiceClient, id string) (r GetResult) {
 	_, r.Err = c.Get(getURL(c, id), &r.Body, nil)
 	return
 }
+
+type UpdateOptsBuilder interface {
+	ToTrunkUpdateMap() (map[string]interface{}, error)
+}
+
+type UpdateOpts struct {
+	AdminStateUp *bool  `json:"admin_state_up,omitempty"`
+	Name         string `json:"name,omitempty"`
+	Description  string `json:"description,omitempty"`
+}
+
+func (opts UpdateOpts) ToTrunkUpdateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "trunk")
+}
+
+func Update(c *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+	body, err := opts.ToTrunkUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Put(updateURL(c, id), body, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}

--- a/openstack/networking/v2/extensions/trunks/results.go
+++ b/openstack/networking/v2/extensions/trunks/results.go
@@ -35,6 +35,12 @@ type GetResult struct {
 	commonResult
 }
 
+// UpdateResult is the result of an Update request. Call its Extract method to
+// interpret it as a Trunk.
+type UpdateResult struct {
+	commonResult
+}
+
 type Trunk struct {
 	// Indicates whether the trunk is currently operational. Possible values include
 	// `ACTIVE', `DOWN', `BUILD', 'DEGRADED' or `ERROR'.

--- a/openstack/networking/v2/extensions/trunks/testing/fixtures.go
+++ b/openstack/networking/v2/extensions/trunks/testing/fixtures.go
@@ -171,6 +171,45 @@ const GetResponse = `
   }
 }`
 
+const UpdateRequest = `
+{
+  "trunk": {
+    "admin_state_up": false,
+    "description": "gophertrunk updated by gophercloud",
+    "name": "updated_gophertrunk"
+  }
+}`
+
+const UpdateResponse = `
+{
+  "trunk": {
+    "admin_state_up": false,
+    "created_at": "2018-10-03T13:57:24Z",
+    "description": "gophertrunk updated by gophercloud",
+    "id": "f6a9718c-5a64-43e3-944f-4deccad8e78c",
+    "name": "updated_gophertrunk",
+    "port_id": "c373d2fa-3d3b-4492-924c-aff54dea19b6",
+    "project_id": "e153f3f9082240a5974f667cfe1036e3",
+    "revision_number": 6,
+    "status": "ACTIVE",
+    "sub_ports": [
+      {
+        "port_id": "28e452d7-4f8a-4be4-b1e6-7f3db4c0430b",
+        "segmentation_id": 1,
+        "segmentation_type": "vlan"
+      },
+      {
+        "port_id": "4c8b2bff-9824-4d4c-9b60-b3f6621b2bab",
+        "segmentation_id": 2,
+        "segmentation_type": "vlan"
+      }
+    ],
+    "tags": [],
+    "tenant_id": "e153f3f9082240a5974f667cfe1036e3",
+    "updated_at": "2018-10-03T13:57:33Z"
+  }
+}`
+
 var ExpectedSubports = []trunks.Subport{
 	{
 		PortID:           "28e452d7-4f8a-4be4-b1e6-7f3db4c0430b",

--- a/openstack/networking/v2/extensions/trunks/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/trunks/testing/requests_test.go
@@ -160,3 +160,36 @@ func TestGet(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.CheckDeepEquals(t, &expectedTrunks[1], n)
 }
+
+func TestUpdate(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/trunks/f6a9718c-5a64-43e3-944f-4deccad8e78c", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, UpdateRequest)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, UpdateResponse)
+	})
+
+	iFalse := false
+	name := "updated_gophertrunk"
+	description := "gophertrunk updated by gophercloud"
+	options := trunks.UpdateOpts{
+		Name:         name,
+		AdminStateUp: &iFalse,
+		Description:  description,
+	}
+	n, err := trunks.Update(fake.ServiceClient(), "f6a9718c-5a64-43e3-944f-4deccad8e78c", options).Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, n.Name, name)
+	th.AssertEquals(t, n.AdminStateUp, iFalse)
+	th.AssertEquals(t, n.Description, description)
+}

--- a/openstack/networking/v2/extensions/trunks/urls.go
+++ b/openstack/networking/v2/extensions/trunks/urls.go
@@ -27,3 +27,7 @@ func listURL(c *gophercloud.ServiceClient) string {
 func getURL(c *gophercloud.ServiceClient, id string) string {
 	return resourceURL(c, id)
 }
+
+func updateURL(c *gophercloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
+}


### PR DESCRIPTION
This patch adds the Networking extension trunk support for the Update
operation.

Signed-off-by: Antoni Segura Puimedon <celebdor@gmail.com>

For #1257 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/neutron/blob/master/neutron/services/trunk/plugin.py#L237-L259
https://github.com/openstack/neutron/blob/master/neutron/objects/base.py#L785-L800
https://github.com/openstack/neutron/blob/master/neutron/objects/trunk.py#L91-L101
