### PR TITLE
Networking trunks - Verify subport missing fields

### DIFF
--- a/openstack/networking/v2/extensions/trunks/results.go
+++ b/openstack/networking/v2/extensions/trunks/results.go
@@ -8,9 +8,9 @@ import (
 )
 
 type Subport struct {
-	SegmentationID   int    `json:"segmentation_id"`
-	SegmentationType string `json:"segmentation_type"`
-	PortID           string `json:"port_id"`
+	SegmentationID   int    `json:"segmentation_id" required:"true"`
+	SegmentationType string `json:"segmentation_type" required:"true"`
+	PortID           string `json:"port_id" required:"true"`
 }
 
 type commonResult struct {

--- a/openstack/networking/v2/extensions/trunks/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/trunks/testing/requests_test.go
@@ -214,3 +214,33 @@ func TestGetSubports(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.CheckDeepEquals(t, ExpectedSubports, subports)
 }
+
+func TestMissingFields(t *testing.T) {
+	iTrue := true
+	opts := trunks.CreateOpts{
+		Name:         "gophertrunk",
+		PortID:       "c373d2fa-3d3b-4492-924c-aff54dea19b6",
+		Description:  "Trunk created by gophercloud",
+		AdminStateUp: &iTrue,
+		Subports: []trunks.Subport{
+			{
+				SegmentationID:   1,
+				SegmentationType: "vlan",
+				PortID:           "28e452d7-4f8a-4be4-b1e6-7f3db4c0430b",
+			},
+			{
+				SegmentationID:   2,
+				SegmentationType: "vlan",
+				PortID:           "4c8b2bff-9824-4d4c-9b60-b3f6621b2bab",
+			},
+			{
+				PortID: "4c8b2bff-9824-4d4c-9b60-b3f6621b2bab",
+			},
+		},
+	}
+
+	_, err := opts.ToTrunkCreateMap()
+	if err == nil {
+		t.Fatalf("Failed to detect missing subport fields")
+	}
+}

--- a/params.go
+++ b/params.go
@@ -120,6 +120,22 @@ func BuildRequestBody(opts interface{}, parent string) (map[string]interface{}, 
 				continue
 			}
 
+			if v.Kind() == reflect.Slice || (v.Kind() == reflect.Ptr && v.Elem().Kind() == reflect.Slice) {
+				sliceValue := v
+				if sliceValue.Kind() == reflect.Ptr {
+					sliceValue = sliceValue.Elem()
+				}
+
+				for i := 0; i < sliceValue.Len(); i++ {
+					element := sliceValue.Index(i)
+					if element.Kind() == reflect.Struct || (element.Kind() == reflect.Ptr && element.Elem().Kind() == reflect.Struct) {
+						_, err := BuildRequestBody(element.Interface(), "")
+						if err != nil {
+							return nil, err
+						}
+					}
+				}
+			}
 			if v.Kind() == reflect.Struct || (v.Kind() == reflect.Ptr && v.Elem().Kind() == reflect.Struct) {
 				if zero {
 					//fmt.Printf("value before change: %+v\n", optsValue.Field(i))


### PR DESCRIPTION
builquery had a bug that made it overlook the required fields in slices
of structs. This patch addresses it and adds a unit test for trunk
creation.

For #1279 