### PR TITLE
Handle filters on list parameters

### DIFF
--- a/acceptance/openstack/workflow/v2/workflow.go
+++ b/acceptance/openstack/workflow/v2/workflow.go
@@ -19,6 +19,9 @@ version: '2.0'
 %s:
   description: Simple workflow example
   type: direct
+  tags:
+    - tag1
+    - tag2
 
   input:
     - msg

--- a/acceptance/openstack/workflow/v2/workflows_test.go
+++ b/acceptance/openstack/workflow/v2/workflows_test.go
@@ -2,6 +2,7 @@ package v2
 
 import (
 	"testing"
+	"time"
 
 	"github.com/gophercloud/gophercloud/acceptance/clients"
 	"github.com/gophercloud/gophercloud/acceptance/tools"
@@ -30,7 +31,14 @@ func TestWorkflowsList(t *testing.T) {
 	th.AssertNoErr(t, err)
 	defer DeleteWorkflow(t, client, workflow)
 	list, err := ListWorkflows(t, client, &workflows.ListOpts{
-		Name: workflow.Name,
+		Name: &workflows.ListFilter{
+			Value: workflow.Name,
+		},
+		Tags: []string{"tag1"},
+		CreatedAt: &workflows.ListDateFilter{
+			Filter: workflows.FilterGT,
+			Value:  time.Now().AddDate(-1, 0, 0),
+		},
 	})
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, 1, len(list))

--- a/openstack/workflow/v2/crontriggers/doc.go
+++ b/openstack/workflow/v2/crontriggers/doc.go
@@ -37,10 +37,10 @@ Default Filter checks equality, but you can override it with provided filter typ
 Create a cron trigger. This example will start the workflow "echo" each day at 8am, and it will end after 10 executions.
 
 	createOpts := &crontriggers.CreateOpts{
-		Name:					"daily",
-		Pattern:				"0 8 * * *",
-		WorkflowName:			"echo",
-		RemainingExecutions:	10,
+		Name:                "daily",
+		Pattern:             "0 8 * * *",
+		WorkflowName:        "echo",
+		RemainingExecutions: 10,
 		WorkflowParams: map[string]interface{}{
 			"msg": "hello",
 		},

--- a/openstack/workflow/v2/crontriggers/requests.go
+++ b/openstack/workflow/v2/crontriggers/requests.go
@@ -92,7 +92,7 @@ type ListOptsBuilder interface {
 // ListOpts filters the result returned by the List() function.
 type ListOpts struct {
 	// WorkflowName allows to filter by workflow name.
-	WorkflowName string `q:"workflow_name"`
+	WorkflowName *ListFilter `q:"-"`
 	// WorkflowID allows to filter by workflow id.
 	WorkflowID string `q:"workflow_id"`
 	// WorkflowInput allows to filter by specific workflow inputs.
@@ -220,6 +220,7 @@ func (opts ListOpts) ToCronTriggerListQuery() (string, error) {
 	}
 
 	for queryParam, value := range map[string]fmt.Stringer{
+		"workflow_name":        opts.WorkflowName,
 		"name":                 opts.Name,
 		"pattern":              opts.Pattern,
 		"remaining_executions": opts.RemainingExecutions,

--- a/openstack/workflow/v2/crontriggers/testing/requests_test.go
+++ b/openstack/workflow/v2/crontriggers/testing/requests_test.go
@@ -256,6 +256,12 @@ func TestToExecutionListQuery(t *testing.T) {
 				Value:  "not_name",
 			},
 		},
+		newValue("workflow_name", `eq:workflow`): &crontriggers.ListOpts{
+			WorkflowName: &crontriggers.ListFilter{
+				Filter: crontriggers.FilterEQ,
+				Value:  "workflow",
+			},
+		},
 		newValue("created_at", `gt:2018-01-01 00:00:00`): &crontriggers.ListOpts{
 			CreatedAt: &crontriggers.ListDateFilter{
 				Filter: crontriggers.FilterGT,

--- a/openstack/workflow/v2/workflows/requests.go
+++ b/openstack/workflow/v2/workflows/requests.go
@@ -1,7 +1,12 @@
 package workflows
 
 import (
+	"fmt"
 	"io"
+	"net/url"
+	"reflect"
+	"strings"
+	"time"
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/pagination"
@@ -76,32 +81,118 @@ type ListOptsBuilder interface {
 
 // ListOpts filters the result returned by the List() function.
 type ListOpts struct {
-	// Name allows to filter by workflow name.
-	Name string `q:"name"`
-	// Namespace allows to filter by workflow namespace.
-	Namespace string `q:"namespace"`
-	// Definition allows to filter by workflow definition.
-	Definition string `q:"definition"`
 	// Scope filters by the workflow's scope.
 	// Values can be "private" or "public".
 	Scope string `q:"scope"`
-	// SortDir allows to select sort direction.
+	// CreatedAt allows to filter by workflow creation date.
+	CreatedAt *ListDateFilter `q:"-"`
+	// UpdatedAt allows to filter by last execution update date.
+	UpdatedAt *ListDateFilter `q:"-"`
+	// Name allows to filter by workflow name.
+	Name *ListFilter `q:"-"`
+	// Tags allows to filter by tags.
+	Tags []string
+	// Definition allows to filter by workflow definition.
+	Definition *ListFilter `q:"-"`
+	// Namespace allows to filter by workflow namespace.
+	Namespace *ListFilter `q:"-"`
+	// SortDirs allows to select sort direction.
 	// It can be "asc" or "desc" (default).
-	SortDir string `q:"sort_dir"`
-	// SortKey allows to sort by one of the cron trigger attributes.
-	SortKey string `q:"sort_key"`
+	SortDirs string `q:"sort_dirs"`
+	// SortKeys allows to sort by one of the cron trigger attributes.
+	SortKeys string `q:"sort_keys"`
 	// Marker and Limit control paging.
 	// Marker instructs List where to start listing from.
 	Marker string `q:"marker"`
 	// Limit instructs List to refrain from sending excessively large lists of
 	// cron triggers.
 	Limit int `q:"limit"`
+	// ProjectID allows to filter by given project id. Admin required.
+	ProjectID string `q:"project_id"`
+	// AllProjects requests to get executions of all projects. Admin required.
+	AllProjects int `q:"all_projects"`
 }
+
+// ListFilter allows to filter string parameters with different filters.
+// Empty value for Filter checks for equality.
+type ListFilter struct {
+	Filter FilterType
+	Value  string
+}
+
+func (l ListFilter) String() string {
+	if l.Filter != "" {
+		return fmt.Sprintf("%s:%s", l.Filter, l.Value)
+	}
+	return l.Value
+}
+
+// ListDateFilter allows to filter date parameters with different filters.
+// Empty value for Filter checks for equality.
+type ListDateFilter struct {
+	Filter FilterType
+	Value  time.Time
+}
+
+func (l ListDateFilter) String() string {
+	v := l.Value.Format(gophercloud.RFC3339ZNoTNoZ)
+	if l.Filter != "" {
+		return fmt.Sprintf("%s:%s", l.Filter, v)
+	}
+	return v
+}
+
+// FilterType represents a valid filter to use for filtering executions.
+type FilterType string
+
+const (
+	// FilterEQ checks equality.
+	FilterEQ = "eq"
+	// FilterNEQ checks non equality.
+	FilterNEQ = "neq"
+	// FilterIN checks for belonging in a list, comma separated.
+	FilterIN = "in"
+	// FilterNIN checks for values that does not belong from a list, comma separated.
+	FilterNIN = "nin"
+	// FilterGT checks for values strictly greater.
+	FilterGT = "gt"
+	// FilterGTE checks for values greater or equal.
+	FilterGTE = "gte"
+	// FilterLT checks for values strictly lower.
+	FilterLT = "lt"
+	// FilterLTE checks for values lower or equal.
+	FilterLTE = "lte"
+	// FilterHas checks for values that contains the requested parameter.
+	FilterHas = "has"
+)
 
 // ToWorkflowListQuery formats a ListOpts into a query string.
 func (opts ListOpts) ToWorkflowListQuery() (string, error) {
 	q, err := gophercloud.BuildQueryString(opts)
-	return q.String(), err
+	if err != nil {
+		return "", err
+	}
+	params := q.Query()
+
+	if opts.Tags != nil {
+		params.Add("tags", strings.Join(opts.Tags, ","))
+	}
+
+	for queryParam, value := range map[string]fmt.Stringer{
+		"created_at": opts.CreatedAt,
+		"updated_at": opts.UpdatedAt,
+		"name":       opts.Name,
+		"definition": opts.Definition,
+		"namespace":  opts.Namespace,
+	} {
+		if !reflect.ValueOf(value).IsNil() {
+			params.Add(queryParam, value.String())
+		}
+	}
+
+	q = &url.URL{RawQuery: params.Encode()}
+
+	return q.String(), nil
 }
 
 // List performs a call to list cron triggers.

--- a/openstack/workflow/v2/workflows/testing/requests_test.go
+++ b/openstack/workflow/v2/workflows/testing/requests_test.go
@@ -3,6 +3,7 @@ package testing
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 	"reflect"
 	"strings"
 	"testing"
@@ -224,4 +225,32 @@ func TestListWorkflows(t *testing.T) {
 	if pages != 1 {
 		t.Errorf("Expected one page, got %d", pages)
 	}
+}
+
+func TestToWorkflowListQuery(t *testing.T) {
+	for expected, opts := range map[string]*workflows.ListOpts{
+		newValue("tags", `tag1,tag2`): &workflows.ListOpts{
+			Tags: []string{"tag1", "tag2"},
+		},
+		newValue("name", `neq:invalid_name`): &workflows.ListOpts{
+			Name: &workflows.ListFilter{
+				Filter: workflows.FilterNEQ,
+				Value:  "invalid_name",
+			},
+		},
+		newValue("created_at", `gt:2018-01-01 00:00:00`): &workflows.ListOpts{
+			CreatedAt: &workflows.ListDateFilter{
+				Filter: workflows.FilterGT,
+				Value:  time.Date(2018, time.January, 1, 0, 0, 0, 0, time.UTC),
+			},
+		},
+	} {
+		actual, _ := opts.ToWorkflowListQuery()
+		th.AssertEquals(t, expected, actual)
+	}
+}
+func newValue(param, value string) string {
+	v := url.Values{}
+	v.Add(param, value)
+	return "?" + v.Encode()
 }


### PR DESCRIPTION
For #1199

https://github.com/openstack/mistral/blob/master/mistral/api/controllers/v2/workflow.py#L201-L252

Please notice that this is a breaking change with the current API, but impacted code was merged a couple of weeks ago (see #1205).

This allows to filter workflows according to filter accepted by Mistral API.