### PR TITLE
Networking v2 Trunk support - Get Subports

### DIFF
--- a/acceptance/openstack/networking/v2/extensions/trunks/trunks_test.go
+++ b/acceptance/openstack/networking/v2/extensions/trunks/trunks_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gophercloud/gophercloud/acceptance/openstack/networking/v2"
 	"github.com/gophercloud/gophercloud/acceptance/tools"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/trunks"
+	th "github.com/gophercloud/gophercloud/testhelper"
 )
 
 func TestTrunkCRUD(t *testing.T) {
@@ -73,6 +74,14 @@ func TestTrunkCRUD(t *testing.T) {
 	if trunk.Name == updatedTrunk.Name {
 		t.Fatalf("Trunk name was not updated correctly")
 	}
+
+	// Get subports
+	subports, err := trunks.GetSubports(client, trunk.ID).Extract()
+	if err != nil {
+		t.Fatalf("Unable to get subports from the Trunk: %v", err)
+	}
+	th.AssertDeepEquals(t, trunk.Subports[0], subports[0])
+	th.AssertDeepEquals(t, trunk.Subports[1], subports[1])
 
 	tools.PrintResource(t, trunk)
 }

--- a/openstack/networking/v2/extensions/trunks/doc.go
+++ b/openstack/networking/v2/extensions/trunks/doc.go
@@ -95,5 +95,11 @@ Example of updating a Trunk
 		log.Fatal(err)
 	}
 	fmt.Printf("%+v\n", trunk)
+
+Example of showing subports of a Trunk
+
+	trunkID := "c36e7f2e-0c53-4742-8696-aee77c9df159"
+	subports, err := trunks.GetSubports(client, trunkID).Extract()
+	fmt.Printf("%+v\n", subports)
 */
 package trunks

--- a/openstack/networking/v2/extensions/trunks/requests.go
+++ b/openstack/networking/v2/extensions/trunks/requests.go
@@ -134,3 +134,10 @@ func Update(c *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r 
 	})
 	return
 }
+
+func GetSubports(c *gophercloud.ServiceClient, id string) (r GetSubportsResult) {
+	_, r.Err = c.Get(getSubportsURL(c, id), &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}

--- a/openstack/networking/v2/extensions/trunks/results.go
+++ b/openstack/networking/v2/extensions/trunks/results.go
@@ -41,6 +41,12 @@ type UpdateResult struct {
 	commonResult
 }
 
+// GetSubportsResult is the result of a Get request on the trunks subports
+// resource. Call its Extract method to interpret it as a slice of Subport.
+type GetSubportsResult struct {
+	commonResult
+}
+
 type Trunk struct {
 	// Indicates whether the trunk is currently operational. Possible values include
 	// `ACTIVE', `DOWN', `BUILD', 'DEGRADED' or `ERROR'.
@@ -109,4 +115,12 @@ func ExtractTrunks(page pagination.Page) ([]Trunk, error) {
 	}
 	err := (page.(TrunkPage)).ExtractInto(&a)
 	return a.Trunks, err
+}
+
+func (r GetSubportsResult) Extract() ([]Subport, error) {
+	var s struct {
+		Subports []Subport `json:"sub_ports"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Subports, err
 }

--- a/openstack/networking/v2/extensions/trunks/testing/fixtures.go
+++ b/openstack/networking/v2/extensions/trunks/testing/fixtures.go
@@ -210,6 +210,22 @@ const UpdateResponse = `
   }
 }`
 
+const ListSubportsResponse = `
+{
+  "sub_ports": [
+    {
+      "port_id": "28e452d7-4f8a-4be4-b1e6-7f3db4c0430b",
+      "segmentation_id": 1,
+      "segmentation_type": "vlan"
+    },
+    {
+      "port_id": "4c8b2bff-9824-4d4c-9b60-b3f6621b2bab",
+      "segmentation_id": 2,
+      "segmentation_type": "vlan"
+    }
+  ]
+}`
+
 var ExpectedSubports = []trunks.Subport{
 	{
 		PortID:           "28e452d7-4f8a-4be4-b1e6-7f3db4c0430b",

--- a/openstack/networking/v2/extensions/trunks/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/trunks/testing/requests_test.go
@@ -193,3 +193,24 @@ func TestUpdate(t *testing.T) {
 	th.AssertEquals(t, n.AdminStateUp, iFalse)
 	th.AssertEquals(t, n.Description, description)
 }
+
+func TestGetSubports(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/trunks/f6a9718c-5a64-43e3-944f-4deccad8e78c/get_subports", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, ListSubportsResponse)
+	})
+
+	client := fake.ServiceClient()
+
+	subports, err := trunks.GetSubports(client, "f6a9718c-5a64-43e3-944f-4deccad8e78c").Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, ExpectedSubports, subports)
+}

--- a/openstack/networking/v2/extensions/trunks/urls.go
+++ b/openstack/networking/v2/extensions/trunks/urls.go
@@ -31,3 +31,7 @@ func getURL(c *gophercloud.ServiceClient, id string) string {
 func updateURL(c *gophercloud.ServiceClient, id string) string {
 	return resourceURL(c, id)
 }
+
+func getSubportsURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL(resourcePath, id, "get_subports")
+}


### PR DESCRIPTION
This patch adds the Networking extension trunk support for the
GetSubports operation.

Signed-off-by: Antoni Segura Puimedon <celebdor@gmail.com>

For #1257 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/neutron/blob/master/neutron/services/trunk/plugin.py#L388-L391
https://github.com/openstack/neutron/blob/master/neutron/services/trunk/models.py#L52-L69
