### PR TITLE
Add Tags to resources that support std-attributes-tags

### DIFF
--- a/acceptance/openstack/networking/v2/extensions/attributestags_test.go
+++ b/acceptance/openstack/networking/v2/extensions/attributestags_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gophercloud/gophercloud/acceptance/clients"
 	networking "github.com/gophercloud/gophercloud/acceptance/openstack/networking/v2"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/attributestags"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
 	th "github.com/gophercloud/gophercloud/testhelper"
 )
 
@@ -28,6 +29,13 @@ func TestTags(t *testing.T) {
 	tags, err := attributestags.ReplaceAll(client, "networks", network.ID, tagReplaceAllOpts).Extract()
 	th.AssertNoErr(t, err)
 	sort.Strings(tags) // Ensure ordering, older OpenStack versions aren't sorted...
+	th.AssertDeepEquals(t, []string{"a", "b", "c"}, tags)
+
+	// Verify the tags are also set in the object Get response
+	gnetwork, err := networks.Get(client, network.ID).Extract()
+	th.AssertNoErr(t, err)
+	tags = gnetwork.Tags
+	sort.Strings(tags)
 	th.AssertDeepEquals(t, []string{"a", "b", "c"}, tags)
 
 	// Add a tag

--- a/acceptance/openstack/networking/v2/extensions/attributestags_test.go
+++ b/acceptance/openstack/networking/v2/extensions/attributestags_test.go
@@ -3,6 +3,7 @@
 package extensions
 
 import (
+	"sort"
 	"testing"
 
 	"github.com/gophercloud/gophercloud/acceptance/clients"
@@ -21,13 +22,13 @@ func TestTags(t *testing.T) {
 	defer networking.DeleteNetwork(t, client, network.ID)
 
 	tagReplaceAllOpts := attributestags.ReplaceAllOpts{
-		// Note Neutron returns tags sorted, and although the API
-		// docs say list of tags, it's a set e.g no duplicates
+		// docs say list of tags, but it's a set e.g no duplicates
 		Tags: []string{"a", "b", "c"},
 	}
 	tags, err := attributestags.ReplaceAll(client, "networks", network.ID, tagReplaceAllOpts).Extract()
 	th.AssertNoErr(t, err)
-	th.AssertDeepEquals(t, tags, []string{"a", "b", "c"})
+	sort.Strings(tags) // Ensure ordering, older OpenStack versions aren't sorted...
+	th.AssertDeepEquals(t, []string{"a", "b", "c"}, tags)
 
 	// Add a tag
 	err = attributestags.Add(client, "networks", network.ID, "d").ExtractErr()
@@ -40,12 +41,13 @@ func TestTags(t *testing.T) {
 	// Verify expected tags are set in the List response
 	tags, err = attributestags.List(client, "networks", network.ID).Extract()
 	th.AssertNoErr(t, err)
-	th.AssertDeepEquals(t, tags, []string{"b", "c", "d"})
+	sort.Strings(tags)
+	th.AssertDeepEquals(t, []string{"b", "c", "d"}, tags)
 
 	// Delete all tags
 	err = attributestags.DeleteAll(client, "networks", network.ID).ExtractErr()
 	th.AssertNoErr(t, err)
 	tags, err = attributestags.List(client, "networks", network.ID).Extract()
 	th.AssertNoErr(t, err)
-	th.AssertDeepEquals(t, tags, []string{})
+	th.AssertEquals(t, 0, len(tags))
 }

--- a/openstack/networking/v2/extensions/layer3/floatingips/results.go
+++ b/openstack/networking/v2/extensions/layer3/floatingips/results.go
@@ -42,6 +42,9 @@ type FloatingIP struct {
 
 	// RouterID is the ID of the router used for this floating IP.
 	RouterID string `json:"router_id"`
+
+	// Tags optionally set via extensions/attributestags
+	Tags []string `json:"tags"`
 }
 
 type commonResult struct {

--- a/openstack/networking/v2/extensions/layer3/routers/results.go
+++ b/openstack/networking/v2/extensions/layer3/routers/results.go
@@ -67,6 +67,9 @@ type Router struct {
 	// Availability zone hints groups network nodes that run services like DHCP, L3, FW, and others.
 	// Used to make network resources highly available.
 	AvailabilityZoneHints []string `json:"availability_zone_hints"`
+
+	// Tags optionally set via extensions/attributestags
+	Tags []string `json:"tags"`
 }
 
 // RouterPage is the page returned by a pager when traversing over a

--- a/openstack/networking/v2/extensions/rbacpolicies/results.go
+++ b/openstack/networking/v2/extensions/rbacpolicies/results.go
@@ -69,6 +69,9 @@ type RBACPolicy struct {
 
 	// ProjectID is the ID of the project.
 	ProjectID string `json:"project_id"`
+
+	// Tags optionally set via extensions/attributestags
+	Tags []string `json:"tags"`
 }
 
 // RBACPolicyPage is the page returned by a pager when traversing over a

--- a/openstack/networking/v2/extensions/security/groups/results.go
+++ b/openstack/networking/v2/extensions/security/groups/results.go
@@ -27,6 +27,9 @@ type SecGroup struct {
 
 	// ProjectID is the project owner of the security group.
 	ProjectID string `json:"project_id"`
+
+	// Tags optionally set via extensions/attributestags
+	Tags []string `json:"tags"`
 }
 
 // SecGroupPage is the page returned by a pager when traversing over a

--- a/openstack/networking/v2/extensions/subnetpools/results.go
+++ b/openstack/networking/v2/extensions/subnetpools/results.go
@@ -111,6 +111,9 @@ type SubnetPool struct {
 
 	// RevisionNumber is the revision number of the subnetpool.
 	RevisionNumber int `json:"revision_number"`
+
+	// Tags optionally set via extensions/attributestags
+	Tags []string `json:"tags"`
 }
 
 func (r *SubnetPool) UnmarshalJSON(b []byte) error {

--- a/openstack/networking/v2/networks/results.go
+++ b/openstack/networking/v2/networks/results.go
@@ -76,6 +76,9 @@ type Network struct {
 	// Availability zone hints groups network nodes that run services like DHCP, L3, FW, and others.
 	// Used to make network resources highly available.
 	AvailabilityZoneHints []string `json:"availability_zone_hints"`
+
+	// Tags optionally set via extensions/attributestags
+	Tags []string `json:"tags"`
 }
 
 // NetworkPage is the page returned by a pager when traversing over a

--- a/openstack/networking/v2/ports/results.go
+++ b/openstack/networking/v2/ports/results.go
@@ -101,6 +101,9 @@ type Port struct {
 
 	// Identifies the list of IP addresses the port will recognize/accept
 	AllowedAddressPairs []AddressPair `json:"allowed_address_pairs"`
+
+	// Tags optionally set via extensions/attributestags
+	Tags []string `json:"tags"`
 }
 
 // PortPage is the page returned by a pager when traversing over a collection

--- a/openstack/networking/v2/subnets/results.go
+++ b/openstack/networking/v2/subnets/results.go
@@ -106,6 +106,9 @@ type Subnet struct {
 
 	// SubnetPoolID is the id of the subnet pool associated with the subnet.
 	SubnetPoolID string `json:"subnetpool_id"`
+
+	// Tags optionally set via extensions/attributestags
+	Tags []string `json:"tags"`
 }
 
 // SubnetPage is the page returned by a pager when traversing over a collection


### PR DESCRIPTION
Since we added the ability to set resource tags via the attributestags
extensione, it is helpful to expose those tags as they are included
in the GET response for resources that support tagging ref:

https://docs.openstack.org/neutron/pike/contributor/internals/tag.html

Issue: #1285

Edit adding links to show the resources which have tag_support = True:

Router: https://github.com/openstack/neutron/blob/master/neutron/db/models/l3.py#L67
FloatingIP: https://github.com/openstack/neutron/blob/master/neutron/db/models/l3.py#L112
SecurityGroup: https://github.com/openstack/neutron/blob/master/neutron/db/models/securitygroup.py#L32
Port: https://github.com/openstack/neutron/blob/master/neutron/db/models_v2.py#L115
Subnet: https://github.com/openstack/neutron/blob/master/neutron/db/models_v2.py#L210
SubnetPool: https://github.com/openstack/neutron/blob/master/neutron/db/models_v2.py#L250
Network: https://github.com/openstack/neutron/blob/master/neutron/db/models_v2.py#L278
QoS/RBAC Policy: https://github.com/openstack/neutron/blob/master/neutron/db/qos/models.py#L36
Trunk: https://github.com/openstack/neutron/blob/master/neutron/services/trunk/models.py#L49

