### PR TITLE
Adds support for FindStack by stack_name or stack_id

### DIFF
--- a/openstack/orchestration/v1/stacks/doc.go
+++ b/openstack/orchestration/v1/stacks/doc.go
@@ -111,6 +111,18 @@ Example for Get Stack
     }
     fmt.Println("Get Stack: Name: ", stack.Name, ", ID: ", stack.ID, ", Status: ", stack.Status)
 
+Example for Find Stack
+
+	find_result  := stacks.Find(client, stackIdentity)
+	if find_result.Err != nil {
+		panic(find_result.Err)
+	}
+	stack, err := find_result.Extract()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("Find Stack: Name: ", stack.Name, ", ID: ", stack.ID, ", Status: ", stack.Status)
+
 Example for Delete Stack
 
     del_r := stacks.Delete(client, stackName, created_stack.ID)

--- a/openstack/orchestration/v1/stacks/requests.go
+++ b/openstack/orchestration/v1/stacks/requests.go
@@ -259,6 +259,12 @@ func Get(c *gophercloud.ServiceClient, stackName, stackID string) (r GetResult) 
 	return
 }
 
+// Find retrieves a stack based on the stack name or stack ID.
+func Find(c *gophercloud.ServiceClient, stackIdentity string) (r GetResult) {
+	_, r.Err =  c.Get(findURL(c, stackIdentity), &r.Body, nil)
+	return
+}
+
 // UpdateOptsBuilder is the interface options structs have to satisfy in order
 // to be used in the Update operation in this package.
 type UpdateOptsBuilder interface {

--- a/openstack/orchestration/v1/stacks/testing/fixtures.go
+++ b/openstack/orchestration/v1/stacks/testing/fixtures.go
@@ -223,6 +223,18 @@ func HandleGetSuccessfully(t *testing.T, output string) {
 	})
 }
 
+func HandleFindSuccessfully(t *testing.T, output string) {
+	th.Mux.HandleFunc("/stacks/16ef0584-4458-41eb-87c8-0dc8d5f66c87", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, output)
+	})
+}
+
 // HandleUpdateSuccessfully creates an HTTP handler at `/stacks/postman_stack/16ef0584-4458-41eb-87c8-0dc8d5f66c87`
 // on the test handler mux that responds with an `Update` response.
 func HandleUpdateSuccessfully(t *testing.T) {

--- a/openstack/orchestration/v1/stacks/testing/requests_test.go
+++ b/openstack/orchestration/v1/stacks/testing/requests_test.go
@@ -139,6 +139,18 @@ func TestGetStack(t *testing.T) {
 	th.AssertDeepEquals(t, expected, actual)
 }
 
+func TestFindStack(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleFindSuccessfully(t, GetOutput)
+
+	actual, err := stacks.Find(fake.ServiceClient(), "16ef0584-4458-41eb-87c8-0dc8d5f66c87").Extract()
+	th.AssertNoErr(t, err)
+
+	expected := GetExpected
+	th.AssertDeepEquals(t, expected, actual)
+}
+
 func TestUpdateStack(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()

--- a/openstack/orchestration/v1/stacks/urls.go
+++ b/openstack/orchestration/v1/stacks/urls.go
@@ -18,6 +18,10 @@ func getURL(c *gophercloud.ServiceClient, name, id string) string {
 	return c.ServiceURL("stacks", name, id)
 }
 
+func findURL(c *gophercloud.ServiceClient, identity string) string {
+	return c.ServiceURL("stacks", identity)
+}
+
 func updateURL(c *gophercloud.ServiceClient, name, id string) string {
 	return getURL(c, name, id)
 }


### PR DESCRIPTION
For #[1157 ](https://github.com/gophercloud/gophercloud/issues/1157)

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

[Openstack API Doc](https://developer.openstack.org/api-ref/orchestration/v1/index.html#find-stack)
['Lookup' stack route](https://github.com/openstack/heat/blob/master/heat/api/openstack/v1/__init__.py#L157)
['Lookup' implementation](https://github.com/openstack/heat/blob/master/heat/api/openstack/v1/stacks.py#L421)
[RPC client](https://github.com/openstack/heat/blob/master/heat/rpc/client.py#L128)
[Service](https://github.com/openstack/heat/blob/master/heat/engine/service.py#L480)
[object layer](https://github.com/openstack/heat/blob/master/heat/objects/stack.py#L117)
[db](https://github.com/openstack/heat/blob/master/heat/db/sqlalchemy/api.py#L567)


This implements the basic "Find" (GET) operation for an orchestration stack, allowing for a lookup by stack name or stack id.


