### PR TITLE
Networking v2 Trunk support - AddSubports

### DIFF
--- a/acceptance/openstack/networking/v2/extensions/trunks/trunks_test.go
+++ b/acceptance/openstack/networking/v2/extensions/trunks/trunks_test.go
@@ -106,3 +106,72 @@ func TestTrunkList(t *testing.T) {
 		tools.PrintResource(t, trunk)
 	}
 }
+
+func TestTrunkSubportOperation(t *testing.T) {
+	client, err := clients.NewNetworkV2Client()
+	if err != nil {
+		t.Fatalf("Unable to create a network client: %v", err)
+	}
+
+	// Create Network
+	network, err := v2.CreateNetwork(t, client)
+	if err != nil {
+		t.Fatalf("Unable to create network: %v", err)
+	}
+	defer v2.DeleteNetwork(t, client, network.ID)
+
+	// Create Subnet
+	subnet, err := v2.CreateSubnet(t, client, network.ID)
+	if err != nil {
+		t.Fatalf("Unable to create subnet: %v", err)
+	}
+	defer v2.DeleteSubnet(t, client, subnet.ID)
+
+	// Create port
+	parentPort, err := v2.CreatePort(t, client, network.ID, subnet.ID)
+	if err != nil {
+		t.Fatalf("Unable to create port: %v", err)
+	}
+	defer v2.DeletePort(t, client, parentPort.ID)
+
+	subport1, err := v2.CreatePort(t, client, network.ID, subnet.ID)
+	if err != nil {
+		t.Fatalf("Unable to create port: %v", err)
+	}
+	defer v2.DeletePort(t, client, subport1.ID)
+
+	subport2, err := v2.CreatePort(t, client, network.ID, subnet.ID)
+	if err != nil {
+		t.Fatalf("Unable to create port: %v", err)
+	}
+	defer v2.DeletePort(t, client, subport2.ID)
+
+	trunk, err := CreateTrunk(t, client, parentPort.ID)
+	if err != nil {
+		t.Fatalf("Unable to create trunk: %v", err)
+	}
+	defer DeleteTrunk(t, client, trunk.ID)
+
+	// Add subports to the trunk
+	addSubportsOpts := trunks.AddSubportsOpts{
+		Subports: []trunks.Subport{
+			{
+				SegmentationID:   1,
+				SegmentationType: "vlan",
+				PortID:           subport1.ID,
+			},
+			{
+				SegmentationID:   11,
+				SegmentationType: "vlan",
+				PortID:           subport2.ID,
+			},
+		},
+	}
+	updatedTrunk, err := trunks.AddSubports(client, trunk.ID, addSubportsOpts).Extract()
+	if err != nil {
+		t.Fatalf("Unable to add subports to the Trunk: %v", err)
+	}
+	th.AssertEquals(t, 2, len(updatedTrunk.Subports))
+	th.AssertDeepEquals(t, addSubportsOpts.Subports[0], updatedTrunk.Subports[0])
+	th.AssertDeepEquals(t, addSubportsOpts.Subports[1], updatedTrunk.Subports[1])
+}

--- a/openstack/networking/v2/extensions/trunks/doc.go
+++ b/openstack/networking/v2/extensions/trunks/doc.go
@@ -101,5 +101,28 @@ Example of showing subports of a Trunk
 	trunkID := "c36e7f2e-0c53-4742-8696-aee77c9df159"
 	subports, err := trunks.GetSubports(client, trunkID).Extract()
 	fmt.Printf("%+v\n", subports)
+
+Example of adding two subports to a Trunk
+
+	trunkID := "c36e7f2e-0c53-4742-8696-aee77c9df159"
+	addSubportsOpts := trunks.AddSubportsOpts{
+		Subports: []trunks.Subport{
+			{
+				SegmentationID:   1,
+				SegmentationType: "vlan",
+				PortID:           "bf4efcc0-b1c7-4674-81f0-31f58a33420a",
+			},
+			{
+				SegmentationID:   10,
+				SegmentationType: "vlan",
+				PortID:           "2cf671b9-02b3-4121-9e85-e0af3548d112",
+			},
+		},
+	}
+	trunk, err := trunks.AddSubports(client, trunkID, addSubportsOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("%+v\n", trunk)
 */
 package trunks

--- a/openstack/networking/v2/extensions/trunks/requests.go
+++ b/openstack/networking/v2/extensions/trunks/requests.go
@@ -141,3 +141,27 @@ func GetSubports(c *gophercloud.ServiceClient, id string) (r GetSubportsResult) 
 	})
 	return
 }
+
+type AddSubportsOpts struct {
+	Subports []Subport `json:"sub_ports" required:"true"`
+}
+
+type AddSubportsOptsBuilder interface {
+	ToTrunkAddSubportsMap() (map[string]interface{}, error)
+}
+
+func (opts AddSubportsOpts) ToTrunkAddSubportsMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "")
+}
+
+func AddSubports(c *gophercloud.ServiceClient, id string, opts AddSubportsOptsBuilder) (r UpdateSubportsResult) {
+	body, err := opts.ToTrunkAddSubportsMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Put(addSubportsURL(c, id), body, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}

--- a/openstack/networking/v2/extensions/trunks/results.go
+++ b/openstack/networking/v2/extensions/trunks/results.go
@@ -47,6 +47,12 @@ type GetSubportsResult struct {
 	commonResult
 }
 
+// UpdateSubportsResult is the result of either an AddSubports or a RemoveSubports
+// request. Call its Extract method to interpret it as a Trunk.
+type UpdateSubportsResult struct {
+	commonResult
+}
+
 type Trunk struct {
 	// Indicates whether the trunk is currently operational. Possible values include
 	// `ACTIVE', `DOWN', `BUILD', 'DEGRADED' or `ERROR'.
@@ -123,4 +129,9 @@ func (r GetSubportsResult) Extract() ([]Subport, error) {
 	}
 	err := r.ExtractInto(&s)
 	return s.Subports, err
+}
+
+func (r UpdateSubportsResult) Extract() (t *Trunk, err error) {
+	err = r.ExtractInto(&t)
+	return
 }

--- a/openstack/networking/v2/extensions/trunks/testing/fixtures.go
+++ b/openstack/networking/v2/extensions/trunks/testing/fixtures.go
@@ -226,6 +226,36 @@ const ListSubportsResponse = `
   ]
 }`
 
+const AddSubportsRequest = ListSubportsResponse
+
+const AddSubportsResponse = `
+{
+  "admin_state_up": true,
+  "created_at": "2018-10-03T13:57:24Z",
+  "description": "Trunk created by gophercloud",
+  "id": "f6a9718c-5a64-43e3-944f-4deccad8e78c",
+  "name": "gophertrunk",
+  "port_id": "c373d2fa-3d3b-4492-924c-aff54dea19b6",
+  "project_id": "e153f3f9082240a5974f667cfe1036e3",
+  "revision_number": 2,
+  "status": "ACTIVE",
+  "sub_ports": [
+    {
+      "port_id": "28e452d7-4f8a-4be4-b1e6-7f3db4c0430b",
+      "segmentation_id": 1,
+      "segmentation_type": "vlan"
+    },
+    {
+      "port_id": "4c8b2bff-9824-4d4c-9b60-b3f6621b2bab",
+      "segmentation_id": 2,
+      "segmentation_type": "vlan"
+    }
+  ],
+  "tags": [],
+  "tenant_id": "e153f3f9082240a5974f667cfe1036e3",
+  "updated_at": "2018-10-03T13:57:30Z"
+}`
+
 var ExpectedSubports = []trunks.Subport{
 	{
 		PortID:           "28e452d7-4f8a-4be4-b1e6-7f3db4c0430b",
@@ -296,5 +326,17 @@ func ExpectedTrunkSlice() (exp []trunks.Trunk, err error) {
 		CreatedAt:      trunk2CreatedAt,
 		UpdatedAt:      trunk2UpdatedAt,
 	}
+	return
+}
+
+func ExpectedSubportsAddedTrunk() (exp trunks.Trunk, err error) {
+	trunkUpdatedAt, err := time.Parse(time.RFC3339, "2018-10-03T13:57:30Z")
+	expectedTrunks, err := ExpectedTrunkSlice()
+	if err != nil {
+		return
+	}
+	exp = expectedTrunks[1]
+	exp.RevisionNumber += 1
+	exp.UpdatedAt = trunkUpdatedAt
 	return
 }

--- a/openstack/networking/v2/extensions/trunks/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/trunks/testing/requests_test.go
@@ -244,3 +244,31 @@ func TestMissingFields(t *testing.T) {
 		t.Fatalf("Failed to detect missing subport fields")
 	}
 }
+
+func TestAddSubports(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/trunks/f6a9718c-5a64-43e3-944f-4deccad8e78c/add_subports", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, AddSubportsRequest)
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, AddSubportsResponse)
+	})
+
+	client := fake.ServiceClient()
+
+	opts := trunks.AddSubportsOpts{
+		Subports: ExpectedSubports,
+	}
+
+	trunk, err := trunks.AddSubports(client, "f6a9718c-5a64-43e3-944f-4deccad8e78c", opts).Extract()
+	th.AssertNoErr(t, err)
+	expectedTrunk, err := ExpectedSubportsAddedTrunk()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, &expectedTrunk, trunk)
+}

--- a/openstack/networking/v2/extensions/trunks/urls.go
+++ b/openstack/networking/v2/extensions/trunks/urls.go
@@ -35,3 +35,7 @@ func updateURL(c *gophercloud.ServiceClient, id string) string {
 func getSubportsURL(c *gophercloud.ServiceClient, id string) string {
 	return c.ServiceURL(resourcePath, id, "get_subports")
 }
+
+func addSubportsURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL(resourcePath, id, "add_subports")
+}


### PR DESCRIPTION
This patch adds the Networking extension trunk support for the
AddSubports operation.

Signed-off-by: Antoni Segura Puimedon <celebdor@gmail.com>

For #1257 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/neutron/blob/master/neutron/services/trunk/plugin.py#L283-L333
https://github.com/openstack/neutron/blob/master/neutron/services/trunk/models.py#L52-L69
