### PR TITLE
Networking v2 Trunk support - RemoveSubports

### DIFF
--- a/acceptance/openstack/networking/v2/extensions/trunks/trunks_test.go
+++ b/acceptance/openstack/networking/v2/extensions/trunks/trunks_test.go
@@ -174,4 +174,17 @@ func TestTrunkSubportOperation(t *testing.T) {
 	th.AssertEquals(t, 2, len(updatedTrunk.Subports))
 	th.AssertDeepEquals(t, addSubportsOpts.Subports[0], updatedTrunk.Subports[0])
 	th.AssertDeepEquals(t, addSubportsOpts.Subports[1], updatedTrunk.Subports[1])
+
+	// Remove the Subports from the trunk
+	subRemoveOpts := trunks.RemoveSubportsOpts{
+		Subports: []trunks.RemoveSubport{
+			{PortID: subport1.ID},
+			{PortID: subport2.ID},
+		},
+	}
+	updatedAgainTrunk, err := trunks.RemoveSubports(client, trunk.ID, subRemoveOpts).Extract()
+	if err != nil {
+		t.Fatalf("Unable to remove subports from the Trunk: %v", err)
+	}
+	th.AssertDeepEquals(t, trunk.Subports, updatedAgainTrunk.Subports)
 }

--- a/openstack/networking/v2/extensions/trunks/doc.go
+++ b/openstack/networking/v2/extensions/trunks/doc.go
@@ -124,5 +124,20 @@ Example of adding two subports to a Trunk
 		panic(err)
 	}
 	fmt.Printf("%+v\n", trunk)
+
+Example of deleting two subports from a Trunk
+
+	trunkID := "c36e7f2e-0c53-4742-8696-aee77c9df159"
+	removeSubportsOpts := trunks.RemoveSubportsOpts{
+		Subports: []trunks.RemoveSubport{
+			{PortID: "bf4efcc0-b1c7-4674-81f0-31f58a33420a"},
+			{PortID: "2cf671b9-02b3-4121-9e85-e0af3548d112"},
+		},
+	}
+	trunk, err := trunks.RemoveSubports(networkClient, trunkID, removeSubportsOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("%+v\n", trunk)
 */
 package trunks

--- a/openstack/networking/v2/extensions/trunks/requests.go
+++ b/openstack/networking/v2/extensions/trunks/requests.go
@@ -165,3 +165,31 @@ func AddSubports(c *gophercloud.ServiceClient, id string, opts AddSubportsOptsBu
 	})
 	return
 }
+
+type RemoveSubport struct {
+	PortID string `json:"port_id" required:"true"`
+}
+
+type RemoveSubportsOpts struct {
+	Subports []RemoveSubport `json:"sub_ports"`
+}
+
+type RemoveSubportsOptsBuilder interface {
+	ToTrunkRemoveSubportsMap() (map[string]interface{}, error)
+}
+
+func (opts RemoveSubportsOpts) ToTrunkRemoveSubportsMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "")
+}
+
+func RemoveSubports(c *gophercloud.ServiceClient, id string, opts RemoveSubportsOptsBuilder) (r UpdateSubportsResult) {
+	body, err := opts.ToTrunkRemoveSubportsMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Put(removeSubportsURL(c, id), body, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}

--- a/openstack/networking/v2/extensions/trunks/testing/fixtures.go
+++ b/openstack/networking/v2/extensions/trunks/testing/fixtures.go
@@ -256,6 +256,35 @@ const AddSubportsResponse = `
   "updated_at": "2018-10-03T13:57:30Z"
 }`
 
+const RemoveSubportsRequest = `
+{
+  "sub_ports": [
+    {
+      "port_id": "28e452d7-4f8a-4be4-b1e6-7f3db4c0430b"
+    },
+    {
+      "port_id": "4c8b2bff-9824-4d4c-9b60-b3f6621b2bab"
+    }
+  ]
+}`
+
+const RemoveSubportsResponse = `
+{
+  "admin_state_up": true,
+  "created_at": "2018-10-03T13:57:24Z",
+  "description": "Trunk created by gophercloud",
+  "id": "f6a9718c-5a64-43e3-944f-4deccad8e78c",
+  "name": "gophertrunk",
+  "port_id": "c373d2fa-3d3b-4492-924c-aff54dea19b6",
+  "project_id": "e153f3f9082240a5974f667cfe1036e3",
+  "revision_number": 2,
+  "status": "ACTIVE",
+  "sub_ports": [],
+  "tags": [],
+  "tenant_id": "e153f3f9082240a5974f667cfe1036e3",
+  "updated_at": "2018-10-03T13:57:27Z"
+}`
+
 var ExpectedSubports = []trunks.Subport{
 	{
 		PortID:           "28e452d7-4f8a-4be4-b1e6-7f3db4c0430b",
@@ -338,5 +367,18 @@ func ExpectedSubportsAddedTrunk() (exp trunks.Trunk, err error) {
 	exp = expectedTrunks[1]
 	exp.RevisionNumber += 1
 	exp.UpdatedAt = trunkUpdatedAt
+	return
+}
+
+func ExpectedSubportsRemovedTrunk() (exp trunks.Trunk, err error) {
+	trunkUpdatedAt, err := time.Parse(time.RFC3339, "2018-10-03T13:57:27Z")
+	expectedTrunks, err := ExpectedTrunkSlice()
+	if err != nil {
+		return
+	}
+	exp = expectedTrunks[1]
+	exp.RevisionNumber += 1
+	exp.UpdatedAt = trunkUpdatedAt
+	exp.Subports = []trunks.Subport{}
 	return
 }

--- a/openstack/networking/v2/extensions/trunks/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/trunks/testing/requests_test.go
@@ -272,3 +272,34 @@ func TestAddSubports(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.CheckDeepEquals(t, &expectedTrunk, trunk)
 }
+
+func TestRemoveSubports(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/trunks/f6a9718c-5a64-43e3-944f-4deccad8e78c/remove_subports", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, RemoveSubportsRequest)
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, RemoveSubportsResponse)
+	})
+
+	client := fake.ServiceClient()
+
+	opts := trunks.RemoveSubportsOpts{
+		Subports: []trunks.RemoveSubport{
+			{PortID: "28e452d7-4f8a-4be4-b1e6-7f3db4c0430b"},
+			{PortID: "4c8b2bff-9824-4d4c-9b60-b3f6621b2bab"},
+		},
+	}
+	trunk, err := trunks.RemoveSubports(client, "f6a9718c-5a64-43e3-944f-4deccad8e78c", opts).Extract()
+
+	th.AssertNoErr(t, err)
+	expectedTrunk, err := ExpectedSubportsRemovedTrunk()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, &expectedTrunk, trunk)
+}

--- a/openstack/networking/v2/extensions/trunks/urls.go
+++ b/openstack/networking/v2/extensions/trunks/urls.go
@@ -39,3 +39,7 @@ func getSubportsURL(c *gophercloud.ServiceClient, id string) string {
 func addSubportsURL(c *gophercloud.ServiceClient, id string) string {
 	return c.ServiceURL(resourcePath, id, "add_subports")
 }
+
+func removeSubportsURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL(resourcePath, id, "remove_subports")
+}


### PR DESCRIPTION
This patch adds the Networking extension trunk support for the
RemoveSubports operation.

Signed-off-by: Antoni Segura Puimedon <celebdor@gmail.com>

For #1257 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:
https://github.com/openstack/neutron/blob/master/neutron/services/trunk/plugin.py#L336-L385
https://github.com/openstack/neutron/blob/master/neutron/services/trunk/models.py#L52-L69
