### PR TITLE
Enable list query by tag for Neutron resources

### DIFF
--- a/acceptance/openstack/networking/v2/extensions/attributestags_test.go
+++ b/acceptance/openstack/networking/v2/extensions/attributestags_test.go
@@ -3,40 +3,49 @@
 package extensions
 
 import (
+	"fmt"
 	"sort"
 	"testing"
 
+	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/acceptance/clients"
 	networking "github.com/gophercloud/gophercloud/acceptance/openstack/networking/v2"
+	"github.com/gophercloud/gophercloud/acceptance/tools"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/attributestags"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
 	th "github.com/gophercloud/gophercloud/testhelper"
 )
+
+func createNetworkWithTags(t *testing.T, client *gophercloud.ServiceClient, tags []string) (network *networks.Network) {
+	// Create Network
+	network, err := networking.CreateNetwork(t, client)
+	th.AssertNoErr(t, err)
+
+	tagReplaceAllOpts := attributestags.ReplaceAllOpts{
+		// docs say list of tags, but it's a set e.g no duplicates
+		Tags: tags,
+	}
+	rtags, err := attributestags.ReplaceAll(client, "networks", network.ID, tagReplaceAllOpts).Extract()
+	th.AssertNoErr(t, err)
+	sort.Strings(rtags) // Ensure ordering, older OpenStack versions aren't sorted...
+	th.AssertDeepEquals(t, rtags, tags)
+
+	// Verify the tags are also set in the object Get response
+	gnetwork, err := networks.Get(client, network.ID).Extract()
+	th.AssertNoErr(t, err)
+	rtags = gnetwork.Tags
+	sort.Strings(rtags)
+	th.AssertDeepEquals(t, rtags, tags)
+	return network
+}
 
 func TestTags(t *testing.T) {
 	client, err := clients.NewNetworkV2Client()
 	th.AssertNoErr(t, err)
 
 	// Create Network
-	network, err := networking.CreateNetwork(t, client)
-	th.AssertNoErr(t, err)
+	network := createNetworkWithTags(t, client, []string{"a", "b", "c"})
 	defer networking.DeleteNetwork(t, client, network.ID)
-
-	tagReplaceAllOpts := attributestags.ReplaceAllOpts{
-		// docs say list of tags, but it's a set e.g no duplicates
-		Tags: []string{"a", "b", "c"},
-	}
-	tags, err := attributestags.ReplaceAll(client, "networks", network.ID, tagReplaceAllOpts).Extract()
-	th.AssertNoErr(t, err)
-	sort.Strings(tags) // Ensure ordering, older OpenStack versions aren't sorted...
-	th.AssertDeepEquals(t, []string{"a", "b", "c"}, tags)
-
-	// Verify the tags are also set in the object Get response
-	gnetwork, err := networks.Get(client, network.ID).Extract()
-	th.AssertNoErr(t, err)
-	tags = gnetwork.Tags
-	sort.Strings(tags)
-	th.AssertDeepEquals(t, []string{"a", "b", "c"}, tags)
 
 	// Add a tag
 	err = attributestags.Add(client, "networks", network.ID, "d").ExtractErr()
@@ -47,7 +56,7 @@ func TestTags(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	// Verify expected tags are set in the List response
-	tags, err = attributestags.List(client, "networks", network.ID).Extract()
+	tags, err := attributestags.List(client, "networks", network.ID).Extract()
 	th.AssertNoErr(t, err)
 	sort.Strings(tags)
 	th.AssertDeepEquals(t, []string{"b", "c", "d"}, tags)
@@ -58,4 +67,58 @@ func TestTags(t *testing.T) {
 	tags, err = attributestags.List(client, "networks", network.ID).Extract()
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, 0, len(tags))
+}
+
+func listNetworkWithTagOpts(t *testing.T, client *gophercloud.ServiceClient, listOpts networks.ListOpts) (ids []string) {
+	allPages, err := networks.List(client, listOpts).AllPages()
+	th.AssertNoErr(t, err)
+	allNetworks, err := networks.ExtractNetworks(allPages)
+	th.AssertNoErr(t, err)
+	for _, network := range allNetworks {
+		ids = append(ids, network.ID)
+	}
+	return ids
+}
+
+func TestQueryByTags(t *testing.T) {
+	client, err := clients.NewNetworkV2Client()
+	th.AssertNoErr(t, err)
+
+	// Create a random tag to ensure we only get networks created
+	// by this test
+	testtag := tools.RandomString("zzz-tag-", 8)
+
+	// Create Networks
+	network1 := createNetworkWithTags(
+		t, client, []string{"a", "b", "c", testtag})
+	defer networking.DeleteNetwork(t, client, network1.ID)
+
+	network2 := createNetworkWithTags(
+		t, client, []string{"b", "c", "d", testtag})
+	defer networking.DeleteNetwork(t, client, network2.ID)
+
+	// Tags - Networks that match all tags will be returned
+	listOpts := networks.ListOpts{
+		Tags: fmt.Sprintf("a,b,c,%s", testtag)}
+	ids := listNetworkWithTagOpts(t, client, listOpts)
+	th.AssertDeepEquals(t, []string{network1.ID}, ids)
+
+	// TagsAny - Networks that match any tag will be returned
+	listOpts = networks.ListOpts{
+		SortKey: "id", SortDir: "asc",
+		TagsAny: fmt.Sprintf("a,b,c,%s", testtag)}
+	ids = listNetworkWithTagOpts(t, client, listOpts)
+	expected_ids := []string{network1.ID, network2.ID}
+	sort.Strings(expected_ids)
+	th.AssertDeepEquals(t, expected_ids, ids)
+
+	// NotTags - Networks that match all tags will be excluded
+	listOpts = networks.ListOpts{Tags: testtag, NotTags: "a,b,c"}
+	ids = listNetworkWithTagOpts(t, client, listOpts)
+	th.AssertDeepEquals(t, []string{network2.ID}, ids)
+
+	// NotTagsAny - Networks that match any tag will be excluded.
+	listOpts = networks.ListOpts{Tags: testtag, NotTagsAny: "d"}
+	ids = listNetworkWithTagOpts(t, client, listOpts)
+	th.AssertDeepEquals(t, []string{network1.ID}, ids)
 }

--- a/openstack/networking/v2/extensions/layer3/floatingips/requests.go
+++ b/openstack/networking/v2/extensions/layer3/floatingips/requests.go
@@ -24,6 +24,10 @@ type ListOpts struct {
 	SortDir           string `q:"sort_dir"`
 	RouterID          string `q:"router_id"`
 	Status            string `q:"status"`
+	Tags              string `q:"tags"`
+	TagsAny           string `q:"tags-any"`
+	NotTags           string `q:"not-tags"`
+	NotTagsAny        string `q:"not-tags-any"`
 }
 
 // List returns a Pager which allows you to iterate over a collection of

--- a/openstack/networking/v2/extensions/layer3/routers/requests.go
+++ b/openstack/networking/v2/extensions/layer3/routers/requests.go
@@ -22,6 +22,10 @@ type ListOpts struct {
 	Marker       string `q:"marker"`
 	SortKey      string `q:"sort_key"`
 	SortDir      string `q:"sort_dir"`
+	Tags         string `q:"tags"`
+	TagsAny      string `q:"tags-any"`
+	NotTags      string `q:"not-tags"`
+	NotTagsAny   string `q:"not-tags-any"`
 }
 
 // List returns a Pager which allows you to iterate over a collection of

--- a/openstack/networking/v2/extensions/rbacpolicies/requests.go
+++ b/openstack/networking/v2/extensions/rbacpolicies/requests.go
@@ -27,6 +27,10 @@ type ListOpts struct {
 	Limit        int          `q:"limit"`
 	SortKey      string       `q:"sort_key"`
 	SortDir      string       `q:"sort_dir"`
+	Tags         string       `q:"tags"`
+	TagsAny      string       `q:"tags-any"`
+	NotTags      string       `q:"not-tags"`
+	NotTagsAny   string       `q:"not-tags-any"`
 }
 
 // ToRBACPolicyListQuery formats a ListOpts into a query string.

--- a/openstack/networking/v2/extensions/security/groups/requests.go
+++ b/openstack/networking/v2/extensions/security/groups/requests.go
@@ -11,14 +11,18 @@ import (
 // sort by a particular network attribute. SortDir sets the direction, and is
 // either `asc' or `desc'. Marker and Limit are used for pagination.
 type ListOpts struct {
-	ID        string `q:"id"`
-	Name      string `q:"name"`
-	TenantID  string `q:"tenant_id"`
-	ProjectID string `q:"project_id"`
-	Limit     int    `q:"limit"`
-	Marker    string `q:"marker"`
-	SortKey   string `q:"sort_key"`
-	SortDir   string `q:"sort_dir"`
+	ID         string `q:"id"`
+	Name       string `q:"name"`
+	TenantID   string `q:"tenant_id"`
+	ProjectID  string `q:"project_id"`
+	Limit      int    `q:"limit"`
+	Marker     string `q:"marker"`
+	SortKey    string `q:"sort_key"`
+	SortDir    string `q:"sort_dir"`
+	Tags       string `q:"tags"`
+	TagsAny    string `q:"tags-any"`
+	NotTags    string `q:"not-tags"`
+	NotTagsAny string `q:"not-tags-any"`
 }
 
 // List returns a Pager which allows you to iterate over a collection of

--- a/openstack/networking/v2/extensions/subnetpools/requests.go
+++ b/openstack/networking/v2/extensions/subnetpools/requests.go
@@ -36,6 +36,10 @@ type ListOpts struct {
 	Marker           string `q:"marker"`
 	SortKey          string `q:"sort_key"`
 	SortDir          string `q:"sort_dir"`
+	Tags             string `q:"tags"`
+	TagsAny          string `q:"tags-any"`
+	NotTags          string `q:"not-tags"`
+	NotTagsAny       string `q:"not-tags-any"`
 }
 
 // ToSubnetPoolListQuery formats a ListOpts into a query string.

--- a/openstack/networking/v2/networks/requests.go
+++ b/openstack/networking/v2/networks/requests.go
@@ -28,6 +28,10 @@ type ListOpts struct {
 	Limit        int    `q:"limit"`
 	SortKey      string `q:"sort_key"`
 	SortDir      string `q:"sort_dir"`
+	Tags         string `q:"tags"`
+	TagsAny      string `q:"tags-any"`
+	NotTags      string `q:"not-tags"`
+	NotTagsAny   string `q:"not-tags-any"`
 }
 
 // ToNetworkListQuery formats a ListOpts into a query string.

--- a/openstack/networking/v2/ports/requests.go
+++ b/openstack/networking/v2/ports/requests.go
@@ -31,6 +31,10 @@ type ListOpts struct {
 	Marker       string `q:"marker"`
 	SortKey      string `q:"sort_key"`
 	SortDir      string `q:"sort_dir"`
+	Tags         string `q:"tags"`
+	TagsAny      string `q:"tags-any"`
+	NotTags      string `q:"not-tags"`
+	NotTagsAny   string `q:"not-tags-any"`
 }
 
 // ToPortListQuery formats a ListOpts into a query string.

--- a/openstack/networking/v2/subnets/requests.go
+++ b/openstack/networking/v2/subnets/requests.go
@@ -33,6 +33,10 @@ type ListOpts struct {
 	Marker          string `q:"marker"`
 	SortKey         string `q:"sort_key"`
 	SortDir         string `q:"sort_dir"`
+	Tags            string `q:"tags"`
+	TagsAny         string `q:"tags-any"`
+	NotTags         string `q:"not-tags"`
+	NotTagsAny      string `q:"not-tags-any"`
 }
 
 // ToSubnetListQuery formats a ListOpts into a query string.


### PR DESCRIPTION
For resources that support std-attribute-tags we can query by tag so
add the ability to do this, with an acceptance test showing the
interface working with Network resources.

Issue: #1289

These neutron code references show the resources which have tag_support = True:

Router: https://github.com/openstack/neutron/blob/master/neutron/db/models/l3.py#L67
FloatingIP: https://github.com/openstack/neutron/blob/master/neutron/db/models/l3.py#L112
SecurityGroup: https://github.com/openstack/neutron/blob/master/neutron/db/models/securitygroup.py#L32
Port: https://github.com/openstack/neutron/blob/master/neutron/db/models_v2.py#L115
Subnet: https://github.com/openstack/neutron/blob/master/neutron/db/models_v2.py#L210
SubnetPool: https://github.com/openstack/neutron/blob/master/neutron/db/models_v2.py#L250
Network: https://github.com/openstack/neutron/blob/master/neutron/db/models_v2.py#L278
QoS/RBAC Policy: https://github.com/openstack/neutron/blob/master/neutron/db/qos/models.py#L36
Trunk: https://github.com/openstack/neutron/blob/master/neutron/services/trunk/models.py#L49

This code shows the API which enables list filtering based on tags:
https://github.com/openstack/neutron/blob/master/neutron/objects/tag.py#L37