### PR TITLE
Fix issues in attributestags acceptance test

### DIFF
--- a/acceptance/openstack/networking/v2/extensions/attributestags_test.go
+++ b/acceptance/openstack/networking/v2/extensions/attributestags_test.go
@@ -3,6 +3,7 @@
 package extensions
 
 import (
+	"sort"
 	"testing"
 
 	"github.com/gophercloud/gophercloud/acceptance/clients"
@@ -21,13 +22,13 @@ func TestTags(t *testing.T) {
 	defer networking.DeleteNetwork(t, client, network.ID)
 
 	tagReplaceAllOpts := attributestags.ReplaceAllOpts{
-		// Note Neutron returns tags sorted, and although the API
-		// docs say list of tags, it's a set e.g no duplicates
+		// docs say list of tags, but it's a set e.g no duplicates
 		Tags: []string{"a", "b", "c"},
 	}
 	tags, err := attributestags.ReplaceAll(client, "networks", network.ID, tagReplaceAllOpts).Extract()
 	th.AssertNoErr(t, err)
-	th.AssertDeepEquals(t, tags, []string{"a", "b", "c"})
+	sort.Strings(tags) // Ensure ordering, older OpenStack versions aren't sorted...
+	th.AssertDeepEquals(t, []string{"a", "b", "c"}, tags)
 
 	// Add a tag
 	err = attributestags.Add(client, "networks", network.ID, "d").ExtractErr()
@@ -40,12 +41,13 @@ func TestTags(t *testing.T) {
 	// Verify expected tags are set in the List response
 	tags, err = attributestags.List(client, "networks", network.ID).Extract()
 	th.AssertNoErr(t, err)
-	th.AssertDeepEquals(t, tags, []string{"b", "c", "d"})
+	sort.Strings(tags)
+	th.AssertDeepEquals(t, []string{"b", "c", "d"}, tags)
 
 	// Delete all tags
 	err = attributestags.DeleteAll(client, "networks", network.ID).ExtractErr()
 	th.AssertNoErr(t, err)
 	tags, err = attributestags.List(client, "networks", network.ID).Extract()
 	th.AssertNoErr(t, err)
-	th.AssertDeepEquals(t, tags, []string{})
+	th.AssertEquals(t, 0, len(tags))
 }


### PR DESCRIPTION
Discussion on #1286 highlighted some issues:

* The order of the DeepEquals is wrong, which means if the actual
  result is an empty list no equivalence is tested
* The DeepEquals can't be used to test the result of DeleteAll, for the same reason
* On older OpenStack versions the tags aren't returned in a sorted order

Closes Issue: #1299
