### PR TITLE
Senlin: Clusters AddNodes

### DIFF
--- a/openstack/clustering/v1/clusters/doc.go
+++ b/openstack/clustering/v1/clusters/doc.go
@@ -223,5 +223,17 @@ Example to Complete Life Cycle
 		panic(err)
 	}
 
+Example to add nodes to a cluster
+
+	addNodesOpts := clusters.AddNodesOpts{
+		Nodes: []string{"node-123"},
+	}
+	clusterID := "b7b870e3-d3c5-4a93-b9d7-846c53b2c2da"
+	actionID, err := clusters.AddNodes(serviceClient, clusterID, addNodesOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+    fmt.Println("action=", actionID)
+
 */
 package clusters

--- a/openstack/clustering/v1/clusters/requests.go
+++ b/openstack/clustering/v1/clusters/requests.go
@@ -523,3 +523,26 @@ func CompleteLifecycle(client *gophercloud.ServiceClient, id string, opts Comple
 
 	return
 }
+
+func (opts AddNodesOpts) ToClusterNodeMap(nodeAction string) (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, nodeAction)
+}
+
+// NodeOpts params
+type AddNodesOpts struct {
+	Nodes []string `json:"nodes" required:"true"`
+}
+
+func AddNodes(client *gophercloud.ServiceClient, id string, opts AddNodesOpts) (r ActionResult) {
+	b, err := opts.ToClusterNodeMap("add_nodes")
+	if err != nil {
+		r.Err = err
+		return
+	}
+	var result *http.Response
+	result, r.Err = client.Post(nodeURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+	})
+	r.Header = result.Header
+	return
+}

--- a/openstack/clustering/v1/clusters/testing/fixtures.go
+++ b/openstack/clustering/v1/clusters/testing/fixtures.go
@@ -622,3 +622,16 @@ func HandleLifecycleSuccessfully(t *testing.T) {
 		fmt.Fprint(w, ActionResponse)
 	})
 }
+
+func HandleAddNodesSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/v1/clusters/7d85f602-a948-4a30-afd4-e84f47471c15/actions", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.Header().Add("X-OpenStack-Request-ID", "req-781e9bdc-4163-46eb-91c9-786c53188bbb")
+		w.WriteHeader(http.StatusAccepted)
+
+		fmt.Fprint(w, ActionResponse)
+	})
+}

--- a/openstack/clustering/v1/clusters/testing/requests_test.go
+++ b/openstack/clustering/v1/clusters/testing/requests_test.go
@@ -426,3 +426,17 @@ func TestLifecycle(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, "2a0ff107-e789-4660-a122-3816c43af703", actionID)
 }
+
+func TestAddNodes(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	HandleAddNodesSuccessfully(t)
+
+	opts := clusters.AddNodesOpts{
+		Nodes: []string{"node1", "node2", "node3"},
+	}
+	result, err := clusters.AddNodes(fake.ServiceClient(), "7d85f602-a948-4a30-afd4-e84f47471c15", opts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, result, "2a0ff107-e789-4660-a122-3816c43af703")
+}

--- a/openstack/clustering/v1/clusters/urls.go
+++ b/openstack/clustering/v1/clusters/urls.go
@@ -44,3 +44,7 @@ func listPoliciesURL(client *gophercloud.ServiceClient, clusterID string) string
 func getPolicyURL(client *gophercloud.ServiceClient, clusterID string, policyID string) string {
 	return client.ServiceURL(apiVersion, apiName, clusterID, "policies", policyID)
 }
+
+func nodeURL(client *gophercloud.ServiceClient, id string) string {
+	return actionURL(client, id)
+}


### PR DESCRIPTION
Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

For #[823 [Add support for Senlin clustering]](https://github.com/gophercloud/gophercloud/issues/823)

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

[[clusters:addnodes]](https://github.com/openstack/senlin/blob/e5bc16b3fea2f10dead365f983c5a937f23d72b0/senlin/api/openstack/v1/clusters.py#L109)
