### PR TITLE
Core: Fix Unchecked Type Assertion

### DIFF
--- a/acceptance/openstack/blockstorage/extensions/volumetenants_test.go
+++ b/acceptance/openstack/blockstorage/extensions/volumetenants_test.go
@@ -1,0 +1,46 @@
+// +build acceptance blockstorage
+
+package extensions
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/acceptance/clients"
+	blockstorage "github.com/gophercloud/gophercloud/acceptance/openstack/blockstorage/v3"
+	"github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/volumetenants"
+	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes"
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestVolumeTenants(t *testing.T) {
+	type volumeWithTenant struct {
+		volumes.Volume
+		volumetenants.VolumeTenantExt
+	}
+
+	var allVolumes []volumeWithTenant
+
+	client, err := clients.NewBlockStorageV3Client()
+	th.AssertNoErr(t, err)
+
+	listOpts := volumes.ListOpts{
+		Name: "I SHOULD NOT EXIST",
+	}
+	allPages, err := volumes.List(client, listOpts).AllPages()
+	th.AssertNoErr(t, err)
+
+	err = volumes.ExtractVolumesInto(allPages, &allVolumes)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, 0, len(allVolumes))
+
+	volume1, err := blockstorage.CreateVolume(t, client)
+	th.AssertNoErr(t, err)
+	defer blockstorage.DeleteVolume(t, client, volume1)
+
+	allPages, err = volumes.List(client, nil).AllPages()
+	th.AssertNoErr(t, err)
+
+	err = volumes.ExtractVolumesInto(allPages, &allVolumes)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, true, len(allVolumes) > 0)
+}


### PR DESCRIPTION
This commit fixes an unchecked type assertion when extracting results
into a slice pointer. The type assertion would previously fail when a
paged result was empty.

For #1269 