### PR TITLE
Senlin: Clusters RemoveNodes

### DIFF
--- a/acceptance/openstack/clustering/v1/clustering.go
+++ b/acceptance/openstack/clustering/v1/clustering.go
@@ -317,12 +317,18 @@ func DeleteCluster(t *testing.T, client *gophercloud.ServiceClient, id string) {
 func DeleteNode(t *testing.T, client *gophercloud.ServiceClient, id string) {
 	t.Logf("Attempting to delete node: %s", id)
 
-	err := nodes.Delete(client, id).ExtractErr()
-	if err != nil {
-		t.Fatalf("Error deleting node %s: %s:", id, err)
+	res := nodes.Delete(client, id)
+	if res.Err != nil {
+		t.Fatalf("Error deleting node %s: %s:", id, res.Err)
 	}
 
-	err = WaitForNodeStatus(client, id, "DELETED")
+	actionID, err := GetActionID(res.Header)
+	if err != nil {
+		t.Fatalf("Error getting actionID %s: %s:", id, err)
+	}
+
+	err = WaitForAction(client, actionID)
+
 	if err != nil {
 		t.Fatalf("Error deleting node %s: %s", id, err)
 	}

--- a/openstack/clustering/v1/clusters/doc.go
+++ b/openstack/clustering/v1/clusters/doc.go
@@ -235,5 +235,16 @@ Example to add nodes to a cluster
 	}
     fmt.Println("action=", actionID)
 
+Example to remove nodes from a cluster
+
+	removeNodesOpts := clusters.RemoveNodesOpts{
+		Nodes: []string{"node-123"},
+	}
+	clusterID := "b7b870e3-d3c5-4a93-b9d7-846c53b2c2da"
+	err := clusters.RemoveNodes(serviceClient, clusterID, removeNodesOpts).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+
 */
 package clusters

--- a/openstack/clustering/v1/clusters/requests.go
+++ b/openstack/clustering/v1/clusters/requests.go
@@ -546,3 +546,25 @@ func AddNodes(client *gophercloud.ServiceClient, id string, opts AddNodesOpts) (
 	r.Header = result.Header
 	return
 }
+
+func (opts RemoveNodesOpts) ToClusterNodeMap(nodeAction string) (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, nodeAction)
+}
+
+type RemoveNodesOpts struct {
+	Nodes []string `json:"nodes" required:"true"`
+}
+
+func RemoveNodes(client *gophercloud.ServiceClient, clusterID string, opts RemoveNodesOpts) (r DeleteResult) {
+	b, err := opts.ToClusterNodeMap("del_nodes")
+	if err != nil {
+		r.Err = err
+		return
+	}
+	var result *http.Response
+	result, r.Err = client.Post(nodeURL(client, clusterID), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+	})
+	r.Header = result.Header
+	return
+}

--- a/openstack/clustering/v1/clusters/requests.go
+++ b/openstack/clustering/v1/clusters/requests.go
@@ -524,17 +524,16 @@ func CompleteLifecycle(client *gophercloud.ServiceClient, id string, opts Comple
 	return
 }
 
-func (opts AddNodesOpts) ToClusterNodeMap(nodeAction string) (map[string]interface{}, error) {
-	return gophercloud.BuildRequestBody(opts, nodeAction)
+func (opts AddNodesOpts) ToClusterAddNodeMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "add_nodes")
 }
 
-// NodeOpts params
 type AddNodesOpts struct {
 	Nodes []string `json:"nodes" required:"true"`
 }
 
 func AddNodes(client *gophercloud.ServiceClient, id string, opts AddNodesOpts) (r ActionResult) {
-	b, err := opts.ToClusterNodeMap("add_nodes")
+	b, err := opts.ToClusterAddNodeMap()
 	if err != nil {
 		r.Err = err
 		return
@@ -547,8 +546,8 @@ func AddNodes(client *gophercloud.ServiceClient, id string, opts AddNodesOpts) (
 	return
 }
 
-func (opts RemoveNodesOpts) ToClusterNodeMap(nodeAction string) (map[string]interface{}, error) {
-	return gophercloud.BuildRequestBody(opts, nodeAction)
+func (opts RemoveNodesOpts) ToClusterRemoveNodeMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "del_nodes")
 }
 
 type RemoveNodesOpts struct {
@@ -556,7 +555,7 @@ type RemoveNodesOpts struct {
 }
 
 func RemoveNodes(client *gophercloud.ServiceClient, clusterID string, opts RemoveNodesOpts) (r DeleteResult) {
-	b, err := opts.ToClusterNodeMap("del_nodes")
+	b, err := opts.ToClusterRemoveNodeMap()
 	if err != nil {
 		r.Err = err
 		return

--- a/openstack/clustering/v1/clusters/testing/fixtures.go
+++ b/openstack/clustering/v1/clusters/testing/fixtures.go
@@ -635,3 +635,14 @@ func HandleAddNodesSuccessfully(t *testing.T) {
 		fmt.Fprint(w, ActionResponse)
 	})
 }
+
+func HandleRemoveNodesSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/v1/clusters/7d85f602-a948-4a30-afd4-e84f47471c15/actions", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.Header().Add("Content-Type", "application/json")
+		w.Header().Add("X-OpenStack-Request-ID", "req-781e9bdc-4163-46eb-91c9-786c53188bbb")
+		w.WriteHeader(http.StatusAccepted)
+		fmt.Fprint(w, ActionResponse)
+	})
+}

--- a/openstack/clustering/v1/clusters/testing/requests_test.go
+++ b/openstack/clustering/v1/clusters/testing/requests_test.go
@@ -440,3 +440,14 @@ func TestAddNodes(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, result, "2a0ff107-e789-4660-a122-3816c43af703")
 }
+
+func TestRemoveNodes(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleRemoveNodesSuccessfully(t)
+	opts := clusters.RemoveNodesOpts{
+		Nodes: []string{"node1", "node2", "node3"},
+	}
+	err := clusters.RemoveNodes(fake.ServiceClient(), "7d85f602-a948-4a30-afd4-e84f47471c15", opts).ExtractErr()
+	th.AssertNoErr(t, err)
+}


### PR DESCRIPTION
Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

For #[823 [Add support for Senlin clustering]](https://github.com/gophercloud/gophercloud/issues/823)

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

[[clusters:removenodes]](https://github.com/openstack/senlin/blob/e5bc16b3fea2f10dead365f983c5a937f23d72b0/senlin/api/openstack/v1/clusters.py#L115)
