### PR TITLE
Blockstorage v2, v3: Implement cascading volume deletion

### DIFF
--- a/acceptance/openstack/blockstorage/extensions/schedulerhints_test.go
+++ b/acceptance/openstack/blockstorage/extensions/schedulerhints_test.go
@@ -29,7 +29,7 @@ func TestSchedulerHints(t *testing.T) {
 
 	err = volumes.WaitForStatus(client, volume1.ID, "available", 60)
 	th.AssertNoErr(t, err)
-	defer volumes.Delete(client, volume1.ID)
+	defer volumes.Delete(client, volume1.ID, volumes.DeleteOpts{})
 
 	volumeName = tools.RandomString("ACPTTEST", 16)
 	base := volumes.CreateOpts{
@@ -54,6 +54,6 @@ func TestSchedulerHints(t *testing.T) {
 	err = volumes.WaitForStatus(client, volume2.ID, "available", 60)
 	th.AssertNoErr(t, err)
 
-	err = volumes.Delete(client, volume2.ID).ExtractErr()
+	err = volumes.Delete(client, volume2.ID, volumes.DeleteOpts{}).ExtractErr()
 	th.AssertNoErr(t, err)
 }

--- a/acceptance/openstack/blockstorage/extensions/volumeactions_test.go
+++ b/acceptance/openstack/blockstorage/extensions/volumeactions_test.go
@@ -108,7 +108,7 @@ func TestVolumeConns(t *testing.T) {
         th.AssertNoErr(t, err)
 
         t.Logf("Deleting volume")
-        err = volumes.Delete(client, cv.ID).ExtractErr()
+        err = volumes.Delete(client, cv.ID, volumes.DeleteOpts{}).ExtractErr()
         th.AssertNoErr(t, err)
     }()
 

--- a/acceptance/openstack/blockstorage/noauth/blockstorage.go
+++ b/acceptance/openstack/blockstorage/noauth/blockstorage.go
@@ -78,7 +78,7 @@ func CreateVolumeFromImage(t *testing.T, client *gophercloud.ServiceClient) (*vo
 // DeleteVolume will delete a volume. A fatal error will occur if the volume
 // failed to be deleted. This works best when used as a deferred function.
 func DeleteVolume(t *testing.T, client *gophercloud.ServiceClient, volume *volumes.Volume) {
-	err := volumes.Delete(client, volume.ID).ExtractErr()
+	err := volumes.Delete(client, volume.ID, volumes.DeleteOpts{}).ExtractErr()
 	if err != nil {
 		t.Fatalf("Unable to delete volume %s: %v", volume.ID, err)
 	}

--- a/acceptance/openstack/blockstorage/v2/blockstorage.go
+++ b/acceptance/openstack/blockstorage/v2/blockstorage.go
@@ -118,7 +118,7 @@ func CreateVolumeFromImage(t *testing.T, client *gophercloud.ServiceClient) (*vo
 func DeleteVolume(t *testing.T, client *gophercloud.ServiceClient, volume *volumes.Volume) {
 	t.Logf("Attempting to delete volume: %s", volume.ID)
 
-	err := volumes.Delete(client, volume.ID).ExtractErr()
+	err := volumes.Delete(client, volume.ID, volumes.DeleteOpts{}).ExtractErr()
 	if err != nil {
 		t.Fatalf("Unable to delete volume %s: %v", volume.ID, err)
 	}

--- a/acceptance/openstack/blockstorage/v2/volumes_test.go
+++ b/acceptance/openstack/blockstorage/v2/volumes_test.go
@@ -5,9 +5,11 @@ package v2
 import (
 	"testing"
 
+	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/acceptance/clients"
 	"github.com/gophercloud/gophercloud/acceptance/tools"
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/volumeactions"
+	"github.com/gophercloud/gophercloud/openstack/blockstorage/v2/snapshots"
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v2/volumes"
 	th "github.com/gophercloud/gophercloud/testhelper"
 )
@@ -58,4 +60,55 @@ func TestVolumesCreateForceDestroy(t *testing.T) {
 
 	err = volumeactions.ForceDelete(client, newVolume.ID).ExtractErr()
 	th.AssertNoErr(t, err)
+}
+
+func TestVolumesCascadeDelete(t *testing.T) {
+	clients.RequireLong(t)
+
+	client, err := clients.NewBlockStorageV3Client()
+	th.AssertNoErr(t, err)
+
+	vol, err := CreateVolume(t, client)
+	th.AssertNoErr(t, err)
+
+	err = volumes.WaitForStatus(client, vol.ID, "available", 60)
+	th.AssertNoErr(t, err)
+
+	snapshot1, err := CreateSnapshot(t, client, vol)
+	th.AssertNoErr(t, err)
+
+	snapshot2, err := CreateSnapshot(t, client, vol)
+	th.AssertNoErr(t, err)
+
+	t.Logf("Attempting to delete volume: %s", vol.ID)
+
+	deleteOpts := volumes.DeleteOpts{Cascade: true}
+	err = volumes.Delete(client, vol.ID, deleteOpts).ExtractErr()
+	if err != nil {
+		t.Fatalf("Unable to delete volume %s: %v", vol.ID, err)
+	}
+
+	for _, sid := range []string{snapshot1.ID, snapshot2.ID} {
+		err := gophercloud.WaitFor(120, func() (bool, error) {
+			_, err := snapshots.Get(client, sid).Extract()
+			if err != nil {
+				return true, nil
+			}
+			return false, nil
+		})
+		th.AssertNoErr(t, err)
+		t.Logf("Successfully deleted snapshot: %s", sid)
+	}
+
+	err = gophercloud.WaitFor(120, func() (bool, error) {
+		_, err := volumes.Get(client, vol.ID).Extract()
+		if err != nil {
+			return true, nil
+		}
+		return false, nil
+	})
+	th.AssertNoErr(t, err)
+
+	t.Logf("Successfully deleted volume: %s", vol.ID)
+
 }

--- a/acceptance/openstack/blockstorage/v3/blockstorage.go
+++ b/acceptance/openstack/blockstorage/v3/blockstorage.go
@@ -130,7 +130,7 @@ func DeleteSnapshot(t *testing.T, client *gophercloud.ServiceClient, snapshot *s
 func DeleteVolume(t *testing.T, client *gophercloud.ServiceClient, volume *volumes.Volume) {
 	t.Logf("Attempting to delete volume: %s", volume.ID)
 
-	err := volumes.Delete(client, volume.ID).ExtractErr()
+	err := volumes.Delete(client, volume.ID, volumes.DeleteOpts{}).ExtractErr()
 	if err != nil {
 		t.Fatalf("Unable to delete volume %s: %v", volume.ID, err)
 	}

--- a/acceptance/openstack/blockstorage/v3/volumes_test.go
+++ b/acceptance/openstack/blockstorage/v3/volumes_test.go
@@ -5,8 +5,10 @@ package v3
 import (
 	"testing"
 
+	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/acceptance/clients"
 	"github.com/gophercloud/gophercloud/acceptance/tools"
+	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/snapshots"
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes"
 	"github.com/gophercloud/gophercloud/pagination"
 	th "github.com/gophercloud/gophercloud/testhelper"
@@ -73,6 +75,57 @@ func TestVolumesMultiAttach(t *testing.T) {
 
 	th.AssertEquals(t, vol.Multiattach, true)
 
-	err = volumes.Delete(client, vol.ID).ExtractErr()
+	err = volumes.Delete(client, vol.ID, volumes.DeleteOpts{}).ExtractErr()
 	th.AssertNoErr(t, err)
+}
+
+func TestVolumesCascadeDelete(t *testing.T) {
+	clients.RequireLong(t)
+
+	client, err := clients.NewBlockStorageV3Client()
+	th.AssertNoErr(t, err)
+
+	vol, err := CreateVolume(t, client)
+	th.AssertNoErr(t, err)
+
+	err = volumes.WaitForStatus(client, vol.ID, "available", 60)
+	th.AssertNoErr(t, err)
+
+	snapshot1, err := CreateSnapshot(t, client, vol)
+	th.AssertNoErr(t, err)
+
+	snapshot2, err := CreateSnapshot(t, client, vol)
+	th.AssertNoErr(t, err)
+
+	t.Logf("Attempting to delete volume: %s", vol.ID)
+
+	deleteOpts := volumes.DeleteOpts{Cascade: true}
+	err = volumes.Delete(client, vol.ID, deleteOpts).ExtractErr()
+	if err != nil {
+		t.Fatalf("Unable to delete volume %s: %v", vol.ID, err)
+	}
+
+	for _, sid := range []string{snapshot1.ID, snapshot2.ID} {
+		err := gophercloud.WaitFor(120, func() (bool, error) {
+			_, err := snapshots.Get(client, sid).Extract()
+			if err != nil {
+				return true, nil
+			}
+			return false, nil
+		})
+		th.AssertNoErr(t, err)
+		t.Logf("Successfully deleted snapshot: %s", sid)
+	}
+
+	err = gophercloud.WaitFor(120, func() (bool, error) {
+		_, err := volumes.Get(client, vol.ID).Extract()
+		if err != nil {
+			return true, nil
+		}
+		return false, nil
+	})
+	th.AssertNoErr(t, err)
+
+	t.Logf("Successfully deleted volume: %s", vol.ID)
+
 }

--- a/openstack/blockstorage/v2/volumes/testing/requests_test.go
+++ b/openstack/blockstorage/v2/volumes/testing/requests_test.go
@@ -220,7 +220,7 @@ func TestDelete(t *testing.T) {
 
 	MockDeleteResponse(t)
 
-	res := volumes.Delete(client.ServiceClient(), "d32019d3-bc6e-4319-9c1d-6722fc136a22")
+	res := volumes.Delete(client.ServiceClient(), "d32019d3-bc6e-4319-9c1d-6722fc136a22", volumes.DeleteOpt{})
 	th.AssertNoErr(t, res.Err)
 }
 

--- a/openstack/blockstorage/v2/volumes/testing/requests_test.go
+++ b/openstack/blockstorage/v2/volumes/testing/requests_test.go
@@ -220,7 +220,7 @@ func TestDelete(t *testing.T) {
 
 	MockDeleteResponse(t)
 
-	res := volumes.Delete(client.ServiceClient(), "d32019d3-bc6e-4319-9c1d-6722fc136a22", volumes.DeleteOpt{})
+	res := volumes.Delete(client.ServiceClient(), "d32019d3-bc6e-4319-9c1d-6722fc136a22", volumes.DeleteOpts{})
 	th.AssertNoErr(t, res.Err)
 }
 

--- a/openstack/blockstorage/v3/volumes/requests.go
+++ b/openstack/blockstorage/v3/volumes/requests.go
@@ -63,9 +63,37 @@ func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r Create
 	return
 }
 
+// DeleteOptsBuilder allows extensions to add additional parameters to the
+// Delete request.
+type DeleteOptsBuilder interface {
+	ToVolumeDeleteQuery() (string, error)
+}
+
+// DeleteOpts contains options for deleting a Volume. This object is passed to
+// the volumes.Delete function.
+type DeleteOpts struct {
+	// Delete all snapshots of this volume as well.
+	Cascade bool `q:"cascade"`
+}
+
+// ToLoadBalancerDeleteQuery formats a DeleteOpts into a query string.
+func (opts DeleteOpts) ToVolumeDeleteQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
 // Delete will delete the existing Volume with the provided ID.
-func Delete(client *gophercloud.ServiceClient, id string) (r DeleteResult) {
-	_, r.Err = client.Delete(deleteURL(client, id), nil)
+func Delete(client *gophercloud.ServiceClient, id string, opts DeleteOptsBuilder) (r DeleteResult) {
+	url := deleteURL(client, id)
+	if opts != nil {
+		query, err := opts.ToVolumeDeleteQuery()
+		if err != nil {
+			r.Err = err
+			return
+		}
+		url += query
+	}
+	_, r.Err = client.Delete(url, nil)
 	return
 }
 

--- a/openstack/blockstorage/v3/volumes/testing/requests_test.go
+++ b/openstack/blockstorage/v3/volumes/testing/requests_test.go
@@ -220,7 +220,7 @@ func TestDelete(t *testing.T) {
 
 	MockDeleteResponse(t)
 
-	res := volumes.Delete(client.ServiceClient(), "d32019d3-bc6e-4319-9c1d-6722fc136a22")
+	res := volumes.Delete(client.ServiceClient(), "d32019d3-bc6e-4319-9c1d-6722fc136a22", volumes.DeleteOpt{})
 	th.AssertNoErr(t, res.Err)
 }
 

--- a/openstack/blockstorage/v3/volumes/testing/requests_test.go
+++ b/openstack/blockstorage/v3/volumes/testing/requests_test.go
@@ -220,7 +220,7 @@ func TestDelete(t *testing.T) {
 
 	MockDeleteResponse(t)
 
-	res := volumes.Delete(client.ServiceClient(), "d32019d3-bc6e-4319-9c1d-6722fc136a22", volumes.DeleteOpt{})
+	res := volumes.Delete(client.ServiceClient(), "d32019d3-bc6e-4319-9c1d-6722fc136a22", volumes.DeleteOpts{})
 	th.AssertNoErr(t, res.Err)
 }
 


### PR DESCRIPTION
For #1309

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

* https://github.com/openstack/cinder/blob/31a885c046a28f795cfc1e83ec5ceca4ef005301/cinder/api/v2/volumes.py#L71
* https://github.com/openstack/cinder/blob/3ef65dfaf3e9f8932c5bbe8cddb1a2a40855f625/cinder/volume/api.py#L379
* https://github.com/openstack/cinder/blob/3ef65dfaf3e9f8932c5bbe8cddb1a2a40855f625/cinder/volume/api.py#L479
* https://developer.openstack.org/api-ref/block-storage/v3/index.html?expanded=delete-a-volume-detail#delete-a-volume