### PR TITLE
Enable neutron trunk extension in integration tests

### DIFF
--- a/.zuul/playbooks/gophercloud-acceptance-test/run.yaml
+++ b/.zuul/playbooks/gophercloud-acceptance-test/run.yaml
@@ -9,6 +9,7 @@
         - 'designate'
         - 'zun'
         - 'octavia'
+        - 'neutron-ext'
     - install-devstack
   tasks:
     - name: Run acceptance tests with gophercloud


### PR DESCRIPTION
Related-Bugs: theopenlab/openlab-zuul-jobs#341
Closes: theopenlab/openlab#92