### PR TITLE
Add DefaultPoolID update support

### DIFF
--- a/openstack/loadbalancer/v2/listeners/requests.go
+++ b/openstack/loadbalancer/v2/listeners/requests.go
@@ -152,6 +152,9 @@ type UpdateOpts struct {
 	// Human-readable name for the Listener. Does not have to be unique.
 	Name string `json:"name,omitempty"`
 
+	// The ID of the default pool with which the Listener is associated.
+	DefaultPoolID *string `json:"default_pool_id,omitempty"`
+
 	// Human-readable description for the Listener.
 	Description string `json:"description,omitempty"`
 

--- a/openstack/networking/v2/extensions/lbaas_v2/listeners/requests.go
+++ b/openstack/networking/v2/extensions/lbaas_v2/listeners/requests.go
@@ -156,6 +156,9 @@ type UpdateOpts struct {
 	// Human-readable name for the Listener. Does not have to be unique.
 	Name string `json:"name,omitempty"`
 
+	// The ID of the default pool with which the Listener is associated.
+	DefaultPoolID *string `json:"default_pool_id,omitempty"`
+
 	// Human-readable description for the Listener.
 	Description string `json:"description,omitempty"`
 


### PR DESCRIPTION
Openstack v2 API supports `default_pool_id` update
https://developer.openstack.org/api-ref/load-balancer/v2/index.html?expanded=update-a-listener-detail#update-a-listener