### PR TITLE
lbaas: l7policies: don't omit invert: bool=false

### DIFF
--- a/openstack/loadbalancer/v2/l7policies/requests.go
+++ b/openstack/loadbalancer/v2/l7policies/requests.go
@@ -306,7 +306,7 @@ type UpdateRuleOpts struct {
 
 	// When true the logic of the rule is inverted. For example, with invert true,
 	// equal to would become not equal to. Default is false.
-	Invert bool `json:"invert,omitempty"`
+	Invert *bool `json:"invert,omitempty"`
 }
 
 // ToRuleUpdateMap builds a request body from UpdateRuleOpts.

--- a/openstack/loadbalancer/v2/l7policies/testing/fixtures.go
+++ b/openstack/loadbalancer/v2/l7policies/testing/fixtures.go
@@ -76,7 +76,7 @@ var (
 		Value:        "/images*",
 		ProjectID:    "e3cd678b11784734bc366148aa37580e",
 		Key:          "",
-		Invert:       false,
+		Invert:       true,
 		AdminStateUp: true,
 	}
 	RuleHostName = l7policies.Rule{
@@ -239,7 +239,7 @@ const SingleRuleBody = `
 {
 	"rule": {
 		"compare_type": "REGEX",
-		"invert": false,
+		"invert": true,
 		"admin_state_up": true,
 		"value": "/images*",
 		"key": null,
@@ -276,7 +276,7 @@ const RulesListBody = `
 	"rules":[
 		{
             "compare_type": "REGEX",
-            "invert": false,
+            "invert": true,
             "admin_state_up": true,
             "value": "/images*",
             "key": null,
@@ -365,6 +365,7 @@ func HandleRuleUpdateSuccessfully(t *testing.T) {
 		th.TestJSONRequest(t, r, `{
 			"rule": {
 				"compare_type": "REGEX",
+				"invert": false,
 				"type": "PATH",
 				"value": "/images/special*"
 			}

--- a/openstack/loadbalancer/v2/l7policies/testing/requests_test.go
+++ b/openstack/loadbalancer/v2/l7policies/testing/requests_test.go
@@ -260,10 +260,12 @@ func TestUpdateRule(t *testing.T) {
 	HandleRuleUpdateSuccessfully(t)
 
 	client := fake.ServiceClient()
+	tmpBool := false
 	actual, err := l7policies.UpdateRule(client, "8a1412f0-4c32-4257-8b07-af4770b604fd", "16621dbb-a736-4888-a57a-3ecd53df784c", l7policies.UpdateRuleOpts{
 		RuleType:    l7policies.TypePath,
 		CompareType: l7policies.CompareTypeRegex,
 		Value:       "/images/special*",
+		Invert:      &tmpBool,
 	}).Extract()
 	if err != nil {
 		t.Fatalf("Unexpected Update error: %v", err)


### PR DESCRIPTION
When the rule was initially created with `invert=true`, it is not possible to update it to `invert=false`, because json engine omits `false` value.