### PR TITLE
core: Revert setting reauth func to nil

### DIFF
--- a/provider_client.go
+++ b/provider_client.go
@@ -126,11 +126,11 @@ func (client *ProviderClient) SetToken(t string) {
 	client.TokenID = t
 }
 
-//Reauthenticate calls client.ReauthFunc in a thread-safe way. If this is
-//called because of a 401 response, the caller may pass the previous token. In
-//this case, the reauthentication can be skipped if another thread has already
-//reauthenticated in the meantime. If no previous token is known, an empty
-//string should be passed instead to force unconditional reauthentication.
+// Reauthenticate calls client.ReauthFunc in a thread-safe way. If this is
+// called because of a 401 response, the caller may pass the previous token. In
+// this case, the reauthentication can be skipped if another thread has already
+// reauthenticated in the meantime. If no previous token is known, an empty
+// string should be passed instead to force unconditional reauthentication.
 func (client *ProviderClient) Reauthenticate(previousToken string) (err error) {
 	if client.ReauthFunc == nil {
 		return nil
@@ -295,11 +295,7 @@ func (client *ProviderClient) Request(method, url string, options *RequestOpts) 
 						seeker.Seek(0, 0)
 					}
 				}
-				// make a new call to request with a nil reauth func in order to avoid infinite loop
-				reauthFunc := client.ReauthFunc
-				client.ReauthFunc = nil
 				resp, err = client.Request(method, url, options)
-				client.ReauthFunc = reauthFunc
 				if err != nil {
 					switch err.(type) {
 					case *ErrUnexpectedResponseCode:


### PR DESCRIPTION
This commit reverts PR #1192. The goal of #1192 was to set the reauth
function to nil when performing reauthentication in order to prevent an
infinite loop. However, this was not done in a concurrent-safe way.
Having reviewed the use-case in more detail, I feel that scenarios in
which this will happen are more site-specific rather than an issue with
Gophercloud and a custom reauth function should be used.

Included in this PR is a simple unit test which verifies that a custom
reauthentication function can be used for these scenarios. However, it's
important to not use this example in production. Rather, users should
use the example provided in the FAQ.

For #1244 
For #1324 