### PR TITLE
[WIP] Senlin: Clusters ReplaceNodes

### DIFF
--- a/openstack/clustering/v1/clusters/doc.go
+++ b/openstack/clustering/v1/clusters/doc.go
@@ -246,5 +246,16 @@ Example to remove nodes from a cluster
 		panic(err)
 	}
 
+Example to replace nodes for a cluster
+
+	replaceNodesOpts := clusters.ReplaceNodesOpts{
+		Nodes: map[string]string{"node-1234": "node-5678"},
+	}
+	clusterID := "b7b870e3-d3c5-4a93-b9d7-846c53b2c2da"
+	actionID, err := clusters.ReplaceNodes(serviceClient, clusterID, replaceNodesOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
 */
 package clusters

--- a/openstack/clustering/v1/clusters/requests.go
+++ b/openstack/clustering/v1/clusters/requests.go
@@ -567,3 +567,25 @@ func RemoveNodes(client *gophercloud.ServiceClient, clusterID string, opts Remov
 	r.Header = result.Header
 	return
 }
+
+func (opts ReplaceNodesOpts) ToClusterReplaceNodeMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "replace_nodes")
+}
+
+type ReplaceNodesOpts struct {
+	Nodes map[string]string `json:"nodes" required:"true"`
+}
+
+func ReplaceNodes(client *gophercloud.ServiceClient, id string, opts ReplaceNodesOpts) (r ActionResult) {
+	b, err := opts.ToClusterReplaceNodeMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	var result *http.Response
+	result, r.Err = client.Post(nodeURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+	})
+	r.Header = result.Header
+	return
+}

--- a/openstack/clustering/v1/clusters/testing/fixtures.go
+++ b/openstack/clustering/v1/clusters/testing/fixtures.go
@@ -646,3 +646,14 @@ func HandleRemoveNodesSuccessfully(t *testing.T) {
 		fmt.Fprint(w, ActionResponse)
 	})
 }
+
+func HandleReplaceNodeSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/v1/clusters/7d85f602-a948-4a30-afd4-e84f47471c15/actions", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.Header().Add("Content-Type", "application/json")
+		w.Header().Add("X-OpenStack-Request-ID", "req-781e9bdc-4163-46eb-91c9-786c53188bbb")
+		w.WriteHeader(http.StatusAccepted)
+		fmt.Fprint(w, ActionResponse)
+	})
+}

--- a/openstack/clustering/v1/clusters/testing/requests_test.go
+++ b/openstack/clustering/v1/clusters/testing/requests_test.go
@@ -451,3 +451,15 @@ func TestRemoveNodes(t *testing.T) {
 	err := clusters.RemoveNodes(fake.ServiceClient(), "7d85f602-a948-4a30-afd4-e84f47471c15", opts).ExtractErr()
 	th.AssertNoErr(t, err)
 }
+
+func TestReplaceNodes(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleReplaceNodeSuccessfully(t)
+	opts := clusters.ReplaceNodesOpts{
+		Nodes: map[string]string{"node-1234": "node-5678"},
+	}
+	actionID, err := clusters.ReplaceNodes(fake.ServiceClient(), "7d85f602-a948-4a30-afd4-e84f47471c15", opts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, actionID, "2a0ff107-e789-4660-a122-3816c43af703")
+}


### PR DESCRIPTION
Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

For #[823 [Add support for Senlin clustering]](https://github.com/gophercloud/gophercloud/issues/823)

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

[[clusters:replacenodes]](https://github.com/openstack/senlin/blob/e5bc16b3fea2f10dead365f983c5a937f23d72b0/senlin/api/openstack/v1/clusters.py#L124)
