### PR TITLE
Only set ResourceBase when we need to

### DIFF
--- a/openstack/client.go
+++ b/openstack/client.go
@@ -3,6 +3,7 @@ package openstack
 import (
 	"fmt"
 	"reflect"
+	"strings"
 
 	"github.com/gophercloud/gophercloud"
 	tokens2 "github.com/gophercloud/gophercloud/openstack/identity/v2/tokens"
@@ -321,7 +322,9 @@ func NewComputeV2(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpt
 // package.
 func NewNetworkV2(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
 	sc, err := initClientOpts(client, eo, "network")
-	sc.ResourceBase = sc.Endpoint + "v2.0/"
+	if !strings.HasSuffix(sc.Endpoint, "v2.0/") {
+		sc.ResourceBase = sc.Endpoint + "v2.0/"
+	}
 	return sc, err
 }
 


### PR DESCRIPTION
I'm having a bit of a time with go eco-system [1], I know PR could be more helpful, but it's all I was able to come up with tonight [2].

1. I got lost in the contributing guide.  Is godep still a thing?  it's dep now, maybe?  only golang 1.12 is all about the modules, right?
2. this is related to terraform-providers/terraform-provider-openstack#498