### PR TITLE
NetworkingV2: add vlan-transparent Create method

### DIFF
--- a/acceptance/openstack/networking/v2/extensions/vlantransparent/vlantransparent.go
+++ b/acceptance/openstack/networking/v2/extensions/vlantransparent/vlantransparent.go
@@ -1,0 +1,13 @@
+package v2
+
+import (
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/vlantransparent"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
+)
+
+// VLANTransparentNetwork represents OpenStack V2 Networking Network with the
+// "vlan-transparent" extension enabled.
+type VLANTransparentNetwork struct {
+	networks.Network
+	vlantransparent.TransparentExt
+}

--- a/acceptance/openstack/networking/v2/extensions/vlantransparent/vlantransparent.go
+++ b/acceptance/openstack/networking/v2/extensions/vlantransparent/vlantransparent.go
@@ -1,6 +1,9 @@
 package v2
 
 import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/vlantransparent"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
 )
@@ -10,4 +13,32 @@ import (
 type VLANTransparentNetwork struct {
 	networks.Network
 	vlantransparent.TransparentExt
+}
+
+// ListVLANTransparentNetworks will list networks with the "vlan-transparent"
+// extension. An error will be returned networks could not be listed.
+func ListVLANTransparentNetworks(t *testing.T, client *gophercloud.ServiceClient) ([]*VLANTransparentNetwork, error) {
+	iTrue := true
+	networkListOpts := networks.ListOpts{}
+	listOpts := vlantransparent.ListOptsExt{
+		ListOptsBuilder: networkListOpts,
+		VLANTransparent: &iTrue,
+	}
+
+	var allNetworks []*VLANTransparentNetwork
+
+	t.Log("Attempting to list VLAN-transparent networks")
+
+	allPages, err := networks.List(client, listOpts).AllPages()
+	if err != nil {
+		return nil, err
+	}
+	err = networks.ExtractNetworksInto(allPages, &allNetworks)
+	if err != nil {
+		return nil, err
+	}
+
+	t.Log("Successfully retrieved networks.")
+
+	return allNetworks, nil
 }

--- a/acceptance/openstack/networking/v2/extensions/vlantransparent/vlantransparent.go
+++ b/acceptance/openstack/networking/v2/extensions/vlantransparent/vlantransparent.go
@@ -4,8 +4,10 @@ import (
 	"testing"
 
 	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/acceptance/tools"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/vlantransparent"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
+	th "github.com/gophercloud/gophercloud/testhelper"
 )
 
 // VLANTransparentNetwork represents OpenStack V2 Networking Network with the
@@ -41,4 +43,34 @@ func ListVLANTransparentNetworks(t *testing.T, client *gophercloud.ServiceClient
 	t.Log("Successfully retrieved networks.")
 
 	return allNetworks, nil
+}
+
+// CreateVLANTransparentNetwork will create a network with the
+// "vlan-transparent" extension. An error will be returned if the network could
+// not be created.
+func CreateVLANTransparentNetwork(t *testing.T, client *gophercloud.ServiceClient) (*VLANTransparentNetwork, error) {
+	networkName := tools.RandomString("TESTACC-", 8)
+	networkCreateOpts := networks.CreateOpts{
+		Name: networkName,
+	}
+
+	iTrue := true
+	createOpts := vlantransparent.CreateOptsExt{
+		CreateOptsBuilder: &networkCreateOpts,
+		VLANTransparent:   &iTrue,
+	}
+
+	t.Logf("Attempting to create a VLAN-transparent network: %s", networkName)
+
+	var network VLANTransparentNetwork
+	err := networks.Create(client, createOpts).ExtractInto(&network)
+	if err != nil {
+		return nil, err
+	}
+
+	t.Logf("Successfully created the network.")
+
+	th.AssertEquals(t, networkName, network.Name)
+
+	return &network, nil
 }

--- a/acceptance/openstack/networking/v2/extensions/vlantransparent/vlantransparent_test.go
+++ b/acceptance/openstack/networking/v2/extensions/vlantransparent/vlantransparent_test.go
@@ -6,21 +6,23 @@ import (
 	"testing"
 
 	"github.com/gophercloud/gophercloud/acceptance/clients"
+	networkingv2 "github.com/gophercloud/gophercloud/acceptance/openstack/networking/v2"
+	"github.com/gophercloud/gophercloud/acceptance/tools"
 	th "github.com/gophercloud/gophercloud/testhelper"
 )
 
 func TestVLANTransparentCRUD(t *testing.T) {
 	t.Skip("We don't have VLAN transparent extension in OpenLab.")
 
-	_, err := clients.NewNetworkV2Client()
+	client, err := clients.NewNetworkV2Client()
 	th.AssertNoErr(t, err)
 
 	// Create a VLAN transparent network.
-	// network, err := CreateVLANTransparentNetwork(t, client)
-	// th.AssertNoErr(t, err)
-	// defer DeleteNetwork(t, client, network.ID)
+	network, err := CreateVLANTransparentNetwork(t, client)
+	th.AssertNoErr(t, err)
+	defer networkingv2.DeleteNetwork(t, client, network.ID)
 
-	// tools.PrintResource(t, network)
+	tools.PrintResource(t, network)
 
 	// Update the created VLAN transparent network.
 	// newNetwork, err := UpdateVLANTransparentNetwork(t, client, network.ID)
@@ -29,15 +31,15 @@ func TestVLANTransparentCRUD(t *testing.T) {
 	// tools.PrintResource(t, newNetwork)
 
 	// Check that the created VLAN transparent network exists.
-	// vlanTransparentNetworks, err := ListVLANTransparentNetworks(t, client)
-	// th.AssertNoErr(t, err)
+	vlanTransparentNetworks, err := ListVLANTransparentNetworks(t, client)
+	th.AssertNoErr(t, err)
 
-	// var found bool
-	// for _, network := range vlanTransparentNetworks {
-	// 	if network.ID == newNetwork.ID {
-	// 		found = true
-	// 	}
-	// }
+	var found bool
+	for _, vlanTransparentNetwork := range vlanTransparentNetworks {
+		if vlanTransparentNetwork.ID == network.ID {
+			found = true
+		}
+	}
 
-	// th.AssertEquals(t, found, true)
+	th.AssertEquals(t, found, true)
 }

--- a/acceptance/openstack/networking/v2/extensions/vlantransparent/vlantransparent_test.go
+++ b/acceptance/openstack/networking/v2/extensions/vlantransparent/vlantransparent_test.go
@@ -1,0 +1,43 @@
+// +build acceptance networking vlantransparent
+
+package v2
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/acceptance/clients"
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestVLANTransparentCRUD(t *testing.T) {
+	t.Skip("We don't have VLAN transparent extension in OpenLab.")
+
+	_, err := clients.NewNetworkV2Client()
+	th.AssertNoErr(t, err)
+
+	// Create a VLAN transparent network.
+	// network, err := CreateVLANTransparentNetwork(t, client)
+	// th.AssertNoErr(t, err)
+	// defer DeleteNetwork(t, client, network.ID)
+
+	// tools.PrintResource(t, network)
+
+	// Update the created VLAN transparent network.
+	// newNetwork, err := UpdateVLANTransparentNetwork(t, client, network.ID)
+	// th.AssertNoErr(t, err)
+
+	// tools.PrintResource(t, newNetwork)
+
+	// Check that the created VLAN transparent network exists.
+	// vlanTransparentNetworks, err := ListVLANTransparentNetworks(t, client)
+	// th.AssertNoErr(t, err)
+
+	// var found bool
+	// for _, network := range vlanTransparentNetworks {
+	// 	if network.ID == newNetwork.ID {
+	// 		found = true
+	// 	}
+	// }
+
+	// th.AssertEquals(t, found, true)
+}

--- a/openstack/networking/v2/extensions/vlantransparent/doc.go
+++ b/openstack/networking/v2/extensions/vlantransparent/doc.go
@@ -39,7 +39,7 @@ Example of Getting a Network with the vlan-transparent extension
 		vlantransparent.TransparentExt
 	}
 
-	err := networks.Get(fake.ServiceClient(), "db193ab3-96e3-4cb3-8fc5-05f4296d0324").ExtractInto(&network)
+	err := networks.Get(networkClient, "db193ab3-96e3-4cb3-8fc5-05f4296d0324").ExtractInto(&network)
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/networking/v2/extensions/vlantransparent/doc.go
+++ b/openstack/networking/v2/extensions/vlantransparent/doc.go
@@ -63,7 +63,7 @@ Example of Creating Network with the vlan-transparent extension
 		vlantransparent.TransparentExt
 	}
 
-	network, err := networks.Create(networkClient, createOpts).ExtractInto(&network)
+	err := networks.Create(networkClient, createOpts).ExtractInto(&network)
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/networking/v2/extensions/vlantransparent/doc.go
+++ b/openstack/networking/v2/extensions/vlantransparent/doc.go
@@ -45,5 +45,29 @@ Example of Getting a Network with the vlan-transparent extension
 	}
 
 	fmt.Println("%+v\n", network)
+
+Example of Creating Network with the vlan-transparent extension
+
+	iTrue := true
+	networkCreateOpts := networks.CreateOpts{
+		Name:         "private",
+	}
+
+	createOpts := vlantransparent.CreateOptsExt{
+		CreateOptsBuilder: &networkCreateOpts,
+		VLANTransparent:   &iTrue,
+	}
+
+	var network struct {
+		networks.Network
+		vlantransparent.TransparentExt
+	}
+
+	network, err := networks.Create(networkClient, createOpts).ExtractInto(&network)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("%+v\n", network)
 */
 package vlantransparent

--- a/openstack/networking/v2/extensions/vlantransparent/doc.go
+++ b/openstack/networking/v2/extensions/vlantransparent/doc.go
@@ -1,0 +1,35 @@
+/*
+Package vlantransparent provides the ability to retrieve and manage networks
+with the vlan-transparent extension through the Neutron API.
+
+Example of Listing Networks with the vlan-transparent extension
+
+    iTrue := true
+    networkListOpts := networks.ListOpts{}
+    listOpts := vlantransparent.ListOptsExt{
+        ListOptsBuilder: networkListOpts,
+        VLANTransparent: &iTrue,
+    }
+
+    type NetworkWithVLANTransparentExt struct {
+        networks.Network
+        vlantransparent.NetworkVLANTransparentExt
+    }
+
+    var allNetworks []NetworkWithVLANTransparentExt
+
+    allPages, err := networks.List(networkClient, listOpts).AllPages()
+    if err != nil {
+        panic(err)
+    }
+
+    err = networks.ExtractNetworksInto(allPages, &allNetworks)
+    if err != nil {
+        panic(err)
+    }
+
+    for _, network := range allNetworks {
+        fmt.Println("%+v\n", network)
+    }
+*/
+package vlantransparent

--- a/openstack/networking/v2/extensions/vlantransparent/doc.go
+++ b/openstack/networking/v2/extensions/vlantransparent/doc.go
@@ -30,6 +30,20 @@ Example of Listing Networks with the vlan-transparent extension
 
     for _, network := range allNetworks {
         fmt.Println("%+v\n", network)
-    }
+	}
+
+Example of Getting a Network with the vlan-transparent extension
+
+	var network struct {
+		networks.Network
+		vlantransparent.TransparentExt
+	}
+
+	err := networks.Get(fake.ServiceClient(), "db193ab3-96e3-4cb3-8fc5-05f4296d0324").ExtractInto(&network)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("%+v\n", network)
 */
 package vlantransparent

--- a/openstack/networking/v2/extensions/vlantransparent/requests.go
+++ b/openstack/networking/v2/extensions/vlantransparent/requests.go
@@ -31,3 +31,29 @@ func (opts ListOptsExt) ToNetworkListQuery() (string, error) {
 	q = &url.URL{RawQuery: params.Encode()}
 	return q.String(), err
 }
+
+// CreateOptsExt is the structure used when creating new vlan-transparent
+// network resources. It embeds networks.CreateOpts and so inherits all of its
+// required and optional fields, with the addition of the VLANTransparent field.
+type CreateOptsExt struct {
+	networks.CreateOptsBuilder
+	VLANTransparent *bool `json:"vlan_transparent,omitempty"`
+}
+
+// ToNetworkCreateMap adds the vlan_transparent option to the base network
+// creation options.
+func (opts CreateOptsExt) ToNetworkCreateMap() (map[string]interface{}, error) {
+	base, err := opts.CreateOptsBuilder.ToNetworkCreateMap()
+	if err != nil {
+		return nil, err
+	}
+
+	if opts.VLANTransparent == nil {
+		return base, nil
+	}
+
+	networkMap := base["network"].(map[string]interface{})
+	networkMap["vlan_transparent"] = opts.VLANTransparent
+
+	return base, nil
+}

--- a/openstack/networking/v2/extensions/vlantransparent/requests.go
+++ b/openstack/networking/v2/extensions/vlantransparent/requests.go
@@ -1,0 +1,33 @@
+package vlantransparent
+
+import (
+	"net/url"
+	"strconv"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
+)
+
+// ListOptsExt adds the vlan-transparent network options to the base ListOpts.
+type ListOptsExt struct {
+	networks.ListOptsBuilder
+	VLANTransparent *bool `q:"vlan_transparent"`
+}
+
+// ToNetworkListQuery adds the vlan_transparent option to the base network
+// list options.
+func (opts ListOptsExt) ToNetworkListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts.ListOptsBuilder)
+	if err != nil {
+		return "", err
+	}
+
+	params := q.Query()
+	if opts.VLANTransparent != nil {
+		v := strconv.FormatBool(*opts.VLANTransparent)
+		params.Add("vlan_transparent", v)
+	}
+
+	q = &url.URL{RawQuery: params.Encode()}
+	return q.String(), err
+}

--- a/openstack/networking/v2/extensions/vlantransparent/results.go
+++ b/openstack/networking/v2/extensions/vlantransparent/results.go
@@ -1,0 +1,8 @@
+package vlantransparent
+
+// TransparentExt represents a decorated form of a network with
+// "vlan-transparent" extension attributes.
+type TransparentExt struct {
+	// VLANTransparent whether the network is a VLAN transparent network or not.
+	VLANTransparent bool `json:"vlan_transparent"`
+}

--- a/openstack/networking/v2/extensions/vlantransparent/testing/doc.go
+++ b/openstack/networking/v2/extensions/vlantransparent/testing/doc.go
@@ -1,0 +1,2 @@
+// vlantransparent extension unit tests
+package testing

--- a/openstack/networking/v2/extensions/vlantransparent/testing/fixtures.go
+++ b/openstack/networking/v2/extensions/vlantransparent/testing/fixtures.go
@@ -40,3 +40,27 @@ const NetworksVLANTransparentListResult = `
         }
     ]
 }`
+
+// NetworksVLANTransparentGetResult represents raw HTTP response for the Get
+// request.
+const NetworksVLANTransparentGetResult = `
+{
+    "network": {
+        "status": "ACTIVE",
+        "subnets": [
+            "08eae331-0402-425a-923c-34f7cfe39c1b"
+        ],
+        "name": "private",
+        "admin_state_up": true,
+        "tenant_id": "26a7980765d0414dbc1fc1f88cdb7e6e",
+        "shared": false,
+        "id": "db193ab3-96e3-4cb3-8fc5-05f4296d0324",
+        "provider:segmentation_id": 1234567890,
+        "provider:physical_network": null,
+        "provider:network_type": "local",
+        "router:external": false,
+        "port_security_enabled": false,
+        "vlan_transparent": true
+    }
+}
+`

--- a/openstack/networking/v2/extensions/vlantransparent/testing/fixtures.go
+++ b/openstack/networking/v2/extensions/vlantransparent/testing/fixtures.go
@@ -1,0 +1,42 @@
+package testing
+
+// NetworksVLANTransparentListResult represents raw HTTP response for the List
+// request.
+const NetworksVLANTransparentListResult = `
+{
+    "networks": [
+        {
+            "status": "ACTIVE",
+            "subnets": [
+                "08eae331-0402-425a-923c-34f7cfe39c1b"
+            ],
+            "name": "private",
+            "admin_state_up": true,
+            "tenant_id": "26a7980765d0414dbc1fc1f88cdb7e6e",
+            "shared": false,
+            "id": "db193ab3-96e3-4cb3-8fc5-05f4296d0324",
+            "provider:segmentation_id": 1234567890,
+            "provider:physical_network": null,
+            "provider:network_type": "local",
+            "router:external": false,
+            "port_security_enabled": false,
+            "vlan_transparent": true
+        },
+        {
+            "status": "ACTIVE",
+            "subnets": [
+                "54d6f61d-db07-451c-9ab3-b9609b6b6f0b"
+            ],
+            "name": "public",
+            "admin_state_up": true,
+            "tenant_id": "4fd44f30292945e481c7b8a0c8908869",
+            "shared": true,
+            "id": "d32019d3-bc6e-4319-9c1d-6722fc136a22",
+            "provider:segmentation_id": 9876543210,
+            "provider:physical_network": null,
+            "provider:network_type": "local",
+            "router:external": true,
+            "port_security_enabled": true
+        }
+    ]
+}`

--- a/openstack/networking/v2/extensions/vlantransparent/testing/fixtures.go
+++ b/openstack/networking/v2/extensions/vlantransparent/testing/fixtures.go
@@ -62,5 +62,38 @@ const NetworksVLANTransparentGetResult = `
         "port_security_enabled": false,
         "vlan_transparent": true
     }
+}`
+
+// NetworksVLANTransparentCreateRequest represents raw HTTP Create request.
+const NetworksVLANTransparentCreateRequest = `
+{
+    "network": {
+        "name": "private",
+        "admin_state_up": true,
+        "vlan_transparent": true
+    }
+}`
+
+// NetworksVLANTransparentCreateResult represents raw HTTP response for the
+// Create request.
+const NetworksVLANTransparentCreateResult = `
+{
+    "network": {
+        "status": "ACTIVE",
+        "subnets": [
+            "08eae331-0402-425a-923c-34f7cfe39c1b"
+        ],
+        "name": "private",
+        "admin_state_up": true,
+        "tenant_id": "26a7980765d0414dbc1fc1f88cdb7e6e",
+        "shared": false,
+        "id": "db193ab3-96e3-4cb3-8fc5-05f4296d0324",
+        "provider:segmentation_id": 1234567890,
+        "provider:physical_network": null,
+        "provider:network_type": "local",
+        "router:external": false,
+        "port_security_enabled": false,
+        "vlan_transparent": true
+    }
 }
 `

--- a/openstack/networking/v2/extensions/vlantransparent/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/vlantransparent/testing/requests_test.go
@@ -1,0 +1,73 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	fake "github.com/gophercloud/gophercloud/openstack/networking/v2/common"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/vlantransparent"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
+	"github.com/gophercloud/gophercloud/pagination"
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestList(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/networks", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, NetworksVLANTransparentListResult)
+	})
+
+	count := 0
+
+	iTrue := true
+	networkListOpts := networks.ListOpts{}
+	listOpts := vlantransparent.ListOptsExt{
+		ListOptsBuilder: networkListOpts,
+		VLANTransparent: &iTrue,
+	}
+
+	networks.List(fake.ServiceClient(), listOpts).EachPage(func(page pagination.Page) (bool, error) {
+		count++
+
+		type networkVLANTransparentExt struct {
+			networks.Network
+			vlantransparent.TransparentExt
+		}
+		var networkWithVLANTransparentExt []networkVLANTransparentExt
+
+		err := networks.ExtractNetworksInto(page, &networkWithVLANTransparentExt)
+		if err != nil {
+			t.Errorf("Failed to extract networks: %v", err)
+			return false, nil
+		}
+
+		networksCount := len(networkWithVLANTransparentExt)
+		if networksCount != 2 {
+			t.Fatalf("Expected 2 networks, got %d", networksCount)
+		}
+
+		th.AssertEquals(t, "db193ab3-96e3-4cb3-8fc5-05f4296d0324", networkWithVLANTransparentExt[0].ID)
+		th.AssertEquals(t, "private", networkWithVLANTransparentExt[0].Name)
+		th.AssertEquals(t, true, networkWithVLANTransparentExt[0].AdminStateUp)
+		th.AssertEquals(t, "ACTIVE", networkWithVLANTransparentExt[0].Status)
+		th.AssertDeepEquals(t, []string{"08eae331-0402-425a-923c-34f7cfe39c1b"}, networkWithVLANTransparentExt[0].Subnets)
+		th.AssertEquals(t, "26a7980765d0414dbc1fc1f88cdb7e6e", networkWithVLANTransparentExt[0].TenantID)
+		th.AssertEquals(t, false, networkWithVLANTransparentExt[0].Shared)
+		th.AssertEquals(t, true, networkWithVLANTransparentExt[0].TransparentExt.VLANTransparent)
+
+		return true, nil
+	})
+
+	if count != 1 {
+		t.Errorf("Expected 1 page, got %d", count)
+	}
+}

--- a/openstack/networking/v2/extensions/vlantransparent/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/vlantransparent/testing/requests_test.go
@@ -78,3 +78,48 @@ func TestGet(t *testing.T) {
 	th.AssertEquals(t, false, s.Shared)
 	th.AssertEquals(t, true, s.VLANTransparent)
 }
+
+func TestCreate(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/networks", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, NetworksVLANTransparentCreateRequest)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+
+		fmt.Fprintf(w, NetworksVLANTransparentCreateResult)
+	})
+
+	iTrue := true
+	networkCreateOpts := networks.CreateOpts{
+		Name:         "private",
+		AdminStateUp: &iTrue,
+	}
+	vlanTransparentCreateOpts := vlantransparent.CreateOptsExt{
+		CreateOptsBuilder: &networkCreateOpts,
+		VLANTransparent:   &iTrue,
+	}
+
+	var s struct {
+		networks.Network
+		vlantransparent.TransparentExt
+	}
+
+	err := networks.Create(fake.ServiceClient(), vlanTransparentCreateOpts).ExtractInto(&s)
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, "db193ab3-96e3-4cb3-8fc5-05f4296d0324", s.ID)
+	th.AssertEquals(t, "private", s.Name)
+	th.AssertEquals(t, true, s.AdminStateUp)
+	th.AssertEquals(t, "ACTIVE", s.Status)
+	th.AssertDeepEquals(t, []string{"08eae331-0402-425a-923c-34f7cfe39c1b"}, s.Subnets)
+	th.AssertEquals(t, "26a7980765d0414dbc1fc1f88cdb7e6e", s.TenantID)
+	th.AssertEquals(t, false, s.Shared)
+	th.AssertEquals(t, true, s.VLANTransparent)
+}


### PR DESCRIPTION
Add a method to create an OpenStack Networking V2 Network with the "vlan-transparent" attribute set.

For #1304

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

[vlantransparent.py](https://github.com/openstack/neutron-lib/blob/stable/rocky/neutron_lib/api/definitions/vlantransparent.py)
