### PR TITLE
Allow empty strings in JSON marshalling

### DIFF
--- a/acceptance/openstack/blockstorage/v3/volumetypes_test.go
+++ b/acceptance/openstack/blockstorage/v3/volumetypes_test.go
@@ -38,8 +38,9 @@ func TestVolumeTypes(t *testing.T) {
 	th.AssertEquals(t, found, true)
 
 	var isPublic = false
+	var name = vt.Name + "-UPDATED"
 	updateOpts := volumetypes.UpdateOpts{
-		Name:     vt.Name + "-UPDATED",
+		Name:     &name,
 		IsPublic: &isPublic,
 	}
 

--- a/acceptance/openstack/compute/v2/secgroup_test.go
+++ b/acceptance/openstack/compute/v2/secgroup_test.go
@@ -45,9 +45,10 @@ func TestSecGroupsCRUD(t *testing.T) {
 	tools.PrintResource(t, securityGroup)
 
 	newName := tools.RandomString("secgroup_", 4)
+	description := tools.RandomString("dec_", 10)
 	updateOpts := secgroups.UpdateOpts{
 		Name:        newName,
-		Description: tools.RandomString("dec_", 10),
+		Description: &description,
 	}
 	updatedSecurityGroup, err := secgroups.Update(client, securityGroup.ID, updateOpts).Extract()
 	th.AssertNoErr(t, err)

--- a/acceptance/openstack/identity/v3/domains_test.go
+++ b/acceptance/openstack/identity/v3/domains_test.go
@@ -75,8 +75,9 @@ func TestDomainsCRUD(t *testing.T) {
 	th.AssertEquals(t, domain.Description, "Testing Domain")
 
 	var iFalse bool = false
+	var description = "Staging Test Domain"
 	updateOpts := domains.UpdateOpts{
-		Description: "Staging Test Domain",
+		Description: &description,
 		Enabled:     &iFalse,
 	}
 

--- a/acceptance/openstack/identity/v3/groups_test.go
+++ b/acceptance/openstack/identity/v3/groups_test.go
@@ -33,8 +33,9 @@ func TestGroupCRUD(t *testing.T) {
 	tools.PrintResource(t, group)
 	tools.PrintResource(t, group.Extra)
 
+	var description = "Test Groups"
 	updateOpts := groups.UpdateOpts{
-		Description: "Test Groups",
+		Description: &description,
 		Extra: map[string]interface{}{
 			"email": "thetestgroup@example.com",
 		},

--- a/acceptance/openstack/identity/v3/regions_test.go
+++ b/acceptance/openstack/identity/v3/regions_test.go
@@ -75,8 +75,9 @@ func TestRegionsCRUD(t *testing.T) {
 	tools.PrintResource(t, region)
 	tools.PrintResource(t, region.Extra)
 
+	var description = "Region A for testing"
 	updateOpts := regions.UpdateOpts{
-		Description: "Region A for testing",
+		Description: &description,
 		/*
 			// Due to a bug in Keystone, the Extra column of the Region table
 			// is not updatable, see: https://bugs.launchpad.net/keystone/+bug/1729933

--- a/acceptance/openstack/networking/v2/extensions/portsbinding/portsbinding_test.go
+++ b/acceptance/openstack/networking/v2/extensions/portsbinding/portsbinding_test.go
@@ -41,7 +41,7 @@ func TestPortsbindingCRUD(t *testing.T) {
 	// Update port
 	newPortName := tools.RandomString("TESTACC-", 8)
 	updateOpts := ports.UpdateOpts{
-		Name: newPortName,
+		Name: &newPortName,
 	}
 	newPort, err := ports.Update(client, port.ID, updateOpts).Extract()
 	th.AssertNoErr(t, err)

--- a/acceptance/openstack/networking/v2/extensions/security_test.go
+++ b/acceptance/openstack/networking/v2/extensions/security_test.go
@@ -26,8 +26,9 @@ func TestSecurityGroupsCreateUpdateDelete(t *testing.T) {
 
 	tools.PrintResource(t, group)
 
+	var description = "A security group"
 	updateOpts := groups.UpdateOpts{
-		Description: "A security group",
+		Description: &description,
 	}
 
 	newGroup, err := groups.Update(client, group.ID, updateOpts).Extract()

--- a/acceptance/openstack/networking/v2/extensions/trunks/trunks_test.go
+++ b/acceptance/openstack/networking/v2/extensions/trunks/trunks_test.go
@@ -65,8 +65,9 @@ func TestTrunkCRUD(t *testing.T) {
 	}
 
 	// Update Trunk
+	var name = "updated_gophertrunk"
 	updateOpts := trunks.UpdateOpts{
-		Name: "updated_gophertrunk",
+		Name: &name,
 	}
 	updatedTrunk, err := trunks.Update(client, trunk.ID, updateOpts).Extract()
 	if err != nil {

--- a/acceptance/openstack/networking/v2/ports_test.go
+++ b/acceptance/openstack/networking/v2/ports_test.go
@@ -42,7 +42,7 @@ func TestPortsCRUD(t *testing.T) {
 	// Update port
 	newPortName := tools.RandomString("TESTACC-", 8)
 	updateOpts := ports.UpdateOpts{
-		Name: newPortName,
+		Name: &newPortName,
 	}
 	newPort, err := ports.Update(client, port.ID, updateOpts).Extract()
 	th.AssertNoErr(t, err)
@@ -146,8 +146,9 @@ func TestPortsDontAlterSecurityGroups(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	// Update the port again
+	var name = "some_port"
 	updateOpts = ports.UpdateOpts{
-		Name: "some_port",
+		Name: &name,
 	}
 	newPort, err = ports.Update(client, port.ID, updateOpts).Extract()
 	th.AssertNoErr(t, err)
@@ -262,8 +263,9 @@ func TestPortsDontUpdateAllowedAddressPairs(t *testing.T) {
 	tools.PrintResource(t, newPort)
 
 	// Remove the address pair
+	var name = "some_port"
 	updateOpts = ports.UpdateOpts{
-		Name: "some_port",
+		Name: &name,
 	}
 	newPort, err = ports.Update(client, port.ID, updateOpts).Extract()
 	th.AssertNoErr(t, err)
@@ -341,7 +343,7 @@ func TestPortsWithExtraDHCPOptsCRUD(t *testing.T) {
 	// Update the port with extra DHCP options.
 	newPortName := tools.RandomString("TESTACC-", 8)
 	portUpdateOpts := ports.UpdateOpts{
-		Name: newPortName,
+		Name: &newPortName,
 	}
 
 	existingOpt := port.ExtraDHCPOpts[0]

--- a/acceptance/openstack/sharedfilesystems/v2/securityservices_test.go
+++ b/acceptance/openstack/sharedfilesystems/v2/securityservices_test.go
@@ -108,9 +108,11 @@ func TestSecurityServiceUpdate(t *testing.T) {
 		t.Fatalf("Unable to create security service: %v", err)
 	}
 
+	name := "NewName"
+	description := "New security service description"
 	options := securityservices.UpdateOpts{
-		Name:        "NewName",
-		Description: "New security service description",
+		Name:        &name,
+		Description: &description,
 		Type:        "ldap",
 	}
 
@@ -124,12 +126,12 @@ func TestSecurityServiceUpdate(t *testing.T) {
 		t.Errorf("Unable to retrieve the security service: %v", err)
 	}
 
-	if newSecurityService.Name != options.Name {
-		t.Fatalf("Security service name was expeted to be: %s", options.Name)
+	if newSecurityService.Name != *options.Name {
+		t.Fatalf("Security service name was expeted to be: %s", *options.Name)
 	}
 
-	if newSecurityService.Description != options.Description {
-		t.Fatalf("Security service description was expeted to be: %s", options.Description)
+	if newSecurityService.Description != *options.Description {
+		t.Fatalf("Security service description was expeted to be: %s", *options.Description)
 	}
 
 	if newSecurityService.Type != options.Type {

--- a/acceptance/openstack/sharedfilesystems/v2/sharenetworks_test.go
+++ b/acceptance/openstack/sharedfilesystems/v2/sharenetworks_test.go
@@ -52,13 +52,15 @@ func TestShareNetworkUpdate(t *testing.T) {
 		t.Errorf("Unable to retrieve shareNetwork: %v", err)
 	}
 
+	name := "NewName"
+	description := "New share network description"
 	options := sharenetworks.UpdateOpts{
-		Name:        "NewName",
-		Description: "New share network description",
+		Name:        &name,
+		Description: &description,
 	}
 
-	expectedShareNetwork.Name = options.Name
-	expectedShareNetwork.Description = options.Description
+	expectedShareNetwork.Name = *options.Name
+	expectedShareNetwork.Description = *options.Description
 
 	_, err = sharenetworks.Update(client, shareNetwork.ID, options).Extract()
 	if err != nil {

--- a/openstack/blockstorage/v1/volumes/requests.go
+++ b/openstack/blockstorage/v1/volumes/requests.go
@@ -110,8 +110,8 @@ type UpdateOptsBuilder interface {
 // to the volumes.Update function. For more information about the parameters, see
 // the Volume object.
 type UpdateOpts struct {
-	Name        string            `json:"display_name,omitempty"`
-	Description string            `json:"display_description,omitempty"`
+	Name        *string           `json:"display_name,omitempty"`
+	Description *string           `json:"display_description,omitempty"`
 	Metadata    map[string]string `json:"metadata,omitempty"`
 }
 

--- a/openstack/blockstorage/v1/volumes/testing/requests_test.go
+++ b/openstack/blockstorage/v1/volumes/testing/requests_test.go
@@ -145,7 +145,8 @@ func TestUpdate(t *testing.T) {
 
 	MockUpdateResponse(t)
 
-	options := volumes.UpdateOpts{Name: "vol-002"}
+	var name = "vol-002"
+	options := volumes.UpdateOpts{Name: &name}
 	v, err := volumes.Update(client.ServiceClient(), "d32019d3-bc6e-4319-9c1d-6722fc136a22", options).Extract()
 	th.AssertNoErr(t, err)
 	th.CheckEquals(t, "vol-002", v.Name)

--- a/openstack/blockstorage/v2/volumes/requests.go
+++ b/openstack/blockstorage/v2/volumes/requests.go
@@ -173,8 +173,8 @@ type UpdateOptsBuilder interface {
 // to the volumes.Update function. For more information about the parameters, see
 // the Volume object.
 type UpdateOpts struct {
-	Name        string            `json:"name,omitempty"`
-	Description string            `json:"description,omitempty"`
+	Name        *string           `json:"name,omitempty"`
+	Description *string           `json:"description,omitempty"`
 	Metadata    map[string]string `json:"metadata,omitempty"`
 }
 

--- a/openstack/blockstorage/v2/volumes/testing/requests_test.go
+++ b/openstack/blockstorage/v2/volumes/testing/requests_test.go
@@ -230,7 +230,8 @@ func TestUpdate(t *testing.T) {
 
 	MockUpdateResponse(t)
 
-	options := volumes.UpdateOpts{Name: "vol-002"}
+	var name = "vol-002"
+	options := volumes.UpdateOpts{Name: &name}
 	v, err := volumes.Update(client.ServiceClient(), "d32019d3-bc6e-4319-9c1d-6722fc136a22", options).Extract()
 	th.AssertNoErr(t, err)
 	th.CheckEquals(t, "vol-002", v.Name)

--- a/openstack/blockstorage/v3/volumes/requests.go
+++ b/openstack/blockstorage/v3/volumes/requests.go
@@ -175,8 +175,8 @@ type UpdateOptsBuilder interface {
 // to the volumes.Update function. For more information about the parameters, see
 // the Volume object.
 type UpdateOpts struct {
-	Name        string            `json:"name,omitempty"`
-	Description string            `json:"description,omitempty"`
+	Name        *string           `json:"name,omitempty"`
+	Description *string           `json:"description,omitempty"`
 	Metadata    map[string]string `json:"metadata,omitempty"`
 }
 

--- a/openstack/blockstorage/v3/volumes/testing/requests_test.go
+++ b/openstack/blockstorage/v3/volumes/testing/requests_test.go
@@ -230,7 +230,8 @@ func TestUpdate(t *testing.T) {
 
 	MockUpdateResponse(t)
 
-	options := volumes.UpdateOpts{Name: "vol-002"}
+	var name = "vol-002"
+	options := volumes.UpdateOpts{Name: &name}
 	v, err := volumes.Update(client.ServiceClient(), "d32019d3-bc6e-4319-9c1d-6722fc136a22", options).Extract()
 	th.AssertNoErr(t, err)
 	th.CheckEquals(t, "vol-002", v.Name)

--- a/openstack/blockstorage/v3/volumetypes/requests.go
+++ b/openstack/blockstorage/v3/volumetypes/requests.go
@@ -112,9 +112,9 @@ type UpdateOptsBuilder interface {
 // to the volumetypes.Update function. For more information about the parameters, see
 // the Volume Type object.
 type UpdateOpts struct {
-	Name        string `json:"name,omitempty"`
-	Description string `json:"description,omitempty"`
-	IsPublic    *bool  `json:"is_public,omitempty"`
+	Name        *string `json:"name,omitempty"`
+	Description *string `json:"description,omitempty"`
+	IsPublic    *bool   `json:"is_public,omitempty"`
 }
 
 // ToVolumeUpdateMap assembles a request body based on the contents of an

--- a/openstack/blockstorage/v3/volumetypes/testing/requests_test.go
+++ b/openstack/blockstorage/v3/volumetypes/testing/requests_test.go
@@ -106,8 +106,9 @@ func TestUpdate(t *testing.T) {
 	MockUpdateResponse(t)
 
 	var isPublic = true
+	var name = "vol-type-002"
 	options := volumetypes.UpdateOpts{
-		Name:     "vol-type-002",
+		Name:     &name,
 		IsPublic: &isPublic,
 	}
 

--- a/openstack/compute/v2/extensions/quotasets/testing/fixtures.go
+++ b/openstack/compute/v2/extensions/quotasets/testing/fixtures.go
@@ -121,7 +121,7 @@ var FirstQuotaSet = quotasets.QuotaSet{
 
 // FirstQuotaDetailsSet is the first result in ListOutput.
 var FirstQuotaDetailsSet = quotasets.QuotaDetailSet{
-	ID: FirstTenantID,
+	ID:                       FirstTenantID,
 	InjectedFileContentBytes: quotasets.QuotaDetail{InUse: 0, Reserved: 0, Limit: 10240},
 	InjectedFilePathBytes:    quotasets.QuotaDetail{InUse: 0, Reserved: 0, Limit: 255},
 	InjectedFiles:            quotasets.QuotaDetail{InUse: 0, Reserved: 0, Limit: 5},

--- a/openstack/compute/v2/extensions/secgroups/requests.go
+++ b/openstack/compute/v2/extensions/secgroups/requests.go
@@ -23,18 +23,13 @@ func ListByServer(client *gophercloud.ServiceClient, serverID string) pagination
 	return commonList(client, listByServerURL(client, serverID))
 }
 
-// GroupOpts is the underlying struct responsible for creating or updating
-// security groups. It therefore represents the mutable attributes of a
-// security group.
-type GroupOpts struct {
+// CreateOpts is the struct responsible for creating a security group.
+type CreateOpts struct {
 	// the name of your security group.
 	Name string `json:"name" required:"true"`
 	// the description of your security group.
-	Description string `json:"description" required:"true"`
+	Description string `json:"description,omitempty"`
 }
-
-// CreateOpts is the struct responsible for creating a security group.
-type CreateOpts GroupOpts
 
 // CreateOptsBuilder allows extensions to add additional parameters to the
 // Create request.
@@ -61,7 +56,12 @@ func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r Create
 }
 
 // UpdateOpts is the struct responsible for updating an existing security group.
-type UpdateOpts GroupOpts
+type UpdateOpts struct {
+	// the name of your security group.
+	Name string `json:"name,omitempty"`
+	// the description of your security group.
+	Description *string `json:"description,omitempty"`
+}
 
 // UpdateOptsBuilder allows extensions to add additional parameters to the
 // Update request.

--- a/openstack/compute/v2/extensions/secgroups/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/secgroups/testing/requests_test.go
@@ -115,9 +115,10 @@ func TestUpdate(t *testing.T) {
 
 	mockUpdateGroupResponse(t, groupID)
 
+	description := "new_desc"
 	opts := secgroups.UpdateOpts{
 		Name:        "new_name",
-		Description: "new_desc",
+		Description: &description,
 	}
 
 	group, err := secgroups.Update(client.ServiceClient(), groupID, opts).Extract()

--- a/openstack/db/v1/configurations/requests.go
+++ b/openstack/db/v1/configurations/requests.go
@@ -80,7 +80,7 @@ type UpdateOpts struct {
 	// Associates the configuration group with a particular datastore.
 	Datastore *DatastoreOpts `json:"datastore,omitempty"`
 	// A human-readable explanation for the group.
-	Description string `json:"description,omitempty"`
+	Description *string `json:"description,omitempty"`
 }
 
 // ToConfigUpdateMap will cast an UpdateOpts struct into a JSON map.

--- a/openstack/dns/v2/recordsets/requests.go
+++ b/openstack/dns/v2/recordsets/requests.go
@@ -119,7 +119,7 @@ type UpdateOptsBuilder interface {
 // RecordSet.
 type UpdateOpts struct {
 	// Description is a description of the RecordSet.
-	Description string `json:"description,omitempty"`
+	Description *string `json:"description,omitempty"`
 
 	// TTL is the time to live of the RecordSet.
 	TTL int `json:"ttl,omitempty"`

--- a/openstack/dns/v2/recordsets/testing/requests_test.go
+++ b/openstack/dns/v2/recordsets/testing/requests_test.go
@@ -109,9 +109,10 @@ func TestUpdate(t *testing.T) {
 	defer th.TeardownHTTP()
 	HandleUpdateSuccessfully(t)
 
+	var description = "Updated description"
 	updateOpts := recordsets.UpdateOpts{
 		TTL:         0,
-		Description: "Updated description",
+		Description: &description,
 		Records:     []string{"10.1.0.2", "10.1.0.3"},
 	}
 

--- a/openstack/dns/v2/zones/requests.go
+++ b/openstack/dns/v2/zones/requests.go
@@ -134,7 +134,7 @@ type UpdateOpts struct {
 	Masters []string `json:"masters,omitempty"`
 
 	// Description of the zone.
-	Description string `json:"description,omitempty"`
+	Description *string `json:"description,omitempty"`
 }
 
 // ToZoneUpdateMap formats an UpdateOpts structure into a request body.

--- a/openstack/dns/v2/zones/testing/requests_test.go
+++ b/openstack/dns/v2/zones/testing/requests_test.go
@@ -72,9 +72,10 @@ func TestUpdate(t *testing.T) {
 	defer th.TeardownHTTP()
 	HandleUpdateSuccessfully(t)
 
+	var description = "Updated Description"
 	updateOpts := zones.UpdateOpts{
 		TTL:         600,
-		Description: "Updated Description",
+		Description: &description,
 	}
 
 	UpdatedZone := CreatedZone

--- a/openstack/identity/v2/tenants/requests.go
+++ b/openstack/identity/v2/tenants/requests.go
@@ -85,7 +85,7 @@ type UpdateOpts struct {
 	Name string `json:"name,omitempty"`
 
 	// Description is the description of the tenant.
-	Description string `json:"description,omitempty"`
+	Description *string `json:"description,omitempty"`
 
 	// Enabled sets the tenant status to enabled or disabled.
 	Enabled *bool `json:"enabled,omitempty"`

--- a/openstack/identity/v2/tenants/testing/requests_test.go
+++ b/openstack/identity/v2/tenants/testing/requests_test.go
@@ -73,9 +73,10 @@ func TestUpdateTenant(t *testing.T) {
 	mockUpdateTenantResponse(t)
 
 	id := "5c62ef576dc7444cbb73b1fe84b97648"
+	description := "This is new name"
 	opts := tenants.UpdateOpts{
 		Name:        "new_name",
-		Description: "This is new name",
+		Description: &description,
 		Enabled:     gophercloud.Enabled,
 	}
 

--- a/openstack/identity/v3/domains/requests.go
+++ b/openstack/identity/v3/domains/requests.go
@@ -101,7 +101,7 @@ type UpdateOpts struct {
 	Name string `json:"name,omitempty"`
 
 	// Description is the description of the domain.
-	Description string `json:"description,omitempty"`
+	Description *string `json:"description,omitempty"`
 
 	// Enabled sets the domain status to enabled or disabled.
 	Enabled *bool `json:"enabled,omitempty"`

--- a/openstack/identity/v3/domains/testing/requests_test.go
+++ b/openstack/identity/v3/domains/testing/requests_test.go
@@ -79,8 +79,9 @@ func TestUpdateDomain(t *testing.T) {
 	defer th.TeardownHTTP()
 	HandleUpdateDomainSuccessfully(t)
 
+	var description = "Staging Domain"
 	updateOpts := domains.UpdateOpts{
-		Description: "Staging Domain",
+		Description: &description,
 	}
 
 	actual, err := domains.Update(client.ServiceClient(), "9fe1d3", updateOpts).Extract()

--- a/openstack/identity/v3/groups/requests.go
+++ b/openstack/identity/v3/groups/requests.go
@@ -133,7 +133,7 @@ type UpdateOpts struct {
 	Name string `json:"name,omitempty"`
 
 	// Description is a description of the group.
-	Description string `json:"description,omitempty"`
+	Description *string `json:"description,omitempty"`
 
 	// DomainID is the ID of the domain the group belongs to.
 	DomainID string `json:"domain_id,omitempty"`

--- a/openstack/identity/v3/groups/testing/requests_test.go
+++ b/openstack/identity/v3/groups/testing/requests_test.go
@@ -111,8 +111,9 @@ func TestUpdateGroup(t *testing.T) {
 	defer th.TeardownHTTP()
 	HandleUpdateGroupSuccessfully(t)
 
+	var description = "L2 Support Team"
 	updateOpts := groups.UpdateOpts{
-		Description: "L2 Support Team",
+		Description: &description,
 		Extra: map[string]interface{}{
 			"email": "supportteam@example.com",
 		},

--- a/openstack/identity/v3/projects/requests.go
+++ b/openstack/identity/v3/projects/requests.go
@@ -152,7 +152,7 @@ type UpdateOpts struct {
 	ParentID string `json:"parent_id,omitempty"`
 
 	// Description is the description of the project.
-	Description string `json:"description,omitempty"`
+	Description *string `json:"description,omitempty"`
 }
 
 // ToUpdateCreateMap formats a UpdateOpts into an update request.

--- a/openstack/identity/v3/projects/testing/requests_test.go
+++ b/openstack/identity/v3/projects/testing/requests_test.go
@@ -100,9 +100,10 @@ func TestUpdateProject(t *testing.T) {
 	defer th.TeardownHTTP()
 	HandleUpdateProjectSuccessfully(t)
 
+	var description = "The team that is bright red"
 	updateOpts := projects.UpdateOpts{
 		Name:        "Bright Red Team",
-		Description: "The team that is bright red",
+		Description: &description,
 	}
 
 	actual, err := projects.Update(client.ServiceClient(), "1234", updateOpts).Extract()

--- a/openstack/identity/v3/regions/requests.go
+++ b/openstack/identity/v3/regions/requests.go
@@ -105,7 +105,7 @@ type UpdateOptsBuilder interface {
 // UpdateOpts provides options for updating a region.
 type UpdateOpts struct {
 	// Description is a description of the region.
-	Description string `json:"description,omitempty"`
+	Description *string `json:"description,omitempty"`
 
 	// ParentRegionID is the ID of the parent region.
 	ParentRegionID string `json:"parent_region_id,omitempty"`

--- a/openstack/identity/v3/regions/testing/requests_test.go
+++ b/openstack/identity/v3/regions/testing/requests_test.go
@@ -77,8 +77,9 @@ func TestUpdateRegion(t *testing.T) {
 	defer th.TeardownHTTP()
 	HandleUpdateRegionSuccessfully(t)
 
+	var description = "First West sub-region of RegionOne"
 	updateOpts := regions.UpdateOpts{
-		Description: "First West sub-region of RegionOne",
+		Description: &description,
 		/*
 			// Due to a bug in Keystone, the Extra column of the Region table
 			// is not updatable, see: https://bugs.launchpad.net/keystone/+bug/1729933

--- a/openstack/identity/v3/users/requests.go
+++ b/openstack/identity/v3/users/requests.go
@@ -178,7 +178,7 @@ type UpdateOpts struct {
 	DefaultProjectID string `json:"default_project_id,omitempty"`
 
 	// Description is a description of the user.
-	Description string `json:"description,omitempty"`
+	Description *string `json:"description,omitempty"`
 
 	// DomainID is the ID of the domain the user belongs to.
 	DomainID string `json:"domain_id,omitempty"`

--- a/openstack/loadbalancer/v2/l7policies/requests.go
+++ b/openstack/loadbalancer/v2/l7policies/requests.go
@@ -163,11 +163,11 @@ type UpdateOpts struct {
 
 	// Requests matching this policy will be redirected to the pool with this ID.
 	// Only valid if action is REDIRECT_TO_POOL.
-	RedirectPoolID string `json:"redirect_pool_id,omitempty"`
+	RedirectPoolID *string `json:"redirect_pool_id,omitempty"`
 
 	// Requests matching this policy will be redirected to this URL.
 	// Only valid if action is REDIRECT_TO_URL.
-	RedirectURL string `json:"redirect_url,omitempty"`
+	RedirectURL *string `json:"redirect_url,omitempty"`
 }
 
 // ToL7PolicyUpdateMap builds a request body from UpdateOpts.
@@ -302,7 +302,7 @@ type UpdateRuleOpts struct {
 	Value string `json:"value,omitempty"`
 
 	// The key to use for the comparison. For example, the name of the cookie to evaluate.
-	Key string `json:"key,omitempty"`
+	Key *string `json:"key,omitempty"`
 
 	// When true the logic of the rule is inverted. For example, with invert true,
 	// equal to would become not equal to. Default is false.

--- a/openstack/loadbalancer/v2/l7policies/testing/requests_test.go
+++ b/openstack/loadbalancer/v2/l7policies/testing/requests_test.go
@@ -115,11 +115,12 @@ func TestUpdateL7Policy(t *testing.T) {
 
 	client := fake.ServiceClient()
 	newName := "NewL7PolicyName"
+	redirectURL := "http://www.new-example.com"
 	actual, err := l7policies.Update(client, "8a1412f0-4c32-4257-8b07-af4770b604fd",
 		l7policies.UpdateOpts{
 			Name:        &newName,
 			Action:      l7policies.ActionRedirectToURL,
-			RedirectURL: "http://www.new-example.com",
+			RedirectURL: &redirectURL,
 		}).Extract()
 	if err != nil {
 		t.Fatalf("Unexpected Update error: %v", err)
@@ -260,12 +261,12 @@ func TestUpdateRule(t *testing.T) {
 	HandleRuleUpdateSuccessfully(t)
 
 	client := fake.ServiceClient()
-	tmpBool := false
+	invert := false
 	actual, err := l7policies.UpdateRule(client, "8a1412f0-4c32-4257-8b07-af4770b604fd", "16621dbb-a736-4888-a57a-3ecd53df784c", l7policies.UpdateRuleOpts{
 		RuleType:    l7policies.TypePath,
 		CompareType: l7policies.CompareTypeRegex,
 		Value:       "/images/special*",
-		Invert:      &tmpBool,
+		Invert:      &invert,
 	}).Extract()
 	if err != nil {
 		t.Fatalf("Unexpected Update error: %v", err)

--- a/openstack/loadbalancer/v2/listeners/requests.go
+++ b/openstack/loadbalancer/v2/listeners/requests.go
@@ -150,10 +150,10 @@ type UpdateOptsBuilder interface {
 // UpdateOpts represents options for updating a Listener.
 type UpdateOpts struct {
 	// Human-readable name for the Listener. Does not have to be unique.
-	Name string `json:"name,omitempty"`
+	Name *string `json:"name,omitempty"`
 
 	// Human-readable description for the Listener.
-	Description string `json:"description,omitempty"`
+	Description *string `json:"description,omitempty"`
 
 	// The maximum number of connections allowed for the Listener.
 	ConnLimit *int `json:"connection_limit,omitempty"`

--- a/openstack/loadbalancer/v2/listeners/testing/requests_test.go
+++ b/openstack/loadbalancer/v2/listeners/testing/requests_test.go
@@ -125,8 +125,9 @@ func TestUpdateListener(t *testing.T) {
 
 	client := fake.ServiceClient()
 	i1001 := 1001
+	name := "NewListenerName"
 	actual, err := listeners.Update(client, "4ec89087-d057-4e2c-911f-60a3b47ee304", listeners.UpdateOpts{
-		Name:      "NewListenerName",
+		Name:      &name,
 		ConnLimit: &i1001,
 	}).Extract()
 	if err != nil {

--- a/openstack/loadbalancer/v2/loadbalancers/requests.go
+++ b/openstack/loadbalancer/v2/loadbalancers/requests.go
@@ -134,10 +134,10 @@ type UpdateOptsBuilder interface {
 // operation.
 type UpdateOpts struct {
 	// Human-readable name for the Loadbalancer. Does not have to be unique.
-	Name string `json:"name,omitempty"`
+	Name *string `json:"name,omitempty"`
 
 	// Human-readable description for the Loadbalancer.
-	Description string `json:"description,omitempty"`
+	Description *string `json:"description,omitempty"`
 
 	// The administrative state of the Loadbalancer. A valid value is true (UP)
 	// or false (DOWN).

--- a/openstack/loadbalancer/v2/loadbalancers/testing/requests_test.go
+++ b/openstack/loadbalancer/v2/loadbalancers/testing/requests_test.go
@@ -133,8 +133,9 @@ func TestUpdateLoadbalancer(t *testing.T) {
 	HandleLoadbalancerUpdateSuccessfully(t)
 
 	client := fake.ServiceClient()
+	name := "NewLoadbalancerName"
 	actual, err := loadbalancers.Update(client, "36e08a3e-a78f-4b40-a229-1e7e23eee1ab", loadbalancers.UpdateOpts{
-		Name: "NewLoadbalancerName",
+		Name: &name,
 	}).Extract()
 	if err != nil {
 		t.Fatalf("Unexpected Update error: %v", err)

--- a/openstack/loadbalancer/v2/monitors/requests.go
+++ b/openstack/loadbalancer/v2/monitors/requests.go
@@ -223,7 +223,7 @@ type UpdateOpts struct {
 	ExpectedCodes string `json:"expected_codes,omitempty"`
 
 	// The Name of the Monitor.
-	Name string `json:"name,omitempty"`
+	Name *string `json:"name,omitempty"`
 
 	// The administrative state of the Monitor. A valid value is true (UP)
 	// or false (DOWN).

--- a/openstack/loadbalancer/v2/monitors/testing/requests_test.go
+++ b/openstack/loadbalancer/v2/monitors/testing/requests_test.go
@@ -113,8 +113,9 @@ func TestUpdateHealthmonitor(t *testing.T) {
 	HandleHealthmonitorUpdateSuccessfully(t)
 
 	client := fake.ServiceClient()
+	name := "NewHealthmonitorName"
 	actual, err := monitors.Update(client, "5d4b5228-33b0-4e60-b225-9b727c1a20e7", monitors.UpdateOpts{
-		Name:          "NewHealthmonitorName",
+		Name:          &name,
 		Delay:         3,
 		Timeout:       20,
 		MaxRetries:    10,

--- a/openstack/loadbalancer/v2/pools/requests.go
+++ b/openstack/loadbalancer/v2/pools/requests.go
@@ -149,10 +149,10 @@ type UpdateOptsBuilder interface {
 // operation.
 type UpdateOpts struct {
 	// Name of the pool.
-	Name string `json:"name,omitempty"`
+	Name *string `json:"name,omitempty"`
 
 	// Human-readable description for the pool.
-	Description string `json:"description,omitempty"`
+	Description *string `json:"description,omitempty"`
 
 	// The algorithm used to distribute load between the members of the pool. The
 	// current specification supports LBMethodRoundRobin, LBMethodLeastConnections
@@ -308,7 +308,7 @@ type UpdateMemberOptsBuilder interface {
 // operation.
 type UpdateMemberOpts struct {
 	// Name of the Member.
-	Name string `json:"name,omitempty"`
+	Name *string `json:"name,omitempty"`
 
 	// A positive integer value that indicates the relative portion of traffic
 	// that this member should receive from the pool. For example, a member with

--- a/openstack/loadbalancer/v2/pools/testing/requests_test.go
+++ b/openstack/loadbalancer/v2/pools/testing/requests_test.go
@@ -98,8 +98,9 @@ func TestUpdatePool(t *testing.T) {
 	HandlePoolUpdateSuccessfully(t)
 
 	client := fake.ServiceClient()
+	name := "NewPoolName"
 	actual, err := pools.Update(client, "c3741b06-df4d-4715-b142-276b6bce75ab", pools.UpdateOpts{
-		Name:     "NewPoolName",
+		Name:     &name,
 		LBMethod: pools.LBMethodLeastConnections,
 	}).Extract()
 	if err != nil {
@@ -252,8 +253,9 @@ func TestUpdateMember(t *testing.T) {
 
 	weight := 4
 	client := fake.ServiceClient()
+	name := "newMemberName"
 	actual, err := pools.UpdateMember(client, "332abe93-f488-41ba-870b-2ac66be7f853", "2a280670-c202-4b0b-a562-34077415aabf", pools.UpdateMemberOpts{
-		Name:   "newMemberName",
+		Name:   &name,
 		Weight: &weight,
 	}).Extract()
 	if err != nil {

--- a/openstack/networking/v2/extensions/fwaas/firewalls/requests.go
+++ b/openstack/networking/v2/extensions/fwaas/firewalls/requests.go
@@ -107,11 +107,11 @@ type UpdateOptsBuilder interface {
 
 // UpdateOpts contains the values used when updating a firewall.
 type UpdateOpts struct {
-	PolicyID     string `json:"firewall_policy_id" required:"true"`
-	Name         string `json:"name,omitempty"`
-	Description  string `json:"description,omitempty"`
-	AdminStateUp *bool  `json:"admin_state_up,omitempty"`
-	Shared       *bool  `json:"shared,omitempty"`
+	PolicyID     string  `json:"firewall_policy_id" required:"true"`
+	Name         *string `json:"name,omitempty"`
+	Description  *string `json:"description,omitempty"`
+	AdminStateUp *bool   `json:"admin_state_up,omitempty"`
+	Shared       *bool   `json:"shared,omitempty"`
 }
 
 // ToFirewallUpdateMap casts a CreateOpts struct to a map.

--- a/openstack/networking/v2/extensions/fwaas/firewalls/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/fwaas/firewalls/testing/requests_test.go
@@ -315,9 +315,11 @@ func TestUpdate(t *testing.T) {
     `)
 	})
 
+	var name = "fw"
+	var description = "updated fw"
 	options := firewalls.UpdateOpts{
-		Name:         "fw",
-		Description:  "updated fw",
+		Name:         &name,
+		Description:  &description,
 		AdminStateUp: gophercloud.Disabled,
 		PolicyID:     "19ab8c87-4a32-4e6a-a74e-b77fffb89a0c",
 	}

--- a/openstack/networking/v2/extensions/fwaas/policies/requests.go
+++ b/openstack/networking/v2/extensions/fwaas/policies/requests.go
@@ -107,8 +107,8 @@ type UpdateOptsBuilder interface {
 
 // UpdateOpts contains the values used when updating a firewall policy.
 type UpdateOpts struct {
-	Name        string   `json:"name,omitempty"`
-	Description string   `json:"description,omitempty"`
+	Name        *string  `json:"name,omitempty"`
+	Description *string  `json:"description,omitempty"`
 	Shared      *bool    `json:"shared,omitempty"`
 	Audited     *bool    `json:"audited,omitempty"`
 	Rules       []string `json:"firewall_rules,omitempty"`

--- a/openstack/networking/v2/extensions/fwaas/policies/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/fwaas/policies/testing/requests_test.go
@@ -246,9 +246,11 @@ func TestUpdate(t *testing.T) {
     `)
 	})
 
+	var name = "policy"
+	var description = "Firewall policy"
 	options := policies.UpdateOpts{
-		Name:        "policy",
-		Description: "Firewall policy",
+		Name:        &name,
+		Description: &description,
 		Rules: []string{
 			"98a58c87-76be-ae7c-a74e-b77fffb88d95",
 			"11a58c87-76be-ae7c-a74e-b77fffb88a32",

--- a/openstack/networking/v2/extensions/fwaas/routerinsertion/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/fwaas/routerinsertion/testing/requests_test.go
@@ -165,9 +165,11 @@ func TestUpdate(t *testing.T) {
     `)
 	})
 
+	var name = "fw"
+	var description = "updated fw"
 	firewallUpdateOpts := firewalls.UpdateOpts{
-		Name:         "fw",
-		Description:  "updated fw",
+		Name:         &name,
+		Description:  &description,
 		AdminStateUp: gophercloud.Disabled,
 		PolicyID:     "19ab8c87-4a32-4e6a-a74e-b77fffb89a0c",
 	}
@@ -219,9 +221,11 @@ func TestUpdateWithNoRouters(t *testing.T) {
     `)
 	})
 
+	var name = "fw"
+	var description = "updated fw"
 	firewallUpdateOpts := firewalls.UpdateOpts{
-		Name:         "fw",
-		Description:  "updated fw",
+		Name:         &name,
+		Description:  &description,
 		AdminStateUp: gophercloud.Disabled,
 		PolicyID:     "19ab8c87-4a32-4e6a-a74e-b77fffb89a0c",
 	}

--- a/openstack/networking/v2/extensions/lbaas/pools/requests.go
+++ b/openstack/networking/v2/extensions/lbaas/pools/requests.go
@@ -123,7 +123,7 @@ type UpdateOptsBuilder interface {
 // UpdateOpts contains the values used when updating a pool.
 type UpdateOpts struct {
 	// Name of the pool.
-	Name string `json:"name,omitempty"`
+	Name *string `json:"name,omitempty"`
 
 	// LBMethod is the algorithm used to distribute load between the members of
 	// the pool. The current specification supports LBMethodRoundRobin and

--- a/openstack/networking/v2/extensions/lbaas/pools/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/lbaas/pools/testing/requests_test.go
@@ -252,7 +252,8 @@ func TestUpdate(t *testing.T) {
 		`)
 	})
 
-	options := pools.UpdateOpts{Name: "SuperPool", LBMethod: pools.LBMethodLeastConnections}
+	var name = "SuperPool"
+	options := pools.UpdateOpts{Name: &name, LBMethod: pools.LBMethodLeastConnections}
 
 	n, err := pools.Update(fake.ServiceClient(), "332abe93-f488-41ba-870b-2ac66be7f853", options).Extract()
 	th.AssertNoErr(t, err)

--- a/openstack/networking/v2/extensions/lbaas_v2/listeners/requests.go
+++ b/openstack/networking/v2/extensions/lbaas_v2/listeners/requests.go
@@ -154,10 +154,10 @@ type UpdateOptsBuilder interface {
 // UpdateOpts represents options for updating a Listener.
 type UpdateOpts struct {
 	// Human-readable name for the Listener. Does not have to be unique.
-	Name string `json:"name,omitempty"`
+	Name *string `json:"name,omitempty"`
 
 	// Human-readable description for the Listener.
-	Description string `json:"description,omitempty"`
+	Description *string `json:"description,omitempty"`
 
 	// The maximum number of connections allowed for the Listener.
 	ConnLimit *int `json:"connection_limit,omitempty"`

--- a/openstack/networking/v2/extensions/lbaas_v2/listeners/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/lbaas_v2/listeners/testing/requests_test.go
@@ -125,8 +125,9 @@ func TestUpdateListener(t *testing.T) {
 
 	client := fake.ServiceClient()
 	i1001 := 1001
+	name := "NewListenerName"
 	actual, err := listeners.Update(client, "4ec89087-d057-4e2c-911f-60a3b47ee304", listeners.UpdateOpts{
-		Name:      "NewListenerName",
+		Name:      &name,
 		ConnLimit: &i1001,
 	}).Extract()
 	if err != nil {

--- a/openstack/networking/v2/extensions/lbaas_v2/loadbalancers/requests.go
+++ b/openstack/networking/v2/extensions/lbaas_v2/loadbalancers/requests.go
@@ -141,10 +141,10 @@ type UpdateOptsBuilder interface {
 // operation.
 type UpdateOpts struct {
 	// Human-readable name for the Loadbalancer. Does not have to be unique.
-	Name string `json:"name,omitempty"`
+	Name *string `json:"name,omitempty"`
 
 	// Human-readable description for the Loadbalancer.
-	Description string `json:"description,omitempty"`
+	Description *string `json:"description,omitempty"`
 
 	// The administrative state of the Loadbalancer. A valid value is true (UP)
 	// or false (DOWN).

--- a/openstack/networking/v2/extensions/lbaas_v2/loadbalancers/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/lbaas_v2/loadbalancers/testing/requests_test.go
@@ -133,8 +133,9 @@ func TestUpdateLoadbalancer(t *testing.T) {
 	HandleLoadbalancerUpdateSuccessfully(t)
 
 	client := fake.ServiceClient()
+	name := "NewLoadbalancerName"
 	actual, err := loadbalancers.Update(client, "36e08a3e-a78f-4b40-a229-1e7e23eee1ab", loadbalancers.UpdateOpts{
-		Name: "NewLoadbalancerName",
+		Name: &name,
 	}).Extract()
 	if err != nil {
 		t.Fatalf("Unexpected Update error: %v", err)

--- a/openstack/networking/v2/extensions/lbaas_v2/monitors/requests.go
+++ b/openstack/networking/v2/extensions/lbaas_v2/monitors/requests.go
@@ -223,7 +223,7 @@ type UpdateOpts struct {
 	ExpectedCodes string `json:"expected_codes,omitempty"`
 
 	// The Name of the Monitor.
-	Name string `json:"name,omitempty"`
+	Name *string `json:"name,omitempty"`
 
 	// The administrative state of the Monitor. A valid value is true (UP)
 	// or false (DOWN).

--- a/openstack/networking/v2/extensions/lbaas_v2/monitors/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/lbaas_v2/monitors/testing/requests_test.go
@@ -113,8 +113,9 @@ func TestUpdateHealthmonitor(t *testing.T) {
 	HandleHealthmonitorUpdateSuccessfully(t)
 
 	client := fake.ServiceClient()
+	name := "NewHealthmonitorName"
 	actual, err := monitors.Update(client, "5d4b5228-33b0-4e60-b225-9b727c1a20e7", monitors.UpdateOpts{
-		Name:          "NewHealthmonitorName",
+		Name:          &name,
 		Delay:         3,
 		Timeout:       20,
 		MaxRetries:    10,

--- a/openstack/networking/v2/extensions/lbaas_v2/pools/requests.go
+++ b/openstack/networking/v2/extensions/lbaas_v2/pools/requests.go
@@ -154,10 +154,10 @@ type UpdateOptsBuilder interface {
 // operation.
 type UpdateOpts struct {
 	// Name of the pool.
-	Name string `json:"name,omitempty"`
+	Name *string `json:"name,omitempty"`
 
 	// Human-readable description for the pool.
-	Description string `json:"description,omitempty"`
+	Description *string `json:"description,omitempty"`
 
 	// The algorithm used to distribute load between the members of the pool. The
 	// current specification supports LBMethodRoundRobin, LBMethodLeastConnections
@@ -317,7 +317,7 @@ type UpdateMemberOptsBuilder interface {
 // operation.
 type UpdateMemberOpts struct {
 	// Name of the Member.
-	Name string `json:"name,omitempty"`
+	Name *string `json:"name,omitempty"`
 
 	// A positive integer value that indicates the relative portion of traffic
 	// that this member should receive from the pool. For example, a member with

--- a/openstack/networking/v2/extensions/lbaas_v2/pools/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/lbaas_v2/pools/testing/requests_test.go
@@ -98,8 +98,9 @@ func TestUpdatePool(t *testing.T) {
 	HandlePoolUpdateSuccessfully(t)
 
 	client := fake.ServiceClient()
+	name := "NewPoolName"
 	actual, err := pools.Update(client, "c3741b06-df4d-4715-b142-276b6bce75ab", pools.UpdateOpts{
-		Name:     "NewPoolName",
+		Name:     &name,
 		LBMethod: pools.LBMethodLeastConnections,
 	}).Extract()
 	if err != nil {
@@ -252,8 +253,9 @@ func TestUpdateMember(t *testing.T) {
 
 	weight := 4
 	client := fake.ServiceClient()
+	name := "newMemberName"
 	actual, err := pools.UpdateMember(client, "332abe93-f488-41ba-870b-2ac66be7f853", "2a280670-c202-4b0b-a562-34077415aabf", pools.UpdateMemberOpts{
-		Name:   "newMemberName",
+		Name:   &name,
 		Weight: &weight,
 	}).Extract()
 	if err != nil {

--- a/openstack/networking/v2/extensions/portsbinding/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/portsbinding/testing/requests_test.go
@@ -156,8 +156,9 @@ func TestUpdate(t *testing.T) {
 		portsbinding.PortsBindingExt
 	}
 
+	name := "new_port_name"
 	portUpdateOpts := ports.UpdateOpts{
-		Name: "new_port_name",
+		Name: &name,
 		FixedIPs: []ports.IP{
 			{SubnetID: "a0304c3a-4f08-4c43-88af-d796509c97d2", IPAddress: "10.0.0.3"},
 		},

--- a/openstack/networking/v2/extensions/security/groups/requests.go
+++ b/openstack/networking/v2/extensions/security/groups/requests.go
@@ -92,7 +92,7 @@ type UpdateOpts struct {
 	Name string `json:"name,omitempty"`
 
 	// Describes the security group.
-	Description string `json:"description,omitempty"`
+	Description *string `json:"description,omitempty"`
 }
 
 // ToSecGroupUpdateMap builds a request body from UpdateOpts.

--- a/openstack/networking/v2/extensions/trunks/requests.go
+++ b/openstack/networking/v2/extensions/trunks/requests.go
@@ -114,9 +114,9 @@ type UpdateOptsBuilder interface {
 }
 
 type UpdateOpts struct {
-	AdminStateUp *bool  `json:"admin_state_up,omitempty"`
-	Name         string `json:"name,omitempty"`
-	Description  string `json:"description,omitempty"`
+	AdminStateUp *bool   `json:"admin_state_up,omitempty"`
+	Name         *string `json:"name,omitempty"`
+	Description  *string `json:"description,omitempty"`
 }
 
 func (opts UpdateOpts) ToTrunkUpdateMap() (map[string]interface{}, error) {

--- a/openstack/networking/v2/extensions/trunks/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/trunks/testing/requests_test.go
@@ -182,9 +182,9 @@ func TestUpdate(t *testing.T) {
 	name := "updated_gophertrunk"
 	description := "gophertrunk updated by gophercloud"
 	options := trunks.UpdateOpts{
-		Name:         name,
+		Name:         &name,
 		AdminStateUp: &iFalse,
-		Description:  description,
+		Description:  &description,
 	}
 	n, err := trunks.Update(fake.ServiceClient(), "f6a9718c-5a64-43e3-944f-4deccad8e78c", options).Extract()
 	th.AssertNoErr(t, err)

--- a/openstack/networking/v2/extensions/vpnaas/ikepolicies/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/vpnaas/ikepolicies/testing/requests_test.go
@@ -74,13 +74,13 @@ func TestCreate(t *testing.T) {
 		IKEVersion:            "v2",
 		TenantID:              "9145d91459d248b1b02fdaca97c6a75d",
 		Phase1NegotiationMode: "main",
-		PFS:                 "Group5",
-		EncryptionAlgorithm: "aes-128",
-		Description:         "IKE policy",
-		Name:                "policy",
-		ID:                  "f2b08c1e-aa81-4668-8ae1-1401bcb0576c",
-		Lifetime:            expectedLifetime,
-		ProjectID:           "9145d91459d248b1b02fdaca97c6a75d",
+		PFS:                   "Group5",
+		EncryptionAlgorithm:   "aes-128",
+		Description:           "IKE policy",
+		Name:                  "policy",
+		ID:                    "f2b08c1e-aa81-4668-8ae1-1401bcb0576c",
+		Lifetime:              expectedLifetime,
+		ProjectID:             "9145d91459d248b1b02fdaca97c6a75d",
 	}
 	th.AssertDeepEquals(t, expected, *actual)
 }
@@ -130,12 +130,12 @@ func TestGet(t *testing.T) {
 		TenantID:              "9145d91459d248b1b02fdaca97c6a75d",
 		ProjectID:             "9145d91459d248b1b02fdaca97c6a75d",
 		Phase1NegotiationMode: "main",
-		PFS:                 "Group5",
-		EncryptionAlgorithm: "aes-128",
-		Description:         "IKE policy",
-		Name:                "policy",
-		ID:                  "5c561d9d-eaea-45f6-ae3e-08d1a7080828",
-		Lifetime:            expectedLifetime,
+		PFS:                   "Group5",
+		EncryptionAlgorithm:   "aes-128",
+		Description:           "IKE policy",
+		Name:                  "policy",
+		ID:                    "5c561d9d-eaea-45f6-ae3e-08d1a7080828",
+		Lifetime:              expectedLifetime,
 	}
 	th.AssertDeepEquals(t, expected, *actual)
 }
@@ -208,12 +208,12 @@ func TestList(t *testing.T) {
 				TenantID:              "9145d91459d248b1b02fdaca97c6a75d",
 				ProjectID:             "9145d91459d248b1b02fdaca97c6a75d",
 				Phase1NegotiationMode: "main",
-				PFS:                 "Group5",
-				EncryptionAlgorithm: "aes-128",
-				Description:         "IKE policy",
-				Name:                "policy",
-				ID:                  "5c561d9d-eaea-45f6-ae3e-08d1a7080828",
-				Lifetime:            expectedLifetime,
+				PFS:                   "Group5",
+				EncryptionAlgorithm:   "aes-128",
+				Description:           "IKE policy",
+				Name:                  "policy",
+				ID:                    "5c561d9d-eaea-45f6-ae3e-08d1a7080828",
+				Lifetime:              expectedLifetime,
 			},
 		}
 

--- a/openstack/networking/v2/ports/requests.go
+++ b/openstack/networking/v2/ports/requests.go
@@ -116,11 +116,11 @@ type UpdateOptsBuilder interface {
 
 // UpdateOpts represents the attributes used when updating an existing port.
 type UpdateOpts struct {
-	Name                string         `json:"name,omitempty"`
+	Name                *string        `json:"name,omitempty"`
 	AdminStateUp        *bool          `json:"admin_state_up,omitempty"`
 	FixedIPs            interface{}    `json:"fixed_ips,omitempty"`
-	DeviceID            string         `json:"device_id,omitempty"`
-	DeviceOwner         string         `json:"device_owner,omitempty"`
+	DeviceID            *string        `json:"device_id,omitempty"`
+	DeviceOwner         *string        `json:"device_owner,omitempty"`
 	SecurityGroups      *[]string      `json:"security_groups,omitempty"`
 	AllowedAddressPairs *[]AddressPair `json:"allowed_address_pairs,omitempty"`
 }

--- a/openstack/networking/v2/ports/testing/requests_test.go
+++ b/openstack/networking/v2/ports/testing/requests_test.go
@@ -377,8 +377,9 @@ func TestUpdate(t *testing.T) {
 		fmt.Fprintf(w, UpdateResponse)
 	})
 
+	name := "new_port_name"
 	options := ports.UpdateOpts{
-		Name: "new_port_name",
+		Name: &name,
 		FixedIPs: []ports.IP{
 			{SubnetID: "a0304c3a-4f08-4c43-88af-d796509c97d2", IPAddress: "10.0.0.3"},
 		},
@@ -418,8 +419,9 @@ func TestUpdateOmitSecurityGroups(t *testing.T) {
 		fmt.Fprintf(w, UpdateOmitSecurityGroupsResponse)
 	})
 
+	name := "new_port_name"
 	options := ports.UpdateOpts{
-		Name: "new_port_name",
+		Name: &name,
 		FixedIPs: []ports.IP{
 			{SubnetID: "a0304c3a-4f08-4c43-88af-d796509c97d2", IPAddress: "10.0.0.3"},
 		},
@@ -495,8 +497,9 @@ func TestRemoveSecurityGroups(t *testing.T) {
 		fmt.Fprintf(w, RemoveSecurityGroupResponse)
 	})
 
+	name := "new_port_name"
 	options := ports.UpdateOpts{
-		Name: "new_port_name",
+		Name: &name,
 		FixedIPs: []ports.IP{
 			{SubnetID: "a0304c3a-4f08-4c43-88af-d796509c97d2", IPAddress: "10.0.0.3"},
 		},
@@ -536,8 +539,9 @@ func TestRemoveAllowedAddressPairs(t *testing.T) {
 		fmt.Fprintf(w, RemoveAllowedAddressPairsResponse)
 	})
 
+	name := "new_port_name"
 	options := ports.UpdateOpts{
-		Name: "new_port_name",
+		Name: &name,
 		FixedIPs: []ports.IP{
 			{SubnetID: "a0304c3a-4f08-4c43-88af-d796509c97d2", IPAddress: "10.0.0.3"},
 		},
@@ -573,8 +577,9 @@ func TestDontUpdateAllowedAddressPairs(t *testing.T) {
 		fmt.Fprintf(w, DontUpdateAllowedAddressPairsResponse)
 	})
 
+	name := "new_port_name"
 	options := ports.UpdateOpts{
-		Name: "new_port_name",
+		Name: &name,
 		FixedIPs: []ports.IP{
 			{SubnetID: "a0304c3a-4f08-4c43-88af-d796509c97d2", IPAddress: "10.0.0.3"},
 		},
@@ -731,8 +736,9 @@ func TestUpdateWithExtraDHCPOpts(t *testing.T) {
 		fmt.Fprintf(w, UpdateWithExtraDHCPOptsResponse)
 	})
 
+	name := "updated-port-with-dhcp-opts"
 	portUpdateOpts := ports.UpdateOpts{
-		Name: "updated-port-with-dhcp-opts",
+		Name: &name,
 		FixedIPs: []ports.IP{
 			{SubnetID: "a0304c3a-4f08-4c43-88af-d796509c97d2", IPAddress: "10.0.0.3"},
 		},

--- a/openstack/sharedfilesystems/v2/securityservices/requests.go
+++ b/openstack/sharedfilesystems/v2/securityservices/requests.go
@@ -142,23 +142,23 @@ type UpdateOptsBuilder interface {
 // the SecurityService object.
 type UpdateOpts struct {
 	// The security service name
-	Name string `json:"name"`
+	Name *string `json:"name"`
 	// The security service description
-	Description string `json:"description,omitempty"`
+	Description *string `json:"description,omitempty"`
 	// The security service type. A valid value is ldap, kerberos, or active_directory
 	Type string `json:"type,omitempty"`
 	// The DNS IP address that is used inside the tenant network
-	DNSIP string `json:"dns_ip,omitempty"`
+	DNSIP *string `json:"dns_ip,omitempty"`
 	// The security service organizational unit (OU). Minimum supported microversion for OU is 2.44.
 	OU *string `json:"ou,omitempty"`
 	// The security service user or group name that is used by the tenant
-	User string `json:"user,omitempty"`
+	User *string `json:"user,omitempty"`
 	// The user password, if you specify a user
-	Password string `json:"password,omitempty"`
+	Password *string `json:"password,omitempty"`
 	// The security service domain
-	Domain string `json:"domain,omitempty"`
+	Domain *string `json:"domain,omitempty"`
 	// The security service host name or IP address
-	Server string `json:"server,omitempty"`
+	Server *string `json:"server,omitempty"`
 }
 
 // ToSecurityServiceUpdateMap assembles a request body based on the contents of an

--- a/openstack/sharedfilesystems/v2/securityservices/testing/requests_test.go
+++ b/openstack/sharedfilesystems/v2/securityservices/testing/requests_test.go
@@ -201,7 +201,8 @@ func TestUpdate(t *testing.T) {
 		Password:    "supersecret",
 	}
 
-	options := securityservices.UpdateOpts{Name: "SecServ2"}
+	name := "SecServ2"
+	options := securityservices.UpdateOpts{Name: &name}
 	s, err := securityservices.Update(client.ServiceClient(), "securityServiceID", options).Extract()
 	th.AssertNoErr(t, err)
 	th.CheckDeepEquals(t, &expected, s)

--- a/openstack/sharedfilesystems/v2/sharenetworks/requests.go
+++ b/openstack/sharedfilesystems/v2/sharenetworks/requests.go
@@ -135,9 +135,9 @@ type UpdateOptsBuilder interface {
 // the ShareNetwork object.
 type UpdateOpts struct {
 	// The share network name
-	Name string `json:"name,omitempty"`
+	Name *string `json:"name,omitempty"`
 	// The share network description
-	Description string `json:"description,omitempty"`
+	Description *string `json:"description,omitempty"`
 	// The UUID of the Neutron network to set up for share servers
 	NeutronNetID string `json:"neutron_net_id,omitempty"`
 	// The UUID of the Neutron subnet to set up for share servers

--- a/openstack/sharedfilesystems/v2/sharenetworks/testing/requests_test.go
+++ b/openstack/sharedfilesystems/v2/sharenetworks/testing/requests_test.go
@@ -191,9 +191,11 @@ func TestUpdateNeutron(t *testing.T) {
 		ProjectID:       "16e1ab15c35a457e9c2b2aa189f544e1",
 	}
 
+	name := "net_my2"
+	description := "new description"
 	options := sharenetworks.UpdateOpts{
-		Name:            "net_my2",
-		Description:     "new description",
+		Name:            &name,
+		Description:     &description,
 		NeutronNetID:    "new-neutron-id",
 		NeutronSubnetID: "new-neutron-subnet-id",
 	}
@@ -226,9 +228,11 @@ func TestUpdateNova(t *testing.T) {
 		ProjectID:       "16e1ab15c35a457e9c2b2aa189f544e1",
 	}
 
+	name := "net_my2"
+	description := "new description"
 	options := sharenetworks.UpdateOpts{
-		Name:        "net_my2",
-		Description: "new description",
+		Name:        &name,
+		Description: &description,
 		NovaNetID:   "new-nova-id",
 	}
 


### PR DESCRIPTION
This PR is a part of #1332

I verified that all the fields are optional.
Strings changes in lbaas l7policies now allow to switch from `REDIRECT_TO_POOL` to `REDIRECT_TO_URL`.
Strings changes in securityservices now allow to unset the password/username/etc. These fields are also not required.