### PR TITLE
Add empty strings update acceptance tests

### DIFF
--- a/acceptance/openstack/blockstorage/v1/blockstorage.go
+++ b/acceptance/openstack/blockstorage/v1/blockstorage.go
@@ -50,11 +50,13 @@ func CreateVolume(t *testing.T, client *gophercloud.ServiceClient) (*volumes.Vol
 	}
 
 	volumeName := tools.RandomString("ACPTTEST", 16)
+	volumeDescription := tools.RandomString("ACPTTEST-DESC", 16)
 	t.Logf("Attempting to create volume: %s", volumeName)
 
 	createOpts := volumes.CreateOpts{
-		Size: 1,
-		Name: volumeName,
+		Size:        1,
+		Name:        volumeName,
+		Description: volumeDescription,
 	}
 
 	volume, err := volumes.Create(client, createOpts).Extract()

--- a/acceptance/openstack/blockstorage/v1/volumes_test.go
+++ b/acceptance/openstack/blockstorage/v1/volumes_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gophercloud/gophercloud/acceptance/clients"
 	"github.com/gophercloud/gophercloud/acceptance/tools"
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v1/volumes"
+	th "github.com/gophercloud/gophercloud/testhelper"
 )
 
 func TestVolumesList(t *testing.T) {
@@ -49,4 +50,20 @@ func TestVolumesCreateDestroy(t *testing.T) {
 	}
 
 	tools.PrintResource(t, newVolume)
+	th.AssertEquals(t, volume.Name, newVolume.Name)
+	th.AssertEquals(t, volume.Description, newVolume.Description)
+
+	// Update volume
+	updatedVolumeName := ""
+	updatedVolumeDescription := ""
+	updateOpts := volumes.UpdateOpts{
+		Name:        &updatedVolumeName,
+		Description: &updatedVolumeDescription,
+	}
+	updatedVolume, err := volumes.Update(client, volume.ID, updateOpts).Extract()
+	th.AssertNoErr(t, err)
+
+	tools.PrintResource(t, updatedVolume)
+	th.AssertEquals(t, updatedVolume.Name, updatedVolumeName)
+	th.AssertEquals(t, updatedVolume.Description, updatedVolumeDescription)
 }

--- a/acceptance/openstack/blockstorage/v2/blockstorage.go
+++ b/acceptance/openstack/blockstorage/v2/blockstorage.go
@@ -46,11 +46,13 @@ func CreateSnapshot(t *testing.T, client *gophercloud.ServiceClient, volume *vol
 // error will be returned if the volume was unable to be created.
 func CreateVolume(t *testing.T, client *gophercloud.ServiceClient) (*volumes.Volume, error) {
 	volumeName := tools.RandomString("ACPTTEST", 16)
+	volumeDescription := tools.RandomString("ACPTTEST-DESC", 16)
 	t.Logf("Attempting to create volume: %s", volumeName)
 
 	createOpts := volumes.CreateOpts{
-		Size: 1,
-		Name: volumeName,
+		Size:        1,
+		Name:        volumeName,
+		Description: volumeDescription,
 	}
 
 	volume, err := volumes.Create(client, createOpts).Extract()
@@ -63,10 +65,10 @@ func CreateVolume(t *testing.T, client *gophercloud.ServiceClient) (*volumes.Vol
 		return volume, err
 	}
 
-	th.AssertEquals(t, volume.Name, volumeName)
-	th.AssertEquals(t, volume.Size, 1)
-
 	tools.PrintResource(t, volume)
+	th.AssertEquals(t, volume.Name, volumeName)
+	th.AssertEquals(t, volume.Description, volumeDescription)
+	th.AssertEquals(t, volume.Size, 1)
 
 	t.Logf("Successfully created volume: %s", volume.ID)
 

--- a/acceptance/openstack/blockstorage/v2/volumes_test.go
+++ b/acceptance/openstack/blockstorage/v2/volumes_test.go
@@ -27,6 +27,20 @@ func TestVolumesCreateDestroy(t *testing.T) {
 	newVolume, err := volumes.Get(client, volume.ID).Extract()
 	th.AssertNoErr(t, err)
 
+	// Update volume
+	updatedVolumeName := ""
+	updatedVolumeDescription := ""
+	updateOpts := volumes.UpdateOpts{
+		Name:        &updatedVolumeName,
+		Description: &updatedVolumeDescription,
+	}
+	updatedVolume, err := volumes.Update(client, volume.ID, updateOpts).Extract()
+	th.AssertNoErr(t, err)
+
+	tools.PrintResource(t, updatedVolume)
+	th.AssertEquals(t, updatedVolume.Name, updatedVolumeName)
+	th.AssertEquals(t, updatedVolume.Description, updatedVolumeDescription)
+
 	allPages, err := volumes.List(client, volumes.ListOpts{}).AllPages()
 	th.AssertNoErr(t, err)
 

--- a/acceptance/openstack/blockstorage/v3/volumes_test.go
+++ b/acceptance/openstack/blockstorage/v3/volumes_test.go
@@ -28,6 +28,20 @@ func TestVolumes(t *testing.T) {
 	th.AssertNoErr(t, err)
 	defer DeleteVolume(t, client, volume2)
 
+	// Update volume
+	updatedVolumeName := ""
+	updatedVolumeDescription := ""
+	updateOpts := volumes.UpdateOpts{
+		Name:        &updatedVolumeName,
+		Description: &updatedVolumeDescription,
+	}
+	updatedVolume, err := volumes.Update(client, volume1.ID, updateOpts).Extract()
+	th.AssertNoErr(t, err)
+
+	tools.PrintResource(t, updatedVolume)
+	th.AssertEquals(t, updatedVolume.Name, updatedVolumeName)
+	th.AssertEquals(t, updatedVolume.Description, updatedVolumeDescription)
+
 	listOpts := volumes.ListOpts{
 		Limit: 1,
 	}

--- a/acceptance/openstack/blockstorage/v3/volumetypes_test.go
+++ b/acceptance/openstack/blockstorage/v3/volumetypes_test.go
@@ -37,17 +37,20 @@ func TestVolumeTypes(t *testing.T) {
 
 	th.AssertEquals(t, found, true)
 
-	var isPublic = false
-	var name = vt.Name + "-UPDATED"
+	isPublic := false
+	name := vt.Name + "-UPDATED"
+	description := ""
 	updateOpts := volumetypes.UpdateOpts{
-		Name:     &name,
-		IsPublic: &isPublic,
+		Name:        &name,
+		Description: &description,
+		IsPublic:    &isPublic,
 	}
 
 	newVT, err := volumetypes.Update(client, vt.ID, updateOpts).Extract()
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, vt.Name+"-UPDATED", newVT.Name)
-	th.AssertEquals(t, false, newVT.IsPublic)
 
 	tools.PrintResource(t, newVT)
+	th.AssertEquals(t, name, newVT.Name)
+	th.AssertEquals(t, description, newVT.Description)
+	th.AssertEquals(t, isPublic, newVT.IsPublic)
 }

--- a/acceptance/openstack/compute/v2/secgroup_test.go
+++ b/acceptance/openstack/compute/v2/secgroup_test.go
@@ -45,7 +45,7 @@ func TestSecGroupsCRUD(t *testing.T) {
 	tools.PrintResource(t, securityGroup)
 
 	newName := tools.RandomString("secgroup_", 4)
-	description := tools.RandomString("dec_", 10)
+	description := ""
 	updateOpts := secgroups.UpdateOpts{
 		Name:        newName,
 		Description: &description,
@@ -58,6 +58,7 @@ func TestSecGroupsCRUD(t *testing.T) {
 	t.Logf("Updated %s's name to %s", updatedSecurityGroup.ID, updatedSecurityGroup.Name)
 
 	th.AssertEquals(t, updatedSecurityGroup.Name, newName)
+	th.AssertEquals(t, updatedSecurityGroup.Description, description)
 }
 
 func TestSecGroupsRuleCreate(t *testing.T) {

--- a/acceptance/openstack/db/v1/configurations_test.go
+++ b/acceptance/openstack/db/v1/configurations_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gophercloud/gophercloud/acceptance/clients"
 	"github.com/gophercloud/gophercloud/acceptance/tools"
 	"github.com/gophercloud/gophercloud/openstack/db/v1/configurations"
+	th "github.com/gophercloud/gophercloud/testhelper"
 )
 
 func TestConfigurationsCRUD(t *testing.T) {
@@ -41,10 +42,38 @@ func TestConfigurationsCRUD(t *testing.T) {
 		t.Fatalf("Unable to create configuration: %v", err)
 	}
 
+	readCgroup, err := configurations.Get(client, cgroup.ID).Extract()
+	if err != nil {
+		t.Fatalf("Unable to read configuration: %v", err)
+	}
+
+	tools.PrintResource(t, readCgroup)
+	th.AssertEquals(t, readCgroup.Name, createOpts.Name)
+	th.AssertEquals(t, readCgroup.Description, createOpts.Description)
+	// TODO: verify datastore
+	//th.AssertDeepEquals(t, readCgroup.Datastore, datastore)
+
+	// Update cgroup
+	newCgroupName := "New configuration name"
+	newCgroupDescription := ""
+	updateOpts := configurations.UpdateOpts{
+		Name:        newCgroupName,
+		Description: &newCgroupDescription,
+	}
+	err = configurations.Update(client, cgroup.ID, updateOpts).ExtractErr()
+	th.AssertNoErr(t, err)
+
+	newCgroup, err := configurations.Get(client, cgroup.ID).Extract()
+	if err != nil {
+		t.Fatalf("Unable to read updated configuration: %v", err)
+	}
+
+	tools.PrintResource(t, newCgroup)
+	th.AssertEquals(t, newCgroup.Name, newCgroupName)
+	th.AssertEquals(t, newCgroup.Description, newCgroupDescription)
+
 	err = configurations.Delete(client, cgroup.ID).ExtractErr()
 	if err != nil {
 		t.Fatalf("Unable to delete configuration: %v", err)
 	}
-
-	tools.PrintResource(t, cgroup)
 }

--- a/acceptance/openstack/dns/v2/recordsets_test.go
+++ b/acceptance/openstack/dns/v2/recordsets_test.go
@@ -72,8 +72,9 @@ func TestRecordSetsCRUD(t *testing.T) {
 
 	tools.PrintResource(t, &rs)
 
+	description := ""
 	updateOpts := recordsets.UpdateOpts{
-		Description: "New description",
+		Description: &description,
 		TTL:         0,
 	}
 
@@ -82,5 +83,5 @@ func TestRecordSetsCRUD(t *testing.T) {
 
 	tools.PrintResource(t, &newRS)
 
-	th.AssertEquals(t, newRS.Description, "New description")
+	th.AssertEquals(t, newRS.Description, description)
 }

--- a/acceptance/openstack/dns/v2/zones_test.go
+++ b/acceptance/openstack/dns/v2/zones_test.go
@@ -40,8 +40,9 @@ func TestZonesCRUD(t *testing.T) {
 
 	th.AssertEquals(t, found, true)
 
+	description := ""
 	updateOpts := zones.UpdateOpts{
-		Description: "New description",
+		Description: &description,
 		TTL:         0,
 	}
 
@@ -50,5 +51,5 @@ func TestZonesCRUD(t *testing.T) {
 
 	tools.PrintResource(t, &newZone)
 
-	th.AssertEquals(t, newZone.Description, "New description")
+	th.AssertEquals(t, newZone.Description, description)
 }

--- a/acceptance/openstack/identity/v2/identity.go
+++ b/acceptance/openstack/identity/v2/identity.go
@@ -34,6 +34,7 @@ func AddUserRole(t *testing.T, client *gophercloud.ServiceClient, tenant *tenant
 // unable to be created.
 func CreateTenant(t *testing.T, client *gophercloud.ServiceClient, c *tenants.CreateOpts) (*tenants.Tenant, error) {
 	name := tools.RandomString("ACPTTEST", 8)
+	description := tools.RandomString("ACPTTEST-DESC", 8)
 	t.Logf("Attempting to create tenant: %s", name)
 
 	var createOpts tenants.CreateOpts
@@ -44,6 +45,7 @@ func CreateTenant(t *testing.T, client *gophercloud.ServiceClient, c *tenants.Cr
 	}
 
 	createOpts.Name = name
+	createOpts.Description = description
 
 	tenant, err := tenants.Create(client, createOpts).Extract()
 	if err != nil {
@@ -53,6 +55,7 @@ func CreateTenant(t *testing.T, client *gophercloud.ServiceClient, c *tenants.Cr
 	t.Logf("Successfully created project %s with ID %s", name, tenant.ID)
 
 	th.AssertEquals(t, name, tenant.Name)
+	th.AssertEquals(t, description, tenant.Description)
 
 	return tenant, nil
 }

--- a/acceptance/openstack/identity/v2/tenant_test.go
+++ b/acceptance/openstack/identity/v2/tenant_test.go
@@ -52,8 +52,9 @@ func TestTenantsCRUD(t *testing.T) {
 
 	tools.PrintResource(t, tenant)
 
+	description := ""
 	updateOpts := tenants.UpdateOpts{
-		Description: "some tenant",
+		Description: &description,
 	}
 
 	newTenant, err := tenants.Update(client, tenant.ID, updateOpts).Extract()
@@ -61,5 +62,5 @@ func TestTenantsCRUD(t *testing.T) {
 
 	tools.PrintResource(t, newTenant)
 
-	th.AssertEquals(t, newTenant.Description, "some tenant")
+	th.AssertEquals(t, newTenant.Description, description)
 }

--- a/acceptance/openstack/identity/v3/domains_test.go
+++ b/acceptance/openstack/identity/v3/domains_test.go
@@ -61,8 +61,9 @@ func TestDomainsCRUD(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	var iTrue bool = true
+	var description = "Testing Domain"
 	createOpts := domains.CreateOpts{
-		Description: "Testing Domain",
+		Description: description,
 		Enabled:     &iTrue,
 	}
 
@@ -72,10 +73,10 @@ func TestDomainsCRUD(t *testing.T) {
 
 	tools.PrintResource(t, domain)
 
-	th.AssertEquals(t, domain.Description, "Testing Domain")
+	th.AssertEquals(t, domain.Description, description)
 
 	var iFalse bool = false
-	var description = "Staging Test Domain"
+	description = ""
 	updateOpts := domains.UpdateOpts{
 		Description: &description,
 		Enabled:     &iFalse,
@@ -86,5 +87,5 @@ func TestDomainsCRUD(t *testing.T) {
 
 	tools.PrintResource(t, newDomain)
 
-	th.AssertEquals(t, newDomain.Description, "Staging Test Domain")
+	th.AssertEquals(t, newDomain.Description, description)
 }

--- a/acceptance/openstack/identity/v3/groups_test.go
+++ b/acceptance/openstack/identity/v3/groups_test.go
@@ -17,9 +17,11 @@ func TestGroupCRUD(t *testing.T) {
 	client, err := clients.NewIdentityV3Client()
 	th.AssertNoErr(t, err)
 
+	description := "Test Groups"
+	domainID := "default"
 	createOpts := groups.CreateOpts{
-		Name:     "testgroup",
-		DomainID: "default",
+		Description: description,
+		DomainID:    domainID,
 		Extra: map[string]interface{}{
 			"email": "testgroup@example.com",
 		},
@@ -33,7 +35,11 @@ func TestGroupCRUD(t *testing.T) {
 	tools.PrintResource(t, group)
 	tools.PrintResource(t, group.Extra)
 
-	var description = "Test Groups"
+	th.AssertEquals(t, group.Description, description)
+	th.AssertEquals(t, group.DomainID, domainID)
+	th.AssertDeepEquals(t, group.Extra, createOpts.Extra)
+
+	description = ""
 	updateOpts := groups.UpdateOpts{
 		Description: &description,
 		Extra: map[string]interface{}{
@@ -46,6 +52,9 @@ func TestGroupCRUD(t *testing.T) {
 
 	tools.PrintResource(t, newGroup)
 	tools.PrintResource(t, newGroup.Extra)
+
+	th.AssertEquals(t, newGroup.Description, description)
+	th.AssertDeepEquals(t, newGroup.Extra, updateOpts.Extra)
 
 	listOpts := groups.ListOpts{
 		DomainID: "default",

--- a/acceptance/openstack/identity/v3/identity.go
+++ b/acceptance/openstack/identity/v3/identity.go
@@ -21,6 +21,7 @@ import (
 // unable to be created.
 func CreateProject(t *testing.T, client *gophercloud.ServiceClient, c *projects.CreateOpts) (*projects.Project, error) {
 	name := tools.RandomString("ACPTTEST", 8)
+	description := tools.RandomString("ACPTTEST-DESC", 8)
 	t.Logf("Attempting to create project: %s", name)
 
 	var createOpts projects.CreateOpts
@@ -31,6 +32,7 @@ func CreateProject(t *testing.T, client *gophercloud.ServiceClient, c *projects.
 	}
 
 	createOpts.Name = name
+	createOpts.Description = description
 
 	project, err := projects.Create(client, createOpts).Extract()
 	if err != nil {
@@ -40,6 +42,7 @@ func CreateProject(t *testing.T, client *gophercloud.ServiceClient, c *projects.
 	t.Logf("Successfully created project %s with ID %s", name, project.ID)
 
 	th.AssertEquals(t, project.Name, name)
+	th.AssertEquals(t, project.Description, description)
 
 	return project, nil
 }

--- a/acceptance/openstack/identity/v3/projects_test.go
+++ b/acceptance/openstack/identity/v3/projects_test.go
@@ -117,15 +117,19 @@ func TestProjectsCRUD(t *testing.T) {
 
 	tools.PrintResource(t, project)
 
-	var iFalse bool = false
+	description := ""
+	iFalse := false
 	updateOpts := projects.UpdateOpts{
-		Enabled: &iFalse,
+		Description: &description,
+		Enabled:     &iFalse,
 	}
 
 	updatedProject, err := projects.Update(client, project.ID, updateOpts).Extract()
 	th.AssertNoErr(t, err)
 
 	tools.PrintResource(t, updatedProject)
+	th.AssertEquals(t, updatedProject.Description, description)
+	th.AssertEquals(t, updatedProject.Enabled, iFalse)
 }
 
 func TestProjectsDomain(t *testing.T) {

--- a/acceptance/openstack/identity/v3/regions_test.go
+++ b/acceptance/openstack/identity/v3/regions_test.go
@@ -75,7 +75,7 @@ func TestRegionsCRUD(t *testing.T) {
 	tools.PrintResource(t, region)
 	tools.PrintResource(t, region.Extra)
 
-	var description = "Region A for testing"
+	var description = ""
 	updateOpts := regions.UpdateOpts{
 		Description: &description,
 		/*
@@ -94,4 +94,6 @@ func TestRegionsCRUD(t *testing.T) {
 
 	tools.PrintResource(t, newRegion)
 	tools.PrintResource(t, newRegion.Extra)
+
+	th.AssertEquals(t, newRegion.Description, description)
 }

--- a/acceptance/openstack/identity/v3/users_test.go
+++ b/acceptance/openstack/identity/v3/users_test.go
@@ -122,6 +122,7 @@ func TestUserCRUD(t *testing.T) {
 
 	createOpts := users.CreateOpts{
 		DefaultProjectID: project.ID,
+		Description:      "test description",
 		Password:         "foobar",
 		DomainID:         "default",
 		Options: map[users.Option]interface{}{
@@ -143,9 +144,16 @@ func TestUserCRUD(t *testing.T) {
 	tools.PrintResource(t, user)
 	tools.PrintResource(t, user.Extra)
 
+	th.AssertEquals(t, user.Description, createOpts.Description)
+	th.AssertEquals(t, user.DomainID, createOpts.DomainID)
+
 	iFalse := false
+	name := "newtestuser"
+	description := ""
 	updateOpts := users.UpdateOpts{
-		Enabled: &iFalse,
+		Name:        name,
+		Description: &description,
+		Enabled:     &iFalse,
 		Options: map[users.Option]interface{}{
 			users.MultiFactorAuthRules: nil,
 		},
@@ -160,6 +168,9 @@ func TestUserCRUD(t *testing.T) {
 	tools.PrintResource(t, newUser)
 	tools.PrintResource(t, newUser.Extra)
 
+	th.AssertEquals(t, newUser.Name, name)
+	th.AssertEquals(t, newUser.Description, description)
+	th.AssertEquals(t, newUser.Enabled, iFalse)
 	th.AssertEquals(t, newUser.Extra["disabled_reason"], "DDOS")
 }
 

--- a/acceptance/openstack/loadbalancer/v2/loadbalancer.go
+++ b/acceptance/openstack/loadbalancer/v2/loadbalancer.go
@@ -22,12 +22,14 @@ const loadbalancerDeleteTimeoutSeconds = 300
 // be created.
 func CreateListener(t *testing.T, client *gophercloud.ServiceClient, lb *loadbalancers.LoadBalancer) (*listeners.Listener, error) {
 	listenerName := tools.RandomString("TESTACCT-", 8)
+	listenerDescription := tools.RandomString("TESTACCT-DESC-", 8)
 	listenerPort := tools.RandomInt(1, 100)
 
 	t.Logf("Attempting to create listener %s on port %d", listenerName, listenerPort)
 
 	createOpts := listeners.CreateOpts{
 		Name:           listenerName,
+		Description:    listenerDescription,
 		LoadbalancerID: lb.ID,
 		Protocol:       "TCP",
 		ProtocolPort:   listenerPort,
@@ -51,11 +53,13 @@ func CreateListener(t *testing.T, client *gophercloud.ServiceClient, lb *loadbal
 // subnet. An error will be returned if the loadbalancer could not be created.
 func CreateLoadBalancer(t *testing.T, client *gophercloud.ServiceClient, subnetID string) (*loadbalancers.LoadBalancer, error) {
 	lbName := tools.RandomString("TESTACCT-", 8)
+	lbDescription := tools.RandomString("TESTACCT-DESC-", 8)
 
 	t.Logf("Attempting to create loadbalancer %s on subnet %s", lbName, subnetID)
 
 	createOpts := loadbalancers.CreateOpts{
 		Name:         lbName,
+		Description:  lbDescription,
 		VipSubnetID:  subnetID,
 		AdminStateUp: gophercloud.Enabled,
 	}
@@ -149,11 +153,13 @@ func CreateMonitor(t *testing.T, client *gophercloud.ServiceClient, lb *loadbala
 // created.
 func CreatePool(t *testing.T, client *gophercloud.ServiceClient, lb *loadbalancers.LoadBalancer) (*pools.Pool, error) {
 	poolName := tools.RandomString("TESTACCT-", 8)
+	poolDescription := tools.RandomString("TESTACCT-DESC-", 8)
 
 	t.Logf("Attempting to create pool %s", poolName)
 
 	createOpts := pools.CreateOpts{
 		Name:           poolName,
+		Description:    poolDescription,
 		Protocol:       pools.ProtocolTCP,
 		LoadbalancerID: lb.ID,
 		LBMethod:       pools.LBMethodLeastConnections,
@@ -178,11 +184,13 @@ func CreatePool(t *testing.T, client *gophercloud.ServiceClient, lb *loadbalance
 // created.
 func CreateL7Policy(t *testing.T, client *gophercloud.ServiceClient, listener *listeners.Listener, lb *loadbalancers.LoadBalancer) (*l7policies.L7Policy, error) {
 	policyName := tools.RandomString("TESTACCT-", 8)
+	policyDescription := tools.RandomString("TESTACCT-DESC-", 8)
 
 	t.Logf("Attempting to create l7 policy %s", policyName)
 
 	createOpts := l7policies.CreateOpts{
 		Name:        policyName,
+		Description: policyDescription,
 		ListenerID:  listener.ID,
 		Action:      l7policies.ActionRedirectToURL,
 		RedirectURL: "http://www.example.com",

--- a/acceptance/openstack/networking/v2/extensions/extensions.go
+++ b/acceptance/openstack/networking/v2/extensions/extensions.go
@@ -17,6 +17,7 @@ import (
 // returned if the creation failed.
 func CreateExternalNetwork(t *testing.T, client *gophercloud.ServiceClient) (*networks.Network, error) {
 	networkName := tools.RandomString("TESTACC-", 8)
+	networkDescription := tools.RandomString("TESTACC-DESC-", 8)
 
 	t.Logf("Attempting to create external network: %s", networkName)
 
@@ -25,6 +26,7 @@ func CreateExternalNetwork(t *testing.T, client *gophercloud.ServiceClient) (*ne
 
 	networkCreateOpts := networks.CreateOpts{
 		Name:         networkName,
+		Description:  networkDescription,
 		AdminStateUp: &adminStateUp,
 	}
 
@@ -41,6 +43,7 @@ func CreateExternalNetwork(t *testing.T, client *gophercloud.ServiceClient) (*ne
 	t.Logf("Created external network: %s", networkName)
 
 	th.AssertEquals(t, network.Name, networkName)
+	th.AssertEquals(t, network.Description, networkDescription)
 
 	return network, nil
 }
@@ -49,6 +52,7 @@ func CreateExternalNetwork(t *testing.T, client *gophercloud.ServiceClient) (*ne
 // attached. An error will be returned if the port could not be created.
 func CreatePortWithSecurityGroup(t *testing.T, client *gophercloud.ServiceClient, networkID, subnetID, secGroupID string) (*ports.Port, error) {
 	portName := tools.RandomString("TESTACC-", 8)
+	portDescription := tools.RandomString("TESTACC-DESC-", 8)
 	iFalse := false
 
 	t.Logf("Attempting to create port: %s", portName)
@@ -56,6 +60,7 @@ func CreatePortWithSecurityGroup(t *testing.T, client *gophercloud.ServiceClient
 	createOpts := ports.CreateOpts{
 		NetworkID:      networkID,
 		Name:           portName,
+		Description:    portDescription,
 		AdminStateUp:   &iFalse,
 		FixedIPs:       []ports.IP{ports.IP{SubnetID: subnetID}},
 		SecurityGroups: &[]string{secGroupID},
@@ -69,6 +74,7 @@ func CreatePortWithSecurityGroup(t *testing.T, client *gophercloud.ServiceClient
 	t.Logf("Successfully created port: %s", portName)
 
 	th.AssertEquals(t, port.Name, portName)
+	th.AssertEquals(t, port.Description, portDescription)
 	th.AssertEquals(t, port.NetworkID, networkID)
 
 	return port, nil
@@ -78,11 +84,13 @@ func CreatePortWithSecurityGroup(t *testing.T, client *gophercloud.ServiceClient
 // An error will be returned if one was failed to be created.
 func CreateSecurityGroup(t *testing.T, client *gophercloud.ServiceClient) (*groups.SecGroup, error) {
 	secGroupName := tools.RandomString("TESTACC-", 8)
+	secGroupDescription := tools.RandomString("TESTACC-DESC-", 8)
 
 	t.Logf("Attempting to create security group: %s", secGroupName)
 
 	createOpts := groups.CreateOpts{
-		Name: secGroupName,
+		Name:        secGroupName,
+		Description: secGroupDescription,
 	}
 
 	secGroup, err := groups.Create(client, createOpts).Extract()
@@ -93,6 +101,7 @@ func CreateSecurityGroup(t *testing.T, client *gophercloud.ServiceClient) (*grou
 	t.Logf("Created security group: %s", secGroup.ID)
 
 	th.AssertEquals(t, secGroup.Name, secGroupName)
+	th.AssertEquals(t, secGroup.Description, secGroupDescription)
 
 	return secGroup, nil
 }
@@ -103,10 +112,12 @@ func CreateSecurityGroup(t *testing.T, client *gophercloud.ServiceClient) (*grou
 func CreateSecurityGroupRule(t *testing.T, client *gophercloud.ServiceClient, secGroupID string) (*rules.SecGroupRule, error) {
 	t.Logf("Attempting to create security group rule in group: %s", secGroupID)
 
+	description := "Rule description"
 	fromPort := tools.RandomInt(80, 89)
 	toPort := tools.RandomInt(90, 99)
 
 	createOpts := rules.CreateOpts{
+		Description:  description,
 		Direction:    "ingress",
 		EtherType:    "IPv4",
 		SecGroupID:   secGroupID,
@@ -123,6 +134,7 @@ func CreateSecurityGroupRule(t *testing.T, client *gophercloud.ServiceClient, se
 	t.Logf("Created security group rule: %s", rule.ID)
 
 	th.AssertEquals(t, rule.SecGroupID, secGroupID)
+	th.AssertEquals(t, rule.Description, description)
 
 	return rule, nil
 }

--- a/acceptance/openstack/networking/v2/extensions/fwaas/firewall_test.go
+++ b/acceptance/openstack/networking/v2/extensions/fwaas/firewall_test.go
@@ -39,18 +39,24 @@ func TestFirewallCRUD(t *testing.T) {
 
 	tools.PrintResource(t, firewall)
 
-	updateOpts := firewalls.UpdateOpts{
+	fwName := ""
+	fwDescription := ""
+	fwUpdateOpts := firewalls.UpdateOpts{
+		Name:        &fwName,
+		Description: &fwDescription,
 		PolicyID:    policy.ID,
-		Description: "Some firewall description",
 	}
 
-	_, err = firewalls.Update(client, firewall.ID, updateOpts).Extract()
+	_, err = firewalls.Update(client, firewall.ID, fwUpdateOpts).Extract()
 	th.AssertNoErr(t, err)
 
 	newFirewall, err := firewalls.Get(client, firewall.ID).Extract()
 	th.AssertNoErr(t, err)
 
 	tools.PrintResource(t, newFirewall)
+	th.AssertEquals(t, newFirewall.Name, fwName)
+	th.AssertEquals(t, newFirewall.Description, fwDescription)
+	th.AssertEquals(t, newFirewall.PolicyID, policy.ID)
 
 	allPages, err := firewalls.List(client, nil).AllPages()
 	th.AssertNoErr(t, err)
@@ -98,9 +104,10 @@ func TestFirewallCRUDRouter(t *testing.T) {
 	th.AssertNoErr(t, err)
 	defer layer3.DeleteRouter(t, client, router2.ID)
 
+	description := "Some firewall description"
 	firewallUpdateOpts := firewalls.UpdateOpts{
 		PolicyID:    policy.ID,
-		Description: "Some firewall description",
+		Description: &description,
 	}
 
 	updateOpts := routerinsertion.UpdateOptsExt{
@@ -143,9 +150,10 @@ func TestFirewallCRUDRemoveRouter(t *testing.T) {
 
 	tools.PrintResource(t, firewall)
 
+	description := "Some firewall description"
 	firewallUpdateOpts := firewalls.UpdateOpts{
 		PolicyID:    policy.ID,
-		Description: "Some firewall description",
+		Description: &description,
 	}
 
 	updateOpts := routerinsertion.UpdateOptsExt{

--- a/acceptance/openstack/networking/v2/extensions/fwaas/fwaas.go
+++ b/acceptance/openstack/networking/v2/extensions/fwaas/fwaas.go
@@ -18,12 +18,14 @@ import (
 // policy ID. An error will be returned if the firewall could not be created.
 func CreateFirewall(t *testing.T, client *gophercloud.ServiceClient, policyID string) (*firewalls.Firewall, error) {
 	firewallName := tools.RandomString("TESTACC-", 8)
+	firewallDescription := tools.RandomString("TESTACC-DESC-", 8)
 
 	t.Logf("Attempting to create firewall %s", firewallName)
 
 	iTrue := true
 	createOpts := firewalls.CreateOpts{
 		Name:         firewallName,
+		Description:  firewallDescription,
 		PolicyID:     policyID,
 		AdminStateUp: &iTrue,
 	}
@@ -41,6 +43,7 @@ func CreateFirewall(t *testing.T, client *gophercloud.ServiceClient, policyID st
 	t.Logf("Successfully created firewall %s", firewallName)
 
 	th.AssertEquals(t, firewall.Name, firewallName)
+	th.AssertEquals(t, firewall.Description, firewallDescription)
 
 	return firewall, nil
 }
@@ -50,12 +53,14 @@ func CreateFirewall(t *testing.T, client *gophercloud.ServiceClient, policyID st
 // returned if the firewall could not be created.
 func CreateFirewallOnRouter(t *testing.T, client *gophercloud.ServiceClient, policyID string, routerID string) (*firewalls.Firewall, error) {
 	firewallName := tools.RandomString("TESTACC-", 8)
+	firewallDescription := tools.RandomString("TESTACC-DESC-", 8)
 
 	t.Logf("Attempting to create firewall %s", firewallName)
 
 	firewallCreateOpts := firewalls.CreateOpts{
-		Name:     firewallName,
-		PolicyID: policyID,
+		Name:        firewallName,
+		Description: firewallDescription,
+		PolicyID:    policyID,
 	}
 
 	createOpts := routerinsertion.CreateOptsExt{
@@ -76,6 +81,7 @@ func CreateFirewallOnRouter(t *testing.T, client *gophercloud.ServiceClient, pol
 	t.Logf("Successfully created firewall %s", firewallName)
 
 	th.AssertEquals(t, firewall.Name, firewallName)
+	th.AssertEquals(t, firewall.Description, firewallDescription)
 
 	return firewall, nil
 }
@@ -84,11 +90,13 @@ func CreateFirewallOnRouter(t *testing.T, client *gophercloud.ServiceClient, pol
 // rule. An error will be returned if the rule could not be created.
 func CreatePolicy(t *testing.T, client *gophercloud.ServiceClient, ruleID string) (*policies.Policy, error) {
 	policyName := tools.RandomString("TESTACC-", 8)
+	policyDescription := tools.RandomString("TESTACC-DESC-", 8)
 
 	t.Logf("Attempting to create policy %s", policyName)
 
 	createOpts := policies.CreateOpts{
-		Name: policyName,
+		Name:        policyName,
+		Description: policyDescription,
 		Rules: []string{
 			ruleID,
 		},
@@ -102,6 +110,7 @@ func CreatePolicy(t *testing.T, client *gophercloud.ServiceClient, ruleID string
 	t.Logf("Successfully created policy %s", policyName)
 
 	th.AssertEquals(t, policy.Name, policyName)
+	th.AssertEquals(t, policy.Description, policyDescription)
 	th.AssertEquals(t, len(policy.Rules), 1)
 
 	return policy, nil

--- a/acceptance/openstack/networking/v2/extensions/fwaas/policy_test.go
+++ b/acceptance/openstack/networking/v2/extensions/fwaas/policy_test.go
@@ -27,8 +27,11 @@ func TestPolicyCRUD(t *testing.T) {
 
 	tools.PrintResource(t, policy)
 
+	name := ""
+	description := ""
 	updateOpts := policies.UpdateOpts{
-		Description: "Some policy description",
+		Name:        &name,
+		Description: &description,
 	}
 
 	_, err = policies.Update(client, policy.ID, updateOpts).Extract()
@@ -38,6 +41,8 @@ func TestPolicyCRUD(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	tools.PrintResource(t, newPolicy)
+	th.AssertEquals(t, newPolicy.Name, name)
+	th.AssertEquals(t, newPolicy.Description, description)
 
 	allPages, err := policies.List(client, nil).AllPages()
 	th.AssertNoErr(t, err)

--- a/acceptance/openstack/networking/v2/extensions/layer3/layer3.go
+++ b/acceptance/openstack/networking/v2/extensions/layer3/layer3.go
@@ -17,7 +17,9 @@ import (
 func CreateFloatingIP(t *testing.T, client *gophercloud.ServiceClient, networkID, portID string) (*floatingips.FloatingIP, error) {
 	t.Logf("Attempting to create floating IP on port: %s", portID)
 
+	fipDescription := "Test floating IP"
 	createOpts := &floatingips.CreateOpts{
+		Description:       fipDescription,
 		FloatingNetworkID: networkID,
 		PortID:            portID,
 	}
@@ -28,6 +30,8 @@ func CreateFloatingIP(t *testing.T, client *gophercloud.ServiceClient, networkID
 	}
 
 	t.Logf("Created floating IP.")
+
+	th.AssertEquals(t, floatingIP.Description, fipDescription)
 
 	return floatingIP, err
 }
@@ -43,6 +47,7 @@ func CreateExternalRouter(t *testing.T, client *gophercloud.ServiceClient) (*rou
 	}
 
 	routerName := tools.RandomString("TESTACC-", 8)
+	routerDescription := tools.RandomString("TESTACC-DESC-", 8)
 
 	t.Logf("Attempting to create external router: %s", routerName)
 
@@ -55,6 +60,7 @@ func CreateExternalRouter(t *testing.T, client *gophercloud.ServiceClient) (*rou
 
 	createOpts := routers.CreateOpts{
 		Name:         routerName,
+		Description:  routerDescription,
 		AdminStateUp: &adminStateUp,
 		GatewayInfo:  &gatewayInfo,
 	}
@@ -71,6 +77,7 @@ func CreateExternalRouter(t *testing.T, client *gophercloud.ServiceClient) (*rou
 	t.Logf("Created router: %s", routerName)
 
 	th.AssertEquals(t, router.Name, routerName)
+	th.AssertEquals(t, router.Description, routerDescription)
 
 	return router, nil
 }
@@ -79,12 +86,14 @@ func CreateExternalRouter(t *testing.T, client *gophercloud.ServiceClient) (*rou
 // returned if the creation failed.
 func CreateRouter(t *testing.T, client *gophercloud.ServiceClient, networkID string) (*routers.Router, error) {
 	routerName := tools.RandomString("TESTACC-", 8)
+	routerDescription := tools.RandomString("TESTACC-DESC-", 8)
 
 	t.Logf("Attempting to create router: %s", routerName)
 
 	adminStateUp := true
 	createOpts := routers.CreateOpts{
 		Name:         routerName,
+		Description:  routerDescription,
 		AdminStateUp: &adminStateUp,
 	}
 
@@ -100,6 +109,7 @@ func CreateRouter(t *testing.T, client *gophercloud.ServiceClient, networkID str
 	t.Logf("Created router: %s", routerName)
 
 	th.AssertEquals(t, router.Name, routerName)
+	th.AssertEquals(t, router.Description, routerDescription)
 
 	return router, nil
 }

--- a/acceptance/openstack/networking/v2/extensions/layer3/routers_test.go
+++ b/acceptance/openstack/networking/v2/extensions/layer3/routers_test.go
@@ -27,8 +27,10 @@ func TestLayer3RouterCreateDelete(t *testing.T) {
 	tools.PrintResource(t, router)
 
 	newName := tools.RandomString("TESTACC-", 8)
+	newDescription := ""
 	updateOpts := routers.UpdateOpts{
-		Name: newName,
+		Name:        newName,
+		Description: &newDescription,
 	}
 
 	_, err = routers.Update(client, router.ID, updateOpts).Extract()
@@ -38,6 +40,8 @@ func TestLayer3RouterCreateDelete(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	tools.PrintResource(t, newRouter)
+	th.AssertEquals(t, newRouter.Name, newName)
+	th.AssertEquals(t, newRouter.Description, newDescription)
 
 	listOpts := routers.ListOpts{}
 	allPages, err := routers.List(client, listOpts).AllPages()
@@ -69,8 +73,10 @@ func TestLayer3ExternalRouterCreateDelete(t *testing.T) {
 	tools.PrintResource(t, router)
 
 	newName := tools.RandomString("TESTACC-", 8)
+	newDescription := ""
 	updateOpts := routers.UpdateOpts{
-		Name: newName,
+		Name:        newName,
+		Description: &newDescription,
 	}
 
 	_, err = routers.Update(client, router.ID, updateOpts).Extract()
@@ -80,6 +86,8 @@ func TestLayer3ExternalRouterCreateDelete(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	tools.PrintResource(t, newRouter)
+	th.AssertEquals(t, newRouter.Name, newName)
+	th.AssertEquals(t, newRouter.Description, newDescription)
 }
 
 func TestLayer3RouterInterface(t *testing.T) {

--- a/acceptance/openstack/networking/v2/extensions/lbaas/members_test.go
+++ b/acceptance/openstack/networking/v2/extensions/lbaas/members_test.go
@@ -71,12 +71,12 @@ func TestMembersCRUD(t *testing.T) {
 
 	_, err = members.Update(client, member.ID, updateOpts).Extract()
 	if err != nil {
-		t.Fatalf("Unable to update member: %v")
+		t.Fatalf("Unable to update member: %v", err)
 	}
 
 	newMember, err := members.Get(client, member.ID).Extract()
 	if err != nil {
-		t.Fatalf("Unable to get member: %v")
+		t.Fatalf("Unable to get member: %v", err)
 	}
 
 	tools.PrintResource(t, newMember)

--- a/acceptance/openstack/networking/v2/extensions/lbaas/monitors_test.go
+++ b/acceptance/openstack/networking/v2/extensions/lbaas/monitors_test.go
@@ -51,12 +51,12 @@ func TestMonitorsCRUD(t *testing.T) {
 
 	_, err = monitors.Update(client, monitor.ID, updateOpts).Extract()
 	if err != nil {
-		t.Fatalf("Unable to update monitor: %v")
+		t.Fatalf("Unable to update monitor: %v", err)
 	}
 
 	newMonitor, err := monitors.Get(client, monitor.ID).Extract()
 	if err != nil {
-		t.Fatalf("Unable to get monitor: %v")
+		t.Fatalf("Unable to get monitor: %v", err)
 	}
 
 	tools.PrintResource(t, newMonitor)

--- a/acceptance/openstack/networking/v2/extensions/lbaas/pools_test.go
+++ b/acceptance/openstack/networking/v2/extensions/lbaas/pools_test.go
@@ -64,12 +64,12 @@ func TestPoolsCRUD(t *testing.T) {
 
 	_, err = pools.Update(client, pool.ID, updateOpts).Extract()
 	if err != nil {
-		t.Fatalf("Unable to update pool: %v")
+		t.Fatalf("Unable to update pool: %v", err)
 	}
 
 	newPool, err := pools.Get(client, pool.ID).Extract()
 	if err != nil {
-		t.Fatalf("Unable to get pool: %v")
+		t.Fatalf("Unable to get pool: %v", err)
 	}
 
 	tools.PrintResource(t, newPool)

--- a/acceptance/openstack/networking/v2/extensions/lbaas/vips_test.go
+++ b/acceptance/openstack/networking/v2/extensions/lbaas/vips_test.go
@@ -71,12 +71,12 @@ func TestVIPsCRUD(t *testing.T) {
 
 	_, err = vips.Update(client, vip.ID, updateOpts).Extract()
 	if err != nil {
-		t.Fatalf("Unable to update vip: %v")
+		t.Fatalf("Unable to update vip: %v", err)
 	}
 
 	newVIP, err := vips.Get(client, vip.ID).Extract()
 	if err != nil {
-		t.Fatalf("Unable to get vip: %v")
+		t.Fatalf("Unable to get vip: %v", err)
 	}
 
 	tools.PrintResource(t, newVIP)

--- a/acceptance/openstack/networking/v2/extensions/lbaas_v2/loadbalancers_test.go
+++ b/acceptance/openstack/networking/v2/extensions/lbaas_v2/loadbalancers_test.go
@@ -59,8 +59,11 @@ func TestLoadbalancersCRUD(t *testing.T) {
 	th.AssertNoErr(t, err)
 	defer DeleteListener(t, client, lb.ID, listener.ID)
 
+	listenerName := ""
+	listenerDescription := ""
 	updateListenerOpts := listeners.UpdateOpts{
-		Description: "Some listener description",
+		Name:        &listenerName,
+		Description: &listenerDescription,
 	}
 	_, err = listeners.Update(client, listener.ID, updateListenerOpts).Extract()
 	th.AssertNoErr(t, err)
@@ -73,14 +76,19 @@ func TestLoadbalancersCRUD(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	tools.PrintResource(t, newListener)
+	th.AssertEquals(t, newListener.Name, listenerName)
+	th.AssertEquals(t, newListener.Description, listenerDescription)
 
 	// Pool
 	pool, err := CreatePool(t, client, lb)
 	th.AssertNoErr(t, err)
 	defer DeletePool(t, client, lb.ID, pool.ID)
 
+	poolName := ""
+	poolDescription := ""
 	updatePoolOpts := pools.UpdateOpts{
-		Description: "Some pool description",
+		Name:        &poolName,
+		Description: &poolDescription,
 	}
 	_, err = pools.Update(client, pool.ID, updatePoolOpts).Extract()
 	th.AssertNoErr(t, err)
@@ -93,14 +101,18 @@ func TestLoadbalancersCRUD(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	tools.PrintResource(t, newPool)
+	th.AssertEquals(t, newPool.Name, poolName)
+	th.AssertEquals(t, newPool.Description, poolDescription)
 
 	// Member
 	member, err := CreateMember(t, client, lb, newPool, subnet.ID, subnet.CIDR)
 	th.AssertNoErr(t, err)
 	defer DeleteMember(t, client, lb.ID, pool.ID, member.ID)
 
+	memberName := ""
 	newWeight := tools.RandomInt(11, 100)
 	updateMemberOpts := pools.UpdateMemberOpts{
+		Name:   &memberName,
 		Weight: &newWeight,
 	}
 	_, err = pools.UpdateMember(client, pool.ID, member.ID, updateMemberOpts).Extract()
@@ -114,14 +126,18 @@ func TestLoadbalancersCRUD(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	tools.PrintResource(t, newMember)
+	th.AssertEquals(t, newMember.Name, memberName)
+	th.AssertEquals(t, newMember.Weight, newWeight)
 
 	// Monitor
 	monitor, err := CreateMonitor(t, client, lb, newPool)
 	th.AssertNoErr(t, err)
 	defer DeleteMonitor(t, client, lb.ID, monitor.ID)
 
+	monName := ""
 	newDelay := tools.RandomInt(20, 30)
 	updateMonitorOpts := monitors.UpdateOpts{
+		Name:  &monName,
 		Delay: newDelay,
 	}
 	_, err = monitors.Update(client, monitor.ID, updateMonitorOpts).Extract()
@@ -135,4 +151,6 @@ func TestLoadbalancersCRUD(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	tools.PrintResource(t, newMonitor)
+	th.AssertEquals(t, newMonitor.Name, newMonitor)
+	th.AssertEquals(t, newMonitor.Delay, newDelay)
 }

--- a/acceptance/openstack/networking/v2/extensions/portsbinding/portsbinding.go
+++ b/acceptance/openstack/networking/v2/extensions/portsbinding/portsbinding.go
@@ -20,6 +20,7 @@ type PortWithBindingExt struct {
 // returned if the port could not be created.
 func CreatePortsbinding(t *testing.T, client *gophercloud.ServiceClient, networkID, subnetID, hostID string) (PortWithBindingExt, error) {
 	portName := tools.RandomString("TESTACC-", 8)
+	portDescription := tools.RandomString("TESTACC-PORT-DESC-", 8)
 	iFalse := false
 
 	t.Logf("Attempting to create port: %s", portName)
@@ -27,6 +28,7 @@ func CreatePortsbinding(t *testing.T, client *gophercloud.ServiceClient, network
 	portCreateOpts := ports.CreateOpts{
 		NetworkID:    networkID,
 		Name:         portName,
+		Description:  portDescription,
 		AdminStateUp: &iFalse,
 		FixedIPs:     []ports.IP{ports.IP{SubnetID: subnetID}},
 	}
@@ -46,6 +48,7 @@ func CreatePortsbinding(t *testing.T, client *gophercloud.ServiceClient, network
 	t.Logf("Successfully created port: %s", portName)
 
 	th.AssertEquals(t, s.Name, portName)
+	th.AssertEquals(t, s.Description, portDescription)
 
 	return s, nil
 }

--- a/acceptance/openstack/networking/v2/extensions/portsbinding/portsbinding_test.go
+++ b/acceptance/openstack/networking/v2/extensions/portsbinding/portsbinding_test.go
@@ -39,12 +39,16 @@ func TestPortsbindingCRUD(t *testing.T) {
 	tools.PrintResource(t, port)
 
 	// Update port
-	newPortName := tools.RandomString("TESTACC-", 8)
+	newPortName := ""
+	newPortDescription := ""
 	updateOpts := ports.UpdateOpts{
-		Name: &newPortName,
+		Name:        &newPortName,
+		Description: &newPortDescription,
 	}
 	newPort, err := ports.Update(client, port.ID, updateOpts).Extract()
 	th.AssertNoErr(t, err)
 
 	tools.PrintResource(t, newPort)
+	th.AssertEquals(t, newPort.Description, newPortName)
+	th.AssertEquals(t, newPort.Description, newPortDescription)
 }

--- a/acceptance/openstack/networking/v2/extensions/security_test.go
+++ b/acceptance/openstack/networking/v2/extensions/security_test.go
@@ -26,8 +26,10 @@ func TestSecurityGroupsCreateUpdateDelete(t *testing.T) {
 
 	tools.PrintResource(t, group)
 
-	var description = "A security group"
+	var name = "Update group"
+	var description = ""
 	updateOpts := groups.UpdateOpts{
+		Name:        name,
 		Description: &description,
 	}
 
@@ -35,6 +37,8 @@ func TestSecurityGroupsCreateUpdateDelete(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	tools.PrintResource(t, newGroup)
+	th.AssertEquals(t, newGroup.Name, name)
+	th.AssertEquals(t, newGroup.Description, description)
 
 	listOpts := groups.ListOpts{}
 	allPages, err := groups.List(client, listOpts).AllPages()

--- a/acceptance/openstack/networking/v2/extensions/subnetpools/subnetpools.go
+++ b/acceptance/openstack/networking/v2/extensions/subnetpools/subnetpools.go
@@ -13,12 +13,14 @@ import (
 // subnetpool could not be created.
 func CreateSubnetPool(t *testing.T, client *gophercloud.ServiceClient) (*subnetpools.SubnetPool, error) {
 	subnetPoolName := tools.RandomString("TESTACC-", 8)
+	subnetPoolDescription := tools.RandomString("TESTACC-DESC-", 8)
 	subnetPoolPrefixes := []string{
 		"10.0.0.0/8",
 	}
 	createOpts := subnetpools.CreateOpts{
-		Name:     subnetPoolName,
-		Prefixes: subnetPoolPrefixes,
+		Name:        subnetPoolName,
+		Description: subnetPoolDescription,
+		Prefixes:    subnetPoolPrefixes,
 	}
 
 	t.Logf("Attempting to create a subnetpool: %s", subnetPoolName)
@@ -31,6 +33,7 @@ func CreateSubnetPool(t *testing.T, client *gophercloud.ServiceClient) (*subnetp
 	t.Logf("Successfully created the subnetpool.")
 
 	th.AssertEquals(t, subnetPool.Name, subnetPoolName)
+	th.AssertEquals(t, subnetPool.Description, subnetPoolDescription)
 
 	return subnetPool, nil
 }

--- a/acceptance/openstack/networking/v2/extensions/subnetpools/subnetpools_test.go
+++ b/acceptance/openstack/networking/v2/extensions/subnetpools/subnetpools_test.go
@@ -23,8 +23,10 @@ func TestSubnetPoolsCRUD(t *testing.T) {
 	tools.PrintResource(t, subnetPool)
 
 	newName := tools.RandomString("TESTACC-", 8)
+	newDescription := ""
 	updateOpts := &subnetpools.UpdateOpts{
-		Name: newName,
+		Name:        newName,
+		Description: &newDescription,
 	}
 
 	_, err = subnetpools.Update(client, subnetPool.ID, updateOpts).Extract()
@@ -34,6 +36,8 @@ func TestSubnetPoolsCRUD(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	tools.PrintResource(t, newSubnetPool)
+	th.AssertEquals(t, newSubnetPool.Name, newName)
+	th.AssertEquals(t, newSubnetPool.Description, newDescription)
 
 	allPages, err := subnetpools.List(client, nil).AllPages()
 	th.AssertNoErr(t, err)

--- a/acceptance/openstack/networking/v2/extensions/trunks/trunks_test.go
+++ b/acceptance/openstack/networking/v2/extensions/trunks/trunks_test.go
@@ -65,9 +65,11 @@ func TestTrunkCRUD(t *testing.T) {
 	}
 
 	// Update Trunk
-	var name = "updated_gophertrunk"
+	name := ""
+	description := ""
 	updateOpts := trunks.UpdateOpts{
-		Name: &name,
+		Name:        &name,
+		Description: &description,
 	}
 	updatedTrunk, err := trunks.Update(client, trunk.ID, updateOpts).Extract()
 	if err != nil {
@@ -77,6 +79,13 @@ func TestTrunkCRUD(t *testing.T) {
 	if trunk.Name == updatedTrunk.Name {
 		t.Fatalf("Trunk name was not updated correctly")
 	}
+
+	if trunk.Description == updatedTrunk.Description {
+		t.Fatalf("Trunk description was not updated correctly")
+	}
+
+	th.AssertDeepEquals(t, updatedTrunk.Name, name)
+	th.AssertDeepEquals(t, updatedTrunk.Description, description)
 
 	// Get subports
 	subports, err := trunks.GetSubports(client, trunk.ID).Extract()

--- a/acceptance/openstack/networking/v2/networking.go
+++ b/acceptance/openstack/networking/v2/networking.go
@@ -24,8 +24,10 @@ type PortWithExtraDHCPOpts struct {
 // network could not be created.
 func CreateNetwork(t *testing.T, client *gophercloud.ServiceClient) (*networks.Network, error) {
 	networkName := tools.RandomString("TESTACC-", 8)
+	networkDescription := tools.RandomString("TESTACC-DESC-", 8)
 	createOpts := networks.CreateOpts{
 		Name:         networkName,
+		Description:  networkDescription,
 		AdminStateUp: gophercloud.Enabled,
 	}
 
@@ -39,6 +41,7 @@ func CreateNetwork(t *testing.T, client *gophercloud.ServiceClient) (*networks.N
 	t.Logf("Successfully created network.")
 
 	th.AssertEquals(t, network.Name, networkName)
+	th.AssertEquals(t, network.Description, networkDescription)
 
 	return network, nil
 }
@@ -76,12 +79,14 @@ func CreateNetworkWithoutPortSecurity(t *testing.T, client *gophercloud.ServiceC
 // returned if the port could not be created.
 func CreatePort(t *testing.T, client *gophercloud.ServiceClient, networkID, subnetID string) (*ports.Port, error) {
 	portName := tools.RandomString("TESTACC-", 8)
+	portDescription := tools.RandomString("TESTACC-DESC-", 8)
 
 	t.Logf("Attempting to create port: %s", portName)
 
 	createOpts := ports.CreateOpts{
 		NetworkID:    networkID,
 		Name:         portName,
+		Description:  portDescription,
 		AdminStateUp: gophercloud.Enabled,
 		FixedIPs:     []ports.IP{ports.IP{SubnetID: subnetID}},
 	}
@@ -103,6 +108,7 @@ func CreatePort(t *testing.T, client *gophercloud.ServiceClient, networkID, subn
 	t.Logf("Successfully created port: %s", portName)
 
 	th.AssertEquals(t, port.Name, portName)
+	th.AssertEquals(t, port.Description, portDescription)
 
 	return newPort, nil
 }
@@ -233,16 +239,18 @@ func CreatePortWithExtraDHCPOpts(t *testing.T, client *gophercloud.ServiceClient
 // will be returned if the subnet could not be created.
 func CreateSubnet(t *testing.T, client *gophercloud.ServiceClient, networkID string) (*subnets.Subnet, error) {
 	subnetName := tools.RandomString("TESTACC-", 8)
+	subnetDescription := tools.RandomString("TESTACC-DESC-", 8)
 	subnetOctet := tools.RandomInt(1, 250)
 	subnetCIDR := fmt.Sprintf("192.168.%d.0/24", subnetOctet)
 	subnetGateway := fmt.Sprintf("192.168.%d.1", subnetOctet)
 	createOpts := subnets.CreateOpts{
-		NetworkID:  networkID,
-		CIDR:       subnetCIDR,
-		IPVersion:  4,
-		Name:       subnetName,
-		EnableDHCP: gophercloud.Disabled,
-		GatewayIP:  &subnetGateway,
+		NetworkID:   networkID,
+		CIDR:        subnetCIDR,
+		IPVersion:   4,
+		Name:        subnetName,
+		Description: subnetDescription,
+		EnableDHCP:  gophercloud.Disabled,
+		GatewayIP:   &subnetGateway,
 	}
 
 	t.Logf("Attempting to create subnet: %s", subnetName)
@@ -255,6 +263,7 @@ func CreateSubnet(t *testing.T, client *gophercloud.ServiceClient, networkID str
 	t.Logf("Successfully created subnet.")
 
 	th.AssertEquals(t, subnet.Name, subnetName)
+	th.AssertEquals(t, subnet.Description, subnetDescription)
 	th.AssertEquals(t, subnet.GatewayIP, subnetGateway)
 	th.AssertEquals(t, subnet.CIDR, subnetCIDR)
 

--- a/acceptance/openstack/networking/v2/networks_test.go
+++ b/acceptance/openstack/networking/v2/networks_test.go
@@ -79,8 +79,10 @@ func TestNetworksCRUD(t *testing.T) {
 	tools.PrintResource(t, network)
 
 	newName := tools.RandomString("TESTACC-", 8)
+	newDescription := ""
 	updateOpts := &networks.UpdateOpts{
-		Name: newName,
+		Name:        newName,
+		Description: &newDescription,
 	}
 
 	_, err = networks.Update(client, network.ID, updateOpts).Extract()
@@ -90,6 +92,8 @@ func TestNetworksCRUD(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	tools.PrintResource(t, newNetwork)
+	th.AssertEquals(t, newNetwork.Name, newName)
+	th.AssertEquals(t, newNetwork.Description, newDescription)
 
 	type networkWithExt struct {
 		networks.Network

--- a/acceptance/openstack/networking/v2/ports_test.go
+++ b/acceptance/openstack/networking/v2/ports_test.go
@@ -40,14 +40,19 @@ func TestPortsCRUD(t *testing.T) {
 	tools.PrintResource(t, port)
 
 	// Update port
-	newPortName := tools.RandomString("TESTACC-", 8)
+	newPortName := ""
+	newPortDescription := ""
 	updateOpts := ports.UpdateOpts{
-		Name: &newPortName,
+		Name:        &newPortName,
+		Description: &newPortDescription,
 	}
 	newPort, err := ports.Update(client, port.ID, updateOpts).Extract()
 	th.AssertNoErr(t, err)
 
 	tools.PrintResource(t, newPort)
+
+	th.AssertEquals(t, newPort.Name, newPortName)
+	th.AssertEquals(t, newPort.Description, newPortDescription)
 
 	allPages, err := ports.List(client, nil).AllPages()
 	th.AssertNoErr(t, err)

--- a/acceptance/openstack/networking/v2/subnets_test.go
+++ b/acceptance/openstack/networking/v2/subnets_test.go
@@ -32,8 +32,10 @@ func TestSubnetCRUD(t *testing.T) {
 
 	// Update Subnet
 	newSubnetName := tools.RandomString("TESTACC-", 8)
+	newSubnetDescription := ""
 	updateOpts := subnets.UpdateOpts{
-		Name: newSubnetName,
+		Name:        newSubnetName,
+		Description: &newSubnetDescription,
 	}
 	_, err = subnets.Update(client, subnet.ID, updateOpts).Extract()
 	th.AssertNoErr(t, err)
@@ -43,6 +45,8 @@ func TestSubnetCRUD(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	tools.PrintResource(t, newSubnet)
+	th.AssertEquals(t, newSubnet.Name, newSubnetName)
+	th.AssertEquals(t, newSubnet.Description, newSubnetDescription)
 
 	allPages, err := subnets.List(client, nil).AllPages()
 	th.AssertNoErr(t, err)

--- a/acceptance/openstack/sharedfilesystems/v2/securityservices.go
+++ b/acceptance/openstack/sharedfilesystems/v2/securityservices.go
@@ -16,11 +16,13 @@ func CreateSecurityService(t *testing.T, client *gophercloud.ServiceClient) (*se
 	}
 
 	securityServiceName := tools.RandomString("ACPTTEST", 16)
+	securityServiceDescription := tools.RandomString("ACPTTEST-DESC", 16)
 	t.Logf("Attempting to create security service: %s", securityServiceName)
 
 	createOpts := securityservices.CreateOpts{
-		Name: securityServiceName,
-		Type: "kerberos",
+		Name:        securityServiceName,
+		Description: securityServiceDescription,
+		Type:        "kerberos",
 	}
 
 	securityService, err := securityservices.Create(client, createOpts).Extract()

--- a/acceptance/openstack/sharedfilesystems/v2/securityservices_test.go
+++ b/acceptance/openstack/sharedfilesystems/v2/securityservices_test.go
@@ -27,6 +27,10 @@ func TestSecurityServiceCreateDelete(t *testing.T) {
 		t.Fatalf("Security service name was expeted to be: %s", securityService.Name)
 	}
 
+	if newSecurityService.Description != securityService.Description {
+		t.Fatalf("Security service description was expeted to be: %s", securityService.Description)
+	}
+
 	PrintSecurityService(t, securityService)
 
 	defer DeleteSecurityService(t, client, securityService)
@@ -109,7 +113,7 @@ func TestSecurityServiceUpdate(t *testing.T) {
 	}
 
 	name := "NewName"
-	description := "New security service description"
+	description := ""
 	options := securityservices.UpdateOpts{
 		Name:        &name,
 		Description: &description,
@@ -126,12 +130,12 @@ func TestSecurityServiceUpdate(t *testing.T) {
 		t.Errorf("Unable to retrieve the security service: %v", err)
 	}
 
-	if newSecurityService.Name != *options.Name {
-		t.Fatalf("Security service name was expeted to be: %s", *options.Name)
+	if newSecurityService.Name != name {
+		t.Fatalf("Security service name was expeted to be: %s", name)
 	}
 
-	if newSecurityService.Description != *options.Description {
-		t.Fatalf("Security service description was expeted to be: %s", *options.Description)
+	if newSecurityService.Description != description {
+		t.Fatalf("Security service description was expeted to be: %s", description)
 	}
 
 	if newSecurityService.Type != options.Type {

--- a/acceptance/openstack/sharedfilesystems/v2/sharenetworks_test.go
+++ b/acceptance/openstack/sharedfilesystems/v2/sharenetworks_test.go
@@ -29,6 +29,10 @@ func TestShareNetworkCreateDestroy(t *testing.T) {
 		t.Fatalf("Share network name was expeted to be: %s", shareNetwork.Name)
 	}
 
+	if newShareNetwork.Description != shareNetwork.Description {
+		t.Fatalf("Share network description was expeted to be: %s", shareNetwork.Description)
+	}
+
 	PrintShareNetwork(t, shareNetwork)
 
 	defer DeleteShareNetwork(t, client, shareNetwork)
@@ -53,14 +57,14 @@ func TestShareNetworkUpdate(t *testing.T) {
 	}
 
 	name := "NewName"
-	description := "New share network description"
+	description := ""
 	options := sharenetworks.UpdateOpts{
 		Name:        &name,
 		Description: &description,
 	}
 
-	expectedShareNetwork.Name = *options.Name
-	expectedShareNetwork.Description = *options.Description
+	expectedShareNetwork.Name = name
+	expectedShareNetwork.Description = description
 
 	_, err = sharenetworks.Update(client, shareNetwork.ID, options).Extract()
 	if err != nil {

--- a/script/acceptancetest
+++ b/script/acceptancetest
@@ -10,103 +10,81 @@ failed=
 # Run the acceptance tests.
 # Check the error code after each suite, but do not exit early if a suite failed.
 
-# Identity v3
-go test -v -timeout $timeout -tags "fixtures acceptance" ./acceptance/openstack/identity/v3/
-if [[ $? != 0 ]]; then
-  failed=1
-fi
+ACCEPTANCE_TESTS=(
+acceptance/openstack/blockstorage/extensions
 
-# Networking v2
-go test -v -timeout $timeout -tags "fixtures acceptance" ./acceptance/openstack/networking/v2/
-if [[ $? != 0 ]]; then
-  failed=1
-fi
+# snapshots_test.go:16: Unable to create a blockstorage client: CinderEndpoint is required
+# acceptance/openstack/blockstorage/noauth
 
-# Networking v2 - extensions
-go test -v -timeout $timeout -tags "fixtures acceptance" ./acceptance/openstack/networking/v2/extensions
-if [[ $? != 0 ]]; then
-  failed=1
-fi
+# snapshots_test.go:21: Unable to retrieve snapshots: Resource not found
+# acceptance/openstack/blockstorage/v1
 
-# Networking v2 - layer3
-go test -v -timeout $timeout -tags "fixtures acceptance" ./acceptance/openstack/networking/v2/extensions/layer3
-if [[ $? != 0 ]]; then
-  failed=1
-fi
+acceptance/openstack/blockstorage/v2
+acceptance/openstack/blockstorage/v3
 
-# Networking v2 - networkipavailabilities
-# requires bug fix
-go test -v -timeout $timeout -tags "fixtures acceptance" ./acceptance/openstack/networking/v2/extensions/networkipavailabilities
-if [[ $? != 0 ]]; then
-  failed=1
-fi
+# No suitable endpoint could be found in the service catalog.
+# acceptance/openstack/clustering/v1
 
-# Networking v2 - portsbinding
-go test -v -timeout $timeout -tags "fixtures acceptance" ./acceptance/openstack/networking/v2/extensions/portsbinding
-if [[ $? != 0 ]]; then
-  failed=1
-fi
+acceptance/openstack/compute/v2
 
-# Networking v2 - rbacpolicies
-go test -v -timeout $timeout -tags "fixtures acceptance" ./acceptance/openstack/networking/v2/extensions/rbacpolicies
-if [[ $? != 0 ]]; then
-  failed=1
-fi
+# No suitable endpoint could be found in the service catalog.
+# acceptance/openstack/containerinfra/v1
 
-# Networking v2 - subnetpools
-go test -v -timeout $timeout -tags "fixtures acceptance" ./acceptance/openstack/networking/v2/extensions/subnetpools
-if [[ $? != 0 ]]; then
-  failed=1
-fi
+acceptance/openstack/container/v1
 
-# Networking v2 - trunks
-go test -v -timeout $timeout -tags "fixtures acceptance" ./acceptance/openstack/networking/v2/extensions/trunks
-if [[ $? != 0 ]]; then
-  failed=1
-fi
+# Unable to create a DB client: No suitable endpoint could be found in the service catalog.
+# acceptance/openstack/db/v1
 
-# Block Storage v2
-go test -v -timeout $timeout -tags "fixtures acceptance" ./acceptance/openstack/blockstorage/v2/
-if [[ $? != 0 ]]; then
-  failed=1
-fi
+acceptance/openstack/dns/v2
+acceptance/openstack/identity/v2
+acceptance/openstack/identity/v3
+acceptance/openstack/imageservice/v2
+acceptance/openstack/keymanager/v1
+acceptance/openstack/loadbalancer/v2
 
-# Block Storage v3
-go test -v -timeout $timeout -tags "fixtures acceptance" ./acceptance/openstack/blockstorage/v3/
-if [[ $? != 0 ]]; then
-  failed=1
-fi
+# No suitable endpoint could be found in the service catalog.
+# acceptance/openstack/messaging/v2
 
-# Block Storage extensions
-go test -v -timeout $timeout -tags "fixtures acceptance" ./acceptance/openstack/blockstorage/extensions/
-if [[ $? != 0 ]]; then
-  failed=1
-fi
+acceptance/openstack/networking/v2
+acceptance/openstack/networking/v2/extensions
 
-# Compute v2
-go test -v -timeout $timeout -tags "fixtures acceptance" ./acceptance/openstack/compute/v2/
-if [[ $? != 0 ]]; then
-  failed=1
-fi
+# Resource not found
+# acceptance/openstack/networking/v2/extensions/fwaas
 
-# Container v1
-go test -v -timeout $timeout -tags "fixtures acceptance" ./acceptance/openstack/container/v1/
-if [[ $? != 0 ]]; then
-  failed=1
-fi
+acceptance/openstack/networking/v2/extensions/layer3
 
-# Image Service v2
-go test -v -timeout $timeout -tags "fixtures acceptance" ./acceptance/openstack/imageservice/v2/
-if [[ $? != 0 ]]; then
-  failed=1
-fi
+# Unable to create: Resource not found
+# acceptance/openstack/networking/v2/extensions/lbaas
 
-# Orchestration v1
-go test -v -timeout $timeout -tags "fixtures acceptance" ./acceptance/openstack/orchestration/v1/
-if [[ $? != 0 ]]; then
-  failed=1
-fi
+# Resource not found
+# acceptance/openstack/networking/v2/extensions/lbaas_v2
 
+acceptance/openstack/networking/v2/extensions/networkipavailabilities
+acceptance/openstack/networking/v2/extensions/portsbinding
+acceptance/openstack/networking/v2/extensions/qos/ruletypes
+acceptance/openstack/networking/v2/extensions/rbacpolicies
+acceptance/openstack/networking/v2/extensions/subnetpools
+acceptance/openstack/networking/v2/extensions/trunks
+
+# Unable to create: Resource not found
+# acceptance/openstack/networking/v2/extensions/vpnaas
+
+acceptance/openstack/objectstorage/v1
+acceptance/openstack/orchestration/v1
+
+# Temporarily disabled, see https://github.com/gophercloud/gophercloud/issues/1345
+# acceptance/openstack/sharedfilesystems/v2
+
+# No suitable endpoint could be found in the service catalog
+# acceptance/openstack/workflow/v2
+)
+
+for acceptance_test in ${ACCEPTANCE_TESTS[@]}; do
+  go test -v -timeout $timeout -tags "fixtures acceptance" ./${acceptance_test}
+  if [[ $? != 0 ]]; then
+    failed=1
+  fi
+done
 
 # If any of the test suites failed, exit 1
 if [[ -n $failed ]]; then


### PR DESCRIPTION
Due to [#1343](https://github.com/gophercloud/gophercloud/pull/1343#discussion_r239680996) it appeared that some tests are not executed in devstack environment. Thus code changes from #1341 were not reflected in acceptance tests. Though we made a decision to perform empty strings tests in terraform, I started to fix tests and decided to put empty strings tests as well.

Additionally this PR covers #1344