### PR TITLE
Senlin: Nodes Op

### DIFF
--- a/acceptance/openstack/clustering/v1/nodes_test.go
+++ b/acceptance/openstack/clustering/v1/nodes_test.go
@@ -89,17 +89,17 @@ func TestNodesOps(t *testing.T) {
 	th.AssertNoErr(t, err)
 	defer DeleteNode(t, client, node.ID)
 
-	ops := []nodes.OpOpts{
+	ops := []nodes.OperationOpts{
 		// TODO: Commented out due to backend returns error, as of 2018-12-14
 		//{Operation: nodes.RebuildOperation},
-		//{Operation: nodes.EvacuateOperation, Params: nodes.OpParams{"EvacuateHost": node.ID, "EvacuateForce", "True"}},
-		{Operation: nodes.RebootOperation, Params: nodes.OpParams{"type": "SOFT"}},
-		{Operation: nodes.ChangePasswordOperation, Params: nodes.OpParams{"admin_pass": "test"}},
+		//{Operation: nodes.EvacuateOperation, Params: nodes.OperationParams{"EvacuateHost": node.ID, "EvacuateForce", "True"}},
+		{Operation: nodes.RebootOperation, Params: nodes.OperationParams{"type": "SOFT"}},
+		{Operation: nodes.ChangePasswordOperation, Params: nodes.OperationParams{"admin_pass": "test"}},
 		{Operation: nodes.LockOperation},
 		{Operation: nodes.UnlockOperation},
 		{Operation: nodes.SuspendOperation},
 		{Operation: nodes.ResumeOperation},
-		{Operation: nodes.RescueOperation, Params: nodes.OpParams{"image_ref": choices.ImageID}},
+		{Operation: nodes.RescueOperation, Params: nodes.OperationParams{"image_ref": choices.ImageID}},
 		{Operation: nodes.PauseOperation},
 		{Operation: nodes.UnpauseOperation},
 		{Operation: nodes.StopOperation},

--- a/openstack/clustering/v1/nodes/doc.go
+++ b/openstack/clustering/v1/nodes/doc.go
@@ -79,7 +79,7 @@ Example to Perform an Operation on a Node
 		Operation: nodes.RebootOperation,
 		Params:    nodes.OperationParams{"type": "SOFT"},
 	}
-    actionID, err := nodes.Ops(serviceClient, nodeID, operationOpts).Extract()
+	actionID, err := nodes.Ops(serviceClient, nodeID, operationOpts).Extract()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/clustering/v1/nodes/doc.go
+++ b/openstack/clustering/v1/nodes/doc.go
@@ -70,5 +70,19 @@ Example to Get a Node
 	}
 
 	fmt.Printf("%+v\n", node)
+
+Example to Perform an Operation on a Node
+
+	serviceClient.Microversion = "1.4"
+	nodeID := "node123"
+	opsOpts := nodes.OpOpts{
+		Operation: nodes.RebootOperation,
+		Params:    nodes.OpParams{"type": "SOFT"},
+	}
+    actionID, err := nodes.Ops(serviceClient, nodeID, opsOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
 */
 package nodes

--- a/openstack/clustering/v1/nodes/doc.go
+++ b/openstack/clustering/v1/nodes/doc.go
@@ -75,11 +75,11 @@ Example to Perform an Operation on a Node
 
 	serviceClient.Microversion = "1.4"
 	nodeID := "node123"
-	opsOpts := nodes.OpOpts{
+	operationOpts := nodes.OperationOpts{
 		Operation: nodes.RebootOperation,
-		Params:    nodes.OpParams{"type": "SOFT"},
+		Params:    nodes.OperationParams{"type": "SOFT"},
 	}
-    actionID, err := nodes.Ops(serviceClient, nodeID, opsOpts).Extract()
+    actionID, err := nodes.Ops(serviceClient, nodeID, operationOpts).Extract()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/clustering/v1/nodes/requests.go
+++ b/openstack/clustering/v1/nodes/requests.go
@@ -169,27 +169,27 @@ const (
 	AbandonOperation OperationName = "abandon"
 )
 
-// ToNodeOpMap constructs a request body from OpOpts.
-func (opts OpOpts) ToNodeOpMap() (map[string]interface{}, error) {
+// ToNodeOperationMap constructs a request body from OperationOpts.
+func (opts OperationOpts) ToNodeOperationMap() (map[string]interface{}, error) {
 	optsMap := map[string]interface{}{string(opts.Operation): opts.Params}
 	return optsMap, nil
 }
 
-// OpOptsBuilder allows extensions to add additional parameters to the
+// OperationOptsBuilder allows extensions to add additional parameters to the
 // Op request.
-type OpOptsBuilder interface {
-	ToNodeOpMap() (map[string]interface{}, error)
+type OperationOptsBuilder interface {
+	ToNodeOperationMap() (map[string]interface{}, error)
 }
-type OpParams map[string]interface{}
+type OperationParams map[string]interface{}
 
-// OpOpts represents options used to perform an operation on a node
-type OpOpts struct {
-	Operation OperationName `json:"operation,omitempty"`
-	Params    OpParams      `json:"params,omitempty"`
+// OperationOpts represents options used to perform an operation on a node
+type OperationOpts struct {
+	Operation OperationName   `json:"operation" required:"true"`
+	Params    OperationParams `json:"params,omitempty"`
 }
 
-func Ops(client *gophercloud.ServiceClient, id string, opts OpOptsBuilder) (r ActionResult) {
-	b, err := opts.ToNodeOpMap()
+func Ops(client *gophercloud.ServiceClient, id string, opts OperationOptsBuilder) (r ActionResult) {
+	b, err := opts.ToNodeOperationMap()
 	if err != nil {
 		r.Err = err
 		return

--- a/openstack/clustering/v1/nodes/requests.go
+++ b/openstack/clustering/v1/nodes/requests.go
@@ -144,3 +144,64 @@ func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {
 	}
 	return
 }
+
+// OperationName represents valid values for node operation
+type OperationName string
+
+const (
+	// Nova Profile Op Names
+	RebootOperation         OperationName = "reboot"
+	RebuildOperation        OperationName = "rebuild"
+	ChangePasswordOperation OperationName = "change_password"
+	PauseOperation          OperationName = "pause"
+	UnpauseOperation        OperationName = "unpause"
+	SuspendOperation        OperationName = "suspend"
+	ResumeOperation         OperationName = "resume"
+	LockOperation           OperationName = "lock"
+	UnlockOperation         OperationName = "unlock"
+	StartOperation          OperationName = "start"
+	StopOperation           OperationName = "stop"
+	RescueOperation         OperationName = "rescue"
+	UnrescueOperation       OperationName = "unrescue"
+	EvacuateOperation       OperationName = "evacuate"
+
+	// Heat Pofile Op Names
+	AbandonOperation OperationName = "abandon"
+)
+
+// ToNodeOpMap constructs a request body from OpOpts.
+func (opts OpOpts) ToNodeOpMap() (map[string]interface{}, error) {
+	optsMap := map[string]interface{}{string(opts.Operation): opts.Params}
+	return optsMap, nil
+}
+
+// OpOptsBuilder allows extensions to add additional parameters to the
+// Op request.
+type OpOptsBuilder interface {
+	ToNodeOpMap() (map[string]interface{}, error)
+}
+type OpParams map[string]interface{}
+
+// OpOpts represents options used to perform an operation on a node
+type OpOpts struct {
+	Operation OperationName `json:"operation,omitempty"`
+	Params    OpParams      `json:"params,omitempty"`
+}
+
+func Ops(client *gophercloud.ServiceClient, id string, opts OpOptsBuilder) (r ActionResult) {
+	b, err := opts.ToNodeOpMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	var result *http.Response
+	result, r.Err = client.Post(opsURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+	})
+	if r.Err == nil {
+		r.Header = result.Header
+	}
+
+	return
+}

--- a/openstack/clustering/v1/nodes/results.go
+++ b/openstack/clustering/v1/nodes/results.go
@@ -127,3 +127,18 @@ func ExtractNodes(r pagination.Page) ([]Node, error) {
 	err := (r.(NodePage)).ExtractInto(&s)
 	return s.Nodes, err
 }
+
+// ActionResult is the response of Senlin actions. Call its Extract method to
+// obtain the Action ID of the action.
+type ActionResult struct {
+	gophercloud.Result
+}
+
+// Extract interprets any Action result as an Action.
+func (r ActionResult) Extract() (string, error) {
+	var s struct {
+		Action string `json:"action"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Action, err
+}

--- a/openstack/clustering/v1/nodes/testing/fixtures.go
+++ b/openstack/clustering/v1/nodes/testing/fixtures.go
@@ -254,6 +254,13 @@ var ExpectedUpdate = nodes.Node{
 	User:         "ab79b9647d074e46ac223a8fa297b846",
 }
 
+const OpsActionResponse = `
+{
+  "action": "2a0ff107-e789-4660-a122-3816c43af703"
+}`
+
+const OpsExpectedActionID = "2a0ff107-e789-4660-a122-3816c43af703"
+
 func HandleCreateSuccessfully(t *testing.T) {
 	th.Mux.HandleFunc("/v1/nodes", func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "POST")
@@ -312,5 +319,17 @@ func HandleUpdateSuccessfully(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 
 		fmt.Fprint(w, UpdateResponse)
+	})
+}
+
+func HandleOpsSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/v1/nodes/7d85f602-a948-4a30-afd4-e84f47471c15/ops", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+
+		fmt.Fprint(w, OpsActionResponse)
 	})
 }

--- a/openstack/clustering/v1/nodes/testing/fixtures.go
+++ b/openstack/clustering/v1/nodes/testing/fixtures.go
@@ -254,12 +254,12 @@ var ExpectedUpdate = nodes.Node{
 	User:         "ab79b9647d074e46ac223a8fa297b846",
 }
 
-const OpsActionResponse = `
+const OperationActionResponse = `
 {
   "action": "2a0ff107-e789-4660-a122-3816c43af703"
 }`
 
-const OpsExpectedActionID = "2a0ff107-e789-4660-a122-3816c43af703"
+const OperationExpectedActionID = "2a0ff107-e789-4660-a122-3816c43af703"
 
 func HandleCreateSuccessfully(t *testing.T) {
 	th.Mux.HandleFunc("/v1/nodes", func(w http.ResponseWriter, r *http.Request) {
@@ -330,6 +330,6 @@ func HandleOpsSuccessfully(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusAccepted)
 
-		fmt.Fprint(w, OpsActionResponse)
+		fmt.Fprint(w, OperationActionResponse)
 	})
 }

--- a/openstack/clustering/v1/nodes/testing/requests_test.go
+++ b/openstack/clustering/v1/nodes/testing/requests_test.go
@@ -103,3 +103,17 @@ func TestUpdateNode(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.AssertDeepEquals(t, ExpectedUpdate, *actual)
 }
+
+func TestOpsNode(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	HandleOpsSuccessfully(t)
+
+	nodeOpts := nodes.OpOpts{
+		Operation: nodes.PauseOperation,
+	}
+	actual, err := nodes.Ops(fake.ServiceClient(), "7d85f602-a948-4a30-afd4-e84f47471c15", nodeOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, OpsExpectedActionID, actual)
+}

--- a/openstack/clustering/v1/nodes/testing/requests_test.go
+++ b/openstack/clustering/v1/nodes/testing/requests_test.go
@@ -110,10 +110,10 @@ func TestOpsNode(t *testing.T) {
 
 	HandleOpsSuccessfully(t)
 
-	nodeOpts := nodes.OpOpts{
+	nodeOpts := nodes.OperationOpts{
 		Operation: nodes.PauseOperation,
 	}
 	actual, err := nodes.Ops(fake.ServiceClient(), "7d85f602-a948-4a30-afd4-e84f47471c15", nodeOpts).Extract()
 	th.AssertNoErr(t, err)
-	th.AssertDeepEquals(t, OpsExpectedActionID, actual)
+	th.AssertDeepEquals(t, OperationExpectedActionID, actual)
 }

--- a/openstack/clustering/v1/nodes/urls.go
+++ b/openstack/clustering/v1/nodes/urls.go
@@ -32,3 +32,7 @@ func getURL(client *gophercloud.ServiceClient, id string) string {
 func updateURL(client *gophercloud.ServiceClient, id string) string {
 	return idURL(client, id)
 }
+
+func opsURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL(apiVersion, apiName, id, "ops")
+}


### PR DESCRIPTION
Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

For #[823 [Add support for Senlin clustering]](https://github.com/gophercloud/gophercloud/issues/823)

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

[[nodes:op api]](https://github.com/openstack/senlin/blob/e5bc16b3fea2f10dead365f983c5a937f23d72b0/senlin/api/openstack/v1/nodes.py#L197)
[[nodes:op engine]](https://github.com/openstack/senlin/blob/e5bc16b3fea2f10dead365f983c5a937f23d72b0/senlin/engine/node.py#L394)
[[nova op names]](https://github.com/openstack/senlin/blob/e5bc16b3fea2f10dead365f983c5a937f23d72b0/senlin/profiles/os/nova/server.py#L241)
[[heat op names]](https://github.com/openstack/senlin/blob/e5bc16b3fea2f10dead365f983c5a937f23d72b0/senlin/profiles/os/heat/stack.py#L88)
