### PR TITLE
LBaaS_v2: Listener's default_pool_id should not be omitted during update

### DIFF
--- a/acceptance/openstack/loadbalancer/v2/loadbalancers_test.go
+++ b/acceptance/openstack/loadbalancer/v2/loadbalancers_test.go
@@ -213,6 +213,43 @@ func TestLoadbalancersCRUD(t *testing.T) {
 	defer DeleteL7Policy(t, lbClient, lb.ID, policy.ID)
 	defer DeleteL7Rule(t, lbClient, lb.ID, policy.ID, rule.ID)
 
+	// Update listener's default pool ID
+	updateListenerOpts = listeners.UpdateOpts{
+		DefaultPoolID: &pool.ID,
+	}
+	_, err = listeners.Update(lbClient, listener.ID, updateListenerOpts).Extract()
+	th.AssertNoErr(t, err)
+
+	if err := WaitForLoadBalancerState(lbClient, lb.ID, "ACTIVE", loadbalancerActiveTimeoutSeconds); err != nil {
+		t.Fatalf("Timed out waiting for loadbalancer to become active")
+	}
+
+	newListener, err = listeners.Get(lbClient, listener.ID).Extract()
+	th.AssertNoErr(t, err)
+
+	tools.PrintResource(t, newListener)
+
+	th.AssertEquals(t, newListener.DefaultPoolID, pool.ID)
+
+	// Remove listener's default pool ID
+	emptyPoolID := ""
+	updateListenerOpts = listeners.UpdateOpts{
+		DefaultPoolID: &emptyPoolID,
+	}
+	_, err = listeners.Update(lbClient, listener.ID, updateListenerOpts).Extract()
+	th.AssertNoErr(t, err)
+
+	if err := WaitForLoadBalancerState(lbClient, lb.ID, "ACTIVE", loadbalancerActiveTimeoutSeconds); err != nil {
+		t.Fatalf("Timed out waiting for loadbalancer to become active")
+	}
+
+	newListener, err = listeners.Get(lbClient, listener.ID).Extract()
+	th.AssertNoErr(t, err)
+
+	tools.PrintResource(t, newListener)
+
+	th.AssertEquals(t, newListener.DefaultPoolID, "")
+
 	// Member
 	member, err := CreateMember(t, lbClient, lb, newPool, subnet.ID, subnet.CIDR)
 	th.AssertNoErr(t, err)

--- a/openstack/loadbalancer/v2/listeners/requests.go
+++ b/openstack/loadbalancer/v2/listeners/requests.go
@@ -174,7 +174,16 @@ type UpdateOpts struct {
 
 // ToListenerUpdateMap builds a request body from UpdateOpts.
 func (opts UpdateOpts) ToListenerUpdateMap() (map[string]interface{}, error) {
-	return gophercloud.BuildRequestBody(opts, "listener")
+	b, err := gophercloud.BuildRequestBody(opts, "listener")
+	if err != nil {
+		return nil, err
+	}
+
+	if m := b["listener"].(map[string]interface{}); m["default_pool_id"] == "" {
+		m["default_pool_id"] = nil
+	}
+
+	return b, nil
 }
 
 // Update is an operation which modifies the attributes of the specified

--- a/openstack/loadbalancer/v2/listeners/testing/fixtures.go
+++ b/openstack/loadbalancer/v2/listeners/testing/fixtures.go
@@ -224,6 +224,7 @@ func HandleListenerUpdateSuccessfully(t *testing.T) {
 		th.TestJSONRequest(t, r, `{
 			"listener": {
 				"name": "NewListenerName",
+				"default_pool_id": null,
 				"connection_limit": 1001
 			}
 		}`)

--- a/openstack/loadbalancer/v2/listeners/testing/requests_test.go
+++ b/openstack/loadbalancer/v2/listeners/testing/requests_test.go
@@ -126,9 +126,11 @@ func TestUpdateListener(t *testing.T) {
 	client := fake.ServiceClient()
 	i1001 := 1001
 	name := "NewListenerName"
+	defaultPoolID := ""
 	actual, err := listeners.Update(client, "4ec89087-d057-4e2c-911f-60a3b47ee304", listeners.UpdateOpts{
-		Name:      &name,
-		ConnLimit: &i1001,
+		Name:          &name,
+		ConnLimit:     &i1001,
+		DefaultPoolID: &defaultPoolID,
 	}).Extract()
 	if err != nil {
 		t.Fatalf("Unexpected Update error: %v", err)

--- a/openstack/networking/v2/extensions/lbaas_v2/listeners/requests.go
+++ b/openstack/networking/v2/extensions/lbaas_v2/listeners/requests.go
@@ -179,7 +179,16 @@ type UpdateOpts struct {
 
 // ToListenerUpdateMap builds a request body from UpdateOpts.
 func (opts UpdateOpts) ToListenerUpdateMap() (map[string]interface{}, error) {
-	return gophercloud.BuildRequestBody(opts, "listener")
+	b, err := gophercloud.BuildRequestBody(opts, "listener")
+	if err != nil {
+		return nil, err
+	}
+
+	if m := b["listener"].(map[string]interface{}); m["default_pool_id"] == "" {
+		m["default_pool_id"] = nil
+	}
+
+	return b, nil
 }
 
 // Update is an operation which modifies the attributes of the specified

--- a/openstack/networking/v2/extensions/lbaas_v2/listeners/testing/fixtures.go
+++ b/openstack/networking/v2/extensions/lbaas_v2/listeners/testing/fixtures.go
@@ -204,6 +204,7 @@ func HandleListenerUpdateSuccessfully(t *testing.T) {
 		th.TestJSONRequest(t, r, `{
 			"listener": {
 				"name": "NewListenerName",
+				"default_pool_id": null,
 				"connection_limit": 1001
 			}
 		}`)

--- a/openstack/networking/v2/extensions/lbaas_v2/listeners/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/lbaas_v2/listeners/testing/requests_test.go
@@ -126,9 +126,11 @@ func TestUpdateListener(t *testing.T) {
 	client := fake.ServiceClient()
 	i1001 := 1001
 	name := "NewListenerName"
+	defaultPoolID := ""
 	actual, err := listeners.Update(client, "4ec89087-d057-4e2c-911f-60a3b47ee304", listeners.UpdateOpts{
-		Name:      &name,
-		ConnLimit: &i1001,
+		Name:          &name,
+		ConnLimit:     &i1001,
+		DefaultPoolID: &defaultPoolID,
 	}).Extract()
 	if err != nil {
 		t.Fatalf("Unexpected Update error: %v", err)


### PR DESCRIPTION
Resolves #1355
Missed this field.