### PR TITLE
Amend example code

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -41,7 +41,7 @@ pass in the parent provider, like so:
 
   opts := gophercloud.EndpointOpts{Region: "RegionOne"}
 
-  client := openstack.NewComputeV2(provider, opts)
+  client, err := openstack.NewComputeV2(provider, opts)
 
 Resources
 


### PR DESCRIPTION
For #1372 

Amend example code in doc.go
client := openstack.NewComputeV2(provider, opts) should be
client, err := openstack.NewComputeV2(provider, opts)