### PR TITLE
NetworkingV2: add prefixlen for Subnet Create

### DIFF
--- a/acceptance/openstack/networking/v2/extensions/subnetpools/subnetpools.go
+++ b/acceptance/openstack/networking/v2/extensions/subnetpools/subnetpools.go
@@ -18,9 +18,10 @@ func CreateSubnetPool(t *testing.T, client *gophercloud.ServiceClient) (*subnetp
 		"10.0.0.0/8",
 	}
 	createOpts := subnetpools.CreateOpts{
-		Name:        subnetPoolName,
-		Description: subnetPoolDescription,
-		Prefixes:    subnetPoolPrefixes,
+		Name:             subnetPoolName,
+		Description:      subnetPoolDescription,
+		Prefixes:         subnetPoolPrefixes,
+		DefaultPrefixLen: 24,
 	}
 
 	t.Logf("Attempting to create a subnetpool: %s", subnetPoolName)

--- a/acceptance/openstack/networking/v2/networking.go
+++ b/acceptance/openstack/networking/v2/networking.go
@@ -401,6 +401,35 @@ func CreateSubnetWithSubnetPoolNoCIDR(t *testing.T, client *gophercloud.ServiceC
 	return subnet, nil
 }
 
+// CreateSubnetWithSubnetPoolPrefixlen will create a subnet associated with the
+// provided subnetpool on the specified Network ID and with overwritten
+// prefixlen instead of the default subnetpool prefixlen.
+// An error will be returned if the subnet or the subnetpool could not be created.
+func CreateSubnetWithSubnetPoolPrefixlen(t *testing.T, client *gophercloud.ServiceClient, networkID string, subnetPoolID string) (*subnets.Subnet, error) {
+	subnetName := tools.RandomString("TESTACC-", 8)
+	createOpts := subnets.CreateOpts{
+		NetworkID:    networkID,
+		IPVersion:    4,
+		Name:         subnetName,
+		EnableDHCP:   gophercloud.Disabled,
+		SubnetPoolID: subnetPoolID,
+		Prefixlen:    12,
+	}
+
+	t.Logf("Attempting to create subnet: %s", subnetName)
+
+	subnet, err := subnets.Create(client, createOpts).Extract()
+	if err != nil {
+		return subnet, err
+	}
+
+	t.Logf("Successfully created subnet.")
+
+	th.AssertEquals(t, subnet.Name, subnetName)
+
+	return subnet, nil
+}
+
 // DeleteNetwork will delete a network with a specified ID. A fatal error will
 // occur if the delete was not successful. This works best when used as a
 // deferred function.

--- a/acceptance/openstack/networking/v2/subnets_test.go
+++ b/acceptance/openstack/networking/v2/subnets_test.go
@@ -182,3 +182,38 @@ func TestSubnetsWithSubnetPoolNoCIDR(t *testing.T) {
 		t.Fatalf("A subnet pool was not associated.")
 	}
 }
+
+func TestSubnetsWithSubnetPoolPrefixlen(t *testing.T) {
+	client, err := clients.NewNetworkV2Client()
+	th.AssertNoErr(t, err)
+
+	// Create Network
+	network, err := CreateNetwork(t, client)
+	th.AssertNoErr(t, err)
+	defer DeleteNetwork(t, client, network.ID)
+
+	// Create SubnetPool
+	subnetPool, err := subnetpools.CreateSubnetPool(t, client)
+	th.AssertNoErr(t, err)
+	defer subnetpools.DeleteSubnetPool(t, client, subnetPool.ID)
+
+	// Create Subnet
+	subnet, err := CreateSubnetWithSubnetPoolPrefixlen(t, client, network.ID, subnetPool.ID)
+	th.AssertNoErr(t, err)
+	defer DeleteSubnet(t, client, subnet.ID)
+
+	tools.PrintResource(t, subnet)
+
+	if subnet.GatewayIP == "" {
+		t.Fatalf("A subnet pool was not associated.")
+	}
+
+	cidrParts := strings.Split(subnet.CIDR, "/")
+	if len(cidrParts) != 2 {
+		t.Fatalf("Got invalid CIDR for subnet '%s': %s", subnet.ID, subnet.CIDR)
+	}
+
+	if cidrParts[1] != "12" {
+		t.Fatalf("Got invalid prefix length for subnet '%s': wanted 12 but got '%s'", subnet.ID, cidrParts[1])
+	}
+}

--- a/openstack/networking/v2/subnets/requests.go
+++ b/openstack/networking/v2/subnets/requests.go
@@ -131,6 +131,10 @@ type CreateOpts struct {
 
 	// SubnetPoolID is the id of the subnet pool that subnet should be associated to.
 	SubnetPoolID string `json:"subnetpool_id,omitempty"`
+
+	// Prefixlen is used when user creates a subnet from the subnetpool. It will
+	// overwrite the "default_prefixlen" value of the referenced subnetpool.
+	Prefixlen int `json:"prefixlen,omitempty"`
 }
 
 // ToSubnetCreateMap builds a request body from CreateOpts.

--- a/openstack/networking/v2/subnets/testing/fixtures.go
+++ b/openstack/networking/v2/subnets/testing/fixtures.go
@@ -348,6 +348,19 @@ const SubnetCreateRequestWithNoCIDR = `
 }
 `
 
+const SubnetCreateRequestWithPrefixlen = `
+{
+    "subnet": {
+        "network_id": "d32019d3-bc6e-4319-9c1d-6722fc136a22",
+        "ip_version": 4,
+        "dns_nameservers": ["foo"],
+        "host_routes": [{"destination":"","nexthop": "bar"}],
+        "subnetpool_id": "b80340c7-9960-4f67-a99c-02501656284b",
+        "prefixlen": 12
+    }
+}
+`
+
 const SubnetUpdateRequest = `
 {
     "subnet": {

--- a/openstack/networking/v2/subnets/testing/requests_test.go
+++ b/openstack/networking/v2/subnets/testing/requests_test.go
@@ -334,6 +334,55 @@ func TestCreateWithNoCIDR(t *testing.T) {
 	th.AssertEquals(t, s.SubnetPoolID, "b80340c7-9960-4f67-a99c-02501656284b")
 }
 
+func TestCreateWithPrefixlen(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/subnets", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, SubnetCreateRequestWithPrefixlen)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+
+		fmt.Fprintf(w, SubnetCreateResult)
+	})
+
+	opts := subnets.CreateOpts{
+		NetworkID:      "d32019d3-bc6e-4319-9c1d-6722fc136a22",
+		IPVersion:      4,
+		DNSNameservers: []string{"foo"},
+		HostRoutes: []subnets.HostRoute{
+			{NextHop: "bar"},
+		},
+		SubnetPoolID: "b80340c7-9960-4f67-a99c-02501656284b",
+		Prefixlen:    12,
+	}
+	s, err := subnets.Create(fake.ServiceClient(), opts).Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, s.Name, "")
+	th.AssertEquals(t, s.EnableDHCP, true)
+	th.AssertEquals(t, s.NetworkID, "d32019d3-bc6e-4319-9c1d-6722fc136a22")
+	th.AssertEquals(t, s.TenantID, "4fd44f30292945e481c7b8a0c8908869")
+	th.AssertDeepEquals(t, s.DNSNameservers, []string{})
+	th.AssertDeepEquals(t, s.AllocationPools, []subnets.AllocationPool{
+		{
+			Start: "192.168.199.2",
+			End:   "192.168.199.254",
+		},
+	})
+	th.AssertDeepEquals(t, s.HostRoutes, []subnets.HostRoute{})
+	th.AssertEquals(t, s.IPVersion, 4)
+	th.AssertEquals(t, s.GatewayIP, "192.168.199.1")
+	th.AssertEquals(t, s.CIDR, "192.168.199.0/24")
+	th.AssertEquals(t, s.ID, "3b80198d-4f7b-4f77-9ef5-774d54e17126")
+	th.AssertEquals(t, s.SubnetPoolID, "b80340c7-9960-4f67-a99c-02501656284b")
+}
+
 func TestRequiredCreateOpts(t *testing.T) {
 	res := subnets.Create(fake.ServiceClient(), subnets.CreateOpts{})
 	if res.Err == nil {


### PR DESCRIPTION
Add Prefixlen field into the Subnet Create call.

Provide unit and acceptance tests with additional helpers.

For #1373 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

[API reference](https://developer.openstack.org/api-ref/network/v2/?expanded=create-subnet-detail,update-subnet-detail#create-subnet)
[Code reference(API)](https://github.com/openstack/neutron-lib/blob/stable/rocky/neutron_lib/api/definitions/subnet.py#L61)
[Code reference(IPAM)](https://github.com/openstack/neutron/blob/stable/rocky/neutron/ipam/requests.py#L289)
[Code reference(DB)](https://github.com/openstack/neutron/blob/stable/rocky/neutron/db/db_base_plugin_v2.py#L788)
