### PR TITLE
NetworkingV2: implement address-scopes Get call

### DIFF
--- a/openstack/networking/v2/extensions/layer3/addressscopes/doc.go
+++ b/openstack/networking/v2/extensions/layer3/addressscopes/doc.go
@@ -1,0 +1,24 @@
+/*
+Package addressscopes provides the ability to retrieve and manage Address scopes through the Neutron API.
+
+Example of Listing Address scopes
+
+	listOpts := addressscopes.ListOpts{
+		IPVersion: 6,
+	}
+
+	allPages, err := addressscopes.List(networkClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allAddressScopes, err := addressscopes.ExtractAddressScopes(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, addressScope := range allAddressScopes {
+		fmt.Printf("%+v\n", addressScope)
+	}
+*/
+package addressscopes

--- a/openstack/networking/v2/extensions/layer3/addressscopes/doc.go
+++ b/openstack/networking/v2/extensions/layer3/addressscopes/doc.go
@@ -20,5 +20,13 @@ Example of Listing Address scopes
 	for _, addressScope := range allAddressScopes {
 		fmt.Printf("%+v\n", addressScope)
 	}
+
+Example to Get an Address scope
+
+    addressScopeID = "9cc35860-522a-4d35-974d-51d4b011801e"
+    addressScope, err := addressscopes.Get(networkClient, addressScopeID).Extract()
+    if err != nil {
+    	panic(err)
+    }
 */
 package addressscopes

--- a/openstack/networking/v2/extensions/layer3/addressscopes/requests.go
+++ b/openstack/networking/v2/extensions/layer3/addressscopes/requests.go
@@ -57,3 +57,9 @@ func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 		return AddressScopePage{pagination.LinkedPageBase{PageResult: r}}
 	})
 }
+
+// Get retrieves a specific address-scope based on its ID.
+func Get(c *gophercloud.ServiceClient, id string) (r GetResult) {
+	_, r.Err = c.Get(getURL(c, id), &r.Body, nil)
+	return
+}

--- a/openstack/networking/v2/extensions/layer3/addressscopes/requests.go
+++ b/openstack/networking/v2/extensions/layer3/addressscopes/requests.go
@@ -1,0 +1,59 @@
+package addressscopes
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// ListOptsBuilder allows extensions to add additional parameters to the
+// List request.
+type ListOptsBuilder interface {
+	ToAddressScopeListQuery() (string, error)
+}
+
+// ListOpts allows the filtering and sorting of paginated collections through
+// the Neutron API. Filtering is achieved by passing in struct field values
+// that map to the subnetpool attributes you want to see returned.
+// SortKey allows you to sort by a particular subnetpool attribute.
+// SortDir sets the direction, and is either `asc' or `desc'.
+// Marker and Limit are used for the pagination.
+type ListOpts struct {
+	ID          string `q:"id"`
+	Name        string `q:"name"`
+	TenantID    string `q:"tenant_id"`
+	ProjectID   string `q:"project_id"`
+	IPVersion   int    `q:"ip_version"`
+	Shared      *bool  `q:"shared"`
+	Description string `q:"description"`
+	Limit       int    `q:"limit"`
+	Marker      string `q:"marker"`
+	SortKey     string `q:"sort_key"`
+	SortDir     string `q:"sort_dir"`
+}
+
+// ToAddressScopeListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToAddressScopeListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List returns a Pager which allows you to iterate over a collection of
+// address-scopes. It accepts a ListOpts struct, which allows you to filter and
+// sort the returned collection for greater efficiency.
+//
+// Default policy settings return only the address-scopes owned by the project
+// of the user submitting the request, unless the user has the administrative
+// role.
+func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(c)
+	if opts != nil {
+		query, err := opts.ToAddressScopeListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		return AddressScopePage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}

--- a/openstack/networking/v2/extensions/layer3/addressscopes/results.go
+++ b/openstack/networking/v2/extensions/layer3/addressscopes/results.go
@@ -1,0 +1,75 @@
+package addressscopes
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// Extract is a function that accepts a result and extracts an address-scope resource.
+func (r commonResult) Extract() (*AddressScope, error) {
+	var s struct {
+		AddressScope *AddressScope `json:"address_scope"`
+	}
+	err := r.ExtractInto(&s)
+	return s.AddressScope, err
+}
+
+// AddressScope represents a Neutron address-scope.
+type AddressScope struct {
+	// ID is the id of the address-scope.
+	ID string `json:"id"`
+
+	// Name is the human-readable name of the address-scope.
+	Name string `json:"name"`
+
+	// TenantID is the id of the Identity project.
+	TenantID string `json:"tenant_id"`
+
+	// ProjectID is the id of the Identity project.
+	ProjectID string `json:"project_id"`
+
+	// IPversion is the IP protocol version.
+	IPversion int `json:"ip_version"`
+
+	// Shared indicates whether this address-scope is shared across all projects.
+	Shared bool `json:"shared"`
+}
+
+// AddressScopePage stores a single page of AddressScopes from a List() API call.
+type AddressScopePage struct {
+	pagination.LinkedPageBase
+}
+
+// NextPageURL is invoked when a paginated collection of address-scope has
+// reached the end of a page and the pager seeks to traverse over a new one.
+// In order to do this, it needs to construct the next page's URL.
+func (r AddressScopePage) NextPageURL() (string, error) {
+	var s struct {
+		Links []gophercloud.Link `json:"address_scopes_links"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return gophercloud.ExtractNextURL(s.Links)
+}
+
+// IsEmpty determines whether or not a AddressScopePage is empty.
+func (r AddressScopePage) IsEmpty() (bool, error) {
+	addressScopes, err := ExtractAddressScopes(r)
+	return len(addressScopes) == 0, err
+}
+
+// ExtractAddressScopes interprets the results of a single page from a List()
+// API call, producing a slice of AddressScopes structs.
+func ExtractAddressScopes(r pagination.Page) ([]AddressScope, error) {
+	var s struct {
+		AddressScopes []AddressScope `json:"address_scopes"`
+	}
+	err := (r.(AddressScopePage)).ExtractInto(&s)
+	return s.AddressScopes, err
+}

--- a/openstack/networking/v2/extensions/layer3/addressscopes/results.go
+++ b/openstack/networking/v2/extensions/layer3/addressscopes/results.go
@@ -18,6 +18,12 @@ func (r commonResult) Extract() (*AddressScope, error) {
 	return s.AddressScope, err
 }
 
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a SubnetPool.
+type GetResult struct {
+	commonResult
+}
+
 // AddressScope represents a Neutron address-scope.
 type AddressScope struct {
 	// ID is the id of the address-scope.

--- a/openstack/networking/v2/extensions/layer3/addressscopes/testing/doc.go
+++ b/openstack/networking/v2/extensions/layer3/addressscopes/testing/doc.go
@@ -1,0 +1,2 @@
+// subnetpools unit tests
+package testing

--- a/openstack/networking/v2/extensions/layer3/addressscopes/testing/fixtures.go
+++ b/openstack/networking/v2/extensions/layer3/addressscopes/testing/fixtures.go
@@ -47,3 +47,17 @@ var AddressScope2 = addressscopes.AddressScope{
 	IPversion: 6,
 	Shared:    true,
 }
+
+// AddressScopesGetResult represents raw response for the Get request.
+const AddressScopesGetResult = `
+{
+    "address_scope": {
+        "name": "scopev4",
+        "tenant_id": "4a9807b773404e979b19633f38370643",
+        "ip_version": 4,
+        "shared": false,
+        "project_id": "4a9807b773404e979b19633f38370643",
+        "id": "9cc35860-522a-4d35-974d-51d4b011801e"
+    }
+}
+`

--- a/openstack/networking/v2/extensions/layer3/addressscopes/testing/fixtures.go
+++ b/openstack/networking/v2/extensions/layer3/addressscopes/testing/fixtures.go
@@ -1,0 +1,49 @@
+package testing
+
+import "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/addressscopes"
+
+// AddressScopesListResult represents raw response for the List request.
+const AddressScopesListResult = `
+{
+    "address_scopes": [
+        {
+            "name": "scopev4",
+            "tenant_id": "4a9807b773404e979b19633f38370643",
+            "ip_version": 4,
+            "shared": false,
+            "project_id": "4a9807b773404e979b19633f38370643",
+            "id": "9cc35860-522a-4d35-974d-51d4b011801e"
+        },
+        {
+            "name": "scopev6",
+            "tenant_id": "4a9807b773404e979b19633f38370643",
+            "ip_version": 6,
+            "shared": true,
+            "project_id": "4a9807b773404e979b19633f38370643",
+            "id": "be992b82-bf42-4ab7-bf7b-6baa8759d388"
+        }
+    ]
+}
+`
+
+// AddressScope1 represents first unmarshalled address scope from the
+// AddressScopesListResult.
+var AddressScope1 = addressscopes.AddressScope{
+	ID:        "9cc35860-522a-4d35-974d-51d4b011801e",
+	Name:      "scopev4",
+	TenantID:  "4a9807b773404e979b19633f38370643",
+	ProjectID: "4a9807b773404e979b19633f38370643",
+	IPversion: 4,
+	Shared:    false,
+}
+
+// AddressScope2 represents second unmarshalled address scope from the
+// AddressScopesListResult.
+var AddressScope2 = addressscopes.AddressScope{
+	ID:        "be992b82-bf42-4ab7-bf7b-6baa8759d388",
+	Name:      "scopev6",
+	TenantID:  "4a9807b773404e979b19633f38370643",
+	ProjectID: "4a9807b773404e979b19633f38370643",
+	IPversion: 6,
+	Shared:    true,
+}

--- a/openstack/networking/v2/extensions/layer3/addressscopes/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/layer3/addressscopes/testing/requests_test.go
@@ -54,7 +54,7 @@ func TestGet(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 
-	th.Mux.HandleFunc("/v2.0/addressscopes/9cc35860-522a-4d35-974d-51d4b011801e", func(w http.ResponseWriter, r *http.Request) {
+	th.Mux.HandleFunc("/v2.0/address-scopes/9cc35860-522a-4d35-974d-51d4b011801e", func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "GET")
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 

--- a/openstack/networking/v2/extensions/layer3/addressscopes/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/layer3/addressscopes/testing/requests_test.go
@@ -1,0 +1,51 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	fake "github.com/gophercloud/gophercloud/openstack/networking/v2/common"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/addressscopes"
+	"github.com/gophercloud/gophercloud/pagination"
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestList(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/addressscopes", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, AddressScopesListResult)
+	})
+
+	count := 0
+
+	addressscopes.List(fake.ServiceClient(), addressscopes.ListOpts{}).EachPage(func(page pagination.Page) (bool, error) {
+		count++
+		actual, err := addressscopes.ExtractAddressScopes(page)
+		if err != nil {
+			t.Errorf("Failed to extract addressscopes: %v", err)
+			return false, nil
+		}
+
+		expected := []addressscopes.AddressScope{
+			AddressScope1,
+			AddressScope2,
+		}
+
+		th.CheckDeepEquals(t, expected, actual)
+
+		return true, nil
+	})
+
+	if count != 1 {
+		t.Errorf("Expected 1 page, got %d", count)
+	}
+}

--- a/openstack/networking/v2/extensions/layer3/addressscopes/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/layer3/addressscopes/testing/requests_test.go
@@ -15,7 +15,7 @@ func TestList(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 
-	th.Mux.HandleFunc("/v2.0/addressscopes", func(w http.ResponseWriter, r *http.Request) {
+	th.Mux.HandleFunc("/v2.0/address-scopes", func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "GET")
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 

--- a/openstack/networking/v2/extensions/layer3/addressscopes/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/layer3/addressscopes/testing/requests_test.go
@@ -49,3 +49,28 @@ func TestList(t *testing.T) {
 		t.Errorf("Expected 1 page, got %d", count)
 	}
 }
+
+func TestGet(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/addressscopes/9cc35860-522a-4d35-974d-51d4b011801e", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, AddressScopesGetResult)
+	})
+
+	s, err := addressscopes.Get(fake.ServiceClient(), "9cc35860-522a-4d35-974d-51d4b011801e").Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, s.ID, "9cc35860-522a-4d35-974d-51d4b011801e")
+	th.AssertEquals(t, s.Name, "scopev4")
+	th.AssertEquals(t, s.TenantID, "4a9807b773404e979b19633f38370643")
+	th.AssertEquals(t, s.ProjectID, "4a9807b773404e979b19633f38370643")
+	th.AssertEquals(t, s.IPversion, 4)
+	th.AssertEquals(t, s.Shared, false)
+}

--- a/openstack/networking/v2/extensions/layer3/addressscopes/urls.go
+++ b/openstack/networking/v2/extensions/layer3/addressscopes/urls.go
@@ -4,10 +4,18 @@ import "github.com/gophercloud/gophercloud"
 
 const resourcePath = "address-scopes"
 
+func resourceURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL(resourcePath, id)
+}
+
 func rootURL(c *gophercloud.ServiceClient) string {
 	return c.ServiceURL(resourcePath)
 }
 
 func listURL(c *gophercloud.ServiceClient) string {
 	return rootURL(c)
+}
+
+func getURL(c *gophercloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
 }

--- a/openstack/networking/v2/extensions/layer3/addressscopes/urls.go
+++ b/openstack/networking/v2/extensions/layer3/addressscopes/urls.go
@@ -2,7 +2,7 @@ package addressscopes
 
 import "github.com/gophercloud/gophercloud"
 
-const resourcePath = "addressscopes"
+const resourcePath = "address-scopes"
 
 func rootURL(c *gophercloud.ServiceClient) string {
 	return c.ServiceURL(resourcePath)

--- a/openstack/networking/v2/extensions/layer3/addressscopes/urls.go
+++ b/openstack/networking/v2/extensions/layer3/addressscopes/urls.go
@@ -1,0 +1,13 @@
+package addressscopes
+
+import "github.com/gophercloud/gophercloud"
+
+const resourcePath = "addressscopes"
+
+func rootURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL(resourcePath)
+}
+
+func listURL(c *gophercloud.ServiceClient) string {
+	return rootURL(c)
+}


### PR DESCRIPTION
Implement address-scopes Get method with tests and documentation.

For #1375

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

[API reference](https://developer.openstack.org/api-ref/network/v2/#address-scopes)
[Code reference(API)](https://github.com/openstack/neutron-lib/blob/stable/rocky/neutron_lib/api/definitions/address_scope.py)
[Code reference(extension class)](https://github.com/openstack/neutron/blob/stable/rocky/neutron/extensions/address_scope.py#L26)
[Code reference(DB)](https://github.com/openstack/neutron/blob/stable/rocky/neutron/db/address_scope_db.py#L96)
