### PR TITLE
Manila: add share snapshots support (list, get)

### DIFF
--- a/openstack/sharedfilesystems/v2/snapshots/requests.go
+++ b/openstack/sharedfilesystems/v2/snapshots/requests.go
@@ -1,0 +1,73 @@
+package snapshots
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// ListOpts holds options for listing Snapshots. It is passed to the
+// snapshots.List function.
+type ListOpts struct {
+	// (Admin only). Defines whether to list the requested resources for all projects.
+	AllTenants bool `q:"all_tenants"`
+	// The snapshot name.
+	Name string `q:"name"`
+	// Filter  by a snapshot description.
+	Description string `q:"description"`
+	// Filters by a share from which the snapshot was created.
+	ShareID string `q:"share_id"`
+	// Filters by a snapshot size in GB.
+	Size int `q:"size"`
+	// Filters by a snapshot status.
+	Status string `q:"status"`
+	// The maximum number of snapshots to return.
+	Limit int `q:"limit"`
+	// The offset to define start point of snapshot or snapshot group listing.
+	Offset int `q:"offset"`
+	// The key to sort a list of snapshots.
+	SortKey string `q:"sort_key"`
+	// The direction to sort a list of snapshots.
+	SortDir string `q:"sort_dir"`
+	// The UUID of the project in which the snapshot was created. Useful with all_tenants parameter.
+	ProjectID string `q:"project_id"`
+	// The name pattern that can be used to filter snapshots, snapshot snapshots, snapshot networks or snapshot groups.
+	NamePattern string `q:"name~"`
+	// The description pattern that can be used to filter snapshots, snapshot snapshots, snapshot networks or snapshot groups.
+	DescriptionPattern string `q:"description~"`
+}
+
+// ListOptsBuilder allows extensions to add additional parameters to the List
+// request.
+type ListOptsBuilder interface {
+	ToSnapshotListQuery() (string, error)
+}
+
+// ToSnapshotListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToSnapshotListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// ListDetail returns []Snapshot optionally limited by the conditions provided in ListOpts.
+func ListDetail(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listDetailURL(client)
+	if opts != nil {
+		query, err := opts.ToSnapshotListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		p := SnapshotPage{pagination.MarkerPageBase{PageResult: r}}
+		p.MarkerPageBase.Owner = p
+		return p
+	})
+}
+
+// Get will get a single snapshot with given UUID
+func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {
+	_, r.Err = client.Get(getURL(client, id), &r.Body, nil)
+	return
+}

--- a/openstack/sharedfilesystems/v2/snapshots/results.go
+++ b/openstack/sharedfilesystems/v2/snapshots/results.go
@@ -1,0 +1,178 @@
+package snapshots
+
+import (
+	"encoding/json"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+const (
+	invalidMarker = "-1"
+)
+
+// Snapshot contains all information associated with an OpenStack Snapshot
+type Snapshot struct {
+	// The UUID of the snapshot
+	ID string `json:"id"`
+	// The name of the snapshot
+	Name string `json:"name,omitempty"`
+	// A description of the snapshot
+	Description string `json:"description,omitempty"`
+	// UUID of the share from which the snapshot was created
+	ShareID string `json:"share_id"`
+	// The shared file system protocol
+	ShareProto string `json:"share_proto"`
+	// Size of the snapshot share in GB
+	ShareSize int `json:"share_size"`
+	// Size of the snapshot in GB
+	Size int `json:"size"`
+	// The snapshot status
+	Status string `json:"status"`
+	// The UUID of the project in which the snapshot was created
+	ProjectID string `json:"project_id"`
+	// Timestamp when the snapshot was created
+	CreatedAt time.Time `json:"-"`
+	// Snapshot links for pagination
+	Links []map[string]string `json:"links"`
+}
+
+func (r *Snapshot) UnmarshalJSON(b []byte) error {
+	type tmp Snapshot
+	var s struct {
+		tmp
+		CreatedAt gophercloud.JSONRFC3339MilliNoZ `json:"created_at"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	*r = Snapshot(s.tmp)
+
+	r.CreatedAt = time.Time(s.CreatedAt)
+
+	return nil
+}
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// Extract will get the Snapshot object from the commonResult
+func (r commonResult) Extract() (*Snapshot, error) {
+	var s struct {
+		Snapshot *Snapshot `json:"snapshot"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Snapshot, err
+}
+
+// SnapshotPage is a pagination.pager that is returned from a call to the List function.
+type SnapshotPage struct {
+	pagination.MarkerPageBase
+}
+
+// NextPageURL generates the URL for the page of results after this one.
+func (r SnapshotPage) NextPageURL() (string, error) {
+	currentURL := r.URL
+	mark, err := r.Owner.LastMarker()
+	if err != nil {
+		return "", err
+	}
+	if mark == invalidMarker {
+		return "", nil
+	}
+
+	q := currentURL.Query()
+	q.Set("offset", mark)
+	currentURL.RawQuery = q.Encode()
+	return currentURL.String(), nil
+}
+
+// LastMarker returns the last offset in a ListResult.
+func (r SnapshotPage) LastMarker() (string, error) {
+	snapshots, err := ExtractSnapshots(r)
+	if err != nil {
+		return invalidMarker, err
+	}
+	if len(snapshots) == 0 {
+		return invalidMarker, nil
+	}
+
+	u, err := url.Parse(r.URL.String())
+	if err != nil {
+		return invalidMarker, err
+	}
+	queryParams := u.Query()
+	offset := queryParams.Get("offset")
+	limit := queryParams.Get("limit")
+
+	// Limit is not present, only one page required
+	if limit == "" {
+		return invalidMarker, nil
+	}
+
+	iOffset := 0
+	if offset != "" {
+		iOffset, err = strconv.Atoi(offset)
+		if err != nil {
+			return invalidMarker, err
+		}
+	}
+	iLimit, err := strconv.Atoi(limit)
+	if err != nil {
+		return invalidMarker, err
+	}
+	iOffset = iOffset + iLimit
+	offset = strconv.Itoa(iOffset)
+
+	return offset, nil
+}
+
+// IsEmpty satisifies the IsEmpty method of the Page interface
+func (r SnapshotPage) IsEmpty() (bool, error) {
+	snapshots, err := ExtractSnapshots(r)
+	return len(snapshots) == 0, err
+}
+
+// ExtractSnapshots extracts and returns a Snapshot slice. It is used while
+// iterating over a snapshots.List call.
+func ExtractSnapshots(r pagination.Page) ([]Snapshot, error) {
+	var s struct {
+		Snapshots []Snapshot `json:"snapshots"`
+	}
+
+	err := (r.(SnapshotPage)).ExtractInto(&s)
+
+	return s.Snapshots, err
+}
+
+// GetResult contains the response body and error from a Get request.
+type GetResult struct {
+	commonResult
+}
+
+// IDFromName is a convenience function that returns a snapshot's ID given its name.
+func IDFromName(client *gophercloud.ServiceClient, name string) (string, error) {
+	r, err := ListDetail(client, &ListOpts{Name: name}).AllPages()
+	if err != nil {
+		return "", err
+	}
+
+	ss, err := ExtractSnapshots(r)
+	if err != nil {
+		return "", err
+	}
+
+	switch len(ss) {
+	case 0:
+		return "", gophercloud.ErrResourceNotFound{Name: name, ResourceType: "snapshot"}
+	case 1:
+		return ss[0].ID, nil
+	default:
+		return "", gophercloud.ErrMultipleResourcesFound{Name: name, Count: len(ss), ResourceType: "snapshot"}
+	}
+}

--- a/openstack/sharedfilesystems/v2/snapshots/testing/fixtures.go
+++ b/openstack/sharedfilesystems/v2/snapshots/testing/fixtures.go
@@ -1,0 +1,102 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	th "github.com/gophercloud/gophercloud/testhelper"
+	fake "github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+const (
+	snapshotEndpoint = "/snapshots"
+	snapshotID       = "bc082e99-3bdb-4400-b95e-b85c7a41622c"
+)
+
+var getResponse = `{
+	"snapshot": {
+		"status": "available",
+		"share_id": "19865c43-3b91-48c9-85a0-7ac4d6bb0efe",
+		"description": null,
+		"links": [
+			{
+				"href": "http://172.18.198.54:8786/v2/16e1ab15c35a457e9c2b2aa189f544e1/snapshots/bc082e99-3bdb-4400-b95e-b85c7a41622c",
+				"rel": "self"
+			},
+			{
+				"href": "http://172.18.198.54:8786/16e1ab15c35a457e9c2b2aa189f544e1/snapshots/bc082e99-3bdb-4400-b95e-b85c7a41622c",
+				"rel": "bookmark"
+			}
+		],
+		"id": "bc082e99-3bdb-4400-b95e-b85c7a41622c",
+		"size": 1,
+		"user_id": "619e2ad074321cf246b03a89e95afee95fb26bb0b2d1fc7ba3bd30fcca25588a",
+		"name": "new_app_snapshot",
+		"created_at": "2019-01-06T11:11:02.000000",
+		"share_proto": "NFS",
+		"project_id": "16e1ab15c35a457e9c2b2aa189f544e1",
+		"share_size": 1
+	}
+}`
+
+// MockGetResponse creates a mock get response
+func MockGetResponse(t *testing.T) {
+	th.Mux.HandleFunc(snapshotEndpoint+"/"+snapshotID, func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, getResponse)
+	})
+}
+
+var listDetailResponse = `{
+	"snapshots": [
+		{
+			"status": "available",
+			"share_id": "19865c43-3b91-48c9-85a0-7ac4d6bb0efe",
+			"description": null,
+			"links": [
+				{
+					"href": "http://172.18.198.54:8786/v2/16e1ab15c35a457e9c2b2aa189f544e1/snapshots/bc082e99-3bdb-4400-b95e-b85c7a41622c",
+					"rel": "self"
+				},
+				{
+					"href": "http://172.18.198.54:8786/16e1ab15c35a457e9c2b2aa189f544e1/snapshots/bc082e99-3bdb-4400-b95e-b85c7a41622c",
+					"rel": "bookmark"
+				}
+			],
+			"id": "bc082e99-3bdb-4400-b95e-b85c7a41622c",
+			"size": 1,
+			"user_id": "619e2ad074321cf246b03a89e95afee95fb26bb0b2d1fc7ba3bd30fcca25588a",
+			"name": "new_app_snapshot",
+			"created_at": "2019-01-06T11:11:02.000000",
+			"share_proto": "NFS",
+			"project_id": "16e1ab15c35a457e9c2b2aa189f544e1",
+			"share_size": 1
+		}
+	]
+}`
+
+var listDetailEmptyResponse = `{"snapshots": []}`
+
+// MockListDetailResponse creates a mock detailed-list response
+func MockListDetailResponse(t *testing.T) {
+	th.Mux.HandleFunc(snapshotEndpoint+"/detail", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		r.ParseForm()
+		marker := r.Form.Get("offset")
+
+		switch marker {
+		case "":
+			fmt.Fprint(w, listDetailResponse)
+		default:
+			fmt.Fprint(w, listDetailEmptyResponse)
+		}
+	})
+}

--- a/openstack/sharedfilesystems/v2/snapshots/testing/request_test.go
+++ b/openstack/sharedfilesystems/v2/snapshots/testing/request_test.go
@@ -1,0 +1,81 @@
+package testing
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/snapshots"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func TestGet(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockGetResponse(t)
+
+	s, err := snapshots.Get(client.ServiceClient(), snapshotID).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, s, &snapshots.Snapshot{
+		ID:          snapshotID,
+		Name:        "new_app_snapshot",
+		Description: "",
+		ShareID:     "19865c43-3b91-48c9-85a0-7ac4d6bb0efe",
+		ShareProto:  "NFS",
+		ShareSize:   1,
+		Size:        1,
+		Status:      "available",
+		ProjectID:   "16e1ab15c35a457e9c2b2aa189f544e1",
+		CreatedAt:   time.Date(2019, time.January, 06, 11, 11, 02, 0, time.UTC),
+		Links: []map[string]string{
+			{
+				"href": "http://172.18.198.54:8786/v2/16e1ab15c35a457e9c2b2aa189f544e1/snapshots/bc082e99-3bdb-4400-b95e-b85c7a41622c",
+				"rel":  "self",
+			},
+			{
+				"href": "http://172.18.198.54:8786/16e1ab15c35a457e9c2b2aa189f544e1/snapshots/bc082e99-3bdb-4400-b95e-b85c7a41622c",
+				"rel":  "bookmark",
+			},
+		},
+	})
+}
+
+func TestListDetail(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockListDetailResponse(t)
+
+	allPages, err := snapshots.ListDetail(client.ServiceClient(), &snapshots.ListOpts{}).AllPages()
+
+	th.AssertNoErr(t, err)
+
+	actual, err := snapshots.ExtractSnapshots(allPages)
+	th.AssertNoErr(t, err)
+
+	th.AssertDeepEquals(t, actual, []snapshots.Snapshot{
+		snapshots.Snapshot{
+			ID:          snapshotID,
+			Name:        "new_app_snapshot",
+			Description: "",
+			ShareID:     "19865c43-3b91-48c9-85a0-7ac4d6bb0efe",
+			ShareProto:  "NFS",
+			ShareSize:   1,
+			Size:        1,
+			Status:      "available",
+			ProjectID:   "16e1ab15c35a457e9c2b2aa189f544e1",
+			CreatedAt:   time.Date(2019, time.January, 06, 11, 11, 02, 0, time.UTC),
+			Links: []map[string]string{
+				{
+					"href": "http://172.18.198.54:8786/v2/16e1ab15c35a457e9c2b2aa189f544e1/snapshots/bc082e99-3bdb-4400-b95e-b85c7a41622c",
+					"rel":  "self",
+				},
+				{
+					"href": "http://172.18.198.54:8786/16e1ab15c35a457e9c2b2aa189f544e1/snapshots/bc082e99-3bdb-4400-b95e-b85c7a41622c",
+					"rel":  "bookmark",
+				},
+			},
+		},
+	})
+}

--- a/openstack/sharedfilesystems/v2/snapshots/urls.go
+++ b/openstack/sharedfilesystems/v2/snapshots/urls.go
@@ -1,0 +1,11 @@
+package snapshots
+
+import "github.com/gophercloud/gophercloud"
+
+func listDetailURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("snapshots", "detail")
+}
+
+func getURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("snapshots", id)
+}


### PR DESCRIPTION
Part of the #1380 

* https://github.com/openstack/manila/blob/e96e46d0d826f4b654773d081094b05e79f33c09/manila/api/v1/share_snapshots.py#L88
* https://github.com/openstack/manila/blob/e96e46d0d826f4b654773d081094b05e79f33c09/manila/api/views/share_snapshots.py#L46

Acceptance tests don't make sense before create/delete methods are implemented.

@jtopjian not sure how exactly to name the package: `sharesnapshots` or `snapshots`