### PR TITLE
Senlin: Node Recover

### DIFF
--- a/openstack/clustering/v1/nodes/doc.go
+++ b/openstack/clustering/v1/nodes/doc.go
@@ -84,5 +84,19 @@ Example to Perform an Operation on a Node
 		panic(err)
 	}
 
+Example to Recover a Node
+
+	nodeID := "b7b870e3-d3c5-4a93-b9d7-846c53b2c2da"
+	check := true
+	recoverOpts := nodes.RecoverOpts{
+		Operation:     nodes.RebuildRecovery,
+		Check:         &check,
+	}
+	actionID, err := nodes.Recover(computeClient, nodeID, recoverOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("action=", actionID)
+
 */
 package nodes

--- a/openstack/clustering/v1/nodes/requests.go
+++ b/openstack/clustering/v1/nodes/requests.go
@@ -60,7 +60,7 @@ type UpdateOpts struct {
 	Metadata  map[string]interface{} `json:"metadata,omitempty"`
 }
 
-// ToClusterUpdateMap constructs a request body from UpdateOpts.
+// ToNodeUpdateMap constructs a request body from UpdateOpts.
 func (opts UpdateOpts) ToNodeUpdateMap() (map[string]interface{}, error) {
 	return gophercloud.BuildRequestBody(opts, "node")
 }
@@ -210,7 +210,7 @@ func (opts RecoverOpts) ToNodeRecoverMap() (map[string]interface{}, error) {
 	return gophercloud.BuildRequestBody(opts, "recover")
 }
 
-// RecoverAction represents valid values for recovering a cluster.
+// RecoverAction represents valid values for recovering a node.
 type RecoverAction string
 
 const (

--- a/openstack/clustering/v1/nodes/requests.go
+++ b/openstack/clustering/v1/nodes/requests.go
@@ -232,7 +232,7 @@ func Recover(client *gophercloud.ServiceClient, id string, opts RecoverOpts) (r 
 		return
 	}
 	var result *http.Response
-	result, r.Err = client.Post(recoverURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
+	result, r.Err = client.Post(actionURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{202},
 	})
 	r.Header = result.Header

--- a/openstack/clustering/v1/nodes/requests.go
+++ b/openstack/clustering/v1/nodes/requests.go
@@ -216,8 +216,8 @@ type RecoverAction string
 const (
 	RebootRecovery  RecoverAction = "REBOOT"
 	RebuildRecovery RecoverAction = "REBUILD"
-	// RECREATE is NOT supported. See https://github.com/openstack/senlin/blob/master/senlin/profiles/base.py#L533
-	// RecreateRecovery RecoverAction = "RECREATE"
+	// RECREATE currently is NOT supported. See https://github.com/openstack/senlin/blob/b30b2b8496b2b8af243ccd5292f38aec7a95664f/senlin/profiles/base.py#L533
+	RecreateRecovery RecoverAction = "RECREATE"
 )
 
 type RecoverOpts struct {

--- a/openstack/clustering/v1/nodes/testing/fixtures.go
+++ b/openstack/clustering/v1/nodes/testing/fixtures.go
@@ -261,6 +261,13 @@ const OperationActionResponse = `
 
 const OperationExpectedActionID = "2a0ff107-e789-4660-a122-3816c43af703"
 
+const ActionResponse = `
+{
+  "action": "2a0ff107-e789-4660-a122-3816c43af703"
+}`
+
+const ExpectedActionID = "2a0ff107-e789-4660-a122-3816c43af703"
+
 func HandleCreateSuccessfully(t *testing.T) {
 	th.Mux.HandleFunc("/v1/nodes", func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "POST")
@@ -331,5 +338,16 @@ func HandleOpsSuccessfully(t *testing.T) {
 		w.WriteHeader(http.StatusAccepted)
 
 		fmt.Fprint(w, OperationActionResponse)
+	})
+}
+
+func HandleRecoverSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/v1/nodes/edce3528-864f-41fb-8759-f4707925cc09/actions", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.Header().Add("Content-Type", "application/json")
+		w.Header().Add("X-OpenStack-Request-ID", "req-edce3528-864f-41fb-8759-f4707925cc09")
+		w.WriteHeader(http.StatusAccepted)
+		fmt.Fprint(w, ActionResponse)
 	})
 }

--- a/openstack/clustering/v1/nodes/testing/requests_test.go
+++ b/openstack/clustering/v1/nodes/testing/requests_test.go
@@ -117,3 +117,17 @@ func TestOpsNode(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.AssertDeepEquals(t, OperationExpectedActionID, actual)
 }
+
+func TestNodeRecover(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	HandleRecoverSuccessfully(t)
+	recoverOpts := nodes.RecoverOpts{
+		Operation: nodes.RebuildRecovery,
+		Check:     new(bool),
+	}
+	actionID, err := nodes.Recover(fake.ServiceClient(), "edce3528-864f-41fb-8759-f4707925cc09", recoverOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, ExpectedActionID, actionID)
+}

--- a/openstack/clustering/v1/nodes/urls.go
+++ b/openstack/clustering/v1/nodes/urls.go
@@ -9,6 +9,10 @@ func commonURL(client *gophercloud.ServiceClient) string {
 	return client.ServiceURL(apiVersion, apiName)
 }
 
+func actionURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL(apiVersion, apiName, id, "actions")
+}
+
 func createURL(client *gophercloud.ServiceClient) string {
 	return commonURL(client)
 }
@@ -35,4 +39,8 @@ func updateURL(client *gophercloud.ServiceClient, id string) string {
 
 func opsURL(client *gophercloud.ServiceClient, id string) string {
 	return client.ServiceURL(apiVersion, apiName, id, "ops")
+}
+
+func recoverURL(client *gophercloud.ServiceClient, id string) string {
+	return actionURL(client, id)
 }

--- a/openstack/clustering/v1/nodes/urls.go
+++ b/openstack/clustering/v1/nodes/urls.go
@@ -40,7 +40,3 @@ func updateURL(client *gophercloud.ServiceClient, id string) string {
 func opsURL(client *gophercloud.ServiceClient, id string) string {
 	return client.ServiceURL(apiVersion, apiName, id, "ops")
 }
-
-func recoverURL(client *gophercloud.ServiceClient, id string) string {
-	return actionURL(client, id)
-}


### PR DESCRIPTION
Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

For #[823 [Add support for Senlin clustering]](https://github.com/gophercloud/gophercloud/issues/823)

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

[[nodes:recover api]](https://github.com/openstack/senlin/blob/8ba9f3f7b71c3895aa5e460b363b61d415fb99b0/senlin/api/openstack/v1/nodes.py#L180)
[[nodes:recover engine]](https://github.com/openstack/senlin/blob/b30b2b8496b2b8af243ccd5292f38aec7a95664f/senlin/engine/node.py#L361)
[[recover const names]](https://github.com/openstack/senlin/blob/b30b2b8496b2b8af243ccd5292f38aec7a95664f/senlin/common/consts.py#L287)
[[profiles:recover_object]](https://github.com/openstack/senlin/blob/b30b2b8496b2b8af243ccd5292f38aec7a95664f/senlin/profiles/base.py#L512)
