### PR TITLE
NetworkingV2: add Address scopes Delete method

### DIFF
--- a/openstack/networking/v2/extensions/layer3/addressscopes/doc.go
+++ b/openstack/networking/v2/extensions/layer3/addressscopes/doc.go
@@ -51,5 +51,13 @@ Example to Update an Address scope
     if err != nil {
         panic(err)
     }
+
+Example to Delete an Address scope
+
+    addressScopeID = "9cc35860-522a-4d35-974d-51d4b011801e"
+    err := addressscopes.Delete(networkClient, addressScopeID).ExtractErr()
+    if err != nil {
+        panic(err)
+    }
 */
 package addressscopes

--- a/openstack/networking/v2/extensions/layer3/addressscopes/doc.go
+++ b/openstack/networking/v2/extensions/layer3/addressscopes/doc.go
@@ -39,5 +39,17 @@ Example to Create a new Address scope
     if err != nil {
         panic(err)
     }
+
+Example to Update an Address scope
+
+    addressScopeID = "9cc35860-522a-4d35-974d-51d4b011801e"
+    updateOpts := addressscopes.UpdateOpts{
+        Name: "awesome_name",
+    }
+
+    addressScope, err := addressscopes.Update(networkClient, addressScopeID, updateOpts).Extract()
+    if err != nil {
+        panic(err)
+    }
 */
 package addressscopes

--- a/openstack/networking/v2/extensions/layer3/addressscopes/requests.go
+++ b/openstack/networking/v2/extensions/layer3/addressscopes/requests.go
@@ -105,3 +105,37 @@ func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r Create
 	})
 	return
 }
+
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
+type UpdateOptsBuilder interface {
+	ToAddressScopeUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts represents options used to update an address-scope.
+type UpdateOpts struct {
+	// Name is the human-readable name of the address-scope.
+	Name string `json:"name,omitempty"`
+
+	// Shared indicates whether this address-scope is shared across all projects.
+	Shared *bool `json:"shared,omitempty"`
+}
+
+// ToAddressScopeUpdateMap builds a request body from UpdateOpts.
+func (opts UpdateOpts) ToAddressScopeUpdateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "address_scope")
+}
+
+// Update accepts a UpdateOpts struct and updates an existing address-scope
+// using the values provided.
+func Update(c *gophercloud.ServiceClient, addressScopeID string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToAddressScopeUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Put(updateURL(c, addressScopeID), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}

--- a/openstack/networking/v2/extensions/layer3/addressscopes/requests.go
+++ b/openstack/networking/v2/extensions/layer3/addressscopes/requests.go
@@ -139,3 +139,9 @@ func Update(c *gophercloud.ServiceClient, addressScopeID string, opts UpdateOpts
 	})
 	return
 }
+
+// Delete accepts a unique ID and deletes the address-scope associated with it.
+func Delete(c *gophercloud.ServiceClient, id string) (r DeleteResult) {
+	_, r.Err = c.Delete(deleteURL(c, id), nil)
+	return
+}

--- a/openstack/networking/v2/extensions/layer3/addressscopes/results.go
+++ b/openstack/networking/v2/extensions/layer3/addressscopes/results.go
@@ -30,6 +30,12 @@ type CreateResult struct {
 	commonResult
 }
 
+// UpdateResult represents the result of an update operation. Call its Extract
+// method to interpret it as an AddressScope.
+type UpdateResult struct {
+	commonResult
+}
+
 // AddressScope represents a Neutron address-scope.
 type AddressScope struct {
 	// ID is the id of the address-scope.

--- a/openstack/networking/v2/extensions/layer3/addressscopes/results.go
+++ b/openstack/networking/v2/extensions/layer3/addressscopes/results.go
@@ -36,6 +36,12 @@ type UpdateResult struct {
 	commonResult
 }
 
+// DeleteResult represents the result of a delete operation. Call its
+// ExtractErr method to determine if the request succeeded or failed.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
 // AddressScope represents a Neutron address-scope.
 type AddressScope struct {
 	// ID is the id of the address-scope.

--- a/openstack/networking/v2/extensions/layer3/addressscopes/testing/fixtures.go
+++ b/openstack/networking/v2/extensions/layer3/addressscopes/testing/fixtures.go
@@ -86,3 +86,27 @@ const AddressScopeCreateResult = `
     }
 }
 `
+
+// AddressScopeUpdateRequest represents raw Update request.
+const AddressScopeUpdateRequest = `
+{
+    "address_scope": {
+        "name": "test1",
+        "shared": true
+    }
+}
+`
+
+// AddressScopeUpdateResult represents raw Update response.
+const AddressScopeUpdateResult = `
+{
+    "address_scope": {
+        "name": "test1",
+        "tenant_id": "4a9807b773404e979b19633f38370643",
+        "ip_version": 4,
+        "shared": true,
+        "project_id": "4a9807b773404e979b19633f38370643",
+        "id": "9cc35860-522a-4d35-974d-51d4b011801e"
+    }
+}
+`

--- a/openstack/networking/v2/extensions/layer3/addressscopes/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/layer3/addressscopes/testing/requests_test.go
@@ -136,3 +136,17 @@ func TestUpdate(t *testing.T) {
 	th.AssertEquals(t, s.Name, "test1")
 	th.AssertEquals(t, s.Shared, true)
 }
+
+func TestDelete(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/address-scopes/9cc35860-522a-4d35-974d-51d4b011801e", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	res := addressscopes.Delete(fake.ServiceClient(), "9cc35860-522a-4d35-974d-51d4b011801e")
+	th.AssertNoErr(t, res.Err)
+}

--- a/openstack/networking/v2/extensions/layer3/addressscopes/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/layer3/addressscopes/testing/requests_test.go
@@ -107,3 +107,32 @@ func TestCreate(t *testing.T) {
 	th.AssertEquals(t, s.ProjectID, "4a9807b773404e979b19633f38370643")
 	th.AssertEquals(t, s.ID, "9cc35860-522a-4d35-974d-51d4b011801e")
 }
+
+func TestUpdate(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/address-scopes/9cc35860-522a-4d35-974d-51d4b011801e", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, AddressScopeUpdateRequest)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, AddressScopeUpdateResult)
+	})
+
+	shared := true
+	updateOpts := addressscopes.UpdateOpts{
+		Name:   "test1",
+		Shared: &shared,
+	}
+	s, err := addressscopes.Update(fake.ServiceClient(), "9cc35860-522a-4d35-974d-51d4b011801e", updateOpts).Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, s.Name, "test1")
+	th.AssertEquals(t, s.Shared, true)
+}

--- a/openstack/networking/v2/extensions/layer3/addressscopes/urls.go
+++ b/openstack/networking/v2/extensions/layer3/addressscopes/urls.go
@@ -23,3 +23,7 @@ func getURL(c *gophercloud.ServiceClient, id string) string {
 func createURL(c *gophercloud.ServiceClient) string {
 	return rootURL(c)
 }
+
+func updateURL(c *gophercloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
+}

--- a/openstack/networking/v2/extensions/layer3/addressscopes/urls.go
+++ b/openstack/networking/v2/extensions/layer3/addressscopes/urls.go
@@ -27,3 +27,7 @@ func createURL(c *gophercloud.ServiceClient) string {
 func updateURL(c *gophercloud.ServiceClient, id string) string {
 	return resourceURL(c, id)
 }
+
+func deleteURL(c *gophercloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
+}


### PR DESCRIPTION
Implement address-scopes Delete method.
Provide unit test and doc example.

For #1375  

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

[API reference](https://developer.openstack.org/api-ref/network/v2/#address-scopes)
[Code reference(API)](https://github.com/openstack/neutron-lib/blob/stable/rocky/neutron_lib/api/definitions/address_scope.py)
[Code reference(DB)](https://github.com/openstack/neutron/blob/stable/rocky/neutron/db/address_scope_db.py#L115)