### PR TITLE
Networking V2: add Agents List request

### DIFF
--- a/openstack/networking/v2/extensions/agents/doc.go
+++ b/openstack/networking/v2/extensions/agents/doc.go
@@ -1,0 +1,24 @@
+/*
+Package agents provides the ability to retrieve and manage Agents through the Neutron API.
+
+Example of Listing Agents
+
+    listOpts := agents.ListOpts{
+        AgentType: "Open vSwitch agent",
+    }
+
+    allPages, err := agents.List(networkClient, listOpts).AllPages()
+    if err != nil {
+        panic(err)
+    }
+
+    allAgents, err := agents.ExtractAgents(allPages)
+    if err != nil {
+        panic(err)
+    }
+
+    for _, agent := range allAgents {
+        fmt.Printf("%+v\n", agent)
+    }
+*/
+package agents

--- a/openstack/networking/v2/extensions/agents/requests.go
+++ b/openstack/networking/v2/extensions/agents/requests.go
@@ -1,0 +1,60 @@
+package agents
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// ListOptsBuilder allows extensions to add additional parameters to the
+// List request.
+type ListOptsBuilder interface {
+	ToAgentListQuery() (string, error)
+}
+
+// ListOpts allows the filtering and sorting of paginated collections through
+// the Neutron API. Filtering is achieved by passing in struct field values
+// that map to the agent attributes you want to see returned.
+// SortKey allows you to sort by a particular agent attribute.
+// SortDir sets the direction, and is either `asc' or `desc'.
+// Marker and Limit are used for the pagination.
+type ListOpts struct {
+	ID               string `json:"id"`
+	AgentType        string `json:"agent_type"`
+	Alive            *bool  `json:"alive"`
+	AvailabilityZone string `json:"availability_zone"`
+	Binary           string `json:"binary"`
+	Description      string `json:"description"`
+	Host             string `json:"host"`
+	Topic            string `json:"topic"`
+	Limit            int    `q:"limit"`
+	Marker           string `q:"marker"`
+	SortKey          string `q:"sort_key"`
+	SortDir          string `q:"sort_dir"`
+}
+
+// ToAgentListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToAgentListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List returns a Pager which allows you to iterate over a collection of
+// agents. It accepts a ListOpts struct, which allows you to filter and
+// sort the returned collection for greater efficiency.
+//
+// Default policy settings return only the agents owned by the project
+// of the user submitting the request, unless the user has the administrative
+// role.
+func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(c)
+	if opts != nil {
+		query, err := opts.ToAgentListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		return AgentPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}

--- a/openstack/networking/v2/extensions/agents/results.go
+++ b/openstack/networking/v2/extensions/agents/results.go
@@ -17,8 +17,8 @@ type Agent struct {
 	// ID is the id of the agent.
 	ID string `json:"id"`
 
-	// AdminStateUP is an administrative state of the agent.
-	AdminStateUP bool `json:"admin_state_up"`
+	// AdminStateUp is an administrative state of the agent.
+	AdminStateUp bool `json:"admin_state_up"`
 
 	// AgentType is a type of the agent.
 	AgentType string `json:"agent_type"`

--- a/openstack/networking/v2/extensions/agents/results.go
+++ b/openstack/networking/v2/extensions/agents/results.go
@@ -1,0 +1,113 @@
+package agents
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// Agent represents a Neutron agent.
+type Agent struct {
+	// ID is the id of the agent.
+	ID string `json:"id"`
+
+	// AdminStateUP is an administrative state of the agent.
+	AdminStateUP bool `json:"admin_state_up"`
+
+	// AgentType is a type of the agent.
+	AgentType string `json:"agent_type"`
+
+	// Alive indicates whether agent is alive or not.
+	Alive bool `json:"alive"`
+
+	// AvailabilityZone is a zone of the agent.
+	AvailabilityZone string `json:"availability_zone"`
+
+	// Binary is an executable binary of the agent.
+	Binary string `json:"binary"`
+
+	// Configurations is a configuration specific key/value pairs that are
+	// determined by the agent binary and type.
+	Configurations map[string]interface{} `json:"configurations"`
+
+	// CreatedAt is a creation timestamp.
+	CreatedAt time.Time `json:"-"`
+
+	// StartedAt is a starting timestamp.
+	StartedAt time.Time `json:"-"`
+
+	// HeartbeatTimestamp is a last heartbeat timestamp.
+	HeartbeatTimestamp time.Time `json:"-"`
+
+	// Description contains agent description.
+	Description string `json:"description"`
+
+	// Host is a hostname of the agent system.
+	Host string `json:"host"`
+
+	// Topic contains name of AMQP topic.
+	Topic string `json:"topic"`
+}
+
+// UnmarshalJSON helps to convert the timestamps into the time.Time type.
+func (r *Agent) UnmarshalJSON(b []byte) error {
+	type tmp Agent
+	var s struct {
+		tmp
+		CreatedAt          gophercloud.JSONRFC3339ZNoTNoZ `json:"created_at"`
+		StartedAt          gophercloud.JSONRFC3339ZNoTNoZ `json:"started_at"`
+		HeartbeatTimestamp gophercloud.JSONRFC3339ZNoTNoZ `json:"heartbeat_timestamp"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	*r = Agent(s.tmp)
+
+	r.CreatedAt = time.Time(s.CreatedAt)
+	r.StartedAt = time.Time(s.StartedAt)
+	r.HeartbeatTimestamp = time.Time(s.HeartbeatTimestamp)
+
+	return nil
+}
+
+// AgentPage stores a single page of Agents from a List() API call.
+type AgentPage struct {
+	pagination.LinkedPageBase
+}
+
+// NextPageURL is invoked when a paginated collection of agent has
+// reached the end of a page and the pager seeks to traverse over a new one.
+// In order to do this, it needs to construct the next page's URL.
+func (r AgentPage) NextPageURL() (string, error) {
+	var s struct {
+		Links []gophercloud.Link `json:"agents_links"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return gophercloud.ExtractNextURL(s.Links)
+}
+
+// IsEmpty determines whether or not a AgentPage is empty.
+func (r AgentPage) IsEmpty() (bool, error) {
+	agents, err := ExtractAgents(r)
+	return len(agents) == 0, err
+}
+
+// ExtractAgents interprets the results of a single page from a List()
+// API call, producing a slice of Agents structs.
+func ExtractAgents(r pagination.Page) ([]Agent, error) {
+	var s struct {
+		Agents []Agent `json:"agents"`
+	}
+	err := (r.(AgentPage)).ExtractInto(&s)
+	return s.Agents, err
+}

--- a/openstack/networking/v2/extensions/agents/testing/doc.go
+++ b/openstack/networking/v2/extensions/agents/testing/doc.go
@@ -1,0 +1,2 @@
+// agents unit tests
+package testing

--- a/openstack/networking/v2/extensions/agents/testing/fixtures.go
+++ b/openstack/networking/v2/extensions/agents/testing/fixtures.go
@@ -1,0 +1,97 @@
+package testing
+
+import (
+	"time"
+
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/agents"
+)
+
+// AgentsListResult represents raw response for the List request.
+const AgentsListResult = `
+{
+    "agents": [
+        {
+            "admin_state_up": true,
+            "agent_type": "Open vSwitch agent",
+            "alive": true,
+            "availability_zone": null,
+            "binary": "neutron-openvswitch-agent",
+            "configurations": {
+                "datapath_type": "system",
+                "extensions": [
+                    "qos"
+                ]
+            },
+            "created_at": "2017-07-26 23:15:44",
+            "description": null,
+            "heartbeat_timestamp": "2019-01-09 10:28:53",
+            "host": "compute1",
+            "id": "59186d7b-b512-4fdf-bbaf-5804ffde8811",
+            "started_at": "2018-06-26 21:46:19",
+            "topic": "N/A"
+        },
+        {
+            "admin_state_up": true,
+            "agent_type": "Open vSwitch agent",
+            "alive": true,
+            "availability_zone": null,
+            "binary": "neutron-openvswitch-agent",
+            "configurations": {
+                "datapath_type": "system",
+                "extensions": [
+                    "qos"
+                ]
+            },
+            "created_at": "2017-01-22 14:00:50",
+            "description": null,
+            "heartbeat_timestamp": "2019-01-09 10:28:50",
+            "host": "compute2",
+            "id": "76af7b1f-d61b-4526-94f7-d2e14e2698df",
+            "started_at": "2018-11-06 12:09:17",
+            "topic": "N/A"
+        }
+    ]
+}
+`
+
+// Agent1 represents first unmarshalled address scope from the
+// AgentsListResult.
+var Agent1 = agents.Agent{
+	ID:           "59186d7b-b512-4fdf-bbaf-5804ffde8811",
+	AdminStateUP: true,
+	AgentType:    "Open vSwitch agent",
+	Alive:        true,
+	Binary:       "neutron-openvswitch-agent",
+	Configurations: map[string]interface{}{
+		"datapath_type": "system",
+		"extensions": []interface{}{
+			"qos",
+		},
+	},
+	CreatedAt:          time.Date(2017, 7, 26, 23, 15, 44, 0, time.UTC),
+	StartedAt:          time.Date(2018, 6, 26, 21, 46, 19, 0, time.UTC),
+	HeartbeatTimestamp: time.Date(2019, 1, 9, 10, 28, 53, 0, time.UTC),
+	Host:               "compute1",
+	Topic:              "N/A",
+}
+
+// Agent2 represents second unmarshalled address scope from the
+// AgentsListResult.
+var Agent2 = agents.Agent{
+	ID:           "76af7b1f-d61b-4526-94f7-d2e14e2698df",
+	AdminStateUP: true,
+	AgentType:    "Open vSwitch agent",
+	Alive:        true,
+	Binary:       "neutron-openvswitch-agent",
+	Configurations: map[string]interface{}{
+		"datapath_type": "system",
+		"extensions": []interface{}{
+			"qos",
+		},
+	},
+	CreatedAt:          time.Date(2017, 1, 22, 14, 00, 50, 0, time.UTC),
+	StartedAt:          time.Date(2018, 11, 6, 12, 9, 17, 0, time.UTC),
+	HeartbeatTimestamp: time.Date(2019, 1, 9, 10, 28, 50, 0, time.UTC),
+	Host:               "compute2",
+	Topic:              "N/A",
+}

--- a/openstack/networking/v2/extensions/agents/testing/fixtures.go
+++ b/openstack/networking/v2/extensions/agents/testing/fixtures.go
@@ -58,7 +58,7 @@ const AgentsListResult = `
 // AgentsListResult.
 var Agent1 = agents.Agent{
 	ID:           "59186d7b-b512-4fdf-bbaf-5804ffde8811",
-	AdminStateUP: true,
+	AdminStateUp: true,
 	AgentType:    "Open vSwitch agent",
 	Alive:        true,
 	Binary:       "neutron-openvswitch-agent",
@@ -79,7 +79,7 @@ var Agent1 = agents.Agent{
 // AgentsListResult.
 var Agent2 = agents.Agent{
 	ID:           "76af7b1f-d61b-4526-94f7-d2e14e2698df",
-	AdminStateUP: true,
+	AdminStateUp: true,
 	AgentType:    "Open vSwitch agent",
 	Alive:        true,
 	Binary:       "neutron-openvswitch-agent",

--- a/openstack/networking/v2/extensions/agents/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/agents/testing/requests_test.go
@@ -1,0 +1,52 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	fake "github.com/gophercloud/gophercloud/openstack/networking/v2/common"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/agents"
+	"github.com/gophercloud/gophercloud/pagination"
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestList(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/agents", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, AgentsListResult)
+	})
+
+	count := 0
+
+	agents.List(fake.ServiceClient(), agents.ListOpts{}).EachPage(func(page pagination.Page) (bool, error) {
+		count++
+		actual, err := agents.ExtractAgents(page)
+
+		if err != nil {
+			t.Errorf("Failed to extract agents: %v", err)
+			return false, nil
+		}
+
+		expected := []agents.Agent{
+			Agent1,
+			Agent2,
+		}
+
+		th.CheckDeepEquals(t, expected, actual)
+
+		return true, nil
+	})
+
+	if count != 1 {
+		t.Errorf("Expected 1 page, got %d", count)
+	}
+}

--- a/openstack/networking/v2/extensions/agents/urls.go
+++ b/openstack/networking/v2/extensions/agents/urls.go
@@ -1,0 +1,13 @@
+package agents
+
+import "github.com/gophercloud/gophercloud"
+
+const resourcePath = "agents"
+
+func rootURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL(resourcePath)
+}
+
+func listURL(c *gophercloud.ServiceClient) string {
+	return rootURL(c)
+}


### PR DESCRIPTION
Add "networking/v2/extensions/agents" package with List request.
Provide unit test and documentation.

For #1389 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

[Code reference(API)](https://github.com/openstack/neutron-lib/blob/stable/rocky/neutron_lib/api/definitions/agent.py)
[Code reference(get resources call)](https://github.com/openstack/neutron/blob/stable/rocky/neutron/extensions/agent.py#L34)
[Code reference(DB)](https://github.com/openstack/neutron/blob/stable/rocky/neutron/db/agents_db.py#L297)