### PR TITLE
Senlin: Node Check

### DIFF
--- a/openstack/clustering/v1/nodes/doc.go
+++ b/openstack/clustering/v1/nodes/doc.go
@@ -98,5 +98,14 @@ Example to Recover a Node
 	}
 	fmt.Println("action=", actionID)
 
+Example to Check a Node
+
+	nodeID := "b7b870e3-d3c5-4a93-b9d7-846c53b2c2da"
+	actionID, err := nodes.Check(serviceClient, nodeID).Extract()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("action=", actionID)
+
 */
 package nodes

--- a/openstack/clustering/v1/nodes/requests.go
+++ b/openstack/clustering/v1/nodes/requests.go
@@ -238,3 +238,18 @@ func Recover(client *gophercloud.ServiceClient, id string, opts RecoverOpts) (r 
 	r.Header = result.Header
 	return
 }
+
+func Check(client *gophercloud.ServiceClient, id string) (r ActionResult) {
+	b := map[string]interface{}{
+		"check": map[string]interface{}{},
+	}
+
+	var result *http.Response
+	result, r.Err = client.Post(actionURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+	})
+	if r.Err == nil {
+		r.Header = result.Header
+	}
+	return
+}

--- a/openstack/clustering/v1/nodes/testing/fixtures.go
+++ b/openstack/clustering/v1/nodes/testing/fixtures.go
@@ -351,3 +351,14 @@ func HandleRecoverSuccessfully(t *testing.T) {
 		fmt.Fprint(w, ActionResponse)
 	})
 }
+
+func HandleCheckSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/v1/nodes/edce3528-864f-41fb-8759-f4707925cc09/actions", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.Header().Add("Content-Type", "application/json")
+		w.Header().Add("X-OpenStack-Request-ID", "req-edce3528-864f-41fb-8759-f4707925cc09")
+		w.WriteHeader(http.StatusAccepted)
+		fmt.Fprint(w, ActionResponse)
+	})
+}

--- a/openstack/clustering/v1/nodes/testing/requests_test.go
+++ b/openstack/clustering/v1/nodes/testing/requests_test.go
@@ -131,3 +131,14 @@ func TestNodeRecover(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, ExpectedActionID, actionID)
 }
+
+func TestNodeCheck(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	HandleCheckSuccessfully(t)
+
+	actionID, err := nodes.Check(fake.ServiceClient(), "edce3528-864f-41fb-8759-f4707925cc09").Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, ExpectedActionID, actionID)
+}


### PR DESCRIPTION
Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

For #[823 [Add support for Senlin clustering]](https://github.com/gophercloud/gophercloud/issues/823)

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

[[nodes:check api]](https://github.com/openstack/senlin/blob/8ba9f3f7b71c3895aa5e460b363b61d415fb99b0/senlin/api/openstack/v1/nodes.py#L165)
[[nodes:check engine]](https://github.com/openstack/senlin/blob/b30b2b8496b2b8af243ccd5292f38aec7a95664f/senlin/engine/node.py#L319)
