### PR TITLE
[Octavia] Support tags for getting load balancer

### DIFF
--- a/openstack/loadbalancer/v2/loadbalancers/results.go
+++ b/openstack/loadbalancer/v2/loadbalancers/results.go
@@ -55,6 +55,10 @@ type LoadBalancer struct {
 
 	// Pools are the pools related to this Loadbalancer.
 	Pools []pools.Pool `json:"pools"`
+
+	// Tags is a list of resource tags. Tags are arbitrarily defined strings
+	// attached to the resource.
+	Tags []string `json:"tags"`
 }
 
 // StatusTree represents the status of a loadbalancer.


### PR DESCRIPTION
For #1404

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

- API: <https://developer.openstack.org/api-ref/load-balancer/v2/index.html?expanded=#show-load-balancer-details>
- source code: <https://github.com/openstack/octavia/blob/d0c499dbd6bd276ca3c8a4d3827734fed27f0643/octavia/api/v2/types/load_balancer.py#L58>
