### PR TITLE
Senlin: Cluster Collect Attributes Across A Cluster

### DIFF
--- a/openstack/clustering/v1/clusters/requests.go
+++ b/openstack/clustering/v1/clusters/requests.go
@@ -591,7 +591,7 @@ func ReplaceNodes(client *gophercloud.ServiceClient, id string, opts ReplaceNode
 }
 
 type CollectOptsBuilder interface {
-	ToClusterCollectPath() (string, error)
+	ToClusterCollectMap() (string, error)
 }
 
 // CollectOpts represents options to collect attribute values across a cluster
@@ -599,18 +599,13 @@ type CollectOpts struct {
 	Path string `q:"path" required:"true"`
 }
 
-func (opts CollectOpts) ToClusterCollectPath() (string, error) {
+func (opts CollectOpts) ToClusterCollectMap() (string, error) {
 	return opts.Path, nil
 }
 
 // Collect instructs OpenStack to aggregate attribute values across a cluster
 func Collect(client *gophercloud.ServiceClient, id string, opts CollectOptsBuilder) (r CollectResult) {
-	if opts == nil {
-		r.Err = fmt.Errorf("Json path format string for node attribute must be provided")
-		return
-	}
-
-	query, err := opts.ToClusterCollectPath()
+	query, err := opts.ToClusterCollectMap()
 	if err != nil {
 		r.Err = err
 		return

--- a/openstack/clustering/v1/clusters/results.go
+++ b/openstack/clustering/v1/clusters/results.go
@@ -84,6 +84,11 @@ type ClusterPolicy struct {
 	PolicyType  string `json:"policy_type"`
 }
 
+type ClusterAttributes struct {
+	ID    string      `json:"id"`
+	Value interface{} `json:"value"`
+}
+
 // Action represents an OpenStack Clustering action.
 type Action struct {
 	Action string `json:"action"`
@@ -181,6 +186,10 @@ func (r ActionResult) Extract() (string, error) {
 	return s.Action, err
 }
 
+type CollectResult struct {
+	gophercloud.Result
+}
+
 // ExtractClusters returns a slice of Clusters from the List operation.
 func ExtractClusters(r pagination.Page) ([]Cluster, error) {
 	var s struct {
@@ -198,4 +207,13 @@ func ExtractClusterPolicies(r pagination.Page) ([]ClusterPolicy, error) {
 	}
 	err := (r.(ClusterPolicyPage)).ExtractInto(&s)
 	return s.ClusterPolicies, err
+}
+
+// Extract returns collected attributes across a cluster
+func (r CollectResult) Extract() ([]ClusterAttributes, error) {
+	var s struct {
+		Attributes []ClusterAttributes `json:"cluster_attributes"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Attributes, err
 }

--- a/openstack/clustering/v1/clusters/testing/fixtures.go
+++ b/openstack/clustering/v1/clusters/testing/fixtures.go
@@ -381,6 +381,22 @@ const GetPolicyResponse = `
   }
 }`
 
+const CollectResponse = `
+{
+  "cluster_attributes": [{
+    "id": "foo",
+    "value":   "bar"
+  }
+  ]	
+}`
+
+var ExpectedCollectAttributes = []clusters.ClusterAttributes{
+	{
+		ID:    "foo",
+		Value: string("bar"),
+	},
+}
+
 func HandleCreateClusterSuccessfully(t *testing.T) {
 	th.Mux.HandleFunc("/v1/clusters", func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "POST")
@@ -655,5 +671,16 @@ func HandleReplaceNodeSuccessfully(t *testing.T) {
 		w.Header().Add("X-OpenStack-Request-ID", "req-781e9bdc-4163-46eb-91c9-786c53188bbb")
 		w.WriteHeader(http.StatusAccepted)
 		fmt.Fprint(w, ActionResponse)
+	})
+}
+
+func HandleClusterCollectSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/v1/clusters/7d85f602-a948-4a30-afd4-e84f47471c15/attrs/foo.bar", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.Header().Add("Content-Type", "application/json")
+		w.Header().Add("X-OpenStack-Request-ID", "req-781e9bdc-4163-46eb-91c9-786c53188bbb")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, CollectResponse)
 	})
 }

--- a/openstack/clustering/v1/clusters/testing/requests_test.go
+++ b/openstack/clustering/v1/clusters/testing/requests_test.go
@@ -463,3 +463,15 @@ func TestReplaceNodes(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, actionID, "2a0ff107-e789-4660-a122-3816c43af703")
 }
+
+func TestClusterCollect(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleClusterCollectSuccessfully(t)
+	opts := clusters.CollectOpts{
+		Path: "foo.bar",
+	}
+	attributes, err := clusters.Collect(fake.ServiceClient(), "7d85f602-a948-4a30-afd4-e84f47471c15", opts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, ExpectedCollectAttributes, attributes)
+}

--- a/openstack/clustering/v1/clusters/urls.go
+++ b/openstack/clustering/v1/clusters/urls.go
@@ -48,3 +48,7 @@ func getPolicyURL(client *gophercloud.ServiceClient, clusterID string, policyID 
 func nodeURL(client *gophercloud.ServiceClient, id string) string {
 	return actionURL(client, id)
 }
+
+func collectURL(client *gophercloud.ServiceClient, clusterID string, path string) string {
+	return client.ServiceURL(apiVersion, apiName, clusterID, "attrs", path)
+}


### PR DESCRIPTION
Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

For #[823 [Add support for Senlin clustering]](https://github.com/gophercloud/gophercloud/issues/823)

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

[[clusters:collect api]](https://github.com/openstack/senlin/blob/8ba9f3f7b71c3895aa5e460b363b61d415fb99b0/senlin/api/openstack/v1/clusters.py#L275)
[[clusters:collect engine]](https://github.com/openstack/senlin/blob/0700a8bf29217b8a24fff0912cd89c0c64fe416b/senlin/engine/service.py#L1364)
