### PR TITLE
Octavia: Update load balancer tags

### DIFF
--- a/openstack/loadbalancer/v2/loadbalancers/doc.go
+++ b/openstack/loadbalancer/v2/loadbalancers/doc.go
@@ -31,7 +31,7 @@ Example to Create a Load Balancer
 		VipAddress:   "10.30.176.48",
 		Flavor:       "medium",
 		Provider:     "haproxy",
-		Tags: 		  []string{"test", "stage"},
+		Tags:         []string{"test", "stage"},
 	}
 
 	lb, err := loadbalancers.Create(networkClient, createOpts).Extract()
@@ -42,12 +42,10 @@ Example to Create a Load Balancer
 Example to Update a Load Balancer
 
 	lbID := "d67d56a6-4a86-4688-a282-f46444705c64"
-
-	i1001 := 1001
+	name := "new-name"
 	updateOpts := loadbalancers.UpdateOpts{
-		Name: "new-name",
+		Name: &name,
 	}
-
 	lb, err := loadbalancers.Update(networkClient, lbID, updateOpts).Extract()
 	if err != nil {
 		panic(err)

--- a/openstack/loadbalancer/v2/loadbalancers/requests.go
+++ b/openstack/loadbalancer/v2/loadbalancers/requests.go
@@ -145,6 +145,9 @@ type UpdateOpts struct {
 	// The administrative state of the Loadbalancer. A valid value is true (UP)
 	// or false (DOWN).
 	AdminStateUp *bool `json:"admin_state_up,omitempty"`
+
+	// Tags is a set of resource tags.
+	Tags *[]string `json:"tags,omitempty"`
 }
 
 // ToLoadBalancerUpdateMap builds a request body from UpdateOpts.

--- a/openstack/loadbalancer/v2/loadbalancers/testing/fixtures.go
+++ b/openstack/loadbalancer/v2/loadbalancers/testing/fixtures.go
@@ -88,7 +88,7 @@ const PostUpdateLoadbalancerBody = `
 		"admin_state_up": true,
 		"provisioning_status": "PENDING_CREATE",
 		"operating_status": "OFFLINE",
-		"tags": ["test", "stage"]
+		"tags": ["test"]
 	}
 }
 `
@@ -187,7 +187,7 @@ var (
 		AdminStateUp:       true,
 		ProvisioningStatus: "PENDING_CREATE",
 		OperatingStatus:    "OFFLINE",
-		Tags:               []string{"test", "stage"},
+		Tags:               []string{"test"},
 	}
 	LoadbalancerStatusesTree = loadbalancers.StatusTree{
 		Loadbalancer: &loadbalancers.LoadBalancer{
@@ -314,7 +314,8 @@ func HandleLoadbalancerUpdateSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "Content-Type", "application/json")
 		th.TestJSONRequest(t, r, `{
 			"loadbalancer": {
-				"name": "NewLoadbalancerName"
+				"name": "NewLoadbalancerName",
+				"tags": ["test"]
 			}
 		}`)
 

--- a/openstack/loadbalancer/v2/loadbalancers/testing/requests_test.go
+++ b/openstack/loadbalancer/v2/loadbalancers/testing/requests_test.go
@@ -135,8 +135,10 @@ func TestUpdateLoadbalancer(t *testing.T) {
 
 	client := fake.ServiceClient()
 	name := "NewLoadbalancerName"
+	tags := []string{"test"}
 	actual, err := loadbalancers.Update(client, "36e08a3e-a78f-4b40-a229-1e7e23eee1ab", loadbalancers.UpdateOpts{
 		Name: &name,
+		Tags: &tags,
 	}).Extract()
 	if err != nil {
 		t.Fatalf("Unexpected Update error: %v", err)


### PR DESCRIPTION
For #1404

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

- API doc: <https://developer.openstack.org/api-ref/load-balancer/v2/index.html?expanded=update-a-load-balancer-detail#update-a-load-balancer>
- Source code: <https://github.com/openstack/octavia/blob/3745e1f55d69fc370d405b0bac4f784d019409a4/octavia/api/v2/types/load_balancer.py#L143>
