### PR TITLE
Fix bug where messaging claims-create causes panic crash because HTTP…

### DIFF
--- a/openstack/messaging/v2/claims/requests.go
+++ b/openstack/messaging/v2/claims/requests.go
@@ -56,6 +56,9 @@ func Create(client *gophercloud.ServiceClient, queueName string, opts CreateOpts
 	resp, r.Err = client.Post(url, b, nil, &gophercloud.RequestOpts{
 		OkCodes: []int{201, 204},
 	})
+	if r.Err != nil {
+		return
+	}
 	// If the Claim has no content return an empty CreateResult
 	if resp.StatusCode == 204 {
 		r.Body = CreateResult{}


### PR DESCRIPTION
… POST encounters error and has no response object.

Reference:  #[1420 [Bug: Messaging Claims Create Causes Crash]](https://github.com/gophercloud/gophercloud/issues/1420)

Code: https://github.com/gophercloud/gophercloud/blob/e102249148e2e09eb5efab07b7c3ea74c161e935/openstack/messaging/v2/claims/requests.go#L55-L62