### PR TITLE
Senlin: Cluster Operations

### DIFF
--- a/acceptance/openstack/clustering/v1/clusters_test.go
+++ b/acceptance/openstack/clustering/v1/clusters_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gophercloud/gophercloud/acceptance/clients"
 	"github.com/gophercloud/gophercloud/acceptance/tools"
+	"github.com/gophercloud/gophercloud/openstack/clustering/v1/actions"
 	"github.com/gophercloud/gophercloud/openstack/clustering/v1/clusters"
 	th "github.com/gophercloud/gophercloud/testhelper"
 )
@@ -447,4 +448,63 @@ func TestClustersCollectAttributes(t *testing.T) {
 		th.AssertEquals(t, attr.Value, "nova")
 	}
 
+}
+
+// Performs an operation on a cluster
+func TestClustersOps(t *testing.T) {
+	choices, err := clients.AcceptanceTestChoicesFromEnv()
+	th.AssertNoErr(t, err)
+
+	client, err := clients.NewClusteringV1Client()
+	th.AssertNoErr(t, err)
+	client.Microversion = "1.4"
+
+	profile, err := CreateProfile(t, client)
+	th.AssertNoErr(t, err)
+	defer DeleteProfile(t, client, profile.ID)
+
+	cluster, err := CreateCluster(t, client, profile.ID)
+	th.AssertNoErr(t, err)
+	defer DeleteCluster(t, client, cluster.ID)
+
+	node, err := CreateNode(t, client, cluster.ID, profile.ID)
+	th.AssertNoErr(t, err)
+	defer DeleteNode(t, client, node.ID)
+
+	ops := []clusters.OperationOpts{
+		// TODO: Commented out due to backend returns error, as of 2019-01-09
+		//{Operation: clusters.RebuildOperation},					// Error in set_admin_password in nova log
+		//{Operation: clusters.EvacuateOperation, Params: clusters.OperationParams{"host": cluster.ID, "force": "True"}},
+		{Operation: clusters.RebootOperation, Params: clusters.OperationParams{"type": "SOFT"}},
+		{Operation: clusters.ChangePasswordOperation, Params: clusters.OperationParams{"admin_pass": "test"}},
+		{Operation: clusters.LockOperation},
+		{Operation: clusters.UnlockOperation},
+		{Operation: clusters.SuspendOperation},
+		{Operation: clusters.ResumeOperation},
+		{Operation: clusters.RescueOperation, Params: clusters.OperationParams{"image_ref": choices.ImageID}},
+		{Operation: clusters.PauseOperation},
+		{Operation: clusters.UnpauseOperation},
+		{Operation: clusters.StopOperation},
+		{Operation: clusters.StartOperation},
+	}
+
+	for _, op := range ops {
+		opName := string(op.Operation)
+		t.Logf("Attempting to perform '%s' on cluster: %s", opName, cluster.ID)
+		actionID, res := clusters.Ops(client, cluster.ID, op).Extract()
+		th.AssertNoErr(t, res)
+
+		err = WaitForAction(client, actionID)
+		th.AssertNoErr(t, err)
+
+		action, err := actions.Get(client, actionID).Extract()
+		th.AssertNoErr(t, err)
+		th.AssertEquals(t, "SUCCEEDED", action.Status)
+
+		t.Logf("Successfully performed '%s' on cluster: %s", opName, cluster.ID)
+	}
+
+	cluster, err = clusters.Get(client, cluster.ID).Extract()
+	th.AssertNoErr(t, err)
+	tools.PrintResource(t, cluster)
 }

--- a/openstack/clustering/v1/clusters/doc.go
+++ b/openstack/clustering/v1/clusters/doc.go
@@ -257,5 +257,31 @@ Example to replace nodes for a cluster
 		panic(err)
 	}
 
+Example to collect node attributes across a cluster
+
+	serviceClient.Microversion = "1.2"
+	clusterID := "b7b870e3-d3c5-4a93-b9d7-846c53b2c2da"
+	opts := clusters.CollectOpts{
+		Path: "status",
+	}
+	attrs, err := clusters.Collect(serviceClient, clusterID, opts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to perform an operation on a cluster
+
+	serviceClient.Microversion = "1.4"
+	clusterID := "cluster123"
+	operationOpts := clusters.OperationOpts{
+		Operation: clusters.RebootOperation,
+		Filters:   clusters.OperationFilters{"role": "slave"},
+		Params:    clusters.OperationParams{"type": "SOFT"},
+	}
+	actionID, err := clusters.Ops(serviceClient, clusterID, operationOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
 */
 package clusters

--- a/openstack/clustering/v1/clusters/requests.go
+++ b/openstack/clustering/v1/clusters/requests.go
@@ -622,3 +622,73 @@ func Collect(client *gophercloud.ServiceClient, id string, opts CollectOptsBuild
 
 	return
 }
+
+// OperationName represents valid values for cluster operation
+type OperationName string
+
+const (
+	// Nova Profile Op Names
+	RebootOperation         OperationName = "reboot"
+	RebuildOperation        OperationName = "rebuild"
+	ChangePasswordOperation OperationName = "change_password"
+	PauseOperation          OperationName = "pause"
+	UnpauseOperation        OperationName = "unpause"
+	SuspendOperation        OperationName = "suspend"
+	ResumeOperation         OperationName = "resume"
+	LockOperation           OperationName = "lock"
+	UnlockOperation         OperationName = "unlock"
+	StartOperation          OperationName = "start"
+	StopOperation           OperationName = "stop"
+	RescueOperation         OperationName = "rescue"
+	UnrescueOperation       OperationName = "unrescue"
+	EvacuateOperation       OperationName = "evacuate"
+
+	// Heat Pofile Op Names
+	AbandonOperation OperationName = "abandon"
+)
+
+// ToClusterOperationMap constructs a request body from OperationOpts.
+func (opts OperationOpts) ToClusterOperationMap() (map[string]interface{}, error) {
+	operationArg := struct {
+		Filters OperationFilters `json:"filters,omitempty"`
+		Params  OperationParams  `json:"params,omitempty"`
+	}{
+		Filters: opts.Filters,
+		Params:  opts.Params,
+	}
+
+	return gophercloud.BuildRequestBody(operationArg, string(opts.Operation))
+}
+
+// OperationOptsBuilder allows extensions to add additional parameters to the
+// Op request.
+type OperationOptsBuilder interface {
+	ToClusterOperationMap() (map[string]interface{}, error)
+}
+type OperationFilters map[string]interface{}
+type OperationParams map[string]interface{}
+
+// OperationOpts represents options used to perform an operation on a cluster
+type OperationOpts struct {
+	Operation OperationName    `json:"operation" required:"true"`
+	Filters   OperationFilters `json:"filters,omitempty"`
+	Params    OperationParams  `json:"params,omitempty"`
+}
+
+func Ops(client *gophercloud.ServiceClient, id string, opts OperationOptsBuilder) (r ActionResult) {
+	b, err := opts.ToClusterOperationMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	var result *http.Response
+	result, r.Err = client.Post(opsURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+	})
+	if r.Err == nil {
+		r.Header = result.Header
+	}
+
+	return
+}

--- a/openstack/clustering/v1/clusters/testing/fixtures.go
+++ b/openstack/clustering/v1/clusters/testing/fixtures.go
@@ -342,6 +342,13 @@ const ActionResponse = `
 
 const ExpectedActionID = "2a0ff107-e789-4660-a122-3816c43af703"
 
+const OperationActionResponse = `
+{
+  "action": "2a0ff107-e789-4660-a122-3816c43af703"
+}`
+
+const OperationExpectedActionID = "2a0ff107-e789-4660-a122-3816c43af703"
+
 const ListPoliciesResult = `{
   "cluster_policies": [
     {
@@ -682,5 +689,17 @@ func HandleClusterCollectSuccessfully(t *testing.T) {
 		w.Header().Add("X-OpenStack-Request-ID", "req-781e9bdc-4163-46eb-91c9-786c53188bbb")
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprint(w, CollectResponse)
+	})
+}
+
+func HandleOpsSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/v1/clusters/7d85f602-a948-4a30-afd4-e84f47471c15/ops", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+
+		fmt.Fprint(w, OperationActionResponse)
 	})
 }

--- a/openstack/clustering/v1/clusters/testing/requests_test.go
+++ b/openstack/clustering/v1/clusters/testing/requests_test.go
@@ -475,3 +475,19 @@ func TestClusterCollect(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.AssertDeepEquals(t, ExpectedCollectAttributes, attributes)
 }
+
+func TestOperation(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	HandleOpsSuccessfully(t)
+
+	clusterOpts := clusters.OperationOpts{
+		Operation: clusters.PauseOperation,
+		Filters:   clusters.OperationFilters{"role": "slave"},
+		Params:    clusters.OperationParams{"type": "soft"},
+	}
+	actual, err := clusters.Ops(fake.ServiceClient(), "7d85f602-a948-4a30-afd4-e84f47471c15", clusterOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, OperationExpectedActionID, actual)
+}

--- a/openstack/clustering/v1/clusters/urls.go
+++ b/openstack/clustering/v1/clusters/urls.go
@@ -52,3 +52,7 @@ func nodeURL(client *gophercloud.ServiceClient, id string) string {
 func collectURL(client *gophercloud.ServiceClient, clusterID string, path string) string {
 	return client.ServiceURL(apiVersion, apiName, clusterID, "attrs", path)
 }
+
+func opsURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL(apiVersion, apiName, id, "ops")
+}


### PR DESCRIPTION
Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

For #[823 [Add support for Senlin clustering]](https://github.com/gophercloud/gophercloud/issues/823)

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

[[clusters:operation api]](https://github.com/openstack/senlin/blob/8ba9f3f7b71c3895aa5e460b363b61d415fb99b0/senlin/api/openstack/v1/clusters.py#L290)
[[clusters:operation engine]](https://github.com/openstack/senlin/blob/0700a8bf29217b8a24fff0912cd89c0c64fe416b/senlin/engine/service.py#L1490)
[[profiles:op names]](https://github.com/openstack/senlin/blob/0700a8bf29217b8a24fff0912cd89c0c64fe416b/senlin/profiles/os/nova/server.py#L241)
