### PR TITLE
Octavia: filter load balancers by tags

### DIFF
--- a/acceptance/openstack/loadbalancer/v2/loadbalancer.go
+++ b/acceptance/openstack/loadbalancer/v2/loadbalancer.go
@@ -58,19 +58,20 @@ func CreateListener(t *testing.T, client *gophercloud.ServiceClient, lb *loadbal
 
 // CreateLoadBalancer will create a load balancer with a random name on a given
 // subnet. An error will be returned if the loadbalancer could not be created.
-func CreateLoadBalancer(t *testing.T, client *gophercloud.ServiceClient, subnetID string) (*loadbalancers.LoadBalancer, error) {
+func CreateLoadBalancer(t *testing.T, client *gophercloud.ServiceClient, subnetID string, tags []string) (*loadbalancers.LoadBalancer, error) {
 	lbName := tools.RandomString("TESTACCT-", 8)
 	lbDescription := tools.RandomString("TESTACCT-DESC-", 8)
 
 	t.Logf("Attempting to create loadbalancer %s on subnet %s", lbName, subnetID)
 
-	tags := []string{"test"}
 	createOpts := loadbalancers.CreateOpts{
 		Name:         lbName,
 		Description:  lbDescription,
 		VipSubnetID:  subnetID,
 		AdminStateUp: gophercloud.Enabled,
-		Tags:         tags,
+	}
+	if len(tags) > 0 {
+		createOpts.Tags = tags
 	}
 
 	lb, err := loadbalancers.Create(client, createOpts).Extract()
@@ -91,7 +92,10 @@ func CreateLoadBalancer(t *testing.T, client *gophercloud.ServiceClient, subnetI
 	th.AssertEquals(t, lb.Description, lbDescription)
 	th.AssertEquals(t, lb.VipSubnetID, subnetID)
 	th.AssertEquals(t, lb.AdminStateUp, true)
-	th.AssertDeepEquals(t, lb.Tags, tags)
+
+	if len(tags) > 0 {
+		th.AssertDeepEquals(t, lb.Tags, tags)
+	}
 
 	return lb, nil
 }

--- a/openstack/loadbalancer/v2/loadbalancers/requests.go
+++ b/openstack/loadbalancer/v2/loadbalancers/requests.go
@@ -17,22 +17,26 @@ type ListOptsBuilder interface {
 // sort by a particular attribute. SortDir sets the direction, and is
 // either `asc' or `desc'. Marker and Limit are used for pagination.
 type ListOpts struct {
-	Description        string `q:"description"`
-	AdminStateUp       *bool  `q:"admin_state_up"`
-	ProjectID          string `q:"project_id"`
-	ProvisioningStatus string `q:"provisioning_status"`
-	VipAddress         string `q:"vip_address"`
-	VipPortID          string `q:"vip_port_id"`
-	VipSubnetID        string `q:"vip_subnet_id"`
-	ID                 string `q:"id"`
-	OperatingStatus    string `q:"operating_status"`
-	Name               string `q:"name"`
-	Flavor             string `q:"flavor"`
-	Provider           string `q:"provider"`
-	Limit              int    `q:"limit"`
-	Marker             string `q:"marker"`
-	SortKey            string `q:"sort_key"`
-	SortDir            string `q:"sort_dir"`
+	Description        string   `q:"description"`
+	AdminStateUp       *bool    `q:"admin_state_up"`
+	ProjectID          string   `q:"project_id"`
+	ProvisioningStatus string   `q:"provisioning_status"`
+	VipAddress         string   `q:"vip_address"`
+	VipPortID          string   `q:"vip_port_id"`
+	VipSubnetID        string   `q:"vip_subnet_id"`
+	ID                 string   `q:"id"`
+	OperatingStatus    string   `q:"operating_status"`
+	Name               string   `q:"name"`
+	Flavor             string   `q:"flavor"`
+	Provider           string   `q:"provider"`
+	Limit              int      `q:"limit"`
+	Marker             string   `q:"marker"`
+	SortKey            string   `q:"sort_key"`
+	SortDir            string   `q:"sort_dir"`
+	Tags               []string `q:"tags"`
+	TagsAny            []string `q:"tags-any"`
+	TagsNot            []string `q:"not-tags"`
+	TagsNotAny         []string `q:"not-tags-any"`
 }
 
 // ToLoadBalancerListQuery formats a ListOpts into a query string.


### PR DESCRIPTION
For #1404

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

- API doc: <https://developer.openstack.org/api-ref/load-balancer/v2/index.html#filtering-and-column-selection>
- Code: <https://github.com/openstack/octavia/blob/6f96401e9c9c0fbac879dc174f129cfcaafb5f09/octavia/api/common/pagination.py#L183>
