### PR TITLE
Senlin: Events Get/List

### DIFF
--- a/acceptance/openstack/clustering/v1/events_test.go
+++ b/acceptance/openstack/clustering/v1/events_test.go
@@ -1,0 +1,31 @@
+// +build acceptance clustering events
+
+package v1
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/acceptance/clients"
+	"github.com/gophercloud/gophercloud/acceptance/tools"
+	"github.com/gophercloud/gophercloud/openstack/clustering/v1/events"
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestEventsList(t *testing.T) {
+	client, err := clients.NewClusteringV1Client()
+	th.AssertNoErr(t, err)
+
+	opts := events.ListOpts{
+		Limit: 200,
+	}
+
+	allPages, err := events.List(client, opts).AllPages()
+	th.AssertNoErr(t, err)
+
+	allEvents, err := events.ExtractEvents(allPages)
+	th.AssertNoErr(t, err)
+
+	for _, event := range allEvents {
+		tools.PrintResource(t, event)
+	}
+}

--- a/openstack/clustering/v1/events/doc.go
+++ b/openstack/clustering/v1/events/doc.go
@@ -1,0 +1,33 @@
+/*
+Package events provides listing and retrieving of senlin events for the
+OpenStack Clustering Service.
+
+Example to List Events
+
+	opts := events.ListOpts{
+		Limit: 5,
+	}
+
+	err = events.List(serviceClient, opts).EachPage(func(page pagination.Page) (bool, error) {
+		eventInfos, err := events.ExtractEvents(page)
+		if err != nil {
+			return false, err
+		}
+
+		for _, eventInfo := range eventInfos {
+			fmt.Println("%+v\n", eventInfo)
+		}
+		return true, nil
+	})
+
+Example to Get an Event
+
+	eventID := "edce3528-864f-41fb-8759-f4707925cc09"
+	event, err := events.Get(serviceClient, eventID).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Event %+v: ", event)
+*/
+package events

--- a/openstack/clustering/v1/events/requests.go
+++ b/openstack/clustering/v1/events/requests.go
@@ -1,0 +1,53 @@
+package events
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// ListOptsBuilder allows extensions to add additional parameters to the
+// List request.
+type ListOptsBuilder interface {
+	ToEventListQuery() (string, error)
+}
+
+// ListOpts represents options used to list events.
+type ListOpts struct {
+	Limit         int    `q:"limit,omitempty"`
+	Level         int    `q:"level,omitempty"`
+	Marker        string `q:"marker,omitempty"`
+	Sort          string `q:"sort,omitempty"`
+	GlobalProject *bool  `q:"global_project,omitempty"`
+	OID           string `q:"oid,omitempty"`
+	OType         string `q:"otype,omitempty"`
+	OName         string `q:"oname,omitempty"`
+	ClusterID     string `q:"cluster_id,omitempty"`
+	Action        string `q:"action"`
+}
+
+// ToEventListQuery builds a query string from ListOpts.
+func (opts ListOpts) ToEventListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List instructs OpenStack to provide a list of events.
+func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(client)
+	if opts != nil {
+		query, err := opts.ToEventListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return EventPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// Get retrieves details of a single event.
+func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {
+	_, r.Err = client.Get(getURL(client, id), &r.Body, &gophercloud.RequestOpts{OkCodes: []int{200}})
+	return
+}

--- a/openstack/clustering/v1/events/results.go
+++ b/openstack/clustering/v1/events/results.go
@@ -1,0 +1,66 @@
+package events
+
+import (
+	"time"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// Event represents a detailed Event.
+type Event struct {
+	Action       string                 `json:"action"`
+	Cluster      string                 `json:"cluster"`
+	ClusterID    string                 `json:"cluster_id"`
+	ID           string                 `json:"id"`
+	Level        string                 `json:"level"`
+	Metadata     map[string]interface{} `json:"meta_data"`
+	OID          string                 `json:"oid"`
+	OName        string                 `json:"oname"`
+	OType        string                 `json:"otype"`
+	Project      string                 `json:"project"`
+	Status       string                 `json:"status"`
+	StatusReason string                 `json:"status_reason"`
+	Timestamp    time.Time              `json:"timestamp"`
+	User         string                 `json:"user"`
+}
+
+// commonResult is the response of a base result.
+type commonResult struct {
+	gophercloud.Result
+}
+
+// Extract interprets any commonResult-based result as an Event.
+func (r commonResult) Extract() (*Event, error) {
+	var s struct {
+		Event *Event `json:"event"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Event, err
+}
+
+// GetResult is the response of a Get operations. Call its Extract method to
+// interpret it as an Event.
+type GetResult struct {
+	commonResult
+}
+
+// EventPage contains a single page of all events from a List call.
+type EventPage struct {
+	pagination.LinkedPageBase
+}
+
+// IsEmpty determines if a EventPage contains any results.
+func (r EventPage) IsEmpty() (bool, error) {
+	events, err := ExtractEvents(r)
+	return len(events) == 0, err
+}
+
+// ExtractEvents returns a slice of Events from the List operation.
+func ExtractEvents(r pagination.Page) ([]Event, error) {
+	var s struct {
+		Events []Event `json:"events"`
+	}
+	err := (r.(EventPage)).ExtractInto(&s)
+	return s.Events, err
+}

--- a/openstack/clustering/v1/events/testing/doc.go
+++ b/openstack/clustering/v1/events/testing/doc.go
@@ -1,0 +1,2 @@
+// clustering_events_v1
+package testing

--- a/openstack/clustering/v1/events/testing/fixtures.go
+++ b/openstack/clustering/v1/events/testing/fixtures.go
@@ -1,0 +1,131 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gophercloud/gophercloud/openstack/clustering/v1/events"
+
+	th "github.com/gophercloud/gophercloud/testhelper"
+	fake "github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+const ListResponse = `
+{
+	"events": [
+		{
+			"action": "CLUSTER_CREATE",
+			"cluster": null,
+			"cluster_id": null,
+			"id": "edce3528-864f-41fb-8759-f4707925cc09",
+			"level": "INFO",
+			"meta_data": {},
+			"oid": "0df0931b-e251-4f2e-8719-4ebfda3627ba",
+			"oname": "cluster001",
+			"otype": "CLUSTER",
+			"project": "f1fe61dcda2f4618a14c10dc7abc214d",
+			"status": "start",
+			"status_reason": "Initializing",
+			"timestamp": "2015-03-05T08:53:15Z",
+			"user": "8bcd2cdca7684c02afc9e4f2fc0f0c79"
+		},
+		{
+			"action": "NODE_DELETE",
+			"cluster": null,
+			"cluster_id": null,
+			"id": "abcd1234-864f-41fb-8759-f4707925dd10",
+			"level": "INFO",
+			"meta_data": {},
+			"oid": "0df0931b-e251-4f2e-8719-4ebfda3627ba",
+			"oname": "node119",
+			"otype": "node",
+			"project": "f1fe61dcda2f4618a14c10dc7abc214d",
+			"status": "start",
+			"status_reason": "84492c96",
+			"timestamp": "2015-03-06T18:53:15Z",
+			"user": "8bcd2cdca7684c02afc9e4f2fc0f0c79"
+		}
+	]
+}
+`
+
+const GetResponse = `
+{
+	"event": {
+		"action": "CLUSTER_CREATE",
+		"cluster_id": null,
+		"id": "edce3528-864f-41fb-8759-f4707925cc09",
+		"level": "INFO",
+		"meta_data": {},
+		"oid": "0df0931b-e251-4f2e-8719-4ebfda3627ba",
+		"oname": "cluster001",
+		"otype": "CLUSTER",
+		"project": "f1fe61dcda2f4618a14c10dc7abc214d",
+		"status": "start",
+		"status_reason": "Initializing",
+		"timestamp": "2015-03-05T08:53:15Z",
+		"user": "8bcd2cdca7684c02afc9e4f2fc0f0c79"
+	}
+}
+`
+
+var ExpectedEvent1 = events.Event{
+	Action:       "CLUSTER_CREATE",
+	Cluster:      "",
+	ClusterID:    "",
+	ID:           "edce3528-864f-41fb-8759-f4707925cc09",
+	Level:        "INFO",
+	Metadata:     map[string]interface{}{},
+	OID:          "0df0931b-e251-4f2e-8719-4ebfda3627ba",
+	OName:        "cluster001",
+	OType:        "CLUSTER",
+	Project:      "f1fe61dcda2f4618a14c10dc7abc214d",
+	Status:       "start",
+	StatusReason: "Initializing",
+	Timestamp:    time.Date(2015, 3, 5, 8, 53, 15, 0, time.UTC),
+	User:         "8bcd2cdca7684c02afc9e4f2fc0f0c79",
+}
+
+var ExpectedEvent2 = events.Event{
+	Action:       "NODE_DELETE",
+	Cluster:      "",
+	ClusterID:    "",
+	ID:           "abcd1234-864f-41fb-8759-f4707925dd10",
+	Level:        "INFO",
+	Metadata:     map[string]interface{}{},
+	OID:          "0df0931b-e251-4f2e-8719-4ebfda3627ba",
+	OName:        "node119",
+	OType:        "node",
+	Project:      "f1fe61dcda2f4618a14c10dc7abc214d",
+	Status:       "start",
+	StatusReason: "84492c96",
+	Timestamp:    time.Date(2015, 3, 6, 18, 53, 15, 0, time.UTC),
+	User:         "8bcd2cdca7684c02afc9e4f2fc0f0c79",
+}
+
+var ExpectedEvents = []events.Event{ExpectedEvent1, ExpectedEvent2}
+
+func HandleListSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/v1/events", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, ListResponse)
+	})
+}
+
+func HandleGetSuccessfully(t *testing.T, id string) {
+	th.Mux.HandleFunc("/v1/events/"+id, func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, GetResponse)
+	})
+}

--- a/openstack/clustering/v1/events/testing/requests_test.go
+++ b/openstack/clustering/v1/events/testing/requests_test.go
@@ -1,0 +1,45 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/clustering/v1/events"
+
+	"github.com/gophercloud/gophercloud/pagination"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	fake "github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func TestListEvents(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	HandleListSuccessfully(t)
+
+	pageCount := 0
+	err := events.List(fake.ServiceClient(), nil).EachPage(func(page pagination.Page) (bool, error) {
+		pageCount++
+		actual, err := events.ExtractEvents(page)
+		th.AssertNoErr(t, err)
+
+		th.AssertDeepEquals(t, ExpectedEvents, actual)
+
+		return true, nil
+	})
+	th.AssertNoErr(t, err)
+
+	if pageCount != 1 {
+		t.Errorf("Expected 1 page, got %d", pageCount)
+	}
+}
+
+func TestGetEvent(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	HandleGetSuccessfully(t, ExpectedEvent1.ID)
+
+	actual, err := events.Get(fake.ServiceClient(), ExpectedEvent1.ID).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, ExpectedEvent1, *actual)
+}

--- a/openstack/clustering/v1/events/urls.go
+++ b/openstack/clustering/v1/events/urls.go
@@ -1,0 +1,22 @@
+package events
+
+import "github.com/gophercloud/gophercloud"
+
+var apiVersion = "v1"
+var apiName = "events"
+
+func commonURL(client *gophercloud.ServiceClient) string {
+	return client.ServiceURL(apiVersion, apiName)
+}
+
+func listURL(client *gophercloud.ServiceClient) string {
+	return commonURL(client)
+}
+
+func idURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL(apiVersion, apiName, id)
+}
+
+func getURL(client *gophercloud.ServiceClient, id string) string {
+	return idURL(client, id)
+}


### PR DESCRIPTION
Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

For #[823 [Add support for Senlin clustering]](https://github.com/gophercloud/gophercloud/issues/823)

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

[[events:get api]](https://github.com/openstack/senlin/blob/master/senlin/api/openstack/v1/events.py#L63)
[[events:list api]](https://github.com/openstack/senlin/blob/master/senlin/api/openstack/v1/events.py#L33)

[[events:get engine]](https://github.com/openstack/senlin/blob/0700a8bf29217b8a24fff0912cd89c0c64fe416b/senlin/engine/service.py#L2626)
[[events:list engine]](https://github.com/openstack/senlin/blob/0700a8bf29217b8a24fff0912cd89c0c64fe416b/senlin/engine/service.py#L2564)
