### PR TITLE
Baremetal v1 API: Nodes

### DIFF
--- a/acceptance/clients/clients.go
+++ b/acceptance/clients/clients.go
@@ -254,6 +254,27 @@ func NewComputeV2Client() (*gophercloud.ServiceClient, error) {
 	})
 }
 
+// NewBareMetalV1Client returns a *ServiceClient for making calls
+// to the OpenStack Bare Metal v1 API. An error will be returned
+// if authentication or client creation was not possible.
+func NewBareMetalV1Client() (*gophercloud.ServiceClient, error) {
+	ao, err := openstack.AuthOptionsFromEnv()
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := openstack.AuthenticatedClient(ao)
+	if err != nil {
+		return nil, err
+	}
+
+	client = configureDebug(client)
+
+	return openstack.NewBareMetalV1(client, gophercloud.EndpointOpts{
+		Region: os.Getenv("OS_REGION_NAME"),
+	})
+}
+
 // NewDBV1Client returns a *ServiceClient for making calls
 // to the OpenStack Database v1 API. An error will be returned
 // if authentication or client creation was not possible.

--- a/acceptance/openstack/baremetal/v1/baremetal.go
+++ b/acceptance/openstack/baremetal/v1/baremetal.go
@@ -1,0 +1,41 @@
+package v1
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/acceptance/tools"
+	"github.com/gophercloud/gophercloud/openstack/baremetal/v1/nodes"
+)
+
+// CreateNode creates a basic node with a randomly generated name.
+func CreateNode(t *testing.T, client *gophercloud.ServiceClient) (*nodes.Node, error) {
+	name := tools.RandomString("ACPTTEST", 16)
+	t.Logf("Attempting to create bare metal node: %s", name)
+
+	node, err := nodes.Create(client, nodes.CreateOpts{
+		Name:          name,
+		Driver:        "ipmi",
+		BootInterface: "pxe",
+		DriverInfo: map[string]interface{}{
+			"ipmi_port":      "6230",
+			"ipmi_username":  "admin",
+			"deploy_kernel":  "http://172.22.0.1/images/tinyipa-stable-rocky.vmlinuz",
+			"ipmi_address":   "192.168.122.1",
+			"deploy_ramdisk": "http://172.22.0.1/images/tinyipa-stable-rocky.gz",
+			"ipmi_password":  "admin",
+		},
+	}).Extract()
+
+	return node, err
+}
+
+// DeleteNode deletes a bare metal node via its UUID.
+func DeleteNode(t *testing.T, client *gophercloud.ServiceClient, node *nodes.Node) {
+	err := nodes.Delete(client, node.UUID).ExtractErr()
+	if err != nil {
+		t.Fatalf("Unable to delete node %s: %s", node.UUID, err)
+	}
+
+	t.Logf("Deleted server: %s", node.UUID)
+}

--- a/acceptance/openstack/baremetal/v1/nodes_test.go
+++ b/acceptance/openstack/baremetal/v1/nodes_test.go
@@ -1,0 +1,66 @@
+package v1
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/acceptance/clients"
+	"github.com/gophercloud/gophercloud/openstack/baremetal/v1/nodes"
+	"github.com/gophercloud/gophercloud/pagination"
+
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestNodesCreateDestroy(t *testing.T) {
+	clients.RequireLong(t)
+
+	client, err := clients.NewBareMetalV1Client()
+	th.AssertNoErr(t, err)
+	client.Microversion = "1.38"
+
+	node, err := CreateNode(t, client)
+	th.AssertNoErr(t, err)
+	defer DeleteNode(t, client, node)
+
+	found := false
+	err = nodes.List(client, nodes.ListOpts{}).EachPage(func(page pagination.Page) (bool, error) {
+		nodeList, err := nodes.ExtractNodes(page)
+		if err != nil {
+			return false, err
+		}
+
+		for _, n := range nodeList {
+			if n.UUID == node.UUID {
+				found = true
+				return true, nil
+			}
+		}
+
+		return false, nil
+	})
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, found, true)
+}
+
+func TestNodesUpdate(t *testing.T) {
+	clients.RequireLong(t)
+
+	client, err := clients.NewBareMetalV1Client()
+	th.AssertNoErr(t, err)
+	client.Microversion = "1.38"
+
+	node, err := CreateNode(t, client)
+	th.AssertNoErr(t, err)
+	defer DeleteNode(t, client, node)
+
+	updated, err := nodes.Update(client, node.UUID, nodes.UpdateOpts{
+		nodes.UpdateOperation{
+			Op:    nodes.ReplaceOp,
+			Path:  "/maintenance",
+			Value: "true",
+		},
+	}).Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, updated.Maintenance, true)
+}

--- a/openstack/baremetal/v1/nodes/doc.go
+++ b/openstack/baremetal/v1/nodes/doc.go
@@ -1,0 +1,65 @@
+package nodes
+
+/*
+Package nodes provides information and interaction with the nodes API
+resource in the OpenStack Bare Metal service.
+
+	// Example to List Nodes
+	nodes.List(client, nodes.ListOpts{
+		Detail: true,
+		ProvisionState: Deploying,
+	}).EachPage(func(page pagination.Page) (bool, error) {
+		nodeList, err := nodes.ExtractNodes(page)
+		if err != nil {
+			return false, err
+		}
+
+		for _, n := range nodeList {
+			// Do something
+		}
+
+		return true, nil
+	})
+
+	// Example to Create Node
+	createNode, err := nodes.Create(client, nodes.CreateOpts{
+		Driver:        "ipmi",
+		BootInterface: PXEBoot,
+		Name:          "coconuts",
+		DriverInfo: map[string]interface{}{
+			"ipmi_port":      "6230",
+			"ipmi_username":  "admin",
+			"deploy_kernel":  "http://172.22.0.1/images/tinyipa-stable-rocky.vmlinuz",
+			"ipmi_address":   "192.168.122.1",
+			"deploy_ramdisk": "http://172.22.0.1/images/tinyipa-stable-rocky.gz",
+			"ipmi_password":  "admin",
+		},
+	}).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	// Example to Get Node
+	showNode, err := nodes.Get(client, "c9afd385-5d89-4ecb-9e1c-68194da6b474").Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	// Example to Update Node
+	updateNode, err := nodes.Update(client, "c9afd385-5d89-4ecb-9e1c-68194da6b474", nodes.UpdateOpts{
+		nodes.UpdateOperation{
+			Op:    ReplaceOp,
+			Path:  "/maintenance",
+			Value: "true",
+		},
+	}).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	// Example to Delete Node
+	err = nodes.Delete(client, "c9afd385-5d89-4ecb-9e1c-68194da6b474").ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+*/

--- a/openstack/baremetal/v1/nodes/doc.go
+++ b/openstack/baremetal/v1/nodes/doc.go
@@ -4,10 +4,24 @@ package nodes
 Package nodes provides information and interaction with the nodes API
 resource in the OpenStack Bare Metal service.
 
+	// Example to List Nodes with Detail
+	nodes.ListDetail(client, nodes.ListOpts{}).EachPage(func(page pagination.Page) (bool, error) {
+		nodeList, err := nodes.ExtractNodes(page)
+		if err != nil {
+			return false, err
+		}
+
+		for _, n := range nodeList {
+			// Do something
+		}
+
+		return true, nil
+	})
+
 	// Example to List Nodes
 	nodes.List(client, nodes.ListOpts{
-		Detail: true,
 		ProvisionState: Deploying,
+		Fields: []string{"name"},
 	}).EachPage(func(page pagination.Page) (bool, error) {
 		nodeList, err := nodes.ExtractNodes(page)
 		if err != nil {

--- a/openstack/baremetal/v1/nodes/doc.go
+++ b/openstack/baremetal/v1/nodes/doc.go
@@ -24,7 +24,7 @@ resource in the OpenStack Bare Metal service.
 	// Example to Create Node
 	createNode, err := nodes.Create(client, nodes.CreateOpts{
 		Driver:        "ipmi",
-		BootInterface: PXEBoot,
+		BootInterface: "pxe",
 		Name:          "coconuts",
 		DriverInfo: map[string]interface{}{
 			"ipmi_port":      "6230",

--- a/openstack/baremetal/v1/nodes/requests.go
+++ b/openstack/baremetal/v1/nodes/requests.go
@@ -237,7 +237,7 @@ const (
 type UpdateOperation struct {
 	Op    UpdateOp `json:"op,required"`
 	Path  string   `json:"path,required"`
-	Value string   `json:"value,required"`
+	Value string   `json:"value,omitempty"`
 }
 
 func (opts UpdateOperation) ToNodeUpdateMap() map[string]interface{} {

--- a/openstack/baremetal/v1/nodes/requests.go
+++ b/openstack/baremetal/v1/nodes/requests.go
@@ -1,0 +1,274 @@
+package nodes
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// ListOptsBuilder allows extensions to add additional parameters to the
+// List request.
+type ListOptsBuilder interface {
+	ToNodeListQuery() (string, error)
+}
+
+// Provision state reports the current provision state of the node, these are only used in filtering
+type ProvisionState string
+
+const (
+	Enroll       ProvisionState = "enroll"
+	Verifying    ProvisionState = "verifying"
+	Manageable   ProvisionState = "manageable"
+	Available    ProvisionState = "available"
+	Active       ProvisionState = "active"
+	DeployWait   ProvisionState = "wait call-back"
+	Deploying    ProvisionState = "deploying"
+	DeployFail   ProvisionState = "deploy failed"
+	DeployDone   ProvisionState = "deploy complete"
+	Deleting     ProvisionState = "deleting"
+	Deleted      ProvisionState = "deleted"
+	Cleaning     ProvisionState = "cleaning"
+	CleanWait    ProvisionState = "clean wait"
+	CleanFail    ProvisionState = "clean failed"
+	Error        ProvisionState = "error"
+	Rebuild      ProvisionState = "rebuild"
+	Inpsecting   ProvisionState = "inspecting"
+	InspectFail  ProvisionState = "inspect failed"
+	InspectWait  ProvisionState = "inspect wait"
+	Adopting     ProvisionState = "adopting"
+	AdoptFail    ProvisionState = "adopt failed"
+	Rescue       ProvisionState = "rescue"
+	RescueFail   ProvisionState = "rescue failed"
+	Rescuing     ProvisionState = "rescuing"
+	UnrescueFail ProvisionState = "unrescue failed"
+)
+
+// ListOpts allows the filtering and sorting of paginated collections through
+// the API. Filtering is achieved by passing in struct field values that map to
+// the node attributes you want to see returned. Marker and Limit are used
+// for pagination.
+type ListOpts struct {
+	// Filter the list by specific instance UUID
+	InstanceUUID string `q:"instance_uuid"`
+
+	// Filter the list by chassis UUID
+	ChassisUUID string `q:"chassis_uuid"`
+
+	// Filter the list by maintenance set to True or False
+	Maintenance bool `q:"maintenance"`
+
+	// Nodes which are, or are not, associated with an instance_uuid.
+	Associated bool `q:"associated"`
+
+	// Only return those with the specified provision_state.
+	ProvisionState ProvisionState `q:"provision_state"`
+
+	// Filter the list with the specified driver.
+	Driver string `q:"driver"`
+
+	// Filter the list with the specified resource class.
+	ResourceClass string `q:"resource_class"`
+
+	// Filter the list with the specified conductor_group.
+	ConductorGroup string `q:"conductor_group"`
+
+	// Filter the list with the specified fault.
+	Fault string `q:"fault"`
+
+	// One or more fields to be returned in the response.
+	Fields []string `q:"fields"`
+
+	// Requests a page size of items.
+	Limit int `q:"limit"`
+
+	// The ID of the last-seen item.
+	Marker string `q:"marker"`
+
+	// Sorts the response by the requested sort direction.
+	SortDir string `q:"sort_dir"`
+
+	// Sorts the response by the this attribute value.
+	SortKey string `q:"sort_key"`
+
+	// Whether to show detailed information about the resource.
+	Detail bool `q:"detail"`
+
+	// A string or UUID of the tenant who owns the baremetal node.
+	Owner string `q:"owner"`
+}
+
+// ToNodeListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToNodeListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List makes a request against the API to list nodes accessible to you.
+func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(client)
+	if opts != nil {
+		query, err := opts.ToNodeListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return NodePage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// Get requests details on a single node, by ID.
+func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {
+	_, r.Err = client.Get(getURL(client, id), &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToNodeCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts specifies node creation parameters.
+type CreateOpts struct {
+	// The boot interface for a Node, e.g. “pxe”.
+	BootInterface string `json:"boot_interface,omitempty"`
+
+	// The conductor group for a node. Case-insensitive string up to 255 characters, containing a-z, 0-9, _, -, and ..
+	ConductorGroup string `json:"conductor_group,omitempty"`
+
+	// The console interface for a node, e.g. “no-console”.
+	ConsoleInterface string `json:"console_interface,omitempty"`
+
+	// The deploy interface for a node, e.g. “iscsi”.
+	DeployInterface string `json:"deploy_interface,omitempty"`
+
+	// All the metadata required by the driver to manage this Node. List of fields varies between drivers, and can
+	// be retrieved from the /v1/drivers/<DRIVER_NAME>/properties resource.
+	DriverInfo map[string]interface{} `json:"driver_info,omitempty"`
+
+	// name of the driver used to manage this Node.
+	Driver string `json:"driver,omitempty"`
+
+	// A set of one or more arbitrary metadata key and value pairs.
+	Extra map[string]interface{} `json:"extra,omitempty"`
+
+	// The interface used for node inspection, e.g. “no-inspect”.
+	InspectInterface string `json:"inspect_interface,omitempty"`
+
+	// Interface for out-of-band node management, e.g. “ipmitool”.
+	ManagementInterface string `json:"management_interface,omitempty"`
+
+	// Human-readable identifier for the Node resource. May be undefined. Certain words are reserved.
+	Name string `json:"name,omitempty"`
+
+	// Which Network Interface provider to use when plumbing the network connections for this Node.
+	NetworkInterface string `json:"network_interface,omitempty"`
+
+	// Interface used for performing power actions on the node, e.g. “ipmitool”.
+	PowerInterface string `json:"power_interface,omitempty"`
+
+	// Physical characteristics of this Node. Populated during inspection, if performed. Can be edited via the REST
+	// API at any time.
+	Properties map[string]interface{} `json:"properties,omitempty"`
+
+	// Interface used for configuring RAID on this node, e.g. “no-raid”.
+	RAIDInterface string `json:"raid_interface,omitempty"`
+
+	// The interface used for node rescue, e.g. “no-rescue”.
+	RescueInterface string `json:"rescue_interface,omitempty"`
+
+	// A string which can be used by external schedulers to identify this Node as a unit of a specific type
+	// of resource.
+	ResourceClass string `json:"resource_class,omitempty"`
+
+	// Interface used for attaching and detaching volumes on this node, e.g. “cinder”.
+	StorageInterface string `json:"storage_interface,omitempty"`
+
+	// The UUID for the resource.
+	UUID string `json:"uuid,omitempty"`
+
+	// Interface for vendor-specific functionality on this node, e.g. “no-vendor”.
+	VendorInterface string `json:"vendor_interface,omitempty"`
+
+	// A string or UUID of the tenant who owns the baremetal node.
+	Owner string `json:"owner,omitempty"`
+}
+
+// ToNodeCreateMap assembles a request body based on the contents of a CreateOpts.
+func (opts CreateOpts) ToNodeCreateMap() (map[string]interface{}, error) {
+	body, err := gophercloud.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	return body, nil
+}
+
+// Create requests a node to be created
+func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	reqBody, err := opts.ToNodeCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = client.Post(createURL(client), reqBody, &r.Body, nil)
+	return
+}
+
+type Patch interface {
+	ToNodeUpdateMap() map[string]interface{}
+}
+
+// UpdateOpts is a slice of Patches used to update a node
+type UpdateOpts []Patch
+
+type UpdateOp string
+
+const (
+	ReplaceOp UpdateOp = "replace"
+	AddOp     UpdateOp = "add"
+	RemoveOp  UpdateOp = "remove"
+)
+
+type UpdateOperation struct {
+	Op    UpdateOp `json:"op,required"`
+	Path  string   `json:"path,required"`
+	Value string   `json:"value,required"`
+}
+
+func (opts UpdateOperation) ToNodeUpdateMap() map[string]interface{} {
+	return map[string]interface{}{
+		"op":    opts.Op,
+		"path":  opts.Path,
+		"value": opts.Value,
+	}
+}
+
+// Update requests that a node be updated
+func Update(client *gophercloud.ServiceClient, id string, opts UpdateOpts) (r UpdateResult) {
+	body := make([]map[string]interface{}, len(opts))
+	for i, patch := range opts {
+		body[i] = patch.ToNodeUpdateMap()
+	}
+
+	resp, err := client.Request("PATCH", updateURL(client, id), &gophercloud.RequestOpts{
+		JSONBody: &body,
+		OkCodes:  []int{200},
+	})
+
+	r.Body = resp.Body
+	r.Header = resp.Header
+	r.Err = err
+
+	return
+}
+
+// Delete requests that a node be removed
+func Delete(client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+	_, r.Err = client.Delete(deleteURL(client, id), nil)
+	return
+}

--- a/openstack/baremetal/v1/nodes/results.go
+++ b/openstack/baremetal/v1/nodes/results.go
@@ -1,0 +1,222 @@
+package nodes
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+type nodeResult struct {
+	gophercloud.Result
+}
+
+// Extract interprets any nodeResult as a Node, if possible.
+func (r nodeResult) Extract() (*Node, error) {
+	var s Node
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+func (r nodeResult) ExtractInto(v interface{}) error {
+	return r.Result.ExtractIntoStructPtr(v, "")
+}
+
+func ExtractNodesInto(r pagination.Page, v interface{}) error {
+	return r.(NodePage).Result.ExtractIntoSlicePtr(v, "nodes")
+}
+
+// Node represents a node in the OpenStack Bare Metal API.
+type Node struct {
+	// UUID for the resource.
+	UUID string `json:"uuid"`
+
+	// Identifier for the Node resource. May be undefined. Certain words are reserved.
+	Name string `json:"name"`
+
+	// Current power state of this Node. Usually, “power on” or “power off”, but may be “None”
+	// if Ironic is unable to determine the power state (eg, due to hardware failure).
+	PowerState string `json:"power_state"`
+
+	// A power state transition has been requested, this field represents the requested (ie, “target”)
+	// state either “power on”, “power off”, “rebooting”, “soft power off” or “soft rebooting”.
+	TargetPowerState string `json:"target_power_state"`
+
+	// Current provisioning state of this Node.
+	ProvisionState string `json:"provision_state"`
+
+	// A provisioning action has been requested, this field represents the requested (ie, “target”) state. Note
+	// that a Node may go through several states during its transition to this target state. For instance, when
+	// requesting an instance be deployed to an AVAILABLE Node, the Node may go through the following state
+	// change progression: AVAILABLE -> DEPLOYING -> DEPLOYWAIT -> DEPLOYING -> ACTIVE
+	TargetProvisionState string `json:"target_provision_state"`
+
+	// Whether or not this Node is currently in “maintenance mode”. Setting a Node into maintenance mode removes it
+	// from the available resource pool and halts some internal automation. This can happen manually (eg, via an API
+	// request) or automatically when Ironic detects a hardware fault that prevents communication with the machine.
+	Maintenance bool `json:"maintenance"`
+
+	// Description of the reason why this Node was placed into maintenance mode
+	MaintenanceReason string `json:"maintenance_reason"`
+
+	// Fault indicates the active fault detected by ironic, typically the Node is in “maintenance mode”. None means no
+	// fault has been detected by ironic. “power failure” indicates ironic failed to retrieve power state from this
+	// node. There are other possible types, e.g., “clean failure” and “rescue abort failure”.
+	Fault string `json:"fault"`
+
+	// Error from the most recent (last) transaction that started but failed to finish.
+	LastError string `json:"last_error"`
+
+	// Name of an Ironic Conductor host which is holding a lock on this node, if a lock is held. Usually “null”,
+	// but this field can be useful for debugging.
+	Reservation string `json:"reservation"`
+
+	// Name of the driver.
+	Driver string `json:"driver"`
+
+	// The metadata required by the driver to manage this Node. List of fields varies between drivers, and can be
+	// retrieved from the /v1/drivers/<DRIVER_NAME>/properties resource.
+	DriverInfo map[string]interface{} `json:"driver_info"`
+
+	// Metadata set and stored by the Node’s driver. This field is read-only.
+	DriverInternalInfo map[string]interface{} `json:"driver_internal_info"`
+
+	// Characteristics of this Node. Populated by ironic-inspector during inspection. May be edited via the REST
+	// API at any time.
+	Properties map[string]interface{} `json:"properties"`
+
+	// Used to customize the deployed image. May include root partition size, a base 64 encoded config drive, and other
+	// metadata. Note that this field is erased automatically when the instance is deleted (this is done by requesting
+	// the Node provision state be changed to DELETED).
+	InstanceInfo map[string]interface{} `json:"instance_info"`
+
+	// ID of the Nova instance associated with this Node.
+	InstanceUUID string `json:"instance_uuid"`
+
+	// ID of the chassis associated with this Node. May be empty or None.
+	ChassisUUID string `json:"chassis_uuid"`
+
+	// Set of one or more arbitrary metadata key and value pairs.
+	Extra map[string]interface{} `json:"extra"`
+
+	// Whether console access is enabled or disabled on this node.
+	ConsoleEnabled bool `json:"console_enabled"`
+
+	// The current RAID configuration of the node. Introduced with the cleaning feature.
+	RAIDConfig map[string]interface{} `json:"raid_config"`
+
+	// The requested RAID configuration of the node, which will be applied when the Node next transitions
+	// through the CLEANING state. Introduced with the cleaning feature.
+	TargetRAIDConfig map[string]interface{} `json:"target_raid_config"`
+
+	// Current clean step. Introduced with the cleaning feature.
+	CleanStep map[string]interface{} `json:"clean_step"`
+
+	// Current deploy step.
+	DeployStep map[string]interface{} `json:"deploy_step"`
+
+	// String which can be used by external schedulers to identify this Node as a unit of a specific type of resource.
+	// For more details, see: https://docs.openstack.org/ironic/latest/install/configure-nova-flavors.html
+	ResourceClass string `json:"resource_class"`
+
+	// Boot interface for a Node, e.g. “pxe”.
+	BootInterface string `json:"boot_interface"`
+
+	// Console interface for a node, e.g. “no-console”.
+	ConsoleInterface string `json:"console_interface"`
+
+	// Deploy interface for a node, e.g. “iscsi”.
+	DeployInterface string `json:"deploy_interface"`
+
+	// Interface used for node inspection, e.g. “no-inspect”.
+	InspectInterface string `json:"inspect_interface"`
+
+	// For out-of-band node management, e.g. “ipmitool”.
+	ManagementInterface string `json:"management_interface"`
+
+	// Network Interface provider to use when plumbing the network connections for this Node.
+	NetworkInterface string `json:"network_interface"`
+
+	// used for performing power actions on the node, e.g. “ipmitool”.
+	PowerInterface string `json:"power_interface"`
+
+	// Used for configuring RAID on this node, e.g. “no-raid”.
+	RAIDInterface string `json:"raid_interface"`
+
+	// Interface used for node rescue, e.g. “no-rescue”.
+	RescueInterface string `json:"rescue_interface"`
+
+	// Used for attaching and detaching volumes on this node, e.g. “cinder”.
+	StorageInterface string `json:"storage_interface"`
+
+	// Array of traits for this node.
+	Traits []string `json:"traits"`
+
+	// For vendor-specific functionality on this node, e.g. “no-vendor”.
+	VendorInterface string `json:"vendor_interface"`
+
+	// Conductor group for a node. Case-insensitive string up to 255 characters, containing a-z, 0-9, _, -, and ..
+	ConductorGroup string `json:"conductor_group"`
+
+	// The node is protected from undeploying, rebuilding and deletion.
+	Protected bool `json:"protected"`
+
+	// Reason the node is marked as protected.
+	ProtectedReason string `json:"protected_reason"`
+}
+
+// NodePage abstracts the raw results of making a List() request against
+// the API. As OpenStack extensions may freely alter the response bodies of
+// structures returned to the client, you may only safely access the data
+// provided through the ExtractNodes call.
+type NodePage struct {
+	pagination.LinkedPageBase
+}
+
+// IsEmpty returns true if a page contains no Node results.
+func (r NodePage) IsEmpty() (bool, error) {
+	s, err := ExtractNodes(r)
+	return len(s) == 0, err
+}
+
+// NextPageURL uses the response's embedded link reference to navigate to the
+// next page of results.
+func (r NodePage) NextPageURL() (string, error) {
+	var s struct {
+		Links []gophercloud.Link `json:"nodes_links"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return gophercloud.ExtractNextURL(s.Links)
+}
+
+// ExtractNodes interprets the results of a single page from a List() call,
+// producing a slice of Node entities.
+func ExtractNodes(r pagination.Page) ([]Node, error) {
+	var s []Node
+	err := ExtractNodesInto(r, &s)
+	return s, err
+}
+
+// GetResult is the response from a Get operation. Call its Extract
+// method to interpret it as a Node.
+type GetResult struct {
+	nodeResult
+}
+
+// CreateResult is the response from a Create operation.
+type CreateResult struct {
+	nodeResult
+}
+
+// UpdateResult is the response from an Update operation. Call its Extract
+// method to interpret it as a Node.
+type UpdateResult struct {
+	nodeResult
+}
+
+// DeleteResult is the response from a Delete operation. Call its ExtractErr
+// method to determine if the call succeeded or failed.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}

--- a/openstack/baremetal/v1/nodes/results.go
+++ b/openstack/baremetal/v1/nodes/results.go
@@ -161,6 +161,9 @@ type Node struct {
 
 	// Reason the node is marked as protected.
 	ProtectedReason string `json:"protected_reason"`
+
+	// A string or UUID of the tenant who owns the baremetal node.
+	Owner string `json:"owner"`
 }
 
 // NodePage abstracts the raw results of making a List() request against

--- a/openstack/baremetal/v1/nodes/testing/doc.go
+++ b/openstack/baremetal/v1/nodes/testing/doc.go
@@ -1,0 +1,2 @@
+// nodes unit tests
+package testing

--- a/openstack/baremetal/v1/nodes/testing/fixtures.go
+++ b/openstack/baremetal/v1/nodes/testing/fixtures.go
@@ -10,8 +10,67 @@ import (
 	"github.com/gophercloud/gophercloud/testhelper/client"
 )
 
-// NodeListBody contains the canned body of a nodes.List response.
+// NodeListBody contains the canned body of a nodes.List response, without detail.
 const NodeListBody = `
+ {
+  "nodes": [
+    {
+      "instance_uuid": null,
+      "links": [
+        {
+          "href": "http://ironic.example.com:6385/v1/nodes/d2630783-6ec8-4836-b556-ab427c4b581e",
+          "rel": "self"
+        },
+        {
+          "href": "http://ironic.example.com:6385/nodes/d2630783-6ec8-4836-b556-ab427c4b581e",
+          "rel": "bookmark"
+        }
+      ],
+      "maintenance": false,
+      "name": "foo",
+      "power_state": null,
+      "provision_state": "enroll"
+    },
+    {
+      "instance_uuid": null,
+      "links": [
+        {
+          "href": "http://ironic.example.com:6385/v1/nodes/08c84581-58f5-4ea2-a0c6-dd2e5d2b3662",
+          "rel": "self"
+        },
+        {
+          "href": "http://ironic.example.com:6385/nodes/08c84581-58f5-4ea2-a0c6-dd2e5d2b3662",
+          "rel": "bookmark"
+        }
+      ],
+      "maintenance": false,
+      "name": "bar",
+      "power_state": null,
+      "provision_state": "enroll"
+    },
+    {
+      "instance_uuid": null,
+      "links": [
+        {
+          "href": "http://ironic.example.com:6385/v1/nodes/c9afd385-5d89-4ecb-9e1c-68194da6b474",
+          "rel": "self"
+        },
+        {
+          "href": "http://ironic.example.com:6385/nodes/c9afd385-5d89-4ecb-9e1c-68194da6b474",
+          "rel": "bookmark"
+        }
+      ],
+      "maintenance": false,
+      "name": "baz",
+      "power_state": null,
+      "provision_state": "enroll"
+    }
+  ]
+}
+`
+
+// NodeListDetailBody contains the canned body of a nodes.ListDetail response.
+const NodeListDetailBody = `
  {
   "nodes": [
     {
@@ -577,6 +636,18 @@ func HandleNodeListSuccessfully(t *testing.T) {
 		default:
 			t.Fatalf("/nodes invoked with unexpected marker=[%s]", marker)
 		}
+	})
+}
+
+// HandleNodeListSuccessfully sets up the test server to respond to a server List request.
+func HandleNodeListDetailSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/nodes/detail", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		w.Header().Add("Content-Type", "application/json")
+		r.ParseForm()
+
+		fmt.Fprintf(w, NodeListDetailBody)
 	})
 }
 

--- a/openstack/baremetal/v1/nodes/testing/fixtures.go
+++ b/openstack/baremetal/v1/nodes/testing/fixtures.go
@@ -1,0 +1,639 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/baremetal/v1/nodes"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+// NodeListBody contains the canned body of a nodes.List response.
+const NodeListBody = `
+ {
+  "nodes": [
+    {
+      "bios_interface": "no-bios",
+      "boot_interface": "pxe",
+      "chassis_uuid": null,
+      "clean_step": {},
+      "conductor_group": "",
+      "console_enabled": false,
+      "console_interface": "no-console",
+      "created_at": "2019-01-31T19:59:28+00:00",
+      "deploy_interface": "iscsi",
+      "deploy_step": {},
+      "driver": "ipmi",
+      "driver_info": {
+        "ipmi_port": "6230",
+        "ipmi_username": "admin",
+        "deploy_kernel": "http://172.22.0.1/images/tinyipa-stable-rocky.vmlinuz",
+        "ipmi_address": "192.168.122.1",
+        "deploy_ramdisk": "http://172.22.0.1/images/tinyipa-stable-rocky.gz",
+        "ipmi_password": "admin"
+
+      },
+      "driver_internal_info": {},
+      "extra": {},
+      "fault": null,
+      "inspect_interface": "no-inspect",
+      "inspection_finished_at": null,
+      "inspection_started_at": null,
+      "instance_info": {},
+      "instance_uuid": null,
+      "last_error": null,
+      "links": [
+        {
+          "href": "http://ironic.example.com:6385/v1/nodes/d2630783-6ec8-4836-b556-ab427c4b581e",
+          "rel": "self"
+        },
+        {
+          "href": "http://ironic.example.com:6385/nodes/d2630783-6ec8-4836-b556-ab427c4b581e",
+          "rel": "bookmark"
+        }
+      ],
+      "maintenance": false,
+      "maintenance_reason": null,
+      "management_interface": "ipmitool",
+      "name": "foo",
+      "network_interface": "flat",
+      "portgroups": [
+        {
+          "href": "http://ironic.example.com:6385/v1/nodes/d2630783-6ec8-4836-b556-ab427c4b581e/portgroups",
+          "rel": "self"
+        },
+        {
+          "href": "http://ironic.example.com:6385/nodes/d2630783-6ec8-4836-b556-ab427c4b581e/portgroups",
+          "rel": "bookmark"
+        }
+      ],
+      "ports": [
+        {
+          "href": "http://ironic.example.com:6385/v1/nodes/d2630783-6ec8-4836-b556-ab427c4b581e/ports",
+          "rel": "self"
+        },
+        {
+          "href": "http://ironic.example.com:6385/nodes/d2630783-6ec8-4836-b556-ab427c4b581e/ports",
+          "rel": "bookmark"
+        }
+      ],
+      "power_interface": "ipmitool",
+      "power_state": null,
+      "properties": {},
+      "provision_state": "enroll",
+      "provision_updated_at": null,
+      "raid_config": {},
+      "raid_interface": "no-raid",
+      "rescue_interface": "no-rescue",
+      "reservation": null,
+      "resource_class": null,
+      "states": [
+        {
+          "href": "http://ironic.example.com:6385/v1/nodes/d2630783-6ec8-4836-b556-ab427c4b581e/states",
+          "rel": "self"
+        },
+        {
+          "href": "http://ironic.example.com:6385/nodes/d2630783-6ec8-4836-b556-ab427c4b581e/states",
+          "rel": "bookmark"
+        }
+      ],
+      "storage_interface": "noop",
+      "target_power_state": null,
+      "target_provision_state": null,
+      "target_raid_config": {},
+      "traits": [],
+      "updated_at": null,
+      "uuid": "d2630783-6ec8-4836-b556-ab427c4b581e",
+      "vendor_interface": "ipmitool",
+      "volume": [
+        {
+          "href": "http://ironic.example.com:6385/v1/nodes/d2630783-6ec8-4836-b556-ab427c4b581e/volume",
+          "rel": "self"
+        },
+        {
+          "href": "http://ironic.example.com:6385/nodes/d2630783-6ec8-4836-b556-ab427c4b581e/volume",
+          "rel": "bookmark"
+        }
+      ]
+    },
+    {
+      "bios_interface": "no-bios",
+      "boot_interface": "pxe",
+      "chassis_uuid": null,
+      "clean_step": {},
+      "conductor_group": "",
+      "console_enabled": false,
+      "console_interface": "no-console",
+      "created_at": "2019-01-31T19:59:29+00:00",
+      "deploy_interface": "iscsi",
+      "deploy_step": {},
+      "driver": "ipmi",
+      "driver_info": {},
+      "driver_internal_info": {},
+      "extra": {},
+      "fault": null,
+      "inspect_interface": "no-inspect",
+      "inspection_finished_at": null,
+      "inspection_started_at": null,
+      "instance_info": {},
+      "instance_uuid": null,
+      "last_error": null,
+      "links": [
+        {
+          "href": "http://ironic.example.com:6385/v1/nodes/08c84581-58f5-4ea2-a0c6-dd2e5d2b3662",
+          "rel": "self"
+        },
+        {
+          "href": "http://ironic.example.com:6385/nodes/08c84581-58f5-4ea2-a0c6-dd2e5d2b3662",
+          "rel": "bookmark"
+        }
+      ],
+      "maintenance": false,
+      "maintenance_reason": null,
+      "management_interface": "ipmitool",
+      "name": "bar",
+      "network_interface": "flat",
+      "portgroups": [
+        {
+          "href": "http://ironic.example.com:6385/v1/nodes/08c84581-58f5-4ea2-a0c6-dd2e5d2b3662/portgroups",
+          "rel": "self"
+        },
+        {
+          "href": "http://ironic.example.com:6385/nodes/08c84581-58f5-4ea2-a0c6-dd2e5d2b3662/portgroups",
+          "rel": "bookmark"
+        }
+      ],
+      "ports": [
+        {
+          "href": "http://ironic.example.com:6385/v1/nodes/08c84581-58f5-4ea2-a0c6-dd2e5d2b3662/ports",
+          "rel": "self"
+        },
+        {
+          "href": "http://ironic.example.com:6385/nodes/08c84581-58f5-4ea2-a0c6-dd2e5d2b3662/ports",
+          "rel": "bookmark"
+        }
+      ],
+      "power_interface": "ipmitool",
+      "power_state": null,
+      "properties": {},
+      "provision_state": "enroll",
+      "provision_updated_at": null,
+      "raid_config": {},
+      "raid_interface": "no-raid",
+      "rescue_interface": "no-rescue",
+      "reservation": null,
+      "resource_class": null,
+      "states": [
+        {
+          "href": "http://ironic.example.com:6385/v1/nodes/08c84581-58f5-4ea2-a0c6-dd2e5d2b3662/states",
+          "rel": "self"
+        },
+        {
+          "href": "http://ironic.example.com:6385/nodes/08c84581-58f5-4ea2-a0c6-dd2e5d2b3662/states",
+          "rel": "bookmark"
+        }
+      ],
+      "storage_interface": "noop",
+      "target_power_state": null,
+      "target_provision_state": null,
+      "target_raid_config": {},
+      "traits": [],
+      "updated_at": null,
+      "uuid": "08c84581-58f5-4ea2-a0c6-dd2e5d2b3662",
+      "vendor_interface": "ipmitool",
+      "volume": [
+        {
+          "href": "http://ironic.example.com:6385/v1/nodes/08c84581-58f5-4ea2-a0c6-dd2e5d2b3662/volume",
+          "rel": "self"
+        },
+        {
+          "href": "http://ironic.example.com:6385/nodes/08c84581-58f5-4ea2-a0c6-dd2e5d2b3662/volume",
+          "rel": "bookmark"
+        }
+      ]
+    },
+    {
+      "bios_interface": "no-bios",
+      "boot_interface": "pxe",
+      "chassis_uuid": null,
+      "clean_step": {},
+      "conductor_group": "",
+      "console_enabled": false,
+      "console_interface": "no-console",
+      "created_at": "2019-01-31T19:59:30+00:00",
+      "deploy_interface": "iscsi",
+      "deploy_step": {},
+      "driver": "ipmi",
+      "driver_info": {},
+      "driver_internal_info": {},
+      "extra": {},
+      "fault": null,
+      "inspect_interface": "no-inspect",
+      "inspection_finished_at": null,
+      "inspection_started_at": null,
+      "instance_info": {},
+      "instance_uuid": null,
+      "last_error": null,
+      "links": [
+        {
+          "href": "http://ironic.example.com:6385/v1/nodes/c9afd385-5d89-4ecb-9e1c-68194da6b474",
+          "rel": "self"
+        },
+        {
+          "href": "http://ironic.example.com:6385/nodes/c9afd385-5d89-4ecb-9e1c-68194da6b474",
+          "rel": "bookmark"
+        }
+      ],
+      "maintenance": false,
+      "maintenance_reason": null,
+      "management_interface": "ipmitool",
+      "name": "baz",
+      "network_interface": "flat",
+      "portgroups": [
+        {
+          "href": "http://ironic.example.com:6385/v1/nodes/c9afd385-5d89-4ecb-9e1c-68194da6b474/portgroups",
+          "rel": "self"
+        },
+        {
+          "href": "http://ironic.example.com:6385/nodes/c9afd385-5d89-4ecb-9e1c-68194da6b474/portgroups",
+          "rel": "bookmark"
+        }
+      ],
+      "ports": [
+        {
+          "href": "http://ironic.example.com:6385/v1/nodes/c9afd385-5d89-4ecb-9e1c-68194da6b474/ports",
+          "rel": "self"
+        },
+        {
+          "href": "http://ironic.example.com:6385/nodes/c9afd385-5d89-4ecb-9e1c-68194da6b474/ports",
+          "rel": "bookmark"
+        }
+      ],
+      "power_interface": "ipmitool",
+      "power_state": null,
+      "properties": {},
+      "provision_state": "enroll",
+      "provision_updated_at": null,
+      "raid_config": {},
+      "raid_interface": "no-raid",
+      "rescue_interface": "no-rescue",
+      "reservation": null,
+      "resource_class": null,
+      "states": [
+        {
+          "href": "http://ironic.example.com:6385/v1/nodes/c9afd385-5d89-4ecb-9e1c-68194da6b474/states",
+          "rel": "self"
+        },
+        {
+          "href": "http://ironic.example.com:6385/nodes/c9afd385-5d89-4ecb-9e1c-68194da6b474/states",
+          "rel": "bookmark"
+        }
+      ],
+      "storage_interface": "noop",
+      "target_power_state": null,
+      "target_provision_state": null,
+      "target_raid_config": {},
+      "traits": [],
+      "updated_at": null,
+      "uuid": "c9afd385-5d89-4ecb-9e1c-68194da6b474",
+      "vendor_interface": "ipmitool",
+      "volume": [
+        {
+          "href": "http://ironic.example.com:6385/v1/nodes/c9afd385-5d89-4ecb-9e1c-68194da6b474/volume",
+          "rel": "self"
+        },
+        {
+          "href": "http://ironic.example.com:6385/nodes/c9afd385-5d89-4ecb-9e1c-68194da6b474/volume",
+          "rel": "bookmark"
+        }
+      ]
+    }
+  ]
+}
+`
+
+// SingleNodeBody is the canned body of a Get request on an existing node.
+const SingleNodeBody = `
+{
+  "bios_interface": "no-bios",
+  "boot_interface": "pxe",
+  "chassis_uuid": null,
+  "clean_step": {},
+  "conductor_group": "",
+  "console_enabled": false,
+  "console_interface": "no-console",
+  "created_at": "2019-01-31T19:59:28+00:00",
+  "deploy_interface": "iscsi",
+  "deploy_step": {},
+  "driver": "ipmi",
+  "driver_info": {
+    "ipmi_port": "6230",
+    "ipmi_username": "admin",
+    "deploy_kernel": "http://172.22.0.1/images/tinyipa-stable-rocky.vmlinuz",
+    "ipmi_address": "192.168.122.1",
+    "deploy_ramdisk": "http://172.22.0.1/images/tinyipa-stable-rocky.gz",
+    "ipmi_password": "admin"
+  },
+  "driver_internal_info": {},
+  "extra": {},
+  "fault": null,
+  "inspect_interface": "no-inspect",
+  "inspection_finished_at": null,
+  "inspection_started_at": null,
+  "instance_info": {},
+  "instance_uuid": null,
+  "last_error": null,
+  "links": [
+    {
+      "href": "http://ironic.example.com:6385/v1/nodes/d2630783-6ec8-4836-b556-ab427c4b581e",
+      "rel": "self"
+    },
+    {
+      "href": "http://ironic.example.com:6385/nodes/d2630783-6ec8-4836-b556-ab427c4b581e",
+      "rel": "bookmark"
+    }
+  ],
+  "maintenance": false,
+  "maintenance_reason": null,
+  "management_interface": "ipmitool",
+  "name": "foo",
+  "network_interface": "flat",
+  "portgroups": [
+    {
+      "href": "http://ironic.example.com:6385/v1/nodes/d2630783-6ec8-4836-b556-ab427c4b581e/portgroups",
+      "rel": "self"
+    },
+    {
+      "href": "http://ironic.example.com:6385/nodes/d2630783-6ec8-4836-b556-ab427c4b581e/portgroups",
+      "rel": "bookmark"
+    }
+  ],
+  "ports": [
+    {
+      "href": "http://ironic.example.com:6385/v1/nodes/d2630783-6ec8-4836-b556-ab427c4b581e/ports",
+      "rel": "self"
+    },
+    {
+      "href": "http://ironic.example.com:6385/nodes/d2630783-6ec8-4836-b556-ab427c4b581e/ports",
+      "rel": "bookmark"
+    }
+  ],
+  "power_interface": "ipmitool",
+  "power_state": null,
+  "properties": {},
+  "provision_state": "enroll",
+  "provision_updated_at": null,
+  "raid_config": {},
+  "raid_interface": "no-raid",
+  "rescue_interface": "no-rescue",
+  "reservation": null,
+  "resource_class": null,
+  "states": [
+    {
+      "href": "http://ironic.example.com:6385/v1/nodes/d2630783-6ec8-4836-b556-ab427c4b581e/states",
+      "rel": "self"
+    },
+    {
+      "href": "http://ironic.example.com:6385/nodes/d2630783-6ec8-4836-b556-ab427c4b581e/states",
+      "rel": "bookmark"
+    }
+  ],
+  "storage_interface": "noop",
+  "target_power_state": null,
+  "target_provision_state": null,
+  "target_raid_config": {},
+  "traits": [],
+  "updated_at": null,
+  "uuid": "d2630783-6ec8-4836-b556-ab427c4b581e",
+  "vendor_interface": "ipmitool",
+  "volume": [
+    {
+      "href": "http://ironic.example.com:6385/v1/nodes/d2630783-6ec8-4836-b556-ab427c4b581e/volume",
+      "rel": "self"
+    },
+    {
+      "href": "http://ironic.example.com:6385/nodes/d2630783-6ec8-4836-b556-ab427c4b581e/volume",
+      "rel": "bookmark"
+    }
+  ]
+}
+`
+
+var (
+	NodeFoo = nodes.Node{
+		UUID:                 "d2630783-6ec8-4836-b556-ab427c4b581e",
+		Name:                 "foo",
+		PowerState:           "",
+		TargetPowerState:     "",
+		ProvisionState:       "enroll",
+		TargetProvisionState: "",
+		Maintenance:          false,
+		MaintenanceReason:    "",
+		Fault:                "",
+		LastError:            "",
+		Reservation:          "",
+		Driver:               "ipmi",
+		DriverInfo: map[string]interface{}{
+			"ipmi_port":      "6230",
+			"ipmi_username":  "admin",
+			"deploy_kernel":  "http://172.22.0.1/images/tinyipa-stable-rocky.vmlinuz",
+			"ipmi_address":   "192.168.122.1",
+			"deploy_ramdisk": "http://172.22.0.1/images/tinyipa-stable-rocky.gz",
+			"ipmi_password":  "admin",
+		},
+		DriverInternalInfo:  map[string]interface{}{},
+		Properties:          map[string]interface{}{},
+		InstanceInfo:        map[string]interface{}{},
+		InstanceUUID:        "",
+		ChassisUUID:         "",
+		Extra:               map[string]interface{}{},
+		ConsoleEnabled:      false,
+		RAIDConfig:          map[string]interface{}{},
+		TargetRAIDConfig:    map[string]interface{}{},
+		CleanStep:           map[string]interface{}{},
+		DeployStep:          map[string]interface{}{},
+		ResourceClass:       "",
+		BootInterface:       "pxe",
+		ConsoleInterface:    "no-console",
+		DeployInterface:     "iscsi",
+		InspectInterface:    "no-inspect",
+		ManagementInterface: "ipmitool",
+		NetworkInterface:    "flat",
+		PowerInterface:      "ipmitool",
+		RAIDInterface:       "no-raid",
+		RescueInterface:     "no-rescue",
+		StorageInterface:    "noop",
+		Traits:              []string{},
+		VendorInterface:     "ipmitool",
+		ConductorGroup:      "",
+		Protected:           false,
+		ProtectedReason:     "",
+	}
+
+	NodeBar = nodes.Node{
+		UUID:                 "08c84581-58f5-4ea2-a0c6-dd2e5d2b3662",
+		Name:                 "bar",
+		PowerState:           "",
+		TargetPowerState:     "",
+		ProvisionState:       "enroll",
+		TargetProvisionState: "",
+		Maintenance:          false,
+		MaintenanceReason:    "",
+		Fault:                "",
+		LastError:            "",
+		Reservation:          "",
+		Driver:               "ipmi",
+		DriverInfo:           map[string]interface{}{},
+		DriverInternalInfo:   map[string]interface{}{},
+		Properties:           map[string]interface{}{},
+		InstanceInfo:         map[string]interface{}{},
+		InstanceUUID:         "",
+		ChassisUUID:          "",
+		Extra:                map[string]interface{}{},
+		ConsoleEnabled:       false,
+		RAIDConfig:           map[string]interface{}{},
+		TargetRAIDConfig:     map[string]interface{}{},
+		CleanStep:            map[string]interface{}{},
+		DeployStep:           map[string]interface{}{},
+		ResourceClass:        "",
+		BootInterface:        "pxe",
+		ConsoleInterface:     "no-console",
+		DeployInterface:      "iscsi",
+		InspectInterface:     "no-inspect",
+		ManagementInterface:  "ipmitool",
+		NetworkInterface:     "flat",
+		PowerInterface:       "ipmitool",
+		RAIDInterface:        "no-raid",
+		RescueInterface:      "no-rescue",
+		StorageInterface:     "noop",
+		Traits:               []string{},
+		VendorInterface:      "ipmitool",
+		ConductorGroup:       "",
+		Protected:            false,
+		ProtectedReason:      "",
+	}
+
+	NodeBaz = nodes.Node{
+		UUID:                 "c9afd385-5d89-4ecb-9e1c-68194da6b474",
+		Name:                 "baz",
+		PowerState:           "",
+		TargetPowerState:     "",
+		ProvisionState:       "enroll",
+		TargetProvisionState: "",
+		Maintenance:          false,
+		MaintenanceReason:    "",
+		Fault:                "",
+		LastError:            "",
+		Reservation:          "",
+		Driver:               "ipmi",
+		DriverInfo:           map[string]interface{}{},
+		DriverInternalInfo:   map[string]interface{}{},
+		Properties:           map[string]interface{}{},
+		InstanceInfo:         map[string]interface{}{},
+		InstanceUUID:         "",
+		ChassisUUID:          "",
+		Extra:                map[string]interface{}{},
+		ConsoleEnabled:       false,
+		RAIDConfig:           map[string]interface{}{},
+		TargetRAIDConfig:     map[string]interface{}{},
+		CleanStep:            map[string]interface{}{},
+		DeployStep:           map[string]interface{}{},
+		ResourceClass:        "",
+		BootInterface:        "pxe",
+		ConsoleInterface:     "no-console",
+		DeployInterface:      "iscsi",
+		InspectInterface:     "no-inspect",
+		ManagementInterface:  "ipmitool",
+		NetworkInterface:     "flat",
+		PowerInterface:       "ipmitool",
+		RAIDInterface:        "no-raid",
+		RescueInterface:      "no-rescue",
+		StorageInterface:     "noop",
+		Traits:               []string{},
+		VendorInterface:      "ipmitool",
+		ConductorGroup:       "",
+		Protected:            false,
+		ProtectedReason:      "",
+	}
+)
+
+// HandleNodeListSuccessfully sets up the test server to respond to a server List request.
+func HandleNodeListSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/nodes", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		w.Header().Add("Content-Type", "application/json")
+		r.ParseForm()
+
+		marker := r.Form.Get("marker")
+		switch marker {
+		case "":
+			fmt.Fprintf(w, NodeListBody)
+
+		case "9e5476bd-a4ec-4653-93d6-72c93aa682ba":
+			fmt.Fprintf(w, `{ "servers": [] }`)
+		default:
+			t.Fatalf("/nodes invoked with unexpected marker=[%s]", marker)
+		}
+	})
+}
+
+// HandleServerCreationSuccessfully sets up the test server to respond to a server creation request
+// with a given response.
+func HandleNodeCreationSuccessfully(t *testing.T, response string) {
+	th.Mux.HandleFunc("/nodes", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, `{
+          "boot_interface": "pxe",
+          "driver": "ipmi",
+          "driver_info": {
+            "deploy_kernel": "http://172.22.0.1/images/tinyipa-stable-rocky.vmlinuz",
+            "deploy_ramdisk": "http://172.22.0.1/images/tinyipa-stable-rocky.gz",
+            "ipmi_address": "192.168.122.1",
+            "ipmi_password": "admin",
+            "ipmi_port": "6230",
+            "ipmi_username": "admin"
+          },
+          "name": "foo"
+        }`)
+
+		w.WriteHeader(http.StatusAccepted)
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprintf(w, response)
+	})
+}
+
+// HandleNodeDeletionSuccessfully sets up the test server to respond to a server deletion request.
+func HandleNodeDeletionSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/nodes/asdfasdfasdf", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.WriteHeader(http.StatusNoContent)
+	})
+}
+
+func HandleNodeGetSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/nodes/1234asdf", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+
+		fmt.Fprintf(w, SingleNodeBody)
+	})
+}
+
+func HandleNodeUpdateSuccessfully(t *testing.T, response string) {
+	th.Mux.HandleFunc("/nodes/1234asdf", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PATCH")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestJSONRequest(t, r, `[{"op": "replace", "path": "/driver", "value": "new-driver"}]`)
+
+		fmt.Fprintf(w, response)
+	})
+}

--- a/openstack/baremetal/v1/nodes/testing/requests_test.go
+++ b/openstack/baremetal/v1/nodes/testing/requests_test.go
@@ -1,0 +1,110 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/baremetal/v1/nodes"
+	"github.com/gophercloud/gophercloud/pagination"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func TestListNodes(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleNodeListSuccessfully(t)
+
+	pages := 0
+	err := nodes.List(client.ServiceClient(), nodes.ListOpts{
+		Detail: true,
+	}).EachPage(func(page pagination.Page) (bool, error) {
+		pages++
+
+		actual, err := nodes.ExtractNodes(page)
+		if err != nil {
+			return false, err
+		}
+
+		if len(actual) != 3 {
+			t.Fatalf("Expected 3 nodes, got %d", len(actual))
+		}
+		th.CheckDeepEquals(t, NodeFoo, actual[0])
+		th.CheckDeepEquals(t, NodeBar, actual[1])
+		th.CheckDeepEquals(t, NodeBaz, actual[2])
+
+		return true, nil
+	})
+
+	th.AssertNoErr(t, err)
+
+	if pages != 1 {
+		t.Errorf("Expected 1 page, saw %d", pages)
+	}
+}
+
+func TestCreateNode(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleNodeCreationSuccessfully(t, SingleNodeBody)
+
+	actual, err := nodes.Create(client.ServiceClient(), nodes.CreateOpts{
+		Name:          "foo",
+		Driver:        "ipmi",
+		BootInterface: "pxe",
+		DriverInfo: map[string]interface{}{
+			"ipmi_port":      "6230",
+			"ipmi_username":  "admin",
+			"deploy_kernel":  "http://172.22.0.1/images/tinyipa-stable-rocky.vmlinuz",
+			"ipmi_address":   "192.168.122.1",
+			"deploy_ramdisk": "http://172.22.0.1/images/tinyipa-stable-rocky.gz",
+			"ipmi_password":  "admin",
+		},
+	}).Extract()
+	th.AssertNoErr(t, err)
+
+	th.CheckDeepEquals(t, NodeFoo, *actual)
+}
+
+func TestDeleteNode(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleNodeDeletionSuccessfully(t)
+
+	res := nodes.Delete(client.ServiceClient(), "asdfasdfasdf")
+	th.AssertNoErr(t, res.Err)
+}
+
+func TestGetNode(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleNodeGetSuccessfully(t)
+
+	c := client.ServiceClient()
+	actual, err := nodes.Get(c, "1234asdf").Extract()
+	if err != nil {
+		t.Fatalf("Unexpected Get error: %v", err)
+	}
+
+	th.CheckDeepEquals(t, NodeFoo, *actual)
+}
+
+func TestUpdateNode(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleNodeUpdateSuccessfully(t, SingleNodeBody)
+
+	c := client.ServiceClient()
+	actual, err := nodes.Update(c, "1234asdf", nodes.UpdateOpts{
+		nodes.UpdateOperation{
+			Op:    nodes.ReplaceOp,
+			Path:  "/driver",
+			Value: "new-driver",
+		},
+	}).Extract()
+	if err != nil {
+		t.Fatalf("Unexpected Update error: %v", err)
+	}
+
+	th.CheckDeepEquals(t, NodeFoo, *actual)
+
+}

--- a/openstack/baremetal/v1/nodes/urls.go
+++ b/openstack/baremetal/v1/nodes/urls.go
@@ -1,0 +1,27 @@
+package nodes
+
+import "github.com/gophercloud/gophercloud"
+
+func createURL(client *gophercloud.ServiceClient) string {
+	return client.ServiceURL("nodes")
+}
+
+func listURL(client *gophercloud.ServiceClient) string {
+	return createURL(client)
+}
+
+func listDetailURL(client *gophercloud.ServiceClient) string {
+	return client.ServiceURL("nodes", "detail")
+}
+
+func deleteURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL("nodes", id)
+}
+
+func getURL(client *gophercloud.ServiceClient, id string) string {
+	return deleteURL(client, id)
+}
+
+func updateURL(client *gophercloud.ServiceClient, id string) string {
+	return deleteURL(client, id)
+}

--- a/openstack/client.go
+++ b/openstack/client.go
@@ -307,6 +307,12 @@ func initClientOpts(client *gophercloud.ProviderClient, eo gophercloud.EndpointO
 	return sc, nil
 }
 
+// NewBareMetalV1 creates a ServiceClient that may be used with the v1
+// bare metal package.
+func NewBareMetalV1(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
+	return initClientOpts(client, eo, "baremetal")
+}
+
 // NewObjectStorageV1 creates a ServiceClient that may be used with the v1
 // object storage package.
 func NewObjectStorageV1(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {

--- a/service_client.go
+++ b/service_client.go
@@ -129,6 +129,8 @@ func (client *ServiceClient) setMicroversionHeader(opts *RequestOpts) {
 		opts.MoreHeaders["X-OpenStack-Manila-API-Version"] = client.Microversion
 	case "volume":
 		opts.MoreHeaders["X-OpenStack-Volume-API-Version"] = client.Microversion
+	case "baremetal":
+		opts.MoreHeaders["X-OpenStack-Ironic-API-Version"] = client.Microversion
 	}
 
 	if client.Type != "" {


### PR DESCRIPTION
For #1429 

First PR to add support for Ironic to gophercloud.  This contains the basics for node support. Node management API will be done separately, along with the other API objects as listed in #1429.

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

General:
- [API Controller](https://github.com/openstack/ironic/blob/master/ironic/api/controllers/v1/node.py)

Create:
- [API Reference](https://developer.openstack.org/api-ref/baremetal/?expanded=create-node-detail#create-node)
- [`Node` class definition code](https://github.com/openstack/ironic/blob/master/ironic/api/controllers/v1/node.py#L885-L1080)
- [Create API endpoint code](https://github.com/openstack/ironic/blob/master/ironic/api/controllers/v1/node.py#L1958-L2023)

List:
- [API Reference](https://developer.openstack.org/api-ref/baremetal/?expanded=list-nodes-detail#create-node)
- [List Filters](https://github.com/openstack/ironic/blob/master/ironic/api/controllers/v1/node.py#L1627-L1649)
- [ProvisionState filter](https://github.com/openstack/ironic/blob/master/ironic/common/states.py#L66-L244)

