### PR TITLE
fix strings.Contains args order

### DIFF
--- a/acceptance/openstack/compute/v2/servers_test.go
+++ b/acceptance/openstack/compute/v2/servers_test.go
@@ -118,7 +118,7 @@ func TestServersWithoutImageRef(t *testing.T) {
 	server, err := CreateServerWithoutImageRef(t, client)
 	if err != nil {
 		if err400, ok := err.(*gophercloud.ErrUnexpectedResponseCode); ok {
-			if !strings.Contains("Missing imageRef attribute", string(err400.Body)) {
+			if !strings.Contains(string(err400.Body), "Missing imageRef attribute") {
 				defer DeleteServer(t, client, server)
 			}
 		}


### PR DESCRIPTION
Swapped the arguments order, since the original
code was looking suspicious.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>

For #818 

