### PR TITLE
Image Service v2: Add Updating MinDisk

### DIFF
--- a/acceptance/openstack/imageservice/v2/images_test.go
+++ b/acceptance/openstack/imageservice/v2/images_test.go
@@ -152,6 +152,7 @@ func TestImagesUpdate(t *testing.T) {
 	updateOpts := images.UpdateOpts{
 		images.ReplaceImageName{NewName: image.Name + "foo"},
 		images.ReplaceImageTags{NewTags: newTags},
+		images.ReplaceImageMinDisk{NewMinDisk: 21},
 		images.UpdateImageProperty{
 			Op:    images.AddOp,
 			Name:  "hw_disk_bus",

--- a/openstack/imageservice/v2/images/requests.go
+++ b/openstack/imageservice/v2/images/requests.go
@@ -321,6 +321,20 @@ func (r ReplaceImageTags) ToImagePatchMap() map[string]interface{} {
 	}
 }
 
+// ReplaceImageMinDisk represents an updated min_disk property request.
+type ReplaceImageMinDisk struct {
+	NewMinDisk int
+}
+
+// ToImagePatchMap assembles a request body based on ReplaceImageTags.
+func (r ReplaceImageMinDisk) ToImagePatchMap() map[string]interface{} {
+	return map[string]interface{}{
+		"op":    "replace",
+		"path":  "/min_disk",
+		"value": r.NewMinDisk,
+	}
+}
+
 // UpdateOp represents a valid update operation.
 type UpdateOp string
 

--- a/openstack/imageservice/v2/images/testing/fixtures.go
+++ b/openstack/imageservice/v2/images/testing/fixtures.go
@@ -312,6 +312,11 @@ func HandleImageUpdateSuccessfully(t *testing.T) {
 					"fedora",
 					"beefy"
 				]
+			},
+			{
+				"op": "replace",
+				"path": "/min_disk",
+				"value": 21
 			}
 		]`)
 
@@ -337,7 +342,7 @@ func HandleImageUpdateSuccessfully(t *testing.T) {
 			"schema": "/v2/schemas/image",
 			"owner": "",
 			"min_ram": 0,
-			"min_disk": 0,
+			"min_disk": 21,
 			"disk_format": "",
 			"virtual_size": 0,
 			"container_format": "",

--- a/openstack/imageservice/v2/images/testing/requests_test.go
+++ b/openstack/imageservice/v2/images/testing/requests_test.go
@@ -254,6 +254,7 @@ func TestUpdateImage(t *testing.T) {
 	actualImage, err := images.Update(fakeclient.ServiceClient(), "da3b75d9-3f4a-40e7-8a2c-bfab23927dea", images.UpdateOpts{
 		images.ReplaceImageName{NewName: "Fedora 17"},
 		images.ReplaceImageTags{NewTags: []string{"fedora", "beefy"}},
+		images.ReplaceImageMinDisk{NewMinDisk: 21},
 	}).Extract()
 
 	th.AssertNoErr(t, err)
@@ -281,7 +282,7 @@ func TestUpdateImage(t *testing.T) {
 
 		Owner:            "",
 		MinRAMMegabytes:  0,
-		MinDiskGigabytes: 0,
+		MinDiskGigabytes: 21,
 
 		DiskFormat:      "",
 		ContainerFormat: "",


### PR DESCRIPTION
This commit adds support to update image min disk.

For #1437 