### PR TITLE
papercut: fix example code for type AuthResult

### DIFF
--- a/auth_result.go
+++ b/auth_result.go
@@ -25,13 +25,13 @@ Usage example:
 			return "", errors.New("no AuthResult available")
 		}
 		switch r := r.(type) {
-		case *tokens2.CreateResult:
+		case tokens2.CreateResult:
 			u, err := r.ExtractUser()
 			if err != nil {
 				return "", err
 			}
 			return u.ID, nil
-		case *tokens3.CreateResult:
+		case tokens3.CreateResult:
 			u, err := r.ExtractUser()
 			if err != nil {
 				return "", err


### PR DESCRIPTION
Followup to #1226: When using the new AuthResult API in application code, I noticed a mistake in the example code snippet. The `AuthResult` interface is implemented by `CreateResult`, not by `*CreateResult`.