### PR TITLE
ContainerInfraV1: add ListDetail method

### DIFF
--- a/acceptance/openstack/containerinfra/v1/clusters_test.go
+++ b/acceptance/openstack/containerinfra/v1/clusters_test.go
@@ -60,5 +60,19 @@ func TestClustersCRUD(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, newCluster.UUID, clusterID)
 
+	allPagesDetail, err := clusters.ListDetail(client, nil).AllPages()
+	th.AssertNoErr(t, err)
+
+	allClustersDetail, err := clusters.ExtractClusters(allPages)
+	th.AssertNoErr(t, err)
+
+	var foundDetail bool
+	for _, v := range allClustersDetail {
+		if v.UUID == clusterID {
+			foundDetail = true
+		}
+	}
+	th.AssertEquals(t, foundDetail, true)
+
 	tools.PrintResource(t, newCluster)
 }

--- a/openstack/containerinfra/v1/clusters/doc.go
+++ b/openstack/containerinfra/v1/clusters/doc.go
@@ -53,6 +53,22 @@ Example to List Clusters
 		fmt.Printf("%+v\n", cluster)
 	}
 
+Example to List Clusters with detailed information
+
+    allPagesDetail, err := clusters.ListDetail(serviceClient, clusters.ListOpts{}).AllPages()
+    if err != nil {
+        panic(err)
+    }
+
+    allClustersDetail, err := clusters.ExtractClusters(allPagesDetail)
+    if err != nil {
+        panic(err)
+    }
+
+    for _, clusterDetail := range allClustersDetail {
+        fmt.Printf("%+v\n", clusterDetail)
+    }
+
 Example to Update a Cluster
 
 	updateOpts := []clusters.UpdateOptsBuilder{

--- a/openstack/containerinfra/v1/clusters/requests.go
+++ b/openstack/containerinfra/v1/clusters/requests.go
@@ -109,6 +109,24 @@ func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 	})
 }
 
+// ListDetail returns a Pager which allows you to iterate over a collection of
+// clusters with detailed information.
+// It accepts a ListOptsBuilder, which allows you to sort the returned
+// collection for greater efficiency.
+func ListDetail(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listDetailURL(c)
+	if opts != nil {
+		query, err := opts.ToClustersListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		return ClusterPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
 type UpdateOp string
 
 const (

--- a/openstack/containerinfra/v1/clusters/testing/fixtures.go
+++ b/openstack/containerinfra/v1/clusters/testing/fixtures.go
@@ -230,6 +230,19 @@ func HandleListClusterSuccessfully(t *testing.T) {
 	})
 }
 
+func HandleListDetailClusterSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/v1/clusters/detail", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.Header().Add("X-OpenStack-Request-Id", requestUUID)
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprint(w, ClusterListResponse)
+	})
+}
+
 var UpdateResponse = fmt.Sprintf(`
 {
 	"uuid":"%s"

--- a/openstack/containerinfra/v1/clusters/testing/requests_test.go
+++ b/openstack/containerinfra/v1/clusters/testing/requests_test.go
@@ -87,6 +87,33 @@ func TestListClusters(t *testing.T) {
 	}
 }
 
+func TestListDetailClusters(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	HandleListDetailClusterSuccessfully(t)
+
+	count := 0
+	sc := fake.ServiceClient()
+	sc.Endpoint = sc.Endpoint + "v1/"
+	clusters.ListDetail(sc, clusters.ListOpts{Limit: 2}).EachPage(func(page pagination.Page) (bool, error) {
+		count++
+		actual, err := clusters.ExtractClusters(page)
+		th.AssertNoErr(t, err)
+		for idx := range actual {
+			actual[idx].CreatedAt = actual[idx].CreatedAt.UTC()
+			actual[idx].UpdatedAt = actual[idx].UpdatedAt.UTC()
+		}
+		th.AssertDeepEquals(t, ExpectedClusters, actual)
+
+		return true, nil
+	})
+
+	if count != 1 {
+		t.Errorf("Expected 1 page, got %d", count)
+	}
+}
+
 func TestUpdateCluster(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()

--- a/openstack/containerinfra/v1/clusters/urls.go
+++ b/openstack/containerinfra/v1/clusters/urls.go
@@ -30,6 +30,10 @@ func listURL(client *gophercloud.ServiceClient) string {
 	return client.ServiceURL("clusters")
 }
 
+func listDetailURL(client *gophercloud.ServiceClient) string {
+	return client.ServiceURL("clusters", "detail")
+}
+
 func updateURL(client *gophercloud.ServiceClient, id string) string {
 	return idURL(client, id)
 }


### PR DESCRIPTION
Add ListDetail method with documentation and tests.
This method uses different URL than List method.

For #1442

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/magnum/blob/master/magnum/api/controllers/v1/cluster.py#L347
