### PR TITLE
Senlin: Receivers Notify

### DIFF
--- a/acceptance/openstack/clustering/v1/clustering.go
+++ b/acceptance/openstack/clustering/v1/clustering.go
@@ -253,9 +253,9 @@ func CreateProfile(t *testing.T, client *gophercloud.ServiceClient) (*profiles.P
 	return profile, nil
 }
 
-// CreateReceiver will create a random profile. An error will be returned if the
-// profile could not be created.
-func CreateReceiver(t *testing.T, client *gophercloud.ServiceClient, clusterID string) (*receivers.Receiver, error) {
+// CreateWebhookReceiver will create a random webhook receiver. An error will be returned if the
+// receiver could not be created.
+func CreateWebhookReceiver(t *testing.T, client *gophercloud.ServiceClient, clusterID string) (*receivers.Receiver, error) {
 	name := tools.RandomString("TESTACC-", 8)
 	t.Logf("Attempting to create receiver: %s", name)
 
@@ -276,7 +276,40 @@ func CreateReceiver(t *testing.T, client *gophercloud.ServiceClient, clusterID s
 		return nil, err
 	}
 
-	t.Logf("Successfully created receiver: %s", receiver.ID)
+	t.Logf("Successfully created webhook receiver: %s", receiver.ID)
+
+	tools.PrintResource(t, receiver)
+	tools.PrintResource(t, receiver.CreatedAt)
+
+	th.AssertEquals(t, name, receiver.Name)
+	th.AssertEquals(t, createOpts.Action, receiver.Action)
+
+	return receiver, nil
+}
+
+// CreateMessageReceiver will create a message receiver with a random name. An error will be returned if the
+// receiver could not be created.
+func CreateMessageReceiver(t *testing.T, client *gophercloud.ServiceClient, clusterID string) (*receivers.Receiver, error) {
+	name := tools.RandomString("TESTACC-", 8)
+	t.Logf("Attempting to create receiver: %s", name)
+
+	createOpts := receivers.CreateOpts{
+		Name:      name,
+		ClusterID: clusterID,
+		Type:      receivers.MessageReceiver,
+	}
+
+	res := receivers.Create(client, createOpts)
+	if res.Err != nil {
+		return nil, res.Err
+	}
+
+	receiver, err := res.Extract()
+	if err != nil {
+		return nil, err
+	}
+
+	t.Logf("Successfully created message receiver: %s", receiver.ID)
 
 	tools.PrintResource(t, receiver)
 	tools.PrintResource(t, receiver.CreatedAt)

--- a/acceptance/openstack/clustering/v1/receivers_test.go
+++ b/acceptance/openstack/clustering/v1/receivers_test.go
@@ -23,7 +23,7 @@ func TestReceiversCRUD(t *testing.T) {
 	th.AssertNoErr(t, err)
 	defer DeleteCluster(t, client, cluster.ID)
 
-	receiver, err := CreateReceiver(t, client, cluster.ID)
+	receiver, err := CreateWebhookReceiver(t, client, cluster.ID)
 	th.AssertNoErr(t, err)
 	defer DeleteReceiver(t, client, receiver.ID)
 
@@ -56,4 +56,27 @@ func TestReceiversCRUD(t *testing.T) {
 	tools.PrintResource(t, receiver.UpdatedAt)
 
 	th.AssertEquals(t, receiver.Name, newName)
+}
+
+func TestReceiversNotify(t *testing.T) {
+	t.Parallel()
+	client, err := clients.NewClusteringV1Client()
+	th.AssertNoErr(t, err)
+
+	profile, err := CreateProfile(t, client)
+	th.AssertNoErr(t, err)
+	defer DeleteProfile(t, client, profile.ID)
+
+	cluster, err := CreateCluster(t, client, profile.ID)
+	th.AssertNoErr(t, err)
+	defer DeleteCluster(t, client, cluster.ID)
+
+	receiver, err := CreateMessageReceiver(t, client, cluster.ID)
+	th.AssertNoErr(t, err)
+	defer DeleteReceiver(t, client, receiver.ID)
+	t.Logf("Created Mesage Receiver Name:[%s] Message Receiver ID:[%s]", receiver.Name, receiver.ID)
+
+	requestID, err := receivers.Notify(client, receiver.ID).Extract()
+	th.AssertNoErr(t, err)
+	t.Logf("Receiver Notify Service Request ID: %s", requestID)
 }

--- a/acceptance/openstack/clustering/v1/webhooktrigger_test.go
+++ b/acceptance/openstack/clustering/v1/webhooktrigger_test.go
@@ -31,7 +31,7 @@ func TestClusteringWebhookTrigger(t *testing.T) {
 	th.AssertNoErr(t, err)
 	defer DeleteCluster(t, client, cluster.ID)
 
-	receiver, err := CreateReceiver(t, client, cluster.ID)
+	receiver, err := CreateWebhookReceiver(t, client, cluster.ID)
 	th.AssertNoErr(t, err)
 	defer DeleteReceiver(t, client, receiver.ID)
 

--- a/openstack/clustering/v1/receivers/doc.go
+++ b/openstack/clustering/v1/receivers/doc.go
@@ -68,5 +68,14 @@ Example to List Receivers
 		}
 		return true, nil
 	})
+
+Example to Notify a Receiver
+
+	receiverID := "6dc6d336e3fc4c0a951b5698cd1236ee"
+	requestID, err := receivers.Notify(serviceClient, receiverID).Extract()
+	if err != nil {
+		panic(err)
+	}
+
 */
 package receivers

--- a/openstack/clustering/v1/receivers/requests.go
+++ b/openstack/clustering/v1/receivers/requests.go
@@ -143,3 +143,15 @@ func Delete(client *gophercloud.ServiceClient, id string) (r DeleteResult) {
 	_, r.Err = client.Delete(deleteURL(client, id), nil)
 	return
 }
+
+// Notify Notifies message type receiver
+func Notify(client *gophercloud.ServiceClient, id string) (r NotifyResult) {
+	result, err := client.Post(notifyURL(client, id), nil, nil, &gophercloud.RequestOpts{
+		OkCodes: []int{204},
+	})
+
+	if err == nil {
+		r.Header = result.Header
+	}
+	return
+}

--- a/openstack/clustering/v1/receivers/results.go
+++ b/openstack/clustering/v1/receivers/results.go
@@ -93,6 +93,12 @@ type DeleteResult struct {
 	gophercloud.ErrResult
 }
 
+// NotifyResult is the result from a Notify operation. Call its Extract
+// method to determine if the call succeeded or failed.
+type NotifyResult struct {
+	commonResult
+}
+
 // ReceiverPage contains a single page of all nodes from a List operation.
 type ReceiverPage struct {
 	pagination.LinkedPageBase
@@ -111,4 +117,10 @@ func ExtractReceivers(r pagination.Page) ([]Receiver, error) {
 	}
 	err := (r.(ReceiverPage)).ExtractInto(&s)
 	return s.Receivers, err
+}
+
+// Extract returns action for notify receivers
+func (r NotifyResult) Extract() (string, error) {
+	requestID := r.Header.Get("X-Openstack-Request-Id")
+	return requestID, r.Err
 }

--- a/openstack/clustering/v1/receivers/testing/fixtures.go
+++ b/openstack/clustering/v1/receivers/testing/fixtures.go
@@ -169,6 +169,7 @@ const ListResponse = `
 }`
 
 var ExpectedReceiversList = []receivers.Receiver{ExpectedUpdateReceiver}
+var ExpectedNotifyRequestID = "66a81d68-bf48-4af5-897b-a3bfef7279a8"
 
 func HandleCreateSuccessfully(t *testing.T) {
 	th.Mux.HandleFunc("/v1/receivers", func(w http.ResponseWriter, r *http.Request) {
@@ -224,6 +225,17 @@ func HandleDeleteSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNoContent)
+	})
+}
+
+func HandleNotifySuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/v1/receivers/6dc6d336e3fc4c0a951b5698cd1236ee/notify", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.Header().Add("X-OpenStack-Request-Id", ExpectedNotifyRequestID)
 		w.WriteHeader(http.StatusNoContent)
 	})
 }

--- a/openstack/clustering/v1/receivers/testing/requests_test.go
+++ b/openstack/clustering/v1/receivers/testing/requests_test.go
@@ -92,3 +92,14 @@ func TestDeleteReceiver(t *testing.T) {
 	deleteResult := receivers.Delete(fake.ServiceClient(), "6dc6d336e3fc4c0a951b5698cd1236ee")
 	th.AssertNoErr(t, deleteResult.ExtractErr())
 }
+
+func TestNotifyReceivers(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	HandleNotifySuccessfully(t)
+
+	requestID, err := receivers.Notify(fake.ServiceClient(), "6dc6d336e3fc4c0a951b5698cd1236ee").Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, ExpectedNotifyRequestID, requestID)
+}

--- a/openstack/clustering/v1/receivers/urls.go
+++ b/openstack/clustering/v1/receivers/urls.go
@@ -32,3 +32,7 @@ func listURL(client *gophercloud.ServiceClient) string {
 func deleteURL(client *gophercloud.ServiceClient, id string) string {
 	return idURL(client, id)
 }
+
+func notifyURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL(apiVersion, apiName, id, "notify")
+}


### PR DESCRIPTION
Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

For #[823 [Add support for Senlin clustering]](https://github.com/gophercloud/gophercloud/issues/823)

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

[[receivers:notify api]](https://github.com/openstack/senlin/blob/8ba9f3f7b71c3895aa5e460b363b61d415fb99b0/senlin/api/openstack/v1/receivers.py#L100)

[[service:receiver_notify engine]](https://github.com/openstack/senlin/blob/0700a8bf29217b8a24fff0912cd89c0c64fe416b/senlin/engine/service.py#L2496)
[[receivers:notify engine]](https://github.com/openstack/senlin/blob/8ba9f3f7b71c3895aa5e460b363b61d415fb99b0/senlin/engine/receivers/message.py#L249)
