### PR TITLE
Enable go modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,19 @@
 language: go
 sudo: false
 install:
-- go get golang.org/x/crypto/ssh
-- go get -v -tags 'fixtures acceptance' ./...
-- go get github.com/wadey/gocovmerge
-- go get github.com/mattn/goveralls
-- go get golang.org/x/tools/cmd/goimports
+- GO111MODULE=off go get golang.org/x/crypto/ssh
+- GO111MODULE=off go get -v -tags 'fixtures acceptance' ./...
+- GO111MODULE=off go get github.com/wadey/gocovmerge
+- GO111MODULE=off go get github.com/mattn/goveralls
+- GO111MODULE=off go get golang.org/x/tools/cmd/goimports
 go:
 - "1.10"
+- "1.11"
 - "tip"
 env:
   global:
   - secure: "xSQsAG5wlL9emjbCdxzz/hYQsSpJ/bABO1kkbwMSISVcJ3Nk0u4ywF+LS4bgeOnwPfmFvNTOqVDu3RwEvMeWXSI76t1piCPcObutb2faKLVD/hLoAS76gYX+Z8yGWGHrSB7Do5vTPj1ERe2UljdrnsSeOXzoDwFxYRaZLX4bBOB4AyoGvRniil5QXPATiA1tsWX1VMicj8a4F8X+xeESzjt1Q5Iy31e7vkptu71bhvXCaoo5QhYwT+pLR9dN0S1b7Ro0KVvkRefmr1lUOSYd2e74h6Lc34tC1h3uYZCS4h47t7v5cOXvMNxinEj2C51RvbjvZI1RLVdkuAEJD1Iz4+Ote46nXbZ//6XRZMZz/YxQ13l7ux1PFjgEB6HAapmF5Xd8PRsgeTU9LRJxpiTJ3P5QJ3leS1va8qnziM5kYipj/Rn+V8g2ad/rgkRox9LSiR9VYZD2Pe45YCb1mTKSl2aIJnV7nkOqsShY5LNB4JZSg7xIffA+9YVDktw8dJlATjZqt7WvJJ49g6A61mIUV4C15q2JPGKTkZzDiG81NtmS7hFa7k0yaE2ELgYocbcuyUcAahhxntYTC0i23nJmEHVNiZmBO3u7EgpWe4KGVfumU+lt12tIn5b3dZRBBUk3QakKKozSK1QPHGpk/AZGrhu7H6l8to6IICKWtDcyMPQ="
+  - GO111MODULE=on
 before_script:
 - go vet ./...
 script:

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,7 @@
+module github.com/gophercloud/gophercloud
+
+require (
+	golang.org/x/crypto v0.0.0-20190211182817-74369b46fc67
+	golang.org/x/sys v0.0.0-20190209173611-3b5209105503 // indirect
+	gopkg.in/yaml.v2 v2.2.2
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,8 @@
+golang.org/x/crypto v0.0.0-20190211182817-74369b46fc67 h1:ng3VDlRp5/DHpSWl02R4rM9I+8M2rhmsuLwAMmkLQWE=
+golang.org/x/crypto v0.0.0-20190211182817-74369b46fc67/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+golang.org/x/sys v0.0.0-20190209173611-3b5209105503 h1:5SvYFrOM3W8Mexn9/oA44Ji7vhXAZQ9hiP+1Q/DMrWg=
+golang.org/x/sys v0.0.0-20190209173611-3b5209105503/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
This is in preparation to switching [Terraform OpenStack provider](https://github.com/terraform-providers/terraform-provider-openstack) to go modules (see https://github.com/terraform-providers/terraform-provider-openstack/issues/656).

Enabling go modules throughout the dependency tree of the provider will make the switch and future upgrades easier.

I ran all tests via `go test ./...` in Go `1.11.5`, but I don't have access to any OpenStack environment to test this thoroughly and some tests naturally failed because of that.

This PR is a result of the following commands (in a clean Go `1.11.5` environment):

```sh
go mod init
go get ./...
go mod tidy
```