### PR TITLE
Baremetal API: noauth support

### DIFF
--- a/acceptance/clients/clients.go
+++ b/acceptance/clients/clients.go
@@ -11,7 +11,8 @@ import (
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack"
-	"github.com/gophercloud/gophercloud/openstack/blockstorage/noauth"
+	baremetalNoAuth "github.com/gophercloud/gophercloud/openstack/baremetal/noauth"
+	blockstorageNoAuth "github.com/gophercloud/gophercloud/openstack/blockstorage/noauth"
 )
 
 // AcceptanceTestChoices contains image and flavor selections for use by the acceptance tests.
@@ -199,7 +200,7 @@ func NewBlockStorageV3Client() (*gophercloud.ServiceClient, error) {
 // making calls to the OpenStack Block Storage v2 API. An error will be
 // returned if client creation was not possible.
 func NewBlockStorageV2NoAuthClient() (*gophercloud.ServiceClient, error) {
-	client, err := noauth.NewClient(gophercloud.AuthOptions{
+	client, err := blockstorageNoAuth.NewClient(gophercloud.AuthOptions{
 		Username:   os.Getenv("OS_USERNAME"),
 		TenantName: os.Getenv("OS_TENANT_NAME"),
 	})
@@ -209,7 +210,7 @@ func NewBlockStorageV2NoAuthClient() (*gophercloud.ServiceClient, error) {
 
 	client = configureDebug(client)
 
-	return noauth.NewBlockStorageNoAuth(client, noauth.EndpointOpts{
+	return blockstorageNoAuth.NewBlockStorageNoAuth(client, blockstorageNoAuth.EndpointOpts{
 		CinderEndpoint: os.Getenv("CINDER_ENDPOINT"),
 	})
 }
@@ -218,7 +219,7 @@ func NewBlockStorageV2NoAuthClient() (*gophercloud.ServiceClient, error) {
 // making calls to the OpenStack Block Storage v2 API. An error will be
 // returned if client creation was not possible.
 func NewBlockStorageV3NoAuthClient() (*gophercloud.ServiceClient, error) {
-	client, err := noauth.NewClient(gophercloud.AuthOptions{
+	client, err := blockstorageNoAuth.NewClient(gophercloud.AuthOptions{
 		Username:   os.Getenv("OS_USERNAME"),
 		TenantName: os.Getenv("OS_TENANT_NAME"),
 	})
@@ -228,7 +229,7 @@ func NewBlockStorageV3NoAuthClient() (*gophercloud.ServiceClient, error) {
 
 	client = configureDebug(client)
 
-	return noauth.NewBlockStorageNoAuth(client, noauth.EndpointOpts{
+	return blockstorageNoAuth.NewBlockStorageNoAuth(client, blockstorageNoAuth.EndpointOpts{
 		CinderEndpoint: os.Getenv("CINDER_ENDPOINT"),
 	})
 }
@@ -272,6 +273,15 @@ func NewBareMetalV1Client() (*gophercloud.ServiceClient, error) {
 
 	return openstack.NewBareMetalV1(client, gophercloud.EndpointOpts{
 		Region: os.Getenv("OS_REGION_NAME"),
+	})
+}
+
+// NewBareMetalV1NoAuthClient returns a *ServiceClient for making calls
+// to the OpenStack Bare Metal v1 API. An error will be returned
+// if authentication or client creation was not possible.
+func NewBareMetalV1NoAuthClient() (*gophercloud.ServiceClient, error) {
+	return baremetalNoAuth.NewBareMetalNoAuth(baremetalNoAuth.EndpointOpts{
+		IronicEndpoint: os.Getenv("IRONIC_ENDPOINT"),
 	})
 }
 

--- a/acceptance/openstack/baremetal/noauth/doc.go
+++ b/acceptance/openstack/baremetal/noauth/doc.go
@@ -1,0 +1,8 @@
+package noauth
+
+/*
+Acceptance tests for Ironic endpoints with auth_strategy=noauth.  Specify
+IRONIC_ENDPOINT environment variable.  For example:
+
+  IRONIC_ENDPOINT="http://127.0.0.1:6385/v1" go test ./acceptance/openstack/baremetal/noauth/...
+*/

--- a/acceptance/openstack/baremetal/noauth/nodes_test.go
+++ b/acceptance/openstack/baremetal/noauth/nodes_test.go
@@ -1,0 +1,67 @@
+package noauth
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/acceptance/clients"
+	v1 "github.com/gophercloud/gophercloud/acceptance/openstack/baremetal/v1"
+	"github.com/gophercloud/gophercloud/openstack/baremetal/v1/nodes"
+	"github.com/gophercloud/gophercloud/pagination"
+
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestNodesCreateDestroy(t *testing.T) {
+	clients.RequireLong(t)
+
+	client, err := clients.NewBareMetalV1NoAuthClient()
+	th.AssertNoErr(t, err)
+	client.Microversion = "1.50"
+
+	node, err := v1.CreateNode(t, client)
+	th.AssertNoErr(t, err)
+	defer v1.DeleteNode(t, client, node)
+
+	found := false
+	err = nodes.List(client, nodes.ListOpts{}).EachPage(func(page pagination.Page) (bool, error) {
+		nodeList, err := nodes.ExtractNodes(page)
+		if err != nil {
+			return false, err
+		}
+
+		for _, n := range nodeList {
+			if n.UUID == node.UUID {
+				found = true
+				return true, nil
+			}
+		}
+
+		return false, nil
+	})
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, found, true)
+}
+
+func TestNodesUpdate(t *testing.T) {
+	clients.RequireLong(t)
+
+	client, err := clients.NewBareMetalV1NoAuthClient()
+	th.AssertNoErr(t, err)
+	client.Microversion = "1.50"
+
+	node, err := v1.CreateNode(t, client)
+	th.AssertNoErr(t, err)
+	defer v1.DeleteNode(t, client, node)
+
+	updated, err := nodes.Update(client, node.UUID, nodes.UpdateOpts{
+		nodes.UpdateOperation{
+			Op:    nodes.ReplaceOp,
+			Path:  "/maintenance",
+			Value: "true",
+		},
+	}).Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, updated.Maintenance, true)
+}

--- a/openstack/baremetal/noauth/doc.go
+++ b/openstack/baremetal/noauth/doc.go
@@ -1,0 +1,18 @@
+package noauth
+
+/*
+Package noauth provides support for noauth bare metal endpoints.
+
+	Example of obtaining and using a client:
+
+	client, err := noauth.NewBareMetalNoAuth(noauth.EndpointOpts{
+		IronicEndpoint: "http://localhost:6385/v1/",
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	client.Microversion = "1.50"
+
+	nodes.ListDetail(client, nodes.ListOpts{})
+*/

--- a/openstack/baremetal/noauth/requests.go
+++ b/openstack/baremetal/noauth/requests.go
@@ -1,0 +1,36 @@
+package noauth
+
+import (
+	"fmt"
+
+	"github.com/gophercloud/gophercloud"
+)
+
+// EndpointOpts specifies a "noauth" Ironic Endpoint.
+type EndpointOpts struct {
+	// IronicEndpoint [required] is currently only used with "noauth" Ironic.
+	// An Ironic endpoint with "auth_strategy=noauth" is necessary, for example:
+	// http://ironic.example.com:6385/v1.
+	IronicEndpoint string
+}
+
+func initClientOpts(client *gophercloud.ProviderClient, eo EndpointOpts) (*gophercloud.ServiceClient, error) {
+	sc := new(gophercloud.ServiceClient)
+	if eo.IronicEndpoint == "" {
+		return nil, fmt.Errorf("IronicEndpoint is required")
+	}
+
+	sc.Endpoint = gophercloud.NormalizeURL(eo.IronicEndpoint)
+	sc.ProviderClient = client
+	return sc, nil
+}
+
+// NewBareMetalNoAuth creates a ServiceClient that may be used to access a
+// "noauth" bare metal service.
+func NewBareMetalNoAuth(eo EndpointOpts) (*gophercloud.ServiceClient, error) {
+	sc, err := initClientOpts(&gophercloud.ProviderClient{}, eo)
+
+	sc.Type = "baremetal"
+
+	return sc, err
+}

--- a/openstack/baremetal/noauth/testing/requests_test.go
+++ b/openstack/baremetal/noauth/testing/requests_test.go
@@ -1,0 +1,16 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/baremetal/noauth"
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestNoAuth(t *testing.T) {
+	noauthClient, err := noauth.NewBareMetalNoAuth(noauth.EndpointOpts{
+		IronicEndpoint: "http://ironic:6385/v1",
+	})
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, "", noauthClient.TokenID)
+}


### PR DESCRIPTION
For #1429

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

- If Ironic is configured for noauth, then authorization is just entirely bypassed:
  https://github.com/openstack/ironic/blob/master/ironic/common/policy.py#L513-L527

