### PR TITLE
Baremetal V1 API: Node management

### DIFF
--- a/openstack/baremetal/v1/nodes/doc.go
+++ b/openstack/baremetal/v1/nodes/doc.go
@@ -76,4 +76,22 @@ resource in the OpenStack Bare Metal service.
 	if err != nil {
 		panic(err)
 	}
+
+	// Example to Validate Node
+	validation, err := nodes.Validate(client, "a62b8495-52e2-407b-b3cb-62775d04c2b8").Extract()
+
+	// Example to inject non-masking interrupts
+	err := nodes.InjectNMI(client, "a62b8495-52e2-407b-b3cb-62775d04c2b8").ExtractErr()
+
+	// Example to get array of supported boot devices for a node
+	bootDevices, err := nodes.GetSupportedBootDevices(client, "a62b8495-52e2-407b-b3cb-62775d04c2b8").Extract()
+
+	// Example to set boot device for a node
+	err := nodes.SetBootDevice(client, "a62b8495-52e2-407b-b3cb-62775d04c2b8", nodes.BootDeviceOpts{
+		BootDevice: "pxe",
+		Persistent: false,
+	})
+
+	// Example to get boot device for a node
+	bootDevice, err := nodes.GetBootDevice(client, "a62b8495-52e2-407b-b3cb-62775d04c2b8").Extract()
 */

--- a/openstack/baremetal/v1/nodes/requests.go
+++ b/openstack/baremetal/v1/nodes/requests.go
@@ -301,3 +301,51 @@ func Delete(client *gophercloud.ServiceClient, id string) (r DeleteResult) {
 	_, r.Err = client.Delete(deleteURL(client, id), nil)
 	return
 }
+
+// Request that Ironic validate whether the Node’s driver has enough information to manage the Node. This polls each
+// interface on the driver, and returns the status of that interface.
+func Validate(client *gophercloud.ServiceClient, id string) (r ValidateResult) {
+	_, r.Err = client.Get(validateURL(client, id), &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// Inject NMI (Non-Masking Interrupts) for the given Node. This feature can be used for hardware diagnostics, and
+// actual support depends on a driver.
+func InjectNMI(client *gophercloud.ServiceClient, id string) (r InjectNMIResult) {
+	_, r.Err = client.Put(injectNMIURL(client, id), map[string]string{}, nil, &gophercloud.RequestOpts{
+		OkCodes: []int{204},
+	})
+	return
+}
+
+type BootDeviceOpts struct {
+	BootDevice string `json:"boot_device"` // e.g., 'pxe', 'disk', etc.
+	Persistent bool   `json:"persistent"`  // Whether this is one-time or not
+}
+
+// Set the boot device for the given Node, and set it persistently or for one-time boot. The exact behaviour
+// of this depends on the hardware driver.
+func SetBootDevice(client *gophercloud.ServiceClient, id string, bootDevice BootDeviceOpts) (r gophercloud.ErrResult) {
+	_, r.Err = client.Put(bootDeviceURL(client, id), bootDevice, nil, &gophercloud.RequestOpts{
+		OkCodes: []int{204},
+	})
+	return
+}
+
+// Get the current boot device for the given Node.
+func GetBootDevice(client *gophercloud.ServiceClient, id string) (r BootDeviceResult) {
+	_, r.Err = client.Get(bootDeviceURL(client, id), &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// Retrieve the acceptable set of supported boot devices for a specific Node.
+func GetSupportedBootDevices(client *gophercloud.ServiceClient, id string) (r SupportedBootDeviceResult) {
+	_, r.Err = client.Get(supportedBootDeviceURL(client, id), &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}

--- a/openstack/baremetal/v1/nodes/results.go
+++ b/openstack/baremetal/v1/nodes/results.go
@@ -266,16 +266,15 @@ type BootDeviceResult struct {
 	gophercloud.Result
 }
 
+// BootDeviceResult is the response from a GetBootDevice operation. Call its Extract
+// method to interpret it as a BootDeviceOpts struct.
+type SetBootDeviceResult struct {
+	gophercloud.ErrResult
+}
 // SupportedBootDeviceResult is the response from a GetSupportedBootDevices operation. Call its Extract
 // method to interpret it as an array of supported boot device values.
 type SupportedBootDeviceResult struct {
 	gophercloud.Result
-}
-
-// ChangeStateResult is the response from any state change operation. Call its ExtractErr
-// method to determine if the call succeeded or failed.
-type ChangeStateResult struct {
-	gophercloud.ErrResult
 }
 
 // Each element in the response will contain a “result” variable, which will have a value of “true” or “false”, and

--- a/openstack/baremetal/v1/nodes/results.go
+++ b/openstack/baremetal/v1/nodes/results.go
@@ -16,6 +16,30 @@ func (r nodeResult) Extract() (*Node, error) {
 	return &s, err
 }
 
+// Extract interprets a BootDeviceResult as BootDeviceOpts, if possible.
+func (r BootDeviceResult) Extract() (*BootDeviceOpts, error) {
+	var s BootDeviceOpts
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+// Extract interprets a SupportedBootDeviceResult as an array of supported boot devices, if possible.
+func (r SupportedBootDeviceResult) Extract() ([]string, error) {
+	var s struct {
+		Devices []string `json:"supported_boot_devices"`
+	}
+
+	err := r.ExtractInto(&s)
+	return s.Devices, err
+}
+
+// Extract interprets a ValidateResult as NodeValidation, if possible.
+func (r ValidateResult) Extract() (*NodeValidation, error) {
+	var s NodeValidation
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
 func (r nodeResult) ExtractInto(v interface{}) error {
 	return r.Result.ExtractIntoStructPtr(v, "")
 }
@@ -222,4 +246,56 @@ type UpdateResult struct {
 // method to determine if the call succeeded or failed.
 type DeleteResult struct {
 	gophercloud.ErrResult
+}
+
+// ValidateResult is the response from a Validate operation. Call its Extract
+// method to interpret it as a NodeValidation struct.
+type ValidateResult struct {
+	gophercloud.Result
+}
+
+// InjectNMIResult is the response from an InjectNMI operation. Call its ExtractErr
+// method to determine if the call succeeded or failed.
+type InjectNMIResult struct {
+	gophercloud.ErrResult
+}
+
+// BootDeviceResult is the response from a GetBootDevice operation. Call its Extract
+// method to interpret it as a BootDeviceOpts struct.
+type BootDeviceResult struct {
+	gophercloud.Result
+}
+
+// SupportedBootDeviceResult is the response from a GetSupportedBootDevices operation. Call its Extract
+// method to interpret it as an array of supported boot device values.
+type SupportedBootDeviceResult struct {
+	gophercloud.Result
+}
+
+// ChangeStateResult is the response from any state change operation. Call its ExtractErr
+// method to determine if the call succeeded or failed.
+type ChangeStateResult struct {
+	gophercloud.ErrResult
+}
+
+// Each element in the response will contain a “result” variable, which will have a value of “true” or “false”, and
+// also potentially a reason. A value of nil indicates that the Node’s driver does not support that interface.
+type DriverValidation struct {
+	Result bool   `json:"result"`
+	Reason string `json:"reason"`
+}
+
+//  Ironic validates whether the Node’s driver has enough information to manage the Node. This polls each interface on
+//  the driver, and returns the status of that interface as an DriverValidation struct.
+type NodeValidation struct {
+	Boot       DriverValidation `json:"boot"`
+	Console    DriverValidation `json:"console"`
+	Deploy     DriverValidation `json:"deploy"`
+	Inspect    DriverValidation `json:"inspect"`
+	Management DriverValidation `json:"management"`
+	Network    DriverValidation `json:"network"`
+	Power      DriverValidation `json:"power"`
+	RAID       DriverValidation `json:"raid"`
+	Rescue     DriverValidation `json:"rescue"`
+	Storage    DriverValidation `json:"storage"`
 }

--- a/openstack/baremetal/v1/nodes/results.go
+++ b/openstack/baremetal/v1/nodes/results.go
@@ -271,6 +271,7 @@ type BootDeviceResult struct {
 type SetBootDeviceResult struct {
 	gophercloud.ErrResult
 }
+
 // SupportedBootDeviceResult is the response from a GetSupportedBootDevices operation. Call its Extract
 // method to interpret it as an array of supported boot device values.
 type SupportedBootDeviceResult struct {

--- a/openstack/baremetal/v1/nodes/testing/requests_test.go
+++ b/openstack/baremetal/v1/nodes/testing/requests_test.go
@@ -152,3 +152,59 @@ func TestUpdateNode(t *testing.T) {
 	th.CheckDeepEquals(t, NodeFoo, *actual)
 
 }
+
+func TestValidateNode(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleNodeValidateSuccessfully(t)
+
+	c := client.ServiceClient()
+	actual, err := nodes.Validate(c, "1234asdf").Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, NodeFooValidation, *actual)
+}
+
+func TestInjectNMI(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleInjectNMISuccessfully(t)
+
+	c := client.ServiceClient()
+	err := nodes.InjectNMI(c, "1234asdf").ExtractErr()
+	th.AssertNoErr(t, err)
+}
+
+func TestSetBootDevice(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleSetBootDeviceSuccessfully(t)
+
+	c := client.ServiceClient()
+	err := nodes.SetBootDevice(c, "1234asdf", nodes.BootDeviceOpts{
+		BootDevice: "pxe",
+		Persistent: false,
+	}).ExtractErr()
+	th.AssertNoErr(t, err)
+}
+
+func TestGetBootDevice(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleGetBootDeviceSuccessfully(t)
+
+	c := client.ServiceClient()
+	bootDevice, err := nodes.GetBootDevice(c, "1234asdf").Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, NodeBootDevice, *bootDevice)
+}
+
+func TestGetSupportedBootDevices(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleGetSupportedBootDeviceSuccessfully(t)
+
+	c := client.ServiceClient()
+	bootDevices, err := nodes.GetSupportedBootDevices(c, "1234asdf").Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, NodeSupportedBootDevice, bootDevices)
+}

--- a/openstack/baremetal/v1/nodes/urls.go
+++ b/openstack/baremetal/v1/nodes/urls.go
@@ -25,3 +25,19 @@ func getURL(client *gophercloud.ServiceClient, id string) string {
 func updateURL(client *gophercloud.ServiceClient, id string) string {
 	return deleteURL(client, id)
 }
+
+func validateURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL("nodes", id, "validate")
+}
+
+func injectNMIURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL("nodes", id, "management", "inject_nmi")
+}
+
+func bootDeviceURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL("nodes", id, "management", "boot_device")
+}
+
+func supportedBootDeviceURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL("nodes", id, "management", "boot_device", "supported")
+}


### PR DESCRIPTION
For #1429  

This covers node management for boot devices, validation, and injecting non-masking interrupts. 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

- [API Ref](https://developer.openstack.org/api-ref/baremetal/?expanded=validate-node-detail)

- Validation
    - [API Controller](https://github.com/openstack/ironic/blob/master/ironic/api/controllers/v1/node.py#L1951-L1976)
    - [Conductor logic](https://github.com/openstack/ironic/blob/master/ironic/conductor/manager.py#L2166-L2221)

- Boot Devices
    - [Get API](https://github.com/openstack/ironic/blob/master/ironic/api/controllers/v1/node.py#L187-L205)
    - [Put API](https://github.com/openstack/ironic/blob/master/ironic/api/controllers/v1/node.py#L207-L233)
    - [Get Supported](https://github.com/openstack/ironic/blob/master/ironic/api/controllers/v1/node.py#L253-L267)

- NMI
    - [API](https://github.com/openstack/ironic/blob/master/ironic/api/controllers/v1/node.py#L270-L302)