### PR TITLE
Baremetal API v1: Node provision state

### DIFF
--- a/openstack/baremetal/v1/nodes/requests.go
+++ b/openstack/baremetal/v1/nodes/requests.go
@@ -392,8 +392,8 @@ func GetSupportedBootDevices(client *gophercloud.ServiceClient, id string) (r Su
 // the value for ‘args’ is a keyword variable argument dictionary that is passed to the cleaning step
 // method.
 type CleanStep struct {
-	Interface string            `json:"interface,required"`
-	Step      string            `json:"step,required"`
+	Interface string            `json:"interface" required:"true"`
+	Step      string            `json:"step" required:"true"`
 	Args      map[string]string `json:"args,omitempty"`
 }
 
@@ -406,7 +406,7 @@ type ProvisionStateOptsBuilder interface {
 // ProvisionStateOpts for a request to change a node's provision state. A config drive should be base64-encoded
 // gzipped ISO9660 image.
 type ProvisionStateOpts struct {
-	Target         TargetProvisionState `json:"target,required"`
+	Target         TargetProvisionState `json:"target" required:"true"`
 	ConfigDrive    string               `json:"configdrive,omitempty"`
 	CleanSteps     []CleanStep          `json:"clean_steps,omitempty"`
 	RescuePassword string               `json:"rescue_password,omitempty"`

--- a/openstack/baremetal/v1/nodes/results.go
+++ b/openstack/baremetal/v1/nodes/results.go
@@ -299,3 +299,9 @@ type NodeValidation struct {
 	Rescue     DriverValidation `json:"rescue"`
 	Storage    DriverValidation `json:"storage"`
 }
+
+// ChangeStateResult is the response from any state change operation. Call its ExtractErr
+// method to determine if the call succeeded or failed.
+type ChangeStateResult struct {
+	gophercloud.ErrResult
+}

--- a/openstack/baremetal/v1/nodes/testing/fixtures.go
+++ b/openstack/baremetal/v1/nodes/testing/fixtures.go
@@ -541,6 +541,27 @@ const NodeSupportedBootDeviceBody = `
 }
 `
 
+const NodeProvisionStateActiveBody = `
+{
+    "target": "active",
+    "configdrive": "http://127.0.0.1/images/test-node-config-drive.iso.gz"
+}
+`
+const NodeProvisionStateCleanBody = `
+{
+    "target": "clean",
+    "clean_steps": [
+        {
+            "interface": "deploy",
+            "step": "upgrade_firmware",
+            "args": {
+                "force": "True"
+            }
+        }
+    ]
+}
+`
+
 var (
 	NodeFoo = nodes.Node{
 		UUID:                 "d2630783-6ec8-4836-b556-ab427c4b581e",
@@ -868,5 +889,23 @@ func HandleGetSupportedBootDeviceSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprintf(w, NodeSupportedBootDeviceBody)
+	})
+}
+
+func HandleNodeChangeProvisionStateActive(t *testing.T) {
+	th.Mux.HandleFunc("/nodes/1234asdf/states/provision", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, NodeProvisionStateActiveBody)
+		w.WriteHeader(http.StatusAccepted)
+	})
+}
+
+func HandleNodeChangeProvisionStateClean(t *testing.T) {
+	th.Mux.HandleFunc("/nodes/1234asdf/states/provision", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, NodeProvisionStateCleanBody)
+		w.WriteHeader(http.StatusAccepted)
 	})
 }

--- a/openstack/baremetal/v1/nodes/testing/requests_test.go
+++ b/openstack/baremetal/v1/nodes/testing/requests_test.go
@@ -208,3 +208,39 @@ func TestGetSupportedBootDevices(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.CheckDeepEquals(t, NodeSupportedBootDevice, bootDevices)
 }
+
+func TestNodeChangeProvisionStateActive(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleNodeChangeProvisionStateActive(t)
+
+	c := client.ServiceClient()
+	err := nodes.ChangeProvisionState(c, "1234asdf", nodes.ProvisionStateOpts{
+		Target:      nodes.TargetActive,
+		ConfigDrive: "http://127.0.0.1/images/test-node-config-drive.iso.gz",
+	}).ExtractErr()
+
+	th.AssertNoErr(t, err)
+}
+
+func TestNodeChangeProvisionStateClean(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleNodeChangeProvisionStateClean(t)
+
+	c := client.ServiceClient()
+	err := nodes.ChangeProvisionState(c, "1234asdf", nodes.ProvisionStateOpts{
+		Target: nodes.TargetClean,
+		CleanSteps: []nodes.CleanStep{
+			{
+				Interface: "deploy",
+				Step:      "upgrade_firmware",
+				Args: map[string]string{
+					"force": "True",
+				},
+			},
+		},
+	}).ExtractErr()
+
+	th.AssertNoErr(t, err)
+}

--- a/openstack/baremetal/v1/nodes/testing/requests_test.go
+++ b/openstack/baremetal/v1/nodes/testing/requests_test.go
@@ -3,6 +3,7 @@ package testing
 import (
 	"testing"
 
+	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/baremetal/v1/nodes"
 	"github.com/gophercloud/gophercloud/pagination"
 	th "github.com/gophercloud/gophercloud/testhelper"
@@ -243,4 +244,42 @@ func TestNodeChangeProvisionStateClean(t *testing.T) {
 	}).ExtractErr()
 
 	th.AssertNoErr(t, err)
+}
+
+func TestCleanStepRequiresInterface(t *testing.T) {
+	c := client.ServiceClient()
+	err := nodes.ChangeProvisionState(c, "1234asdf", nodes.ProvisionStateOpts{
+		Target: nodes.TargetClean,
+		CleanSteps: []nodes.CleanStep{
+			{
+				Step: "upgrade_firmware",
+				Args: map[string]string{
+					"force": "True",
+				},
+			},
+		},
+	}).ExtractErr()
+
+	if _, ok := err.(gophercloud.ErrMissingInput); !ok {
+		t.Fatal("ErrMissingInput was expected to occur")
+	}
+}
+
+func TestCleanStepRequiresStep(t *testing.T) {
+	c := client.ServiceClient()
+	err := nodes.ChangeProvisionState(c, "1234asdf", nodes.ProvisionStateOpts{
+		Target: nodes.TargetClean,
+		CleanSteps: []nodes.CleanStep{
+			{
+				Interface: "deploy",
+				Args: map[string]string{
+					"force": "True",
+				},
+			},
+		},
+	}).ExtractErr()
+
+	if _, ok := err.(gophercloud.ErrMissingInput); !ok {
+		t.Fatal("ErrMissingInput was expected to occur")
+	}
 }

--- a/openstack/baremetal/v1/nodes/urls.go
+++ b/openstack/baremetal/v1/nodes/urls.go
@@ -41,3 +41,7 @@ func bootDeviceURL(client *gophercloud.ServiceClient, id string) string {
 func supportedBootDeviceURL(client *gophercloud.ServiceClient, id string) string {
 	return client.ServiceURL("nodes", id, "management", "boot_device", "supported")
 }
+
+func provisionStateURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL("nodes", id, "states", "provision")
+}


### PR DESCRIPTION
For #1429

This implements the code to adjust provisioning state.

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

- [API reference](https://developer.openstack.org/api-ref/baremetal/?expanded=change-node-provision-state-detail)
- [API endpoint for set provision state](https://github.com/openstack/ironic/blob/master/ironic/api/controllers/v1/node.py#L605-L710)
- [Target states for provision state](https://github.com/openstack/ironic/blob/master/ironic/common/states.py#L42-L53)
- [Config drive storage from base64](https://github.com/openstack/ironic/blob/master/ironic/conductor/manager.py#L3545-L3583)
