### PR TITLE
Baremetal V1 API Ports

### DIFF
--- a/acceptance/openstack/baremetal/noauth/ports_test.go
+++ b/acceptance/openstack/baremetal/noauth/ports_test.go
@@ -63,5 +63,5 @@ func TestPortsUpdate(t *testing.T) {
 	}).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, updated.Maintenance, true)
+	th.AssertEquals(t, updated.Address, "aa:bb:cc:dd:ee:ff")
 }

--- a/acceptance/openstack/baremetal/noauth/ports_test.go
+++ b/acceptance/openstack/baremetal/noauth/ports_test.go
@@ -18,10 +18,10 @@ func TestPortsCreateDestroy(t *testing.T) {
 	th.AssertNoErr(t, err)
 	client.Microversion = "1.53"
 
-	node, err := CreateFakeNode(t, client)
+	node, err := v1.CreateFakeNode(t, client)
 	port, err := v1.CreatePort(t, client, node)
 	th.AssertNoErr(t, err)
-	defer DeleteNode(t, client, node)
+	defer v1.DeleteNode(t, client, node)
 	defer v1.DeletePort(t, client, port)
 
 	found := false
@@ -52,10 +52,10 @@ func TestPortsUpdate(t *testing.T) {
 	th.AssertNoErr(t, err)
 	client.Microversion = "1.53"
 
-	node, err := CreateFakeNode(t, client)
+	node, err := v1.CreateFakeNode(t, client)
 	port, err := v1.CreatePort(t, client, node)
 	th.AssertNoErr(t, err)
-	defer DeleteNode(t, client, node)
+	defer v1.DeleteNode(t, client, node)
 	defer v1.DeletePort(t, client, port)
 
 	updated, err := ports.Update(client, port.UUID, ports.UpdateOpts{

--- a/acceptance/openstack/baremetal/noauth/ports_test.go
+++ b/acceptance/openstack/baremetal/noauth/ports_test.go
@@ -18,8 +18,10 @@ func TestPortsCreateDestroy(t *testing.T) {
 	th.AssertNoErr(t, err)
 	client.Microversion = "1.53"
 
-	port, err := v1.CreatePort(t, client)
+	node, err := CreateFakeNode(t, client)
+	port, err := v1.CreatePort(t, client, node)
 	th.AssertNoErr(t, err)
+	defer DeleteNode(t, client, node)
 	defer v1.DeletePort(t, client, port)
 
 	found := false
@@ -50,8 +52,10 @@ func TestPortsUpdate(t *testing.T) {
 	th.AssertNoErr(t, err)
 	client.Microversion = "1.53"
 
-	port, err := v1.CreatePort(t, client)
+	node, err := CreateFakeNode(t, client)
+	port, err := v1.CreatePort(t, client, node)
 	th.AssertNoErr(t, err)
+	defer DeleteNode(t, client, node)
 	defer v1.DeletePort(t, client, port)
 
 	updated, err := ports.Update(client, port.UUID, ports.UpdateOpts{

--- a/acceptance/openstack/baremetal/noauth/ports_test.go
+++ b/acceptance/openstack/baremetal/noauth/ports_test.go
@@ -1,3 +1,5 @@
+// +build acceptance baremetal ports
+
 package noauth
 
 import (

--- a/acceptance/openstack/baremetal/noauth/ports_test.go
+++ b/acceptance/openstack/baremetal/noauth/ports_test.go
@@ -1,0 +1,67 @@
+package noauth
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/acceptance/clients"
+	v1 "github.com/gophercloud/gophercloud/acceptance/openstack/baremetal/v1"
+	"github.com/gophercloud/gophercloud/openstack/baremetal/v1/ports"
+	"github.com/gophercloud/gophercloud/pagination"
+
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestPortsCreateDestroy(t *testing.T) {
+	clients.RequireLong(t)
+
+	client, err := clients.NewBareMetalV1NoAuthClient()
+	th.AssertNoErr(t, err)
+	client.Microversion = "1.53"
+
+	port, err := v1.CreatePort(t, client)
+	th.AssertNoErr(t, err)
+	defer v1.DeletePort(t, client, port)
+
+	found := false
+	err = ports.List(client, ports.ListOpts{}).EachPage(func(page pagination.Page) (bool, error) {
+		portList, err := ports.ExtractPorts(page)
+		if err != nil {
+			return false, err
+		}
+
+		for _, p := range portList {
+			if p.UUID == port.UUID {
+				found = true
+				return true, nil
+			}
+		}
+
+		return false, nil
+	})
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, found, true)
+}
+
+func TestPortsUpdate(t *testing.T) {
+	clients.RequireLong(t)
+
+	client, err := clients.NewBareMetalV1NoAuthClient()
+	th.AssertNoErr(t, err)
+	client.Microversion = "1.53"
+
+	port, err := v1.CreatePort(t, client)
+	th.AssertNoErr(t, err)
+	defer v1.DeletePort(t, client, port)
+
+	updated, err := ports.Update(client, port.UUID, ports.UpdateOpts{
+		ports.UpdateOperation{
+			Op:    ports.ReplaceOp,
+			Path:  "/address",
+			Value: "aa:bb:cc:dd:ee:ff",
+		},
+	}).Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, updated.Maintenance, true)
+}

--- a/acceptance/openstack/baremetal/v1/baremetal.go
+++ b/acceptance/openstack/baremetal/v1/baremetal.go
@@ -42,23 +42,22 @@ func DeleteNode(t *testing.T, client *gophercloud.ServiceClient, node *nodes.Nod
 }
 
 // CreatePort - creates a port with a fixed NodeUUID and Address
-func CreatePort(t *testing.T, client *gophercloud.ServiceClient) (*ports.Port, error){
+func CreatePort(t *testing.T, client *gophercloud.ServiceClient) (*ports.Port, error) {
 	nodeUUID := "1be26c0b-03f2-4d2e-ae87-c02d7f33c123"
 	address := "fe:54:00:77:07:d9"
 	t.Logf("Attempting to create Port for Node: %s with Address: %s", nodeUUID, address)
 
 	port, err := ports.Create(client, ports.CreateOpts{
-		UUID: "27e3153e-d5bf-4b7e-b517-fb518e17f34c",
-    NodeUUID: nodeUUID,
-    Address: address,
-    PXEEnabled: true,
+		NodeUUID:   nodeUUID,
+		Address:    address,
+		PXEEnabled: true,
 	}).Extract()
 
 	return port, err
 }
 
 // DeletePort - deletes a port via its UUID
-func DeletePort(t *testing.T, client *gophercloud.ServiceClient, port *ports.Port){
+func DeletePort(t *testing.T, client *gophercloud.ServiceClient, port *ports.Port) {
 	err := ports.Delete(client, port.UUID).ExtractErr()
 	if err != nil {
 		t.Fatalf("Unable to delete port %s: %s", port.UUID, err)

--- a/acceptance/openstack/baremetal/v1/baremetal.go
+++ b/acceptance/openstack/baremetal/v1/baremetal.go
@@ -72,7 +72,7 @@ func CreatePort(t *testing.T, client *gophercloud.ServiceClient, node *nodes.Nod
 	port, err := ports.Create(client, ports.CreateOpts{
 		NodeUUID:   node.UUID,
 		Address:    mac,
-		PXEEnabled: &itrue,
+		PXEEnabled: &iTrue,
 	}).Extract()
 
 	return port, err

--- a/acceptance/openstack/baremetal/v1/baremetal.go
+++ b/acceptance/openstack/baremetal/v1/baremetal.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/acceptance/tools"
 	"github.com/gophercloud/gophercloud/openstack/baremetal/v1/nodes"
+	"github.com/gophercloud/gophercloud/openstack/baremetal/v1/ports"
 )
 
 // CreateNode creates a basic node with a randomly generated name.
@@ -38,4 +39,31 @@ func DeleteNode(t *testing.T, client *gophercloud.ServiceClient, node *nodes.Nod
 	}
 
 	t.Logf("Deleted server: %s", node.UUID)
+}
+
+// CreatePort - creates a port with a fixed NodeUUID and Address
+func CreatePort(t *testing.T, client *gophercloud.ServiceClient) (*ports.Port, error){
+	nodeUUID := "1be26c0b-03f2-4d2e-ae87-c02d7f33c123"
+	address := "fe:54:00:77:07:d9"
+	t.Logf("Attempting to create Port for Node: %s with Address: %s", nodeUUID, address)
+
+	port, err := ports.Create(client, ports.CreateOpts{
+		UUID: "27e3153e-d5bf-4b7e-b517-fb518e17f34c",
+    NodeUUID: nodeUUID,
+    Address: address,
+    PXEEnabled: true,
+	}).Extract()
+
+	return port, err
+}
+
+// DeletePort - deletes a port via its UUID
+func DeletePort(t *testing.T, client *gophercloud.ServiceClient, port *ports.Port){
+	err := ports.Delete(client, port.UUID).ExtractErr()
+	if err != nil {
+		t.Fatalf("Unable to delete port %s: %s", port.UUID, err)
+	}
+
+	t.Logf("Deleted port: %s", port.UUID)
+
 }

--- a/acceptance/openstack/baremetal/v1/baremetal.go
+++ b/acceptance/openstack/baremetal/v1/baremetal.go
@@ -68,10 +68,11 @@ func CreatePort(t *testing.T, client *gophercloud.ServiceClient, node *nodes.Nod
 	mac := "e6:72:1f:52:00:f4"
 	t.Logf("Attempting to create Port for Node: %s with Address: %s", node.UUID, mac)
 
+	iTrue := true
 	port, err := ports.Create(client, ports.CreateOpts{
 		NodeUUID:   node.UUID,
 		Address:    mac,
-		PXEEnabled: true,
+		PXEEnabled: &itrue,
 	}).Extract()
 
 	return port, err

--- a/acceptance/openstack/baremetal/v1/ports_test.go
+++ b/acceptance/openstack/baremetal/v1/ports_test.go
@@ -17,8 +17,10 @@ func TestPortsCreateDestroy(t *testing.T) {
 	th.AssertNoErr(t, err)
 	client.Microversion = "1.53"
 
-	port, err := CreatePort(t, client)
+	node, err := CreateFakeNode(t, client)
+	port, err := CreatePort(t, client, node)
 	th.AssertNoErr(t, err)
+	defer DeleteNode(t, client, node)
 	defer DeletePort(t, client, port)
 
 	found := false
@@ -49,8 +51,10 @@ func TestPortsUpdate(t *testing.T) {
 	th.AssertNoErr(t, err)
 	client.Microversion = "1.53"
 
-	port, err := CreatePort(t, client)
+	node, err := CreateFakeNode(t, client)
+	port, err := CreatePort(t, client, node)
 	th.AssertNoErr(t, err)
+	defer DeleteNode(t, client, node)
 	defer DeletePort(t, client, port)
 
 	updated, err := ports.Update(client, port.UUID, ports.UpdateOpts{

--- a/acceptance/openstack/baremetal/v1/ports_test.go
+++ b/acceptance/openstack/baremetal/v1/ports_test.go
@@ -1,0 +1,66 @@
+package v1
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/acceptance/clients"
+	"github.com/gophercloud/gophercloud/openstack/baremetal/v1/ports"
+	"github.com/gophercloud/gophercloud/pagination"
+
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestPortsCreateDestroy(t *testing.T) {
+	clients.RequireLong(t)
+
+	client, err := clients.NewBareMetalV1Client()
+	th.AssertNoErr(t, err)
+	client.Microversion = "1.53"
+
+	port, err := CreatePort(t, client)
+	th.AssertNoErr(t, err)
+	defer DeletePort(t, client, port)
+
+	found := false
+	err = ports.List(client, ports.ListOpts{}).EachPage(func(page pagination.Page) (bool, error) {
+		portList, err := ports.ExtractPorts(page)
+		if err != nil {
+			return false, err
+		}
+
+		for _, p := range portList {
+			if p.UUID == port.UUID {
+				found = true
+				return true, nil
+			}
+		}
+
+		return false, nil
+	})
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, found, true)
+}
+
+func TestPortsUpdate(t *testing.T) {
+	clients.RequireLong(t)
+
+	client, err := clients.NewBareMetalV1Client()
+	th.AssertNoErr(t, err)
+	client.Microversion = "1.53"
+
+	port, err := CreatePort(t, client)
+	th.AssertNoErr(t, err)
+	defer DeletePort(t, client, port)
+
+	updated, err := ports.Update(client, port.UUID, ports.UpdateOpts{
+		ports.UpdateOperation{
+			Op:    ports.ReplaceOp,
+			Path:  "/address",
+			Value: "aa:bb:cc:dd:ee:ff",
+		},
+	}).Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, updated.Maintenance, true)
+}

--- a/acceptance/openstack/baremetal/v1/ports_test.go
+++ b/acceptance/openstack/baremetal/v1/ports_test.go
@@ -62,5 +62,5 @@ func TestPortsUpdate(t *testing.T) {
 	}).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, updated.Maintenance, true)
+	th.AssertEquals(t, updated.Address, "aa:bb:cc:dd:ee:ff")
 }

--- a/acceptance/openstack/baremetal/v1/ports_test.go
+++ b/acceptance/openstack/baremetal/v1/ports_test.go
@@ -1,3 +1,5 @@
+// +build acceptance baremetal ports
+
 package v1
 
 import (

--- a/openstack/baremetal/v1/ports/doc.go
+++ b/openstack/baremetal/v1/ports/doc.go
@@ -1,0 +1,73 @@
+package ports
+
+/*
+ Package ports contains the functionality to Listing, Searching, Creating, Updating,
+ and Deleting of bare metal Port resources
+
+ API reference: https://developer.openstack.org/api-ref/baremetal/#ports-ports
+
+
+ 	// Example to List Ports with Detail
+ 	ports.ListDetail(client, ports.ListOpts{}).EachPage(func(page pagination.Page) (bool, error) {
+ 		portList, err := ports.ExtractPorts(page)
+ 		if err != nil {
+ 			return false, err
+ 		}
+
+ 		for _, n := range portList {
+ 			// Do something
+ 		}
+
+ 		return true, nil
+ 	})
+
+ 	// Example to List Ports
+ 	ports.List(client, ports.ListOpts{
+ 		Limit: 10,
+ 	}).EachPage(func(page pagination.Page) (bool, error) {
+ 		portList, err := ports.ExtractPorts(page)
+ 		if err != nil {
+ 			return false, err
+ 		}
+
+ 		for _, n := range portList {
+ 			// Do something
+ 		}
+
+ 		return true, nil
+ 	})
+
+ 	// Example to Create a Port
+ 	createPort, err := ports.Create(client, ports.CreateOpts{
+ 		NodeUUID: "e8920409-e07e-41bb-8cc1-72acb103e2dd",
+ 		Address: "00-1B-63-84-45-E6",
+    PhysicalNetwork: "my-network",
+ 	}).Extract()
+ 	if err != nil {
+ 		panic(err)
+ 	}
+
+ 	// Example to Get a Port
+ 	showPort, err := ports.Get(client, "c9afd385-5d89-4ecb-9e1c-68194da6b474").Extract()
+ 	if err != nil {
+ 		panic(err)
+ 	}
+
+ 	// Example to Update a Port
+ 	updatePort, err := ports.Update(client, "c9afd385-5d89-4ecb-9e1c-68194da6b474", ports.UpdateOpts{
+ 		ports.UpdateOperation{
+ 			Op:    ReplaceOp,
+ 			Path:  "/address",
+ 			Value: "22:22:22:22:22:22",
+ 		},
+ 	}).Extract()
+ 	if err != nil {
+ 		panic(err)
+ 	}
+
+ 	// Example to Delete a Port
+ 	err = ports.Delete(client, "c9afd385-5d89-4ecb-9e1c-68194da6b474").ExtractErr()
+ 	if err != nil {
+ 		panic(err)
+
+*/

--- a/openstack/baremetal/v1/ports/doc.go
+++ b/openstack/baremetal/v1/ports/doc.go
@@ -40,7 +40,7 @@ package ports
  	// Example to Create a Port
  	createPort, err := ports.Create(client, ports.CreateOpts{
  		NodeUUID: "e8920409-e07e-41bb-8cc1-72acb103e2dd",
- 		Address: "00-1B-63-84-45-E6",
+		Address: "00:1B:63:84:45:E6",
     PhysicalNetwork: "my-network",
  	}).Extract()
  	if err != nil {

--- a/openstack/baremetal/v1/ports/requests.go
+++ b/openstack/baremetal/v1/ports/requests.go
@@ -1,51 +1,51 @@
 package ports
 
 import (
-  "fmt"
+	"fmt"
 
-  "github.com/gophercloud/gophercloud"
-  "github.com/gophercloud/gophercloud/pagination"
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
 )
 
 // ListOptsBuilder allows extensions to add additional parameters to the
 // List request.
 type ListOptsBuilder interface {
 	ToPortListQuery() (string, error)
-  ToPortListDetailQuery() (string, error)
+	ToPortListDetailQuery() (string, error)
 }
 
 // ListOpts allows the filtering and sorting of paginated collections through
 // the API. Filtering is achieved by passing in struct field values that map to
 // the node attributes you want to see returned. Marker and Limit are used
 // for pagination.
-type ListOpts struct{
-  // Filter the list by the name or uuid of the Node
-  Node string `q:"node"`
+type ListOpts struct {
+	// Filter the list by the name or uuid of the Node
+	Node string `q:"node"`
 
-  // Filter the list by the Node uuid
-  NodeUUID string `q:"node_uuid"`
+	// Filter the list by the Node uuid
+	NodeUUID string `q:"node_uuid"`
 
-  // Filter the list with the specified Portgroup (name or UUID)
-  PortGroup string`q:"portgroup"`
+	// Filter the list with the specified Portgroup (name or UUID)
+	PortGroup string `q:"portgroup"`
 
-  // Filter the list with the specified physical hardware address, typically MAC
-  Address string `q:"address"`
+	// Filter the list with the specified physical hardware address, typically MAC
+	Address string `q:"address"`
 
-  // One or more fields to be returned in the response.
-  Fields []string `q:"fields"`
+	// One or more fields to be returned in the response.
+	Fields []string `q:"fields"`
 
-  // Requests a page size of items.
-  Limit int `q:"limit"`
+	// Requests a page size of items.
+	Limit int `q:"limit"`
 
-  // The ID of the last-seen item
-  Marker string `q:"marker"`
+	// The ID of the last-seen item
+	Marker string `q:"marker"`
 
-  // Sorts the response by the requested sort direction.
-  // Valid value is asc (ascending) or desc (descending). Default is asc.
-  SortDir string `q:"sort_dir"`
+	// Sorts the response by the requested sort direction.
+	// Valid value is asc (ascending) or desc (descending). Default is asc.
+	SortDir string `q:"sort_dir"`
 
-  // Sorts the response by the this attribute value. Default is id.
-  SortKey string `q:"sort_key"`
+	// Sorts the response by the this attribute value. Default is id.
+	SortKey string `q:"sort_key"`
 }
 
 // ToPortListQuery formats a ListOpts into a query string.
@@ -112,36 +112,35 @@ type CreateOptsBuilder interface {
 
 // CreateOpts specifies port creation parameters.
 type CreateOpts struct {
-  // UUID of the Node this resource belongs to.
-  NodeUUID string `json:"node_uuid,omitempty"`
+	// UUID of the Node this resource belongs to.
+	NodeUUID string `json:"node_uuid,omitempty"`
 
-  // Physical hardware address of this network Port,
-  // typically the hardware MAC address.
-  Address string `json:"address,omitempty"`
+	// Physical hardware address of this network Port,
+	// typically the hardware MAC address.
+	Address string `json:"address,omitempty"`
 
-  // UUID of the Portgroup this resource belongs to.
-  PortGroupUUID string `json:"portgroup_uuid,omitempty"`
+	// UUID of the Portgroup this resource belongs to.
+	PortGroupUUID string `json:"portgroup_uuid,omitempty"`
 
-  // The Port binding profile. If specified, must contain switch_id (only a MAC
-  // address or an OpenFlow based datapath_id of the switch are accepted in this
-  // field) and port_id (identifier of the physical port on the switch to which
-  // node’s port is connected to) fields. switch_info is an optional string
-  // field to be used to store any vendor-specific information.
-  LocalLinkConnection map[string]interface{} `json:"local_link_connection,omitempty"`
+	// The Port binding profile. If specified, must contain switch_id (only a MAC
+	// address or an OpenFlow based datapath_id of the switch are accepted in this
+	// field) and port_id (identifier of the physical port on the switch to which
+	// node’s port is connected to) fields. switch_info is an optional string
+	// field to be used to store any vendor-specific information.
+	LocalLinkConnection map[string]interface{} `json:"local_link_connection,omitempty"`
 
-  // Indicates whether PXE is enabled or disabled on the Port.
-  PXEEnabled bool `json:"pxe_enabled,omitempty"`
+	// Indicates whether PXE is enabled or disabled on the Port.
+	PXEEnabled bool `json:"pxe_enabled,omitempty"`
 
-  // The name of the physical network to which a port is connected. May be empty.
-  PhysicalNetwork string `json:"physical_network,omitempty"`
+	// The name of the physical network to which a port is connected. May be empty.
+	PhysicalNetwork string `json:"physical_network,omitempty"`
 
-  // A set of one or more arbitrary metadata key and value pairs.
-  Extra map[string]interface{} `json:"extra,omitempty"`
+	// A set of one or more arbitrary metadata key and value pairs.
+	Extra map[string]interface{} `json:"extra,omitempty"`
 
-  // Indicates whether the Port is a Smart NIC port.
-  IsSmartnic bool `json:"is_smartnic,omitempty"`
+	// Indicates whether the Port is a Smart NIC port.
+	IsSmartNIC bool `json:"is_smartnic,omitempty"`
 }
-
 
 // ToPortCreateMap assembles a request body based on the contents of a CreateOpts.
 func (opts CreateOpts) ToPortCreateMap() (map[string]interface{}, error) {
@@ -165,7 +164,6 @@ func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r Create
 	return
 }
 
-
 // TODO Update
 type Patch interface {
 	ToPortUpdateMap() map[string]interface{}
@@ -187,7 +185,6 @@ type UpdateOperation struct {
 	Path  string   `json:"path,required"`
 	Value string   `json:"value,omitempty"`
 }
-
 
 func (opts UpdateOperation) ToPortUpdateMap() map[string]interface{} {
 	return map[string]interface{}{

--- a/openstack/baremetal/v1/ports/requests.go
+++ b/openstack/baremetal/v1/ports/requests.go
@@ -80,7 +80,8 @@ func (opts ListOpts) ToPortListDetailQuery() (string, error) {
 	return q.String(), err
 }
 
-// Return a list ports with complete details. Some filtering is possible by passing in flags in ListOpts,
+// ListDetail - Return a list ports with complete details.
+// Some filtering is possible by passing in flags in "ListOpts",
 // but you cannot limit by the fields returned.
 func ListDetail(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 	url := listDetailURL(client)
@@ -130,7 +131,7 @@ type CreateOpts struct {
 	LocalLinkConnection map[string]interface{} `json:"local_link_connection,omitempty"`
 
 	// Indicates whether PXE is enabled or disabled on the Port.
-	PXEEnabled bool `json:"pxe_enabled,omitempty"`
+	PXEEnabled *bool `json:"pxe_enabled,omitempty"`
 
 	// The name of the physical network to which a port is connected. May be empty.
 	PhysicalNetwork string `json:"physical_network,omitempty"`
@@ -139,7 +140,7 @@ type CreateOpts struct {
 	Extra map[string]interface{} `json:"extra,omitempty"`
 
 	// Indicates whether the Port is a Smart NIC port.
-	IsSmartNIC bool `json:"is_smartnic,omitempty"`
+	IsSmartNIC *bool `json:"is_smartnic,omitempty"`
 }
 
 // ToPortCreateMap assembles a request body based on the contents of a CreateOpts.
@@ -181,9 +182,9 @@ const (
 )
 
 type UpdateOperation struct {
-	Op    UpdateOp `json:"op,required"`
-	Path  string   `json:"path,required"`
-	Value string   `json:"value,omitempty"`
+	Op    UpdateOp    `json:"op,required"`
+	Path  string      `json:"path,required"`
+	Value interface{} `json:"value,omitempty"`
 }
 
 func (opts UpdateOperation) ToPortUpdateMap() map[string]interface{} {

--- a/openstack/baremetal/v1/ports/requests.go
+++ b/openstack/baremetal/v1/ports/requests.go
@@ -1,0 +1,223 @@
+package ports
+
+import (
+  "fmt"
+
+  "github.com/gophercloud/gophercloud"
+  "github.com/gophercloud/gophercloud/pagination"
+)
+
+// ListOptsBuilder allows extensions to add additional parameters to the
+// List request.
+type ListOptsBuilder interface {
+	ToPortListQuery() (string, error)
+  ToPortListDetailQuery() (string, error)
+}
+
+// ListOpts allows the filtering and sorting of paginated collections through
+// the API. Filtering is achieved by passing in struct field values that map to
+// the node attributes you want to see returned. Marker and Limit are used
+// for pagination.
+type ListOpts struct{
+  // Filter the list by the name or uuid of the Node
+  Node string `q:"node"`
+
+  // Filter the list by the Node uuid
+  NodeUUID string `q:"node_uuid"`
+
+  // Filter the list with the specified Portgroup (name or UUID)
+  PortGroup string`q:"portgroup"`
+
+  // Filter the list with the specified physical hardware address, typically MAC
+  Address string `q:"address"`
+
+  // One or more fields to be returned in the response.
+  Fields []string `q:"fields"`
+
+  // Requests a page size of items.
+  Limit int `q:"limit"`
+
+  // The ID of the last-seen item
+  Marker string `q:"marker"`
+
+  // Sorts the response by the requested sort direction.
+  // Valid value is asc (ascending) or desc (descending). Default is asc.
+  SortDir string `q:"sort_dir"`
+
+  // Sorts the response by the this attribute value. Default is id.
+  SortKey string `q:"sort_key"`
+}
+
+// ToPortListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToPortListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List makes a request against the API to list ports accessible to you.
+func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(client)
+	if opts != nil {
+		query, err := opts.ToPortListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return PortPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// ToPortListDetailQuery formats a ListOpts into a query string for the list details API.
+func (opts ListOpts) ToPortListDetailQuery() (string, error) {
+	// Detail endpoint can't filter by Fields
+	if len(opts.Fields) > 0 {
+		return "", fmt.Errorf("fields is not a valid option when getting a detailed listing of ports")
+	}
+
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// Return a list ports with complete details. Some filtering is possible by passing in flags in ListOpts,
+// but you cannot limit by the fields returned.
+func ListDetail(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listDetailURL(client)
+	if opts != nil {
+		query, err := opts.ToPortListDetailQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return PortPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// Get - requests the details off a port, by ID.
+func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {
+	_, r.Err = client.Get(getURL(client, id), &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToPortCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts specifies port creation parameters.
+type CreateOpts struct {
+  // UUID of the Node this resource belongs to.
+  NodeUUID string `json:"node_uuid,omitempty"`
+
+  // Physical hardware address of this network Port,
+  // typically the hardware MAC address.
+  Address string `json:"address,omitempty"`
+
+  // UUID of the Portgroup this resource belongs to.
+  PortGroupUUID string `json:"portgroup_uuid,omitempty"`
+
+  // The Port binding profile. If specified, must contain switch_id (only a MAC
+  // address or an OpenFlow based datapath_id of the switch are accepted in this
+  // field) and port_id (identifier of the physical port on the switch to which
+  // node’s port is connected to) fields. switch_info is an optional string
+  // field to be used to store any vendor-specific information.
+  LocalLinkConnection map[string]interface{} `json:"local_link_connection,omitempty"`
+
+  // Indicates whether PXE is enabled or disabled on the Port.
+  PXEEnabled bool `json:"pxe_enabled,omitempty"`
+
+  // The name of the physical network to which a port is connected. May be empty.
+  PhysicalNetwork string `json:"physical_network,omitempty"`
+
+  // A set of one or more arbitrary metadata key and value pairs.
+  Extra map[string]interface{} `json:"extra,omitempty"`
+
+  // Indicates whether the Port is a Smart NIC port.
+  IsSmartnic bool `json:"is_smartnic,omitempty"`
+}
+
+
+// ToPortCreateMap assembles a request body based on the contents of a CreateOpts.
+func (opts CreateOpts) ToPortCreateMap() (map[string]interface{}, error) {
+	body, err := gophercloud.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	return body, nil
+}
+
+// Create - requests the creation of a port
+func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	reqBody, err := opts.ToPortCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = client.Post(createURL(client), reqBody, &r.Body, nil)
+	return
+}
+
+
+// TODO Update
+type Patch interface {
+	ToPortUpdateMap() map[string]interface{}
+}
+
+// UpdateOpts is a slice of Patches used to update a port
+type UpdateOpts []Patch
+
+type UpdateOp string
+
+const (
+	ReplaceOp UpdateOp = "replace"
+	AddOp     UpdateOp = "add"
+	RemoveOp  UpdateOp = "remove"
+)
+
+type UpdateOperation struct {
+	Op    UpdateOp `json:"op,required"`
+	Path  string   `json:"path,required"`
+	Value string   `json:"value,omitempty"`
+}
+
+
+func (opts UpdateOperation) ToPortUpdateMap() map[string]interface{} {
+	return map[string]interface{}{
+		"op":    opts.Op,
+		"path":  opts.Path,
+		"value": opts.Value,
+	}
+}
+
+// Update - requests the update of a port
+func Update(client *gophercloud.ServiceClient, id string, opts UpdateOpts) (r UpdateResult) {
+	body := make([]map[string]interface{}, len(opts))
+	for i, patch := range opts {
+		body[i] = patch.ToPortUpdateMap()
+	}
+
+	resp, err := client.Request("PATCH", updateURL(client, id), &gophercloud.RequestOpts{
+		JSONBody: &body,
+		OkCodes:  []int{200},
+	})
+
+	r.Body = resp.Body
+	r.Header = resp.Header
+	r.Err = err
+
+	return
+}
+
+// Delete - requests the deletion of a port
+func Delete(client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+	_, r.Err = client.Delete(deleteURL(client, id), nil)
+	return
+}

--- a/openstack/baremetal/v1/ports/results.go
+++ b/openstack/baremetal/v1/ports/results.go
@@ -66,7 +66,7 @@ type Port struct {
 	UpdatedAt string `json:"updated_at"`
 
 	// A list of relative links. Includes the self and bookmark links.
-	Links []string `json:"links"`
+	Links []interface{} `json:"links"`
 
 	// Indicates whether the Port is a Smart NIC port.
 	IsSmartNIC bool `json:"is_smartnic"`

--- a/openstack/baremetal/v1/ports/results.go
+++ b/openstack/baremetal/v1/ports/results.go
@@ -1,0 +1,130 @@
+package ports
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+type portResult struct{
+  gophercloud.Result
+}
+
+func (r portResult) Extract() (*Port, error){
+  var s Port
+  err := r.ExtractInto(&s)
+  return &s, err
+}
+
+func (r portResult) ExtractInto(v interface{}) error{
+  return r.Result.ExtractIntoStructPtr(v, "")
+}
+
+func ExtractPortsInto(r pagination.Page, v interface{}) error {
+  return r.(PortPage).Result.ExtractIntoSlicePtr(v, "ports")
+}
+
+
+// Port represents a port in the OpenStack Bare Metal API.
+type Port struct{
+	// UUID for the resource.
+	UUID string `json:"uuid"`
+
+	// Physical hardware address of this network Port,
+	// typically the hardware MAC address.
+	Address string `json:"address"`
+
+	// UUID of the Node this resource belongs to.
+	NodeUUID string `json:"node_uuid"`
+
+	// UUID of the Portgroup this resource belongs to.
+	PortGroupUUID string `json:"portgroup_uuid"`
+
+	// The Port binding profile. If specified, must contain switch_id (only a MAC
+	// address or an OpenFlow based datapath_id of the switch are accepted in this
+	// field) and port_id (identifier of the physical port on the switch to which
+	// node’s port is connected to) fields. switch_info is an optional string
+	// field to be used to store any vendor-specific information.
+	LocalLinkConnection map[string]interface{} `json:"local_link_connection"`
+
+	// Indicates whether PXE is enabled or disabled on the Port.
+	PXEEnabled bool `json:"pxe_enabled"`
+
+	// The name of the physical network to which a port is connected.
+	// May be empty.
+	PhysicalNetwork string `json:"physical_network"`
+
+	// Internal metadata set and stored by the Port. This field is read-only.
+	InternalInfo map[string]interface{} `json:"internal_info"`
+
+	// A set of one or more arbitrary metadata key and value pairs.
+	Extra map[string]interface{} `json:"extra"`
+
+	// The UTC date and time when the resource was created, ISO 8601 format.
+	CreatedAt string `json:"created_at"`
+
+	// The UTC date and time when the resource was updated, ISO 8601 format.
+	// May be “null”.
+	UpdatedAt string `json:"updated_at"`
+
+	// A list of relative links. Includes the self and bookmark links.
+	Links []string `json:"links"`
+
+	// Indicates whether the Port is a Smart NIC port.
+	IsSmartnic bool `json:"is_smartnic"`
+}
+
+// PortPage abstracts the raw results of making a List() request against
+// the API.
+type PortPage struct {
+	pagination.LinkedPageBase
+}
+
+// IsEmpty returns true if a page contains no Port results.
+func (r PortPage) IsEmpty() (bool, error) {
+	s, err := ExtractPorts(r)
+	return len(s) == 0, err
+}
+
+// NextPageURL uses the response's embedded link reference to navigate to the
+// next page of results.
+func (r PortPage) NextPageURL() (string, error) {
+	var s struct {
+		Links []gophercloud.Link `json:"ports_links"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return gophercloud.ExtractNextURL(s.Links)
+}
+
+// ExtractPorts interprets the results of a single page from a List() call,
+// producing a slice of Port entities.
+func ExtractPorts(r pagination.Page) ([]Port, error) {
+	var s []Port
+	err := ExtractPortsInto(r, &s)
+	return s, err
+}
+
+// GetResult is the response from a Get operation. Call its Extract
+// method to interpret it as a Port.
+type GetResult struct {
+	portResult
+}
+
+// CreateResult is the response from a Create operation.
+type CreateResult struct {
+	portResult
+}
+
+// UpdateResult is the response from an Update operation. Call its Extract
+// method to interpret it as a Port.
+type UpdateResult struct {
+	portResult
+}
+
+// DeleteResult is the response from a Delete operation. Call its ExtractErr
+// method to determine if the call succeeded or failed.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}

--- a/openstack/baremetal/v1/ports/results.go
+++ b/openstack/baremetal/v1/ports/results.go
@@ -5,27 +5,26 @@ import (
 	"github.com/gophercloud/gophercloud/pagination"
 )
 
-type portResult struct{
-  gophercloud.Result
+type portResult struct {
+	gophercloud.Result
 }
 
-func (r portResult) Extract() (*Port, error){
-  var s Port
-  err := r.ExtractInto(&s)
-  return &s, err
+func (r portResult) Extract() (*Port, error) {
+	var s Port
+	err := r.ExtractInto(&s)
+	return &s, err
 }
 
-func (r portResult) ExtractInto(v interface{}) error{
-  return r.Result.ExtractIntoStructPtr(v, "")
+func (r portResult) ExtractInto(v interface{}) error {
+	return r.Result.ExtractIntoStructPtr(v, "")
 }
 
 func ExtractPortsInto(r pagination.Page, v interface{}) error {
-  return r.(PortPage).Result.ExtractIntoSlicePtr(v, "ports")
+	return r.(PortPage).Result.ExtractIntoSlicePtr(v, "ports")
 }
 
-
 // Port represents a port in the OpenStack Bare Metal API.
-type Port struct{
+type Port struct {
 	// UUID for the resource.
 	UUID string `json:"uuid"`
 
@@ -70,7 +69,7 @@ type Port struct{
 	Links []string `json:"links"`
 
 	// Indicates whether the Port is a Smart NIC port.
-	IsSmartnic bool `json:"is_smartnic"`
+	IsSmartNIC bool `json:"is_smartnic"`
 }
 
 // PortPage abstracts the raw results of making a List() request against

--- a/openstack/baremetal/v1/ports/testing/doc.go
+++ b/openstack/baremetal/v1/ports/testing/doc.go
@@ -1,0 +1,2 @@
+// ports unit tests
+package testing

--- a/openstack/baremetal/v1/ports/testing/fixtures.go
+++ b/openstack/baremetal/v1/ports/testing/fixtures.go
@@ -1,0 +1,245 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/baremetal/v1/ports"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+// PortListBody contains the canned body of a ports.List response, without detail.
+const PortListBody = `
+{
+   "ports": [
+       {
+           "uuid": "3abe3f36-9708-4e9f-b07e-0f898061d3a7",
+           "links": [
+               {
+                   "href": "http://192.168.0.8/baremetal/v1/ports/3abe3f36-9708-4e9f-b07e-0f898061d3a7",
+                   "rel": "self"
+               },
+               {
+                   "href": "http://192.168.0.8/baremetal/ports/3abe3f36-9708-4e9f-b07e-0f898061d3a7",
+                   "rel": "bookmark"
+               }
+           ],
+           "address": "52:54:00:0a:af:d1"
+       },
+       {
+           "uuid": "f2845e11-dbd4-4728-a8c0-30d19f48924a",
+           "links": [
+               {
+                   "href": "http://192.168.0.8/baremetal/v1/ports/f2845e11-dbd4-4728-a8c0-30d19f48924a",
+                   "rel": "self"
+               },
+               {
+                   "href": "http://192.168.0.8/baremetal/ports/f2845e11-dbd4-4728-a8c0-30d19f48924a",
+                   "rel": "bookmark"
+               }
+           ],
+           "address": "52:54:00:4d:87:e6"
+       }
+   ]
+}
+`
+
+// PortListDetailBody contains the canned body of a port.ListDetail response.
+const PortListDetailBody = `
+{
+   "ports": [
+       {
+           "local_link_connection": {
+
+           },
+           "node_uuid": "ddd06a60-b91e-4ab4-a6e7-56c0b25b6086",
+           "uuid": "3abe3f36-9708-4e9f-b07e-0f898061d3a7",
+           "links": [
+               {
+                   "href": "http://192.168.0.8/baremetal/v1/ports/3abe3f36-9708-4e9f-b07e-0f898061d3a7",
+                   "rel": "self"
+               },
+               {
+                   "href": "http://192.168.0.8/baremetal/ports/3abe3f36-9708-4e9f-b07e-0f898061d3a7",
+                   "rel": "bookmark"
+               }
+           ],
+           "extra": {
+
+           },
+           "pxe_enabled": true,
+           "portgroup_uuid": null,
+           "updated_at": "2019-02-15T09:55:19+00:00",
+           "physical_network": null,
+           "address": "52:54:00:0a:af:d1",
+           "internal_info": {
+
+           },
+           "created_at": "2019-02-15T09:52:23+00:00"
+       },
+       {
+           "local_link_connection": {
+
+           },
+           "node_uuid": "ddd06a60-b91e-4ab4-a6e7-56c0b25b6086",
+           "uuid": "f2845e11-dbd4-4728-a8c0-30d19f48924a",
+           "links": [
+               {
+                   "href": "http://192.168.0.8/baremetal/v1/ports/f2845e11-dbd4-4728-a8c0-30d19f48924a",
+                   "rel": "self"
+               },
+               {
+                   "href": "http://192.168.0.8/baremetal/ports/f2845e11-dbd4-4728-a8c0-30d19f48924a",
+                   "rel": "bookmark"
+               }
+           ],
+           "extra": {
+
+           },
+           "pxe_enabled": true,
+           "portgroup_uuid": null,
+           "updated_at": "2019-02-15T09:55:19+00:00",
+           "physical_network": null,
+           "address": "52:54:00:4d:87:e6",
+           "internal_info": {
+
+           },
+           "created_at": "2019-02-15T09:52:24+00:00"
+       }
+   ]
+}
+`
+
+// SinglePortBody is the canned body of a Get request on an existing port.
+const SinglePortBody = `
+{
+    "local_link_connection": {
+
+    },
+    "node_uuid": "ddd06a60-b91e-4ab4-a6e7-56c0b25b6086",
+    "uuid": "f2845e11-dbd4-4728-a8c0-30d19f48924a",
+    "links": [
+        {
+            "href": "http://192.168.0.8/baremetal/v1/ports/f2845e11-dbd4-4728-a8c0-30d19f48924a",
+            "rel": "self"
+        },
+        {
+            "href": "http://192.168.0.8/baremetal/ports/f2845e11-dbd4-4728-a8c0-30d19f48924a",
+            "rel": "bookmark"
+        }
+    ],
+    "extra": {
+
+    },
+    "pxe_enabled": true,
+    "portgroup_uuid": null,
+    "updated_at": "2019-02-15T09:55:19+00:00",
+    "physical_network": null,
+    "address": "52:54:00:4d:87:e6",
+    "internal_info": {
+
+    },
+    "created_at": "2019-02-15T09:52:24+00:00"
+}
+`
+
+var (
+	PortFoo = ports.Port{
+    UUID: "f2845e11-dbd4-4728-a8c0-30d19f48924a",
+    NodeUUID: "ddd06a60-b91e-4ab4-a6e7-56c0b25b6086",
+    Address: "52:54:00:4d:87:e6",
+    PXEEnabled: true,
+	}
+
+	PortBar = ports.Port{
+    UUID: "3abe3f36-9708-4e9f-b07e-0f898061d3a7",
+    NodeUUID: "ddd06a60-b91e-4ab4-a6e7-56c0b25b6086",
+    Address: "52:54:00:0a:af:d1",
+    PXEEnabled: true,
+	}
+)
+
+// HandlePortListSuccessfully sets up the test server to respond to a port List request.
+func HandlePortListSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/v1/ports", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		w.Header().Add("Content-Type", "application/json")
+		r.ParseForm()
+
+		marker := r.Form.Get("marker")
+		switch marker {
+		case "":
+			fmt.Fprintf(w, PortListBody)
+
+		case "f2845e11-dbd4-4728-a8c0-30d19f48924a":
+			fmt.Fprintf(w, `{ "ports": [] }`)
+		default:
+			t.Fatalf("/ports invoked with unexpected marker=[%s]", marker)
+		}
+	})
+}
+
+// HandlePortListSuccessfully sets up the test server to respond to a server List request.
+func HandlePortListDetailSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/v1/ports/detail", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		w.Header().Add("Content-Type", "application/json")
+		r.ParseForm()
+
+		fmt.Fprintf(w, PortListDetailBody)
+	})
+}
+
+// HandleSPortCreationSuccessfully sets up the test server to respond to a server creation request
+// with a given response.
+func HandlePortCreationSuccessfully(t *testing.T, response string) {
+	th.Mux.HandleFunc("/v1/ports", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, `{
+          "boot_interface": "pxe",
+          "driver": "ipmi",
+          "name": "foo"
+        }`)
+
+		w.WriteHeader(http.StatusAccepted)
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprintf(w, response)
+	})
+}
+
+// HandlePortDeletionSuccessfully sets up the test server to respond to a port deletion request.
+func HandlePortDeletionSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/v1/ports/3abe3f36-9708-4e9f-b07e-0f898061d3a7", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.WriteHeader(http.StatusNoContent)
+	})
+}
+
+func HandlePortGetSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/v1/ports/f2845e11-dbd4-4728-a8c0-30d19f48924a", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+
+		fmt.Fprintf(w, SinglePortBody)
+	})
+}
+
+func HandlePortUpdateSuccessfully(t *testing.T, response string) {
+	th.Mux.HandleFunc("/v1/ports/f2845e11-dbd4-4728-a8c0-30d19f48924a", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PATCH")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestJSONRequest(t, r, `[{"op": "replace", "path": "/address", "value": "22:22:22:22:22:22"}]`)
+
+		fmt.Fprintf(w, response)
+	})
+}

--- a/openstack/baremetal/v1/ports/testing/fixtures.go
+++ b/openstack/baremetal/v1/ports/testing/fixtures.go
@@ -147,17 +147,17 @@ const SinglePortBody = `
 
 var (
 	PortFoo = ports.Port{
-    UUID: "f2845e11-dbd4-4728-a8c0-30d19f48924a",
-    NodeUUID: "ddd06a60-b91e-4ab4-a6e7-56c0b25b6086",
-    Address: "52:54:00:4d:87:e6",
-    PXEEnabled: true,
+		UUID:       "f2845e11-dbd4-4728-a8c0-30d19f48924a",
+		NodeUUID:   "ddd06a60-b91e-4ab4-a6e7-56c0b25b6086",
+		Address:    "52:54:00:4d:87:e6",
+		PXEEnabled: true,
 	}
 
 	PortBar = ports.Port{
-    UUID: "3abe3f36-9708-4e9f-b07e-0f898061d3a7",
-    NodeUUID: "ddd06a60-b91e-4ab4-a6e7-56c0b25b6086",
-    Address: "52:54:00:0a:af:d1",
-    PXEEnabled: true,
+		UUID:       "3abe3f36-9708-4e9f-b07e-0f898061d3a7",
+		NodeUUID:   "ddd06a60-b91e-4ab4-a6e7-56c0b25b6086",
+		Address:    "52:54:00:0a:af:d1",
+		PXEEnabled: true,
 	}
 )
 

--- a/openstack/baremetal/v1/ports/testing/fixtures.go
+++ b/openstack/baremetal/v1/ports/testing/fixtures.go
@@ -51,9 +51,7 @@ const PortListDetailBody = `
 {
    "ports": [
        {
-           "local_link_connection": {
-
-           },
+           "local_link_connection": {},
            "node_uuid": "ddd06a60-b91e-4ab4-a6e7-56c0b25b6086",
            "uuid": "3abe3f36-9708-4e9f-b07e-0f898061d3a7",
            "links": [
@@ -66,9 +64,7 @@ const PortListDetailBody = `
                    "rel": "bookmark"
                }
            ],
-           "extra": {
-
-           },
+           "extra": {},
            "pxe_enabled": true,
            "portgroup_uuid": null,
            "updated_at": "2019-02-15T09:55:19+00:00",
@@ -80,9 +76,7 @@ const PortListDetailBody = `
            "created_at": "2019-02-15T09:52:23+00:00"
        },
        {
-           "local_link_connection": {
-
-           },
+           "local_link_connection": {},
            "node_uuid": "ddd06a60-b91e-4ab4-a6e7-56c0b25b6086",
            "uuid": "f2845e11-dbd4-4728-a8c0-30d19f48924a",
            "links": [
@@ -95,17 +89,13 @@ const PortListDetailBody = `
                    "rel": "bookmark"
                }
            ],
-           "extra": {
-
-           },
+           "extra": {},
            "pxe_enabled": true,
            "portgroup_uuid": null,
            "updated_at": "2019-02-15T09:55:19+00:00",
            "physical_network": null,
            "address": "52:54:00:4d:87:e6",
-           "internal_info": {
-
-           },
+           "internal_info": {},
            "created_at": "2019-02-15T09:52:24+00:00"
        }
    ]
@@ -147,23 +137,35 @@ const SinglePortBody = `
 
 var (
 	PortFoo = ports.Port{
-		UUID:       "f2845e11-dbd4-4728-a8c0-30d19f48924a",
-		NodeUUID:   "ddd06a60-b91e-4ab4-a6e7-56c0b25b6086",
-		Address:    "52:54:00:4d:87:e6",
-		PXEEnabled: true,
+		UUID:                "f2845e11-dbd4-4728-a8c0-30d19f48924a",
+		NodeUUID:            "ddd06a60-b91e-4ab4-a6e7-56c0b25b6086",
+		Address:             "52:54:00:4d:87:e6",
+		PXEEnabled:          true,
+		LocalLinkConnection: map[string]interface{}{},
+		InternalInfo:        map[string]interface{}{},
+		Extra:               map[string]interface{}{},
+		CreatedAt:           "2019-02-15T09:52:24+00:00",
+		UpdatedAt:           "2019-02-15T09:55:19+00:00",
+		Links:               []interface{}{map[string]interface{}{"href": "http://192.168.0.8/baremetal/v1/ports/f2845e11-dbd4-4728-a8c0-30d19f48924a", "rel": "self"}, map[string]interface{}{"href": "http://192.168.0.8/baremetal/ports/f2845e11-dbd4-4728-a8c0-30d19f48924a", "rel": "bookmark"}},
 	}
 
 	PortBar = ports.Port{
-		UUID:       "3abe3f36-9708-4e9f-b07e-0f898061d3a7",
-		NodeUUID:   "ddd06a60-b91e-4ab4-a6e7-56c0b25b6086",
-		Address:    "52:54:00:0a:af:d1",
-		PXEEnabled: true,
+		UUID:                "3abe3f36-9708-4e9f-b07e-0f898061d3a7",
+		NodeUUID:            "ddd06a60-b91e-4ab4-a6e7-56c0b25b6086",
+		Address:             "52:54:00:0a:af:d1",
+		PXEEnabled:          true,
+		LocalLinkConnection: map[string]interface{}{},
+		InternalInfo:        map[string]interface{}{},
+		Extra:               map[string]interface{}{},
+		CreatedAt:           "2019-02-15T09:52:23+00:00",
+		UpdatedAt:           "2019-02-15T09:55:19+00:00",
+		Links:               []interface{}{map[string]interface{}{"href": "http://192.168.0.8/baremetal/v1/ports/3abe3f36-9708-4e9f-b07e-0f898061d3a7", "rel": "self"}, map[string]interface{}{"rel": "bookmark", "href": "http://192.168.0.8/baremetal/ports/3abe3f36-9708-4e9f-b07e-0f898061d3a7"}},
 	}
 )
 
 // HandlePortListSuccessfully sets up the test server to respond to a port List request.
 func HandlePortListSuccessfully(t *testing.T) {
-	th.Mux.HandleFunc("/v1/ports", func(w http.ResponseWriter, r *http.Request) {
+	th.Mux.HandleFunc("/ports", func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "GET")
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		w.Header().Add("Content-Type", "application/json")
@@ -182,9 +184,9 @@ func HandlePortListSuccessfully(t *testing.T) {
 	})
 }
 
-// HandlePortListSuccessfully sets up the test server to respond to a server List request.
+// HandlePortListSuccessfully sets up the test server to respond to a port List request.
 func HandlePortListDetailSuccessfully(t *testing.T) {
-	th.Mux.HandleFunc("/v1/ports/detail", func(w http.ResponseWriter, r *http.Request) {
+	th.Mux.HandleFunc("/ports/detail", func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "GET")
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		w.Header().Add("Content-Type", "application/json")
@@ -194,16 +196,16 @@ func HandlePortListDetailSuccessfully(t *testing.T) {
 	})
 }
 
-// HandleSPortCreationSuccessfully sets up the test server to respond to a server creation request
+// HandleSPortCreationSuccessfully sets up the test server to respond to a port creation request
 // with a given response.
 func HandlePortCreationSuccessfully(t *testing.T, response string) {
-	th.Mux.HandleFunc("/v1/ports", func(w http.ResponseWriter, r *http.Request) {
+	th.Mux.HandleFunc("/ports", func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "POST")
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		th.TestJSONRequest(t, r, `{
-          "boot_interface": "pxe",
-          "driver": "ipmi",
-          "name": "foo"
+          "node_uuid": "ddd06a60-b91e-4ab4-a6e7-56c0b25b6086",
+          "address": "52:54:00:4d:87:e6",
+          "pxe_enabled": true
         }`)
 
 		w.WriteHeader(http.StatusAccepted)
@@ -214,7 +216,7 @@ func HandlePortCreationSuccessfully(t *testing.T, response string) {
 
 // HandlePortDeletionSuccessfully sets up the test server to respond to a port deletion request.
 func HandlePortDeletionSuccessfully(t *testing.T) {
-	th.Mux.HandleFunc("/v1/ports/3abe3f36-9708-4e9f-b07e-0f898061d3a7", func(w http.ResponseWriter, r *http.Request) {
+	th.Mux.HandleFunc("/ports/3abe3f36-9708-4e9f-b07e-0f898061d3a7", func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "DELETE")
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
@@ -223,7 +225,7 @@ func HandlePortDeletionSuccessfully(t *testing.T) {
 }
 
 func HandlePortGetSuccessfully(t *testing.T) {
-	th.Mux.HandleFunc("/v1/ports/f2845e11-dbd4-4728-a8c0-30d19f48924a", func(w http.ResponseWriter, r *http.Request) {
+	th.Mux.HandleFunc("/ports/f2845e11-dbd4-4728-a8c0-30d19f48924a", func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "GET")
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		th.TestHeader(t, r, "Accept", "application/json")
@@ -233,7 +235,7 @@ func HandlePortGetSuccessfully(t *testing.T) {
 }
 
 func HandlePortUpdateSuccessfully(t *testing.T, response string) {
-	th.Mux.HandleFunc("/v1/ports/f2845e11-dbd4-4728-a8c0-30d19f48924a", func(w http.ResponseWriter, r *http.Request) {
+	th.Mux.HandleFunc("/ports/f2845e11-dbd4-4728-a8c0-30d19f48924a", func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "PATCH")
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		th.TestHeader(t, r, "Accept", "application/json")

--- a/openstack/baremetal/v1/ports/testing/requests_test.go
+++ b/openstack/baremetal/v1/ports/testing/requests_test.go
@@ -1,0 +1,145 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/baremetal/v1/ports"
+	"github.com/gophercloud/gophercloud/pagination"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func TestListDetailPorts(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandlePortListDetailSuccessfully(t)
+
+	pages := 0
+	err := ports.ListDetail(client.ServiceClient(), ports.ListOpts{}).EachPage(func(page pagination.Page) (bool, error) {
+		pages++
+
+		actual, err := ports.ExtractPorts(page)
+		if err != nil {
+			return false, err
+		}
+
+		if len(actual) != 2 {
+			t.Fatalf("Expected 2 ports, got %d", len(actual))
+		}
+		th.CheckDeepEquals(t, PortFoo, actual[0])
+		th.CheckDeepEquals(t, PortBar, actual[1])
+
+
+		return true, nil
+	})
+
+	th.AssertNoErr(t, err)
+
+	if pages != 1 {
+		t.Errorf("Expected 1 page, saw %d", pages)
+	}
+}
+
+func TestListPorts(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandlePortListSuccessfully(t)
+
+	pages := 0
+	err := ports.List(client.ServiceClient(), ports.ListOpts{}).EachPage(func(page pagination.Page) (bool, error) {
+		pages++
+
+		actual, err := ports.ExtractPorts(page)
+		if err != nil {
+			return false, err
+		}
+
+		if len(actual) != 2 {
+			t.Fatalf("Expected 2 ports, got %d", len(actual))
+		}
+		th.AssertEquals(t, PortFoo, actual[0].Name)
+		th.AssertEquals(t, PortBar, actual[1].Name)
+
+
+		return true, nil
+	})
+
+	th.AssertNoErr(t, err)
+
+	if pages != 1 {
+		t.Errorf("Expected 1 page, saw %d", pages)
+	}
+}
+
+func TestListOpts(t *testing.T) {
+	// Detail cannot take Fields
+	opts := ports.ListOpts{
+		Fields: []string{"uuid", "address"},
+	}
+
+	_, err := opts.ToPortListDetailQuery()
+	th.AssertEquals(t, err.Error(), "fields is not a valid option when getting a detailed listing of ports")
+
+	// Regular ListOpts can
+	query, err := opts.ToPortListQuery()
+	th.AssertEquals(t, query, "?fields=uuid&fields=address")
+	th.AssertNoErr(t, err)
+}
+
+func TestCreatePort(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandlePortCreationSuccessfully(t, SinglePortBody)
+
+	actual, err := ports.Create(client.ServiceClient(), ports.CreateOpts{
+    NodeUUID: "ddd06a60-b91e-4ab4-a6e7-56c0b25b6086",
+    Address: "52:54:00:4d:87:e6",
+    PXEEnabled: true,
+	}).Extract()
+	th.AssertNoErr(t, err)
+
+	th.CheckDeepEquals(t, PortFoo, *actual)
+}
+
+func TestDeletePort(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandlePortDeletionSuccessfully(t)
+
+	res := ports.Delete(client.ServiceClient(), "3abe3f36-9708-4e9f-b07e-0f898061d3a7")
+	th.AssertNoErr(t, res.Err)
+}
+
+func TestGetPort(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandlePortGetSuccessfully(t)
+
+	c := client.ServiceClient()
+	actual, err := ports.Get(c, "f2845e11-dbd4-4728-a8c0-30d19f48924a").Extract()
+	if err != nil {
+		t.Fatalf("Unexpected Get error: %v", err)
+	}
+
+	th.CheckDeepEquals(t, PortFoo, *actual)
+}
+
+func TestUpdatePort(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandlePortUpdateSuccessfully(t, SinglePortBody)
+
+	c := client.ServiceClient()
+	actual, err := ports.Update(c, "f2845e11-dbd4-4728-a8c0-30d19f48924a", ports.UpdateOpts{
+		ports.UpdateOperation{
+			Op:    ports.ReplaceOp,
+			Path:  "/address",
+			Value: "22:22:22:22:22:22",
+		},
+	}).Extract()
+	if err != nil {
+		t.Fatalf("Unexpected Update error: %v", err)
+	}
+
+	th.CheckDeepEquals(t, PortFoo, *actual)
+}

--- a/openstack/baremetal/v1/ports/testing/requests_test.go
+++ b/openstack/baremetal/v1/ports/testing/requests_test.go
@@ -29,7 +29,6 @@ func TestListDetailPorts(t *testing.T) {
 		th.CheckDeepEquals(t, PortFoo, actual[0])
 		th.CheckDeepEquals(t, PortBar, actual[1])
 
-
 		return true, nil
 	})
 
@@ -59,7 +58,6 @@ func TestListPorts(t *testing.T) {
 		}
 		th.AssertEquals(t, PortFoo, actual[0].Name)
 		th.AssertEquals(t, PortBar, actual[1].Name)
-
 
 		return true, nil
 	})
@@ -92,9 +90,9 @@ func TestCreatePort(t *testing.T) {
 	HandlePortCreationSuccessfully(t, SinglePortBody)
 
 	actual, err := ports.Create(client.ServiceClient(), ports.CreateOpts{
-    NodeUUID: "ddd06a60-b91e-4ab4-a6e7-56c0b25b6086",
-    Address: "52:54:00:4d:87:e6",
-    PXEEnabled: true,
+		NodeUUID:   "ddd06a60-b91e-4ab4-a6e7-56c0b25b6086",
+		Address:    "52:54:00:4d:87:e6",
+		PXEEnabled: true,
 	}).Extract()
 	th.AssertNoErr(t, err)
 

--- a/openstack/baremetal/v1/ports/testing/requests_test.go
+++ b/openstack/baremetal/v1/ports/testing/requests_test.go
@@ -89,10 +89,11 @@ func TestCreatePort(t *testing.T) {
 	defer th.TeardownHTTP()
 	HandlePortCreationSuccessfully(t, SinglePortBody)
 
+	iTrue := true
 	actual, err := ports.Create(client.ServiceClient(), ports.CreateOpts{
 		NodeUUID:   "ddd06a60-b91e-4ab4-a6e7-56c0b25b6086",
 		Address:    "52:54:00:4d:87:e6",
-		PXEEnabled: true,
+		PXEEnabled: &iTrue,
 	}).Extract()
 	th.AssertNoErr(t, err)
 

--- a/openstack/baremetal/v1/ports/testing/requests_test.go
+++ b/openstack/baremetal/v1/ports/testing/requests_test.go
@@ -56,8 +56,8 @@ func TestListPorts(t *testing.T) {
 		if len(actual) != 2 {
 			t.Fatalf("Expected 2 ports, got %d", len(actual))
 		}
-		th.AssertEquals(t, PortFoo, actual[0].Name)
-		th.AssertEquals(t, PortBar, actual[1].Name)
+		th.AssertEquals(t, PortFoo, actual[0])
+		th.AssertEquals(t, PortBar, actual[1])
 
 		return true, nil
 	})

--- a/openstack/baremetal/v1/ports/testing/requests_test.go
+++ b/openstack/baremetal/v1/ports/testing/requests_test.go
@@ -26,8 +26,8 @@ func TestListDetailPorts(t *testing.T) {
 		if len(actual) != 2 {
 			t.Fatalf("Expected 2 ports, got %d", len(actual))
 		}
-		th.CheckDeepEquals(t, PortFoo, actual[0])
-		th.CheckDeepEquals(t, PortBar, actual[1])
+		th.CheckDeepEquals(t, PortBar, actual[0])
+		th.CheckDeepEquals(t, PortFoo, actual[1])
 
 		return true, nil
 	})
@@ -56,8 +56,8 @@ func TestListPorts(t *testing.T) {
 		if len(actual) != 2 {
 			t.Fatalf("Expected 2 ports, got %d", len(actual))
 		}
-		th.AssertEquals(t, PortFoo, actual[0])
-		th.AssertEquals(t, PortBar, actual[1])
+		th.AssertEquals(t, "3abe3f36-9708-4e9f-b07e-0f898061d3a7", actual[0].UUID)
+		th.AssertEquals(t, "f2845e11-dbd4-4728-a8c0-30d19f48924a", actual[1].UUID)
 
 		return true, nil
 	})

--- a/openstack/baremetal/v1/ports/urls.go
+++ b/openstack/baremetal/v1/ports/urls.go
@@ -3,23 +3,23 @@ package ports
 import "github.com/gophercloud/gophercloud"
 
 func createURL(client *gophercloud.ServiceClient) string {
-  return client.ServiceURL("ports")
+	return client.ServiceURL("ports")
 }
 
 func listURL(client *gophercloud.ServiceClient) string {
-  return createURL(client)
+	return createURL(client)
 }
 
 func listDetailURL(client *gophercloud.ServiceClient) string {
-  return client.ServiceURL("ports", "detail")
+	return client.ServiceURL("ports", "detail")
 }
 
-func resourceURL(client *gophercloud.ServiceClient, id string) string{
+func resourceURL(client *gophercloud.ServiceClient, id string) string {
 	return client.ServiceURL("ports", id)
 }
 
 func deleteURL(client *gophercloud.ServiceClient, id string) string {
-  return resourceURL(client, id)
+	return resourceURL(client, id)
 }
 
 func getURL(client *gophercloud.ServiceClient, id string) string {

--- a/openstack/baremetal/v1/ports/urls.go
+++ b/openstack/baremetal/v1/ports/urls.go
@@ -1,0 +1,31 @@
+package ports
+
+import "github.com/gophercloud/gophercloud"
+
+func createURL(client *gophercloud.ServiceClient) string {
+  return client.ServiceURL("ports")
+}
+
+func listURL(client *gophercloud.ServiceClient) string {
+  return createURL(client)
+}
+
+func listDetailURL(client *gophercloud.ServiceClient) string {
+  return client.ServiceURL("ports", "detail")
+}
+
+func resourceURL(client *gophercloud.ServiceClient, id string) string{
+	return client.ServiceURL("ports", id)
+}
+
+func deleteURL(client *gophercloud.ServiceClient, id string) string {
+  return resourceURL(client, id)
+}
+
+func getURL(client *gophercloud.ServiceClient, id string) string {
+	return resourceURL(client, id)
+}
+
+func updateURL(client *gophercloud.ServiceClient, id string) string {
+	return resourceURL(client, id)
+}


### PR DESCRIPTION
For #1429 

This PR covers the Ports API calls  according to the [Baremetal API reference](https://developer.openstack.org/api-ref/baremetal/?expanded=#ports-ports)
- List Ports (GET)
- Create Port (POST)
- List Detailed Ports (GET)
- Show Port Details (GET)
- Update a Port (PATCH)
- Delete Port (DELETE)

You can view the source code [here](https://github.com/openstack/ironic/blob/master/ironic/api/controllers/v1/port.py)