### PR TITLE
Container Infra v1: Use interface for update value

### DIFF
--- a/acceptance/openstack/containerinfra/v1/clusters_test.go
+++ b/acceptance/openstack/containerinfra/v1/clusters_test.go
@@ -63,7 +63,7 @@ func TestClustersCRUD(t *testing.T) {
 	allPagesDetail, err := clusters.ListDetail(client, nil).AllPages()
 	th.AssertNoErr(t, err)
 
-	allClustersDetail, err := clusters.ExtractClusters(allPages)
+	allClustersDetail, err := clusters.ExtractClusters(allPagesDetail)
 	th.AssertNoErr(t, err)
 
 	var foundDetail bool

--- a/openstack/containerinfra/v1/clusters/requests.go
+++ b/openstack/containerinfra/v1/clusters/requests.go
@@ -136,9 +136,9 @@ const (
 )
 
 type UpdateOpts struct {
-	Op    UpdateOp `json:"op" required:"true"`
-	Path  string   `json:"path" required:"true"`
-	Value string   `json:"value,omitempty"`
+	Op    UpdateOp    `json:"op" required:"true"`
+	Path  string      `json:"path" required:"true"`
+	Value interface{} `json:"value,omitempty"`
 }
 
 // UpdateOptsBuilder allows extensions to add additional parameters to the

--- a/openstack/containerinfra/v1/clustertemplates/requests.go
+++ b/openstack/containerinfra/v1/clustertemplates/requests.go
@@ -133,9 +133,9 @@ const (
 )
 
 type UpdateOpts struct {
-	Op    UpdateOp `json:"op" required:"true"`
-	Path  string   `json:"path" required:"true"`
-	Value string   `json:"value,omitempty"`
+	Op    UpdateOp    `json:"op" required:"true"`
+	Path  string      `json:"path" required:"true"`
+	Value interface{} `json:"value,omitempty"`
 }
 
 // UpdateOptsBuilder allows extensions to add additional parameters to the


### PR DESCRIPTION
This commit changes the Value field of UpdateOpts to be an interface{}
instead of a string. This is to send type-specific values to the API
service.

For #1458 

/cc @tghartland would you be able to test this and confirm it's working?