### PR TITLE
Core: Fix deadlock with reauthentication

### DIFF
--- a/acceptance/openstack/identity/v3/reauth_test.go
+++ b/acceptance/openstack/identity/v3/reauth_test.go
@@ -1,0 +1,34 @@
+// +build acceptance
+
+package v3
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/acceptance/clients"
+	"github.com/gophercloud/gophercloud/openstack"
+	th "github.com/gophercloud/gophercloud/testhelper"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/projects"
+)
+
+func TestReauthAuthResultDeadlock(t *testing.T) {
+	clients.RequireAdmin(t)
+
+	ao, err := openstack.AuthOptionsFromEnv()
+	th.AssertNoErr(t, err)
+
+	ao.AllowReauth = true
+
+	provider, err := openstack.AuthenticatedClient(ao)
+	th.AssertNoErr(t, err)
+
+	provider.SetToken("this is not a valid token")
+
+	client, err := openstack.NewIdentityV3(provider, gophercloud.EndpointOpts{})
+	pages, err := projects.List(client, nil).AllPages()
+	th.AssertNoErr(t, err)
+	_, err = projects.ExtractProjects(pages)
+	th.AssertNoErr(t, err)
+}

--- a/provider_client.go
+++ b/provider_client.go
@@ -234,9 +234,6 @@ func (client *ProviderClient) Reauthenticate(previousToken string) (err error) {
 	}
 	client.reauthmut.Unlock()
 
-	client.mut.Lock()
-	defer client.mut.Unlock()
-
 	client.reauthmut.Lock()
 	client.reauthmut.reauthing = true
 	client.reauthmut.done = sync.NewCond(client.reauthmut)

--- a/provider_client.go
+++ b/provider_client.go
@@ -76,13 +76,18 @@ type ProviderClient struct {
 	// with the token and reauth func zeroed. Such client can be used to perform reauthorization.
 	Throwaway bool
 
+	// mut is a mutex for the client. It protects read and write access to client attributes such as getting
+	// and setting the TokenID.
 	mut *sync.RWMutex
 
+	// reauthmut is a mutex for reauthentication it attempts to ensure that only one reauthentication
+	// attempt happens at one time.
 	reauthmut *reauthlock
 
 	authResult AuthResult
 }
 
+// reauthlock represents a set of attributes used to help in the reauthentication process.
 type reauthlock struct {
 	sync.RWMutex
 	reauthing    bool
@@ -219,7 +224,7 @@ func (client *ProviderClient) Reauthenticate(previousToken string) (err error) {
 		return nil
 	}
 
-	if client.mut == nil {
+	if client.reauthmut == nil {
 		return client.ReauthFunc()
 	}
 


### PR DESCRIPTION
This commit fixes a deadlock issue during reauthentication. It removes a
possibly unnecessary locking of the client's locking mechanism so the
reauthentication process can safely lock the client.

For #1459 

/cc @majewsky This resolves the problem for me. I think this fix also makes sense. I could be wrong :)