### PR TITLE
Compute V2: Create multiple servers

### DIFF
--- a/openstack/compute/v2/servers/requests.go
+++ b/openstack/compute/v2/servers/requests.go
@@ -192,9 +192,6 @@ type CreateOpts struct {
 	// Max specifies Maximum number of servers to launch.
 	Max int `json:"max_count,omitempty"`
 
-	// ReturnReservationID sets respond with reservation_id only.
-	ReturnReservationID bool `json:"return_reservation_id,omitempty"`
-
 	// ServiceClient will allow calls to be made to retrieve an image or
 	// flavor ID by name.
 	ServiceClient *gophercloud.ServiceClient `json:"-"`

--- a/openstack/compute/v2/servers/requests.go
+++ b/openstack/compute/v2/servers/requests.go
@@ -183,8 +183,17 @@ type CreateOpts struct {
 	// AccessIPv4 specifies an IPv4 address for the instance.
 	AccessIPv4 string `json:"accessIPv4,omitempty"`
 
-	// AccessIPv6 pecifies an IPv6 address for the instance.
+	// AccessIPv6 specifies an IPv6 address for the instance.
 	AccessIPv6 string `json:"accessIPv6,omitempty"`
+
+	// Min specifies Minimum number of servers to launch.
+	Min int `json:"min_count,omitempty"`
+
+	// Max specifies Maximum number of servers to launch.
+	Max int `json:"max_count,omitempty"`
+
+	// ReturnReservationID sets respond with reservation_id only.
+	ReturnReservationID bool `json:"return_reservation_id,omitempty"`
 
 	// ServiceClient will allow calls to be made to retrieve an image or
 	// flavor ID by name.
@@ -274,6 +283,18 @@ func (opts CreateOpts) ToServerCreateMap() (map[string]interface{}, error) {
 			return nil, err
 		}
 		b["flavorRef"] = flavorID
+	}
+
+	if opts.Min != 0 {
+		b["min_count"] = opts.Min
+	}
+
+	if opts.Max != 0 {
+		b["max_count"] = opts.Max
+	}
+
+	if opts.ReturnReservationID {
+		b["return_reservation_id"] = "true"
 	}
 
 	return map[string]interface{}{"server": b}, nil

--- a/openstack/compute/v2/servers/requests.go
+++ b/openstack/compute/v2/servers/requests.go
@@ -290,10 +290,6 @@ func (opts CreateOpts) ToServerCreateMap() (map[string]interface{}, error) {
 		b["max_count"] = opts.Max
 	}
 
-	if opts.ReturnReservationID {
-		b["return_reservation_id"] = "true"
-	}
-
 	return map[string]interface{}{"server": b}, nil
 }
 

--- a/openstack/compute/v2/servers/testing/fixtures.go
+++ b/openstack/compute/v2/servers/testing/fixtures.go
@@ -776,6 +776,28 @@ func HandleServerCreationSuccessfully(t *testing.T, response string) {
 
 // HandleServerCreationWithCustomFieldSuccessfully sets up the test server to respond to a server creation request
 // with a given response.
+func HandleServersCreationSuccessfully(t *testing.T, response string) {
+	th.Mux.HandleFunc("/servers", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, `{
+			"server": {
+				"name": "derp",
+				"imageRef": "f90f6034-2570-4974-8351-6b49732ef2eb",
+				"flavorRef": "1",
+				"min_count": 3,
+				"max_count": 3
+			}
+		}`)
+
+		w.WriteHeader(http.StatusAccepted)
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprintf(w, response)
+	})
+}
+
+// HandleServerCreationWithCustomFieldSuccessfully sets up the test server to respond to a server creation request
+// with a given response.
 func HandleServerCreationWithCustomFieldSuccessfully(t *testing.T, response string) {
 	th.Mux.HandleFunc("/servers", func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "POST")

--- a/openstack/compute/v2/servers/testing/requests_test.go
+++ b/openstack/compute/v2/servers/testing/requests_test.go
@@ -100,6 +100,23 @@ func TestCreateServer(t *testing.T) {
 	th.CheckDeepEquals(t, ServerDerp, *actual)
 }
 
+func TestCreateServers(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleServersCreationSuccessfully(t, SingleServerBody)
+
+	actual, err := servers.Create(client.ServiceClient(), servers.CreateOpts{
+		Name:      "derp",
+		ImageRef:  "f90f6034-2570-4974-8351-6b49732ef2eb",
+		FlavorRef: "1",
+		Min:       3,
+		Max:       3,
+	}).Extract()
+	th.AssertNoErr(t, err)
+
+	th.CheckDeepEquals(t, ServerDerp, *actual)
+}
+
 func TestCreateServerWithCustomField(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()


### PR DESCRIPTION
For #1306 

API:
https://developer.openstack.org/api-ref/compute/?expanded=create-multiple-servers-detail#create-server

Schema:
https://github.com/openstack/nova/blob/5852bae034533129608dd24b58e33733e093e957/nova/api/openstack/compute/schemas/servers.py#L195