### PR TITLE
Baremetal API v1: Node Power State

### DIFF
--- a/openstack/baremetal/v1/nodes/requests.go
+++ b/openstack/baremetal/v1/nodes/requests.go
@@ -438,3 +438,49 @@ func ChangeProvisionState(client *gophercloud.ServiceClient, id string, opts Pro
 	})
 	return
 }
+
+type TargetPowerState string
+
+// TargetPowerState is used when changing the power state of a node.
+const (
+	PowerOn       TargetPowerState = "power on"
+	PowerOff                       = "power off"
+	Rebooting                      = "rebooting"
+	SoftPowerOff                   = "soft power off"
+	SoftRebooting                  = "soft rebooting"
+)
+
+// PowerStateOptsBuilder allows extensions to add additional parameters to the ChangePowerState request.
+type PowerStateOptsBuilder interface {
+	ToPowerStateMap() (map[string]interface{}, error)
+}
+
+// PowerStateOpts for a request to change a node's power state.
+type PowerStateOpts struct {
+	Target  TargetPowerState `json:"target" required:"true"`
+	Timeout int              `json:"timeout,omitempty"`
+}
+
+// ToPowerStateMap assembles a request body based on the contents of a PowerStateOpts.
+func (opts PowerStateOpts) ToPowerStateMap() (map[string]interface{}, error) {
+	body, err := gophercloud.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	return body, nil
+}
+
+// Request to change a Node's power state.
+func ChangePowerState(client *gophercloud.ServiceClient, id string, opts PowerStateOptsBuilder) (r ChangePowerStateResult) {
+	reqBody, err := opts.ToPowerStateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = client.Put(powerStateURL(client, id), reqBody, nil, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+	})
+	return
+}

--- a/openstack/baremetal/v1/nodes/results.go
+++ b/openstack/baremetal/v1/nodes/results.go
@@ -278,6 +278,12 @@ type SupportedBootDeviceResult struct {
 	gophercloud.Result
 }
 
+// ChangePowerStateResult is the response from a ChangePowerState operation. Call its ExtractErr
+// method to determine if the call succeeded or failed.
+type ChangePowerStateResult struct {
+	gophercloud.ErrResult
+}
+
 // Each element in the response will contain a “result” variable, which will have a value of “true” or “false”, and
 // also potentially a reason. A value of nil indicates that the Node’s driver does not support that interface.
 type DriverValidation struct {

--- a/openstack/baremetal/v1/nodes/testing/fixtures.go
+++ b/openstack/baremetal/v1/nodes/testing/fixtures.go
@@ -909,3 +909,17 @@ func HandleNodeChangeProvisionStateClean(t *testing.T) {
 		w.WriteHeader(http.StatusAccepted)
 	})
 }
+
+// HandleChangePowerStateSuccessfully sets up the test server to respond to a change power state request for a node
+func HandleChangePowerStateSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/nodes/1234asdf/states/power", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, `{
+			"target": "power on",
+			"timeout": 100
+		}`)
+
+		w.WriteHeader(http.StatusAccepted)
+	})
+}

--- a/openstack/baremetal/v1/nodes/testing/requests_test.go
+++ b/openstack/baremetal/v1/nodes/testing/requests_test.go
@@ -311,3 +311,18 @@ func TestCleanStepRequiresStep(t *testing.T) {
 		t.Fatal("ErrMissingInput was expected to occur")
 	}
 }
+
+func TestChangePowerState(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleChangePowerStateSuccessfully(t)
+
+	opts := nodes.PowerStateOpts{
+		Target:  nodes.PowerOn,
+		Timeout: 100,
+	}
+
+	c := client.ServiceClient()
+	err := nodes.ChangePowerState(c, "1234asdf", opts).ExtractErr()
+	th.AssertNoErr(t, err)
+}

--- a/openstack/baremetal/v1/nodes/urls.go
+++ b/openstack/baremetal/v1/nodes/urls.go
@@ -42,6 +42,14 @@ func supportedBootDeviceURL(client *gophercloud.ServiceClient, id string) string
 	return client.ServiceURL("nodes", id, "management", "boot_device", "supported")
 }
 
+func statesResourceURL(client *gophercloud.ServiceClient, id string, state string) string {
+	return client.ServiceURL("nodes", id, "states", state)
+}
+
+func powerStateURL(client *gophercloud.ServiceClient, id string) string {
+	return statesResourceURL(client, id, "power")
+}
+
 func provisionStateURL(client *gophercloud.ServiceClient, id string) string {
-	return client.ServiceURL("nodes", id, "states", "provision")
+	return statesResourceURL(client, id, "provision")
 }


### PR DESCRIPTION
For #1429

API's for changing a Node's power state.

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

- [API Ref](https://developer.openstack.org/api-ref/baremetal/?expanded=change-node-power-state-detail)
- [API endpoint](https://github.com/openstack/ironic/blob/master/ironic/api/controllers/v1/node.py#L500-L551)
