### PR TITLE
Baremetal API V1: Handle required opts correctly

### DIFF
--- a/openstack/baremetal/v1/nodes/requests.go
+++ b/openstack/baremetal/v1/nodes/requests.go
@@ -249,7 +249,7 @@ func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r Create
 }
 
 type Patch interface {
-	ToNodeUpdateMap() map[string]interface{}
+	ToNodeUpdateMap() (map[string]interface{}, error)
 }
 
 // UpdateOpts is a slice of Patches used to update a node
@@ -264,24 +264,26 @@ const (
 )
 
 type UpdateOperation struct {
-	Op    UpdateOp `json:"op,required"`
-	Path  string   `json:"path,required"`
+	Op    UpdateOp `json:"op" required:"true"`
+	Path  string   `json:"path" required:"true"`
 	Value string   `json:"value,omitempty"`
 }
 
-func (opts UpdateOperation) ToNodeUpdateMap() map[string]interface{} {
-	return map[string]interface{}{
-		"op":    opts.Op,
-		"path":  opts.Path,
-		"value": opts.Value,
-	}
+func (opts UpdateOperation) ToNodeUpdateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "")
 }
 
 // Update requests that a node be updated
 func Update(client *gophercloud.ServiceClient, id string, opts UpdateOpts) (r UpdateResult) {
 	body := make([]map[string]interface{}, len(opts))
 	for i, patch := range opts {
-		body[i] = patch.ToNodeUpdateMap()
+		result, err := patch.ToNodeUpdateMap()
+		if err != nil {
+			r.Err = err
+			return
+		}
+
+		body[i] = result
 	}
 
 	resp, err := client.Request("PATCH", updateURL(client, id), &gophercloud.RequestOpts{

--- a/openstack/baremetal/v1/nodes/testing/requests_test.go
+++ b/openstack/baremetal/v1/nodes/testing/requests_test.go
@@ -3,6 +3,7 @@ package testing
 import (
 	"testing"
 
+	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/baremetal/v1/nodes"
 	"github.com/gophercloud/gophercloud/pagination"
 	th "github.com/gophercloud/gophercloud/testhelper"
@@ -150,7 +151,35 @@ func TestUpdateNode(t *testing.T) {
 	}
 
 	th.CheckDeepEquals(t, NodeFoo, *actual)
+}
 
+func TestUpdateRequiredOp(t *testing.T) {
+	c := client.ServiceClient()
+	_, err := nodes.Update(c, "1234asdf", nodes.UpdateOpts{
+		nodes.UpdateOperation{
+			Path:  "/driver",
+			Value: "new-driver",
+		},
+	}).Extract()
+
+	if _, ok := err.(gophercloud.ErrMissingInput); !ok {
+		t.Fatal("ErrMissingInput was expected to occur")
+	}
+
+}
+
+func TestUpdateRequiredPath(t *testing.T) {
+	c := client.ServiceClient()
+	_, err := nodes.Update(c, "1234asdf", nodes.UpdateOpts{
+		nodes.UpdateOperation{
+			Op:    nodes.ReplaceOp,
+			Value: "new-driver",
+		},
+	}).Extract()
+
+	if _, ok := err.(gophercloud.ErrMissingInput); !ok {
+		t.Fatal("ErrMissingInput was expected to occur")
+	}
 }
 
 func TestValidateNode(t *testing.T) {


### PR DESCRIPTION
For #1429

Corrects the wrong annotation on json fields for required, and includes a test to verify.

