### PR TITLE
Baremetal Inspector Client Node Introspection

### DIFF
--- a/acceptance/clients/clients.go
+++ b/acceptance/clients/clients.go
@@ -285,6 +285,27 @@ func NewBareMetalV1NoAuthClient() (*gophercloud.ServiceClient, error) {
 	})
 }
 
+// NewBareMetalIntrospectionV1Client returns a *ServiceClient for making calls
+// to the OpenStack Bare Metal Introspection v1 API. An error will be returned
+// if authentication or client creation was not possible.
+func NewBareMetalIntrospectionV1Client() (*gophercloud.ServiceClient, error) {
+	ao, err := openstack.AuthOptionsFromEnv()
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := openstack.AuthenticatedClient(ao)
+	if err != nil {
+		return nil, err
+	}
+
+	client = configureDebug(client)
+
+	return openstack.NewBareMetalIntrospectionV1(client, gophercloud.EndpointOpts{
+		Region: os.Getenv("OS_REGION_NAME"),
+	})
+}
+
 // NewDBV1Client returns a *ServiceClient for making calls
 // to the OpenStack Database v1 API. An error will be returned
 // if authentication or client creation was not possible.

--- a/openstack/baremetalintrospection/v1/introspection/doc.go
+++ b/openstack/baremetalintrospection/v1/introspection/doc.go
@@ -1,0 +1,40 @@
+package introspection
+
+/*
+Package introspection contains the functionality for Starting introspection,
+Get introspection status, List all introspection statuses, Abort an
+introspection, Get stored introspection data and reapply introspection on
+stored data.
+
+API reference https://developer.openstack.org/api-ref/baremetal-introspection/#node-introspection
+
+    // Example to Start Introspection
+    introspection.StartIntrospection(client, NodeUUID, introspection.StartOpts{}).ExtractErr()
+
+    // Example to Get an Introspection status
+    introspection.GetIntrospectionStatus(client, NodeUUID).Extract()
+    if err != nil {
+        panic(err)
+    }
+
+    // Example to List all introspection statuses
+    introspection.ListIntrospections(client.ServiceClient(), introspection.ListIntrospectionsOpts{}).EachPage(func(page pagination.Page) (bool, error) {
+        introspectionsList, err := introspection.ExtractIntrospections(page)
+            if err != nil {
+                return false, err
+            }
+            for _, n := range introspectionsList {
+                // Do something
+            }
+        return true, nil
+    })
+
+    // Example to Abort an Introspection
+    introspection.AbortIntrospection(client, NodeUUID).ExtractErr()
+
+    // Example to Get stored Introspection Data
+    introspection.GetIntrospectionData(c, NodeUUID).Extract()
+
+    // Example to apply Introspection Data
+    introspection.ApplyIntrospectionData(c, NodeUUID).ExtractErr()
+*/

--- a/openstack/baremetalintrospection/v1/introspection/requests.go
+++ b/openstack/baremetalintrospection/v1/introspection/requests.go
@@ -1,0 +1,116 @@
+package introspection
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// ListIntrospectionsOptsBuilder allows extensions to add additional parameters to the
+// ListIntrospections request.
+type ListIntrospectionsOptsBuilder interface {
+	ToIntrospectionsListQuery() (string, error)
+}
+
+// ListIntrospectionsOpts allows the filtering and sorting of paginated collections through
+// the Introspection API. Filtering is achieved by passing in struct field values that map to
+// the node attributes you want to see returned. Marker and Limit are used
+// for pagination.
+type ListIntrospectionsOpts struct {
+	// Requests a page size of items.
+	Limit int `q:"limit"`
+
+	// The ID of the last-seen item.
+	Marker string `q:"marker"`
+}
+
+// ToIntrospectionsListQuery formats a ListIntrospectionsOpts into a query string.
+func (opts ListIntrospectionsOpts) ToIntrospectionsListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// ListIntrospections makes a request against the Inspector API to list the current introspections.
+func ListIntrospections(client *gophercloud.ServiceClient, opts ListIntrospectionsOptsBuilder) pagination.Pager {
+	url := listIntrospectionsURL(client)
+	if opts != nil {
+		query, err := opts.ToIntrospectionsListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		var rpage = IntrospectionPage{pagination.LinkedPageBase{PageResult: r}}
+		return rpage
+	})
+}
+
+// GetIntrospectionStatus makes a request against the Inspector API to get the
+// status of a single introspection.
+func GetIntrospectionStatus(client *gophercloud.ServiceClient, nodeID string) (r GetIntrospectionStatusResult) {
+	_, r.Err = client.Get(introspectionURL(client, nodeID), &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// StartOptsBuilder allows extensions to add additional parameters to the
+// Start request.
+type StartOptsBuilder interface {
+	ToStartIntrospectionQuery() (string, error)
+}
+
+// StartOpts represents options to start an introspection.
+type StartOpts struct {
+	// Whether the current installation of ironic-inspector can manage PXE booting of nodes.
+	ManageBoot *bool `q:"manage_boot"`
+}
+
+// ToStartIntrospectionQuery converts a StartOpts into a request.
+func (opts StartOpts) ToStartIntrospectionQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// StartIntrospection initiate hardware introspection for node NodeID .
+// All power management configuration for this node needs to be done prior to calling the endpoint.
+func StartIntrospection(client *gophercloud.ServiceClient, nodeID string, opts StartOptsBuilder) (r StartResult) {
+	_, err := opts.ToStartIntrospectionQuery()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = client.Post(introspectionURL(client, nodeID), nil, nil, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+	})
+
+	return
+}
+
+// AbortIntrospection abort running introspection.
+func AbortIntrospection(client *gophercloud.ServiceClient, nodeID string) (r AbortResult) {
+	_, r.Err = client.Post(abortIntrospectionURL(client, nodeID), nil, nil, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+	})
+
+	return
+}
+
+// GetIntrospectionData return stored data from successful introspection.
+func GetIntrospectionData(client *gophercloud.ServiceClient, nodeID string) (r DataResult) {
+	_, r.Err = client.Get(introspectionDataURL(client, nodeID), &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// ReApplyIntrospection triggers introspection on stored unprocessed data.
+// No data is allowed to be sent along with the request.
+func ReApplyIntrospection(client *gophercloud.ServiceClient, nodeID string) (r ApplyDataResult) {
+	_, r.Err = client.Post(introspectionUnprocessedDataURL(client, nodeID), nil, nil, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+	})
+
+	return
+}

--- a/openstack/baremetalintrospection/v1/introspection/results.go
+++ b/openstack/baremetalintrospection/v1/introspection/results.go
@@ -1,0 +1,260 @@
+package introspection
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+type introspectionResult struct {
+	gophercloud.Result
+}
+
+// Extract interprets any introspectionResult as an Introspection, if possible.
+func (r introspectionResult) Extract() (*Introspection, error) {
+	var s Introspection
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+// ExtractInto will extract a response body into an Introspection struct.
+func (r introspectionResult) ExtractInto(v interface{}) error {
+	return r.Result.ExtractIntoStructPtr(v, "")
+}
+
+// ExtractIntrospectionsInto will extract a collection of introspectResult pages into a
+// slice of Introspection entities.
+func ExtractIntrospectionsInto(r pagination.Page, v interface{}) error {
+	return r.(IntrospectionPage).Result.ExtractIntoSlicePtr(v, "introspection")
+}
+
+// ExtractIntrospections interprets the results of a single page from a
+// ListIntrospections() call, producing a slice of Introspection entities.
+func ExtractIntrospections(r pagination.Page) ([]Introspection, error) {
+	var s []Introspection
+	err := ExtractIntrospectionsInto(r, &s)
+	return s, err
+}
+
+// IntrospectionPage abstracts the raw results of making a ListIntrospections()
+// request against the Inspector API. As OpenStack extensions may freely alter
+// the response bodies of structures returned to the client, you may only safely
+// access the data provided through the ExtractIntrospections call.
+type IntrospectionPage struct {
+	pagination.LinkedPageBase
+}
+
+// Introspection represents an introspection in the OpenStack Bare Metal Introspector API.
+type Introspection struct {
+	// Whether introspection is finished
+	Finished bool `json:"finished"`
+
+	// State of the introspection
+	State string `json:"state"`
+
+	// Error message, can be null; "Canceled by operator" in case introspection was aborted
+	Error string `json:"error"`
+
+	// UUID of the introspection
+	UUID string `json:"uuid"`
+
+	// UTC ISO8601 timestamp
+	StartedAt time.Time `json:"-"`
+
+	// UTC ISO8601 timestamp or null
+	FinishedAt time.Time `json:"-"`
+
+	// Link to the introspection URL
+	Links []interface{} `json:"links"`
+}
+
+// IsEmpty returns true if a page contains no Introspection results.
+func (r IntrospectionPage) IsEmpty() (bool, error) {
+	s, err := ExtractIntrospections(r)
+	return len(s) == 0, err
+}
+
+// NextPageURL uses the response's embedded link reference to navigate to the
+// next page of results.
+func (r IntrospectionPage) NextPageURL() (string, error) {
+	var s struct {
+		Links []gophercloud.Link `json:"introspection_links"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return gophercloud.ExtractNextURL(s.Links)
+}
+
+// UnmarshalJSON trie to convert values for started_at and finished_at from the
+// json response into RFC3339 standard. Since Introspection API can remove the
+// Z from the format, if the conversion fails, it falls back to an RFC3339
+// with no Z format supported by gophercloud.
+func (r *Introspection) UnmarshalJSON(b []byte) error {
+	type tmp Introspection
+	var s struct {
+		tmp
+		StartedAt  string `json:"started_at"`
+		FinishedAt string `json:"finished_at"`
+	}
+
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+
+	*r = Introspection(s.tmp)
+
+	if s.StartedAt != "" {
+		t, err := time.Parse(time.RFC3339, s.StartedAt)
+		if err != nil {
+			t, err = time.Parse(gophercloud.RFC3339NoZ, s.StartedAt)
+			if err != nil {
+				return err
+			}
+		}
+		r.StartedAt = t
+	}
+
+	if s.FinishedAt != "" {
+		t, err := time.Parse(time.RFC3339, s.FinishedAt)
+		if err != nil {
+			t, err = time.Parse(gophercloud.RFC3339NoZ, s.FinishedAt)
+			if err != nil {
+				return err
+			}
+		}
+		r.FinishedAt = t
+	}
+
+	return nil
+}
+
+// GetIntrospectionStatusResult is the response from a GetIntrospectionStatus operation.
+// Call its Extract method to interpret it as an Introspection.
+type GetIntrospectionStatusResult struct {
+	introspectionResult
+}
+
+// StartResult is the response from a StartIntrospection operation.
+// Call its ExtractErr method to determine if the call succeeded or failed.
+type StartResult struct {
+	gophercloud.ErrResult
+}
+
+// AbortResult is the response from an AbortIntrospection operation.
+// Call its ExtractErr method to determine if the call succeeded or failed.
+type AbortResult struct {
+	gophercloud.ErrResult
+}
+
+// Data represents the full introspection data collected.
+// The format and contents of the stored data depends on the ramdisk used
+// and plugins enabled both in the ramdisk and in inspector itself.
+// This structure has been provided for basic compatibility but it
+// will need extensions
+type Data struct {
+	AllInterfaces map[string]BaseInterfaceType `json:"all_interfaces"`
+	BootInterface string                       `json:"boot_interface"`
+	CPUArch       string                       `json:"cpu_arch"`
+	CPUs          int                          `json:"cpus"`
+	Error         string                       `json:"error"`
+	Interfaces    map[string]BaseInterfaceType `json:"interfaces"`
+	Inventory     InventoryType                `json:"inventory"`
+	IPMIAddress   string                       `json:"ipmi_address"`
+	LocalGB       int                          `json:"local_gb"`
+	MACs          []string                     `json:"macs"`
+	MemoryMB      int                          `json:"memory_mb"`
+	RootDisk      RootDiskType                 `json:"root_disk"`
+}
+
+// Sub Types defined under Data and deeper in the structure
+
+type BaseInterfaceType struct {
+	ClientID string `json:"client_id"`
+	IP       string `json:"ip"`
+	MAC      string `json:"mac"`
+	PXE      bool   `json:"pxe"`
+}
+
+type BootInfoType struct {
+	CurrentBootMode string `json:"current_boot_mode"`
+	PXEInterface    string `json:"pxe_interface"`
+}
+
+type CPUType struct {
+	Architecture string   `json:"architecture"`
+	Count        int      `json:"count"`
+	Flags        []string `json:"flags"`
+	Frequency    string   `json:"frequency"`
+	ModelName    string   `json:"model_name"`
+}
+
+type InterfaceType struct {
+	BIOSDevName string                 `json:"biosdevname"`
+	ClientID    string                 `json:"client_id"`
+	HasCarrier  bool                   `json:"has_carrier"`
+	IPV4Address string                 `json:"ipv4_address"`
+	IPV6Address string                 `json:"ipv6_address"`
+	Lldp        map[string]interface{} `json:"lldp"`
+	MACAddress  string                 `json:"mac_address"`
+	Name        string                 `json:"name"`
+	Product     string                 `json:"product"`
+	Vendor      string                 `json:"vendor"`
+}
+
+type InventoryType struct {
+	BmcAddress   string           `json:"bmc_address"`
+	Boot         BootInfoType     `json:"boot"`
+	CPU          CPUType          `json:"cpu"`
+	Disks        []RootDiskType   `json:"disks"`
+	Interfaces   []InterfaceType  `json:"interfaces"`
+	Memory       MemoryType       `json:"memory"`
+	SystemVendor SystemVendorType `json:"system_vendor"`
+}
+
+type MemoryType struct {
+	PhysicalMb int `json:"physical_mb"`
+	Total      int `json:"total"`
+}
+
+type RootDiskType struct {
+	Hctl               string `json:"hctl"`
+	Model              string `json:"model"`
+	Name               string `json:"name"`
+	Rotational         bool   `json:"rotational"`
+	Serial             string `json:"serial"`
+	Size               int    `json:"size"`
+	Vendor             string `json:"vendor"`
+	Wwn                string `json:"wwn"`
+	WwnVendorExtension string `json:"wwn_vendor_extension"`
+	WwnWithExtension   string `json:"wwn_with_extension"`
+}
+
+type SystemVendorType struct {
+	Manufacturer string `json:"manufacturer"`
+	ProductName  string `json:"product_name"`
+	SerialNumber string `json:"serial_number"`
+}
+
+// Extract interprets any IntrospectionDataResult as IntrospectionData, if possible.
+func (r DataResult) Extract() (*Data, error) {
+	var s Data
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+// DataResult represents the response from a GetIntrospectionData operation.
+// Call its Extract method to interpret it as a Data.
+type DataResult struct {
+	gophercloud.Result
+}
+
+// ApplyDataResult is the response from an ApplyData operation.
+// Call its ExtractErr method to determine if the call succeeded or failed.
+type ApplyDataResult struct {
+	gophercloud.ErrResult
+}

--- a/openstack/baremetalintrospection/v1/introspection/testing/doc.go
+++ b/openstack/baremetalintrospection/v1/introspection/testing/doc.go
@@ -1,0 +1,1 @@
+package testing

--- a/openstack/baremetalintrospection/v1/introspection/testing/fixtures.go
+++ b/openstack/baremetalintrospection/v1/introspection/testing/fixtures.go
@@ -1,0 +1,374 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/baremetalintrospection/v1/introspection"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+// IntrospectionListBody contains the canned body of a introspection.IntrospectionList response.
+const IntrospectionListBody = `
+{
+  "introspection": [
+    {
+      "error": null,
+      "finished": true,
+      "finished_at": "2017-08-17T11:36:16",
+      "links": [
+        {
+          "href": "http://127.0.0.1:5050/v1/introspection/05ccda19-581b-49bf-8f5a-6ded99701d87",
+          "rel": "self"
+        }
+      ],
+      "started_at": "2017-08-17T11:33:43",
+      "state": "finished",
+      "uuid": "05ccda19-581b-49bf-8f5a-6ded99701d87"
+    },
+    {
+      "error": null,
+      "finished": true,
+      "finished_at": "2017-08-16T12:24:30",
+      "links": [
+        {
+          "href": "http://127.0.0.1:5050/v1/introspection/c244557e-899f-46fa-a1ff-5b2c6718616b",
+          "rel": "self"
+        }
+      ],
+      "started_at": "2017-08-16T12:22:01",
+      "state": "finished",
+      "uuid": "c244557e-899f-46fa-a1ff-5b2c6718616b"
+    }
+  ]
+}
+`
+
+// IntrospectionStatus contains the respnse of a single introspection satus.
+const IntrospectionStatus = `
+{
+  "error": null,
+  "finished": true,
+  "finished_at": "2017-08-16T12:24:30",
+  "links": [
+    {
+      "href": "http://127.0.0.1:5050/v1/introspection/c244557e-899f-46fa-a1ff-5b2c6718616b",
+      "rel": "self"
+    }
+  ],
+  "started_at": "2017-08-16T12:22:01",
+  "state": "finished",
+  "uuid": "c244557e-899f-46fa-a1ff-5b2c6718616b"
+}
+`
+
+// IntrospectionDataJSONSample contains sample data reported by the introspection process.
+const IntrospectionDataJSONSample = `
+{
+   "cpu_arch":"x86_64",
+   "macs":[
+      "52:54:00:4e:3d:30"
+   ],
+   "root_disk":{
+      "rotational":true,
+      "vendor":"0x1af4",
+      "name":"/dev/vda",
+      "hctl":null,
+      "wwn_vendor_extension":null,
+      "wwn_with_extension":null,
+      "model":"",
+      "wwn":null,
+      "serial":null,
+      "size":13958643712
+   },
+   "interfaces": {
+      "eth0": {
+         "ip":"172.24.42.100",
+         "mac":"52:54:00:4e:3d:30",
+         "pxe":true,
+         "client_id":null
+     }
+   },
+   "cpus":2,
+   "boot_interface":"52:54:00:4e:3d:30",
+   "memory_mb":2048,
+   "ipmi_address":"192.167.2.134",
+   "inventory":{
+      "bmc_address":"192.167.2.134",
+      "interfaces":[
+         {
+            "lldp":null,
+            "product":"0x0001",
+            "vendor":"0x1af4",
+            "name":"eth1",
+            "has_carrier":true,
+            "ipv4_address":"172.24.42.101",
+            "client_id":null,
+            "mac_address":"52:54:00:47:20:4d"
+         },
+         {
+            "lldp":null,
+            "product":"0x0001",
+            "vendor":"0x1af4",
+            "name":"eth0",
+            "has_carrier":true,
+            "ipv4_address":"172.24.42.100",
+            "client_id":null,
+            "mac_address":"52:54:00:4e:3d:30"
+         }
+      ],
+      "disks":[
+         {
+            "rotational":true,
+            "vendor":"0x1af4",
+            "name":"/dev/vda",
+            "hctl":null,
+            "wwn_vendor_extension":null,
+            "wwn_with_extension":null,
+            "model":"",
+            "wwn":null,
+            "serial":null,
+            "size":13958643712
+         }
+      ],
+      "boot":{
+         "current_boot_mode":"bios",
+         "pxe_interface":"52:54:00:4e:3d:30"
+      },
+      "system_vendor":{
+         "serial_number":"Not Specified",
+         "product_name":"Bochs",
+         "manufacturer":"Bochs"
+      },
+      "memory":{
+         "physical_mb":2048,
+         "total":2105864192
+      },
+      "cpu":{
+         "count":2,
+         "frequency":"2100.084",
+      "flags": [
+        "fpu",
+        "mmx",
+        "fxsr",
+        "sse",
+        "sse2"
+        ],
+         "architecture":"x86_64"
+      }
+   },
+   "error":null,
+   "local_gb":12,
+   "all_interfaces":{
+      "eth1":{
+         "ip":"172.24.42.101",
+         "mac":"52:54:00:47:20:4d",
+         "pxe":false,
+         "client_id":null
+      },
+      "eth0":{
+         "ip":"172.24.42.100",
+         "mac":"52:54:00:4e:3d:30",
+         "pxe":true,
+         "client_id":null
+     }
+   }
+}
+`
+
+var (
+	fooTimeStarted, _  = time.Parse(gophercloud.RFC3339NoZ, "2017-08-17T11:33:43")
+	fooTimeFinished, _ = time.Parse(gophercloud.RFC3339NoZ, "2017-08-17T11:36:16")
+	IntrospectionFoo   = introspection.Introspection{
+		Finished:   true,
+		State:      "finished",
+		Error:      "",
+		UUID:       "05ccda19-581b-49bf-8f5a-6ded99701d87",
+		StartedAt:  fooTimeStarted,
+		FinishedAt: fooTimeFinished,
+		Links: []interface{}{
+			map[string]interface{}{
+				"href": "http://127.0.0.1:5050/v1/introspection/05ccda19-581b-49bf-8f5a-6ded99701d87",
+				"rel":  "self",
+			},
+		},
+	}
+
+	barTimeStarted, _  = time.Parse(gophercloud.RFC3339NoZ, "2017-08-16T12:22:01")
+	barTimeFinished, _ = time.Parse(gophercloud.RFC3339NoZ, "2017-08-16T12:24:30")
+	IntrospectionBar   = introspection.Introspection{
+		Finished:   true,
+		State:      "finished",
+		Error:      "",
+		UUID:       "c244557e-899f-46fa-a1ff-5b2c6718616b",
+		StartedAt:  barTimeStarted,
+		FinishedAt: barTimeFinished,
+		Links: []interface{}{
+			map[string]interface{}{
+				"href": "http://127.0.0.1:5050/v1/introspection/c244557e-899f-46fa-a1ff-5b2c6718616b",
+				"rel":  "self",
+			},
+		},
+	}
+
+	IntrospectionDataRes = introspection.Data{
+		CPUArch: "x86_64",
+		MACs:    []string{"52:54:00:4e:3d:30"},
+		RootDisk: introspection.RootDiskType{
+			Rotational: true,
+			Model:      "",
+			Name:       "/dev/vda",
+			Size:       13958643712,
+			Vendor:     "0x1af4",
+		},
+		Interfaces: map[string]introspection.BaseInterfaceType{
+			"eth0": {
+				IP:  "172.24.42.100",
+				MAC: "52:54:00:4e:3d:30",
+				PXE: true,
+			},
+		},
+		CPUs:          2,
+		BootInterface: "52:54:00:4e:3d:30",
+		MemoryMB:      2048,
+		IPMIAddress:   "192.167.2.134",
+		Inventory: introspection.InventoryType{
+			SystemVendor: introspection.SystemVendorType{
+				Manufacturer: "Bochs",
+				ProductName:  "Bochs",
+				SerialNumber: "Not Specified",
+			},
+			BmcAddress: "192.167.2.134",
+			Boot: introspection.BootInfoType{
+				CurrentBootMode: "bios",
+				PXEInterface:    "52:54:00:4e:3d:30",
+			},
+			CPU: introspection.CPUType{
+				Count:        2,
+				Flags:        []string{"fpu", "mmx", "fxsr", "sse", "sse2"},
+				Frequency:    "2100.084",
+				Architecture: "x86_64",
+			},
+			Disks: []introspection.RootDiskType{
+				introspection.RootDiskType{
+					Rotational: true,
+					Model:      "",
+					Name:       "/dev/vda",
+					Size:       13958643712,
+					Vendor:     "0x1af4",
+				},
+			},
+			Interfaces: []introspection.InterfaceType{
+				introspection.InterfaceType{
+					Vendor:      "0x1af4",
+					HasCarrier:  true,
+					MACAddress:  "52:54:00:47:20:4d",
+					Name:        "eth1",
+					Product:     "0x0001",
+					IPV4Address: "172.24.42.101",
+				},
+				introspection.InterfaceType{
+					IPV4Address: "172.24.42.100",
+					MACAddress:  "52:54:00:4e:3d:30",
+					Name:        "eth0",
+					Product:     "0x0001",
+					HasCarrier:  true,
+					Vendor:      "0x1af4",
+				},
+			},
+			Memory: introspection.MemoryType{
+				PhysicalMb: 2048.0,
+				Total:      2.105864192e+09,
+			},
+		},
+		Error:   "",
+		LocalGB: 12,
+		AllInterfaces: map[string]introspection.BaseInterfaceType{
+			"eth1": {
+				IP:  "172.24.42.101",
+				MAC: "52:54:00:47:20:4d",
+				PXE: false,
+			},
+			"eth0": {
+				IP:  "172.24.42.100",
+				MAC: "52:54:00:4e:3d:30",
+				PXE: true,
+			},
+		},
+	}
+)
+
+// HandleListIntrospectionsSuccessfully sets up the test server to respond to a server ListIntrospections request.
+func HandleListIntrospectionsSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/introspection", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		w.Header().Add("Content-Type", "application/json")
+		r.ParseForm()
+
+		marker := r.Form.Get("marker")
+
+		switch marker {
+		case "":
+			fmt.Fprintf(w, IntrospectionListBody)
+
+		case "c244557e-899f-46fa-a1ff-5b2c6718616b":
+			fmt.Fprintf(w, `{ "introspection": [] }`)
+
+		default:
+			t.Fatalf("/introspection invoked with unexpected marker=[%s]", marker)
+		}
+	})
+}
+
+// HandleGetIntrospectionStatusSuccessfully sets up the test server to respond to a GetIntrospectionStatus request.
+func HandleGetIntrospectionStatusSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/introspection/c244557e-899f-46fa-a1ff-5b2c6718616b", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+		fmt.Fprintf(w, IntrospectionStatus)
+	})
+}
+
+// HandleStartIntrospectionSuccessfully sets up the test server to respond to a StartIntrospection request.
+func HandleStartIntrospectionSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/introspection/c244557e-899f-46fa-a1ff-5b2c6718616b", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		w.WriteHeader(http.StatusAccepted)
+	})
+}
+
+// HandleAbortIntrospectionSuccessfully sets up the test server to respond to an AbortIntrospection request.
+func HandleAbortIntrospectionSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/introspection/c244557e-899f-46fa-a1ff-5b2c6718616b/abort", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		w.WriteHeader(http.StatusAccepted)
+	})
+}
+
+// HandleGetIntrospectionDataSuccessfully sets up the test server to respond to a GetIntrospectionData request.
+func HandleGetIntrospectionDataSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/introspection/c244557e-899f-46fa-a1ff-5b2c6718616b/data", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+
+		fmt.Fprintf(w, IntrospectionDataJSONSample)
+	})
+}
+
+// HandleReApplyIntrospectionSuccessfully sets up the test server to respond to a ReApplyIntrospection request.
+func HandleReApplyIntrospectionSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/introspection/c244557e-899f-46fa-a1ff-5b2c6718616b/data/unprocessed", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		w.WriteHeader(http.StatusAccepted)
+	})
+}

--- a/openstack/baremetalintrospection/v1/introspection/testing/requests_test.go
+++ b/openstack/baremetalintrospection/v1/introspection/testing/requests_test.go
@@ -1,0 +1,98 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/baremetalintrospection/v1/introspection"
+	"github.com/gophercloud/gophercloud/pagination"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func TestListIntrospections(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleListIntrospectionsSuccessfully(t)
+
+	pages := 0
+	err := introspection.ListIntrospections(client.ServiceClient(), introspection.ListIntrospectionsOpts{}).EachPage(func(page pagination.Page) (bool, error) {
+		pages++
+
+		actual, err := introspection.ExtractIntrospections(page)
+		if err != nil {
+			return false, err
+		}
+
+		if len(actual) != 2 {
+			t.Fatalf("Expected 2 introspections, got %d", len(actual))
+		}
+		th.CheckDeepEquals(t, IntrospectionFoo, actual[0])
+		th.CheckDeepEquals(t, IntrospectionBar, actual[1])
+
+		return true, nil
+	})
+
+	th.AssertNoErr(t, err)
+
+	if pages != 1 {
+		t.Errorf("Expected 1 page, saw %d", pages)
+	}
+}
+
+func TestGetIntrospectionStatus(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleGetIntrospectionStatusSuccessfully(t)
+
+	c := client.ServiceClient()
+	actual, err := introspection.GetIntrospectionStatus(c, "c244557e-899f-46fa-a1ff-5b2c6718616b").Extract()
+	if err != nil {
+		t.Fatalf("Unexpected Get error: %v", err)
+	}
+
+	th.CheckDeepEquals(t, IntrospectionBar, *actual)
+}
+
+func TestStartIntrospection(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleStartIntrospectionSuccessfully(t)
+
+	c := client.ServiceClient()
+	err := introspection.StartIntrospection(c, "c244557e-899f-46fa-a1ff-5b2c6718616b", introspection.StartOpts{}).ExtractErr()
+	th.AssertNoErr(t, err)
+}
+
+func TestAbortIntrospection(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleAbortIntrospectionSuccessfully(t)
+
+	c := client.ServiceClient()
+	err := introspection.AbortIntrospection(c, "c244557e-899f-46fa-a1ff-5b2c6718616b").ExtractErr()
+	th.AssertNoErr(t, err)
+}
+
+func TestGetIntrospectionData(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleGetIntrospectionDataSuccessfully(t)
+
+	c := client.ServiceClient()
+	actual, err := introspection.GetIntrospectionData(c, "c244557e-899f-46fa-a1ff-5b2c6718616b").Extract()
+	if err != nil {
+		t.Fatalf("Unexpected Get error: %v", err)
+	}
+
+	th.CheckDeepEquals(t, IntrospectionDataRes, *actual)
+}
+
+func TestReApplyIntrospection(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleReApplyIntrospectionSuccessfully(t)
+
+	c := client.ServiceClient()
+	err := introspection.ReApplyIntrospection(c, "c244557e-899f-46fa-a1ff-5b2c6718616b").ExtractErr()
+	th.AssertNoErr(t, err)
+}

--- a/openstack/baremetalintrospection/v1/introspection/urls.go
+++ b/openstack/baremetalintrospection/v1/introspection/urls.go
@@ -1,0 +1,23 @@
+package introspection
+
+import "github.com/gophercloud/gophercloud"
+
+func listIntrospectionsURL(client *gophercloud.ServiceClient) string {
+	return client.ServiceURL("introspection")
+}
+
+func introspectionURL(client *gophercloud.ServiceClient, nodeID string) string {
+	return client.ServiceURL("introspection", nodeID)
+}
+
+func abortIntrospectionURL(client *gophercloud.ServiceClient, nodeID string) string {
+	return client.ServiceURL("introspection", nodeID, "abort")
+}
+
+func introspectionDataURL(client *gophercloud.ServiceClient, nodeID string) string {
+	return client.ServiceURL("introspection", nodeID, "data")
+}
+
+func introspectionUnprocessedDataURL(client *gophercloud.ServiceClient, nodeID string) string {
+	return client.ServiceURL("introspection", nodeID, "data", "unprocessed")
+}

--- a/openstack/client.go
+++ b/openstack/client.go
@@ -310,6 +310,12 @@ func NewBareMetalV1(client *gophercloud.ProviderClient, eo gophercloud.EndpointO
 	return initClientOpts(client, eo, "baremetal")
 }
 
+// NewBareMetalIntrospectionV1 creates a ServiceClient that may be used with the v1
+// bare metal introspection package.
+func NewBareMetalIntrospectionV1(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
+	return initClientOpts(client, eo, "baremetal-inspector")
+}
+
 // NewObjectStorageV1 creates a ServiceClient that may be used with the v1
 // object storage package.
 func NewObjectStorageV1(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {

--- a/service_client.go
+++ b/service_client.go
@@ -131,6 +131,8 @@ func (client *ServiceClient) setMicroversionHeader(opts *RequestOpts) {
 		opts.MoreHeaders["X-OpenStack-Volume-API-Version"] = client.Microversion
 	case "baremetal":
 		opts.MoreHeaders["X-OpenStack-Ironic-API-Version"] = client.Microversion
+	case "baremetal-introspection":
+		opts.MoreHeaders["X-OpenStack-Ironic-Inspector-API-Version"] = client.Microversion
 	}
 
 	if client.Type != "" {


### PR DESCRIPTION
For #1485

This patch adds the Node Introspection API calls according to [1]

Start Introspection (POST)
Get Introspection status (GET)
List all Introspection statuses (GET)
Abort Introspection (POST)
Get Introspection Data (GET)
Reapply Introspection on stored data (POST)

Source code reference:
https://github.com/openstack/ironic-inspector/tree/master/ironic_inspector

[1] https://developer.openstack.org/api-ref/baremetal-introspection/#node-introspection
