### PR TITLE
Octavia: Support to specify vip_port_id for creating load balancer

### DIFF
--- a/openstack/loadbalancer/v2/loadbalancers/requests.go
+++ b/openstack/loadbalancer/v2/loadbalancers/requests.go
@@ -81,10 +81,16 @@ type CreateOpts struct {
 	// Human-readable description for the Loadbalancer.
 	Description string `json:"description,omitempty"`
 
+	// Providing a neutron port ID for the vip_port_id tells Octavia to use this
+	// port for the VIP. If the port has more than one subnet you must specify
+	// either the vip_subnet_id or vip_address to clarify which address should
+	// be used for the VIP.
+	VipPortID string `json:"vip_port_id,omitempty"`
+
 	// The subnet on which to allocate the Loadbalancer's address. A project can
 	// only create Loadbalancers on networks authorized by policy (e.g. networks
 	// that belong to them or networks that are shared).
-	VipSubnetID string `json:"vip_subnet_id" required:"true"`
+	VipSubnetID string `json:"vip_subnet_id,omitempty"`
 
 	// The network on which to allocate the Loadbalancer's address. A tenant can
 	// only create Loadbalancers on networks authorized by policy (e.g. networks

--- a/openstack/loadbalancer/v2/loadbalancers/testing/fixtures.go
+++ b/openstack/loadbalancer/v2/loadbalancers/testing/fixtures.go
@@ -258,6 +258,7 @@ func HandleLoadbalancerCreationSuccessfully(t *testing.T, response string) {
 		th.TestJSONRequest(t, r, `{
 			"loadbalancer": {
 				"name": "db_lb",
+				"vip_port_id": "2bf413c8-41a9-4477-b505-333d5cbe8b55",
 				"vip_subnet_id": "9cedb85d-0759-4898-8a4b-fa5a5ea10086",
 				"vip_address": "10.30.176.48",
 				"flavor": "medium",

--- a/openstack/loadbalancer/v2/loadbalancers/testing/requests_test.go
+++ b/openstack/loadbalancer/v2/loadbalancers/testing/requests_test.go
@@ -61,6 +61,7 @@ func TestCreateLoadbalancer(t *testing.T) {
 	actual, err := loadbalancers.Create(fake.ServiceClient(), loadbalancers.CreateOpts{
 		Name:         "db_lb",
 		AdminStateUp: gophercloud.Enabled,
+		VipPortID:    "2bf413c8-41a9-4477-b505-333d5cbe8b55",
 		VipSubnetID:  "9cedb85d-0759-4898-8a4b-fa5a5ea10086",
 		VipAddress:   "10.30.176.48",
 		Flavor:       "medium",
@@ -70,25 +71,6 @@ func TestCreateLoadbalancer(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	th.CheckDeepEquals(t, LoadbalancerDb, *actual)
-}
-
-func TestRequiredCreateOpts(t *testing.T) {
-	res := loadbalancers.Create(fake.ServiceClient(), loadbalancers.CreateOpts{})
-	if res.Err == nil {
-		t.Fatalf("Expected error, got none")
-	}
-	res = loadbalancers.Create(fake.ServiceClient(), loadbalancers.CreateOpts{Name: "foo"})
-	if res.Err == nil {
-		t.Fatalf("Expected error, got none")
-	}
-	res = loadbalancers.Create(fake.ServiceClient(), loadbalancers.CreateOpts{Name: "foo", Description: "bar"})
-	if res.Err == nil {
-		t.Fatalf("Expected error, got none")
-	}
-	res = loadbalancers.Create(fake.ServiceClient(), loadbalancers.CreateOpts{Name: "foo", Description: "bar", VipAddress: "bar"})
-	if res.Err == nil {
-		t.Fatalf("Expected error, got none")
-	}
 }
 
 func TestGetLoadbalancer(t *testing.T) {


### PR DESCRIPTION
For #1489

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

- Source code: <https://github.com/openstack/octavia/blob/612b042e64d9fcffb983f958ed0d6de6a9f765d3/octavia/api/v2/types/load_balancer.py#L115>
- API doc: <https://developer.openstack.org/api-ref/load-balancer/v2/index.html#create-a-load-balancer>
