### PR TITLE
check for project id if project name specified

### DIFF
--- a/openstack/auth_env.go
+++ b/openstack/auth_env.go
@@ -13,15 +13,19 @@ AuthOptionsFromEnv fills out an identity.AuthOptions structure with the
 settings found on the various OpenStack OS_* environment variables.
 
 The following variables provide sources of truth: OS_AUTH_URL, OS_USERNAME,
-OS_PASSWORD, OS_TENANT_ID, and OS_TENANT_NAME.
+OS_PASSWORD and OS_PROJECT_ID.
 
 Of these, OS_USERNAME, OS_PASSWORD, and OS_AUTH_URL must have settings,
-or an error will result.  OS_TENANT_ID, OS_TENANT_NAME, OS_PROJECT_ID, and
-OS_PROJECT_NAME are optional.
+or an error will result.  OS_PROJECT_ID, is optional.
 
-OS_TENANT_ID and OS_TENANT_NAME are mutually exclusive to OS_PROJECT_ID and
-OS_PROJECT_NAME. If OS_PROJECT_ID and OS_PROJECT_NAME are set, they will
-still be referred as "tenant" in Gophercloud.
+OS_TENANT_ID and OS_TENANT_NAME are deprecated forms of OS_PROJECT_ID and
+OS_PROJECT_NAME and the latter are expected against a v3 auth api.
+
+If OS_PROJECT_ID and OS_PROJECT_NAME are set, they will still be referred
+as "tenant" in Gophercloud.
+
+If OS_PROJECT_NAME is set, it requires OS_PROJECT_ID to be set as well to
+handle projects not on the default domain.
 
 To use this function, first set the OS_* environment variables (for example,
 by sourcing an `openrc` file), then:
@@ -79,6 +83,13 @@ func AuthOptionsFromEnv() (gophercloud.AuthOptions, error) {
 	if (applicationCredentialID != "" || applicationCredentialName != "") && applicationCredentialSecret == "" {
 		err := gophercloud.ErrMissingEnvironmentVariable{
 			EnvironmentVariable: "OS_APPLICATION_CREDENTIAL_SECRET",
+		}
+		return nilOptions, err
+	}
+
+	if domainID == "" && domainName == "" && tenantID == "" && tenantName != "" {
+		err := gophercloud.ErrMissingEnvironmentVariable{
+			EnvironmentVariable: "OS_PROJECT_ID",
 		}
 		return nilOptions, err
 	}


### PR DESCRIPTION
Check extra params are set if project name is given

Setting project name is insufficient according to the spec for project scoped auth.

For #1491 

https://developer.openstack.org/api-ref/identity/v3/?expanded=password-authentication-with-scoped-authorization-detail#authenticating-with-an-application-credential

