### PR TITLE
Baremetal API V1: Update can use any serializable value

### DIFF
--- a/openstack/baremetal/v1/nodes/requests.go
+++ b/openstack/baremetal/v1/nodes/requests.go
@@ -280,9 +280,9 @@ const (
 )
 
 type UpdateOperation struct {
-	Op    UpdateOp `json:"op" required:"true"`
-	Path  string   `json:"path" required:"true"`
-	Value string   `json:"value,omitempty"`
+	Op    UpdateOp    `json:"op" required:"true"`
+	Path  string      `json:"path" required:"true"`
+	Value interface{} `json:"value,omitempty"`
 }
 
 func (opts UpdateOperation) ToNodeUpdateMap() (map[string]interface{}, error) {
@@ -307,9 +307,12 @@ func Update(client *gophercloud.ServiceClient, id string, opts UpdateOpts) (r Up
 		OkCodes:  []int{200},
 	})
 
-	r.Body = resp.Body
-	r.Header = resp.Header
-	r.Err = err
+	if err != nil {
+		r.Err = err
+	} else {
+		r.Body = resp.Body
+		r.Header = resp.Header
+	}
 
 	return
 }

--- a/openstack/baremetal/v1/nodes/testing/fixtures.go
+++ b/openstack/baremetal/v1/nodes/testing/fixtures.go
@@ -834,7 +834,7 @@ func HandleNodeUpdateSuccessfully(t *testing.T, response string) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		th.TestHeader(t, r, "Accept", "application/json")
 		th.TestHeader(t, r, "Content-Type", "application/json")
-		th.TestJSONRequest(t, r, `[{"op": "replace", "path": "/driver", "value": "new-driver"}]`)
+		th.TestJSONRequest(t, r, `[{"op": "replace", "path": "/properties", "value": {"root_gb": 25}}]`)
 
 		fmt.Fprintf(w, response)
 	})

--- a/openstack/baremetal/v1/nodes/testing/requests_test.go
+++ b/openstack/baremetal/v1/nodes/testing/requests_test.go
@@ -141,9 +141,11 @@ func TestUpdateNode(t *testing.T) {
 	c := client.ServiceClient()
 	actual, err := nodes.Update(c, "1234asdf", nodes.UpdateOpts{
 		nodes.UpdateOperation{
-			Op:    nodes.ReplaceOp,
-			Path:  "/driver",
-			Value: "new-driver",
+			Op:   nodes.ReplaceOp,
+			Path: "/properties",
+			Value: map[string]interface{}{
+				"root_gb": 25,
+			},
 		},
 	}).Extract()
 	if err != nil {


### PR DESCRIPTION
For #1429

The `Value` field for Updates can actually be any serializable value, depending on the `Path` you're modifying.  For example, `properties` can be a `map[string]interface{}`, `maintenance` can be just a boolean, etc.

- API ref: https://developer.openstack.org/api-ref/baremetal/?expanded=update-node-detail


