### PR TITLE
baremetal v1: add support for 409 errors

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -122,6 +122,11 @@ type ErrDefault408 struct {
 	ErrUnexpectedResponseCode
 }
 
+// ErrDefault409 is the default error type returned on a 409 HTTP response code.
+type ErrDefault409 struct {
+	ErrUnexpectedResponseCode
+}
+
 // ErrDefault429 is the default error type returned on a 429 HTTP response code.
 type ErrDefault429 struct {
 	ErrUnexpectedResponseCode
@@ -209,6 +214,12 @@ type Err405er interface {
 // from a 408 error.
 type Err408er interface {
 	Error408(ErrUnexpectedResponseCode) error
+}
+
+// Err409er is the interface resource error types implement to override the error message
+// from a 409 error.
+type Err409er interface {
+	Error409(ErrUnexpectedResponseCode) error
 }
 
 // Err429er is the interface resource error types implement to override the error message

--- a/openstack/baremetal/v1/nodes/testing/fixtures.go
+++ b/openstack/baremetal/v1/nodes/testing/fixtures.go
@@ -910,6 +910,15 @@ func HandleNodeChangeProvisionStateClean(t *testing.T) {
 	})
 }
 
+func HandleNodeChangeProvisionStateCleanWithConflict(t *testing.T) {
+	th.Mux.HandleFunc("/nodes/1234asdf/states/provision", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, NodeProvisionStateCleanBody)
+		w.WriteHeader(http.StatusConflict)
+	})
+}
+
 // HandleChangePowerStateSuccessfully sets up the test server to respond to a change power state request for a node
 func HandleChangePowerStateSuccessfully(t *testing.T) {
 	th.Mux.HandleFunc("/nodes/1234asdf/states/power", func(w http.ResponseWriter, r *http.Request) {
@@ -921,5 +930,19 @@ func HandleChangePowerStateSuccessfully(t *testing.T) {
 		}`)
 
 		w.WriteHeader(http.StatusAccepted)
+	})
+}
+
+// HandleChangePowerStateWithConflict sets up the test server to respond to a change power state request for a node with a 409 error
+func HandleChangePowerStateWithConflict(t *testing.T) {
+	th.Mux.HandleFunc("/nodes/1234asdf/states/power", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, `{
+			"target": "power on",
+			"timeout": 100
+		}`)
+
+		w.WriteHeader(http.StatusConflict)
 	})
 }

--- a/provider_client.go
+++ b/provider_client.go
@@ -436,6 +436,11 @@ func (client *ProviderClient) Request(method, url string, options *RequestOpts) 
 			if error408er, ok := errType.(Err408er); ok {
 				err = error408er.Error408(respErr)
 			}
+		case http.StatusConflict:
+			err = ErrDefault409{respErr}
+			if error409er, ok := errType.(Err409er); ok {
+				err = error409er.Error409(respErr)
+			}
 		case 429:
 			err = ErrDefault429{respErr}
 			if error429er, ok := errType.(Err429er); ok {


### PR DESCRIPTION
For #1497

Add ErrDefault409 and convert http.StatusConflict errors to ErrDefault409.

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

- https://github.com/openstack/ironic/blob/master/ironic/api/controllers/v1/node.py#L507
- https://github.com/openstack/ironic/blob/master/ironic/api/controllers/v1/node.py#L642
