### PR TITLE
Compute V2: add support for hypervisor string UUID

### DIFF
--- a/acceptance/openstack/compute/v2/hypervisors_test.go
+++ b/acceptance/openstack/compute/v2/hypervisors_test.go
@@ -80,7 +80,7 @@ func TestHypervisorsGetUptime(t *testing.T) {
 	th.AssertEquals(t, hypervisorID, hypervisor.ID)
 }
 
-func getHypervisorID(t *testing.T, client *gophercloud.ServiceClient) (int, error) {
+func getHypervisorID(t *testing.T, client *gophercloud.ServiceClient) (string, error) {
 	allPages, err := hypervisors.List(client).AllPages()
 	th.AssertNoErr(t, err)
 
@@ -91,5 +91,5 @@ func getHypervisorID(t *testing.T, client *gophercloud.ServiceClient) (int, erro
 		return allHypervisors[0].ID, nil
 	}
 
-	return 0, fmt.Errorf("Unable to get hypervisor ID")
+	return "", fmt.Errorf("Unable to get hypervisor ID")
 }

--- a/openstack/compute/v2/extensions/hypervisors/doc.go
+++ b/openstack/compute/v2/extensions/hypervisors/doc.go
@@ -4,11 +4,21 @@ and shows summary statistics for all hypervisors over all compute nodes in the O
 
 Example of Show Hypervisor Details
 
-	hypervisorID := 42
-	hypervisor, err := hypervisors.Get(computeClient, 42).Extract()
+	hypervisorID := "42"
+	hypervisor, err := hypervisors.Get(computeClient, hypervisorID).Extract()
 	if err != nil {
 		panic(err)
 	}
+
+	fmt.Printf("%+v\n", hypervisor)
+
+Example of Show Hypervisor Details with Compute API microversion older that 2.53
+
+    hypervisorID := "c48f6247-abe4-4a24-824e-ea39e108874f"
+    hypervisor, err := hypervisors.Get(computeClient, hypervisorID).Extract()
+    if err != nil {
+        panic(err)
+    }
 
 	fmt.Printf("%+v\n", hypervisor)
 
@@ -28,7 +38,7 @@ Example of Retrieving Details of All Hypervisors
 		fmt.Printf("%+v\n", hypervisor)
 	}
 
-Example of Show Hypervisor Statistics
+Example of Show Hypervisors Statistics
 
 	hypervisorsStatistics, err := hypervisors.GetStatistics(computeClient).Extract()
 	if err != nil {
@@ -37,9 +47,9 @@ Example of Show Hypervisor Statistics
 
 	fmt.Printf("%+v\n", hypervisorsStatistics)
 
-Example of Show Hypervisor Uptime
+Example of Show Hypervisor Uptime with Compute API microversion older that 2.53
 
-	hypervisorID := 42
+	hypervisorID := "42"
 	hypervisorUptime, err := hypervisors.GetUptime(computeClient, hypervisorID).Extract()
 	if err != nil {
 		panic(err)
@@ -47,5 +57,14 @@ Example of Show Hypervisor Uptime
 
 	fmt.Printf("%+v\n", hypervisorUptime)
 
+Example of Show Hypervisor Uptime
+
+    hypervisorID := "c48f6247-abe4-4a24-824e-ea39e108874f"
+    hypervisorUptime, err := hypervisors.GetUptime(computeClient, hypervisorID).Extract()
+    if err != nil {
+        panic(err)
+    }
+
+	fmt.Printf("%+v\n", hypervisorUptime)
 */
 package hypervisors

--- a/openstack/compute/v2/extensions/hypervisors/requests.go
+++ b/openstack/compute/v2/extensions/hypervisors/requests.go
@@ -1,8 +1,6 @@
 package hypervisors
 
 import (
-	"strconv"
-
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/pagination"
 )
@@ -23,18 +21,16 @@ func GetStatistics(client *gophercloud.ServiceClient) (r StatisticsResult) {
 }
 
 // Get makes a request against the API to get details for specific hypervisor.
-func Get(client *gophercloud.ServiceClient, hypervisorID int) (r HypervisorResult) {
-	v := strconv.Itoa(hypervisorID)
-	_, r.Err = client.Get(hypervisorsGetURL(client, v), &r.Body, &gophercloud.RequestOpts{
+func Get(client *gophercloud.ServiceClient, hypervisorID string) (r HypervisorResult) {
+	_, r.Err = client.Get(hypervisorsGetURL(client, hypervisorID), &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{200},
 	})
 	return
 }
 
 // GetUptime makes a request against the API to get uptime for specific hypervisor.
-func GetUptime(client *gophercloud.ServiceClient, hypervisorID int) (r UptimeResult) {
-	v := strconv.Itoa(hypervisorID)
-	_, r.Err = client.Get(hypervisorsUptimeURL(client, v), &r.Body, &gophercloud.RequestOpts{
+func GetUptime(client *gophercloud.ServiceClient, hypervisorID string) (r UptimeResult) {
+	_, r.Err = client.Get(hypervisorsUptimeURL(client, hypervisorID), &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{200},
 	})
 	return

--- a/openstack/compute/v2/extensions/hypervisors/results.go
+++ b/openstack/compute/v2/extensions/hypervisors/results.go
@@ -148,7 +148,7 @@ func (r *Hypervisor) UnmarshalJSON(b []byte) error {
 	case float64:
 		r.HypervisorVersion = int(t)
 	default:
-		return fmt.Errorf("Hypervisor version of unexpected type")
+		return fmt.Errorf("Hypervisor version has unexpected type: %T", t)
 	}
 
 	switch t := s.FreeDiskGB.(type) {
@@ -157,7 +157,7 @@ func (r *Hypervisor) UnmarshalJSON(b []byte) error {
 	case float64:
 		r.FreeDiskGB = int(t)
 	default:
-		return fmt.Errorf("Free disk GB of unexpected type")
+		return fmt.Errorf("Free disk GB has unexpected type: %T", t)
 	}
 
 	switch t := s.LocalGB.(type) {
@@ -166,7 +166,7 @@ func (r *Hypervisor) UnmarshalJSON(b []byte) error {
 	case float64:
 		r.LocalGB = int(t)
 	default:
-		return fmt.Errorf("Local GB of unexpected type")
+		return fmt.Errorf("Local GB has unexpected type: %T", t)
 	}
 
 	// OpenStack Compute service returns ID in string representation since
@@ -179,7 +179,7 @@ func (r *Hypervisor) UnmarshalJSON(b []byte) error {
 	case string:
 		r.ID = t
 	default:
-		return fmt.Errorf("ID of unexpected type: %+v", t)
+		return fmt.Errorf("ID has unexpected type: %T", t)
 	}
 
 	return nil
@@ -315,7 +315,7 @@ func (r *Uptime) UnmarshalJSON(b []byte) error {
 	case string:
 		r.ID = t
 	default:
-		return fmt.Errorf("ID of unexpected type: %+v", t)
+		return fmt.Errorf("ID has unexpected type: %T", t)
 	}
 
 	return nil

--- a/openstack/compute/v2/extensions/hypervisors/testing/fixtures.go
+++ b/openstack/compute/v2/extensions/hypervisors/testing/fixtures.go
@@ -122,7 +122,7 @@ const HypervisorListBody = `
             "running_vms": 0,
             "service": {
                 "host": "e6a37ee802d74863ab8b91ade8f12a67",
-                "id": 2,
+                "id": "9c2566e7-7a54-4777-a1ae-c2662f0c407c",
                 "disabled_reason": null
             },
             "vcpus": 1,
@@ -148,7 +148,7 @@ const HypervisorListBody = `
             "running_vms": 0,
             "service": {
                 "host": "e6a37ee802d74863ab8b91ade8f12a67",
-                "id": 2,
+                "id": "9c2566e7-7a54-4777-a1ae-c2662f0c407c",
                 "disabled_reason": null
             },
             "vcpus": 1,
@@ -212,7 +212,7 @@ const HypervisorGetBody = `
         "running_vms":0,
         "service":{
             "host":"e6a37ee802d74863ab8b91ade8f12a67",
-            "id":2,
+            "id":"9c2566e7-7a54-4777-a1ae-c2662f0c407c",
             "disabled_reason":null
         },
         "vcpus":1,
@@ -269,7 +269,7 @@ var (
 		RunningVMs:         0,
 		Service: hypervisors.Service{
 			Host:           "e6a37ee802d74863ab8b91ade8f12a67",
-			ID:             2,
+			ID:             "2",
 			DisabledReason: "",
 		},
 		VCPUs:     1,
@@ -308,7 +308,7 @@ var (
 		RunningVMs:         0,
 		Service: hypervisors.Service{
 			Host:           "e6a37ee802d74863ab8b91ade8f12a67",
-			ID:             2,
+			ID:             "9c2566e7-7a54-4777-a1ae-c2662f0c407c",
 			DisabledReason: "",
 		},
 		VCPUs:     1,

--- a/openstack/compute/v2/extensions/hypervisors/testing/fixtures.go
+++ b/openstack/compute/v2/extensions/hypervisors/testing/fixtures.go
@@ -3,7 +3,6 @@ package testing
 import (
 	"fmt"
 	"net/http"
-	"strconv"
 	"testing"
 
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/hypervisors"
@@ -11,9 +10,11 @@ import (
 	"github.com/gophercloud/gophercloud/testhelper/client"
 )
 
+// HypervisorListBodyPre253 represents a raw hypervisor list from the Compute
+// API with microversion older than 2.53.
 // The first hypervisor represents what the specification says (~Newton)
 // The second is exactly the same, but what you can get off a real system (~Kilo)
-const HypervisorListBody = `
+const HypervisorListBodyPre253 = `
 {
     "hypervisors": [
         {
@@ -84,6 +85,78 @@ const HypervisorListBody = `
     ]
 }`
 
+// HypervisorListBody represents a raw hypervisor list result with Pike+ release.
+const HypervisorListBody = `
+{
+    "hypervisors": [
+        {
+            "cpu_info": {
+                "arch": "x86_64",
+                "model": "Nehalem",
+                "vendor": "Intel",
+                "features": [
+                    "pge",
+                    "clflush"
+                ],
+                "topology": {
+                    "cores": 1,
+                    "threads": 1,
+                    "sockets": 4
+                }
+            },
+            "current_workload": 0,
+            "status": "enabled",
+            "state": "up",
+            "disk_available_least": 0,
+            "host_ip": "1.1.1.1",
+            "free_disk_gb": 1028,
+            "free_ram_mb": 7680,
+            "hypervisor_hostname": "fake-mini",
+            "hypervisor_type": "fake",
+            "hypervisor_version": 2002000,
+            "id": "c48f6247-abe4-4a24-824e-ea39e108874f",
+            "local_gb": 1028,
+            "local_gb_used": 0,
+            "memory_mb": 8192,
+            "memory_mb_used": 512,
+            "running_vms": 0,
+            "service": {
+                "host": "e6a37ee802d74863ab8b91ade8f12a67",
+                "id": 2,
+                "disabled_reason": null
+            },
+            "vcpus": 1,
+            "vcpus_used": 0
+        },
+        {
+            "cpu_info": "{\"arch\": \"x86_64\", \"model\": \"Nehalem\", \"vendor\": \"Intel\", \"features\": [\"pge\", \"clflush\"], \"topology\": {\"cores\": 1, \"threads\": 1, \"sockets\": 4}}",
+            "current_workload": 0,
+            "status": "enabled",
+            "state": "up",
+            "disk_available_least": 0,
+            "host_ip": "1.1.1.1",
+            "free_disk_gb": 1028,
+            "free_ram_mb": 7680,
+            "hypervisor_hostname": "fake-mini",
+            "hypervisor_type": "fake",
+            "hypervisor_version": 2.002e+06,
+            "id": "c48f6247-abe4-4a24-824e-ea39e108874f",
+            "local_gb": 1028,
+            "local_gb_used": 0,
+            "memory_mb": 8192,
+            "memory_mb_used": 512,
+            "running_vms": 0,
+            "service": {
+                "host": "e6a37ee802d74863ab8b91ade8f12a67",
+                "id": 2,
+                "disabled_reason": null
+            },
+            "vcpus": 1,
+            "vcpus_used": 0
+        }
+    ]
+}`
+
 const HypervisorsStatisticsBody = `
 {
     "hypervisor_statistics": {
@@ -103,6 +176,7 @@ const HypervisorsStatisticsBody = `
 }
 `
 
+// HypervisorGetBody represents a raw hypervisor GET result with Pike+ release.
 const HypervisorGetBody = `
 {
     "hypervisor":{
@@ -130,7 +204,7 @@ const HypervisorGetBody = `
         "hypervisor_hostname":"fake-mini",
         "hypervisor_type":"fake",
         "hypervisor_version":2002000,
-        "id":1,
+        "id":"c48f6247-abe4-4a24-824e-ea39e108874f",
         "local_gb":1028,
         "local_gb_used":0,
         "memory_mb":8192,
@@ -147,11 +221,13 @@ const HypervisorGetBody = `
 }
 `
 
+// HypervisorUptimeBody represents a raw hypervisor uptime request result with
+// Pike+ release.
 const HypervisorUptimeBody = `
 {
     "hypervisor": {
         "hypervisor_hostname": "fake-mini",
-        "id": 1,
+        "id": "c48f6247-abe4-4a24-824e-ea39e108874f",
         "state": "up",
         "status": "enabled",
         "uptime": " 08:32:11 up 93 days, 18:25, 12 users,  load average: 0.20, 0.12, 0.14"
@@ -160,6 +236,45 @@ const HypervisorUptimeBody = `
 `
 
 var (
+	HypervisorFakePre253 = hypervisors.Hypervisor{
+		CPUInfo: hypervisors.CPUInfo{
+			Arch:   "x86_64",
+			Model:  "Nehalem",
+			Vendor: "Intel",
+			Features: []string{
+				"pge",
+				"clflush",
+			},
+			Topology: hypervisors.Topology{
+				Cores:   1,
+				Threads: 1,
+				Sockets: 4,
+			},
+		},
+		CurrentWorkload:    0,
+		Status:             "enabled",
+		State:              "up",
+		DiskAvailableLeast: 0,
+		HostIP:             "1.1.1.1",
+		FreeDiskGB:         1028,
+		FreeRamMB:          7680,
+		HypervisorHostname: "fake-mini",
+		HypervisorType:     "fake",
+		HypervisorVersion:  2002000,
+		ID:                 "1",
+		LocalGB:            1028,
+		LocalGBUsed:        0,
+		MemoryMB:           8192,
+		MemoryMBUsed:       512,
+		RunningVMs:         0,
+		Service: hypervisors.Service{
+			Host:           "e6a37ee802d74863ab8b91ade8f12a67",
+			ID:             2,
+			DisabledReason: "",
+		},
+		VCPUs:     1,
+		VCPUsUsed: 0,
+	}
 	HypervisorFake = hypervisors.Hypervisor{
 		CPUInfo: hypervisors.CPUInfo{
 			Arch:   "x86_64",
@@ -185,7 +300,7 @@ var (
 		HypervisorHostname: "fake-mini",
 		HypervisorType:     "fake",
 		HypervisorVersion:  2002000,
-		ID:                 1,
+		ID:                 "c48f6247-abe4-4a24-824e-ea39e108874f",
 		LocalGB:            1028,
 		LocalGBUsed:        0,
 		MemoryMB:           8192,
@@ -215,7 +330,7 @@ var (
 	}
 	HypervisorUptimeExpected = hypervisors.Uptime{
 		HypervisorHostname: "fake-mini",
-		ID:                 1,
+		ID:                 "c48f6247-abe4-4a24-824e-ea39e108874f",
 		State:              "up",
 		Status:             "enabled",
 		Uptime:             " 08:32:11 up 93 days, 18:25, 12 users,  load average: 0.20, 0.12, 0.14",
@@ -232,6 +347,16 @@ func HandleHypervisorsStatisticsSuccessfully(t *testing.T) {
 	})
 }
 
+func HandleHypervisorListPre253Successfully(t *testing.T) {
+	testhelper.Mux.HandleFunc("/os-hypervisors/detail", func(w http.ResponseWriter, r *http.Request) {
+		testhelper.TestMethod(t, r, "GET")
+		testhelper.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprintf(w, HypervisorListBodyPre253)
+	})
+}
+
 func HandleHypervisorListSuccessfully(t *testing.T) {
 	testhelper.Mux.HandleFunc("/os-hypervisors/detail", func(w http.ResponseWriter, r *http.Request) {
 		testhelper.TestMethod(t, r, "GET")
@@ -243,8 +368,7 @@ func HandleHypervisorListSuccessfully(t *testing.T) {
 }
 
 func HandleHypervisorGetSuccessfully(t *testing.T) {
-	v := strconv.Itoa(HypervisorFake.ID)
-	testhelper.Mux.HandleFunc("/os-hypervisors/"+v, func(w http.ResponseWriter, r *http.Request) {
+	testhelper.Mux.HandleFunc("/os-hypervisors/"+HypervisorFake.ID, func(w http.ResponseWriter, r *http.Request) {
 		testhelper.TestMethod(t, r, "GET")
 		testhelper.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
@@ -254,8 +378,7 @@ func HandleHypervisorGetSuccessfully(t *testing.T) {
 }
 
 func HandleHypervisorUptimeSuccessfully(t *testing.T) {
-	v := strconv.Itoa(HypervisorFake.ID)
-	testhelper.Mux.HandleFunc("/os-hypervisors/"+v+"/uptime", func(w http.ResponseWriter, r *http.Request) {
+	testhelper.Mux.HandleFunc("/os-hypervisors/"+HypervisorFake.ID+"/uptime", func(w http.ResponseWriter, r *http.Request) {
 		testhelper.TestMethod(t, r, "GET")
 		testhelper.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 

--- a/openstack/compute/v2/extensions/hypervisors/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/hypervisors/testing/requests_test.go
@@ -9,6 +9,49 @@ import (
 	"github.com/gophercloud/gophercloud/testhelper/client"
 )
 
+func TestListHypervisorsPre253(t *testing.T) {
+	testhelper.SetupHTTP()
+	defer testhelper.TeardownHTTP()
+	HandleHypervisorListPre253Successfully(t)
+
+	pages := 0
+	err := hypervisors.List(client.ServiceClient()).EachPage(func(page pagination.Page) (bool, error) {
+		pages++
+
+		actual, err := hypervisors.ExtractHypervisors(page)
+		if err != nil {
+			return false, err
+		}
+
+		if len(actual) != 2 {
+			t.Fatalf("Expected 2 hypervisors, got %d", len(actual))
+		}
+		testhelper.CheckDeepEquals(t, HypervisorFakePre253, actual[0])
+		testhelper.CheckDeepEquals(t, HypervisorFakePre253, actual[1])
+
+		return true, nil
+	})
+
+	testhelper.AssertNoErr(t, err)
+
+	if pages != 1 {
+		t.Errorf("Expected 1 page, saw %d", pages)
+	}
+}
+
+func TestListAllHypervisorsPre253(t *testing.T) {
+	testhelper.SetupHTTP()
+	defer testhelper.TeardownHTTP()
+	HandleHypervisorListPre253Successfully(t)
+
+	allPages, err := hypervisors.List(client.ServiceClient()).AllPages()
+	testhelper.AssertNoErr(t, err)
+	actual, err := hypervisors.ExtractHypervisors(allPages)
+	testhelper.AssertNoErr(t, err)
+	testhelper.CheckDeepEquals(t, HypervisorFakePre253, actual[0])
+	testhelper.CheckDeepEquals(t, HypervisorFakePre253, actual[1])
+}
+
 func TestListHypervisors(t *testing.T) {
 	testhelper.SetupHTTP()
 	defer testhelper.TeardownHTTP()


### PR DESCRIPTION
This commit adds support for the Compute API 2.53 microversion
hypervisors implementation by adding string UUIDs in the basic and
uptime hypervisor result structure.

It also updates unit and acceptance tests and extends the hypervisor
package documentation.

For #1388

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/nova/blob/stable/rocky/nova/api/openstack/compute/hypervisors.py#L60
https://github.com/openstack/nova/blob/stable/rocky/nova/api/openstack/compute/hypervisors.py#L75
https://github.com/openstack/nova/blob/stable/rocky/nova/api/openstack/compute/hypervisors.py#L252
