### PR TITLE
Compute V2: add 2.3 microversion OS-EXT-SRV-ATTR

### DIFF
--- a/acceptance/openstack/compute/v2/servers_test.go
+++ b/acceptance/openstack/compute/v2/servers_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gophercloud/gophercloud/acceptance/tools"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/attachinterfaces"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/availabilityzones"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/extendedserverattributes"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/extendedstatus"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/lockunlock"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/pauseunpause"
@@ -505,4 +506,57 @@ func TestServersTags(t *testing.T) {
 	server, err := CreateServerWithTags(t, client, networkID)
 	th.AssertNoErr(t, err)
 	defer DeleteServer(t, client, server)
+}
+
+func TestServersWithExtendedAttributesCreateDestroy(t *testing.T) {
+	clients.RequireLong(t)
+	clients.RequireAdmin(t)
+	clients.SkipRelease(t, "stable/mitaka")
+	clients.SkipRelease(t, "stable/newton")
+
+	client, err := clients.NewComputeV2Client()
+	th.AssertNoErr(t, err)
+	client.Microversion = "2.3"
+
+	server, err := CreateServer(t, client)
+	th.AssertNoErr(t, err)
+	defer DeleteServer(t, client, server)
+
+	result := servers.Get(client, server.ID)
+	th.AssertNoErr(t, result.Err)
+
+	reservationID, err := extendedserverattributes.ExtractReservationID(result.Result)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, reservationID != "", true)
+	t.Logf("reservationID: %s", reservationID)
+
+	launchIndex, err := extendedserverattributes.ExtractLaunchIndex(result.Result)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, launchIndex, 0)
+	t.Logf("launchIndex: %d", launchIndex)
+
+	ramdiskID, err := extendedserverattributes.ExtractRamdiskID(result.Result)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, ramdiskID == "", true)
+	t.Logf("ramdiskID: %s", ramdiskID)
+
+	kernelID, err := extendedserverattributes.ExtractKernelID(result.Result)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, kernelID == "", true)
+	t.Logf("kernelID: %s", kernelID)
+
+	hostname, err := extendedserverattributes.ExtractHostname(result.Result)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, hostname != "", true)
+	t.Logf("hostname: %s", hostname)
+
+	rootDeviceName, err := extendedserverattributes.ExtractRootDeviceName(result.Result)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, rootDeviceName != "", true)
+	t.Logf("rootDeviceName: %s", rootDeviceName)
+
+	userData, err := extendedserverattributes.ExtractUserData(result.Result)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, userData == "", true)
+	t.Logf("userData: %s", userData)
 }

--- a/openstack/compute/v2/extensions/extendedserverattributes/doc.go
+++ b/openstack/compute/v2/extensions/extendedserverattributes/doc.go
@@ -2,7 +2,7 @@
 Package extendedserverattributes provides the ability to extend a
 server result with the extended usage information.
 
-Example to Get an extended information:
+Example to Get basic extended information:
 
   type serverAttributesExt struct {
     servers.Server
@@ -16,5 +16,52 @@ Example to Get an extended information:
   }
 
   fmt.Printf("%+v\n", serverWithAttributesExt)
+
+Example to get additional fields with microversion 2.3 or later
+
+  computeClient.Microversion = "2.3"
+  result := servers.Get(computeClient, "d650a0ce-17c3-497d-961a-43c4af80998a")
+
+  reservationID, err := extendedserverattributes.ExtractReservationID(result.Result)
+  if err != nil {
+    panic(err)
+  }
+  fmt.Printf("%s\n", reservationID)
+
+  launchIndex, err := extendedserverattributes.ExtractLaunchIndex(result.Result)
+  if err != nil {
+    panic(err)
+  }
+  fmt.Printf("%d\n", launchIndex)
+
+  ramdiskID, err := extendedserverattributes.ExtractRamdiskID(result.Result)
+  if err != nil {
+    panic(err)
+  }
+  fmt.Printf("%s\n", ramdiskID)
+
+  kernelID, err := extendedserverattributes.ExtractKernelID(result.Result)
+  if err != nil {
+    panic(err)
+  }
+  fmt.Printf("%s\n", kernelID)
+
+  hostname, err := extendedserverattributes.ExtractHostname(result.Result)
+  if err != nil {
+    panic(err)
+  }
+  fmt.Printf("%s\n", hostname)
+
+  rootDeviceName, err := extendedserverattributes.ExtractRootDeviceName(result.Result)
+  if err != nil {
+    panic(err)
+  }
+  fmt.Printf("%s\n", rootDeviceName)
+
+  userData, err := extendedserverattributes.ExtractUserData(result.Result)
+  if err != nil {
+    panic(err)
+  }
+  fmt.Printf("%s\n", userData)
 */
 package extendedserverattributes

--- a/openstack/compute/v2/extensions/extendedserverattributes/microversions.go
+++ b/openstack/compute/v2/extensions/extendedserverattributes/microversions.go
@@ -1,0 +1,82 @@
+package extendedserverattributes
+
+import (
+	"github.com/gophercloud/gophercloud"
+)
+
+// ExtractReservationID will extract the reservation_id attribute.
+// This requires the client to be set to microversion 2.3 or later.
+func ExtractReservationID(r gophercloud.Result) (string, error) {
+	var s struct {
+		ReservationID string `json:"OS-EXT-SRV-ATTR:reservation_id"`
+	}
+	err := r.ExtractIntoStructPtr(&s, "server")
+
+	return s.ReservationID, err
+}
+
+// ExtractLaunchIndex will extract the launch_index attribute.
+// This requires the client to be set to microversion 2.3 or later.
+func ExtractLaunchIndex(r gophercloud.Result) (int, error) {
+	var s struct {
+		LaunchIndex int `json:"OS-EXT-SRV-ATTR:launch_index"`
+	}
+	err := r.ExtractIntoStructPtr(&s, "server")
+
+	return s.LaunchIndex, err
+}
+
+// ExtractRamdiskID will extract the ramdisk_id attribute.
+// This requires the client to be set to microversion 2.3 or later.
+func ExtractRamdiskID(r gophercloud.Result) (string, error) {
+	var s struct {
+		RamdiskID string `json:"OS-EXT-SRV-ATTR:ramdisk_id"`
+	}
+	err := r.ExtractIntoStructPtr(&s, "server")
+
+	return s.RamdiskID, err
+}
+
+// ExtractKernelID will extract the kernel_id attribute.
+// This requires the client to be set to microversion 2.3 or later.
+func ExtractKernelID(r gophercloud.Result) (string, error) {
+	var s struct {
+		KernelID string `json:"OS-EXT-SRV-ATTR:kernel_id"`
+	}
+	err := r.ExtractIntoStructPtr(&s, "server")
+
+	return s.KernelID, err
+}
+
+// ExtractHostname will extract the hostname attribute.
+// This requires the client to be set to microversion 2.3 or later.
+func ExtractHostname(r gophercloud.Result) (string, error) {
+	var s struct {
+		Hostname string `json:"OS-EXT-SRV-ATTR:hostname"`
+	}
+	err := r.ExtractIntoStructPtr(&s, "server")
+
+	return s.Hostname, err
+}
+
+// ExtractRootDeviceName will extract the root_device_name attribute.
+// This requires the client to be set to microversion 2.3 or later.
+func ExtractRootDeviceName(r gophercloud.Result) (string, error) {
+	var s struct {
+		RootDeviceName string `json:"OS-EXT-SRV-ATTR:root_device_name"`
+	}
+	err := r.ExtractIntoStructPtr(&s, "server")
+
+	return s.RootDeviceName, err
+}
+
+// ExtractUserData will extract the userdata attribute.
+// This requires the client to be set to microversion 2.3 or later.
+func ExtractUserData(r gophercloud.Result) (string, error) {
+	var s struct {
+		Userdata string `json:"OS-EXT-SRV-ATTR:userdata"`
+	}
+	err := r.ExtractIntoStructPtr(&s, "server")
+
+	return s.Userdata, err
+}

--- a/openstack/compute/v2/extensions/extendedserverattributes/results.go
+++ b/openstack/compute/v2/extensions/extendedserverattributes/results.go
@@ -1,17 +1,8 @@
 package extendedserverattributes
 
-// ServerAttributesExt represents OS-EXT-SRV-ATTR server response fields.
-//
-// Following fields will be added after implementing full API microversion
-// support in the Gophercloud:
-//
-//  - OS-EXT-SRV-ATTR:reservation_id"
-//  - OS-EXT-SRV-ATTR:launch_index"
-//  - OS-EXT-SRV-ATTR:hostname"
-//  - OS-EXT-SRV-ATTR:kernel_id"
-//  - OS-EXT-SRV-ATTR:ramdisk_id"
-//  - OS-EXT-SRV-ATTR:root_device_name"
-//  - OS-EXT-SRV-ATTR:user_data"
+// ServerAttributesExt represents basic OS-EXT-SRV-ATTR server response fields.
+// You should use extract methods from microversions.go to retrieve additional
+// fields.
 type ServerAttributesExt struct {
 	Host               string `json:"OS-EXT-SRV-ATTR:host"`
 	InstanceName       string `json:"OS-EXT-SRV-ATTR:instance_name"`

--- a/openstack/compute/v2/extensions/extendedserverattributes/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/extendedserverattributes/testing/requests_test.go
@@ -28,10 +28,31 @@ func TestServerWithUsageExt(t *testing.T) {
 		extendedserverattributes.ServerAttributesExt
 	}
 	var serverWithAttributesExt serverAttributesExt
+
+	result := servers.Get(fake.ServiceClient(), "d650a0ce-17c3-497d-961a-43c4af80998a")
+
+	// Extract basic fields.
 	err := servers.Get(fake.ServiceClient(), "d650a0ce-17c3-497d-961a-43c4af80998a").ExtractInto(&serverWithAttributesExt)
+	th.AssertNoErr(t, err)
+
+	// Extract additional fields.
+	reservationID, err := extendedserverattributes.ExtractReservationID(result.Result)
+	th.AssertNoErr(t, err)
+
+	launchIndex, err := extendedserverattributes.ExtractLaunchIndex(result.Result)
+	th.AssertNoErr(t, err)
+
+	hostname, err := extendedserverattributes.ExtractHostname(result.Result)
+	th.AssertNoErr(t, err)
+
+	rootDeviceName, err := extendedserverattributes.ExtractRootDeviceName(result.Result)
 	th.AssertNoErr(t, err)
 
 	th.AssertEquals(t, serverWithAttributesExt.Host, "compute01")
 	th.AssertEquals(t, serverWithAttributesExt.InstanceName, "instance-00000001")
 	th.AssertEquals(t, serverWithAttributesExt.HypervisorHostname, "compute01")
+	th.AssertEquals(t, reservationID, "r-ky9gim1l")
+	th.AssertEquals(t, launchIndex, 0)
+	th.AssertEquals(t, hostname, "test00")
+	th.AssertEquals(t, rootDeviceName, "/dev/sda")
 }


### PR DESCRIPTION
Add microversions.go to extendedserverattributes extension with support
to retrieve the following fields from the servers responses:
 - OS-EXT-SRV-ATTR:reservation_id
 - OS-EXT-SRV-ATTR:launch_index
 - OS-EXT-SRV-ATTR:ramdisk_id
 - OS-EXT-SRV-ATTR:kernel_id
 - OS-EXT-SRV-ATTR:hostname
 - OS-EXT-SRV-ATTR:root_device_name
 - OS-EXT-SRV-ATTR:userdata

Update unit tests and documentation.

For #1160

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/nova/blob/stable/rocky/nova/db/sqlalchemy/models.py#L253
