### PR TITLE
Add description into create server request

### DIFF
--- a/openstack/compute/v2/servers/microversions.go
+++ b/openstack/compute/v2/servers/microversions.go
@@ -1,0 +1,11 @@
+package servers
+
+// ExtractDescription will extract the description of a server.
+// This requires the client to be set to microversion 2.19 or later.
+func (r serverResult) ExtractDescription() (string, error) {
+	var s struct {
+		Description string `json:"description"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Description, err
+}

--- a/openstack/compute/v2/servers/requests.go
+++ b/openstack/compute/v2/servers/requests.go
@@ -225,6 +225,9 @@ type CreateOpts struct {
 	// Tags allows a server to be tagged with single-word metadata.
 	// Requires microversion 2.52 or later.
 	Tags []string `json:"tags,omitempty"`
+
+	// Description allows add description to a server
+	Description string `json:"description,omitempty"`
 }
 
 // ToServerCreateMap assembles a request body based on the contents of a

--- a/openstack/compute/v2/servers/requests.go
+++ b/openstack/compute/v2/servers/requests.go
@@ -227,6 +227,7 @@ type CreateOpts struct {
 	Tags []string `json:"tags,omitempty"`
 
 	// Description allows add description to a server
+	// Requires microversion 2.19 or later.
 	Description string `json:"description,omitempty"`
 }
 

--- a/openstack/compute/v2/servers/results.go
+++ b/openstack/compute/v2/servers/results.go
@@ -227,6 +227,9 @@ type Server struct {
 	// contain at most one entry.
 	// New in microversion 2.71
 	ServerGroups *[]string `json:"server_groups"`
+
+	// Description allows add description to a server
+	Description string `json:"description"`
 }
 
 type AttachedVolume struct {

--- a/openstack/compute/v2/servers/testing/fixtures.go
+++ b/openstack/compute/v2/servers/testing/fixtures.go
@@ -405,6 +405,16 @@ const ServerWithTagsCreateRequest = `
   }
 }`
 
+const ServerWithDescriptionCreateRequest = `
+{
+  "server": {
+    "name": "derp",
+    "imageRef": "f90f6034-2570-4974-8351-6b49732ef2eb",
+    "flavorRef": "1",
+    "description": "server1"
+  }
+}`
+
 // SingleServerWithTagsBody is the canned body of a Get request on an existing server with tags.
 const SingleServerWithTagsBody = `
 {
@@ -479,6 +489,83 @@ const SingleServerWithTagsBody = `
 		"metadata": {},
 		"tags": ["foo", "bar"]
 	}
+}
+`
+
+// SingleServerWithDescriptionBody is the canned body of a Get request on an existing server with tags.
+const SingleServerWithDescriptionBody = `
+{
+        "server": {
+                "status": "ACTIVE",
+                "updated": "2014-09-25T13:04:49Z",
+                "hostId": "29d3c8c896a45aa4c34e52247875d7fefc3d94bbcc9f622b5d204362",
+                "OS-EXT-SRV-ATTR:host": "devstack",
+                "addresses": {
+                        "private": [
+                                {
+                                        "OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:9e:89:be",
+                                        "version": 4,
+                                        "addr": "10.0.0.31",
+                                        "OS-EXT-IPS:type": "fixed"
+                                }
+                        ]
+                },
+                "links": [
+                        {
+                                "href": "http://104.130.131.164:8774/v2/fcad67a6189847c4aecfa3c81a05783b/servers/9e5476bd-a4ec-4653-93d6-72c93aa682ba",
+                                "rel": "self"
+                        },
+                        {
+                                "href": "http://104.130.131.164:8774/fcad67a6189847c4aecfa3c81a05783b/servers/9e5476bd-a4ec-4653-93d6-72c93aa682ba",
+                                "rel": "bookmark"
+                        }
+                ],
+                "key_name": null,
+                "image": {
+                        "id": "f90f6034-2570-4974-8351-6b49732ef2eb",
+                        "links": [
+                                {
+                                        "href": "http://104.130.131.164:8774/fcad67a6189847c4aecfa3c81a05783b/images/f90f6034-2570-4974-8351-6b49732ef2eb",
+                                        "rel": "bookmark"
+                                }
+                        ]
+                },
+                "OS-EXT-STS:task_state": null,
+                "OS-EXT-STS:vm_state": "active",
+                "OS-EXT-SRV-ATTR:instance_name": "instance-0000001d",
+                "OS-SRV-USG:launched_at": "2014-09-25T13:04:49.000000",
+                "OS-EXT-SRV-ATTR:hypervisor_hostname": "devstack",
+                "flavor": {
+                        "id": "1",
+                        "links": [
+                                {
+                                        "href": "http://104.130.131.164:8774/fcad67a6189847c4aecfa3c81a05783b/flavors/1",
+                                        "rel": "bookmark"
+                                }
+                        ]
+                },
+                "id": "9e5476bd-a4ec-4653-93d6-72c93aa682ba",
+                "security_groups": [
+                        {
+                                "name": "default"
+                        }
+                ],
+                "OS-SRV-USG:terminated_at": null,
+                "OS-EXT-AZ:availability_zone": "nova",
+                "user_id": "9349aff8be7545ac9d2f1d00999a23cd",
+                "name": "derp",
+                "created": "2014-09-25T13:04:41Z",
+                "tenant_id": "fcad67a6189847c4aecfa3c81a05783b",
+                "OS-DCF:diskConfig": "MANUAL",
+                "os-extended-volumes:volumes_attached": [],
+                "accessIPv4": "",
+                "accessIPv6": "",
+                "progress": 0,
+                "OS-EXT-STS:power_state": 1,
+                "config_drive": "",
+                "metadata": {},
+		"description": "server1"
+        }
 }
 `
 
@@ -1234,5 +1321,20 @@ func HandleServerWithTagsCreationSuccessfully(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 
 		fmt.Fprintf(w, SingleServerWithTagsBody)
+	})
+}
+
+// HandleServerWithDescriptionCreationSuccessfully sets up the test server to respond
+// to a server creation request with a given response.
+func HandleServerWithDescriptionCreationSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/servers", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, ServerWithDescriptionCreateRequest)
+
+		w.WriteHeader(http.StatusAccepted)
+		w.Header().Add("Content-Type", "application/json")
+
+		fmt.Fprintf(w, SingleServerWithDescriptionBody)
 	})
 }

--- a/openstack/compute/v2/servers/testing/requests_test.go
+++ b/openstack/compute/v2/servers/testing/requests_test.go
@@ -592,3 +592,30 @@ func TestCreateServerWithTags(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.CheckDeepEquals(t, ServerDerpTags, *actualServer)
 }
+
+func TestCreateServerWithDescription(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleServerWithDescriptionCreationSuccessfully(t)
+
+	c := client.ServiceClient()
+	c.Microversion = "2.19"
+	description := "server1"
+	createOpts := servers.CreateOpts{
+		Name:        "derp",
+		ImageRef:    "f90f6034-2570-4974-8351-6b49732ef2eb",
+		FlavorRef:   "1",
+		Description: description,
+	}
+	ServerDerpDescription := ServerDerp
+	ServerDerpDescription.Description = "server1"
+	res := servers.Create(c, createOpts)
+	th.AssertNoErr(t, res.Err)
+	actualServer, err := res.Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, ServerDerpDescription, *actualServer)
+
+	actualDescription, err := res.ExtractDescription()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, "server1", actualDescription)
+}


### PR DESCRIPTION
descrption added in nova 2.19 and not support now


For #1504

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:
https://developer.openstack.org/api-ref/compute/?expanded=list-all-metadata-detail,create-server-detail#create-server


description (Optional) | body | string | A free form description of the server. Limited to 255 characters in length. Before microversion 2.19 this was set to the server name. New in version 2.19
-- | -- | -- | --

https://github.com/openstack/nova/blob/14c4c8040ce7b3180c2ff2ef1513a30c94805e41/nova/api/openstack/compute/servers.py#L576-L577

