### PR TITLE
Change UpdatedAt and CreatedAt to time.Time

### DIFF
--- a/openstack/baremetal/v1/ports/results.go
+++ b/openstack/baremetal/v1/ports/results.go
@@ -1,6 +1,9 @@
 package ports
 
 import (
+	"encoding/json"
+	"time"
+
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/pagination"
 )
@@ -59,17 +62,37 @@ type Port struct {
 	Extra map[string]interface{} `json:"extra"`
 
 	// The UTC date and time when the resource was created, ISO 8601 format.
-	CreatedAt string `json:"created_at"`
+	CreatedAt time.Time `json:"-"`
 
 	// The UTC date and time when the resource was updated, ISO 8601 format.
 	// May be “null”.
-	UpdatedAt string `json:"updated_at"`
+	UpdatedAt time.Time `json:"-"`
 
 	// A list of relative links. Includes the self and bookmark links.
 	Links []interface{} `json:"links"`
 
 	// Indicates whether the Port is a Smart NIC port.
 	IsSmartNIC bool `json:"is_smartnic"`
+}
+
+// UnmarshalJSON to override default
+func (r *Port) UnmarshalJSON(b []byte) error {
+	type tmp Port
+	var s struct {
+		tmp
+		CreatedAt gophercloud.JSONRFC3339MilliNoZ `json:"created_at"`
+		UpdatedAt gophercloud.JSONRFC3339MilliNoZ `json:"updated_at"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	*r = Port(s.tmp)
+
+	r.CreatedAt = time.Time(s.CreatedAt)
+	r.UpdatedAt = time.Time(s.UpdatedAt)
+
+	return nil
 }
 
 // PortPage abstracts the raw results of making a List() request against

--- a/openstack/baremetal/v1/ports/results.go
+++ b/openstack/baremetal/v1/ports/results.go
@@ -80,8 +80,8 @@ func (r *Port) UnmarshalJSON(b []byte) error {
 	type tmp Port
 	var s struct {
 		tmp
-		CreatedAt gophercloud.JSONRFC3339MilliNoZ `json:"created_at"`
-		UpdatedAt gophercloud.JSONRFC3339MilliNoZ `json:"updated_at"`
+		CreatedAt gophercloud.JSONRFC3339ZNoT `json:"created_at"`
+		UpdatedAt gophercloud.JSONRFC3339ZNoT `json:"updated_at"`
 	}
 	err := json.Unmarshal(b, &s)
 	if err != nil {

--- a/openstack/baremetal/v1/ports/results.go
+++ b/openstack/baremetal/v1/ports/results.go
@@ -1,7 +1,6 @@
 package ports
 
 import (
-	"encoding/json"
 	"time"
 
 	"github.com/gophercloud/gophercloud"
@@ -62,37 +61,17 @@ type Port struct {
 	Extra map[string]interface{} `json:"extra"`
 
 	// The UTC date and time when the resource was created, ISO 8601 format.
-	CreatedAt time.Time `json:"-"`
+	CreatedAt time.Time `json:"created_at"`
 
 	// The UTC date and time when the resource was updated, ISO 8601 format.
 	// May be “null”.
-	UpdatedAt time.Time `json:"-"`
+	UpdatedAt time.Time `json:"updated_at"`
 
 	// A list of relative links. Includes the self and bookmark links.
 	Links []interface{} `json:"links"`
 
 	// Indicates whether the Port is a Smart NIC port.
 	IsSmartNIC bool `json:"is_smartnic"`
-}
-
-// UnmarshalJSON to override default
-func (r *Port) UnmarshalJSON(b []byte) error {
-	type tmp Port
-	var s struct {
-		tmp
-		CreatedAt gophercloud.JSONRFC3339ZNoT `json:"created_at"`
-		UpdatedAt gophercloud.JSONRFC3339ZNoT `json:"updated_at"`
-	}
-	err := json.Unmarshal(b, &s)
-	if err != nil {
-		return err
-	}
-	*r = Port(s.tmp)
-
-	r.CreatedAt = time.Time(s.CreatedAt)
-	r.UpdatedAt = time.Time(s.UpdatedAt)
-
-	return nil
 }
 
 // PortPage abstracts the raw results of making a List() request against

--- a/openstack/baremetal/v1/ports/testing/fixtures.go
+++ b/openstack/baremetal/v1/ports/testing/fixtures.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/baremetal/v1/ports"
 	th "github.com/gophercloud/gophercloud/testhelper"
 	"github.com/gophercloud/gophercloud/testhelper/client"
@@ -137,10 +138,10 @@ const SinglePortBody = `
 `
 
 var (
-	fooCreated, _ = time.Parse(time.RFC3339, "2019-02-15T09:52:24+00:00")
-	fooUpdated, _ = time.Parse(time.RFC3339, "2019-02-15T09:55:19+00:00")
-	BarCreated, _ = time.Parse(time.RFC3339, "2019-02-15T09:52:23+00:00")
-	BarUpdated, _ = time.Parse(time.RFC3339, "2019-02-15T09:55:19+00:00")
+	fooCreated, _ = time.Parse(gophercloud.JSONRFC3339ZNoT, "2019-02-15T09:52:24+00:00")
+	fooUpdated, _ = time.Parse(gophercloud.JSONRFC3339ZNoT, "2019-02-15T09:55:19+00:00")
+	BarCreated, _ = time.Parse(gophercloud.JSONRFC3339ZNoT, "2019-02-15T09:52:23+00:00")
+	BarUpdated, _ = time.Parse(gophercloud.JSONRFC3339ZNoT, "2019-02-15T09:55:19+00:00")
 	PortFoo       = ports.Port{
 		UUID:                "f2845e11-dbd4-4728-a8c0-30d19f48924a",
 		NodeUUID:            "ddd06a60-b91e-4ab4-a6e7-56c0b25b6086",

--- a/openstack/baremetal/v1/ports/testing/fixtures.go
+++ b/openstack/baremetal/v1/ports/testing/fixtures.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/gophercloud/gophercloud/openstack/baremetal/v1/ports"
 	th "github.com/gophercloud/gophercloud/testhelper"
@@ -136,7 +137,11 @@ const SinglePortBody = `
 `
 
 var (
-	PortFoo = ports.Port{
+	fooCreated, _ = time.Parse(time.RFC3339, "2019-02-15T09:52:24+00:00")
+	fooUpdated, _ = time.Parse(time.RFC3339, "2019-02-15T09:55:19+00:00")
+	BarCreated, _ = time.Parse(time.RFC3339, "2019-02-15T09:52:23+00:00")
+	BarUpdated, _ = time.Parse(time.RFC3339, "2019-02-15T09:55:19+00:00")
+	PortFoo       = ports.Port{
 		UUID:                "f2845e11-dbd4-4728-a8c0-30d19f48924a",
 		NodeUUID:            "ddd06a60-b91e-4ab4-a6e7-56c0b25b6086",
 		Address:             "52:54:00:4d:87:e6",
@@ -144,8 +149,8 @@ var (
 		LocalLinkConnection: map[string]interface{}{},
 		InternalInfo:        map[string]interface{}{},
 		Extra:               map[string]interface{}{},
-		CreatedAt:           "2019-02-15T09:52:24+00:00",
-		UpdatedAt:           "2019-02-15T09:55:19+00:00",
+		CreatedAt:           fooCreated,
+		UpdatedAt:           fooUpdated,
 		Links:               []interface{}{map[string]interface{}{"href": "http://192.168.0.8/baremetal/v1/ports/f2845e11-dbd4-4728-a8c0-30d19f48924a", "rel": "self"}, map[string]interface{}{"href": "http://192.168.0.8/baremetal/ports/f2845e11-dbd4-4728-a8c0-30d19f48924a", "rel": "bookmark"}},
 	}
 
@@ -157,8 +162,8 @@ var (
 		LocalLinkConnection: map[string]interface{}{},
 		InternalInfo:        map[string]interface{}{},
 		Extra:               map[string]interface{}{},
-		CreatedAt:           "2019-02-15T09:52:23+00:00",
-		UpdatedAt:           "2019-02-15T09:55:19+00:00",
+		CreatedAt:           BarCreated,
+		UpdatedAt:           BarUpdated,
 		Links:               []interface{}{map[string]interface{}{"href": "http://192.168.0.8/baremetal/v1/ports/3abe3f36-9708-4e9f-b07e-0f898061d3a7", "rel": "self"}, map[string]interface{}{"rel": "bookmark", "href": "http://192.168.0.8/baremetal/ports/3abe3f36-9708-4e9f-b07e-0f898061d3a7"}},
 	}
 )

--- a/openstack/baremetal/v1/ports/testing/fixtures.go
+++ b/openstack/baremetal/v1/ports/testing/fixtures.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/baremetal/v1/ports"
 	th "github.com/gophercloud/gophercloud/testhelper"
 	"github.com/gophercloud/gophercloud/testhelper/client"
@@ -138,10 +137,10 @@ const SinglePortBody = `
 `
 
 var (
-	fooCreated, _ = time.Parse(gophercloud.JSONRFC3339ZNoT, "2019-02-15T09:52:24+00:00")
-	fooUpdated, _ = time.Parse(gophercloud.JSONRFC3339ZNoT, "2019-02-15T09:55:19+00:00")
-	BarCreated, _ = time.Parse(gophercloud.JSONRFC3339ZNoT, "2019-02-15T09:52:23+00:00")
-	BarUpdated, _ = time.Parse(gophercloud.JSONRFC3339ZNoT, "2019-02-15T09:55:19+00:00")
+	fooCreated, _ = time.Parse(time.RFC3339, "2019-02-15T09:52:24+00:00")
+	fooUpdated, _ = time.Parse(time.RFC3339, "2019-02-15T09:55:19+00:00")
+	BarCreated, _ = time.Parse(time.RFC3339, "2019-02-15T09:52:23+00:00")
+	BarUpdated, _ = time.Parse(time.RFC3339, "2019-02-15T09:55:19+00:00")
 	PortFoo       = ports.Port{
 		UUID:                "f2845e11-dbd4-4728-a8c0-30d19f48924a",
 		NodeUUID:            "ddd06a60-b91e-4ab4-a6e7-56c0b25b6086",


### PR DESCRIPTION
For #1429

This PR updates the type of the variables `UpdatedAt` and `CreatedAt` to time.Time
and adds the `UnmarshalJSON` function