### PR TITLE
Baremetal API V1: Support new config drive JSON for nodes

### DIFF
--- a/openstack/baremetal/v1/nodes/requests.go
+++ b/openstack/baremetal/v1/nodes/requests.go
@@ -399,11 +399,19 @@ type ProvisionStateOptsBuilder interface {
 	ToProvisionStateMap() (map[string]interface{}, error)
 }
 
+// Starting with Ironic API version 1.56, a configdrive may be a JSON object with structured data.
+// Prior to this version, it must be a base64-encoded, gzipped ISO9660 image.
+type ConfigDrive struct {
+	MetaData    map[string]interface{} `json:"meta_data,omitempty"`
+	NetworkData map[string]interface{} `json:"network_data,omitempty"`
+	UserData    interface{}            `json:"user_data,omitempty"`
+}
+
 // ProvisionStateOpts for a request to change a node's provision state. A config drive should be base64-encoded
 // gzipped ISO9660 image.
 type ProvisionStateOpts struct {
 	Target         TargetProvisionState `json:"target" required:"true"`
-	ConfigDrive    string               `json:"configdrive,omitempty"`
+	ConfigDrive    interface{}          `json:"configdrive,omitempty"`
 	CleanSteps     []CleanStep          `json:"clean_steps,omitempty"`
 	RescuePassword string               `json:"rescue_password,omitempty"`
 }

--- a/openstack/baremetal/v1/nodes/testing/fixtures.go
+++ b/openstack/baremetal/v1/nodes/testing/fixtures.go
@@ -562,6 +562,27 @@ const NodeProvisionStateCleanBody = `
 }
 `
 
+const NodeProvisionStateConfigDriveBody = `
+{
+	"target": "active",
+	"configdrive": {
+		"user_data": {
+			"ignition": {
+			"version": "2.2.0"
+			},
+			"systemd": {
+				"units": [
+					{
+						"enabled": true,
+						"name": "example.service"
+					}
+				]
+			}
+		}
+	}
+}
+`
+
 var (
 	NodeFoo = nodes.Node{
 		UUID:                 "d2630783-6ec8-4836-b556-ab427c4b581e",
@@ -747,6 +768,21 @@ var (
 		Protected:            false,
 		ProtectedReason:      "",
 	}
+
+	ConfigDriveMap = nodes.ConfigDrive{
+		UserData: map[string]interface{}{
+			"ignition": map[string]string{
+				"version": "2.2.0",
+			},
+			"systemd": map[string]interface{}{
+				"units": []map[string]interface{}{{
+					"name":    "example.service",
+					"enabled": true,
+				},
+				},
+			},
+		},
+	}
 )
 
 // HandleNodeListSuccessfully sets up the test server to respond to a server List request.
@@ -916,6 +952,15 @@ func HandleNodeChangeProvisionStateCleanWithConflict(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		th.TestJSONRequest(t, r, NodeProvisionStateCleanBody)
 		w.WriteHeader(http.StatusConflict)
+	})
+}
+
+func HandleNodeChangeProvisionStateConfigDrive(t *testing.T) {
+	th.Mux.HandleFunc("/nodes/1234asdf/states/provision", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, NodeProvisionStateConfigDriveBody)
+		w.WriteHeader(http.StatusAccepted)
 	})
 }
 

--- a/openstack/baremetal/v1/nodes/testing/requests_test.go
+++ b/openstack/baremetal/v1/nodes/testing/requests_test.go
@@ -254,6 +254,22 @@ func TestNodeChangeProvisionStateActive(t *testing.T) {
 	th.AssertNoErr(t, err)
 }
 
+func TestHandleNodeChangeProvisionStateConfigDrive(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	HandleNodeChangeProvisionStateConfigDrive(t)
+
+	c := client.ServiceClient()
+
+	err := nodes.ChangeProvisionState(c, "1234asdf", nodes.ProvisionStateOpts{
+		Target:      nodes.TargetActive,
+		ConfigDrive: ConfigDriveMap,
+	}).ExtractErr()
+
+	th.AssertNoErr(t, err)
+}
+
 func TestNodeChangeProvisionStateClean(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()


### PR DESCRIPTION
Config drives may be a URL, a base64-encoded gzipped ISO9660 image, or beginning in Ironic API microversion 1.56, JSON with user, network, and meta data keys.

Users on earlier than 1.56 will need to encode user data themselves, or use gophercloud/utils' helper.

For #1429

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

 - Ironic API ref: https://developer.openstack.org/api-ref/baremetal/?expanded=change-node-provision-state-detail
 - Implementation https://github.com/openstack/ironic/commit/3e1e0c9d5e6e5753d0fe2529901986ea36934971#diff-0475f180604c34b6fe131ce1bd3c26a0
