### PR TITLE
Octavia: Support insert_headers for creating listener

### DIFF
--- a/openstack/loadbalancer/v2/listeners/requests.go
+++ b/openstack/loadbalancer/v2/listeners/requests.go
@@ -120,6 +120,9 @@ type CreateOpts struct {
 
 	// Backend member inactivity timeout in milliseconds
 	TimeoutMemberData *int `json:"timeout_member_data,omitempty"`
+
+	// A dictionary of optional headers to insert into the request before it is sent to the backend member.
+	InsertHeaders map[string]string `json:"insert_headers,omitempty"`
 }
 
 // ToListenerCreateMap builds a request body from CreateOpts.

--- a/openstack/loadbalancer/v2/listeners/results.go
+++ b/openstack/loadbalancer/v2/listeners/results.go
@@ -68,6 +68,9 @@ type Listener struct {
 
 	// Backend member inactivity timeout in milliseconds
 	TimeoutMemberData int `json:"timeout_member_data"`
+
+	// A dictionary of optional headers to insert into the request before it is sent to the backend member.
+	InsertHeaders map[string]string `json:"insert_headers"`
 }
 
 type Stats struct {

--- a/openstack/loadbalancer/v2/listeners/testing/fixtures.go
+++ b/openstack/loadbalancer/v2/listeners/testing/fixtures.go
@@ -41,7 +41,10 @@ const ListenersListBody = `
 			"default_tls_container_ref": "2c433435-20de-4411-84ae-9cc8917def76",
 			"sni_container_refs": ["3d328d82-2547-4921-ac2f-61c3b452b5ff", "b3cfd7e3-8c19-455c-8ebb-d78dfd8f7e7d"],
 			"timeout_client_data": 50000,
-			"timeout_member_data": 50000
+			"timeout_member_data": 50000,
+			"insert_headers": {
+				"X-Forwarded-For": "true"
+			}
 		}
 	]
 }
@@ -64,8 +67,10 @@ const SingleListenerBody = `
 		"default_tls_container_ref": "2c433435-20de-4411-84ae-9cc8917def76",
 		"sni_container_refs": ["3d328d82-2547-4921-ac2f-61c3b452b5ff", "b3cfd7e3-8c19-455c-8ebb-d78dfd8f7e7d"],
 		"timeout_client_data": 50000,
-		"timeout_member_data": 50000
-
+		"timeout_member_data": 50000,
+        "insert_headers": {
+            "X-Forwarded-For": "true"
+        }
 	}
 }
 `
@@ -135,6 +140,7 @@ var (
 		SniContainerRefs:       []string{"3d328d82-2547-4921-ac2f-61c3b452b5ff", "b3cfd7e3-8c19-455c-8ebb-d78dfd8f7e7d"},
 		TimeoutClientData:      50000,
 		TimeoutMemberData:      50000,
+		InsertHeaders:          map[string]string{"X-Forwarded-For": "true"},
 	}
 	ListenerUpdated = listeners.Listener{
 		ID:                     "36e08a3e-a78f-4b40-a229-1e7e23eee1ab",
@@ -195,7 +201,10 @@ func HandleListenerCreationSuccessfully(t *testing.T, response string) {
 			        "admin_state_up": true,
 			        "default_tls_container_ref": "2c433435-20de-4411-84ae-9cc8917def76",
 			        "default_pool_id": "41efe233-7591-43c5-9cf7-923964759f9e",
-			        "protocol_port": 3306
+			        "protocol_port": 3306,
+					"insert_headers": {
+						"X-Forwarded-For": "true"
+					}
 			    }
 		}`)
 

--- a/openstack/loadbalancer/v2/listeners/testing/requests_test.go
+++ b/openstack/loadbalancer/v2/listeners/testing/requests_test.go
@@ -66,6 +66,7 @@ func TestCreateListener(t *testing.T) {
 		DefaultTlsContainerRef: "2c433435-20de-4411-84ae-9cc8917def76",
 		DefaultPoolID:          "41efe233-7591-43c5-9cf7-923964759f9e",
 		ProtocolPort:           3306,
+		InsertHeaders:          map[string]string{"X-Forwarded-For": "true"},
 	}).Extract()
 	th.AssertNoErr(t, err)
 


### PR DESCRIPTION
For #1513

- [API doc](https://developer.openstack.org/api-ref/load-balancer/v2/index.html#create-listener)
- [Source code](https://github.com/openstack/octavia/blob/68b9d06dae65c20b26aa63b78884f94b6642c542/octavia/api/v2/types/listener.py#L123)
