### PR TITLE
Support Magnum resize API

### DIFF
--- a/openstack/containerinfra/v1/clusters/requests.go
+++ b/openstack/containerinfra/v1/clusters/requests.go
@@ -175,3 +175,40 @@ func Update(client *gophercloud.ServiceClient, id string, opts []UpdateOptsBuild
 	}
 	return
 }
+
+// ResizeOptsBuilder allows extensions to add additional parameters to the
+// Resize request.
+type ResizeOptsBuilder interface {
+	ToClusterResizeMap() (map[string]interface{}, error)
+}
+
+// ResizeOpts params
+type ResizeOpts struct {
+	NodeCount     *int     `json:"node_count" required:"true"`
+	NodesToRemove []string `json:"nodes_to_remove,omitempty"`
+	NodeGroup     string   `json:"nodegroup,omitempty"`
+}
+
+// ToClusterResizeMap constructs a request body from ResizeOpts.
+func (opts ResizeOpts) ToClusterResizeMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "")
+}
+
+// Resize an existing cluster node count.
+func Resize(client *gophercloud.ServiceClient, id string, opts ResizeOptsBuilder) (r ResizeResult) {
+	b, err := opts.ToClusterResizeMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	var result *http.Response
+	result, r.Err = client.Post(resizeURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200, 202},
+	})
+
+	if r.Err == nil {
+		r.Header = result.Header
+	}
+	return
+}

--- a/openstack/containerinfra/v1/clusters/results.go
+++ b/openstack/containerinfra/v1/clusters/results.go
@@ -39,6 +39,11 @@ type UpdateResult struct {
 	commonResult
 }
 
+// ResizeResult is the response of a Resize operations.
+type ResizeResult struct {
+	commonResult
+}
+
 func (r CreateResult) Extract() (string, error) {
 	var s struct {
 		UUID string

--- a/openstack/containerinfra/v1/clusters/testing/fixtures.go
+++ b/openstack/containerinfra/v1/clusters/testing/fixtures.go
@@ -271,3 +271,22 @@ func HandleDeleteClusterSuccessfully(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 }
+
+var ResizeResponse = fmt.Sprintf(`
+{
+	"uuid": "%s",
+	"node_count": 2
+}`, clusterUUID)
+
+func HandleResizeClusterSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/v1/clusters/"+clusterUUID+"/actions/resize", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.Header().Add("X-OpenStack-Request-Id", requestUUID)
+		w.WriteHeader(http.StatusAccepted)
+
+		fmt.Fprint(w, ResizeResponse)
+	})
+}

--- a/openstack/containerinfra/v1/clusters/testing/requests_test.go
+++ b/openstack/containerinfra/v1/clusters/testing/requests_test.go
@@ -172,3 +172,30 @@ func TestDeleteCluster(t *testing.T) {
 
 	th.AssertEquals(t, requestUUID, uuid)
 }
+
+func TestResizeCluster(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	HandleResizeClusterSuccessfully(t)
+
+	nodeCount := 2
+
+	var opts clusters.ResizeOptsBuilder
+	opts = clusters.ResizeOpts{
+		NodeCount: &nodeCount,
+	}
+
+	sc := fake.ServiceClient()
+	sc.Endpoint = sc.Endpoint + "v1/"
+	res := clusters.Resize(sc, clusterUUID, opts)
+	th.AssertNoErr(t, res.Err)
+
+	requestID := res.Header.Get("X-OpenStack-Request-Id")
+	th.AssertEquals(t, requestUUID, requestID)
+
+	actual, err := res.Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, nodeCount, actual.NodeCount)
+}

--- a/openstack/containerinfra/v1/clusters/urls.go
+++ b/openstack/containerinfra/v1/clusters/urls.go
@@ -37,3 +37,7 @@ func listDetailURL(client *gophercloud.ServiceClient) string {
 func updateURL(client *gophercloud.ServiceClient, id string) string {
 	return idURL(client, id)
 }
+
+func resizeURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL("clusters", id, "actions/resize")
+}


### PR DESCRIPTION
Recently in Magnum we introduced a new API v1/clusters/clusterID/actions/resize [1]
to enable the capability that consumer can resize the node count of the
cluster and meanwhile the API allows to pass in the node instance ID
so as to delete particular nodes. That's very useful for the auto-healing
and auto-scaling cases which Magnum will leverage k8s cluster Autoscaler
to achieve that.

Without this new API, the consumer has to call Heat API firstly to remove
the particular to remove the nodes and then call Magnum API again to
update the node count, which is not ideal obviously. Hence the new API
was proposed. More information please refer [2] [3].

For #1515

[1] https://review.openstack.org/638572
[2] https://review.openstack.org/631378
[3] kubernetes/autoscaler#1690
