### PR TITLE
Fix OK codes in keypair creation

### DIFF
--- a/openstack/compute/v2/extensions/keypairs/requests.go
+++ b/openstack/compute/v2/extensions/keypairs/requests.go
@@ -68,7 +68,7 @@ func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r Create
 		return
 	}
 	_, r.Err = client.Post(createURL(client), b, &r.Body, &gophercloud.RequestOpts{
-		OkCodes: []int{200},
+		OkCodes: []int{200, 201},
 	})
 	return
 }


### PR DESCRIPTION
Added code 201 (accepted) to ok codes in keypair creation.
Without this fix, keypair creation fails with compute microversion "2.60" because it gets status 201.

For #1518 