### PR TITLE
Acc Tests: Re-enable TestVolumeActionsUploadImageDestroy

### DIFF
--- a/acceptance/openstack/blockstorage/extensions/volumeactions_test.go
+++ b/acceptance/openstack/blockstorage/extensions/volumeactions_test.go
@@ -14,8 +14,6 @@ import (
 )
 
 func TestVolumeActionsUploadImageDestroy(t *testing.T) {
-	t.Skip("This test is diabled because it sometimes fails in OpenLab")
-
 	blockClient, err := clients.NewBlockStorageV2Client()
 	th.AssertNoErr(t, err)
 


### PR DESCRIPTION
For https://github.com/theopenlab/openlab/issues/222