### PR TITLE
Add apiversions package for Magnum

### DIFF
--- a/openstack/containerinfra/apiversions/doc.go
+++ b/openstack/containerinfra/apiversions/doc.go
@@ -1,0 +1,3 @@
+// Package apiversions provides information and interaction with the different
+// API versions for the Container Infra service, code-named Magnum.
+package apiversions

--- a/openstack/containerinfra/apiversions/errors.go
+++ b/openstack/containerinfra/apiversions/errors.go
@@ -1,0 +1,23 @@
+package apiversions
+
+import (
+	"fmt"
+)
+
+// ErrVersionNotFound is the error when the requested API version
+// could not be found.
+type ErrVersionNotFound struct{}
+
+func (e ErrVersionNotFound) Error() string {
+	return fmt.Sprintf("Unable to find requested API version")
+}
+
+// ErrMultipleVersionsFound is the error when a request for an API
+// version returns multiple results.
+type ErrMultipleVersionsFound struct {
+	Count int
+}
+
+func (e ErrMultipleVersionsFound) Error() string {
+	return fmt.Sprintf("Found %d API versions", e.Count)
+}

--- a/openstack/containerinfra/apiversions/requests.go
+++ b/openstack/containerinfra/apiversions/requests.go
@@ -1,0 +1,19 @@
+package apiversions
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// List lists all the API versions available to end-users.
+func List(c *gophercloud.ServiceClient) pagination.Pager {
+	return pagination.NewPager(c, listURL(c), func(r pagination.PageResult) pagination.Page {
+		return APIVersionPage{pagination.SinglePageBase(r)}
+	})
+}
+
+// Get will get a specific API version, specified by major ID.
+func Get(client *gophercloud.ServiceClient, v string) (r GetResult) {
+	_, r.Err = client.Get(getURL(client, v), &r.Body, nil)
+	return
+}

--- a/openstack/containerinfra/apiversions/results.go
+++ b/openstack/containerinfra/apiversions/results.go
@@ -1,0 +1,68 @@
+package apiversions
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// APIVersion represents an API version for the Container Infra service.
+type APIVersion struct {
+	// ID is the unique identifier of the API version.
+	ID string `json:"id"`
+
+	// MinVersion is the minimum microversion supported.
+	MinVersion string `json:"min_version"`
+
+	// Status is the API versions status.
+	Status string `json:"status"`
+
+	// Version is the maximum microversion supported.
+	Version string `json:"max_version"`
+}
+
+// APIVersionPage is the page returned by a pager when traversing over a
+// collection of API versions.
+type APIVersionPage struct {
+	pagination.SinglePageBase
+}
+
+// IsEmpty checks whether an APIVersionPage struct is empty.
+func (r APIVersionPage) IsEmpty() (bool, error) {
+	is, err := ExtractAPIVersions(r)
+	return len(is) == 0, err
+}
+
+// ExtractAPIVersions takes a collection page, extracts all of the elements,
+// and returns them a slice of APIVersion structs. It is effectively a cast.
+func ExtractAPIVersions(r pagination.Page) ([]APIVersion, error) {
+	var s struct {
+		Versions []APIVersion `json:"versions"`
+	}
+	err := (r.(APIVersionPage)).ExtractInto(&s)
+	return s.Versions, err
+}
+
+// GetResult represents the result of a get operation.
+type GetResult struct {
+	gophercloud.Result
+}
+
+// Extract is a function that accepts a result and extracts an API version resource.
+func (r GetResult) Extract() (*APIVersion, error) {
+	var s struct {
+		Versions []APIVersion `json:"versions"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return nil, err
+	}
+
+	switch len(s.Versions) {
+	case 0:
+		return nil, ErrVersionNotFound{}
+	case 1:
+		return &s.Versions[0], nil
+	default:
+		return nil, ErrMultipleVersionsFound{Count: len(s.Versions)}
+	}
+}

--- a/openstack/containerinfra/apiversions/testing/doc.go
+++ b/openstack/containerinfra/apiversions/testing/doc.go
@@ -1,0 +1,2 @@
+// apiversions_v1
+package testing

--- a/openstack/containerinfra/apiversions/testing/fixtures.go
+++ b/openstack/containerinfra/apiversions/testing/fixtures.go
@@ -1,0 +1,88 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/containerinfra/apiversions"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+const MagnumAPIVersionResponse = `
+{
+    "versions":[
+       {
+          "status":"CURRENT",
+          "min_version":"1.1",
+          "max_version":"1.7",
+          "id":"v1",
+          "links":[
+             {
+                "href":"http://10.164.180.104:9511/v1/",
+                "rel":"self"
+             }
+          ]
+       }
+    ],
+    "name":"OpenStack Magnum API",
+    "description":"Magnum is an OpenStack project which aims to provide container management."
+ }
+`
+
+const MagnumAllAPIVersionsResponse = `
+{
+    "versions":[
+       {
+          "status":"CURRENT",
+          "min_version":"1.1",
+          "max_version":"1.7",
+          "id":"v1",
+          "links":[
+             {
+                "href":"http://10.164.180.104:9511/v1/",
+                "rel":"self"
+             }
+          ]
+       }
+    ],
+    "name":"OpenStack Magnum API",
+    "description":"Magnum is an OpenStack project which aims to provide container management."
+ }
+`
+
+var MagnumAPIVersion1Result = apiversions.APIVersion{
+	ID:         "v1",
+	Status:     "CURRENT",
+	MinVersion: "1.1",
+	Version:    "1.7",
+}
+
+var MagnumAllAPIVersionResults = []apiversions.APIVersion{
+	MagnumAPIVersion1Result,
+}
+
+func MockListResponse(t *testing.T) {
+	th.Mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, MagnumAllAPIVersionsResponse)
+	})
+}
+
+func MockGetResponse(t *testing.T) {
+	th.Mux.HandleFunc("/v1/", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, MagnumAPIVersionResponse)
+	})
+}

--- a/openstack/containerinfra/apiversions/testing/requests_test.go
+++ b/openstack/containerinfra/apiversions/testing/requests_test.go
@@ -1,0 +1,37 @@
+package testing
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/containerinfra/apiversions"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func TestListAPIVersions(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockListResponse(t)
+
+	allVersions, err := apiversions.List(client.ServiceClient()).AllPages()
+	th.AssertNoErr(t, err)
+
+	actual, err := apiversions.ExtractAPIVersions(allVersions)
+	th.AssertNoErr(t, err)
+	fmt.Println(actual)
+	th.AssertDeepEquals(t, MagnumAllAPIVersionResults, actual)
+}
+
+func TestGetAPIVersion(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockGetResponse(t)
+
+	actual, err := apiversions.Get(client.ServiceClient(), "v1").Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertDeepEquals(t, MagnumAPIVersion1Result, *actual)
+}

--- a/openstack/containerinfra/apiversions/urls.go
+++ b/openstack/containerinfra/apiversions/urls.go
@@ -1,0 +1,20 @@
+package apiversions
+
+import (
+	"net/url"
+	"strings"
+
+	"github.com/gophercloud/gophercloud"
+)
+
+func getURL(c *gophercloud.ServiceClient, version string) string {
+	u, _ := url.Parse(c.ServiceURL(""))
+	u.Path = "/" + strings.TrimRight(version, "/") + "/"
+	return u.String()
+}
+
+func listURL(c *gophercloud.ServiceClient) string {
+	u, _ := url.Parse(c.ServiceURL(""))
+	u.Path = "/"
+	return u.String()
+}


### PR DESCRIPTION
New package "apiversions" is introducing so that the consumer of Magnum API can discovery the correct version of Magnum to leverage.

For #1520

[1] https://developer.openstack.org/api-ref/container-infrastructure-management/?expanded=list-api-versions-detail,show-v1-api-version-detail#api-versions
