### PR TITLE
Add support to Load Balancer api version requests

### DIFF
--- a/openstack/loadbalancer/v2/apiversions/doc.go
+++ b/openstack/loadbalancer/v2/apiversions/doc.go
@@ -1,0 +1,22 @@
+/*
+Package apiversions provides information and interaction with the different
+API versions for the OpenStack Load Balancer service. This functionality is not
+restricted to this particular version.
+
+Example to List API Versions
+
+	allPages, err := apiversions.List(loadbalancerClient).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allVersions, err := apiversions.ExtractAPIVersions(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, version := range allVersions {
+		fmt.Printf("%+v\n", version)
+	}
+*/
+package apiversions

--- a/openstack/loadbalancer/v2/apiversions/requests.go
+++ b/openstack/loadbalancer/v2/apiversions/requests.go
@@ -5,7 +5,7 @@ import (
 	"github.com/gophercloud/gophercloud/pagination"
 )
 
-// lists all the load balancer API versions available to end-users.
+// List lists all the load balancer API versions available to end-users.
 func List(c *gophercloud.ServiceClient) pagination.Pager {
 	return pagination.NewPager(c, apiVersionsURL(c), func(r pagination.PageResult) pagination.Page {
 		return APIVersionPage{pagination.SinglePageBase(r)}

--- a/openstack/loadbalancer/v2/apiversions/requests.go
+++ b/openstack/loadbalancer/v2/apiversions/requests.go
@@ -1,0 +1,13 @@
+package apiversions
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// lists all the load balancer API versions available to end-users.
+func List(c *gophercloud.ServiceClient) pagination.Pager {
+	return pagination.NewPager(c, apiVersionsURL(c), func(r pagination.PageResult) pagination.Page {
+		return APIVersionPage{pagination.SinglePageBase(r)}
+	})
+}

--- a/openstack/loadbalancer/v2/apiversions/results.go
+++ b/openstack/loadbalancer/v2/apiversions/results.go
@@ -1,0 +1,32 @@
+package apiversions
+
+import "github.com/gophercloud/gophercloud/pagination"
+
+// APIVersion represents an API version for load balancer. It contains
+// the status of the API, and its unique ID.
+type APIVersion struct {
+	Status string `son:"status"`
+	ID     string `json:"id"`
+}
+
+// APIVersionPage is the page returned by a pager when traversing over a
+// collection of API versions.
+type APIVersionPage struct {
+	pagination.SinglePageBase
+}
+
+// IsEmpty checks whether an APIVersionPage struct is empty.
+func (r APIVersionPage) IsEmpty() (bool, error) {
+	is, err := ExtractAPIVersions(r)
+	return len(is) == 0, err
+}
+
+// ExtractAPIVersions takes a collection page, extracts all of the elements,
+// and returns them a slice of APIVersion structs. It is effectively a cast.
+func ExtractAPIVersions(r pagination.Page) ([]APIVersion, error) {
+	var s struct {
+		Versions []APIVersion `json:"versions"`
+	}
+	err := (r.(APIVersionPage)).ExtractInto(&s)
+	return s.Versions, err
+}

--- a/openstack/loadbalancer/v2/apiversions/testing/doc.go
+++ b/openstack/loadbalancer/v2/apiversions/testing/doc.go
@@ -1,0 +1,2 @@
+// apiversions unit tests
+package testing

--- a/openstack/loadbalancer/v2/apiversions/testing/fixture.go
+++ b/openstack/loadbalancer/v2/apiversions/testing/fixture.go
@@ -1,0 +1,93 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/apiversions"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+const OctaviaAllAPIVersionsResponse = `
+{
+    "versions": [
+        {
+            "id": "v1",
+            "links": [
+                {
+                    "href": "http://10.0.0.105:9876/v1",
+                    "rel": "self"
+                }
+            ],
+            "status": "DEPRECATED",
+            "updated": "2014-12-11T00:00:00Z"
+        },
+        {
+            "id": "v2.0",
+            "links": [
+                {
+                    "href": "http://10.0.0.105:9876/v2",
+                    "rel": "self"
+                }
+            ],
+            "status": "SUPPORTED",
+            "updated": "2016-12-11T00:00:00Z"
+        },
+        {
+            "id": "v2.1",
+            "links": [
+                {
+                    "href": "http://10.0.0.105:9876/v2",
+                    "rel": "self"
+                }
+            ],
+            "status": "SUPPORTED",
+            "updated": "2018-04-20T00:00:00Z"
+        },
+        {
+            "id": "v2.2",
+            "links": [
+                {
+                    "href": "http://10.0.0.105:9876/v2",
+                    "rel": "self"
+                }
+            ],
+            "status": "CURRENT",
+            "updated": "2018-07-31T00:00:00Z"
+        }
+    ]
+}
+`
+
+var OctaviaAllAPIVersionResults = []apiversions.APIVersion{
+	apiversions.APIVersion{
+		ID:     "v1",
+		Status: "DEPRECATED",
+	},
+	apiversions.APIVersion{
+		ID:     "v2.0",
+		Status: "SUPPORTED",
+	},
+	apiversions.APIVersion{
+		ID:     "v2.1",
+		Status: "SUPPORTED",
+	},
+	apiversions.APIVersion{
+		ID:     "v2.2",
+		Status: "CURRENT",
+	},
+}
+
+func MockListResponse(t *testing.T) {
+	th.Mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, OctaviaAllAPIVersionsResponse)
+	})
+}

--- a/openstack/loadbalancer/v2/apiversions/testing/requests_test.go
+++ b/openstack/loadbalancer/v2/apiversions/testing/requests_test.go
@@ -1,0 +1,24 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/apiversions"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func TestListVersions(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockListResponse(t)
+
+	allVersions, err := apiversions.List(client.ServiceClient()).AllPages()
+	th.AssertNoErr(t, err)
+
+	actual, err := apiversions.ExtractAPIVersions(allVersions)
+	th.AssertNoErr(t, err)
+
+	th.AssertDeepEquals(t, OctaviaAllAPIVersionResults, actual)
+}

--- a/openstack/loadbalancer/v2/apiversions/urls.go
+++ b/openstack/loadbalancer/v2/apiversions/urls.go
@@ -1,0 +1,7 @@
+package apiversions
+
+import "github.com/gophercloud/gophercloud"
+
+func apiVersionsURL(c *gophercloud.ServiceClient) string {
+	return c.Endpoint
+}


### PR DESCRIPTION
This PR adds apiversion package for load balancer resources, enabling API consumers to discover available versions. 

For #1523

[Octavia API version support ](https://developer.openstack.org/api-ref/load-balancer/?expanded=#)
