### PR TITLE
Move periodic jobs back to OpenLab

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -100,7 +100,3 @@
     recheck-rocky:
       jobs:
         - gophercloud-acceptance-test-rocky
-    periodic:
-      jobs:
-        - gophercloud-unittest
-        - gophercloud-acceptance-test


### PR DESCRIPTION
We hope to move all of outside periodic jobs back to OpenLab
projects.yaml, so that we can plan the periodic testing resource
usage amount for OpenLab and avoid periodic jobs define confusion
in different project branch maintaining policy. Periodic jobs will
be moved to theopenlab/openlab-zuul-jobs#479 and will be triggered
at UTC-0 04:00 and 16:00 of everyday.

Related-Bug: theopenlab/openlab#173