### PR TITLE
Keymanager: add "Expiration" into the secrets CreateOpts

### DIFF
--- a/openstack/keymanager/v1/secrets/requests.go
+++ b/openstack/keymanager/v1/secrets/requests.go
@@ -223,6 +223,9 @@ type CreateOpts struct {
 
 	// SecretType is the type of secret.
 	SecretType SecretType `json:"secret_type,omitempty"`
+
+	// If set, the secret will not be available after this time.
+	Expiration string `json:"expiration,omitempty"`
 }
 
 // ToSecretCreateMap formats a CreateOpts into a create request.


### PR DESCRIPTION
Resolves #1526

P.S. @jtopjian  Probably I'm mistaken, but the `Payload` element in the `UpdateOpts` is useless.

UPD. Yes, I'm mistaken. Left the payload as is.