### PR TITLE
Baremetal API V1: Allocations

### DIFF
--- a/acceptance/openstack/baremetal/noauth/allocations_test.go
+++ b/acceptance/openstack/baremetal/noauth/allocations_test.go
@@ -1,0 +1,45 @@
+// +build acceptance baremetal allocations
+
+package noauth
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/acceptance/clients"
+	v1 "github.com/gophercloud/gophercloud/acceptance/openstack/baremetal/v1"
+	"github.com/gophercloud/gophercloud/openstack/baremetal/v1/allocations"
+	"github.com/gophercloud/gophercloud/pagination"
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestAllocationsCreateDestroy(t *testing.T) {
+	clients.RequireLong(t)
+
+	client, err := clients.NewBareMetalV1NoAuthClient()
+	th.AssertNoErr(t, err)
+
+	client.Microversion = "1.52"
+
+	allocation, err := v1.CreateAllocation(t, client)
+	th.AssertNoErr(t, err)
+	defer v1.DeleteAllocation(t, client, allocation)
+
+	found := false
+	err = allocations.List(client, allocations.ListOpts{}).EachPage(func(page pagination.Page) (bool, error) {
+		allocationList, err := allocations.ExtractAllocations(page)
+		if err != nil {
+			return false, err
+		}
+
+		for _, a := range allocationList {
+			if a.UUID == allocation.UUID {
+				found = true
+				return true, nil
+			}
+		}
+
+		return false, nil
+	})
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, found, true)
+}

--- a/acceptance/openstack/baremetal/v1/allocations_test.go
+++ b/acceptance/openstack/baremetal/v1/allocations_test.go
@@ -1,0 +1,44 @@
+// +build acceptance baremetal allocations
+
+package v1
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/acceptance/clients"
+	"github.com/gophercloud/gophercloud/openstack/baremetal/v1/allocations"
+	"github.com/gophercloud/gophercloud/pagination"
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestAllocationsCreateDestroy(t *testing.T) {
+	clients.RequireLong(t)
+
+	client, err := clients.NewBareMetalV1Client()
+	th.AssertNoErr(t, err)
+
+	client.Microversion = "1.52"
+
+	allocation, err := CreateAllocation(t, client)
+	th.AssertNoErr(t, err)
+	defer DeleteAllocation(t, client, allocation)
+
+	found := false
+	err = allocations.List(client, allocations.ListOpts{}).EachPage(func(page pagination.Page) (bool, error) {
+		allocationList, err := allocations.ExtractAllocations(page)
+		if err != nil {
+			return false, err
+		}
+
+		for _, a := range allocationList {
+			if a.UUID == allocation.UUID {
+				found = true
+				return true, nil
+			}
+		}
+
+		return false, nil
+	})
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, found, true)
+}

--- a/acceptance/openstack/baremetal/v1/baremetal.go
+++ b/acceptance/openstack/baremetal/v1/baremetal.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/acceptance/tools"
+	"github.com/gophercloud/gophercloud/openstack/baremetal/v1/allocations"
 	"github.com/gophercloud/gophercloud/openstack/baremetal/v1/nodes"
 	"github.com/gophercloud/gophercloud/openstack/baremetal/v1/ports"
 )
@@ -39,6 +40,29 @@ func DeleteNode(t *testing.T, client *gophercloud.ServiceClient, node *nodes.Nod
 	}
 
 	t.Logf("Deleted server: %s", node.UUID)
+}
+
+// CreateAllocation creates an allocation
+func CreateAllocation(t *testing.T, client *gophercloud.ServiceClient) (*allocations.Allocation, error) {
+	name := tools.RandomString("ACPTTEST", 16)
+	t.Logf("Attempting to create bare metal allocation: %s", name)
+
+	allocation, err := allocations.Create(client, allocations.CreateOpts{
+		Name:          name,
+		ResourceClass: "baremetal",
+	}).Extract()
+
+	return allocation, err
+}
+
+// DeleteAllocation deletes a bare metal allocation via its UUID.
+func DeleteAllocation(t *testing.T, client *gophercloud.ServiceClient, allocation *allocations.Allocation) {
+	err := allocations.Delete(client, allocation.UUID).ExtractErr()
+	if err != nil {
+		t.Fatalf("Unable to delete allocation %s: %s", allocation.UUID, err)
+	}
+
+	t.Logf("Deleted allocation: %s", allocation.UUID)
 }
 
 // CreateFakeNode creates a node with fake-hardware to use for port tests.

--- a/acceptance/openstack/baremetal/v1/nodes_test.go
+++ b/acceptance/openstack/baremetal/v1/nodes_test.go
@@ -1,3 +1,5 @@
+// +build acceptance baremetal nodes
+
 package v1
 
 import (

--- a/openstack/baremetal/v1/allocations/requests.go
+++ b/openstack/baremetal/v1/allocations/requests.go
@@ -1,0 +1,131 @@
+package allocations
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToAllocationCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts specifies allocation creation parameters
+type CreateOpts struct {
+	// The requested resource class for the allocation.
+	ResourceClass string `json:"resource_class" required:"true"`
+
+	// The list of nodes (names or UUIDs) that should be considered for this allocation. If not provided, all available nodes will be considered.
+	CandidateNodes []string `json:"candidate_nodes,omitempty"`
+
+	// The unique name of the Allocation.
+	Name string `json:"name,omitempty"`
+
+	// The list of requested traits for the allocation.
+	Traits []string `json:"traits,omitempty"`
+
+	// The UUID for the resource.
+	UUID string `json:"uuid,omitempty"`
+
+	// A set of one or more arbitrary metadata key and value pairs.
+	Extra map[string]string `json:"extra,omitempty"`
+}
+
+// ToAllocationCreateMap assembles a request body based on the contents of a CreateOpts.
+func (opts CreateOpts) ToAllocationCreateMap() (map[string]interface{}, error) {
+	body, err := gophercloud.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	return body, nil
+}
+
+// Create requests a node to be created
+func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	reqBody, err := opts.ToAllocationCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = client.Post(createURL(client), reqBody, &r.Body, nil)
+	return
+}
+
+type AllocationState string
+
+var (
+	Allocating AllocationState = "allocating"
+	Active                     = "active"
+	Error                      = "error"
+)
+
+// ListOptsBuilder allows extensions to add additional parameters to the List request.
+type ListOptsBuilder interface {
+	ToAllocationListQuery() (string, error)
+}
+
+// ListOpts allows the filtering and sorting of paginated collections through the API.
+type ListOpts struct {
+	// Filter the list of allocations by the node UUID or name.
+	Node string `q:"node"`
+
+	// Filter the list of returned nodes, and only return the ones with the specified resource class.
+	ResourceClass string `q:"resource_class"`
+
+	// Filter the list of allocations by the allocation state, one of active, allocating or error.
+	State AllocationState `q:"state"`
+
+	// One or more fields to be returned in the response.
+	Fields []string `q:"fields"`
+
+	// Requests a page size of items.
+	Limit int `q:"limit"`
+
+	// The ID of the last-seen item
+	Marker string `q:"marker"`
+
+	// Sorts the response by the requested sort direction.
+	// Valid value is asc (ascending) or desc (descending). Default is asc.
+	SortDir string `q:"sort_dir"`
+
+	// Sorts the response by the this attribute value. Default is id.
+	SortKey string `q:"sort_key"`
+}
+
+// ToAllocationListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToAllocationListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List makes a request against the API to list allocations accessible to you.
+func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(client)
+	if opts != nil {
+		query, err := opts.ToAllocationListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return AllocationPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// Get requests the details of an allocation by ID.
+func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {
+	_, r.Err = client.Get(getURL(client, id), &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// Delete requests the deletion of an allocation
+func Delete(client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+	_, r.Err = client.Delete(deleteURL(client, id), nil)
+	return
+}

--- a/openstack/baremetal/v1/allocations/results.go
+++ b/openstack/baremetal/v1/allocations/results.go
@@ -1,0 +1,114 @@
+package allocations
+
+import (
+	"time"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+type Allocation struct {
+	// The UUID for the resource.
+	UUID string `json:"uuid"`
+
+	// A list of UUIDs of the nodes that are candidates for this allocation.
+	CandidateNodes []string `json:"candidate_nodes"`
+
+	// The error message for the allocation if it is in the error state, null otherwise.
+	LastError string `json:"last_error"`
+
+	// The unique name of the allocation.
+	Name string `json:"name"`
+
+	// The UUID of the node assigned to the allocation. Will be null if a node is not yet assigned.
+	NodeUUID string `json:"node_uuid"`
+
+	// The current state of the allocation. One of: allocation, active, error
+	State string `json:"state"`
+
+	// The resource class requested for the allocation.
+	ResourceClass string `json:"resource_class"`
+
+	// The list of the traits requested for the allocation.
+	Traits []string `json:"traits"`
+
+	// A set of one or more arbitrary metadata key and value pairs.
+	Extra map[string]string `json:"extra"`
+
+	// The UTC date and time when the resource was created, ISO 8601 format.
+	CreatedAt time.Time `json:"created_at"`
+
+	// The UTC date and time when the resource was updated, ISO 8601 format. May be “null”.
+	UpdatedAt time.Time `json:"updated_at"`
+
+	// A list of relative links. Includes the self and bookmark links.
+	Links []interface{} `json:"links"`
+}
+
+type allocationResult struct {
+	gophercloud.Result
+}
+
+func (r allocationResult) Extract() (*Allocation, error) {
+	var s Allocation
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+func (r allocationResult) ExtractInto(v interface{}) error {
+	return r.Result.ExtractIntoStructPtr(v, "")
+}
+
+func ExtractAllocationsInto(r pagination.Page, v interface{}) error {
+	return r.(AllocationPage).Result.ExtractIntoSlicePtr(v, "allocations")
+}
+
+// AllocationPage abstracts the raw results of making a List() request against
+// the API.
+type AllocationPage struct {
+	pagination.LinkedPageBase
+}
+
+// IsEmpty returns true if a page contains no Allocation results.
+func (r AllocationPage) IsEmpty() (bool, error) {
+	s, err := ExtractAllocations(r)
+	return len(s) == 0, err
+}
+
+// NextPageURL uses the response's embedded link reference to navigate to the
+// next page of results.
+func (r AllocationPage) NextPageURL() (string, error) {
+	var s struct {
+		Links []gophercloud.Link `json:"allocations_links"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return gophercloud.ExtractNextURL(s.Links)
+}
+
+// ExtractAllocations interprets the results of a single page from a List() call,
+// producing a slice of Allocation entities.
+func ExtractAllocations(r pagination.Page) ([]Allocation, error) {
+	var s []Allocation
+	err := ExtractAllocationsInto(r, &s)
+	return s, err
+}
+
+// GetResult is the response from a Get operation. Call its Extract
+// method to interpret it as a Allocation.
+type GetResult struct {
+	allocationResult
+}
+
+// CreateResult is the response from a Create operation.
+type CreateResult struct {
+	allocationResult
+}
+
+// DeleteResult is the response from a Delete operation. Call its ExtractErr
+// method to determine if the call succeeded or failed.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}

--- a/openstack/baremetal/v1/allocations/testing/fixtures.go
+++ b/openstack/baremetal/v1/allocations/testing/fixtures.go
@@ -1,0 +1,168 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gophercloud/gophercloud/openstack/baremetal/v1/allocations"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+const AllocationListBody = `
+{
+  "allocations": [
+    {
+      "candidate_nodes": [],
+      "created_at": "2019-02-20T09:43:58+00:00",
+      "extra": {},
+      "last_error": null,
+      "links": [
+        {
+          "href": "http://127.0.0.1:6385/v1/allocations/5344a3e2-978a-444e-990a-cbf47c62ef88",
+          "rel": "self"
+        },
+        {
+          "href": "http://127.0.0.1:6385/allocations/5344a3e2-978a-444e-990a-cbf47c62ef88",
+          "rel": "bookmark"
+        }
+      ],
+      "name": "allocation-1",
+      "node_uuid": "6d85703a-565d-469a-96ce-30b6de53079d",
+      "resource_class": "bm-large",
+      "state": "active",
+      "traits": [],
+      "updated_at": "2019-02-20T09:43:58+00:00",
+      "uuid": "5344a3e2-978a-444e-990a-cbf47c62ef88"
+    },
+    {
+      "candidate_nodes": [],
+      "created_at": "2019-02-20T09:43:58+00:00",
+      "extra": {},
+      "last_error": "Failed to process allocation eff80f47-75f0-4d41-b1aa-cf07c201adac: no available nodes match the resource class bm-large.",
+      "links": [
+        {
+          "href": "http://127.0.0.1:6385/v1/allocations/eff80f47-75f0-4d41-b1aa-cf07c201adac",
+          "rel": "self"
+        },
+        {
+          "href": "http://127.0.0.1:6385/allocations/eff80f47-75f0-4d41-b1aa-cf07c201adac",
+          "rel": "bookmark"
+        }
+      ],
+      "name": "allocation-2",
+      "node_uuid": null,
+      "resource_class": "bm-large",
+      "state": "error",
+      "traits": [
+        "CUSTOM_GOLD"
+      ],
+      "updated_at": "2019-02-20T09:43:58+00:00",
+      "uuid": "eff80f47-75f0-4d41-b1aa-cf07c201adac"
+    }
+  ]
+}
+`
+
+const SingleAllocationBody = `
+{
+  "candidate_nodes": ["344a3e2-978a-444e-990a-cbf47c62ef88"],
+  "created_at": "2019-02-20T09:43:58+00:00",
+  "extra": {},
+  "last_error": null,
+  "links": [
+    {
+      "href": "http://127.0.0.1:6385/v1/allocations/5344a3e2-978a-444e-990a-cbf47c62ef88",
+      "rel": "self"
+    },
+    {
+      "href": "http://127.0.0.1:6385/allocations/5344a3e2-978a-444e-990a-cbf47c62ef88",
+      "rel": "bookmark"
+    }
+  ],
+  "name": "allocation-1",
+  "node_uuid": null,
+  "resource_class": "baremetal",
+  "state": "allocating",
+  "traits": ["foo"],
+  "updated_at": null,
+  "uuid": "5344a3e2-978a-444e-990a-cbf47c62ef88"
+}`
+
+var (
+	createdAt, _ = time.Parse(time.RFC3339, "2019-02-20T09:43:58+00:00")
+
+	Allocation1 = allocations.Allocation{
+		UUID:           "5344a3e2-978a-444e-990a-cbf47c62ef88",
+		CandidateNodes: []string{"344a3e2-978a-444e-990a-cbf47c62ef88"},
+		Name:           "allocation-1",
+		State:          "allocating",
+		ResourceClass:  "baremetal",
+		Traits:         []string{"foo"},
+		Extra:          map[string]string{},
+		CreatedAt:      createdAt,
+		Links:          []interface{}{map[string]interface{}{"href": "http://127.0.0.1:6385/v1/allocations/5344a3e2-978a-444e-990a-cbf47c62ef88", "rel": "self"}, map[string]interface{}{"href": "http://127.0.0.1:6385/allocations/5344a3e2-978a-444e-990a-cbf47c62ef88", "rel": "bookmark"}},
+	}
+)
+
+// HandleAllocationListSuccessfully sets up the test server to respond to a allocation List request.
+func HandleAllocationListSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/allocations", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		w.Header().Add("Content-Type", "application/json")
+		r.ParseForm()
+
+		marker := r.Form.Get("marker")
+		switch marker {
+		case "":
+			fmt.Fprintf(w, AllocationListBody)
+
+		case "eff80f47-75f0-4d41-b1aa-cf07c201adac":
+			fmt.Fprintf(w, `{ "allocations": [] }`)
+		default:
+			t.Fatalf("/allocations invoked with unexpected marker=[%s]", marker)
+		}
+	})
+}
+
+// HandleAllocationCreationSuccessfully sets up the test server to respond to a allocation creation request
+// with a given response.
+func HandleAllocationCreationSuccessfully(t *testing.T, response string) {
+	th.Mux.HandleFunc("/allocations", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, `{
+    		"name": "allocation-1",
+    		"resource_class": "baremetal",
+			"candidate_nodes": ["344a3e2-978a-444e-990a-cbf47c62ef88"],
+		 	"traits": ["foo"]
+        }`)
+
+		w.WriteHeader(http.StatusAccepted)
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprintf(w, response)
+	})
+}
+
+// HandleAllocationDeletionSuccessfully sets up the test server to respond to a allocation deletion request.
+func HandleAllocationDeletionSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/allocations/344a3e2-978a-444e-990a-cbf47c62ef88", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.WriteHeader(http.StatusNoContent)
+	})
+}
+
+func HandleAllocationGetSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/allocations/344a3e2-978a-444e-990a-cbf47c62ef88", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+
+		fmt.Fprintf(w, SingleAllocationBody)
+	})
+}

--- a/openstack/baremetal/v1/allocations/testing/requests_test.go
+++ b/openstack/baremetal/v1/allocations/testing/requests_test.go
@@ -1,0 +1,79 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/baremetal/v1/allocations"
+	"github.com/gophercloud/gophercloud/pagination"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func TestListAllocations(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleAllocationListSuccessfully(t)
+
+	pages := 0
+	err := allocations.List(client.ServiceClient(), allocations.ListOpts{}).EachPage(func(page pagination.Page) (bool, error) {
+		pages++
+
+		actual, err := allocations.ExtractAllocations(page)
+		if err != nil {
+			return false, err
+		}
+
+		if len(actual) != 2 {
+			t.Fatalf("Expected 2 allocations, got %d", len(actual))
+		}
+		th.AssertEquals(t, "5344a3e2-978a-444e-990a-cbf47c62ef88", actual[0].UUID)
+		th.AssertEquals(t, "eff80f47-75f0-4d41-b1aa-cf07c201adac", actual[1].UUID)
+
+		return true, nil
+	})
+
+	th.AssertNoErr(t, err)
+
+	if pages != 1 {
+		t.Errorf("Expected 1 page, saw %d", pages)
+	}
+}
+
+func TestCreateAllocation(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleAllocationCreationSuccessfully(t, SingleAllocationBody)
+
+	actual, err := allocations.Create(client.ServiceClient(), allocations.CreateOpts{
+		Name:           "allocation-1",
+		ResourceClass:  "baremetal",
+		CandidateNodes: []string{"344a3e2-978a-444e-990a-cbf47c62ef88"},
+		Traits:         []string{"foo"},
+	}).Extract()
+	th.AssertNoErr(t, err)
+
+	th.CheckDeepEquals(t, Allocation1, *actual)
+}
+
+func TestDeleteAllocation(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleAllocationDeletionSuccessfully(t)
+
+	res := allocations.Delete(client.ServiceClient(), "344a3e2-978a-444e-990a-cbf47c62ef88")
+	th.AssertNoErr(t, res.Err)
+}
+
+func TestGetAllocation(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleAllocationGetSuccessfully(t)
+
+	c := client.ServiceClient()
+	actual, err := allocations.Get(c, "344a3e2-978a-444e-990a-cbf47c62ef88").Extract()
+	if err != nil {
+		t.Fatalf("Unexpected Get error: %v", err)
+	}
+
+	th.CheckDeepEquals(t, Allocation1, *actual)
+}

--- a/openstack/baremetal/v1/allocations/urls.go
+++ b/openstack/baremetal/v1/allocations/urls.go
@@ -1,0 +1,23 @@
+package allocations
+
+import "github.com/gophercloud/gophercloud"
+
+func createURL(client *gophercloud.ServiceClient) string {
+	return client.ServiceURL("allocations")
+}
+
+func listURL(client *gophercloud.ServiceClient) string {
+	return createURL(client)
+}
+
+func resourceURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL("allocations", id)
+}
+
+func deleteURL(client *gophercloud.ServiceClient, id string) string {
+	return resourceURL(client, id)
+}
+
+func getURL(client *gophercloud.ServiceClient, id string) string {
+	return resourceURL(client, id)
+}


### PR DESCRIPTION
This PR adds support for Ironic Allocations.

For #1429

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

- API Ref: https://developer.openstack.org/api-ref/baremetal/?expanded=create-allocation-detail,list-allocations-detail
- Base class: https://github.com/openstack/ironic/blob/master/ironic/api/controllers/v1/allocation.py#L39-L70
- List https://github.com/openstack/ironic/blob/master/ironic/api/controllers/v1/allocation.py#L274-L298
-  Get https://github.com/openstack/ironic/blob/master/ironic/api/controllers/v1/allocation.py#L306-L318
- Create https://github.com/openstack/ironic/blob/master/ironic/api/controllers/v1/allocation.py#L320-L378
