### PR TITLE
Fix apiversions base URLs

### DIFF
--- a/acceptance/openstack/networking/v2/apiversion_test.go
+++ b/acceptance/openstack/networking/v2/apiversion_test.go
@@ -39,7 +39,7 @@ func TestAPIResourcesList(t *testing.T) {
 
 	allPages, err := apiversions.ListVersionResources(client, "v2.0").AllPages()
 	if err != nil {
-		t.Fatalf("Unable to list api version reosources: %v", err)
+		t.Fatalf("Unable to list api version resources: %v", err)
 	}
 
 	allVersionResources, err := apiversions.ExtractVersionResources(allPages)

--- a/openstack/blockstorage/v1/apiversions/urls.go
+++ b/openstack/blockstorage/v1/apiversions/urls.go
@@ -1,18 +1,20 @@
 package apiversions
 
 import (
-	"net/url"
 	"strings"
 
 	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/utils"
 )
 
 func getURL(c *gophercloud.ServiceClient, version string) string {
-	return c.ServiceURL(strings.TrimRight(version, "/") + "/")
+	baseEndpoint, _ := utils.BaseEndpoint(c.Endpoint)
+	endpoint := strings.TrimRight(baseEndpoint, "/") + "/" + strings.TrimRight(version, "/") + "/"
+	return endpoint
 }
 
 func listURL(c *gophercloud.ServiceClient) string {
-	u, _ := url.Parse(c.ServiceURL(""))
-	u.Path = "/"
-	return u.String()
+	baseEndpoint, _ := utils.BaseEndpoint(c.Endpoint)
+	endpoint := strings.TrimRight(baseEndpoint, "/") + "/"
+	return endpoint
 }

--- a/openstack/containerinfra/apiversions/urls.go
+++ b/openstack/containerinfra/apiversions/urls.go
@@ -1,20 +1,20 @@
 package apiversions
 
 import (
-	"net/url"
 	"strings"
 
 	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/utils"
 )
 
 func getURL(c *gophercloud.ServiceClient, version string) string {
-	u, _ := url.Parse(c.ServiceURL(""))
-	u.Path = "/" + strings.TrimRight(version, "/") + "/"
-	return u.String()
+	baseEndpoint, _ := utils.BaseEndpoint(c.Endpoint)
+	endpoint := strings.TrimRight(baseEndpoint, "/") + "/" + strings.TrimRight(version, "/") + "/"
+	return endpoint
 }
 
 func listURL(c *gophercloud.ServiceClient) string {
-	u, _ := url.Parse(c.ServiceURL(""))
-	u.Path = "/"
-	return u.String()
+	baseEndpoint, _ := utils.BaseEndpoint(c.Endpoint)
+	endpoint := strings.TrimRight(baseEndpoint, "/") + "/"
+	return endpoint
 }

--- a/openstack/loadbalancer/v2/apiversions/requests.go
+++ b/openstack/loadbalancer/v2/apiversions/requests.go
@@ -7,7 +7,7 @@ import (
 
 // List lists all the load balancer API versions available to end-users.
 func List(c *gophercloud.ServiceClient) pagination.Pager {
-	return pagination.NewPager(c, apiVersionsURL(c), func(r pagination.PageResult) pagination.Page {
+	return pagination.NewPager(c, listURL(c), func(r pagination.PageResult) pagination.Page {
 		return APIVersionPage{pagination.SinglePageBase(r)}
 	})
 }

--- a/openstack/loadbalancer/v2/apiversions/urls.go
+++ b/openstack/loadbalancer/v2/apiversions/urls.go
@@ -1,7 +1,14 @@
 package apiversions
 
-import "github.com/gophercloud/gophercloud"
+import (
+	"strings"
 
-func apiVersionsURL(c *gophercloud.ServiceClient) string {
-	return c.Endpoint
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/utils"
+)
+
+func listURL(c *gophercloud.ServiceClient) string {
+	baseEndpoint, _ := utils.BaseEndpoint(c.Endpoint)
+	endpoint := strings.TrimRight(baseEndpoint, "/") + "/"
+	return endpoint
 }

--- a/openstack/networking/v2/apiversions/requests.go
+++ b/openstack/networking/v2/apiversions/requests.go
@@ -7,7 +7,7 @@ import (
 
 // ListVersions lists all the Neutron API versions available to end-users.
 func ListVersions(c *gophercloud.ServiceClient) pagination.Pager {
-	return pagination.NewPager(c, apiVersionsURL(c), func(r pagination.PageResult) pagination.Page {
+	return pagination.NewPager(c, listURL(c), func(r pagination.PageResult) pagination.Page {
 		return APIVersionPage{pagination.SinglePageBase(r)}
 	})
 }
@@ -16,7 +16,7 @@ func ListVersions(c *gophercloud.ServiceClient) pagination.Pager {
 // particular API versions. Typical resources for Neutron might be: networks,
 // subnets, etc.
 func ListVersionResources(c *gophercloud.ServiceClient, v string) pagination.Pager {
-	return pagination.NewPager(c, apiInfoURL(c, v), func(r pagination.PageResult) pagination.Page {
+	return pagination.NewPager(c, getURL(c, v), func(r pagination.PageResult) pagination.Page {
 		return APIVersionResourcePage{pagination.SinglePageBase(r)}
 	})
 }

--- a/openstack/networking/v2/apiversions/urls.go
+++ b/openstack/networking/v2/apiversions/urls.go
@@ -4,12 +4,17 @@ import (
 	"strings"
 
 	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/utils"
 )
 
-func apiVersionsURL(c *gophercloud.ServiceClient) string {
-	return c.Endpoint
+func getURL(c *gophercloud.ServiceClient, version string) string {
+	baseEndpoint, _ := utils.BaseEndpoint(c.Endpoint)
+	endpoint := strings.TrimRight(baseEndpoint, "/") + "/" + strings.TrimRight(version, "/") + "/"
+	return endpoint
 }
 
-func apiInfoURL(c *gophercloud.ServiceClient, version string) string {
-	return c.Endpoint + strings.TrimRight(version, "/") + "/"
+func listURL(c *gophercloud.ServiceClient) string {
+	baseEndpoint, _ := utils.BaseEndpoint(c.Endpoint)
+	endpoint := strings.TrimRight(baseEndpoint, "/") + "/"
+	return endpoint
 }

--- a/openstack/orchestration/v1/apiversions/requests.go
+++ b/openstack/orchestration/v1/apiversions/requests.go
@@ -7,7 +7,7 @@ import (
 
 // ListVersions lists all the Neutron API versions available to end-users
 func ListVersions(c *gophercloud.ServiceClient) pagination.Pager {
-	return pagination.NewPager(c, apiVersionsURL(c), func(r pagination.PageResult) pagination.Page {
+	return pagination.NewPager(c, listURL(c), func(r pagination.PageResult) pagination.Page {
 		return APIVersionPage{pagination.SinglePageBase(r)}
 	})
 }

--- a/openstack/orchestration/v1/apiversions/urls.go
+++ b/openstack/orchestration/v1/apiversions/urls.go
@@ -1,7 +1,14 @@
 package apiversions
 
-import "github.com/gophercloud/gophercloud"
+import (
+	"strings"
 
-func apiVersionsURL(c *gophercloud.ServiceClient) string {
-	return c.Endpoint
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/utils"
+)
+
+func listURL(c *gophercloud.ServiceClient) string {
+	baseEndpoint, _ := utils.BaseEndpoint(c.Endpoint)
+	endpoint := strings.TrimRight(baseEndpoint, "/") + "/"
+	return endpoint
 }

--- a/openstack/sharedfilesystems/apiversions/urls.go
+++ b/openstack/sharedfilesystems/apiversions/urls.go
@@ -1,20 +1,20 @@
 package apiversions
 
 import (
-	"net/url"
 	"strings"
 
 	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/utils"
 )
 
 func getURL(c *gophercloud.ServiceClient, version string) string {
-	u, _ := url.Parse(c.ServiceURL(""))
-	u.Path = "/" + strings.TrimRight(version, "/") + "/"
-	return u.String()
+	baseEndpoint, _ := utils.BaseEndpoint(c.Endpoint)
+	endpoint := strings.TrimRight(baseEndpoint, "/") + "/" + strings.TrimRight(version, "/") + "/"
+	return endpoint
 }
 
 func listURL(c *gophercloud.ServiceClient) string {
-	u, _ := url.Parse(c.ServiceURL(""))
-	u.Path = "/"
-	return u.String()
+	baseEndpoint, _ := utils.BaseEndpoint(c.Endpoint)
+	endpoint := strings.TrimRight(baseEndpoint, "/") + "/"
+	return endpoint
 }


### PR DESCRIPTION
For #1529 

This commit updates the `apiversions` packages to account for a variety of base URLs which have been known to exist in the Keystone catalog: https://github.com/gophercloud/gophercloud/blob/master/openstack/utils/testing/base_endpoint_test.go

These packages should also be housed under a versionless directory. For example, `networking/v2/apiversions` _should_ be `networking/apiversions` since it should be possible to use this package to retrieve the API versions for _all_ major versions.

However, there is a catch: services such as Block Storage changed the format of the API results a while back. this is why `blockstorage/v1/apiversions` exists. I fell down a rabbit hole looking into this a while back (https://github.com/gophercloud/gophercloud/pull/458). I haven't reviewed all of these packages to determine if there are other occurrences like this, so for now, the packages will stay where they are.