### PR TITLE
Baremetal Inspector noauth support

### DIFF
--- a/openstack/baremetalintrospection/noauth/doc.go
+++ b/openstack/baremetalintrospection/noauth/doc.go
@@ -1,0 +1,16 @@
+package noauth
+
+/*
+Package noauth provides support for noauth bare metal introspection endpoints.
+
+	Example of obtaining and using a client:
+
+	client, err := noauth.NewBareMetalIntrospectionNoAuth(noauth.EndpointOpts{
+		IronicInspectorEndpoint: "http://localhost:5050/v1/",
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	introspection.GetIntrospectionStatus(client, "a62b8495-52e2-407b-b3cb-62775d04c2b8")
+*/

--- a/openstack/baremetalintrospection/noauth/requests.go
+++ b/openstack/baremetalintrospection/noauth/requests.go
@@ -1,0 +1,36 @@
+package noauth
+
+import (
+	"fmt"
+
+	"github.com/gophercloud/gophercloud"
+)
+
+// EndpointOpts specifies a "noauth" Ironic Inspector Endpoint.
+type EndpointOpts struct {
+	// IronicInspectorEndpoint [required] is currently only used with "noauth" Ironic introspection.
+	// An Ironic inspector endpoint with "auth_strategy=noauth" is necessary, for example:
+	// http://ironic.example.com:5050/v1.
+	IronicInspectorEndpoint string
+}
+
+func initClientOpts(client *gophercloud.ProviderClient, eo EndpointOpts) (*gophercloud.ServiceClient, error) {
+	sc := new(gophercloud.ServiceClient)
+	if eo.IronicInspectorEndpoint == "" {
+		return nil, fmt.Errorf("IronicInspectorEndpoint is required")
+	}
+
+	sc.Endpoint = gophercloud.NormalizeURL(eo.IronicInspectorEndpoint)
+	sc.ProviderClient = client
+	return sc, nil
+}
+
+// NewBareMetalIntrospectionNoAuth creates a ServiceClient that may be used to access a
+// "noauth" bare metal introspection service.
+func NewBareMetalIntrospectionNoAuth(eo EndpointOpts) (*gophercloud.ServiceClient, error) {
+	sc, err := initClientOpts(&gophercloud.ProviderClient{}, eo)
+
+	sc.Type = "baremetal-inspector"
+
+	return sc, err
+}

--- a/openstack/baremetalintrospection/noauth/testing/requests_test.go
+++ b/openstack/baremetalintrospection/noauth/testing/requests_test.go
@@ -1,0 +1,16 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/baremetalintrospection/noauth"
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestNoAuth(t *testing.T) {
+	noauthClient, err := noauth.NewBareMetalIntrospectionNoAuth(noauth.EndpointOpts{
+		IronicInspectorEndpoint: "http://ironic:5050/v1",
+	})
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, "", noauthClient.TokenID)
+}


### PR DESCRIPTION
For #1485

Add noauth support for the baremetal introspection (ironic-inspector)
service.

This is heavily based on the equivalent noauth support already present for the main Ironic API.

Source reference:
https://github.com/openstack/ironic-inspector/tree/master/ironic_inspector
