### PR TITLE
Object Storage v1: Enable removal of container metadata

### DIFF
--- a/acceptance/openstack/objectstorage/v1/containers_test.go
+++ b/acceptance/openstack/objectstorage/v1/containers_test.go
@@ -77,12 +77,25 @@ func TestContainers(t *testing.T) {
 	th.AssertNoErr(t, updateres.Err)
 	// After the tests are done, delete the metadata that was set.
 	defer func() {
-		tempMap := make(map[string]string)
-		for k := range metadata {
-			tempMap[k] = ""
+		temp := []string{}
+		for k, _ := range metadata {
+			temp = append(temp, k)
 		}
-		res := containers.Update(client, cNames[0], &containers.UpdateOpts{Metadata: tempMap})
+		res := containers.Update(client, cNames[0], &containers.UpdateOpts{RemoveMetadata: temp})
 		th.AssertNoErr(t, res.Err)
+
+		// confirm the metadata was removed
+		getOpts := containers.GetOpts{
+			Newest: true,
+		}
+
+		cm, err := containers.Get(client, cNames[0], getOpts).ExtractMetadata()
+		th.AssertNoErr(t, err)
+		for k, _ := range metadata {
+			if _, ok := cm[k]; ok {
+				t.Errorf("Unexpected custom metadata with key: %s", k)
+			}
+		}
 	}()
 
 	// Retrieve a container's metadata.

--- a/openstack/objectstorage/v1/containers/doc.go
+++ b/openstack/objectstorage/v1/containers/doc.go
@@ -73,6 +73,9 @@ Example to Update a Container
 		Metadata: map[string]string{
 			"bar": "baz",
 		},
+		RemoveMetadata: []string{
+			"foo",
+		},
 	}
 
 	container, err := containers.Update(objectStorageClient, containerName, updateOpts).Extract()

--- a/openstack/objectstorage/v1/containers/requests.go
+++ b/openstack/objectstorage/v1/containers/requests.go
@@ -130,6 +130,7 @@ type UpdateOptsBuilder interface {
 // deleting a container's metadata.
 type UpdateOpts struct {
 	Metadata               map[string]string
+	RemoveMetadata         []string
 	ContainerRead          string `h:"X-Container-Read"`
 	ContainerSyncTo        string `h:"X-Container-Sync-To"`
 	ContainerSyncKey       string `h:"X-Container-Sync-Key"`
@@ -148,9 +149,15 @@ func (opts UpdateOpts) ToContainerUpdateMap() (map[string]string, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	for k, v := range opts.Metadata {
 		h["X-Container-Meta-"+k] = v
 	}
+
+	for _, k := range opts.RemoveMetadata {
+		h["X-Remove-Container-Meta-"+k] = "remove"
+	}
+
 	return h, nil
 }
 


### PR DESCRIPTION
This commit enables metadata to be removed from a container. Gophercloud
internally strips empty strings from headers to enable deletion of
headers before they are sent in the request. This conflicts with the
ability to actually send an empty string when needed. Thereforer, a new
UpdateOpt has been added that sends the special X-Remove header with a
dummy value of "remove".

For #1511 