### PR TITLE
Compute v2: Account for empty cpu_info in hypervisors

### DIFF
--- a/openstack/compute/v2/extensions/hypervisors/results.go
+++ b/openstack/compute/v2/extensions/hypervisors/results.go
@@ -165,9 +165,11 @@ func (r *Hypervisor) UnmarshalJSON(b []byte) error {
 		return fmt.Errorf("CPUInfo has unexpected type: %T", t)
 	}
 
-	err = json.Unmarshal(tmpb, &r.CPUInfo)
-	if err != nil {
-		return err
+	if len(tmpb) != 0 {
+		err = json.Unmarshal(tmpb, &r.CPUInfo)
+		if err != nil {
+			return err
+		}
 	}
 
 	// These fields may be returned as a scientific notation, so they need

--- a/openstack/compute/v2/extensions/hypervisors/testing/fixtures.go
+++ b/openstack/compute/v2/extensions/hypervisors/testing/fixtures.go
@@ -221,6 +221,39 @@ const HypervisorGetBody = `
 }
 `
 
+// HypervisorGetEmptyCPUInfoBody represents a raw hypervisor GET result with
+// no cpu_info
+const HypervisorGetEmptyCPUInfoBody = `
+{
+    "hypervisor":{
+        "cpu_info": "",
+        "current_workload":0,
+        "status":"enabled",
+        "state":"up",
+        "disk_available_least":0,
+        "host_ip":"1.1.1.1",
+        "free_disk_gb":1028,
+        "free_ram_mb":7680,
+        "hypervisor_hostname":"fake-mini",
+        "hypervisor_type":"fake",
+        "hypervisor_version":2002000,
+        "id":"c48f6247-abe4-4a24-824e-ea39e108874f",
+        "local_gb":1028,
+        "local_gb_used":0,
+        "memory_mb":8192,
+        "memory_mb_used":512,
+        "running_vms":0,
+        "service":{
+            "host":"e6a37ee802d74863ab8b91ade8f12a67",
+            "id":"9c2566e7-7a54-4777-a1ae-c2662f0c407c",
+            "disabled_reason":null
+        },
+        "vcpus":1,
+        "vcpus_used":0
+    }
+}
+`
+
 // HypervisorUptimeBody represents a raw hypervisor uptime request result with
 // Pike+ release.
 const HypervisorUptimeBody = `
@@ -275,6 +308,7 @@ var (
 		VCPUs:     1,
 		VCPUsUsed: 0,
 	}
+
 	HypervisorFake = hypervisors.Hypervisor{
 		CPUInfo: hypervisors.CPUInfo{
 			Arch:   "x86_64",
@@ -314,6 +348,33 @@ var (
 		VCPUs:     1,
 		VCPUsUsed: 0,
 	}
+
+	HypervisorEmptyCPUInfo = hypervisors.Hypervisor{
+		CurrentWorkload:    0,
+		Status:             "enabled",
+		State:              "up",
+		DiskAvailableLeast: 0,
+		HostIP:             "1.1.1.1",
+		FreeDiskGB:         1028,
+		FreeRamMB:          7680,
+		HypervisorHostname: "fake-mini",
+		HypervisorType:     "fake",
+		HypervisorVersion:  2002000,
+		ID:                 "c48f6247-abe4-4a24-824e-ea39e108874f",
+		LocalGB:            1028,
+		LocalGBUsed:        0,
+		MemoryMB:           8192,
+		MemoryMBUsed:       512,
+		RunningVMs:         0,
+		Service: hypervisors.Service{
+			Host:           "e6a37ee802d74863ab8b91ade8f12a67",
+			ID:             "9c2566e7-7a54-4777-a1ae-c2662f0c407c",
+			DisabledReason: "",
+		},
+		VCPUs:     1,
+		VCPUsUsed: 0,
+	}
+
 	HypervisorsStatisticsExpected = hypervisors.Statistics{
 		Count:              1,
 		CurrentWorkload:    0,
@@ -328,6 +389,7 @@ var (
 		VCPUs:              2,
 		VCPUsUsed:          0,
 	}
+
 	HypervisorUptimeExpected = hypervisors.Uptime{
 		HypervisorHostname: "fake-mini",
 		ID:                 "c48f6247-abe4-4a24-824e-ea39e108874f",
@@ -374,6 +436,16 @@ func HandleHypervisorGetSuccessfully(t *testing.T) {
 
 		w.Header().Add("Content-Type", "application/json")
 		fmt.Fprintf(w, HypervisorGetBody)
+	})
+}
+
+func HandleHypervisorGetEmptyCPUInfoSuccessfully(t *testing.T) {
+	testhelper.Mux.HandleFunc("/os-hypervisors/"+HypervisorFake.ID, func(w http.ResponseWriter, r *http.Request) {
+		testhelper.TestMethod(t, r, "GET")
+		testhelper.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprintf(w, HypervisorGetEmptyCPUInfoBody)
 	})
 }
 

--- a/openstack/compute/v2/extensions/hypervisors/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/hypervisors/testing/requests_test.go
@@ -119,6 +119,18 @@ func TestGetHypervisor(t *testing.T) {
 	testhelper.CheckDeepEquals(t, &expected, actual)
 }
 
+func TestGetHypervisorEmptyCPUInfo(t *testing.T) {
+	testhelper.SetupHTTP()
+	defer testhelper.TeardownHTTP()
+	HandleHypervisorGetEmptyCPUInfoSuccessfully(t)
+
+	expected := HypervisorEmptyCPUInfo
+
+	actual, err := hypervisors.Get(client.ServiceClient(), expected.ID).Extract()
+	testhelper.AssertNoErr(t, err)
+	testhelper.CheckDeepEquals(t, &expected, actual)
+}
+
 func TestHypervisorsUptime(t *testing.T) {
 	testhelper.SetupHTTP()
 	defer testhelper.TeardownHTTP()


### PR DESCRIPTION
For #1319 