### PR TITLE
Remove imagePullPolicy from acceptance test

### DIFF
--- a/acceptance/openstack/container/v1/fixtures.go
+++ b/acceptance/openstack/container/v1/fixtures.go
@@ -24,7 +24,6 @@ const capsuleTemplate = `
 						"ENV2": "/usr/bin"
 					},
 					"image": "ubuntu",
-					"imagePullPolicy": "ifnotpresent",
 					"ports": [
 						{
 							"containerPort": 80,


### PR DESCRIPTION
Zun is going to require admin privilege [1] to create resource
with this field specified. Gophercloud acceptance test should
use non-admin credential to test so we remove this field from
acceptance test.

[1] https://review.openstack.org/#/c/650585/

For #1545