### PR TITLE
Loadbalancer v2: Listener createopts TimeoutMemberConnect & TimeoutTCPInspect

### DIFF
--- a/openstack/loadbalancer/v2/listeners/requests.go
+++ b/openstack/loadbalancer/v2/listeners/requests.go
@@ -127,7 +127,7 @@ type CreateOpts struct {
 	TimeoutMemberConnect *int `json:"timeout_member_connect,omitempty"`
 
 	// Time, in milliseconds, to wait for additional TCP packets for content inspection
-	TimeoutTCPInspect *int `json:timeout_tcp_inspect,omitempty"`
+	TimeoutTCPInspect *int `json:"timeout_tcp_inspect,omitempty"`
 
 	// A dictionary of optional headers to insert into the request before it is sent to the backend member.
 	InsertHeaders map[string]string `json:"insert_headers,omitempty"`
@@ -201,7 +201,7 @@ type UpdateOpts struct {
 	TimeoutMemberConnect *int `json:"timeout_member_connect,omitempty"`
 
 	// Time, in milliseconds, to wait for additional TCP packets for content inspection
-	TimeoutTCPInspect *int `json:timeout_tcp_inspect,omitempty"`
+	TimeoutTCPInspect *int `json:"timeout_tcp_inspect,omitempty"`
 }
 
 // ToListenerUpdateMap builds a request body from UpdateOpts.

--- a/openstack/loadbalancer/v2/listeners/requests.go
+++ b/openstack/loadbalancer/v2/listeners/requests.go
@@ -29,21 +29,23 @@ type ListOptsBuilder interface {
 // sort by a particular listener attribute. SortDir sets the direction, and is
 // either `asc' or `desc'. Marker and Limit are used for pagination.
 type ListOpts struct {
-	ID                string `q:"id"`
-	Name              string `q:"name"`
-	AdminStateUp      *bool  `q:"admin_state_up"`
-	ProjectID         string `q:"project_id"`
-	LoadbalancerID    string `q:"loadbalancer_id"`
-	DefaultPoolID     string `q:"default_pool_id"`
-	Protocol          string `q:"protocol"`
-	ProtocolPort      int    `q:"protocol_port"`
-	ConnectionLimit   int    `q:"connection_limit"`
-	Limit             int    `q:"limit"`
-	Marker            string `q:"marker"`
-	SortKey           string `q:"sort_key"`
-	SortDir           string `q:"sort_dir"`
-	TimeoutClientData *int   `q:"timeout_client_data"`
-	TimeoutMemberData *int   `q:"timeout_member_data"`
+	ID                   string `q:"id"`
+	Name                 string `q:"name"`
+	AdminStateUp         *bool  `q:"admin_state_up"`
+	ProjectID            string `q:"project_id"`
+	LoadbalancerID       string `q:"loadbalancer_id"`
+	DefaultPoolID        string `q:"default_pool_id"`
+	Protocol             string `q:"protocol"`
+	ProtocolPort         int    `q:"protocol_port"`
+	ConnectionLimit      int    `q:"connection_limit"`
+	Limit                int    `q:"limit"`
+	Marker               string `q:"marker"`
+	SortKey              string `q:"sort_key"`
+	SortDir              string `q:"sort_dir"`
+	TimeoutClientData    *int   `q:"timeout_client_data"`
+	TimeoutMemberData    *int   `q:"timeout_member_data"`
+	TimeoutMemberConnect *int   `q:"timeout_member_connect"`
+	TimeoutTCPInspect    *int   `q:"timeout_tcp_inspect"`
 }
 
 // ToListenerListQuery formats a ListOpts into a query string.
@@ -121,6 +123,12 @@ type CreateOpts struct {
 	// Backend member inactivity timeout in milliseconds
 	TimeoutMemberData *int `json:"timeout_member_data,omitempty"`
 
+	// Backend member connection timeout in milliseconds
+	TimeoutMemberConnect *int `json:"timeout_member_connect,omitempty"`
+
+	// Time, in milliseconds, to wait for additional TCP packets for content inspection
+	TimeoutTCPInspect *int `json:timeout_tcp_inspect,omitempty"`
+
 	// A dictionary of optional headers to insert into the request before it is sent to the backend member.
 	InsertHeaders map[string]string `json:"insert_headers,omitempty"`
 }
@@ -188,6 +196,12 @@ type UpdateOpts struct {
 
 	// Backend member inactivity timeout in milliseconds
 	TimeoutMemberData *int `json:"timeout_member_data,omitempty"`
+
+	// Backend member connection timeout in milliseconds
+	TimeoutMemberConnect *int `json:"timeout_member_connect,omitempty"`
+
+	// Time, in milliseconds, to wait for additional TCP packets for content inspection
+	TimeoutTCPInspect *int `json:timeout_tcp_inspect,omitempty"`
 }
 
 // ToListenerUpdateMap builds a request body from UpdateOpts.

--- a/openstack/loadbalancer/v2/listeners/results.go
+++ b/openstack/loadbalancer/v2/listeners/results.go
@@ -70,10 +70,10 @@ type Listener struct {
 	TimeoutMemberData int `json:"timeout_member_data"`
 
 	// Backend member connection timeout in milliseconds
-	TimeoutMemberConnect *int `json:"timeout_member_connect,omitempty"`
+	TimeoutMemberConnect int `json:"timeout_member_connect,omitempty"`
 
 	// Time, in milliseconds, to wait for additional TCP packets for content inspection
-	TimeoutTCPInspect *int `json:"timeout_tcp_inspect,omitempty"`
+	TimeoutTCPInspect int `json:"timeout_tcp_inspect,omitempty"`
 
 	// A dictionary of optional headers to insert into the request before it is sent to the backend member.
 	InsertHeaders map[string]string `json:"insert_headers"`

--- a/openstack/loadbalancer/v2/listeners/results.go
+++ b/openstack/loadbalancer/v2/listeners/results.go
@@ -69,6 +69,12 @@ type Listener struct {
 	// Backend member inactivity timeout in milliseconds
 	TimeoutMemberData int `json:"timeout_member_data"`
 
+	// Backend member connection timeout in milliseconds
+	TimeoutMemberConnect *int `json:"timeout_member_connect,omitempty"`
+
+	// Time, in milliseconds, to wait for additional TCP packets for content inspection
+	TimeoutTCPInspect *int `json:"timeout_tcp_inspect,omitempty"`
+
 	// A dictionary of optional headers to insert into the request before it is sent to the backend member.
 	InsertHeaders map[string]string `json:"insert_headers"`
 }

--- a/openstack/loadbalancer/v2/listeners/results.go
+++ b/openstack/loadbalancer/v2/listeners/results.go
@@ -70,10 +70,10 @@ type Listener struct {
 	TimeoutMemberData int `json:"timeout_member_data"`
 
 	// Backend member connection timeout in milliseconds
-	TimeoutMemberConnect int `json:"timeout_member_connect,omitempty"`
+	TimeoutMemberConnect int `json:"timeout_member_connect"`
 
 	// Time, in milliseconds, to wait for additional TCP packets for content inspection
-	TimeoutTCPInspect int `json:"timeout_tcp_inspect,omitempty"`
+	TimeoutTCPInspect int `json:"timeout_tcp_inspect"`
 
 	// A dictionary of optional headers to insert into the request before it is sent to the backend member.
 	InsertHeaders map[string]string `json:"insert_headers"`

--- a/openstack/loadbalancer/v2/listeners/testing/fixtures.go
+++ b/openstack/loadbalancer/v2/listeners/testing/fixtures.go
@@ -146,6 +146,8 @@ var (
 		SniContainerRefs:       []string{"3d328d82-2547-4921-ac2f-61c3b452b5ff", "b3cfd7e3-8c19-455c-8ebb-d78dfd8f7e7d"},
 		TimeoutClientData:      50000,
 		TimeoutMemberData:      50000,
+		TimeoutMemberConnect:   5000,
+		TimeoutTCPInspect:      0,
 		InsertHeaders:          map[string]string{"X-Forwarded-For": "true"},
 	}
 	ListenerUpdated = listeners.Listener{
@@ -163,6 +165,8 @@ var (
 		SniContainerRefs:       []string{"3d328d82-2547-4921-ac2f-61c3b452b5ff", "b3cfd7e3-8c19-455c-8ebb-d78dfd8f7e7d"},
 		TimeoutClientData:      181000,
 		TimeoutMemberData:      181000,
+		TimeoutMemberConnect:   181000,
+		TimeoutTCPInspect:      181000,
 	}
 	ListenerStatsTree = listeners.Stats{
 		ActiveConnections: 0,

--- a/openstack/loadbalancer/v2/listeners/testing/fixtures.go
+++ b/openstack/loadbalancer/v2/listeners/testing/fixtures.go
@@ -42,6 +42,8 @@ const ListenersListBody = `
 			"sni_container_refs": ["3d328d82-2547-4921-ac2f-61c3b452b5ff", "b3cfd7e3-8c19-455c-8ebb-d78dfd8f7e7d"],
 			"timeout_client_data": 50000,
 			"timeout_member_data": 50000,
+			"timeout_member_connect": 5000,
+			"timeout_tcp_inspect": 0,
 			"insert_headers": {
 				"X-Forwarded-For": "true"
 			}
@@ -68,6 +70,8 @@ const SingleListenerBody = `
 		"sni_container_refs": ["3d328d82-2547-4921-ac2f-61c3b452b5ff", "b3cfd7e3-8c19-455c-8ebb-d78dfd8f7e7d"],
 		"timeout_client_data": 50000,
 		"timeout_member_data": 50000,
+		"timeout_member_connect": 5000,
+		"timeout_tcp_inspect": 0,
         	"insert_headers": {
             		"X-Forwarded-For": "true"
         	}
@@ -92,7 +96,9 @@ const PostUpdateListenerBody = `
 		"default_tls_container_ref": "2c433435-20de-4411-84ae-9cc8917def76",
 		"sni_container_refs": ["3d328d82-2547-4921-ac2f-61c3b452b5ff", "b3cfd7e3-8c19-455c-8ebb-d78dfd8f7e7d"],
 		"timeout_client_data": 181000,
-		"timeout_member_data": 181000
+		"timeout_member_data": 181000,
+		"timeout_member_connect": 181000,
+		"timeout_tcp_inspect": 181000
 
 	}
 }
@@ -248,7 +254,9 @@ func HandleListenerUpdateSuccessfully(t *testing.T) {
 				"default_pool_id": null,
 				"connection_limit": 1001,
 				"timeout_client_data": 181000,
-				"timeout_member_data": 181000
+				"timeout_member_data": 181000,
+				"timeout_member_connect": 181000,
+				"timeout_tcp_inspect": 181000
 			}
 		}`)
 

--- a/openstack/loadbalancer/v2/listeners/testing/requests_test.go
+++ b/openstack/loadbalancer/v2/listeners/testing/requests_test.go
@@ -130,11 +130,13 @@ func TestUpdateListener(t *testing.T) {
 	name := "NewListenerName"
 	defaultPoolID := ""
 	actual, err := listeners.Update(client, "4ec89087-d057-4e2c-911f-60a3b47ee304", listeners.UpdateOpts{
-		Name:              &name,
-		ConnLimit:         &i1001,
-		DefaultPoolID:     &defaultPoolID,
-		TimeoutMemberData: &i181000,
-		TimeoutClientData: &i181000,
+		Name:                 &name,
+		ConnLimit:            &i1001,
+		DefaultPoolID:        &defaultPoolID,
+		TimeoutMemberData:    &i181000,
+		TimeoutClientData:    &i181000,
+		TimeoutMemberConnect: &i181000,
+		TimeoutTCPInspect:    &i181000,
 	}).Extract()
 	if err != nil {
 		t.Fatalf("Unexpected Update error: %v", err)


### PR DESCRIPTION
For #1543

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

Base definition:
* https://github.com/openstack/octavia/blob/stable/rocky/octavia/common/data_models.py#L384
* https://github.com/openstack/octavia/blob/stable/rocky/octavia/common/data_models.py#L386

Create:
* https://github.com/openstack/octavia/blob/stable/rocky/octavia/api/v2/types/listener.py#L120-L123
* https://github.com/openstack/octavia/blob/stable/rocky/octavia/api/v2/types/listener.py#L128-L130

Update:
* https://github.com/openstack/octavia/blob/stable/rocky/octavia/api/v2/types/listener.py#L154-L156
* https://github.com/openstack/octavia/blob/stable/rocky/octavia/api/v2/types/listener.py#L160-L162
