### PR TITLE
Baremetal introspection: correct handling of LLDP data

### DIFF
--- a/openstack/baremetalintrospection/v1/introspection/results.go
+++ b/openstack/baremetalintrospection/v1/introspection/results.go
@@ -199,7 +199,7 @@ type InterfaceType struct {
 	HasCarrier  bool                   `json:"has_carrier"`
 	IPV4Address string                 `json:"ipv4_address"`
 	IPV6Address string                 `json:"ipv6_address"`
-	Lldp        map[string]interface{} `json:"lldp"`
+	LLDP        map[string]interface{} `json:"lldp"`
 	MACAddress  string                 `json:"mac_address"`
 	Name        string                 `json:"name"`
 	Product     string                 `json:"product"`

--- a/openstack/baremetalintrospection/v1/introspection/results.go
+++ b/openstack/baremetalintrospection/v1/introspection/results.go
@@ -2,6 +2,7 @@ package introspection
 
 import (
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/gophercloud/gophercloud"
@@ -174,10 +175,11 @@ type Data struct {
 // Sub Types defined under Data and deeper in the structure
 
 type BaseInterfaceType struct {
-	ClientID string `json:"client_id"`
-	IP       string `json:"ip"`
-	MAC      string `json:"mac"`
-	PXE      bool   `json:"pxe"`
+	ClientID      string                 `json:"client_id"`
+	IP            string                 `json:"ip"`
+	MAC           string                 `json:"mac"`
+	PXE           bool                   `json:"pxe"`
+	LLDPProcessed map[string]interface{} `json:"lldp_processed"`
 }
 
 type BootInfoType struct {
@@ -193,17 +195,22 @@ type CPUType struct {
 	ModelName    string   `json:"model_name"`
 }
 
+type LLDPTLVType struct {
+	Type  int
+	Value string
+}
+
 type InterfaceType struct {
-	BIOSDevName string                 `json:"biosdevname"`
-	ClientID    string                 `json:"client_id"`
-	HasCarrier  bool                   `json:"has_carrier"`
-	IPV4Address string                 `json:"ipv4_address"`
-	IPV6Address string                 `json:"ipv6_address"`
-	LLDP        map[string]interface{} `json:"lldp"`
-	MACAddress  string                 `json:"mac_address"`
-	Name        string                 `json:"name"`
-	Product     string                 `json:"product"`
-	Vendor      string                 `json:"vendor"`
+	BIOSDevName string        `json:"biosdevname"`
+	ClientID    string        `json:"client_id"`
+	HasCarrier  bool          `json:"has_carrier"`
+	IPV4Address string        `json:"ipv4_address"`
+	IPV6Address string        `json:"ipv6_address"`
+	LLDP        []LLDPTLVType `json:"lldp"`
+	MACAddress  string        `json:"mac_address"`
+	Name        string        `json:"name"`
+	Product     string        `json:"product"`
+	Vendor      string        `json:"vendor"`
 }
 
 type InventoryType struct {
@@ -238,6 +245,32 @@ type SystemVendorType struct {
 	Manufacturer string `json:"manufacturer"`
 	ProductName  string `json:"product_name"`
 	SerialNumber string `json:"serial_number"`
+}
+
+// UnmarshalJSON interprets an LLDP TLV [key, value] pair as an LLDPTLVType structure
+func (r *LLDPTLVType) UnmarshalJSON(data []byte) error {
+	var list []interface{}
+	if err := json.Unmarshal(data, &list); err != nil {
+		return err
+	}
+
+	if len(list) != 2 {
+		return fmt.Errorf("Invalid LLDP TLV key-value pair")
+	}
+
+	fieldtype, ok := list[0].(float64)
+	if !ok {
+		return fmt.Errorf("LLDP TLV key is not number")
+	}
+
+	value, ok := list[1].(string)
+	if !ok {
+		return fmt.Errorf("LLDP TLV value is not string")
+	}
+
+	r.Type = int(fieldtype)
+	r.Value = value
+	return nil
 }
 
 // Extract interprets any IntrospectionDataResult as IntrospectionData, if possible.

--- a/openstack/baremetalintrospection/v1/introspection/testing/fixtures.go
+++ b/openstack/baremetalintrospection/v1/introspection/testing/fixtures.go
@@ -101,7 +101,7 @@ const IntrospectionDataJSONSample = `
       "bmc_address":"192.167.2.134",
       "interfaces":[
          {
-            "lldp":null,
+            "lldp":[],
             "product":"0x0001",
             "vendor":"0x1af4",
             "name":"eth1",
@@ -111,7 +111,7 @@ const IntrospectionDataJSONSample = `
             "mac_address":"52:54:00:47:20:4d"
          },
          {
-            "lldp":null,
+            "lldp":[],
             "product":"0x0001",
             "vendor":"0x1af4",
             "name":"eth0",
@@ -270,6 +270,7 @@ var (
 					Name:        "eth1",
 					Product:     "0x0001",
 					IPV4Address: "172.24.42.101",
+					LLDP:        []introspection.LLDPTLVType{},
 				},
 				introspection.InterfaceType{
 					IPV4Address: "172.24.42.100",
@@ -278,6 +279,7 @@ var (
 					Product:     "0x0001",
 					HasCarrier:  true,
 					Vendor:      "0x1af4",
+					LLDP:        []introspection.LLDPTLVType{},
 				},
 			},
 			Memory: introspection.MemoryType{

--- a/openstack/baremetalintrospection/v1/introspection/testing/fixtures.go
+++ b/openstack/baremetalintrospection/v1/introspection/testing/fixtures.go
@@ -111,7 +111,10 @@ const IntrospectionDataJSONSample = `
             "mac_address":"52:54:00:47:20:4d"
          },
          {
-            "lldp":[],
+            "lldp": [
+              [1, "04112233aabbcc"],
+              [5, "737730312d646973742d31622d623132"]
+            ],
             "product":"0x0001",
             "vendor":"0x1af4",
             "name":"eth0",
@@ -174,8 +177,12 @@ const IntrospectionDataJSONSample = `
          "ip":"172.24.42.100",
          "mac":"52:54:00:4e:3d:30",
          "pxe":true,
-         "client_id":null
-     }
+         "client_id":null,
+         "lldp_processed":{
+           "switch_chassis_id":"11:22:33:aa:bb:cc",
+           "switch_system_name":"sw01-dist-1b-b12"
+         }
+      }
    }
 }
 `
@@ -279,7 +286,16 @@ var (
 					Product:     "0x0001",
 					HasCarrier:  true,
 					Vendor:      "0x1af4",
-					LLDP:        []introspection.LLDPTLVType{},
+					LLDP: []introspection.LLDPTLVType{
+						introspection.LLDPTLVType{
+							Type:  1,
+							Value: "04112233aabbcc",
+						},
+						introspection.LLDPTLVType{
+							Type:  5,
+							Value: "737730312d646973742d31622d623132",
+						},
+					},
 				},
 			},
 			Memory: introspection.MemoryType{
@@ -299,6 +315,10 @@ var (
 				IP:  "172.24.42.100",
 				MAC: "52:54:00:4e:3d:30",
 				PXE: true,
+				LLDPProcessed: map[string]interface{}{
+					"switch_chassis_id":  "11:22:33:aa:bb:cc",
+					"switch_system_name": "sw01-dist-1b-b12",
+				},
 			},
 		},
 	}

--- a/openstack/baremetalintrospection/v1/introspection/testing/results_test.go
+++ b/openstack/baremetalintrospection/v1/introspection/testing/results_test.go
@@ -1,0 +1,29 @@
+package testing
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/baremetalintrospection/v1/introspection"
+)
+
+func TestLLDPTLVErrors(t *testing.T) {
+	badInputs := []string{
+		"[1]",
+		"[1, 2]",
+		"[\"foo\", \"bar\"]",
+	}
+
+	for _, input := range badInputs {
+		var output introspection.LLDPTLVType
+		err := json.Unmarshal([]byte(input), &output)
+		if err == nil {
+			t.Errorf("No JSON parse error for invalid LLDP TLV %s", input)
+		}
+		if !strings.Contains(err.Error(), "LLDP TLV") {
+			t.Errorf("Unexpected JSON parse error \"%s\" for invalid LLDP TLV %s",
+				err, input)
+		}
+	}
+}


### PR DESCRIPTION
The LLDP data in the inventory doesn't appear as a JSON object, but as
a JSON array of [type, value] pairs such as:

[[1, "04112233aabbcc"], [2, "07373334"], ...]

(There can be multiple fields with the same type, which is why they are
not returned as a JSON object.)

There is a place where the raw LLDP data is processed into a JSON object
- under the `lldp_processed` key in the top-level `all_interfaces` list
(i.e. not in the inventory), here represented by BaseInterfaceType.

This patch corrects handling for LLDP data in the inventory (i.e. in
InterfaceType) and adds handling for it in BaseInterfaceType

For #1485 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/ironic-inspector/blob/8.2.0/ironic_inspector/test/unit/test_plugins_lldp_basic.py#L171-L196
