### PR TITLE
Support acceptance test against OpenStack Stein release

### DIFF
--- a/acceptance/openstack/compute/v2/quotaset_test.go
+++ b/acceptance/openstack/compute/v2/quotaset_test.go
@@ -19,6 +19,7 @@ func TestQuotasetGet(t *testing.T) {
 	clients.SkipRelease(t, "master")
 	clients.SkipRelease(t, "stable/queens")
 	clients.SkipRelease(t, "stable/rocky")
+	clients.SkipRelease(t, "stable/stein")
 
 	client, err := clients.NewComputeV2Client()
 	th.AssertNoErr(t, err)
@@ -107,6 +108,7 @@ func TestQuotasetUpdateDelete(t *testing.T) {
 	clients.SkipRelease(t, "master")
 	clients.SkipRelease(t, "stable/queens")
 	clients.SkipRelease(t, "stable/rocky")
+	clients.SkipRelease(t, "stable/stein")
 
 	clients.RequireAdmin(t)
 

--- a/acceptance/openstack/identity/v3/roles_test.go
+++ b/acceptance/openstack/identity/v3/roles_test.go
@@ -116,6 +116,7 @@ func TestRolesFilterList(t *testing.T) {
 	clients.SkipRelease(t, "master")
 	clients.SkipRelease(t, "stable/queens")
 	clients.SkipRelease(t, "stable/rocky")
+	clients.SkipRelease(t, "stable/stein")
 
 	client, err := clients.NewIdentityV3Client()
 	th.AssertNoErr(t, err)


### PR DESCRIPTION
We have to skip several tests to support acceptance
test against OpenStack Stein release like we do for
master, stable/queen and stable/rocky.

Related-Bug: theopenlab/openlab#231

Prior to starting a PR, please make sure you have read our
[contributor tutorial](https://github.com/gophercloud/gophercloud/tree/master/docs/contributor-tutorial).

Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

For #[PUT ISSUE NUMBER HERE]

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

[PUT URLS HERE]
