### PR TITLE
Baremetal: Fix microversion headers in node.Update

### DIFF
--- a/openstack/baremetal/v1/nodes/requests.go
+++ b/openstack/baremetal/v1/nodes/requests.go
@@ -301,19 +301,10 @@ func Update(client *gophercloud.ServiceClient, id string, opts UpdateOpts) (r Up
 
 		body[i] = result
 	}
-
-	resp, err := client.Request("PATCH", updateURL(client, id), &gophercloud.RequestOpts{
+	_, r.Err = client.Patch(updateURL(client, id), body, &r.Body, &gophercloud.RequestOpts{
 		JSONBody: &body,
 		OkCodes:  []int{200},
 	})
-
-	if err != nil {
-		r.Err = err
-	} else {
-		r.Body = resp.Body
-		r.Header = resp.Header
-	}
-
 	return
 }
 

--- a/openstack/baremetal/v1/ports/requests.go
+++ b/openstack/baremetal/v1/ports/requests.go
@@ -202,15 +202,10 @@ func Update(client *gophercloud.ServiceClient, id string, opts UpdateOpts) (r Up
 		body[i] = patch.ToPortUpdateMap()
 	}
 
-	resp, err := client.Request("PATCH", updateURL(client, id), &gophercloud.RequestOpts{
+	_, r.Err = client.Patch(updateURL(client, id), body, &r.Body, &gophercloud.RequestOpts{
 		JSONBody: &body,
 		OkCodes:  []int{200},
 	})
-
-	r.Body = resp.Body
-	r.Header = resp.Header
-	r.Err = err
-
 	return
 }
 


### PR DESCRIPTION
Fix for #1554 

Use method `client.Patch` instead of `client.Request`

The problem with `client.Request` is in missing call to `initReqOpts`.