### PR TITLE
Baremetal API V1: Support set RAID config

### DIFF
--- a/acceptance/openstack/baremetal/noauth/nodes_test.go
+++ b/acceptance/openstack/baremetal/noauth/nodes_test.go
@@ -65,3 +65,31 @@ func TestNodesUpdate(t *testing.T) {
 
 	th.AssertEquals(t, updated.Maintenance, true)
 }
+
+func TestNodesRAIDConfig(t *testing.T) {
+	clients.RequireLong(t)
+
+	client, err := clients.NewBareMetalV1NoAuthClient()
+	th.AssertNoErr(t, err)
+	client.Microversion = "1.50"
+
+	node, err := v1.CreateNode(t, client)
+	th.AssertNoErr(t, err)
+	defer v1.DeleteNode(t, client, node)
+
+	sizeGB := 100
+	isTrue := true
+
+	err = nodes.SetRAIDConfig(client, node.UUID, nodes.RAIDConfigOpts{
+		LogicalDisks: []nodes.LogicalDisk{
+			{
+				SizeGB:                &sizeGB,
+				IsRootVolume:          &isTrue,
+				RAIDLevel:             nodes.RAID5,
+				DiskType:              nodes.HDD,
+				NumberOfPhysicalDisks: 5,
+			},
+		},
+	}).ExtractErr()
+	th.AssertNoErr(t, err)
+}

--- a/acceptance/openstack/baremetal/v1/baremetal.go
+++ b/acceptance/openstack/baremetal/v1/baremetal.go
@@ -19,6 +19,7 @@ func CreateNode(t *testing.T, client *gophercloud.ServiceClient) (*nodes.Node, e
 		Name:          name,
 		Driver:        "ipmi",
 		BootInterface: "pxe",
+		RAIDInterface: "agent",
 		DriverInfo: map[string]interface{}{
 			"ipmi_port":      "6230",
 			"ipmi_username":  "admin",

--- a/acceptance/openstack/baremetal/v1/nodes_test.go
+++ b/acceptance/openstack/baremetal/v1/nodes_test.go
@@ -66,3 +66,31 @@ func TestNodesUpdate(t *testing.T) {
 
 	th.AssertEquals(t, updated.Maintenance, true)
 }
+
+func TestNodesRAIDConfig(t *testing.T) {
+	clients.RequireLong(t)
+
+	client, err := clients.NewBareMetalV1Client()
+	th.AssertNoErr(t, err)
+	client.Microversion = "1.50"
+
+	node, err := CreateNode(t, client)
+	th.AssertNoErr(t, err)
+	defer DeleteNode(t, client, node)
+
+	sizeGB := 100
+	isTrue := true
+
+	err = nodes.SetRAIDConfig(client, node.UUID, nodes.RAIDConfigOpts{
+		LogicalDisks: []nodes.LogicalDisk{
+			{
+				SizeGB:                &sizeGB,
+				IsRootVolume:          &isTrue,
+				RAIDLevel:             nodes.RAID5,
+				DiskType:              nodes.HDD,
+				NumberOfPhysicalDisks: 5,
+			},
+		},
+	}).ExtractErr()
+	th.AssertNoErr(t, err)
+}

--- a/openstack/baremetal/v1/nodes/testing/fixtures.go
+++ b/openstack/baremetal/v1/nodes/testing/fixtures.go
@@ -946,3 +946,43 @@ func HandleChangePowerStateWithConflict(t *testing.T) {
 		w.WriteHeader(http.StatusConflict)
 	})
 }
+
+func HandleSetRAIDConfig(t *testing.T) {
+	th.Mux.HandleFunc("/nodes/1234asdf/states/raid", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, `
+			{
+			   "logical_disks" : [
+				  {
+					 "size_gb" : 100,
+					 "is_root_volume" : true,
+					 "raid_level" : "1"
+				  }
+			   ]
+			}
+		`)
+
+		w.WriteHeader(http.StatusNoContent)
+	})
+}
+
+func HandleSetRAIDConfigMaxSize(t *testing.T) {
+	th.Mux.HandleFunc("/nodes/1234asdf/states/raid", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, `
+			{
+			   "logical_disks" : [
+				  {
+					 "size_gb" : "MAX",
+					 "is_root_volume" : true,
+					 "raid_level" : "1"
+				  }
+			   ]
+			}
+		`)
+
+		w.WriteHeader(http.StatusNoContent)
+	})
+}

--- a/openstack/baremetal/v1/nodes/testing/requests_test.go
+++ b/openstack/baremetal/v1/nodes/testing/requests_test.go
@@ -369,3 +369,48 @@ func TestChangePowerStateWithConflict(t *testing.T) {
 		t.Fatal("ErrDefault409 was expected to occur")
 	}
 }
+
+func TestSetRAIDConfig(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleSetRAIDConfig(t)
+
+	sizeGB := 100
+	isRootVolume := true
+
+	config := nodes.RAIDConfigOpts{
+		LogicalDisks: []nodes.LogicalDisk{
+			{
+				SizeGB:       &sizeGB,
+				IsRootVolume: &isRootVolume,
+				RAIDLevel:    nodes.RAID1,
+			},
+		},
+	}
+
+	c := client.ServiceClient()
+	err := nodes.SetRAIDConfig(c, "1234asdf", config).ExtractErr()
+	th.AssertNoErr(t, err)
+}
+
+// Without specifying a size, we need to send a string: "MAX"
+func TestSetRAIDConfigMaxSize(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleSetRAIDConfigMaxSize(t)
+
+	isRootVolume := true
+
+	config := nodes.RAIDConfigOpts{
+		LogicalDisks: []nodes.LogicalDisk{
+			{
+				IsRootVolume: &isRootVolume,
+				RAIDLevel:    nodes.RAID1,
+			},
+		},
+	}
+
+	c := client.ServiceClient()
+	err := nodes.SetRAIDConfig(c, "1234asdf", config).ExtractErr()
+	th.AssertNoErr(t, err)
+}

--- a/openstack/baremetal/v1/nodes/urls.go
+++ b/openstack/baremetal/v1/nodes/urls.go
@@ -53,3 +53,7 @@ func powerStateURL(client *gophercloud.ServiceClient, id string) string {
 func provisionStateURL(client *gophercloud.ServiceClient, id string) string {
 	return statesResourceURL(client, id, "provision")
 }
+
+func raidConfigURL(client *gophercloud.ServiceClient, id string) string {
+	return statesResourceURL(client, id, "raid")
+}


### PR DESCRIPTION
For #1429

This adds support to set a node's RAID configuration.

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

## Docs

- [API Ref](https://developer.openstack.org/api-ref/baremetal/?expanded=set-raid-config-detail#set-raid-config)
- [Target RAID Config](https://docs.openstack.org/ironic/latest/admin/raid.html)

## Code

- https://github.com/openstack/ironic/blob/master/ironic/api/controllers/v1/node.py#L466-L494
- Each driver (if it supports RAID) reads from the same format of the TargetRaidConfig data structure defined in the doc above. It's spread out in the case base, but for example - here's DRAC: https://github.com/openstack/ironic/blob/master/ironic/drivers/modules/drac/raid.py


