### PR TITLE
Don't print token on token auth method

### DIFF
--- a/acceptance/clients/http.go
+++ b/acceptance/clients/http.go
@@ -129,6 +129,9 @@ func (lrt *LogRoundTripper) formatJSON(raw []byte) string {
 					v["password"] = "***"
 				}
 			}
+			if v, ok := v["token"].(map[string]interface{}); ok {
+				v["id"] = "***"
+			}
 		}
 	}
 


### PR DESCRIPTION
it is a part of the #1566

this PR prevents token to be printed. Same should be done for the terraform openstack provider in future.