### PR TITLE
do not swallow connection errors in tokens.Get()

### DIFF
--- a/openstack/identity/v3/tokens/requests.go
+++ b/openstack/identity/v3/tokens/requests.go
@@ -134,9 +134,9 @@ func Get(c *gophercloud.ServiceClient, token string) (r GetResult) {
 		OkCodes:     []int{200, 203},
 	})
 	if resp != nil {
-		r.Err = err
 		r.Header = resp.Header
 	}
+	r.Err = err
 	return
 }
 


### PR DESCRIPTION
For #1569.

It might be worthwhile to check if this problem also exists in other request methods in other packages.