### PR TITLE
Hide application credential auth while debug

### DIFF
--- a/acceptance/clients/http.go
+++ b/acceptance/clients/http.go
@@ -129,6 +129,9 @@ func (lrt *LogRoundTripper) formatJSON(raw []byte) string {
 					v["password"] = "***"
 				}
 			}
+			if v, ok := v["application_credential"].(map[string]interface{}); ok {
+				v["secret"] = "***"
+			}
 			if v, ok := v["token"].(map[string]interface{}); ok {
 				v["id"] = "***"
 			}


### PR DESCRIPTION
Relates to #1567. There is no need to replicate it in terraform, it is already there.