### PR TITLE
Support mark unhealthy action for stack resource

### DIFF
--- a/acceptance/openstack/orchestration/v1/stackresources_test.go
+++ b/acceptance/openstack/orchestration/v1/stackresources_test.go
@@ -27,6 +27,19 @@ func TestStackResources(t *testing.T) {
 	th.AssertNoErr(t, err)
 	tools.PrintResource(t, metadata)
 
+	markUnhealthyOpts := &stackresources.MarkUnhealthyOpts{
+		MarkUnhealthy:        true,
+		ResourceStatusReason: "Wrong security policy is detected.",
+	}
+
+	err = stackresources.MarkUnhealthy(client, stack.Name, stack.ID, basicTemplateResourceName, markUnhealthyOpts).ExtractErr()
+	th.AssertNoErr(t, err)
+
+	unhealthyResource, err := stackresources.Get(client, stack.Name, stack.ID, basicTemplateResourceName).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, "CHECK_FAILED", unhealthyResource.Status)
+	tools.PrintResource(t, unhealthyResource)
+
 	allPages, err := stackresources.List(client, stack.Name, stack.ID, nil).AllPages()
 	th.AssertNoErr(t, err)
 	allResources, err := stackresources.ExtractResources(allPages)

--- a/openstack/orchestration/v1/stackresources/requests.go
+++ b/openstack/orchestration/v1/stackresources/requests.go
@@ -75,3 +75,39 @@ func Template(c *gophercloud.ServiceClient, resourceType string) (r TemplateResu
 	_, r.Err = c.Get(templateURL(c, resourceType), &r.Body, nil)
 	return
 }
+
+// MarkUnhealthyOpts contains the common options struct used in this package's
+// MarkUnhealthy operations.
+type MarkUnhealthyOpts struct {
+	// A boolean indicating whether the target resource should be marked as unhealthy.
+	MarkUnhealthy bool `json:"mark_unhealthy"`
+	// The reason for the current stack resource state.
+	ResourceStatusReason string `json:"resource_status_reason,omitempty"`
+}
+
+// MarkUnhealthyOptsBuilder is the interface options structs have to satisfy in order
+// to be used in the MarkUnhealthy operation in this package
+type MarkUnhealthyOptsBuilder interface {
+	ToMarkUnhealthyMap() (map[string]interface{}, error)
+}
+
+// ToMarkUnhealthyMap validates that a template was supplied and calls
+// the ToMarkUnhealthyMap private function.
+func (opts MarkUnhealthyOpts) ToMarkUnhealthyMap() (map[string]interface{}, error) {
+	b, err := gophercloud.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+// MarkUnhealthy marks the specified resource in the stack as unhealthy.
+func MarkUnhealthy(c *gophercloud.ServiceClient, stackName, stackID, resourceName string, opts MarkUnhealthyOptsBuilder) (r MarkUnhealthyResult) {
+	b, err := opts.ToMarkUnhealthyMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Patch(markUnhealthyURL(c, stackName, stackID, resourceName), b, nil, nil)
+	return
+}

--- a/openstack/orchestration/v1/stackresources/results.go
+++ b/openstack/orchestration/v1/stackresources/results.go
@@ -204,3 +204,8 @@ func (r TemplateResult) Extract() ([]byte, error) {
 	template, err := json.MarshalIndent(r.Body, "", "  ")
 	return template, err
 }
+
+// MarkUnhealthyResult represents the result of a mark unhealthy operation.
+type MarkUnhealthyResult struct {
+	gophercloud.ErrResult
+}

--- a/openstack/orchestration/v1/stackresources/testing/fixtures.go
+++ b/openstack/orchestration/v1/stackresources/testing/fixtures.go
@@ -441,3 +441,16 @@ func HandleGetTemplateSuccessfully(t *testing.T, output string) {
 		fmt.Fprintf(w, output)
 	})
 }
+
+// HandleMarkUnhealthySuccessfully creates an HTTP handler at `/stacks/teststack/0b1771bd-9336-4f2b-ae86-a80f971faf1e/resources/wordpress_instance`
+// on the test handler mux that responds with a `MarkUnhealthy` response.
+func HandleMarkUnhealthySuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/stacks/teststack/0b1771bd-9336-4f2b-ae86-a80f971faf1e/resources/wordpress_instance", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PATCH")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+	})
+}

--- a/openstack/orchestration/v1/stackresources/testing/requests_test.go
+++ b/openstack/orchestration/v1/stackresources/testing/requests_test.go
@@ -110,3 +110,16 @@ func TestGetResourceTemplate(t *testing.T) {
 	expected := GetTemplateExpected
 	th.AssertDeepEquals(t, expected, string(actual))
 }
+
+func TestMarkUnhealthyResource(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleMarkUnhealthySuccessfully(t)
+
+	markUnhealthyOpts := &stackresources.MarkUnhealthyOpts{
+		MarkUnhealthy:        true,
+		ResourceStatusReason: "Kubelet.Ready is Unknown more than 10 mins.",
+	}
+	err := stackresources.MarkUnhealthy(fake.ServiceClient(), "teststack", "0b1771bd-9336-4f2b-ae86-a80f971faf1e", "wordpress_instance", markUnhealthyOpts).ExtractErr()
+	th.AssertNoErr(t, err)
+}

--- a/openstack/orchestration/v1/stackresources/urls.go
+++ b/openstack/orchestration/v1/stackresources/urls.go
@@ -29,3 +29,7 @@ func schemaURL(c *gophercloud.ServiceClient, typeName string) string {
 func templateURL(c *gophercloud.ServiceClient, typeName string) string {
 	return c.ServiceURL("resource_types", typeName, "template")
 }
+
+func markUnhealthyURL(c *gophercloud.ServiceClient, stackName, stackID, resourceName string) string {
+	return c.ServiceURL("stacks", stackName, stackID, "resources", resourceName)
+}


### PR DESCRIPTION
Heat supports mark a resource as unhealthy via API, which is very
useful for auto healing use case. After marked a resource unhealthy,
the status of the resource will be 'CHECK_FAILED', then the resource
will be rebuilt as long as a Heat stack update triggered.

For #1573

Here is the API reference for resource mark unhealthy:

https://developer.openstack.org/api-ref/orchestration/v1/index.html?expanded=mark-a-resource-as-unhealthy-detail#mark-a-resource-as-unhealthy
