### PR TITLE
Add parent_resource attribute for Heat stack resource

### DIFF
--- a/openstack/orchestration/v1/stackresources/results.go
+++ b/openstack/orchestration/v1/stackresources/results.go
@@ -10,18 +10,19 @@ import (
 
 // Resource represents a stack resource.
 type Resource struct {
-	Attributes   map[string]interface{} `json:"attributes"`
-	CreationTime time.Time              `json:"-"`
-	Description  string                 `json:"description"`
-	Links        []gophercloud.Link     `json:"links"`
-	LogicalID    string                 `json:"logical_resource_id"`
-	Name         string                 `json:"resource_name"`
-	PhysicalID   string                 `json:"physical_resource_id"`
-	RequiredBy   []interface{}          `json:"required_by"`
-	Status       string                 `json:"resource_status"`
-	StatusReason string                 `json:"resource_status_reason"`
-	Type         string                 `json:"resource_type"`
-	UpdatedTime  time.Time              `json:"-"`
+	Attributes     map[string]interface{} `json:"attributes"`
+	CreationTime   time.Time              `json:"-"`
+	Description    string                 `json:"description"`
+	Links          []gophercloud.Link     `json:"links"`
+	LogicalID      string                 `json:"logical_resource_id"`
+	Name           string                 `json:"resource_name"`
+	PhysicalID     string                 `json:"physical_resource_id"`
+	RequiredBy     []interface{}          `json:"required_by"`
+	Status         string                 `json:"resource_status"`
+	StatusReason   string                 `json:"resource_status_reason"`
+	Type           string                 `json:"resource_type"`
+	UpdatedTime    time.Time              `json:"-"`
+	ParentResource string                 `json:"parent_resource"`
 }
 
 func (r *Resource) UnmarshalJSON(b []byte) error {


### PR DESCRIPTION
The attribute `parent_resource` is helpful when building a reverse mapping between the resource and their parents.

[1] https://github.com/openstack/heat/blob/master/heat/rpc/api.py#L76


For #1575 
