### PR TITLE
Baremetal API: Return versions supported by the API

### DIFF
--- a/openstack/baremetal/apiversions/doc.go
+++ b/openstack/baremetal/apiversions/doc.go
@@ -1,0 +1,13 @@
+/*
+Package apiversions provides information about the versions supported by a specific Ironic API.
+
+	Example to list versions
+
+		allVersions, err := apiversions.List(client.ServiceClient()).AllPages()
+
+	Example to get a specific version
+
+		actual, err := apiversions.Get(client.ServiceClient(), "v1").Extract()
+
+*/
+package apiversions

--- a/openstack/baremetal/apiversions/requests.go
+++ b/openstack/baremetal/apiversions/requests.go
@@ -1,0 +1,17 @@
+package apiversions
+
+import (
+	"github.com/gophercloud/gophercloud"
+)
+
+// List lists all the API versions available to end users.
+func List(client *gophercloud.ServiceClient) (r ListResult) {
+	_, r.Err = client.Get(listURL(client), &r.Body, nil)
+	return
+}
+
+// Get will get a specific API version, specified by major ID.
+func Get(client *gophercloud.ServiceClient, v string) (r GetResult) {
+	_, r.Err = client.Get(getURL(client, v), &r.Body, nil)
+	return
+}

--- a/openstack/baremetal/apiversions/results.go
+++ b/openstack/baremetal/apiversions/results.go
@@ -1,0 +1,62 @@
+package apiversions
+
+import (
+	"github.com/gophercloud/gophercloud"
+)
+
+// APIVersions represents the result from getting a list of all versions available
+type APIVersions struct {
+	DefaultVersion APIVersion   `json:"default_version"`
+	Versions       []APIVersion `json:"versions"`
+}
+
+// APIVersion represents an API version for Ironic
+type APIVersion struct {
+	// ID is the unique identifier of the API version.
+	ID string `json:"id"`
+
+	// MinVersion is the minimum microversion supported.
+	MinVersion string `json:"min_version"`
+
+	// Status is the API versions status.
+	Status string `json:"status"`
+
+	// Version is the maximum microversion supported.
+	Version string `json:"version"`
+}
+
+// GetResult represents the result of a get operation.
+type GetResult struct {
+	gophercloud.Result
+}
+
+// ListResult represents the result of a list operation.
+type ListResult struct {
+	gophercloud.Result
+}
+
+// Extract is a function that accepts a get result and extracts an API version resource.
+func (r GetResult) Extract() (*APIVersion, error) {
+	var s struct {
+		Version APIVersion `json:"version"`
+	}
+
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return nil, err
+	}
+
+	return &s.Version, nil
+}
+
+// Extract is a function that accepts a list result and extracts an APIVersions resource
+func (r ListResult) Extract() (*APIVersions, error) {
+	var version APIVersions
+
+	err := r.ExtractInto(&version)
+	if err != nil {
+		return nil, err
+	}
+
+	return &version, nil
+}

--- a/openstack/baremetal/apiversions/testing/fixtures.go
+++ b/openstack/baremetal/apiversions/testing/fixtures.go
@@ -1,0 +1,106 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/baremetal/apiversions"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+const IronicAPIAllVersionResponse = `
+{
+  "default_version": {
+    "status": "CURRENT",
+    "min_version": "1.1",
+    "version": "1.56",
+    "id": "v1",
+    "links": [
+      {
+        "href": "http://localhost:6385/v1/",
+        "rel": "self"
+      }
+    ]
+  },
+  "versions": [
+    {
+      "status": "CURRENT",
+      "min_version": "1.1",
+      "version": "1.56",
+      "id": "v1",
+      "links": [
+        {
+          "href": "http://localhost:6385/v1/",
+          "rel": "self"
+        }
+      ]
+    }
+  ],
+  "name": "OpenStack Ironic API",
+  "description": "Ironic is an OpenStack project which aims to provision baremetal machines."
+}
+`
+
+const IronicAPIVersionResponse = `
+{
+  "media_types": [
+    {
+      "base": "application/json",
+      "type": "application/vnd.openstack.ironic.v1+json"
+    }
+  ],
+  "version": {
+    "status": "CURRENT",
+    "min_version": "1.1",
+    "version": "1.56",
+    "id": "v1",
+    "links": [
+      {
+        "href": "http://localhost:6385/v1/",
+        "rel": "self"
+      }
+    ]
+  },
+  "id": "v1"
+}
+`
+
+var IronicAPIVersion1Result = apiversions.APIVersion{
+	ID:         "v1",
+	Status:     "CURRENT",
+	MinVersion: "1.1",
+	Version:    "1.56",
+}
+
+var IronicAllAPIVersionResults = apiversions.APIVersions{
+	DefaultVersion: IronicAPIVersion1Result,
+	Versions: []apiversions.APIVersion{
+		IronicAPIVersion1Result,
+	},
+}
+
+func MockListResponse(t *testing.T) {
+	th.Mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, IronicAPIAllVersionResponse)
+	})
+}
+
+func MockGetResponse(t *testing.T) {
+	th.Mux.HandleFunc("/v1/", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, IronicAPIVersionResponse)
+	})
+}

--- a/openstack/baremetal/apiversions/testing/requests_test.go
+++ b/openstack/baremetal/apiversions/testing/requests_test.go
@@ -1,0 +1,33 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/baremetal/apiversions"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func TestListAPIVersions(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockListResponse(t)
+
+	actual, err := apiversions.List(client.ServiceClient()).Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertDeepEquals(t, IronicAllAPIVersionResults, *actual)
+}
+
+func TestGetAPIVersion(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockGetResponse(t)
+
+	actual, err := apiversions.Get(client.ServiceClient(), "v1").Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertDeepEquals(t, IronicAPIVersion1Result, *actual)
+}

--- a/openstack/baremetal/apiversions/urls.go
+++ b/openstack/baremetal/apiversions/urls.go
@@ -1,0 +1,13 @@
+package apiversions
+
+import (
+	"github.com/gophercloud/gophercloud"
+)
+
+func getURL(c *gophercloud.ServiceClient, version string) string {
+	return c.ServiceURL(version)
+}
+
+func listURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL()
+}


### PR DESCRIPTION
For #1429

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

- https://github.com/openstack/ironic/blob/master/ironic/api/controllers/version.py
- https://github.com/openstack/ironic/blob/master/ironic/api/controllers/v1/versions.py
