### PR TITLE
Networking V2: add QoS policy extension for Net

### DIFF
--- a/openstack/networking/v2/extensions/qos/policies/doc.go
+++ b/openstack/networking/v2/extensions/qos/policies/doc.go
@@ -89,5 +89,93 @@ Example to delete a QoS policy from the existing Port
     }
 
     fmt.Printf("Port: %+v\n", portWithQoS)
+
+Example to Get a Network with a QoS policy
+
+    var networkWithQoS struct {
+        networks.Network
+        policies.QoSPolicyExt
+    }
+
+    networkID := "46d4bfb9-b26e-41f3-bd2e-e6dcc1ccedb2"
+
+    err = networks.Get(client, networkID).ExtractInto(&networkWithQoS)
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    fmt.Printf("Network: %+v\n", networkWithQoS)
+
+Example to Create a Network with a QoS policy
+
+    var networkWithQoS struct {
+        networks.Network
+        policies.QoSPolicyExt
+    }
+
+    policyID := "d6ae28ce-fcb5-4180-aa62-d260a27e09ae"
+    networkID := "7069db8d-e817-4b39-a654-d2dd76e73d36"
+
+    networkCreateOpts := networks.CreateOpts{
+        NetworkID: networkID,
+    }
+
+    createOpts := policies.NetworkCreateOptsExt{
+        CreateOptsBuilder: networkCreateOpts,
+        QoSPolicyID:       policyID,
+    }
+
+    err = networks.Create(client, createOpts).ExtractInto(&networkWithQoS)
+    if err != nil {
+        panic(err)
+    }
+
+    fmt.Printf("Network: %+v\n", networkWithQoS)
+
+Example to add a QoS policy to an existing Network
+
+    var networkWithQoS struct {
+        networks.Network
+        policies.QoSPolicyExt
+    }
+
+    networkUpdateOpts := networks.UpdateOpts{}
+
+    policyID := "d6ae28ce-fcb5-4180-aa62-d260a27e09ae"
+
+    updateOpts := policies.NetworkUpdateOptsExt{
+        UpdateOptsBuilder: networkUpdateOpts,
+        QoSPolicyID: &policyID,
+    }
+
+    err := networks.Update(client, "65c0ee9f-d634-4522-8954-51021b570b0d", updateOpts).ExtractInto(&networkWithQoS)
+    if err != nil {
+        panic(err)
+    }
+
+    fmt.Printf("Network: %+v\n", networkWithQoS)
+
+Example to delete a QoS policy from the existing Network
+
+    var networkWithQoS struct {
+        networks.Network
+        policies.QoSPolicyExt
+    }
+
+    networkUpdateOpts := networks.UpdateOpts{}
+
+    policyID := ""
+
+    updateOpts := policies.NetworkUpdateOptsExt{
+        UpdateOptsBuilder: networkUpdateOpts,
+        QoSPolicyID: &policyID,
+    }
+
+    err := networks.Update(client, "65c0ee9f-d634-4522-8954-51021b570b0d", updateOpts).ExtractInto(&networkWithQoS)
+    if err != nil {
+        panic(err)
+    }
+
+    fmt.Printf("Network: %+v\n", networkWithQoS)
 */
 package policies

--- a/openstack/networking/v2/extensions/qos/policies/requests.go
+++ b/openstack/networking/v2/extensions/qos/policies/requests.go
@@ -1,6 +1,7 @@
 package policies
 
 import (
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
 )
 
@@ -52,6 +53,60 @@ func (opts PortUpdateOptsExt) ToPortUpdateMap() (map[string]interface{}, error) 
 			port["qos_policy_id"] = qosPolicyID
 		} else {
 			port["qos_policy_id"] = nil
+		}
+	}
+
+	return base, nil
+}
+
+// NetworkCreateOptsExt adds QoS options to the base networks.CreateOpts.
+type NetworkCreateOptsExt struct {
+	networks.CreateOptsBuilder
+
+	// QoSPolicyID represents an associated QoS policy.
+	QoSPolicyID string `json:"qos_policy_id,omitempty"`
+}
+
+// ToNetworkCreateMap casts a CreateOpts struct to a map.
+func (opts NetworkCreateOptsExt) ToNetworkCreateMap() (map[string]interface{}, error) {
+	base, err := opts.CreateOptsBuilder.ToNetworkCreateMap()
+	if err != nil {
+		return nil, err
+	}
+
+	network := base["network"].(map[string]interface{})
+
+	if opts.QoSPolicyID != "" {
+		network["qos_policy_id"] = opts.QoSPolicyID
+	}
+
+	return base, nil
+}
+
+// NetworkUpdateOptsExt adds QoS options to the base networks.UpdateOpts.
+type NetworkUpdateOptsExt struct {
+	networks.UpdateOptsBuilder
+
+	// QoSPolicyID represents an associated QoS policy.
+	// Setting it to a pointer of an empty string will remove associated QoS policy from network.
+	QoSPolicyID *string `json:"qos_policy_id,omitempty"`
+}
+
+// ToNetworkUpdateMap casts a UpdateOpts struct to a map.
+func (opts NetworkUpdateOptsExt) ToNetworkUpdateMap() (map[string]interface{}, error) {
+	base, err := opts.UpdateOptsBuilder.ToNetworkUpdateMap()
+	if err != nil {
+		return nil, err
+	}
+
+	network := base["network"].(map[string]interface{})
+
+	if opts.QoSPolicyID != nil {
+		qosPolicyID := *opts.QoSPolicyID
+		if qosPolicyID != "" {
+			network["qos_policy_id"] = qosPolicyID
+		} else {
+			network["qos_policy_id"] = nil
 		}
 	}
 

--- a/openstack/networking/v2/extensions/qos/policies/testing/fixtures.go
+++ b/openstack/networking/v2/extensions/qos/policies/testing/fixtures.go
@@ -66,3 +66,69 @@ const UpdatePortWithoutPolicyResponse = `
     }
 }
 `
+
+const GetNetworkResponse = `
+{
+    "network": {
+        "id": "65c0ee9f-d634-4522-8954-51021b570b0d",
+        "qos_policy_id": "591e0597-39a6-4665-8149-2111d8de9a08"
+    }
+}
+`
+
+const CreateNetworkRequest = `
+{
+    "network": {
+        "name": "private",
+        "qos_policy_id": "591e0597-39a6-4665-8149-2111d8de9a08"
+    }
+}
+`
+
+const CreateNetworkResponse = `
+{
+    "network": {
+        "tenant_id": "4fd44f30292945e481c7b8a0c8908869",
+        "id": "65c0ee9f-d634-4522-8954-51021b570b0d",
+        "qos_policy_id": "591e0597-39a6-4665-8149-2111d8de9a08"
+    }
+}
+`
+
+const UpdateNetworkWithPolicyRequest = `
+{
+    "network": {
+        "name": "updated",
+        "qos_policy_id": "591e0597-39a6-4665-8149-2111d8de9a08"
+    }
+}
+`
+
+const UpdateNetworkWithPolicyResponse = `
+{
+    "network": {
+        "tenant_id": "4fd44f30292945e481c7b8a0c8908869",
+        "id": "65c0ee9f-d634-4522-8954-51021b570b0d",
+        "name": "updated",
+        "qos_policy_id": "591e0597-39a6-4665-8149-2111d8de9a08"
+    }
+}
+`
+
+const UpdateNetworkWithoutPolicyRequest = `
+{
+    "network": {
+        "qos_policy_id": null
+    }
+}
+`
+
+const UpdateNetworkWithoutPolicyResponse = `
+{
+    "network": {
+        "tenant_id": "4fd44f30292945e481c7b8a0c8908869",
+        "id": "65c0ee9f-d634-4522-8954-51021b570b0d",
+        "qos_policy_id": ""
+    }
+}
+`

--- a/openstack/networking/v2/extensions/qos/policies/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/qos/policies/testing/requests_test.go
@@ -7,6 +7,7 @@ import (
 
 	fake "github.com/gophercloud/gophercloud/openstack/networking/v2/common"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/qos/policies"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
 	th "github.com/gophercloud/gophercloud/testhelper"
 )
@@ -149,4 +150,145 @@ func TestUpdatePortWithoutPolicy(t *testing.T) {
 	th.AssertEquals(t, p.TenantID, "d6700c0c9ffa4f1cb322cd4a1f3906fa")
 	th.AssertEquals(t, p.ID, "65c0ee9f-d634-4522-8954-51021b570b0d")
 	th.AssertEquals(t, p.QoSPolicyID, "")
+}
+
+func TestGetNetwork(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/networks/65c0ee9f-d634-4522-8954-51021b570b0d", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		_, err := fmt.Fprintf(w, GetNetworkResponse)
+		th.AssertNoErr(t, err)
+	})
+
+	var n struct {
+		networks.Network
+		policies.QoSPolicyExt
+	}
+	err := networks.Get(fake.ServiceClient(), "65c0ee9f-d634-4522-8954-51021b570b0d").ExtractInto(&n)
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, n.ID, "65c0ee9f-d634-4522-8954-51021b570b0d")
+	th.AssertEquals(t, n.QoSPolicyID, "591e0597-39a6-4665-8149-2111d8de9a08")
+}
+
+func TestCreateNetwork(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/networks", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, CreateNetworkRequest)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+
+		_, err := fmt.Fprintf(w, CreateNetworkResponse)
+		th.AssertNoErr(t, err)
+	})
+
+	var n struct {
+		networks.Network
+		policies.QoSPolicyExt
+	}
+	networkCreateOpts := networks.CreateOpts{
+		Name: "private",
+	}
+	createOpts := policies.NetworkCreateOptsExt{
+		CreateOptsBuilder: networkCreateOpts,
+		QoSPolicyID:       "591e0597-39a6-4665-8149-2111d8de9a08",
+	}
+	err := networks.Create(fake.ServiceClient(), createOpts).ExtractInto(&n)
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, n.TenantID, "4fd44f30292945e481c7b8a0c8908869")
+	th.AssertEquals(t, n.ID, "65c0ee9f-d634-4522-8954-51021b570b0d")
+	th.AssertEquals(t, n.QoSPolicyID, "591e0597-39a6-4665-8149-2111d8de9a08")
+}
+
+func TestUpdateNetworkWithPolicy(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/networks/65c0ee9f-d634-4522-8954-51021b570b0d", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, UpdateNetworkWithPolicyRequest)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		_, err := fmt.Fprintf(w, UpdateNetworkWithPolicyResponse)
+		th.AssertNoErr(t, err)
+	})
+
+	policyID := "591e0597-39a6-4665-8149-2111d8de9a08"
+	name := "updated"
+
+	var n struct {
+		networks.Network
+		policies.QoSPolicyExt
+	}
+	networkUpdateOpts := networks.UpdateOpts{
+		Name: &name,
+	}
+	updateOpts := policies.NetworkUpdateOptsExt{
+		UpdateOptsBuilder: networkUpdateOpts,
+		QoSPolicyID:       &policyID,
+	}
+	err := networks.Update(fake.ServiceClient(), "65c0ee9f-d634-4522-8954-51021b570b0d", updateOpts).ExtractInto(&n)
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, n.TenantID, "4fd44f30292945e481c7b8a0c8908869")
+	th.AssertEquals(t, n.ID, "65c0ee9f-d634-4522-8954-51021b570b0d")
+	th.AssertEquals(t, n.Name, "updated")
+	th.AssertEquals(t, n.QoSPolicyID, "591e0597-39a6-4665-8149-2111d8de9a08")
+}
+
+func TestUpdateNetworkWithoutPolicy(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/networks/65c0ee9f-d634-4522-8954-51021b570b0d", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, UpdateNetworkWithoutPolicyRequest)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		_, err := fmt.Fprintf(w, UpdateNetworkWithoutPolicyResponse)
+		th.AssertNoErr(t, err)
+	})
+
+	policyID := ""
+
+	var n struct {
+		networks.Network
+		policies.QoSPolicyExt
+	}
+	networkUpdateOpts := networks.UpdateOpts{}
+	updateOpts := policies.NetworkUpdateOptsExt{
+		UpdateOptsBuilder: networkUpdateOpts,
+		QoSPolicyID:       &policyID,
+	}
+	err := networks.Update(fake.ServiceClient(), "65c0ee9f-d634-4522-8954-51021b570b0d", updateOpts).ExtractInto(&n)
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, n.TenantID, "4fd44f30292945e481c7b8a0c8908869")
+	th.AssertEquals(t, n.ID, "65c0ee9f-d634-4522-8954-51021b570b0d")
+	th.AssertEquals(t, n.QoSPolicyID, "")
 }


### PR DESCRIPTION
For #1027

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/neutron-lib/blob/stable/stein/neutron_lib/api/definitions/qos.py#L100
