### PR TITLE
Networking V2: add bw limit rules List

### DIFF
--- a/openstack/networking/v2/extensions/qos/rules/doc.go
+++ b/openstack/networking/v2/extensions/qos/rules/doc.go
@@ -1,0 +1,26 @@
+/*
+Package rules provides the ability to retrieve and manage QoS policy rules through the Neutron API.
+
+Example of Listing BandwidthLimitRules
+
+    listOpts := rules.BandwidthLimitRuleListOpts{
+        MaxKBps: 3000,
+    }
+
+    policyID := "501005fa-3b56-4061-aaca-3f24995112e1"
+
+    allPages, err := rules.BandwidthLimitRuleList(networkClient, policyID, listOpts).AllPages()
+    if err != nil {
+        panic(err)
+    }
+
+    allBandwidthLimitRules, err := rules.ExtractBandwidthLimitRules(allPages)
+    if err != nil {
+        panic(err)
+    }
+
+    for _, bandwidthLimitRule := range allBandwidthLimitRules {
+        fmt.Printf("%+v\n", bandwidthLimitRule)
+    }
+*/
+package rules

--- a/openstack/networking/v2/extensions/qos/rules/doc.go
+++ b/openstack/networking/v2/extensions/qos/rules/doc.go
@@ -3,13 +3,13 @@ Package rules provides the ability to retrieve and manage QoS policy rules throu
 
 Example of Listing BandwidthLimitRules
 
-    listOpts := rules.BandwidthLimitRuleListOpts{
+    listOpts := rules.BandwidthLimitRulesListOpts{
         MaxKBps: 3000,
     }
 
     policyID := "501005fa-3b56-4061-aaca-3f24995112e1"
 
-    allPages, err := rules.BandwidthLimitRuleList(networkClient, policyID, listOpts).AllPages()
+    allPages, err := rules.BandwidthLimitRulesList(networkClient, policyID, listOpts).AllPages()
     if err != nil {
         panic(err)
     }

--- a/openstack/networking/v2/extensions/qos/rules/requests.go
+++ b/openstack/networking/v2/extensions/qos/rules/requests.go
@@ -1,16 +1,14 @@
 package rules
 
 import (
-	"fmt"
-
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/pagination"
 )
 
 // ListOptsBuilder allows extensions to add additional parameters to the
 // List request.
-type ListOptsBuilder interface {
-	ToBandwidthLimitRuleListQuery() (string, error)
+type BandwidthLimitRulesListOptsBuilder interface {
+	ToBandwidthLimitRulesListQuery() (string, error)
 }
 
 // ListOpts allows the filtering and sorting of paginated collections through
@@ -19,7 +17,7 @@ type ListOptsBuilder interface {
 // SortKey allows you to sort by a particular BandwidthLimitRule attribute.
 // SortDir sets the direction, and is either `asc' or `desc'.
 // Marker and Limit are used for the pagination.
-type BandwidthLimitRuleListOpts struct {
+type BandwidthLimitRulesListOpts struct {
 	ID           string `q:"id"`
 	TenantID     string `q:"tenant_id"`
 	MaxKBps      int    `q:"max_kbps"`
@@ -35,8 +33,8 @@ type BandwidthLimitRuleListOpts struct {
 	NotTagsAny   string `q:"not-tags-any"`
 }
 
-// ToBandwidthLimitRuleListQuery formats a ListOpts into a query string.
-func (opts BandwidthLimitRuleListOpts) ToBandwidthLimitRuleListQuery() (string, error) {
+// ToBandwidthLimitRulesListQuery formats a ListOpts into a query string.
+func (opts BandwidthLimitRulesListOpts) ToBandwidthLimitRulesListQuery() (string, error) {
 	q, err := gophercloud.BuildQueryString(opts)
 	return q.String(), err
 }
@@ -44,11 +42,10 @@ func (opts BandwidthLimitRuleListOpts) ToBandwidthLimitRuleListQuery() (string, 
 // BandwidthLimitRuleList returns a Pager which allows you to iterate over a collection of
 // BandwidthLimitRules. It accepts a ListOpts struct, which allows you to filter and sort
 // the returned collection for greater efficiency.
-func BandwidthLimitRuleList(c *gophercloud.ServiceClient, policyID string, opts ListOptsBuilder) pagination.Pager {
+func BandwidthLimitRulesList(c *gophercloud.ServiceClient, policyID string, opts BandwidthLimitRulesListOptsBuilder) pagination.Pager {
 	url := listBandwidthLimitRulesURL(c, policyID)
-	fmt.Printf("URL: %s\n", url)
 	if opts != nil {
-		query, err := opts.ToBandwidthLimitRuleListQuery()
+		query, err := opts.ToBandwidthLimitRulesListQuery()
 		if err != nil {
 			return pagination.Pager{Err: err}
 		}

--- a/openstack/networking/v2/extensions/qos/rules/requests.go
+++ b/openstack/networking/v2/extensions/qos/rules/requests.go
@@ -1,0 +1,61 @@
+package rules
+
+import (
+	"fmt"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// ListOptsBuilder allows extensions to add additional parameters to the
+// List request.
+type ListOptsBuilder interface {
+	ToBandwidthLimitRuleListQuery() (string, error)
+}
+
+// ListOpts allows the filtering and sorting of paginated collections through
+// the Neutron API. Filtering is achieved by passing in struct field values
+// that map to the BandwidthLimitRules attributes you want to see returned.
+// SortKey allows you to sort by a particular BandwidthLimitRule attribute.
+// SortDir sets the direction, and is either `asc' or `desc'.
+// Marker and Limit are used for the pagination.
+type BandwidthLimitRuleListOpts struct {
+	ID           string `q:"id"`
+	TenantID     string `q:"tenant_id"`
+	MaxKBps      int    `q:"max_kbps"`
+	MaxBurstKBps int    `q:"max_burst_kbps"`
+	Direction    string `q:"direction"`
+	Limit        int    `q:"limit"`
+	Marker       string `q:"marker"`
+	SortKey      string `q:"sort_key"`
+	SortDir      string `q:"sort_dir"`
+	Tags         string `q:"tags"`
+	TagsAny      string `q:"tags-any"`
+	NotTags      string `q:"not-tags"`
+	NotTagsAny   string `q:"not-tags-any"`
+}
+
+// ToBandwidthLimitRuleListQuery formats a ListOpts into a query string.
+func (opts BandwidthLimitRuleListOpts) ToBandwidthLimitRuleListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// BandwidthLimitRuleList returns a Pager which allows you to iterate over a collection of
+// BandwidthLimitRules. It accepts a ListOpts struct, which allows you to filter and sort
+// the returned collection for greater efficiency.
+func BandwidthLimitRuleList(c *gophercloud.ServiceClient, policyID string, opts ListOptsBuilder) pagination.Pager {
+	url := listBandwidthLimitRulesURL(c, policyID)
+	fmt.Printf("URL: %s\n", url)
+	if opts != nil {
+		query, err := opts.ToBandwidthLimitRuleListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		return BandwidthLimitRulePage{pagination.LinkedPageBase{PageResult: r}}
+
+	})
+}

--- a/openstack/networking/v2/extensions/qos/rules/results.go
+++ b/openstack/networking/v2/extensions/qos/rules/results.go
@@ -1,0 +1,50 @@
+package rules
+
+import (
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// BandwidthLimitRule represents a QoS policy rule to set bandwidth limits.
+type BandwidthLimitRule struct {
+	// ID is a unique ID of the policy.
+	ID string `json:"id"`
+
+	// TenantID is the ID of the Identity project.
+	TenantID string `json:"tenant_id"`
+
+	// MaxKBps is a maximum kilobits per second.
+	MaxKBps int `json:"max_kbps"`
+
+	// MaxBurstKBps is a maximum burst size in kilobits.
+	MaxBurstKBps int `json:"max_burst_kbps"`
+
+	// Direction represents the direction of traffic.
+	Direction string `json:"direction"`
+
+	// Tags optionally set via extensions/attributestags.
+	Tags []string `json:"tags"`
+}
+
+// BandwidthLimitRulePage stores a single page of BandwidthLimitRules from a List() API call.
+type BandwidthLimitRulePage struct {
+	pagination.LinkedPageBase
+}
+
+// IsEmpty checks whether a BandwidthLimitRulePage is empty.
+func (r BandwidthLimitRulePage) IsEmpty() (bool, error) {
+	is, err := ExtractBandwidthLimitRules(r)
+	return len(is) == 0, err
+}
+
+// ExtractBandwidthLimitRules accepts a BandwidthLimitRulePage, and extracts the elements into a slice of
+// BandwidthLimitRules.
+func ExtractBandwidthLimitRules(r pagination.Page) ([]BandwidthLimitRule, error) {
+	var s []BandwidthLimitRule
+	err := ExtractBandwidthLimitRulesInto(r, &s)
+	return s, err
+}
+
+// ExtractBandwidthLimitRulesInto extracts the elements into a slice of RBAC Policy structs.
+func ExtractBandwidthLimitRulesInto(r pagination.Page, v interface{}) error {
+	return r.(BandwidthLimitRulePage).Result.ExtractIntoSlicePtr(v, "bandwidth_limit_rules")
+}

--- a/openstack/networking/v2/extensions/qos/rules/testing/doc.go
+++ b/openstack/networking/v2/extensions/qos/rules/testing/doc.go
@@ -1,0 +1,2 @@
+// QoS policy rules unit tests
+package testing

--- a/openstack/networking/v2/extensions/qos/rules/testing/fixtures.go
+++ b/openstack/networking/v2/extensions/qos/rules/testing/fixtures.go
@@ -1,0 +1,15 @@
+package testing
+
+// BandwidthLimitRulesListResult represents a raw result of a List call to BandwidthLimitRules.
+const BandwidthLimitRulesListResult = `
+{
+    "bandwidth_limit_rules": [
+        {
+            "max_kbps": 3000,
+            "direction": "egress",
+            "id": "30a57f4a-336b-4382-8275-d708babd2241",
+            "max_burst_kbps": 300
+        }
+    ]
+}
+`

--- a/openstack/networking/v2/extensions/qos/rules/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/qos/rules/testing/requests_test.go
@@ -1,0 +1,60 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	fake "github.com/gophercloud/gophercloud/openstack/networking/v2/common"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/qos/rules"
+	"github.com/gophercloud/gophercloud/pagination"
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestList(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/qos/policies/501005fa-3b56-4061-aaca-3f24995112e1/bandwidth_limit_rules", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, BandwidthLimitRulesListResult)
+	})
+
+	count := 0
+
+	err := rules.BandwidthLimitRuleList(
+		fake.ServiceClient(),
+		"501005fa-3b56-4061-aaca-3f24995112e1",
+		rules.BandwidthLimitRuleListOpts{},
+	).EachPage(func(page pagination.Page) (bool, error) {
+		count++
+		actual, err := rules.ExtractBandwidthLimitRules(page)
+		if err != nil {
+			t.Errorf("Failed to extract bandwith limit rules: %v", err)
+			return false, nil
+		}
+
+		expected := []rules.BandwidthLimitRule{
+			{
+				ID:           "30a57f4a-336b-4382-8275-d708babd2241",
+				MaxKBps:      3000,
+				MaxBurstKBps: 300,
+				Direction:    "egress",
+			},
+		}
+
+		th.CheckDeepEquals(t, expected, actual)
+
+		return true, nil
+	})
+	th.AssertNoErr(t, err)
+
+	if count != 1 {
+		t.Errorf("Expected 1 page, got %d", count)
+	}
+}

--- a/openstack/networking/v2/extensions/qos/rules/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/qos/rules/testing/requests_test.go
@@ -27,10 +27,10 @@ func TestList(t *testing.T) {
 
 	count := 0
 
-	err := rules.BandwidthLimitRuleList(
+	err := rules.BandwidthLimitRulesList(
 		fake.ServiceClient(),
 		"501005fa-3b56-4061-aaca-3f24995112e1",
-		rules.BandwidthLimitRuleListOpts{},
+		rules.BandwidthLimitRulesListOpts{},
 	).EachPage(func(page pagination.Page) (bool, error) {
 		count++
 		actual, err := rules.ExtractBandwidthLimitRules(page)

--- a/openstack/networking/v2/extensions/qos/rules/urls.go
+++ b/openstack/networking/v2/extensions/qos/rules/urls.go
@@ -8,10 +8,10 @@ const (
 	bandwidthLimitRulesResourcePath = "bandwidth_limit_rules"
 )
 
-func listBandwidthLimitRulesRootURL(c *gophercloud.ServiceClient, policyID string) string {
+func bandwidthLimitRulesRootURL(c *gophercloud.ServiceClient, policyID string) string {
 	return c.ServiceURL(rootPath, policyID, bandwidthLimitRulesResourcePath)
 }
 
 func listBandwidthLimitRulesURL(c *gophercloud.ServiceClient, policyID string) string {
-	return listBandwidthLimitRulesRootURL(c, policyID)
+	return bandwidthLimitRulesRootURL(c, policyID)
 }

--- a/openstack/networking/v2/extensions/qos/rules/urls.go
+++ b/openstack/networking/v2/extensions/qos/rules/urls.go
@@ -1,0 +1,17 @@
+package rules
+
+import "github.com/gophercloud/gophercloud"
+
+const (
+	rootPath = "qos/policies"
+
+	bandwidthLimitRulesResourcePath = "bandwidth_limit_rules"
+)
+
+func listBandwidthLimitRulesRootURL(c *gophercloud.ServiceClient, policyID string) string {
+	return c.ServiceURL(rootPath, policyID, bandwidthLimitRulesResourcePath)
+}
+
+func listBandwidthLimitRulesURL(c *gophercloud.ServiceClient, policyID string) string {
+	return listBandwidthLimitRulesRootURL(c, policyID)
+}


### PR DESCRIPTION
Allow to list bandwidth limit rules.

For #1027

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/neutron-lib/blob/master/neutron_lib/api/definitions/qos.py#L30
https://github.com/openstack/neutron-lib/blob/master/neutron_lib/api/definitions/qos.py#L115
