### PR TITLE
[WIP] Diagnostics for servers

### DIFF
--- a/openstack/compute/v2/servers/requests.go
+++ b/openstack/compute/v2/servers/requests.go
@@ -810,3 +810,9 @@ func ShowConsoleOutput(client *gophercloud.ServiceClient, id string, opts ShowCo
 	})
 	return
 }
+
+// Diagnostics
+func GetServerDiagnostics(client *gophercloud.ServiceClient, serverId string) (r ServerDiagnosticsResult) {
+	_, r.Err = client.Get(serverDiagnosticsURL(client, serverId), &r.Body, nil)
+	return
+}

--- a/openstack/compute/v2/servers/results.go
+++ b/openstack/compute/v2/servers/results.go
@@ -412,3 +412,9 @@ func ExtractNetworkAddresses(r pagination.Page) ([]Address, error) {
 
 	return s[key], err
 }
+
+// Diagnostic result, response depends on nova api microversion so leaving as
+// generic result caller can ExtractInto an interface -- see test
+type ServerDiagnosticsResult struct {
+	gophercloud.Result
+}

--- a/openstack/compute/v2/servers/testing/fixtures.go
+++ b/openstack/compute/v2/servers/testing/fixtures.go
@@ -1204,3 +1204,15 @@ func HandleServerWithTagsCreationSuccessfully(t *testing.T) {
 		fmt.Fprintf(w, SingleServerWithTagsBody)
 	})
 }
+
+// HandleDiagnosticGetSuccessfully sets up the test server to respond to a diagnostic Get request.
+func HandleDiagnosticGetSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/servers/1234asdf/diagnostics", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"cpu0_time":173,"memory":524288}`))
+	})
+}

--- a/openstack/compute/v2/servers/testing/requests_test.go
+++ b/openstack/compute/v2/servers/testing/requests_test.go
@@ -593,3 +593,20 @@ func TestCreateServerWithTags(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.CheckDeepEquals(t, tags, actualTags)
 }
+
+func TestGetDiagnostics(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	HandleDiagnosticGetSuccessfully(t)
+
+	expected := map[string]interface {}{"cpu0_time":float64(173),"memory":float64(524288)}
+
+	res := servers.GetServerDiagnostics(client.ServiceClient(), "1234asdf")
+	th.AssertNoErr(t, res.Err)
+
+	var s map[string]interface{}
+	_ = res.ExtractInto(&s)
+
+	th.AssertDeepEquals(t, expected, s)
+}

--- a/openstack/compute/v2/servers/urls.go
+++ b/openstack/compute/v2/servers/urls.go
@@ -49,3 +49,7 @@ func listAddressesByNetworkURL(client *gophercloud.ServiceClient, id, network st
 func passwordURL(client *gophercloud.ServiceClient, id string) string {
 	return client.ServiceURL("servers", id, "os-server-password")
 }
+
+func serverDiagnosticsURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL("servers", id, "diagnostics")
+}


### PR DESCRIPTION
For #1585

I can only test with <2.48 of the nova api, so I didn't implement any custom extraction functions or properly model the response, as my available version just returns something easily extracted into a map. 

https://developer.openstack.org/api-ref/compute/?expanded=show-server-diagnostics-detail
