### PR TITLE
Networking V2: rename qos bw rules List call

### DIFF
--- a/openstack/networking/v2/extensions/qos/rules/doc.go
+++ b/openstack/networking/v2/extensions/qos/rules/doc.go
@@ -9,7 +9,7 @@ Example of Listing BandwidthLimitRules
 
     policyID := "501005fa-3b56-4061-aaca-3f24995112e1"
 
-    allPages, err := rules.BandwidthLimitRulesList(networkClient, policyID, listOpts).AllPages()
+    allPages, err := rules.ListBandwidthLimitRules(networkClient, policyID, listOpts).AllPages()
     if err != nil {
         panic(err)
     }

--- a/openstack/networking/v2/extensions/qos/rules/requests.go
+++ b/openstack/networking/v2/extensions/qos/rules/requests.go
@@ -39,10 +39,10 @@ func (opts BandwidthLimitRulesListOpts) ToBandwidthLimitRulesListQuery() (string
 	return q.String(), err
 }
 
-// BandwidthLimitRuleList returns a Pager which allows you to iterate over a collection of
+// ListBandwidthLimitRules returns a Pager which allows you to iterate over a collection of
 // BandwidthLimitRules. It accepts a ListOpts struct, which allows you to filter and sort
 // the returned collection for greater efficiency.
-func BandwidthLimitRulesList(c *gophercloud.ServiceClient, policyID string, opts BandwidthLimitRulesListOptsBuilder) pagination.Pager {
+func ListBandwidthLimitRules(c *gophercloud.ServiceClient, policyID string, opts BandwidthLimitRulesListOptsBuilder) pagination.Pager {
 	url := listBandwidthLimitRulesURL(c, policyID)
 	if opts != nil {
 		query, err := opts.ToBandwidthLimitRulesListQuery()

--- a/openstack/networking/v2/extensions/qos/rules/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/qos/rules/testing/requests_test.go
@@ -27,7 +27,7 @@ func TestList(t *testing.T) {
 
 	count := 0
 
-	err := rules.BandwidthLimitRulesList(
+	err := rules.ListBandwidthLimitRules(
 		fake.ServiceClient(),
 		"501005fa-3b56-4061-aaca-3f24995112e1",
 		rules.BandwidthLimitRulesListOpts{},


### PR DESCRIPTION
Use ListBandwidthLimitRules as a method name for the List call.

For #1027