### PR TITLE
Networking V2: add bw limit rule Update

### DIFF
--- a/openstack/networking/v2/extensions/qos/rules/doc.go
+++ b/openstack/networking/v2/extensions/qos/rules/doc.go
@@ -9,7 +9,7 @@ Example of Listing BandwidthLimitRules
 
     policyID := "501005fa-3b56-4061-aaca-3f24995112e1"
 
-    allPages, err := rules.BandwidthLimitRulesList(networkClient, policyID, listOpts).AllPages()
+    allPages, err := rules.ListBandwidthLimitRules(networkClient, policyID, listOpts).AllPages()
     if err != nil {
         panic(err)
     }

--- a/openstack/networking/v2/extensions/qos/rules/doc.go
+++ b/openstack/networking/v2/extensions/qos/rules/doc.go
@@ -34,5 +34,26 @@ Example of Getting a single BandwidthLimitRule
     }
 
     fmt.Printf("Rule: %+v\n", rule)
+
+Example of Updating a single BandwidthLimitRule
+
+    maxKBps := 500
+    maxBurstKBps := 0
+
+    opts := rules.UpdateBandwidthLimitRuleOpts{
+        MaxKBps:      &maxKBps,
+        MaxBurstKBps: &maxBurstKBps,
+    }
+
+    policyID := "501005fa-3b56-4061-aaca-3f24995112e1"
+    ruleID   := "30a57f4a-336b-4382-8275-d708babd2241"
+
+    rule, err := rules.UpdateBandwidthLimitRule(fake.ServiceClient(), policyID, ruleID, opts).ExtractBandwidthLimitRule()
+    if err != nil {
+        panic(err)
+    }
+
+    fmt.Printf("Rule: %+v\n", rule)
+
 */
 package rules

--- a/openstack/networking/v2/extensions/qos/rules/requests.go
+++ b/openstack/networking/v2/extensions/qos/rules/requests.go
@@ -98,3 +98,39 @@ func CreateBandwidthLimitRule(client *gophercloud.ServiceClient, policyID string
 	})
 	return
 }
+
+// UpdateBandwidthLimitRuleOptsBuilder allows to add additional parameters to the
+// UpdateBandwidthLimitRule request.
+type UpdateBandwidthLimitRuleOptsBuilder interface {
+	ToBandwidthLimitRuleUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateBandwidthLimitRuleOpts specifies parameters for the Update call.
+type UpdateBandwidthLimitRuleOpts struct {
+	// MaxKBps is a maximum kilobits per second.
+	MaxKBps *int `json:"max_kbps,omitempty"`
+
+	// MaxBurstKBps is a maximum burst size in kilobits.
+	MaxBurstKBps *int `json:"max_burst_kbps,omitempty"`
+
+	// Direction represents the direction of traffic.
+	Direction string `json:"direction,omitempty"`
+}
+
+// ToBandwidthLimitRuleUpdateMap constructs a request body from UpdateBandwidthLimitRuleOpts.
+func (opts UpdateBandwidthLimitRuleOpts) ToBandwidthLimitRuleUpdateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "bandwidth_limit_rule")
+}
+
+// UpdateBandwidthLimitRule requests the creation of a new BandwidthLimitRule on the server.
+func UpdateBandwidthLimitRule(client *gophercloud.ServiceClient, policyID, ruleID string, opts UpdateBandwidthLimitRuleOptsBuilder) (r UpdateBandwidthLimitRuleResult) {
+	b, err := opts.ToBandwidthLimitRuleUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Put(updateBandwidthLimitRuleURL(client, policyID, ruleID), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+	})
+	return
+}

--- a/openstack/networking/v2/extensions/qos/rules/requests.go
+++ b/openstack/networking/v2/extensions/qos/rules/requests.go
@@ -39,10 +39,10 @@ func (opts BandwidthLimitRulesListOpts) ToBandwidthLimitRulesListQuery() (string
 	return q.String(), err
 }
 
-// BandwidthLimitRuleList returns a Pager which allows you to iterate over a collection of
+// ListBandwidthLimitRules returns a Pager which allows you to iterate over a collection of
 // BandwidthLimitRules. It accepts a ListOpts struct, which allows you to filter and sort
 // the returned collection for greater efficiency.
-func BandwidthLimitRulesList(c *gophercloud.ServiceClient, policyID string, opts BandwidthLimitRulesListOptsBuilder) pagination.Pager {
+func ListBandwidthLimitRules(c *gophercloud.ServiceClient, policyID string, opts BandwidthLimitRulesListOptsBuilder) pagination.Pager {
 	url := listBandwidthLimitRulesURL(c, policyID)
 	if opts != nil {
 		query, err := opts.ToBandwidthLimitRulesListQuery()

--- a/openstack/networking/v2/extensions/qos/rules/results.go
+++ b/openstack/networking/v2/extensions/qos/rules/results.go
@@ -30,6 +30,12 @@ type CreateBandwidthLimitRuleResult struct {
 	commonResult
 }
 
+// UpdateBandwidthLimitRuleResult represents the result of a Update operation. Call its Extract
+// method to interpret it as a BandwidthLimitRule.
+type UpdateBandwidthLimitRuleResult struct {
+	commonResult
+}
+
 // BandwidthLimitRule represents a QoS policy rule to set bandwidth limits.
 type BandwidthLimitRule struct {
 	// ID is a unique ID of the policy.

--- a/openstack/networking/v2/extensions/qos/rules/testing/fixtures.go
+++ b/openstack/networking/v2/extensions/qos/rules/testing/fixtures.go
@@ -46,3 +46,24 @@ const BandwidthLimitRulesCreateResult = `
     }
 }
 `
+
+// BandwidthLimitRulesUpdateRequest represents a raw body of a Update BandwidthLimitRule call.
+const BandwidthLimitRulesUpdateRequest = `
+{
+    "bandwidth_limit_rule": {
+        "max_kbps": 500,
+        "max_burst_kbps": 0
+    }
+}
+`
+
+// BandwidthLimitRulesUpdateResult represents a raw result of a Update BandwidthLimitRule call.
+const BandwidthLimitRulesUpdateResult = `
+{
+    "bandwidth_limit_rule": {
+        "max_kbps": 500,
+        "id": "30a57f4a-336b-4382-8275-d708babd2241",
+        "max_burst_kbps": 0
+    }
+}
+`

--- a/openstack/networking/v2/extensions/qos/rules/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/qos/rules/testing/requests_test.go
@@ -27,7 +27,7 @@ func TestList(t *testing.T) {
 
 	count := 0
 
-	err := rules.BandwidthLimitRulesList(
+	err := rules.ListBandwidthLimitRules(
 		fake.ServiceClient(),
 		"501005fa-3b56-4061-aaca-3f24995112e1",
 		rules.BandwidthLimitRulesListOpts{},

--- a/openstack/networking/v2/extensions/qos/rules/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/qos/rules/testing/requests_test.go
@@ -11,7 +11,7 @@ import (
 	th "github.com/gophercloud/gophercloud/testhelper"
 )
 
-func TestList(t *testing.T) {
+func TestListBandwidthLimitRule(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 
@@ -59,7 +59,7 @@ func TestList(t *testing.T) {
 	}
 }
 
-func TestGet(t *testing.T) {
+func TestGetBandwidthLimitRule(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 
@@ -82,7 +82,7 @@ func TestGet(t *testing.T) {
 	th.AssertEquals(t, r.MaxKBps, 3000)
 }
 
-func TestCreate(t *testing.T) {
+func TestCreateBandwidthLimitRule(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 
@@ -108,4 +108,34 @@ func TestCreate(t *testing.T) {
 
 	th.AssertEquals(t, 200, r.MaxBurstKBps)
 	th.AssertEquals(t, 2000, r.MaxKBps)
+}
+
+func TestUpdateBandwidthLimitRule(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/qos/policies/501005fa-3b56-4061-aaca-3f24995112e1/bandwidth_limit_rules/30a57f4a-336b-4382-8275-d708babd2241", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, BandwidthLimitRulesUpdateRequest)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+
+		fmt.Fprintf(w, BandwidthLimitRulesUpdateResult)
+	})
+
+	maxKBps := 500
+	maxBurstKBps := 0
+	opts := rules.UpdateBandwidthLimitRuleOpts{
+		MaxKBps:      &maxKBps,
+		MaxBurstKBps: &maxBurstKBps,
+	}
+	r, err := rules.UpdateBandwidthLimitRule(fake.ServiceClient(), "501005fa-3b56-4061-aaca-3f24995112e1", "30a57f4a-336b-4382-8275-d708babd2241", opts).ExtractBandwidthLimitRule()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, 0, r.MaxBurstKBps)
+	th.AssertEquals(t, 500, r.MaxKBps)
 }

--- a/openstack/networking/v2/extensions/qos/rules/urls.go
+++ b/openstack/networking/v2/extensions/qos/rules/urls.go
@@ -27,3 +27,7 @@ func getBandwidthLimitRuleURL(c *gophercloud.ServiceClient, policyID, ruleID str
 func createBandwidthLimitRuleURL(c *gophercloud.ServiceClient, policyID string) string {
 	return bandwidthLimitRulesRootURL(c, policyID)
 }
+
+func updateBandwidthLimitRuleURL(c *gophercloud.ServiceClient, policyID, ruleID string) string {
+	return bandwidthLimitRulesResourceURL(c, policyID, ruleID)
+}


### PR DESCRIPTION
For #1027

Allow to update a bandwidth limit rule.

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/neutron-lib/blob/master/neutron_lib/api/definitions/qos.py#L30
https://github.com/openstack/neutron-lib/blob/master/neutron_lib/api/definitions/qos.py#L115
