### PR TITLE
Networking V2: add bw limit rule Delete

### DIFF
--- a/openstack/networking/v2/extensions/qos/rules/doc.go
+++ b/openstack/networking/v2/extensions/qos/rules/doc.go
@@ -71,5 +71,14 @@ Example of Updating a single BandwidthLimitRule
 
     fmt.Printf("Rule: %+v\n", rule)
 
+Example of Deleting a single BandwidthLimitRule
+
+    policyID := "501005fa-3b56-4061-aaca-3f24995112e1"
+    ruleID   := "30a57f4a-336b-4382-8275-d708babd2241"
+
+    err := rules.DeleteBandwidthLimitRule(fake.ServiceClient(), "501005fa-3b56-4061-aaca-3f24995112e1", "30a57f4a-336b-4382-8275-d708babd2241").ExtractErr()
+    if err != nil {
+        panic(err)
+    }
 */
 package rules

--- a/openstack/networking/v2/extensions/qos/rules/requests.go
+++ b/openstack/networking/v2/extensions/qos/rules/requests.go
@@ -134,3 +134,9 @@ func UpdateBandwidthLimitRule(client *gophercloud.ServiceClient, policyID, ruleI
 	})
 	return
 }
+
+// Delete accepts policy and rule ID and deletes the BandwidthLimitRule associated with them.
+func DeleteBandwidthLimitRule(c *gophercloud.ServiceClient, policyID, ruleID string) (r DeleteBandwidthLimitRuleResult) {
+	_, r.Err = c.Delete(deleteBandwidthLimitRuleURL(c, policyID, ruleID), nil)
+	return
+}

--- a/openstack/networking/v2/extensions/qos/rules/results.go
+++ b/openstack/networking/v2/extensions/qos/rules/results.go
@@ -36,6 +36,12 @@ type UpdateBandwidthLimitRuleResult struct {
 	commonResult
 }
 
+// DeleteBandwidthLimitRuleResult represents the result of a Delete operation. Call its Extract
+// method to interpret it as a BandwidthLimitRule.
+type DeleteBandwidthLimitRuleResult struct {
+	gophercloud.ErrResult
+}
+
 // BandwidthLimitRule represents a QoS policy rule to set bandwidth limits.
 type BandwidthLimitRule struct {
 	// ID is a unique ID of the policy.

--- a/openstack/networking/v2/extensions/qos/rules/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/qos/rules/testing/requests_test.go
@@ -139,3 +139,17 @@ func TestUpdateBandwidthLimitRule(t *testing.T) {
 	th.AssertEquals(t, 0, r.MaxBurstKBps)
 	th.AssertEquals(t, 500, r.MaxKBps)
 }
+
+func TestDeleteBandwidthLimitRule(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/qos/policies/501005fa-3b56-4061-aaca-3f24995112e1/bandwidth_limit_rules/30a57f4a-336b-4382-8275-d708babd2241", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	res := rules.DeleteBandwidthLimitRule(fake.ServiceClient(), "501005fa-3b56-4061-aaca-3f24995112e1", "30a57f4a-336b-4382-8275-d708babd2241")
+	th.AssertNoErr(t, res.Err)
+}

--- a/openstack/networking/v2/extensions/qos/rules/urls.go
+++ b/openstack/networking/v2/extensions/qos/rules/urls.go
@@ -31,3 +31,7 @@ func createBandwidthLimitRuleURL(c *gophercloud.ServiceClient, policyID string) 
 func updateBandwidthLimitRuleURL(c *gophercloud.ServiceClient, policyID, ruleID string) string {
 	return bandwidthLimitRulesResourceURL(c, policyID, ruleID)
 }
+
+func deleteBandwidthLimitRuleURL(c *gophercloud.ServiceClient, policyID, ruleID string) string {
+	return bandwidthLimitRulesResourceURL(c, policyID, ruleID)
+}


### PR DESCRIPTION
Allow to delete a bandwidth limit rule.

For #1027

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/neutron-lib/blob/master/neutron_lib/api/definitions/qos.py#L30
https://github.com/openstack/neutron-lib/blob/master/neutron_lib/api/definitions/qos.py#L115
