### PR TITLE
Diagnostics Compute Extension

### DIFF
--- a/openstack/compute/v2/extensions/diagnostics/doc.go
+++ b/openstack/compute/v2/extensions/diagnostics/doc.go
@@ -1,0 +1,14 @@
+/*
+Package diagnostics returns details about a nova instance diagnostics
+
+Example of Show Diagnostics
+
+	diags, err := diagnostics.Get(computeClient, serverId).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v\n", diags)
+
+*/
+package diagnostics

--- a/openstack/compute/v2/extensions/diagnostics/requests.go
+++ b/openstack/compute/v2/extensions/diagnostics/requests.go
@@ -1,0 +1,11 @@
+package diagnostics
+
+import (
+	"github.com/gophercloud/gophercloud"
+)
+
+// Diagnostics
+func Get(client *gophercloud.ServiceClient, serverId string) (r serverDiagnosticsResult) {
+	_, r.Err = client.Get(serverDiagnosticsURL(client, serverId), &r.Body, nil)
+	return
+}

--- a/openstack/compute/v2/extensions/diagnostics/results.go
+++ b/openstack/compute/v2/extensions/diagnostics/results.go
@@ -1,0 +1,17 @@
+package diagnostics
+
+import (
+	"github.com/gophercloud/gophercloud"
+)
+
+
+type serverDiagnosticsResult struct {
+	gophercloud.Result
+}
+
+// Extract interprets any diagnostic response as a map
+func (r serverDiagnosticsResult) Extract() (*map[string]interface{}, error) {
+	var s map[string]interface{}
+	err := r.ExtractInto(&s)
+	return &s, err
+}

--- a/openstack/compute/v2/extensions/diagnostics/results.go
+++ b/openstack/compute/v2/extensions/diagnostics/results.go
@@ -4,7 +4,6 @@ import (
 	"github.com/gophercloud/gophercloud"
 )
 
-
 type serverDiagnosticsResult struct {
 	gophercloud.Result
 }

--- a/openstack/compute/v2/extensions/diagnostics/testing/fixtures.go
+++ b/openstack/compute/v2/extensions/diagnostics/testing/fixtures.go
@@ -1,0 +1,21 @@
+package testing
+
+import (
+	"net/http"
+	"testing"
+
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+// HandleDiagnosticGetSuccessfully sets up the test server to respond to a diagnostic Get request.
+func HandleDiagnosticGetSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/servers/1234asdf/diagnostics", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"cpu0_time":173,"memory":524288}`))
+	})
+}

--- a/openstack/compute/v2/extensions/diagnostics/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/diagnostics/testing/requests_test.go
@@ -1,0 +1,22 @@
+package testing
+
+import ( "testing"
+
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/diagnostics"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func TestGetDiagnostics(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	HandleDiagnosticGetSuccessfully(t)
+
+	expected := map[string]interface{}{"cpu0_time":float64(173),"memory":float64(524288)}
+
+	res, err := diagnostics.Get(client.ServiceClient(), "1234asdf").Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertDeepEquals(t, &expected, res)
+}

--- a/openstack/compute/v2/extensions/diagnostics/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/diagnostics/testing/requests_test.go
@@ -1,6 +1,7 @@
 package testing
 
-import ( "testing"
+import (
+	"testing"
 
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/diagnostics"
 	th "github.com/gophercloud/gophercloud/testhelper"
@@ -13,7 +14,7 @@ func TestGetDiagnostics(t *testing.T) {
 
 	HandleDiagnosticGetSuccessfully(t)
 
-	expected := map[string]interface{}{"cpu0_time":float64(173),"memory":float64(524288)}
+	expected := map[string]interface{}{"cpu0_time": float64(173), "memory": float64(524288)}
 
 	res, err := diagnostics.Get(client.ServiceClient(), "1234asdf").Extract()
 	th.AssertNoErr(t, err)

--- a/openstack/compute/v2/extensions/diagnostics/urls.go
+++ b/openstack/compute/v2/extensions/diagnostics/urls.go
@@ -1,0 +1,8 @@
+package diagnostics
+
+import "github.com/gophercloud/gophercloud"
+
+// serverDiagnosticsURL returns the diagnostics url for a nova instance/server
+func serverDiagnosticsURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL("servers", id, "diagnostics")
+}


### PR DESCRIPTION
For #1585

The call for diagnostics comes into the nova api[1], is sent over rpc to the compute manager[2], and finally ends up depending on the driver[3]. My env uses libvirt, which builds and returns a 'single-level' python dict[4]. The response is hard to map to a struct in this scenario because there are possible extra values for extra vnics and disks.

Future work needs to be done on adding diagnostics/microversions.go to provide extract methods for a better structured, 'multi-level' dict response that is available with nova microversion 2.48 or higher[1][5], but I don't feel comfortable working on that without having it available in my environment to fully test against.

[1] https://github.com/openstack/nova/blob/master/nova/api/openstack/compute/server_diagnostics.py#L42-L47
[2] https://github.com/openstack/nova/blob/master/nova/compute/api.py#L3681-L3683
[3] https://github.com/openstack/nova/blob/master/nova/compute/manager.py#L4930-L4935
[4] https://github.com/openstack/nova/blob/master/nova/virt/libvirt/driver.py#L9183-L9241
[5] https://github.com/openstack/nova/blob/master/nova/api/openstack/compute/views/server_diagnostics.py