### PR TITLE
Networking: add QoS policies Get, cleanup QoS doc

### DIFF
--- a/acceptance/openstack/networking/v2/extensions/qos/policies/policies.go
+++ b/acceptance/openstack/networking/v2/extensions/qos/policies/policies.go
@@ -1,0 +1,1 @@
+package policies

--- a/acceptance/openstack/networking/v2/extensions/qos/policies/policies_test.go
+++ b/acceptance/openstack/networking/v2/extensions/qos/policies/policies_test.go
@@ -1,0 +1,51 @@
+// +build acceptance networking qos policies
+
+package policies
+
+import (
+	"testing"
+)
+
+func TestPoliciesCRUD(t *testing.T) {
+	//client, err := clients.NewNetworkV2Client()
+	//th.AssertNoErr(t, err)
+
+	// Create a QoS policy
+	//policy, err := CreatePolicy(t, client)
+	//th.AssertNoErr(t, err)
+	//defer DeletePolicy(t, client, policy.ID)
+	//
+	//tools.PrintResource(t, policy)
+	//
+	//newName := tools.RandomString("TESTACC-", 8)
+	//newDescription := ""
+	//updateOpts := &policies.UpdateOpts{
+	//	Name:        newName,
+	//	Description: &newDescription,
+	//}
+	//
+	//_, err = policies.Update(client, policy.ID, updateOpts).Extract()
+	//th.AssertNoErr(t, err)
+
+	//newPolicy, err := policies.Get(client, policy.ID).Extract()
+	//th.AssertNoErr(t, err)
+	//
+	//tools.PrintResource(t, newPolicy)
+	//th.AssertEquals(t, newPolicy.Name, newName)
+	//th.AssertEquals(t, newPolicy.Description, newDescription)
+	//
+	//allPages, err := policies.List(client, nil).AllPages()
+	//th.AssertNoErr(t, err)
+	//
+	//allPolicies, err := policies.ExtractPolicies(allPages)
+	//th.AssertNoErr(t, err)
+	//
+	//var found bool
+	//for _, policy := range allPolicies {
+	//	if policy.ID == newPolicy.ID {
+	//		found = true
+	//	}
+	//}
+	//
+	//th.AssertEquals(t, found, true)
+}

--- a/openstack/networking/v2/extensions/qos/policies/doc.go
+++ b/openstack/networking/v2/extensions/qos/policies/doc.go
@@ -4,7 +4,7 @@ for the OpenStack Networking service.
 
 Example to Get a Port with a QoS policy
 
-	var portWithQoS struct {
+    var portWithQoS struct {
         ports.Port
         policies.QoSPolicyExt
     }
@@ -20,31 +20,31 @@ Example to Get a Port with a QoS policy
 
 Example to Create a Port with a QoS policy
 
-	var portWithQoS struct {
-		ports.Port
-		policies.QoSPolicyExt
-	}
+    var portWithQoS struct {
+        ports.Port
+        policies.QoSPolicyExt
+    }
 
-	policyID := "d6ae28ce-fcb5-4180-aa62-d260a27e09ae"
-	networkID := "7069db8d-e817-4b39-a654-d2dd76e73d36"
+    policyID := "d6ae28ce-fcb5-4180-aa62-d260a27e09ae"
+    networkID := "7069db8d-e817-4b39-a654-d2dd76e73d36"
 
-	portCreateOpts := ports.CreateOpts{
-		NetworkID: networkID,
-	}
+    portCreateOpts := ports.CreateOpts{
+        NetworkID: networkID,
+    }
 
-	createOpts := policies.PortCreateOptsExt{
-		CreateOptsBuilder: portCreateOpts,
-		QoSPolicyID:       policyID,
-	}
+    createOpts := policies.PortCreateOptsExt{
+        CreateOptsBuilder: portCreateOpts,
+        QoSPolicyID:       policyID,
+    }
 
-	err = ports.Create(client, createOpts).ExtractInto(&portWithQoS)
-	if err != nil {
-		panic(err)
-	}
+    err = ports.Create(client, createOpts).ExtractInto(&portWithQoS)
+    if err != nil {
+        panic(err)
+    }
 
-	fmt.Printf("Port: %+v\n", portWithQoS)
+    fmt.Printf("Port: %+v\n", portWithQoS)
 
-Example to add a QoS policy to an existing Port
+Example to Add a QoS policy to an existing Port
 
     var portWithQoS struct {
         ports.Port
@@ -57,7 +57,7 @@ Example to add a QoS policy to an existing Port
 
     updateOpts := policies.PortUpdateOptsExt{
         UpdateOptsBuilder: portUpdateOpts,
-        QoSPolicyID: &policyID,
+        QoSPolicyID:       &policyID,
     }
 
     err := ports.Update(client, "65c0ee9f-d634-4522-8954-51021b570b0d", updateOpts).ExtractInto(&portWithQoS)
@@ -67,7 +67,7 @@ Example to add a QoS policy to an existing Port
 
     fmt.Printf("Port: %+v\n", portWithQoS)
 
-Example to delete a QoS policy from the existing Port
+Example to Delete a QoS policy from the existing Port
 
     var portWithQoS struct {
         ports.Port
@@ -80,7 +80,7 @@ Example to delete a QoS policy from the existing Port
 
     updateOpts := policies.PortUpdateOptsExt{
         UpdateOptsBuilder: portUpdateOpts,
-        QoSPolicyID: &policyID,
+        QoSPolicyID:       &policyID,
     }
 
     err := ports.Update(client, "65c0ee9f-d634-4522-8954-51021b570b0d", updateOpts).ExtractInto(&portWithQoS)
@@ -145,7 +145,7 @@ Example to add a QoS policy to an existing Network
 
     updateOpts := policies.NetworkUpdateOptsExt{
         UpdateOptsBuilder: networkUpdateOpts,
-        QoSPolicyID: &policyID,
+        QoSPolicyID:       &policyID,
     }
 
     err := networks.Update(client, "65c0ee9f-d634-4522-8954-51021b570b0d", updateOpts).ExtractInto(&networkWithQoS)
@@ -168,7 +168,7 @@ Example to delete a QoS policy from the existing Network
 
     updateOpts := policies.NetworkUpdateOptsExt{
         UpdateOptsBuilder: networkUpdateOpts,
-        QoSPolicyID: &policyID,
+        QoSPolicyID:       &policyID,
     }
 
     err := networks.Update(client, "65c0ee9f-d634-4522-8954-51021b570b0d", updateOpts).ExtractInto(&networkWithQoS)
@@ -178,7 +178,7 @@ Example to delete a QoS policy from the existing Network
 
     fmt.Printf("Network: %+v\n", networkWithQoS)
 
-Example to list QoS policies
+Example to List QoS policies
 
     shared := true
     listOpts := policies.ListOpts{
@@ -199,5 +199,16 @@ Example to list QoS policies
     for _, policy := range allPolicies {
         fmt.Printf("%+v\n", policy)
     }
+
+Example to Get a specific QoS policy
+
+    policyID := "30a57f4a-336b-4382-8275-d708babd2241"
+
+    policy, err := policies.Get(networkClient, policyID).Extract()
+    if err != nil {
+        panic(err)
+    }
+
+    fmt.Printf("%+v\n", policy)
 */
 package policies

--- a/openstack/networking/v2/extensions/qos/policies/requests.go
+++ b/openstack/networking/v2/extensions/qos/policies/requests.go
@@ -168,3 +168,9 @@ func List(c *gophercloud.ServiceClient, opts PolicyListOptsBuilder) pagination.P
 
 	})
 }
+
+// Get retrieves a specific QoS policy based on its ID.
+func Get(c *gophercloud.ServiceClient, id string) (r GetResult) {
+	_, r.Err = c.Get(getURL(c, id), &r.Body, nil)
+	return
+}

--- a/openstack/networking/v2/extensions/qos/policies/results.go
+++ b/openstack/networking/v2/extensions/qos/policies/results.go
@@ -13,6 +13,25 @@ type QoSPolicyExt struct {
 	QoSPolicyID string `json:"qos_policy_id"`
 }
 
+type commonResult struct {
+	gophercloud.Result
+}
+
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a QoS policy.
+type GetResult struct {
+	commonResult
+}
+
+// Extract is a function that accepts a result and extracts a QoS policy resource.
+func (r commonResult) Extract() (*Policy, error) {
+	var s struct {
+		Policy *Policy `json:"policy"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Policy, err
+}
+
 // Policy represents a QoS policy.
 type Policy struct {
 	// ID is the id of the policy.

--- a/openstack/networking/v2/extensions/qos/policies/testing/fixtures.go
+++ b/openstack/networking/v2/extensions/qos/policies/testing/fixtures.go
@@ -215,3 +215,31 @@ var Policy2 = policies.Policy{
 	ProjectID:      "a77cbe0998374aed9a6798ad6c61677e",
 	ID:             "d6e7c2fe-24dc-43be-a088-24b47d4f8f88",
 }
+
+const GetPolicyResponse = `
+{
+    "policy": {
+        "name": "bw-limiter",
+        "tags": [],
+        "rules": [
+            {
+                "max_kbps": 3000,
+                "direction": "egress",
+                "qos_policy_id": "d6ae28ce-fcb5-4180-aa62-d260a27e09ae",
+                "type": "bandwidth_limit",
+                "id": "30a57f4a-336b-4382-8275-d708babd2241",
+                "max_burst_kbps": 300
+            }
+        ],
+        "tenant_id": "a77cbe0998374aed9a6798ad6c61677e",
+        "created_at": "2019-05-19T11:17:50Z",
+        "updated_at": "2019-05-19T11:17:57Z",
+        "is_default": false,
+        "revision_number": 1,
+        "shared": false,
+        "project_id": "a77cbe0998374aed9a6798ad6c61677e",
+        "id": "d6ae28ce-fcb5-4180-aa62-d260a27e09ae",
+        "description": ""
+    }
+}
+`

--- a/openstack/networking/v2/extensions/qos/policies/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/qos/policies/testing/requests_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	fake "github.com/gophercloud/gophercloud/openstack/networking/v2/common"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/qos/policies"
@@ -332,4 +333,41 @@ func TestListPolicies(t *testing.T) {
 	if count != 1 {
 		t.Errorf("Expected 1 page, got %d", count)
 	}
+}
+
+func TestGetPolicy(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/qos/policies/30a57f4a-336b-4382-8275-d708babd2241", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, GetPolicyResponse)
+	})
+
+	p, err := policies.Get(fake.ServiceClient(), "30a57f4a-336b-4382-8275-d708babd2241").Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, "bw-limiter", p.Name)
+	th.AssertDeepEquals(t, []string{}, p.Tags)
+	th.AssertDeepEquals(t, []map[string]interface{}{
+		{
+			"max_kbps":       float64(3000),
+			"direction":      "egress",
+			"qos_policy_id":  "d6ae28ce-fcb5-4180-aa62-d260a27e09ae",
+			"type":           "bandwidth_limit",
+			"id":             "30a57f4a-336b-4382-8275-d708babd2241",
+			"max_burst_kbps": float64(300),
+		},
+	}, p.Rules)
+	th.AssertEquals(t, "a77cbe0998374aed9a6798ad6c61677e", p.TenantID)
+	th.AssertEquals(t, "a77cbe0998374aed9a6798ad6c61677e", p.ProjectID)
+	th.AssertEquals(t, time.Date(2019, 5, 19, 11, 17, 50, 0, time.UTC), p.CreatedAt)
+	th.AssertEquals(t, time.Date(2019, 5, 19, 11, 17, 57, 0, time.UTC), p.UpdatedAt)
+	th.AssertEquals(t, 1, p.RevisionNumber)
+	th.AssertEquals(t, "d6ae28ce-fcb5-4180-aa62-d260a27e09ae", p.ID)
 }

--- a/openstack/networking/v2/extensions/qos/policies/urls.go
+++ b/openstack/networking/v2/extensions/qos/policies/urls.go
@@ -8,6 +8,14 @@ func rootURL(c *gophercloud.ServiceClient) string {
 	return c.ServiceURL(resourcePath)
 }
 
+func resourceURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL(resourcePath, id)
+}
+
 func listURL(c *gophercloud.ServiceClient) string {
 	return rootURL(c)
+}
+
+func getURL(c *gophercloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
 }


### PR DESCRIPTION
Add Get function for QoS policies package.

Cleanup QoS extension documentation.

Add acceptance test for QoS policies CRUD that will be temporary
disabled.

For #1027

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/neutron-lib/blob/stable/stein/neutron_lib/api/definitions/qos.py#L54
https://github.com/openstack/neutron/blob/stable/stein/neutron/extensions/qos.py#L43
