### PR TITLE
Networking V2: add QoS DSCP marking rules List

### DIFF
--- a/openstack/networking/v2/extensions/qos/rules/doc.go
+++ b/openstack/networking/v2/extensions/qos/rules/doc.go
@@ -80,5 +80,25 @@ Example of Deleting a single BandwidthLimitRule
     if err != nil {
         panic(err)
     }
+
+Example of Listing DSCP marking rules
+
+    listOpts := rules.DSCPMarkingRulesListOpts{}
+
+    policyID := "501005fa-3b56-4061-aaca-3f24995112e1"
+
+    allPages, err := rules.ListDSCPMarkingRules(networkClient, policyID, listOpts).AllPages()
+    if err != nil {
+        panic(err)
+    }
+
+    allDSCPMarkingRules, err := rules.ExtractDSCPMarkingRules(allPages)
+    if err != nil {
+        panic(err)
+    }
+
+    for _, dscpMarkingRule := range allDSCPMarkingRules {
+        fmt.Printf("%+v\n", dscpMarkingRule)
+    }
 */
 package rules

--- a/openstack/networking/v2/extensions/qos/rules/requests.go
+++ b/openstack/networking/v2/extensions/qos/rules/requests.go
@@ -140,3 +140,53 @@ func DeleteBandwidthLimitRule(c *gophercloud.ServiceClient, policyID, ruleID str
 	_, r.Err = c.Delete(deleteBandwidthLimitRuleURL(c, policyID, ruleID), nil)
 	return
 }
+
+// DSCPMarkingRulesListOptsBuilder allows extensions to add additional parameters to the
+// List request.
+type DSCPMarkingRulesListOptsBuilder interface {
+	ToDSCPMarkingRulesListQuery() (string, error)
+}
+
+// DSCPMarkingRulesListOpts allows the filtering and sorting of paginated collections through
+// the Neutron API. Filtering is achieved by passing in struct field values
+// that map to the DSCPMarking attributes you want to see returned.
+// SortKey allows you to sort by a particular DSCPMarkingRule attribute.
+// SortDir sets the direction, and is either `asc' or `desc'.
+// Marker and Limit are used for the pagination.
+type DSCPMarkingRulesListOpts struct {
+	ID         string `q:"id"`
+	TenantID   string `q:"tenant_id"`
+	DSCPMark   int    `q:"dscp_mark"`
+	Limit      int    `q:"limit"`
+	Marker     string `q:"marker"`
+	SortKey    string `q:"sort_key"`
+	SortDir    string `q:"sort_dir"`
+	Tags       string `q:"tags"`
+	TagsAny    string `q:"tags-any"`
+	NotTags    string `q:"not-tags"`
+	NotTagsAny string `q:"not-tags-any"`
+}
+
+// ToDSCPMarkingRulesListQuery formats a ListOpts into a query string.
+func (opts DSCPMarkingRulesListOpts) ToDSCPMarkingRulesListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// ListDSCPMarkingRules returns a Pager which allows you to iterate over a collection of
+// DSCPMarkingRules. It accepts a ListOpts struct, which allows you to filter and sort
+// the returned collection for greater efficiency.
+func ListDSCPMarkingRules(c *gophercloud.ServiceClient, policyID string, opts DSCPMarkingRulesListOptsBuilder) pagination.Pager {
+	url := listDSCPMarkingRulesURL(c, policyID)
+	if opts != nil {
+		query, err := opts.ToDSCPMarkingRulesListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		return DSCPMarkingRulePage{pagination.LinkedPageBase{PageResult: r}}
+
+	})
+}

--- a/openstack/networking/v2/extensions/qos/rules/results.go
+++ b/openstack/networking/v2/extensions/qos/rules/results.go
@@ -86,3 +86,42 @@ func ExtractBandwidthLimitRules(r pagination.Page) ([]BandwidthLimitRule, error)
 func ExtractBandwidthLimitRulesInto(r pagination.Page, v interface{}) error {
 	return r.(BandwidthLimitRulePage).Result.ExtractIntoSlicePtr(v, "bandwidth_limit_rules")
 }
+
+// DSCPMarkingRule represents a QoS policy rule to set DSCP marking.
+type DSCPMarkingRule struct {
+	// ID is a unique ID of the policy.
+	ID string `json:"id"`
+
+	// TenantID is the ID of the Identity project.
+	TenantID string `json:"tenant_id"`
+
+	// DSCPMark contains DSCP mark value.
+	DSCPMark int `json:"dscp_mark"`
+
+	// Tags optionally set via extensions/attributestags.
+	Tags []string `json:"tags"`
+}
+
+// DSCPMarkingRulePage stores a single page of DSCPMarkingRules from a List() API call.
+type DSCPMarkingRulePage struct {
+	pagination.LinkedPageBase
+}
+
+// IsEmpty checks whether a DSCPMarkingRulePage is empty.
+func (r DSCPMarkingRulePage) IsEmpty() (bool, error) {
+	is, err := ExtractDSCPMarkingRules(r)
+	return len(is) == 0, err
+}
+
+// ExtractDSCPMarkingRules accepts a DSCPMarkingRulePage, and extracts the elements into a slice of
+// DSCPMarkingRules.
+func ExtractDSCPMarkingRules(r pagination.Page) ([]DSCPMarkingRule, error) {
+	var s []DSCPMarkingRule
+	err := ExtractDSCPMarkingRulesInto(r, &s)
+	return s, err
+}
+
+// ExtractDSCPMarkingRulesInto extracts the elements into a slice of RBAC Policy structs.
+func ExtractDSCPMarkingRulesInto(r pagination.Page, v interface{}) error {
+	return r.(DSCPMarkingRulePage).Result.ExtractIntoSlicePtr(v, "dscp_marking_rules")
+}

--- a/openstack/networking/v2/extensions/qos/rules/testing/fixtures.go
+++ b/openstack/networking/v2/extensions/qos/rules/testing/fixtures.go
@@ -67,3 +67,15 @@ const BandwidthLimitRulesUpdateResult = `
     }
 }
 `
+
+// DSCPMarkingRulesListResult represents a raw result of a List call to DSCPMarkingRules.
+const DSCPMarkingRulesListResult = `
+{
+    "dscp_marking_rules": [
+        {
+            "id": "30a57f4a-336b-4382-8275-d708babd2241",
+            "dscp_mark": 20
+        }
+    ]
+}
+`

--- a/openstack/networking/v2/extensions/qos/rules/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/qos/rules/testing/requests_test.go
@@ -153,3 +153,49 @@ func TestDeleteBandwidthLimitRule(t *testing.T) {
 	res := rules.DeleteBandwidthLimitRule(fake.ServiceClient(), "501005fa-3b56-4061-aaca-3f24995112e1", "30a57f4a-336b-4382-8275-d708babd2241")
 	th.AssertNoErr(t, res.Err)
 }
+
+func TestListDSCPMarkingRule(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/qos/policies/501005fa-3b56-4061-aaca-3f24995112e1/dscp_marking_rules", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, DSCPMarkingRulesListResult)
+	})
+
+	count := 0
+
+	err := rules.ListDSCPMarkingRules(
+		fake.ServiceClient(),
+		"501005fa-3b56-4061-aaca-3f24995112e1",
+		rules.DSCPMarkingRulesListOpts{},
+	).EachPage(func(page pagination.Page) (bool, error) {
+		count++
+		actual, err := rules.ExtractDSCPMarkingRules(page)
+		if err != nil {
+			t.Errorf("Failed to extract DSCP marking rules: %v", err)
+			return false, nil
+		}
+
+		expected := []rules.DSCPMarkingRule{
+			{
+				ID:       "30a57f4a-336b-4382-8275-d708babd2241",
+				DSCPMark: 20,
+			},
+		}
+
+		th.CheckDeepEquals(t, expected, actual)
+
+		return true, nil
+	})
+	th.AssertNoErr(t, err)
+
+	if count != 1 {
+		t.Errorf("Expected 1 page, got %d", count)
+	}
+}

--- a/openstack/networking/v2/extensions/qos/rules/urls.go
+++ b/openstack/networking/v2/extensions/qos/rules/urls.go
@@ -6,6 +6,7 @@ const (
 	rootPath = "qos/policies"
 
 	bandwidthLimitRulesResourcePath = "bandwidth_limit_rules"
+	dscpMarkingRulesResourcePath    = "dscp_marking_rules"
 )
 
 func bandwidthLimitRulesRootURL(c *gophercloud.ServiceClient, policyID string) string {
@@ -34,4 +35,12 @@ func updateBandwidthLimitRuleURL(c *gophercloud.ServiceClient, policyID, ruleID 
 
 func deleteBandwidthLimitRuleURL(c *gophercloud.ServiceClient, policyID, ruleID string) string {
 	return bandwidthLimitRulesResourceURL(c, policyID, ruleID)
+}
+
+func dscpMarkingRulesRootURL(c *gophercloud.ServiceClient, policyID string) string {
+	return c.ServiceURL(rootPath, policyID, dscpMarkingRulesResourcePath)
+}
+
+func listDSCPMarkingRulesURL(c *gophercloud.ServiceClient, policyID string) string {
+	return dscpMarkingRulesRootURL(c, policyID)
 }


### PR DESCRIPTION
Add QoS DSCP marking rules List function.

For #1027

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/neutron-lib/blob/stable/stein/neutron_lib/api/definitions/qos.py#L137
https://github.com/openstack/neutron/blob/stable/stein/neutron/extensions/qos.py#L84