### PR TITLE
Networking V2: add QoS policy Delete call

### DIFF
--- a/openstack/networking/v2/extensions/qos/policies/doc.go
+++ b/openstack/networking/v2/extensions/qos/policies/doc.go
@@ -225,5 +225,24 @@ Example to Create a QoS policy
     }
 
     fmt.Printf("%+v\n", policy)
+
+Example to Update a QoS policy
+
+    shared := true
+    isDefault := false
+    opts := policies.UpdateOpts{
+        Name:      "new-name",
+        Shared:    &shared,
+        IsDefault: &isDefault,
+    }
+
+    policyID := "30a57f4a-336b-4382-8275-d708babd2241"
+
+    policy, err := policies.Update(networkClient, policyID, opts).Extract()
+    if err != nil {
+        panic(err)
+    }
+
+    fmt.Printf("%+v\n", policy)
 */
 package policies

--- a/openstack/networking/v2/extensions/qos/policies/doc.go
+++ b/openstack/networking/v2/extensions/qos/policies/doc.go
@@ -244,5 +244,14 @@ Example to Update a QoS policy
     }
 
     fmt.Printf("%+v\n", policy)
+
+Example to Delete a QoS policy
+
+    policyID := "30a57f4a-336b-4382-8275-d708babd2241"
+
+    err := policies.Delete(networkClient, policyID).ExtractErr()
+    if err != nil {
+        panic(err)
+    }
 */
 package policies

--- a/openstack/networking/v2/extensions/qos/policies/requests.go
+++ b/openstack/networking/v2/extensions/qos/policies/requests.go
@@ -259,3 +259,9 @@ func Update(c *gophercloud.ServiceClient, policyID string, opts UpdateOptsBuilde
 	})
 	return
 }
+
+// Delete accepts a unique ID and deletes the QoS policy associated with it.
+func Delete(c *gophercloud.ServiceClient, id string) (r DeleteResult) {
+	_, r.Err = c.Delete(deleteURL(c, id), nil)
+	return
+}

--- a/openstack/networking/v2/extensions/qos/policies/requests.go
+++ b/openstack/networking/v2/extensions/qos/policies/requests.go
@@ -219,3 +219,43 @@ func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r Create
 	})
 	return
 }
+
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
+type UpdateOptsBuilder interface {
+	ToPolicyUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts represents options used to update a QoS policy.
+type UpdateOpts struct {
+	// Name is the human-readable name of the QoS policy.
+	Name string `json:"name,omitempty"`
+
+	// Shared indicates whether this QoS policy is shared across all projects.
+	Shared *bool `json:"shared,omitempty"`
+
+	// Description is the human-readable description for the QoS policy.
+	Description *string `json:"description,omitempty"`
+
+	// IsDefault indicates if this QoS policy is default policy or not.
+	IsDefault *bool `json:"is_default,omitempty"`
+}
+
+// ToPolicyUpdateMap builds a request body from UpdateOpts.
+func (opts UpdateOpts) ToPolicyUpdateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "policy")
+}
+
+// Update accepts a UpdateOpts struct and updates an existing policy using the
+// values provided.
+func Update(c *gophercloud.ServiceClient, policyID string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToPolicyUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Put(updateURL(c, policyID), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+	})
+	return
+}

--- a/openstack/networking/v2/extensions/qos/policies/results.go
+++ b/openstack/networking/v2/extensions/qos/policies/results.go
@@ -29,6 +29,12 @@ type CreateResult struct {
 	commonResult
 }
 
+// UpdateResult represents the result of a Create operation. Call its Extract
+// method to interpret it as a QoS policy.
+type UpdateResult struct {
+	commonResult
+}
+
 // Extract is a function that accepts a result and extracts a QoS policy resource.
 func (r commonResult) Extract() (*Policy, error) {
 	var s struct {

--- a/openstack/networking/v2/extensions/qos/policies/results.go
+++ b/openstack/networking/v2/extensions/qos/policies/results.go
@@ -35,6 +35,12 @@ type UpdateResult struct {
 	commonResult
 }
 
+// DeleteResult represents the result of a delete operation. Call its
+// ExtractErr method to determine if the request succeeded or failed.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
 // Extract is a function that accepts a result and extracts a QoS policy resource.
 func (r commonResult) Extract() (*Policy, error) {
 	var s struct {

--- a/openstack/networking/v2/extensions/qos/policies/testing/fixtures.go
+++ b/openstack/networking/v2/extensions/qos/policies/testing/fixtures.go
@@ -273,3 +273,32 @@ const CreatePolicyResponse = `
     }
 }
 `
+
+const UpdatePolicyRequest = `
+{
+    "policy": {
+        "name": "new-name",
+        "shared": true,
+        "description": ""
+    }
+}
+`
+
+const UpdatePolicyResponse = `
+{
+    "policy": {
+        "name": "new-name",
+        "tags": [],
+        "rules": [],
+        "tenant_id": "a77cbe0998374aed9a6798ad6c61677e",
+        "created_at": "2019-05-19T11:17:50Z",
+        "updated_at": "2019-06-01T13:17:57Z",
+        "is_default": false,
+        "revision_number": 1,
+        "shared": true,
+        "project_id": "a77cbe0998374aed9a6798ad6c61677e",
+        "id": "d6ae28ce-fcb5-4180-aa62-d260a27e09ae",
+        "description": ""
+    }
+}
+`

--- a/openstack/networking/v2/extensions/qos/policies/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/qos/policies/testing/requests_test.go
@@ -448,3 +448,17 @@ func TestUpdatePolicy(t *testing.T) {
 	th.AssertEquals(t, 1, p.RevisionNumber)
 	th.AssertEquals(t, "d6ae28ce-fcb5-4180-aa62-d260a27e09ae", p.ID)
 }
+
+func TestDeletePolicy(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/qos/policies/d6ae28ce-fcb5-4180-aa62-d260a27e09ae", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	res := policies.Delete(fake.ServiceClient(), "d6ae28ce-fcb5-4180-aa62-d260a27e09ae")
+	th.AssertNoErr(t, res.Err)
+}

--- a/openstack/networking/v2/extensions/qos/policies/urls.go
+++ b/openstack/networking/v2/extensions/qos/policies/urls.go
@@ -23,3 +23,7 @@ func getURL(c *gophercloud.ServiceClient, id string) string {
 func createURL(c *gophercloud.ServiceClient) string {
 	return rootURL(c)
 }
+
+func updateURL(c *gophercloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
+}

--- a/openstack/networking/v2/extensions/qos/policies/urls.go
+++ b/openstack/networking/v2/extensions/qos/policies/urls.go
@@ -27,3 +27,7 @@ func createURL(c *gophercloud.ServiceClient) string {
 func updateURL(c *gophercloud.ServiceClient, id string) string {
 	return resourceURL(c, id)
 }
+
+func deleteURL(c *gophercloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
+}


### PR DESCRIPTION
Implement QoS policy delete method.

For #1027

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/neutron-lib/blob/stable/stein/neutron_lib/api/definitions/qos.py#L54
https://github.com/openstack/neutron/blob/stable/stein/neutron/extensions/qos.py#L43
