### PR TITLE
Networking V2: add QoS DSCPMarking rule Create

### DIFF
--- a/openstack/networking/v2/extensions/qos/rules/doc.go
+++ b/openstack/networking/v2/extensions/qos/rules/doc.go
@@ -100,5 +100,20 @@ Example of Listing DSCP marking rules
     for _, dscpMarkingRule := range allDSCPMarkingRules {
         fmt.Printf("%+v\n", dscpMarkingRule)
     }
+
+Example of Creating a single DSCPMarkingRule
+
+    opts := rules.CreateDSCPMarkingRuleOpts{
+        DSCPMark: 20,
+    }
+
+    policyID := "501005fa-3b56-4061-aaca-3f24995112e1"
+
+    rule, err := rules.CreateDSCPMarkingRule(networkClient, policyID, opts).ExtractDSCPMarkingRule()
+    if err != nil {
+        panic(err)
+    }
+
+    fmt.Printf("Rule: %+v\n", rule)
 */
 package rules

--- a/openstack/networking/v2/extensions/qos/rules/requests.go
+++ b/openstack/networking/v2/extensions/qos/rules/requests.go
@@ -190,3 +190,33 @@ func ListDSCPMarkingRules(c *gophercloud.ServiceClient, policyID string, opts DS
 
 	})
 }
+
+// CreateDSCPMarkingRuleOptsBuilder allows to add additional parameters to the
+// CreateDSCPMarkingRule request.
+type CreateDSCPMarkingRuleOptsBuilder interface {
+	ToDSCPMarkingRuleCreateMap() (map[string]interface{}, error)
+}
+
+// CreateDSCPMarkingRuleOpts specifies parameters of a new DSCPMarkingRule.
+type CreateDSCPMarkingRuleOpts struct {
+	// DSCPMark contains DSCP mark value.
+	DSCPMark int `json:"dscp_mark"`
+}
+
+// ToDSCPMarkingRuleCreateMap constructs a request body from CreateDSCPMarkingRuleOpts.
+func (opts CreateDSCPMarkingRuleOpts) ToDSCPMarkingRuleCreateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "dscp_marking_rule")
+}
+
+// CreateDSCPMarkingRule requests the creation of a new DSCPMarkingRule on the server.
+func CreateDSCPMarkingRule(client *gophercloud.ServiceClient, policyID string, opts CreateDSCPMarkingRuleOptsBuilder) (r CreateDSCPMarkingRuleResult) {
+	b, err := opts.ToDSCPMarkingRuleCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(createDSCPMarkingRuleURL(client, policyID), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{201},
+	})
+	return
+}

--- a/openstack/networking/v2/extensions/qos/rules/results.go
+++ b/openstack/networking/v2/extensions/qos/rules/results.go
@@ -87,6 +87,21 @@ func ExtractBandwidthLimitRulesInto(r pagination.Page, v interface{}) error {
 	return r.(BandwidthLimitRulePage).Result.ExtractIntoSlicePtr(v, "bandwidth_limit_rules")
 }
 
+// Extract is a function that accepts a result and extracts a DSCPMarkingRule.
+func (r commonResult) ExtractDSCPMarkingRule() (*DSCPMarkingRule, error) {
+	var s struct {
+		DSCPMarkingRule *DSCPMarkingRule `json:"dscp_marking_rule"`
+	}
+	err := r.ExtractInto(&s)
+	return s.DSCPMarkingRule, err
+}
+
+// CreateDSCPMarkingRuleResult represents the result of a Create operation. Call its Extract
+// method to interpret it as a DSCPMarkingRule.
+type CreateDSCPMarkingRuleResult struct {
+	commonResult
+}
+
 // DSCPMarkingRule represents a QoS policy rule to set DSCP marking.
 type DSCPMarkingRule struct {
 	// ID is a unique ID of the policy.

--- a/openstack/networking/v2/extensions/qos/rules/testing/fixtures.go
+++ b/openstack/networking/v2/extensions/qos/rules/testing/fixtures.go
@@ -79,3 +79,22 @@ const DSCPMarkingRulesListResult = `
     ]
 }
 `
+
+// DSCPMarkingRuleCreateRequest represents a raw body of a Create DSCPMarkingRule call.
+const DSCPMarkingRuleCreateRequest = `
+{
+    "dscp_marking_rule": {
+        "dscp_mark": 20
+    }
+}
+`
+
+// DSCPMarkingRuleCreateResult represents a raw result of a Update DSCPMarkingRule call.
+const DSCPMarkingRuleCreateResult = `
+{
+    "dscp_marking_rule": {
+        "id": "30a57f4a-336b-4382-8275-d708babd2241",
+        "dscp_mark": 20
+    }
+}
+`

--- a/openstack/networking/v2/extensions/qos/rules/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/qos/rules/testing/requests_test.go
@@ -199,3 +199,30 @@ func TestListDSCPMarkingRule(t *testing.T) {
 		t.Errorf("Expected 1 page, got %d", count)
 	}
 }
+
+func TestCreateDSCPMarkingRule(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/qos/policies/501005fa-3b56-4061-aaca-3f24995112e1/dscp_marking_rules", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, DSCPMarkingRuleCreateRequest)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+
+		fmt.Fprintf(w, DSCPMarkingRuleCreateResult)
+	})
+
+	opts := rules.CreateDSCPMarkingRuleOpts{
+		DSCPMark: 20,
+	}
+	r, err := rules.CreateDSCPMarkingRule(fake.ServiceClient(), "501005fa-3b56-4061-aaca-3f24995112e1", opts).ExtractDSCPMarkingRule()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, "30a57f4a-336b-4382-8275-d708babd2241", r.ID)
+	th.AssertEquals(t, 20, r.DSCPMark)
+}

--- a/openstack/networking/v2/extensions/qos/rules/urls.go
+++ b/openstack/networking/v2/extensions/qos/rules/urls.go
@@ -44,3 +44,7 @@ func dscpMarkingRulesRootURL(c *gophercloud.ServiceClient, policyID string) stri
 func listDSCPMarkingRulesURL(c *gophercloud.ServiceClient, policyID string) string {
 	return dscpMarkingRulesRootURL(c, policyID)
 }
+
+func createDSCPMarkingRuleURL(c *gophercloud.ServiceClient, policyID string) string {
+	return dscpMarkingRulesRootURL(c, policyID)
+}


### PR DESCRIPTION
Implement QoS DSCPMarking rule creating.

For #1027

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/neutron-lib/blob/stable/stein/neutron_lib/api/definitions/qos.py#L137
https://github.com/openstack/neutron/blob/stable/stein/neutron/extensions/qos.py#L84
