### PR TITLE
Networking V2: add QoS DSCP rule Get call

### DIFF
--- a/openstack/networking/v2/extensions/qos/rules/doc.go
+++ b/openstack/networking/v2/extensions/qos/rules/doc.go
@@ -101,6 +101,18 @@ Example of Listing DSCP marking rules
         fmt.Printf("%+v\n", dscpMarkingRule)
     }
 
+Example of Getting a single DSCPMarkingRule
+
+    policyID := "501005fa-3b56-4061-aaca-3f24995112e1"
+    ruleID   := "30a57f4a-336b-4382-8275-d708babd2241"
+
+    rule, err := rules.GetDSCPMarkingRule(networkClient, policyID, ruleID).ExtractDSCPMarkingRule()
+    if err != nil {
+        panic(err)
+    }
+
+    fmt.Printf("Rule: %+v\n", rule)
+
 Example of Creating a single DSCPMarkingRule
 
     opts := rules.CreateDSCPMarkingRuleOpts{

--- a/openstack/networking/v2/extensions/qos/rules/requests.go
+++ b/openstack/networking/v2/extensions/qos/rules/requests.go
@@ -191,6 +191,12 @@ func ListDSCPMarkingRules(c *gophercloud.ServiceClient, policyID string, opts DS
 	})
 }
 
+// GetDSCPMarkingRule retrieves a specific DSCPMarkingRule based on its ID.
+func GetDSCPMarkingRule(c *gophercloud.ServiceClient, policyID, ruleID string) (r GetDSCPMarkingRuleResult) {
+	_, r.Err = c.Get(getDSCPMarkingRuleURL(c, policyID, ruleID), &r.Body, nil)
+	return
+}
+
 // CreateDSCPMarkingRuleOptsBuilder allows to add additional parameters to the
 // CreateDSCPMarkingRule request.
 type CreateDSCPMarkingRuleOptsBuilder interface {

--- a/openstack/networking/v2/extensions/qos/rules/results.go
+++ b/openstack/networking/v2/extensions/qos/rules/results.go
@@ -96,6 +96,12 @@ func (r commonResult) ExtractDSCPMarkingRule() (*DSCPMarkingRule, error) {
 	return s.DSCPMarkingRule, err
 }
 
+// GetDSCPMarkingRuleResult represents the result of a Get operation. Call its Extract
+// method to interpret it as a DSCPMarkingRule.
+type GetDSCPMarkingRuleResult struct {
+	commonResult
+}
+
 // CreateDSCPMarkingRuleResult represents the result of a Create operation. Call its Extract
 // method to interpret it as a DSCPMarkingRule.
 type CreateDSCPMarkingRuleResult struct {

--- a/openstack/networking/v2/extensions/qos/rules/testing/fixtures.go
+++ b/openstack/networking/v2/extensions/qos/rules/testing/fixtures.go
@@ -80,6 +80,16 @@ const DSCPMarkingRulesListResult = `
 }
 `
 
+// DSCPMarkingRuleGetResult represents a raw result of a Get DSCPMarkingRule call.
+const DSCPMarkingRuleGetResult = `
+{
+    "dscp_marking_rule": {
+        "id": "30a57f4a-336b-4382-8275-d708babd2241",
+        "dscp_mark": 26
+    }
+}
+`
+
 // DSCPMarkingRuleCreateRequest represents a raw body of a Create DSCPMarkingRule call.
 const DSCPMarkingRuleCreateRequest = `
 {

--- a/openstack/networking/v2/extensions/qos/rules/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/qos/rules/testing/requests_test.go
@@ -200,6 +200,27 @@ func TestListDSCPMarkingRule(t *testing.T) {
 	}
 }
 
+func TestGetDSCPMarkingRule(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/qos/policies/501005fa-3b56-4061-aaca-3f24995112e1/dscp_marking_rules/30a57f4a-336b-4382-8275-d708babd2241", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, DSCPMarkingRuleGetResult)
+	})
+
+	r, err := rules.GetDSCPMarkingRule(fake.ServiceClient(), "501005fa-3b56-4061-aaca-3f24995112e1", "30a57f4a-336b-4382-8275-d708babd2241").ExtractDSCPMarkingRule()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, r.ID, "30a57f4a-336b-4382-8275-d708babd2241")
+	th.AssertEquals(t, 26, r.DSCPMark)
+}
+
 func TestCreateDSCPMarkingRule(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()

--- a/openstack/networking/v2/extensions/qos/rules/urls.go
+++ b/openstack/networking/v2/extensions/qos/rules/urls.go
@@ -49,6 +49,10 @@ func listDSCPMarkingRulesURL(c *gophercloud.ServiceClient, policyID string) stri
 	return dscpMarkingRulesRootURL(c, policyID)
 }
 
+func getDSCPMarkingRuleURL(c *gophercloud.ServiceClient, policyID, ruleID string) string {
+	return dscpMarkingRulesResourceURL(c, policyID, ruleID)
+}
+
 func createDSCPMarkingRuleURL(c *gophercloud.ServiceClient, policyID string) string {
 	return dscpMarkingRulesRootURL(c, policyID)
 }


### PR DESCRIPTION
Implement QoS DSCP marking rule Get call.

For #1027

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/neutron-lib/blob/stable/stein/neutron_lib/api/definitions/qos.py#L137
https://github.com/openstack/neutron/blob/stable/stein/neutron/extensions/qos.py#L84
