### PR TITLE
Baremetal introspection: Read extra_hardware data

### DIFF
--- a/openstack/baremetalintrospection/v1/introspection/results.go
+++ b/openstack/baremetalintrospection/v1/introspection/results.go
@@ -171,6 +171,7 @@ type Data struct {
 	MemoryMB      int                          `json:"memory_mb"`
 	RootDisk      RootDiskType                 `json:"root_disk"`
 	Hostname      string                       `json:"hostname"`
+	Extra         ExtraHardwareDataType        `json:"extra"`
 }
 
 // Sub Types defined under Data and deeper in the structure
@@ -246,6 +247,20 @@ type SystemVendorType struct {
 	Manufacturer string `json:"manufacturer"`
 	ProductName  string `json:"product_name"`
 	SerialNumber string `json:"serial_number"`
+}
+
+type ExtraHardwareData map[string]interface{}
+
+type ExtraHardwareDataSection map[string]ExtraHardwareData
+
+type ExtraHardwareDataType struct {
+	CPU      ExtraHardwareDataSection `json:"cpu"`
+	Disk     ExtraHardwareDataSection `json:"disk"`
+	Firmware ExtraHardwareDataSection `json:"firmware"`
+	IPMI     ExtraHardwareDataSection `json:"ipmi"`
+	Memory   ExtraHardwareDataSection `json:"memory"`
+	Network  ExtraHardwareDataSection `json:"network"`
+	System   ExtraHardwareDataSection `json:"system"`
 }
 
 // UnmarshalJSON interprets an LLDP TLV [key, value] pair as an LLDPTLVType structure

--- a/openstack/baremetalintrospection/v1/introspection/testing/results_test.go
+++ b/openstack/baremetalintrospection/v1/introspection/testing/results_test.go
@@ -27,3 +27,63 @@ func TestLLDPTLVErrors(t *testing.T) {
 		}
 	}
 }
+
+func TestExtraHardware(t *testing.T) {
+	extraJson := `{
+		"cpu": {
+			"logical": {"number": 16},
+			"physical": {
+				"clock": 2105032704,
+				"cores": 8,
+				"flags": "lm fpu fpu_exception wp vme de"}
+		},
+		"disk": {
+			"sda": {
+				"rotational": 1,
+				"vendor": "TEST"
+			}
+		},
+		"firmware": {
+			"bios": {
+				"date": "01/01/1970",
+				"vendor": "test"
+			}
+		},
+		"ipmi": {
+			"Fan1A RPM": {"unit": "RPM", "value": 3120},
+			"Fan1B RPM": {"unit": "RPM", "value": 2280}
+		},
+		"memory": {
+			"bank0": {
+				"clock": 1600000000.0,
+				"description": "DIMM DDR3 Synchronous Registered (Buffered) 1600 MHz (0.6 ns)"
+			},
+			"bank1": {
+				"clock": 1600000000.0,
+				"description": "DIMM DDR3 Synchronous Registered (Buffered) 1600 MHz (0.6 ns)"
+			}
+		},
+		"network": {
+			"em1": {
+				"Autonegotiate": "on",
+				"loopback": "off [fixed]"
+			},
+			"p2p1": {
+				"Autonegotiate": "on",
+				"loopback": "off [fixed]"
+			}
+		},
+		"system": {
+			"ipmi": {"channel": 1},
+			"kernel": {"arch": "x86_64", "version": "3.10.0"},
+			"motherboard": {"vendor": "Test"},
+			"product": {"name": "test", "vendor": "Test"}
+		}
+	}`
+
+	var output introspection.ExtraHardwareDataType
+	err := json.Unmarshal([]byte(extraJson), &output)
+	if err != nil {
+		t.Errorf("Failed to unmarshal ExtraHardware data: %s", err)
+	}
+}


### PR DESCRIPTION
If the `extra_hardware` processing hook is enabled in ironic-inspector,
then additional data is provided as a top-level object named `"extra"`,
with a number of sections, each of which is also an object containing
objects with various key/value data.

For #1485

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://opendev.org/openstack/ironic-inspector/src/branch/master/ironic_inspector/plugins/extra_hardware.py