### PR TITLE
Baremetal Introspection: Add hostname to introspection data

### DIFF
--- a/openstack/baremetalintrospection/v1/introspection/results.go
+++ b/openstack/baremetalintrospection/v1/introspection/results.go
@@ -170,6 +170,7 @@ type Data struct {
 	MACs          []string                     `json:"macs"`
 	MemoryMB      int                          `json:"memory_mb"`
 	RootDisk      RootDiskType                 `json:"root_disk"`
+	Hostname      string                       `json:"hostname,omitempty"`
 }
 
 // Sub Types defined under Data and deeper in the structure


### PR DESCRIPTION
A patch is being made to the Ironic Python Agent to return the hostname
that the introspected machine thinks it has. This enables Gophercloud
to pass that along.

For #1616 

https://review.opendev.org/#/c/663991/
