### PR TITLE
Compute v2: Scheduler Hints Fix

### DIFF
--- a/openstack/compute/v2/extensions/schedulerhints/requests.go
+++ b/openstack/compute/v2/extensions/schedulerhints/requests.go
@@ -1,6 +1,7 @@
 package schedulerhints
 
 import (
+	"encoding/json"
 	"net"
 	"regexp"
 	"strings"
@@ -105,7 +106,18 @@ func (opts SchedulerHints) ToServerSchedulerHintsCreateMap() (map[string]interfa
 			err.Info = "Must be a conditional statement in the format of [op,variable,value]"
 			return nil, err
 		}
-		sh["query"] = opts.Query
+
+		// The query needs to be sent as a marshalled string.
+		b, err := json.Marshal(opts.Query)
+		if err != nil {
+			err := gophercloud.ErrInvalidInput{}
+			err.Argument = "schedulerhints.SchedulerHints.Query"
+			err.Value = opts.Query
+			err.Info = "Must be a conditional statement in the format of [op,variable,value]"
+			return nil, err
+		}
+
+		sh["query"] = string(b)
 	}
 
 	if opts.TargetCell != "" {

--- a/openstack/compute/v2/extensions/schedulerhints/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/schedulerhints/testing/requests_test.go
@@ -25,7 +25,7 @@ func TestCreateOpts(t *testing.T) {
 			"a0cf03a5-d921-4877-bb5c-86d26cf818e1",
 			"8c19174f-4220-44f0-824a-cd1eeef10287",
 		},
-		Query:                []interface{}{">=", "$free_ram_mb", "1024"},
+		Query:                []interface{}{"=", "$free_ram_mb", "1024"},
 		TargetCell:           "foobar",
 		BuildNearHostIP:      "192.168.1.1/24",
 		AdditionalProperties: map[string]interface{}{"reservation": "a0cf03a5-d921-4877-bb5c-86d26cf818e1"},
@@ -53,9 +53,7 @@ func TestCreateOpts(t *testing.T) {
 					"a0cf03a5-d921-4877-bb5c-86d26cf818e1",
 					"8c19174f-4220-44f0-824a-cd1eeef10287"
 				],
-				"query": [
-					">=", "$free_ram_mb", "1024"
-				],
+				"query": "[\"=\",\"$free_ram_mb\",\"1024\"]",
 				"target_cell": "foobar",
 				"build_near_host_ip": "192.168.1.1",
 				"cidr": "/24",
@@ -85,7 +83,7 @@ func TestCreateOptsWithComplexQuery(t *testing.T) {
 			"a0cf03a5-d921-4877-bb5c-86d26cf818e1",
 			"8c19174f-4220-44f0-824a-cd1eeef10287",
 		},
-		Query:                []interface{}{"and", []string{">=", "$free_ram_mb", "1024"}, []string{">=", "$free_disk_mb", "204800"}},
+		Query:                []interface{}{"and", []string{"=", "$free_ram_mb", "1024"}, []string{"=", "$free_disk_mb", "204800"}},
 		TargetCell:           "foobar",
 		BuildNearHostIP:      "192.168.1.1/24",
 		AdditionalProperties: map[string]interface{}{"reservation": "a0cf03a5-d921-4877-bb5c-86d26cf818e1"},
@@ -113,11 +111,7 @@ func TestCreateOptsWithComplexQuery(t *testing.T) {
 					"a0cf03a5-d921-4877-bb5c-86d26cf818e1",
 					"8c19174f-4220-44f0-824a-cd1eeef10287"
 				],
-				"query": [
-					"and",
-					[">=", "$free_ram_mb", "1024"],
-					[">=", "$free_disk_mb", "204800"]
-				],
+				"query": "[\"and\",[\"=\",\"$free_ram_mb\",\"1024\"],[\"=\",\"$free_disk_mb\",\"204800\"]]",
 				"target_cell": "foobar",
 				"build_near_host_ip": "192.168.1.1",
 				"cidr": "/24",


### PR DESCRIPTION
The "query" part of the scheduler_hints has never been correct. Instead
of sending a nested JSON structure, the Nova API actually expects a
marshalled JSON string which it will then decode.

Normally we would probably just change `Query` to a type `string` and make the application do the marshaling, but since this extension already has a lot of validation included, I opted to do the marshaling here.

For #1619 