### PR TITLE
Adds support for setting image metadata for a volume

### DIFF
--- a/acceptance/openstack/blockstorage/extensions/extensions.go
+++ b/acceptance/openstack/blockstorage/extensions/extensions.go
@@ -174,8 +174,8 @@ func ExtendVolumeSize(t *testing.T, client *gophercloud.ServiceClient, volume *v
 	return nil
 }
 
-// ImageMetadata will apply the metadata to a volume.
-func ImageMetadata(t *testing.T, client *gophercloud.ServiceClient, volume *volumes.Volume) error {
+// SetImageMetadata will apply the metadata to a volume.
+func SetImageMetadata(t *testing.T, client *gophercloud.ServiceClient, volume *volumes.Volume) error {
 	t.Logf("Attempting to apply image metadata to volume %s", volume.ID)
 
 	imageMetadataOpts := volumeactions.ImageMetadataOpts{
@@ -184,7 +184,7 @@ func ImageMetadata(t *testing.T, client *gophercloud.ServiceClient, volume *volu
 		},
 	}
 
-	err := volumeactions.ImageMetadata(client, volume.ID, imageMetadataOpts).ExtractErr()
+	err := volumeactions.SetImageMetadata(client, volume.ID, imageMetadataOpts).ExtractErr()
 	if err != nil {
 		return err
 	}

--- a/acceptance/openstack/blockstorage/extensions/extensions.go
+++ b/acceptance/openstack/blockstorage/extensions/extensions.go
@@ -174,6 +174,24 @@ func ExtendVolumeSize(t *testing.T, client *gophercloud.ServiceClient, volume *v
 	return nil
 }
 
+// ImageMetadata will apply the metadata to a volume.
+func ImageMetadata(t *testing.T, client *gophercloud.ServiceClient, volume *volumes.Volume) error {
+	t.Logf("Attempting to apply image metadata to volume %s", volume.ID)
+
+	imageMetadataOpts := volumeactions.ImageMetadataOpts{
+		Metadata: map[string]string{
+			"image_name": "testimage",
+		},
+	}
+
+	err := volumeactions.ImageMetadata(client, volume.ID, imageMetadataOpts).ExtractErr()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // CreateBackup will create a backup based on a volume. An error will be
 // will be returned if the backup could not be created.
 func CreateBackup(t *testing.T, client *gophercloud.ServiceClient, volumeID string) (*backups.Backup, error) {

--- a/acceptance/openstack/blockstorage/extensions/volumeactions_test.go
+++ b/acceptance/openstack/blockstorage/extensions/volumeactions_test.go
@@ -91,6 +91,18 @@ func TestVolumeActionsExtendSize(t *testing.T) {
 	tools.PrintResource(t, newVolume)
 }
 
+func TestVolumeActionsImageMetadata(t *testing.T) {
+	blockClient, err := clients.NewBlockStorageV2Client()
+	th.AssertNoErr(t, err)
+
+	volume, err := blockstorage.CreateVolume(t, blockClient)
+	th.AssertNoErr(t, err)
+	defer blockstorage.DeleteVolume(t, blockClient, volume)
+
+	err = ImageMetadata(t, blockClient, volume)
+	th.AssertNoErr(t, err)
+}
+
 // Note(jtopjian): I plan to work on this at some point, but it requires
 // setting up a server with iscsi utils.
 /*

--- a/acceptance/openstack/blockstorage/extensions/volumeactions_test.go
+++ b/acceptance/openstack/blockstorage/extensions/volumeactions_test.go
@@ -99,7 +99,7 @@ func TestVolumeActionsImageMetadata(t *testing.T) {
 	th.AssertNoErr(t, err)
 	defer blockstorage.DeleteVolume(t, blockClient, volume)
 
-	err = ImageMetadata(t, blockClient, volume)
+	err = SetImageMetadata(t, blockClient, volume)
 	th.AssertNoErr(t, err)
 }
 

--- a/openstack/blockstorage/extensions/volumeactions/requests.go
+++ b/openstack/blockstorage/extensions/volumeactions/requests.go
@@ -268,27 +268,27 @@ func ForceDelete(client *gophercloud.ServiceClient, id string) (r ForceDeleteRes
 	return
 }
 
-// SetImageMetdataOptsBuilder allows extensions to add additional parameters to the
-// SetImageMetadataRequest request.
-type SetImageMetdataOptsBuilder interface {
-	ToSetImageMetadataMap() (map[string]interface{}, error)
+// ImageMetdataOptsBuilder allows extensions to add additional parameters to the
+// ImageMetadataRequest request.
+type ImageMetdataOptsBuilder interface {
+	ToImageMetadataMap() (map[string]interface{}, error)
 }
 
-// SetImageMetadataOpts contains options for setting image metadata to a volume.
-type SetImageMetadataOpts struct {
+// ImageMetadataOpts contains options for setting image metadata to a volume.
+type ImageMetadataOpts struct {
 	// The image metadata to add to the volume as a set of metadata key and value pairs.
 	Metadata map[string]string `json:"metadata"`
 }
 
-// ToSetImageMetadataMap assembles a request body based on the contents of a
-// SetImageMetadataOpts.
-func (opts SetImageMetadataOpts) ToSetImageMetadataMap() (map[string]interface{}, error) {
+// ToImageMetadataMap assembles a request body based on the contents of a
+// ImageMetadataOpts.
+func (opts ImageMetadataOpts) ToImageMetadataMap() (map[string]interface{}, error) {
 	return gophercloud.BuildRequestBody(opts, "os-set_image_metadata")
 }
 
-// SetImageMetadata will set image metadata on a volume based on the values in UploadImageOptsBuilder.
-func SetImageMetadata(client *gophercloud.ServiceClient, id string, opts SetImageMetdataOptsBuilder) (r SetImageMetadataResult) {
-	b, err := opts.ToSetImageMetadataMap()
+// ImageMetadata will set image metadata on a volume based on the values in ImageMetadataOptsBuilder.
+func ImageMetadata(client *gophercloud.ServiceClient, id string, opts ImageMetdataOptsBuilder) (r ImageMetadataResult) {
+	b, err := opts.ToImageMetadataMap()
 	if err != nil {
 		r.Err = err
 		return

--- a/openstack/blockstorage/extensions/volumeactions/requests.go
+++ b/openstack/blockstorage/extensions/volumeactions/requests.go
@@ -268,9 +268,9 @@ func ForceDelete(client *gophercloud.ServiceClient, id string) (r ForceDeleteRes
 	return
 }
 
-// ImageMetdataOptsBuilder allows extensions to add additional parameters to the
+// ImageMetadataOptsBuilder allows extensions to add additional parameters to the
 // ImageMetadataRequest request.
-type ImageMetdataOptsBuilder interface {
+type ImageMetadataOptsBuilder interface {
 	ToImageMetadataMap() (map[string]interface{}, error)
 }
 
@@ -287,7 +287,7 @@ func (opts ImageMetadataOpts) ToImageMetadataMap() (map[string]interface{}, erro
 }
 
 // ImageMetadata will set image metadata on a volume based on the values in ImageMetadataOptsBuilder.
-func ImageMetadata(client *gophercloud.ServiceClient, id string, opts ImageMetdataOptsBuilder) (r ImageMetadataResult) {
+func ImageMetadata(client *gophercloud.ServiceClient, id string, opts ImageMetadataOptsBuilder) (r ImageMetadataResult) {
 	b, err := opts.ToImageMetadataMap()
 	if err != nil {
 		r.Err = err

--- a/openstack/blockstorage/extensions/volumeactions/requests.go
+++ b/openstack/blockstorage/extensions/volumeactions/requests.go
@@ -294,7 +294,7 @@ func SetImageMetadata(client *gophercloud.ServiceClient, id string, opts SetImag
 		return
 	}
 	_, r.Err = client.Post(actionURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
-		OkCodes: []int{202},
+		OkCodes: []int{200},
 	})
 	return
 }

--- a/openstack/blockstorage/extensions/volumeactions/requests.go
+++ b/openstack/blockstorage/extensions/volumeactions/requests.go
@@ -267,3 +267,34 @@ func ForceDelete(client *gophercloud.ServiceClient, id string) (r ForceDeleteRes
 	_, r.Err = client.Post(actionURL(client, id), map[string]interface{}{"os-force_delete": ""}, nil, nil)
 	return
 }
+
+// SetImageMetdataOptsBuilder allows extensions to add additional parameters to the
+// SetImageMetadataRequest request.
+type SetImageMetdataOptsBuilder interface {
+	ToSetImageMetadataMap() (map[string]interface{}, error)
+}
+
+// SetImageMetadataOpts contains options for setting image metadata to a volume.
+type SetImageMetadataOpts struct {
+	// The image metadata to add to the volume as a set of metadata key and value pairs.
+	Metadata map[string]string `json:"metadata"`
+}
+
+// ToSetImageMetadataMap assembles a request body based on the contents of a
+// SetImageMetadataOpts.
+func (opts SetImageMetadataOpts) ToSetImageMetadataMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "os-set_image_metadata")
+}
+
+// SetImageMetadata will set image metadata on a volume based on the values in UploadImageOptsBuilder.
+func SetImageMetadata(client *gophercloud.ServiceClient, id string, opts SetImageMetdataOptsBuilder) (r SetImageMetadataResult) {
+	b, err := opts.ToSetImageMetadataMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(actionURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+	})
+	return
+}

--- a/openstack/blockstorage/extensions/volumeactions/requests.go
+++ b/openstack/blockstorage/extensions/volumeactions/requests.go
@@ -286,8 +286,8 @@ func (opts ImageMetadataOpts) ToImageMetadataMap() (map[string]interface{}, erro
 	return gophercloud.BuildRequestBody(opts, "os-set_image_metadata")
 }
 
-// ImageMetadata will set image metadata on a volume based on the values in ImageMetadataOptsBuilder.
-func ImageMetadata(client *gophercloud.ServiceClient, id string, opts ImageMetadataOptsBuilder) (r ImageMetadataResult) {
+// SetImageMetadata will set image metadata on a volume based on the values in ImageMetadataOptsBuilder.
+func SetImageMetadata(client *gophercloud.ServiceClient, id string, opts ImageMetadataOptsBuilder) (r SetImageMetadataResult) {
 	b, err := opts.ToImageMetadataMap()
 	if err != nil {
 		r.Err = err

--- a/openstack/blockstorage/extensions/volumeactions/results.go
+++ b/openstack/blockstorage/extensions/volumeactions/results.go
@@ -29,6 +29,12 @@ type UploadImageResult struct {
 	gophercloud.Result
 }
 
+// SetImageMetadataResult contains the response body and error from an SetImageMetadata
+// request.
+type SetImageMetadataResult struct {
+	gophercloud.ErrResult
+}
+
 // ReserveResult contains the response body and error from a Reserve request.
 type ReserveResult struct {
 	gophercloud.ErrResult

--- a/openstack/blockstorage/extensions/volumeactions/results.go
+++ b/openstack/blockstorage/extensions/volumeactions/results.go
@@ -29,9 +29,9 @@ type UploadImageResult struct {
 	gophercloud.Result
 }
 
-// ImageMetadataResult contains the response body and error from an SetImageMetadata
+// SetImageMetadataResult contains the response body and error from an SetImageMetadata
 // request.
-type ImageMetadataResult struct {
+type SetImageMetadataResult struct {
 	gophercloud.ErrResult
 }
 

--- a/openstack/blockstorage/extensions/volumeactions/results.go
+++ b/openstack/blockstorage/extensions/volumeactions/results.go
@@ -29,9 +29,9 @@ type UploadImageResult struct {
 	gophercloud.Result
 }
 
-// SetImageMetadataResult contains the response body and error from an SetImageMetadata
+// ImageMetadataResult contains the response body and error from an SetImageMetadata
 // request.
-type SetImageMetadataResult struct {
+type ImageMetadataResult struct {
 	gophercloud.ErrResult
 }
 

--- a/openstack/blockstorage/extensions/volumeactions/testing/fixtures.go
+++ b/openstack/blockstorage/extensions/volumeactions/testing/fixtures.go
@@ -285,3 +285,25 @@ func MockForceDeleteResponse(t *testing.T) {
 		w.WriteHeader(http.StatusAccepted)
 	})
 }
+
+func MockSetImageMetadataResponse(t *testing.T) {
+	th.Mux.HandleFunc("/volumes/cd281d77-8217-4830-be95-9528227c105c/action", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, `
+{
+	"os-set_image_metadata": {
+		"metadata": {
+			"label": "test"
+		}
+	}
+}
+		`)
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, `{}`)
+	})
+}

--- a/openstack/blockstorage/extensions/volumeactions/testing/fixtures.go
+++ b/openstack/blockstorage/extensions/volumeactions/testing/fixtures.go
@@ -286,7 +286,7 @@ func MockForceDeleteResponse(t *testing.T) {
 	})
 }
 
-func MockSetImageMetadataResponse(t *testing.T) {
+func MockImageMetadataResponse(t *testing.T) {
 	th.Mux.HandleFunc("/volumes/cd281d77-8217-4830-be95-9528227c105c/action", func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "POST")
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)

--- a/openstack/blockstorage/extensions/volumeactions/testing/fixtures.go
+++ b/openstack/blockstorage/extensions/volumeactions/testing/fixtures.go
@@ -286,7 +286,7 @@ func MockForceDeleteResponse(t *testing.T) {
 	})
 }
 
-func MockImageMetadataResponse(t *testing.T) {
+func MockSetImageMetadataResponse(t *testing.T) {
 	th.Mux.HandleFunc("/volumes/cd281d77-8217-4830-be95-9528227c105c/action", func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "POST")
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)

--- a/openstack/blockstorage/extensions/volumeactions/testing/requests_test.go
+++ b/openstack/blockstorage/extensions/volumeactions/testing/requests_test.go
@@ -164,3 +164,19 @@ func TestForceDelete(t *testing.T) {
 	res := volumeactions.ForceDelete(client.ServiceClient(), "d32019d3-bc6e-4319-9c1d-6722fc136a22")
 	th.AssertNoErr(t, res.Err)
 }
+
+func TestSetImageMetadata(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockSetImageMetadataResponse(t)
+
+	options := &volumeactions.SetImageMetadataOpts{
+		Metadata: map[string]string{
+			"label": "test",
+		},
+	}
+
+	err := volumeactions.SetImageMetadata(client.ServiceClient(), "cd281d77-8217-4830-be95-9528227c105c", options).ExtractErr()
+	th.AssertNoErr(t, err)
+}

--- a/openstack/blockstorage/extensions/volumeactions/testing/requests_test.go
+++ b/openstack/blockstorage/extensions/volumeactions/testing/requests_test.go
@@ -165,18 +165,18 @@ func TestForceDelete(t *testing.T) {
 	th.AssertNoErr(t, res.Err)
 }
 
-func TestSetImageMetadata(t *testing.T) {
+func TestImageMetadata(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 
-	MockSetImageMetadataResponse(t)
+	MockImageMetadataResponse(t)
 
-	options := &volumeactions.SetImageMetadataOpts{
+	options := &volumeactions.ImageMetadataOpts{
 		Metadata: map[string]string{
 			"label": "test",
 		},
 	}
 
-	err := volumeactions.SetImageMetadata(client.ServiceClient(), "cd281d77-8217-4830-be95-9528227c105c", options).ExtractErr()
+	err := volumeactions.ImageMetadata(client.ServiceClient(), "cd281d77-8217-4830-be95-9528227c105c", options).ExtractErr()
 	th.AssertNoErr(t, err)
 }

--- a/openstack/blockstorage/extensions/volumeactions/testing/requests_test.go
+++ b/openstack/blockstorage/extensions/volumeactions/testing/requests_test.go
@@ -165,11 +165,11 @@ func TestForceDelete(t *testing.T) {
 	th.AssertNoErr(t, res.Err)
 }
 
-func TestImageMetadata(t *testing.T) {
+func TestSetImageMetadata(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 
-	MockImageMetadataResponse(t)
+	MockSetImageMetadataResponse(t)
 
 	options := &volumeactions.ImageMetadataOpts{
 		Metadata: map[string]string{
@@ -177,6 +177,6 @@ func TestImageMetadata(t *testing.T) {
 		},
 	}
 
-	err := volumeactions.ImageMetadata(client.ServiceClient(), "cd281d77-8217-4830-be95-9528227c105c", options).ExtractErr()
+	err := volumeactions.SetImageMetadata(client.ServiceClient(), "cd281d77-8217-4830-be95-9528227c105c", options).ExtractErr()
 	th.AssertNoErr(t, err)
 }


### PR DESCRIPTION
For #1610 
Adds support for setting image metadata for a volume in volumeactions.

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:
- [Source Code](https://github.com/openstack/cinder/blob/master/cinder/api/contrib/volume_image_metadata.py#L88-L101)
- [Docs](https://developer.openstack.org/api-ref/block-storage/v3/index.html?expanded=upload-volume-to-image-detail,set-image-metadata-for-a-volume-detail#set-image-metadata-for-a-volume)
