### PR TITLE
Networking V2: add QoS rule type Get call

### DIFF
--- a/acceptance/openstack/networking/v2/extensions/qos/ruletypes/ruletypes_test.go
+++ b/acceptance/openstack/networking/v2/extensions/qos/ruletypes/ruletypes_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/qos/ruletypes"
 )
 
-func TestListRuleTypes(t *testing.T) {
+func TestRuleTypes(t *testing.T) {
 	client, err := clients.NewNetworkV2Client()
 	if err != nil {
 		t.Fatalf("Unable to create a network client: %v", err)
@@ -28,4 +28,15 @@ func TestListRuleTypes(t *testing.T) {
 	}
 
 	tools.PrintResource(t, ruleTypes)
+
+	if len(ruleTypes) > 0 {
+		t.Logf("Trying to get rule type: %s", ruleTypes[0].Type)
+
+		ruleType, err := ruletypes.GetRuleType(client, ruleTypes[0].Type).Extract()
+		if err != nil {
+			t.Fatalf("Failed to get rule type %s: %s", ruleTypes[0].Type, err)
+		}
+
+		tools.PrintResource(t, ruleType)
+	}
 }

--- a/openstack/networking/v2/extensions/qos/ruletypes/doc.go
+++ b/openstack/networking/v2/extensions/qos/ruletypes/doc.go
@@ -1,7 +1,7 @@
 /*
 Package ruletypes contains functionality for working with Neutron 'quality of service' rule-type resources.
 
-Example: You can list rule-types in the following way:
+Example of Listing QoS rule types
 
 	page, err := ruletypes.ListRuleTypes(client).AllPages()
 	if err != nil {
@@ -15,5 +15,15 @@ Example: You can list rule-types in the following way:
 
 	fmt.Printf("%v <- Rule Types\n", rules)
 
+Example of Getting a single QoS rule type by it's name
+
+    ruleTypeName := "bandwidth_limit"
+
+    ruleType, err := ruletypes.Get(networkClient, ruleTypeName).Extract()
+    if err != nil {
+        panic(err)
+    }
+
+    fmt.Printf("%+v\n", ruleTypeName)
 */
 package ruletypes

--- a/openstack/networking/v2/extensions/qos/ruletypes/requests.go
+++ b/openstack/networking/v2/extensions/qos/ruletypes/requests.go
@@ -11,3 +11,9 @@ func ListRuleTypes(c *gophercloud.ServiceClient) (result pagination.Pager) {
 		return ListRuleTypesPage{pagination.SinglePageBase(r)}
 	})
 }
+
+// GetRuleType retrieves a specific QoS RuleType based on its name.
+func GetRuleType(c *gophercloud.ServiceClient, name string) (r GetResult) {
+	_, r.Err = c.Get(getRuleTypeURL(c, name), &r.Body, nil)
+	return
+}

--- a/openstack/networking/v2/extensions/qos/ruletypes/results.go
+++ b/openstack/networking/v2/extensions/qos/ruletypes/results.go
@@ -1,10 +1,45 @@
 package ruletypes
 
-import "github.com/gophercloud/gophercloud/pagination"
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
 
-// The result of listing the qos rule types
+type commonResult struct {
+	gophercloud.Result
+}
+
+func (r commonResult) Extract() (*RuleType, error) {
+	var s struct {
+		RuleType *RuleType `json:"rule_type"`
+	}
+	err := r.ExtractInto(&s)
+	return s.RuleType, err
+}
+
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a RuleType.
+type GetResult struct {
+	commonResult
+}
+
+// RuleType represents a single QoS rule type.
 type RuleType struct {
-	Type string `json:"type"`
+	Type    string   `json:"type"`
+	Drivers []Driver `json:"drivers"`
+}
+
+// Driver represents a single QoS driver.
+type Driver struct {
+	Name                string               `json:"name"`
+	SupportedParameters []SupportedParameter `json:"supported_parameters"`
+}
+
+// SupportedParameter represents a single set of supported parameters for a some QoS driver's .
+type SupportedParameter struct {
+	ParameterName   string      `json:"parameter_name"`
+	ParameterType   string      `json:"parameter_type"`
+	ParameterValues interface{} `json:"parameter_values"`
 }
 
 type ListRuleTypesPage struct {

--- a/openstack/networking/v2/extensions/qos/ruletypes/testing/fixtures.go
+++ b/openstack/networking/v2/extensions/qos/ruletypes/testing/fixtures.go
@@ -16,4 +16,72 @@ const (
     ]
 }
 `
+
+	GetRuleTypeResponse = `
+{
+    "rule_type": {
+        "drivers": [
+            {
+                "name": "linuxbridge",
+                "supported_parameters": [
+                    {
+                        "parameter_values": {
+                            "start": 0,
+                            "end": 2147483647
+                        },
+                        "parameter_type": "range",
+                        "parameter_name": "max_kbps"
+                    },
+                    {
+                        "parameter_values": [
+                            "ingress",
+                            "egress"
+                        ],
+                        "parameter_type": "choices",
+                        "parameter_name": "direction"
+                    },
+                    {
+                        "parameter_values": {
+                            "start": 0,
+                            "end": 2147483647
+                        },
+                        "parameter_type": "range",
+                        "parameter_name": "max_burst_kbps"
+                    }
+                ]
+            },
+            {
+                "name": "openvswitch",
+                "supported_parameters": [
+                    {
+                        "parameter_values": {
+                            "start": 0,
+                            "end": 2147483647
+                        },
+                        "parameter_type": "range",
+                        "parameter_name": "max_kbps"
+                    },
+                    {
+                        "parameter_values": [
+                            "ingress",
+                            "egress"
+                        ],
+                        "parameter_type": "choices",
+                        "parameter_name": "direction"
+                    },
+                    {
+                        "parameter_values": {
+                            "start": 0,
+                            "end": 2147483647
+                        },
+                        "parameter_type": "range",
+                        "parameter_name": "max_burst_kbps"
+                    }
+                ]
+            }
+        ],
+        "type": "bandwidth_limit"
+    }
+}
+`
 )

--- a/openstack/networking/v2/extensions/qos/ruletypes/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/qos/ruletypes/testing/requests_test.go
@@ -39,3 +39,32 @@ func TestListRuleTypes(t *testing.T) {
 	expected := []ruletypes.RuleType{{Type: "bandwidth_limit"}, {Type: "dscp_marking"}, {Type: "minimum_bandwidth"}}
 	th.AssertDeepEquals(t, expected, rules)
 }
+
+func TestGetRuleType(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/qos/rule-types/bandwidth_limit", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		_, err := fmt.Fprintf(w, GetRuleTypeResponse)
+		th.AssertNoErr(t, err)
+	})
+
+	r, err := ruletypes.GetRuleType(fake.ServiceClient(), "bandwidth_limit").Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, "bandwidth_limit", r.Type)
+
+	th.AssertEquals(t, 2, len(r.Drivers))
+
+	th.AssertEquals(t, "linuxbridge", r.Drivers[0].Name)
+	th.AssertEquals(t, 3, len(r.Drivers[0].SupportedParameters))
+
+	th.AssertEquals(t, "openvswitch", r.Drivers[1].Name)
+	th.AssertEquals(t, 3, len(r.Drivers[1].SupportedParameters))
+}

--- a/openstack/networking/v2/extensions/qos/ruletypes/urls.go
+++ b/openstack/networking/v2/extensions/qos/ruletypes/urls.go
@@ -5,3 +5,7 @@ import "github.com/gophercloud/gophercloud"
 func listRuleTypesURL(c *gophercloud.ServiceClient) string {
 	return c.ServiceURL("qos", "rule-types")
 }
+
+func getRuleTypeURL(c *gophercloud.ServiceClient, name string) string {
+	return c.ServiceURL("qos", "rule-types", name)
+}


### PR DESCRIPTION
Implement GetRuleType function with unit test.

Update QoS rule types documentation.

Update QoS rule types acceptance test.

Extend RuleType struct with additional fields. Unfortunately the
ParameterValues field is implemented as interface{} given it's dynamic
behavior (it can be map or slice in different situtations).

For #1027

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/neutron-lib/blob/stable/stein/neutron_lib/api/definitions/qos_rule_type_details.py
https://github.com/openstack/neutron/blob/stable/stein/neutron/services/qos/drivers/manager.py#L88
https://github.com/openstack/neutron/blob/stable/stein/neutron/services/qos/qos_plugin.py#L369
