### PR TITLE
Baremetal Introspection: Move hostname to InventoryType

### DIFF
--- a/openstack/baremetalintrospection/v1/introspection/results.go
+++ b/openstack/baremetalintrospection/v1/introspection/results.go
@@ -170,7 +170,6 @@ type Data struct {
 	MACs          []string                     `json:"macs"`
 	MemoryMB      int                          `json:"memory_mb"`
 	RootDisk      RootDiskType                 `json:"root_disk"`
-	Hostname      string                       `json:"hostname"`
 	Extra         ExtraHardwareDataType        `json:"extra"`
 }
 
@@ -223,6 +222,7 @@ type InventoryType struct {
 	Interfaces   []InterfaceType  `json:"interfaces"`
 	Memory       MemoryType       `json:"memory"`
 	SystemVendor SystemVendorType `json:"system_vendor"`
+	Hostname     string           `json:"hostname"`
 }
 
 type MemoryType struct {

--- a/openstack/baremetalintrospection/v1/introspection/testing/fixtures.go
+++ b/openstack/baremetalintrospection/v1/introspection/testing/fixtures.go
@@ -162,7 +162,8 @@ const IntrospectionDataJSONSample = `
         "sse2"
         ],
          "architecture":"x86_64"
-      }
+	  },
+	  "hostname": "myawesomehost"
    },
    "error":null,
    "local_gb":12,
@@ -302,6 +303,7 @@ var (
 				PhysicalMb: 2048.0,
 				Total:      2.105864192e+09,
 			},
+			Hostname: "myawesomehost",
 		},
 		Error:   "",
 		LocalGB: 12,

--- a/openstack/baremetalintrospection/v1/introspection/testing/results_test.go
+++ b/openstack/baremetalintrospection/v1/introspection/testing/results_test.go
@@ -87,3 +87,80 @@ func TestExtraHardware(t *testing.T) {
 		t.Errorf("Failed to unmarshal ExtraHardware data: %s", err)
 	}
 }
+
+func TestHostnameInInventory(t *testing.T) {
+	inventoryJson := `{
+		"bmc_address":"192.167.2.134",
+		"interfaces":[
+		   {
+			  "lldp":[],
+			  "product":"0x0001",
+			  "vendor":"0x1af4",
+			  "name":"eth1",
+			  "has_carrier":true,
+			  "ipv4_address":"172.24.42.101",
+			  "client_id":null,
+			  "mac_address":"52:54:00:47:20:4d"
+		   },
+		   {
+			  "lldp": [
+				[1, "04112233aabbcc"],
+				[5, "737730312d646973742d31622d623132"]
+			  ],
+			  "product":"0x0001",
+			  "vendor":"0x1af4",
+			  "name":"eth0",
+			  "has_carrier":true,
+			  "ipv4_address":"172.24.42.100",
+			  "client_id":null,
+			  "mac_address":"52:54:00:4e:3d:30"
+		   }
+		],
+		"disks":[
+		   {
+			  "rotational":true,
+			  "vendor":"0x1af4",
+			  "name":"/dev/vda",
+			  "hctl":null,
+			  "wwn_vendor_extension":null,
+			  "wwn_with_extension":null,
+			  "model":"",
+			  "wwn":null,
+			  "serial":null,
+			  "size":13958643712
+		   }
+		],
+		"boot":{
+		   "current_boot_mode":"bios",
+		   "pxe_interface":"52:54:00:4e:3d:30"
+		},
+		"system_vendor":{
+		   "serial_number":"Not Specified",
+		   "product_name":"Bochs",
+		   "manufacturer":"Bochs"
+		},
+		"memory":{
+		   "physical_mb":2048,
+		   "total":2105864192
+		},
+		"cpu":{
+		   "count":2,
+		   "frequency":"2100.084",
+			"flags": [
+				"fpu",
+				"mmx",
+				"fxsr",
+			  	"sse",
+			  	"sse2"
+			],
+			"architecture":"x86_64"
+		},
+		"hostname": "master-0"
+	}`
+
+	var output introspection.InventoryType
+	err := json.Unmarshal([]byte(inventoryJson), &output)
+	if err != nil {
+		t.Errorf("Failed to unmarshal Inventory data: %s", err)
+	}
+}


### PR DESCRIPTION
The IPA patch added the hostname to the Inventory field, not as a top-level
field. This moves the hostname into the InventoryType where it belongs.

For #1626 

