### PR TITLE
Skip some tests for the certain releases of OpenStack

### DIFF
--- a/acceptance/clients/conditions.go
+++ b/acceptance/clients/conditions.go
@@ -66,10 +66,13 @@ func RequireNovaNetwork(t *testing.T) {
 	}
 }
 
-// SkipRelease will have the test be skipped on a certain
-// release. Releases are named such as 'stable/mitaka', master, etc.
-func SkipRelease(t *testing.T, release string) {
-	if os.Getenv("OS_BRANCH") == release {
-		t.Skipf("this is not supported in %s", release)
+// SkipReleases will have the test be skipped on the certain
+// releases. Releases are named such as 'stable/mitaka', 'master', etc.
+func SkipReleases(t *testing.T, releases []string) {
+	for _, r := range releases {
+		if os.Getenv("OS_BRANCH") == r {
+			t.Skipf("this is not supported in %s", r)
+			break
+		}
 	}
 }

--- a/acceptance/openstack/compute/v2/keypairs_test.go
+++ b/acceptance/openstack/compute/v2/keypairs_test.go
@@ -16,8 +16,8 @@ import (
 const keyName = "gophercloud_test_key_pair"
 
 func TestKeypairsParse(t *testing.T) {
-	clients.SkipRelease(t, "stable/mitaka")
-	clients.SkipRelease(t, "stable/newton")
+	releases := []string{"stable/mitaka", "stable/newton"}
+	clients.SkipReleases(t, releases)
 
 	client, err := clients.NewComputeV2Client()
 	th.AssertNoErr(t, err)

--- a/acceptance/openstack/compute/v2/quotaset_test.go
+++ b/acceptance/openstack/compute/v2/quotaset_test.go
@@ -16,10 +16,8 @@ import (
 )
 
 func TestQuotasetGet(t *testing.T) {
-	clients.SkipRelease(t, "master")
-	clients.SkipRelease(t, "stable/queens")
-	clients.SkipRelease(t, "stable/rocky")
-	clients.SkipRelease(t, "stable/stein")
+	releases := []string{"stable/queens", "stable/rocky", "stable/stein", "master"}
+	clients.SkipRelease(t, releases)
 
 	client, err := clients.NewComputeV2Client()
 	th.AssertNoErr(t, err)
@@ -105,10 +103,8 @@ var UpdatedQuotas = quotasets.QuotaSet{
 }
 
 func TestQuotasetUpdateDelete(t *testing.T) {
-	clients.SkipRelease(t, "master")
-	clients.SkipRelease(t, "stable/queens")
-	clients.SkipRelease(t, "stable/rocky")
-	clients.SkipRelease(t, "stable/stein")
+	releases := []string{"stable/queens", "stable/rocky", "stable/stein", "master"}
+	clients.SkipRelease(t, releases)
 
 	clients.RequireAdmin(t)
 

--- a/acceptance/openstack/compute/v2/servers_test.go
+++ b/acceptance/openstack/compute/v2/servers_test.go
@@ -487,8 +487,8 @@ func TestServersConsoleOutput(t *testing.T) {
 
 func TestServersTags(t *testing.T) {
 	clients.RequireLong(t)
-	clients.SkipRelease(t, "mitaka")
-	clients.SkipRelease(t, "newton")
+	releases := []string{"stable/mitaka", "stable/newton"}
+	clients.SkipRelease(t, releases)
 
 	choices, err := clients.AcceptanceTestChoicesFromEnv()
 	th.AssertNoErr(t, err)
@@ -511,8 +511,8 @@ func TestServersTags(t *testing.T) {
 func TestServersWithExtendedAttributesCreateDestroy(t *testing.T) {
 	clients.RequireLong(t)
 	clients.RequireAdmin(t)
-	clients.SkipRelease(t, "stable/mitaka")
-	clients.SkipRelease(t, "stable/newton")
+	releases := []string{"stable/mitaka", "stable/newton"}
+	clients.SkipRelease(t, releases)
 
 	client, err := clients.NewComputeV2Client()
 	th.AssertNoErr(t, err)

--- a/acceptance/openstack/container/v1/capsules_test.go
+++ b/acceptance/openstack/container/v1/capsules_test.go
@@ -55,6 +55,8 @@ func TestCapsuleBase(t *testing.T) {
 }
 
 func TestCapsuleV132(t *testing.T) {
+	releases := []string{"stable/mitaka", "stable/newton", "stable/ocata", "stable/pike", "stable/queen", "stable/rocky"}
+	clients.SkipRelease(t, releases)
 	client, err := clients.NewContainerV1Client()
 	th.AssertNoErr(t, err)
 

--- a/acceptance/openstack/identity/v3/roles_test.go
+++ b/acceptance/openstack/identity/v3/roles_test.go
@@ -113,10 +113,8 @@ func TestRolesFilterList(t *testing.T) {
 
 	// For some reason this is not longer working.
 	// It might be a temporary issue.
-	clients.SkipRelease(t, "master")
-	clients.SkipRelease(t, "stable/queens")
-	clients.SkipRelease(t, "stable/rocky")
-	clients.SkipRelease(t, "stable/stein")
+	releases := []string{"stable/queens", "stable/rocky", "stable/stein", "master"}
+	clients.SkipRelease(t, releases)
 
 	client, err := clients.NewIdentityV3Client()
 	th.AssertNoErr(t, err)

--- a/acceptance/openstack/loadbalancer/v2/loadbalancers_test.go
+++ b/acceptance/openstack/loadbalancer/v2/loadbalancers_test.go
@@ -32,6 +32,8 @@ func TestLoadbalancersList(t *testing.T) {
 }
 
 func TestLoadbalancersListByTags(t *testing.T) {
+	releases := []string{"stable/mitaka", "stable/newton", "stable/ocata", "stable/pike", "stable/queen", "stable/rocky"}
+	clients.SkipRelease(t, releases)
 	netClient, err := clients.NewNetworkV2Client()
 	th.AssertNoErr(t, err)
 
@@ -108,9 +110,8 @@ func TestLoadbalancersCRUD(t *testing.T) {
 	subnet, err := networking.CreateSubnet(t, netClient, network.ID)
 	th.AssertNoErr(t, err)
 	defer networking.DeleteSubnet(t, netClient, subnet.ID)
-
-	tags := []string{"test"}
-	lb, err := CreateLoadBalancer(t, lbClient, subnet.ID, tags)
+	
+	lb, err := CreateLoadBalancer(t, lbClient, subnet.ID, []string{})
 	th.AssertNoErr(t, err)
 	defer DeleteLoadBalancer(t, lbClient, lb.ID)
 
@@ -399,9 +400,7 @@ func TestLoadbalancersCascadeCRUD(t *testing.T) {
 	subnet, err := networking.CreateSubnet(t, netClient, network.ID)
 	th.AssertNoErr(t, err)
 	defer networking.DeleteSubnet(t, netClient, subnet.ID)
-
-	tags := []string{"test"}
-	lb, err := CreateLoadBalancer(t, lbClient, subnet.ID, tags)
+	lb, err := CreateLoadBalancer(t, lbClient, subnet.ID, []string{})
 	th.AssertNoErr(t, err)
 	defer CascadeDeleteLoadBalancer(t, lbClient, lb.ID)
 


### PR DESCRIPTION
This changes:
1. refactor the func clients.SkipRelease
2. skip some of lb and container tests which are supportted after stein

Related-Bug: theopenlab/openlab#305