### PR TITLE
Generic error interface to get status code For #1632

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -92,6 +92,17 @@ func (e ErrUnexpectedResponseCode) Error() string {
 	return e.choseErrString()
 }
 
+// GetStatusCode returns the actual status code of the error.
+func (e ErrUnexpectedResponseCode) GetStatusCode() int {
+	return e.Actual
+}
+
+// GenericError can be used to easily get the error status code without doing switch case on all error types.
+type GenericError interface {
+	Error() string
+	GetStatusCode() int
+}
+
 // ErrDefault400 is the default error type returned on a 400 HTTP response code.
 type ErrDefault400 struct {
 	ErrUnexpectedResponseCode

--- a/testing/errors_test.go
+++ b/testing/errors_test.go
@@ -1,0 +1,24 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud"
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestGetResponseCode(t *testing.T) {
+	respErr := gophercloud.ErrUnexpectedResponseCode{
+		URL:      "http://example.com",
+		Method:   "GET",
+		Expected: []int{200},
+		Actual:   404,
+		Body:     nil,
+	}
+
+	var err404 error = gophercloud.ErrDefault404{ErrUnexpectedResponseCode: respErr}
+
+	errHTTP, ok := err404.(gophercloud.GenericError)
+	th.AssertEquals(t, true, ok)
+	th.AssertEquals(t, errHTTP.GetStatusCode(), 404)
+}


### PR DESCRIPTION
For #1632

Permit to handle gopher error easily of need to just return a status code.
Eg : 
```go
gophError := err.(gophercloud.GenericError)
fmt.Println(gophError.GetStatusCode()) 
```