### PR TITLE
Compute V2: "policy", "rules" for servergroups GET

### DIFF
--- a/openstack/compute/v2/extensions/servergroups/doc.go
+++ b/openstack/compute/v2/extensions/servergroups/doc.go
@@ -36,5 +36,23 @@ Example to Delete a Server Group
 	if err != nil {
 		panic(err)
 	}
+
+Example to get additional fields with microversion 2.64 or later
+
+    computeClient.Microversion = "2.64"
+    result := servergroups.Get(computeClient, "616fb98f-46ca-475e-917e-2563e5a8cd19")
+
+    policy, err := servergroups.ExtractPolicy(result.Result)
+    if err != nil {
+        panic(err)
+    }
+    fmt.Printf("Policy: %s\n", policy)
+
+    rules, err := servergroups.ExtractRules(result.Result)
+    if err != nil {
+        panic(err)
+    }
+    fmt.Printf("Max server per host: %s\n", rules.MaxServerPerHost)
+
 */
 package servergroups

--- a/openstack/compute/v2/extensions/servergroups/microversions.go
+++ b/openstack/compute/v2/extensions/servergroups/microversions.go
@@ -1,0 +1,32 @@
+package servergroups
+
+import "github.com/gophercloud/gophercloud"
+
+// ExtractPolicy will extract the policy attribute.
+// This requires the client to be set to microversion 2.64 or later.
+func ExtractPolicy(r gophercloud.Result) (string, error) {
+	var s struct {
+		Policy string `json:"policy"`
+	}
+	err := r.ExtractIntoStructPtr(&s, "server_group")
+
+	return s.Policy, err
+}
+
+// ExtractRules will extract the rules attribute.
+// This requires the client to be set to microversion 2.64 or later.
+func ExtractRules(r gophercloud.Result) (Rules, error) {
+	var s struct {
+		Rules Rules `json:"rules"`
+	}
+	err := r.ExtractIntoStructPtr(&s, "server_group")
+
+	return s.Rules, err
+}
+
+// Rules represents set of rules for a policy.
+type Rules struct {
+	// MaxServerPerHost specifies how many servers can reside on a single compute host.
+	// It can be used only with the "anti-affinity" policy.
+	MaxServerPerHost int `json:"max_server_per_host"`
+}

--- a/openstack/compute/v2/extensions/servergroups/results.go
+++ b/openstack/compute/v2/extensions/servergroups/results.go
@@ -6,6 +6,8 @@ import (
 )
 
 // A ServerGroup creates a policy for instance placement in the cloud.
+// You should use extract methods from microversions.go to retrieve additional
+// fields.
 type ServerGroup struct {
 	// ID is the unique ID of the Server Group.
 	ID string `json:"id"`

--- a/openstack/compute/v2/extensions/servergroups/testing/fixtures.go
+++ b/openstack/compute/v2/extensions/servergroups/testing/fixtures.go
@@ -45,6 +45,10 @@ const GetOutput = `
         "policies": [
             "anti-affinity"
         ],
+        "policy": "anti-affinity",
+        "rules": {
+          "max_server_per_host": 3
+        },
         "members": [],
         "metadata": {}
     }

--- a/openstack/compute/v2/extensions/servergroups/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/servergroups/testing/requests_test.go
@@ -45,9 +45,21 @@ func TestGet(t *testing.T) {
 	defer th.TeardownHTTP()
 	HandleGetSuccessfully(t)
 
-	actual, err := servergroups.Get(client.ServiceClient(), "4d8c3732-a248-40ed-bebc-539a6ffd25c0").Extract()
+	result := servergroups.Get(client.ServiceClient(), "4d8c3732-a248-40ed-bebc-539a6ffd25c0")
+
+	// Extract basic fields.
+	actual, err := result.Extract()
 	th.AssertNoErr(t, err)
 	th.CheckDeepEquals(t, &FirstServerGroup, actual)
+
+	// Extract additional fields.
+	policy, err := servergroups.ExtractPolicy(result.Result)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, "anti-affinity", policy)
+
+	rules, err := servergroups.ExtractRules(result.Result)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, 3, rules.MaxServerPerHost)
 }
 
 func TestDelete(t *testing.T) {


### PR DESCRIPTION
Add "policy" and "rules" extract methods to servergroups package.
Those methods are available in 2.64 microversion.

For #1600

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/nova/blob/stable/stein/nova/api/openstack/compute/server_groups.py#L42
https://github.com/openstack/nova/blob/stable/stein/nova/api/openstack/compute/server_groups.py#L105
https://github.com/openstack/nova/blob/stable/stein/nova/api/openstack/compute/schemas/server_groups.py#L59
https://github.com/openstack/nova/blob/stable/stein/nova/api/openstack/compute/schemas/server_groups.py#L65
