### PR TITLE
Compute: "policy", "rules" add servergroups Create

### DIFF
--- a/acceptance/openstack/compute/v2/compute.go
+++ b/acceptance/openstack/compute/v2/compute.go
@@ -614,6 +614,34 @@ func CreateServerGroup(t *testing.T, client *gophercloud.ServiceClient, policy s
 	return sg, nil
 }
 
+// CreateServerGroupMicroversion will create a server with a random name using 2.64 microversion. An error will be
+// returned if the server group failed to be created.
+func CreateServerGroupMicroversion(t *testing.T, client *gophercloud.ServiceClient) (*servergroups.ServerGroup, error) {
+	name := tools.RandomString("ACPTTEST", 16)
+	policy := "anti-affinity"
+	maxServerPerHost := 3
+
+	t.Logf("Attempting to create %s server group with max server per host = %d: %s", policy, maxServerPerHost, name)
+
+	sg, err := servergroups.Create(client, &servergroups.CreateOpts{
+		Name:   name,
+		Policy: policy,
+		Rules: &servergroups.Rules{
+			MaxServerPerHost: maxServerPerHost,
+		},
+	}).Extract()
+
+	if err != nil {
+		return nil, err
+	}
+
+	t.Logf("Successfully created server group %s", name)
+
+	th.AssertEquals(t, sg.Name, name)
+
+	return sg, nil
+}
+
 // CreateServerInServerGroup works like CreateServer but places the instance in
 // a specified Server Group.
 func CreateServerInServerGroup(t *testing.T, client *gophercloud.ServiceClient, serverGroup *servergroups.ServerGroup) (*servers.Server, error) {

--- a/acceptance/openstack/compute/v2/servergroup_test.go
+++ b/acceptance/openstack/compute/v2/servergroup_test.go
@@ -69,3 +69,35 @@ func TestServergroupsAffinityPolicy(t *testing.T) {
 
 	th.AssertEquals(t, firstServer.HostID, secondServer.HostID)
 }
+
+func TestServergroupsMicroversionCreateDelete(t *testing.T) {
+	client, err := clients.NewComputeV2Client()
+	th.AssertNoErr(t, err)
+
+	client.Microversion = "2.64"
+	serverGroup, err := CreateServerGroupMicroversion(t, client)
+	th.AssertNoErr(t, err)
+	defer DeleteServerGroup(t, client, serverGroup)
+
+	serverGroup, err = servergroups.Get(client, serverGroup.ID).Extract()
+	th.AssertNoErr(t, err)
+
+	tools.PrintResource(t, serverGroup)
+
+	allPages, err := servergroups.List(client).AllPages()
+	th.AssertNoErr(t, err)
+
+	allServerGroups, err := servergroups.ExtractServerGroups(allPages)
+	th.AssertNoErr(t, err)
+
+	var found bool
+	for _, sg := range allServerGroups {
+		tools.PrintResource(t, serverGroup)
+
+		if sg.ID == serverGroup.ID {
+			found = true
+		}
+	}
+
+	th.AssertEquals(t, found, true)
+}

--- a/openstack/compute/v2/extensions/servergroups/doc.go
+++ b/openstack/compute/v2/extensions/servergroups/doc.go
@@ -34,7 +34,7 @@ Example to Create a Server Group with additional microversion 2.64 fields
     createOpts := servergroups.CreateOpts{
 		Name:   "my_sg",
 		Policy: "anti-affinity",
-        Rules: servergroups.Rules{
+        Rules: &servergroups.Rules{
             MaxServerPerHost: 3,
         },
 	}

--- a/openstack/compute/v2/extensions/servergroups/doc.go
+++ b/openstack/compute/v2/extensions/servergroups/doc.go
@@ -36,5 +36,23 @@ Example to Delete a Server Group
 	if err != nil {
 		panic(err)
 	}
+
+Example to get additional fields with microversion 2.64 or later
+
+    computeClient.Microversion = "2.64"
+    result := servergroups.Get(computeClient, "616fb98f-46ca-475e-917e-2563e5a8cd19")
+
+    policy, err := servergroups.ExtractPolicy(result.Result)
+    if err != nil {
+        panic(err)
+    }
+    fmt.Printf("Policy: %s\n", policy)
+
+    rules, err := servergroups.ExtractRules(result.Result)
+    if err != nil {
+        panic(err)
+    }
+    fmt.Printf("Max server per host: %s\n", rules.MaxServerPerHost)
+
 */
 package servergroups

--- a/openstack/compute/v2/extensions/servergroups/doc.go
+++ b/openstack/compute/v2/extensions/servergroups/doc.go
@@ -29,6 +29,34 @@ Example to Create a Server Group
 		panic(err)
 	}
 
+Example to Create a Server Group with additional microversion 2.64 fields
+
+    createOpts := servergroups.CreateOpts{
+		Name:   "my_sg",
+		Policy: "anti-affinity",
+        Rules: servergroups.Rules{
+            MaxServerPerHost: 3,
+        },
+	}
+
+    computeClient.Microversion = "2.64"
+	result := servergroups.Create(computeClient, createOpts)
+
+    serverGroup, err := result.Extract()
+    if err != nil {
+		panic(err)
+	}
+
+    policy, err := servergroups.ExtractPolicy(result.Result)
+    if err != nil {
+        panic(err)
+    }
+
+    rules, err := servergroups.ExtractRules(result.Result)
+    if err != nil {
+        panic(err)
+    }
+
 Example to Delete a Server Group
 
 	sgID := "7a6f29ad-e34d-4368-951a-58a08f11cfb7"

--- a/openstack/compute/v2/extensions/servergroups/microversions.go
+++ b/openstack/compute/v2/extensions/servergroups/microversions.go
@@ -28,5 +28,5 @@ func ExtractRules(r gophercloud.Result) (Rules, error) {
 type Rules struct {
 	// MaxServerPerHost specifies how many servers can reside on a single compute host.
 	// It can be used only with the "anti-affinity" policy.
-	MaxServerPerHost int `json:"max_server_per_host"`
+	MaxServerPerHost int `json:"max_server_per_host,omitempty"`
 }

--- a/openstack/compute/v2/extensions/servergroups/microversions.go
+++ b/openstack/compute/v2/extensions/servergroups/microversions.go
@@ -1,0 +1,32 @@
+package servergroups
+
+import "github.com/gophercloud/gophercloud"
+
+// ExtractPolicy will extract the policy attribute.
+// This requires the client to be set to microversion 2.64 or later.
+func ExtractPolicy(r gophercloud.Result) (string, error) {
+	var s struct {
+		Policy string `json:"policy"`
+	}
+	err := r.ExtractIntoStructPtr(&s, "server_group")
+
+	return s.Policy, err
+}
+
+// ExtractRules will extract the rules attribute.
+// This requires the client to be set to microversion 2.64 or later.
+func ExtractRules(r gophercloud.Result) (Rules, error) {
+	var s struct {
+		Rules Rules `json:"rules"`
+	}
+	err := r.ExtractIntoStructPtr(&s, "server_group")
+
+	return s.Rules, err
+}
+
+// Rules represents set of rules for a policy.
+type Rules struct {
+	// MaxServerPerHost specifies how many servers can reside on a single compute host.
+	// It can be used only with the "anti-affinity" policy.
+	MaxServerPerHost int `json:"max_server_per_host"`
+}

--- a/openstack/compute/v2/extensions/servergroups/requests.go
+++ b/openstack/compute/v2/extensions/servergroups/requests.go
@@ -33,7 +33,7 @@ type CreateOpts struct {
 
 	// Rules specifies the set of rules.
 	// Requires microversion 2.64 or later.
-	Rules Rules `json:"rules,omitempty"`
+	Rules *Rules `json:"rules,omitempty"`
 }
 
 // ToServerGroupCreateMap constructs a request body from CreateOpts.

--- a/openstack/compute/v2/extensions/servergroups/requests.go
+++ b/openstack/compute/v2/extensions/servergroups/requests.go
@@ -21,11 +21,19 @@ type CreateOptsBuilder interface {
 
 // CreateOpts specifies Server Group creation parameters.
 type CreateOpts struct {
-	// Name is the name of the server group
+	// Name is the name of the server group.
 	Name string `json:"name" required:"true"`
 
-	// Policies are the server group policies
-	Policies []string `json:"policies" required:"true"`
+	// Policies are the server group policies.
+	Policies []string `json:"policies,omitempty"`
+
+	// Policy specifies the name of a policy.
+	// Requires microversion 2.64 or later.
+	Policy string `json:"policy,omitempty"`
+
+	// Rules specifies the set of rules.
+	// Requires microversion 2.64 or later.
+	Rules Rules `json:"rules,omitempty"`
 }
 
 // ToServerGroupCreateMap constructs a request body from CreateOpts.

--- a/openstack/compute/v2/extensions/servergroups/results.go
+++ b/openstack/compute/v2/extensions/servergroups/results.go
@@ -6,6 +6,8 @@ import (
 )
 
 // A ServerGroup creates a policy for instance placement in the cloud.
+// You should use extract methods from microversions.go to retrieve additional
+// fields.
 type ServerGroup struct {
 	// ID is the unique ID of the Server Group.
 	ID string `json:"id"`

--- a/openstack/compute/v2/extensions/servergroups/testing/fixtures.go
+++ b/openstack/compute/v2/extensions/servergroups/testing/fixtures.go
@@ -64,6 +64,10 @@ const CreateOutput = `
         "policies": [
             "anti-affinity"
         ],
+        "policy": "anti-affinity",
+        "rules": {
+          "max_server_per_host": 3
+        },
         "members": [],
         "metadata": {}
     }
@@ -142,7 +146,11 @@ func HandleCreateSuccessfully(t *testing.T) {
         "name": "test",
         "policies": [
             "anti-affinity"
-        ]
+        ],
+        "policy": "anti-affinity",
+        "rules": {
+            "max_server_per_host": 3
+        }
     }
 }
 `)

--- a/openstack/compute/v2/extensions/servergroups/testing/fixtures.go
+++ b/openstack/compute/v2/extensions/servergroups/testing/fixtures.go
@@ -45,6 +45,10 @@ const GetOutput = `
         "policies": [
             "anti-affinity"
         ],
+        "policy": "anti-affinity",
+        "rules": {
+          "max_server_per_host": 3
+        },
         "members": [],
         "metadata": {}
     }

--- a/openstack/compute/v2/extensions/servergroups/testing/fixtures.go
+++ b/openstack/compute/v2/extensions/servergroups/testing/fixtures.go
@@ -45,6 +45,21 @@ const GetOutput = `
         "policies": [
             "anti-affinity"
         ],
+        "members": [],
+        "metadata": {}
+    }
+}
+`
+
+// GetOutputMicroversion is a sample response to a Get call with microversion set to 2.64
+const GetOutputMicroversion = `
+{
+    "server_group": {
+        "id": "616fb98f-46ca-475e-917e-2563e5a8cd19",
+        "name": "test",
+        "policies": [
+            "anti-affinity"
+        ],
         "policy": "anti-affinity",
         "rules": {
           "max_server_per_host": 3
@@ -57,6 +72,21 @@ const GetOutput = `
 
 // CreateOutput is a sample response to a Post call
 const CreateOutput = `
+{
+    "server_group": {
+        "id": "616fb98f-46ca-475e-917e-2563e5a8cd19",
+        "name": "test",
+        "policies": [
+            "anti-affinity"
+        ],
+        "members": [],
+        "metadata": {}
+    }
+}
+`
+
+// CreateOutputMicroversion is a sample response to a Post call with microversion set to 2.64
+const CreateOutputMicroversion = `
 {
     "server_group": {
         "id": "616fb98f-46ca-475e-917e-2563e5a8cd19",
@@ -134,9 +164,43 @@ func HandleGetSuccessfully(t *testing.T) {
 	})
 }
 
+// HandleGetMicroversionSuccessfully configures the test server to respond to a Get request
+// for an existing server group with microversion set to 2.64
+func HandleGetMicroversionSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/os-server-groups/4d8c3732-a248-40ed-bebc-539a6ffd25c0", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprintf(w, GetOutputMicroversion)
+	})
+}
+
 // HandleCreateSuccessfully configures the test server to respond to a Create request
 // for a new server group
 func HandleCreateSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/os-server-groups", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, `
+{
+    "server_group": {
+        "name": "test",
+        "policies": [
+            "anti-affinity"
+        ]
+    }
+}
+`)
+
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprintf(w, CreateOutput)
+	})
+}
+
+// HandleCreateMicroversionSuccessfully configures the test server to respond to a Create request
+// for a new server group with microversion set to 2.64
+func HandleCreateMicroversionSuccessfully(t *testing.T) {
 	th.Mux.HandleFunc("/os-server-groups", func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "POST")
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
@@ -156,7 +220,7 @@ func HandleCreateSuccessfully(t *testing.T) {
 `)
 
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, CreateOutput)
+		fmt.Fprintf(w, CreateOutputMicroversion)
 	})
 }
 

--- a/openstack/compute/v2/extensions/servergroups/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/servergroups/testing/requests_test.go
@@ -32,11 +32,24 @@ func TestCreate(t *testing.T) {
 	defer th.TeardownHTTP()
 	HandleCreateSuccessfully(t)
 
+	actual, err := servergroups.Create(client.ServiceClient(), servergroups.CreateOpts{
+		Name:     "test",
+		Policies: []string{"anti-affinity"},
+	}).Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, &CreatedServerGroup, actual)
+}
+
+func TestCreateMicroversion(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleCreateMicroversionSuccessfully(t)
+
 	result := servergroups.Create(client.ServiceClient(), servergroups.CreateOpts{
 		Name:     "test",
 		Policies: []string{"anti-affinity"},
 		Policy:   "anti-affinity",
-		Rules: servergroups.Rules{
+		Rules: &servergroups.Rules{
 			MaxServerPerHost: 3,
 		},
 	})
@@ -60,6 +73,16 @@ func TestGet(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 	HandleGetSuccessfully(t)
+
+	actual, err := servergroups.Get(client.ServiceClient(), "4d8c3732-a248-40ed-bebc-539a6ffd25c0").Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, &FirstServerGroup, actual)
+}
+
+func TestGetMicroversion(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleGetMicroversionSuccessfully(t)
 
 	result := servergroups.Get(client.ServiceClient(), "4d8c3732-a248-40ed-bebc-539a6ffd25c0")
 

--- a/openstack/compute/v2/extensions/servergroups/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/servergroups/testing/requests_test.go
@@ -32,12 +32,28 @@ func TestCreate(t *testing.T) {
 	defer th.TeardownHTTP()
 	HandleCreateSuccessfully(t)
 
-	actual, err := servergroups.Create(client.ServiceClient(), servergroups.CreateOpts{
+	result := servergroups.Create(client.ServiceClient(), servergroups.CreateOpts{
 		Name:     "test",
 		Policies: []string{"anti-affinity"},
-	}).Extract()
+		Policy:   "anti-affinity",
+		Rules: servergroups.Rules{
+			MaxServerPerHost: 3,
+		},
+	})
+
+	// Extract basic fields.
+	actual, err := result.Extract()
 	th.AssertNoErr(t, err)
 	th.CheckDeepEquals(t, &CreatedServerGroup, actual)
+
+	// Extract additional fields.
+	policy, err := servergroups.ExtractPolicy(result.Result)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, "anti-affinity", policy)
+
+	rules, err := servergroups.ExtractRules(result.Result)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, 3, rules.MaxServerPerHost)
 }
 
 func TestGet(t *testing.T) {

--- a/openstack/compute/v2/extensions/servergroups/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/servergroups/testing/requests_test.go
@@ -45,9 +45,21 @@ func TestGet(t *testing.T) {
 	defer th.TeardownHTTP()
 	HandleGetSuccessfully(t)
 
-	actual, err := servergroups.Get(client.ServiceClient(), "4d8c3732-a248-40ed-bebc-539a6ffd25c0").Extract()
+	result := servergroups.Get(client.ServiceClient(), "4d8c3732-a248-40ed-bebc-539a6ffd25c0")
+
+	// Extract basic fields.
+	actual, err := result.Extract()
 	th.AssertNoErr(t, err)
 	th.CheckDeepEquals(t, &FirstServerGroup, actual)
+
+	// Extract additional fields.
+	policy, err := servergroups.ExtractPolicy(result.Result)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, "anti-affinity", policy)
+
+	rules, err := servergroups.ExtractRules(result.Result)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, 3, rules.MaxServerPerHost)
 }
 
 func TestDelete(t *testing.T) {


### PR DESCRIPTION
Add "policy" and "rules" fields for servergroups Create call.
Those fields are available in 2.64 microversion.

Remove required attribute from the "policies" field.

Add "omitempty" attribute to the Rules.MaxServerPerHost field.

For #1600

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/nova/blob/stable/stein/nova/api/openstack/compute/server_groups.py#L186