### PR TITLE
Baremetal API: Update CleanStep struct to support manual cleaning

### DIFF
--- a/openstack/baremetal/v1/nodes/requests.go
+++ b/openstack/baremetal/v1/nodes/requests.go
@@ -388,9 +388,9 @@ func GetSupportedBootDevices(client *gophercloud.ServiceClient, id string) (r Su
 // the value for ‘args’ is a keyword variable argument dictionary that is passed to the cleaning step
 // method.
 type CleanStep struct {
-	Interface string            `json:"interface" required:"true"`
-	Step      string            `json:"step" required:"true"`
-	Args      map[string]string `json:"args,omitempty"`
+	Interface string                 `json:"interface" required:"true"`
+	Step      string                 `json:"step" required:"true"`
+	Args      map[string]interface{} `json:"args,omitempty"`
 }
 
 // ProvisionStateOptsBuilder allows extensions to add additional parameters to the

--- a/openstack/baremetal/v1/nodes/testing/requests_test.go
+++ b/openstack/baremetal/v1/nodes/testing/requests_test.go
@@ -282,7 +282,7 @@ func TestNodeChangeProvisionStateClean(t *testing.T) {
 			{
 				Interface: "deploy",
 				Step:      "upgrade_firmware",
-				Args: map[string]string{
+				Args: map[string]interface{}{
 					"force": "True",
 				},
 			},
@@ -304,7 +304,7 @@ func TestNodeChangeProvisionStateCleanWithConflict(t *testing.T) {
 			{
 				Interface: "deploy",
 				Step:      "upgrade_firmware",
-				Args: map[string]string{
+				Args: map[string]interface{}{
 					"force": "True",
 				},
 			},
@@ -323,7 +323,7 @@ func TestCleanStepRequiresInterface(t *testing.T) {
 		CleanSteps: []nodes.CleanStep{
 			{
 				Step: "upgrade_firmware",
-				Args: map[string]string{
+				Args: map[string]interface{}{
 					"force": "True",
 				},
 			},
@@ -342,7 +342,7 @@ func TestCleanStepRequiresStep(t *testing.T) {
 		CleanSteps: []nodes.CleanStep{
 			{
 				Interface: "deploy",
-				Args: map[string]string{
+				Args: map[string]interface{}{
 					"force": "True",
 				},
 			},


### PR DESCRIPTION
Currently, the **Args** property in CleanStep struct has **map[string]string that
does not match with manual cleaning steps in Ironic. It should be dictionary in python[1][2] and interface{} in golang . For example:

BIOS setting for a node:

```
[
        {
            "interface": "bios",
            "step": "apply_configuration",
            "args": {
                "settings": [{"name": "hyper_threading_enabled", "value": "false"}]
            }
        }
]
```

This PR aims to update **Args** in **CleanStep** struct.
[1] https://github.com/openstack/ironic/blob/master/ironic/api/controllers/v1/node.py#L76
[2] https://github.com/openstack/ironic/blob/master/ironic/api/controllers/v1/node.py#L624

Signed-off-by: Kim Bao Long <longkb@vn.fujitsu.com>
