### PR TITLE
Load Balancer v2: Remove Health Monitor Validation

### DIFF
--- a/openstack/loadbalancer/v2/monitors/requests.go
+++ b/openstack/loadbalancer/v2/monitors/requests.go
@@ -108,7 +108,6 @@ type CreateOpts struct {
 	MaxRetries int `json:"max_retries" required:"true"`
 
 	// URI path that will be accessed if Monitor type is HTTP or HTTPS.
-	// Required for HTTP(S) types.
 	URLPath string `json:"url_path,omitempty"`
 
 	// The HTTP method used for requests by the Monitor. If this attribute
@@ -116,8 +115,7 @@ type CreateOpts struct {
 	HTTPMethod string `json:"http_method,omitempty"`
 
 	// Expected HTTP codes for a passing HTTP(S) Monitor. You can either specify
-	// a single status like "200", or a range like "200-202". Required for HTTP(S)
-	// types.
+	// a single status like "200", or a range like "200-202".
 	ExpectedCodes string `json:"expected_codes,omitempty"`
 
 	// TenantID is the UUID of the project who owns the Monitor.
@@ -138,24 +136,7 @@ type CreateOpts struct {
 
 // ToMonitorCreateMap builds a request body from CreateOpts.
 func (opts CreateOpts) ToMonitorCreateMap() (map[string]interface{}, error) {
-	b, err := gophercloud.BuildRequestBody(opts, "healthmonitor")
-	if err != nil {
-		return nil, err
-	}
-
-	switch opts.Type {
-	case TypeHTTP, TypeHTTPS:
-		switch opts.URLPath {
-		case "":
-			return nil, fmt.Errorf("URLPath must be provided for HTTP and HTTPS")
-		}
-		switch opts.ExpectedCodes {
-		case "":
-			return nil, fmt.Errorf("ExpectedCodes must be provided for HTTP and HTTPS")
-		}
-	}
-
-	return b, nil
+	return gophercloud.BuildRequestBody(opts, "healthmonitor")
 }
 
 /*


### PR DESCRIPTION
For #1639 

Octavia now supports defaults for when the url_path and expected_codes
are not supplied in the request body. This commit removes the local
validation for these fields to allow the API defaults to be used.

Users working with earlier versions of Octavia will need to be mindful
that they cannot rely on defaults being provided by the API and
therefore must provide explicit values.

https://github.com/openstack/octavia/blob/b2d40c1120727c68b570955413516290ad85f809/octavia/api/v2/controllers/health_monitor.py#L134-L143
