### PR TITLE
WIP ContainerInfra: extract ID from cluster resize result

### DIFF
--- a/openstack/containerinfra/v1/clusters/results.go
+++ b/openstack/containerinfra/v1/clusters/results.go
@@ -60,6 +60,14 @@ func (r UpdateResult) Extract() (string, error) {
 	return s.UUID, err
 }
 
+func (r ResizeResult) Extract() (string, error) {
+	var s struct {
+		UUID string
+	}
+	err := r.ExtractInto(&s)
+	return s.UUID, err
+}
+
 type Cluster struct {
 	APIAddress        string             `json:"api_address"`
 	COEVersion        string             `json:"coe_version"`

--- a/openstack/containerinfra/v1/clusters/testing/fixtures.go
+++ b/openstack/containerinfra/v1/clusters/testing/fixtures.go
@@ -289,8 +289,7 @@ func HandleDeleteClusterSuccessfully(t *testing.T) {
 
 var ResizeResponse = fmt.Sprintf(`
 {
-	"uuid": "%s",
-	"node_count": 2
+	"uuid": "%s"
 }`, clusterUUID)
 
 func HandleResizeClusterSuccessfully(t *testing.T) {

--- a/openstack/containerinfra/v1/clusters/testing/requests_test.go
+++ b/openstack/containerinfra/v1/clusters/testing/requests_test.go
@@ -201,5 +201,5 @@ func TestResizeCluster(t *testing.T) {
 	actual, err := res.Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, nodeCount, actual.NodeCount)
+	th.AssertDeepEquals(t, clusterUUID, actual)
 }


### PR DESCRIPTION
The cluster resize result should contain just the cluster's ID, so it needs its own `Extract` method. Currently magnum is sending an empty response which is causing a different error in gophercloud, this will be fixed in magnum with [1].

Will keep as WIP until the fix is merged in magnum and I have been able to test with it.

For #1631 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

[1] https://review.opendev.org/#/c/672600/
