### PR TITLE
Delete Port Forwarding

### DIFF
--- a/acceptance/openstack/networking/v2/extensions/layer3/layer3.go
+++ b/acceptance/openstack/networking/v2/extensions/layer3/layer3.go
@@ -93,6 +93,19 @@ func CreatePortForwarding(t *testing.T, client *gophercloud.ServiceClient, fipID
 	return pf, err
 }
 
+// DeletePortForwarding deletes a Port Forwarding with a given ID and a given floating IP ID.
+// A fatal error is returned if the deletion fails. Works best as a deferred function
+func DeletePortForwarding(t *testing.T, client *gophercloud.ServiceClient, fipID string, pfID string) {
+	t.Logf("Attempting to delete the port forwarding with ID %s for floating IP with ID %s", pfID, fipID)
+
+	err := portforwarding.Delete(client, fipID, pfID).ExtractErr()
+	if err != nil {
+		t.Fatalf("Failed to delete Port forwarding with ID %s for floating IP with ID %s", pfID, fipID)
+	}
+	t.Logf("Successfully deleted the port forwarding with ID %s for floating IP with ID %s", pfID, fipID)
+
+}
+
 // CreateExternalRouter creates a router on the external network. This requires
 // the OS_EXTGW_ID environment variable to be set. An error is returned if the
 // creation failed.

--- a/acceptance/openstack/networking/v2/extensions/layer3/portforwardings_test.go
+++ b/acceptance/openstack/networking/v2/extensions/layer3/portforwardings_test.go
@@ -52,6 +52,7 @@ func TestLayer3PortForwardingsCreateDelete(t *testing.T) {
 
 	pf, err := CreatePortForwarding(t, client, fip.ID, port.ID, port.FixedIPs)
 	th.AssertNoErr(t, err)
+	defer DeletePortForwarding(t, client, fip.ID, pf.ID)
 	tools.PrintResource(t, pf)
 
 }

--- a/openstack/networking/v2/extensions/layer3/portforwarding/doc.go
+++ b/openstack/networking/v2/extensions/layer3/portforwarding/doc.go
@@ -13,6 +13,16 @@ Example to Create a Port Forwarding for a floating IP
 	}
 
 	pf, err := portforwarding.Create(networkingClient, floatingIPID, createOpts).Extract()
+
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete a Port forwarding
+
+	fipID := "2f245a7b-796b-4f26-9cf9-9e82d248fda7"
+	pfID := "725ade3c-9760-4880-8080-8fc2dbab9acc"
+	err := floatingips.Delete(networkClient, fipID, pfID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/networking/v2/extensions/layer3/portforwarding/requests.go
+++ b/openstack/networking/v2/extensions/layer3/portforwarding/requests.go
@@ -35,3 +35,9 @@ func Create(c *gophercloud.ServiceClient, floatingIpId string, opts CreateOptsBu
 	_, r.Err = c.Post(portForwardingUrl(c, floatingIpId), b, &r.Body, nil)
 	return
 }
+
+// Delete will permanently delete a particular port forwarding for a given floating ID.
+func Delete(c *gophercloud.ServiceClient, floatingIpId string, pfId string) (r DeleteResult) {
+	_, r.Err = c.Delete(singlePortForwardingUrl(c, floatingIpId, pfId), nil)
+	return
+}

--- a/openstack/networking/v2/extensions/layer3/portforwarding/results.go
+++ b/openstack/networking/v2/extensions/layer3/portforwarding/results.go
@@ -36,6 +36,12 @@ type CreateResult struct {
 	commonResult
 }
 
+// DeleteResult represents the result of a delete operation. Call its
+// ExtractErr method to determine if the request succeeded or failed.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
 // Extract will extract a Port Forwarding resource from a result.
 func (r commonResult) Extract() (*PortForwarding, error) {
 	var s PortForwarding

--- a/openstack/networking/v2/extensions/layer3/portforwarding/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/layer3/portforwarding/testing/requests_test.go
@@ -66,3 +66,17 @@ func TestCreate(t *testing.T) {
 	th.AssertEquals(t, 2230, pf.ExternalPort)
 	th.AssertEquals(t, "tcp", pf.Protocol)
 }
+
+func TestDelete(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/floatingips/2f245a7b-796b-4f26-9cf9-9e82d248fda7/port_forwardings/725ade3c-9760-4880-8080-8fc2dbab9acc", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	res := portforwarding.Delete(fake.ServiceClient(), "2f245a7b-796b-4f26-9cf9-9e82d248fda7", "725ade3c-9760-4880-8080-8fc2dbab9acc")
+	th.AssertNoErr(t, res.Err)
+}


### PR DESCRIPTION
Please merge #1651 first

For #1637 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

Code:
https://github.com/openstack/neutron/blob/f21444f247108212dc835036c98e354d6e6f7ace/neutron/services/portforwarding/pf_plugin.py#L498

API:
https://docs.openstack.org/api-ref/network/v2/?expanded=create-port-forwarding-detail#delete-a-floating-ip-port-forwarding


