### PR TITLE
[Neutron][SecurityGroup] updated_at/created_at fields

### DIFF
--- a/openstack/networking/v2/extensions/security/groups/results.go
+++ b/openstack/networking/v2/extensions/security/groups/results.go
@@ -1,6 +1,8 @@
 package groups
 
 import (
+	"time"
+
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules"
 	"github.com/gophercloud/gophercloud/pagination"
@@ -24,6 +26,11 @@ type SecGroup struct {
 
 	// TenantID is the project owner of the security group.
 	TenantID string `json:"tenant_id"`
+
+	// UpdatedAt and CreatedAt contain ISO-8601 timestamps of when the state of the
+	// security group last changed, and when it was created.
+	UpdatedAt time.Time `json:"updated_at"`
+	CreatedAt time.Time `json:"created_at"`
 
 	// ProjectID is the project owner of the security group.
 	ProjectID string `json:"project_id"`

--- a/openstack/networking/v2/extensions/security/groups/testing/fixtures.go
+++ b/openstack/networking/v2/extensions/security/groups/testing/fixtures.go
@@ -1,6 +1,8 @@
 package testing
 
 import (
+	"time"
+
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules"
 )
@@ -13,19 +15,28 @@ const SecurityGroupListResponse = `
             "id": "85cc3048-abc3-43cc-89b3-377341426ac5",
             "name": "default",
             "security_group_rules": [],
-            "tenant_id": "e4f50856753b4dc6afee5fa6b9b6c550"
+            "tenant_id": "e4f50856753b4dc6afee5fa6b9b6c550",
+            "created_at": "2019-06-30T04:15:37Z",
+            "updated_at": "2019-06-30T05:18:49Z"
         }
     ]
 }
 `
 
-var SecurityGroup1 = groups.SecGroup{
-	Description: "default",
-	ID:          "85cc3048-abc3-43cc-89b3-377341426ac5",
-	Name:        "default",
-	Rules:       []rules.SecGroupRule{},
-	TenantID:    "e4f50856753b4dc6afee5fa6b9b6c550",
-}
+var (
+	createdTime, _ = time.Parse(time.RFC3339, "2019-06-30T04:15:37Z")
+	updatedTime, _ = time.Parse(time.RFC3339, "2019-06-30T05:18:49Z")
+
+	SecurityGroup1 = groups.SecGroup{
+		Description: "default",
+		ID:          "85cc3048-abc3-43cc-89b3-377341426ac5",
+		Name:        "default",
+		Rules:       []rules.SecGroupRule{},
+		TenantID:    "e4f50856753b4dc6afee5fa6b9b6c550",
+		CreatedAt:   createdTime,
+		UpdatedAt:   updatedTime,
+	}
+)
 
 const SecurityGroupCreateRequest = `
 {
@@ -68,7 +79,9 @@ const SecurityGroupCreateResponse = `
                 "tenant_id": "e4f50856753b4dc6afee5fa6b9b6c550"
             }
         ],
-        "tenant_id": "e4f50856753b4dc6afee5fa6b9b6c550"
+        "tenant_id": "e4f50856753b4dc6afee5fa6b9b6c550",
+        "created_at": "2019-06-30T04:15:37Z",
+        "updated_at": "2019-06-30T05:18:49Z"
     }
 }
 `
@@ -113,7 +126,9 @@ const SecurityGroupUpdateResponse = `
                 "tenant_id": "e4f50856753b4dc6afee5fa6b9b6c550"
             }
         ],
-        "tenant_id": "e4f50856753b4dc6afee5fa6b9b6c550"
+        "tenant_id": "e4f50856753b4dc6afee5fa6b9b6c550",
+        "created_at": "2019-06-30T04:15:37Z",
+        "updated_at": "2019-06-30T05:18:49Z"
     }
 }
 `
@@ -150,7 +165,9 @@ const SecurityGroupGetResponse = `
                 "tenant_id": "e4f50856753b4dc6afee5fa6b9b6c550"
             }
         ],
-        "tenant_id": "e4f50856753b4dc6afee5fa6b9b6c550"
+        "tenant_id": "e4f50856753b4dc6afee5fa6b9b6c550",
+        "created_at": "2019-06-30T04:15:37Z",
+        "updated_at": "2019-06-30T05:18:49Z"
     }
 }
 `

--- a/openstack/networking/v2/extensions/security/groups/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/security/groups/testing/requests_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	fake "github.com/gophercloud/gophercloud/openstack/networking/v2/common"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups"
@@ -93,6 +94,8 @@ func TestUpdate(t *testing.T) {
 	th.AssertEquals(t, "newer-webservers", sg.Name)
 	th.AssertEquals(t, "security group for webservers", sg.Description)
 	th.AssertEquals(t, "2076db17-a522-4506-91de-c6dd8e837028", sg.ID)
+	th.AssertEquals(t, "2019-06-30T04:15:37Z", sg.CreatedAt.Format(time.RFC3339))
+	th.AssertEquals(t, "2019-06-30T05:18:49Z", sg.UpdatedAt.Format(time.RFC3339))
 }
 
 func TestGet(t *testing.T) {
@@ -117,6 +120,8 @@ func TestGet(t *testing.T) {
 	th.AssertEquals(t, "default", sg.Name)
 	th.AssertEquals(t, 2, len(sg.Rules))
 	th.AssertEquals(t, "e4f50856753b4dc6afee5fa6b9b6c550", sg.TenantID)
+	th.AssertEquals(t, "2019-06-30T04:15:37Z", sg.CreatedAt.Format(time.RFC3339))
+	th.AssertEquals(t, "2019-06-30T05:18:49Z", sg.UpdatedAt.Format(time.RFC3339))
 }
 
 func TestDelete(t *testing.T) {


### PR DESCRIPTION
for: #1648

* time.Time object
* mapped to existing json fields

General API reference: https://developer.openstack.org/api-ref/network/v2/?expanded=show-security-group-detail#show-security-group

that fields defined in standard_attr.py , that means that it should be applied to all neutron-resources though decorator:
https://github.com/openstack/neutron/blob/041203f1bb1a9cb814ab58c6088d0229cfe9d9bb/neutron/db/standard_attr.py#L181
https://github.com/openstack/neutron/blob/041203f1bb1a9cb814ab58c6088d0229cfe9d9bb/neutron/db/models/securitygroup.py#L26