### PR TITLE
Manila: add support for share metadata modification

### DIFF
--- a/acceptance/openstack/sharedfilesystems/v2/shares_test.go
+++ b/acceptance/openstack/sharedfilesystems/v2/shares_test.go
@@ -248,9 +248,9 @@ func TestShareMetadata(t *testing.T) {
 		t.Fatalf("Unable to delete share metadatum: %v", err)
 	}
 
-	metadata, err = shares.ShowMetadata(client, share.ID).Extract()
+	metadata, err = shares.GetMetadata(client, share.ID).Extract()
 	if err != nil {
-		t.Fatalf("Unable to show share metadata: %v", err)
+		t.Fatalf("Unable to get share metadata: %v", err)
 	}
 
 	if metadata == nil || len(metadata) != 0 {

--- a/acceptance/openstack/sharedfilesystems/v2/shares_test.go
+++ b/acceptance/openstack/sharedfilesystems/v2/shares_test.go
@@ -243,14 +243,11 @@ func TestShareMetadata(t *testing.T) {
 	}
 	checkMetadataEq(metadata, v2)
 
-	value, err := shares.GetMetadatum(client, share.ID, k).Extract()
+	metadata, err = shares.GetMetadatum(client, share.ID, k).Extract()
 	if err != nil {
 		t.Fatalf("Unable to get share metadatum: %v", err)
 	}
-
-	if value != v2 {
-		t.Fatalf("Unexpected value in share metadata: expected %q, got %q", v2, value)
-	}
+	checkMetadataEq(metadata, v2)
 
 	err = shares.DeleteMetadatum(client, share.ID, k).ExtractErr()
 	if err != nil {

--- a/acceptance/openstack/sharedfilesystems/v2/shares_test.go
+++ b/acceptance/openstack/sharedfilesystems/v2/shares_test.go
@@ -243,9 +243,9 @@ func TestShareMetadata(t *testing.T) {
 	}
 	checkMetadataEq(metadata, v2)
 
-	err = shares.UnsetMetadata(client, share.ID, k).ExtractErr()
+	err = shares.DeleteMetadatum(client, share.ID, k).ExtractErr()
 	if err != nil {
-		t.Fatalf("Unable to unset share metadata: %v", err)
+		t.Fatalf("Unable to delete share metadatum: %v", err)
 	}
 
 	metadata, err = shares.ShowMetadata(client, share.ID).Extract()

--- a/acceptance/openstack/sharedfilesystems/v2/shares_test.go
+++ b/acceptance/openstack/sharedfilesystems/v2/shares_test.go
@@ -243,6 +243,15 @@ func TestShareMetadata(t *testing.T) {
 	}
 	checkMetadataEq(metadata, v2)
 
+	value, err := shares.GetMetadatum(client, share.ID, k).Extract()
+	if err != nil {
+		t.Fatalf("Unable to get share metadatum: %v", err)
+	}
+
+	if value != v2 {
+		t.Fatalf("Unexpected value in share metadata: expected %q, got %q", v2, value)
+	}
+
 	err = shares.DeleteMetadatum(client, share.ID, k).ExtractErr()
 	if err != nil {
 		t.Fatalf("Unable to delete share metadatum: %v", err)

--- a/openstack/sharedfilesystems/v2/shares/requests.go
+++ b/openstack/sharedfilesystems/v2/shares/requests.go
@@ -406,8 +406,10 @@ type SetMetadataOptsBuilder interface {
 	ToSetMetadataMap() (map[string]interface{}, error)
 }
 
-// SetMetadata sets metadata of the specified share. To extract the updated
-// metadata from the response, call the Extract method on the SetMetadataResult.
+// SetMetadata sets metadata of the specified share.
+// Existing metadata items are either kept or overwritten by the metadata from the request.
+// To extract the updated metadata from the response, call the Extract
+// method on the SetMetadataResult.
 func SetMetadata(client *gophercloud.ServiceClient, id string, opts SetMetadataOptsBuilder) (r SetMetadataResult) {
 	b, err := opts.ToSetMetadataMap()
 	if err != nil {
@@ -441,8 +443,10 @@ type UpdateMetadataOptsBuilder interface {
 	ToUpdateMetadataMap() (map[string]interface{}, error)
 }
 
-// UpdateMetadata updates metadata of the specified share. To extract the updated
-// metadata from the response, call the Extract method on the SetMetadataResult.
+// UpdateMetadata updates metadata of the specified share.
+// All existing metadata items are discarded and replaced by the metadata from the request.
+// To extract the updated metadata from the response, call the Extract
+// method on the SetMetadataResult.
 func UpdateMetadata(client *gophercloud.ServiceClient, id string, opts UpdateMetadataOptsBuilder) (r UpdateMetadataResult) {
 	b, err := opts.ToUpdateMetadataMap()
 	if err != nil {

--- a/openstack/sharedfilesystems/v2/shares/requests.go
+++ b/openstack/sharedfilesystems/v2/shares/requests.go
@@ -379,3 +379,89 @@ func Update(client *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder
 	})
 	return
 }
+
+// ShowMetadata retrieves metadata of the specified share. To extract the retrieved
+// metadata from the response, call the Extract method on the ShowMetadataResult.
+func ShowMetadata(client *gophercloud.ServiceClient, id string) (r ShowMetadataResult) {
+	_, r.Err = client.Get(showMetadataURL(client, id), &r.Body, nil)
+	return
+}
+
+// SetMetadataOpts contains options for setting share metadata.
+// For more information about these parameters, please, refer to the shared file systems API v2,
+// Share Metadata, Show share metadata documentation.
+type SetMetadataOpts struct {
+	Metadata map[string]string `json:"metadata"`
+}
+
+// ToSetMetadataMap assembles a request body based on the contents of an
+// SetMetadataOpts.
+func (opts SetMetadataOpts) ToSetMetadataMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "")
+}
+
+// SetMetadataOptsBuilder allows extensions to add additional parameters to the
+// SetMetadata request.
+type SetMetadataOptsBuilder interface {
+	ToSetMetadataMap() (map[string]interface{}, error)
+}
+
+// SetMetadata sets metadata of the specified share. To extract the updated
+// metadata from the response, call the Extract method on the SetMetadataResult.
+func SetMetadata(client *gophercloud.ServiceClient, id string, opts SetMetadataOptsBuilder) (r SetMetadataResult) {
+	b, err := opts.ToSetMetadataMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = client.Post(setMetadataURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+
+	return
+}
+
+// UpdateMetadataOpts contains options for updating share metadata.
+// For more information about these parameters, please, refer to the shared file systems API v2,
+// Share Metadata, Update share metadata documentation.
+type UpdateMetadataOpts struct {
+	Metadata map[string]string `json:"metadata"`
+}
+
+// ToUpdateMetadataMap assembles a request body based on the contents of an
+// UpdateMetadataOpts.
+func (opts UpdateMetadataOpts) ToUpdateMetadataMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "")
+}
+
+// UpdateMetadataOptsBuilder allows extensions to add additional parameters to the
+// UpdateMetadata request.
+type UpdateMetadataOptsBuilder interface {
+	ToUpdateMetadataMap() (map[string]interface{}, error)
+}
+
+// UpdateMetadata updates metadata of the specified share. To extract the updated
+// metadata from the response, call the Extract method on the SetMetadataResult.
+func UpdateMetadata(client *gophercloud.ServiceClient, id string, opts UpdateMetadataOptsBuilder) (r UpdateMetadataResult) {
+	b, err := opts.ToUpdateMetadataMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = client.Post(updateMetadataURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+
+	return
+}
+
+// UnsetMetadata deletes a single key-value pair from the metadata of the specified share.
+func UnsetMetadata(client *gophercloud.ServiceClient, id, key string) (r UnsetMetadataResult) {
+	_, r.Err = client.Delete(unsetMetadataURL(client, id, key), &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+
+	return
+}

--- a/openstack/sharedfilesystems/v2/shares/requests.go
+++ b/openstack/sharedfilesystems/v2/shares/requests.go
@@ -380,10 +380,10 @@ func Update(client *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder
 	return
 }
 
-// ShowMetadata retrieves metadata of the specified share. To extract the retrieved
-// metadata from the response, call the Extract method on the ShowMetadataResult.
-func ShowMetadata(client *gophercloud.ServiceClient, id string) (r ShowMetadataResult) {
-	_, r.Err = client.Get(showMetadataURL(client, id), &r.Body, nil)
+// GetMetadata retrieves metadata of the specified share. To extract the retrieved
+// metadata from the response, call the Extract method on the GetMetadataResult.
+func GetMetadata(client *gophercloud.ServiceClient, id string) (r GetMetadataResult) {
+	_, r.Err = client.Get(getMetadataURL(client, id), &r.Body, nil)
 	return
 }
 

--- a/openstack/sharedfilesystems/v2/shares/requests.go
+++ b/openstack/sharedfilesystems/v2/shares/requests.go
@@ -381,15 +381,16 @@ func Update(client *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder
 }
 
 // GetMetadata retrieves metadata of the specified share. To extract the retrieved
-// metadata from the response, call the Extract method on the GetMetadataResult.
-func GetMetadata(client *gophercloud.ServiceClient, id string) (r GetMetadataResult) {
+// metadata from the response, call the Extract method on the MetadataResult.
+func GetMetadata(client *gophercloud.ServiceClient, id string) (r MetadataResult) {
 	_, r.Err = client.Get(getMetadataURL(client, id), &r.Body, nil)
 	return
 }
 
+// GetMetadatum retrieves a single metadata item of the specified share. To extract the retrieved
+// metadata from the response, call the Extract method on the GetMetadatumResult.
 func GetMetadatum(client *gophercloud.ServiceClient, id, key string) (r GetMetadatumResult) {
 	_, r.Err = client.Get(getMetadatumURL(client, id, key), &r.Body, nil)
-	r.key = key
 	return
 }
 
@@ -415,8 +416,8 @@ type SetMetadataOptsBuilder interface {
 // SetMetadata sets metadata of the specified share.
 // Existing metadata items are either kept or overwritten by the metadata from the request.
 // To extract the updated metadata from the response, call the Extract
-// method on the SetMetadataResult.
-func SetMetadata(client *gophercloud.ServiceClient, id string, opts SetMetadataOptsBuilder) (r SetMetadataResult) {
+// method on the MetadataResult.
+func SetMetadata(client *gophercloud.ServiceClient, id string, opts SetMetadataOptsBuilder) (r MetadataResult) {
 	b, err := opts.ToSetMetadataMap()
 	if err != nil {
 		r.Err = err
@@ -452,8 +453,8 @@ type UpdateMetadataOptsBuilder interface {
 // UpdateMetadata updates metadata of the specified share.
 // All existing metadata items are discarded and replaced by the metadata from the request.
 // To extract the updated metadata from the response, call the Extract
-// method on the SetMetadataResult.
-func UpdateMetadata(client *gophercloud.ServiceClient, id string, opts UpdateMetadataOptsBuilder) (r UpdateMetadataResult) {
+// method on the MetadataResult.
+func UpdateMetadata(client *gophercloud.ServiceClient, id string, opts UpdateMetadataOptsBuilder) (r MetadataResult) {
 	b, err := opts.ToUpdateMetadataMap()
 	if err != nil {
 		r.Err = err

--- a/openstack/sharedfilesystems/v2/shares/requests.go
+++ b/openstack/sharedfilesystems/v2/shares/requests.go
@@ -387,6 +387,12 @@ func GetMetadata(client *gophercloud.ServiceClient, id string) (r GetMetadataRes
 	return
 }
 
+func GetMetadatum(client *gophercloud.ServiceClient, id, key string) (r GetMetadatumResult) {
+	_, r.Err = client.Get(getMetadatumURL(client, id, key), &r.Body, nil)
+	r.key = key
+	return
+}
+
 // SetMetadataOpts contains options for setting share metadata.
 // For more information about these parameters, please, refer to the shared file systems API v2,
 // Share Metadata, Show share metadata documentation.

--- a/openstack/sharedfilesystems/v2/shares/requests.go
+++ b/openstack/sharedfilesystems/v2/shares/requests.go
@@ -457,9 +457,9 @@ func UpdateMetadata(client *gophercloud.ServiceClient, id string, opts UpdateMet
 	return
 }
 
-// UnsetMetadata deletes a single key-value pair from the metadata of the specified share.
-func UnsetMetadata(client *gophercloud.ServiceClient, id, key string) (r UnsetMetadataResult) {
-	_, r.Err = client.Delete(unsetMetadataURL(client, id, key), &gophercloud.RequestOpts{
+// DeleteMetadatum deletes a single key-value pair from the metadata of the specified share.
+func DeleteMetadatum(client *gophercloud.ServiceClient, id, key string) (r DeleteMetadatumResult) {
+	_, r.Err = client.Delete(deleteMetadatumURL(client, id, key), &gophercloud.RequestOpts{
 		OkCodes: []int{200},
 	})
 

--- a/openstack/sharedfilesystems/v2/shares/results.go
+++ b/openstack/sharedfilesystems/v2/shares/results.go
@@ -325,56 +325,27 @@ type ShrinkResult struct {
 	gophercloud.ErrResult
 }
 
-// GetMetadataResult contains the response body and error from a GetMetadata request.
-type GetMetadataResult struct {
-	gophercloud.Result
-}
-
-// Extract will get the string-string map from GetMetadataResult
-func (r GetMetadataResult) Extract() (map[string]string, error) {
-	var s struct {
-		Metadata map[string]string `json:"metadata"`
-	}
-	err := r.ExtractInto(&s)
-	return s.Metadata, err
-}
-
 // GetMetadatumResult contains the response body and error from a GetMetadatum request.
 type GetMetadatumResult struct {
 	gophercloud.Result
-	key string
 }
 
-// Extract will get the string value from GetMetadatumResult
-func (r GetMetadatumResult) Extract() (string, error) {
+// Extract will get the string-string map from GetMetadatumResult
+func (r GetMetadatumResult) Extract() (map[string]string, error) {
 	var s struct {
 		Meta map[string]string `json:"meta"`
 	}
 	err := r.ExtractInto(&s)
-	return s.Meta[r.key], err
+	return s.Meta, err
 }
 
-// SetMetadataResult contains the response body and error from a SetMetadata request.
-type SetMetadataResult struct {
+// MetadataResult contains the response body and error from GetMetadata, SetMetadata or UpdateMetadata requests.
+type MetadataResult struct {
 	gophercloud.Result
 }
 
-// Extract will get the string-string map from SetMetadataResult
-func (r SetMetadataResult) Extract() (map[string]string, error) {
-	var s struct {
-		Metadata map[string]string `json:"metadata"`
-	}
-	err := r.ExtractInto(&s)
-	return s.Metadata, err
-}
-
-// UpdateMetadataResult contains the response body and error from a UpdateMetadata request.
-type UpdateMetadataResult struct {
-	gophercloud.Result
-}
-
-// Extract will get the string-string map from UpdateMetadataResult
-func (r UpdateMetadataResult) Extract() (map[string]string, error) {
+// Extract will get the string-string map from MetadataResult
+func (r MetadataResult) Extract() (map[string]string, error) {
 	var s struct {
 		Metadata map[string]string `json:"metadata"`
 	}

--- a/openstack/sharedfilesystems/v2/shares/results.go
+++ b/openstack/sharedfilesystems/v2/shares/results.go
@@ -367,7 +367,7 @@ func (r UpdateMetadataResult) Extract() (map[string]string, error) {
 	return s.Metadata, err
 }
 
-// UnsetMetadataResult contains the response body and error from a UnsetMetadata request.
-type UnsetMetadataResult struct {
+// DeleteMetadatumResult contains the response body and error from a DeleteMetadatum request.
+type DeleteMetadatumResult struct {
 	gophercloud.ErrResult
 }

--- a/openstack/sharedfilesystems/v2/shares/results.go
+++ b/openstack/sharedfilesystems/v2/shares/results.go
@@ -325,13 +325,13 @@ type ShrinkResult struct {
 	gophercloud.ErrResult
 }
 
-// ShowMetadataResult contains the response body and error from a ShowMetadata request.
-type ShowMetadataResult struct {
+// GetMetadataResult contains the response body and error from a GetMetadata request.
+type GetMetadataResult struct {
 	gophercloud.Result
 }
 
-// Extract will get the string-string map from ShowMetadataResult
-func (r ShowMetadataResult) Extract() (map[string]string, error) {
+// Extract will get the string-string map from GetMetadataResult
+func (r GetMetadataResult) Extract() (map[string]string, error) {
 	var s struct {
 		Metadata map[string]string `json:"metadata"`
 	}

--- a/openstack/sharedfilesystems/v2/shares/results.go
+++ b/openstack/sharedfilesystems/v2/shares/results.go
@@ -324,3 +324,50 @@ type ExtendResult struct {
 type ShrinkResult struct {
 	gophercloud.ErrResult
 }
+
+// ShowMetadataResult contains the response body and error from a ShowMetadata request.
+type ShowMetadataResult struct {
+	gophercloud.Result
+}
+
+// Extract will get the string-string map from ShowMetadataResult
+func (r ShowMetadataResult) Extract() (map[string]string, error) {
+	var s struct {
+		Metadata map[string]string `json:"metadata"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Metadata, err
+}
+
+// SetMetadataResult contains the response body and error from a SetMetadata request.
+type SetMetadataResult struct {
+	gophercloud.Result
+}
+
+// Extract will get the string-string map from SetMetadataResult
+func (r SetMetadataResult) Extract() (map[string]string, error) {
+	var s struct {
+		Metadata map[string]string `json:"metadata"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Metadata, err
+}
+
+// UpdateMetadataResult contains the response body and error from a UpdateMetadata request.
+type UpdateMetadataResult struct {
+	gophercloud.Result
+}
+
+// Extract will get the string-string map from UpdateMetadataResult
+func (r UpdateMetadataResult) Extract() (map[string]string, error) {
+	var s struct {
+		Metadata map[string]string `json:"metadata"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Metadata, err
+}
+
+// UnsetMetadataResult contains the response body and error from a UnsetMetadata request.
+type UnsetMetadataResult struct {
+	gophercloud.ErrResult
+}

--- a/openstack/sharedfilesystems/v2/shares/results.go
+++ b/openstack/sharedfilesystems/v2/shares/results.go
@@ -339,6 +339,21 @@ func (r GetMetadataResult) Extract() (map[string]string, error) {
 	return s.Metadata, err
 }
 
+// GetMetadatumResult contains the response body and error from a GetMetadatum request.
+type GetMetadatumResult struct {
+	gophercloud.Result
+	key string
+}
+
+// Extract will get the string value from GetMetadatumResult
+func (r GetMetadatumResult) Extract() (string, error) {
+	var s struct {
+		Meta map[string]string `json:"meta"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Meta[r.key], err
+}
+
 // SetMetadataResult contains the response body and error from a SetMetadata request.
 type SetMetadataResult struct {
 	gophercloud.Result

--- a/openstack/sharedfilesystems/v2/shares/testing/fixtures.go
+++ b/openstack/sharedfilesystems/v2/shares/testing/fixtures.go
@@ -489,14 +489,14 @@ func MockUpdateMetadataResponse(t *testing.T) {
 	})
 }
 
-var unsetMetadataRequest = `{
+var deleteMetadatumRequest = `{
 		"metadata": {
 			"foo": "bar"
 		}
 	}`
 
-// MockUnsetMetadataResponse creates a mock unset metadata response
-func MockUnsetMetadataResponse(t *testing.T, key string) {
+// MockDeleteMetadatumResponse creates a mock unset metadata response
+func MockDeleteMetadatumResponse(t *testing.T, key string) {
 	th.Mux.HandleFunc(shareEndpoint+"/"+shareID+"/metadata/"+key, func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "DELETE")
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)

--- a/openstack/sharedfilesystems/v2/shares/testing/fixtures.go
+++ b/openstack/sharedfilesystems/v2/shares/testing/fixtures.go
@@ -425,7 +425,7 @@ var getMetadataResponse = `{
 		}
 	}`
 
-// MockGetMetadataResponse creates a mock show metadata response
+// MockGetMetadataResponse creates a mock get metadata response
 func MockGetMetadataResponse(t *testing.T) {
 	th.Mux.HandleFunc(shareEndpoint+"/"+shareID+"/metadata", func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "GET")
@@ -434,6 +434,24 @@ func MockGetMetadataResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprint(w, getMetadataResponse)
+	})
+}
+
+var getMetadatumResponse = `{
+		"meta": {
+			"foo": "bar"
+		}
+	}`
+
+// MockGetMetadatumResponse creates a mock get metadatum response
+func MockGetMetadatumResponse(t *testing.T, key string) {
+	th.Mux.HandleFunc(shareEndpoint+"/"+shareID+"/metadata/"+key, func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, getMetadatumResponse)
 	})
 }
 

--- a/openstack/sharedfilesystems/v2/shares/testing/fixtures.go
+++ b/openstack/sharedfilesystems/v2/shares/testing/fixtures.go
@@ -419,21 +419,21 @@ func MockShrinkResponse(t *testing.T) {
 	})
 }
 
-var showMetadataResponse = `{
+var getMetadataResponse = `{
 		"metadata": {
 			"foo": "bar"
 		}
 	}`
 
-// MockShowMetadataResponse creates a mock show metadata response
-func MockShowMetadataResponse(t *testing.T) {
+// MockGetMetadataResponse creates a mock show metadata response
+func MockGetMetadataResponse(t *testing.T) {
 	th.Mux.HandleFunc(shareEndpoint+"/"+shareID+"/metadata", func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "GET")
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 		th.TestHeader(t, r, "Accept", "application/json")
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprint(w, showMetadataResponse)
+		fmt.Fprint(w, getMetadataResponse)
 	})
 }
 

--- a/openstack/sharedfilesystems/v2/shares/testing/fixtures.go
+++ b/openstack/sharedfilesystems/v2/shares/testing/fixtures.go
@@ -418,3 +418,88 @@ func MockShrinkResponse(t *testing.T) {
 		w.WriteHeader(http.StatusAccepted)
 	})
 }
+
+var showMetadataResponse = `{
+		"metadata": {
+			"foo": "bar"
+		}
+	}`
+
+// MockShowMetadataResponse creates a mock show metadata response
+func MockShowMetadataResponse(t *testing.T) {
+	th.Mux.HandleFunc(shareEndpoint+"/"+shareID+"/metadata", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, showMetadataResponse)
+	})
+}
+
+var setMetadataRequest = `{
+		"metadata": {
+			"foo": "bar"
+		}
+	}`
+
+var setMetadataResponse = `{
+		"metadata": {
+			"foo": "bar"
+		}
+	}`
+
+// MockSetMetadataResponse creates a mock set metadata response
+func MockSetMetadataResponse(t *testing.T) {
+	th.Mux.HandleFunc(shareEndpoint+"/"+shareID+"/metadata", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, setMetadataRequest)
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, setMetadataResponse)
+	})
+}
+
+var updateMetadataRequest = `{
+		"metadata": {
+			"foo": "bar"
+		}
+	}`
+
+var updateMetadataResponse = `{
+		"metadata": {
+			"foo": "bar"
+		}
+	}`
+
+// MockUpdateMetadataResponse creates a mock update metadata response
+func MockUpdateMetadataResponse(t *testing.T) {
+	th.Mux.HandleFunc(shareEndpoint+"/"+shareID+"/metadata", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, updateMetadataRequest)
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, updateMetadataResponse)
+	})
+}
+
+var unsetMetadataRequest = `{
+		"metadata": {
+			"foo": "bar"
+		}
+	}`
+
+// MockUnsetMetadataResponse creates a mock unset metadata response
+func MockUnsetMetadataResponse(t *testing.T, key string) {
+	th.Mux.HandleFunc(shareEndpoint+"/"+shareID+"/metadata/"+key, func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.WriteHeader(http.StatusOK)
+	})
+}

--- a/openstack/sharedfilesystems/v2/shares/testing/request_test.go
+++ b/openstack/sharedfilesystems/v2/shares/testing/request_test.go
@@ -297,6 +297,19 @@ func TestGetMetadataSuccess(t *testing.T) {
 	th.AssertDeepEquals(t, map[string]string{"foo": "bar"}, actual)
 }
 
+func TestGetMetadatumSuccess(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockGetMetadatumResponse(t, "foo")
+
+	c := client.ServiceClient()
+
+	actual, err := shares.GetMetadatum(c, shareID, "foo").Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, "bar", actual)
+}
+
 func TestSetMetadataSuccess(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()

--- a/openstack/sharedfilesystems/v2/shares/testing/request_test.go
+++ b/openstack/sharedfilesystems/v2/shares/testing/request_test.go
@@ -119,7 +119,7 @@ func TestListDetail(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	th.AssertDeepEquals(t, actual, []shares.Share{
-		shares.Share{
+		{
 			AvailabilityZone:   "nova",
 			ShareNetworkID:     "713df749-aac0-4a54-af52-10f6c991e80c",
 			ShareServerID:      "e268f4aa-d571-43dd-9ab3-f49ad06ffaef",

--- a/openstack/sharedfilesystems/v2/shares/testing/request_test.go
+++ b/openstack/sharedfilesystems/v2/shares/testing/request_test.go
@@ -307,7 +307,7 @@ func TestGetMetadatumSuccess(t *testing.T) {
 
 	actual, err := shares.GetMetadatum(c, shareID, "foo").Extract()
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, "bar", actual)
+	th.AssertDeepEquals(t, map[string]string{"foo": "bar"}, actual)
 }
 
 func TestSetMetadataSuccess(t *testing.T) {

--- a/openstack/sharedfilesystems/v2/shares/testing/request_test.go
+++ b/openstack/sharedfilesystems/v2/shares/testing/request_test.go
@@ -327,10 +327,10 @@ func TestUnsetMetadataSuccess(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 
-	MockUnsetMetadataResponse(t, "foo")
+	MockDeleteMetadatumResponse(t, "foo")
 
 	c := client.ServiceClient()
 
-	err := shares.UnsetMetadata(c, shareID, "foo").ExtractErr()
+	err := shares.DeleteMetadatum(c, shareID, "foo").ExtractErr()
 	th.AssertNoErr(t, err)
 }

--- a/openstack/sharedfilesystems/v2/shares/testing/request_test.go
+++ b/openstack/sharedfilesystems/v2/shares/testing/request_test.go
@@ -284,15 +284,15 @@ func TestShrinkSuccess(t *testing.T) {
 	th.AssertNoErr(t, err)
 }
 
-func TestShowMetadataSuccess(t *testing.T) {
+func TestGetMetadataSuccess(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 
-	MockShowMetadataResponse(t)
+	MockGetMetadataResponse(t)
 
 	c := client.ServiceClient()
 
-	actual, err := shares.ShowMetadata(c, shareID).Extract()
+	actual, err := shares.GetMetadata(c, shareID).Extract()
 	th.AssertNoErr(t, err)
 	th.AssertDeepEquals(t, map[string]string{"foo": "bar"}, actual)
 }

--- a/openstack/sharedfilesystems/v2/shares/testing/request_test.go
+++ b/openstack/sharedfilesystems/v2/shares/testing/request_test.go
@@ -283,3 +283,54 @@ func TestShrinkSuccess(t *testing.T) {
 	err := shares.Shrink(c, shareID, &shares.ShrinkOpts{NewSize: 1}).ExtractErr()
 	th.AssertNoErr(t, err)
 }
+
+func TestShowMetadataSuccess(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockShowMetadataResponse(t)
+
+	c := client.ServiceClient()
+
+	actual, err := shares.ShowMetadata(c, shareID).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, map[string]string{"foo": "bar"}, actual)
+}
+
+func TestSetMetadataSuccess(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockSetMetadataResponse(t)
+
+	c := client.ServiceClient()
+
+	actual, err := shares.SetMetadata(c, shareID, &shares.SetMetadataOpts{Metadata: map[string]string{"foo": "bar"}}).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, map[string]string{"foo": "bar"}, actual)
+}
+
+func TestUpdateMetadataSuccess(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockUpdateMetadataResponse(t)
+
+	c := client.ServiceClient()
+
+	actual, err := shares.UpdateMetadata(c, shareID, &shares.UpdateMetadataOpts{Metadata: map[string]string{"foo": "bar"}}).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, map[string]string{"foo": "bar"}, actual)
+}
+
+func TestUnsetMetadataSuccess(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockUnsetMetadataResponse(t, "foo")
+
+	c := client.ServiceClient()
+
+	err := shares.UnsetMetadata(c, shareID, "foo").ExtractErr()
+	th.AssertNoErr(t, err)
+}

--- a/openstack/sharedfilesystems/v2/shares/urls.go
+++ b/openstack/sharedfilesystems/v2/shares/urls.go
@@ -58,6 +58,6 @@ func updateMetadataURL(c *gophercloud.ServiceClient, id string) string {
 	return c.ServiceURL("shares", id, "metadata")
 }
 
-func unsetMetadataURL(c *gophercloud.ServiceClient, id, key string) string {
+func deleteMetadatumURL(c *gophercloud.ServiceClient, id, key string) string {
 	return c.ServiceURL("shares", id, "metadata", key)
 }

--- a/openstack/sharedfilesystems/v2/shares/urls.go
+++ b/openstack/sharedfilesystems/v2/shares/urls.go
@@ -50,6 +50,10 @@ func getMetadataURL(c *gophercloud.ServiceClient, id string) string {
 	return c.ServiceURL("shares", id, "metadata")
 }
 
+func getMetadatumURL(c *gophercloud.ServiceClient, id, key string) string {
+	return c.ServiceURL("shares", id, "metadata", key)
+}
+
 func setMetadataURL(c *gophercloud.ServiceClient, id string) string {
 	return c.ServiceURL("shares", id, "metadata")
 }

--- a/openstack/sharedfilesystems/v2/shares/urls.go
+++ b/openstack/sharedfilesystems/v2/shares/urls.go
@@ -45,3 +45,19 @@ func extendURL(c *gophercloud.ServiceClient, id string) string {
 func shrinkURL(c *gophercloud.ServiceClient, id string) string {
 	return c.ServiceURL("shares", id, "action")
 }
+
+func showMetadataURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("shares", id, "metadata")
+}
+
+func setMetadataURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("shares", id, "metadata")
+}
+
+func updateMetadataURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("shares", id, "metadata")
+}
+
+func unsetMetadataURL(c *gophercloud.ServiceClient, id, key string) string {
+	return c.ServiceURL("shares", id, "metadata", key)
+}

--- a/openstack/sharedfilesystems/v2/shares/urls.go
+++ b/openstack/sharedfilesystems/v2/shares/urls.go
@@ -46,7 +46,7 @@ func shrinkURL(c *gophercloud.ServiceClient, id string) string {
 	return c.ServiceURL("shares", id, "action")
 }
 
-func showMetadataURL(c *gophercloud.ServiceClient, id string) string {
+func getMetadataURL(c *gophercloud.ServiceClient, id string) string {
 	return c.ServiceURL("shares", id, "metadata")
 }
 


### PR DESCRIPTION
For #1653

Manila API reference for Share metadata: https://docs.openstack.org/api-ref/shared-file-system/#share-metadata

* [Show metadata implementation](https://github.com/openstack/manila/blob/cec13b8057fa025fa1b1c3bef180687a394d6fd6/manila/api/v1/share_metadata.py#L42-L45)
* [Set metadata implementation](https://github.com/openstack/manila/blob/master/manila/api/v1/share_metadata.py#L98-L119)
* [Update metadata implementation](https://github.com/openstack/manila/blob/master/manila/api/v1/share_metadata.py#L98-L119)
* [Unset metadata implementation](https://github.com/openstack/manila/blob/master/manila/share/api.py#L1805-L1807)