### PR TITLE
Identity V3: Fix RegionID type

### DIFF
--- a/openstack/identity/v3/endpoints/requests.go
+++ b/openstack/identity/v3/endpoints/requests.go
@@ -62,7 +62,7 @@ type ListOpts struct {
 	ServiceID string `q:"service_id"`
 
 	// RegionID is the ID of the region the Endpoint refers to.
-	RegionID int `q:"region_id"`
+	RegionID string `q:"region_id"`
 }
 
 // ToEndpointListParams builds a list request from the List options.


### PR DESCRIPTION
For #1665 

Region ID is a string, not an int

https://docs.openstack.org/api-ref/identity/v3/?expanded=list-endpoints-detail#service-catalog-and-endpoints