### PR TITLE
Blockstorage: add groups to quotaset result

### DIFF
--- a/acceptance/openstack/blockstorage/v3/quotaset_test.go
+++ b/acceptance/openstack/blockstorage/v3/quotaset_test.go
@@ -53,6 +53,7 @@ var UpdateQuotaOpts = quotasets.UpdateOpts{
 	PerVolumeGigabytes: gophercloud.IntToPointer(50),
 	Backups:            gophercloud.IntToPointer(2),
 	BackupGigabytes:    gophercloud.IntToPointer(300),
+	Groups:             gophercloud.IntToPointer(350),
 }
 
 var UpdatedQuotas = quotasets.QuotaSet{
@@ -62,6 +63,7 @@ var UpdatedQuotas = quotasets.QuotaSet{
 	PerVolumeGigabytes: 50,
 	Backups:            2,
 	BackupGigabytes:    300,
+	Groups:             350,
 }
 
 func TestQuotasetUpdate(t *testing.T) {
@@ -142,4 +144,5 @@ func FillUpdateOptsFromQuotaSet(src quotasets.QuotaSet, dest *quotasets.UpdateOp
 	dest.PerVolumeGigabytes = &src.PerVolumeGigabytes
 	dest.Backups = &src.Backups
 	dest.BackupGigabytes = &src.BackupGigabytes
+	dest.Groups = &src.Groups
 }

--- a/openstack/blockstorage/extensions/quotasets/results.go
+++ b/openstack/blockstorage/extensions/quotasets/results.go
@@ -31,6 +31,9 @@ type QuotaSet struct {
 	// BackupGigabytes is the size (GB) of backups that are allowed for each
 	// project.
 	BackupGigabytes int `json:"backup_gigabytes"`
+
+	// Groups is the number of groups that are allowed for each project.
+	Groups int `json:"groups,omitempty"`
 }
 
 // QuotaUsageSet represents details of both operational limits of block
@@ -71,6 +74,11 @@ type QuotaUsageSet struct {
 	// Note: allocated attribute is available only when nested quota is
 	// enabled.
 	BackupGigabytes QuotaUsage `json:"backup_gigabytes"`
+
+	// Groups is the number of groups that are allowed for each project.
+	// Note: allocated attribute is available only when nested quota is
+	// enabled.
+	Groups QuotaUsage `json:"groups"`
 }
 
 // QuotaUsage is a set of details about a single operational limit that allows

--- a/openstack/blockstorage/extensions/quotasets/testing/fixtures.go
+++ b/openstack/blockstorage/extensions/quotasets/testing/fixtures.go
@@ -15,14 +15,15 @@ const FirstTenantID = "555544443333222211110000ffffeeee"
 
 var getExpectedJSONBody = `
 {
-	"quota_set" : {
-		"volumes" : 8,
-		"snapshots" : 9,
-		"gigabytes" : 10,
-		"per_volume_gigabytes" : 11,
-		"backups" : 12,
-		"backup_gigabytes" : 13
-	}
+    "quota_set" : {
+        "volumes" : 8,
+        "snapshots" : 9,
+        "gigabytes" : 10,
+        "per_volume_gigabytes" : 11,
+        "backups" : 12,
+        "backup_gigabytes" : 13,
+        "groups": 14
+    }
 }`
 
 var getExpectedQuotaSet = quotasets.QuotaSet{
@@ -32,43 +33,48 @@ var getExpectedQuotaSet = quotasets.QuotaSet{
 	PerVolumeGigabytes: 11,
 	Backups:            12,
 	BackupGigabytes:    13,
+	Groups:             14,
 }
 
 var getUsageExpectedJSONBody = `
 {
-	"quota_set" : {
-		"id": "555544443333222211110000ffffeeee",
-		"volumes" : {
-			"in_use": 15,
-			"limit": 16,
-			"reserved": 17
-		},
-		"snapshots" : {
-			"in_use": 18,
-			"limit": 19,
-			"reserved": 20
-		},
-		"gigabytes" : {
-			"in_use": 21,
-			"limit": 22,
-			"reserved": 23
-		},
-		"per_volume_gigabytes" : {
-			"in_use": 24,
-			"limit": 25,
-			"reserved": 26
-		},
-		"backups" : {
-			"in_use": 27,
-			"limit": 28,
-			"reserved": 29
-		},
-		"backup_gigabytes" : {
-			"in_use": 30,
-			"limit": 31,
-			"reserved": 32
-		}
-		}
+    "quota_set" : {
+        "id": "555544443333222211110000ffffeeee",
+        "volumes" : {
+            "in_use": 15,
+            "limit": 16,
+            "reserved": 17
+        },
+        "snapshots" : {
+            "in_use": 18,
+            "limit": 19,
+            "reserved": 20
+        },
+        "gigabytes" : {
+            "in_use": 21,
+            "limit": 22,
+            "reserved": 23
+        },
+        "per_volume_gigabytes" : {
+            "in_use": 24,
+            "limit": 25,
+            "reserved": 26
+        },
+        "backups" : {
+            "in_use": 27,
+            "limit": 28,
+            "reserved": 29
+        },
+        "backup_gigabytes" : {
+            "in_use": 30,
+            "limit": 31,
+            "reserved": 32
+        },
+        "groups" : {
+            "in_use": 40,
+            "limit": 41,
+            "reserved": 42
+        }
 	}
 }`
 
@@ -80,18 +86,20 @@ var getUsageExpectedQuotaSet = quotasets.QuotaUsageSet{
 	PerVolumeGigabytes: quotasets.QuotaUsage{InUse: 24, Limit: 25, Reserved: 26},
 	Backups:            quotasets.QuotaUsage{InUse: 27, Limit: 28, Reserved: 29},
 	BackupGigabytes:    quotasets.QuotaUsage{InUse: 30, Limit: 31, Reserved: 32},
+	Groups:             quotasets.QuotaUsage{InUse: 40, Limit: 41, Reserved: 42},
 }
 
 var fullUpdateExpectedJSONBody = `
 {
-	"quota_set": {
-		"volumes": 8,
-		"snapshots": 9,
-		"gigabytes": 10,
-		"per_volume_gigabytes": 11,
-		"backups": 12,
-		"backup_gigabytes": 13
-	}
+    "quota_set": {
+        "volumes": 8,
+        "snapshots": 9,
+        "gigabytes": 10,
+        "per_volume_gigabytes": 11,
+        "backups": 12,
+        "backup_gigabytes": 13,
+        "groups": 14
+    }
 }`
 
 var fullUpdateOpts = quotasets.UpdateOpts{
@@ -101,6 +109,7 @@ var fullUpdateOpts = quotasets.UpdateOpts{
 	PerVolumeGigabytes: gophercloud.IntToPointer(11),
 	Backups:            gophercloud.IntToPointer(12),
 	BackupGigabytes:    gophercloud.IntToPointer(13),
+	Groups:             gophercloud.IntToPointer(14),
 }
 
 var fullUpdateExpectedQuotaSet = quotasets.QuotaSet{
@@ -110,18 +119,19 @@ var fullUpdateExpectedQuotaSet = quotasets.QuotaSet{
 	PerVolumeGigabytes: 11,
 	Backups:            12,
 	BackupGigabytes:    13,
+	Groups:             14,
 }
 
 var partialUpdateExpectedJSONBody = `
 {
-	"quota_set": {
-		"volumes": 200,
-		"snapshots": 0,
-		"gigabytes": 0,
-		"per_volume_gigabytes": 0,
-		"backups": 0,
-		"backup_gigabytes": 0
-	}
+    "quota_set": {
+        "volumes": 200,
+        "snapshots": 0,
+        "gigabytes": 0,
+        "per_volume_gigabytes": 0,
+        "backups": 0,
+        "backup_gigabytes": 0
+    }
 }`
 
 var partialUpdateOpts = quotasets.UpdateOpts{


### PR DESCRIPTION
Allow to retrieve groups attribute for the Blockstorage quotaset.

Update tests.

For #1667 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/cinder/blob/stable/stein/cinder/quota.py#L48
