### PR TITLE
Containerinfra: Allow setting fixed_network when creating cluster

### DIFF
--- a/openstack/containerinfra/v1/clusters/requests.go
+++ b/openstack/containerinfra/v1/clusters/requests.go
@@ -25,6 +25,7 @@ type CreateOpts struct {
 	MasterFlavorID    string            `json:"master_flavor_id,omitempty"`
 	Name              string            `json:"name"`
 	NodeCount         *int              `json:"node_count,omitempty"`
+	FixedNetwork      string            `json:"fixed_network,omitempty"`
 }
 
 // ToClusterCreateMap constructs a request body from CreateOpts.

--- a/openstack/containerinfra/v1/clusters/results.go
+++ b/openstack/containerinfra/v1/clusters/results.go
@@ -87,6 +87,7 @@ type Cluster struct {
 	UUID              string             `json:"uuid"`
 	UpdatedAt         time.Time          `json:"updated_at"`
 	UserID            string             `json:"user_id"`
+	FixedNetwork      string             `json:"fixed_network"`
 }
 
 type ClusterPage struct {

--- a/openstack/containerinfra/v1/clusters/testing/fixtures.go
+++ b/openstack/containerinfra/v1/clusters/testing/fixtures.go
@@ -49,6 +49,7 @@ var ExpectedCluster = clusters.Cluster{
 	StatusReason:    "Stack CREATE completed successfully",
 	UpdatedAt:       time.Date(2016, 8, 29, 6, 53, 24, 0, time.UTC),
 	UUID:            clusterUUID,
+	FixedNetwork:    "private_network",
 }
 
 var ExpectedCluster2 = clusters.Cluster{
@@ -79,6 +80,7 @@ var ExpectedCluster2 = clusters.Cluster{
 	StatusReason:    "Stack CREATE completed successfully",
 	UpdatedAt:       time.Date(2016, 8, 29, 6, 53, 24, 0, time.UTC),
 	UUID:            clusterUUID2,
+	FixedNetwork:    "private_network",
 }
 
 var ExpectedClusterUUID = clusterUUID
@@ -140,7 +142,8 @@ var ClusterGetResponse = fmt.Sprintf(`
 		],
 		"status_reason":"Stack CREATE completed successfully",
 		"create_timeout":60,
-		"name":"k8s"
+		"name":"k8s",
+		"fixed_network": "private_network"
 }`, clusterUUID)
 
 var ClusterListResponse = fmt.Sprintf(`
@@ -177,7 +180,8 @@ var ClusterListResponse = fmt.Sprintf(`
 			"status":"CREATE_COMPLETE",
 			"status_reason":"Stack CREATE completed successfully",
 			"updated_at":"2016-08-29T06:53:24+00:00",
-			"uuid":"%s"
+			"uuid":"%s",
+			"fixed_network": "private_network"
 		},
 		{
 			"api_address":"https://172.24.4.6:6443",
@@ -210,7 +214,8 @@ var ClusterListResponse = fmt.Sprintf(`
 			"status":"CREATE_COMPLETE",
 			"status_reason":"Stack CREATE completed successfully",
 			"updated_at":null,
-			"uuid":"%s"
+			"uuid":"%s",
+			"fixed_network": "private_network"
 		}
 	]
 }`, clusterUUID, clusterUUID2)

--- a/openstack/containerinfra/v1/clusters/testing/requests_test.go
+++ b/openstack/containerinfra/v1/clusters/testing/requests_test.go
@@ -29,6 +29,7 @@ func TestCreateCluster(t *testing.T) {
 		MasterFlavorID:    "m1.small",
 		Name:              "k8s",
 		NodeCount:         &nodeCount,
+		FixedNetwork:      "private_network",
 	}
 
 	sc := fake.ServiceClient()


### PR DESCRIPTION
For #1673

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/magnum/blob/04fd0470ad3b35c4af5212eee82431b1be43d64c/magnum/api/controllers/v1/cluster.py#L177