### PR TITLE
Containerinfra: Allow setting fixed_subnet when creating cluster

### DIFF
--- a/openstack/containerinfra/v1/clusters/requests.go
+++ b/openstack/containerinfra/v1/clusters/requests.go
@@ -26,6 +26,7 @@ type CreateOpts struct {
 	Name              string            `json:"name"`
 	NodeCount         *int              `json:"node_count,omitempty"`
 	FixedNetwork      string            `json:"fixed_network,omitempty"`
+	FixedSubnet       string            `json:"fixed_subnet,omitempty"`
 }
 
 // ToClusterCreateMap constructs a request body from CreateOpts.

--- a/openstack/containerinfra/v1/clusters/results.go
+++ b/openstack/containerinfra/v1/clusters/results.go
@@ -88,6 +88,7 @@ type Cluster struct {
 	UpdatedAt         time.Time          `json:"updated_at"`
 	UserID            string             `json:"user_id"`
 	FixedNetwork      string             `json:"fixed_network"`
+	FixedSubnet       string             `json:"fixed_subnet"`
 }
 
 type ClusterPage struct {

--- a/openstack/containerinfra/v1/clusters/testing/fixtures.go
+++ b/openstack/containerinfra/v1/clusters/testing/fixtures.go
@@ -50,6 +50,7 @@ var ExpectedCluster = clusters.Cluster{
 	UpdatedAt:       time.Date(2016, 8, 29, 6, 53, 24, 0, time.UTC),
 	UUID:            clusterUUID,
 	FixedNetwork:    "private_network",
+	FixedSubnet:     "private_subnet",
 }
 
 var ExpectedCluster2 = clusters.Cluster{
@@ -81,6 +82,7 @@ var ExpectedCluster2 = clusters.Cluster{
 	UpdatedAt:       time.Date(2016, 8, 29, 6, 53, 24, 0, time.UTC),
 	UUID:            clusterUUID2,
 	FixedNetwork:    "private_network",
+	FixedSubnet:     "private_subnet",
 }
 
 var ExpectedClusterUUID = clusterUUID
@@ -143,7 +145,8 @@ var ClusterGetResponse = fmt.Sprintf(`
 		"status_reason":"Stack CREATE completed successfully",
 		"create_timeout":60,
 		"name":"k8s",
-		"fixed_network": "private_network"
+		"fixed_network": "private_network",
+		"fixed_subnet": "private_subnet"
 }`, clusterUUID)
 
 var ClusterListResponse = fmt.Sprintf(`
@@ -181,7 +184,8 @@ var ClusterListResponse = fmt.Sprintf(`
 			"status_reason":"Stack CREATE completed successfully",
 			"updated_at":"2016-08-29T06:53:24+00:00",
 			"uuid":"%s",
-			"fixed_network": "private_network"
+			"fixed_network": "private_network",
+			"fixed_subnet": "private_subnet"
 		},
 		{
 			"api_address":"https://172.24.4.6:6443",
@@ -215,7 +219,8 @@ var ClusterListResponse = fmt.Sprintf(`
 			"status_reason":"Stack CREATE completed successfully",
 			"updated_at":null,
 			"uuid":"%s",
-			"fixed_network": "private_network"
+			"fixed_network": "private_network",
+			"fixed_subnet": "private_subnet"
 		}
 	]
 }`, clusterUUID, clusterUUID2)

--- a/openstack/containerinfra/v1/clusters/testing/requests_test.go
+++ b/openstack/containerinfra/v1/clusters/testing/requests_test.go
@@ -30,6 +30,7 @@ func TestCreateCluster(t *testing.T) {
 		Name:              "k8s",
 		NodeCount:         &nodeCount,
 		FixedNetwork:      "private_network",
+		FixedSubnet:       "private_subnet",
 	}
 
 	sc := fake.ServiceClient()


### PR DESCRIPTION
For #1673

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/magnum/blob/04fd0470ad3b35c4af5212eee82431b1be43d64c/magnum/api/controllers/v1/cluster.py#L180