### PR TITLE
Compute V2: add tags extension with List call

### DIFF
--- a/openstack/compute/v2/extensions/tags/doc.go
+++ b/openstack/compute/v2/extensions/tags/doc.go
@@ -1,0 +1,17 @@
+/*
+Package tags manages Tags on Compute V2 servers.
+
+This extension is available since 2.26 Compute V2 API microversion.
+
+Example to List all server Tags
+
+	client.Microversion = "2.62"
+
+    serverTags, err = tags.List(client, server.ID).Extract()
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    fmt.Printf("Tags: %v\n", serverTags)
+*/
+package tags

--- a/openstack/compute/v2/extensions/tags/requests.go
+++ b/openstack/compute/v2/extensions/tags/requests.go
@@ -1,0 +1,12 @@
+package tags
+
+import "github.com/gophercloud/gophercloud"
+
+// List all tags on a server.
+func List(client *gophercloud.ServiceClient, serverID string) (r ListResult) {
+	url := listURL(client, serverID)
+	_, r.Err = client.Get(url, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}

--- a/openstack/compute/v2/extensions/tags/results.go
+++ b/openstack/compute/v2/extensions/tags/results.go
@@ -1,0 +1,20 @@
+package tags
+
+import "github.com/gophercloud/gophercloud"
+
+type tagResult struct {
+	gophercloud.Result
+}
+
+// Extract interprets tagResult to return the list of tags
+func (r tagResult) Extract() ([]string, error) {
+	var s struct {
+		Tags []string `json:"tags"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Tags, err
+}
+
+type ListResult struct {
+	tagResult
+}

--- a/openstack/compute/v2/extensions/tags/testing/doc.go
+++ b/openstack/compute/v2/extensions/tags/testing/doc.go
@@ -1,0 +1,2 @@
+// tags unit tests
+package testing

--- a/openstack/compute/v2/extensions/tags/testing/fixtures.go
+++ b/openstack/compute/v2/extensions/tags/testing/fixtures.go
@@ -1,0 +1,8 @@
+package testing
+
+// TagsListResponse represents a raw tags response.
+const TagsListResponse = `
+{
+    "tags": ["foo", "bar", "baz"]
+}
+`

--- a/openstack/compute/v2/extensions/tags/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/tags/testing/requests_test.go
@@ -1,0 +1,33 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/tags"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func TestList(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/servers/uuid1/tags", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		_, err := fmt.Fprintf(w, TagsListResponse)
+		th.AssertNoErr(t, err)
+	})
+
+	expected := []string{"foo", "bar", "baz"}
+	actual, err := tags.List(client.ServiceClient(), "uuid1").Extract()
+
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expected, actual)
+}

--- a/openstack/compute/v2/extensions/tags/urls.go
+++ b/openstack/compute/v2/extensions/tags/urls.go
@@ -1,0 +1,16 @@
+package tags
+
+import "github.com/gophercloud/gophercloud"
+
+const (
+	rootResourcePath = "servers"
+	resourcePath     = "tags"
+)
+
+func rootURL(c *gophercloud.ServiceClient, serverID string) string {
+	return c.ServiceURL(rootResourcePath, serverID, resourcePath)
+}
+
+func listURL(c *gophercloud.ServiceClient, serverID string) string {
+	return rootURL(c, serverID)
+}


### PR DESCRIPTION
Add the new tags extension with the List method.

Provide unit test and documentation.

For #1669

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/nova/blob/stable/stein/nova/api/openstack/compute/server_tags.py#L86
https://github.com/openstack/nova/blob/stable/stein/nova/objects/tag.py#L65
