### PR TITLE
Compute V2: add tags Check call

### DIFF
--- a/openstack/compute/v2/extensions/tags/doc.go
+++ b/openstack/compute/v2/extensions/tags/doc.go
@@ -1,0 +1,17 @@
+/*
+Package tags manages Tags on Compute V2 servers.
+
+This extension is available since 2.26 Compute V2 API microversion.
+
+Example to List all server Tags
+
+	client.Microversion = "2.62"
+
+    serverTags, err = tags.List(client, server.ID).Extract()
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    fmt.Printf("Tags: %v\n", serverTags)
+*/
+package tags

--- a/openstack/compute/v2/extensions/tags/doc.go
+++ b/openstack/compute/v2/extensions/tags/doc.go
@@ -7,11 +7,26 @@ Example to List all server Tags
 
 	client.Microversion = "2.62"
 
-    serverTags, err = tags.List(client, server.ID).Extract()
+    serverTags, err := tags.List(client, serverID).Extract()
     if err != nil {
         log.Fatal(err)
     }
 
     fmt.Printf("Tags: %v\n", serverTags)
+
+Example to Check if the specific Tag exists on a server.
+
+    client.Microversion = "2.62"
+
+    exists, err := tags.Check(client, serverID, tag).Extract()
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    if exists {
+        log.Printf("Tag %s is set\n", tag)
+    } else {
+        log.Printf("Tag %s is not set\n", tag)
+    }
 */
 package tags

--- a/openstack/compute/v2/extensions/tags/requests.go
+++ b/openstack/compute/v2/extensions/tags/requests.go
@@ -10,3 +10,12 @@ func List(client *gophercloud.ServiceClient, serverID string) (r ListResult) {
 	})
 	return
 }
+
+// Check if a tag exists on a server.
+func Check(client *gophercloud.ServiceClient, serverID, tag string) (r CheckResult) {
+	url := checkURL(client, serverID, tag)
+	_, r.Err = client.Get(url, nil, &gophercloud.RequestOpts{
+		OkCodes: []int{204},
+	})
+	return
+}

--- a/openstack/compute/v2/extensions/tags/requests.go
+++ b/openstack/compute/v2/extensions/tags/requests.go
@@ -1,0 +1,12 @@
+package tags
+
+import "github.com/gophercloud/gophercloud"
+
+// List all tags on a server.
+func List(client *gophercloud.ServiceClient, serverID string) (r ListResult) {
+	url := listURL(client, serverID)
+	_, r.Err = client.Get(url, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}

--- a/openstack/compute/v2/extensions/tags/results.go
+++ b/openstack/compute/v2/extensions/tags/results.go
@@ -1,0 +1,20 @@
+package tags
+
+import "github.com/gophercloud/gophercloud"
+
+type tagResult struct {
+	gophercloud.Result
+}
+
+// Extract interprets tagResult to return the list of tags
+func (r tagResult) Extract() ([]string, error) {
+	var s struct {
+		Tags []string `json:"tags"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Tags, err
+}
+
+type ListResult struct {
+	tagResult
+}

--- a/openstack/compute/v2/extensions/tags/results.go
+++ b/openstack/compute/v2/extensions/tags/results.go
@@ -2,12 +2,12 @@ package tags
 
 import "github.com/gophercloud/gophercloud"
 
-type tagResult struct {
+type commonResult struct {
 	gophercloud.Result
 }
 
-// Extract interprets tagResult to return the list of tags
-func (r tagResult) Extract() ([]string, error) {
+// Extract is a function that accepts a result and extracts a tags resource.
+func (r commonResult) Extract() ([]string, error) {
 	var s struct {
 		Tags []string `json:"tags"`
 	}
@@ -16,5 +16,22 @@ func (r tagResult) Extract() ([]string, error) {
 }
 
 type ListResult struct {
-	tagResult
+	commonResult
+}
+
+// CheckResult is the result from the Check operation.
+type CheckResult struct {
+	gophercloud.Result
+}
+
+func (r CheckResult) Extract() (bool, error) {
+	exists := r.Err == nil
+
+	if r.Err != nil {
+		if _, ok := r.Err.(gophercloud.ErrDefault404); ok {
+			r.Err = nil
+		}
+	}
+
+	return exists, r.Err
 }

--- a/openstack/compute/v2/extensions/tags/testing/doc.go
+++ b/openstack/compute/v2/extensions/tags/testing/doc.go
@@ -1,0 +1,2 @@
+// tags unit tests
+package testing

--- a/openstack/compute/v2/extensions/tags/testing/fixtures.go
+++ b/openstack/compute/v2/extensions/tags/testing/fixtures.go
@@ -1,0 +1,8 @@
+package testing
+
+// TagsListResponse represents a raw tags response.
+const TagsListResponse = `
+{
+    "tags": ["foo", "bar", "baz"]
+}
+`

--- a/openstack/compute/v2/extensions/tags/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/tags/testing/requests_test.go
@@ -1,0 +1,33 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/tags"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func TestList(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/servers/uuid1/tags", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		_, err := fmt.Fprintf(w, TagsListResponse)
+		th.AssertNoErr(t, err)
+	})
+
+	expected := []string{"foo", "bar", "baz"}
+	actual, err := tags.List(client.ServiceClient(), "uuid1").Extract()
+
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expected, actual)
+}

--- a/openstack/compute/v2/extensions/tags/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/tags/testing/requests_test.go
@@ -31,3 +31,37 @@ func TestList(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.AssertDeepEquals(t, expected, actual)
 }
+
+func TestCheckOk(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/servers/uuid1/tags/foo", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	exists, err := tags.Check(client.ServiceClient(), "uuid1", "foo").Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, true, exists)
+}
+
+func TestCheckFail(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/servers/uuid1/tags/bar", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	exists, err := tags.Check(client.ServiceClient(), "uuid1", "bar").Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, false, exists)
+}

--- a/openstack/compute/v2/extensions/tags/urls.go
+++ b/openstack/compute/v2/extensions/tags/urls.go
@@ -1,0 +1,16 @@
+package tags
+
+import "github.com/gophercloud/gophercloud"
+
+const (
+	rootResourcePath = "servers"
+	resourcePath     = "tags"
+)
+
+func rootURL(c *gophercloud.ServiceClient, serverID string) string {
+	return c.ServiceURL(rootResourcePath, serverID, resourcePath)
+}
+
+func listURL(c *gophercloud.ServiceClient, serverID string) string {
+	return rootURL(c, serverID)
+}

--- a/openstack/compute/v2/extensions/tags/urls.go
+++ b/openstack/compute/v2/extensions/tags/urls.go
@@ -11,6 +11,14 @@ func rootURL(c *gophercloud.ServiceClient, serverID string) string {
 	return c.ServiceURL(rootResourcePath, serverID, resourcePath)
 }
 
+func resourceURL(c *gophercloud.ServiceClient, serverID, tag string) string {
+	return c.ServiceURL(rootResourcePath, serverID, resourcePath, tag)
+}
+
 func listURL(c *gophercloud.ServiceClient, serverID string) string {
 	return rootURL(c, serverID)
+}
+
+func checkURL(c *gophercloud.ServiceClient, serverID, tag string) string {
+	return resourceURL(c, serverID, tag)
 }


### PR DESCRIPTION
Add Check method for tags extension.
Update docs and inline comments.

Provide unit tests.

For #1669

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/nova/blob/stable/stein/nova/api/openstack/compute/server_tags.py#L66
https://github.com/openstack/nova/blob/stable/stein/nova/objects/tag.py#L50
