### PR TITLE
 [Octavia][Loadbalancers] updated_at/created_at fields

### DIFF
--- a/openstack/loadbalancer/v2/loadbalancers/results.go
+++ b/openstack/loadbalancer/v2/loadbalancers/results.go
@@ -1,6 +1,9 @@
 package loadbalancers
 
 import (
+	"encoding/json"
+	"time"
+
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/listeners"
 	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/pools"
@@ -20,6 +23,11 @@ type LoadBalancer struct {
 
 	// Owner of the LoadBalancer.
 	ProjectID string `json:"project_id"`
+
+	// UpdatedAt and CreatedAt contain ISO-8601 timestamps of when the state of the
+	// loadbalancer last changed, and when it was created.
+	UpdatedAt time.Time `json:"-"`
+	CreatedAt time.Time `json:"-"`
 
 	// The provisioning status of the LoadBalancer.
 	// This value is ACTIVE, PENDING_CREATE or ERROR.
@@ -63,6 +71,44 @@ type LoadBalancer struct {
 	// Tags is a list of resource tags. Tags are arbitrarily defined strings
 	// attached to the resource.
 	Tags []string `json:"tags"`
+}
+
+func (r *LoadBalancer) UnmarshalJSON(b []byte) error {
+	type tmp LoadBalancer
+
+	// Support for older neutron time format
+	var s1 struct {
+		tmp
+		CreatedAt gophercloud.JSONRFC3339NoZ `json:"created_at"`
+		UpdatedAt gophercloud.JSONRFC3339NoZ `json:"updated_at"`
+	}
+
+	err := json.Unmarshal(b, &s1)
+	if err == nil {
+		*r = LoadBalancer(s1.tmp)
+		r.CreatedAt = time.Time(s1.CreatedAt)
+		r.UpdatedAt = time.Time(s1.UpdatedAt)
+
+		return nil
+	}
+
+	// Support for newer neutron time format
+	var s2 struct {
+		tmp
+		CreatedAt time.Time `json:"created_at"`
+		UpdatedAt time.Time `json:"updated_at"`
+	}
+
+	err = json.Unmarshal(b, &s2)
+	if err != nil {
+		return err
+	}
+
+	*r = LoadBalancer(s2.tmp)
+	r.CreatedAt = time.Time(s2.CreatedAt)
+	r.UpdatedAt = time.Time(s2.UpdatedAt)
+
+	return nil
 }
 
 // StatusTree represents the status of a loadbalancer.

--- a/openstack/loadbalancer/v2/loadbalancers/testing/fixtures.go
+++ b/openstack/loadbalancer/v2/loadbalancers/testing/fixtures.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/listeners"
 	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/loadbalancers"
@@ -20,6 +21,8 @@ const LoadbalancersListBody = `
 	         {
 			"id": "c331058c-6a40-4144-948e-b9fb1df9db4b",
 			"project_id": "54030507-44f7-473c-9342-b4d14a95f692",
+			"created_at": "2019-06-30T04:15:37",
+			"updated_at": "2019-06-30T05:18:49",
 			"name": "web_lb",
 			"description": "lb config for the web tier",
 			"vip_subnet_id": "8a49c438-848f-467b-9655-ea1548708154",
@@ -35,6 +38,8 @@ const LoadbalancersListBody = `
 		{
 			"id": "36e08a3e-a78f-4b40-a229-1e7e23eee1ab",
 			"project_id": "54030507-44f7-473c-9342-b4d14a95f692",
+			"created_at": "2019-06-30T04:15:37",
+			"updated_at": "2019-06-30T05:18:49",
 			"name": "db_lb",
 			"description": "lb config for the db tier",
 			"vip_subnet_id": "9cedb85d-0759-4898-8a4b-fa5a5ea10086",
@@ -57,6 +62,8 @@ const SingleLoadbalancerBody = `
 	"loadbalancer": {
 		"id": "36e08a3e-a78f-4b40-a229-1e7e23eee1ab",
 		"project_id": "54030507-44f7-473c-9342-b4d14a95f692",
+		"created_at": "2019-06-30T04:15:37",
+		"updated_at": "2019-06-30T05:18:49",
 		"name": "db_lb",
 		"description": "lb config for the db tier",
 		"vip_subnet_id": "9cedb85d-0759-4898-8a4b-fa5a5ea10086",
@@ -78,6 +85,8 @@ const PostUpdateLoadbalancerBody = `
 	"loadbalancer": {
 		"id": "36e08a3e-a78f-4b40-a229-1e7e23eee1ab",
 		"project_id": "54030507-44f7-473c-9342-b4d14a95f692",
+		"created_at": "2019-06-30T04:15:37",
+		"updated_at": "2019-06-30T05:18:49",
 		"name": "NewLoadbalancerName",
 		"description": "lb config for the db tier",
 		"vip_subnet_id": "9cedb85d-0759-4898-8a4b-fa5a5ea10086",
@@ -143,10 +152,15 @@ const GetLoadbalancerStatsBody = `
 }
 `
 
+var createdTime, _ = time.Parse(time.RFC3339, "2019-06-30T04:15:37Z")
+var updatedTime, _ = time.Parse(time.RFC3339, "2019-06-30T05:18:49Z")
+
 var (
 	LoadbalancerWeb = loadbalancers.LoadBalancer{
 		ID:                 "c331058c-6a40-4144-948e-b9fb1df9db4b",
 		ProjectID:          "54030507-44f7-473c-9342-b4d14a95f692",
+		CreatedAt:          createdTime,
+		UpdatedAt:          updatedTime,
 		Name:               "web_lb",
 		Description:        "lb config for the web tier",
 		VipSubnetID:        "8a49c438-848f-467b-9655-ea1548708154",
@@ -162,6 +176,8 @@ var (
 	LoadbalancerDb = loadbalancers.LoadBalancer{
 		ID:                 "36e08a3e-a78f-4b40-a229-1e7e23eee1ab",
 		ProjectID:          "54030507-44f7-473c-9342-b4d14a95f692",
+		CreatedAt:          createdTime,
+		UpdatedAt:          updatedTime,
 		Name:               "db_lb",
 		Description:        "lb config for the db tier",
 		VipSubnetID:        "9cedb85d-0759-4898-8a4b-fa5a5ea10086",
@@ -177,6 +193,8 @@ var (
 	LoadbalancerUpdated = loadbalancers.LoadBalancer{
 		ID:                 "36e08a3e-a78f-4b40-a229-1e7e23eee1ab",
 		ProjectID:          "54030507-44f7-473c-9342-b4d14a95f692",
+		CreatedAt:          createdTime,
+		UpdatedAt:          updatedTime,
 		Name:               "NewLoadbalancerName",
 		Description:        "lb config for the db tier",
 		VipSubnetID:        "9cedb85d-0759-4898-8a4b-fa5a5ea10086",


### PR DESCRIPTION
for: #1680

time.Time object
mapped to existing json fields

General API reference:https://docs.openstack.org/api-ref/load-balancer/v2/index.html?expanded=show-load-balancer-details-detail#show-load-balancer-details

that fields defined in:
https://github.com/openstack/octavia/blob/22df2e0f484b3560cbb47d33b7f2f62cb57519fd/octavia/api/v2/types/load_balancer.py#L46