### PR TITLE
Fix InterfaceType enums

### DIFF
--- a/openstack/baremetal/v1/nodes/requests.go
+++ b/openstack/baremetal/v1/nodes/requests.go
@@ -523,9 +523,9 @@ const (
 type InterfaceType string
 
 const (
-	SATA DiskType = "sata"
-	SCSI DiskType = "scsi"
-	SAS  DiskType = "sas"
+	SATA InterfaceType = "sata"
+	SCSI InterfaceType = "scsi"
+	SAS  InterfaceType = "sas"
 )
 
 type LogicalDisk struct {


### PR DESCRIPTION
This PR aims to change the type of InterfaceType's enums from `DiskType` to `InterfaceType` to solve issue #1684

Signed-off-by: Kim Bao Long <longkb@vn.fujitsu.com>
