### PR TITLE
Network v2: add listDHCPNetworks for agents extension

### DIFF
--- a/openstack/networking/v2/extensions/agents/requests.go
+++ b/openstack/networking/v2/extensions/agents/requests.go
@@ -64,3 +64,10 @@ func Get(c *gophercloud.ServiceClient, id string) (r GetResult) {
 	_, r.Err = c.Get(getURL(c, id), &r.Body, nil)
 	return
 }
+
+// ListDHCPNetworks returns a list of networks scheduled to a specific
+// dhcp agent
+func ListDHCPNetworks(c *gophercloud.ServiceClient, id string) (r ListDHCPNetworksResult) {
+	_, r.Err = c.Get(listDHCPNetworksURL(c, id), &r.Body, nil)
+	return
+}

--- a/openstack/networking/v2/extensions/agents/results.go
+++ b/openstack/networking/v2/extensions/agents/results.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
 	"github.com/gophercloud/gophercloud/pagination"
 )
 
@@ -125,4 +126,20 @@ func ExtractAgents(r pagination.Page) ([]Agent, error) {
 	}
 	err := (r.(AgentPage)).ExtractInto(&s)
 	return s.Agents, err
+}
+
+// ListDHCPNetworksResult is the response from a List operation.
+// Call its Extract method to interpret it as networks.
+type ListDHCPNetworksResult struct {
+	gophercloud.Result
+}
+
+// Extract interprets any ListDHCPNetworksResult as an array of networks.
+func (r ListDHCPNetworksResult) Extract() ([]networks.Network, error) {
+	var s struct {
+		Networks []networks.Network `json:"networks"`
+	}
+
+	err := r.ExtractInto(&s)
+	return s.Networks, err
 }

--- a/openstack/networking/v2/extensions/agents/testing/fixtures.go
+++ b/openstack/networking/v2/extensions/agents/testing/fixtures.go
@@ -123,3 +123,41 @@ const AgentsGetResult = `
     }
 }
 `
+
+// AgentDHCPNetworksListResult represents raw response for the ListDHCPNetworks request.
+const AgentDHCPNetworksListResult = `
+{
+    "networks": [
+        {
+            "admin_state_up": true,
+            "availability_zone_hints": [],
+            "availability_zones": [
+                "nova"
+            ],
+            "created_at": "2016-03-08T20:19:41",
+            "dns_domain": "my-domain.org.",
+            "id": "d32019d3-bc6e-4319-9c1d-6722fc136a22",
+            "ipv4_address_scope": null,
+            "ipv6_address_scope": null,
+            "l2_adjacency": false,
+            "mtu": 1500,
+            "name": "net1",
+            "port_security_enabled": true,
+            "project_id": "4fd44f30292945e481c7b8a0c8908869",
+            "qos_policy_id": "6a8454ade84346f59e8d40665f878b2e",
+            "revision_number": 1,
+            "router:external": false,
+            "shared": false,
+            "status": "ACTIVE",
+            "subnets": [
+                "54d6f61d-db07-451c-9ab3-b9609b6b6f0b"
+            ],
+            "tenant_id": "4fd44f30292945e481c7b8a0c8908869",
+            "updated_at": "2016-03-08T20:19:41",
+            "vlan_transparent": true,
+            "description": "",
+            "is_default": false
+        }
+    ]
+}
+`

--- a/openstack/networking/v2/extensions/agents/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/agents/testing/requests_test.go
@@ -88,3 +88,35 @@ func TestGet(t *testing.T) {
 		"enable_distributed_routing": false,
 	})
 }
+
+func TestListDHCPNetworks(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/agents/43583cf5-472e-4dc8-af5b-6aed4c94ee3a/dhcp-networks", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, AgentDHCPNetworksListResult)
+	})
+
+	s, err := agents.ListDHCPNetworks(fake.ServiceClient(), "43583cf5-472e-4dc8-af5b-6aed4c94ee3a").Extract()
+	th.AssertNoErr(t, err)
+
+	var nilSlice []string
+	th.AssertEquals(t, len(s), 1)
+	th.AssertEquals(t, s[0].ID, "d32019d3-bc6e-4319-9c1d-6722fc136a22")
+	th.AssertEquals(t, s[0].AdminStateUp, true)
+	th.AssertEquals(t, s[0].ProjectID, "4fd44f30292945e481c7b8a0c8908869")
+	th.AssertEquals(t, s[0].Shared, false)
+	th.AssertEquals(t, s[0].Name, "net1")
+	th.AssertEquals(t, s[0].Status, "ACTIVE")
+	th.AssertDeepEquals(t, s[0].Tags, nilSlice)
+	th.AssertEquals(t, s[0].TenantID, "4fd44f30292945e481c7b8a0c8908869")
+	th.AssertDeepEquals(t, s[0].AvailabilityZoneHints, []string{})
+	th.AssertDeepEquals(t, s[0].Subnets, []string{"54d6f61d-db07-451c-9ab3-b9609b6b6f0b"})
+
+}

--- a/openstack/networking/v2/extensions/agents/urls.go
+++ b/openstack/networking/v2/extensions/agents/urls.go
@@ -3,6 +3,7 @@ package agents
 import "github.com/gophercloud/gophercloud"
 
 const resourcePath = "agents"
+const dhcpNetworksResourcePath = "dhcp-networks"
 
 func resourceURL(c *gophercloud.ServiceClient, id string) string {
 	return c.ServiceURL(resourcePath, id)
@@ -18,4 +19,12 @@ func listURL(c *gophercloud.ServiceClient) string {
 
 func getURL(c *gophercloud.ServiceClient, id string) string {
 	return resourceURL(c, id)
+}
+
+func dhcpNetworksURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL(resourcePath, id, dhcpNetworksResourcePath)
+}
+
+func listDHCPNetworksURL(c *gophercloud.ServiceClient, id string) string {
+	return dhcpNetworksURL(c, id)
 }


### PR DESCRIPTION
this add the listDHCPNetworks call for agents, enabling them
to fetch a list of networks scheduled to a specific agent.

Prior to starting a PR, please make sure you have read our
[contributor tutorial](https://github.com/gophercloud/gophercloud/tree/master/docs/contributor-tutorial).

Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

For #1389

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:
https://github.com/openstack/neutron/blob/76754e06f56a7a9e4c23bef6a6e0e340e4110fa8/neutron/db/agentschedulers_db.py#L433-L443
https://docs.openstack.org/api-ref/network/v2/?expanded=list-networks-hosted-by-a-dhcp-agent-detail#list-networks-hosted-by-a-dhcp-agent
