### PR TITLE
Compute v2: Adding VolumeType to bootfromvolume

### DIFF
--- a/openstack/compute/v2/extensions/bootfromvolume/requests.go
+++ b/openstack/compute/v2/extensions/bootfromvolume/requests.go
@@ -75,6 +75,10 @@ type BlockDevice struct {
 	// DiskBus is the bus type of the block devices.
 	// Examples of this are ide, usb, virtio, scsi, etc.
 	DiskBus string `json:"disk_bus,omitempty"`
+
+	// VolumeType is the volume type of the block device.
+	// This requires Compute API microversion 2.67 or later.
+	VolumeType string `json:"volume_type,omitempty"`
 }
 
 // CreateOptsExt is a structure that extends the server `CreateOpts` structure

--- a/openstack/compute/v2/extensions/bootfromvolume/testing/fixtures.go
+++ b/openstack/compute/v2/extensions/bootfromvolume/testing/fixtures.go
@@ -273,3 +273,38 @@ var ImageAndExistingVolumeRequest = bootfromvolume.CreateOptsExt{
 		},
 	},
 }
+
+const ExpectedNewVolumeTypeRequest = `
+{
+	"server": {
+		"name":"createdserver",
+		"flavorRef":"performance1-1",
+		"imageRef":"",
+		"block_device_mapping_v2":[
+			{
+				"uuid":"123456",
+				"source_type":"image",
+				"destination_type":"volume",
+				"boot_index": 0,
+				"delete_on_termination": true,
+				"volume_size": 10,
+				"volume_type": "ssd"
+			}
+		]
+	}
+}
+`
+
+var NewVolumeTypeRequest = bootfromvolume.CreateOptsExt{
+	CreateOptsBuilder: BaseCreateOpts,
+	BlockDevice: []bootfromvolume.BlockDevice{
+		{
+			UUID:                "123456",
+			SourceType:          bootfromvolume.SourceImage,
+			DestinationType:     bootfromvolume.DestinationVolume,
+			VolumeSize:          10,
+			DeleteOnTermination: true,
+			VolumeType:          "ssd",
+		},
+	},
+}

--- a/openstack/compute/v2/extensions/bootfromvolume/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/bootfromvolume/testing/requests_test.go
@@ -7,7 +7,6 @@ import (
 )
 
 func TestBootFromNewVolume(t *testing.T) {
-
 	actual, err := NewVolumeRequest.ToServerCreateMap()
 	th.AssertNoErr(t, err)
 	th.CheckJSONEquals(t, ExpectedNewVolumeRequest, actual)
@@ -41,4 +40,10 @@ func TestAttachExistingVolume(t *testing.T) {
 	actual, err := ImageAndExistingVolumeRequest.ToServerCreateMap()
 	th.AssertNoErr(t, err)
 	th.CheckJSONEquals(t, ExpectedImageAndExistingVolumeRequest, actual)
+}
+
+func TestBootFromNewVolumeType(t *testing.T) {
+	actual, err := NewVolumeTypeRequest.ToServerCreateMap()
+	th.AssertNoErr(t, err)
+	th.CheckJSONEquals(t, ExpectedNewVolumeTypeRequest, actual)
 }


### PR DESCRIPTION
For #1689 

* https://github.com/openstack/nova/blob/324db786c86eeb69278736c8e9db6d22f68080e6/nova/objects/block_device.py#L96
* https://github.com/openstack/nova/blob/c883f2201026b9237a1fba9a0a55ff607d57e787/nova/block_device.py#L44-L48
* https://github.com/openstack/nova/blob/b879f1b6dfe285c143dfee41dbb0c8d697a775b4/nova/api/openstack/compute/schemas/servers.py#L354-L356