### PR TITLE
[Compute] AvailabilityZone field in server response

### DIFF
--- a/openstack/compute/v2/servers/results.go
+++ b/openstack/compute/v2/servers/results.go
@@ -152,6 +152,9 @@ type Server struct {
 	// TenantID identifies the tenant owning this server resource.
 	TenantID string `json:"tenant_id"`
 
+	// AvailabilityZone identifies the availability zone name where resource located.
+	AvailabilityZone string `json:"OS-EXT-AZ:availability_zone"`
+
 	// UserID uniquely identifies the user account owning the tenant.
 	UserID string `json:"user_id"`
 


### PR DESCRIPTION
for #1692
mapped to existing json field

* General API reference:https://docs.openstack.org/api-ref/compute/?expanded=list-all-metadata-detail,show-server-details-detail#show-server-details

* that field defined in:
https://github.com/openstack/nova/blob/38cd8d3cd712e205722bb77639a5a1b08d167e4a/api-ref/source/parameters.yaml#L5041
