### PR TITLE
Compute V2: implement Add method for Tags

### DIFF
--- a/openstack/compute/v2/extensions/tags/doc.go
+++ b/openstack/compute/v2/extensions/tags/doc.go
@@ -14,7 +14,7 @@ Example to List all server Tags
 
     fmt.Printf("Tags: %v\n", serverTags)
 
-Example to Check if the specific Tag exists on a server.
+Example to Check if the specific Tag exists on a server
 
     client.Microversion = "2.62"
 
@@ -28,5 +28,16 @@ Example to Check if the specific Tag exists on a server.
     } else {
         log.Printf("Tag %s is not set\n", tag)
     }
+
+Example to Replace all Tags on a server
+
+    client.Microversion = "2.62"
+
+    newTags, err := tags.Replace(client, serverID, tags. tags.ReplaceOpts{Tags: []string{"foo", "bar"}}).Extract()
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    fmt.Printf("New tags: %v\n", newTags)
 */
 package tags

--- a/openstack/compute/v2/extensions/tags/doc.go
+++ b/openstack/compute/v2/extensions/tags/doc.go
@@ -33,11 +33,20 @@ Example to Replace all Tags on a server
 
     client.Microversion = "2.62"
 
-    newTags, err := tags.ReplaceAll(client, serverID, tags. tags.ReplaceAllOpts{Tags: []string{"foo", "bar"}}).Extract()
+    newTags, err := tags.ReplaceAll(client, serverID, tags.ReplaceAllOpts{Tags: []string{"foo", "bar"}}).Extract()
     if err != nil {
         log.Fatal(err)
     }
 
     fmt.Printf("New tags: %v\n", newTags)
+
+Example to Add a new Tag on a server
+
+    client.Microversion = "2.62"
+
+    err := tags.Add(client, serverID, "foo").ExtractErr()
+    if err != nil {
+        log.Fatal(err)
+    }
 */
 package tags

--- a/openstack/compute/v2/extensions/tags/doc.go
+++ b/openstack/compute/v2/extensions/tags/doc.go
@@ -33,7 +33,7 @@ Example to Replace all Tags on a server
 
     client.Microversion = "2.62"
 
-    newTags, err := tags.Replace(client, serverID, tags. tags.ReplaceOpts{Tags: []string{"foo", "bar"}}).Extract()
+    newTags, err := tags.ReplaceAll(client, serverID, tags. tags.ReplaceAllOpts{Tags: []string{"foo", "bar"}}).Extract()
     if err != nil {
         log.Fatal(err)
     }

--- a/openstack/compute/v2/extensions/tags/requests.go
+++ b/openstack/compute/v2/extensions/tags/requests.go
@@ -35,7 +35,7 @@ func (opts ReplaceAllOpts) ToTagsReplaceAllMap() (map[string]interface{}, error)
 	return gophercloud.BuildRequestBody(opts, "")
 }
 
-// ReplaceAll replaces all tags on a server.
+// ReplaceAll replaces all Tags on a server.
 func ReplaceAll(client *gophercloud.ServiceClient, serverID string, opts ReplaceAllOptsBuilder) (r ReplaceAllResult) {
 	b, err := opts.ToTagsReplaceAllMap()
 	url := replaceAllURL(client, serverID)
@@ -45,6 +45,15 @@ func ReplaceAll(client *gophercloud.ServiceClient, serverID string, opts Replace
 	}
 	_, r.Err = client.Put(url, &b, &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{200},
+	})
+	return
+}
+
+// Add adds a new Tag on a server.
+func Add(client *gophercloud.ServiceClient, serverID, tag string) (r AddResult) {
+	url := addURL(client, serverID, tag)
+	_, r.Err = client.Put(url, nil, nil, &gophercloud.RequestOpts{
+		OkCodes: []int{201, 204},
 	})
 	return
 }

--- a/openstack/compute/v2/extensions/tags/requests.go
+++ b/openstack/compute/v2/extensions/tags/requests.go
@@ -20,25 +20,25 @@ func Check(client *gophercloud.ServiceClient, serverID, tag string) (r CheckResu
 	return
 }
 
-// ReplaceOptsBuilder allows to add additional parameters to the Replace request.
-type ReplaceOptsBuilder interface {
-	ToTagsReplaceMap() (map[string]interface{}, error)
+// ReplaceAllOptsBuilder allows to add additional parameters to the ReplaceAll request.
+type ReplaceAllOptsBuilder interface {
+	ToTagsReplaceAllMap() (map[string]interface{}, error)
 }
 
-// ReplaceOpts provides options used to replace Tags on a server.
-type ReplaceOpts struct {
+// ReplaceAllOpts provides options used to replace Tags on a server.
+type ReplaceAllOpts struct {
 	Tags []string `json:"tags" required:"true"`
 }
 
-// ToTagsReplaceMap formats a ReplaceOpts into the body of the replace request.
-func (opts ReplaceOpts) ToTagsReplaceMap() (map[string]interface{}, error) {
+// ToTagsReplaceAllMap formats a ReplaceALlOpts into the body of the ReplaceAll request.
+func (opts ReplaceAllOpts) ToTagsReplaceAllMap() (map[string]interface{}, error) {
 	return gophercloud.BuildRequestBody(opts, "")
 }
 
-// Replace replaces all tags on a server.
-func Replace(client *gophercloud.ServiceClient, serverID string, opts ReplaceOptsBuilder) (r ReplaceResult) {
-	b, err := opts.ToTagsReplaceMap()
-	url := replaceURL(client, serverID)
+// ReplaceAll replaces all tags on a server.
+func ReplaceAll(client *gophercloud.ServiceClient, serverID string, opts ReplaceAllOptsBuilder) (r ReplaceAllResult) {
+	b, err := opts.ToTagsReplaceAllMap()
+	url := replaceAllURL(client, serverID)
 	if err != nil {
 		r.Err = err
 		return

--- a/openstack/compute/v2/extensions/tags/requests.go
+++ b/openstack/compute/v2/extensions/tags/requests.go
@@ -19,3 +19,32 @@ func Check(client *gophercloud.ServiceClient, serverID, tag string) (r CheckResu
 	})
 	return
 }
+
+// ReplaceOptsBuilder allows to add additional parameters to the Replace request.
+type ReplaceOptsBuilder interface {
+	ToTagsReplaceMap() (map[string]interface{}, error)
+}
+
+// ReplaceOpts provides options used to replace Tags on a server.
+type ReplaceOpts struct {
+	Tags []string `json:"tags" required:"true"`
+}
+
+// ToTagsReplaceMap formats a ReplaceOpts into the body of the replace request.
+func (opts ReplaceOpts) ToTagsReplaceMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "")
+}
+
+// Replace replaces all tags on a server.
+func Replace(client *gophercloud.ServiceClient, serverID string, opts ReplaceOptsBuilder) (r ReplaceResult) {
+	b, err := opts.ToTagsReplaceMap()
+	url := replaceURL(client, serverID)
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Put(url, &b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}

--- a/openstack/compute/v2/extensions/tags/results.go
+++ b/openstack/compute/v2/extensions/tags/results.go
@@ -35,3 +35,8 @@ func (r CheckResult) Extract() (bool, error) {
 
 	return exists, r.Err
 }
+
+// ReplaceResult is the result from the Replace operation.
+type ReplaceResult struct {
+	commonResult
+}

--- a/openstack/compute/v2/extensions/tags/results.go
+++ b/openstack/compute/v2/extensions/tags/results.go
@@ -40,3 +40,8 @@ func (r CheckResult) Extract() (bool, error) {
 type ReplaceAllResult struct {
 	commonResult
 }
+
+// AddResult is the result from the Add operation.
+type AddResult struct {
+	gophercloud.ErrResult
+}

--- a/openstack/compute/v2/extensions/tags/results.go
+++ b/openstack/compute/v2/extensions/tags/results.go
@@ -36,7 +36,7 @@ func (r CheckResult) Extract() (bool, error) {
 	return exists, r.Err
 }
 
-// ReplaceResult is the result from the Replace operation.
-type ReplaceResult struct {
+// ReplaceAllResult is the result from the ReplaceAll operation.
+type ReplaceAllResult struct {
 	commonResult
 }

--- a/openstack/compute/v2/extensions/tags/testing/fixtures.go
+++ b/openstack/compute/v2/extensions/tags/testing/fixtures.go
@@ -7,15 +7,15 @@ const TagsListResponse = `
 }
 `
 
-// TagsReplaceRequest represents a raw tags Replace request.
-const TagsReplaceRequest = `
+// TagsReplaceAllRequest represents a raw tags Replace request.
+const TagsReplaceAllRequest = `
 {
     "tags": ["tag1", "tag2", "tag3"]
 }
 `
 
-// TagsReplaceResponse represents a raw tags Replace response.
-const TagsReplaceResponse = `
+// TagsReplaceAllResponse represents a raw tags Replace response.
+const TagsReplaceAllResponse = `
 {
     "tags": ["tag1", "tag2", "tag3"]
 }

--- a/openstack/compute/v2/extensions/tags/testing/fixtures.go
+++ b/openstack/compute/v2/extensions/tags/testing/fixtures.go
@@ -6,3 +6,17 @@ const TagsListResponse = `
     "tags": ["foo", "bar", "baz"]
 }
 `
+
+// TagsReplaceRequest represents a raw tags Replace request.
+const TagsReplaceRequest = `
+{
+    "tags": ["tag1", "tag2", "tag3"]
+}
+`
+
+// TagsReplaceResponse represents a raw tags Replace response.
+const TagsReplaceResponse = `
+{
+    "tags": ["tag1", "tag2", "tag3"]
+}
+`

--- a/openstack/compute/v2/extensions/tags/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/tags/testing/requests_test.go
@@ -66,7 +66,7 @@ func TestCheckFail(t *testing.T) {
 	th.AssertEquals(t, false, exists)
 }
 
-func TestReplace(t *testing.T) {
+func TestReplaceAll(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 
@@ -77,12 +77,12 @@ func TestReplace(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		_, err := fmt.Fprintf(w, TagsReplaceResponse)
+		_, err := fmt.Fprintf(w, TagsReplaceAllResponse)
 		th.AssertNoErr(t, err)
 	})
 
 	expected := []string{"tag1", "tag2", "tag3"}
-	actual, err := tags.Replace(client.ServiceClient(), "uuid1", tags.ReplaceOpts{Tags: []string{"tag1", "tag2", "tag3"}}).Extract()
+	actual, err := tags.ReplaceAll(client.ServiceClient(), "uuid1", tags.ReplaceAllOpts{Tags: []string{"tag1", "tag2", "tag3"}}).Extract()
 
 	th.AssertNoErr(t, err)
 	th.AssertDeepEquals(t, expected, actual)

--- a/openstack/compute/v2/extensions/tags/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/tags/testing/requests_test.go
@@ -87,3 +87,35 @@ func TestReplaceAll(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.AssertDeepEquals(t, expected, actual)
 }
+
+func TestAddCreated(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/servers/uuid1/tags/foo", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+	})
+
+	err := tags.Add(client.ServiceClient(), "uuid1", "foo").ExtractErr()
+	th.AssertNoErr(t, err)
+}
+
+func TestAddExists(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/servers/uuid1/tags/foo", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	err := tags.Add(client.ServiceClient(), "uuid1", "foo").ExtractErr()
+	th.AssertNoErr(t, err)
+}

--- a/openstack/compute/v2/extensions/tags/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/tags/testing/requests_test.go
@@ -65,3 +65,25 @@ func TestCheckFail(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, false, exists)
 }
+
+func TestReplace(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/servers/uuid1/tags", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		_, err := fmt.Fprintf(w, TagsReplaceResponse)
+		th.AssertNoErr(t, err)
+	})
+
+	expected := []string{"tag1", "tag2", "tag3"}
+	actual, err := tags.Replace(client.ServiceClient(), "uuid1", tags.ReplaceOpts{Tags: []string{"tag1", "tag2", "tag3"}}).Extract()
+
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expected, actual)
+}

--- a/openstack/compute/v2/extensions/tags/urls.go
+++ b/openstack/compute/v2/extensions/tags/urls.go
@@ -23,6 +23,6 @@ func checkURL(c *gophercloud.ServiceClient, serverID, tag string) string {
 	return resourceURL(c, serverID, tag)
 }
 
-func replaceURL(c *gophercloud.ServiceClient, serverID string) string {
+func replaceAllURL(c *gophercloud.ServiceClient, serverID string) string {
 	return rootURL(c, serverID)
 }

--- a/openstack/compute/v2/extensions/tags/urls.go
+++ b/openstack/compute/v2/extensions/tags/urls.go
@@ -26,3 +26,7 @@ func checkURL(c *gophercloud.ServiceClient, serverID, tag string) string {
 func replaceAllURL(c *gophercloud.ServiceClient, serverID string) string {
 	return rootURL(c, serverID)
 }
+
+func addURL(c *gophercloud.ServiceClient, serverID, tag string) string {
+	return resourceURL(c, serverID, tag)
+}

--- a/openstack/compute/v2/extensions/tags/urls.go
+++ b/openstack/compute/v2/extensions/tags/urls.go
@@ -22,3 +22,7 @@ func listURL(c *gophercloud.ServiceClient, serverID string) string {
 func checkURL(c *gophercloud.ServiceClient, serverID, tag string) string {
 	return resourceURL(c, serverID, tag)
 }
+
+func replaceURL(c *gophercloud.ServiceClient, serverID string) string {
+	return rootURL(c, serverID)
+}


### PR DESCRIPTION
Implement compute/v2/extensions/tags.Add.

Update package documentation.

For #1669

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/nova/blob/stable/stein/nova/api/openstack/compute/server_tags.py#L104
https://github.com/openstack/nova/blob/stable/stein/nova/objects/tag.py#L70
