### PR TITLE
Compute V2: add DeleteAll method for Tags

### DIFF
--- a/openstack/compute/v2/extensions/tags/doc.go
+++ b/openstack/compute/v2/extensions/tags/doc.go
@@ -48,5 +48,23 @@ Example to Add a new Tag on a server
     if err != nil {
         log.Fatal(err)
     }
+
+Example to Delete a Tag on a server
+
+    client.Microversion = "2.62"
+
+    err := tags.Delete(client, serverID, "foo").ExtractErr()
+    if err != nil {
+        log.Fatal(err)
+    }
+
+Example to Delete all Tags on a server
+
+    client.Microversion = "2.62"
+
+    err := tags.DeleteAll(client, serverID).ExtractErr()
+    if err != nil {
+        log.Fatal(err)
+    }
 */
 package tags

--- a/openstack/compute/v2/extensions/tags/requests.go
+++ b/openstack/compute/v2/extensions/tags/requests.go
@@ -66,3 +66,12 @@ func Delete(client *gophercloud.ServiceClient, serverID, tag string) (r DeleteRe
 	})
 	return
 }
+
+// DeleteAll removes all tag from a server.
+func DeleteAll(client *gophercloud.ServiceClient, serverID string) (r DeleteResult) {
+	url := deleteAllURL(client, serverID)
+	_, r.Err = client.Delete(url, &gophercloud.RequestOpts{
+		OkCodes: []int{204},
+	})
+	return
+}

--- a/openstack/compute/v2/extensions/tags/requests.go
+++ b/openstack/compute/v2/extensions/tags/requests.go
@@ -57,3 +57,12 @@ func Add(client *gophercloud.ServiceClient, serverID, tag string) (r AddResult) 
 	})
 	return
 }
+
+// Delete removes a tag from a server.
+func Delete(client *gophercloud.ServiceClient, serverID, tag string) (r DeleteResult) {
+	url := deleteURL(client, serverID, tag)
+	_, r.Err = client.Delete(url, &gophercloud.RequestOpts{
+		OkCodes: []int{204},
+	})
+	return
+}

--- a/openstack/compute/v2/extensions/tags/results.go
+++ b/openstack/compute/v2/extensions/tags/results.go
@@ -45,3 +45,8 @@ type ReplaceAllResult struct {
 type AddResult struct {
 	gophercloud.ErrResult
 }
+
+// DeleteResult is the result from the Delete operation.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}

--- a/openstack/compute/v2/extensions/tags/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/tags/testing/requests_test.go
@@ -135,3 +135,19 @@ func TestDelete(t *testing.T) {
 	err := tags.Delete(client.ServiceClient(), "uuid1", "foo").ExtractErr()
 	th.AssertNoErr(t, err)
 }
+
+func TestDeleteAll(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/servers/uuid1/tags", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, http.MethodDelete)
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	err := tags.DeleteAll(client.ServiceClient(), "uuid1").ExtractErr()
+	th.AssertNoErr(t, err)
+}

--- a/openstack/compute/v2/extensions/tags/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/tags/testing/requests_test.go
@@ -15,7 +15,7 @@ func TestList(t *testing.T) {
 	defer th.TeardownHTTP()
 
 	th.Mux.HandleFunc("/servers/uuid1/tags", func(w http.ResponseWriter, r *http.Request) {
-		th.TestMethod(t, r, "GET")
+		th.TestMethod(t, r, http.MethodGet)
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
@@ -37,7 +37,7 @@ func TestCheckOk(t *testing.T) {
 	defer th.TeardownHTTP()
 
 	th.Mux.HandleFunc("/servers/uuid1/tags/foo", func(w http.ResponseWriter, r *http.Request) {
-		th.TestMethod(t, r, "GET")
+		th.TestMethod(t, r, http.MethodGet)
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
@@ -54,7 +54,7 @@ func TestCheckFail(t *testing.T) {
 	defer th.TeardownHTTP()
 
 	th.Mux.HandleFunc("/servers/uuid1/tags/bar", func(w http.ResponseWriter, r *http.Request) {
-		th.TestMethod(t, r, "GET")
+		th.TestMethod(t, r, http.MethodGet)
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
@@ -71,7 +71,7 @@ func TestReplaceAll(t *testing.T) {
 	defer th.TeardownHTTP()
 
 	th.Mux.HandleFunc("/servers/uuid1/tags", func(w http.ResponseWriter, r *http.Request) {
-		th.TestMethod(t, r, "PUT")
+		th.TestMethod(t, r, http.MethodPut)
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
@@ -93,7 +93,7 @@ func TestAddCreated(t *testing.T) {
 	defer th.TeardownHTTP()
 
 	th.Mux.HandleFunc("/servers/uuid1/tags/foo", func(w http.ResponseWriter, r *http.Request) {
-		th.TestMethod(t, r, "PUT")
+		th.TestMethod(t, r, http.MethodPut)
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
@@ -109,7 +109,7 @@ func TestAddExists(t *testing.T) {
 	defer th.TeardownHTTP()
 
 	th.Mux.HandleFunc("/servers/uuid1/tags/foo", func(w http.ResponseWriter, r *http.Request) {
-		th.TestMethod(t, r, "PUT")
+		th.TestMethod(t, r, http.MethodPut)
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
@@ -117,5 +117,21 @@ func TestAddExists(t *testing.T) {
 	})
 
 	err := tags.Add(client.ServiceClient(), "uuid1", "foo").ExtractErr()
+	th.AssertNoErr(t, err)
+}
+
+func TestDelete(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/servers/uuid1/tags/foo", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, http.MethodDelete)
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	err := tags.Delete(client.ServiceClient(), "uuid1", "foo").ExtractErr()
 	th.AssertNoErr(t, err)
 }

--- a/openstack/compute/v2/extensions/tags/urls.go
+++ b/openstack/compute/v2/extensions/tags/urls.go
@@ -34,3 +34,7 @@ func addURL(c *gophercloud.ServiceClient, serverID, tag string) string {
 func deleteURL(c *gophercloud.ServiceClient, serverID, tag string) string {
 	return resourceURL(c, serverID, tag)
 }
+
+func deleteAllURL(c *gophercloud.ServiceClient, serverID string) string {
+	return rootURL(c, serverID)
+}

--- a/openstack/compute/v2/extensions/tags/urls.go
+++ b/openstack/compute/v2/extensions/tags/urls.go
@@ -30,3 +30,7 @@ func replaceAllURL(c *gophercloud.ServiceClient, serverID string) string {
 func addURL(c *gophercloud.ServiceClient, serverID, tag string) string {
 	return resourceURL(c, serverID, tag)
 }
+
+func deleteURL(c *gophercloud.ServiceClient, serverID, tag string) string {
+	return resourceURL(c, serverID, tag)
+}


### PR DESCRIPTION
Implement compute/v2/extensions/tags.DeleteAll.

Update package documentation.

For #1669

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/nova/blob/stable/stein/nova/api/openstack/compute/server_tags.py#L204
