### PR TITLE
Neutron LB listeners V2: use UpdateOptsBuilder

### DIFF
--- a/openstack/networking/v2/extensions/lbaas_v2/listeners/requests.go
+++ b/openstack/networking/v2/extensions/lbaas_v2/listeners/requests.go
@@ -193,7 +193,7 @@ func (opts UpdateOpts) ToListenerUpdateMap() (map[string]interface{}, error) {
 
 // Update is an operation which modifies the attributes of the specified
 // Listener.
-func Update(c *gophercloud.ServiceClient, id string, opts UpdateOpts) (r UpdateResult) {
+func Update(c *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToListenerUpdateMap()
 	if err != nil {
 		r.Err = err


### PR DESCRIPTION
Use the UpdateOptsBuilder instead of the specific UpdateOpts struct
type in extensions/lbaas_v2/listeners/requests.Update.

For #1704
