### PR TITLE
Octavia: Support to query api versions

### DIFF
--- a/openstack/loadbalancer/apiversions/doc.go
+++ b/openstack/loadbalancer/apiversions/doc.go
@@ -1,0 +1,1 @@
+package apiversions

--- a/openstack/loadbalancer/apiversions/requests.go
+++ b/openstack/loadbalancer/apiversions/requests.go
@@ -1,0 +1,13 @@
+package apiversions
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// List lists all the API versions available to end-users.
+func List(c *gophercloud.ServiceClient) pagination.Pager {
+	return pagination.NewPager(c, listURL(c), func(r pagination.PageResult) pagination.Page {
+		return APIVersionPage{pagination.SinglePageBase(r)}
+	})
+}

--- a/openstack/loadbalancer/apiversions/results.go
+++ b/openstack/loadbalancer/apiversions/results.go
@@ -1,0 +1,33 @@
+package apiversions
+
+import (
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// APIVersion represents an API version for Octavia.
+type APIVersion struct {
+	// ID is the unique identifier of the API version.
+	ID string `json:"id"`
+
+	// Status is the API versions status, e.g. CURRENT, SUPPORTED
+	Status string `json:"status"`
+
+	// Updated is the time when the version was added.
+	Updated string `json:"updated"`
+}
+
+// APIVersionPage is the page returned by a pager when traversing over a
+// collection of API versions.
+type APIVersionPage struct {
+	pagination.SinglePageBase
+}
+
+// ExtractAPIVersions takes a collection page, extracts all of the elements,
+// and returns them a slice of APIVersion structs
+func ExtractAPIVersions(r pagination.Page) ([]APIVersion, error) {
+	var s struct {
+		Versions []APIVersion `json:"versions"`
+	}
+	err := (r.(APIVersionPage)).ExtractInto(&s)
+	return s.Versions, err
+}

--- a/openstack/loadbalancer/apiversions/testing/doc.go
+++ b/openstack/loadbalancer/apiversions/testing/doc.go
@@ -1,0 +1,1 @@
+package testing

--- a/openstack/loadbalancer/apiversions/testing/fixtures.go
+++ b/openstack/loadbalancer/apiversions/testing/fixtures.go
@@ -1,0 +1,69 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/loadbalancer/apiversions"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+const OctaviaAllAPIVersionsResponse = `
+{
+    "versions": [
+        {
+            "id": "v2.9",
+            "links": [
+                {
+                    "href": "http://192.168.206.8/load-balancer//v2",
+                    "rel": "self"
+                }
+            ],
+            "status": "SUPPORTED",
+            "updated": "2019-03-04T00:00:00Z"
+        },
+        {
+            "id": "v2.10",
+            "links": [
+                {
+                    "href": "http://192.168.206.8/load-balancer//v2",
+                    "rel": "self"
+                }
+            ],
+            "status": "CURRENT",
+            "updated": "2019-03-05T00:00:00Z"
+        }
+    ]
+}
+`
+
+var APIVersion29 = apiversions.APIVersion{
+	ID:      "v2.9",
+	Status:  "SUPPORTED",
+	Updated: "2019-03-04T00:00:00Z",
+}
+
+var APIVersion210 = apiversions.APIVersion{
+	ID:      "v2.10",
+	Status:  "CURRENT",
+	Updated: "2019-03-05T00:00:00Z",
+}
+
+var APIVersions = []apiversions.APIVersion{
+	APIVersion29,
+	APIVersion210,
+}
+
+func MockListResponse(t *testing.T) {
+	th.Mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, OctaviaAllAPIVersionsResponse)
+	})
+}

--- a/openstack/loadbalancer/apiversions/testing/requests_test.go
+++ b/openstack/loadbalancer/apiversions/testing/requests_test.go
@@ -1,0 +1,23 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/loadbalancer/apiversions"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func TestListAPIVersions(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockListResponse(t)
+
+	allVersions, err := apiversions.List(client.ServiceClient()).AllPages()
+	th.AssertNoErr(t, err)
+
+	actual, err := apiversions.ExtractAPIVersions(allVersions)
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, APIVersions, actual)
+}

--- a/openstack/loadbalancer/apiversions/urls.go
+++ b/openstack/loadbalancer/apiversions/urls.go
@@ -1,0 +1,14 @@
+package apiversions
+
+import (
+	"strings"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/utils"
+)
+
+func listURL(c *gophercloud.ServiceClient) string {
+	baseEndpoint, _ := utils.BaseEndpoint(c.Endpoint)
+	endpoint := strings.TrimRight(baseEndpoint, "/") + "/"
+	return endpoint
+}


### PR DESCRIPTION
For #1707

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

- source code: <https://github.com/openstack/octavia/blob/926179c97dd2f86ad3476a7f63b10ed121d9bed1/octavia/api/root_controller.py#L48>