### PR TITLE
Remove go version from go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,3 @@ require (
 	golang.org/x/sys v0.0.0-20190209173611-3b5209105503 // indirect
 	gopkg.in/yaml.v2 v2.2.2
 )
-
-go 1.13


### PR DESCRIPTION
Remove go version to not break compatibility with old environments.

For #1714