### PR TITLE
Acc Tests: Disabling sharedfilesystem temporarily

### DIFF
--- a/script/acceptancetest
+++ b/script/acceptancetest
@@ -75,7 +75,9 @@ acceptance/openstack/networking/v2/extensions/trunks
 
 acceptance/openstack/objectstorage/v1
 acceptance/openstack/orchestration/v1
-acceptance/openstack/sharedfilesystems/v2
+
+# Disabled temporarily
+#acceptance/openstack/sharedfilesystems/v2
 
 # No suitable endpoint could be found in the service catalog
 # acceptance/openstack/workflow/v2


### PR DESCRIPTION
For https://github.com/theopenlab/openlab/issues/360

I think the OpenLab issue is only affecting Manila/sharedfilesystem. If tests pass, I'll merge this for a temporary fix.