### PR TITLE
loadbalancer: Fix AllowedCIDRs for listener update

### DIFF
--- a/openstack/loadbalancer/v2/listeners/requests.go
+++ b/openstack/loadbalancer/v2/listeners/requests.go
@@ -207,7 +207,7 @@ type UpdateOpts struct {
 	TimeoutTCPInspect *int `json:"timeout_tcp_inspect,omitempty"`
 
 	// A list of IPv4, IPv6 or mix of both CIDRs
-	AllowedCIDRs []string `json:"allowed_cidrs,omitempty"`
+	AllowedCIDRs *[]string `json:"allowed_cidrs,omitempty"`
 }
 
 // ToListenerUpdateMap builds a request body from UpdateOpts.


### PR DESCRIPTION
For #1709

Octavia code: https://github.com/openstack/octavia/blob/master/octavia/api/v2/types/listener.py#L189

When using `*[]string{}`, the `listener.AllowedCIDRs` could be updated to `[]`