### PR TITLE
Add disk/by_path to available introspection data

### DIFF
--- a/openstack/baremetalintrospection/v1/introspection/results.go
+++ b/openstack/baremetalintrospection/v1/introspection/results.go
@@ -234,6 +234,7 @@ type RootDiskType struct {
 	Hctl               string `json:"hctl"`
 	Model              string `json:"model"`
 	Name               string `json:"name"`
+	ByPath             string `json:"by_path"`
 	Rotational         bool   `json:"rotational"`
 	Serial             string `json:"serial"`
 	Size               int    `json:"size"`


### PR DESCRIPTION
Disk by path (e.g. /dev/disk/by-path/pci-0000:00:07.0) is available in
ironic inspector results and may be required by some projects.

Tested and works as expected.

#1733 