### PR TITLE
Compute V2: allow to read Tags from Server body

### DIFF
--- a/acceptance/openstack/compute/v2/servers_test.go
+++ b/acceptance/openstack/compute/v2/servers_test.go
@@ -512,6 +512,21 @@ func TestServersTags(t *testing.T) {
 	th.AssertNoErr(t, err)
 	defer DeleteServer(t, client, server)
 
+	// All the following calls should work with "2.26" microversion.
+	client.Microversion = "2.26"
+
+	// Check server tags in body.
+	type serverWithTagsExt struct {
+		servers.Server
+		tags.ServerTagsExt
+	}
+
+	serverWithTags := serverWithTagsExt{}
+
+	err = servers.Get(client, server.ID).ExtractInto(&serverWithTags)
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, []string{"tag1", "tag2"}, serverWithTags.Tags)
+
 	// Check all tags.
 	allTags, err := tags.List(client, server.ID).Extract()
 	th.AssertNoErr(t, err)

--- a/openstack/compute/v2/extensions/tags/doc.go
+++ b/openstack/compute/v2/extensions/tags/doc.go
@@ -5,7 +5,7 @@ This extension is available since 2.26 Compute V2 API microversion.
 
 Example to List all server Tags
 
-	client.Microversion = "2.62"
+	client.Microversion = "2.26"
 
     serverTags, err := tags.List(client, serverID).Extract()
     if err != nil {
@@ -16,7 +16,7 @@ Example to List all server Tags
 
 Example to Check if the specific Tag exists on a server
 
-    client.Microversion = "2.62"
+    client.Microversion = "2.26"
 
     exists, err := tags.Check(client, serverID, tag).Extract()
     if err != nil {
@@ -31,7 +31,7 @@ Example to Check if the specific Tag exists on a server
 
 Example to Replace all Tags on a server
 
-    client.Microversion = "2.62"
+    client.Microversion = "2.26"
 
     newTags, err := tags.ReplaceAll(client, serverID, tags.ReplaceAllOpts{Tags: []string{"foo", "bar"}}).Extract()
     if err != nil {
@@ -42,7 +42,7 @@ Example to Replace all Tags on a server
 
 Example to Add a new Tag on a server
 
-    client.Microversion = "2.62"
+    client.Microversion = "2.26"
 
     err := tags.Add(client, serverID, "foo").ExtractErr()
     if err != nil {
@@ -51,7 +51,7 @@ Example to Add a new Tag on a server
 
 Example to Delete a Tag on a server
 
-    client.Microversion = "2.62"
+    client.Microversion = "2.26"
 
     err := tags.Delete(client, serverID, "foo").ExtractErr()
     if err != nil {
@@ -60,11 +60,36 @@ Example to Delete a Tag on a server
 
 Example to Delete all Tags on a server
 
-    client.Microversion = "2.62"
+    client.Microversion = "2.26"
 
     err := tags.DeleteAll(client, serverID).ExtractErr()
     if err != nil {
         log.Fatal(err)
+    }
+
+Example of Extend server result with Tags:
+
+    client.Microversion = "2.26"
+
+    type ServerWithTags struct {
+        servers.Server
+        tags.ServerTagsExt
+    }
+
+    var allServers []ServerWithTags
+
+    allPages, err := servers.List(client, nil).AllPages()
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    err = servers.ExtractServersInto(allPages, &allServers)
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    for _, server := range allServers {
+        fmt.Println(server.Tags)
     }
 */
 package tags

--- a/openstack/compute/v2/extensions/tags/results.go
+++ b/openstack/compute/v2/extensions/tags/results.go
@@ -2,6 +2,12 @@ package tags
 
 import "github.com/gophercloud/gophercloud"
 
+// ServerTagsExt is an extension to the base Server object.
+type ServerTagsExt struct {
+	// Tags contains a list of server tags.
+	Tags []string `json:"tags"`
+}
+
 type commonResult struct {
 	gophercloud.Result
 }


### PR DESCRIPTION
Add compute/v2/extensions/tags.ServerTagsExt to allow read tags right
from a Server body.

Fix compute/v2/extensions/tags to use the valid microversion.

Add ServerTagsExt usage example to compute/v2/extensions/tags docs.

Add ServerTagsExt into ServerTags acceptance test.

For #1669

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/nova/blob/stable/stein/nova/api/openstack/compute/servers.py#L353
