### PR TITLE
Networking V2: add quotas package

### DIFF
--- a/acceptance/openstack/networking/v2/extensions/quotas/quotas_test.go
+++ b/acceptance/openstack/networking/v2/extensions/quotas/quotas_test.go
@@ -1,4 +1,5 @@
 // +build acceptance networking quotas
+
 package quotas
 
 import (

--- a/acceptance/openstack/networking/v2/extensions/quotas/quotas_test.go
+++ b/acceptance/openstack/networking/v2/extensions/quotas/quotas_test.go
@@ -1,0 +1,24 @@
+// +build acceptance networking quotas
+package quotas
+
+import (
+	"os"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/acceptance/clients"
+	"github.com/gophercloud/gophercloud/acceptance/tools"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/quotas"
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestQuotasGet(t *testing.T) {
+	clients.RequireAdmin(t)
+
+	client, err := clients.NewNetworkV2Client()
+	th.AssertNoErr(t, err)
+
+	quotasInfo, err := quotas.Get(client, os.Getenv("OS_PROJECT_NAME")).Extract()
+	th.AssertNoErr(t, err)
+
+	tools.PrintResource(t, quotasInfo)
+}

--- a/openstack/networking/v2/extensions/quotas/doc.go
+++ b/openstack/networking/v2/extensions/quotas/doc.go
@@ -1,0 +1,12 @@
+/*
+Package quotas provides the ability to retrieve and manage Networking quotas through the Neutron API.
+
+Example to Get project quotas
+
+    projectID = "23d5d3f79dfa4f73b72b8b0b0063ec55"
+    quotasInfo, err := quotas.Get(networkClient, projectID).Extract()
+    if err != nil {
+        log.Fatal(err)
+    }
+*/
+package quotas

--- a/openstack/networking/v2/extensions/quotas/requests.go
+++ b/openstack/networking/v2/extensions/quotas/requests.go
@@ -1,0 +1,9 @@
+package quotas
+
+import "github.com/gophercloud/gophercloud"
+
+// Get returns Networking Quotas for a project.
+func Get(client *gophercloud.ServiceClient, projectID string) (r GetResult) {
+	_, r.Err = client.Get(getURL(client, projectID), &r.Body, nil)
+	return
+}

--- a/openstack/networking/v2/extensions/quotas/results.go
+++ b/openstack/networking/v2/extensions/quotas/results.go
@@ -1,0 +1,52 @@
+package quotas
+
+import "github.com/gophercloud/gophercloud"
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// Extract is a function that accepts a result and extracts a Quota resource.
+func (r commonResult) Extract() (*Quota, error) {
+	var s struct {
+		Quota *Quota `json:"quota"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Quota, err
+}
+
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a Quota.
+type GetResult struct {
+	commonResult
+}
+
+// Quota contains Networking quotas for a project.
+type Quota struct {
+	// FloatingIP represents a number of floating IPs. A "-1" value means no limit.
+	FloatingIP int `json:"floatingip"`
+
+	// Network represents a number of networks. A "-1" value means no limit.
+	Network int `json:"network"`
+
+	// Port represents a number of ports. A "-1" value means no limit.
+	Port int `json:"port"`
+
+	// RBACPolicy represents a number of RBAC policies. A "-1" value means no limit.
+	RBACPolicy int `json:"rbac_policy"`
+
+	// Router represents a number of routers. A "-1" value means no limit.
+	Router int `json:"router"`
+
+	// SecurityGroup represents a number of security groups. A "-1" value means no limit.
+	SecurityGroup int `json:"security_group"`
+
+	// SecurityGroupRule represents a number of security group rules. A "-1" value means no limit.
+	SecurityGroupRule int `json:"security_group_rule"`
+
+	// Subnet represents a number of subnets. A "-1" value means no limit.
+	Subnet int `json:"subnet"`
+
+	// SubnetPool represents a number of subnet pools. A "-1" value means no limit.
+	SubnetPool int `json:"subnetpool"`
+}

--- a/openstack/networking/v2/extensions/quotas/testing/doc.go
+++ b/openstack/networking/v2/extensions/quotas/testing/doc.go
@@ -1,0 +1,2 @@
+// quotas unit tests
+package testing

--- a/openstack/networking/v2/extensions/quotas/testing/fixtures.go
+++ b/openstack/networking/v2/extensions/quotas/testing/fixtures.go
@@ -1,0 +1,31 @@
+package testing
+
+import "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/quotas"
+
+const GetResponseRaw = `
+{
+    "quota": {
+        "floatingip": 15,
+        "network": 20,
+        "port": 25,
+        "rbac_policy": -1,
+        "router": 30,
+        "security_group": 35,
+        "security_group_rule": 40,
+        "subnet": 45,
+        "subnetpool": -1
+    }
+}
+`
+
+var GetResponse = quotas.Quota{
+	FloatingIP:        15,
+	Network:           20,
+	Port:              25,
+	RBACPolicy:        -1,
+	Router:            30,
+	SecurityGroup:     35,
+	SecurityGroupRule: 40,
+	Subnet:            45,
+	SubnetPool:        -1,
+}

--- a/openstack/networking/v2/extensions/quotas/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/quotas/testing/requests_test.go
@@ -1,0 +1,30 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	fake "github.com/gophercloud/gophercloud/openstack/networking/v2/common"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/quotas"
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestGet(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/quotas/0a73845280574ad389c292f6a74afa76", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, GetResponseRaw)
+	})
+
+	q, err := quotas.Get(fake.ServiceClient(), "0a73845280574ad389c292f6a74afa76").Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, q, &GetResponse)
+}

--- a/openstack/networking/v2/extensions/quotas/urls.go
+++ b/openstack/networking/v2/extensions/quotas/urls.go
@@ -1,0 +1,9 @@
+package quotas
+
+import "github.com/gophercloud/gophercloud"
+
+const resourcePath = "quotas"
+
+func getURL(c *gophercloud.ServiceClient, projectID string) string {
+	return c.ServiceURL(resourcePath, projectID)
+}

--- a/script/acceptancetest
+++ b/script/acceptancetest
@@ -66,6 +66,7 @@ acceptance/openstack/networking/v2/extensions/portsbinding
 acceptance/openstack/networking/v2/extensions/qos/policies
 acceptance/openstack/networking/v2/extensions/qos/rules
 acceptance/openstack/networking/v2/extensions/qos/ruletypes
+acceptance/openstack/networking/v2/extensions/quotas
 acceptance/openstack/networking/v2/extensions/rbacpolicies
 acceptance/openstack/networking/v2/extensions/subnetpools
 acceptance/openstack/networking/v2/extensions/trunks


### PR DESCRIPTION
Add openstack/networking/v2/extensions/quotas.Get.

Add unit and acceptance tests.

For #1666

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/neutron/blob/stable/train/neutron/quota/__init__.py#L102
https://github.com/openstack/neutron/blob/stable/train/neutron/extensions/quotasv2.py#L66

