### PR TITLE
avoid reauthentication loops

### DIFF
--- a/provider_client.go
+++ b/provider_client.go
@@ -94,9 +94,10 @@ type ProviderClient struct {
 // reauthlock represents a set of attributes used to help in the reauthentication process.
 type reauthlock struct {
 	sync.RWMutex
-	reauthing    bool
-	reauthingErr error
-	done         *sync.Cond
+	//This channel is non-nil during reauthentication. It can be used to ask the
+	//goroutine doing Reauthenticate() for its result. Look at the implementation
+	//of Reauthenticate() for details.
+	ongoing chan<- (chan<- error)
 }
 
 // AuthenticatedHeaders returns a map of HTTP headers that are common for all
@@ -106,11 +107,15 @@ func (client *ProviderClient) AuthenticatedHeaders() (m map[string]string) {
 		return
 	}
 	if client.reauthmut != nil {
+		//if a Reauthenticate is in progress, wait for it to complete
 		client.reauthmut.Lock()
-		for client.reauthmut.reauthing {
-			client.reauthmut.done.Wait()
-		}
+		ongoing := client.reauthmut.ongoing
 		client.reauthmut.Unlock()
+		if ongoing != nil {
+			responseChannel := make(chan error)
+			ongoing <- responseChannel
+			_ = <-responseChannel
+		}
 	}
 	t := client.Token()
 	if t == "" {
@@ -223,7 +228,7 @@ func (client *ProviderClient) SetThrowaway(v bool) {
 // this case, the reauthentication can be skipped if another thread has already
 // reauthenticated in the meantime. If no previous token is known, an empty
 // string should be passed instead to force unconditional reauthentication.
-func (client *ProviderClient) Reauthenticate(previousToken string) (err error) {
+func (client *ProviderClient) Reauthenticate(previousToken string) error {
 	if client.ReauthFunc == nil {
 		return nil
 	}
@@ -232,33 +237,50 @@ func (client *ProviderClient) Reauthenticate(previousToken string) (err error) {
 		return client.ReauthFunc()
 	}
 
+	messages := make(chan (chan<- error))
+
+	//check if a Reauthenticate is in progress, or start one if not
 	client.reauthmut.Lock()
-	if client.reauthmut.reauthing {
-		for !client.reauthmut.reauthing {
-			client.reauthmut.done.Wait()
-		}
-		err = client.reauthmut.reauthingErr
-		client.reauthmut.Unlock()
-		return err
+	ongoing := client.reauthmut.ongoing
+	if ongoing == nil {
+		client.reauthmut.ongoing = messages
 	}
 	client.reauthmut.Unlock()
 
-	client.reauthmut.Lock()
-	client.reauthmut.reauthing = true
-	client.reauthmut.done = sync.NewCond(client.reauthmut)
-	client.reauthmut.reauthingErr = nil
-	client.reauthmut.Unlock()
+	//if Reauthenticate is running elsewhere, wait for its result
+	if ongoing != nil {
+		responseChannel := make(chan error)
+		ongoing <- responseChannel
+		return <-responseChannel
+	}
 
+	//perform the actual reauthentication
+	var err error
 	if previousToken == "" || client.TokenID == previousToken {
 		err = client.ReauthFunc()
+	} else {
+		err = nil
 	}
 
+	//mark Reauthenticate as finished
 	client.reauthmut.Lock()
-	client.reauthmut.reauthing = false
-	client.reauthmut.reauthingErr = err
-	client.reauthmut.done.Broadcast()
+	client.reauthmut.ongoing = nil
 	client.reauthmut.Unlock()
-	return
+
+	//report result to all other interested goroutines
+	//
+	//This happens in a separate goroutine because another goroutine might have
+	//acquired a copy of `client.reauthmut.ongoing` before we cleared it, but not
+	//have come around to sending its request. By answering in a goroutine, we
+	//can have that goroutine linger until all responseChannels have been sent.
+	//When GC has collected all sendings ends of the channel, our receiving end
+	//will be closed and the goroutine will end.
+	go func() {
+		for responseChannel := range messages {
+			responseChannel <- err
+		}
+	}()
+	return err
 }
 
 // RequestOpts customizes the behavior of the provider.Request() method.


### PR DESCRIPTION
It does not make sense to reauthenticate multiple times for a single request. When the backing service returns 401 for a brand-new token, reauthenticating again will just send us into an infinite loop.

Closes #1745.