### PR TITLE
Networking V2: add quotas.Update method

### DIFF
--- a/acceptance/openstack/networking/v2/extensions/quotas/quotas.go
+++ b/acceptance/openstack/networking/v2/extensions/quotas/quotas.go
@@ -1,0 +1,18 @@
+package quotas
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/quotas"
+)
+
+var updateOpts = quotas.UpdateOpts{
+	FloatingIP:        gophercloud.IntToPointer(10),
+	Network:           gophercloud.IntToPointer(-1),
+	Port:              gophercloud.IntToPointer(11),
+	RBACPolicy:        gophercloud.IntToPointer(0),
+	Router:            gophercloud.IntToPointer(-1),
+	SecurityGroup:     gophercloud.IntToPointer(12),
+	SecurityGroupRule: gophercloud.IntToPointer(13),
+	Subnet:            gophercloud.IntToPointer(14),
+	SubnetPool:        gophercloud.IntToPointer(15),
+}

--- a/acceptance/openstack/networking/v2/extensions/quotas/quotas_test.go
+++ b/acceptance/openstack/networking/v2/extensions/quotas/quotas_test.go
@@ -3,7 +3,9 @@
 package quotas
 
 import (
+	"log"
 	"os"
+	"reflect"
 	"testing"
 
 	"github.com/gophercloud/gophercloud/acceptance/clients"
@@ -22,4 +24,41 @@ func TestQuotasGet(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	tools.PrintResource(t, quotasInfo)
+}
+
+func TestQuotasUpdate(t *testing.T) {
+	clients.RequireAdmin(t)
+
+	client, err := clients.NewNetworkV2Client()
+	th.AssertNoErr(t, err)
+
+	originalQuotas, err := quotas.Get(client, os.Getenv("OS_PROJECT_NAME")).Extract()
+	th.AssertNoErr(t, err)
+
+	newQuotas, err := quotas.Update(client, os.Getenv("OS_PROJECT_NAME"), updateOpts).Extract()
+	th.AssertNoErr(t, err)
+
+	tools.PrintResource(t, newQuotas)
+
+	if reflect.DeepEqual(originalQuotas, newQuotas) {
+		log.Fatal("Original and New Networking Quotas are the same")
+	}
+
+	// Restore original quotas.
+	restoredQuotas, err := quotas.Update(client, os.Getenv("OS_PROJECT_NAME"), quotas.UpdateOpts{
+		FloatingIP:        &originalQuotas.FloatingIP,
+		Network:           &originalQuotas.Network,
+		Port:              &originalQuotas.Port,
+		RBACPolicy:        &originalQuotas.RBACPolicy,
+		Router:            &originalQuotas.Router,
+		SecurityGroup:     &originalQuotas.SecurityGroup,
+		SecurityGroupRule: &originalQuotas.SecurityGroupRule,
+		Subnet:            &originalQuotas.Subnet,
+		SubnetPool:        &originalQuotas.SubnetPool,
+	}).Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertDeepEquals(t, originalQuotas, restoredQuotas)
+
+	tools.PrintResource(t, restoredQuotas)
 }

--- a/openstack/networking/v2/extensions/quotas/doc.go
+++ b/openstack/networking/v2/extensions/quotas/doc.go
@@ -8,5 +8,29 @@ Example to Get project quotas
     if err != nil {
         log.Fatal(err)
     }
+
+    fmt.Printf("quotas: %#v\n", quotasInfo)
+
+Example to Update project quotas
+
+    projectID = "23d5d3f79dfa4f73b72b8b0b0063ec55"
+
+    updateOpts := quotas.UpdateOpts{
+        FloatingIP:        gophercloud.IntToPointer(0),
+        Network:           gophercloud.IntToPointer(-1),
+        Port:              gophercloud.IntToPointer(5),
+        RBACPolicy:        gophercloud.IntToPointer(10),
+        Router:            gophercloud.IntToPointer(15),
+        SecurityGroup:     gophercloud.IntToPointer(20),
+        SecurityGroupRule: gophercloud.IntToPointer(-1),
+        Subnet:            gophercloud.IntToPointer(25),
+        SubnetPool:        gophercloud.IntToPointer(0),
+    }
+    quotasInfo, err := quotas.Update(networkClient, projectID)
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    fmt.Printf("quotas: %#v\n", quotasInfo)
 */
 package quotas

--- a/openstack/networking/v2/extensions/quotas/requests.go
+++ b/openstack/networking/v2/extensions/quotas/requests.go
@@ -7,3 +7,59 @@ func Get(client *gophercloud.ServiceClient, projectID string) (r GetResult) {
 	_, r.Err = client.Get(getURL(client, projectID), &r.Body, nil)
 	return
 }
+
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
+type UpdateOptsBuilder interface {
+	ToQuotaUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts represents options used to update the Networking Quotas.
+type UpdateOpts struct {
+	// FloatingIP represents a number of floating IPs. A "-1" value means no limit.
+	FloatingIP *int `json:"floatingip,omitempty"`
+
+	// Network represents a number of networks. A "-1" value means no limit.
+	Network *int `json:"network,omitempty"`
+
+	// Port represents a number of ports. A "-1" value means no limit.
+	Port *int `json:"port,omitempty"`
+
+	// RBACPolicy represents a number of RBAC policies. A "-1" value means no limit.
+	RBACPolicy *int `json:"rbac_policy,omitempty"`
+
+	// Router represents a number of routers. A "-1" value means no limit.
+	Router *int `json:"router,omitempty"`
+
+	// SecurityGroup represents a number of security groups. A "-1" value means no limit.
+	SecurityGroup *int `json:"security_group,omitempty"`
+
+	// SecurityGroupRule represents a number of security group rules. A "-1" value means no limit.
+	SecurityGroupRule *int `json:"security_group_rule,omitempty"`
+
+	// Subnet represents a number of subnets. A "-1" value means no limit.
+	Subnet *int `json:"subnet,omitempty"`
+
+	// SubnetPool represents a number of subnet pools. A "-1" value means no limit.
+	SubnetPool *int `json:"subnetpool,omitempty"`
+}
+
+// ToQuotaUpdateMap builds a request body from UpdateOpts.
+func (opts UpdateOpts) ToQuotaUpdateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "quota")
+}
+
+// Update accepts a UpdateOpts struct and updates an existing Networking Quotas using the
+// values provided.
+func Update(c *gophercloud.ServiceClient, projectID string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToQuotaUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Put(updateURL(c, projectID), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+
+	return
+}

--- a/openstack/networking/v2/extensions/quotas/results.go
+++ b/openstack/networking/v2/extensions/quotas/results.go
@@ -21,6 +21,12 @@ type GetResult struct {
 	commonResult
 }
 
+// UpdateResult represents the result of an update operation. Call its Extract
+// method to interpret it as a Quota.
+type UpdateResult struct {
+	commonResult
+}
+
 // Quota contains Networking quotas for a project.
 type Quota struct {
 	// FloatingIP represents a number of floating IPs. A "-1" value means no limit.

--- a/openstack/networking/v2/extensions/quotas/testing/fixtures.go
+++ b/openstack/networking/v2/extensions/quotas/testing/fixtures.go
@@ -29,3 +29,31 @@ var GetResponse = quotas.Quota{
 	Subnet:            45,
 	SubnetPool:        -1,
 }
+
+const UpdateRequestResponseRaw = `
+{
+    "quota": {
+        "floatingip": 0,
+        "network": -1,
+        "port": 5,
+        "rbac_policy": 10,
+        "router": 15,
+        "security_group": 20,
+        "security_group_rule": -1,
+        "subnet": 25,
+        "subnetpool": 0
+    }
+}
+`
+
+var UpdateResponse = quotas.Quota{
+	FloatingIP:        0,
+	Network:           -1,
+	Port:              5,
+	RBACPolicy:        10,
+	Router:            15,
+	SecurityGroup:     20,
+	SecurityGroupRule: -1,
+	Subnet:            25,
+	SubnetPool:        0,
+}

--- a/openstack/networking/v2/extensions/quotas/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/quotas/testing/requests_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/gophercloud/gophercloud"
 	fake "github.com/gophercloud/gophercloud/openstack/networking/v2/common"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/quotas"
 	th "github.com/gophercloud/gophercloud/testhelper"
@@ -27,4 +28,34 @@ func TestGet(t *testing.T) {
 	q, err := quotas.Get(fake.ServiceClient(), "0a73845280574ad389c292f6a74afa76").Extract()
 	th.AssertNoErr(t, err)
 	th.AssertDeepEquals(t, q, &GetResponse)
+}
+
+func TestUpdate(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/quotas/0a73845280574ad389c292f6a74afa76", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, UpdateRequestResponseRaw)
+	})
+
+	q, err := quotas.Update(fake.ServiceClient(), "0a73845280574ad389c292f6a74afa76", quotas.UpdateOpts{
+		FloatingIP:        gophercloud.IntToPointer(0),
+		Network:           gophercloud.IntToPointer(-1),
+		Port:              gophercloud.IntToPointer(5),
+		RBACPolicy:        gophercloud.IntToPointer(10),
+		Router:            gophercloud.IntToPointer(15),
+		SecurityGroup:     gophercloud.IntToPointer(20),
+		SecurityGroupRule: gophercloud.IntToPointer(-1),
+		Subnet:            gophercloud.IntToPointer(25),
+		SubnetPool:        gophercloud.IntToPointer(0),
+	}).Extract()
+
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, q, &UpdateResponse)
 }

--- a/openstack/networking/v2/extensions/quotas/urls.go
+++ b/openstack/networking/v2/extensions/quotas/urls.go
@@ -4,6 +4,14 @@ import "github.com/gophercloud/gophercloud"
 
 const resourcePath = "quotas"
 
-func getURL(c *gophercloud.ServiceClient, projectID string) string {
+func resourceURL(c *gophercloud.ServiceClient, projectID string) string {
 	return c.ServiceURL(resourcePath, projectID)
+}
+
+func getURL(c *gophercloud.ServiceClient, projectID string) string {
+	return resourceURL(c, projectID)
+}
+
+func updateURL(c *gophercloud.ServiceClient, projectID string) string {
+	return resourceURL(c, projectID)
 }


### PR DESCRIPTION
Add openstack/networking/v2/extensions/quotas.Update.

Add unit and acceptance tests.

Update package docs.

For #1666

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/neutron/blob/stable/train/neutron/extensions/quotasv2.py#L116
