### PR TITLE
Compute V2: implement server tags filtering support

### DIFF
--- a/openstack/compute/v2/servers/requests.go
+++ b/openstack/compute/v2/servers/requests.go
@@ -55,6 +55,22 @@ type ListOpts struct {
 	// TenantID lists servers for a particular tenant.
 	// Setting "AllTenants = true" is required.
 	TenantID string `q:"tenant_id"`
+
+	// This requires the client to be set to microversion 2.26 or later.
+	// Tags filters on specific server tags. All tags must be present for the server.
+	Tags string `q:"tags"`
+
+	// This requires the client to be set to microversion 2.26 or later.
+	// TagsAny filters on specific server tags. At least one of the tags must be present for the server.
+	TagsAny string `q:"tags-any"`
+
+	// This requires the client to be set to microversion 2.26 or later.
+	// NotTags filters on specific server tags. All tags must be absent for the server.
+	NotTags string `q:"not-tags"`
+
+	// This requires the client to be set to microversion 2.26 or later.
+	// NotTagsAny filters on specific server tags. At least one of the tags must be absent for the server.
+	NotTagsAny string `q:"not-tags-any"`
 }
 
 // ToServerListQuery formats a ListOpts into a query string.


### PR DESCRIPTION
Server tags support was added in Nova API since 2.26, so we can implement it here as well.

For #1669

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/nova/blob/3b54979ae02cc74bcf215713c16916bbf4131443/nova/api/openstack/compute/schemas/servers.py#L645-L651
https://docs.openstack.org/api-ref/compute/?expanded=list-servers-detail,show-server-details-detail#list-servers
