### PR TITLE
Compute v2: Move ServerTagsExt to servers.TagsExt

### DIFF
--- a/acceptance/openstack/compute/v2/servers_test.go
+++ b/acceptance/openstack/compute/v2/servers_test.go
@@ -518,7 +518,7 @@ func TestServersTags(t *testing.T) {
 	// Check server tags in body.
 	type serverWithTagsExt struct {
 		servers.Server
-		tags.ServerTagsExt
+		servers.TagsExt
 	}
 
 	serverWithTags := serverWithTagsExt{}

--- a/openstack/compute/v2/extensions/tags/doc.go
+++ b/openstack/compute/v2/extensions/tags/doc.go
@@ -66,30 +66,5 @@ Example to Delete all Tags on a server
     if err != nil {
         log.Fatal(err)
     }
-
-Example of Extend server result with Tags:
-
-    client.Microversion = "2.26"
-
-    type ServerWithTags struct {
-        servers.Server
-        tags.ServerTagsExt
-    }
-
-    var allServers []ServerWithTags
-
-    allPages, err := servers.List(client, nil).AllPages()
-    if err != nil {
-        log.Fatal(err)
-    }
-
-    err = servers.ExtractServersInto(allPages, &allServers)
-    if err != nil {
-        log.Fatal(err)
-    }
-
-    for _, server := range allServers {
-        fmt.Println(server.Tags)
-    }
 */
 package tags

--- a/openstack/compute/v2/extensions/tags/results.go
+++ b/openstack/compute/v2/extensions/tags/results.go
@@ -2,12 +2,6 @@ package tags
 
 import "github.com/gophercloud/gophercloud"
 
-// ServerTagsExt is an extension to the base Server object.
-type ServerTagsExt struct {
-	// Tags contains a list of server tags.
-	Tags []string `json:"tags"`
-}
-
 type commonResult struct {
 	gophercloud.Result
 }

--- a/openstack/compute/v2/servers/doc.go
+++ b/openstack/compute/v2/servers/doc.go
@@ -111,5 +111,30 @@ Example to Snapshot a Server
 	if err != nil {
 		panic(err)
 	}
+
+Example of Extend server result with Tags:
+
+	client.Microversion = "2.26"
+
+	type ServerWithTags struct {
+		servers.Server
+		servers.TagsExt
+	}
+
+	var allServers []ServerWithTags
+
+	allPages, err := servers.List(client, nil).AllPages()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	err = servers.ExtractServersInto(allPages, &allServers)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for _, server := range allServers {
+		fmt.Println(server.Tags)
+	}
 */
 package servers

--- a/openstack/compute/v2/servers/microversions.go
+++ b/openstack/compute/v2/servers/microversions.go
@@ -1,7 +1,25 @@
 package servers
 
-// ExtractTags will extract the tags of a server.
+// TagsExt is an extension to the base Server struct.
+// Use this in combination with the Server struct to create
+// a composed struct in order to extract a slice of servers
+// with the Tag field.
+//
 // This requires the client to be set to microversion 2.26 or later.
+//
+// To interact with a server's tags directly, see the
+// openstack/compute/v2/extensions/tags package.
+type TagsExt struct {
+	// Tags contains a list of server tags.
+	Tags []string `json:"tags"`
+}
+
+// ExtractTags will extract the tags of a server.
+//
+// This requires the client to be set to microversion 2.26 or later.
+//
+// To interact with a server's tags directly, see the
+// openstack/compute/v2/extensions/tags package.
 func (r serverResult) ExtractTags() ([]string, error) {
 	var s struct {
 		Tags []string `json:"tags"`


### PR DESCRIPTION
This commit moves the tags extension's ServerTagsExt to
the servers package. While this is slighly nuanced, the tags
extension can be thought of to work directly on a server's
tags and the ability to extract a server's tags can be part
of the servers package since the original ExtractTags
microversion support already exists.

For #1669 