### PR TITLE
Add providers support to openstack loadbalancer

### DIFF
--- a/acceptance/openstack/loadbalancer/v2/providers_test.go
+++ b/acceptance/openstack/loadbalancer/v2/providers_test.go
@@ -1,0 +1,39 @@
+// +build acceptance networking loadbalancer providers
+
+package v2
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/acceptance/clients"
+	"github.com/gophercloud/gophercloud/acceptance/tools"
+	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/providers"
+)
+
+func TestProvidersList(t *testing.T) {
+	clients.SkipRelease(t, "stable/mitaka")
+	clients.SkipRelease(t, "stable/newton")
+	clients.SkipRelease(t, "stable/ocata")
+	clients.SkipRelease(t, "stable/pike")
+	clients.SkipRelease(t, "stable/queens")
+	clients.SkipRelease(t, "stable/rocky")
+
+	client, err := clients.NewLoadBalancerV2Client()
+	if err != nil {
+		t.Fatalf("Unable to create a loadbalancer client: %v", err)
+	}
+
+	allPages, err := providers.List(client, nil).AllPages()
+	if err != nil {
+		t.Fatalf("Unable to list providers: %v", err)
+	}
+
+	allProviders, err := providers.ExtractProviders(allPages)
+	if err != nil {
+		t.Fatalf("Unable to extract providers: %v", err)
+	}
+
+	for _, provider := range allProviders {
+		tools.PrintResource(t, provider)
+	}
+}

--- a/openstack/loadbalancer/v2/providers/doc.go
+++ b/openstack/loadbalancer/v2/providers/doc.go
@@ -1,0 +1,22 @@
+/*
+Package providers provides information about the supported providers
+at OpenStack Octavia Load Balancing service.
+
+Example to List Providers
+
+	allPages, err := providers.List(lbClient).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allProviders, err := providers.ExtractProviders(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, p := range allProviders {
+		fmt.Printf("%+v\n", p)
+	}
+
+*/
+package providers

--- a/openstack/loadbalancer/v2/providers/requests.go
+++ b/openstack/loadbalancer/v2/providers/requests.go
@@ -1,0 +1,44 @@
+package providers
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// ListOptsBuilder allows extensions to add additional parameters to the
+// List request.
+type ListOptsBuilder interface {
+	ToProviderListQuery() (string, error)
+}
+
+// ListOpts allows the filtering and sorting of paginated collections through
+// the API. Filtering is achieved by passing in struct field values that map to
+// the Provider attributes you want to see returned.
+type ListOpts struct {
+	Fields []string `q:"fields"`
+}
+
+// ToProviderListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToProviderListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List returns a Pager which allows you to iterate over a collection of
+// providers.
+//
+// Default policy settings return only those providers that are owned by
+// the project who submits the request, unless an admin user submits the request.
+func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := rootURL(c)
+	if opts != nil {
+		query, err := opts.ToProviderListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		return ProviderPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}

--- a/openstack/loadbalancer/v2/providers/results.go
+++ b/openstack/loadbalancer/v2/providers/results.go
@@ -1,0 +1,71 @@
+package providers
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// Provider is the Octavia driver that implements the load balancing mechanism
+type Provider struct {
+	// Human-readable description for the Loadbalancer.
+	Description string `json:"description"`
+
+	// Human-readable name for the Provider.
+	Name string `json:"name"`
+}
+
+// ProviderPage is the page returned by a pager when traversing over a
+// collection of providers.
+type ProviderPage struct {
+	pagination.LinkedPageBase
+}
+
+// NextPageURL is invoked when a paginated collection of providers has
+// reached the end of a page and the pager seeks to traverse over a new one.
+// In order to do this, it needs to construct the next page's URL.
+func (r ProviderPage) NextPageURL() (string, error) {
+	var s struct {
+		Links []gophercloud.Link `json:"providers_links"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return gophercloud.ExtractNextURL(s.Links)
+}
+
+// IsEmpty checks whether a ProviderPage struct is empty.
+func (r ProviderPage) IsEmpty() (bool, error) {
+	is, err := ExtractProviders(r)
+	return len(is) == 0, err
+}
+
+// ExtractProviders accepts a Page struct, specifically a ProviderPage
+// struct, and extracts the elements into a slice of Provider structs. In
+// other words, a generic collection is mapped into a relevant slice.
+func ExtractProviders(r pagination.Page) ([]Provider, error) {
+	var s struct {
+		Providers []Provider `json:"providers"`
+	}
+	err := (r.(ProviderPage)).ExtractInto(&s)
+	return s.Providers, err
+}
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// Extract is a function that accepts a result and extracts a provider.
+func (r commonResult) Extract() (*Provider, error) {
+	var s struct {
+		Provider *Provider `json:"provider"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Provider, err
+}
+
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a Provider.
+type GetResult struct {
+	commonResult
+}

--- a/openstack/loadbalancer/v2/providers/testing/doc.go
+++ b/openstack/loadbalancer/v2/providers/testing/doc.go
@@ -1,0 +1,2 @@
+// providers unit tests
+package testing

--- a/openstack/loadbalancer/v2/providers/testing/fixtures.go
+++ b/openstack/loadbalancer/v2/providers/testing/fixtures.go
@@ -1,0 +1,56 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/providers"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+// ProvidersListBody contains the canned body of a provider list response.
+const ProvidersListBody = `
+{
+	"providers":[
+	         {
+			"name": "amphora",
+			"description": "The Octavia Amphora driver."
+		},
+		{
+			"name": "ovn",
+			"description": "The Octavia OVN driver"
+		}
+	]
+}
+`
+
+var (
+	ProviderAmphora = providers.Provider{
+		Name:        "amphora",
+		Description: "The Octavia Amphora driver.",
+	}
+	ProviderOVN = providers.Provider{
+		Name:        "ovn",
+		Description: "The Octavia OVN driver",
+	}
+)
+
+// HandleProviderListSuccessfully sets up the test server to respond to a provider List request.
+func HandleProviderListSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/v2.0/lbaas/providers", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		r.ParseForm()
+		marker := r.Form.Get("marker")
+		switch marker {
+		case "":
+			fmt.Fprintf(w, ProvidersListBody)
+		default:
+			t.Fatalf("/v2.0/lbaas/providers invoked with unexpected marker=[%s]", marker)
+		}
+	})
+}

--- a/openstack/loadbalancer/v2/providers/testing/requests_test.go
+++ b/openstack/loadbalancer/v2/providers/testing/requests_test.go
@@ -1,0 +1,53 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/providers"
+	fake "github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/testhelper"
+	"github.com/gophercloud/gophercloud/pagination"
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestListProviders(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleProviderListSuccessfully(t)
+
+	pages := 0
+	err := providers.List(fake.ServiceClient(), providers.ListOpts{}).EachPage(func(page pagination.Page) (bool, error) {
+		pages++
+
+		actual, err := providers.ExtractProviders(page)
+		if err != nil {
+			return false, err
+		}
+
+		if len(actual) != 2 {
+			t.Fatalf("Expected 2 providers, got %d", len(actual))
+		}
+		th.CheckDeepEquals(t, ProviderAmphora, actual[0])
+		th.CheckDeepEquals(t, ProviderOVN, actual[1])
+
+		return true, nil
+	})
+
+	th.AssertNoErr(t, err)
+
+	if pages != 1 {
+		t.Errorf("Expected 1 page, saw %d", pages)
+	}
+}
+
+func TestListAllProviders(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleProviderListSuccessfully(t)
+
+	allPages, err := providers.List(fake.ServiceClient(), providers.ListOpts{}).AllPages()
+	th.AssertNoErr(t, err)
+	actual, err := providers.ExtractProviders(allPages)
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, ProviderAmphora, actual[0])
+	th.CheckDeepEquals(t, ProviderOVN, actual[1])
+}

--- a/openstack/loadbalancer/v2/providers/urls.go
+++ b/openstack/loadbalancer/v2/providers/urls.go
@@ -1,0 +1,12 @@
+package providers
+
+import "github.com/gophercloud/gophercloud"
+
+const (
+	rootPath     = "lbaas"
+	resourcePath = "providers"
+)
+
+func rootURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL(rootPath, resourcePath)
+}


### PR DESCRIPTION
This PR adds support for listing octavia providers

For #1773 

Octavia Providers API: https://docs.openstack.org/api-ref/load-balancer/v2/#providers
Octavia Providers API code (list providers) : 

* https://github.com/openstack/octavia/blob/master/octavia/api/v2/controllers/provider.py#L41
* https://github.com/openstack/octavia/blob/4a5c24ef6fcd3b5f198a20d780dedd7f7976296d/octavia/api/v2/types/provider.py#L20