### PR TITLE
Don't Error on Multiple Endpoints

### DIFF
--- a/openstack/endpoint_location.go
+++ b/openstack/endpoint_location.go
@@ -29,11 +29,12 @@ func V2EndpointURL(catalog *tokens2.ServiceCatalog, opts gophercloud.EndpointOpt
 		}
 	}
 
-	// Report an error if the options were ambiguous.
+	// If multiple endpoints were found, use the first result
+	// and disregard the other endpoints.
+	//
+	// This behavior matches the Python library. See GH-1764.
 	if len(endpoints) > 1 {
-		err := &ErrMultipleMatchingEndpointsV2{}
-		err.Endpoints = endpoints
-		return "", err
+		endpoints = endpoints[0:1]
 	}
 
 	// Extract the appropriate URL from the matching Endpoint.
@@ -91,9 +92,12 @@ func V3EndpointURL(catalog *tokens3.ServiceCatalog, opts gophercloud.EndpointOpt
 		}
 	}
 
-	// Report an error if the options were ambiguous.
+	// If multiple endpoints were found, use the first result
+	// and disregard the other endpoints.
+	//
+	// This behavior matches the Python library. See GH-1764.
 	if len(endpoints) > 1 {
-		return "", ErrMultipleMatchingEndpointsV3{Endpoints: endpoints}
+		endpoints = endpoints[0:1]
 	}
 
 	// Extract the URL from the matching Endpoint.

--- a/openstack/errors.go
+++ b/openstack/errors.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 
 	"github.com/gophercloud/gophercloud"
-	tokens2 "github.com/gophercloud/gophercloud/openstack/identity/v2/tokens"
-	tokens3 "github.com/gophercloud/gophercloud/openstack/identity/v3/tokens"
 )
 
 // ErrEndpointNotFound is the error when no suitable endpoint can be found
@@ -22,28 +20,6 @@ type ErrInvalidAvailabilityProvided struct{ gophercloud.ErrInvalidInput }
 
 func (e ErrInvalidAvailabilityProvided) Error() string {
 	return fmt.Sprintf("Unexpected availability in endpoint query: %s", e.Value)
-}
-
-// ErrMultipleMatchingEndpointsV2 is the error when more than one endpoint
-// for the given options is found in the v2 catalog
-type ErrMultipleMatchingEndpointsV2 struct {
-	gophercloud.BaseError
-	Endpoints []tokens2.Endpoint
-}
-
-func (e ErrMultipleMatchingEndpointsV2) Error() string {
-	return fmt.Sprintf("Discovered %d matching endpoints: %#v", len(e.Endpoints), e.Endpoints)
-}
-
-// ErrMultipleMatchingEndpointsV3 is the error when more than one endpoint
-// for the given options is found in the v3 catalog
-type ErrMultipleMatchingEndpointsV3 struct {
-	gophercloud.BaseError
-	Endpoints []tokens3.Endpoint
-}
-
-func (e ErrMultipleMatchingEndpointsV3) Error() string {
-	return fmt.Sprintf("Discovered %d matching endpoints: %#v", len(e.Endpoints), e.Endpoints)
 }
 
 // ErrNoAuthURL is the error when the OS_AUTH_URL environment variable is not

--- a/openstack/testing/endpoint_location_test.go
+++ b/openstack/testing/endpoint_location_test.go
@@ -1,7 +1,6 @@
 package testing
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/gophercloud/gophercloud"
@@ -90,14 +89,14 @@ func TestV2EndpointNone(t *testing.T) {
 }
 
 func TestV2EndpointMultiple(t *testing.T) {
-	_, err := openstack.V2EndpointURL(&catalog2, gophercloud.EndpointOpts{
+	actual, err := openstack.V2EndpointURL(&catalog2, gophercloud.EndpointOpts{
 		Type:         "same",
 		Region:       "same",
 		Availability: gophercloud.AvailabilityPublic,
 	})
-	if !strings.HasPrefix(err.Error(), "Discovered 2 matching endpoints:") {
-		t.Errorf("Received unexpected error: %v", err)
-	}
+
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, "https://public.correct.com/", actual)
 }
 
 func TestV2EndpointBadAvailability(t *testing.T) {
@@ -234,14 +233,14 @@ func TestV3EndpointNone(t *testing.T) {
 }
 
 func TestV3EndpointMultiple(t *testing.T) {
-	_, err := openstack.V3EndpointURL(&catalog3, gophercloud.EndpointOpts{
+	actual, err := openstack.V3EndpointURL(&catalog3, gophercloud.EndpointOpts{
 		Type:         "same",
 		Region:       "same",
 		Availability: gophercloud.AvailabilityPublic,
 	})
-	if !strings.HasPrefix(err.Error(), "Discovered 2 matching endpoints:") {
-		t.Errorf("Received unexpected error: %v", err)
-	}
+
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, "https://public.correct.com/", actual)
 }
 
 func TestV3EndpointBadAvailability(t *testing.T) {


### PR DESCRIPTION
This commit changes the behvior when multiple endpoints are
discovered. Instead of returning an error, the first endpoint will
be used, discarding the other endpoints.

This change helps keep behavior in line with the Python SDK.

For #1764 