### PR TITLE
LoadBalancer V2: add monitor Create MaxRetriesDown

### DIFF
--- a/acceptance/openstack/loadbalancer/v2/loadbalancer.go
+++ b/acceptance/openstack/loadbalancer/v2/loadbalancer.go
@@ -147,12 +147,13 @@ func CreateMonitor(t *testing.T, client *gophercloud.ServiceClient, lb *loadbala
 	t.Logf("Attempting to create monitor %s", monitorName)
 
 	createOpts := monitors.CreateOpts{
-		PoolID:     pool.ID,
-		Name:       monitorName,
-		Delay:      10,
-		Timeout:    5,
-		MaxRetries: 5,
-		Type:       monitors.TypePING,
+		PoolID:         pool.ID,
+		Name:           monitorName,
+		Delay:          10,
+		Timeout:        5,
+		MaxRetries:     5,
+		MaxRetriesDown: 4,
+		Type:           monitors.TypePING,
 	}
 
 	monitor, err := monitors.Create(client, createOpts).Extract()

--- a/openstack/loadbalancer/v2/monitors/doc.go
+++ b/openstack/loadbalancer/v2/monitors/doc.go
@@ -25,14 +25,15 @@ Example to List Monitors
 Example to Create a Monitor
 
 	createOpts := monitors.CreateOpts{
-		Type:          "HTTP",
-		Name:          "db",
-		PoolID:        "84f1b61f-58c4-45bf-a8a9-2dafb9e5214d",
-		Delay:         20,
-		Timeout:       10,
-		MaxRetries:    5,
-		URLPath:       "/check",
-		ExpectedCodes: "200-299",
+		Type:           "HTTP",
+		Name:           "db",
+		PoolID:         "84f1b61f-58c4-45bf-a8a9-2dafb9e5214d",
+		Delay:          20,
+		Timeout:        10,
+		MaxRetries:     5,
+		MaxRetriesDown: 4,
+		URLPath:        "/check",
+		ExpectedCodes:  "200-299",
 	}
 
 	monitor, err := monitors.Create(networkClient, createOpts).Extract()

--- a/openstack/loadbalancer/v2/monitors/requests.go
+++ b/openstack/loadbalancer/v2/monitors/requests.go
@@ -107,6 +107,10 @@ type CreateOpts struct {
 	// status to INACTIVE. Must be a number between 1 and 10.
 	MaxRetries int `json:"max_retries" required:"true"`
 
+	// Number of permissible ping failures befor changing the member's
+	// status to ERROR. Must be a number between 1 and 10.
+	MaxRetriesDown int `json:"max_retries_down,omitempty"`
+
 	// URI path that will be accessed if Monitor type is HTTP or HTTPS.
 	URLPath string `json:"url_path,omitempty"`
 

--- a/openstack/loadbalancer/v2/monitors/testing/fixtures.go
+++ b/openstack/loadbalancer/v2/monitors/testing/fixtures.go
@@ -160,6 +160,7 @@ func HandleHealthmonitorCreationSuccessfully(t *testing.T, response string) {
 				"name":"db",
 				"timeout":10,
 				"max_retries":5,
+				"max_retries_down":4,
 				"url_path":"/check",
 				"expected_codes":"200-299"
 			}

--- a/openstack/loadbalancer/v2/monitors/testing/requests_test.go
+++ b/openstack/loadbalancer/v2/monitors/testing/requests_test.go
@@ -58,15 +58,16 @@ func TestCreateHealthmonitor(t *testing.T) {
 	HandleHealthmonitorCreationSuccessfully(t, SingleHealthmonitorBody)
 
 	actual, err := monitors.Create(fake.ServiceClient(), monitors.CreateOpts{
-		Type:          "HTTP",
-		Name:          "db",
-		PoolID:        "84f1b61f-58c4-45bf-a8a9-2dafb9e5214d",
-		ProjectID:     "453105b9-1754-413f-aab1-55f1af620750",
-		Delay:         20,
-		Timeout:       10,
-		MaxRetries:    5,
-		URLPath:       "/check",
-		ExpectedCodes: "200-299",
+		Type:           "HTTP",
+		Name:           "db",
+		PoolID:         "84f1b61f-58c4-45bf-a8a9-2dafb9e5214d",
+		ProjectID:      "453105b9-1754-413f-aab1-55f1af620750",
+		Delay:          20,
+		Timeout:        10,
+		MaxRetries:     5,
+		MaxRetriesDown: 4,
+		URLPath:        "/check",
+		ExpectedCodes:  "200-299",
 	}).Extract()
 	th.AssertNoErr(t, err)
 


### PR DESCRIPTION
Add loadbalancer/v2/monitors.CreateOpts.MaxRetriesDown.

Update tests and docs.

For #1784 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/octavia/blob/stable/train/octavia/api/v2/types/health_monitor.py#L87
