### PR TITLE
LoadBalancer V2: add monitor Update MaxRetriesDown

### DIFF
--- a/acceptance/openstack/loadbalancer/v2/loadbalancer.go
+++ b/acceptance/openstack/loadbalancer/v2/loadbalancer.go
@@ -147,12 +147,13 @@ func CreateMonitor(t *testing.T, client *gophercloud.ServiceClient, lb *loadbala
 	t.Logf("Attempting to create monitor %s", monitorName)
 
 	createOpts := monitors.CreateOpts{
-		PoolID:     pool.ID,
-		Name:       monitorName,
-		Delay:      10,
-		Timeout:    5,
-		MaxRetries: 5,
-		Type:       monitors.TypePING,
+		PoolID:         pool.ID,
+		Name:           monitorName,
+		Delay:          10,
+		Timeout:        5,
+		MaxRetries:     5,
+		MaxRetriesDown: 4,
+		Type:           monitors.TypePING,
 	}
 
 	monitor, err := monitors.Create(client, createOpts).Extract()

--- a/acceptance/openstack/loadbalancer/v2/loadbalancers_test.go
+++ b/acceptance/openstack/loadbalancer/v2/loadbalancers_test.go
@@ -386,9 +386,11 @@ func TestLoadbalancersCRUD(t *testing.T) {
 
 	monName := ""
 	newDelay := tools.RandomInt(20, 30)
+	newMaxRetriesDown := tools.RandomInt(4, 10)
 	updateMonitorOpts := monitors.UpdateOpts{
-		Name:  &monName,
-		Delay: newDelay,
+		Name:           &monName,
+		Delay:          newDelay,
+		MaxRetriesDown: newMaxRetriesDown,
 	}
 	_, err = monitors.Update(lbClient, monitor.ID, updateMonitorOpts).Extract()
 	th.AssertNoErr(t, err)

--- a/openstack/loadbalancer/v2/monitors/doc.go
+++ b/openstack/loadbalancer/v2/monitors/doc.go
@@ -46,12 +46,13 @@ Example to Update a Monitor
 	monitorID := "d67d56a6-4a86-4688-a282-f46444705c64"
 
 	updateOpts := monitors.UpdateOpts{
-		Name:          "NewHealthmonitorName",
-		Delay:         3,
-		Timeout:       20,
-		MaxRetries:    10,
-		URLPath:       "/another_check",
-		ExpectedCodes: "301",
+		Name:           "NewHealthmonitorName",
+		Delay:          3,
+		Timeout:        20,
+		MaxRetries:     10,
+		MaxRetriesDown: 8,
+		URLPath:        "/another_check",
+		ExpectedCodes:  "301",
 	}
 
 	monitor, err := monitors.Update(networkClient, monitorID, updateOpts).Extract()

--- a/openstack/loadbalancer/v2/monitors/doc.go
+++ b/openstack/loadbalancer/v2/monitors/doc.go
@@ -25,14 +25,15 @@ Example to List Monitors
 Example to Create a Monitor
 
 	createOpts := monitors.CreateOpts{
-		Type:          "HTTP",
-		Name:          "db",
-		PoolID:        "84f1b61f-58c4-45bf-a8a9-2dafb9e5214d",
-		Delay:         20,
-		Timeout:       10,
-		MaxRetries:    5,
-		URLPath:       "/check",
-		ExpectedCodes: "200-299",
+		Type:           "HTTP",
+		Name:           "db",
+		PoolID:         "84f1b61f-58c4-45bf-a8a9-2dafb9e5214d",
+		Delay:          20,
+		Timeout:        10,
+		MaxRetries:     5,
+		MaxRetriesDown: 4,
+		URLPath:        "/check",
+		ExpectedCodes:  "200-299",
 	}
 
 	monitor, err := monitors.Create(networkClient, createOpts).Extract()

--- a/openstack/loadbalancer/v2/monitors/requests.go
+++ b/openstack/loadbalancer/v2/monitors/requests.go
@@ -195,6 +195,10 @@ type UpdateOpts struct {
 	// status to INACTIVE. Must be a number between 1 and 10.
 	MaxRetries int `json:"max_retries,omitempty"`
 
+	// Number of permissible ping failures befor changing the member's
+	// status to ERROR. Must be a number between 1 and 10.
+	MaxRetriesDown int `json:"max_retries_down,omitempty"`
+
 	// URI path that will be accessed if Monitor type is HTTP or HTTPS.
 	// Required for HTTP(S) types.
 	URLPath string `json:"url_path,omitempty"`

--- a/openstack/loadbalancer/v2/monitors/requests.go
+++ b/openstack/loadbalancer/v2/monitors/requests.go
@@ -107,6 +107,10 @@ type CreateOpts struct {
 	// status to INACTIVE. Must be a number between 1 and 10.
 	MaxRetries int `json:"max_retries" required:"true"`
 
+	// Number of permissible ping failures befor changing the member's
+	// status to ERROR. Must be a number between 1 and 10.
+	MaxRetriesDown int `json:"max_retries_down,omitempty"`
+
 	// URI path that will be accessed if Monitor type is HTTP or HTTPS.
 	URLPath string `json:"url_path,omitempty"`
 

--- a/openstack/loadbalancer/v2/monitors/testing/fixtures.go
+++ b/openstack/loadbalancer/v2/monitors/testing/fixtures.go
@@ -206,6 +206,7 @@ func HandleHealthmonitorUpdateSuccessfully(t *testing.T) {
 				"delay": 3,
 				"timeout": 20,
 				"max_retries": 10,
+				"max_retries_down": 8,
 				"url_path": "/another_check",
 				"expected_codes": "301"
 			}

--- a/openstack/loadbalancer/v2/monitors/testing/fixtures.go
+++ b/openstack/loadbalancer/v2/monitors/testing/fixtures.go
@@ -160,6 +160,7 @@ func HandleHealthmonitorCreationSuccessfully(t *testing.T, response string) {
 				"name":"db",
 				"timeout":10,
 				"max_retries":5,
+				"max_retries_down":4,
 				"url_path":"/check",
 				"expected_codes":"200-299"
 			}

--- a/openstack/loadbalancer/v2/monitors/testing/requests_test.go
+++ b/openstack/loadbalancer/v2/monitors/testing/requests_test.go
@@ -116,12 +116,13 @@ func TestUpdateHealthmonitor(t *testing.T) {
 	client := fake.ServiceClient()
 	name := "NewHealthmonitorName"
 	actual, err := monitors.Update(client, "5d4b5228-33b0-4e60-b225-9b727c1a20e7", monitors.UpdateOpts{
-		Name:          &name,
-		Delay:         3,
-		Timeout:       20,
-		MaxRetries:    10,
-		URLPath:       "/another_check",
-		ExpectedCodes: "301",
+		Name:           &name,
+		Delay:          3,
+		Timeout:        20,
+		MaxRetries:     10,
+		MaxRetriesDown: 8,
+		URLPath:        "/another_check",
+		ExpectedCodes:  "301",
 	}).Extract()
 	if err != nil {
 		t.Fatalf("Unexpected Update error: %v", err)

--- a/openstack/loadbalancer/v2/monitors/testing/requests_test.go
+++ b/openstack/loadbalancer/v2/monitors/testing/requests_test.go
@@ -58,15 +58,16 @@ func TestCreateHealthmonitor(t *testing.T) {
 	HandleHealthmonitorCreationSuccessfully(t, SingleHealthmonitorBody)
 
 	actual, err := monitors.Create(fake.ServiceClient(), monitors.CreateOpts{
-		Type:          "HTTP",
-		Name:          "db",
-		PoolID:        "84f1b61f-58c4-45bf-a8a9-2dafb9e5214d",
-		ProjectID:     "453105b9-1754-413f-aab1-55f1af620750",
-		Delay:         20,
-		Timeout:       10,
-		MaxRetries:    5,
-		URLPath:       "/check",
-		ExpectedCodes: "200-299",
+		Type:           "HTTP",
+		Name:           "db",
+		PoolID:         "84f1b61f-58c4-45bf-a8a9-2dafb9e5214d",
+		ProjectID:      "453105b9-1754-413f-aab1-55f1af620750",
+		Delay:          20,
+		Timeout:        10,
+		MaxRetries:     5,
+		MaxRetriesDown: 4,
+		URLPath:        "/check",
+		ExpectedCodes:  "200-299",
 	}).Extract()
 	th.AssertNoErr(t, err)
 


### PR DESCRIPTION
Add loadbalancer/v2/monitors.UpdateOpts.MaxRetriesDown.

Update tests and docs.

For #1784 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/octavia/blob/stable/train/octavia/api/v2/types/health_monitor.py#L122
https://github.com/openstack/octavia/blob/stable/train/octavia/api/v2/controllers/health_monitor.py#L330
