### PR TITLE
Containerinfra: acceptance test timeout changes and fixes

### DIFF
--- a/acceptance/openstack/containerinfra/v1/clusters_test.go
+++ b/acceptance/openstack/containerinfra/v1/clusters_test.go
@@ -42,7 +42,7 @@ func TestClustersCRUD(t *testing.T) {
 		clusters.UpdateOpts{
 			Op:    clusters.ReplaceOp,
 			Path:  "/node_count",
-			Value: "2",
+			Value: 2,
 		},
 	}
 	updateResult := clusters.Update(client, clusterID, updateOpts)

--- a/acceptance/openstack/containerinfra/v1/clusters_test.go
+++ b/acceptance/openstack/containerinfra/v1/clusters_test.go
@@ -4,6 +4,7 @@ package v1
 
 import (
 	"testing"
+	"time"
 
 	"github.com/gophercloud/gophercloud/acceptance/clients"
 	"github.com/gophercloud/gophercloud/acceptance/tools"
@@ -53,7 +54,7 @@ func TestClustersCRUD(t *testing.T) {
 	clusterID, err = updateResult.Extract()
 	th.AssertNoErr(t, err)
 
-	err = WaitForCluster(client, clusterID, "UPDATE_COMPLETE")
+	err = WaitForCluster(client, clusterID, "UPDATE_COMPLETE", time.Second*300)
 	th.AssertNoErr(t, err)
 
 	newCluster, err := clusters.Get(client, clusterID).Extract()

--- a/acceptance/openstack/containerinfra/v1/clusters_test.go
+++ b/acceptance/openstack/containerinfra/v1/clusters_test.go
@@ -21,6 +21,7 @@ func TestClustersCRUD(t *testing.T) {
 	defer DeleteClusterTemplate(t, client, clusterTemplate.UUID)
 
 	clusterID, err := CreateCluster(t, client, clusterTemplate.UUID)
+	th.AssertNoErr(t, err)
 	tools.PrintResource(t, clusterID)
 	defer DeleteCluster(t, client, clusterID)
 

--- a/acceptance/openstack/containerinfra/v1/containerinfra.go
+++ b/acceptance/openstack/containerinfra/v1/containerinfra.go
@@ -2,8 +2,10 @@ package v1
 
 import (
 	"fmt"
+	"math"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/acceptance/clients"
@@ -85,9 +87,9 @@ func DeleteClusterTemplate(t *testing.T, client *gophercloud.ServiceClient, id s
 	return
 }
 
-// CreateCluster will create a random cluster. An error will be returned if the
-// cluster could not be created.
-func CreateCluster(t *testing.T, client *gophercloud.ServiceClient, clusterTemplateID string) (string, error) {
+// CreateClusterTimeout will create a random cluster and wait for it to reach CREATE_COMPLETE status
+// within the given timeout duration. An error will be returned if the cluster could not be created.
+func CreateClusterTimeout(t *testing.T, client *gophercloud.ServiceClient, clusterTemplateID string, timeout time.Duration) (string, error) {
 	clusterName := tools.RandomString("TESTACC-", 8)
 	t.Logf("Attempting to create cluster: %s using template %s", clusterName, clusterTemplateID)
 
@@ -98,7 +100,8 @@ func CreateCluster(t *testing.T, client *gophercloud.ServiceClient, clusterTempl
 
 	masterCount := 1
 	nodeCount := 1
-	createTimeout := 100
+	// createTimeout is the creation timeout on the magnum side in minutes
+	createTimeout := int(math.Ceil(timeout.Minutes()))
 	createOpts := clusters.CreateOpts{
 		ClusterTemplateID: clusterTemplateID,
 		CreateTimeout:     &createTimeout,
@@ -124,13 +127,19 @@ func CreateCluster(t *testing.T, client *gophercloud.ServiceClient, clusterTempl
 
 	t.Logf("Cluster created: %+v", clusterID)
 
-	err = WaitForCluster(client, clusterID, "CREATE_COMPLETE")
+	err = WaitForCluster(client, clusterID, "CREATE_COMPLETE", timeout)
 	if err != nil {
 		return clusterID, err
 	}
 
 	t.Logf("Successfully created cluster: %s id: %s", clusterName, clusterID)
 	return clusterID, nil
+}
+
+// CreateCluster will create a random cluster. An error will be returned if the
+// cluster could not be created. Has a timeout of 300 seconds.
+func CreateCluster(t *testing.T, client *gophercloud.ServiceClient, clusterTemplateID string) (string, error) {
+	return CreateClusterTimeout(t, client, clusterTemplateID, 300*time.Second)
 }
 
 func DeleteCluster(t *testing.T, client *gophercloud.ServiceClient, id string) {
@@ -147,7 +156,7 @@ func DeleteCluster(t *testing.T, client *gophercloud.ServiceClient, id string) {
 		t.Fatalf("Error deleting cluster. requestID=%s clusterID=%s: err%s:", deleteRequestID, id, err)
 	}
 
-	err = WaitForCluster(client, id, "DELETE_COMPLETE")
+	err = WaitForCluster(client, id, "DELETE_COMPLETE", 300*time.Second)
 	if err != nil {
 		t.Fatalf("Error deleting cluster %s: %s:", id, err)
 	}
@@ -157,8 +166,8 @@ func DeleteCluster(t *testing.T, client *gophercloud.ServiceClient, id string) {
 	return
 }
 
-func WaitForCluster(client *gophercloud.ServiceClient, clusterID string, status string) error {
-	return tools.WaitFor(func() (bool, error) {
+func WaitForCluster(client *gophercloud.ServiceClient, clusterID string, status string, timeout time.Duration) error {
+	return tools.WaitForTimeout(func() (bool, error) {
 		cluster, err := clusters.Get(client, clusterID).Extract()
 		if err != nil {
 			if _, ok := err.(gophercloud.ErrDefault404); ok && status == "DELETE_COMPLETE" {
@@ -177,7 +186,7 @@ func WaitForCluster(client *gophercloud.ServiceClient, clusterID string, status 
 		}
 
 		return false, nil
-	})
+	}, timeout)
 }
 
 // CreateQuota will create a random quota. An error will be returned if the

--- a/acceptance/openstack/containerinfra/v1/containerinfra.go
+++ b/acceptance/openstack/containerinfra/v1/containerinfra.go
@@ -32,7 +32,7 @@ func CreateClusterTemplate(t *testing.T, client *gophercloud.ServiceClient) (*cl
 	createOpts := clustertemplates.CreateOpts{
 		COE:                 "swarm",
 		DNSNameServer:       "8.8.8.8",
-		DockerStorageDriver: "devicemapper",
+		DockerStorageDriver: "overlay2",
 		ExternalNetworkID:   choices.ExternalNetworkID,
 		FlavorID:            choices.FlavorID,
 		FloatingIPEnabled:   &boolFalse,

--- a/acceptance/tools/tools.go
+++ b/acceptance/tools/tools.go
@@ -9,12 +9,20 @@ import (
 	"time"
 )
 
-// ErrTimeout is returned if WaitFor takes longer than 300 second to happen.
+// ErrTimeout is returned if WaitFor/WaitForTimeout take longer than their timeout duration.
 var ErrTimeout = errors.New("Timed out")
 
-// WaitFor polls a predicate function once per second to wait for a certain state to arrive.
+// WaitFor uses WaitForTimeout to poll a predicate function once per second to
+// wait for a certain state to arrive, with a default timeout of 300 seconds.
 func WaitFor(predicate func() (bool, error)) error {
-	for i := 0; i < 300; i++ {
+	return WaitForTimeout(predicate, 300*time.Second)
+}
+
+// WaitForTimeout polls a predicate function once per second to wait for a
+// certain state to arrive, or until the given timeout is reached.
+func WaitForTimeout(predicate func() (bool, error), timeout time.Duration) error {
+	startTime := time.Now()
+	for time.Since(startTime) < timeout {
 		time.Sleep(1 * time.Second)
 
 		satisfied, err := predicate()


### PR DESCRIPTION
For #1767

Adds configurable timeouts to cluster creation which will be needed for kubernetes clusters, to be able to test node groups. A kubernetes cluster needs longer than 5 minutes to create.

There are also some fixes for the existing clusters API acceptance tests.
* Check timeout error when creating the cluster
* Fix update opts value type for replacing node count
* Change template storage driver

I have tried to make as few changes and additions as possible to the existing code, by making the existing functions just call to the versions that accept a timeout.

With these fixes, the cluster acceptance tests pass in my devstack on magnum master branch.
For the tests in CI, the timeouts may need to be tweaked.