### PR TITLE
[WIP]Switch to install devstack on ubuntu 18.04

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -12,6 +12,7 @@
     description: |
       Run gophercloud acceptance test on master branch
     run: .zuul/playbooks/gophercloud-acceptance-test/run.yaml
+    nodeset: ubuntu-bionic
 
 - job:
     name: gophercloud-acceptance-test-ironic
@@ -19,6 +20,7 @@
     description: |
       Run gophercloud ironic acceptance test on master branch
     run: .zuul/playbooks/gophercloud-acceptance-test-ironic/run.yaml
+    nodeset: ubuntu-bionic
 
 - job:
     name: gophercloud-acceptance-test-stein

--- a/.zuul/playbooks/gophercloud-acceptance-test/run.yaml
+++ b/.zuul/playbooks/gophercloud-acceptance-test/run.yaml
@@ -19,7 +19,7 @@
           set -o pipefail
           set -x
           echo $(export |grep OS_BRANCH)
-
+          export OS_DEBUG=1
           go get ./... || true
           ./script/acceptancetest -v 2>&1 | tee $TEST_RESULTS_TXT
         executable: /bin/bash

--- a/acceptance/openstack/sharedfilesystems/v2/shares_test.go
+++ b/acceptance/openstack/sharedfilesystems/v2/shares_test.go
@@ -118,7 +118,7 @@ func TestGrantAndRevokeAccess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to create a shared file system client: %v", err)
 	}
-	client.Microversion = "2.51"
+	client.Microversion = "2.49"
 
 	share, err := CreateShare(t, client)
 	if err != nil {

--- a/acceptance/openstack/sharedfilesystems/v2/shares_test.go
+++ b/acceptance/openstack/sharedfilesystems/v2/shares_test.go
@@ -118,7 +118,7 @@ func TestGrantAndRevokeAccess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to create a shared file system client: %v", err)
 	}
-	client.Microversion = "2.7"
+	client.Microversion = "2.51"
 
 	share, err := CreateShare(t, client)
 	if err != nil {


### PR DESCRIPTION
This change switch to install devstack on ubuntu
bionic, because openstack/devstack has dropped
xenial support.

Related-Bug: theopenlab/openlab#412
