### PR TITLE
openstack/networking/v2/ports/testing: fix dropped error

### DIFF
--- a/openstack/networking/v2/ports/testing/requests_test.go
+++ b/openstack/networking/v2/ports/testing/requests_test.go
@@ -93,6 +93,7 @@ func TestListWithExtensions(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	err = ports.ExtractPortsInto(allPages, &allPorts)
+	th.AssertNoErr(t, err)
 
 	th.AssertEquals(t, allPorts[0].Status, "ACTIVE")
 	th.AssertEquals(t, allPorts[0].PortSecurityEnabled, false)


### PR DESCRIPTION
For #1796 

This fixes a dropped test error in `openstack/networking/v2/ports/testing`.
