### PR TITLE
Added Shelve, Shelve-offload and Unshelve API

### DIFF
--- a/openstack/compute/v2/extensions/evacuate/requests.go
+++ b/openstack/compute/v2/extensions/evacuate/requests.go
@@ -2,6 +2,7 @@ package evacuate
 
 import (
 	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions"
 )
 
 // EvacuateOptsBuilder allows extensions to add additional parameters to the
@@ -34,7 +35,7 @@ func Evacuate(client *gophercloud.ServiceClient, id string, opts EvacuateOptsBui
 		r.Err = err
 		return
 	}
-	_, r.Err = client.Post(actionURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
+	_, r.Err = client.Post(extensions.ActionURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{200},
 	})
 	return

--- a/openstack/compute/v2/extensions/evacuate/urls.go
+++ b/openstack/compute/v2/extensions/evacuate/urls.go
@@ -1,9 +1,0 @@
-package evacuate
-
-import (
-	"github.com/gophercloud/gophercloud"
-)
-
-func actionURL(client *gophercloud.ServiceClient, id string) string {
-	return client.ServiceURL("servers", id, "action")
-}

--- a/openstack/compute/v2/extensions/lockunlock/requests.go
+++ b/openstack/compute/v2/extensions/lockunlock/requests.go
@@ -1,19 +1,18 @@
 package lockunlock
 
-import "github.com/gophercloud/gophercloud"
-
-func actionURL(client *gophercloud.ServiceClient, id string) string {
-	return client.ServiceURL("servers", id, "action")
-}
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions"
+)
 
 // Lock is the operation responsible for locking a Compute server.
 func Lock(client *gophercloud.ServiceClient, id string) (r LockResult) {
-	_, r.Err = client.Post(actionURL(client, id), map[string]interface{}{"lock": nil}, nil, nil)
+	_, r.Err = client.Post(extensions.ActionURL(client, id), map[string]interface{}{"lock": nil}, nil, nil)
 	return
 }
 
 // Unlock is the operation responsible for unlocking a Compute server.
 func Unlock(client *gophercloud.ServiceClient, id string) (r UnlockResult) {
-	_, r.Err = client.Post(actionURL(client, id), map[string]interface{}{"unlock": nil}, nil, nil)
+	_, r.Err = client.Post(extensions.ActionURL(client, id), map[string]interface{}{"unlock": nil}, nil, nil)
 	return
 }

--- a/openstack/compute/v2/extensions/migrate/requests.go
+++ b/openstack/compute/v2/extensions/migrate/requests.go
@@ -2,11 +2,12 @@ package migrate
 
 import (
 	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions"
 )
 
 // Migrate will initiate a migration of the instance to another host.
 func Migrate(client *gophercloud.ServiceClient, id string) (r MigrateResult) {
-	_, r.Err = client.Post(actionURL(client, id), map[string]interface{}{"migrate": nil}, nil, nil)
+	_, r.Err = client.Post(extensions.ActionURL(client, id), map[string]interface{}{"migrate": nil}, nil, nil)
 	return
 }
 
@@ -45,6 +46,6 @@ func LiveMigrate(client *gophercloud.ServiceClient, id string, opts LiveMigrateO
 		r.Err = err
 		return
 	}
-	_, r.Err = client.Post(actionURL(client, id), b, nil, nil)
+	_, r.Err = client.Post(extensions.ActionURL(client, id), b, nil, nil)
 	return
 }

--- a/openstack/compute/v2/extensions/migrate/urls.go
+++ b/openstack/compute/v2/extensions/migrate/urls.go
@@ -1,9 +1,0 @@
-package migrate
-
-import (
-	"github.com/gophercloud/gophercloud"
-)
-
-func actionURL(client *gophercloud.ServiceClient, id string) string {
-	return client.ServiceURL("servers", id, "action")
-}

--- a/openstack/compute/v2/extensions/pauseunpause/requests.go
+++ b/openstack/compute/v2/extensions/pauseunpause/requests.go
@@ -1,19 +1,18 @@
 package pauseunpause
 
-import "github.com/gophercloud/gophercloud"
-
-func actionURL(client *gophercloud.ServiceClient, id string) string {
-	return client.ServiceURL("servers", id, "action")
-}
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions"
+)
 
 // Pause is the operation responsible for pausing a Compute server.
 func Pause(client *gophercloud.ServiceClient, id string) (r PauseResult) {
-	_, r.Err = client.Post(actionURL(client, id), map[string]interface{}{"pause": nil}, nil, nil)
+	_, r.Err = client.Post(extensions.ActionURL(client, id), map[string]interface{}{"pause": nil}, nil, nil)
 	return
 }
 
 // Unpause is the operation responsible for unpausing a Compute server.
 func Unpause(client *gophercloud.ServiceClient, id string) (r UnpauseResult) {
-	_, r.Err = client.Post(actionURL(client, id), map[string]interface{}{"unpause": nil}, nil, nil)
+	_, r.Err = client.Post(extensions.ActionURL(client, id), map[string]interface{}{"unpause": nil}, nil, nil)
 	return
 }

--- a/openstack/compute/v2/extensions/rescueunrescue/requests.go
+++ b/openstack/compute/v2/extensions/rescueunrescue/requests.go
@@ -1,6 +1,9 @@
 package rescueunrescue
 
-import "github.com/gophercloud/gophercloud"
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions"
+)
 
 // RescueOptsBuilder is an interface that allows extensions to override the
 // default structure of a Rescue request.
@@ -35,7 +38,7 @@ func Rescue(client *gophercloud.ServiceClient, id string, opts RescueOptsBuilder
 		r.Err = err
 		return
 	}
-	_, r.Err = client.Post(actionURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
+	_, r.Err = client.Post(extensions.ActionURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{200},
 	})
 	return
@@ -43,6 +46,6 @@ func Rescue(client *gophercloud.ServiceClient, id string, opts RescueOptsBuilder
 
 // Unrescue instructs the provider to return the server from RESCUE mode.
 func Unrescue(client *gophercloud.ServiceClient, id string) (r UnrescueResult) {
-	_, r.Err = client.Post(actionURL(client, id), map[string]interface{}{"unrescue": nil}, nil, nil)
+	_, r.Err = client.Post(extensions.ActionURL(client, id), map[string]interface{}{"unrescue": nil}, nil, nil)
 	return
 }

--- a/openstack/compute/v2/extensions/resetstate/requests.go
+++ b/openstack/compute/v2/extensions/resetstate/requests.go
@@ -2,6 +2,7 @@ package resetstate
 
 import (
 	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions"
 )
 
 // ServerState refers to the states usable in ResetState Action
@@ -18,6 +19,6 @@ const (
 // ResetState will reset the state of a server
 func ResetState(client *gophercloud.ServiceClient, id string, state ServerState) (r ResetResult) {
 	stateMap := map[string]interface{}{"state": state}
-	_, r.Err = client.Post(actionURL(client, id), map[string]interface{}{"os-resetState": stateMap}, nil, nil)
+	_, r.Err = client.Post(extensions.ActionURL(client, id), map[string]interface{}{"os-resetState": stateMap}, nil, nil)
 	return
 }

--- a/openstack/compute/v2/extensions/resetstate/urls.go
+++ b/openstack/compute/v2/extensions/resetstate/urls.go
@@ -1,9 +1,0 @@
-package resetstate
-
-import (
-	"github.com/gophercloud/gophercloud"
-)
-
-func actionURL(client *gophercloud.ServiceClient, id string) string {
-	return client.ServiceURL("servers", id, "action")
-}

--- a/openstack/compute/v2/extensions/shelveunshelve/doc.go
+++ b/openstack/compute/v2/extensions/shelveunshelve/doc.go
@@ -1,0 +1,24 @@
+/*
+Package startstop provides functionality to start and stop servers that have
+been provisioned by the OpenStack Compute service.
+
+Example to Shelve, Shelve-offload and Unshelve a Server
+
+	serverID := "47b6b7b7-568d-40e4-868c-d5c41735532e"
+
+	err := startstop.Shelve(computeClient, serverID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+
+	err := startstop.ShelveOffload(computeClient, serverID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+
+	err := startstop.Unshelve(computeClient, serverID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+*/
+package shelveunshelve

--- a/openstack/compute/v2/extensions/shelveunshelve/doc.go
+++ b/openstack/compute/v2/extensions/shelveunshelve/doc.go
@@ -1,22 +1,22 @@
 /*
-Package startstop provides functionality to start and stop servers that have
+Package shelveunshelve provides functionality to start and stop servers that have
 been provisioned by the OpenStack Compute service.
 
 Example to Shelve, Shelve-offload and Unshelve a Server
 
 	serverID := "47b6b7b7-568d-40e4-868c-d5c41735532e"
 
-	err := startstop.Shelve(computeClient, serverID).ExtractErr()
+	err := shelveunshelve.Shelve(computeClient, serverID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
 
-	err := startstop.ShelveOffload(computeClient, serverID).ExtractErr()
+	err := shelveunshelve.ShelveOffload(computeClient, serverID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
 
-	err := startstop.Unshelve(computeClient, serverID).ExtractErr()
+	err := shelveunshelve.Unshelve(computeClient, serverID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/compute/v2/extensions/shelveunshelve/requests.go
+++ b/openstack/compute/v2/extensions/shelveunshelve/requests.go
@@ -23,14 +23,14 @@ type UnshelveOptsBuilder interface {
 	ToUnshelveMap() (map[string]interface{}, error)
 }
 
-// ShelveOffloadOpts specifies parameters of shelve-offload action.
-type UnshelvedOpts struct {
+// UnshelveOpts specifies parameters of shelve-offload action.
+type UnshelveOpts struct {
 	// Sets the availability zone to unshelve a server
 	// Available only after nova 2.77
 	AvailabilityZone string `json:"availability_zone,omitempty"`
 }
 
-func (opts UnshelvedOpts) ToUnshelveMap() (map[string]interface{}, error) {
+func (opts UnshelveOpts) ToUnshelveMap() (map[string]interface{}, error) {
 	// Key 'availabilty_zone' is required if the unshelve action is an object
 	// i.e {"unshelve": {}} will be rejected
 	b, err := gophercloud.BuildRequestBody(opts, "unshelve")

--- a/openstack/compute/v2/extensions/shelveunshelve/requests.go
+++ b/openstack/compute/v2/extensions/shelveunshelve/requests.go
@@ -1,25 +1,24 @@
 package shelveunshelve
 
-import "github.com/gophercloud/gophercloud"
-
-func actionURL(client *gophercloud.ServiceClient, id string) string {
-	return client.ServiceURL("servers", id, "action")
-}
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions"
+)
 
 // Shelve is the operation responsible for shelving a Compute server.
 func Shelve(client *gophercloud.ServiceClient, id string) (r ShelveResult) {
-	_, r.Err = client.Post(actionURL(client, id), map[string]interface{}{"shelve": nil}, nil, nil)
+	_, r.Err = client.Post(extensions.ActionURL(client, id), map[string]interface{}{"shelve": nil}, nil, nil)
 	return
 }
 
 // ShelveOffload is the operation responsible for Shelve-Offload a Compute server.
 func ShelveOffload(client *gophercloud.ServiceClient, id string) (r ShelveOffloadResult) {
-	_, r.Err = client.Post(actionURL(client, id), map[string]interface{}{"shelveOffload": nil}, nil, nil)
+	_, r.Err = client.Post(extensions.ActionURL(client, id), map[string]interface{}{"shelveOffload": nil}, nil, nil)
 	return
 }
 
 // Unshelve is the operation responsible for unshelve a Compute server.
 func Unshelve(client *gophercloud.ServiceClient, id string) (r UnshelveResult) {
-	_, r.Err = client.Post(actionURL(client, id), map[string]interface{}{"unshelve": nil}, nil, nil)
+	_, r.Err = client.Post(extensions.ActionURL(client, id), map[string]interface{}{"unshelve": nil}, nil, nil)
 	return
 }

--- a/openstack/compute/v2/extensions/shelveunshelve/requests.go
+++ b/openstack/compute/v2/extensions/shelveunshelve/requests.go
@@ -1,0 +1,25 @@
+package shelveunshelve
+
+import "github.com/gophercloud/gophercloud"
+
+func actionURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL("servers", id, "action")
+}
+
+// Shelve is the operation responsible for shelving a Compute server.
+func Shelve(client *gophercloud.ServiceClient, id string) (r ShelveResult) {
+	_, r.Err = client.Post(actionURL(client, id), map[string]interface{}{"shelve": nil}, nil, nil)
+	return
+}
+
+// ShelveOffload is the operation responsible for Shelve-Offload a Compute server.
+func ShelveOffload(client *gophercloud.ServiceClient, id string) (r ShelveOffloadResult) {
+	_, r.Err = client.Post(actionURL(client, id), map[string]interface{}{"shelveOffload": nil}, nil, nil)
+	return
+}
+
+// Unshelve is the operation responsible for unshelve a Compute server.
+func Unshelve(client *gophercloud.ServiceClient, id string) (r UnshelveResult) {
+	_, r.Err = client.Post(actionURL(client, id), map[string]interface{}{"unshelve": nil}, nil, nil)
+	return
+}

--- a/openstack/compute/v2/extensions/shelveunshelve/results.go
+++ b/openstack/compute/v2/extensions/shelveunshelve/results.go
@@ -1,0 +1,21 @@
+package shelveunshelve
+
+import "github.com/gophercloud/gophercloud"
+
+// ShelveResult is the response from a Shelve operation. Call its ExtractErr
+// method to determine if the request succeeded or failed.
+type ShelveResult struct {
+	gophercloud.ErrResult
+}
+
+// ShelveOffloadResult is the response from a Shelve operation. Call its ExtractErr
+// method to determine if the request succeeded or failed.
+type ShelveOffloadResult struct {
+	gophercloud.ErrResult
+}
+
+// UnshelveResult is the response from Stop operation. Call its ExtractErr
+// method to determine if the request succeeded or failed.
+type UnshelveResult struct {
+	gophercloud.ErrResult
+}

--- a/openstack/compute/v2/extensions/shelveunshelve/testing/fixtures.go
+++ b/openstack/compute/v2/extensions/shelveunshelve/testing/fixtures.go
@@ -1,0 +1,36 @@
+package testing
+
+import (
+	"net/http"
+	"testing"
+
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func mockShelveServerResponse(t *testing.T, id string) {
+	th.Mux.HandleFunc("/servers/"+id+"/action", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, `{"shelve": null}`)
+		w.WriteHeader(http.StatusAccepted)
+	})
+}
+
+func mockShelveOffloadServerResponse(t *testing.T, id string) {
+	th.Mux.HandleFunc("/servers/"+id+"/action", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, `{"shelveOffload": null}`)
+		w.WriteHeader(http.StatusAccepted)
+	})
+}
+
+func mockUnshelveServerResponse(t *testing.T, id string) {
+	th.Mux.HandleFunc("/servers/"+id+"/action", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, `{"unshelve": null}`)
+		w.WriteHeader(http.StatusAccepted)
+	})
+}

--- a/openstack/compute/v2/extensions/shelveunshelve/testing/fixtures.go
+++ b/openstack/compute/v2/extensions/shelveunshelve/testing/fixtures.go
@@ -1,6 +1,7 @@
 package testing
 
 import (
+	"fmt"
 	"net/http"
 	"testing"
 
@@ -26,7 +27,20 @@ func mockShelveOffloadServerResponse(t *testing.T, id string) {
 	})
 }
 
-func mockUnshelveServerResponse(t *testing.T, id string) {
+func mockUnshelveServerResponseWithAvailabilityZone(t *testing.T, id string, az string) {
+	th.Mux.HandleFunc("/servers/"+id+"/action", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, fmt.Sprintf(`{
+			"unshelve": {
+				"availability_zone": "%s"
+			} 
+		}`, az))
+		w.WriteHeader(http.StatusAccepted)
+	})
+}
+
+func mockUnshelveServerResponseNoAvailabilityZone(t *testing.T, id string) {
 	th.Mux.HandleFunc("/servers/"+id+"/action", func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "POST")
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)

--- a/openstack/compute/v2/extensions/shelveunshelve/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/shelveunshelve/testing/requests_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 const serverID = "{serverId}"
+const availabilityZone = "test-zone"
 
 func TestShelve(t *testing.T) {
 	th.SetupHTTP()
@@ -30,12 +31,28 @@ func TestShelveOffload(t *testing.T) {
 	th.AssertNoErr(t, err)
 }
 
-func TestUnshelve(t *testing.T) {
+func TestUnshelveNoAvailabilityZone(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 
-	mockUnshelveServerResponse(t, serverID)
+	unshelveOpts := shelveunshelve.UnshelvedOpts{}
 
-	err := shelveunshelve.Unshelve(client.ServiceClient(), serverID).ExtractErr()
+	mockUnshelveServerResponseNoAvailabilityZone(t, serverID)
+
+	err := shelveunshelve.Unshelve(client.ServiceClient(), serverID, unshelveOpts).ExtractErr()
+	th.AssertNoErr(t, err)
+}
+
+func TestUnshelveWithAvailabilityZone(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	unshelveOpts := shelveunshelve.UnshelvedOpts{
+		AvailabilityZone: availabilityZone,
+	}
+
+	mockUnshelveServerResponseWithAvailabilityZone(t, serverID, availabilityZone)
+
+	err := shelveunshelve.Unshelve(client.ServiceClient(), serverID, unshelveOpts).ExtractErr()
 	th.AssertNoErr(t, err)
 }

--- a/openstack/compute/v2/extensions/shelveunshelve/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/shelveunshelve/testing/requests_test.go
@@ -1,0 +1,41 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/shelveunshelve"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+const serverID = "{serverId}"
+
+func TestShelve(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	mockShelveServerResponse(t, serverID)
+
+	err := shelveunshelve.Shelve(client.ServiceClient(), serverID).ExtractErr()
+	th.AssertNoErr(t, err)
+}
+
+func TestShelveOffload(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	mockShelveOffloadServerResponse(t, serverID)
+
+	err := shelveunshelve.ShelveOffload(client.ServiceClient(), serverID).ExtractErr()
+	th.AssertNoErr(t, err)
+}
+
+func TestUnshelve(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	mockUnshelveServerResponse(t, serverID)
+
+	err := shelveunshelve.Unshelve(client.ServiceClient(), serverID).ExtractErr()
+	th.AssertNoErr(t, err)
+}

--- a/openstack/compute/v2/extensions/shelveunshelve/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/shelveunshelve/testing/requests_test.go
@@ -35,7 +35,7 @@ func TestUnshelveNoAvailabilityZone(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 
-	unshelveOpts := shelveunshelve.UnshelvedOpts{}
+	unshelveOpts := shelveunshelve.UnshelveOpts{}
 
 	mockUnshelveServerResponseNoAvailabilityZone(t, serverID)
 
@@ -47,7 +47,7 @@ func TestUnshelveWithAvailabilityZone(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 
-	unshelveOpts := shelveunshelve.UnshelvedOpts{
+	unshelveOpts := shelveunshelve.UnshelveOpts{
 		AvailabilityZone: availabilityZone,
 	}
 

--- a/openstack/compute/v2/extensions/startstop/requests.go
+++ b/openstack/compute/v2/extensions/startstop/requests.go
@@ -1,19 +1,18 @@
 package startstop
 
-import "github.com/gophercloud/gophercloud"
-
-func actionURL(client *gophercloud.ServiceClient, id string) string {
-	return client.ServiceURL("servers", id, "action")
-}
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions"
+)
 
 // Start is the operation responsible for starting a Compute server.
 func Start(client *gophercloud.ServiceClient, id string) (r StartResult) {
-	_, r.Err = client.Post(actionURL(client, id), map[string]interface{}{"os-start": nil}, nil, nil)
+	_, r.Err = client.Post(extensions.ActionURL(client, id), map[string]interface{}{"os-start": nil}, nil, nil)
 	return
 }
 
 // Stop is the operation responsible for stopping a Compute server.
 func Stop(client *gophercloud.ServiceClient, id string) (r StopResult) {
-	_, r.Err = client.Post(actionURL(client, id), map[string]interface{}{"os-stop": nil}, nil, nil)
+	_, r.Err = client.Post(extensions.ActionURL(client, id), map[string]interface{}{"os-stop": nil}, nil, nil)
 	return
 }

--- a/openstack/compute/v2/extensions/suspendresume/requests.go
+++ b/openstack/compute/v2/extensions/suspendresume/requests.go
@@ -1,19 +1,18 @@
 package suspendresume
 
-import "github.com/gophercloud/gophercloud"
-
-func actionURL(client *gophercloud.ServiceClient, id string) string {
-	return client.ServiceURL("servers", id, "action")
-}
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions"
+)
 
 // Suspend is the operation responsible for suspending a Compute server.
 func Suspend(client *gophercloud.ServiceClient, id string) (r SuspendResult) {
-	_, r.Err = client.Post(actionURL(client, id), map[string]interface{}{"suspend": nil}, nil, nil)
+	_, r.Err = client.Post(extensions.ActionURL(client, id), map[string]interface{}{"suspend": nil}, nil, nil)
 	return
 }
 
 // Resume is the operation responsible for resuming a Compute server.
 func Resume(client *gophercloud.ServiceClient, id string) (r UnsuspendResult) {
-	_, r.Err = client.Post(actionURL(client, id), map[string]interface{}{"resume": nil}, nil, nil)
+	_, r.Err = client.Post(extensions.ActionURL(client, id), map[string]interface{}{"resume": nil}, nil, nil)
 	return
 }

--- a/openstack/compute/v2/extensions/urls.go
+++ b/openstack/compute/v2/extensions/urls.go
@@ -1,7 +1,7 @@
-package rescueunrescue
+package extensions
 
 import "github.com/gophercloud/gophercloud"
 
-func actionURL(client *gophercloud.ServiceClient, id string) string {
+func ActionURL(client *gophercloud.ServiceClient, id string) string {
 	return client.ServiceURL("servers", id, "action")
 }


### PR DESCRIPTION
Prior to starting a PR, please make sure you have read our
[contributor tutorial](https://github.com/gophercloud/gophercloud/tree/master/docs/contributor-tutorial).

Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

For #1798 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://docs.openstack.org/api-guide/compute/server_concepts.html
https://docs.openstack.org/api-ref/compute/?expanded=shelve-server-shelve-action-detail,unshelve-restore-shelved-server-unshelve-action-detail,shelf-offload-remove-server-shelveoffload-action-detail

### Controllers
https://github.com/openstack/nova/blob/17b5a1ab85c358a1096788371849f0cccfe84972/nova/api/openstack/compute/shelve.py#L40
https://github.com/openstack/nova/blob/17b5a1ab85c358a1096788371849f0cccfe84972/nova/api/openstack/compute/shelve.py#L60
https://github.com/openstack/nova/blob/17b5a1ab85c358a1096788371849f0cccfe84972/nova/api/openstack/compute/shelve.py#L78

https://github.com/openstack/nova/blob/c6218428e9b29a2c52808ec7d27b4b21aadc0299/nova/compute/instance_actions.py#49

### APIs
https://github.com/openstack/nova/blob/6695b5633ba34b758b7f742985bc21122acb2637/nova/compute/api.py#L3906
https://github.com/openstack/nova/blob/6695b5633ba34b758b7f742985bc21122acb2637/nova/compute/api.py#L3930
https://github.com/openstack/nova/blob/6695b5633ba34b758b7f742985bc21122acb2637/nova/compute/api.py#L3994

https://github.com/openstack/nova/blob/c45d9da8d1c9b9e40a43965ea757a74015272ded/nova/compute/rpcapi.py#L1286

### Schema
https://github.com/openstack/nova/blob/master/nova/api/openstack/compute/schemas/shelve.py