### PR TITLE
Acc Tests: Enable Shared Filesystem access tests

### DIFF
--- a/acceptance/openstack/sharedfilesystems/v2/shares_test.go
+++ b/acceptance/openstack/sharedfilesystems/v2/shares_test.go
@@ -150,7 +150,6 @@ func TestShareListDetail(t *testing.T) {
 }
 
 func TestGrantAndRevokeAccess(t *testing.T) {
-	t.Skip("Currently failing in OpenLab")
 	clients.SkipRelease(t, "stable/mitaka")
 	clients.SkipRelease(t, "stable/newton")
 
@@ -180,7 +179,6 @@ func TestGrantAndRevokeAccess(t *testing.T) {
 }
 
 func TestListAccessRights(t *testing.T) {
-	t.Skip("Currently failing in OpenLab")
 	clients.SkipRelease(t, "stable/mitaka")
 	clients.SkipRelease(t, "stable/newton")
 


### PR DESCRIPTION
For #1801 

This PR is to troubleshoot the issues seen with the Shared Filesystem access tests.