### PR TITLE
Orchestration: Add support for resource_type endpoints

### DIFF
--- a/openstack/orchestration/v1/resourcetypes/doc.go
+++ b/openstack/orchestration/v1/resourcetypes/doc.go
@@ -1,0 +1,21 @@
+/*
+Package resourcetypes provides operations for listing available resource types,
+obtaining their properties schema, and generating example templates that can be
+customised to use as provider templates.
+
+Example of listing available resource types:
+
+    listOpts := resourcetypes.ListOpts{
+        SupportStatus: resourcetypes.SupportStatusSupported,
+    }
+
+    resourceTypes, err := resourcetypes.List(client, listOpts).Extract()
+    if err != nil {
+        panic(err)
+    }
+    fmt.Println("Get Resource Type List")
+    for _, rt := range resTypes {
+        fmt.Println(rt.ResourceType)
+    }
+*/
+package resourcetypes

--- a/openstack/orchestration/v1/resourcetypes/requests.go
+++ b/openstack/orchestration/v1/resourcetypes/requests.go
@@ -1,0 +1,118 @@
+package resourcetypes
+
+import (
+	"github.com/gophercloud/gophercloud"
+)
+
+// SupportStatus is a type for specifying by which support status to filter the
+// list of resource types.
+type SupportStatus string
+
+const (
+	// SupportStatusUnknown is returned when the resource type does not have a
+	// support status.
+	SupportStatusUnknown SupportStatus = "UNKNOWN"
+	// SupportStatusSupported indicates a resource type that is expected to
+	// work.
+	SupportStatusSupported SupportStatus = "SUPPORTED"
+	// SupportStatusDeprecated indicates a resource type that is in the process
+	// being removed, and may or may not be replaced by something else.
+	SupportStatusDeprecated SupportStatus = "DEPRECATED"
+	// SupportStatusHidden indicates a resource type that has been removed.
+	// Existing stacks that contain resources of this type can still be
+	// deleted or updated to remove the resources, but they may not actually
+	// do anything any more.
+	SupportStatusHidden SupportStatus = "HIDDEN"
+	// SupportStatusUnsupported indicates a resource type that is provided for
+	// preview or other purposes and should not be relied upon.
+	SupportStatusUnsupported SupportStatus = "UNSUPPORTED"
+)
+
+// ListOptsBuilder allows extensions to add additional parameters to the
+// List request.
+type ListOptsBuilder interface {
+	ToResourceTypeListQuery() (string, error)
+}
+
+// ListOpts allows the filtering of collections through the API.
+type ListOpts struct {
+	// Filters the resource type list by a regex on the name.
+	NameRegex string `q:"name"`
+	// Filters the resource list by the specified SupportStatus.
+	SupportStatus SupportStatus `q:"support_status"`
+	// Return descriptions as well as names of resource types
+	WithDescription bool `q:"with_description"`
+}
+
+// ToResourceTypeListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToResourceTypeListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List makes a request against the API to list available resource types.
+func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) (r ListResult) {
+	url := listURL(client)
+
+	if opts == nil {
+		opts = ListOpts{}
+	}
+	query, err := opts.ToResourceTypeListQuery()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	url += query
+
+	_, r.Err = client.Get(url, &r.Body, nil)
+	return
+}
+
+// GetSchema retreives the schema for a given resource type.
+func GetSchema(client *gophercloud.ServiceClient, resourceType string) (r GetSchemaResult) {
+	_, r.Err = client.Get(getSchemaURL(client, resourceType), &r.Body, nil)
+	return
+}
+
+// GenerateTemplateOptsBuilder allows extensions to add additional parameters
+// to the GenerateTemplate request.
+type GenerateTemplateOptsBuilder interface {
+	ToGenerateTemplateQuery() (string, error)
+}
+
+type GeneratedTemplateType string
+
+const (
+	TemplateTypeHOT GeneratedTemplateType = "hot"
+	TemplateTypeCFn GeneratedTemplateType = "cfn"
+)
+
+// GenerateTemplateOpts allows the filtering of collections through the API.
+type GenerateTemplateOpts struct {
+	TemplateType GeneratedTemplateType `q:"template_type"`
+}
+
+// ToGenerateTemplateQuery formats a GenerateTemplateOpts into a query string.
+func (opts GenerateTemplateOpts) ToGenerateTemplateQuery() (string, error) {
+	if opts.TemplateType == "" {
+		opts.TemplateType = TemplateTypeHOT
+	}
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// GenerateTemplate retreives an example template for a given resource type.
+func GenerateTemplate(client *gophercloud.ServiceClient, resourceType string, opts GenerateTemplateOptsBuilder) (r TemplateResult) {
+	url := generateTemplateURL(client, resourceType)
+	if opts == nil {
+		opts = GenerateTemplateOpts{}
+	}
+	query, err := opts.ToGenerateTemplateQuery()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	url += query
+	_, r.Err = client.Get(url, &r.Body, nil)
+	return
+}

--- a/openstack/orchestration/v1/resourcetypes/results.go
+++ b/openstack/orchestration/v1/resourcetypes/results.go
@@ -1,0 +1,150 @@
+package resourcetypes
+
+import (
+	"github.com/gophercloud/gophercloud"
+)
+
+// ResourceTypeSummary contains the result of listing an available resource
+// type.
+type ResourceTypeSummary struct {
+	ResourceType string `json:"resource_type"`
+	Description  string `json:"description"`
+}
+
+// PropertyType represents the expected type of a property or attribute value.
+type PropertyType string
+
+const (
+	// StringProperty indicates a string property type.
+	StringProperty PropertyType = "string"
+	// IntegerProperty indicates an integer property type.
+	IntegerProperty PropertyType = "integer"
+	// NumberProperty indicates a number property type. It may be an integer or
+	// float.
+	NumberProperty PropertyType = "number"
+	// BooleanProperty indicates a boolean property type.
+	BooleanProperty PropertyType = "boolean"
+	// MapProperty indicates a map property type.
+	MapProperty PropertyType = "map"
+	// ListProperty indicates a list property type.
+	ListProperty PropertyType = "list"
+	// UntypedProperty indicates a property that could have any type.
+	UntypedProperty PropertyType = "any"
+)
+
+// AttributeSchema is the schema of a resource attribute
+type AttributeSchema struct {
+	Description string       `json:"description,omitempty"`
+	Type        PropertyType `json:"type"`
+}
+
+// MinMaxConstraint is a type of constraint with minimum and maximum values.
+// This is used for both Range and Length constraints.
+type MinMaxConstraint struct {
+	Min float64 `json:"min,omitempty"`
+	Max float64 `json:"max,omitempty"`
+}
+
+// ModuloConstraint constrains an integer to have a certain value given a
+// particular modulus.
+type ModuloConstraint struct {
+	Step   int `json:"step,omitempty"`
+	Offset int `json:"offset,omitempty"`
+}
+
+// ConstraintSchema describes all possible types of constraints. Besides the
+// description, only one other field is ever set at a time.
+type ConstraintSchema struct {
+	Description      string            `json:"description,omitempty"`
+	Range            *MinMaxConstraint `json:"range,omitempty"`
+	Length           *MinMaxConstraint `json:"length,omitempty"`
+	Modulo           *ModuloConstraint `json:"modulo,omitempty"`
+	AllowedValues    *[]interface{}    `json:"allowed_values,omitempty"`
+	AllowedPattern   *string           `json:"allowed_pattern,omitempty"`
+	CustomConstraint *string           `json:"custom_constraint,omitempty"`
+}
+
+// PropertySchema is the schema of a resource property.
+type PropertySchema struct {
+	Type          PropertyType              `json:"type"`
+	Description   string                    `json:"description,omitempty"`
+	Default       interface{}               `json:"default,omitempty"`
+	Constraints   []ConstraintSchema        `json:"constraints,omitempty"`
+	Required      bool                      `json:"required"`
+	Immutable     bool                      `json:"immutable"`
+	UpdateAllowed bool                      `json:"update_allowed"`
+	Schema        map[string]PropertySchema `json:"schema,omitempty"`
+}
+
+// SupportStatusDetails contains information about the support status of the
+// resource and its history.
+type SupportStatusDetails struct {
+	Status         SupportStatus         `json:"status"`
+	Message        string                `json:"message,omitempty"`
+	Version        string                `json:"version,omitempty"`
+	PreviousStatus *SupportStatusDetails `json:"previous_status,omitempty"`
+}
+
+// ResourceSchema is the schema for a resource type, its attributes, and
+// properties.
+type ResourceSchema struct {
+	ResourceType  string                     `json:"resource_type"`
+	SupportStatus SupportStatusDetails       `json:"support_status"`
+	Attributes    map[string]AttributeSchema `json:"attributes"`
+	Properties    map[string]PropertySchema  `json:"properties"`
+}
+
+// ListResult represents the result of a List operation.
+type ListResult struct {
+	gophercloud.Result
+}
+
+// Extract returns a slice of ResourceTypeSummary objects and is called after
+// a List operation.
+func (r ListResult) Extract() (rts []ResourceTypeSummary, err error) {
+	var full struct {
+		ResourceTypes []ResourceTypeSummary `json:"resource_types"`
+	}
+	err = r.ExtractInto(&full)
+	if err == nil {
+		rts = full.ResourceTypes
+		return
+	}
+
+	var basic struct {
+		ResourceTypes []string `json:"resource_types"`
+	}
+	err2 := r.ExtractInto(&basic)
+	if err2 == nil {
+		err = nil
+		rts = make([]ResourceTypeSummary, len(basic.ResourceTypes))
+		for i, n := range basic.ResourceTypes {
+			rts[i] = ResourceTypeSummary{ResourceType: n}
+		}
+	}
+	return
+}
+
+// GetSchemaResult represents the result of a GetSchema operation.
+type GetSchemaResult struct {
+	gophercloud.Result
+}
+
+// Extract returns a ResourceSchema object and is called after a GetSchema
+// operation.
+func (r GetSchemaResult) Extract() (rts ResourceSchema, err error) {
+	err = r.ExtractInto(&rts)
+	return
+}
+
+// TemplateResult represents the result of a Template get operation.
+type TemplateResult struct {
+	gophercloud.Result
+}
+
+// Extract returns a Template object and is called after a Template get
+// operation.
+func (r TemplateResult) Extract() (template map[string]interface{}, err error) {
+	err = r.ExtractInto(&template)
+	return
+}

--- a/openstack/orchestration/v1/resourcetypes/testing/doc.go
+++ b/openstack/orchestration/v1/resourcetypes/testing/doc.go
@@ -1,0 +1,3 @@
+// orchestration_resourcetypes_v1
+
+package testing

--- a/openstack/orchestration/v1/resourcetypes/testing/fixtures.go
+++ b/openstack/orchestration/v1/resourcetypes/testing/fixtures.go
@@ -1,0 +1,387 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/orchestration/v1/resourcetypes"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	fake "github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+const BasicListOutput = `
+{
+    "resource_types": [
+		"OS::Nova::Server",
+		"OS::Heat::Stack"
+    ]
+}
+`
+
+var BasicListExpected = []resourcetypes.ResourceTypeSummary{
+	resourcetypes.ResourceTypeSummary{
+		ResourceType: "OS::Nova::Server",
+	},
+	resourcetypes.ResourceTypeSummary{
+		ResourceType: "OS::Heat::Stack",
+	},
+}
+
+const FullListOutput = `
+{
+    "resource_types": [
+        {
+            "description": "A Nova Server",
+			"resource_type": "OS::Nova::Server"
+        },
+        {
+            "description": "A Heat Stack",
+			"resource_type": "OS::Heat::Stack"
+        }
+    ]
+}
+`
+
+var FullListExpected = []resourcetypes.ResourceTypeSummary{
+	resourcetypes.ResourceTypeSummary{
+		ResourceType: "OS::Nova::Server",
+		Description:  "A Nova Server",
+	},
+	resourcetypes.ResourceTypeSummary{
+		ResourceType: "OS::Heat::Stack",
+		Description:  "A Heat Stack",
+	},
+}
+
+const listFilterRegex = "OS::Heat::.*"
+const FilteredListOutput = `
+{
+    "resource_types": [
+        {
+            "description": "A Heat Stack",
+			"resource_type": "OS::Heat::Stack"
+        }
+    ]
+}
+`
+
+var FilteredListExpected = []resourcetypes.ResourceTypeSummary{
+	resourcetypes.ResourceTypeSummary{
+		ResourceType: "OS::Heat::Stack",
+		Description:  "A Heat Stack",
+	},
+}
+
+// HandleListSuccessfully creates an HTTP handler at `/resource_types`
+// on the test handler mux that responds with a `List` response.
+func HandleListSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/resource_types",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "GET")
+			th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+			th.TestHeader(t, r, "Accept", "application/json")
+
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			r.ParseForm()
+			var output string
+			if r.Form.Get("with_description") == "true" {
+				if r.Form.Get("name") == listFilterRegex {
+					output = FilteredListOutput
+				} else {
+					output = FullListOutput
+				}
+			} else {
+				output = BasicListOutput
+			}
+			fmt.Fprint(w, output)
+		})
+}
+
+var glanceImageConstraint = "glance.image"
+
+var GetSchemaExpected = resourcetypes.ResourceSchema{
+	ResourceType: "OS::Test::TestServer",
+	SupportStatus: resourcetypes.SupportStatusDetails{
+		Status:  resourcetypes.SupportStatusDeprecated,
+		Message: "Bye bye.",
+		Version: "10.0.0",
+		PreviousStatus: &resourcetypes.SupportStatusDetails{
+			Status: resourcetypes.SupportStatusSupported,
+		},
+	},
+	Attributes: map[string]resourcetypes.AttributeSchema{
+		"show": resourcetypes.AttributeSchema{
+			Description: "Detailed information about resource.",
+			Type:        resourcetypes.MapProperty,
+		},
+		"tags": resourcetypes.AttributeSchema{
+			Description: "Tags from the server.",
+			Type:        resourcetypes.ListProperty,
+		},
+		"name": resourcetypes.AttributeSchema{
+			Description: "Name of the server.",
+			Type:        resourcetypes.StringProperty,
+		},
+	},
+	Properties: map[string]resourcetypes.PropertySchema{
+		"name": resourcetypes.PropertySchema{
+			Type:          resourcetypes.StringProperty,
+			Description:   "Server name.",
+			UpdateAllowed: true,
+		},
+		"image": resourcetypes.PropertySchema{
+			Type:        resourcetypes.StringProperty,
+			Description: "The ID or name of the image to boot with.",
+			Required:    true,
+			Constraints: []resourcetypes.ConstraintSchema{
+				resourcetypes.ConstraintSchema{
+					CustomConstraint: &glanceImageConstraint,
+				},
+			},
+		},
+		"block_device_mapping": resourcetypes.PropertySchema{
+			Type:        resourcetypes.ListProperty,
+			Description: "Block device mappings for this server.",
+			Schema: map[string]resourcetypes.PropertySchema{
+				"*": resourcetypes.PropertySchema{
+					Type: resourcetypes.MapProperty,
+					Schema: map[string]resourcetypes.PropertySchema{
+						"ephemeral_format": resourcetypes.PropertySchema{
+							Type:        resourcetypes.StringProperty,
+							Description: "The format of the local ephemeral block device.",
+							Constraints: []resourcetypes.ConstraintSchema{
+								resourcetypes.ConstraintSchema{
+									AllowedValues: &[]interface{}{
+										"ext3", "ext4", "xfs",
+									},
+								},
+							},
+						},
+						"ephemeral_size": resourcetypes.PropertySchema{
+							Type:        resourcetypes.IntegerProperty,
+							Description: "The size of the local ephemeral block device, in GB.",
+							Constraints: []resourcetypes.ConstraintSchema{
+								resourcetypes.ConstraintSchema{
+									Range: &resourcetypes.MinMaxConstraint{
+										Min: 1,
+									},
+								},
+							},
+						},
+						"delete_on_termination": resourcetypes.PropertySchema{
+							Type:        resourcetypes.BooleanProperty,
+							Description: "Delete volume on server termination.",
+							Default:     true,
+							Immutable:   true,
+						},
+					},
+				},
+			},
+		},
+		"image_update_policy": resourcetypes.PropertySchema{
+			Type:        resourcetypes.StringProperty,
+			Description: "Policy on how to apply an image-id update.",
+			Default:     "REBUILD",
+			Constraints: []resourcetypes.ConstraintSchema{
+				resourcetypes.ConstraintSchema{
+					AllowedValues: &[]interface{}{
+						"REBUILD", "REPLACE",
+					},
+				},
+			},
+			UpdateAllowed: true,
+		},
+	},
+}
+
+const GetSchemaOutput = `
+{
+  "resource_type": "OS::Test::TestServer",
+  "support_status": {
+    "status": "DEPRECATED",
+    "message": "Bye bye.",
+    "version": "10.0.0",
+    "previous_status": {
+      "status": "SUPPORTED",
+      "message": null,
+      "version": null,
+      "previous_status": null
+    }
+  },
+  "attributes": {
+    "show": {
+      "type": "map",
+      "description": "Detailed information about resource."
+    },
+    "tags": {
+      "type": "list",
+      "description": "Tags from the server."
+    },
+    "name": {
+      "type": "string",
+      "description": "Name of the server."
+    }
+  },
+  "properties": {
+    "name": {
+      "update_allowed": true,
+      "required": false,
+      "type": "string",
+      "description": "Server name.",
+      "immutable": false
+    },
+    "image": {
+      "description": "The ID or name of the image to boot with.",
+      "required": true,
+      "update_allowed": false,
+      "type": "string",
+      "immutable": false,
+      "constraints": [
+        {
+          "custom_constraint": "glance.image"
+        }
+      ]
+    },
+    "block_device_mapping": {
+      "description": "Block device mappings for this server.",
+      "required": false,
+      "update_allowed": false,
+      "type": "list",
+      "immutable": false,
+      "schema": {
+        "*": {
+          "update_allowed": false,
+          "required": false,
+          "type": "map",
+          "immutable": false,
+          "schema": {
+            "ephemeral_format": {
+              "description": "The format of the local ephemeral block device.",
+              "required": false,
+              "update_allowed": false,
+              "type": "string",
+              "immutable": false,
+              "constraints": [
+                {
+                  "allowed_values": [
+                    "ext3",
+                    "ext4",
+                    "xfs"
+                  ]
+                }
+              ]
+            },
+            "ephemeral_size": {
+              "description": "The size of the local ephemeral block device, in GB.",
+              "required": false,
+              "update_allowed": false,
+              "type": "integer",
+              "immutable": false,
+              "constraints": [
+                {
+                  "range": {
+                    "min": 1
+                  }
+                }
+              ]
+            },
+            "delete_on_termination": {
+              "update_allowed": false,
+              "default": true,
+              "required": false,
+              "type": "boolean",
+              "description": "Delete volume on server termination.",
+              "immutable": true
+            }
+          }
+        }
+      }
+    },
+    "image_update_policy": {
+      "description": "Policy on how to apply an image-id update.",
+      "default": "REBUILD",
+      "required": false,
+      "update_allowed": true,
+      "type": "string",
+      "immutable": false,
+      "constraints": [
+        {
+          "allowed_values": [
+            "REBUILD",
+            "REPLACE"
+          ]
+        }
+      ]
+    }
+  }
+}
+`
+
+// HandleGetSchemaSuccessfully creates an HTTP handler at
+// `/resource_types/OS::Test::TestServer` on the test handler mux that
+// responds with a `GetSchema` response.
+func HandleGetSchemaSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/resource_types/OS::Test::TestServer",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "GET")
+			th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+			th.TestHeader(t, r, "Accept", "application/json")
+
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, GetSchemaOutput)
+		})
+}
+
+const GenerateTemplateOutput = `
+{
+  "outputs": {
+    "OS::stack_id": {
+      "value": {
+        "get_resource": "NoneResource"
+      }
+    },
+    "show": {
+      "description": "Detailed information about resource.",
+      "value": {
+        "get_attr": [
+          "NoneResource",
+          "show"
+        ]
+      }
+    }
+  },
+  "heat_template_version": "2016-10-14",
+  "description": "Initial template of NoneResource",
+  "parameters": {},
+  "resources": {
+    "NoneResource": {
+      "type": "OS::Heat::None",
+      "properties": {}
+    }
+  }
+}
+`
+
+// HandleGenerateTemplateSuccessfully creates an HTTP handler at
+// `/resource_types/OS::Heat::None/template` on the test handler mux that
+// responds with a template.
+func HandleGenerateTemplateSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/resource_types/OS::Heat::None/template",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "GET")
+			th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+			th.TestHeader(t, r, "Accept", "application/json")
+
+			w.Header().Set("Content-Type", "application/json")
+			r.ParseForm()
+			if r.Form.Get("template_type") == "hot" {
+				w.WriteHeader(http.StatusOK)
+				fmt.Fprint(w, GenerateTemplateOutput)
+			} else {
+				w.WriteHeader(http.StatusBadRequest)
+			}
+		})
+}

--- a/openstack/orchestration/v1/resourcetypes/testing/requests_test.go
+++ b/openstack/orchestration/v1/resourcetypes/testing/requests_test.go
@@ -1,0 +1,84 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/orchestration/v1/resourcetypes"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	fake "github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func TestBasicListResourceTypes(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleListSuccessfully(t)
+
+	result := resourcetypes.List(fake.ServiceClient(), nil)
+	th.AssertNoErr(t, result.Err)
+
+	actual, err := result.Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertDeepEquals(t, BasicListExpected, actual)
+}
+
+func TestFullListResourceTypes(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleListSuccessfully(t)
+
+	result := resourcetypes.List(fake.ServiceClient(), resourcetypes.ListOpts{
+		WithDescription: true,
+	})
+	th.AssertNoErr(t, result.Err)
+
+	actual, err := result.Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertDeepEquals(t, FullListExpected, actual)
+}
+
+func TestFilteredListResourceTypes(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleListSuccessfully(t)
+
+	result := resourcetypes.List(fake.ServiceClient(), resourcetypes.ListOpts{
+		NameRegex:       listFilterRegex,
+		WithDescription: true,
+	})
+	th.AssertNoErr(t, result.Err)
+
+	actual, err := result.Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertDeepEquals(t, FilteredListExpected, actual)
+}
+
+func TestGetSchema(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleGetSchemaSuccessfully(t)
+
+	result := resourcetypes.GetSchema(fake.ServiceClient(), "OS::Test::TestServer")
+	th.AssertNoErr(t, result.Err)
+
+	actual, err := result.Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertDeepEquals(t, GetSchemaExpected, actual)
+}
+
+func TestGenerateTemplate(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleGenerateTemplateSuccessfully(t)
+
+	result := resourcetypes.GenerateTemplate(fake.ServiceClient(), "OS::Heat::None", nil)
+	th.AssertNoErr(t, result.Err)
+
+	actual, err := result.Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, "2016-10-14", actual["heat_template_version"])
+}

--- a/openstack/orchestration/v1/resourcetypes/urls.go
+++ b/openstack/orchestration/v1/resourcetypes/urls.go
@@ -1,0 +1,19 @@
+package resourcetypes
+
+import "github.com/gophercloud/gophercloud"
+
+const (
+	resTypesPath = "resource_types"
+)
+
+func listURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL(resTypesPath)
+}
+
+func getSchemaURL(c *gophercloud.ServiceClient, resourceType string) string {
+	return c.ServiceURL(resTypesPath, resourceType)
+}
+
+func generateTemplateURL(c *gophercloud.ServiceClient, resourceType string) string {
+	return c.ServiceURL(resTypesPath, resourceType, "template")
+}


### PR DESCRIPTION
Add client support for listing available resource types in Heat, getting
their schemata, and downloading example templates for use as provider
templates.

For #1805

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

* https://opendev.org/openstack/heat/src/branch/stable/train/heat/api/openstack/v1/stacks.py#L638-L659
* https://opendev.org/openstack/heat/src/branch/stable/train/heat/api/openstack/v1/stacks.py#L686-L707
