### PR TITLE
Fix sort_key / sort_keys

### DIFF
--- a/openstack/workflow/v2/crontriggers/requests.go
+++ b/openstack/workflow/v2/crontriggers/requests.go
@@ -124,7 +124,7 @@ type ListOpts struct {
 	// It can be "asc" or "desc" (default).
 	SortDirs string `q:"sort_dirs"`
 	// SortKeys allows to sort by one of the cron trigger attributes.
-	SortKeys string `q:"sort_key"`
+	SortKeys string `q:"sort_keys"`
 	// Marker and Limit control paging.
 	// Marker instructs List where to start listing from.
 	Marker string `q:"marker"`


### PR DESCRIPTION
Just add missing s in sort_keys query param of cron triggers : 
https://docs.openstack.org/mistral/latest/api/v2.html#get--v2-workflows

For #1808

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/mistral/blob/master/mistral/api/controllers/v2/cron_trigger.py#L119
