### PR TITLE
Fix ironic acceptance tests

### DIFF
--- a/acceptance/openstack/baremetal/v1/baremetal.go
+++ b/acceptance/openstack/baremetal/v1/baremetal.go
@@ -18,7 +18,7 @@ func CreateNode(t *testing.T, client *gophercloud.ServiceClient) (*nodes.Node, e
 	node, err := nodes.Create(client, nodes.CreateOpts{
 		Name:          name,
 		Driver:        "ipmi",
-		BootInterface: "pxe",
+		BootInterface: "ipxe",
 		RAIDInterface: "agent",
 		DriverInfo: map[string]interface{}{
 			"ipmi_port":      "6230",
@@ -74,7 +74,7 @@ func CreateFakeNode(t *testing.T, client *gophercloud.ServiceClient) (*nodes.Nod
 	node, err := nodes.Create(client, nodes.CreateOpts{
 		Name:          name,
 		Driver:        "fake-hardware",
-		BootInterface: "pxe",
+		BootInterface: "fake",
 		DriverInfo: map[string]interface{}{
 			"ipmi_port":      "6230",
 			"ipmi_username":  "admin",

--- a/acceptance/openstack/baremetal/v1/ports_test.go
+++ b/acceptance/openstack/baremetal/v1/ports_test.go
@@ -20,9 +20,10 @@ func TestPortsCreateDestroy(t *testing.T) {
 	client.Microversion = "1.53"
 
 	node, err := CreateFakeNode(t, client)
-	port, err := CreatePort(t, client, node)
 	th.AssertNoErr(t, err)
 	defer DeleteNode(t, client, node)
+	port, err := CreatePort(t, client, node)
+	th.AssertNoErr(t, err)
 	defer DeletePort(t, client, port)
 
 	found := false
@@ -54,9 +55,10 @@ func TestPortsUpdate(t *testing.T) {
 	client.Microversion = "1.53"
 
 	node, err := CreateFakeNode(t, client)
-	port, err := CreatePort(t, client, node)
 	th.AssertNoErr(t, err)
 	defer DeleteNode(t, client, node)
+	port, err := CreatePort(t, client, node)
+	th.AssertNoErr(t, err)
 	defer DeletePort(t, client, port)
 
 	updated, err := ports.Update(client, port.UUID, ports.UpdateOpts{


### PR DESCRIPTION
For #1813 

The Ironic configuration being used in the tests enables only the iPXE
and Fake boot interfaces, so use those instead of PXE.