### PR TITLE
Barbican V1: Allow multiple ACL types in one request

### DIFF
--- a/acceptance/openstack/keymanager/v1/acls_test.go
+++ b/acceptance/openstack/keymanager/v1/acls_test.go
@@ -30,9 +30,11 @@ func TestACLCRUD(t *testing.T) {
 	users := []string{user}
 	iFalse := false
 	setOpts := acls.SetOpts{
-		Type:          "read",
-		Users:         &users,
-		ProjectAccess: &iFalse,
+		acls.SetOpt{
+			Type:          "read",
+			Users:         &users,
+			ProjectAccess: &iFalse,
+		},
 	}
 
 	aclRef, err := acls.SetSecretACL(client, secretID, setOpts).Extract()
@@ -55,8 +57,10 @@ func TestACLCRUD(t *testing.T) {
 
 	newUsers := []string{}
 	updateOpts := acls.SetOpts{
-		Type:  "read",
-		Users: &newUsers,
+		acls.SetOpt{
+			Type:  "read",
+			Users: &newUsers,
+		},
 	}
 
 	aclRef, err = acls.UpdateSecretACL(client, secretID, updateOpts).Extract()

--- a/openstack/keymanager/v1/acls/requests.go
+++ b/openstack/keymanager/v1/acls/requests.go
@@ -22,8 +22,8 @@ type SetOptsBuilder interface {
 	ToACLSetMap() (map[string]interface{}, error)
 }
 
-// SetOpts represents options to set an ACL on a resource.
-type SetOpts struct {
+// SetOpt represents options to set a particular ACL type on a resource.
+type SetOpt struct {
 	// Type is the type of ACL to set. ie: read.
 	Type string `json:"-" required:"true"`
 
@@ -34,9 +34,20 @@ type SetOpts struct {
 	ProjectAccess *bool `json:"project-access,omitempty"`
 }
 
+// SetOpts represents options to set an ACL on a resource.
+type SetOpts []SetOpt
+
 // ToACLSetMap formats a SetOpts into a set request.
 func (opts SetOpts) ToACLSetMap() (map[string]interface{}, error) {
-	return gophercloud.BuildRequestBody(opts, opts.Type)
+	b := make(map[string]interface{})
+	for _, v := range opts {
+		m, err := gophercloud.BuildRequestBody(v, v.Type)
+		if err != nil {
+			return nil, err
+		}
+		b[v.Type] = m[v.Type]
+	}
+	return b, nil
 }
 
 // SetContainerACL will set an ACL on a container.

--- a/openstack/keymanager/v1/acls/testing/requests_test.go
+++ b/openstack/keymanager/v1/acls/testing/requests_test.go
@@ -36,9 +36,11 @@ func TestSetSecretACL(t *testing.T) {
 	users := []string{"GG27dVwR9gBMnsOaRoJ1DFJmZfdVjIdW"}
 	iFalse := false
 	setOpts := acls.SetOpts{
-		Type:          "read",
-		Users:         &users,
-		ProjectAccess: &iFalse,
+		acls.SetOpt{
+			Type:          "read",
+			Users:         &users,
+			ProjectAccess: &iFalse,
+		},
 	}
 
 	actual, err := acls.SetSecretACL(client.ServiceClient(), "1b8068c4-3bb6-4be6-8f1e-da0d1ea0b67c", setOpts).Extract()
@@ -54,9 +56,11 @@ func TestSetContainerACL(t *testing.T) {
 	users := []string{"GG27dVwR9gBMnsOaRoJ1DFJmZfdVjIdW"}
 	iFalse := false
 	setOpts := acls.SetOpts{
-		Type:          "read",
-		Users:         &users,
-		ProjectAccess: &iFalse,
+		acls.SetOpt{
+			Type:          "read",
+			Users:         &users,
+			ProjectAccess: &iFalse,
+		},
 	}
 
 	actual, err := acls.SetContainerACL(client.ServiceClient(), "1b8068c4-3bb6-4be6-8f1e-da0d1ea0b67c", setOpts).Extract()
@@ -89,8 +93,10 @@ func TestUpdateSecretACL(t *testing.T) {
 
 	newUsers := []string{}
 	updateOpts := acls.SetOpts{
-		Type:  "read",
-		Users: &newUsers,
+		acls.SetOpt{
+			Type:  "read",
+			Users: &newUsers,
+		},
 	}
 
 	actual, err := acls.UpdateSecretACL(client.ServiceClient(), "1b8068c4-3bb6-4be6-8f1e-da0d1ea0b67c", updateOpts).Extract()
@@ -105,8 +111,10 @@ func TestUpdateContainerACL(t *testing.T) {
 
 	newUsers := []string{}
 	updateOpts := acls.SetOpts{
-		Type:  "read",
-		Users: &newUsers,
+		acls.SetOpt{
+			Type:  "read",
+			Users: &newUsers,
+		},
 	}
 
 	actual, err := acls.UpdateContainerACL(client.ServiceClient(), "1b8068c4-3bb6-4be6-8f1e-da0d1ea0b67c", updateOpts).Extract()


### PR DESCRIPTION
Resolves #1763 