### PR TITLE
Block Storage: Fix Capabilities Parsing

### DIFF
--- a/openstack/blockstorage/extensions/schedulerstats/results.go
+++ b/openstack/blockstorage/extensions/schedulerstats/results.go
@@ -3,6 +3,7 @@ package schedulerstats
 import (
 	"encoding/json"
 	"math"
+	"strconv"
 
 	"github.com/gophercloud/gophercloud/pagination"
 )
@@ -23,7 +24,7 @@ type Capabilities struct {
 	LocationInfo             string  `json:"location_info"`
 	QoSSupport               bool    `json:"QoS_support"`
 	ProvisionedCapacityGB    float64 `json:"provisioned_capacity_gb"`
-	MaxOverSubscriptionRatio string  `json:"max_over_subscription_ratio"`
+	MaxOverSubscriptionRatio string  `json:"-"`
 	ThinProvisioningSupport  bool    `json:"thin_provisioning_support"`
 	ThickProvisioningSupport bool    `json:"thick_provisioning_support"`
 	TotalVolumes             int64   `json:"total_volumes"`
@@ -44,8 +45,9 @@ func (r *Capabilities) UnmarshalJSON(b []byte) error {
 	type tmp Capabilities
 	var s struct {
 		tmp
-		FreeCapacityGB  interface{} `json:"free_capacity_gb"`
-		TotalCapacityGB interface{} `json:"total_capacity_gb"`
+		FreeCapacityGB           interface{} `json:"free_capacity_gb"`
+		MaxOverSubscriptionRatio interface{} `json:"max_over_subscription_ratio"`
+		TotalCapacityGB          interface{} `json:"total_capacity_gb"`
 	}
 	err := json.Unmarshal(b, &s)
 	if err != nil {
@@ -71,6 +73,15 @@ func (r *Capabilities) UnmarshalJSON(b []byte) error {
 
 	r.FreeCapacityGB = parseCapacity(s.FreeCapacityGB)
 	r.TotalCapacityGB = parseCapacity(s.TotalCapacityGB)
+
+	if s.MaxOverSubscriptionRatio != nil {
+		switch t := s.MaxOverSubscriptionRatio.(type) {
+		case float64:
+			r.MaxOverSubscriptionRatio = strconv.FormatFloat(t, 'f', -1, 64)
+		case string:
+			r.MaxOverSubscriptionRatio = t
+		}
+	}
 
 	return nil
 }

--- a/openstack/blockstorage/extensions/schedulerstats/testing/fixtures.go
+++ b/openstack/blockstorage/extensions/schedulerstats/testing/fixtures.go
@@ -33,6 +33,7 @@ const StoragePoolsListBodyDetail = `
                 "filter_function": null,
                 "free_capacity_gb": 64765,
                 "goodness_function": null,
+                "max_over_subscription_ratio": "1.5",
                 "multiattach": false,
                 "reserved_percentage": 0,
                 "storage_protocol": "ceph",
@@ -49,6 +50,7 @@ const StoragePoolsListBodyDetail = `
                 "filter_function": null,
                 "free_capacity_gb": "unknown",
                 "goodness_function": null,
+                "max_over_subscription_ratio": 1.5,
                 "multiattach": false,
                 "reserved_percentage": 0,
                 "storage_protocol": "ceph",
@@ -67,24 +69,26 @@ var (
 	StoragePoolFake1 = schedulerstats.StoragePool{
 		Name: "rbd:cinder.volumes.ssd@cinder.volumes.ssd#cinder.volumes.ssd",
 		Capabilities: schedulerstats.Capabilities{
-			DriverVersion:     "1.2.0",
-			FreeCapacityGB:    64765,
-			StorageProtocol:   "ceph",
-			TotalCapacityGB:   787947.93,
-			VendorName:        "Open Source",
-			VolumeBackendName: "cinder.volumes.ssd",
+			DriverVersion:            "1.2.0",
+			FreeCapacityGB:           64765,
+			MaxOverSubscriptionRatio: "1.5",
+			StorageProtocol:          "ceph",
+			TotalCapacityGB:          787947.93,
+			VendorName:               "Open Source",
+			VolumeBackendName:        "cinder.volumes.ssd",
 		},
 	}
 
 	StoragePoolFake2 = schedulerstats.StoragePool{
 		Name: "rbd:cinder.volumes.hdd@cinder.volumes.hdd#cinder.volumes.hdd",
 		Capabilities: schedulerstats.Capabilities{
-			DriverVersion:     "1.2.0",
-			FreeCapacityGB:    0.0,
-			StorageProtocol:   "ceph",
-			TotalCapacityGB:   math.Inf(1),
-			VendorName:        "Open Source",
-			VolumeBackendName: "cinder.volumes.hdd",
+			DriverVersion:            "1.2.0",
+			FreeCapacityGB:           0.0,
+			MaxOverSubscriptionRatio: "1.5",
+			StorageProtocol:          "ceph",
+			TotalCapacityGB:          math.Inf(1),
+			VendorName:               "Open Source",
+			VolumeBackendName:        "cinder.volumes.hdd",
 		},
 	}
 )


### PR DESCRIPTION
It appears that the max_over_subscription_ratio stat returned
by the schedulerstats extension can be both a string and float64
depending on the OpenStack release.

This commit enables both to be supported, converting either value
to a string.

For #1810
