### PR TITLE
Add convenient access to error's status code

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -97,8 +97,14 @@ func (e ErrUnexpectedResponseCode) GetStatusCode() int {
 	return e.Actual
 }
 
-// GenericError can be used to easily get the error status code without doing switch case on all error types.
-type GenericError interface {
+// StatusCodeError is a convenience interface to easily allow access to the
+// status code field of the various ErrDefault* types.
+//
+// By using this interface, you only have to make a single type cast of
+// the returned error to err.(StatusCodeError) and then call GetStatusCode()
+// instead of having a large switch statement checking for each of the
+// ErrDefault* types.
+type StatusCodeError interface {
 	Error() string
 	GetStatusCode() int
 }

--- a/errors.go
+++ b/errors.go
@@ -92,6 +92,17 @@ func (e ErrUnexpectedResponseCode) Error() string {
 	return e.choseErrString()
 }
 
+// GetStatusCode returns the actual status code of the error.
+func (e ErrUnexpectedResponseCode) GetStatusCode() int {
+	return e.Actual
+}
+
+// GenericError can be used to easily get the error status code without doing switch case on all error types.
+type GenericError interface {
+	Error() string
+	GetStatusCode() int
+}
+
 // ErrDefault400 is the default error type returned on a 400 HTTP response code.
 type ErrDefault400 struct {
 	ErrUnexpectedResponseCode

--- a/testing/errors_test.go
+++ b/testing/errors_test.go
@@ -1,0 +1,24 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud"
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestGetResponseCode(t *testing.T) {
+	respErr := gophercloud.ErrUnexpectedResponseCode{
+		URL:      "http://example.com",
+		Method:   "GET",
+		Expected: []int{200},
+		Actual:   404,
+		Body:     nil,
+	}
+
+	var err404 error = gophercloud.ErrDefault404{ErrUnexpectedResponseCode: respErr}
+
+	errHTTP, ok := err404.(gophercloud.GenericError)
+	th.AssertEquals(t, true, ok)
+	th.AssertEquals(t, errHTTP.GetStatusCode(), 404)
+}

--- a/testing/errors_test.go
+++ b/testing/errors_test.go
@@ -18,7 +18,7 @@ func TestGetResponseCode(t *testing.T) {
 
 	var err404 error = gophercloud.ErrDefault404{ErrUnexpectedResponseCode: respErr}
 
-	errHTTP, ok := err404.(gophercloud.GenericError)
+	err, ok := err404.(gophercloud.StatusCodeError)
 	th.AssertEquals(t, true, ok)
-	th.AssertEquals(t, errHTTP.GetStatusCode(), 404)
+	th.AssertEquals(t, err.GetStatusCode(), 404)
 }


### PR DESCRIPTION
For #1632 
Supersedes #1633 

/cc @snigle I apologize for the delay following-up with this. After reviewing, I understand the need for the interface. However, I wanted to rename it from `GenericError` to something that describes the interface more specifically.