### PR TITLE
To add the NUMA topology in gophercloud

### DIFF
--- a/openstack/baremetalintrospection/v1/introspection/results.go
+++ b/openstack/baremetalintrospection/v1/introspection/results.go
@@ -171,6 +171,7 @@ type Data struct {
 	MemoryMB      int                          `json:"memory_mb"`
 	RootDisk      RootDiskType                 `json:"root_disk"`
 	Extra         ExtraHardwareDataType        `json:"extra"`
+	NumaTopology  NumaTopology                 `json:"numa_topology"`
 }
 
 // Sub Types defined under Data and deeper in the structure
@@ -262,6 +263,25 @@ type ExtraHardwareDataType struct {
 	Memory   ExtraHardwareDataSection `json:"memory"`
 	Network  ExtraHardwareDataSection `json:"network"`
 	System   ExtraHardwareDataSection `json:"system"`
+}
+
+type NumaTopology struct {
+	NumaNics NumaNICS `json:"nics"`
+	NumaRAM  NumaRAM  `json:"ram"`
+	NumaCPU  NumaCPU  `json:"cpus"`
+}
+type NumaNICS struct {
+	NumaNodeID int    `json:"numa_node"`
+	Name       string `json:"name"`
+}
+type NumaRAM struct {
+	NumaNodeID int `json:"numa_node"`
+	SizeKb     int `json:"size_kb"`
+}
+type NumaCPU struct {
+	NumaNodeID     int `json:"numa_node"`
+	CPUID          int `json:"cpu"`
+	ThreadSiblings int `json:"thread_siblings"`
 }
 
 // UnmarshalJSON interprets an LLDP TLV [key, value] pair as an LLDPTLVType structure

--- a/openstack/baremetalintrospection/v1/introspection/results.go
+++ b/openstack/baremetalintrospection/v1/introspection/results.go
@@ -266,9 +266,9 @@ type ExtraHardwareDataType struct {
 }
 
 type NumaTopology struct {
-	NumaNics NumaNICS `json:"nics"`
-	NumaRAM  NumaRAM  `json:"ram"`
-	NumaCPU  NumaCPU  `json:"cpus"`
+	NumaNics []NumaNICS `json:"nics"`
+	NumaRAM  []NumaRAM  `json:"ram"`
+	NumaCPU  []NumaCPU  `json:"cpus"`
 }
 type NumaNICS struct {
 	NumaNodeID int    `json:"numa_node"`
@@ -279,9 +279,9 @@ type NumaRAM struct {
 	SizeKb     int `json:"size_kb"`
 }
 type NumaCPU struct {
-	NumaNodeID     int `json:"numa_node"`
-	CPUID          int `json:"cpu"`
-	ThreadSiblings int `json:"thread_siblings"`
+	NumaNodeID     int   `json:"numa_node"`
+	CPUID          int   `json:"cpu"`
+	ThreadSiblings []int `json:"thread_siblings"`
 }
 
 // UnmarshalJSON interprets an LLDP TLV [key, value] pair as an LLDPTLVType structure

--- a/openstack/baremetalintrospection/v1/introspection/testing/fixtures.go
+++ b/openstack/baremetalintrospection/v1/introspection/testing/fixtures.go
@@ -73,6 +73,31 @@ const IntrospectionDataJSONSample = `
    "macs":[
       "52:54:00:4e:3d:30"
    ],
+   "numa_topology": {
+				"nics": [{
+				"numa_node": 0,
+				"name": "p2p1"
+				}, {
+				"numa_node": 1,
+				"name": "p2p2"
+				}],
+				"ram": [{
+				"numa_node": 0,
+				"size_kb": 99289532
+				}, {
+				"numa_node": 1,
+				"size_kb": 100663296
+				}],
+				"cpus": [{
+				"numa_node": 1,
+				"thread_siblings": [3, 27],
+				"cpu": 6
+				}, {
+				"numa_node": 0,
+				"thread_siblings": [20, 44],
+				"cpu": 10
+				}]
+				},
    "root_disk":{
       "rotational":true,
       "vendor":"0x1af4",

--- a/openstack/baremetalintrospection/v1/introspection/testing/fixtures.go
+++ b/openstack/baremetalintrospection/v1/introspection/testing/fixtures.go
@@ -265,6 +265,13 @@ var (
 				PXE: true,
 			},
 		},
+		NumaTopology: introspection.NumaTopology{
+			NumaNics: []introspection.NumaNICS{introspection.NumaNICS{NumaNodeID: 0, Name: "p2p1"},
+				introspection.NumaNICS{NumaNodeID: 1, Name: "p2p2"}},
+			NumaRAM: []introspection.NumaRAM{introspection.NumaRAM{NumaNodeID: 0, SizeKb: 99289532},
+				introspection.NumaRAM{NumaNodeID: 1, SizeKb: 100663296}},
+			NumaCPU: []introspection.NumaCPU{introspection.NumaCPU{NumaNodeID: 1, ThreadSiblings: []int{3, 27},
+				CPUID: 6}, {NumaNodeID: 0, ThreadSiblings: []int{20, 44}, CPUID: 10}}},
 		CPUs:          2,
 		BootInterface: "52:54:00:4e:3d:30",
 		MemoryMB:      2048,

--- a/openstack/baremetalintrospection/v1/introspection/testing/results_test.go
+++ b/openstack/baremetalintrospection/v1/introspection/testing/results_test.go
@@ -88,19 +88,11 @@ func TestExtraHardware(t *testing.T) {
 	}
 }
 
-func TestNumaTopology(t *testing.T) {
-	numatopology := `{
-		"NumaTopology": {
-			"NumaNics": [{"NumaNodeID": 0, "Name": "p2p1"},{"NumaNodeID": 1, "Name": "p1p1"}],
-			"NumaRAM": [{"NumaNodeID": 0, "SizeKb": 13244},{"NumaNodeID": 1, "SizeKb": 1329944}],
-			"NumaCPU": [{"NumaNodeID": 0, "CPUID": 10, "ThreadSiblings": [6,7]}, 
-						{"NumaNodeID": 1, "CPUID": 14, "ThreadSiblings": [9,2]}]
-		}
-	}`
-	var output introspection.NumaTopology
-	err := json.Unmarshal([]byte(numatopology), &output)
+func TestIntrospectionData(t *testing.T) {
+	var output introspection.Data
+	err := json.Unmarshal([]byte(IntrospectionDataJSONSample), &output)
 	if err != nil {
-		t.Errorf("Failed to unmarshal NumaTopology data: %s", err)
+		t.Errorf("Failed to unmarshal Introspection data: %s", err)
 	}
 }
 

--- a/openstack/baremetalintrospection/v1/introspection/testing/results_test.go
+++ b/openstack/baremetalintrospection/v1/introspection/testing/results_test.go
@@ -88,6 +88,22 @@ func TestExtraHardware(t *testing.T) {
 	}
 }
 
+func TestNumaTopology(t *testing.T) {
+	numatopology := `{
+		"NumaTopology": {
+			"NumaNics": [{"NumaNodeID": 0, "Name": "p2p1"},{"NumaNodeID": 1, "Name": "p1p1"}],
+			"NumaRAM": [{"NumaNodeID": 0, "SizeKb": 13244},{"NumaNodeID": 1, "SizeKb": 1329944}],
+			"NumaCPU": [{"NumaNodeID": 0, "CPUID": 10, "ThreadSiblings": [6,7]}, 
+						{"NumaNodeID": 1, "CPUID": 14, "ThreadSiblings": [9,2]}]
+		}
+	}`
+	var output introspection.NumaTopology
+	err := json.Unmarshal([]byte(numatopology), &output)
+	if err != nil {
+		t.Errorf("Failed to unmarshal NumaTopology data: %s", err)
+	}
+}
+
 func TestHostnameInInventory(t *testing.T) {
 	inventoryJson := `{
 		"bmc_address":"192.167.2.134",


### PR DESCRIPTION
For #1825 

API for introspection is already implemented, this structure will store NUMA details that we will receive from introspection.
Below is the sample introspection data for NUMA Topology that is received from ironic-inspector after baremetal introspection of a node -:

"numa_topology": {
    "nics": [{
      "numa_node": 0,
      "name": "p2p1"
    }, {
      "numa_node": 0,
      "name": "p2p2"
    }, {
      "numa_node": 0,
      "name": "p1p2"
    }],
    "ram": [{
      "numa_node": 0,
      "size_kb": 99289532
    }, {
      "numa_node": 1,
      "size_kb": 100663296
    }],
    "cpus": [{
      "numa_node": 1,
      "thread_siblings": [3, 27],
      "cpu": 6
    }, {
      "numa_node": 0,
      "thread_siblings": [20, 44],
      "cpu": 10
    }, {
      "numa_node": 0,
      "thread_siblings": [8, 32],
      "cpu": 3
    }, {
      "numa_node": 1,
      "thread_siblings": [23, 47],
      "cpu": 11
    }]
  }
  
Gophercloud is introspecting the baremetal-nodes and storing the introspection data in the respective pre-defined structures. There is no structure defined for details like, NUMA topology that we receive from Ironic introspection. To fetch the NUMA details for further use, we recommend adding the NUMA topology structure in the Gophercloud.

	type Data struct {
	...
	NumaTopology  NumaTopology                 `json:"numa_topology"`
	}

	// Sub Types defined under Data and deeper in the structure for NumaTopology

	type NumaTopology struct {
		NumaNics	[] NumaNICS 	`json:"nics"`
		NumaRAM  	[] NumaRAM  	`json:"ram"`
		NumaCPU  	[] NumaCPU  	`json:"cpus"`
	}
	type NumaNICS struct {
		NumaNodeID 		int    	`json:"numa_node"`
		Name       		string       `json:"name"`
	}
	type NumaRAM struct {
		NumaNodeID 		int     `json:"numa_node"`
		SizeKb     		int     `json:"size_kb"`
	}
	type NumaCPU struct {
		NumaNodeID      int 	`json:"numa_node"`
		CPUID                  int 	`json:"cpu"`
		ThreadSiblings   [] int  	`json:"thread_siblings"`
	}
