### PR TITLE
LoadBalancer V2: add InsertHeaders into UpdateOpts

### DIFF
--- a/acceptance/openstack/loadbalancer/v2/loadbalancers_test.go
+++ b/acceptance/openstack/loadbalancer/v2/loadbalancers_test.go
@@ -168,9 +168,13 @@ func TestLoadbalancersCRUD(t *testing.T) {
 
 	listenerName := ""
 	listenerDescription := ""
+	listenerHeaders := map[string]string{
+		"X-Forwarded-For": "true",
+	}
 	updateListenerOpts := listeners.UpdateOpts{
-		Name:        &listenerName,
-		Description: &listenerDescription,
+		Name:          &listenerName,
+		Description:   &listenerDescription,
+		InsertHeaders: listenerHeaders,
 	}
 	_, err = listeners.Update(lbClient, listener.ID, updateListenerOpts).Extract()
 	th.AssertNoErr(t, err)
@@ -186,6 +190,7 @@ func TestLoadbalancersCRUD(t *testing.T) {
 
 	th.AssertEquals(t, newListener.Name, listenerName)
 	th.AssertEquals(t, newListener.Description, listenerDescription)
+	th.AssertDeepEquals(t, newListener.InsertHeaders, listenerHeaders)
 
 	listenerStats, err := listeners.GetStats(lbClient, listener.ID).Extract()
 	th.AssertNoErr(t, err)

--- a/openstack/loadbalancer/v2/listeners/requests.go
+++ b/openstack/loadbalancer/v2/listeners/requests.go
@@ -206,6 +206,9 @@ type UpdateOpts struct {
 	// Time, in milliseconds, to wait for additional TCP packets for content inspection
 	TimeoutTCPInspect *int `json:"timeout_tcp_inspect,omitempty"`
 
+	// A dictionary of optional headers to insert into the request before it is sent to the backend member.
+	InsertHeaders map[string]string `json:"insert_headers,omitempty"`
+
 	// A list of IPv4, IPv6 or mix of both CIDRs
 	AllowedCIDRs *[]string `json:"allowed_cidrs,omitempty"`
 }

--- a/openstack/loadbalancer/v2/listeners/testing/fixtures.go
+++ b/openstack/loadbalancer/v2/listeners/testing/fixtures.go
@@ -110,7 +110,11 @@ const PostUpdateListenerBody = `
 		"timeout_client_data": 181000,
 		"timeout_member_data": 181000,
 		"timeout_member_connect": 181000,
-		"timeout_tcp_inspect": 181000
+		"timeout_tcp_inspect": 181000,
+		"insert_headers": {
+			"X-Forwarded-For": "true",
+			"X-Forwarded-Port": "false"
+		}
 	}
 }
 `
@@ -180,6 +184,10 @@ var (
 		TimeoutMemberData:      181000,
 		TimeoutMemberConnect:   181000,
 		TimeoutTCPInspect:      181000,
+		InsertHeaders: map[string]string{
+			"X-Forwarded-For":  "true",
+			"X-Forwarded-Port": "false",
+		},
 	}
 	ListenerStatsTree = listeners.Stats{
 		ActiveConnections: 0,
@@ -277,7 +285,11 @@ func HandleListenerUpdateSuccessfully(t *testing.T) {
 				"timeout_client_data": 181000,
 				"timeout_member_data": 181000,
 				"timeout_member_connect": 181000,
-				"timeout_tcp_inspect": 181000
+				"timeout_tcp_inspect": 181000,
+				"insert_headers": {
+					"X-Forwarded-For": "true",
+					"X-Forwarded-Port": "false"
+				}
 			}
 		}`)
 

--- a/openstack/loadbalancer/v2/listeners/testing/requests_test.go
+++ b/openstack/loadbalancer/v2/listeners/testing/requests_test.go
@@ -138,6 +138,10 @@ func TestUpdateListener(t *testing.T) {
 		TimeoutClientData:    &i181000,
 		TimeoutMemberConnect: &i181000,
 		TimeoutTCPInspect:    &i181000,
+		InsertHeaders: map[string]string{
+			"X-Forwarded-For":  "true",
+			"X-Forwarded-Port": "false",
+		},
 	}).Extract()
 	if err != nil {
 		t.Fatalf("Unexpected Update error: %v", err)


### PR DESCRIPTION
Add openstack/loadbalancer/v2/listeners.UpdateOpts.InsertHeaders.

For #1834

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/octavia/blob/stable/train/octavia/api/v2/types/listener.py#L170
