### PR TITLE
LoadBalancer V2: use map ptr for insert headers

### DIFF
--- a/acceptance/openstack/loadbalancer/v2/loadbalancers_test.go
+++ b/acceptance/openstack/loadbalancer/v2/loadbalancers_test.go
@@ -174,7 +174,7 @@ func TestLoadbalancersCRUD(t *testing.T) {
 	updateListenerOpts := listeners.UpdateOpts{
 		Name:          &listenerName,
 		Description:   &listenerDescription,
-		InsertHeaders: listenerHeaders,
+		InsertHeaders: &listenerHeaders,
 	}
 	_, err = listeners.Update(lbClient, listener.ID, updateListenerOpts).Extract()
 	th.AssertNoErr(t, err)
@@ -303,9 +303,11 @@ func TestLoadbalancersCRUD(t *testing.T) {
 	defer DeleteL7Policy(t, lbClient, lb.ID, policy.ID)
 	defer DeleteL7Rule(t, lbClient, lb.ID, policy.ID, rule.ID)
 
-	// Update listener's default pool ID
+	// Update listener's default pool ID and remove headers
+	listenerHeaders = map[string]string{}
 	updateListenerOpts = listeners.UpdateOpts{
 		DefaultPoolID: &pool.ID,
+		InsertHeaders: &listenerHeaders,
 	}
 	_, err = listeners.Update(lbClient, listener.ID, updateListenerOpts).Extract()
 	th.AssertNoErr(t, err)

--- a/acceptance/openstack/loadbalancer/v2/loadbalancers_test.go
+++ b/acceptance/openstack/loadbalancer/v2/loadbalancers_test.go
@@ -322,6 +322,7 @@ func TestLoadbalancersCRUD(t *testing.T) {
 	tools.PrintResource(t, newListener)
 
 	th.AssertEquals(t, newListener.DefaultPoolID, pool.ID)
+	th.AssertDeepEquals(t, newListener.InsertHeaders, listenerHeaders)
 
 	// Remove listener's default pool ID
 	emptyPoolID := ""

--- a/openstack/loadbalancer/v2/listeners/requests.go
+++ b/openstack/loadbalancer/v2/listeners/requests.go
@@ -207,7 +207,7 @@ type UpdateOpts struct {
 	TimeoutTCPInspect *int `json:"timeout_tcp_inspect,omitempty"`
 
 	// A dictionary of optional headers to insert into the request before it is sent to the backend member.
-	InsertHeaders map[string]string `json:"insert_headers,omitempty"`
+	InsertHeaders *map[string]string `json:"insert_headers,omitempty"`
 
 	// A list of IPv4, IPv6 or mix of both CIDRs
 	AllowedCIDRs *[]string `json:"allowed_cidrs,omitempty"`

--- a/openstack/loadbalancer/v2/listeners/testing/requests_test.go
+++ b/openstack/loadbalancer/v2/listeners/testing/requests_test.go
@@ -130,6 +130,10 @@ func TestUpdateListener(t *testing.T) {
 	i181000 := 181000
 	name := "NewListenerName"
 	defaultPoolID := ""
+	insertHeaders := map[string]string{
+		"X-Forwarded-For":  "true",
+		"X-Forwarded-Port": "false",
+	}
 	actual, err := listeners.Update(client, "4ec89087-d057-4e2c-911f-60a3b47ee304", listeners.UpdateOpts{
 		Name:                 &name,
 		ConnLimit:            &i1001,
@@ -138,10 +142,7 @@ func TestUpdateListener(t *testing.T) {
 		TimeoutClientData:    &i181000,
 		TimeoutMemberConnect: &i181000,
 		TimeoutTCPInspect:    &i181000,
-		InsertHeaders: map[string]string{
-			"X-Forwarded-For":  "true",
-			"X-Forwarded-Port": "false",
-		},
+		InsertHeaders:        &insertHeaders,
 	}).Extract()
 	if err != nil {
 		t.Fatalf("Unexpected Update error: %v", err)


### PR DESCRIPTION
Use pointer to a map to allow unsetting headers for listener.

For #1834

