### PR TITLE
Fix json struct tags

### DIFF
--- a/openstack/baremetal/v1/ports/requests.go
+++ b/openstack/baremetal/v1/ports/requests.go
@@ -182,8 +182,8 @@ const (
 )
 
 type UpdateOperation struct {
-	Op    UpdateOp    `json:"op,required"`
-	Path  string      `json:"path,required"`
+	Op    UpdateOp    `json:"op" required:"true"`
+	Path  string      `json:"path" required:"true"`
 	Value interface{} `json:"value,omitempty"`
 }
 

--- a/openstack/networking/v2/extensions/lbaas/vips/results.go
+++ b/openstack/networking/v2/extensions/lbaas/vips/results.go
@@ -125,7 +125,7 @@ type commonResult struct {
 // Extract is a function that accepts a result and extracts a VirtualIP.
 func (r commonResult) Extract() (*VirtualIP, error) {
 	var s struct {
-		VirtualIP *VirtualIP `json:"vip" json:"vip"`
+		VirtualIP *VirtualIP `json:"vip"`
 	}
 	err := r.ExtractInto(&s)
 	return s.VirtualIP, err


### PR DESCRIPTION
For #1839 

This fixes malformed JSON struct tags in `networking/v2/extensions/lbaas/vips` and `baremetal/v1/ports`.