### PR TITLE
add fixedIPs filter on network port

### DIFF
--- a/openstack/networking/v2/ports/testing/requests_test.go
+++ b/openstack/networking/v2/ports/testing/requests_test.go
@@ -3,6 +3,7 @@ package testing
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 	"testing"
 
 	fake "github.com/gophercloud/gophercloud/openstack/networking/v2/common"
@@ -783,4 +784,20 @@ func TestUpdateWithExtraDHCPOpts(t *testing.T) {
 	th.AssertDeepEquals(t, s.ExtraDHCPOpts[0].OptName, "option2")
 	th.AssertDeepEquals(t, s.ExtraDHCPOpts[0].OptValue, "value2")
 	th.AssertDeepEquals(t, s.ExtraDHCPOpts[0].IPVersion, 4)
+}
+
+func TestPortsListOpts(t *testing.T) {
+	for expected, opts := range map[string]ports.ListOpts{
+		newValue("fixed_ips", `ip_address=1.2.3.4,subnet_id=42`): ports.ListOpts{
+			FixedIPs: []ports.FixedIPOpts{{IPAddress: "1.2.3.4", SubnetID: "42"}},
+		},
+	} {
+		actual, _ := opts.ToPortListQuery()
+		th.AssertEquals(t, expected, actual)
+	}
+}
+func newValue(param, value string) string {
+	v := url.Values{}
+	v.Add(param, value)
+	return "?" + v.Encode()
 }


### PR DESCRIPTION
For gophercloud#1847

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://docs.openstack.org/api-ref/network/v2/?expanded=list-ports-detail

https://github.com/openstack/neutron-lib/blob/478502b3dfb8c3ff66318169377251826563a398/neutron_lib/api/validators/__init__.py#L514-L551

https://github.com/openstack/neutron-lib/blob/56033ba643812a30577f6ab17648806c2ee494ba/neutron_lib/api/definitions/port.py#L62-L69

https://github.com/openstack/neutron/blob/79e6da0004a0e4e6996d2443121fdf84ae0eb34d/neutron/plugins/ml2/plugin.py#L2241