### PR TITLE
acceptance/openstack/compute/v2: Fix Dropped Error

### DIFF
--- a/acceptance/openstack/compute/v2/compute.go
+++ b/acceptance/openstack/compute/v2/compute.go
@@ -337,7 +337,9 @@ func CreateMultiEphemeralServer(t *testing.T, client *gophercloud.ServiceClient,
 	}
 
 	newServer, err := servers.Get(client, server.ID).Extract()
-
+	if err != nil {
+		return server, err
+	}
 	th.AssertEquals(t, newServer.Name, name)
 	th.AssertEquals(t, newServer.Flavor["id"], choices.FlavorID)
 	th.AssertEquals(t, newServer.Image["id"], choices.ImageID)


### PR DESCRIPTION
This fixes a dropped error in `acceptance/openstack/compute/v2`.

For #818 