### PR TITLE
Identity V3: add Trust Get and List funcions

### DIFF
--- a/acceptance/openstack/identity/v3/identity.go
+++ b/acceptance/openstack/identity/v3/identity.go
@@ -368,3 +368,30 @@ func DeleteTrust(t *testing.T, client *gophercloud.ServiceClient, trustID string
 
 	t.Logf("Deleted trust: %s", trustID)
 }
+
+// FindTrust finds all trusts that the current authenticated client has access
+// to and returns the first one found. An error will be returned if the lookup
+// was unsuccessful.
+func FindTrust(t *testing.T, client *gophercloud.ServiceClient) (*trusts.Trust, error) {
+	t.Log("Attempting to find a trust")
+	var trust *trusts.Trust
+
+	allPages, err := trusts.List(client, nil).AllPages()
+	if err != nil {
+		return nil, err
+	}
+
+	allTrusts, err := trusts.ExtractTrusts(allPages)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, t := range allTrusts {
+		trust = &t
+		break
+	}
+
+	t.Logf("Successfully found a trust %s ", trust.ID)
+
+	return trust, nil
+}

--- a/acceptance/openstack/identity/v3/trusts_test.go
+++ b/acceptance/openstack/identity/v3/trusts_test.go
@@ -93,15 +93,8 @@ func TestTrustCRUD(t *testing.T) {
 	})
 	th.AssertNoErr(t, err)
 	defer DeleteTrust(t, client, trust.ID)
-}
 
-func TestTrustGet(t *testing.T) {
-	clients.RequireAdmin(t)
-
-	client, err := clients.NewIdentityV3Client()
-	th.AssertNoErr(t, err)
-
-	trust, err := FindTrust(t, client)
+	trust, err = FindTrust(t, client)
 	th.AssertNoErr(t, err)
 
 	p, err := trusts.Get(client, trust.ID).Extract()

--- a/acceptance/openstack/identity/v3/trusts_test.go
+++ b/acceptance/openstack/identity/v3/trusts_test.go
@@ -94,3 +94,18 @@ func TestTrustCRUD(t *testing.T) {
 	th.AssertNoErr(t, err)
 	defer DeleteTrust(t, client, trust.ID)
 }
+
+func TestTrustGet(t *testing.T) {
+	clients.RequireAdmin(t)
+
+	client, err := clients.NewIdentityV3Client()
+	th.AssertNoErr(t, err)
+
+	trust, err := FindTrust(t, client)
+	th.AssertNoErr(t, err)
+
+	p, err := trusts.Get(client, trust.ID).Extract()
+	th.AssertNoErr(t, err)
+
+	tools.PrintResource(t, p)
+}

--- a/go.mod
+++ b/go.mod
@@ -11,4 +11,3 @@ require (
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/yaml.v2 v2.2.7
 )
-

--- a/openstack/identity/v3/extensions/trusts/doc.go
+++ b/openstack/identity/v3/extensions/trusts/doc.go
@@ -54,5 +54,33 @@ Example to Delete a Trust
     if err != nil {
         panic(err)
     }
+
+Example to Get a Trust
+
+    trustID := "3422b7c113894f5d90665e1a79655e23"
+    err := trusts.Get(identityClient, trustID).ExtractErr()
+    if err != nil {
+        panic(err)
+    }
+
+Example to List a Trust
+
+	listOpts := trusts.ListOpts{
+		TrustorUserId: "3422b7c113894f5d90665e1a79655e23",
+	}
+
+	allPages, err := trusts.List(identityClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allTrusts, err := trusts.ExtractTrusts(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, trust := range allTrusts {
+		fmt.Printf("%+v\n", region)
+	}
 */
 package trusts

--- a/openstack/identity/v3/extensions/trusts/requests.go
+++ b/openstack/identity/v3/extensions/trusts/requests.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/tokens"
+	"github.com/gophercloud/gophercloud/pagination"
 )
 
 // AuthOptsExt extends the base Identity v3 tokens AuthOpts with a TrustID.
@@ -97,6 +98,25 @@ func (opts CreateOpts) ToTrustCreateMap() (map[string]interface{}, error) {
 	return b, nil
 }
 
+type ListOptsBuilder interface {
+	ToTrustListQuery() (string, error)
+}
+
+// ListOpts provides options to filter the List results.
+type ListOpts struct {
+	// TrustorUserID filters the response by a trustor user Id.
+	TrustorUserID string `q:"trustor_user_id"`
+
+	// TrusteeUserID filters the response by a trustee user Id.
+	TrusteeUserID string `q:"trustee_user_id"`
+}
+
+// ToTrustListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToTrustListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
 // Create creates a new Trust.
 func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToTrustCreateMap()
@@ -113,5 +133,26 @@ func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r Create
 // Delete deletes a trust.
 func Delete(client *gophercloud.ServiceClient, trustID string) (r DeleteResult) {
 	_, r.Err = client.Delete(deleteURL(client, trustID), nil)
+	return
+}
+
+// List enumerates the Trust to which the current token has access.
+func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(client)
+	if opts != nil {
+		query, err := opts.ToTrustListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return TrustPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// Get retrieves details on a single trust, by ID.
+func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {
+	_, r.Err = client.Get(resourceURL(client, id), &r.Body, nil)
 	return
 }

--- a/openstack/identity/v3/extensions/trusts/results.go
+++ b/openstack/identity/v3/extensions/trusts/results.go
@@ -1,6 +1,9 @@
 package trusts
 
-import "github.com/gophercloud/gophercloud"
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
 
 type trustResult struct {
 	gophercloud.Result
@@ -18,34 +21,70 @@ type DeleteResult struct {
 	gophercloud.ErrResult
 }
 
+// TrustPage is a single page of Region results.
+type TrustPage struct {
+	pagination.LinkedPageBase
+}
+
+// GetResult is the response from a Get operation. Call its Extract method
+// to interpret it as a Trust.
+type GetResult struct {
+	trustResult
+}
+
+// IsEmpty determines whether or not a page of Trusts contains any results.
+func (t TrustPage) IsEmpty() (bool, error) {
+	roles, err := ExtractTrusts(t)
+	return len(roles) == 0, err
+}
+
+// NextPageURL extracts the "next" link from the links section of the result.
+func (t TrustPage) NextPageURL() (string, error) {
+	var s struct {
+		Links struct {
+			Next     string `json:"next"`
+			Previous string `json:"previous"`
+		} `json:"links"`
+	}
+	err := t.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return s.Links.Next, err
+}
+
+// ExtractProjects returns a slice of Trusts contained in a single page of
+// results.
+func ExtractTrusts(r pagination.Page) ([]Trust, error) {
+	var s struct {
+		Trusts []Trust `json:"trusts"`
+	}
+	err := (r.(TrustPage)).ExtractInto(&s)
+	return s.Trusts, err
+}
+
 // Extract interprets any trust result as a Trust.
-func (r trustResult) Extract() (*Trust, error) {
+func (t trustResult) Extract() (*Trust, error) {
 	var s struct {
 		Trust *Trust `json:"trust"`
 	}
-	err := r.ExtractInto(&s)
+	err := t.ExtractInto(&s)
 	return s.Trust, err
-}
-
-// TrusteeUser represents the trusted user ID of a trust.
-type TrusteeUser struct {
-	ID string `json:"id"`
-}
-
-// TrustorUser represents the trusting user ID of a trust.
-type TrustorUser struct {
-	ID string `json:"id"`
 }
 
 // Trust represents a delegated authorization request between two
 // identities.
 type Trust struct {
-	ID                 string      `json:"id"`
-	Impersonation      bool        `json:"impersonation"`
-	TrusteeUser        TrusteeUser `json:"trustee_user"`
-	TrustorUser        TrustorUser `json:"trustor_user"`
-	RedelegatedTrustID string      `json:"redelegated_trust_id"`
-	RedelegationCount  int         `json:"redelegation_count"`
+	ID                 string `json:"id"`
+	Impersonation      bool   `json:"impersonation"`
+	TrusteeUserID      string `json:"trustee_user_id"`
+	TrustorUserID      string `json:"trustor_user_id"`
+	RedelegatedTrustID string `json:"redelegated_trust_id"`
+	RedelegationCount  int    `json:"redelegation_count,omitempty"`
+	AllowRedelegation  bool   `json:"allow_redelegation,omitempty"`
+	ProjectID          string `json:"project_id,omitempty"`
+	RemainingUses      bool   `json:"remaining_uses,omitempty"`
+	Roles              []Role `json:"roles,omitempty"`
 }
 
 // Role specifies a single role that is granted to a trustee.

--- a/openstack/identity/v3/extensions/trusts/testing/fixtures.go
+++ b/openstack/identity/v3/extensions/trusts/testing/fixtures.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/extensions/trusts"
+
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/tokens"
 	"github.com/gophercloud/gophercloud/testhelper"
 	"github.com/gophercloud/gophercloud/testhelper/client"
@@ -49,6 +51,66 @@ const CreateResponse = `
         "trustee_user_id": "ecb37e88cc86431c99d0332208cb6fbf",
         "trustor_user_id": "959ed913a32c4ec88c041c98e61cbbc3"
     }
+}
+`
+
+// GetOutput provides a Get result.
+const GetResponse = `
+{
+    "trust": {
+        "id": "987fe8",
+        "expires_at": "2013-02-27T18:30:59.999999Z",
+        "impersonation": true,
+        "links": {
+            "self": "http://example.com/identity/v3/OS-TRUST/trusts/987fe8"
+        },
+        "roles": [
+            {
+                "id": "ed7b78",
+                "links": {
+                    "self": "http://example.com/identity/v3/roles/ed7b78"
+                },
+                "name": "member"
+            }
+        ],
+        "roles_links": {
+            "next": null,
+            "previous": null,
+            "self": "http://example.com/identity/v3/OS-TRUST/trusts/1ff900/roles"
+        },
+        "project_id": "0f1233",
+        "trustee_user_id": "be34d1",
+        "trustor_user_id": "56ae32"
+    }
+}
+`
+
+// ListOutput provides a single page of Role results.
+const ListResponse = `
+{
+    "trusts": [
+        {
+            "id": "1ff900",
+            "expires_at": "2013-02-27T18:30:59.999999Z",
+            "impersonation": true,
+            "links": {
+                "self": "http://example.com/identity/v3/OS-TRUST/trusts/1ff900"
+            },
+            "project_id": "0f1233",
+            "trustee_user_id": "86c0d5",
+            "trustor_user_id": "a0fdfd"
+        },
+        {
+            "id": "f4513a",
+            "impersonation": false,
+            "links": {
+                "self": "http://example.com/identity/v3/OS-TRUST/trusts/f45513a"
+            },
+            "project_id": "0f1233",
+            "trustee_user_id": "86c0d5",
+            "trustor_user_id": "3cd2ce"
+        }
+    ]
 }
 `
 
@@ -131,5 +193,52 @@ func HandleDeleteTrust(t *testing.T) {
 		testhelper.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.WriteHeader(http.StatusNoContent)
+	})
+}
+
+// HandleGetTrustSuccessfully creates an HTTP handler at `/OS-TRUST/trusts` on the
+// test handler mux that responds with a single trusts.
+func HandleGetTrustSuccessfully(t *testing.T) {
+	testhelper.Mux.HandleFunc("/OS-TRUST/trusts/987fe8", func(w http.ResponseWriter, r *http.Request) {
+		testhelper.TestMethod(t, r, "GET")
+		testhelper.TestHeader(t, r, "Accept", "application/json")
+		testhelper.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, GetResponse)
+	})
+}
+
+var FirstTrust = trusts.Trust{
+	ID:            "1ff900",
+	Impersonation: true,
+	TrusteeUserID: "86c0d5",
+	TrustorUserID: "a0fdfd",
+	ProjectID:     "0f1233",
+}
+
+var SecondTrust = trusts.Trust{
+	ID:            "f4513a",
+	Impersonation: false,
+	TrusteeUserID: "86c0d5",
+	TrustorUserID: "3cd2ce",
+	ProjectID:     "0f1233",
+}
+
+// ExpectedRolesSlice is the slice of roles expected to be returned from ListOutput.
+var ExpectedTrustsSlice = []trusts.Trust{FirstTrust, SecondTrust}
+
+// HandleListTrustsSuccessfully creates an HTTP handler at `/OS-TRUST/trusts` on the
+// test handler mux that responds with a list of two trusts.
+func HandleListTrustsSuccessfully(t *testing.T) {
+	testhelper.Mux.HandleFunc("/OS-TRUST/trusts", func(w http.ResponseWriter, r *http.Request) {
+		testhelper.TestMethod(t, r, "GET")
+		testhelper.TestHeader(t, r, "Accept", "application/json")
+		testhelper.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, ListResponse)
 	})
 }

--- a/openstack/identity/v3/extensions/trusts/testing/requests_test.go
+++ b/openstack/identity/v3/extensions/trusts/testing/requests_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gophercloud/gophercloud/pagination"
+
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/extensions/trusts"
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/tokens"
 	th "github.com/gophercloud/gophercloud/testhelper"
@@ -56,14 +58,8 @@ func TestCreateUserIDPasswordTrustID(t *testing.T) {
 		},
 		trusts.TokenExt{
 			Trust: trusts.Trust{
-				ID:            "fe0aef",
-				Impersonation: false,
-				TrusteeUser: trusts.TrusteeUser{
-					ID: "0ca8f6",
-				},
-				TrustorUser: trusts.TrustorUser{
-					ID: "bd263c",
-				},
+				ID:                 "fe0aef",
+				Impersonation:      false,
 				RedelegatedTrustID: "3ba234",
 				RedelegationCount:  2,
 			},
@@ -105,4 +101,59 @@ func TestDeleteTrust(t *testing.T) {
 
 	res := trusts.Delete(client.ServiceClient(), "3422b7c113894f5d90665e1a79655e23")
 	th.AssertNoErr(t, res.Err)
+}
+
+func TestGetTrust(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleGetTrustSuccessfully(t)
+
+	res := trusts.Get(client.ServiceClient(), "987fe8")
+	th.AssertNoErr(t, res.Err)
+}
+
+func TestListTrusts(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleListTrustsSuccessfully(t)
+
+	count := 0
+	err := trusts.List(client.ServiceClient(), nil).EachPage(func(page pagination.Page) (bool, error) {
+		count++
+
+		actual, err := trusts.ExtractTrusts(page)
+		th.AssertNoErr(t, err)
+
+		th.CheckDeepEquals(t, ExpectedTrustsSlice, actual)
+
+		return true, nil
+	})
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, count, 1)
+}
+
+func TestListTrustsAllPages(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleListTrustsSuccessfully(t)
+
+	allPages, err := trusts.List(client.ServiceClient(), nil).AllPages()
+	th.AssertNoErr(t, err)
+	actual, err := trusts.ExtractTrusts(allPages)
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, ExpectedTrustsSlice, actual)
+}
+
+func TestListTrustsFiltered(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleListTrustsSuccessfully(t)
+	trustsListOpts := trusts.ListOpts{
+		TrustorUserID: "86c0d5",
+	}
+	allPages, err := trusts.List(client.ServiceClient(), trustsListOpts).AllPages()
+	th.AssertNoErr(t, err)
+	actual, err := trusts.ExtractTrusts(allPages)
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, ExpectedTrustsSlice, actual)
 }

--- a/openstack/identity/v3/extensions/trusts/urls.go
+++ b/openstack/identity/v3/extensions/trusts/urls.go
@@ -19,3 +19,7 @@ func createURL(c *gophercloud.ServiceClient) string {
 func deleteURL(c *gophercloud.ServiceClient, id string) string {
 	return resourceURL(c, id)
 }
+
+func listURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL(resourcePath)
+}


### PR DESCRIPTION
Implement Get and List functions for v3/extensions/trusts package
with unit tests and docs.

For #1642 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/keystone/blob/stable/stein/keystone/trust/core.py#L118
https://github.com/openstack/keystone/blob/stable/stein/keystone/api/trusts.py#L197
https://github.com/openstack/keystone/blob/stable/stein/keystone/api/trusts.py#L156