### PR TITLE
Identity v3: Adding ExpiresAt and DeletedAt fields to Trust results

### DIFF
--- a/acceptance/openstack/identity/v3/trusts_test.go
+++ b/acceptance/openstack/identity/v3/trusts_test.go
@@ -4,6 +4,7 @@ package v3
 
 import (
 	"testing"
+	"time"
 
 	"github.com/gophercloud/gophercloud/acceptance/clients"
 	"github.com/gophercloud/gophercloud/acceptance/tools"
@@ -80,11 +81,13 @@ func TestTrustCRUD(t *testing.T) {
 	th.AssertNoErr(t, err)
 	defer DeleteUser(t, client, trusteeUser.ID)
 
+	expiresAt := time.Now().Add(time.Minute)
 	// Create a trust.
 	trust, err := CreateTrust(t, client, trusts.CreateOpts{
 		TrusteeUserID: trusteeUser.ID,
 		TrustorUserID: adminUser.ID,
 		ProjectID:     trusteeProject.ID,
+		ExpiresAt:     &expiresAt,
 		Roles: []trusts.Role{
 			{
 				ID: memberRoleID,
@@ -99,6 +102,8 @@ func TestTrustCRUD(t *testing.T) {
 
 	p, err := trusts.Get(client, trust.ID).Extract()
 	th.AssertNoErr(t, err)
+	th.AssertEquals(t, p.ExpiresAt.IsZero(), false)
+	th.AssertEquals(t, p.DeletedAt.IsZero(), true)
 
 	tools.PrintResource(t, p)
 }

--- a/openstack/identity/v3/extensions/trusts/results.go
+++ b/openstack/identity/v3/extensions/trusts/results.go
@@ -1,6 +1,8 @@
 package trusts
 
 import (
+	"time"
+
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/pagination"
 )
@@ -75,16 +77,18 @@ func (t trustResult) Extract() (*Trust, error) {
 // Trust represents a delegated authorization request between two
 // identities.
 type Trust struct {
-	ID                 string `json:"id"`
-	Impersonation      bool   `json:"impersonation"`
-	TrusteeUserID      string `json:"trustee_user_id"`
-	TrustorUserID      string `json:"trustor_user_id"`
-	RedelegatedTrustID string `json:"redelegated_trust_id"`
-	RedelegationCount  int    `json:"redelegation_count,omitempty"`
-	AllowRedelegation  bool   `json:"allow_redelegation,omitempty"`
-	ProjectID          string `json:"project_id,omitempty"`
-	RemainingUses      bool   `json:"remaining_uses,omitempty"`
-	Roles              []Role `json:"roles,omitempty"`
+	ID                 string    `json:"id"`
+	Impersonation      bool      `json:"impersonation"`
+	TrusteeUserID      string    `json:"trustee_user_id"`
+	TrustorUserID      string    `json:"trustor_user_id"`
+	RedelegatedTrustID string    `json:"redelegated_trust_id"`
+	RedelegationCount  int       `json:"redelegation_count,omitempty"`
+	AllowRedelegation  bool      `json:"allow_redelegation,omitempty"`
+	ProjectID          string    `json:"project_id,omitempty"`
+	RemainingUses      bool      `json:"remaining_uses,omitempty"`
+	Roles              []Role    `json:"roles,omitempty"`
+	DeletedAt          time.Time `json:"deleted_at"`
+	ExpiresAt          time.Time `json:"expires_at"`
 }
 
 // Role specifies a single role that is granted to a trustee.

--- a/openstack/identity/v3/extensions/trusts/testing/fixtures.go
+++ b/openstack/identity/v3/extensions/trusts/testing/fixtures.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/extensions/trusts"
-
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/tokens"
 	"github.com/gophercloud/gophercloud/testhelper"
 	"github.com/gophercloud/gophercloud/testhelper/client"
@@ -216,6 +216,8 @@ var FirstTrust = trusts.Trust{
 	TrusteeUserID: "86c0d5",
 	TrustorUserID: "a0fdfd",
 	ProjectID:     "0f1233",
+	ExpiresAt:     time.Date(2013, 02, 27, 18, 30, 59, 999999000, time.UTC),
+	DeletedAt:     time.Time{},
 }
 
 var SecondTrust = trusts.Trust{
@@ -224,6 +226,8 @@ var SecondTrust = trusts.Trust{
 	TrusteeUserID: "86c0d5",
 	TrustorUserID: "3cd2ce",
 	ProjectID:     "0f1233",
+	ExpiresAt:     time.Time{},
+	DeletedAt:     time.Time{},
 }
 
 // ExpectedRolesSlice is the slice of roles expected to be returned from ListOutput.

--- a/openstack/identity/v3/extensions/trusts/testing/requests_test.go
+++ b/openstack/identity/v3/extensions/trusts/testing/requests_test.go
@@ -4,10 +4,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gophercloud/gophercloud/pagination"
-
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/extensions/trusts"
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/tokens"
+	"github.com/gophercloud/gophercloud/pagination"
 	th "github.com/gophercloud/gophercloud/testhelper"
 	"github.com/gophercloud/gophercloud/testhelper/client"
 )


### PR DESCRIPTION
For #1642 

* `deleted_at`: https://github.com/openstack/keystone/blob/04316beecc0d20290fb36e7791eb3050953c1011/keystone/trust/backends/sql.py#L34

* `expires_at`: https://github.com/openstack/keystone/blob/589152d094b248da81dc88db2449fb560985ae8b/keystone/trust/schema.py#L42-L44

I'm not sure why `deleted_at` isn't in `schema.py`, but it's a valid field that shows up in the API response.