### PR TITLE
Compute v2: InstanceActions ListOpts

### DIFF
--- a/acceptance/openstack/compute/v2/instance_actions_test.go
+++ b/acceptance/openstack/compute/v2/instance_actions_test.go
@@ -1,0 +1,109 @@
+// +build acceptance compute limits
+
+package v2
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gophercloud/gophercloud/acceptance/clients"
+	"github.com/gophercloud/gophercloud/acceptance/tools"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/instanceactions"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestInstanceActions(t *testing.T) {
+	client, err := clients.NewComputeV2Client()
+	th.AssertNoErr(t, err)
+
+	server, err := CreateServer(t, client)
+	th.AssertNoErr(t, err)
+	defer DeleteServer(t, client, server)
+
+	allPages, err := instanceactions.List(client, server.ID, nil).AllPages()
+	th.AssertNoErr(t, err)
+	allActions, err := instanceactions.ExtractInstanceActions(allPages)
+	th.AssertNoErr(t, err)
+
+	var found bool
+
+	for _, action := range allActions {
+		action, err := instanceactions.Get(client, server.ID, action.RequestID).Extract()
+		th.AssertNoErr(t, err)
+		tools.PrintResource(t, action)
+
+		if action.Action == "create" {
+			found = true
+		}
+	}
+
+	th.AssertEquals(t, found, true)
+}
+
+func TestInstanceActionsMicroversions(t *testing.T) {
+	clients.RequireLong(t)
+	clients.SkipRelease(t, "stable/mitaka")
+	clients.SkipRelease(t, "stable/newton")
+	clients.SkipRelease(t, "stable/ocata")
+	clients.SkipRelease(t, "stable/pike")
+	clients.SkipRelease(t, "stable/queens")
+	clients.SkipRelease(t, "stable/rocky")
+
+	now := time.Now()
+
+	client, err := clients.NewComputeV2Client()
+	th.AssertNoErr(t, err)
+	client.Microversion = "2.66"
+
+	server, err := CreateMicroversionServer(t, client)
+	th.AssertNoErr(t, err)
+	defer DeleteServer(t, client, server)
+
+	rebootOpts := servers.RebootOpts{
+		Type: servers.HardReboot,
+	}
+
+	err = servers.Reboot(client, server.ID, rebootOpts).ExtractErr()
+	if err = WaitForComputeStatus(client, server, "ACTIVE"); err != nil {
+		t.Fatal(err)
+	}
+
+	listOpts := instanceactions.ListOpts{
+		Limit:        1,
+		ChangesSince: &now,
+	}
+
+	allPages, err := instanceactions.List(client, server.ID, listOpts).AllPages()
+	th.AssertNoErr(t, err)
+
+	allActions, err := instanceactions.ExtractInstanceActions(allPages)
+	th.AssertNoErr(t, err)
+
+	var found bool
+
+	for _, action := range allActions {
+		action, err := instanceactions.Get(client, server.ID, action.RequestID).Extract()
+		th.AssertNoErr(t, err)
+		tools.PrintResource(t, action)
+
+		if action.Action == "reboot" {
+			found = true
+		}
+	}
+
+	th.AssertEquals(t, found, true)
+
+	listOpts = instanceactions.ListOpts{
+		Limit:         1,
+		ChangesBefore: &now,
+	}
+
+	allPages, err = instanceactions.List(client, server.ID, listOpts).AllPages()
+	th.AssertNoErr(t, err)
+
+	allActions, err = instanceactions.ExtractInstanceActions(allPages)
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, len(allActions), 0)
+}

--- a/acceptance/openstack/compute/v2/network_test.go
+++ b/acceptance/openstack/compute/v2/network_test.go
@@ -43,7 +43,7 @@ func TestNetworksGet(t *testing.T) {
 	client, err := clients.NewComputeV2Client()
 	th.AssertNoErr(t, err)
 
-	networkID, err := GetNetworkIDFromNetworks(t, client, choices.NetworkName)
+	networkID, err := GetNetworkIDFromOSNetworks(t, client, choices.NetworkName)
 	th.AssertNoErr(t, err)
 
 	network, err := networks.Get(client, networkID).Extract()

--- a/openstack/compute/v2/extensions/instanceactions/doc.go
+++ b/openstack/compute/v2/extensions/instanceactions/doc.go
@@ -2,12 +2,14 @@ package instanceactions
 
 /*
 Package instanceactions provides the ability to list or get a server instance-action.
-Example:
 
-	pages, err := instanceactions.List(client, "server-id").AllPages()
+Example to List and Get actions:
+
+	pages, err := instanceactions.List(client, "server-id", nil).AllPages()
 	if err != nil {
 		panic("fail to get actions pages")
 	}
+
 	actions, err := instanceactions.ExtractInstanceActions(pages)
 	if err != nil {
 		panic("fail to list instance actions")
@@ -18,6 +20,7 @@ Example:
 		if err != nil {
 			panic("fail to get instance action")
 		}
+
 		fmt.Println(action)
 	}
 */

--- a/openstack/compute/v2/extensions/instanceactions/request.go
+++ b/openstack/compute/v2/extensions/instanceactions/request.go
@@ -1,13 +1,71 @@
 package instanceactions
 
 import (
+	"net/url"
+	"time"
+
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/pagination"
 )
 
+// ListOptsBuilder allows extensions to add additional parameters to the
+// List request.
+type ListOptsBuilder interface {
+	ToInstanceActionsListQuery() (string, error)
+}
+
+// ListOpts represents options used to filter instance action results
+// in a List request.
+type ListOpts struct {
+	// Limit is an integer value to limit the results to return.
+	// This requires microversion 2.58 or later.
+	Limit int `q:"limit"`
+
+	// Marker is the request ID of the last-seen instance action.
+	// This requires microversion 2.58 or later.
+	Marker string `q:"marker"`
+
+	// ChangesSince filters the response by actions after the given time.
+	// This requires microversion 2.58 or later.
+	ChangesSince *time.Time `q:"changes-since"`
+
+	// ChangesBefore filters the response by actions before the given time.
+	// This requires microversion 2.66 or later.
+	ChangesBefore *time.Time `q:"changes-before"`
+}
+
+// ToInstanceActionsListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToInstanceActionsListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	if err != nil {
+		return "", err
+	}
+
+	params := q.Query()
+
+	if opts.ChangesSince != nil {
+		params.Add("changes-since", opts.ChangesSince.Format(time.RFC3339))
+	}
+
+	if opts.ChangesBefore != nil {
+		params.Add("changes-before", opts.ChangesBefore.Format(time.RFC3339))
+	}
+
+	q = &url.URL{RawQuery: params.Encode()}
+	return q.String(), nil
+}
+
 // List makes a request against the API to list the servers actions.
-func List(client *gophercloud.ServiceClient, id string) pagination.Pager {
-	return pagination.NewPager(client, ListURL(client, id), func(r pagination.PageResult) pagination.Page {
+func List(client *gophercloud.ServiceClient, id string, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(client, id)
+	if opts != nil {
+		query, err := opts.ToInstanceActionsListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
 		return InstanceActionPage{pagination.SinglePageBase(r)}
 	})
 }

--- a/openstack/compute/v2/extensions/instanceactions/results.go
+++ b/openstack/compute/v2/extensions/instanceactions/results.go
@@ -10,13 +10,26 @@ import (
 
 // InstanceAction represents an instance action.
 type InstanceAction struct {
-	Action       string    `json:"action"`
-	InstanceUUID string    `json:"instance_uuid"`
-	Message      string    `json:"message"`
-	ProjectID    string    `json:"project_id"`
-	RequestID    string    `json:"request_id"`
-	StartTime    time.Time `json:"-"`
-	UserID       string    `json:"user_id"`
+	// Action is the name of the action.
+	Action string `json:"action"`
+
+	// InstanceUUID is the UUID of the instance.
+	InstanceUUID string `json:"instance_uuid"`
+
+	// Message is the related error message for when an action fails.
+	Message string `json:"message"`
+
+	// Project ID is the ID of the project which initiated the action.
+	ProjectID string `json:"project_id"`
+
+	// RequestID is the ID generated when performing the action.
+	RequestID string `json:"request_id"`
+
+	// StartTime is the time the action started.
+	StartTime time.Time `json:"-"`
+
+	// UserID is the ID of the user which initiated the action.
+	UserID string `json:"user_id"`
 }
 
 // UnmarshalJSON converts our JSON API response into our instance action struct
@@ -37,7 +50,7 @@ func (i *InstanceAction) UnmarshalJSON(b []byte) error {
 	return err
 }
 
-// InstanceActionPage abstracts the raw results of making a ListInstanceActiones() request
+// InstanceActionPage abstracts the raw results of making a List() request
 // against the API. As OpenStack extensions may freely alter the response bodies
 // of structures returned to the client, you may only safely access the data
 // provided through the ExtractInstanceActions call.
@@ -51,7 +64,8 @@ func (r InstanceActionPage) IsEmpty() (bool, error) {
 	return len(instanceactions) == 0, err
 }
 
-// ListInstanceActiones() call, producing a map of instanceActions.
+// ExtractInstanceActions interprets a page of results as a slice
+// of InstanceAction.
 func ExtractInstanceActions(r pagination.Page) ([]InstanceAction, error) {
 	var resp []InstanceAction
 	err := ExtractInstanceActionsInto(r, &resp)
@@ -60,20 +74,31 @@ func ExtractInstanceActions(r pagination.Page) ([]InstanceAction, error) {
 
 // Event represents an event of instance action.
 type Event struct {
+	// Event is the name of the event.
 	Event string `json:"event"`
+
 	// Host is the host of the event.
 	// This requires microversion 2.62 or later.
 	Host *string `json:"host"`
+
 	// HostID is the host id of the event.
 	// This requires microversion 2.62 or later.
-	HostID     *string   `json:"hostId"`
-	Result     string    `json:"result"`
-	Traceback  string    `json:"traceback"`
-	StartTime  time.Time `json:"-"`
+	HostID *string `json:"hostId"`
+
+	// Result is the result of the event.
+	Result string `json:"result"`
+
+	// Traceback is the traceback stack if an error occurred.
+	Traceback string `json:"traceback"`
+
+	// StartTime is the time the action started.
+	StartTime time.Time `json:"-"`
+
+	// FinishTime is the time the event finished.
 	FinishTime time.Time `json:"-"`
 }
 
-// UnmarshalJSON converts our JSON API response into our instance action struct
+// UnmarshalJSON converts our JSON API response into our instance action struct.
 func (e *Event) UnmarshalJSON(b []byte) error {
 	type tmp Event
 	var s struct {
@@ -93,21 +118,36 @@ func (e *Event) UnmarshalJSON(b []byte) error {
 	return err
 }
 
-// InstanceActionDetail gives more details on instance action.
+// InstanceActionDetail represents the details of an Action.
 type InstanceActionDetail struct {
-	Action       string `json:"action"`
+	// Action is the name of the Action.
+	Action string `json:"action"`
+
+	// InstanceUUID is the UUID of the instance.
 	InstanceUUID string `json:"instance_uuid"`
-	Message      string `json:"message"`
-	ProjectID    string `json:"project_id"`
-	RequestID    string `json:"request_id"`
-	UserID       string `json:"user_id"`
+
+	// Message is the related error message for when an action fails.
+	Message string `json:"message"`
+
+	// Project ID is the ID of the project which initiated the action.
+	ProjectID string `json:"project_id"`
+
+	// RequestID is the ID generated when performing the action.
+	RequestID string `json:"request_id"`
+
+	// UserID is the ID of the user which initiated the action.
+	UserID string `json:"user_id"`
+
 	// Events is the list of events of the action.
 	// This requires microversion 2.50 or later.
 	Events *[]Event `json:"events"`
+
 	// UpdatedAt last update date of the action.
 	// This requires microversion 2.58 or later.
 	UpdatedAt *time.Time `json:"-"`
-	StartTime time.Time  `json:"-"`
+
+	// StartTime is the time the action started.
+	StartTime time.Time `json:"-"`
 }
 
 // UnmarshalJSON converts our JSON API response into our instance action struct
@@ -134,7 +174,7 @@ type InstanceActionResult struct {
 	gophercloud.Result
 }
 
-// Extract interprets any instanceActionResult as an InstanceActionDetail, if possible.
+// Extract interprets a result as an InstanceActionDetail.
 func (r InstanceActionResult) Extract() (InstanceActionDetail, error) {
 	var s InstanceActionDetail
 	err := r.ExtractInto(&s)

--- a/openstack/compute/v2/extensions/instanceactions/testing/request_test.go
+++ b/openstack/compute/v2/extensions/instanceactions/testing/request_test.go
@@ -16,7 +16,7 @@ func TestList(t *testing.T) {
 
 	expected := ListExpected
 	pages := 0
-	err := instanceactions.List(client.ServiceClient(), "asdfasdfasdf").EachPage(func(page pagination.Page) (bool, error) {
+	err := instanceactions.List(client.ServiceClient(), "asdfasdfasdf", nil).EachPage(func(page pagination.Page) (bool, error) {
 		pages++
 
 		actual, err := instanceactions.ExtractInstanceActions(page)

--- a/openstack/compute/v2/extensions/instanceactions/urls.go
+++ b/openstack/compute/v2/extensions/instanceactions/urls.go
@@ -2,7 +2,7 @@ package instanceactions
 
 import "github.com/gophercloud/gophercloud"
 
-func ListURL(client *gophercloud.ServiceClient, id string) string {
+func listURL(client *gophercloud.ServiceClient, id string) string {
 	return client.ServiceURL("servers", id, "os-instance-actions")
 }
 


### PR DESCRIPTION
For #1845 

This commit adds support for list params in the instanceactions extension. It also does some documentation cleanup and adds acceptance tests.

* https://github.com/openstack/nova/blob/master/nova/api/openstack/compute/instance_actions.py#L106

* https://github.com/openstack/nova/blob/master/nova/api/openstack/compute/instance_actions.py#L110

* https://github.com/openstack/nova/blob/master/nova/api/openstack/compute/instance_actions.py#L120

/cc @snigle FYI on the breaking function signature for `List`.