### PR TITLE
openstack/networking/v2/extensions/trunks/testing: Fix Two Dropped Errors

### DIFF
--- a/openstack/networking/v2/extensions/trunks/testing/fixtures.go
+++ b/openstack/networking/v2/extensions/trunks/testing/fixtures.go
@@ -360,6 +360,9 @@ func ExpectedTrunkSlice() (exp []trunks.Trunk, err error) {
 
 func ExpectedSubportsAddedTrunk() (exp trunks.Trunk, err error) {
 	trunkUpdatedAt, err := time.Parse(time.RFC3339, "2018-10-03T13:57:30Z")
+	if err != nil {
+		return
+	}
 	expectedTrunks, err := ExpectedTrunkSlice()
 	if err != nil {
 		return

--- a/openstack/networking/v2/extensions/trunks/testing/fixtures.go
+++ b/openstack/networking/v2/extensions/trunks/testing/fixtures.go
@@ -372,6 +372,9 @@ func ExpectedSubportsAddedTrunk() (exp trunks.Trunk, err error) {
 
 func ExpectedSubportsRemovedTrunk() (exp trunks.Trunk, err error) {
 	trunkUpdatedAt, err := time.Parse(time.RFC3339, "2018-10-03T13:57:27Z")
+	if err != nil {
+		return
+	}
 	expectedTrunks, err := ExpectedTrunkSlice()
 	if err != nil {
 		return


### PR DESCRIPTION
For #1876

This fixes two dropped errors in `openstack/networking/v2/extensions/trunks/testing`.