### PR TITLE
Add tags to the identity v3 project

### DIFF
--- a/acceptance/openstack/identity/v3/projects_test.go
+++ b/acceptance/openstack/identity/v3/projects_test.go
@@ -194,3 +194,135 @@ func TestProjectsNested(t *testing.T) {
 
 	th.AssertEquals(t, project.ParentID, projectMain.ID)
 }
+
+func TestProjectsTags(t *testing.T) {
+	clients.RequireAdmin(t)
+
+	client, err := clients.NewIdentityV3Client()
+	th.AssertNoErr(t, err)
+
+	createOpts := projects.CreateOpts{
+		Tags: []string{"Tag1", "Tag2"},
+	}
+
+	projectMain, err := CreateProject(t, client, &createOpts)
+	th.AssertNoErr(t, err)
+	defer DeleteProject(t, client, projectMain.ID)
+
+	// Search using all tags
+	listOpts := projects.ListOpts{
+		Tags: &[]string{"Tag1", "Tag2"},
+	}
+
+	allPages, err := projects.List(client, listOpts).AllPages()
+	th.AssertNoErr(t, err)
+
+	allProjects, err := projects.ExtractProjects(allPages)
+	th.AssertNoErr(t, err)
+
+	found := false
+	for _, project := range allProjects {
+		tools.PrintResource(t, project)
+
+		if project.Name == "admin" {
+			found = true
+		}
+	}
+
+	th.AssertEquals(t, found, true)
+
+	// Search using all tags, including a not existing one
+	listOpts = projects.ListOpts{
+		Tags: &[]string{"Tag1", "Tag2", "Tag3"},
+	}
+
+	allPages, err = projects.List(client, listOpts).AllPages()
+	th.AssertNoErr(t, err)
+
+	allProjects, err = projects.ExtractProjects(allPages)
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, len(allProjects), 0)
+
+	// Search matching at least one tag
+	listOpts = projects.ListOpts{
+		TagsAny: &[]string{"Tag1", "Tag2", "Tag3"},
+	}
+
+	allPages, err = projects.List(client, listOpts).AllPages()
+	th.AssertNoErr(t, err)
+
+	allProjects, err = projects.ExtractProjects(allPages)
+	th.AssertNoErr(t, err)
+
+	found = false
+	for _, project := range allProjects {
+		tools.PrintResource(t, project)
+
+		if project.Name == "admin" {
+			found = true
+		}
+	}
+
+	th.AssertEquals(t, found, true)
+
+	// Search not matching any single tag
+	listOpts = projects.ListOpts{
+		NotTagsAny: &[]string{"Tag1"},
+	}
+
+	allPages, err = projects.List(client, listOpts).AllPages()
+	th.AssertNoErr(t, err)
+
+	allProjects, err = projects.ExtractProjects(allPages)
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, len(allProjects), 0)
+
+	// Search matching not all tags
+	listOpts = projects.ListOpts{
+		NotTags: &[]string{"Tag1", "Tag2", "Tag3"},
+	}
+
+	allPages, err = projects.List(client, listOpts).AllPages()
+	th.AssertNoErr(t, err)
+
+	allProjects, err = projects.ExtractProjects(allPages)
+	th.AssertNoErr(t, err)
+
+	found = false
+	for _, project := range allProjects {
+		tools.PrintResource(t, project)
+
+		if project.Name == "admin" {
+			found = true
+		}
+	}
+
+	th.AssertEquals(t, found, true)
+
+	// Update the tags
+	updateOpts := projects.UpdateOpts{
+		Tags: &[]string{"Tag1"},
+	}
+
+	updatedProject, err := projects.Update(client, projectMain.ID, updateOpts).Extract()
+	th.AssertNoErr(t, err)
+
+	tools.PrintResource(t, updatedProject)
+	th.AssertEquals(t, len(updatedProject.Tags), 1)
+	th.AssertEquals(t, updatedProject.Tags[0], "Tag1")
+
+	// Update the project, but not its tags
+	description := "Test description"
+	updateOpts = projects.UpdateOpts{
+		Description: &description,
+	}
+
+	updatedProject, err = projects.Update(client, projectMain.ID, updateOpts).Extract()
+	th.AssertNoErr(t, err)
+
+	tools.PrintResource(t, updatedProject)
+	th.AssertEquals(t, len(updatedProject.Tags), 1)
+	th.AssertEquals(t, updatedProject.Tags[0], "Tag1")
+}

--- a/acceptance/openstack/identity/v3/projects_test.go
+++ b/acceptance/openstack/identity/v3/projects_test.go
@@ -211,7 +211,7 @@ func TestProjectsTags(t *testing.T) {
 
 	// Search using all tags
 	listOpts := projects.ListOpts{
-		Tags: &[]string{"Tag1", "Tag2"},
+		Tags: "Tag1,Tag2",
 	}
 
 	allPages, err := projects.List(client, listOpts).AllPages()
@@ -233,7 +233,7 @@ func TestProjectsTags(t *testing.T) {
 
 	// Search using all tags, including a not existing one
 	listOpts = projects.ListOpts{
-		Tags: &[]string{"Tag1", "Tag2", "Tag3"},
+		Tags: "Tag1,Tag2,Tag3",
 	}
 
 	allPages, err = projects.List(client, listOpts).AllPages()
@@ -246,7 +246,7 @@ func TestProjectsTags(t *testing.T) {
 
 	// Search matching at least one tag
 	listOpts = projects.ListOpts{
-		TagsAny: &[]string{"Tag1", "Tag2", "Tag3"},
+		TagsAny: "Tag1,Tag2,Tag3",
 	}
 
 	allPages, err = projects.List(client, listOpts).AllPages()
@@ -268,7 +268,7 @@ func TestProjectsTags(t *testing.T) {
 
 	// Search not matching any single tag
 	listOpts = projects.ListOpts{
-		NotTagsAny: &[]string{"Tag1"},
+		NotTagsAny: "Tag1",
 	}
 
 	allPages, err = projects.List(client, listOpts).AllPages()
@@ -281,7 +281,7 @@ func TestProjectsTags(t *testing.T) {
 
 	// Search matching not all tags
 	listOpts = projects.ListOpts{
-		NotTags: &[]string{"Tag1", "Tag2", "Tag3"},
+		NotTags: "Tag1,Tag2,Tag3",
 	}
 
 	allPages, err = projects.List(client, listOpts).AllPages()

--- a/acceptance/openstack/identity/v3/projects_test.go
+++ b/acceptance/openstack/identity/v3/projects_test.go
@@ -224,7 +224,7 @@ func TestProjectsTags(t *testing.T) {
 	for _, project := range allProjects {
 		tools.PrintResource(t, project)
 
-		if project.Name == "admin" {
+		if project.Name == projectMain.Name {
 			found = true
 		}
 	}
@@ -259,7 +259,7 @@ func TestProjectsTags(t *testing.T) {
 	for _, project := range allProjects {
 		tools.PrintResource(t, project)
 
-		if project.Name == "admin" {
+		if project.Name == projectMain.Name {
 			found = true
 		}
 	}
@@ -277,7 +277,16 @@ func TestProjectsTags(t *testing.T) {
 	allProjects, err = projects.ExtractProjects(allPages)
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, len(allProjects), 0)
+	found = false
+	for _, project := range allProjects {
+		tools.PrintResource(t, project)
+
+		if project.Name == projectMain.Name {
+			found = true
+		}
+	}
+
+	th.AssertEquals(t, found, false)
 
 	// Search matching not all tags
 	listOpts = projects.ListOpts{
@@ -325,4 +334,15 @@ func TestProjectsTags(t *testing.T) {
 	tools.PrintResource(t, updatedProject)
 	th.AssertEquals(t, len(updatedProject.Tags), 1)
 	th.AssertEquals(t, updatedProject.Tags[0], "Tag1")
+
+	// Remove all Tags
+	updateOpts = projects.UpdateOpts{
+		Tags: &[]string{},
+	}
+
+	updatedProject, err = projects.Update(client, projectMain.ID, updateOpts).Extract()
+	th.AssertNoErr(t, err)
+
+	tools.PrintResource(t, updatedProject)
+	th.AssertEquals(t, len(updatedProject.Tags), 0)
 }

--- a/openstack/identity/v3/projects/doc.go
+++ b/openstack/identity/v3/projects/doc.go
@@ -26,7 +26,8 @@ Example to Create a Project
 
 	createOpts := projects.CreateOpts{
 		Name:        "project_name",
-		Description: "Project Description"
+		Description: "Project Description",
+		Tags:        []string{"FirstTag", "SecondTag"},
 	}
 
 	project, err := projects.Create(identityClient, createOpts).Extract()
@@ -43,6 +44,15 @@ Example to Update a Project
 	}
 
 	project, err := projects.Update(identityClient, projectID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	updateOpts = projects.UpdateOpts{
+		Tags: &[]string{"FirstTag"},
+	}
+
+	project, err = projects.Update(identityClient, projectID, updateOpts).Extract()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/identity/v3/projects/requests.go
+++ b/openstack/identity/v3/projects/requests.go
@@ -33,16 +33,16 @@ type ListOpts struct {
 	ParentID string `q:"parent_id"`
 
 	// Tags filters on specific project tags. All tags must be present for the project.
-	Tags *[]string `q:"tags"`
+	Tags string `q:"tags"`
 
 	// TagsAny filters on specific project tags. At least one of the tags must be present for the project.
-	TagsAny *[]string `q:"tags-any"`
+	TagsAny string `q:"tags-any"`
 
 	// NotTags filters on specific project tags. All tags must be absent for the project.
-	NotTags *[]string `q:"not-tags"`
+	NotTags string `q:"not-tags"`
 
 	// NotTagsAny filters on specific project tags. At least one of the tags must be absent for the project.
-	NotTagsAny *[]string `q:"not-tags-any"`
+	NotTagsAny string `q:"not-tags-any"`
 
 	// Filters filters the response by custom filters such as
 	// 'name__contains=foo'

--- a/openstack/identity/v3/projects/requests.go
+++ b/openstack/identity/v3/projects/requests.go
@@ -33,16 +33,16 @@ type ListOpts struct {
 	ParentID string `q:"parent_id"`
 
 	// Tags filters on specific project tags. All tags must be present for the project.
-	Tags string `q:"tags"`
+	Tags *[]string `q:"tags"`
 
 	// TagsAny filters on specific project tags. At least one of the tags must be present for the project.
-	TagsAny string `q:"tags-any"`
+	TagsAny *[]string `q:"tags-any"`
 
 	// NotTags filters on specific project tags. All tags must be absent for the project.
-	NotTags string `q:"not-tags"`
+	NotTags *[]string `q:"not-tags"`
 
 	// NotTagsAny filters on specific project tags. At least one of the tags must be absent for the project.
-	NotTagsAny string `q:"not-tags-any"`
+	NotTagsAny *[]string `q:"not-tags-any"`
 
 	// Filters filters the response by custom filters such as
 	// 'name__contains=foo'
@@ -170,7 +170,7 @@ type UpdateOpts struct {
 	Description *string `json:"description,omitempty"`
 
 	// Tags is a list of tags to associate with the project.
-	Tags []string `json:"tags,omitempty"`
+	Tags *[]string `json:"tags,omitempty"`
 }
 
 // ToUpdateCreateMap formats a UpdateOpts into an update request.

--- a/openstack/identity/v3/projects/requests.go
+++ b/openstack/identity/v3/projects/requests.go
@@ -32,6 +32,18 @@ type ListOpts struct {
 	// ParentID filters the response by projects of a given parent project.
 	ParentID string `q:"parent_id"`
 
+	// Tags filters on specific project tags. All tags must be present for the project.
+	Tags string `q:"tags"`
+
+	// TagsAny filters on specific project tags. At least one of the tags must be present for the project.
+	TagsAny string `q:"tags-any"`
+
+	// NotTags filters on specific project tags. All tags must be absent for the project.
+	NotTags string `q:"not-tags"`
+
+	// NotTagsAny filters on specific project tags. At least one of the tags must be absent for the project.
+	NotTagsAny string `q:"not-tags-any"`
+
 	// Filters filters the response by custom filters such as
 	// 'name__contains=foo'
 	Filters map[string]string `q:"-"`
@@ -104,6 +116,9 @@ type CreateOpts struct {
 
 	// Description is the description of the project.
 	Description string `json:"description,omitempty"`
+
+	// Tags is a list of tags to associate with the project.
+	Tags []string `json:"tags,omitempty"`
 }
 
 // ToProjectCreateMap formats a CreateOpts into a create request.
@@ -153,6 +168,9 @@ type UpdateOpts struct {
 
 	// Description is the description of the project.
 	Description *string `json:"description,omitempty"`
+
+	// Tags is a list of tags to associate with the project.
+	Tags []string `json:"tags,omitempty"`
 }
 
 // ToUpdateCreateMap formats a UpdateOpts into an update request.

--- a/openstack/identity/v3/projects/results.go
+++ b/openstack/identity/v3/projects/results.go
@@ -55,6 +55,9 @@ type Project struct {
 
 	// ParentID is the parent_id of the project.
 	ParentID string `json:"parent_id"`
+
+	// Tags is the list of tags associated with the project.
+	Tags []string `json:"tags,omitempty"`
 }
 
 // ProjectPage is a single page of Project results.

--- a/openstack/identity/v3/projects/testing/fixtures.go
+++ b/openstack/identity/v3/projects/testing/fixtures.go
@@ -21,7 +21,8 @@ const ListOutput = `
       "enabled": true,
       "id": "1234",
       "name": "Red Team",
-      "parent_id": null
+      "parent_id": null,
+	  "tags": ["Red", "Team"]
     },
     {
       "is_domain": false,
@@ -30,7 +31,7 @@ const ListOutput = `
       "enabled": true,
       "id": "9876",
       "name": "Blue Team",
-      "parent_id": null
+	  "parent_id": null
     }
   ],
   "links": {
@@ -50,8 +51,9 @@ const GetOutput = `
 		"enabled": true,
 		"id": "1234",
 		"name": "Red Team",
-		"parent_id": null
-  }
+		"parent_id": null,
+		"tags": ["Red", "Team"]
+	}
 }
 `
 
@@ -60,7 +62,8 @@ const CreateRequest = `
 {
   "project": {
 		"description": "The team that is red",
-		"name": "Red Team"
+		"name": "Red Team",
+		"tags": ["Red", "Team"]
   }
 }
 `
@@ -70,7 +73,8 @@ const UpdateRequest = `
 {
   "project": {
 		"description": "The team that is bright red",
-		"name": "Bright Red Team"
+		"name": "Bright Red Team",
+		"tags": ["Red"]
   }
 }
 `
@@ -85,8 +89,9 @@ const UpdateOutput = `
 		"enabled": true,
 		"id": "1234",
 		"name": "Bright Red Team",
-		"parent_id": null
-  }
+		"parent_id": null,
+		"tags": ["Red"]
+	}
 }
 `
 
@@ -99,6 +104,7 @@ var RedTeam = projects.Project{
 	ID:          "1234",
 	Name:        "Red Team",
 	ParentID:    "",
+	Tags:        []string{"Red", "Team"},
 }
 
 // BlueTeam is a Project fixture.
@@ -121,6 +127,7 @@ var UpdatedRedTeam = projects.Project{
 	ID:          "1234",
 	Name:        "Bright Red Team",
 	ParentID:    "",
+	Tags:        []string{"Red"},
 }
 
 // ExpectedProjectSlice is the slice of projects expected to be returned from ListOutput.

--- a/openstack/identity/v3/projects/testing/fixtures.go
+++ b/openstack/identity/v3/projects/testing/fixtures.go
@@ -22,7 +22,7 @@ const ListOutput = `
       "id": "1234",
       "name": "Red Team",
       "parent_id": null,
-	  "tags": ["Red", "Team"]
+      "tags": ["Red", "Team"]
     },
     {
       "is_domain": false,
@@ -31,7 +31,7 @@ const ListOutput = `
       "enabled": true,
       "id": "9876",
       "name": "Blue Team",
-	  "parent_id": null
+      "parent_id": null
     }
   ],
   "links": {

--- a/openstack/identity/v3/projects/testing/requests_test.go
+++ b/openstack/identity/v3/projects/testing/requests_test.go
@@ -79,6 +79,7 @@ func TestCreateProject(t *testing.T) {
 	createOpts := projects.CreateOpts{
 		Name:        "Red Team",
 		Description: "The team that is red",
+		Tags:        []string{"Red", "Team"},
 	}
 
 	actual, err := projects.Create(client.ServiceClient(), createOpts).Extract()
@@ -104,6 +105,7 @@ func TestUpdateProject(t *testing.T) {
 	updateOpts := projects.UpdateOpts{
 		Name:        "Bright Red Team",
 		Description: &description,
+		Tags:        []string{"Red"},
 	}
 
 	actual, err := projects.Update(client.ServiceClient(), "1234", updateOpts).Extract()

--- a/openstack/identity/v3/projects/testing/requests_test.go
+++ b/openstack/identity/v3/projects/testing/requests_test.go
@@ -105,7 +105,7 @@ func TestUpdateProject(t *testing.T) {
 	updateOpts := projects.UpdateOpts{
 		Name:        "Bright Red Team",
 		Description: &description,
-		Tags:        []string{"Red"},
+		Tags:        &[]string{"Red"},
 	}
 
 	actual, err := projects.Update(client.ServiceClient(), "1234", updateOpts).Extract()


### PR DESCRIPTION
For #1687

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:
https://github.com/openstack/keystone/blob/fe39838f712880c336e18eadf320e7c9e2007448/keystone/api/projects.py#L111
https://github.com/openstack/keystone/blob/fe39838f712880c336e18eadf320e7c9e2007448/keystone/api/projects.py#L233
https://github.com/openstack/keystone/blob/fe39838f712880c336e18eadf320e7c9e2007448/keystone/api/projects.py#L265
https://github.com/openstack/keystone/blob/fe39838f712880c336e18eadf320e7c9e2007448/keystone/api/projects.py#L490

This pull request adds supports for assocaiting tags to projects using the idenetity v3 APIs. The tags are optional thua llowing backward compatibility with OpenStack versions older than Queens: it is enough to not specify tags when creating or updating a project.