### PR TITLE
openstack/compute/v2/servers/testing: Dropped Error

### DIFF
--- a/openstack/compute/v2/servers/testing/results_test.go
+++ b/openstack/compute/v2/servers/testing/results_test.go
@@ -24,6 +24,7 @@ func TestExtractPassword_no_pwd_data(t *testing.T) {
 	resp := servers.GetPasswordResult{Result: gophercloud.Result{Body: dejson}}
 
 	pwd, err := resp.ExtractPassword(nil)
+	th.AssertNoErr(t, err)
 	th.AssertEquals(t, pwd, "")
 }
 


### PR DESCRIPTION
For #1887

This fixes a dropped error in `openstack/compute/v2/servers/testing`.