### PR TITLE
Identity v3: OS-EP-FILTERS endpoint group list/get

### DIFF
--- a/openstack/identity/v3/extensions/endpointgroups/doc.go
+++ b/openstack/identity/v3/extensions/endpointgroups/doc.go
@@ -1,0 +1,32 @@
+/*
+Package endpointgroups enables management of OpenStack Identity Endpoint Groups
+and Endpoint associations.
+
+Example to Get an Endpoint Group
+
+    err := endpointgroups.Get(identityClient, endpointGroupID).ExtractErr()
+    if err != nil {
+    	panic(err)
+    }
+
+Example to List all Endpoint Groups by name
+
+	listOpts := endpointgropus.ListOpts{
+		Name: "mygroup",
+	}
+
+    allPages, err := endpointgroups.List(identityClient, listOpts).AllPages()
+    if err != nil {
+    	panic(err)
+    }
+
+	allGroups, err := endpointgroups.ExtractEndpointGroups(allPages)
+    if err != nil {
+    	panic(err)
+    }
+
+	for _, endpointgroup := range allGroups {
+		fmt.Printf("%+v\n", endpointgroup)
+	}
+*/
+package endpointgroups

--- a/openstack/identity/v3/extensions/endpointgroups/doc.go
+++ b/openstack/identity/v3/extensions/endpointgroups/doc.go
@@ -4,10 +4,10 @@ and Endpoint associations.
 
 Example to Get an Endpoint Group
 
-    err := endpointgroups.Get(identityClient, endpointGroupID).ExtractErr()
-    if err != nil {
-    	panic(err)
-    }
+	err := endpointgroups.Get(identityClient, endpointGroupID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
 
 Example to List all Endpoint Groups by name
 
@@ -15,15 +15,15 @@ Example to List all Endpoint Groups by name
 		Name: "mygroup",
 	}
 
-    allPages, err := endpointgroups.List(identityClient, listOpts).AllPages()
-    if err != nil {
-    	panic(err)
-    }
+	allPages, err := endpointgroups.List(identityClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
 
 	allGroups, err := endpointgroups.ExtractEndpointGroups(allPages)
-    if err != nil {
-    	panic(err)
-    }
+	if err != nil {
+		panic(err)
+	}
 
 	for _, endpointgroup := range allGroups {
 		fmt.Printf("%+v\n", endpointgroup)

--- a/openstack/identity/v3/extensions/endpointgroups/requests.go
+++ b/openstack/identity/v3/extensions/endpointgroups/requests.go
@@ -1,0 +1,46 @@
+package endpointgroups
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// Get retrieves details on a single endpoint group, by ID.
+func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {
+	_, r.Err = client.Get(resourceURL(client, id), &r.Body, nil)
+	return
+}
+
+// ListOptsBuilder allows extensions to add additional parameters to
+// the List request
+type ListOptsBuilder interface {
+	ToEndpointGroupListQuery() (string, error)
+}
+
+// ListOpts provides options to filter the List results.
+type ListOpts struct {
+	// Name filters the response by endpoint group name.
+	Name string `q:"name"`
+}
+
+// ToEndpointGroupListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToEndpointGroupListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List enumerates the endpoint groups
+func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := rootURL(client)
+	if opts != nil {
+		query, err := opts.ToEndpointGroupListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return EndpointGroupPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}

--- a/openstack/identity/v3/extensions/endpointgroups/results.go
+++ b/openstack/identity/v3/extensions/endpointgroups/results.go
@@ -37,9 +37,6 @@ type EndpointFilter struct {
 
 	// RegionID is the ID of the region to filter
 	RegionID string `json:"region_id,omitempty"`
-
-	// Enabled filters on enabled or disabled endpoints
-	Enabled *bool `json:"enabled,omitempty"`
 }
 
 // EndpointGroup represents a group of endpoints matching one or several filter

--- a/openstack/identity/v3/extensions/endpointgroups/results.go
+++ b/openstack/identity/v3/extensions/endpointgroups/results.go
@@ -1,0 +1,79 @@
+package endpointgroups
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// Extract interprets a GetResult, CreateResult or UpdateResult as a concrete
+// EndpointGroup. An error is returned if the original call or the extraction
+// failed.
+func (r commonResult) Extract() (*EndpointGroup, error) {
+	var s struct {
+		EndpointGroup *EndpointGroup `json:"endpoint_group"`
+	}
+	err := r.ExtractInto(&s)
+	return s.EndpointGroup, err
+}
+
+// GetResult is the response from a Get operation. Call its Extract method
+// to interpret it as an EndpointGroup.
+type GetResult struct {
+	commonResult
+}
+
+// EndpointFilter represents a set of one or several criteria to match endpoints.
+type EndpointFilter struct {
+	// Availability is the interface type to filter (admin, internal,
+	// or public), referenced by the gophercloud.Availability type.
+	Availability gophercloud.Availability `json:"interface,omitempty"`
+
+	// ServiceID is the ID of the service to filter
+	ServiceID string `json:"service_id,omitempty"`
+
+	// RegionID is the ID of the region to filter
+	RegionID string `json:"region_id,omitempty"`
+
+	// Enabled filters on enabled or disabled endpoints
+	Enabled *bool `json:"enabled,omitempty"`
+}
+
+// EndpointGroup represents a group of endpoints matching one or several filter
+// criteria.
+type EndpointGroup struct {
+	// ID is the unique ID of the endpoint group.
+	ID string `json:"id"`
+
+	// Name is the name of the new endpoint group.
+	Name string `json:"name"`
+
+	// Filters is an EndpointFilter type describing the filter criteria
+	Filters EndpointFilter `json:"filters"`
+
+	// Description is the description of the endpoint group
+	Description string `json:"description"`
+}
+
+// EndpointGroupPage is a single page of EndpointGroup results.
+type EndpointGroupPage struct {
+	pagination.LinkedPageBase
+}
+
+// IsEmpty returns true if no EndpointGroups were returned.
+func (r EndpointGroupPage) IsEmpty() (bool, error) {
+	es, err := ExtractEndpointGroups(r)
+	return len(es) == 0, err
+}
+
+// ExtractEndpointGroups extracts an EndpointGroup slice from a Page.
+func ExtractEndpointGroups(r pagination.Page) ([]EndpointGroup, error) {
+	var s struct {
+		EndpointGroups []EndpointGroup `json:"endpoint_groups"`
+	}
+	err := (r.(EndpointGroupPage)).ExtractInto(&s)
+	return s.EndpointGroups, err
+}

--- a/openstack/identity/v3/extensions/endpointgroups/testing/requests_test.go
+++ b/openstack/identity/v3/extensions/endpointgroups/testing/requests_test.go
@@ -27,8 +27,7 @@ func TestGetEndpointGroup(t *testing.T) {
 			    "filters": {
 				    "interface": "public",
 					"service_id": "1234",
-					"region_id": "5678",
-					"enabled": true
+					"region_id": "5678"
 			    },
 			    "name": "endpointgroup1",
 			    "description": "public endpoint group 1",
@@ -40,12 +39,10 @@ func TestGetEndpointGroup(t *testing.T) {
 		`)
 	})
 
-	enabled := true
 	filters := endpointgroups.EndpointFilter{
 		Availability: gophercloud.AvailabilityPublic,
 		ServiceID:    "1234",
 		RegionID:     "5678",
-		Enabled:      &enabled,
 	}
 
 	actual, err := endpointgroups.Get(client.ServiceClient(), "24").Extract()
@@ -80,7 +77,6 @@ func TestListEndpointGroups(t *testing.T) {
 						"interface": "public",
 						"service_id": "1234",
 						"region_id": "5678",
-						"enabled": true
 				    },
 				    "name": "endpointgroup1",
 				    "description": "public endpoint group 1",
@@ -114,12 +110,10 @@ func TestListEndpointGroups(t *testing.T) {
 		}
 
 		// Filters for endpointgroup1
-		enabled := true
 		filters1 := endpointgroups.EndpointFilter{
 			Availability: gophercloud.AvailabilityPublic,
 			ServiceID:    "1234",
 			RegionID:     "5678",
-			Enabled:      &enabled,
 		}
 
 		// Filters for endpointgroup1

--- a/openstack/identity/v3/extensions/endpointgroups/testing/requests_test.go
+++ b/openstack/identity/v3/extensions/endpointgroups/testing/requests_test.go
@@ -1,0 +1,147 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/extensions/endpointgroups"
+	"github.com/gophercloud/gophercloud/pagination"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func TestGetEndpointGroup(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/OS-EP-FILTER/endpoint_groups/24", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		fmt.Fprintf(w, `
+		{
+			"endpoint_group": {
+			    "id": "24",
+			    "filters": {
+				    "interface": "public",
+					"service_id": "1234",
+					"region_id": "5678",
+					"enabled": true
+			    },
+			    "name": "endpointgroup1",
+			    "description": "public endpoint group 1",
+			    "links": {
+					"self": "https://localhost:5000/v3/OS-EP-FILTER/endpoint_groups/24"
+			    }
+			}
+		}
+		`)
+	})
+
+	enabled := true
+	filters := endpointgroups.EndpointFilter{
+		Availability: gophercloud.AvailabilityPublic,
+		ServiceID:    "1234",
+		RegionID:     "5678",
+		Enabled:      &enabled,
+	}
+
+	actual, err := endpointgroups.Get(client.ServiceClient(), "24").Extract()
+	if err != nil {
+		t.Fatalf("Failed to extract EndpointGroup: %v", err)
+	}
+
+	expected := &endpointgroups.EndpointGroup{
+		ID:          "24",
+		Filters:     filters,
+		Name:        "endpointgroup1",
+		Description: "public endpoint group 1",
+	}
+	th.AssertDeepEquals(t, expected, actual)
+}
+
+func TestListEndpointGroups(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/OS-EP-FILTER/endpoint_groups", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprintf(w, `
+		{
+			"endpoint_groups": [
+				{
+				    "id": "24",
+				    "filters": {
+						"interface": "public",
+						"service_id": "1234",
+						"region_id": "5678",
+						"enabled": true
+				    },
+				    "name": "endpointgroup1",
+				    "description": "public endpoint group 1",
+				    "links": {
+						"self": "https://localhost:5000/v3/OS-EP-FILTER/endpoint_groups/24"
+				    }
+				},
+				{
+				    "id": "25",
+				    "filters": {
+						"interface": "internal"
+				    },
+				    "name": "endpointgroup2",
+				    "description": "internal endpoint group 1",
+				    "links": {
+						"self": "https://localhost:5000/v3/OS-EP-FILTER/endpoint_groups/25"
+				    }
+				}
+			]
+		}
+		`)
+	})
+
+	count := 0
+	endpointgroups.List(client.ServiceClient(), endpointgroups.ListOpts{}).EachPage(func(page pagination.Page) (bool, error) {
+		count++
+		actual, err := endpointgroups.ExtractEndpointGroups(page)
+		if err != nil {
+			t.Errorf("Failed to extract EndpointGroups: %v", err)
+			return false, err
+		}
+
+		// Filters for endpointgroup1
+		enabled := true
+		filters1 := endpointgroups.EndpointFilter{
+			Availability: gophercloud.AvailabilityPublic,
+			ServiceID:    "1234",
+			RegionID:     "5678",
+			Enabled:      &enabled,
+		}
+
+		// Filters for endpointgroup1
+		filters2 := endpointgroups.EndpointFilter{
+			Availability: gophercloud.AvailabilityInternal,
+		}
+
+		expected := []endpointgroups.EndpointGroup{
+			{
+				ID:          "24",
+				Filters:     filters1,
+				Name:        "endpointgroup1",
+				Description: "public endpoint group 1",
+			},
+			{
+				ID:          "25",
+				Filters:     filters2,
+				Name:        "endpointgroup2",
+				Description: "internal endpoint group 1",
+			},
+		}
+		th.AssertDeepEquals(t, expected, actual)
+		return true, nil
+	})
+}

--- a/openstack/identity/v3/extensions/endpointgroups/urls.go
+++ b/openstack/identity/v3/extensions/endpointgroups/urls.go
@@ -1,0 +1,15 @@
+package endpointgroups
+
+import "github.com/gophercloud/gophercloud"
+
+const (
+	endpointGroupPath = "OS-EP-FILTER/endpoint_groups"
+)
+
+func rootURL(client *gophercloud.ServiceClient) string {
+	return client.ServiceURL(endpointGroupPath)
+}
+
+func resourceURL(client *gophercloud.ServiceClient, endointGroupID string) string {
+	return client.ServiceURL(endpointGroupPath, endointGroupID)
+}


### PR DESCRIPTION
For #1889

API doc:
https://docs.openstack.org/api-ref/identity/v3-ext/index.html#os-ep-filter-api

API calls:
https://github.com/openstack/keystone/blob/ba2e4b83e88d5c1576e9d2cd6a760367deef3a62/keystone/api/os_ep_filter.py#L68-L79

Structures: https://github.com/openstack/keystone/blob/ba2e4b83e88d5c1576e9d2cd6a760367deef3a62/keystone/catalog/backends/sql.py#L605

EndpointGroupFilter structure: https://github.com/openstack/keystone/blob/ba2e4b83e88d5c1576e9d2cd6a760367deef3a62/keystone/api/os_ep_filter.py#L54