### PR TITLE
Auth: introduce ec2 credentials auth support

### DIFF
--- a/openstack/client.go
+++ b/openstack/client.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gophercloud/gophercloud"
 	tokens2 "github.com/gophercloud/gophercloud/openstack/identity/v2/tokens"
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/extensions/ec2tokens"
 	tokens3 "github.com/gophercloud/gophercloud/openstack/identity/v3/tokens"
 	"github.com/gophercloud/gophercloud/openstack/utils"
 )
@@ -224,7 +225,13 @@ func v3auth(client *gophercloud.ProviderClient, endpoint string, opts tokens3.Au
 			return err
 		}
 	} else {
-		result := tokens3.Create(v3Client, opts)
+		var result tokens3.CreateResult
+		switch opts.(type) {
+		case *ec2tokens.AuthOptions:
+			result = ec2tokens.Create(v3Client, opts)
+		default:
+			result = tokens3.Create(v3Client, opts)
+		}
 
 		err = client.SetTokenAndAuthResult(result)
 		if err != nil {
@@ -252,6 +259,10 @@ func v3auth(client *gophercloud.ProviderClient, endpoint string, opts tokens3.Au
 			o.AllowReauth = false
 			tao = &o
 		case *tokens3.AuthOptions:
+			o := *ot
+			o.AllowReauth = false
+			tao = &o
+		case *ec2tokens.AuthOptions:
 			o := *ot
 			o.AllowReauth = false
 			tao = &o

--- a/openstack/identity/v3/extensions/ec2tokens/doc.go
+++ b/openstack/identity/v3/extensions/ec2tokens/doc.go
@@ -1,0 +1,41 @@
+/*
+Package tokens provides information and interaction with the EC2 token API
+resource for the OpenStack Identity service.
+
+For more information, see:
+https://docs.openstack.org/api-ref/identity/v2-ext/
+
+Example to Create a Token From an EC2 access and secret keys
+
+	var authOptions tokens.AuthOptionsBuilder
+	authOptions = &ec2tokens.AuthOptions{
+		Access: "a7f1e798b7c2417cba4a02de97dc3cdc",
+		Secret: "18f4f6761ada4e3795fa5273c30349b9",
+	}
+
+	token, err := ec2tokens.Create(identityClient, authOptions).ExtractToken()
+	if err != nil {
+		panic(err)
+	}
+
+Example to auth a client using EC2 access and secret keys
+
+	client, err := openstack.NewClient("http://localhost:5000/v3")
+	if err != nil {
+		panic(err)
+	}
+
+	var authOptions tokens.AuthOptionsBuilder
+	authOptions = &ec2tokens.AuthOptions{
+		Access:      "a7f1e798b7c2417cba4a02de97dc3cdc",
+		Secret:      "18f4f6761ada4e3795fa5273c30349b9",
+		AllowReauth: true,
+	}
+
+	err = openstack.AuthenticateV3(client, authOptions, gophercloud.EndpointOpts{})
+	if err != nil {
+		panic(err)
+	}
+
+*/
+package ec2tokens

--- a/openstack/identity/v3/extensions/ec2tokens/requests.go
+++ b/openstack/identity/v3/extensions/ec2tokens/requests.go
@@ -1,0 +1,323 @@
+package ec2tokens
+
+import (
+	"crypto/hmac"
+	"crypto/sha1"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"math/rand"
+	"net/url"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/tokens"
+)
+
+const (
+	// aws4Request is a constant, used to generate AWS Credential V4.
+	aws4Request = "aws4_request"
+	// v2AlgoSha1 is a HMAC SHA1 signature method. Used to generate AWS
+	// Credential V2.
+	v2AlgoSha1 = "HmacSHA1"
+	// v2AlgoSha1 is a HMAC SHA256 signature method. Used to generate AWS
+	// Credential V2.
+	v2AlgoSha256 = "HmacSHA256"
+	// v4Algo is an AWS signature V4 signing method.
+	// More details:
+	// https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html
+	v4Algo = "AWS4-HMAC-SHA256"
+	// iso8601utc is an AWS signature V4 timestamp format.
+	iso8601utc = "20060102T150405Z"
+	// iso8601utc is an AWS signature V4 date format.
+	yyyymmdd = "20060102"
+)
+
+// AuthOptions represents options for authenticating a user using EC2 credentials.
+type AuthOptions struct {
+	// Access is the EC2 Credential Access ID.
+	Access string `json:"access" required:"true"`
+	// Secret is the EC2 Credential Secret, used to calculate signature.
+	// Not used, when a Signature is is.
+	Secret string `json:"-"`
+	// Host is a HTTP request Host header. Used to calculate an AWS
+	// signature V2. For signature V4 set the Host inside Headers map.
+	// Optional.
+	Host string `json:"host"`
+	// Path is a HTTP request path. Optional.
+	Path string `json:"path"`
+	// Verb is a HTTP request method. Optional.
+	Verb string `json:"verb"`
+	// Headers is a map of HTTP request headers. Optional.
+	Headers map[string]string `json:"headers"`
+	// Region is a region name to calculate an AWS signature V4. Optional.
+	Region string `json:"-"`
+	// Service is a service name to calculate an AWS signature V4. Optional.
+	Service string `json:"-"`
+	// Params is a map of parameters, used to configure an AWS signature
+	// calculation method. Defaults to AWS signature V4 parameters.
+	// Optional.
+	Params map[string]string `json:"params"`
+	// AllowReauth allows Gophercloud to re-authenticate automatically
+	// if/when your token expires.
+	AllowReauth bool `json:"-"`
+	// Signature can be either a []byte (encoded to base64 automatically) or
+	// a string. You can set the singature explicitly, when you already know
+	// it. In this case default Params won't be automatically set. Optional.
+	Signature interface{} `json:"signature"`
+	// BodyHash is a HTTP request body sha256 hash. When nil and Signature
+	// is not set, a random hash is generated. Optional.
+	BodyHash *string `json:"body_hash"`
+	// Timestamp is a timestamp to calculate a V4 signature. Optional.
+	Timestamp *time.Time `json:"-"`
+}
+
+// EC2CredentialsBuildCanonicalQueryStringV2 builds a canonical query string
+// for an AWS signature V2.
+// https://github.com/openstack/python-keystoneclient/blob/stable/train/keystoneclient/contrib/ec2/utils.py#L133
+func EC2CredentialsBuildCanonicalQueryStringV2(params map[string]string) string {
+	var keys []string
+	for k := range params {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var pairs []string
+	for _, k := range keys {
+		pairs = append(pairs, fmt.Sprintf("%s=%s", k, url.QueryEscape(params[k])))
+	}
+
+	return strings.Join(pairs, "&")
+}
+
+// EC2CredentialsBuildStringToSignV2 builds a string to sign an AWS signature
+// V2.
+// https://github.com/openstack/python-keystoneclient/blob/stable/train/keystoneclient/contrib/ec2/utils.py#L148
+func EC2CredentialsBuildStringToSignV2(opts AuthOptions, params map[string]string) string {
+	stringToSign := strings.Join([]string{
+		opts.Verb,
+		opts.Host,
+		opts.Path,
+	}, "\n")
+
+	return strings.Join([]string{
+		stringToSign,
+		EC2CredentialsBuildCanonicalQueryStringV2(params),
+	}, "\n")
+}
+
+// EC2CredentialsBuildCanonicalQueryStringV2 builds a canonical query string
+// for an AWS signature V4.
+// https://github.com/openstack/python-keystoneclient/blob/stable/train/keystoneclient/contrib/ec2/utils.py#L244
+func EC2CredentialsBuildCanonicalQueryStringV4(verb string, params map[string]string) string {
+	if verb == "POST" {
+		return ""
+	}
+	return EC2CredentialsBuildCanonicalQueryStringV2(params)
+}
+
+// EC2CredentialsBuildCanonicalHeadersV4 builds a canonical string based on
+// "headers" map and "signedHeaders" string parameters.
+// https://github.com/openstack/python-keystoneclient/blob/stable/train/keystoneclient/contrib/ec2/utils.py#L216
+func EC2CredentialsBuildCanonicalHeadersV4(headers map[string]string, signedHeaders string) string {
+	headersLower := make(map[string]string, len(headers))
+	for k, v := range headers {
+		headersLower[strings.ToLower(k)] = v
+	}
+
+	var headersList []string
+	for _, h := range strings.Split(signedHeaders, ";") {
+		if v, ok := headersLower[h]; ok {
+			headersList = append(headersList, h+":"+v)
+		}
+	}
+
+	return strings.Join(headersList, "\n") + "\n"
+}
+
+// EC2CredentialsBuildSignatureKeyV4 builds a HMAC 256 signature key based on
+// input parameters.
+// https://github.com/openstack/python-keystoneclient/blob/stable/train/keystoneclient/contrib/ec2/utils.py#L169
+func EC2CredentialsBuildSignatureKeyV4(secret, date, region, service string) []byte {
+	kDate := sumHMAC256([]byte("AWS4"+secret), []byte(date))
+	kRegion := sumHMAC256(kDate, []byte(region))
+	kService := sumHMAC256(kRegion, []byte(service))
+	return sumHMAC256(kService, []byte(aws4Request))
+}
+
+// EC2CredentialsBuildSignatureV4 builds an AWS v4 signature based on input
+// parameters.
+// https://github.com/openstack/python-keystoneclient/blob/stable/train/keystoneclient/contrib/ec2/utils.py#L251
+func EC2CredentialsBuildSignatureV4(opts AuthOptions, params map[string]string, date time.Time, bodyHash string) string {
+	scope := strings.Join([]string{
+		date.Format(yyyymmdd),
+		opts.Region,
+		opts.Service,
+		aws4Request,
+	}, "/")
+
+	canonicalRequest := strings.Join([]string{
+		opts.Verb,
+		opts.Path,
+		EC2CredentialsBuildCanonicalQueryStringV4(opts.Verb, params),
+		EC2CredentialsBuildCanonicalHeadersV4(opts.Headers, params["X-Amz-SignedHeaders"]),
+		params["X-Amz-SignedHeaders"],
+		bodyHash,
+	}, "\n")
+	hash := sha256.Sum256([]byte(canonicalRequest))
+
+	strToSign := strings.Join([]string{
+		v4Algo,
+		date.Format(iso8601utc),
+		scope,
+		hex.EncodeToString(hash[:]),
+	}, "\n")
+
+	key := EC2CredentialsBuildSignatureKeyV4(opts.Secret, date.Format(yyyymmdd), opts.Region, opts.Service)
+
+	return hex.EncodeToString(sumHMAC256(key, []byte(strToSign)))
+}
+
+// ToTokenV3ScopeMap is a dummy method to satisfy tokens.AuthOptionsBuilder interface
+func (opts *AuthOptions) ToTokenV3ScopeMap() (map[string]interface{}, error) {
+	return nil, nil
+}
+
+// CanReauth is a method method to satisfy tokens.AuthOptionsBuilder interface
+func (opts *AuthOptions) CanReauth() bool {
+	return opts.AllowReauth
+}
+
+// ToTokenV3CreateMap formats an AuthOptions into a create request.
+func (opts *AuthOptions) ToTokenV3CreateMap(map[string]interface{}) (map[string]interface{}, error) {
+	b, err := gophercloud.BuildRequestBody(opts, "credentials")
+	if err != nil {
+		return nil, err
+	}
+
+	if opts.Signature != nil {
+		return b, nil
+	}
+
+	// calculate signature, when it is not set
+	c, _ := b["credentials"].(map[string]interface{})
+	p := paramsToMap(c)
+
+	// detect and process a signature v2
+	if v, ok := p["SignatureVersion"]; ok && v == "2" {
+		if _, ok := c["body_hash"]; ok {
+			delete(c, "body_hash")
+		}
+		if _, ok := c["headers"]; ok {
+			delete(c, "headers")
+		}
+		if v, ok := p["SignatureMethod"]; ok {
+			// params is a map of strings
+			strToSign := EC2CredentialsBuildStringToSignV2(*opts, p)
+			switch v {
+			case v2AlgoSha1:
+				// keystone uses this method only when HmacSHA256 is not available on the server side
+				// https://github.com/openstack/python-keystoneclient/blob/stable/train/keystoneclient/contrib/ec2/utils.py#L151..L156
+				c["signature"] = sumHMAC1([]byte(opts.Secret), []byte(strToSign))
+				return b, nil
+			case v2AlgoSha256:
+				c["signature"] = sumHMAC256([]byte(opts.Secret), []byte(strToSign))
+				return b, nil
+			}
+			return nil, fmt.Errorf("unsupported signature method: %s", v)
+		}
+		return nil, fmt.Errorf("signature method must be provided")
+	} else if ok {
+		return nil, fmt.Errorf("unsupported signature version: %s", v)
+	}
+
+	// it is not a signature v2, but a signature v4
+	date := time.Now().UTC()
+	if opts.Timestamp != nil {
+		date = *opts.Timestamp
+	}
+	if v, _ := c["body_hash"]; v == nil {
+		// when body_hash is not set, generate a random one
+		c["body_hash"] = randomBodyHash()
+	}
+	if v, _ := c["headers"]; v == nil {
+		// when headers is not set, make an empty map
+		c["headers"] = make(map[string]string)
+	}
+	if _, ok := p["X-Amz-SignedHeaders"]; !ok {
+		// when X-Amz-SignedHeaders is not set, make an empty string
+		p["X-Amz-SignedHeaders"] = ""
+	}
+	p["X-Amz-Date"] = date.Format(iso8601utc)
+	p["X-Amz-Algorithm"] = v4Algo
+	p["X-Amz-Credential"] = strings.Join([]string{
+		opts.Access,
+		date.Format(yyyymmdd),
+		opts.Region,
+		opts.Service,
+		aws4Request,
+	}, "/")
+	c["signature"] = EC2CredentialsBuildSignatureV4(*opts, p, date, c["body_hash"].(string))
+
+	return b, nil
+}
+
+// Create authenticates and either generates a new token from EC2 credentials
+func Create(c *gophercloud.ServiceClient, opts tokens.AuthOptionsBuilder) (r tokens.CreateResult) {
+	b, err := opts.ToTokenV3CreateMap(nil)
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	resp, err := c.Post(ec2tokensURL(c), b, &r.Body, &gophercloud.RequestOpts{
+		MoreHeaders: map[string]string{"X-Auth-Token": ""},
+		OkCodes:     []int{200},
+	})
+	r.Err = err
+	if resp != nil {
+		r.Header = resp.Header
+	}
+	return
+}
+
+// The following are small helper functions used to help build the signature.
+
+// sumHMAC1 is a func to implement the HMAC SHA1 signature method.
+func sumHMAC1(key []byte, data []byte) []byte {
+	hash := hmac.New(sha1.New, key)
+	hash.Write(data)
+	return hash.Sum(nil)
+}
+
+// sumHMAC256 is a func to implement the HMAC SHA256 signature method.
+func sumHMAC256(key []byte, data []byte) []byte {
+	hash := hmac.New(sha256.New, key)
+	hash.Write(data)
+	return hash.Sum(nil)
+}
+
+// randomBodyHash is a func to generate a random sha256 hexdigest.
+func randomBodyHash() string {
+	h := make([]byte, 64)
+	rand.Read(h)
+	return hex.EncodeToString(h)
+}
+
+// paramsToMap is a func used to represent a "credentials" map "params" value
+// as a "map[string]string"
+func paramsToMap(c map[string]interface{}) map[string]string {
+	// convert map[string]interface{} to map[string]string
+	p := make(map[string]string)
+	if v, _ := c["params"].(map[string]interface{}); v != nil {
+		for k, v := range v {
+			p[k] = v.(string)
+		}
+	}
+
+	c["params"] = p
+
+	return p
+}

--- a/openstack/identity/v3/extensions/ec2tokens/testing/requests_test.go
+++ b/openstack/identity/v3/extensions/ec2tokens/testing/requests_test.go
@@ -1,0 +1,293 @@
+package testing
+
+import (
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/extensions/ec2tokens"
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/tokens"
+	tokens_testing "github.com/gophercloud/gophercloud/openstack/identity/v3/tokens/testing"
+	"github.com/gophercloud/gophercloud/testhelper"
+)
+
+// authTokenPost verifies that providing certain AuthOptions and Scope results in an expected JSON structure.
+func authTokenPost(t *testing.T, options ec2tokens.AuthOptions, requestJSON string) {
+	testhelper.SetupHTTP()
+	defer testhelper.TeardownHTTP()
+
+	client := gophercloud.ServiceClient{
+		ProviderClient: &gophercloud.ProviderClient{},
+		Endpoint:       testhelper.Endpoint(),
+	}
+
+	testhelper.Mux.HandleFunc("/ec2tokens", func(w http.ResponseWriter, r *http.Request) {
+		testhelper.TestMethod(t, r, "POST")
+		testhelper.TestHeader(t, r, "Content-Type", "application/json")
+		testhelper.TestHeader(t, r, "Accept", "application/json")
+		testhelper.TestJSONRequest(t, r, requestJSON)
+
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, tokens_testing.TokenOutput)
+	})
+
+	expected := &tokens.Token{
+		ExpiresAt: time.Date(2017, 6, 3, 2, 19, 49, 0, time.UTC),
+	}
+
+	actual, err := ec2tokens.Create(&client, &options).Extract()
+	testhelper.AssertNoErr(t, err)
+	testhelper.CheckDeepEquals(t, expected, actual)
+}
+
+func TestCreateV2(t *testing.T) {
+	credentials := ec2tokens.AuthOptions{
+		Access: "a7f1e798b7c2417cba4a02de97dc3cdc",
+		Host:   "localhost",
+		Path:   "/",
+		Secret: "18f4f6761ada4e3795fa5273c30349b9",
+		Verb:   "GET",
+		// this should be removed from JSON request
+		BodyHash: new(string),
+		// this should be removed from JSON request
+		Headers: map[string]string{
+			"Foo": "Bar",
+		},
+		Params: map[string]string{
+			"Action":           "Test",
+			"SignatureMethod":  "HmacSHA256",
+			"SignatureVersion": "2",
+		},
+	}
+	authTokenPost(t, credentials, `{
+    "credentials": {
+        "access": "a7f1e798b7c2417cba4a02de97dc3cdc",
+        "host": "localhost",
+        "params": {
+            "Action": "Test",
+            "SignatureMethod": "HmacSHA256",
+            "SignatureVersion": "2"
+        },
+        "path": "/",
+        "signature": "Up+MbVbbrvdR5FRkUz+n3nc+VW6xieuN50wh6ONEJ4w=",
+        "verb": "GET"
+    }
+}`)
+}
+
+func TestCreateV4(t *testing.T) {
+	bodyHash := "foo"
+	credentials := ec2tokens.AuthOptions{
+		Access:    "a7f1e798b7c2417cba4a02de97dc3cdc",
+		BodyHash:  &bodyHash,
+		Timestamp: new(time.Time),
+		Region:    "region1",
+		Service:   "ec2",
+		Path:      "/",
+		Secret:    "18f4f6761ada4e3795fa5273c30349b9",
+		Verb:      "GET",
+		Headers: map[string]string{
+			"Host": "localhost",
+		},
+		Params: map[string]string{
+			"Action": "Test",
+		},
+	}
+	authTokenPost(t, credentials, `{
+    "credentials": {
+        "access": "a7f1e798b7c2417cba4a02de97dc3cdc",
+        "body_hash": "foo",
+        "host": "",
+        "headers": {
+            "Host": "localhost"
+         },
+        "params": {
+            "Action": "Test",
+            "X-Amz-Algorithm": "AWS4-HMAC-SHA256",
+            "X-Amz-Credential": "a7f1e798b7c2417cba4a02de97dc3cdc/00010101/region1/ec2/aws4_request",
+            "X-Amz-Date": "00010101T000000Z",
+            "X-Amz-SignedHeaders": ""
+        },
+        "path": "/",
+        "signature": "f8b67f8bc0c8c7a6b84fcb37dd9007f1c728625fe783fe8616b6ba150e1d0655",
+        "verb": "GET"
+    }
+}`)
+}
+
+func TestCreateV4Empty(t *testing.T) {
+	credentials := ec2tokens.AuthOptions{
+		Access:    "a7f1e798b7c2417cba4a02de97dc3cdc",
+		Secret:    "18f4f6761ada4e3795fa5273c30349b9",
+		BodyHash:  new(string),
+		Timestamp: new(time.Time),
+	}
+	authTokenPost(t, credentials, `{
+    "credentials": {
+        "access": "a7f1e798b7c2417cba4a02de97dc3cdc",
+        "body_hash": "",
+        "host": "",
+        "headers": {},
+        "params": {
+            "X-Amz-Algorithm": "AWS4-HMAC-SHA256",
+            "X-Amz-Credential": "a7f1e798b7c2417cba4a02de97dc3cdc/00010101///aws4_request",
+            "X-Amz-Date": "00010101T000000Z",
+            "X-Amz-SignedHeaders": ""
+        },
+        "path": "",
+        "signature": "a7f7a34f93ccd460e67079743d05d1b4488c6e9d708869b6b687d51244c68857",
+        "verb": ""
+    }
+}`)
+}
+
+func TestCreateV4Headers(t *testing.T) {
+	credentials := ec2tokens.AuthOptions{
+		Access:    "a7f1e798b7c2417cba4a02de97dc3cdc",
+		BodyHash:  new(string),
+		Timestamp: new(time.Time),
+		Region:    "region1",
+		Service:   "ec2",
+		Path:      "/",
+		Secret:    "18f4f6761ada4e3795fa5273c30349b9",
+		Verb:      "GET",
+		Headers: map[string]string{
+			"Foo":  "Bar",
+			"Host": "localhost",
+		},
+		Params: map[string]string{
+			"Action": "Test",
+		},
+	}
+	authTokenPost(t, credentials, `{
+    "credentials": {
+        "access": "a7f1e798b7c2417cba4a02de97dc3cdc",
+        "body_hash": "",
+        "host": "",
+        "headers": {
+            "Foo": "Bar",
+            "Host": "localhost"
+        },
+        "params": {
+            "Action": "Test",
+            "X-Amz-Algorithm": "AWS4-HMAC-SHA256",
+            "X-Amz-Credential": "a7f1e798b7c2417cba4a02de97dc3cdc/00010101/region1/ec2/aws4_request",
+            "X-Amz-Date": "00010101T000000Z",
+            "X-Amz-SignedHeaders": ""
+        },
+        "path": "/",
+        "signature": "becc7d835c1d96835b772158198aed5583cb3fee4e7c7459a15fe710e3f533c6",
+        "verb": "GET"
+    }
+}`)
+}
+
+func TestCreateV4WithSignature(t *testing.T) {
+	credentials := ec2tokens.AuthOptions{
+		Access:    "a7f1e798b7c2417cba4a02de97dc3cdc",
+		BodyHash:  new(string),
+		Path:      "/",
+		Signature: "becc7d835c1d96835b772158198aed5583cb3fee4e7c7459a15fe710e3f533c6",
+		Verb:      "GET",
+		Headers: map[string]string{
+			"Foo":  "Bar",
+			"Host": "localhost",
+		},
+		Params: map[string]string{
+			"Action":              "Test",
+			"X-Amz-Algorithm":     "AWS4-HMAC-SHA256",
+			"X-Amz-Credential":    "a7f1e798b7c2417cba4a02de97dc3cdc/00010101/region1/ec2/aws4_request",
+			"X-Amz-Date":          "00010101T000000Z",
+			"X-Amz-SignedHeaders": "",
+		},
+	}
+	authTokenPost(t, credentials, `{
+    "credentials": {
+        "access": "a7f1e798b7c2417cba4a02de97dc3cdc",
+        "body_hash": "",
+        "host": "",
+        "headers": {
+            "Foo": "Bar",
+            "Host": "localhost"
+        },
+        "params": {
+            "Action": "Test",
+            "X-Amz-Algorithm": "AWS4-HMAC-SHA256",
+            "X-Amz-Credential": "a7f1e798b7c2417cba4a02de97dc3cdc/00010101/region1/ec2/aws4_request",
+            "X-Amz-Date": "00010101T000000Z",
+            "X-Amz-SignedHeaders": ""
+        },
+        "path": "/",
+        "signature": "becc7d835c1d96835b772158198aed5583cb3fee4e7c7459a15fe710e3f533c6",
+        "verb": "GET"
+    }
+}`)
+}
+
+func TestEC2CredentialsBuildCanonicalQueryStringV2(t *testing.T) {
+	params := map[string]string{
+		"Action": "foo",
+		"Value":  "bar",
+	}
+	expected := "Action=foo&Value=bar"
+	testhelper.CheckEquals(t, expected, ec2tokens.EC2CredentialsBuildCanonicalQueryStringV2(params))
+}
+
+func TestEC2CredentialsBuildStringToSignV2(t *testing.T) {
+	opts := ec2tokens.AuthOptions{
+		Verb: "GET",
+		Host: "localhost",
+		Path: "/",
+	}
+	params := map[string]string{
+		"Action": "foo",
+		"Value":  "bar",
+	}
+	expected := "GET\nlocalhost\n/\nAction=foo&Value=bar"
+	testhelper.CheckEquals(t, expected, ec2tokens.EC2CredentialsBuildStringToSignV2(opts, params))
+}
+
+func TestEC2CredentialsBuildCanonicalQueryStringV4(t *testing.T) {
+	params := map[string]string{
+		"Action": "foo",
+		"Value":  "bar",
+	}
+	expected := "Action=foo&Value=bar"
+	testhelper.CheckEquals(t, expected, ec2tokens.EC2CredentialsBuildCanonicalQueryStringV4("foo", params))
+	testhelper.CheckEquals(t, "", ec2tokens.EC2CredentialsBuildCanonicalQueryStringV4("POST", params))
+}
+
+func TestEC2CredentialsBuildCanonicalHeadersV4(t *testing.T) {
+	headers := map[string]string{
+		"Foo": "bar",
+		"Baz": "qux",
+	}
+	signedHeaders := "foo;baz"
+	expected := "foo:bar\nbaz:qux\n"
+	testhelper.CheckEquals(t, expected, ec2tokens.EC2CredentialsBuildCanonicalHeadersV4(headers, signedHeaders))
+}
+
+func TestEC2CredentialsBuildSignatureKeyV4(t *testing.T) {
+	expected := "5f06633a42b1324477cb006b24b1266722703b5dcf9186481be6592b9554c38f"
+	testhelper.CheckEquals(t, expected, hex.EncodeToString((ec2tokens.EC2CredentialsBuildSignatureKeyV4("foo", "bar", "baz", "qux"))))
+}
+
+func TestEC2CredentialsBuildSignatureV4(t *testing.T) {
+	opts := ec2tokens.AuthOptions{
+		Verb: "GET",
+		Path: "/",
+		Headers: map[string]string{
+			"Host": "localhost",
+		},
+	}
+	params := map[string]string{
+		"Action":              "foo",
+		"Value":               "bar",
+		"X-Amz-SignedHeaders": "host",
+	}
+	expected := "76ecaab5616b005227ad98bcdf7e802120a16a4e840faf5193e49db7fe7db178"
+	testhelper.CheckEquals(t, expected, ec2tokens.EC2CredentialsBuildSignatureV4(opts, params, time.Time{}, "foo"))
+}

--- a/openstack/identity/v3/extensions/ec2tokens/testing/requests_test.go
+++ b/openstack/identity/v3/extensions/ec2tokens/testing/requests_test.go
@@ -102,17 +102,15 @@ func TestCreateV4(t *testing.T) {
         "body_hash": "foo",
         "host": "",
         "headers": {
-            "Host": "localhost"
+            "Host": "localhost",
+            "Authorization": "AWS4-HMAC-SHA256 Credential=a7f1e798b7c2417cba4a02de97dc3cdc/00010101/region1/ec2/aws4_request, SignedHeaders=, Signature=f36f79118f75d7d6ec86ead9a61679cbdcf94c0cbfe5e9cf2407e8406aa82028",
+            "X-Amz-Date": "00010101T000000Z"
          },
         "params": {
-            "Action": "Test",
-            "X-Amz-Algorithm": "AWS4-HMAC-SHA256",
-            "X-Amz-Credential": "a7f1e798b7c2417cba4a02de97dc3cdc/00010101/region1/ec2/aws4_request",
-            "X-Amz-Date": "00010101T000000Z",
-            "X-Amz-SignedHeaders": ""
+            "Action": "Test"
         },
         "path": "/",
-        "signature": "f8b67f8bc0c8c7a6b84fcb37dd9007f1c728625fe783fe8616b6ba150e1d0655",
+        "signature": "f36f79118f75d7d6ec86ead9a61679cbdcf94c0cbfe5e9cf2407e8406aa82028",
         "verb": "GET"
     }
 }`)
@@ -130,15 +128,13 @@ func TestCreateV4Empty(t *testing.T) {
         "access": "a7f1e798b7c2417cba4a02de97dc3cdc",
         "body_hash": "",
         "host": "",
-        "headers": {},
-        "params": {
-            "X-Amz-Algorithm": "AWS4-HMAC-SHA256",
-            "X-Amz-Credential": "a7f1e798b7c2417cba4a02de97dc3cdc/00010101///aws4_request",
-            "X-Amz-Date": "00010101T000000Z",
-            "X-Amz-SignedHeaders": ""
+        "headers": {
+            "Authorization": "AWS4-HMAC-SHA256 Credential=a7f1e798b7c2417cba4a02de97dc3cdc/00010101///aws4_request, SignedHeaders=, Signature=140a31abf1efe93a607dcac6cd8f66887b86d2bc8f712c290d9aa06edf428608",
+            "X-Amz-Date": "00010101T000000Z"
         },
+        "params": {},
         "path": "",
-        "signature": "a7f7a34f93ccd460e67079743d05d1b4488c6e9d708869b6b687d51244c68857",
+        "signature": "140a31abf1efe93a607dcac6cd8f66887b86d2bc8f712c290d9aa06edf428608",
         "verb": ""
     }
 }`)
@@ -169,17 +165,15 @@ func TestCreateV4Headers(t *testing.T) {
         "host": "",
         "headers": {
             "Foo": "Bar",
-            "Host": "localhost"
+            "Host": "localhost",
+            "Authorization": "AWS4-HMAC-SHA256 Credential=a7f1e798b7c2417cba4a02de97dc3cdc/00010101/region1/ec2/aws4_request, SignedHeaders=, Signature=f5cd6995be98e5576a130b30cca277375f10439217ea82169aa8386e83965611",
+            "X-Amz-Date": "00010101T000000Z"
         },
         "params": {
-            "Action": "Test",
-            "X-Amz-Algorithm": "AWS4-HMAC-SHA256",
-            "X-Amz-Credential": "a7f1e798b7c2417cba4a02de97dc3cdc/00010101/region1/ec2/aws4_request",
-            "X-Amz-Date": "00010101T000000Z",
-            "X-Amz-SignedHeaders": ""
+            "Action": "Test"
         },
         "path": "/",
-        "signature": "becc7d835c1d96835b772158198aed5583cb3fee4e7c7459a15fe710e3f533c6",
+        "signature": "f5cd6995be98e5576a130b30cca277375f10439217ea82169aa8386e83965611",
         "verb": "GET"
     }
 }`)
@@ -190,18 +184,16 @@ func TestCreateV4WithSignature(t *testing.T) {
 		Access:    "a7f1e798b7c2417cba4a02de97dc3cdc",
 		BodyHash:  new(string),
 		Path:      "/",
-		Signature: "becc7d835c1d96835b772158198aed5583cb3fee4e7c7459a15fe710e3f533c6",
+		Signature: "f5cd6995be98e5576a130b30cca277375f10439217ea82169aa8386e83965611",
 		Verb:      "GET",
 		Headers: map[string]string{
-			"Foo":  "Bar",
-			"Host": "localhost",
+			"Foo":           "Bar",
+			"Host":          "localhost",
+			"Authorization": "AWS4-HMAC-SHA256 Credential=a7f1e798b7c2417cba4a02de97dc3cdc/00010101/region1/ec2/aws4_request, SignedHeaders=, Signature=f5cd6995be98e5576a130b30cca277375f10439217ea82169aa8386e83965611",
+			"X-Amz-Date":    "00010101T000000Z",
 		},
 		Params: map[string]string{
-			"Action":              "Test",
-			"X-Amz-Algorithm":     "AWS4-HMAC-SHA256",
-			"X-Amz-Credential":    "a7f1e798b7c2417cba4a02de97dc3cdc/00010101/region1/ec2/aws4_request",
-			"X-Amz-Date":          "00010101T000000Z",
-			"X-Amz-SignedHeaders": "",
+			"Action": "Test",
 		},
 	}
 	authTokenPost(t, credentials, `{
@@ -211,17 +203,15 @@ func TestCreateV4WithSignature(t *testing.T) {
         "host": "",
         "headers": {
             "Foo": "Bar",
-            "Host": "localhost"
+            "Host": "localhost",
+            "Authorization": "AWS4-HMAC-SHA256 Credential=a7f1e798b7c2417cba4a02de97dc3cdc/00010101/region1/ec2/aws4_request, SignedHeaders=, Signature=f5cd6995be98e5576a130b30cca277375f10439217ea82169aa8386e83965611",
+            "X-Amz-Date": "00010101T000000Z"
         },
         "params": {
-            "Action": "Test",
-            "X-Amz-Algorithm": "AWS4-HMAC-SHA256",
-            "X-Amz-Credential": "a7f1e798b7c2417cba4a02de97dc3cdc/00010101/region1/ec2/aws4_request",
-            "X-Amz-Date": "00010101T000000Z",
-            "X-Amz-SignedHeaders": ""
+            "Action": "Test"
         },
         "path": "/",
-        "signature": "becc7d835c1d96835b772158198aed5583cb3fee4e7c7459a15fe710e3f533c6",
+        "signature": "f5cd6995be98e5576a130b30cca277375f10439217ea82169aa8386e83965611",
         "verb": "GET"
     }
 }`)
@@ -241,13 +231,13 @@ func TestEC2CredentialsBuildStringToSignV2(t *testing.T) {
 		Verb: "GET",
 		Host: "localhost",
 		Path: "/",
-	}
-	params := map[string]string{
-		"Action": "foo",
-		"Value":  "bar",
+		Params: map[string]string{
+			"Action": "foo",
+			"Value":  "bar",
+		},
 	}
 	expected := "GET\nlocalhost\n/\nAction=foo&Value=bar"
-	testhelper.CheckEquals(t, expected, ec2tokens.EC2CredentialsBuildStringToSignV2(opts, params))
+	testhelper.CheckEquals(t, expected, ec2tokens.EC2CredentialsBuildStringToSignV2(opts))
 }
 
 func TestEC2CredentialsBuildCanonicalQueryStringV4(t *testing.T) {
@@ -282,12 +272,11 @@ func TestEC2CredentialsBuildSignatureV4(t *testing.T) {
 		Headers: map[string]string{
 			"Host": "localhost",
 		},
+		Params: map[string]string{
+			"Action": "foo",
+			"Value":  "bar",
+		},
 	}
-	params := map[string]string{
-		"Action":              "foo",
-		"Value":               "bar",
-		"X-Amz-SignedHeaders": "host",
-	}
-	expected := "76ecaab5616b005227ad98bcdf7e802120a16a4e840faf5193e49db7fe7db178"
-	testhelper.CheckEquals(t, expected, ec2tokens.EC2CredentialsBuildSignatureV4(opts, params, time.Time{}, "foo"))
+	expected := "6a5febe41427bf601f0ae7c34dbb0fd67094776138b03fb8e65783d733d302a5"
+	testhelper.CheckEquals(t, expected, ec2tokens.EC2CredentialsBuildSignatureV4(opts, "host", time.Time{}, "foo"))
 }

--- a/openstack/identity/v3/extensions/ec2tokens/urls.go
+++ b/openstack/identity/v3/extensions/ec2tokens/urls.go
@@ -1,0 +1,7 @@
+package ec2tokens
+
+import "github.com/gophercloud/gophercloud"
+
+func ec2tokensURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("ec2tokens")
+}


### PR DESCRIPTION
Resolves #1898
@jtopjian before I introduce unit tests please take a look on this and let me know your opinion. It is hard to introduce unit tests, since token signature changes every call. I'd prefer to introduce an interface to create, list, delete ec2 credentials, then integrate them with ec2 auth.