### PR TITLE
Support system scope in v3 auth

### DIFF
--- a/auth_options.go
+++ b/auth_options.go
@@ -98,6 +98,7 @@ type AuthScope struct {
 	ProjectName string
 	DomainID    string
 	DomainName  string
+	System      bool
 }
 
 // ToTokenV2CreateMap allows AuthOptions to satisfy the AuthOptionsBuilder
@@ -362,6 +363,14 @@ func (opts *AuthOptions) ToTokenV3ScopeMap() (map[string]interface{}, error) {
 				opts.Scope.DomainName = opts.DomainName
 			}
 		}
+	}
+
+	if opts.Scope.System {
+		return map[string]interface{}{
+			"system": map[string]interface{}{
+				"all": true,
+			},
+		}, nil
 	}
 
 	if opts.Scope.ProjectName != "" {

--- a/openstack/identity/v3/tokens/requests.go
+++ b/openstack/identity/v3/tokens/requests.go
@@ -8,6 +8,7 @@ type Scope struct {
 	ProjectName string
 	DomainID    string
 	DomainName  string
+	System      bool
 }
 
 // AuthOptionsBuilder provides the ability for extensions to add additional

--- a/openstack/identity/v3/tokens/testing/requests_test.go
+++ b/openstack/identity/v3/tokens/testing/requests_test.go
@@ -275,6 +275,31 @@ func TestCreateProjectNameAndDomainNameScope(t *testing.T) {
 	`)
 }
 
+func TestCreateSystemScope(t *testing.T) {
+	options := tokens.AuthOptions{UserID: "fenris", Password: "g0t0h311"}
+	scope := &tokens.Scope{System: true}
+	authTokenPost(t, options, scope, `
+		{
+			"auth": {
+				"identity": {
+					"methods": ["password"],
+					"password": {
+						"user": {
+							"id": "fenris",
+							"password": "g0t0h311"
+						}
+					}
+				},
+				"scope": {
+					"system": {
+						"all": true
+					}
+				}
+			}
+		}
+	`)
+}
+
 func TestCreateApplicationCredentialIDAndSecret(t *testing.T) {
 	authTokenPost(t, tokens.AuthOptions{ApplicationCredentialID: "12345abcdef", ApplicationCredentialSecret: "mysecret"}, nil, `
 		{


### PR DESCRIPTION
For #1907

https://docs.openstack.org/api-ref/identity/v3/?expanded=password-authentication-with-scoped-authorization-detail#system-scoped-example

https://github.com/openstack/keystone/blob/f5c9b094af8442219e75265a87551873e058003b/keystone/auth/schema.py#L97-L102