### PR TITLE
Octavia: Failover amphora

### DIFF
--- a/openstack/loadbalancer/v2/amphorae/doc.go
+++ b/openstack/loadbalancer/v2/amphorae/doc.go
@@ -21,5 +21,14 @@ Example to List Amphorae
 	for _, amphora := range allAmphorae {
 		fmt.Printf("%+v\n", amphora)
 	}
+
+Example to Failover an amphora
+
+	ampID := "d67d56a6-4a86-4688-a282-f46444705c64"
+
+	err := amphorae.Failover(octaviaClient, ampID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
 */
 package amphorae

--- a/openstack/loadbalancer/v2/amphorae/requests.go
+++ b/openstack/loadbalancer/v2/amphorae/requests.go
@@ -57,3 +57,11 @@ func Get(c *gophercloud.ServiceClient, id string) (r GetResult) {
 	_, r.Err = c.Get(resourceURL(c, id), &r.Body, nil)
 	return
 }
+
+// Failover performs a failover of an amphora.
+func Failover(c *gophercloud.ServiceClient, id string) (r FailoverResult) {
+	_, r.Err = c.Put(failoverRootURL(c, id), nil, nil, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+	})
+	return
+}

--- a/openstack/loadbalancer/v2/amphorae/results.go
+++ b/openstack/loadbalancer/v2/amphorae/results.go
@@ -146,3 +146,9 @@ func (r commonResult) Extract() (*Amphora, error) {
 type GetResult struct {
 	commonResult
 }
+
+// FailoverResult represents the result of a failover operation. Call its
+// ExtractErr method to determine if the request succeeded or failed.
+type FailoverResult struct {
+	gophercloud.ErrResult
+}

--- a/openstack/loadbalancer/v2/amphorae/testing/fixtures.go
+++ b/openstack/loadbalancer/v2/amphorae/testing/fixtures.go
@@ -167,3 +167,13 @@ func HandleAmphoraGetSuccessfully(t *testing.T) {
 		fmt.Fprintf(w, SingleAmphoraBody)
 	})
 }
+
+// HandleAmphoraFailoverSuccessfully sets up the test server to respond to an amphora failover request.
+func HandleAmphoraFailoverSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/v2.0/octavia/amphorae/36e08a3e-a78f-4b40-a229-1e7e23eee1ab/failover", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.WriteHeader(http.StatusAccepted)
+	})
+}

--- a/openstack/loadbalancer/v2/amphorae/testing/requests_test.go
+++ b/openstack/loadbalancer/v2/amphorae/testing/requests_test.go
@@ -63,3 +63,12 @@ func TestGetAmphora(t *testing.T) {
 
 	th.CheckDeepEquals(t, FirstAmphora, *actual)
 }
+
+func TestFailoverAmphora(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleAmphoraFailoverSuccessfully(t)
+
+	res := amphorae.Failover(fake.ServiceClient(), "36e08a3e-a78f-4b40-a229-1e7e23eee1ab")
+	th.AssertNoErr(t, res.Err)
+}

--- a/openstack/loadbalancer/v2/amphorae/urls.go
+++ b/openstack/loadbalancer/v2/amphorae/urls.go
@@ -5,6 +5,7 @@ import "github.com/gophercloud/gophercloud"
 const (
 	rootPath     = "octavia"
 	resourcePath = "amphorae"
+	failoverPath = "failover"
 )
 
 func rootURL(c *gophercloud.ServiceClient) string {
@@ -13,4 +14,8 @@ func rootURL(c *gophercloud.ServiceClient) string {
 
 func resourceURL(c *gophercloud.ServiceClient, id string) string {
 	return c.ServiceURL(rootPath, resourcePath, id)
+}
+
+func failoverRootURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL(rootPath, resourcePath, id, failoverPath)
 }


### PR DESCRIPTION
For #1911

- Source code: https://github.com/openstack/octavia/blob/master/octavia/api/v2/controllers/amphora.py#L96
- API doc: https://docs.openstack.org/api-ref/load-balancer/v2/index.html#failover-amphora