### PR TITLE
Fix orchestration template parsing

### DIFF
--- a/acceptance/openstack/orchestration/v1/stacktemplates_test.go
+++ b/acceptance/openstack/orchestration/v1/stacktemplates_test.go
@@ -40,3 +40,17 @@ func TestStackTemplatesValidate(t *testing.T) {
 	th.AssertNoErr(t, err)
 	tools.PrintResource(t, validatedTemplate)
 }
+
+func TestStackTemplateWithFile(t *testing.T) {
+	clients.SkipRelease(t, "stable/mitaka")
+	client, err := clients.NewOrchestrationV1Client()
+	th.AssertNoErr(t, err)
+
+	stack, err := CreateStackWithFile(t, client)
+	th.AssertNoErr(t, err)
+	defer DeleteStack(t, client, stack.Name, stack.ID)
+
+	tmpl, err := stacktemplates.Get(client, stack.Name, stack.ID).Extract()
+	th.AssertNoErr(t, err)
+	tools.PrintResource(t, tmpl)
+}

--- a/acceptance/openstack/orchestration/v1/testdata/samplefile
+++ b/acceptance/openstack/orchestration/v1/testdata/samplefile
@@ -1,0 +1,1 @@
+@this is not valid yaml

--- a/openstack/orchestration/v1/stacks/template.go
+++ b/openstack/orchestration/v1/stacks/template.go
@@ -85,7 +85,7 @@ func (t *Template) getFileContents(te interface{}, ignoreIf igFunc, recurse bool
 				childTemplate.client = t.client
 
 				// fetch the contents of the child template
-				if err := childTemplate.Parse(); err != nil {
+				if err := childTemplate.Fetch(); err != nil {
 					return err
 				}
 
@@ -93,8 +93,10 @@ func (t *Template) getFileContents(te interface{}, ignoreIf igFunc, recurse bool
 				// required if the child template itself contains references to
 				// other templates
 				if recurse {
-					if err := childTemplate.getFileContents(childTemplate.Parsed, ignoreIf, recurse); err != nil {
-						return err
+					if err := childTemplate.Parse(); err == nil {
+						if err := childTemplate.getFileContents(childTemplate.Parsed, ignoreIf, recurse); err != nil {
+							return err
+						}
 					}
 				}
 				// update parent template with current child templates' content.

--- a/openstack/orchestration/v1/stacks/template.go
+++ b/openstack/orchestration/v1/stacks/template.go
@@ -94,8 +94,10 @@ func (t *Template) getFileContents(te interface{}, ignoreIf igFunc, recurse bool
 				// other templates
 				if recurse {
 					if err := childTemplate.Parse(); err == nil {
-						if err := childTemplate.getFileContents(childTemplate.Parsed, ignoreIf, recurse); err != nil {
-							return err
+						if err := childTemplate.Validate(); err == nil {
+							if err := childTemplate.getFileContents(childTemplate.Parsed, ignoreIf, recurse); err != nil {
+								return err
+							}
 						}
 					}
 				}

--- a/openstack/orchestration/v1/stacks/utils.go
+++ b/openstack/orchestration/v1/stacks/utils.go
@@ -122,11 +122,6 @@ func (t *TE) Parse() error {
 	return nil
 }
 
-// Validate validates the contents of TE
-func (t *TE) Validate() error {
-	return nil
-}
-
 // igfunc is a parameter used by GetFileContents and GetRRFileContents to check
 // for valid URL's.
 type igFunc func(string, interface{}) bool

--- a/openstack/orchestration/v1/stacks/utils.go
+++ b/openstack/orchestration/v1/stacks/utils.go
@@ -81,6 +81,9 @@ func (t *TE) Fetch() error {
 	if err != nil {
 		return err
 	}
+	if !(resp.StatusCode >= 200 && resp.StatusCode < 300) {
+		return fmt.Errorf("error fetching %s: %s", t.URL, resp.Status)
+	}
 	t.Bin = body
 	return nil
 }
@@ -116,7 +119,7 @@ func (t *TE) Parse() error {
 			return ErrInvalidDataFormat{}
 		}
 	}
-	return t.Validate()
+	return t.Validate() // FIXME This always calls TE.Validate, not Template.Validate/Environment.Validate
 }
 
 // Validate validates the contents of TE

--- a/openstack/orchestration/v1/stacks/utils.go
+++ b/openstack/orchestration/v1/stacks/utils.go
@@ -119,7 +119,7 @@ func (t *TE) Parse() error {
 			return ErrInvalidDataFormat{}
 		}
 	}
-	return t.Validate() // FIXME This always calls TE.Validate, not Template.Validate/Environment.Validate
+	return nil
 }
 
 // Validate validates the contents of TE


### PR DESCRIPTION
When get_file is used in a template and the referenced file is not json/yaml,
gophercloud throws a cryptic error: "Data in neither json nor yaml format."

For #1914
