### PR TITLE
include response headers in ErrUnexpectedResponseCode

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -2,6 +2,7 @@ package gophercloud
 
 import (
 	"fmt"
+	"net/http"
 	"strings"
 )
 
@@ -77,11 +78,12 @@ func (e ErrMissingAnyoneOfEnvironmentVariables) Error() string {
 // those listed in OkCodes is encountered.
 type ErrUnexpectedResponseCode struct {
 	BaseError
-	URL      string
-	Method   string
-	Expected []int
-	Actual   int
-	Body     []byte
+	URL            string
+	Method         string
+	Expected       []int
+	Actual         int
+	Body           []byte
+	ResponseHeader http.Header
 }
 
 func (e ErrUnexpectedResponseCode) Error() string {

--- a/provider_client.go
+++ b/provider_client.go
@@ -414,11 +414,12 @@ func (client *ProviderClient) doRequest(method, url string, options *RequestOpts
 		body, _ := ioutil.ReadAll(resp.Body)
 		resp.Body.Close()
 		respErr := ErrUnexpectedResponseCode{
-			URL:      url,
-			Method:   method,
-			Expected: options.OkCodes,
-			Actual:   resp.StatusCode,
-			Body:     body,
+			URL:            url,
+			Method:         method,
+			Expected:       options.OkCodes,
+			Actual:         resp.StatusCode,
+			Body:           body,
+			ResponseHeader: resp.Header,
 		}
 
 		errType := options.ErrorContext

--- a/testing/errors_test.go
+++ b/testing/errors_test.go
@@ -9,11 +9,12 @@ import (
 
 func TestGetResponseCode(t *testing.T) {
 	respErr := gophercloud.ErrUnexpectedResponseCode{
-		URL:      "http://example.com",
-		Method:   "GET",
-		Expected: []int{200},
-		Actual:   404,
-		Body:     nil,
+		URL:            "http://example.com",
+		Method:         "GET",
+		Expected:       []int{200},
+		Actual:         404,
+		Body:           nil,
+		ResponseHeader: nil,
 	}
 
 	var err404 error = gophercloud.ErrDefault404{ErrUnexpectedResponseCode: respErr}


### PR DESCRIPTION
Possible usecases include:
- including the X-Openstack-Request-Id when logging the error message
- respecting the Retry-After header when backing off after a 429 response

Solves #1918.