### PR TITLE
Keystone V3: Introduce TOTP (two factor) auth support

### DIFF
--- a/auth_options.go
+++ b/auth_options.go
@@ -181,7 +181,7 @@ func (opts *AuthOptions) ToTokenV3CreateMap(scope map[string]interface{}) (map[s
 		Password              *passwordReq              `json:"password,omitempty"`
 		Token                 *tokenReq                 `json:"token,omitempty"`
 		ApplicationCredential *applicationCredentialReq `json:"application_credential,omitempty"`
-		Totp                  *totpReq                  `json:"totp,omitempty"`
+		TOTP                  *totpReq                  `json:"totp,omitempty"`
 	}
 
 	type authReq struct {
@@ -325,7 +325,7 @@ func (opts *AuthOptions) ToTokenV3CreateMap(scope map[string]interface{}) (map[s
 					}
 				}
 				if opts.Passcode != "" {
-					req.Auth.Identity.Totp = &totpReq{
+					req.Auth.Identity.TOTP = &totpReq{
 						User: &userReq{
 							Name:     &opts.Username,
 							Passcode: &opts.Passcode,
@@ -348,7 +348,7 @@ func (opts *AuthOptions) ToTokenV3CreateMap(scope map[string]interface{}) (map[s
 				}
 
 				if opts.Passcode != "" {
-					req.Auth.Identity.Totp = &totpReq{
+					req.Auth.Identity.TOTP = &totpReq{
 						User: &userReq{
 							Name:     &opts.Username,
 							Passcode: &opts.Passcode,
@@ -379,7 +379,7 @@ func (opts *AuthOptions) ToTokenV3CreateMap(scope map[string]interface{}) (map[s
 			}
 
 			if opts.Passcode != "" {
-				req.Auth.Identity.Totp = &totpReq{
+				req.Auth.Identity.TOTP = &totpReq{
 					User: &userReq{
 						ID:       &opts.UserID,
 						Passcode: &opts.Passcode,

--- a/openstack/auth_env.go
+++ b/openstack/auth_env.go
@@ -38,6 +38,7 @@ func AuthOptionsFromEnv() (gophercloud.AuthOptions, error) {
 	username := os.Getenv("OS_USERNAME")
 	userID := os.Getenv("OS_USERID")
 	password := os.Getenv("OS_PASSWORD")
+	passcode := os.Getenv("OS_PASSCODE")
 	tenantID := os.Getenv("OS_TENANT_ID")
 	tenantName := os.Getenv("OS_TENANT_NAME")
 	domainID := os.Getenv("OS_DOMAIN_ID")
@@ -73,8 +74,9 @@ func AuthOptionsFromEnv() (gophercloud.AuthOptions, error) {
 		}
 	}
 
-	if password == "" && applicationCredentialID == "" && applicationCredentialName == "" {
+	if password == "" && passcode == "" && applicationCredentialID == "" && applicationCredentialName == "" {
 		err := gophercloud.ErrMissingEnvironmentVariable{
+			// silently ignore TOTP passcode warning, since it is not a common auth method
 			EnvironmentVariable: "OS_PASSWORD",
 		}
 		return nilOptions, err
@@ -112,6 +114,7 @@ func AuthOptionsFromEnv() (gophercloud.AuthOptions, error) {
 		UserID:                      userID,
 		Username:                    username,
 		Password:                    password,
+		Passcode:                    passcode,
 		TenantID:                    tenantID,
 		TenantName:                  tenantName,
 		DomainID:                    domainID,

--- a/openstack/identity/v3/tokens/requests.go
+++ b/openstack/identity/v3/tokens/requests.go
@@ -37,6 +37,9 @@ type AuthOptions struct {
 
 	Password string `json:"password,omitempty"`
 
+	// Passcode is used in TOTP authentication method
+	Passcode string `json:"passcode,omitempty"`
+
 	// At most one of DomainID and DomainName must be provided if using Username
 	// with Identity V3. Otherwise, either are optional.
 	DomainID   string `json:"-"`
@@ -68,6 +71,7 @@ func (opts *AuthOptions) ToTokenV3CreateMap(scope map[string]interface{}) (map[s
 		Username:                    opts.Username,
 		UserID:                      opts.UserID,
 		Password:                    opts.Password,
+		Passcode:                    opts.Passcode,
 		DomainID:                    opts.DomainID,
 		DomainName:                  opts.DomainName,
 		AllowReauth:                 opts.AllowReauth,
@@ -94,6 +98,11 @@ func (opts *AuthOptions) ToTokenV3ScopeMap() (map[string]interface{}, error) {
 }
 
 func (opts *AuthOptions) CanReauth() bool {
+	if opts.Passcode != "" {
+		// cannot reauth using TOTP passcode
+		return false
+	}
+
 	return opts.AllowReauth
 }
 

--- a/openstack/identity/v3/tokens/testing/requests_test.go
+++ b/openstack/identity/v3/tokens/testing/requests_test.go
@@ -342,6 +342,68 @@ func TestCreateApplicationCredentialNameAndSecret(t *testing.T) {
 	`)
 }
 
+func TestCreateTotpProjectNameAndDomainNameScope(t *testing.T) {
+	options := tokens.AuthOptions{UserID: "fenris", Passcode: "12345678"}
+	scope := &tokens.Scope{ProjectName: "world-domination", DomainName: "evil-plans"}
+	authTokenPost(t, options, scope, `
+		{
+			"auth": {
+				"identity": {
+					"methods": ["totp"],
+					"totp": {
+						"user": {
+							"id": "fenris",
+							"passcode": "12345678"
+						}
+					}
+				},
+				"scope": {
+					"project": {
+						"domain": {
+							"name": "evil-plans"
+						},
+						"name": "world-domination"
+					}
+				}
+			}
+		}
+	`)
+}
+
+func TestCreatePasswordTotpProjectNameAndDomainNameScope(t *testing.T) {
+	options := tokens.AuthOptions{UserID: "fenris", Password: "g0t0h311", Passcode: "12345678"}
+	scope := &tokens.Scope{ProjectName: "world-domination", DomainName: "evil-plans"}
+	authTokenPost(t, options, scope, `
+		{
+			"auth": {
+				"identity": {
+					"methods": ["password","totp"],
+					"password": {
+						"user": {
+							"id": "fenris",
+							"password": "g0t0h311"
+						}
+					},
+					"totp": {
+						"user": {
+							"id": "fenris",
+							"passcode": "12345678"
+						}
+					}
+				},
+				"scope": {
+					"project": {
+						"domain": {
+							"name": "evil-plans"
+						},
+						"name": "world-domination"
+					}
+				}
+			}
+		}
+	`)
+}
+
 func TestCreateExtractsTokenFromResponse(t *testing.T) {
 	testhelper.SetupHTTP()
 	defer testhelper.TeardownHTTP()

--- a/openstack/identity/v3/tokens/testing/requests_test.go
+++ b/openstack/identity/v3/tokens/testing/requests_test.go
@@ -342,8 +342,8 @@ func TestCreateApplicationCredentialNameAndSecret(t *testing.T) {
 	`)
 }
 
-func TestCreateTotpProjectNameAndDomainNameScope(t *testing.T) {
-	options := tokens.AuthOptions{UserID: "fenris", Passcode: "12345678"}
+func TestCreateTOTPProjectNameAndDomainNameScope(t *testing.T) {
+	options := tokens.AuthOptions{UserID: "someuser", Passcode: "12345678"}
 	scope := &tokens.Scope{ProjectName: "world-domination", DomainName: "evil-plans"}
 	authTokenPost(t, options, scope, `
 		{
@@ -352,7 +352,7 @@ func TestCreateTotpProjectNameAndDomainNameScope(t *testing.T) {
 					"methods": ["totp"],
 					"totp": {
 						"user": {
-							"id": "fenris",
+							"id": "someuser",
 							"passcode": "12345678"
 						}
 					}
@@ -370,8 +370,8 @@ func TestCreateTotpProjectNameAndDomainNameScope(t *testing.T) {
 	`)
 }
 
-func TestCreatePasswordTotpProjectNameAndDomainNameScope(t *testing.T) {
-	options := tokens.AuthOptions{UserID: "fenris", Password: "g0t0h311", Passcode: "12345678"}
+func TestCreatePasswordTOTPProjectNameAndDomainNameScope(t *testing.T) {
+	options := tokens.AuthOptions{UserID: "someuser", Password: "somepassword", Passcode: "12345678"}
 	scope := &tokens.Scope{ProjectName: "world-domination", DomainName: "evil-plans"}
 	authTokenPost(t, options, scope, `
 		{
@@ -380,13 +380,13 @@ func TestCreatePasswordTotpProjectNameAndDomainNameScope(t *testing.T) {
 					"methods": ["password","totp"],
 					"password": {
 						"user": {
-							"id": "fenris",
-							"password": "g0t0h311"
+							"id": "someuser",
+							"password": "somepassword"
 						}
 					},
 					"totp": {
 						"user": {
-							"id": "fenris",
+							"id": "someuser",
 							"passcode": "12345678"
 						}
 					}


### PR DESCRIPTION
Resolves #1917

@jtopjian  I didn't find a way to perform tests in multi-step approach https://docs.openstack.org/api-ref/identity/v3/?expanded=multi-step-authentication-2-factor-password-and-totp-example-detail#multi-step-authentication-2-factor-password-and-totp-example

In my case passcodes are generated using a dongle and I can enter them in advance, therefore the auth request sends both password and totp auth requests in one call.

I'll try to add a receipt response handler in further PRs.