### PR TITLE
Nova V2: Introduce injectNetworkInfo and resetNetwork server actions support

### DIFF
--- a/openstack/compute/v2/extensions/injectnetworkinfo/doc.go
+++ b/openstack/compute/v2/extensions/injectnetworkinfo/doc.go
@@ -1,0 +1,14 @@
+/*
+Package injectnetworkinfo provides functionality to inject the network info into
+a server that has been provisioned by the OpenStack Compute service. This action
+requires admin privileges and Nova configured with a Xen hypervisor driver.
+
+Example to Inject a Network Info into a Server
+
+	serverID := "47b6b7b7-568d-40e4-868c-d5c41735532e"
+	err := injectnetworkinfo.InjectNetworkInfo(client, id).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+*/
+package injectnetworkinfo

--- a/openstack/compute/v2/extensions/injectnetworkinfo/requests.go
+++ b/openstack/compute/v2/extensions/injectnetworkinfo/requests.go
@@ -1,0 +1,16 @@
+package injectnetworkinfo
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions"
+)
+
+// InjectNetworkInfo will inject the network info into a server
+func InjectNetworkInfo(client *gophercloud.ServiceClient, id string) (r InjectNetworkResult) {
+	b := map[string]interface{}{
+		"injectNetworkInfo": nil,
+	}
+	resp, err := client.Post(extensions.ActionURL(client, id), b, nil, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}

--- a/openstack/compute/v2/extensions/injectnetworkinfo/results.go
+++ b/openstack/compute/v2/extensions/injectnetworkinfo/results.go
@@ -1,0 +1,11 @@
+package injectnetworkinfo
+
+import (
+	"github.com/gophercloud/gophercloud"
+)
+
+// InjectNetworkResult is the response of a InjectNetworkInfo operation. Call
+// its ExtractErr method to determine if the request suceeded or failed.
+type InjectNetworkResult struct {
+	gophercloud.ErrResult
+}

--- a/openstack/compute/v2/extensions/injectnetworkinfo/testing/fixtures.go
+++ b/openstack/compute/v2/extensions/injectnetworkinfo/testing/fixtures.go
@@ -1,0 +1,18 @@
+package testing
+
+import (
+	"net/http"
+	"testing"
+
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func mockInjectNetworkInfoResponse(t *testing.T, id string) {
+	th.Mux.HandleFunc("/servers/"+id+"/action", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, `{"injectNetworkInfo": null}`)
+		w.WriteHeader(http.StatusAccepted)
+	})
+}

--- a/openstack/compute/v2/extensions/injectnetworkinfo/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/injectnetworkinfo/testing/requests_test.go
@@ -1,0 +1,21 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/injectnetworkinfo"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+const serverID = "b16ba811-199d-4ffd-8839-ba96c1185a67"
+
+func TestInjectNetworkInfo(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	mockInjectNetworkInfoResponse(t, serverID)
+
+	err := injectnetworkinfo.InjectNetworkInfo(client.ServiceClient(), serverID).ExtractErr()
+	th.AssertNoErr(t, err)
+}

--- a/openstack/compute/v2/extensions/resetnetwork/doc.go
+++ b/openstack/compute/v2/extensions/resetnetwork/doc.go
@@ -1,0 +1,14 @@
+/*
+Package resetnetwork provides functionality to reset the network of a server
+that has been provisioned by the OpenStack Compute service. This action
+requires admin privileges and Nova configured with a Xen hypervisor driver.
+
+Example to Reset a Network of a Server
+
+	serverID := "47b6b7b7-568d-40e4-868c-d5c41735532e"
+	err := resetnetwork.ResetNetwork(client, id).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+*/
+package resetnetwork

--- a/openstack/compute/v2/extensions/resetnetwork/requests.go
+++ b/openstack/compute/v2/extensions/resetnetwork/requests.go
@@ -1,0 +1,16 @@
+package resetnetwork
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions"
+)
+
+// ResetNetwork will reset the network of a server
+func ResetNetwork(client *gophercloud.ServiceClient, id string) (r ResetResult) {
+	b := map[string]interface{}{
+		"resetNetwork": nil,
+	}
+	resp, err := client.Post(extensions.ActionURL(client, id), b, nil, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}

--- a/openstack/compute/v2/extensions/resetnetwork/results.go
+++ b/openstack/compute/v2/extensions/resetnetwork/results.go
@@ -1,0 +1,11 @@
+package resetnetwork
+
+import (
+	"github.com/gophercloud/gophercloud"
+)
+
+// ResetResult is the response of a ResetNetwork operation. Call its ExtractErr
+// method to determine if the request suceeded or failed.
+type ResetResult struct {
+	gophercloud.ErrResult
+}

--- a/openstack/compute/v2/extensions/resetnetwork/testing/fixtures.go
+++ b/openstack/compute/v2/extensions/resetnetwork/testing/fixtures.go
@@ -1,0 +1,18 @@
+package testing
+
+import (
+	"net/http"
+	"testing"
+
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func mockResetNetworkResponse(t *testing.T, id string) {
+	th.Mux.HandleFunc("/servers/"+id+"/action", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, `{"resetNetwork": null}`)
+		w.WriteHeader(http.StatusAccepted)
+	})
+}

--- a/openstack/compute/v2/extensions/resetnetwork/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/resetnetwork/testing/requests_test.go
@@ -1,0 +1,21 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/resetnetwork"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+const serverID = "b16ba811-199d-4ffd-8839-ba96c1185a67"
+
+func TestResetNetwork(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	mockResetNetworkResponse(t, serverID)
+
+	err := resetnetwork.ResetNetwork(client.ServiceClient(), serverID).ExtractErr()
+	th.AssertNoErr(t, err)
+}


### PR DESCRIPTION
Resolves #535

* `resetNetwork` - [API](https://docs.openstack.org/api-ref/compute/?expanded=inject-network-information-injectnetworkinfo-action-detail#inject-network-information-injectnetworkinfo-action) [code](https://github.com/openstack/nova/blob/stable/train/nova/api/openstack/compute/admin_actions.py#L40)
* `injectNetworkInfo` - [API](https://docs.openstack.org/api-ref/compute/?expanded=reset-networking-on-a-server-resetnetwork-action-detail#reset-networking-on-a-server-resetnetwork-action) [code](https://github.com/openstack/nova/blob/stable/train/nova/api/openstack/compute/admin_actions.py#L53)