### PR TITLE
Fix misleading/typo in openstack client doc

### DIFF
--- a/openstack/client.go
+++ b/openstack/client.go
@@ -69,7 +69,7 @@ Example:
 
 	ao, err := openstack.AuthOptionsFromEnv()
 	provider, err := openstack.AuthenticatedClient(ao)
-	client, err := openstack.NewNetworkV2(client, gophercloud.EndpointOpts{
+	client, err := openstack.NewNetworkV2(provider, gophercloud.EndpointOpts{
 		Region: os.Getenv("OS_REGION_NAME"),
 	})
 */

--- a/openstack/doc.go
+++ b/openstack/doc.go
@@ -7,7 +7,7 @@ Example of Creating a Service Client
 
 	ao, err := openstack.AuthOptionsFromEnv()
 	provider, err := openstack.AuthenticatedClient(ao)
-	client, err := openstack.NewNetworkV2(client, gophercloud.EndpointOpts{
+	client, err := openstack.NewNetworkV2(provider, gophercloud.EndpointOpts{
 		Region: os.Getenv("OS_REGION_NAME"),
 	})
 */


### PR DESCRIPTION
For #1948

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/gophercloud/gophercloud/blob/master/openstack/doc.go#L10

https://github.com/gophercloud/gophercloud/blob/master/openstack/client.go#L72
