### PR TITLE
switch bootfromvolume from os-volumes_boot to servers

### DIFF
--- a/openstack/compute/v2/extensions/bootfromvolume/urls.go
+++ b/openstack/compute/v2/extensions/bootfromvolume/urls.go
@@ -3,5 +3,5 @@ package bootfromvolume
 import "github.com/gophercloud/gophercloud"
 
 func createURL(c *gophercloud.ServiceClient) string {
-	return c.ServiceURL("os-volumes_boot")
+	return c.ServiceURL("servers")
 }


### PR DESCRIPTION
according to
https://github.com/openstack/nova/blob/master/nova/api/openstack/compute/routes.py#L726
os-volumes_boot is identical to servers routes and it will be deprecated later

https://docs.openstack.org/api-ref/compute/
os-volumes_boot is not listed at all

so switch from os-volumes_boot to servers

For #1974 
