### PR TITLE
Modify PhysicalDisks's type to support physical disks hints

### DIFF
--- a/acceptance/openstack/baremetal/v1/nodes_test.go
+++ b/acceptance/openstack/baremetal/v1/nodes_test.go
@@ -84,6 +84,26 @@ func TestNodesRAIDConfig(t *testing.T) {
 	err = nodes.SetRAIDConfig(client, node.UUID, nodes.RAIDConfigOpts{
 		LogicalDisks: []nodes.LogicalDisk{
 			{
+				SizeGB:       &sizeGB,
+				IsRootVolume: &isTrue,
+				RAIDLevel:    nodes.RAID5,
+				Controller:   "software",
+				PhysicalDisks: []interface{}{
+					map[string]string{
+						"size": "> 100",
+					},
+					map[string]string{
+						"size": "> 100",
+					},
+				},
+			},
+		},
+	}).ExtractErr()
+	th.AssertNoErr(t, err)
+
+	err = nodes.SetRAIDConfig(client, node.UUID, nodes.RAIDConfigOpts{
+		LogicalDisks: []nodes.LogicalDisk{
+			{
 				SizeGB:                &sizeGB,
 				IsRootVolume:          &isTrue,
 				RAIDLevel:             nodes.RAID5,

--- a/openstack/baremetal/v1/nodes/requests.go
+++ b/openstack/baremetal/v1/nodes/requests.go
@@ -568,7 +568,7 @@ type LogicalDisk struct {
 	Controller string `json:"controller,omitempty"`
 
 	// A list of physical disks to use as read by the RAID interface.
-	PhysicalDisks []string `json:"physical_disks,omitempty"`
+	PhysicalDisks []interface{} `json:"physical_disks,omitempty"`
 }
 
 func (opts RAIDConfigOpts) ToRAIDConfigMap() (map[string]interface{}, error) {
@@ -577,10 +577,12 @@ func (opts RAIDConfigOpts) ToRAIDConfigMap() (map[string]interface{}, error) {
 		return nil, err
 	}
 
-	for _, v := range body["logical_disks"].([]interface{}) {
-		if logicalDisk, ok := v.(map[string]interface{}); ok {
-			if logicalDisk["size_gb"] == nil {
-				logicalDisk["size_gb"] = "MAX"
+	if body["logical_disks"] != nil {
+		for _, v := range body["logical_disks"].([]interface{}) {
+			if logicalDisk, ok := v.(map[string]interface{}); ok {
+				if logicalDisk["size_gb"] == nil {
+					logicalDisk["size_gb"] = "MAX"
+				}
 			}
 		}
 	}


### PR DESCRIPTION
For #1981 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:
https://github.com/openstack/ironic/blob/master/ironic/conductor/manager.py#L2999
https://github.com/openstack/ironic/blob/master/ironic/common/raid.py#L63
https://github.com/openstack/ironic/blob/master/ironic/drivers/raid_config_schema.json#L59
