### PR TITLE
Support http_basic auth_strategy for Ironic

### DIFF
--- a/acceptance/clients/clients.go
+++ b/acceptance/clients/clients.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack"
+	baremetalHTTPBasic "github.com/gophercloud/gophercloud/openstack/baremetal/httpbasic"
 	baremetalNoAuth "github.com/gophercloud/gophercloud/openstack/baremetal/noauth"
 	blockstorageNoAuth "github.com/gophercloud/gophercloud/openstack/blockstorage/noauth"
 )
@@ -282,6 +283,17 @@ func NewBareMetalV1Client() (*gophercloud.ServiceClient, error) {
 func NewBareMetalV1NoAuthClient() (*gophercloud.ServiceClient, error) {
 	return baremetalNoAuth.NewBareMetalNoAuth(baremetalNoAuth.EndpointOpts{
 		IronicEndpoint: os.Getenv("IRONIC_ENDPOINT"),
+	})
+}
+
+// NewBareMetalV1HTTPBasic returns a *ServiceClient for making calls
+// to the OpenStack Bare Metal v1 API. An error will be returned
+// if authentication or client creation was not possible.
+func NewBareMetalV1HTTPBasic() (*gophercloud.ServiceClient, error) {
+	return baremetalHTTPBasic.NewBareMetalHTTPBasic(baremetalHTTPBasic.EndpointOpts{
+		IronicEndpoint:     os.Getenv("IRONIC_ENDPOINT"),
+		IronicUser:         os.Getenv("OS_USERNAME"),
+		IronicUserPassword: os.Getenv("OS_PASSWORD"),
 	})
 }
 

--- a/acceptance/clients/conditions.go
+++ b/acceptance/clients/conditions.go
@@ -74,6 +74,14 @@ func RequireNovaNetwork(t *testing.T) {
 	}
 }
 
+// RequireIronicHTTPBasic will restric a test to be only run in
+// environments that have Ironic using http_basic.
+func RequireIronicHTTPBasic(t *testing.T) {
+	if os.Getenv("IRONIC_ENDPOINT") == "" || os.Getenv("OS_USERNAME") == "" || os.Getenv("OS_PASSWORD") == "" {
+		t.Skip("this test requires Ironic using http_basic, set OS_USERNAME, OS_PASSWORD and IRONIC_ENDPOINT")
+	}
+}
+
 // SkipRelease will have the test be skipped on a certain
 // release. Releases are named such as 'stable/mitaka', master, etc.
 func SkipRelease(t *testing.T, release string) {

--- a/acceptance/openstack/baremetal/httpbasic/allocations_test.go
+++ b/acceptance/openstack/baremetal/httpbasic/allocations_test.go
@@ -1,0 +1,46 @@
+// +build acceptance baremetal allocations
+
+package httpbasic
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/acceptance/clients"
+	v1 "github.com/gophercloud/gophercloud/acceptance/openstack/baremetal/v1"
+	"github.com/gophercloud/gophercloud/openstack/baremetal/v1/allocations"
+	"github.com/gophercloud/gophercloud/pagination"
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestAllocationsCreateDestroy(t *testing.T) {
+	clients.RequireLong(t)
+	clients.RequireIronicHTTPBasic(t)
+
+	client, err := clients.NewBareMetalV1HTTPBasic()
+	th.AssertNoErr(t, err)
+
+	client.Microversion = "1.52"
+
+	allocation, err := v1.CreateAllocation(t, client)
+	th.AssertNoErr(t, err)
+	defer v1.DeleteAllocation(t, client, allocation)
+
+	found := false
+	err = allocations.List(client, allocations.ListOpts{}).EachPage(func(page pagination.Page) (bool, error) {
+		allocationList, err := allocations.ExtractAllocations(page)
+		if err != nil {
+			return false, err
+		}
+
+		for _, a := range allocationList {
+			if a.UUID == allocation.UUID {
+				found = true
+				return true, nil
+			}
+		}
+
+		return false, nil
+	})
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, found, true)
+}

--- a/acceptance/openstack/baremetal/httpbasic/doc.go
+++ b/acceptance/openstack/baremetal/httpbasic/doc.go
@@ -1,0 +1,12 @@
+package httpbasic
+
+/*
+Acceptance tests for Ironic endpoints with auth_strategy=noauth.  Specify
+IRONIC_ENDPOINT, OS_USERNAME and OS_PASSWORD environment variables.  For example:
+
+  IRONIC_ENDPOINT="http://127.0.0.1:6385/v1"
+  OS_USERNAME="myUser"
+  OS_PASSWORD="myPassword"
+  go test ./acceptance/openstack/baremetal/httpbasic/...
+
+*/

--- a/acceptance/openstack/baremetal/httpbasic/nodes_test.go
+++ b/acceptance/openstack/baremetal/httpbasic/nodes_test.go
@@ -1,0 +1,98 @@
+package httpbasic
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/acceptance/clients"
+	v1 "github.com/gophercloud/gophercloud/acceptance/openstack/baremetal/v1"
+	"github.com/gophercloud/gophercloud/openstack/baremetal/v1/nodes"
+	"github.com/gophercloud/gophercloud/pagination"
+
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestNodesCreateDestroy(t *testing.T) {
+	clients.RequireLong(t)
+	clients.RequireIronicHTTPBasic(t)
+
+	client, err := clients.NewBareMetalV1HTTPBasic()
+	th.AssertNoErr(t, err)
+	client.Microversion = "1.50"
+
+	node, err := v1.CreateNode(t, client)
+	th.AssertNoErr(t, err)
+	defer v1.DeleteNode(t, client, node)
+
+	found := false
+	err = nodes.List(client, nodes.ListOpts{}).EachPage(func(page pagination.Page) (bool, error) {
+		nodeList, err := nodes.ExtractNodes(page)
+		if err != nil {
+			return false, err
+		}
+
+		for _, n := range nodeList {
+			if n.UUID == node.UUID {
+				found = true
+				return true, nil
+			}
+		}
+
+		return false, nil
+	})
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, found, true)
+}
+
+func TestNodesUpdate(t *testing.T) {
+	clients.RequireLong(t)
+	clients.RequireIronicHTTPBasic(t)
+
+	client, err := clients.NewBareMetalV1HTTPBasic()
+	th.AssertNoErr(t, err)
+	client.Microversion = "1.50"
+
+	node, err := v1.CreateNode(t, client)
+	th.AssertNoErr(t, err)
+	defer v1.DeleteNode(t, client, node)
+
+	updated, err := nodes.Update(client, node.UUID, nodes.UpdateOpts{
+		nodes.UpdateOperation{
+			Op:    nodes.ReplaceOp,
+			Path:  "/maintenance",
+			Value: "true",
+		},
+	}).Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, updated.Maintenance, true)
+}
+
+func TestNodesRAIDConfig(t *testing.T) {
+	clients.RequireLong(t)
+	clients.RequireIronicHTTPBasic(t)
+
+	client, err := clients.NewBareMetalV1HTTPBasic()
+	th.AssertNoErr(t, err)
+	client.Microversion = "1.50"
+
+	node, err := v1.CreateNode(t, client)
+	th.AssertNoErr(t, err)
+	defer v1.DeleteNode(t, client, node)
+
+	sizeGB := 100
+	isTrue := true
+
+	err = nodes.SetRAIDConfig(client, node.UUID, nodes.RAIDConfigOpts{
+		LogicalDisks: []nodes.LogicalDisk{
+			{
+				SizeGB:                &sizeGB,
+				IsRootVolume:          &isTrue,
+				RAIDLevel:             nodes.RAID5,
+				DiskType:              nodes.HDD,
+				NumberOfPhysicalDisks: 5,
+			},
+		},
+	}).ExtractErr()
+	th.AssertNoErr(t, err)
+}

--- a/acceptance/openstack/baremetal/httpbasic/ports_test.go
+++ b/acceptance/openstack/baremetal/httpbasic/ports_test.go
@@ -1,0 +1,75 @@
+// +build acceptance baremetal ports
+
+package httpbasic
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/acceptance/clients"
+	v1 "github.com/gophercloud/gophercloud/acceptance/openstack/baremetal/v1"
+	"github.com/gophercloud/gophercloud/openstack/baremetal/v1/ports"
+	"github.com/gophercloud/gophercloud/pagination"
+
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestPortsCreateDestroy(t *testing.T) {
+	clients.RequireLong(t)
+	clients.RequireIronicHTTPBasic(t)
+
+	client, err := clients.NewBareMetalV1HTTPBasic()
+	th.AssertNoErr(t, err)
+	client.Microversion = "1.53"
+
+	node, err := v1.CreateFakeNode(t, client)
+	port, err := v1.CreatePort(t, client, node)
+	th.AssertNoErr(t, err)
+	defer v1.DeleteNode(t, client, node)
+	defer v1.DeletePort(t, client, port)
+
+	found := false
+	err = ports.List(client, ports.ListOpts{}).EachPage(func(page pagination.Page) (bool, error) {
+		portList, err := ports.ExtractPorts(page)
+		if err != nil {
+			return false, err
+		}
+
+		for _, p := range portList {
+			if p.UUID == port.UUID {
+				found = true
+				return true, nil
+			}
+		}
+
+		return false, nil
+	})
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, found, true)
+}
+
+func TestPortsUpdate(t *testing.T) {
+	clients.RequireLong(t)
+	clients.RequireIronicHTTPBasic(t)
+
+	client, err := clients.NewBareMetalV1HTTPBasic()
+	th.AssertNoErr(t, err)
+	client.Microversion = "1.53"
+
+	node, err := v1.CreateFakeNode(t, client)
+	port, err := v1.CreatePort(t, client, node)
+	th.AssertNoErr(t, err)
+	defer v1.DeleteNode(t, client, node)
+	defer v1.DeletePort(t, client, port)
+
+	updated, err := ports.Update(client, port.UUID, ports.UpdateOpts{
+		ports.UpdateOperation{
+			Op:    ports.ReplaceOp,
+			Path:  "/address",
+			Value: "aa:bb:cc:dd:ee:ff",
+		},
+	}).Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, updated.Address, "aa:bb:cc:dd:ee:ff")
+}

--- a/openstack/baremetal/httpbasic/doc.go
+++ b/openstack/baremetal/httpbasic/doc.go
@@ -1,0 +1,18 @@
+/*
+Package httpbasic provides support for http_basic bare metal endpoints.
+
+Example of obtaining and using a client:
+
+      client, err := httpbasic.NewBareMetalHTTPBasic(httpbasic.Endpoints{
+		IronicEndpoing:     "http://localhost:6385/v1/",
+		IronicUser:         "myUser",
+		IronicUserPassword: "myPassword",
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	client.Microversion = "1.50"
+	nodes.ListDetail(client, nodes.listOpts{})
+*/
+package httpbasic

--- a/openstack/baremetal/httpbasic/requests.go
+++ b/openstack/baremetal/httpbasic/requests.go
@@ -1,0 +1,45 @@
+package httpbasic
+
+import (
+	"encoding/base64"
+	"fmt"
+
+	"github.com/gophercloud/gophercloud"
+)
+
+// EndpointOpts specifies a "http_basic" Ironic Endpoint
+type EndpointOpts struct {
+	IronicEndpoint     string
+	IronicUser         string
+	IronicUserPassword string
+}
+
+func initClientOpts(client *gophercloud.ProviderClient, eo EndpointOpts) (*gophercloud.ServiceClient, error) {
+	sc := new(gophercloud.ServiceClient)
+	if eo.IronicEndpoint == "" {
+		return nil, fmt.Errorf("IronicEndpoint is required")
+	}
+	if eo.IronicUser == "" || eo.IronicUserPassword == "" {
+		return nil, fmt.Errorf("User and Password are required")
+	}
+
+	token := []byte(eo.IronicUser + ":" + eo.IronicUserPassword)
+	encodedToken := base64.StdEncoding.EncodeToString(token)
+	sc.MoreHeaders = map[string]string{"Authorization": "Basic " + encodedToken}
+	sc.Endpoint = gophercloud.NormalizeURL(eo.IronicEndpoint)
+	sc.ProviderClient = client
+	return sc, nil
+}
+
+// NewBareMetalHTTPBasic creates a ServiceClient that may be used to access a
+// "http_basic" bare metal service.
+func NewBareMetalHTTPBasic(eo EndpointOpts) (*gophercloud.ServiceClient, error) {
+	sc, err := initClientOpts(&gophercloud.ProviderClient{}, eo)
+	if err != nil {
+		return nil, err
+	}
+
+	sc.Type = "baremetal"
+
+	return sc, nil
+}

--- a/openstack/baremetal/httpbasic/testing/requests_test.go
+++ b/openstack/baremetal/httpbasic/testing/requests_test.go
@@ -1,0 +1,36 @@
+package testing
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/baremetal/httpbasic"
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestHttpBasic(t *testing.T) {
+	httpClient, err := httpbasic.NewBareMetalHTTPBasic(httpbasic.EndpointOpts{
+		IronicEndpoint:     "http://ironic:6385/v1",
+		IronicUser:         "myUser",
+		IronicUserPassword: "myPasswd",
+	})
+	th.AssertNoErr(t, err)
+	encToken := base64.StdEncoding.EncodeToString([]byte("myUser:myPasswd"))
+	headerValue := "Basic " + encToken
+
+	th.AssertEquals(t, headerValue, httpClient.MoreHeaders["Authorization"])
+
+	errTest1, err := httpbasic.NewBareMetalHTTPBasic(httpbasic.EndpointOpts{
+		IronicEndpoint: "http://ironic:6385/v1",
+	})
+	_ = errTest1
+	th.AssertEquals(t, "User and Password are required", err.Error())
+
+	errTest2, err := httpbasic.NewBareMetalHTTPBasic(httpbasic.EndpointOpts{
+		IronicUser:         "myUser",
+		IronicUserPassword: "myPasswd",
+	})
+	_ = errTest2
+	th.AssertEquals(t, "IronicEndpoint is required", err.Error())
+
+}


### PR DESCRIPTION
For #1429 

This PR adds the support to use  Ironic when `auth_strategy` is `http_basic`.

Ironic introduced a new auth_type `http_basic` that can
be used in standalone deployments[1].

This commit adds the support to use the new authentication
type.

The code was introduced by the changes [2] and [3].

[1] https://docs.openstack.org/ironic/latest/install/standalone.html
[2] https://review.opendev.org/727467
[3] https://review.opendev.org/729070