### PR TITLE
Support `merge_labels` when creating Magnum cluster

### DIFF
--- a/openstack/containerinfra/v1/clusters/requests.go
+++ b/openstack/containerinfra/v1/clusters/requests.go
@@ -26,6 +26,7 @@ type CreateOpts struct {
 	FloatingIPEnabled *bool             `json:"floating_ip_enabled,omitempty"`
 	FixedNetwork      string            `json:"fixed_network,omitempty"`
 	FixedSubnet       string            `json:"fixed_subnet,omitempty"`
+	MergeLabels       *bool             `json:"merge_labels,omitempty"`
 }
 
 // ToClusterCreateMap constructs a request body from CreateOpts.

--- a/openstack/containerinfra/v1/clusters/testing/requests_test.go
+++ b/openstack/containerinfra/v1/clusters/testing/requests_test.go
@@ -33,6 +33,7 @@ func TestCreateCluster(t *testing.T) {
 		FloatingIPEnabled: gophercloud.Enabled,
 		FixedNetwork:      "private_network",
 		FixedSubnet:       "private_subnet",
+		MergeLabels:       gophercloud.Enabled,
 	}
 
 	sc := fake.ServiceClient()


### PR DESCRIPTION
For #1984 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

The feature was introduced in OpenStack Magnum by https://review.opendev.org/#/c/720221/