### PR TITLE
Support http_basic auth_strategy for Ironic Inspector

### DIFF
--- a/openstack/baremetalintrospection/httpbasic/doc.go
+++ b/openstack/baremetalintrospection/httpbasic/doc.go
@@ -1,0 +1,17 @@
+/*
+Package httpbasic provides support for http_basic bare metal introspection endpoints.
+
+Example of obtaining and using a client:
+
+	client, err := httpbasic.NewBareMetalIntrospectionHTTPBasic(httpbasic.EndpointOpts{
+		IronicInspectorEndpoint:     "http://localhost:5050/v1/",
+		IronicInspectorUser:         "myUser",
+		IronicInspectorUserPassword: "myPassword",
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	introspection.GetIntrospectionStatus(client, "a62b8495-52e2-407b-b3cb-62775d04c2b8")
+*/
+package httpbasic

--- a/openstack/baremetalintrospection/httpbasic/requests.go
+++ b/openstack/baremetalintrospection/httpbasic/requests.go
@@ -1,0 +1,45 @@
+package httpbasic
+
+import (
+	"encoding/base64"
+	"fmt"
+
+	"github.com/gophercloud/gophercloud"
+)
+
+// EndpointOpts specifies a "http_basic" Ironic Inspector Endpoint.
+type EndpointOpts struct {
+	IronicInspectorEndpoint     string
+	IronicInspectorUser         string
+	IronicInspectorUserPassword string
+}
+
+func initClientOpts(client *gophercloud.ProviderClient, eo EndpointOpts) (*gophercloud.ServiceClient, error) {
+	sc := new(gophercloud.ServiceClient)
+	if eo.IronicInspectorEndpoint == "" {
+		return nil, fmt.Errorf("IronicInspectorEndpoint is required")
+	}
+	if eo.IronicInspectorUser == "" || eo.IronicInspectorUserPassword == "" {
+		return nil, fmt.Errorf("User and Password are required")
+	}
+
+	token := []byte(eo.IronicInspectorUser + ":" + eo.IronicInspectorUserPassword)
+	encodedToken := base64.StdEncoding.EncodeToString(token)
+	sc.MoreHeaders = map[string]string{"Authorization": "Basic " + encodedToken}
+	sc.Endpoint = gophercloud.NormalizeURL(eo.IronicInspectorEndpoint)
+	sc.ProviderClient = client
+	return sc, nil
+}
+
+// NewBareMetalIntrospectionHTTPBasic creates a ServiceClient that may be used to access a
+// "http_basic" bare metal introspection service.
+func NewBareMetalIntrospectionHTTPBasic(eo EndpointOpts) (*gophercloud.ServiceClient, error) {
+	sc, err := initClientOpts(&gophercloud.ProviderClient{}, eo)
+	if err != nil {
+		return nil, err
+	}
+
+	sc.Type = "baremetal-inspector"
+
+	return sc, nil
+}

--- a/openstack/baremetalintrospection/httpbasic/testing/requests_test.go
+++ b/openstack/baremetalintrospection/httpbasic/testing/requests_test.go
@@ -1,0 +1,34 @@
+package testing
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/baremetalintrospection/httpbasic"
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestNoAuth(t *testing.T) {
+	httpClient, err := httpbasic.NewBareMetalIntrospectionHTTPBasic(httpbasic.EndpointOpts{
+		IronicInspectorEndpoint:     "http://ironic:5050/v1",
+		IronicInspectorUser:         "myUser",
+		IronicInspectorUserPassword: "myPasswd",
+	})
+	th.AssertNoErr(t, err)
+	encToken := base64.StdEncoding.EncodeToString([]byte("myUser:myPasswd"))
+	headerValue := "Basic " + encToken
+	th.AssertEquals(t, headerValue, httpClient.MoreHeaders["Authorization"])
+
+	errTest1, err := httpbasic.NewBareMetalIntrospectionHTTPBasic(httpbasic.EndpointOpts{
+		IronicInspectorEndpoint: "http://ironic:5050/v1",
+	})
+	_ = errTest1
+	th.AssertEquals(t, "User and Password are required", err.Error())
+
+	errTest2, err := httpbasic.NewBareMetalIntrospectionHTTPBasic(httpbasic.EndpointOpts{
+		IronicInspectorUser:         "myUser",
+		IronicInspectorUserPassword: "myPasswd",
+	})
+	_ = errTest2
+	th.AssertEquals(t, "IronicInspectorEndpoint is required", err.Error())
+}


### PR DESCRIPTION
For #1485 

Ironic Inspector introduced a new auth_type http_basic that can
be used in standalone deployments. The code was introduced by the change [1]

This commit adds the support to use the new authentication
type.

[1] https://review.opendev.org/#/c/729463/