### PR TITLE
make introspection.RootDiskType int64 rather than int (#1634)

### DIFF
--- a/openstack/baremetalintrospection/v1/introspection/results.go
+++ b/openstack/baremetalintrospection/v1/introspection/results.go
@@ -238,7 +238,7 @@ type RootDiskType struct {
 	ByPath             string `json:"by_path"`
 	Rotational         bool   `json:"rotational"`
 	Serial             string `json:"serial"`
-	Size               int    `json:"size"`
+	Size               int64  `json:"size"`
 	Vendor             string `json:"vendor"`
 	Wwn                string `json:"wwn"`
 	WwnVendorExtension string `json:"wwn_vendor_extension"`


### PR DESCRIPTION
Fixes tests (and functionality I suspect!) on 32-bit systems.
