### PR TITLE
support TERMINATED_HTTPS protocol for listeners

### DIFF
--- a/openstack/loadbalancer/v2/listeners/requests.go
+++ b/openstack/loadbalancer/v2/listeners/requests.go
@@ -10,11 +10,12 @@ type Protocol string
 
 // Supported attributes for create/update operations.
 const (
-	ProtocolTCP   Protocol = "TCP"
-	ProtocolUDP   Protocol = "UDP"
-	ProtocolPROXY Protocol = "PROXY"
-	ProtocolHTTP  Protocol = "HTTP"
-	ProtocolHTTPS Protocol = "HTTPS"
+	ProtocolTCP             Protocol = "TCP"
+	ProtocolUDP             Protocol = "UDP"
+	ProtocolPROXY           Protocol = "PROXY"
+	ProtocolHTTP            Protocol = "HTTP"
+	ProtocolHTTPS           Protocol = "HTTPS"
+	ProtocolTerminatedHTTPS Protocol = "TERMINATED_HTTPS"
 )
 
 // ListOptsBuilder allows extensions to add additional parameters to the
@@ -85,7 +86,7 @@ type CreateOpts struct {
 	// The load balancer on which to provision this listener.
 	LoadbalancerID string `json:"loadbalancer_id" required:"true"`
 
-	// The protocol - can either be TCP, HTTP or HTTPS.
+	// The protocol - can either be TCP, HTTP, HTTPS or TERMINATED_HTTPS.
 	Protocol Protocol `json:"protocol" required:"true"`
 
 	// The port on which to listen for client traffic.


### PR DESCRIPTION
For [1991](https://github.com/gophercloud/gophercloud/issues/1991)

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

- [ListenerPOST](https://github.com/openstack/octavia/blob/f14ccb52ed004f1c30c49e87407f2ce569c045e9/octavia/api/v2/types/listener.py#L116)
- [supported-protocols octavia common](https://github.com/openstack/octavia/blob/77786595e5803488f46e9b4faae02b5bccdfe88d/octavia/common/constants.py#L152)
- [supported-protocol octavia lib common](https://github.com/openstack/octavia-lib/blob/ec7195d713d71370fa6a72d3839253b9789b3b4e/octavia_lib/common/constants.py#L141)