### PR TITLE
Fix/create temp url escaping

### DIFF
--- a/acceptance/openstack/objectstorage/v1/objects_test.go
+++ b/acceptance/openstack/objectstorage/v1/objects_test.go
@@ -96,11 +96,11 @@ func TestObjects(t *testing.T) {
 
 		resp, err := http.Get(objURLs[i])
 		th.AssertNoErr(t, err)
-		defer resp.Body.Close()
 
 		body, err := ioutil.ReadAll(resp.Body)
 		th.AssertNoErr(t, err)
 		th.AssertEquals(t, oContents[i], body)
+		resp.Body.Close()
 	}
 
 	// Copy the contents of one object to another.

--- a/acceptance/openstack/objectstorage/v1/objects_test.go
+++ b/acceptance/openstack/objectstorage/v1/objects_test.go
@@ -99,7 +99,7 @@ func TestObjects(t *testing.T) {
 
 		body, err := ioutil.ReadAll(resp.Body)
 		th.AssertNoErr(t, err)
-		th.AssertEquals(t, oContents[i].Bytes(), body)
+		th.AssertDeepEquals(t, oContents[i].Bytes(), body)
 		resp.Body.Close()
 	}
 

--- a/acceptance/openstack/objectstorage/v1/objects_test.go
+++ b/acceptance/openstack/objectstorage/v1/objects_test.go
@@ -99,7 +99,7 @@ func TestObjects(t *testing.T) {
 
 		body, err := ioutil.ReadAll(resp.Body)
 		th.AssertNoErr(t, err)
-		th.AssertEquals(t, oContents[i], body)
+		th.AssertEquals(t, oContents[i].Bytes(), body)
 		resp.Body.Close()
 	}
 

--- a/openstack/objectstorage/v1/accounts/testing/fixtures.go
+++ b/openstack/objectstorage/v1/accounts/testing/fixtures.go
@@ -21,6 +21,7 @@ func HandleGetAccountSuccessfully(t *testing.T) {
 		w.Header().Set("X-Account-Bytes-Used", "14")
 		w.Header().Set("X-Account-Meta-Subject", "books")
 		w.Header().Set("Date", "Fri, 17 Jan 2014 16:09:56 UTC")
+		w.Header().Set("X-Account-Meta-Temp-URL-Key", "testsecret")
 
 		w.WriteHeader(http.StatusNoContent)
 	})

--- a/openstack/objectstorage/v1/accounts/testing/requests_test.go
+++ b/openstack/objectstorage/v1/accounts/testing/requests_test.go
@@ -31,7 +31,7 @@ func TestGetAccount(t *testing.T) {
 	defer th.TeardownHTTP()
 	HandleGetAccountSuccessfully(t)
 
-	expectedMetadata := map[string]string{"Subject": "books", "Quota-Bytes": "42"}
+	expectedMetadata := map[string]string{"Subject": "books", "Quota-Bytes": "42", "Temp-Url-Key": "testsecret"}
 	res := accounts.Get(fake.ServiceClient(), &accounts.GetOpts{})
 	th.AssertNoErr(t, res.Err)
 	actualMetadata, _ := res.ExtractMetadata()
@@ -46,6 +46,7 @@ func TestGetAccount(t *testing.T) {
 		ObjectCount:    5,
 		BytesUsed:      14,
 		Date:           time.Date(2014, time.January, 17, 16, 9, 56, 0, time.UTC),
+		TempURLKey:     "testsecret",
 	}
 	actual, err := res.Extract()
 	th.AssertNoErr(t, err)

--- a/openstack/objectstorage/v1/objects/requests.go
+++ b/openstack/objectstorage/v1/objects/requests.go
@@ -40,6 +40,10 @@ type ListOpts struct {
 	Path      string `q:"path"`
 }
 
+func init() {
+	ResetClockImplementation()
+}
+
 // ToObjectListParams formats a ListOpts into a query string and boolean
 // representing whether to list complete information for each object.
 func (opts ListOpts) ToObjectListParams() (bool, string, error) {
@@ -464,6 +468,14 @@ var NowFunc nowFuncT
 
 func timeNow() time.Time {
 	return NowFunc().UTC()
+}
+
+// ResetClockImplementation resets implementation of Time.
+// Used only for testing.
+func ResetClockImplementation() {
+	NowFunc = func() time.Time {
+		return time.Now()
+	}
 }
 
 // CreateTempURL is a function for creating a temporary URL for an object. It

--- a/openstack/objectstorage/v1/objects/requests.go
+++ b/openstack/objectstorage/v1/objects/requests.go
@@ -456,6 +456,16 @@ type CreateTempURLOpts struct {
 	Split string
 }
 
+type nowFuncT func() time.Time
+
+// NowFunc allows to modify function for getting current time.
+// This offers developers flexibility to stub time in tests.
+var NowFunc nowFuncT
+
+func timeNow() time.Time {
+	return NowFunc().UTC()
+}
+
 // CreateTempURL is a function for creating a temporary URL for an object. It
 // allows users to have "GET" or "POST" access to a particular tenant's object
 // for a limited amount of time.
@@ -464,7 +474,7 @@ func CreateTempURL(c *gophercloud.ServiceClient, containerName, objectName strin
 		opts.Split = "/v1/"
 	}
 	duration := time.Duration(opts.TTL) * time.Second
-	expiry := time.Now().Add(duration).Unix()
+	expiry := timeNow().Add(duration).Unix()
 	getHeader, err := containers.Get(c, url.QueryEscape(containerName), nil).Extract()
 	if err != nil {
 		return "", err

--- a/openstack/objectstorage/v1/objects/requests.go
+++ b/openstack/objectstorage/v1/objects/requests.go
@@ -479,7 +479,7 @@ func CreateTempURL(c *gophercloud.ServiceClient, containerName, objectName strin
 		tempURLKey = getHeader.TempURLKey
 	}
 	secretKey := []byte(tempURLKey)
-	url := getURL(c, url.QueryEscape(containerName), url.QueryEscape(objectName))
+	url := getURL(c, containerName, objectName)
 	splitPath := strings.Split(url, opts.Split)
 	baseURL, objectPath := splitPath[0], splitPath[1]
 	objectPath = opts.Split + objectPath

--- a/openstack/objectstorage/v1/objects/testing/requests_test.go
+++ b/openstack/objectstorage/v1/objects/testing/requests_test.go
@@ -332,6 +332,7 @@ func TestCreateTempURL(t *testing.T) {
 	th.SetupHTTP()
 	th.SetupPersistentPortHTTP(t, port)
 	defer th.TeardownHTTP()
+	defer objects.ResetClockImplementation()
 
 	// Handle fetching of secret key inside of CreateTempURL
 	containerTesting.HandleGetContainerSuccessfully(t)

--- a/openstack/objectstorage/v1/objects/testing/requests_test.go
+++ b/openstack/objectstorage/v1/objects/testing/requests_test.go
@@ -344,14 +344,14 @@ func TestCreateTempURL(t *testing.T) {
 
 	// Append v1/ to client endpoint URL to be compliant with tempURL generator
 	client.Endpoint = client.Endpoint + "v1/"
-	tempURL, err := objects.CreateTempURL(client, "testContainer", "testObject", objects.CreateTempURLOpts{
+	tempURL, err := objects.CreateTempURL(client, "testContainer", "testObject/testFile.txt", objects.CreateTempURLOpts{
 		Method: http.MethodGet,
 		TTL:    60,
 	})
 
-	sig := "71cec7484e318c4e7fae99369dd709014180165e"
-	expiry := "1595600453"
-	expectedURL := fmt.Sprintf("http://127.0.0.1:%v/v1/testContainer/testObject?temp_url_sig=%v&temp_url_expires=%v", port, sig, expiry)
+	sig := "89be454a9c7e2e9f3f50a8441815e0b5801cba5b"
+	expiry := "1593565980"
+	expectedURL := fmt.Sprintf("http://127.0.0.1:%v/v1/testContainer/testObject/testFile.txt?temp_url_sig=%v&temp_url_expires=%v", port, sig, expiry)
 
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, expectedURL, tempURL)

--- a/openstack/objectstorage/v1/objects/testing/requests_test.go
+++ b/openstack/objectstorage/v1/objects/testing/requests_test.go
@@ -338,6 +338,10 @@ func TestCreateTempURL(t *testing.T) {
 	accountTesting.HandleGetAccountSuccessfully(t)
 	client := fake.ServiceClient()
 
+	objects.NowFunc = func() time.Time {
+		return time.Date(2020, 07, 01, 01, 12, 00, 00, time.UTC)
+	}
+
 	// Append v1/ to client endpoint URL to be compliant with tempURL generator
 	client.Endpoint = client.Endpoint + "v1/"
 	tempURL, err := objects.CreateTempURL(client, "testContainer", "testObject", objects.CreateTempURLOpts{

--- a/openstack/objectstorage/v1/objects/testing/requests_test.go
+++ b/openstack/objectstorage/v1/objects/testing/requests_test.go
@@ -328,17 +328,15 @@ func TestObjectCreateParamsWithSeek(t *testing.T) {
 }
 
 func TestCreateTempURL(t *testing.T) {
+	port := 33199
 	th.SetupHTTP()
+	th.SetupPersistentPortHTTP(t, port)
 	defer th.TeardownHTTP()
 
 	// Handle fetching of secret key inside of CreateTempURL
 	containerTesting.HandleGetContainerSuccessfully(t)
 	accountTesting.HandleGetAccountSuccessfully(t)
 	client := fake.ServiceClient()
-
-	// Get dynamically generated port number so that it can be used to compare final URL
-	port := strings.Split(client.Endpoint, ":")[2]
-	port = strings.TrimRight(port, "/")
 
 	// Append v1/ to client endpoint URL to be compliant with tempURL generator
 	client.Endpoint = client.Endpoint + "v1/"
@@ -347,6 +345,10 @@ func TestCreateTempURL(t *testing.T) {
 		TTL:    60,
 	})
 
+	sig := "71cec7484e318c4e7fae99369dd709014180165e"
+	expiry := "1595600453"
+	expectedURL := fmt.Sprintf("http://127.0.0.1:%v/v1/testContainer/testObject?temp_url_sig=%v&temp_url_expires=%v", port, sig, expiry)
+
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, "http://127.0.0.1:"+port+"/v1/testContainer/testObject?temp_url_sig=71cec7484e318c4e7fae99369dd709014180165e&temp_url_expires=1595600453", tempURL)
+	th.AssertEquals(t, expectedURL, tempURL)
 }

--- a/openstack/objectstorage/v1/objects/testing/requests_test.go
+++ b/openstack/objectstorage/v1/objects/testing/requests_test.go
@@ -332,22 +332,18 @@ func TestCreateTempURL(t *testing.T) {
 	th.SetupHTTP()
 	th.SetupPersistentPortHTTP(t, port)
 	defer th.TeardownHTTP()
-	defer objects.ResetClockImplementation()
 
 	// Handle fetching of secret key inside of CreateTempURL
 	containerTesting.HandleGetContainerSuccessfully(t)
 	accountTesting.HandleGetAccountSuccessfully(t)
 	client := fake.ServiceClient()
 
-	objects.NowFunc = func() time.Time {
-		return time.Date(2020, 07, 01, 01, 12, 00, 00, time.UTC)
-	}
-
 	// Append v1/ to client endpoint URL to be compliant with tempURL generator
 	client.Endpoint = client.Endpoint + "v1/"
 	tempURL, err := objects.CreateTempURL(client, "testContainer", "testObject/testFile.txt", objects.CreateTempURLOpts{
-		Method: http.MethodGet,
-		TTL:    60,
+		Method:    http.MethodGet,
+		TTL:       60,
+		Timestamp: time.Date(2020, 07, 01, 01, 12, 00, 00, time.UTC),
 	})
 
 	sig := "89be454a9c7e2e9f3f50a8441815e0b5801cba5b"

--- a/openstack/objectstorage/v1/objects/testing/requests_test.go
+++ b/openstack/objectstorage/v1/objects/testing/requests_test.go
@@ -328,7 +328,7 @@ func TestObjectCreateParamsWithSeek(t *testing.T) {
 }
 
 func TestCreateTempURL(t *testing.T) {
-	port := 33199
+	port := 33200
 	th.SetupHTTP()
 	th.SetupPersistentPortHTTP(t, port)
 	defer th.TeardownHTTP()


### PR DESCRIPTION
For #1993 

Fix issue with generating temporary URLs, which are invalid when conatiner or object name contains characters, which are subject to query escaping.