### PR TITLE
Support RFC3339 when unmarshal volume CreatedAt and UpdatedAt

### DIFF
--- a/openstack/blockstorage/v2/volumes/results.go
+++ b/openstack/blockstorage/v2/volumes/results.go
@@ -95,8 +95,8 @@ func (r *Volume) UnmarshalJSON(b []byte) error {
 
 	var s1 struct{
 		tmp
-		CreatedAt time.Time `json: "created_at"`
-		UpdatedAt time.Time `json: "updated_at"`
+		CreatedAt time.Time `json:"created_at"`
+		UpdatedAt time.Time `json:"updated_at"`
 	}
 	err = json.Unmarshal(b, &s1)
 	if err != nil {

--- a/openstack/blockstorage/v2/volumes/results.go
+++ b/openstack/blockstorage/v2/volumes/results.go
@@ -85,15 +85,28 @@ func (r *Volume) UnmarshalJSON(b []byte) error {
 		UpdatedAt gophercloud.JSONRFC3339MilliNoZ `json:"updated_at"`
 	}
 	err := json.Unmarshal(b, &s)
+	if err == nil {
+		*r = Volume(s.tmp)
+		r.CreatedAt = time.Time(s.CreatedAt)
+		r.UpdatedAt = time.Time(s.UpdatedAt)
+
+		return nil
+	}
+
+	var s1 struct{
+		tmp
+		CreatedAt time.Time `json: "created_at"`
+		UpdatedAt time.Time `json: "updated_at"`
+	}
+	err = json.Unmarshal(b, &s1)
 	if err != nil {
 		return err
 	}
-	*r = Volume(s.tmp)
+	*r = Volume(s1.tmp)
+	r.CreatedAt = time.Time(s1.CreatedAt)
+	r.UpdatedAt = time.Time(s1.UpdatedAt)
 
-	r.CreatedAt = time.Time(s.CreatedAt)
-	r.UpdatedAt = time.Time(s.UpdatedAt)
-
-	return err
+	return nil
 }
 
 // VolumePage is a pagination.pager that is returned from a call to the List function.

--- a/openstack/blockstorage/v3/volumes/results.go
+++ b/openstack/blockstorage/v3/volumes/results.go
@@ -93,15 +93,28 @@ func (r *Volume) UnmarshalJSON(b []byte) error {
 		UpdatedAt gophercloud.JSONRFC3339MilliNoZ `json:"updated_at"`
 	}
 	err := json.Unmarshal(b, &s)
+	if err == nil {
+		*r = Volume(s.tmp)
+		r.CreatedAt = time.Time(s.CreatedAt)
+		r.UpdatedAt = time.Time(s.UpdatedAt)
+
+		return nil
+	}
+
+	var s1 struct{
+		tmp
+		CreatedAt time.Time `json:"created_at"`
+		UpdatedAt time.Time `json:"updated_at"`
+	}
+	err = json.Unmarshal(b, &s1)
 	if err != nil {
 		return err
 	}
-	*r = Volume(s.tmp)
+	*r = Volume(s1.tmp)
+	r.CreatedAt = time.Time(s1.CreatedAt)
+	r.UpdatedAt = time.Time(s1.UpdatedAt)
 
-	r.CreatedAt = time.Time(s.CreatedAt)
-	r.UpdatedAt = time.Time(s.UpdatedAt)
-
-	return err
+	return nil
 }
 
 // VolumePage is a pagination.pager that is returned from a call to the List function.


### PR DESCRIPTION
Fix this error by trying to unmarshal volume CreatedAt and UpdatedAt via time.Time, to support RFC3339 timestamp.

I've tested in our OpenStack environment, it seems after tryting to unmarshal voluem.CreatedAt and volume.UpdatedAt using this fix, I can get volume details via Extract() correctly :

```
Volume is &{45fdb4fc-ad85-4512-85e6-980451edc57e available 20 nova 2020-07-31 07:18:53 +0000 UTC 2020-07-31 07:18:56 +0000 UTC [] el-volume el-volume default_volume_type   <nil> map[] bfa8089a9eb542a7b43288979f697883 true false   false map[checksum:441af00e2dd98f1b2795b4b9a1ef84f0 container_format:bare ctcm_enabled:true disk_format:raw hw_qemu_guest_agent:yes hw_vif_multiqueue_enabled:true image_id:f9de62d7-1896-4561-8571-b8e83b52696b image_name:newCentOS7.6 image_version:v1.1 min_disk:0 min_ram:0 os_distro:centos os_type:linux os_version:7.6 size:21474836480]} 
```

Looks fine.

For  #1997
Signed-off-by: Fan Zhang <zh.f@outlook.com>

