### PR TITLE
LoadBalancer V2: add quotas package

### DIFF
--- a/acceptance/openstack/loadbalancer/v2/quotas_test.go
+++ b/acceptance/openstack/loadbalancer/v2/quotas_test.go
@@ -1,0 +1,23 @@
+package v2
+
+import (
+	"os"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/acceptance/clients"
+	"github.com/gophercloud/gophercloud/acceptance/tools"
+	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/quotas"
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestQuotasGet(t *testing.T) {
+	clients.RequireAdmin(t)
+
+	client, err := clients.NewLoadBalancerV2Client()
+	th.AssertNoErr(t, err)
+
+	quotasInfo, err := quotas.Get(client, os.Getenv("OS_PROJECT_NAME")).Extract()
+	th.AssertNoErr(t, err)
+
+	tools.PrintResource(t, quotasInfo)
+}

--- a/acceptance/openstack/loadbalancer/v2/quotas_test.go
+++ b/acceptance/openstack/loadbalancer/v2/quotas_test.go
@@ -1,3 +1,5 @@
+// +build acceptance networking loadbalancer quotas
+
 package v2
 
 import (

--- a/openstack/loadbalancer/v2/quotas/doc.go
+++ b/openstack/loadbalancer/v2/quotas/doc.go
@@ -1,0 +1,15 @@
+/*
+Package quotas provides the ability to retrieve and manage Load Balancer quotas
+
+Example to Get project quotas
+
+    projectID = "23d5d3f79dfa4f73b72b8b0b0063ec55"
+    quotasInfo, err := quotas.Get(networkClient, projectID).Extract()
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    fmt.Printf("quotas: %#v\n", quotasInfo)
+
+*/
+package quotas

--- a/openstack/loadbalancer/v2/quotas/requests.go
+++ b/openstack/loadbalancer/v2/quotas/requests.go
@@ -1,0 +1,10 @@
+package quotas
+
+import "github.com/gophercloud/gophercloud"
+
+// Get returns load balancer Quotas for a project.
+func Get(client *gophercloud.ServiceClient, projectID string) (r GetResult) {
+	resp, err := client.Get(getURL(client, projectID), &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}

--- a/openstack/loadbalancer/v2/quotas/results.go
+++ b/openstack/loadbalancer/v2/quotas/results.go
@@ -24,7 +24,7 @@ type GetResult struct {
 // Quota contains load balancer quotas for a project.
 type Quota struct {
 	// Loadbalancer represents the number of load balancers. A "-1" value means no limit.
-	Loadbalancer int `json:"load_balancer"`
+	Loadbalancer int `json:"loadbalancer"`
 
 	// Listener represents the number of listeners. A "-1" value means no limit.
 	Listener int `json:"listener"`
@@ -36,7 +36,7 @@ type Quota struct {
 	Pool int `json:"pool"`
 
 	// HealthMonitor represents the number of healthmonitors. A "-1" value means no limit.
-	Healthmonitor int `json:"health_monitor"`
+	Healthmonitor int `json:"healthmonitor"`
 
 	// L7Policy represents the number of l7policies. A "-1" value means no limit.
 	L7Policy int `json:"l7policy"`

--- a/openstack/loadbalancer/v2/quotas/results.go
+++ b/openstack/loadbalancer/v2/quotas/results.go
@@ -1,0 +1,46 @@
+package quotas
+
+import "github.com/gophercloud/gophercloud"
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// Extract is a function that accepts a result and extracts a Quota resource.
+func (r commonResult) Extract() (*Quota, error) {
+	var s struct {
+		Quota *Quota `json:"quota"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Quota, err
+}
+
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a Quota.
+type GetResult struct {
+	commonResult
+}
+
+// Quota contains load balancer quotas for a project.
+type Quota struct {
+	// Loadbalancer represents the number of load balancers. A "-1" value means no limit.
+	Loadbalancer int `json:"load_balancer"`
+
+	// Listener represents the number of listeners. A "-1" value means no limit.
+	Listener int `json:"listener"`
+
+	// Member represents the number of members. A "-1" value means no limit.
+	Member int `json:"member"`
+
+	// Poool represents the number of pools. A "-1" value means no limit.
+	Pool int `json:"pool"`
+
+	// HealthMonitor represents the number of healthmonitors. A "-1" value means no limit.
+	Healthmonitor int `json:"health_monitor"`
+
+	// L7Policy represents the number of l7policies. A "-1" value means no limit.
+	L7Policy int `json:"l7policy"`
+
+	// L7Rule represents the number of l7rules. A "-1" value means no limit.
+	L7Rule int `json:"l7rule"`
+}

--- a/openstack/loadbalancer/v2/quotas/results.go
+++ b/openstack/loadbalancer/v2/quotas/results.go
@@ -1,6 +1,10 @@
 package quotas
 
-import "github.com/gophercloud/gophercloud"
+import (
+	"encoding/json"
+
+	"github.com/gophercloud/gophercloud"
+)
 
 type commonResult struct {
 	gophercloud.Result
@@ -24,7 +28,7 @@ type GetResult struct {
 // Quota contains load balancer quotas for a project.
 type Quota struct {
 	// Loadbalancer represents the number of load balancers. A "-1" value means no limit.
-	Loadbalancer int `json:"loadbalancer"`
+	Loadbalancer int `json:"-"`
 
 	// Listener represents the number of listeners. A "-1" value means no limit.
 	Listener int `json:"listener"`
@@ -36,11 +40,53 @@ type Quota struct {
 	Pool int `json:"pool"`
 
 	// HealthMonitor represents the number of healthmonitors. A "-1" value means no limit.
-	Healthmonitor int `json:"healthmonitor"`
+	Healthmonitor int `json:"-"`
 
 	// L7Policy represents the number of l7policies. A "-1" value means no limit.
 	L7Policy int `json:"l7policy"`
 
 	// L7Rule represents the number of l7rules. A "-1" value means no limit.
 	L7Rule int `json:"l7rule"`
+}
+
+// UnmarshalJSON provides backwards compatibility to OpenStack APIs which still
+// return the deprecated `load_balancer` or `health_monitor` as quota values
+// instead of `loadbalancer` and `healthmonitor`.
+func (r *Quota) UnmarshalJSON(b []byte) error {
+	type tmp Quota
+
+	// Support both underscore and non-underscore naming.
+	var s struct {
+		tmp
+		LoadBalancer *int `json:"load_balancer"`
+		Loadbalancer *int `json:"loadbalancer"`
+
+		HealthMonitor *int `json:"health_monitor"`
+		Healthmonitor *int `json:"healthmonitor"`
+	}
+
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+
+	*r = Quota(s.tmp)
+
+	if s.LoadBalancer != nil {
+		r.Loadbalancer = *s.LoadBalancer
+	}
+
+	if s.Loadbalancer != nil {
+		r.Loadbalancer = *s.Loadbalancer
+	}
+
+	if s.HealthMonitor != nil {
+		r.Healthmonitor = *s.HealthMonitor
+	}
+
+	if s.Healthmonitor != nil {
+		r.Healthmonitor = *s.Healthmonitor
+	}
+
+	return nil
 }

--- a/openstack/loadbalancer/v2/quotas/testing/doc.go
+++ b/openstack/loadbalancer/v2/quotas/testing/doc.go
@@ -1,0 +1,2 @@
+// quotas unit tests
+package testing

--- a/openstack/loadbalancer/v2/quotas/testing/fixtures.go
+++ b/openstack/loadbalancer/v2/quotas/testing/fixtures.go
@@ -5,11 +5,11 @@ import "github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/quotas"
 const GetResponseRaw = `
 {
     "quota": {
-        "load_balancer": 15,
+        "loadbalancer": 15,
         "listener": 30,
         "member": -1,
         "pool": 15,
-        "health_monitor": 30,
+        "healthmonitor": 30,
         "l7policy": 100,
         "l7rule": -1
     }

--- a/openstack/loadbalancer/v2/quotas/testing/fixtures.go
+++ b/openstack/loadbalancer/v2/quotas/testing/fixtures.go
@@ -2,7 +2,7 @@ package testing
 
 import "github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/quotas"
 
-const GetResponseRaw = `
+const GetResponseRaw_1 = `
 {
     "quota": {
         "loadbalancer": 15,
@@ -10,6 +10,20 @@ const GetResponseRaw = `
         "member": -1,
         "pool": 15,
         "healthmonitor": 30,
+        "l7policy": 100,
+        "l7rule": -1
+    }
+}
+`
+
+const GetResponseRaw_2 = `
+{
+    "quota": {
+        "load_balancer": 15,
+        "listener": 30,
+        "member": -1,
+        "pool": 15,
+        "health_monitor": 30,
         "l7policy": 100,
         "l7rule": -1
     }

--- a/openstack/loadbalancer/v2/quotas/testing/fixtures.go
+++ b/openstack/loadbalancer/v2/quotas/testing/fixtures.go
@@ -1,0 +1,27 @@
+package testing
+
+import "github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/quotas"
+
+const GetResponseRaw = `
+{
+    "quota": {
+        "load_balancer": 15,
+        "listener": 30,
+        "member": -1,
+        "pool": 15,
+        "health_monitor": 30,
+        "l7policy": 100,
+        "l7rule": -1
+    }
+}
+`
+
+var GetResponse = quotas.Quota{
+	Loadbalancer:  15,
+	Listener:      30,
+	Member:        -1,
+	Pool:          15,
+	Healthmonitor: 30,
+	L7Policy:      100,
+	L7Rule:        -1,
+}

--- a/openstack/loadbalancer/v2/quotas/testing/requests_test.go
+++ b/openstack/loadbalancer/v2/quotas/testing/requests_test.go
@@ -10,7 +10,7 @@ import (
 	th "github.com/gophercloud/gophercloud/testhelper"
 )
 
-func TestGet(t *testing.T) {
+func TestGet_1(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 
@@ -21,7 +21,26 @@ func TestGet(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, GetResponseRaw)
+		fmt.Fprintf(w, GetResponseRaw_1)
+	})
+
+	q, err := quotas.Get(fake.ServiceClient(), "0a73845280574ad389c292f6a74afa76").Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, q, &GetResponse)
+}
+
+func TestGet_2(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/quotas/0a73845280574ad389c292f6a74afa76", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, GetResponseRaw_2)
 	})
 
 	q, err := quotas.Get(fake.ServiceClient(), "0a73845280574ad389c292f6a74afa76").Extract()

--- a/openstack/loadbalancer/v2/quotas/testing/requests_test.go
+++ b/openstack/loadbalancer/v2/quotas/testing/requests_test.go
@@ -1,0 +1,30 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/quotas"
+	fake "github.com/gophercloud/gophercloud/openstack/networking/v2/common"
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestGet(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/quotas/0a73845280574ad389c292f6a74afa76", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, GetResponseRaw)
+	})
+
+	q, err := quotas.Get(fake.ServiceClient(), "0a73845280574ad389c292f6a74afa76").Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, q, &GetResponse)
+}

--- a/openstack/loadbalancer/v2/quotas/urls.go
+++ b/openstack/loadbalancer/v2/quotas/urls.go
@@ -1,0 +1,13 @@
+package quotas
+
+import "github.com/gophercloud/gophercloud"
+
+const resourcePath = "quotas"
+
+func resourceURL(c *gophercloud.ServiceClient, projectID string) string {
+	return c.ServiceURL(resourcePath, projectID)
+}
+
+func getURL(c *gophercloud.ServiceClient, projectID string) string {
+	return resourceURL(c, projectID)
+}


### PR DESCRIPTION
Add openstack/loadbalancer/v2/quotas.Get.

Add unit and acceptance tests.

For #1826 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

* https://github.com/openstack/octavia/blob/bf3d5372b9fc670ecd08339fa989c9b738ad8d69/octavia/api/v2/types/quotas.py
* https://github.com/openstack/octavia/blob/master/octavia/api/v2/controllers/quotas.py#L43
* https://github.com/openstack/octavia/blob/0b1d8dd5e76edc4b3058a36b47f6c059f970e516/octavia/api/v2/controllers/base.py#L192

<sup>
Christian Schlotter <christian.schlotter@daimler.com>, Daimler TSS GmbH,
<a href="https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md">Imprint</a>
</sup>