### PR TITLE
schedulerhints: support DifferentCell filter

### DIFF
--- a/openstack/compute/v2/extensions/schedulerhints/requests.go
+++ b/openstack/compute/v2/extensions/schedulerhints/requests.go
@@ -31,6 +31,9 @@ type SchedulerHints struct {
 	// TargetCell specifies a cell name where the instance will be placed.
 	TargetCell string `json:"target_cell,omitempty"`
 
+	// DifferentCell specifies cells names where an instance should not be placed.
+	DifferentCell []string `json:"different_cell,omitempty"`
+
 	// BuildNearHostIP specifies a subnet of compute nodes to host the instance.
 	BuildNearHostIP string
 
@@ -122,6 +125,10 @@ func (opts SchedulerHints) ToServerSchedulerHintsCreateMap() (map[string]interfa
 
 	if opts.TargetCell != "" {
 		sh["target_cell"] = opts.TargetCell
+	}
+
+	if len(opts.DifferentCell) > 0 {
+		sh["different_cell"] = opts.DifferentCell
 	}
 
 	if opts.BuildNearHostIP != "" {

--- a/openstack/compute/v2/extensions/schedulerhints/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/schedulerhints/testing/requests_test.go
@@ -25,8 +25,12 @@ func TestCreateOpts(t *testing.T) {
 			"a0cf03a5-d921-4877-bb5c-86d26cf818e1",
 			"8c19174f-4220-44f0-824a-cd1eeef10287",
 		},
-		Query:                []interface{}{"=", "$free_ram_mb", "1024"},
-		TargetCell:           "foobar",
+		Query:      []interface{}{"=", "$free_ram_mb", "1024"},
+		TargetCell: "foobar",
+		DifferentCell: []string{
+			"bazbar",
+			"barbaz",
+		},
 		BuildNearHostIP:      "192.168.1.1/24",
 		AdditionalProperties: map[string]interface{}{"reservation": "a0cf03a5-d921-4877-bb5c-86d26cf818e1"},
 	}
@@ -55,6 +59,10 @@ func TestCreateOpts(t *testing.T) {
 				],
 				"query": "[\"=\",\"$free_ram_mb\",\"1024\"]",
 				"target_cell": "foobar",
+				"different_cell": [
+					"bazbar",
+					"barbaz"
+				],
 				"build_near_host_ip": "192.168.1.1",
 				"cidr": "/24",
 				"reservation": "a0cf03a5-d921-4877-bb5c-86d26cf818e1"
@@ -83,8 +91,12 @@ func TestCreateOptsWithComplexQuery(t *testing.T) {
 			"a0cf03a5-d921-4877-bb5c-86d26cf818e1",
 			"8c19174f-4220-44f0-824a-cd1eeef10287",
 		},
-		Query:                []interface{}{"and", []string{"=", "$free_ram_mb", "1024"}, []string{"=", "$free_disk_mb", "204800"}},
-		TargetCell:           "foobar",
+		Query:      []interface{}{"and", []string{"=", "$free_ram_mb", "1024"}, []string{"=", "$free_disk_mb", "204800"}},
+		TargetCell: "foobar",
+		DifferentCell: []string{
+			"bazbar",
+			"barbaz",
+		},
 		BuildNearHostIP:      "192.168.1.1/24",
 		AdditionalProperties: map[string]interface{}{"reservation": "a0cf03a5-d921-4877-bb5c-86d26cf818e1"},
 	}
@@ -113,6 +125,10 @@ func TestCreateOptsWithComplexQuery(t *testing.T) {
 				],
 				"query": "[\"and\",[\"=\",\"$free_ram_mb\",\"1024\"],[\"=\",\"$free_disk_mb\",\"204800\"]]",
 				"target_cell": "foobar",
+				"different_cell": [
+					"bazbar",
+					"barbaz"
+				],
 				"build_near_host_ip": "192.168.1.1",
 				"cidr": "/24",
 				"reservation": "a0cf03a5-d921-4877-bb5c-86d26cf818e1"


### PR DESCRIPTION
The TargetCell filter from cells v1 is supported in the code base but
support for the DifferentCell filter was never added. DifferentCell
filter is part of cells v1 but for anyone still using cells v1 this is
useful.

For #2011

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/nova/commit/596ee8796a028596e5ea1ad0529aa3f14b6f5934
