### PR TITLE
feat: update Messaging v2 API to support _enable_encrypt_messages field

### DIFF
--- a/openstack/messaging/v2/queues/requests.go
+++ b/openstack/messaging/v2/queues/requests.go
@@ -85,6 +85,9 @@ type CreateOpts struct {
 	// for any messages posted to the queue.
 	MaxMessagesPostSize int `json:"_max_messages_post_size,omitempty"`
 
+	// Does messages should be encrypted
+	EnableEncryptMessages *bool `json:"_enable_encrypt_messages,omitempty"`
+
 	// Extra is free-form extra key/value pairs to describe the queue.
 	Extra map[string]interface{} `json:"-"`
 }

--- a/openstack/messaging/v2/queues/results.go
+++ b/openstack/messaging/v2/queues/results.go
@@ -88,6 +88,9 @@ type QueueDetails struct {
 	// The max post size of messages defined for the queue.
 	MaxMessagesPostSize int `json:"_max_messages_post_size"`
 
+	// Is message encryption enabled
+	EnableEncryptMessages bool `json:"_enable_encrypt_messages"`
+
 	// The flavor defined for the queue.
 	Flavor string `json:"flavor"`
 }

--- a/openstack/messaging/v2/queues/testing/fixtures.go
+++ b/openstack/messaging/v2/queues/testing/fixtures.go
@@ -22,6 +22,7 @@ const CreateQueueRequest = `
     "_dead_letter_queue": "dead_letter",
     "_dead_letter_queue_messages_ttl": 3600,
     "_max_claim_count": 10,
+    "_enable_encrypt_messages": false,
     "description": "Queue for unit testing."
 }`
 
@@ -53,6 +54,7 @@ const ListQueuesResponse1 = `
                 "_default_message_ttl":3700,
                 "_max_claim_count":10,
                 "_max_messages_post_size":262143,
+                "_enable_encrypt_messages":true,
                 "description":"Test queue."
             }
         }
@@ -155,6 +157,7 @@ var FirstQueue = queues.Queue{
 		DefaultMessageTTL:         3700,
 		MaxClaimCount:             10,
 		MaxMessagesPostSize:       262143,
+		EnableEncryptMessages:     true,
 		Extra:                     map[string]interface{}{"description": "Test queue."},
 	},
 }

--- a/openstack/messaging/v2/queues/testing/requests_test.go
+++ b/openstack/messaging/v2/queues/testing/requests_test.go
@@ -37,6 +37,7 @@ func TestCreate(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 	HandleCreateSuccessfully(t)
+	var enableEncrypted *bool = new(bool)
 
 	createOpts := queues.CreateOpts{
 		QueueName:                  QueueName,
@@ -46,6 +47,7 @@ func TestCreate(t *testing.T) {
 		DeadLetterQueue:            "dead_letter",
 		DeadLetterQueueMessagesTTL: 3600,
 		MaxClaimCount:              10,
+		EnableEncryptMessages:      enableEncrypted,
 		Extra:                      map[string]interface{}{"description": "Queue for unit testing."},
 	}
 


### PR DESCRIPTION
Prior to starting a PR, please make sure you have read our
[contributor tutorial](https://github.com/gophercloud/gophercloud/tree/master/docs/contributor-tutorial).

Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

For #2015 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:
https://docs.openstack.org/api-ref/message/?expanded=show-queue-details-detail