### PR TITLE
feat: add name and with_count params into listing queues

### DIFF
--- a/openstack/messaging/v2/queues/requests.go
+++ b/openstack/messaging/v2/queues/requests.go
@@ -21,6 +21,12 @@ type ListOpts struct {
 
 	// Specifies if showing the detailed information when querying queues
 	Detailed bool `q:"detailed,omitempty"`
+
+	// Specifies if filter the queues by queue’s name when querying queues.
+	Name bool `q:"name,omitempty"`
+
+	// Specifies if showing the amount of queues when querying them.
+	WithCount bool `q:"with_count,omitempty"`
 }
 
 // ToQueueListQuery formats a ListOpts into a query string.

--- a/openstack/messaging/v2/queues/results.go
+++ b/openstack/messaging/v2/queues/results.go
@@ -173,6 +173,18 @@ func (r QueuePage) NextPageURL() (string, error) {
 	return nextPageURL(r.URL.String(), next)
 }
 
+// GetCount value if it request was supplied `WithCount` param
+func (r QueuePage) GetCount() (int, error) {
+	var s struct {
+		Count int `json:"count"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return 0, err
+	}
+	return s.Count, nil
+}
+
 func (r *QueueDetails) UnmarshalJSON(b []byte) error {
 	type tmp QueueDetails
 	var s struct {

--- a/openstack/messaging/v2/queues/testing/fixtures.go
+++ b/openstack/messaging/v2/queues/testing/fixtures.go
@@ -64,7 +64,8 @@ const ListQueuesResponse1 = `
             "href":"/v2/queues?marker=london",
             "rel":"next"
         }
-    ]
+	],
+	"count": 2
 }`
 
 // ListQueuesResponse2 is a sample response to a List queues.
@@ -90,7 +91,8 @@ const ListQueuesResponse2 = `
             "href":"/v2/queues?marker=beijing",
             "rel":"next"
         }
-    ]
+	],
+	"count": 2
 }`
 
 // UpdateQueueRequest is a sample request to update a queue.
@@ -223,7 +225,7 @@ func HandleListSuccessfully(t *testing.T) {
 			next := r.RequestURI
 
 			switch next {
-			case "/v2/queues?limit=1":
+			case "/v2/queues?limit=1&with_count=true":
 				fmt.Fprintf(w, ListQueuesResponse1)
 			case "/v2/queues?marker=london":
 				fmt.Fprint(w, ListQueuesResponse2)

--- a/openstack/messaging/v2/queues/testing/requests_test.go
+++ b/openstack/messaging/v2/queues/testing/requests_test.go
@@ -15,17 +15,21 @@ func TestList(t *testing.T) {
 	HandleListSuccessfully(t)
 
 	listOpts := queues.ListOpts{
-		Limit: 1,
+		Limit:     1,
+		WithCount: true,
 	}
 
 	count := 0
 	err := queues.List(fake.ServiceClient(), listOpts).EachPage(func(page pagination.Page) (bool, error) {
 		actual, err := queues.ExtractQueues(page)
 		th.AssertNoErr(t, err)
+		countField, err := page.(queues.QueuePage).GetCount()
+
+		th.AssertNoErr(t, err)
+		th.AssertEquals(t, countField, 2)
 
 		th.CheckDeepEquals(t, ExpectedQueueSlice[count], actual)
 		count++
-
 		return true, nil
 	})
 	th.AssertNoErr(t, err)


### PR DESCRIPTION
For #2017 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/zaqar/blob/e12c65a369825ea5469bdb31f5c7151268d7926b/zaqar/transport/wsgi/v2_0/queues.py#L300-L301
https://github.com/openstack/zaqar/blob/e12c65a369825ea5469bdb31f5c7151268d7926b/zaqar/transport/wsgi/v2_0/queues.py#L260-L270