### PR TITLE
LoadBalancer V2: implement quotas.Update

### DIFF
--- a/acceptance/openstack/loadbalancer/v2/quotas.go
+++ b/acceptance/openstack/loadbalancer/v2/quotas.go
@@ -1,0 +1,16 @@
+package v2
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/quotas"
+)
+
+var quotaUpdateOpts = quotas.UpdateOpts{
+	Loadbalancer:  gophercloud.IntToPointer(25),
+	Listener:      gophercloud.IntToPointer(45),
+	Member:        gophercloud.IntToPointer(205),
+	Pool:          gophercloud.IntToPointer(25),
+	Healthmonitor: gophercloud.IntToPointer(5),
+	L7Policy:      gophercloud.IntToPointer(55),
+	L7Rule:        gophercloud.IntToPointer(105),
+}

--- a/acceptance/openstack/loadbalancer/v2/quotas_test.go
+++ b/acceptance/openstack/loadbalancer/v2/quotas_test.go
@@ -3,7 +3,9 @@
 package v2
 
 import (
+	"log"
 	"os"
+	"reflect"
 	"testing"
 
 	"github.com/gophercloud/gophercloud/acceptance/clients"
@@ -22,4 +24,39 @@ func TestQuotasGet(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	tools.PrintResource(t, quotasInfo)
+}
+
+func TestQuotasUpdate(t *testing.T) {
+	clients.RequireAdmin(t)
+
+	client, err := clients.NewLoadBalancerV2Client()
+	th.AssertNoErr(t, err)
+
+	originalQuotas, err := quotas.Get(client, os.Getenv("OS_PROJECT_NAME")).Extract()
+	th.AssertNoErr(t, err)
+
+	newQuotas, err := quotas.Update(client, os.Getenv("OS_PROJECT_NAME"), quotaUpdateOpts).Extract()
+	th.AssertNoErr(t, err)
+
+	tools.PrintResource(t, newQuotas)
+
+	if reflect.DeepEqual(originalQuotas, newQuotas) {
+		log.Fatal("Original and New Loadbalancer Quotas are the same")
+	}
+
+	// Restore original quotas.
+	restoredQuotas, err := quotas.Update(client, os.Getenv("OS_PROJECT_NAME"), quotas.UpdateOpts{
+		Loadbalancer:  &originalQuotas.Loadbalancer,
+		Listener:      &originalQuotas.Listener,
+		Member:        &originalQuotas.Member,
+		Pool:          &originalQuotas.Pool,
+		Healthmonitor: &originalQuotas.Healthmonitor,
+		L7Policy:      &originalQuotas.L7Policy,
+		L7Rule:        &originalQuotas.L7Rule,
+	}).Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertDeepEquals(t, originalQuotas, restoredQuotas)
+
+	tools.PrintResource(t, restoredQuotas)
 }

--- a/openstack/loadbalancer/v2/quotas/doc.go
+++ b/openstack/loadbalancer/v2/quotas/doc.go
@@ -11,5 +11,24 @@ Example to Get project quotas
 
     fmt.Printf("quotas: %#v\n", quotasInfo)
 
+Example to Update project quotas
+
+    projectID = "23d5d3f79dfa4f73b72b8b0b0063ec55"
+
+    updateOpts := quotas.UpdateOpts{
+		Loadbalancer:  gophercloud.IntToPointer(20),
+		Listener:      gophercloud.IntToPointer(40),
+		Member:        gophercloud.IntToPointer(200),
+		Pool:          gophercloud.IntToPointer(20),
+		Healthmonitor: gophercloud.IntToPointer(1),
+		L7Policy:      gophercloud.IntToPointer(50),
+		L7Rule:        gophercloud.IntToPointer(100),
+    }
+    quotasInfo, err := quotas.Update(networkClient, projectID)
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    fmt.Printf("quotas: %#v\n", quotasInfo)
 */
 package quotas

--- a/openstack/loadbalancer/v2/quotas/requests.go
+++ b/openstack/loadbalancer/v2/quotas/requests.go
@@ -1,10 +1,63 @@
 package quotas
 
-import "github.com/gophercloud/gophercloud"
+import (
+	"github.com/gophercloud/gophercloud"
+)
 
 // Get returns load balancer Quotas for a project.
 func Get(client *gophercloud.ServiceClient, projectID string) (r GetResult) {
 	resp, err := client.Get(getURL(client, projectID), &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
+type UpdateOptsBuilder interface {
+	ToQuotaUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts represents options used to update the load balancer Quotas.
+type UpdateOpts struct {
+	// Loadbalancer represents the number of load balancers. A "-1" value means no limit.
+	Loadbalancer *int `json:"loadbalancer,omitempty"`
+
+	// Listener represents the number of listeners. A "-1" value means no limit.
+	Listener *int `json:"listener,omitempty"`
+
+	// Member represents the number of members. A "-1" value means no limit.
+	Member *int `json:"member,omitempty"`
+
+	// Poool represents the number of pools. A "-1" value means no limit.
+	Pool *int `json:"pool,omitempty"`
+
+	// HealthMonitor represents the number of healthmonitors. A "-1" value means no limit.
+	Healthmonitor *int `json:"healthmonitor,omitempty"`
+
+	// L7Policy represents the number of l7policies. A "-1" value means no limit.
+	L7Policy *int `json:"l7policy,omitempty"`
+
+	// L7Rule represents the number of l7rules. A "-1" value means no limit.
+	L7Rule *int `json:"l7rule,omitempty"`
+}
+
+// ToQuotaUpdateMap builds a request body from UpdateOpts.
+func (opts UpdateOpts) ToQuotaUpdateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "quota")
+}
+
+// Update accepts a UpdateOpts struct and updates an existing load balancer Quotas using the
+// values provided.
+func Update(c *gophercloud.ServiceClient, projectID string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToQuotaUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := c.Put(updateURL(c, projectID), b, &r.Body, &gophercloud.RequestOpts{
+		// allow 200 (neutron/lbaasv2) and 202 (octavia)
+		OkCodes: []int{200, 202},
+	})
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }

--- a/openstack/loadbalancer/v2/quotas/results.go
+++ b/openstack/loadbalancer/v2/quotas/results.go
@@ -25,6 +25,12 @@ type GetResult struct {
 	commonResult
 }
 
+// UpdateResult represents the result of an update operation. Call its Extract
+// method to interpret it as a Quota.
+type UpdateResult struct {
+	commonResult
+}
+
 // Quota contains load balancer quotas for a project.
 type Quota struct {
 	// Loadbalancer represents the number of load balancers. A "-1" value means no limit.

--- a/openstack/loadbalancer/v2/quotas/testing/fixtures.go
+++ b/openstack/loadbalancer/v2/quotas/testing/fixtures.go
@@ -39,3 +39,41 @@ var GetResponse = quotas.Quota{
 	L7Policy:      100,
 	L7Rule:        -1,
 }
+
+const UpdateRequestResponseRaw_1 = `
+{
+    "quota": {
+        "loadbalancer": 20,
+        "listener": 40,
+        "member": 200,
+        "pool": 20,
+        "healthmonitor": -1,
+        "l7policy": 50,
+        "l7rule": 100
+    }
+}
+`
+
+const UpdateRequestResponseRaw_2 = `
+{
+    "quota": {
+        "load_balancer": 20,
+        "listener": 40,
+        "member": 200,
+        "pool": 20,
+        "health_monitor": -1,
+        "l7policy": 50,
+        "l7rule": 100
+    }
+}
+`
+
+var UpdateResponse = quotas.Quota{
+	Loadbalancer:  20,
+	Listener:      40,
+	Member:        200,
+	Pool:          20,
+	Healthmonitor: -1,
+	L7Policy:      50,
+	L7Rule:        100,
+}

--- a/openstack/loadbalancer/v2/quotas/testing/requests_test.go
+++ b/openstack/loadbalancer/v2/quotas/testing/requests_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/quotas"
 	fake "github.com/gophercloud/gophercloud/openstack/networking/v2/common"
 	th "github.com/gophercloud/gophercloud/testhelper"
@@ -46,4 +47,60 @@ func TestGet_2(t *testing.T) {
 	q, err := quotas.Get(fake.ServiceClient(), "0a73845280574ad389c292f6a74afa76").Extract()
 	th.AssertNoErr(t, err)
 	th.AssertDeepEquals(t, q, &GetResponse)
+}
+
+func TestUpdate_1(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/quotas/0a73845280574ad389c292f6a74afa76", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+
+		fmt.Fprintf(w, UpdateRequestResponseRaw_1)
+	})
+
+	q, err := quotas.Update(fake.ServiceClient(), "0a73845280574ad389c292f6a74afa76", quotas.UpdateOpts{
+		Loadbalancer:  gophercloud.IntToPointer(20),
+		Listener:      gophercloud.IntToPointer(40),
+		Member:        gophercloud.IntToPointer(200),
+		Pool:          gophercloud.IntToPointer(20),
+		Healthmonitor: gophercloud.IntToPointer(-1),
+		L7Policy:      gophercloud.IntToPointer(50),
+		L7Rule:        gophercloud.IntToPointer(100),
+	}).Extract()
+
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, q, &UpdateResponse)
+}
+
+func TestUpdate_2(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/quotas/0a73845280574ad389c292f6a74afa76", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+
+		fmt.Fprintf(w, UpdateRequestResponseRaw_2)
+	})
+
+	q, err := quotas.Update(fake.ServiceClient(), "0a73845280574ad389c292f6a74afa76", quotas.UpdateOpts{
+		Loadbalancer:  gophercloud.IntToPointer(20),
+		Listener:      gophercloud.IntToPointer(40),
+		Member:        gophercloud.IntToPointer(200),
+		Pool:          gophercloud.IntToPointer(20),
+		Healthmonitor: gophercloud.IntToPointer(-1),
+		L7Policy:      gophercloud.IntToPointer(50),
+		L7Rule:        gophercloud.IntToPointer(100),
+	}).Extract()
+
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, q, &UpdateResponse)
 }

--- a/openstack/loadbalancer/v2/quotas/urls.go
+++ b/openstack/loadbalancer/v2/quotas/urls.go
@@ -11,3 +11,7 @@ func resourceURL(c *gophercloud.ServiceClient, projectID string) string {
 func getURL(c *gophercloud.ServiceClient, projectID string) string {
 	return resourceURL(c, projectID)
 }
+
+func updateURL(c *gophercloud.ServiceClient, projectID string) string {
+	return resourceURL(c, projectID)
+}


### PR DESCRIPTION
Add `openstack/loadbalancer/v2/quotas.Update`.

Add unit and acceptance tests.

For #1826 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

* https://github.com/openstack/octavia/blob/bf3d5372b9fc670ecd08339fa989c9b738ad8d69/octavia/api/v2/types/quotas.py#L108
* https://github.com/openstack/octavia/blob/master/octavia/api/v2/controllers/quotas.py#L75
* https://github.com/openstack/octavia/blob/c3ad32d1a8b542adceaf095bbf0e5229cccb3316/octavia/common/data_models.py#L761

I did not implement any handling for `load_balancer` or `health_monitor` for now. Duplicating the values and adding these to the json request too leads to a `400` from API side.

However the not-deprecated way (`loadbalancer` and `healthmonitor`) did work for me on two different stacks.

<sup>
Christian Schlotter <christian.schlotter@daimler.com>, Daimler TSS GmbH, 
<a href="https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md">Imprint</a>
</sup>


