### PR TITLE
Add l3agent list for router with HA

### DIFF
--- a/acceptance/openstack/networking/v2/extensions/layer3/layer3.go
+++ b/acceptance/openstack/networking/v2/extensions/layer3/layer3.go
@@ -182,38 +182,6 @@ func CreateRouter(t *testing.T, client *gophercloud.ServiceClient, networkID str
 	return router, nil
 }
 
-// CreateHARouter creates a ha router on a specified Network ID. An error will be
-// returned if the creation failed.
-func CreateHARouter(t *testing.T, client *gophercloud.ServiceClient, networkID string) (*routers.Router, error) {
-	routerName := tools.RandomString("TESTACC-", 8)
-	routerDescription := tools.RandomString("TESTACC-DESC-", 8)
-
-	t.Logf("Attempting to create router: %s", routerName)
-
-	adminStateUp := true
-	createOpts := routers.CreateOpts{
-		Name:         routerName,
-		Description:  routerDescription,
-		AdminStateUp: &adminStateUp,
-	}
-
-	router, err := routers.Create(client, createOpts).Extract()
-	if err != nil {
-		return router, err
-	}
-
-	if err := WaitForRouterToCreate(client, router.ID); err != nil {
-		return router, err
-	}
-
-	t.Logf("Created router: %s", routerName)
-
-	th.AssertEquals(t, router.Name, routerName)
-	th.AssertEquals(t, router.Description, routerDescription)
-
-	return router, nil
-}
-
 // CreateRouterInterface will attach a subnet to a router. An error will be
 // returned if the operation fails.
 func CreateRouterInterface(t *testing.T, client *gophercloud.ServiceClient, portID, routerID string) (*routers.InterfaceInfo, error) {

--- a/acceptance/openstack/networking/v2/extensions/layer3/layer3.go
+++ b/acceptance/openstack/networking/v2/extensions/layer3/layer3.go
@@ -182,6 +182,38 @@ func CreateRouter(t *testing.T, client *gophercloud.ServiceClient, networkID str
 	return router, nil
 }
 
+// CreateHARouter creates a ha router on a specified Network ID. An error will be
+// returned if the creation failed.
+func CreateHARouter(t *testing.T, client *gophercloud.ServiceClient, networkID string) (*routers.Router, error) {
+	routerName := tools.RandomString("TESTACC-", 8)
+	routerDescription := tools.RandomString("TESTACC-DESC-", 8)
+
+	t.Logf("Attempting to create router: %s", routerName)
+
+	adminStateUp := true
+	createOpts := routers.CreateOpts{
+		Name:         routerName,
+		Description:  routerDescription,
+		AdminStateUp: &adminStateUp,
+	}
+
+	router, err := routers.Create(client, createOpts).Extract()
+	if err != nil {
+		return router, err
+	}
+
+	if err := WaitForRouterToCreate(client, router.ID); err != nil {
+		return router, err
+	}
+
+	t.Logf("Created router: %s", routerName)
+
+	th.AssertEquals(t, router.Name, routerName)
+	th.AssertEquals(t, router.Description, routerDescription)
+
+	return router, nil
+}
+
 // CreateRouterInterface will attach a subnet to a router. An error will be
 // returned if the operation fails.
 func CreateRouterInterface(t *testing.T, client *gophercloud.ServiceClient, portID, routerID string) (*routers.InterfaceInfo, error) {

--- a/acceptance/openstack/networking/v2/extensions/layer3/routers_test.go
+++ b/acceptance/openstack/networking/v2/extensions/layer3/routers_test.go
@@ -47,6 +47,7 @@ func TestLayer3RouterCreateDelete(t *testing.T) {
 	allPages, err := routers.List(client, listOpts).AllPages()
 	th.AssertNoErr(t, err)
 
+	// Test ListL3Agents for HA or not HA router
 	_, err := routers.ListL3Agents(client, router.ID)
 	th.AssertNoErr(t, err)
 

--- a/acceptance/openstack/networking/v2/extensions/layer3/routers_test.go
+++ b/acceptance/openstack/networking/v2/extensions/layer3/routers_test.go
@@ -47,7 +47,7 @@ func TestLayer3RouterCreateDelete(t *testing.T) {
 	allPages, err := routers.List(client, listOpts).AllPages()
 	th.AssertNoErr(t, err)
 
-	routersList ,err routers.ListL3Agents(client, router.ID)
+	_, err := routers.ListL3Agents(client, router.ID)
 	th.AssertNoErr(t, err)
 
 	allRouters, err := routers.ExtractRouters(allPages)

--- a/acceptance/openstack/networking/v2/extensions/layer3/routers_test.go
+++ b/acceptance/openstack/networking/v2/extensions/layer3/routers_test.go
@@ -47,6 +47,9 @@ func TestLayer3RouterCreateDelete(t *testing.T) {
 	allPages, err := routers.List(client, listOpts).AllPages()
 	th.AssertNoErr(t, err)
 
+	routersList ,err routers.ListL3Agents(client, router.ID)
+	th.AssertNoErr(t, err)
+
 	allRouters, err := routers.ExtractRouters(allPages)
 	th.AssertNoErr(t, err)
 

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,5 @@
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20191202143827-86a70503ff7e h1:egKlR8l7Nu9vHGWbcUV8lqR4987UfUbBd7GbhqGzNYU=
 golang.org/x/crypto v0.0.0-20191202143827-86a70503ff7e/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
@@ -16,4 +17,5 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/openstack/networking/v2/extensions/layer3/routers/doc.go
+++ b/openstack/networking/v2/extensions/layer3/routers/doc.go
@@ -105,13 +105,22 @@ Example to Remove an Interface from a Router
 		panic(err)
 	}
 
-Example to List an L3 agnets for a Router
+Example to List an L3 agents for a Router
 
 	routerID := "4e8e5957-649f-477b-9e5b-f1f75b21c03c"
 
-	interface, err := routers.ListL3Agents(networkClient, routerID).Extract()
+	allPages, err := routers.ListL3Agents(networkClient, routerID).AllPages()
 	if err != nil {
 		panic(err)
+	}
+
+	allL3Agents, err := routers.ExtractL3Agents(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, agent := range allL3Agents {
+		fmt.Printf("%+v\n", agent)
 	}
 */
 package routers

--- a/openstack/networking/v2/extensions/layer3/routers/doc.go
+++ b/openstack/networking/v2/extensions/layer3/routers/doc.go
@@ -104,5 +104,14 @@ Example to Remove an Interface from a Router
 	if err != nil {
 		panic(err)
 	}
+
+Example to List an L3 agnets for a Router
+
+	routerID := "4e8e5957-649f-477b-9e5b-f1f75b21c03c"
+
+	interface, err := routers.ListL3Agents(networkClient, routerID).Extract()
+	if err != nil {
+		panic(err)
+	}
 */
 package routers

--- a/openstack/networking/v2/extensions/layer3/routers/requests.go
+++ b/openstack/networking/v2/extensions/layer3/routers/requests.go
@@ -238,9 +238,9 @@ func RemoveInterface(c *gophercloud.ServiceClient, id string, opts RemoveInterfa
 	return
 }
 
-// ListL3Agents returns a list of l3-agents scheduled for a specific router
-func ListL3Agents(c *gophercloud.ServiceClient, id string) (r ListL3AgentsResult) {
-	resp, err := c.Get(listl3AgentsURL(c, id), &r.Body, nil)
-	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
-	return
+// ListL3Agents returns a list of l3-agents scheduled for a specific router.
+func ListL3Agents(c *gophercloud.ServiceClient, id string) (result pagination.Pager) {
+	return pagination.NewPager(c, listl3AgentsURL(c, id), func(r pagination.PageResult) pagination.Page {
+		return ListL3AgentsPage{pagination.SinglePageBase(r)}
+	})
 }

--- a/openstack/networking/v2/extensions/layer3/routers/requests.go
+++ b/openstack/networking/v2/extensions/layer3/routers/requests.go
@@ -237,3 +237,10 @@ func RemoveInterface(c *gophercloud.ServiceClient, id string, opts RemoveInterfa
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
+
+// ListL3Agents returns a list of l3-agents scheduled for a specific router
+func ListL3Agents(c *gophercloud.ServiceClient, id string) (r ListL3AgentsResult) {
+	resp, err := c.Get(listl3AgentsURL(c, id), &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}

--- a/openstack/networking/v2/extensions/layer3/routers/results.go
+++ b/openstack/networking/v2/extensions/layer3/routers/results.go
@@ -131,8 +131,10 @@ type L3Agent struct {
 	Topic string `json:"topic"`
 
 	// HAState is a ha state of agent(active/standby) for router
-	//
 	HAState string `json:"ha_state"`
+
+	// ResourceVersions is a list agent known objects and version numbers
+	ResourceVersions map[string]interface{} `json:"resource_versions"`
 }
 
 // UnmarshalJSON helps to convert the timestamps into the time.Time type.

--- a/openstack/networking/v2/extensions/layer3/routers/results.go
+++ b/openstack/networking/v2/extensions/layer3/routers/results.go
@@ -84,81 +84,6 @@ type RouterPage struct {
 	pagination.LinkedPageBase
 }
 
-// L3Agent represents a Neutron agent for router in HA.
-type L3Agent struct {
-	// ID is the id of the agent.
-	ID string `json:"id"`
-
-	// AdminStateUp is an administrative state of the agent.
-	AdminStateUp bool `json:"admin_state_up"`
-
-	// AgentType is a type of the agent.
-	AgentType string `json:"agent_type"`
-
-	// Alive indicates whether agent is alive or not.
-	Alive bool `json:"alive"`
-
-	// ResourcesSynced indicates whether agent is synced or not.
-	// Not all agent types track resources via Placement.
-	ResourcesSynced bool `json:"resources_synced"`
-
-	// AvailabilityZone is a zone of the agent.
-	AvailabilityZone string `json:"availability_zone"`
-
-	// Binary is an executable binary of the agent.
-	Binary string `json:"binary"`
-
-	// Configurations is a configuration specific key/value pairs that are
-	// determined by the agent binary and type.
-	Configurations map[string]interface{} `json:"configurations"`
-
-	// CreatedAt is a creation timestamp.
-	CreatedAt time.Time `json:"-"`
-
-	// StartedAt is a starting timestamp.
-	StartedAt time.Time `json:"-"`
-
-	// HeartbeatTimestamp is a last heartbeat timestamp.
-	HeartbeatTimestamp time.Time `json:"-"`
-
-	// Description contains agent description.
-	Description string `json:"description"`
-
-	// Host is a hostname of the agent system.
-	Host string `json:"host"`
-
-	// Topic contains name of AMQP topic.
-	Topic string `json:"topic"`
-
-	// HAState is a ha state of agent(active/standby) for router
-	HAState string `json:"ha_state"`
-
-	// ResourceVersions is a list agent known objects and version numbers
-	ResourceVersions map[string]interface{} `json:"resource_versions"`
-}
-
-// UnmarshalJSON helps to convert the timestamps into the time.Time type.
-func (r *L3Agent) UnmarshalJSON(b []byte) error {
-	type tmp L3Agent
-	var s struct {
-		tmp
-		CreatedAt          gophercloud.JSONRFC3339ZNoTNoZ `json:"created_at"`
-		StartedAt          gophercloud.JSONRFC3339ZNoTNoZ `json:"started_at"`
-		HeartbeatTimestamp gophercloud.JSONRFC3339ZNoTNoZ `json:"heartbeat_timestamp"`
-	}
-	err := json.Unmarshal(b, &s)
-	if err != nil {
-		return err
-	}
-	*r = L3Agent(s.tmp)
-
-	r.CreatedAt = time.Time(s.CreatedAt)
-	r.StartedAt = time.Time(s.StartedAt)
-	r.HeartbeatTimestamp = time.Time(s.HeartbeatTimestamp)
-
-	return nil
-}
-
 // NextPageURL is invoked when a paginated collection of routers has reached
 // the end of a page and the pager seeks to traverse over a new one. In order
 // to do this, it needs to construct the next page's URL.
@@ -258,18 +183,95 @@ func (r InterfaceResult) Extract() (*InterfaceInfo, error) {
 	return &s, err
 }
 
-// ListL3AgentsResult is the response from a List operation.
-// Call its Extract method to interpret it as l3-agents.
-type ListL3AgentsResult struct {
-	gophercloud.Result
+// L3Agent represents a Neutron agent for routers.
+type L3Agent struct {
+	// ID is the id of the agent.
+	ID string `json:"id"`
+
+	// AdminStateUp is an administrative state of the agent.
+	AdminStateUp bool `json:"admin_state_up"`
+
+	// AgentType is a type of the agent.
+	AgentType string `json:"agent_type"`
+
+	// Alive indicates whether agent is alive or not.
+	Alive bool `json:"alive"`
+
+	// ResourcesSynced indicates whether agent is synced or not.
+	// Not all agent types track resources via Placement.
+	ResourcesSynced bool `json:"resources_synced"`
+
+	// AvailabilityZone is a zone of the agent.
+	AvailabilityZone string `json:"availability_zone"`
+
+	// Binary is an executable binary of the agent.
+	Binary string `json:"binary"`
+
+	// Configurations is a configuration specific key/value pairs that are
+	// determined by the agent binary and type.
+	Configurations map[string]interface{} `json:"configurations"`
+
+	// CreatedAt is a creation timestamp.
+	CreatedAt time.Time `json:"-"`
+
+	// StartedAt is a starting timestamp.
+	StartedAt time.Time `json:"-"`
+
+	// HeartbeatTimestamp is a last heartbeat timestamp.
+	HeartbeatTimestamp time.Time `json:"-"`
+
+	// Description contains agent description.
+	Description string `json:"description"`
+
+	// Host is a hostname of the agent system.
+	Host string `json:"host"`
+
+	// Topic contains name of AMQP topic.
+	Topic string `json:"topic"`
+
+	// HAState is a ha state of agent(active/standby) for router
+	HAState string `json:"ha_state"`
+
+	// ResourceVersions is a list agent known objects and version numbers
+	ResourceVersions map[string]interface{} `json:"resource_versions"`
 }
 
-// Extract interprets any ListL3AgentsResult as an array of networks.
-func (r ListL3AgentsResult) Extract() ([]L3Agent, error) {
+// UnmarshalJSON helps to convert the timestamps into the time.Time type.
+func (r *L3Agent) UnmarshalJSON(b []byte) error {
+	type tmp L3Agent
+	var s struct {
+		tmp
+		CreatedAt          gophercloud.JSONRFC3339ZNoTNoZ `json:"created_at"`
+		StartedAt          gophercloud.JSONRFC3339ZNoTNoZ `json:"started_at"`
+		HeartbeatTimestamp gophercloud.JSONRFC3339ZNoTNoZ `json:"heartbeat_timestamp"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	*r = L3Agent(s.tmp)
+
+	r.CreatedAt = time.Time(s.CreatedAt)
+	r.StartedAt = time.Time(s.StartedAt)
+	r.HeartbeatTimestamp = time.Time(s.HeartbeatTimestamp)
+
+	return nil
+}
+
+type ListL3AgentsPage struct {
+	pagination.SinglePageBase
+}
+
+func (r ListL3AgentsPage) IsEmpty() (bool, error) {
+	v, err := ExtractL3Agents(r)
+	return len(v) == 0, err
+}
+
+func ExtractL3Agents(r pagination.Page) ([]L3Agent, error) {
 	var s struct {
 		L3Agents []L3Agent `json:"agents"`
 	}
 
-	err := r.ExtractInto(&s)
+	err := (r.(ListL3AgentsPage)).ExtractInto(&s)
 	return s.L3Agents, err
 }

--- a/openstack/networking/v2/extensions/layer3/routers/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/layer3/routers/testing/requests_test.go
@@ -480,7 +480,7 @@ func TestRemoveInterface(t *testing.T) {
 	th.AssertEquals(t, "9a83fa11-8da5-436e-9afe-3d3ac5ce7770", res.ID)
 }
 
-func ListL3Agents(t *testing.T) {
+func TestListL3Agents(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 
@@ -501,9 +501,9 @@ func ListL3Agents(t *testing.T) {
             "topic": "l3_agent",
             "host": "os-ctrl-02",
             "admin_state_up": true,
-            "created_at": "2020-08-28 15:43:15",
-            "started_at": "2020-09-21 12:11:25",
-            "heartbeat_timestamp": "2020-09-21 12:35:55",
+            "created_at": "2017-07-26 23:15:44",
+            "started_at": "2018-06-26 21:46:19",
+            "heartbeat_timestamp": "2019-01-09 10:28:53",
             "description": "My L3 agent for OpenStack",
             "resources_synced": true,
             "availability_zone": "nova",
@@ -528,9 +528,9 @@ func ListL3Agents(t *testing.T) {
             "topic": "l3_agent",
             "host": "os-ctrl-03",
             "admin_state_up": true,
-            "created_at": "2020-08-28 15:43:11.066068",
-            "started_at": "2020-09-21 12:11:25.307587",
-            "heartbeat_timestamp": "2020-09-21 12:35:55.373391",
+            "created_at": "2017-01-22 14:00:50",
+            "started_at": "2018-11-06 12:09:17",
+            "heartbeat_timestamp": "2019-01-09 10:28:50",
             "description": "My L3 agent for OpenStack",
             "resources_synced": true,
             "availability_zone": "nova",
@@ -568,17 +568,17 @@ func ListL3Agents(t *testing.T) {
 			AvailabilityZone: "nova",
 			Configurations: map[string]interface{}{
 				"agent_mode":                   "legacy",
-				"ex_gw_ports":                  2,
-				"floating_ips":                 2,
+				"ex_gw_ports":                  float64(2),
+				"floating_ips":                 float64(2),
 				"handle_internal_only_routers": true,
 				"interface_driver":             "linuxbridge",
-				"interfaces":                   1,
+				"interfaces":                   float64(1),
 				"log_agent_heartbeats":         false,
-				"routers":                      2,
+				"routers":                      float64(2),
 			},
-			CreatedAt:          time.Date(2020, 8, 28, 15, 43, 15, 0, time.UTC),
-			StartedAt:          time.Date(2020, 9, 21, 12, 11, 25, 0, time.UTC),
-			HeartbeatTimestamp: time.Date(2020, 9, 21, 12, 35, 55, 0, time.UTC),
+			CreatedAt:          time.Date(2017, 7, 26, 23, 15, 44, 0, time.UTC),
+			StartedAt:          time.Date(2018, 6, 26, 21, 46, 19, 0, time.UTC),
+			HeartbeatTimestamp: time.Date(2019, 1, 9, 10, 28, 53, 0, time.UTC),
 			Host:               "os-ctrl-02",
 			Topic:              "l3_agent",
 			HAState:            "standby",
@@ -595,23 +595,22 @@ func ListL3Agents(t *testing.T) {
 			AvailabilityZone: "nova",
 			Configurations: map[string]interface{}{
 				"agent_mode":                   "legacy",
-				"ex_gw_ports":                  2,
-				"floating_ips":                 2,
+				"ex_gw_ports":                  float64(2),
+				"floating_ips":                 float64(2),
 				"handle_internal_only_routers": true,
 				"interface_driver":             "linuxbridge",
-				"interfaces":                   1,
+				"interfaces":                   float64(1),
 				"log_agent_heartbeats":         false,
-				"routers":                      2,
+				"routers":                      float64(2),
 			},
-			CreatedAt:          time.Date(2020, 8, 28, 15, 43, 15, 0, time.UTC),
-			StartedAt:          time.Date(2020, 9, 21, 12, 11, 25, 0, time.UTC),
-			HeartbeatTimestamp: time.Date(2020, 9, 21, 12, 35, 55, 0, time.UTC),
+			CreatedAt:          time.Date(2017, 1, 22, 14, 00, 50, 0, time.UTC),
+			StartedAt:          time.Date(2018, 11, 6, 12, 9, 17, 0, time.UTC),
+			HeartbeatTimestamp: time.Date(2019, 1, 9, 10, 28, 50, 0, time.UTC),
 			Host:               "os-ctrl-03",
 			Topic:              "l3_agent",
 			HAState:            "active",
 			ResourceVersions:   map[string]interface{}{},
 		},
 	}
-
 	th.CheckDeepEquals(t, expected, actual)
 }

--- a/openstack/networking/v2/extensions/layer3/routers/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/layer3/routers/testing/requests_test.go
@@ -553,8 +553,9 @@ func TestListL3Agents(t *testing.T) {
 			`)
 	})
 
-	actual, err := routers.ListL3Agents(fake.ServiceClient(), "fa3a4aaa-c73f-48aa-a603-8c8bf642b7c0").Extract()
+	l3AgentsPages, err := routers.ListL3Agents(fake.ServiceClient(), "fa3a4aaa-c73f-48aa-a603-8c8bf642b7c0").AllPages()
 	th.AssertNoErr(t, err)
+	actual, err := routers.ExtractL3Agents(l3AgentsPages)
 
 	expected := []routers.L3Agent{
 		{

--- a/openstack/networking/v2/extensions/layer3/routers/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/layer3/routers/testing/requests_test.go
@@ -582,6 +582,7 @@ func ListL3Agents(t *testing.T) {
 			Host:               "os-ctrl-02",
 			Topic:              "l3_agent",
 			HAState:            "standby",
+			ResourceVersions:   map[string]interface{}{},
 		},
 		{
 			ID:               "4541cc6c-87bc-4cee-bad2-36ca78836c91",
@@ -608,6 +609,7 @@ func ListL3Agents(t *testing.T) {
 			Host:               "os-ctrl-03",
 			Topic:              "l3_agent",
 			HAState:            "active",
+			ResourceVersions:   map[string]interface{}{},
 		},
 	}
 

--- a/openstack/networking/v2/extensions/layer3/routers/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/layer3/routers/testing/requests_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	fake "github.com/gophercloud/gophercloud/openstack/networking/v2/common"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers"
@@ -477,4 +478,138 @@ func TestRemoveInterface(t *testing.T) {
 	th.AssertEquals(t, "017d8de156df4177889f31a9bd6edc00", res.TenantID)
 	th.AssertEquals(t, "3f990102-4485-4df1-97a0-2c35bdb85b31", res.PortID)
 	th.AssertEquals(t, "9a83fa11-8da5-436e-9afe-3d3ac5ce7770", res.ID)
+}
+
+func ListL3Agents(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/routers/fa3a4aaa-c73f-48aa-a603-8c8bf642b7c0/l3-agents", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, `
+{
+    "agents": [
+        {
+            "id": "ddbf087c-e38f-4a73-bcb3-c38f2a719a03",
+            "agent_type": "L3 agent",
+            "binary": "neutron-l3-agent",
+            "topic": "l3_agent",
+            "host": "os-ctrl-02",
+            "admin_state_up": true,
+            "created_at": "2020-08-28 15:43:15",
+            "started_at": "2020-09-21 12:11:25",
+            "heartbeat_timestamp": "2020-09-21 12:35:55",
+            "description": "My L3 agent for OpenStack",
+            "resources_synced": true,
+            "availability_zone": "nova",
+            "alive": true,
+            "configurations": {
+                "agent_mode": "legacy",
+                "ex_gw_ports": 2,
+                "floating_ips": 2,
+                "handle_internal_only_routers": true,
+                "interface_driver": "linuxbridge",
+                "interfaces": 1,
+                "log_agent_heartbeats": false,
+                "routers": 2
+            },
+            "resource_versions": {},
+            "ha_state": "standby"
+        },
+        {
+            "id": "4541cc6c-87bc-4cee-bad2-36ca78836c91",
+            "agent_type": "L3 agent",
+            "binary": "neutron-l3-agent",
+            "topic": "l3_agent",
+            "host": "os-ctrl-03",
+            "admin_state_up": true,
+            "created_at": "2020-08-28 15:43:11.066068",
+            "started_at": "2020-09-21 12:11:25.307587",
+            "heartbeat_timestamp": "2020-09-21 12:35:55.373391",
+            "description": "My L3 agent for OpenStack",
+            "resources_synced": true,
+            "availability_zone": "nova",
+            "alive": true,
+            "configurations": {
+                "agent_mode": "legacy",
+                "ex_gw_ports": 2,
+                "floating_ips": 2,
+                "handle_internal_only_routers": true,
+                "interface_driver": "linuxbridge",
+                "interfaces": 1,
+                "log_agent_heartbeats": false,
+                "routers": 2
+            },
+            "resource_versions": {},
+            "ha_state": "active"
+        }
+    ]
+}
+			`)
+	})
+
+	actual, err := routers.ListL3Agents(fake.ServiceClient(), "fa3a4aaa-c73f-48aa-a603-8c8bf642b7c0").Extract()
+	th.AssertNoErr(t, err)
+
+	expected := []routers.L3Agent{
+		{
+			ID:               "ddbf087c-e38f-4a73-bcb3-c38f2a719a03",
+			AdminStateUp:     true,
+			AgentType:        "L3 agent",
+			Description:      "My L3 agent for OpenStack",
+			Alive:            true,
+			ResourcesSynced:  true,
+			Binary:           "neutron-l3-agent",
+			AvailabilityZone: "nova",
+			Configurations: map[string]interface{}{
+				"agent_mode":                   "legacy",
+				"ex_gw_ports":                  2,
+				"floating_ips":                 2,
+				"handle_internal_only_routers": true,
+				"interface_driver":             "linuxbridge",
+				"interfaces":                   1,
+				"log_agent_heartbeats":         false,
+				"routers":                      2,
+			},
+			CreatedAt:          time.Date(2020, 8, 28, 15, 43, 15, 0, time.UTC),
+			StartedAt:          time.Date(2020, 9, 21, 12, 11, 25, 0, time.UTC),
+			HeartbeatTimestamp: time.Date(2020, 9, 21, 12, 35, 55, 0, time.UTC),
+			Host:               "os-ctrl-02",
+			Topic:              "l3_agent",
+			HAState:            "standby",
+		},
+		{
+			ID:               "4541cc6c-87bc-4cee-bad2-36ca78836c91",
+			AdminStateUp:     true,
+			AgentType:        "L3 agent",
+			Description:      "My L3 agent for OpenStack",
+			Alive:            true,
+			ResourcesSynced:  true,
+			Binary:           "neutron-l3-agent",
+			AvailabilityZone: "nova",
+			Configurations: map[string]interface{}{
+				"agent_mode":                   "legacy",
+				"ex_gw_ports":                  2,
+				"floating_ips":                 2,
+				"handle_internal_only_routers": true,
+				"interface_driver":             "linuxbridge",
+				"interfaces":                   1,
+				"log_agent_heartbeats":         false,
+				"routers":                      2,
+			},
+			CreatedAt:          time.Date(2020, 8, 28, 15, 43, 15, 0, time.UTC),
+			StartedAt:          time.Date(2020, 9, 21, 12, 11, 25, 0, time.UTC),
+			HeartbeatTimestamp: time.Date(2020, 9, 21, 12, 35, 55, 0, time.UTC),
+			Host:               "os-ctrl-03",
+			Topic:              "l3_agent",
+			HAState:            "active",
+		},
+	}
+
+	th.CheckDeepEquals(t, expected, actual)
 }

--- a/openstack/networking/v2/extensions/layer3/routers/urls.go
+++ b/openstack/networking/v2/extensions/layer3/routers/urls.go
@@ -19,3 +19,7 @@ func addInterfaceURL(c *gophercloud.ServiceClient, id string) string {
 func removeInterfaceURL(c *gophercloud.ServiceClient, id string) string {
 	return c.ServiceURL(resourcePath, id, "remove_router_interface")
 }
+
+func listl3AgentsURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL(resourcePath, id, "l3-agents")
+}


### PR DESCRIPTION
For https://github.com/gophercloud/gophercloud/issues/2022

API doc:
https://docs.openstack.org/api-ref/network/v2/?expanded=list-l3-agents-hosting-a-router-detail#l3-agent-scheduler
Source code:
https://github.com/openstack/neutron/blob/fefd9a6bb1e5b685d56c75e7a538b0dfc0a959ec/neutron/db/l3_hascheduler_db.py#L44-L55