### PR TITLE
Support Magnum upgrade API

### DIFF
--- a/openstack/containerinfra/v1/clusters/doc.go
+++ b/openstack/containerinfra/v1/clusters/doc.go
@@ -89,6 +89,17 @@ Example to Update a Cluster
 	}
 	fmt.Printf("%s\n", clusterUUID)
 
+Example to Upgrade a Cluster
+
+	upgradeOpts := clusters.UpgradeOpts{
+		ClusterTemplate: "0562d357-8641-4759-8fed-8173f02c9633",
+	}
+	clusterUUID, err := clusters.Upgrade(serviceClient, clusterUUID, upgradeOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("%s\n", clusterUUID)
+
 Example to Delete a Cluster
 
 	clusterUUID := "dc6d336e3fc4c0a951b5698cd1236ee"

--- a/openstack/containerinfra/v1/clusters/requests.go
+++ b/openstack/containerinfra/v1/clusters/requests.go
@@ -164,6 +164,42 @@ func Update(client *gophercloud.ServiceClient, id string, opts []UpdateOptsBuild
 	return
 }
 
+type UpgradeOpts struct {
+	ClusterTemplate string `json:"cluster_template" required:"true"`
+	MaxBatchSize    *int   `json:"max_batch_size,omitempty"`
+	NodeGroup       string `json:"nodegroup,omitempty"`
+}
+
+// UpgradeOptsBuilder allows extensions to add additional parameters to the
+// Upgrade request.
+type UpgradeOptsBuilder interface {
+	ToClustersUpgradeMap() (map[string]interface{}, error)
+}
+
+// ToClustersUpgradeMap constructs a request body from UpgradeOpts.
+func (opts UpgradeOpts) ToClustersUpgradeMap() (map[string]interface{}, error) {
+	if opts.MaxBatchSize == nil {
+		defaultMaxBatchSize := 1
+		opts.MaxBatchSize = &defaultMaxBatchSize
+	}
+	return gophercloud.BuildRequestBody(opts, "")
+}
+
+// Upgrade implements cluster upgrade request.
+func Upgrade(client *gophercloud.ServiceClient, id string, opts UpgradeOptsBuilder) (r UpgradeResult) {
+	b, err := opts.ToClustersUpgradeMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	resp, err := client.Post(upgradeURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
 // ResizeOptsBuilder allows extensions to add additional parameters to the
 // Resize request.
 type ResizeOptsBuilder interface {

--- a/openstack/containerinfra/v1/clusters/results.go
+++ b/openstack/containerinfra/v1/clusters/results.go
@@ -39,6 +39,11 @@ type UpdateResult struct {
 	commonResult
 }
 
+// UpgradeResult is the response of a Upgrade operations.
+type UpgradeResult struct {
+	commonResult
+}
+
 // ResizeResult is the response of a Resize operations.
 type ResizeResult struct {
 	commonResult
@@ -53,6 +58,14 @@ func (r CreateResult) Extract() (string, error) {
 }
 
 func (r UpdateResult) Extract() (string, error) {
+	var s struct {
+		UUID string
+	}
+	err := r.ExtractInto(&s)
+	return s.UUID, err
+}
+
+func (r UpgradeResult) Extract() (string, error) {
 	var s struct {
 		UUID string
 	}

--- a/openstack/containerinfra/v1/clusters/testing/fixtures.go
+++ b/openstack/containerinfra/v1/clusters/testing/fixtures.go
@@ -286,6 +286,24 @@ func HandleUpdateClusterSuccessfully(t *testing.T) {
 	})
 }
 
+var UpgradeResponse = fmt.Sprintf(`
+{
+	"uuid":"%s"
+}`, clusterUUID)
+
+func HandleUpgradeClusterSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/v1/clusters/"+clusterUUID+"/actions/upgrade", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.Header().Add("X-OpenStack-Request-Id", requestUUID)
+		w.WriteHeader(http.StatusAccepted)
+
+		fmt.Fprint(w, UpgradeResponse)
+	})
+}
+
 func HandleDeleteClusterSuccessfully(t *testing.T) {
 	th.Mux.HandleFunc("/v1/clusters/"+clusterUUID, func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "DELETE")

--- a/openstack/containerinfra/v1/clusters/testing/requests_test.go
+++ b/openstack/containerinfra/v1/clusters/testing/requests_test.go
@@ -152,6 +152,31 @@ func TestUpdateCluster(t *testing.T) {
 	th.AssertDeepEquals(t, clusterUUID, actual)
 }
 
+func TestUpgradeCluster(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	HandleUpgradeClusterSuccessfully(t)
+
+	var opts clusters.UpgradeOptsBuilder
+	opts = clusters.UpgradeOpts{
+		ClusterTemplate: "0562d357-8641-4759-8fed-8173f02c9633",
+	}
+
+	sc := fake.ServiceClient()
+	sc.Endpoint = sc.Endpoint + "v1/"
+	res := clusters.Upgrade(sc, clusterUUID, opts)
+	th.AssertNoErr(t, res.Err)
+
+	requestID := res.Header.Get("X-OpenStack-Request-Id")
+	th.AssertEquals(t, requestUUID, requestID)
+
+	actual, err := res.Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertDeepEquals(t, clusterUUID, actual)
+}
+
 func TestDeleteCluster(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()

--- a/openstack/containerinfra/v1/clusters/urls.go
+++ b/openstack/containerinfra/v1/clusters/urls.go
@@ -38,6 +38,10 @@ func updateURL(client *gophercloud.ServiceClient, id string) string {
 	return idURL(client, id)
 }
 
+func upgradeURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL("clusters", id, "actions/upgrade")
+}
+
 func resizeURL(client *gophercloud.ServiceClient, id string) string {
 	return client.ServiceURL("clusters", id, "actions/resize")
 }


### PR DESCRIPTION
Currently there is no support for the cluster upgrade-action. This PR implements the missing api-call.

For #2031

API doc:
- https://docs.openstack.org/api-ref/container-infrastructure-management/?expanded=upgrade-a-cluster-detail#upgrade-a-cluster

source from cluster-actions controller:
- https://github.com/openstack/magnum/blob/e8467e94d88b6feb67ff7c167f5e167cd452c772/magnum/api/controllers/v1/cluster_actions.py#L58
- https://github.com/openstack/magnum/blob/e8467e94d88b6feb67ff7c167f5e167cd452c772/magnum/api/controllers/v1/cluster_actions.py#L132
