### PR TITLE
openstack/networking: fix dropped test error

### DIFF
--- a/openstack/networking/v2/extensions/layer3/routers/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/layer3/routers/testing/requests_test.go
@@ -556,6 +556,7 @@ func TestListL3Agents(t *testing.T) {
 	l3AgentsPages, err := routers.ListL3Agents(fake.ServiceClient(), "fa3a4aaa-c73f-48aa-a603-8c8bf642b7c0").AllPages()
 	th.AssertNoErr(t, err)
 	actual, err := routers.ExtractL3Agents(l3AgentsPages)
+	th.AssertNoErr(t, err)
 
 	expected := []routers.L3Agent{
 		{


### PR DESCRIPTION
For #2034 

This fixes a dropped test error in `openstack/networking/v2/extensions/layer3/routers/testing`.