### PR TITLE
Add ip, ip6, and user_id to servers.ListOpts

### DIFF
--- a/openstack/compute/v2/servers/requests.go
+++ b/openstack/compute/v2/servers/requests.go
@@ -29,6 +29,14 @@ type ListOpts struct {
 	// Flavor is the name of the flavor in URL format.
 	Flavor string `q:"flavor"`
 
+	// IP is a regular expression to match the IPv4 address of the server.
+	IP string `q:"ip"`
+
+	// This requires the client to be set to microversion 2.5 or later, unless
+	// the user is an admin.
+	// IP is a regular expression to match the IPv6 address of the server.
+	IP6 string `q:"ip6"`
+
 	// Name of the server as a string; can be queried with regular expressions.
 	// Realize that ?name=bob returns both bob and bobb. If you need to match bob
 	// only, you can use a regular expression matching the syntax of the
@@ -54,6 +62,11 @@ type ListOpts struct {
 	// TenantID lists servers for a particular tenant.
 	// Setting "AllTenants = true" is required.
 	TenantID string `q:"tenant_id"`
+
+	// This requires the client to be set to microversion 2.83 or later, unless
+	// the user is an admin.
+	// UserID lists servers for a particular user.
+	UserID string `q:"user_id"`
 
 	// This requires the client to be set to microversion 2.26 or later.
 	// Tags filters on specific server tags. All tags must be present for the server.


### PR DESCRIPTION
Add ip, ip6, and user_id to servers.ListOpts

As listed in https://docs.openstack.org/api-guide/compute/server_concepts.html#server-query:
* ip
* ip6 (New in version 2.5)
* user_id (New in version 2.83)

And the CLI documentation:

    --ip <ip-address-regex>
                          Regular expression to match IP addresses
    --ip6 <ip-address-regex>
                          Regular expression to match IPv6 addresses. Note that
                          this option only applies for non-admin users when
                          using ``--os-compute-api-version`` 2.5 or greater.
    --user <user>         Search by user (admin only) (name or ID)

Note the difference between the user_id docs. My understanding is that
it’s the same as ip6: the option was initially admin-only, and became
generally available with API 2.83 (this is what I have documented).

For #2035

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/nova/blob/a948a803b561606a892133940915caae610c080b/nova/api/openstack/compute/schemas/servers.py#L567