### PR TITLE
Networking / routers: Allow updating routers, without specifying the static routes

### DIFF
--- a/openstack/networking/v2/extensions/layer3/routers/doc.go
+++ b/openstack/networking/v2/extensions/layer3/routers/doc.go
@@ -48,7 +48,20 @@ Example to Update a Router
 
 	updateOpts := routers.UpdateOpts{
 		Name:   "new_name",
-		Routes: routes,
+		Routes: &routes,
+	}
+
+	router, err := routers.Update(networkClient, routerID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Update just the Router name, keeping everything else as-is
+
+	routerID := "4e8e5957-649f-477b-9e5b-f1f75b21c03c"
+
+	updateOpts := routers.UpdateOpts{
+		Name:   "new_name",
 	}
 
 	router, err := routers.Update(networkClient, routerID, updateOpts).Extract()
@@ -63,7 +76,7 @@ Example to Remove all Routes from a Router
 	routes := []routers.Route{}
 
 	updateOpts := routers.UpdateOpts{
-		Routes: routes,
+		Routes: &routes,
 	}
 
 	router, err := routers.Update(networkClient, routerID, updateOpts).Extract()

--- a/openstack/networking/v2/extensions/layer3/routers/requests.go
+++ b/openstack/networking/v2/extensions/layer3/routers/requests.go
@@ -109,7 +109,7 @@ type UpdateOpts struct {
 	AdminStateUp *bool        `json:"admin_state_up,omitempty"`
 	Distributed  *bool        `json:"distributed,omitempty"`
 	GatewayInfo  *GatewayInfo `json:"external_gateway_info,omitempty"`
-	Routes       []Route      `json:"routes"`
+	Routes       *[]Route     `json:"routes,omitempty"`
 }
 
 // ToRouterUpdateMap builds an update body based on UpdateOpts.

--- a/openstack/networking/v2/extensions/layer3/routers/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/layer3/routers/testing/requests_test.go
@@ -344,13 +344,10 @@ func TestUpdateWithoutRoutes(t *testing.T) {
 		th.TestJSONRequest(t, r, `
 {
     "router": {
-			"name": "new_name",
-        "external_gateway_info": {
-            "network_id": "8ca37218-28ff-41cb-9b10-039601ea7e6b"
-		}
+        "name": "new_name"
     }
 }
-			`)
+		`)
 
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -381,18 +378,12 @@ func TestUpdateWithoutRoutes(t *testing.T) {
 		`)
 	})
 
-	gwi := routers.GatewayInfo{NetworkID: "8ca37218-28ff-41cb-9b10-039601ea7e6b"}
-	options := routers.UpdateOpts{Name: "new_name", GatewayInfo: &gwi}
+	options := routers.UpdateOpts{Name: "new_name"}
 
 	n, err := routers.Update(fake.ServiceClient(), "4e8e5957-649f-477b-9e5b-f1f75b21c03c", options).Extract()
 	th.AssertNoErr(t, err)
 
-	gwi.ExternalFixedIPs = []routers.ExternalFixedIP{
-		{IPAddress: "192.0.2.17", SubnetID: "ab561bc4-1a8e-48f2-9fbd-376fcb1a1def"},
-	}
-
 	th.AssertEquals(t, n.Name, "new_name")
-	th.AssertDeepEquals(t, n.GatewayInfo, gwi)
 	th.AssertDeepEquals(t, n.Routes, []routers.Route{{DestinationCIDR: "40.0.1.0/24", NextHop: "10.1.0.10"}})
 }
 

--- a/openstack/networking/v2/extensions/layer3/routers/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/layer3/routers/testing/requests_test.go
@@ -318,7 +318,71 @@ func TestUpdate(t *testing.T) {
 
 	gwi := routers.GatewayInfo{NetworkID: "8ca37218-28ff-41cb-9b10-039601ea7e6b"}
 	r := []routers.Route{{DestinationCIDR: "40.0.1.0/24", NextHop: "10.1.0.10"}}
-	options := routers.UpdateOpts{Name: "new_name", GatewayInfo: &gwi, Routes: r}
+	options := routers.UpdateOpts{Name: "new_name", GatewayInfo: &gwi, Routes: &r}
+
+	n, err := routers.Update(fake.ServiceClient(), "4e8e5957-649f-477b-9e5b-f1f75b21c03c", options).Extract()
+	th.AssertNoErr(t, err)
+
+	gwi.ExternalFixedIPs = []routers.ExternalFixedIP{
+		{IPAddress: "192.0.2.17", SubnetID: "ab561bc4-1a8e-48f2-9fbd-376fcb1a1def"},
+	}
+
+	th.AssertEquals(t, n.Name, "new_name")
+	th.AssertDeepEquals(t, n.GatewayInfo, gwi)
+	th.AssertDeepEquals(t, n.Routes, []routers.Route{{DestinationCIDR: "40.0.1.0/24", NextHop: "10.1.0.10"}})
+}
+
+func TestUpdateWithoutRoutes(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/routers/4e8e5957-649f-477b-9e5b-f1f75b21c03c", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, `
+{
+    "router": {
+			"name": "new_name",
+        "external_gateway_info": {
+            "network_id": "8ca37218-28ff-41cb-9b10-039601ea7e6b"
+		}
+    }
+}
+			`)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, `
+{
+    "router": {
+        "status": "ACTIVE",
+        "external_gateway_info": {
+            "network_id": "8ca37218-28ff-41cb-9b10-039601ea7e6b",
+            "external_fixed_ips": [
+                {"ip_address": "192.0.2.17", "subnet_id": "ab561bc4-1a8e-48f2-9fbd-376fcb1a1def"}
+            ]
+        },
+        "name": "new_name",
+        "admin_state_up": true,
+        "tenant_id": "6b96ff0cb17a4b859e1e575d221683d3",
+        "distributed": false,
+        "id": "8604a0de-7f6b-409a-a47c-a1cc7bc77b2e",
+        "routes": [
+            {
+                "nexthop": "10.1.0.10",
+                "destination": "40.0.1.0/24"
+            }
+        ]
+    }
+}
+		`)
+	})
+
+	gwi := routers.GatewayInfo{NetworkID: "8ca37218-28ff-41cb-9b10-039601ea7e6b"}
+	options := routers.UpdateOpts{Name: "new_name", GatewayInfo: &gwi}
 
 	n, err := routers.Update(fake.ServiceClient(), "4e8e5957-649f-477b-9e5b-f1f75b21c03c", options).Extract()
 	th.AssertNoErr(t, err)
@@ -371,7 +435,7 @@ func TestAllRoutesRemoved(t *testing.T) {
 	})
 
 	r := []routers.Route{}
-	options := routers.UpdateOpts{Routes: r}
+	options := routers.UpdateOpts{Routes: &r}
 
 	n, err := routers.Update(fake.ServiceClient(), "4e8e5957-649f-477b-9e5b-f1f75b21c03c", options).Extract()
 	th.AssertNoErr(t, err)


### PR DESCRIPTION
This is helpful when it is necessary to rename a router,
but it is not desired by the user to touch the static routes.

The OpenStack API just allows to omit the static routes (e.g.
verifyable with `openstack router set --name new_name --debug`).

This change makes sure that static routes parameter can be omitted with
gophercloud as well.

Also added a unit test.

For #2044

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

(I could not find a specific line of code, but provided the openstack CLI command for quick verification that this works above)