### PR TITLE
Fwaasv2 firewall groups acc tests (depends on #2049)

### DIFF
--- a/acceptance/openstack/networking/v2/extensions/fwaas/fwaas.go
+++ b/acceptance/openstack/networking/v2/extensions/fwaas/fwaas.go
@@ -14,7 +14,7 @@ import (
 	th "github.com/gophercloud/gophercloud/testhelper"
 )
 
-// CreateFirewall will create a Firewaill with a random name and a specified
+// CreateFirewall will create a Firewall with a random name and a specified
 // policy ID. An error will be returned if the firewall could not be created.
 func CreateFirewall(t *testing.T, client *gophercloud.ServiceClient, policyID string) (*firewalls.Firewall, error) {
 	firewallName := tools.RandomString("TESTACC-", 8)

--- a/acceptance/openstack/networking/v2/extensions/fwaas_v2/fwaas_v2.go
+++ b/acceptance/openstack/networking/v2/extensions/fwaas_v2/fwaas_v2.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/acceptance/tools"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas_v2/groups"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas_v2/rules"
 	th "github.com/gophercloud/gophercloud/testhelper"
 )
@@ -64,4 +65,48 @@ func DeleteRule(t *testing.T, client *gophercloud.ServiceClient, ruleID string) 
 	}
 
 	t.Logf("Deleted rule: %s", ruleID)
+}
+
+// CreateGroup will create a Firewall Group. An error will be returned if the
+// firewall group could not be created.
+func CreateGroup(t *testing.T, client *gophercloud.ServiceClient) (*groups.Group, error) {
+
+	groupName := tools.RandomString("TESTACC-", 8)
+	description := tools.RandomString("TESTACC-", 8)
+	adminStateUp := true
+	shared := false
+
+	createOpts := groups.CreateOpts{
+		Name:         groupName,
+		Description:  description,
+		AdminStateUp: &adminStateUp,
+		Shared:       &shared,
+	}
+
+	t.Logf("Attempting to create firewall group %s",
+		groupName)
+
+	group, err := groups.Create(client, createOpts).Extract()
+	if err != nil {
+		return group, err
+	}
+
+	t.Logf("firewall group %s successfully created", groupName)
+
+	th.AssertEquals(t, group.Name, groupName)
+	return group, nil
+}
+
+// DeleteGroup will delete a group with a specified ID. A fatal error will occur
+// if the delete was not successful. This works best when used as a deferred
+// function.
+func DeleteGroup(t *testing.T, client *gophercloud.ServiceClient, groupId string) {
+	t.Logf("Attempting to delete firewall group %s", groupId)
+
+	err := groups.Delete(client, groupId).ExtractErr()
+	if err != nil {
+		t.Fatalf("Unable to delete firewall group %s: %v", groupId, err)
+	}
+
+	t.Logf("Deleted firewall group %s", groupId)
 }

--- a/acceptance/openstack/networking/v2/extensions/fwaas_v2/groups_test.go
+++ b/acceptance/openstack/networking/v2/extensions/fwaas_v2/groups_test.go
@@ -1,0 +1,62 @@
+// +build acceptance networking fwaas_v2
+
+package fwaas_v2
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/acceptance/clients"
+	"github.com/gophercloud/gophercloud/acceptance/tools"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas_v2/groups"
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestGroupCRUD(t *testing.T) {
+
+	client, err := clients.NewNetworkV2Client()
+	th.AssertNoErr(t, err)
+
+	createdGroup, err := CreateGroup(t, client)
+	th.AssertNoErr(t, err)
+	defer DeleteGroup(t, client, createdGroup.ID)
+
+	tools.PrintResource(t, createdGroup)
+
+	groupName := tools.RandomString("TESTACC-", 8)
+	adminStateUp := false
+	description := ("Some firewall group description")
+	updateOpts := groups.UpdateOpts{
+		Name:         &groupName,
+		Description:  &description,
+		AdminStateUp: &adminStateUp,
+	}
+
+	groupUpdated, err := groups.Update(client, createdGroup.ID, updateOpts).Extract()
+	if err != nil {
+		t.Fatalf("Unable to update firewall group %s: %v", createdGroup.ID, err)
+	}
+
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, groupUpdated.Name, groupName)
+	th.AssertEquals(t, groupUpdated.Description, description)
+	th.AssertEquals(t, groupUpdated.AdminStateUp, adminStateUp)
+
+	t.Logf("Updated firewall group %s", groupUpdated.ID)
+
+	allPages, err := groups.List(client, nil).AllPages()
+	th.AssertNoErr(t, err)
+
+	allGroups, err := groups.ExtractGroups(allPages)
+	th.AssertNoErr(t, err)
+
+	t.Logf("Attempting to find firewall group %s\n", createdGroup.ID)
+	var found bool
+	for _, group := range allGroups {
+		if group.ID == createdGroup.ID {
+			found = true
+			t.Logf("Found firewall group %s\n", group.ID)
+		}
+	}
+
+	th.AssertEquals(t, found, true)
+}

--- a/openstack/networking/v2/extensions/fwaas_v2/groups/requests.go
+++ b/openstack/networking/v2/extensions/fwaas_v2/groups/requests.go
@@ -1,0 +1,153 @@
+package groups
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// ListOptsBuilder allows extensions to add additional parameters to the
+// List request.
+type ListOptsBuilder interface {
+	ToGroupListQuery() (string, error)
+}
+
+// ListOpts allows the filtering and sorting of paginated collections through
+// the API. Filtering is achieved by passing in struct field values that map to
+// the firewall group attributes you want to see returned. SortKey allows you
+// to sort by a particular firewall group attribute. SortDir sets the direction,
+// and is either `asc' or `desc'. Marker and Limit are used for pagination.
+type ListOpts struct {
+	TenantID                string    `q:"tenant_id"`
+	Name                    string    `q:"name"`
+	Description             string    `q:"description"`
+	IngressFirewallPolicyID string    `q:"ingress_firewall_policy_id"`
+	EgressFirewallPolicyID  string    `q:"egress_firewall_policy_id"`
+	AdminStateUp            *bool     `q:"admin_state_up"`
+	Ports                   *[]string `q:"ports"`
+	Status                  string    `q:"status"`
+	ID                      string    `q:"id"`
+	Shared                  *bool     `q:"shared"`
+	ProjectID               string    `q:"project_id"`
+	Limit                   int       `q:"limit"`
+	Marker                  string    `q:"marker"`
+	SortKey                 string    `q:"sort_key"`
+	SortDir                 string    `q:"sort_dir"`
+}
+
+// ToGroupListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToGroupListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	if err != nil {
+		return "", err
+	}
+	return q.String(), err
+}
+
+// List returns a Pager which allows you to iterate over a collection of
+// firewall groups. It accepts a ListOpts struct, which allows you to filter
+// and sort the returned collection for greater efficiency.
+//
+// Default group settings return only those firewall groups that are owned by the
+// tenant who submits the request, unless an admin user submits the request.
+func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := rootURL(c)
+
+	if opts != nil {
+		query, err := opts.ToGroupListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+
+	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		return GroupPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// Get retrieves a particular firewall group based on its unique ID.
+func Get(c *gophercloud.ServiceClient, id string) (r GetResult) {
+	_, r.Err = c.Get(resourceURL(c, id), &r.Body, nil)
+	return
+}
+
+// CreateOptsBuilder is the interface options structs have to satisfy in order
+// to be used in the main Create operation in this package. Since many
+// extensions decorate or modify the common logic, it is useful for them to
+// satisfy a basic interface in order for them to be used.
+type CreateOptsBuilder interface {
+	ToFirewallGroupCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts contains all the values needed to create a new firewall group.
+type CreateOpts struct {
+	ID                      string   `json:"id,omitempty"`
+	TenantID                string   `json:"tenant_id,omitempty"`
+	Name                    string   `json:"name,omitempty"`
+	Description             string   `json:"description,omitempty"`
+	IngressFirewallPolicyID string   `json:"ingress_firewall_policy_id,omitempty"`
+	EgressFirewallPolicyID  string   `json:"egress_firewall_policy_id,omitempty"`
+	AdminStateUp            *bool    `json:"admin_state_up,omitempty"`
+	Ports                   []string `json:"ports,omitempty"`
+	Shared                  *bool    `json:"shared,omitempty"`
+	ProjectID               string   `json:"project_id,omitempty"`
+}
+
+// ToFirewallGroupCreateMap casts a CreateOpts struct to a map.
+func (opts CreateOpts) ToFirewallGroupCreateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "firewall_group")
+}
+
+// Create accepts a CreateOpts struct and uses the values to create a new firewall group
+func Create(c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToFirewallGroupCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Post(rootURL(c), b, &r.Body, nil)
+	return
+}
+
+// UpdateOptsBuilder is the interface options structs have to satisfy in order
+// to be used in the main Update operation in this package. Since many
+// extensions decorate or modify the common logic, it is useful for them to
+// satisfy a basic interface in order for them to be used.
+type UpdateOptsBuilder interface {
+	ToFirewallGroupUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts contains the values used when updating a firewall group.
+type UpdateOpts struct {
+	Name                    *string  `json:"name,omitempty"`
+	Description             *string  `json:"description,omitempty"`
+	IngressFirewallPolicyID *string  `json:"ingress_firewall_policy_id,omitempty"`
+	EgressFirewallPolicyID  *string  `json:"egress_firewall_policy_id,omitempty"`
+	AdminStateUp            *bool    `json:"admin_state_up,omitempty"`
+	Ports                   []string `json:"ports,omitempty"`
+	Shared                  *bool    `json:"shared,omitempty"`
+}
+
+// ToFirewallGroupUpdateMap casts a CreateOpts struct to a map.
+func (opts UpdateOpts) ToFirewallGroupUpdateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "firewall_group")
+}
+
+// Update allows firewall groups to be updated.
+func Update(c *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToFirewallGroupUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Put(resourceURL(c, id), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// Delete will permanently delete a particular firewall group based on its unique ID.
+func Delete(c *gophercloud.ServiceClient, id string) (r DeleteResult) {
+	_, r.Err = c.Delete(resourceURL(c, id), nil)
+	return
+}

--- a/openstack/networking/v2/extensions/fwaas_v2/groups/results.go
+++ b/openstack/networking/v2/extensions/fwaas_v2/groups/results.go
@@ -1,0 +1,91 @@
+package groups
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// Group is a firewall group.
+type Group struct {
+	ID                      string   `json:"id"`
+	TenantID                string   `json:"tenant_id"`
+	Name                    string   `json:"name"`
+	Description             string   `json:"description"`
+	IngressFirewallPolicyID string   `json:"ingress_firewall_policy_id"`
+	EgressFirewallPolicyID  string   `json:"egress_firewall_policy_id"`
+	AdminStateUp            bool     `json:"admin_state_up"`
+	Ports                   []string `json:"ports"`
+	Status                  string   `json:"status"`
+	Shared                  bool     `json:"shared"`
+	ProjectID               string   `json:"project_id"`
+}
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// Extract is a function that accepts a result and extracts a firewall group.
+func (r commonResult) Extract() (*Group, error) {
+	var s struct {
+		Group *Group `json:"firewall_group"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Group, err
+}
+
+// GroupPage is the page returned by a pager when traversing over a
+// collection of firewall groups.
+type GroupPage struct {
+	pagination.LinkedPageBase
+}
+
+// NextPageURL is invoked when a paginated collection of firewall groups has
+// reached the end of a page and the pager seeks to traverse over a new one.
+// In order to do this, it needs to construct the next page's URL.
+func (r GroupPage) NextPageURL() (string, error) {
+	var s struct {
+		Links []gophercloud.Link `json:"firewall_groups_links"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return gophercloud.ExtractNextURL(s.Links)
+}
+
+// IsEmpty checks whether a GroupPage struct is empty.
+func (r GroupPage) IsEmpty() (bool, error) {
+	is, err := ExtractGroups(r)
+	return len(is) == 0, err
+}
+
+// ExtractGroups accepts a Page struct, specifically a GroupPage struct,
+// and extracts the elements into a slice of Group structs. In other words,
+// a generic collection is mapped into a relevant slice.
+func ExtractGroups(r pagination.Page) ([]Group, error) {
+	var s struct {
+		Groups []Group `json:"firewall_groups"`
+	}
+	err := (r.(GroupPage)).ExtractInto(&s)
+	return s.Groups, err
+}
+
+// GetResult represents the result of a get operation.
+type GetResult struct {
+	commonResult
+}
+
+// CreateResult represents the result of a create operation.
+type CreateResult struct {
+	commonResult
+}
+
+// UpdateResult represents the result of an update operation.
+type UpdateResult struct {
+	commonResult
+}
+
+// DeleteResult represents the result of a delete operation.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}

--- a/openstack/networking/v2/extensions/fwaas_v2/groups/testing/doc.go
+++ b/openstack/networking/v2/extensions/fwaas_v2/groups/testing/doc.go
@@ -1,0 +1,2 @@
+// networking_extensions_fwaas_groups_v2
+package testing

--- a/openstack/networking/v2/extensions/fwaas_v2/groups/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/fwaas_v2/groups/testing/requests_test.go
@@ -1,0 +1,310 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	fake "github.com/gophercloud/gophercloud/openstack/networking/v2/common"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas_v2/groups"
+	"github.com/gophercloud/gophercloud/pagination"
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestList(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/fwaas/firewall_groups", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, `
+{
+  "firewall_groups": [
+    {
+      "id": "3af94f0e-b52d-491a-87d2-704497305948",
+      "tenant_id": "9f98fc0e5f944cd1b51798b668dc8778",
+      "name": "test",
+      "description": "fancy group",
+      "ingress_firewall_policy_id": "e3f11142-3792-454b-8d3e-91ac1bf127b4",
+      "egress_firewall_policy_id": null,
+      "admin_state_up": true,
+      "ports": [
+        "a6af1e56-b12b-4733-8f77-49166afd5719"
+      ],
+      "status": "ACTIVE",
+      "shared": false,
+      "project_id": "9f98fc0e5f944cd1b51798b668dc8778"
+    },
+    {
+      "id": "f9fbb80c-eeb4-4f3f-aa50-1032960c08ea",
+      "tenant_id": "9f98fc0e5f944cd1b51798b668dc8778",
+      "name": "default",
+      "description": "Default firewall group",
+      "ingress_firewall_policy_id": "90e3fcac-3bfb-48f9-8e91-2a78fb352b92",
+      "egress_firewall_policy_id": "122fb344-3c28-49f0-af00-f7fcbc88330b",
+      "admin_state_up": true,
+      "ports": [
+        "20da216c-bab3-4cf6-bd6b-8904b133a816",
+        "4f4c714c-185f-487e-998c-c1a35da3c4f4",
+        "681b1db4-40ca-4314-b098-d2f43225e7f7",
+        "82f9d868-6f56-44fb-9684-654dc473bed0",
+        "a5858b5d-20dc-4bb1-9f95-1d322c8bb81b",
+        "d25a04a2-447b-4ee1-80d7-b32967dbb643"
+      ],
+      "status": "ACTIVE",
+      "shared": false,
+      "project_id": "9f98fc0e5f944cd1b51798b668dc8778"
+    }
+  ]
+}
+        `)
+	})
+
+	count := 0
+
+	groups.List(fake.ServiceClient(), groups.ListOpts{}).EachPage(func(page pagination.Page) (bool, error) {
+		count++
+		actual, err := groups.ExtractGroups(page)
+		if err != nil {
+			t.Errorf("Failed to extract members: %v", err)
+			return false, err
+		}
+
+		expected := []groups.Group{
+			{
+				ID:                      "3af94f0e-b52d-491a-87d2-704497305948",
+				TenantID:                "9f98fc0e5f944cd1b51798b668dc8778",
+				Name:                    "test",
+				Description:             "fancy group",
+				IngressFirewallPolicyID: "e3f11142-3792-454b-8d3e-91ac1bf127b4",
+				EgressFirewallPolicyID:  "",
+				AdminStateUp:            true,
+				Ports: []string{
+					"a6af1e56-b12b-4733-8f77-49166afd5719",
+				},
+				Status:    "ACTIVE",
+				Shared:    false,
+				ProjectID: "9f98fc0e5f944cd1b51798b668dc8778",
+			},
+			{
+				ID:                      "f9fbb80c-eeb4-4f3f-aa50-1032960c08ea",
+				TenantID:                "9f98fc0e5f944cd1b51798b668dc8778",
+				Name:                    "default",
+				Description:             "Default firewall group",
+				IngressFirewallPolicyID: "90e3fcac-3bfb-48f9-8e91-2a78fb352b92",
+				EgressFirewallPolicyID:  "122fb344-3c28-49f0-af00-f7fcbc88330b",
+				AdminStateUp:            true,
+				Ports: []string{
+					"20da216c-bab3-4cf6-bd6b-8904b133a816",
+					"4f4c714c-185f-487e-998c-c1a35da3c4f4",
+					"681b1db4-40ca-4314-b098-d2f43225e7f7",
+					"82f9d868-6f56-44fb-9684-654dc473bed0",
+					"a5858b5d-20dc-4bb1-9f95-1d322c8bb81b",
+					"d25a04a2-447b-4ee1-80d7-b32967dbb643",
+				},
+				Status:    "ACTIVE",
+				Shared:    false,
+				ProjectID: "9f98fc0e5f944cd1b51798b668dc8778",
+			},
+		}
+
+		th.CheckDeepEquals(t, expected, actual)
+
+		return true, nil
+	})
+
+	if count != 1 {
+		t.Errorf("Expected 1 page, got %d", count)
+	}
+}
+
+func TestGet(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/fwaas/firewall_groups/6bfb0f10-07f7-4a40-b534-bad4b4ca3428", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, `
+{
+  "firewall_group": {
+    "id": "6bfb0f10-07f7-4a40-b534-bad4b4ca3428",
+    "tenant_id": "9f98fc0e5f944cd1b51798b668dc8778",
+    "name": "test",
+    "description": "some information",
+    "ingress_firewall_policy_id": "e3f11142-3792-454b-8d3e-91ac1bf127b4",
+    "egress_firewall_policy_id": null,
+    "admin_state_up": true,
+    "ports": [
+      "a6af1e56-b12b-4733-8f77-49166afd5719"
+    ],
+    "status": "ACTIVE",
+    "shared": false,
+    "project_id": "9f98fc0e5f944cd1b51798b668dc8778"
+  }
+}
+        `)
+	})
+
+	group, err := groups.Get(fake.ServiceClient(), "6bfb0f10-07f7-4a40-b534-bad4b4ca3428").Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, "6bfb0f10-07f7-4a40-b534-bad4b4ca3428", group.ID)
+	th.AssertEquals(t, "9f98fc0e5f944cd1b51798b668dc8778", group.TenantID)
+	th.AssertEquals(t, "test", group.Name)
+	th.AssertEquals(t, "some information", group.Description)
+	th.AssertEquals(t, "e3f11142-3792-454b-8d3e-91ac1bf127b4", group.IngressFirewallPolicyID)
+	th.AssertEquals(t, "", group.EgressFirewallPolicyID)
+	th.AssertEquals(t, true, group.AdminStateUp)
+	th.AssertEquals(t, 1, len(group.Ports))
+	th.AssertEquals(t, "a6af1e56-b12b-4733-8f77-49166afd5719", group.Ports[0])
+	th.AssertEquals(t, "ACTIVE", group.Status)
+	th.AssertEquals(t, false, group.Shared)
+	th.AssertEquals(t, "9f98fc0e5f944cd1b51798b668dc8778", group.TenantID)
+}
+
+func TestCreate(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/fwaas/firewall_groups", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, `
+{
+  "firewall_group": {
+    "ports": [
+      "a6af1e56-b12b-4733-8f77-49166afd5719"
+    ],
+    "ingress_firewall_policy_id": "e3f11142-3792-454b-8d3e-91ac1bf127b4",
+    "name": "test"
+  }
+}
+      `)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+
+		fmt.Fprintf(w, `
+{
+  "firewall_group": {
+    "id": "6bfb0f10-07f7-4a40-b534-bad4b4ca3428",
+    "tenant_id": "9f98fc0e5f944cd1b51798b668dc8778",
+    "name": "test",
+    "description": "",
+    "ingress_firewall_policy_id": "e3f11142-3792-454b-8d3e-91ac1bf127b4",
+    "egress_firewall_policy_id": null,
+    "admin_state_up": true,
+    "ports": [
+      "a6af1e56-b12b-4733-8f77-49166afd5719"
+    ],
+    "status": "CREATED",
+    "shared": false,
+    "project_id": "9f98fc0e5f944cd1b51798b668dc8778"
+  }
+}
+        `)
+	})
+
+	options := groups.CreateOpts{
+		Name:                    "test",
+		Description:             "",
+		IngressFirewallPolicyID: "e3f11142-3792-454b-8d3e-91ac1bf127b4",
+		Ports: []string{
+			"a6af1e56-b12b-4733-8f77-49166afd5719",
+		},
+	}
+
+	_, err := groups.Create(fake.ServiceClient(), options).Extract()
+	th.AssertNoErr(t, err)
+}
+
+func TestUpdate(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/fwaas/firewall_groups/6bfb0f10-07f7-4a40-b534-bad4b4ca3428", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, `
+{
+    "firewall_group":{
+        "name": "the group",
+        "ports": [
+					"a6af1e56-b12b-4733-8f77-49166afd5719",
+					"11a58c87-76be-ae7c-a74e-b77fffb88a32"
+        ],
+				"description": "Firewall group",
+				"admin_state_up": false
+    }
+}
+      `)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, `
+{
+  "firewall_group": {
+    "id": "6bfb0f10-07f7-4a40-b534-bad4b4ca3428",
+    "tenant_id": "9f98fc0e5f944cd1b51798b668dc8778",
+    "name": "test",
+    "description": "some information",
+    "ingress_firewall_policy_id": "e3f11142-3792-454b-8d3e-91ac1bf127b4",
+    "egress_firewall_policy_id": null,
+    "admin_state_up": true,
+    "ports": [
+      "a6af1e56-b12b-4733-8f77-49166afd5719",
+			"11a58c87-76be-ae7c-a74e-b77fffb88a32"
+    ],
+    "status": "ACTIVE",
+    "shared": false,
+    "project_id": "9f98fc0e5f944cd1b51798b668dc8778"
+  }
+}
+    `)
+	})
+
+	name := "the group"
+	description := "Firewall group"
+	adminStateUp := false
+	options := groups.UpdateOpts{
+		Name:        &name,
+		Description: &description,
+		Ports: []string{
+			"a6af1e56-b12b-4733-8f77-49166afd5719",
+			"11a58c87-76be-ae7c-a74e-b77fffb88a32",
+		},
+		AdminStateUp: &adminStateUp,
+	}
+
+	_, err := groups.Update(fake.ServiceClient(), "6bfb0f10-07f7-4a40-b534-bad4b4ca3428", options).Extract()
+	th.AssertNoErr(t, err)
+}
+
+func TestDelete(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/fwaas/firewall_groups/4ec89077-d057-4a2b-911f-60a3b47ee304", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	res := groups.Delete(fake.ServiceClient(), "4ec89077-d057-4a2b-911f-60a3b47ee304")
+	th.AssertNoErr(t, res.Err)
+}

--- a/openstack/networking/v2/extensions/fwaas_v2/groups/urls.go
+++ b/openstack/networking/v2/extensions/fwaas_v2/groups/urls.go
@@ -1,0 +1,16 @@
+package groups
+
+import "github.com/gophercloud/gophercloud"
+
+const (
+	rootPath     = "fwaas"
+	resourcePath = "firewall_groups"
+)
+
+func rootURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL(rootPath, resourcePath)
+}
+
+func resourceURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL(rootPath, resourcePath, id)
+}


### PR DESCRIPTION
For #514

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/neutron-fwaas/blob/stable/ussuri/neutron_fwaas/db/firewall/v2/firewall_db_v2.py#L85-L103
https://github.com/openstack/neutron-fwaas/blob/stable/ussuri/neutron_fwaas/db/firewall/v2/firewall_db_v2.py#L307:L322
https://github.com/openstack/neutron-fwaas/blob/stable/ussuri/neutron_fwaas/services/firewall/fwaas_plugin_v2.py#L313-L369

**this PR:
Acceptance test for fwaasv2 firewall groups**


kind regards, 
Georg


<sub>Georg Schreiber georg.g.schreiber@daimler.com, Daimler TSS GmbH, [legal info/Impressum](https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md)</sub>