### PR TITLE
Add missing options to member types

### DIFF
--- a/openstack/loadbalancer/v2/pools/requests.go
+++ b/openstack/loadbalancer/v2/pools/requests.go
@@ -280,14 +280,20 @@ type CreateMemberOpts struct {
 	// or false (DOWN).
 	AdminStateUp *bool `json:"admin_state_up,omitempty"`
 
-	// Is the member a backup? Backup members only receive traffic when all non-backup members are down.
+	// Is the member a backup? Backup members only receive traffic when all
+	// non-backup members are down.
+	// Requires microversion 2.1 or later.
 	Backup *bool `json:"backup,omitempty"`
 
 	// An alternate IP address used for health monitoring a backend member.
-	MonitorAddress string `json:"monitor_address,omitempty"`
+	MonitorAddress *string `json:"monitor_address,omitempty"`
 
 	// An alternate protocol port used for health monitoring a backend member.
 	MonitorPort *int `json:"monitor_port,omitempty"`
+
+	// A list of simple strings assigned to the resource.
+	// Requires microversion 2.5 or later.
+	Tags []string `json:"tags,omitempty"`
 }
 
 // ToMemberCreateMap builds a request body from CreateMemberOpts.
@@ -335,6 +341,21 @@ type UpdateMemberOpts struct {
 	// The administrative state of the Pool. A valid value is true (UP)
 	// or false (DOWN).
 	AdminStateUp *bool `json:"admin_state_up,omitempty"`
+
+	// Is the member a backup? Backup members only receive traffic when all
+	// non-backup members are down.
+	// Requires microversion 2.1 or later.
+	Backup *bool `json:"backup,omitempty"`
+
+	// An alternate IP address used for health monitoring a backend member.
+	MonitorAddress *string `json:"monitor_address,omitempty"`
+
+	// An alternate protocol port used for health monitoring a backend member.
+	MonitorPort *int `json:"monitor_port,omitempty"`
+
+	// A list of simple strings assigned to the resource.
+	// Requires microversion 2.5 or later.
+	Tags []string `json:"tags,omitempty"`
 }
 
 // ToMemberUpdateMap builds a request body from UpdateMemberOpts.
@@ -390,6 +411,21 @@ type BatchUpdateMemberOpts struct {
 	// The administrative state of the Pool. A valid value is true (UP)
 	// or false (DOWN).
 	AdminStateUp *bool `json:"admin_state_up,omitempty"`
+
+	// Is the member a backup? Backup members only receive traffic when all
+	// non-backup members are down.
+	// Requires microversion 2.1 or later.
+	Backup *bool `json:"backup,omitempty"`
+
+	// An alternate IP address used for health monitoring a backend member.
+	MonitorAddress *string `json:"monitor_address,omitempty"`
+
+	// An alternate protocol port used for health monitoring a backend member.
+	MonitorPort *int `json:"monitor_port,omitempty"`
+
+	// A list of simple strings assigned to the resource.
+	// Requires microversion 2.5 or later.
+	Tags []string `json:"tags,omitempty"`
 }
 
 // ToBatchMemberUpdateMap builds a request body from BatchUpdateMemberOpts.

--- a/openstack/loadbalancer/v2/pools/results.go
+++ b/openstack/loadbalancer/v2/pools/results.go
@@ -228,6 +228,10 @@ type Member struct {
 
 	// An alternate protocol port used for health monitoring a backend member.
 	MonitorPort int `json:"monitor_port"`
+
+	// A list of simple strings assigned to the resource.
+	// Requires microversion 2.5 or later.
+	Tags []string `json:"tags"`
 }
 
 // MemberPage is the page returned by a pager when traversing over a


### PR DESCRIPTION
For #2055

This adds Backup, MonitorAddress, MonitorPort and Tags to member types.

Links to the line numbers/files in the OpenStack source code that support the code in this PR:

**`CreateMemberOpts`**

[Documentation](https://docs.openstack.org/api-ref/load-balancer/v2/?expanded=create-member-detail#create-member)
[Code](https://github.com/openstack/octavia/blob/198980639cbe02820f90783fa04d5239717ed80d/octavia/api/v2/types/member.py#L87)

**`UpdateMemberOpts`**

[Documentation](https://docs.openstack.org/api-ref/load-balancer/v2/?expanded=update-a-member-detail#update-a-member)
[Code](https://github.com/openstack/octavia/blob/198980639cbe02820f90783fa04d5239717ed80d/octavia/api/v2/types/member.py#L100-L104)

**`BatchUpdateMemberOpts`**

[Documentation](https://docs.openstack.org/api-ref/load-balancer/v2/?expanded=batch-update-members-detail#batch-update-members)
[Code](https://github.com/openstack/octavia/blob/198980639cbe02820f90783fa04d5239717ed80d/octavia/api/v2/types/member.py#L79-L87)