### PR TITLE
FWaaSv2.0 Policy CRUD

### DIFF
--- a/acceptance/openstack/networking/v2/extensions/fwaas_v2/fwaas_v2.go
+++ b/acceptance/openstack/networking/v2/extensions/fwaas_v2/fwaas_v2.go
@@ -13,6 +13,21 @@ import (
 	th "github.com/gophercloud/gophercloud/testhelper"
 )
 
+// AddRule will add a rule to to a policy.
+func AddRule(t *testing.T, client *gophercloud.ServiceClient, policyID string, ruleID string, beforeRuleID string) {
+	t.Logf("Attempting to insert rule %s in to policy %s", ruleID, policyID)
+
+	addOpts := policies.InsertRuleOpts{
+		ID:           ruleID,
+		BeforeRuleID: beforeRuleID,
+	}
+
+	_, err := policies.AddRule(client, policyID, addOpts).Extract()
+	if err != nil {
+		t.Fatalf("Unable to insert rule %s before rule %s in policy %s: %v", ruleID, beforeRuleID, policyID, err)
+	}
+}
+
 // CreatePolicy will create a Firewall Policy with a random name and given
 // rule. An error will be returned if the rule could not be created.
 func CreatePolicy(t *testing.T, client *gophercloud.ServiceClient, ruleID string) (*policies.Policy, error) {

--- a/acceptance/openstack/networking/v2/extensions/fwaas_v2/fwaas_v2.go
+++ b/acceptance/openstack/networking/v2/extensions/fwaas_v2/fwaas_v2.go
@@ -29,10 +29,10 @@ func AddRule(t *testing.T, client *gophercloud.ServiceClient, policyID string, r
 
 	addOpts := policies.InsertRuleOpts{
 		ID:           ruleID,
-		BeforeRuleID: beforeRuleID,
+		InsertBefore: beforeRuleID,
 	}
 
-	_, err := policies.AddRule(client, policyID, addOpts).Extract()
+	_, err := policies.InsertRule(client, policyID, addOpts).Extract()
 	if err != nil {
 		t.Fatalf("Unable to insert rule %s before rule %s in policy %s: %v", ruleID, beforeRuleID, policyID, err)
 	}
@@ -49,7 +49,7 @@ func CreatePolicy(t *testing.T, client *gophercloud.ServiceClient, ruleID string
 	createOpts := policies.CreateOpts{
 		Name:        policyName,
 		Description: policyDescription,
-		Rules: []string{
+		FirewallRules: []string{
 			ruleID,
 		},
 	}

--- a/acceptance/openstack/networking/v2/extensions/fwaas_v2/fwaas_v2.go
+++ b/acceptance/openstack/networking/v2/extensions/fwaas_v2/fwaas_v2.go
@@ -7,10 +7,41 @@ import (
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/acceptance/tools"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas_v2/policies"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas_v2/groups"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas_v2/rules"
 	th "github.com/gophercloud/gophercloud/testhelper"
 )
+
+// CreatePolicy will create a Firewall Policy with a random name and given
+// rule. An error will be returned if the rule could not be created.
+func CreatePolicy(t *testing.T, client *gophercloud.ServiceClient, ruleID string) (*policies.Policy, error) {
+	policyName := tools.RandomString("TESTACC-", 8)
+	policyDescription := tools.RandomString("TESTACC-DESC-", 8)
+
+	t.Logf("Attempting to create policy %s", policyName)
+
+	createOpts := policies.CreateOpts{
+		Name:        policyName,
+		Description: policyDescription,
+		Rules: []string{
+			ruleID,
+		},
+	}
+
+	policy, err := policies.Create(client, createOpts).Extract()
+	if err != nil {
+		return policy, err
+	}
+
+	t.Logf("Successfully created policy %s", policyName)
+
+	th.AssertEquals(t, policy.Name, policyName)
+	th.AssertEquals(t, policy.Description, policyDescription)
+	th.AssertEquals(t, len(policy.Rules), 1)
+
+	return policy, nil
+}
 
 // CreateRule will create a Firewall Rule with a random source address and
 //source port, destination address and port. An error will be returned if
@@ -51,6 +82,20 @@ func CreateRule(t *testing.T, client *gophercloud.ServiceClient) (*rules.Rule, e
 	th.AssertEquals(t, rule.DestinationPort, destinationPort)
 
 	return rule, nil
+}
+
+// DeletePolicy will delete a policy with a specified ID. A fatal error will
+// occur if the delete was not successful. This works best when used as a
+// deferred function.
+func DeletePolicy(t *testing.T, client *gophercloud.ServiceClient, policyID string) {
+	t.Logf("Attempting to delete policy: %s", policyID)
+
+	err := policies.Delete(client, policyID).ExtractErr()
+	if err != nil {
+		t.Fatalf("Unable to delete policy %s: %v", policyID, err)
+	}
+
+	t.Logf("Deleted policy: %s", policyID)
 }
 
 // DeleteRule will delete a rule with a specified ID. A fatal error will occur

--- a/acceptance/openstack/networking/v2/extensions/fwaas_v2/fwaas_v2.go
+++ b/acceptance/openstack/networking/v2/extensions/fwaas_v2/fwaas_v2.go
@@ -13,6 +13,16 @@ import (
 	th "github.com/gophercloud/gophercloud/testhelper"
 )
 
+// RemoveRule will remove a rule from the  policy.
+func RemoveRule(t *testing.T, client *gophercloud.ServiceClient, policyID string, ruleID string) {
+	t.Logf("Attempting to remove rule %s from policy %s", ruleID, policyID)
+
+	_, err := policies.RemoveRule(client, policyID, ruleID).Extract()
+	if err != nil {
+		t.Fatalf("Unable to remove rule %s from policy %s: %v", ruleID, policyID, err)
+	}
+}
+
 // AddRule will add a rule to to a policy.
 func AddRule(t *testing.T, client *gophercloud.ServiceClient, policyID string, ruleID string, beforeRuleID string) {
 	t.Logf("Attempting to insert rule %s in to policy %s", ruleID, policyID)

--- a/acceptance/openstack/networking/v2/extensions/fwaas_v2/fwaas_v2.go
+++ b/acceptance/openstack/networking/v2/extensions/fwaas_v2/fwaas_v2.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/acceptance/tools"
-	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas_v2/policies"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas_v2/groups"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas_v2/policies"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas_v2/rules"
 	th "github.com/gophercloud/gophercloud/testhelper"
 )

--- a/acceptance/openstack/networking/v2/extensions/fwaas_v2/policy_test.go
+++ b/acceptance/openstack/networking/v2/extensions/fwaas_v2/policy_test.go
@@ -39,6 +39,9 @@ func TestPolicyCRUD(t *testing.T) {
 	// Inject the second rule
 	AddRule(t, client, policy.ID, ruleToInsert.ID, rule.ID)
 
+	// Remove the first rule
+	RemoveRule(t, client, policy.ID, rule.ID)
+
 	name := ""
 	description := ""
 	updateOpts := policies.UpdateOpts{

--- a/acceptance/openstack/networking/v2/extensions/fwaas_v2/policy_test.go
+++ b/acceptance/openstack/networking/v2/extensions/fwaas_v2/policy_test.go
@@ -1,0 +1,61 @@
+// +build acceptance networking fwaas_v2
+
+package fwaas_v2
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/acceptance/clients"
+	"github.com/gophercloud/gophercloud/acceptance/tools"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas_v2/policies"
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestPolicyCRUD(t *testing.T) {
+	client, err := clients.NewNetworkV2Client()
+	th.AssertNoErr(t, err)
+
+	rule, err := CreateRule(t, client)
+	th.AssertNoErr(t, err)
+	defer DeleteRule(t, client, rule.ID)
+
+	tools.PrintResource(t, rule)
+
+	policy, err := CreatePolicy(t, client, rule.ID)
+	th.AssertNoErr(t, err)
+	defer DeletePolicy(t, client, policy.ID)
+
+	tools.PrintResource(t, policy)
+
+	name := ""
+	description := ""
+	updateOpts := policies.UpdateOpts{
+		Name:        &name,
+		Description: &description,
+	}
+
+	_, err = policies.Update(client, policy.ID, updateOpts).Extract()
+	th.AssertNoErr(t, err)
+
+	newPolicy, err := policies.Get(client, policy.ID).Extract()
+	th.AssertNoErr(t, err)
+
+	tools.PrintResource(t, newPolicy)
+	th.AssertEquals(t, newPolicy.Name, name)
+	th.AssertEquals(t, newPolicy.Description, description)
+
+	allPages, err := policies.List(client, nil).AllPages()
+	th.AssertNoErr(t, err)
+
+	allPolicies, err := policies.ExtractPolicies(allPages)
+	th.AssertNoErr(t, err)
+
+	var found bool
+	for _, policy := range allPolicies {
+		if policy.ID == newPolicy.ID {
+			found = true
+		}
+	}
+
+	th.AssertEquals(t, found, true)
+}

--- a/acceptance/openstack/networking/v2/extensions/fwaas_v2/policy_test.go
+++ b/acceptance/openstack/networking/v2/extensions/fwaas_v2/policy_test.go
@@ -15,17 +15,29 @@ func TestPolicyCRUD(t *testing.T) {
 	client, err := clients.NewNetworkV2Client()
 	th.AssertNoErr(t, err)
 
+	// Create First Rule. This will be used as part of the Policy creation
 	rule, err := CreateRule(t, client)
 	th.AssertNoErr(t, err)
 	defer DeleteRule(t, client, rule.ID)
 
 	tools.PrintResource(t, rule)
 
+	// Create Second rule. This will be injected in to the policy after its creation
+	ruleToInsert, err := CreateRule(t, client)
+	th.AssertNoErr(t, err)
+	defer DeleteRule(t, client, ruleToInsert.ID)
+
+	tools.PrintResource(t, ruleToInsert)
+
+	// Create the Policy using the first rule
 	policy, err := CreatePolicy(t, client, rule.ID)
 	th.AssertNoErr(t, err)
 	defer DeletePolicy(t, client, policy.ID)
 
 	tools.PrintResource(t, policy)
+
+	// Inject the second rule
+	AddRule(t, client, policy.ID, ruleToInsert.ID, rule.ID)
 
 	name := ""
 	description := ""

--- a/acceptance/openstack/networking/v2/extensions/fwaas_v2/policy_test.go
+++ b/acceptance/openstack/networking/v2/extensions/fwaas_v2/policy_test.go
@@ -47,6 +47,7 @@ func TestPolicyCRUD(t *testing.T) {
 	updateOpts := policies.UpdateOpts{
 		Name:        &name,
 		Description: &description,
+		Rules:       &[]string{},
 	}
 
 	_, err = policies.Update(client, policy.ID, updateOpts).Extract()
@@ -58,6 +59,7 @@ func TestPolicyCRUD(t *testing.T) {
 	tools.PrintResource(t, newPolicy)
 	th.AssertEquals(t, newPolicy.Name, name)
 	th.AssertEquals(t, newPolicy.Description, description)
+	th.AssertEquals(t, len(newPolicy.Rules), 0)
 
 	allPages, err := policies.List(client, nil).AllPages()
 	th.AssertNoErr(t, err)

--- a/acceptance/openstack/networking/v2/extensions/fwaas_v2/policy_test.go
+++ b/acceptance/openstack/networking/v2/extensions/fwaas_v2/policy_test.go
@@ -45,9 +45,9 @@ func TestPolicyCRUD(t *testing.T) {
 	name := ""
 	description := ""
 	updateOpts := policies.UpdateOpts{
-		Name:        &name,
-		Description: &description,
-		Rules:       &[]string{},
+		Name:          &name,
+		Description:   &description,
+		FirewallRules: &[]string{},
 	}
 
 	_, err = policies.Update(client, policy.ID, updateOpts).Extract()

--- a/openstack/networking/v2/extensions/fwaas_v2/policies/requests.go
+++ b/openstack/networking/v2/extensions/fwaas_v2/policies/requests.go
@@ -107,11 +107,11 @@ type UpdateOptsBuilder interface {
 
 // UpdateOpts contains the values used when updating a firewall policy.
 type UpdateOpts struct {
-	Name        *string  `json:"name,omitempty"`
-	Description *string  `json:"description,omitempty"`
-	Shared      *bool    `json:"shared,omitempty"`
-	Audited     *bool    `json:"audited,omitempty"`
-	Rules       []string `json:"firewall_rules,omitempty"`
+	Name        *string   `json:"name,omitempty"`
+	Description *string   `json:"description,omitempty"`
+	Shared      *bool     `json:"shared,omitempty"`
+	Audited     *bool     `json:"audited,omitempty"`
+	Rules       *[]string `json:"firewall_rules,omitempty"`
 }
 
 // ToFirewallPolicyUpdateMap casts a CreateOpts struct to a map.

--- a/openstack/networking/v2/extensions/fwaas_v2/policies/requests.go
+++ b/openstack/networking/v2/extensions/fwaas_v2/policies/requests.go
@@ -1,0 +1,173 @@
+package policies
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// ListOptsBuilder allows extensions to add additional parameters to the
+// List request.
+type ListOptsBuilder interface {
+	ToPolicyListQuery() (string, error)
+}
+
+// ListOpts allows the filtering and sorting of paginated collections through
+// the API. Filtering is achieved by passing in struct field values that map to
+// the firewall policy attributes you want to see returned. SortKey allows you
+// to sort by a particular firewall policy attribute. SortDir sets the direction,
+// and is either `asc' or `desc'. Marker and Limit are used for pagination.
+type ListOpts struct {
+	TenantID    string `q:"tenant_id"`
+	Name        string `q:"name"`
+	Description string `q:"description"`
+	Shared      *bool  `q:"shared"`
+	Audited     *bool  `q:"audited"`
+	ID          string `q:"id"`
+	Limit       int    `q:"limit"`
+	Marker      string `q:"marker"`
+	SortKey     string `q:"sort_key"`
+	SortDir     string `q:"sort_dir"`
+}
+
+// ToPolicyListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToPolicyListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List returns a Pager which allows you to iterate over a collection of
+// firewall policies. It accepts a ListOpts struct, which allows you to filter
+// and sort the returned collection for greater efficiency.
+//
+// Default policy settings return only those firewall policies that are owned by the
+// tenant who submits the request, unless an admin user submits the request.
+func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := rootURL(c)
+	if opts != nil {
+		query, err := opts.ToPolicyListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		return PolicyPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// CreateOptsBuilder is the interface options structs have to satisfy in order
+// to be used in the main Create operation in this package. Since many
+// extensions decorate or modify the common logic, it is useful for them to
+// satisfy a basic interface in order for them to be used.
+type CreateOptsBuilder interface {
+	ToFirewallPolicyCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts contains all the values needed to create a new firewall policy.
+type CreateOpts struct {
+	// Only required if the caller has an admin role and wants to create a firewall policy
+	// for another tenant.
+	TenantID    string   `json:"tenant_id,omitempty"`
+	Name        string   `json:"name,omitempty"`
+	Description string   `json:"description,omitempty"`
+	Shared      *bool    `json:"shared,omitempty"`
+	Audited     *bool    `json:"audited,omitempty"`
+	Rules       []string `json:"firewall_rules,omitempty"`
+}
+
+// ToFirewallPolicyCreateMap casts a CreateOpts struct to a map.
+func (opts CreateOpts) ToFirewallPolicyCreateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "firewall_policy")
+}
+
+// Create accepts a CreateOpts struct and uses the values to create a new firewall policy
+func Create(c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToFirewallPolicyCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Post(rootURL(c), b, &r.Body, nil)
+	return
+}
+
+// Get retrieves a particular firewall policy based on its unique ID.
+func Get(c *gophercloud.ServiceClient, id string) (r GetResult) {
+	_, r.Err = c.Get(resourceURL(c, id), &r.Body, nil)
+	return
+}
+
+// UpdateOptsBuilder is the interface options structs have to satisfy in order
+// to be used in the main Update operation in this package. Since many
+// extensions decorate or modify the common logic, it is useful for them to
+// satisfy a basic interface in order for them to be used.
+type UpdateOptsBuilder interface {
+	ToFirewallPolicyUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts contains the values used when updating a firewall policy.
+type UpdateOpts struct {
+	Name        *string  `json:"name,omitempty"`
+	Description *string  `json:"description,omitempty"`
+	Shared      *bool    `json:"shared,omitempty"`
+	Audited     *bool    `json:"audited,omitempty"`
+	Rules       []string `json:"firewall_rules,omitempty"`
+}
+
+// ToFirewallPolicyUpdateMap casts a CreateOpts struct to a map.
+func (opts UpdateOpts) ToFirewallPolicyUpdateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "firewall_policy")
+}
+
+// Update allows firewall policies to be updated.
+func Update(c *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToFirewallPolicyUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Put(resourceURL(c, id), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// Delete will permanently delete a particular firewall policy based on its unique ID.
+func Delete(c *gophercloud.ServiceClient, id string) (r DeleteResult) {
+	_, r.Err = c.Delete(resourceURL(c, id), nil)
+	return
+}
+
+type InsertRuleOptsBuilder interface {
+	ToFirewallPolicyInsertRuleMap() (map[string]interface{}, error)
+}
+
+type InsertRuleOpts struct {
+	ID           string `json:"firewall_rule_id" required:"true"`
+	BeforeRuleID string `json:"insert_before,omitempty"`
+	AfterRuleID  string `json:"insert_after,omitempty"`
+}
+
+func (opts InsertRuleOpts) ToFirewallPolicyInsertRuleMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "")
+}
+
+func AddRule(c *gophercloud.ServiceClient, id string, opts InsertRuleOptsBuilder) (r InsertRuleResult) {
+	b, err := opts.ToFirewallPolicyInsertRuleMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Put(insertURL(c, id), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+func RemoveRule(c *gophercloud.ServiceClient, id, ruleID string) (r RemoveRuleResult) {
+	b := map[string]interface{}{"firewall_rule_id": ruleID}
+	_, r.Err = c.Put(removeURL(c, id), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}

--- a/openstack/networking/v2/extensions/fwaas_v2/policies/requests.go
+++ b/openstack/networking/v2/extensions/fwaas_v2/policies/requests.go
@@ -67,12 +67,12 @@ type CreateOptsBuilder interface {
 type CreateOpts struct {
 	// Only required if the caller has an admin role and wants to create a firewall policy
 	// for another tenant.
-	TenantID    string   `json:"tenant_id,omitempty"`
-	Name        string   `json:"name,omitempty"`
-	Description string   `json:"description,omitempty"`
-	Shared      *bool    `json:"shared,omitempty"`
-	Audited     *bool    `json:"audited,omitempty"`
-	Rules       []string `json:"firewall_rules,omitempty"`
+	TenantID      string   `json:"tenant_id,omitempty"`
+	Name          string   `json:"name,omitempty"`
+	Description   string   `json:"description,omitempty"`
+	Shared        *bool    `json:"shared,omitempty"`
+	Audited       *bool    `json:"audited,omitempty"`
+	FirewallRules []string `json:"firewall_rules,omitempty"`
 }
 
 // ToFirewallPolicyCreateMap casts a CreateOpts struct to a map.
@@ -107,11 +107,11 @@ type UpdateOptsBuilder interface {
 
 // UpdateOpts contains the values used when updating a firewall policy.
 type UpdateOpts struct {
-	Name        *string   `json:"name,omitempty"`
-	Description *string   `json:"description,omitempty"`
-	Shared      *bool     `json:"shared,omitempty"`
-	Audited     *bool     `json:"audited,omitempty"`
-	Rules       *[]string `json:"firewall_rules,omitempty"`
+	Name          *string   `json:"name,omitempty"`
+	Description   *string   `json:"description,omitempty"`
+	Shared        *bool     `json:"shared,omitempty"`
+	Audited       *bool     `json:"audited,omitempty"`
+	FirewallRules *[]string `json:"firewall_rules,omitempty"`
 }
 
 // ToFirewallPolicyUpdateMap casts a CreateOpts struct to a map.
@@ -144,15 +144,15 @@ type InsertRuleOptsBuilder interface {
 
 type InsertRuleOpts struct {
 	ID           string `json:"firewall_rule_id" required:"true"`
-	BeforeRuleID string `json:"insert_before,omitempty"`
-	AfterRuleID  string `json:"insert_after,omitempty"`
+	InsertBefore string `json:"insert_before,omitempty" xor:"InsertAfter"`
+	InsertAfter  string `json:"insert_after,omitempty" xor:"InsertBefore"`
 }
 
 func (opts InsertRuleOpts) ToFirewallPolicyInsertRuleMap() (map[string]interface{}, error) {
 	return gophercloud.BuildRequestBody(opts, "")
 }
 
-func AddRule(c *gophercloud.ServiceClient, id string, opts InsertRuleOptsBuilder) (r InsertRuleResult) {
+func InsertRule(c *gophercloud.ServiceClient, id string, opts InsertRuleOptsBuilder) (r InsertRuleResult) {
 	b, err := opts.ToFirewallPolicyInsertRuleMap()
 	if err != nil {
 		r.Err = err

--- a/openstack/networking/v2/extensions/fwaas_v2/policies/results.go
+++ b/openstack/networking/v2/extensions/fwaas_v2/policies/results.go
@@ -1,0 +1,97 @@
+package policies
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// Policy is a firewall policy.
+type Policy struct {
+	ID          string   `json:"id"`
+	Name        string   `json:"name"`
+	Description string   `json:"description"`
+	TenantID    string   `json:"tenant_id"`
+	Audited     bool     `json:"audited"`
+	Shared      bool     `json:"shared"`
+	Rules       []string `json:"firewall_rules,omitempty"`
+}
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// Extract is a function that accepts a result and extracts a firewall policy.
+func (r commonResult) Extract() (*Policy, error) {
+	var s struct {
+		Policy *Policy `json:"firewall_policy"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Policy, err
+}
+
+// PolicyPage is the page returned by a pager when traversing over a
+// collection of firewall policies.
+type PolicyPage struct {
+	pagination.LinkedPageBase
+}
+
+// NextPageURL is invoked when a paginated collection of firewall policies has
+// reached the end of a page and the pager seeks to traverse over a new one.
+// In order to do this, it needs to construct the next page's URL.
+func (r PolicyPage) NextPageURL() (string, error) {
+	var s struct {
+		Links []gophercloud.Link `json:"firewall_policies_links"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return gophercloud.ExtractNextURL(s.Links)
+}
+
+// IsEmpty checks whether a PolicyPage struct is empty.
+func (r PolicyPage) IsEmpty() (bool, error) {
+	is, err := ExtractPolicies(r)
+	return len(is) == 0, err
+}
+
+// ExtractPolicies accepts a Page struct, specifically a RouterPage struct,
+// and extracts the elements into a slice of Router structs. In other words,
+// a generic collection is mapped into a relevant slice.
+func ExtractPolicies(r pagination.Page) ([]Policy, error) {
+	var s struct {
+		Policies []Policy `json:"firewall_policies"`
+	}
+	err := (r.(PolicyPage)).ExtractInto(&s)
+	return s.Policies, err
+}
+
+// GetResult represents the result of a get operation.
+type GetResult struct {
+	commonResult
+}
+
+// UpdateResult represents the result of an update operation.
+type UpdateResult struct {
+	commonResult
+}
+
+// DeleteResult represents the result of a delete operation.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
+// CreateResult represents the result of a create operation.
+type CreateResult struct {
+	commonResult
+}
+
+// InsertRuleResult represents the result of an InsertRule operation.
+type InsertRuleResult struct {
+	commonResult
+}
+
+// RemoveRuleResult represents the result of a RemoveRule operation.
+type RemoveRuleResult struct {
+	commonResult
+}

--- a/openstack/networking/v2/extensions/fwaas_v2/policies/results.go
+++ b/openstack/networking/v2/extensions/fwaas_v2/policies/results.go
@@ -55,8 +55,8 @@ func (r PolicyPage) IsEmpty() (bool, error) {
 	return len(is) == 0, err
 }
 
-// ExtractPolicies accepts a Page struct, specifically a RouterPage struct,
-// and extracts the elements into a slice of Router structs. In other words,
+// ExtractPolicies accepts a Page struct, specifically a PolicyPage struct,
+// and extracts the elements into a slice of Policy structs. In other words,
 // a generic collection is mapped into a relevant slice.
 func ExtractPolicies(r pagination.Page) ([]Policy, error) {
 	var s struct {

--- a/openstack/networking/v2/extensions/fwaas_v2/policies/results.go
+++ b/openstack/networking/v2/extensions/fwaas_v2/policies/results.go
@@ -20,6 +20,10 @@ type commonResult struct {
 	gophercloud.Result
 }
 
+type insertRuleResult struct {
+	gophercloud.Result
+}
+
 // Extract is a function that accepts a result and extracts a firewall policy.
 func (r commonResult) Extract() (*Policy, error) {
 	var s struct {
@@ -27,6 +31,13 @@ func (r commonResult) Extract() (*Policy, error) {
 	}
 	err := r.ExtractInto(&s)
 	return s.Policy, err
+}
+
+// Extract is a function that accepts a insertRuleResult and extracts a firewall policy.
+func (r insertRuleResult) Extract() (*Policy, error) {
+	var policy *Policy
+	err := r.ExtractInto(&policy)
+	return policy, err
 }
 
 // PolicyPage is the page returned by a pager when traversing over a
@@ -88,7 +99,7 @@ type CreateResult struct {
 
 // InsertRuleResult represents the result of an InsertRule operation.
 type InsertRuleResult struct {
-	commonResult
+	insertRuleResult
 }
 
 // RemoveRuleResult represents the result of a RemoveRule operation.

--- a/openstack/networking/v2/extensions/fwaas_v2/policies/results.go
+++ b/openstack/networking/v2/extensions/fwaas_v2/policies/results.go
@@ -20,7 +20,7 @@ type commonResult struct {
 	gophercloud.Result
 }
 
-type insertRuleResult struct {
+type shortResult struct {
 	gophercloud.Result
 }
 
@@ -33,8 +33,8 @@ func (r commonResult) Extract() (*Policy, error) {
 	return s.Policy, err
 }
 
-// Extract is a function that accepts a insertRuleResult and extracts a firewall policy.
-func (r insertRuleResult) Extract() (*Policy, error) {
+// Extract is a function that accepts a shortResult and extracts a firewall policy.
+func (r shortResult) Extract() (*Policy, error) {
 	var policy *Policy
 	err := r.ExtractInto(&policy)
 	return policy, err
@@ -99,10 +99,10 @@ type CreateResult struct {
 
 // InsertRuleResult represents the result of an InsertRule operation.
 type InsertRuleResult struct {
-	insertRuleResult
+	shortResult
 }
 
 // RemoveRuleResult represents the result of a RemoveRule operation.
 type RemoveRuleResult struct {
-	commonResult
+	shortResult
 }

--- a/openstack/networking/v2/extensions/fwaas_v2/policies/testing/doc.go
+++ b/openstack/networking/v2/extensions/fwaas_v2/policies/testing/doc.go
@@ -1,0 +1,2 @@
+// networking_extensions_fwaas_policies_v2
+package testing

--- a/openstack/networking/v2/extensions/fwaas_v2/policies/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/fwaas_v2/policies/testing/requests_test.go
@@ -252,7 +252,7 @@ func TestUpdate(t *testing.T) {
 	options := policies.UpdateOpts{
 		Name:        &name,
 		Description: &description,
-		Rules: []string{
+		Rules: &[]string{
 			"98a58c87-76be-ae7c-a74e-b77fffb88d95",
 			"11a58c87-76be-ae7c-a74e-b77fffb88a32",
 		},

--- a/openstack/networking/v2/extensions/fwaas_v2/policies/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/fwaas_v2/policies/testing/requests_test.go
@@ -1,0 +1,277 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/gophercloud/gophercloud"
+	fake "github.com/gophercloud/gophercloud/openstack/networking/v2/common"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas_v2/policies"
+	"github.com/gophercloud/gophercloud/pagination"
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestList(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/fwaas/firewall_policies", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, `
+{
+    "firewall_policies": [
+        {
+            "name": "policy1",
+            "firewall_rules": [
+                "75452b36-268e-4e75-aaf4-f0e7ed50bc97",
+                "c9e77ca0-1bc8-497d-904d-948107873dc6"
+            ],
+            "tenant_id": "9145d91459d248b1b02fdaca97c6a75d",
+            "audited": true,
+			"shared": false,
+            "id": "f2b08c1e-aa81-4668-8ae1-1401bcb0576c",
+            "description": "Firewall policy 1"
+        },
+        {
+            "name": "policy2",
+            "firewall_rules": [
+                "03d2a6ad-633f-431a-8463-4370d06a22c8"
+            ],
+            "tenant_id": "9145d91459d248b1b02fdaca97c6a75d",
+            "audited": false,
+			"shared": true,
+            "id": "c854fab5-bdaf-4a86-9359-78de93e5df01",
+            "description": "Firewall policy 2"
+        }
+    ]
+}
+        `)
+	})
+
+	count := 0
+
+	policies.List(fake.ServiceClient(), policies.ListOpts{}).EachPage(func(page pagination.Page) (bool, error) {
+		count++
+		actual, err := policies.ExtractPolicies(page)
+		if err != nil {
+			t.Errorf("Failed to extract members: %v", err)
+			return false, err
+		}
+
+		expected := []policies.Policy{
+			{
+				Name: "policy1",
+				Rules: []string{
+					"75452b36-268e-4e75-aaf4-f0e7ed50bc97",
+					"c9e77ca0-1bc8-497d-904d-948107873dc6",
+				},
+				TenantID:    "9145d91459d248b1b02fdaca97c6a75d",
+				Audited:     true,
+				Shared:      false,
+				ID:          "f2b08c1e-aa81-4668-8ae1-1401bcb0576c",
+				Description: "Firewall policy 1",
+			},
+			{
+				Name: "policy2",
+				Rules: []string{
+					"03d2a6ad-633f-431a-8463-4370d06a22c8",
+				},
+				TenantID:    "9145d91459d248b1b02fdaca97c6a75d",
+				Audited:     false,
+				Shared:      true,
+				ID:          "c854fab5-bdaf-4a86-9359-78de93e5df01",
+				Description: "Firewall policy 2",
+			},
+		}
+
+		th.CheckDeepEquals(t, expected, actual)
+
+		return true, nil
+	})
+
+	if count != 1 {
+		t.Errorf("Expected 1 page, got %d", count)
+	}
+}
+
+func TestCreate(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/fwaas/firewall_policies", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, `
+{
+    "firewall_policy":{
+        "name": "policy",
+        "firewall_rules": [
+            "98a58c87-76be-ae7c-a74e-b77fffb88d95",
+            "11a58c87-76be-ae7c-a74e-b77fffb88a32"
+        ],
+        "description": "Firewall policy",
+		"tenant_id": "9145d91459d248b1b02fdaca97c6a75d",
+		"audited": true,
+		"shared": false
+    }
+}
+      `)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+
+		fmt.Fprintf(w, `
+{
+    "firewall_policy":{
+        "name": "policy",
+        "firewall_rules": [
+            "98a58c87-76be-ae7c-a74e-b77fffb88d95",
+            "11a58c87-76be-ae7c-a74e-b77fffb88a32"
+        ],
+        "tenant_id": "9145d91459d248b1b02fdaca97c6a75d",
+        "audited": false,
+        "id": "f2b08c1e-aa81-4668-8ae1-1401bcb0576c",
+        "description": "Firewall policy"
+    }
+}
+        `)
+	})
+
+	options := policies.CreateOpts{
+		TenantID:    "9145d91459d248b1b02fdaca97c6a75d",
+		Name:        "policy",
+		Description: "Firewall policy",
+		Shared:      gophercloud.Disabled,
+		Audited:     gophercloud.Enabled,
+		Rules: []string{
+			"98a58c87-76be-ae7c-a74e-b77fffb88d95",
+			"11a58c87-76be-ae7c-a74e-b77fffb88a32",
+		},
+	}
+
+	_, err := policies.Create(fake.ServiceClient(), options).Extract()
+	th.AssertNoErr(t, err)
+}
+
+func TestGet(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/fwaas/firewall_policies/f2b08c1e-aa81-4668-8ae1-1401bcb0576c", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, `
+{
+    "firewall_policy":{
+        "name": "www",
+        "firewall_rules": [
+            "75452b36-268e-4e75-aaf4-f0e7ed50bc97",
+            "c9e77ca0-1bc8-497d-904d-948107873dc6",
+            "03d2a6ad-633f-431a-8463-4370d06a22c8"
+        ],
+        "tenant_id": "9145d91459d248b1b02fdaca97c6a75d",
+        "audited": false,
+        "id": "f2b08c1e-aa81-4668-8ae1-1401bcb0576c",
+        "description": "Firewall policy web"
+    }
+}
+        `)
+	})
+
+	policy, err := policies.Get(fake.ServiceClient(), "f2b08c1e-aa81-4668-8ae1-1401bcb0576c").Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, "www", policy.Name)
+	th.AssertEquals(t, "f2b08c1e-aa81-4668-8ae1-1401bcb0576c", policy.ID)
+	th.AssertEquals(t, "Firewall policy web", policy.Description)
+	th.AssertEquals(t, 3, len(policy.Rules))
+	th.AssertEquals(t, "75452b36-268e-4e75-aaf4-f0e7ed50bc97", policy.Rules[0])
+	th.AssertEquals(t, "c9e77ca0-1bc8-497d-904d-948107873dc6", policy.Rules[1])
+	th.AssertEquals(t, "03d2a6ad-633f-431a-8463-4370d06a22c8", policy.Rules[2])
+	th.AssertEquals(t, "9145d91459d248b1b02fdaca97c6a75d", policy.TenantID)
+}
+
+func TestUpdate(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/fwaas/firewall_policies/f2b08c1e-aa81-4668-8ae1-1401bcb0576c", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, `
+{
+    "firewall_policy":{
+        "name": "policy",
+        "firewall_rules": [
+            "98a58c87-76be-ae7c-a74e-b77fffb88d95",
+            "11a58c87-76be-ae7c-a74e-b77fffb88a32"
+        ],
+        "description": "Firewall policy"
+    }
+}
+      `)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, `
+{
+    "firewall_policy":{
+        "name": "policy",
+        "firewall_rules": [
+            "75452b36-268e-4e75-aaf4-f0e7ed50bc97",
+            "c9e77ca0-1bc8-497d-904d-948107873dc6",
+            "03d2a6ad-633f-431a-8463-4370d06a22c8"
+        ],
+        "tenant_id": "9145d91459d248b1b02fdaca97c6a75d",
+        "audited": false,
+        "id": "f2b08c1e-aa81-4668-8ae1-1401bcb0576c",
+        "description": "Firewall policy"
+    }
+}
+    `)
+	})
+
+	name := "policy"
+	description := "Firewall policy"
+
+	options := policies.UpdateOpts{
+		Name:        &name,
+		Description: &description,
+		Rules: []string{
+			"98a58c87-76be-ae7c-a74e-b77fffb88d95",
+			"11a58c87-76be-ae7c-a74e-b77fffb88a32",
+		},
+	}
+
+	_, err := policies.Update(fake.ServiceClient(), "f2b08c1e-aa81-4668-8ae1-1401bcb0576c", options).Extract()
+	th.AssertNoErr(t, err)
+}
+
+func TestDelete(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/fwaas/firewall_policies/4ec89077-d057-4a2b-911f-60a3b47ee304", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	res := policies.Delete(fake.ServiceClient(), "4ec89077-d057-4a2b-911f-60a3b47ee304")
+	th.AssertNoErr(t, res.Err)
+}

--- a/openstack/networking/v2/extensions/fwaas_v2/policies/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/fwaas_v2/policies/testing/requests_test.go
@@ -328,3 +328,43 @@ func TestDelete(t *testing.T) {
 	res := policies.Delete(fake.ServiceClient(), "4ec89077-d057-4a2b-911f-60a3b47ee304")
 	th.AssertNoErr(t, res.Err)
 }
+
+func TestRemoveRule(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/fwaas/firewall_policies/9fed8075-06ee-463f-83a6-d4118791b02f/remove_rule", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, `
+{
+    "firewall_rule_id": "9fed8075-06ee-463f-83a6-d4118791b02f"
+}
+        `)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, `
+{
+    "audited": false,
+    "description": "TESTACC-DESC-skno2e52",
+    "firewall_rules": [
+      "3ccc0f2b-4a04-4e7c-bb47-dd1701127a47"
+    ],
+    "id": "9fed8075-06ee-463f-83a6-d4118791b02f",
+    "name": "TESTACC-Qf7pMSkq",
+    "project_id": "TESTID-era34jkaslk",
+    "shared": false,
+    "tenant_id": "TESTID-334sdfassdf"
+}
+    `)
+	})
+
+	policy, err := policies.RemoveRule(fake.ServiceClient(), "9fed8075-06ee-463f-83a6-d4118791b02f", "9fed8075-06ee-463f-83a6-d4118791b02f").Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, "9fed8075-06ee-463f-83a6-d4118791b02f", policy.ID)
+
+}

--- a/openstack/networking/v2/extensions/fwaas_v2/policies/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/fwaas_v2/policies/testing/requests_test.go
@@ -151,7 +151,7 @@ func TestCreate(t *testing.T) {
 		Description: "Firewall policy",
 		Shared:      gophercloud.Disabled,
 		Audited:     gophercloud.Enabled,
-		Rules: []string{
+		FirewallRules: []string{
 			"98a58c87-76be-ae7c-a74e-b77fffb88d95",
 			"11a58c87-76be-ae7c-a74e-b77fffb88a32",
 		},
@@ -161,7 +161,7 @@ func TestCreate(t *testing.T) {
 	th.AssertNoErr(t, err)
 }
 
-func TestAddRule(t *testing.T) {
+func TestInsertRule(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 
@@ -199,10 +199,10 @@ func TestAddRule(t *testing.T) {
 
 	options := policies.InsertRuleOpts{
 		ID:           "7d305689-6cb1-4e75-9f4d-517b9ba792b5",
-		BeforeRuleID: "3062ed90-1fb0-4c25-af3d-318dff2143ae",
+		InsertBefore: "3062ed90-1fb0-4c25-af3d-318dff2143ae",
 	}
 
-	policy, err := policies.AddRule(fake.ServiceClient(), "e3c78ab6-e827-4297-8d68-739063865a8b", options).Extract()
+	policy, err := policies.InsertRule(fake.ServiceClient(), "e3c78ab6-e827-4297-8d68-739063865a8b", options).Extract()
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, "TESTACC-2LnMayeG", policy.Name)
 	th.AssertEquals(t, 2, len(policy.Rules))
@@ -212,6 +212,24 @@ func TestAddRule(t *testing.T) {
 	th.AssertEquals(t, "TESTACC-DESC-8P12aLfW", policy.Description)
 	th.AssertEquals(t, "9f98fc0e5f944cd1b51798b668dc8778", policy.TenantID)
 
+}
+
+func TestInsertRuleWithInvalidParameters(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	//invalid opts, its not allowed to specify InsertBefore and InsertAfter together
+	options := policies.InsertRuleOpts{
+		ID:           "unknown",
+		InsertBefore: "1",
+		InsertAfter:  "2",
+	}
+
+	_, err := policies.InsertRule(fake.ServiceClient(), "0", options).Extract()
+
+	// expect to fail with an gophercloud error
+	th.AssertErr(t, err)
+	th.AssertEquals(t, "Exactly one of InsertBefore and InsertAfter must be provided", err.Error())
 }
 
 func TestGet(t *testing.T) {
@@ -305,7 +323,7 @@ func TestUpdate(t *testing.T) {
 	options := policies.UpdateOpts{
 		Name:        &name,
 		Description: &description,
-		Rules: &[]string{
+		FirewallRules: &[]string{
 			"98a58c87-76be-ae7c-a74e-b77fffb88d95",
 			"11a58c87-76be-ae7c-a74e-b77fffb88a32",
 		},

--- a/openstack/networking/v2/extensions/fwaas_v2/policies/urls.go
+++ b/openstack/networking/v2/extensions/fwaas_v2/policies/urls.go
@@ -1,0 +1,26 @@
+package policies
+
+import "github.com/gophercloud/gophercloud"
+
+const (
+	rootPath     = "fwaas"
+	resourcePath = "firewall_policies"
+	insertPath   = "insert_rule"
+	removePath   = "remove_rule"
+)
+
+func rootURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL(rootPath, resourcePath)
+}
+
+func resourceURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL(rootPath, resourcePath, id)
+}
+
+func insertURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL(rootPath, resourcePath, id, insertPath)
+}
+
+func removeURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL(rootPath, resourcePath, id, removePath)
+}

--- a/openstack/networking/v2/extensions/fwaas_v2/rules/results.go
+++ b/openstack/networking/v2/extensions/fwaas_v2/rules/results.go
@@ -7,21 +7,21 @@ import (
 
 // Rule represents a firewall rule
 type Rule struct {
-	ID                   string `json:"id"`
-	Name                 string `json:"name,omitempty"`
-	Description          string `json:"description,omitempty"`
-	Protocol             string `json:"protocol"`
-	Action               string `json:"action"`
-	IPVersion            int    `json:"ip_version,omitempty"`
-	SourceIPAddress      string `json:"source_ip_address,omitempty"`
-	DestinationIPAddress string `json:"destination_ip_address,omitempty"`
-	SourcePort           string `json:"source_port,omitempty"`
-	DestinationPort      string `json:"destination_port,omitempty"`
-	Shared               bool   `json:"shared,omitempty"`
-	Enabled              bool   `json:"enabled,omitempty"`
-	FirewallPolicyID     string `json:"firewall_policy_id"`
-	TenantID             string `json:"tenant_id"`
-	ProjectID            string `json:"project_id"`
+	ID                   string   `json:"id"`
+	Name                 string   `json:"name,omitempty"`
+	Description          string   `json:"description,omitempty"`
+	Protocol             string   `json:"protocol"`
+	Action               string   `json:"action"`
+	IPVersion            int      `json:"ip_version,omitempty"`
+	SourceIPAddress      string   `json:"source_ip_address,omitempty"`
+	DestinationIPAddress string   `json:"destination_ip_address,omitempty"`
+	SourcePort           string   `json:"source_port,omitempty"`
+	DestinationPort      string   `json:"destination_port,omitempty"`
+	Shared               bool     `json:"shared,omitempty"`
+	Enabled              bool     `json:"enabled,omitempty"`
+	FirewallPolicyID     []string `json:"firewall_policy_id"`
+	TenantID             string   `json:"tenant_id"`
+	ProjectID            string   `json:"project_id"`
 }
 
 // RulePage is the page returned by a pager when traversing over a

--- a/openstack/networking/v2/extensions/fwaas_v2/rules/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/fwaas_v2/rules/testing/requests_test.go
@@ -32,7 +32,7 @@ func TestList(t *testing.T) {
             "source_port": null,
             "source_ip_address": null,
             "destination_ip_address": "192.168.1.0/24",
-            "firewall_policy_id": "e2a5fb51-698c-4898-87e8-f1eee6b50919",
+            "firewall_policy_id": ["e2a5fb51-698c-4898-87e8-f1eee6b50919"],
             "destination_port": "22",
             "id": "f03bd950-6c56-4f5e-a307-45967078f507",
             "name": "ssh_form_any",
@@ -48,7 +48,7 @@ func TestList(t *testing.T) {
             "source_port": null,
             "source_ip_address": null,
             "destination_ip_address": null,
-            "firewall_policy_id": "98d7fb51-698c-4123-87e8-f1eee6b5ab7e",
+            "firewall_policy_id": ["98d7fb51-698c-4123-87e8-f1eee6b5ab7e"],
             "destination_port": null,
             "id": "ab7bd950-6c56-4f5e-a307-45967078f890",
             "name": "deny_all_udp",
@@ -80,7 +80,7 @@ func TestList(t *testing.T) {
 				SourcePort:           "",
 				SourceIPAddress:      "",
 				DestinationIPAddress: "192.168.1.0/24",
-				FirewallPolicyID:     "e2a5fb51-698c-4898-87e8-f1eee6b50919",
+				FirewallPolicyID:     []string{"e2a5fb51-698c-4898-87e8-f1eee6b50919"},
 				DestinationPort:      "22",
 				ID:                   "f03bd950-6c56-4f5e-a307-45967078f507",
 				Name:                 "ssh_form_any",
@@ -96,7 +96,7 @@ func TestList(t *testing.T) {
 				SourcePort:           "",
 				SourceIPAddress:      "",
 				DestinationIPAddress: "",
-				FirewallPolicyID:     "98d7fb51-698c-4123-87e8-f1eee6b5ab7e",
+				FirewallPolicyID:     []string{"98d7fb51-698c-4123-87e8-f1eee6b5ab7e"},
 				DestinationPort:      "",
 				ID:                   "ab7bd950-6c56-4f5e-a307-45967078f890",
 				Name:                 "deny_all_udp",
@@ -151,7 +151,7 @@ func TestCreate(t *testing.T) {
 		"source_port": null,
 		"source_ip_address": null,
 		"destination_ip_address": "192.168.1.0/24",
-		"firewall_policy_id": "e2a5fb51-698c-4898-87e8-f1eee6b50919",
+		"firewall_policy_id": ["e2a5fb51-698c-4898-87e8-f1eee6b50919"],
 		"position": 2,
 		"destination_port": "22",
 		"id": "f03bd950-6c56-4f5e-a307-45967078f507",
@@ -213,7 +213,7 @@ func TestCreateAnyProtocol(t *testing.T) {
 		"source_port": null,
 		"source_ip_address": null,
 		"destination_ip_address": "192.168.1.0/24",
-		"firewall_policy_id": "e2a5fb51-698c-4898-87e8-f1eee6b50919",
+		"firewall_policy_id": ["e2a5fb51-698c-4898-87e8-f1eee6b50919"],
 		"position": 2,
 		"destination_port": null,
 		"id": "f03bd950-6c56-4f5e-a307-45967078f507",
@@ -260,7 +260,7 @@ func TestGet(t *testing.T) {
 		"source_port": null,
 		"source_ip_address": null,
 		"destination_ip_address": "192.168.1.0/24",
-		"firewall_policy_id": "e2a5fb51-698c-4898-87e8-f1eee6b50919",
+		"firewall_policy_id": ["e2a5fb51-698c-4898-87e8-f1eee6b50919"],
 		"position": 2,
 		"destination_port": "22",
 		"id": "f03bd950-6c56-4f5e-a307-45967078f507",
@@ -281,7 +281,8 @@ func TestGet(t *testing.T) {
 	th.AssertEquals(t, "tcp", rule.Protocol)
 	th.AssertEquals(t, "ssh rule", rule.Description)
 	th.AssertEquals(t, "192.168.1.0/24", rule.DestinationIPAddress)
-	th.AssertEquals(t, "e2a5fb51-698c-4898-87e8-f1eee6b50919", rule.FirewallPolicyID)
+	th.AssertEquals(t, 1, len(rule.FirewallPolicyID))
+	th.AssertEquals(t, "e2a5fb51-698c-4898-87e8-f1eee6b50919", rule.FirewallPolicyID[0])
 	th.AssertEquals(t, "22", rule.DestinationPort)
 	th.AssertEquals(t, "f03bd950-6c56-4f5e-a307-45967078f507", rule.ID)
 	th.AssertEquals(t, "ssh_form_any", rule.Name)
@@ -324,7 +325,7 @@ func TestUpdate(t *testing.T) {
 		"protocol": "tcp",
 		"description": "ssh rule",
 		"destination_ip_address": "192.168.1.0/24",
-		"firewall_policy_id": "e2a5fb51-698c-4898-87e8-f1eee6b50919",
+		"firewall_policy_id": ["e2a5fb51-698c-4898-87e8-f1eee6b50919"],
 		"position": 2,
 		"destination_port": "22",
 		"id": "f03bd950-6c56-4f5e-a307-45967078f507",


### PR DESCRIPTION
follow up PR for  #1789 by @Elethiomel (I asked for the permission to get this done)
contains 2 cherry-picks from https://github.com/Daimler/gophercloud/commits/fwaas-v2 by @chrischdi 




For #514

https://github.com/openstack/neutron-lib/blob/56033ba643812a30577f6ab17648806c2ee494ba/neutron_lib/api/definitions/firewall_v2.py#L159
https://github.com/openstack/neutron-fwaas/blob/27906d0acff349c9e5ac7955d203fb2233c295db/neutron_fwaas/db/firewall/v2/firewall_db_v2.py#L148

- [x] acceptance test for updatePolicies, verify policy's rules length is 0 (from [discussion](https://github.com/gophercloud/gophercloud/pull/1789#discussion_r353527621))


<sub>Georg Schreiber georg.g.schreiber@daimler.com, Daimler TSS GmbH, [legal info/Impressum](https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md)</sub>