### PR TITLE
Prune sharedfilesystems

### DIFF
--- a/openstack/sharedfilesystems/v2/availabilityzones/results.go
+++ b/openstack/sharedfilesystems/v2/availabilityzones/results.go
@@ -21,10 +21,6 @@ type AvailabilityZone struct {
 	UpdatedAt time.Time `json:"-"`
 }
 
-type commonResult struct {
-	gophercloud.Result
-}
-
 // ListResult contains the response body and error from a List request.
 type AvailabilityZonePage struct {
 	pagination.SinglePageBase

--- a/openstack/sharedfilesystems/v2/shares/testing/fixtures.go
+++ b/openstack/sharedfilesystems/v2/shares/testing/fixtures.go
@@ -528,12 +528,6 @@ func MockUpdateMetadataResponse(t *testing.T) {
 	})
 }
 
-var deleteMetadatumRequest = `{
-		"metadata": {
-			"foo": "bar"
-		}
-	}`
-
 // MockDeleteMetadatumResponse creates a mock unset metadata response
 func MockDeleteMetadatumResponse(t *testing.T, key string) {
 	th.Mux.HandleFunc(shareEndpoint+"/"+shareID+"/metadata/"+key, func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
This removes an unused variable and an unused type from subpackages of `sharedfilesystems/v2`.

For #2034 