### PR TITLE
Networking v2:  Add Get Detailed Quota for project + 'trunk' extension support

### DIFF
--- a/openstack/networking/v2/extensions/quotas/doc.go
+++ b/openstack/networking/v2/extensions/quotas/doc.go
@@ -35,6 +35,7 @@ Example to Update project quotas
         SecurityGroupRule: gophercloud.IntToPointer(-1),
         Subnet:            gophercloud.IntToPointer(25),
         SubnetPool:        gophercloud.IntToPointer(0),
+        Trunk:             gophercloud.IntToPointer(0),
     }
     quotasInfo, err := quotas.Update(networkClient, projectID)
     if err != nil {

--- a/openstack/networking/v2/extensions/quotas/doc.go
+++ b/openstack/networking/v2/extensions/quotas/doc.go
@@ -11,6 +11,16 @@ Example to Get project quotas
 
     fmt.Printf("quotas: %#v\n", quotasInfo)
 
+Example to Get a Detailed Quota Set
+
+    projectID = "23d5d3f79dfa4f73b72b8b0b0063ec55"
+    quotasInfo, err := quotas.GetDetail(networkClient, projectID).Extract()
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    fmt.Printf("quotas: %#v\n", quotasInfo)
+
 Example to Update project quotas
 
     projectID = "23d5d3f79dfa4f73b72b8b0b0063ec55"

--- a/openstack/networking/v2/extensions/quotas/requests.go
+++ b/openstack/networking/v2/extensions/quotas/requests.go
@@ -9,6 +9,13 @@ func Get(client *gophercloud.ServiceClient, projectID string) (r GetResult) {
 	return
 }
 
+// GetDetail returns detailed Networking Quotas for a project.
+func GetDetail(client *gophercloud.ServiceClient, projectID string) (r GetDetailResult) {
+	resp, err := client.Get(getDetailURL(client, projectID), &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
 // UpdateOptsBuilder allows extensions to add additional parameters to the
 // Update request.
 type UpdateOptsBuilder interface {

--- a/openstack/networking/v2/extensions/quotas/requests.go
+++ b/openstack/networking/v2/extensions/quotas/requests.go
@@ -50,6 +50,9 @@ type UpdateOpts struct {
 
 	// SubnetPool represents a number of subnet pools. A "-1" value means no limit.
 	SubnetPool *int `json:"subnetpool,omitempty"`
+
+	// Trunk represents a number of trunks. A "-1" value means no limit.
+	Trunk *int `json:"trunk,omitempty"`
 }
 
 // ToQuotaUpdateMap builds a request body from UpdateOpts.

--- a/openstack/networking/v2/extensions/quotas/results.go
+++ b/openstack/networking/v2/extensions/quotas/results.go
@@ -74,6 +74,9 @@ type Quota struct {
 
 	// SubnetPool represents a number of subnet pools. A "-1" value means no limit.
 	SubnetPool int `json:"subnetpool"`
+
+	// Trunk represents a number of trunks. A "-1" value means no limit.
+	Trunk int `json:"trunk"`
 }
 
 // QuotaDetailSet represents details of both operational limits of Networking resources for a project
@@ -105,14 +108,17 @@ type QuotaDetailSet struct {
 
 	// SubnetPool represents a number of subnet pools. A "-1" value means no limit.
 	SubnetPool QuotaDetail `json:"subnetpool"`
+
+	// Trunk represents a number of trunks. A "-1" value means no limit.
+	Trunk QuotaDetail `json:"trunk"`
 }
 
 // QuotaDetail is a set of details about a single operational limit that allows
 // for control of networking usage.
 type QuotaDetail struct {
-	// InUse is the current number of provisioned/allocated resources of the
+	// Used is the current number of provisioned/allocated resources of the
 	// given type.
-	InUse int `json:"used"`
+	Used int `json:"used"`
 
 	// Reserved is a transitional state when a claim against quota has been made
 	// but the resource is not yet fully online.

--- a/openstack/networking/v2/extensions/quotas/results.go
+++ b/openstack/networking/v2/extensions/quotas/results.go
@@ -6,6 +6,10 @@ type commonResult struct {
 	gophercloud.Result
 }
 
+type detailResult struct {
+	gophercloud.Result
+}
+
 // Extract is a function that accepts a result and extracts a Quota resource.
 func (r commonResult) Extract() (*Quota, error) {
 	var s struct {
@@ -15,10 +19,25 @@ func (r commonResult) Extract() (*Quota, error) {
 	return s.Quota, err
 }
 
+// Extract is a function that accepts a result and extracts a QuotaDetailSet resource.
+func (r detailResult) Extract() (*QuotaDetailSet, error) {
+	var s struct {
+		Quota *QuotaDetailSet `json:"quota"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Quota, err
+}
+
 // GetResult represents the result of a get operation. Call its Extract
 // method to interpret it as a Quota.
 type GetResult struct {
 	commonResult
+}
+
+// GetDetailResult represents the detailed result of a get operation. Call its Extract
+// method to interpret it as a Quota.
+type GetDetailResult struct {
+	detailResult
 }
 
 // UpdateResult represents the result of an update operation. Call its Extract
@@ -55,4 +74,51 @@ type Quota struct {
 
 	// SubnetPool represents a number of subnet pools. A "-1" value means no limit.
 	SubnetPool int `json:"subnetpool"`
+}
+
+// QuotaDetailSet represents details of both operational limits of Networking resources for a project
+// and the current usage of those resources.
+type QuotaDetailSet struct {
+	// FloatingIP represents a number of floating IPs. A "-1" value means no limit.
+	FloatingIP QuotaDetail `json:"floatingip"`
+
+	// Network represents a number of networks. A "-1" value means no limit.
+	Network QuotaDetail `json:"network"`
+
+	// Port represents a number of ports. A "-1" value means no limit.
+	Port QuotaDetail `json:"port"`
+
+	// RBACPolicy represents a number of RBAC policies. A "-1" value means no limit.
+	RBACPolicy QuotaDetail `json:"rbac_policy"`
+
+	// Router represents a number of routers. A "-1" value means no limit.
+	Router QuotaDetail `json:"router"`
+
+	// SecurityGroup represents a number of security groups. A "-1" value means no limit.
+	SecurityGroup QuotaDetail `json:"security_group"`
+
+	// SecurityGroupRule represents a number of security group rules. A "-1" value means no limit.
+	SecurityGroupRule QuotaDetail `json:"security_group_rule"`
+
+	// Subnet represents a number of subnets. A "-1" value means no limit.
+	Subnet QuotaDetail `json:"subnet"`
+
+	// SubnetPool represents a number of subnet pools. A "-1" value means no limit.
+	SubnetPool QuotaDetail `json:"subnetpool"`
+}
+
+// QuotaDetail is a set of details about a single operational limit that allows
+// for control of networking usage.
+type QuotaDetail struct {
+	// InUse is the current number of provisioned/allocated resources of the
+	// given type.
+	InUse int `json:"used"`
+
+	// Reserved is a transitional state when a claim against quota has been made
+	// but the resource is not yet fully online.
+	Reserved int `json:"reserved"`
+
+	// Limit is the maximum number of a given resource that can be
+	// allocated/provisioned.  This is what "quota" usually refers to.
+	Limit int `json:"limit"`
 }

--- a/openstack/networking/v2/extensions/quotas/testing/fixtures.go
+++ b/openstack/networking/v2/extensions/quotas/testing/fixtures.go
@@ -15,7 +15,8 @@ const GetResponseRaw = `
         "security_group": 35,
         "security_group_rule": 40,
         "subnet": 45,
-        "subnetpool": -1
+        "subnetpool": -1,
+        "trunk": 50
     }
 }
 `
@@ -68,6 +69,11 @@ const GetDetailedResponseRaw = `
           "used": 0,
           "limit": -1,
           "reserved": 0
+      },
+      "trunk" : {
+          "used": 0,
+          "limit": 50,
+          "reserved": 0
       }
    }
 }
@@ -83,19 +89,21 @@ var GetResponse = quotas.Quota{
 	SecurityGroupRule: 40,
 	Subnet:            45,
 	SubnetPool:        -1,
+	Trunk:             50,
 }
 
 // GetDetailResponse is the first result in ListOutput.
 var GetDetailResponse = quotas.QuotaDetailSet{
-	FloatingIP:        quotas.QuotaDetail{InUse: 0, Reserved: 0, Limit: 15},
-	Network:           quotas.QuotaDetail{InUse: 0, Reserved: 0, Limit: 20},
-	Port:              quotas.QuotaDetail{InUse: 0, Reserved: 0, Limit: 25},
-	RBACPolicy:        quotas.QuotaDetail{InUse: 0, Reserved: 0, Limit: -1},
-	Router:            quotas.QuotaDetail{InUse: 0, Reserved: 0, Limit: 30},
-	SecurityGroup:     quotas.QuotaDetail{InUse: 0, Reserved: 0, Limit: 35},
-	SecurityGroupRule: quotas.QuotaDetail{InUse: 0, Reserved: 0, Limit: 40},
-	Subnet:            quotas.QuotaDetail{InUse: 0, Reserved: 0, Limit: 45},
-	SubnetPool:        quotas.QuotaDetail{InUse: 0, Reserved: 0, Limit: -1},
+	FloatingIP:        quotas.QuotaDetail{Used: 0, Reserved: 0, Limit: 15},
+	Network:           quotas.QuotaDetail{Used: 0, Reserved: 0, Limit: 20},
+	Port:              quotas.QuotaDetail{Used: 0, Reserved: 0, Limit: 25},
+	RBACPolicy:        quotas.QuotaDetail{Used: 0, Reserved: 0, Limit: -1},
+	Router:            quotas.QuotaDetail{Used: 0, Reserved: 0, Limit: 30},
+	SecurityGroup:     quotas.QuotaDetail{Used: 0, Reserved: 0, Limit: 35},
+	SecurityGroupRule: quotas.QuotaDetail{Used: 0, Reserved: 0, Limit: 40},
+	Subnet:            quotas.QuotaDetail{Used: 0, Reserved: 0, Limit: 45},
+	SubnetPool:        quotas.QuotaDetail{Used: 0, Reserved: 0, Limit: -1},
+	Trunk:             quotas.QuotaDetail{Used: 0, Reserved: 0, Limit: 50},
 }
 
 const UpdateRequestResponseRaw = `
@@ -109,7 +117,8 @@ const UpdateRequestResponseRaw = `
         "security_group": 20,
         "security_group_rule": -1,
         "subnet": 25,
-        "subnetpool": 0
+        "subnetpool": 0,
+        "trunk": 5
     }
 }
 `
@@ -124,4 +133,5 @@ var UpdateResponse = quotas.Quota{
 	SecurityGroupRule: -1,
 	Subnet:            25,
 	SubnetPool:        0,
+	Trunk:             5,
 }

--- a/openstack/networking/v2/extensions/quotas/testing/fixtures.go
+++ b/openstack/networking/v2/extensions/quotas/testing/fixtures.go
@@ -1,6 +1,8 @@
 package testing
 
-import "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/quotas"
+import (
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/quotas"
+)
 
 const GetResponseRaw = `
 {
@@ -18,6 +20,59 @@ const GetResponseRaw = `
 }
 `
 
+// GetDetailedResponseRaw is a sample response to a Get call with the detailed option.
+const GetDetailedResponseRaw = `
+{
+   "quota" : {
+      "floatingip" : {
+          "used": 0,
+          "limit": 15,
+          "reserved": 0
+      },
+      "network" : {
+          "used": 0,
+          "limit": 20,
+          "reserved": 0
+      },
+      "port" : {
+          "used": 0,
+          "limit": 25,
+          "reserved": 0
+      },
+      "rbac_policy" : {
+          "used": 0,
+          "limit": -1,
+          "reserved": 0
+      },
+      "router" : {
+          "used": 0,
+          "limit": 30,
+          "reserved": 0
+      },
+      "security_group" : {
+          "used": 0,
+          "limit": 35,
+          "reserved": 0
+      },
+      "security_group_rule" : {
+          "used": 0,
+          "limit": 40,
+          "reserved": 0
+      },
+      "subnet" : {
+          "used": 0,
+          "limit": 45,
+          "reserved": 0
+      },
+      "subnetpool" : {
+          "used": 0,
+          "limit": -1,
+          "reserved": 0
+      }
+   }
+}
+`
+
 var GetResponse = quotas.Quota{
 	FloatingIP:        15,
 	Network:           20,
@@ -28,6 +83,19 @@ var GetResponse = quotas.Quota{
 	SecurityGroupRule: 40,
 	Subnet:            45,
 	SubnetPool:        -1,
+}
+
+// GetDetailResponse is the first result in ListOutput.
+var GetDetailResponse = quotas.QuotaDetailSet{
+	FloatingIP:        quotas.QuotaDetail{InUse: 0, Reserved: 0, Limit: 15},
+	Network:           quotas.QuotaDetail{InUse: 0, Reserved: 0, Limit: 20},
+	Port:              quotas.QuotaDetail{InUse: 0, Reserved: 0, Limit: 25},
+	RBACPolicy:        quotas.QuotaDetail{InUse: 0, Reserved: 0, Limit: -1},
+	Router:            quotas.QuotaDetail{InUse: 0, Reserved: 0, Limit: 30},
+	SecurityGroup:     quotas.QuotaDetail{InUse: 0, Reserved: 0, Limit: 35},
+	SecurityGroupRule: quotas.QuotaDetail{InUse: 0, Reserved: 0, Limit: 40},
+	Subnet:            quotas.QuotaDetail{InUse: 0, Reserved: 0, Limit: 45},
+	SubnetPool:        quotas.QuotaDetail{InUse: 0, Reserved: 0, Limit: -1},
 }
 
 const UpdateRequestResponseRaw = `

--- a/openstack/networking/v2/extensions/quotas/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/quotas/testing/requests_test.go
@@ -73,6 +73,7 @@ func TestUpdate(t *testing.T) {
 		SecurityGroupRule: gophercloud.IntToPointer(-1),
 		Subnet:            gophercloud.IntToPointer(25),
 		SubnetPool:        gophercloud.IntToPointer(0),
+		Trunk:             gophercloud.IntToPointer(5),
 	}).Extract()
 
 	th.AssertNoErr(t, err)

--- a/openstack/networking/v2/extensions/quotas/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/quotas/testing/requests_test.go
@@ -30,6 +30,25 @@ func TestGet(t *testing.T) {
 	th.AssertDeepEquals(t, q, &GetResponse)
 }
 
+func TestGetDetail(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/quotas/0a73845280574ad389c292f6a74afa76/details.json", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, GetDetailedResponseRaw)
+	})
+
+	q, err := quotas.GetDetail(fake.ServiceClient(), "0a73845280574ad389c292f6a74afa76").Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, q, &GetDetailResponse)
+}
+
 func TestUpdate(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()

--- a/openstack/networking/v2/extensions/quotas/urls.go
+++ b/openstack/networking/v2/extensions/quotas/urls.go
@@ -3,13 +3,22 @@ package quotas
 import "github.com/gophercloud/gophercloud"
 
 const resourcePath = "quotas"
+const resourcePathDetail = "details.json"
 
 func resourceURL(c *gophercloud.ServiceClient, projectID string) string {
 	return c.ServiceURL(resourcePath, projectID)
 }
 
+func resourceDetailURL(c *gophercloud.ServiceClient, projectID string) string {
+	return c.ServiceURL(resourcePath, projectID, resourcePathDetail)
+}
+
 func getURL(c *gophercloud.ServiceClient, projectID string) string {
 	return resourceURL(c, projectID)
+}
+
+func getDetailURL(c *gophercloud.ServiceClient, projectID string) string {
+	return resourceDetailURL(c, projectID)
 }
 
 func updateURL(c *gophercloud.ServiceClient, projectID string) string {


### PR DESCRIPTION
* Networking v2: Add Get Detailed Quota for Tenant
* Add GetDetail function for the quotas extension in Gophercloud's OpenStack Networking v2 API
* Add 'trunk' resource in Networking v2 quotas

- Allows a caller to get the list of quota types with in_use, reserved, and limit values for each
- Effectively wraps OpenStack Networking v2 API function /v2.0/quotas/{project_id}/details.json
- Inspired from the Compute API implementation.
- When the 'trunk' extension is enabled, it's possible to set quotas for 
trunks resources, the same way as other networking resources.

For #2060 (detailed quota)
For #2064 (trunk support)
API reference: https://docs.openstack.org/api-ref/network/v2/index.html?expanded=show-quota-details-for-a-tenant-detail#quotas-extension-quotas

Code references:
* (extension) https://opendev.org/openstack/neutron/src/branch/master/neutron/extensions/quotasv2_detail.py
* (options) https://opendev.org/openstack/neutron/src/branch/master/neutron/conf/quota.py
* (trunk api) https://opendev.org/openstack/neutron-lib/src/branch/master/neutron_lib/api/definitions/trunk.py#L49
* It is registered as a quota resource in neutron here: https://opendev.org/openstack/neutron/src/branch/master/neutron/extensions/trunk.py