### PR TITLE
Objectstore v1: allow to remove account and object metadata

### DIFF
--- a/openstack/objectstorage/v1/accounts/requests.go
+++ b/openstack/objectstorage/v1/accounts/requests.go
@@ -53,6 +53,7 @@ type UpdateOptsBuilder interface {
 // deleting an account's metadata.
 type UpdateOpts struct {
 	Metadata          map[string]string
+	RemoveMetadata    []string
 	ContentType       string `h:"Content-Type"`
 	DetectContentType bool   `h:"X-Detect-Content-Type"`
 	TempURLKey        string `h:"X-Account-Meta-Temp-URL-Key"`
@@ -65,9 +66,15 @@ func (opts UpdateOpts) ToAccountUpdateMap() (map[string]string, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	for k, v := range opts.Metadata {
 		headers["X-Account-Meta-"+k] = v
 	}
+
+	for _, k := range opts.RemoveMetadata {
+		headers["X-Remove-Account-Meta-"+k] = "remove"
+	}
+
 	return headers, err
 }
 

--- a/openstack/objectstorage/v1/accounts/testing/fixtures.go
+++ b/openstack/objectstorage/v1/accounts/testing/fixtures.go
@@ -51,6 +51,7 @@ func HandleUpdateAccountSuccessfully(t *testing.T) {
 		th.TestMethod(t, r, "POST")
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 		th.TestHeader(t, r, "X-Account-Meta-Gophercloud-Test", "accounts")
+		th.TestHeader(t, r, "X-Remove-Account-Meta-Gophercloud-Test-Remove", "remove")
 
 		w.Header().Set("Date", "Fri, 17 Jan 2014 16:09:56 UTC")
 		w.WriteHeader(http.StatusNoContent)

--- a/openstack/objectstorage/v1/accounts/testing/requests_test.go
+++ b/openstack/objectstorage/v1/accounts/testing/requests_test.go
@@ -14,7 +14,10 @@ func TestUpdateAccount(t *testing.T) {
 	defer th.TeardownHTTP()
 	HandleUpdateAccountSuccessfully(t)
 
-	options := &accounts.UpdateOpts{Metadata: map[string]string{"gophercloud-test": "accounts"}}
+	options := &accounts.UpdateOpts{
+		Metadata:       map[string]string{"gophercloud-test": "accounts"},
+		RemoveMetadata: []string{"gophercloud-test-remove"},
+	}
 	res := accounts.Update(fake.ServiceClient(), options)
 	th.AssertNoErr(t, res.Err)
 

--- a/openstack/objectstorage/v1/objects/requests.go
+++ b/openstack/objectstorage/v1/objects/requests.go
@@ -388,6 +388,7 @@ type UpdateOptsBuilder interface {
 // deleting an object's metadata.
 type UpdateOpts struct {
 	Metadata           map[string]string
+	RemoveMetadata     []string
 	ContentDisposition string `h:"Content-Disposition"`
 	ContentEncoding    string `h:"Content-Encoding"`
 	ContentType        string `h:"Content-Type"`
@@ -402,8 +403,13 @@ func (opts UpdateOpts) ToObjectUpdateMap() (map[string]string, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	for k, v := range opts.Metadata {
 		h["X-Object-Meta-"+k] = v
+	}
+
+	for _, k := range opts.RemoveMetadata {
+		h["X-Remove-Object-Meta-"+k] = "remove"
 	}
 	return h, nil
 }

--- a/openstack/objectstorage/v1/objects/testing/fixtures.go
+++ b/openstack/objectstorage/v1/objects/testing/fixtures.go
@@ -264,6 +264,7 @@ func HandleUpdateObjectSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 		th.TestHeader(t, r, "Accept", "application/json")
 		th.TestHeader(t, r, "X-Object-Meta-Gophercloud-Test", "objects")
+		th.TestHeader(t, r, "X-Remove-Object-Meta-Gophercloud-Test-Remove", "remove")
 		w.WriteHeader(http.StatusAccepted)
 	})
 }

--- a/openstack/objectstorage/v1/objects/testing/requests_test.go
+++ b/openstack/objectstorage/v1/objects/testing/requests_test.go
@@ -238,7 +238,10 @@ func TestUpateObjectMetadata(t *testing.T) {
 	defer th.TeardownHTTP()
 	HandleUpdateObjectSuccessfully(t)
 
-	options := &objects.UpdateOpts{Metadata: map[string]string{"Gophercloud-Test": "objects"}}
+	options := &objects.UpdateOpts{
+		Metadata:       map[string]string{"Gophercloud-Test": "objects"},
+		RemoveMetadata: []string{"Gophercloud-Test-Remove"},
+	}
 	res := objects.Update(fake.ServiceClient(), "testContainer", "testObject", options)
 	th.AssertNoErr(t, res.Err)
 }


### PR DESCRIPTION
For #2062

Documentation about metadata handling in middlewares.
https://github.com/openstack/swift/blob/master/doc/source/development_middleware.rst#user-metadata

Actual code that handles `X-Remove-xxx-Meta-name` haders.
https://github.com/openstack/swift/blob/master/swift/proxy/controllers/base.py#L1647

Documentation update account.
https://docs.openstack.org/api-ref/object-store/#create-update-or-delete-account-metadata

> X-Remove-Account-name (Optional) | header | string | Removes the metadata item named name. For example, X-Remove-Account-Meta-Blue removes custom metadata.



