### PR TITLE
[Identity v3] Add service catalog listing

### DIFF
--- a/acceptance/openstack/identity/v3/catalog_test.go
+++ b/acceptance/openstack/identity/v3/catalog_test.go
@@ -1,0 +1,25 @@
+package v3
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/acceptance/clients"
+	"github.com/gophercloud/gophercloud/acceptance/tools"
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/catalog"
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestCatalogList(t *testing.T) {
+	client, err := clients.NewIdentityV3Client()
+	th.AssertNoErr(t, err)
+
+	allPages, err := catalog.List(client).AllPages()
+	th.AssertNoErr(t, err)
+
+	allEntities, err := catalog.ExtractServiceCatalog(allPages)
+	th.AssertNoErr(t, err)
+
+	for _, entity := range allEntities {
+		tools.PrintResource(t, entity)
+	}
+}

--- a/openstack/identity/v3/catalog/requests.go
+++ b/openstack/identity/v3/catalog/requests.go
@@ -1,0 +1,14 @@
+package catalog
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// List enumerates the services available to a specific user.
+func List(client *gophercloud.ServiceClient) pagination.Pager {
+	url := listURL(client)
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return ServiceCatalogPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}

--- a/openstack/identity/v3/catalog/results.go
+++ b/openstack/identity/v3/catalog/results.go
@@ -1,0 +1,26 @@
+package catalog
+
+import (
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/tokens"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// ServiceCatalogPage is a single page of Service results.
+type ServiceCatalogPage struct {
+	pagination.LinkedPageBase
+}
+
+// IsEmpty returns true if the ServiceCatalogPage contains no results.
+func (r ServiceCatalogPage) IsEmpty() (bool, error) {
+	services, err := ExtractServiceCatalog(r)
+	return len(services) == 0, err
+}
+
+// ExtractServiceCatalog extracts a slice of Catalog from a Collection acquired from List.
+func ExtractServiceCatalog(r pagination.Page) ([]tokens.CatalogEntry, error) {
+	var s struct {
+		Entries []tokens.CatalogEntry `json:"catalog"`
+	}
+	err := (r.(ServiceCatalogPage)).ExtractInto(&s)
+	return s.Entries, err
+}

--- a/openstack/identity/v3/catalog/testing/catalog_test.go
+++ b/openstack/identity/v3/catalog/testing/catalog_test.go
@@ -1,0 +1,30 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/catalog"
+	"github.com/gophercloud/gophercloud/pagination"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func TestListCatalog(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleListCatalogSuccessfully(t)
+
+	count := 0
+	err := catalog.List(client.ServiceClient()).EachPage(func(page pagination.Page) (bool, error) {
+		count++
+
+		actual, err := catalog.ExtractServiceCatalog(page)
+		th.AssertNoErr(t, err)
+
+		th.CheckDeepEquals(t, ExpectedCatalogSlice, actual)
+
+		return true, nil
+	})
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, count, 1)
+}

--- a/openstack/identity/v3/catalog/testing/fixtures.go
+++ b/openstack/identity/v3/catalog/testing/fixtures.go
@@ -1,0 +1,90 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/tokens"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+// ListOutput provides a single page of ServiceCatalog results.
+const ListOutput = `
+{
+    "catalog": [
+        {
+            "endpoints": [
+                {
+                    "id": "39dc322ce86c4111b4f06c2eeae0841b",
+                    "interface": "public",
+                    "region": "RegionOne",
+                    "url": "http://localhost:5000"
+                },
+                {
+                    "id": "ec642f27474842e78bf059f6c48f4e99",
+                    "interface": "internal",
+                    "region": "RegionOne",
+                    "url": "http://localhost:5000"
+                },
+                {
+                    "id": "c609fc430175452290b62a4242e8a7e8",
+                    "interface": "admin",
+                    "region": "RegionOne",
+                    "url": "http://localhost:5000"
+                }
+            ],
+            "id": "4363ae44bdf34a3981fde3b823cb9aa2",
+            "type": "identity",
+            "name": "keystone"
+        }
+    ],
+    "links": {
+        "self": "https://example.com/identity/v3/catalog",
+        "previous": null,
+        "next": null
+    }
+}
+`
+
+// ExpectedCatalogSlice is the slice of domains expected to be returned from ListOutput.
+var ExpectedCatalogSlice = []tokens.CatalogEntry{{
+	ID:   "4363ae44bdf34a3981fde3b823cb9aa2",
+	Name: "keystone",
+	Type: "identity",
+	Endpoints: []tokens.Endpoint{
+		{
+			ID:        "39dc322ce86c4111b4f06c2eeae0841b",
+			Interface: "public",
+			Region:    "RegionOne",
+			URL:       "http://localhost:5000",
+		},
+		{
+			ID:        "ec642f27474842e78bf059f6c48f4e99",
+			Interface: "internal",
+			Region:    "RegionOne",
+			URL:       "http://localhost:5000",
+		},
+		{
+			ID:        "c609fc430175452290b62a4242e8a7e8",
+			Region:    "RegionOne",
+			Interface: "admin",
+			URL:       "http://localhost:5000",
+		},
+	},
+}}
+
+// HandleListCatalogSuccessfully creates an HTTP handler at `/domains` on the
+// test handler mux that responds with a list of two domains.
+func HandleListCatalogSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/auth/catalog", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintf(w, ListOutput)
+	})
+}

--- a/openstack/identity/v3/catalog/urls.go
+++ b/openstack/identity/v3/catalog/urls.go
@@ -1,0 +1,7 @@
+package catalog
+
+import "github.com/gophercloud/gophercloud"
+
+func listURL(client *gophercloud.ServiceClient) string {
+	return client.ServiceURL("auth", "catalog")
+}


### PR DESCRIPTION
For #1719 (one of four requested resources)

Add support of service catalog list

API reference:
https://docs.openstack.org/api-ref/identity/v3/?expanded=get-service-catalog-detail#get-service-catalog

Implementation:
https://github.com/openstack/keystone/blob/stable/victoria/keystone/catalog/core.py#L237
