### PR TITLE
openstack/networking/v2/extensions/fwaas_v2/groups/requests.go 

### DIFF
--- a/openstack/networking/v2/extensions/fwaas_v2/groups/requests.go
+++ b/openstack/networking/v2/extensions/fwaas_v2/groups/requests.go
@@ -119,13 +119,13 @@ type UpdateOptsBuilder interface {
 
 // UpdateOpts contains the values used when updating a firewall group.
 type UpdateOpts struct {
-	Name                    *string  `json:"name,omitempty"`
-	Description             *string  `json:"description,omitempty"`
-	IngressFirewallPolicyID *string  `json:"ingress_firewall_policy_id,omitempty"`
-	EgressFirewallPolicyID  *string  `json:"egress_firewall_policy_id,omitempty"`
-	AdminStateUp            *bool    `json:"admin_state_up,omitempty"`
-	Ports                   []string `json:"ports,omitempty"`
-	Shared                  *bool    `json:"shared,omitempty"`
+	Name                    *string   `json:"name,omitempty"`
+	Description             *string   `json:"description,omitempty"`
+	IngressFirewallPolicyID *string   `json:"ingress_firewall_policy_id,omitempty"`
+	EgressFirewallPolicyID  *string   `json:"egress_firewall_policy_id,omitempty"`
+	AdminStateUp            *bool     `json:"admin_state_up,omitempty"`
+	Ports                   *[]string `json:"ports,omitempty"`
+	Shared                  *bool     `json:"shared,omitempty"`
 }
 
 // ToFirewallGroupUpdateMap casts a CreateOpts struct to a map.

--- a/openstack/networking/v2/extensions/fwaas_v2/groups/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/fwaas_v2/groups/testing/requests_test.go
@@ -284,7 +284,7 @@ func TestUpdate(t *testing.T) {
 	options := groups.UpdateOpts{
 		Name:        &name,
 		Description: &description,
-		Ports: []string{
+		Ports: &[]string{
 			"a6af1e56-b12b-4733-8f77-49166afd5719",
 			"11a58c87-76be-ae7c-a74e-b77fffb88a32",
 		},


### PR DESCRIPTION
For #2099

make UpdateOpts.Ports to pointer to allow unsetting it explicitly.

By this change it will be possible to do the same as `openstack firewall group unset --all-ports <id>`.

As long as the Ports field is only a `[]string`:
* whenever I want to set the empty array, the attribute will get dropped due to `omitempty` resulting in not unsetting the value.
* however removing the `omitempty` will result in always having to set the value (and implicitly do a unset, if not setting the attribute, when only updating other values is wanted).

The struct was introduced in https://github.com/gophercloud/gophercloud/pull/2050

We need to be able to unset the value in our openstack, because on our openstack the fwaas group will only be able to get deleted when we get a status of `DOWN`. So we have to delete by:
* setting the firewall group to `disable`
* setting the ports of the firewall group to empty (to trigger reconciling the status in the fwaas driver)

---
<sup>
Christian Schlotter <christian.schlotter@daimler.com>, Daimler TSS GmbH, 
<a href="https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md">Imprint</a>
</sup>