### PR TITLE
loadbalancer/v2 Support fully populated load balancer

### DIFF
--- a/openstack/loadbalancer/v2/l7policies/requests.go
+++ b/openstack/loadbalancer/v2/l7policies/requests.go
@@ -67,8 +67,12 @@ type CreateOpts struct {
 	// or false (DOWN).
 	AdminStateUp *bool `json:"admin_state_up,omitempty"`
 
-	// Create rules opts
-	Rules []CreateRuleOpts `json:"rules,omitempty"`
+	// Rules is a slice of CreateRuleOpts which allows a set of rules
+	// to be created at the same time the policy is created.
+	//
+	// This is only possible to use when creating a fully populated
+	// Loadbalancer.
+	Rules []CreateRuleOpts `json:"rules,omitempty" xor:"ListenerID"`
 }
 
 // ToL7PolicyCreateMap builds a request body from CreateOpts.
@@ -185,9 +189,6 @@ type UpdateOpts struct {
 	// The administrative state of the Loadbalancer. A valid value is true (UP)
 	// or false (DOWN).
 	AdminStateUp *bool `json:"admin_state_up,omitempty"`
-
-	// Update rules opts
-	Rules *[]UpdateRuleOpts `json:"rules,omitempty"`
 }
 
 // ToL7PolicyUpdateMap builds a request body from UpdateOpts.

--- a/openstack/loadbalancer/v2/l7policies/requests.go
+++ b/openstack/loadbalancer/v2/l7policies/requests.go
@@ -40,7 +40,7 @@ type CreateOpts struct {
 	Name string `json:"name,omitempty"`
 
 	// The ID of the listener.
-	ListenerID string `json:"listener_id" required:"true"`
+	ListenerID string `json:"listener_id,omitempty"`
 
 	// The L7 policy action. One of REDIRECT_TO_POOL, REDIRECT_TO_URL, or REJECT.
 	Action Action `json:"action" required:"true"`
@@ -66,6 +66,9 @@ type CreateOpts struct {
 	// The administrative state of the Loadbalancer. A valid value is true (UP)
 	// or false (DOWN).
 	AdminStateUp *bool `json:"admin_state_up,omitempty"`
+
+	// Create rules opts
+	Rules []CreateRuleOpts `json:"rules,omitempty"`
 }
 
 // ToL7PolicyCreateMap builds a request body from CreateOpts.
@@ -182,6 +185,9 @@ type UpdateOpts struct {
 	// The administrative state of the Loadbalancer. A valid value is true (UP)
 	// or false (DOWN).
 	AdminStateUp *bool `json:"admin_state_up,omitempty"`
+
+	// Update rules opts
+	Rules *[]UpdateRuleOpts `json:"rules,omitempty"`
 }
 
 // ToL7PolicyUpdateMap builds a request body from UpdateOpts.

--- a/openstack/loadbalancer/v2/listeners/requests.go
+++ b/openstack/loadbalancer/v2/listeners/requests.go
@@ -104,8 +104,12 @@ type CreateOpts struct {
 	// The ID of the default pool with which the Listener is associated.
 	DefaultPoolID string `json:"default_pool_id,omitempty"`
 
-	// The default pool with which the Listener is associated.
-	DefaultPool *pools.CreateOpts `json:"default_pool,omitempty"`
+	// DefaultPool an instance of pools.CreateOpts which allows a
+	// (default) pool to be created at the same time the listener is created.
+	//
+	// This is only possible to use when creating a fully populated
+	// load balancer.
+	DefaultPool *pools.CreateOpts `json:"default_pool,omitempty" xor:"LoadbalancerID"`
 
 	// Human-readable description for the Listener.
 	Description string `json:"description,omitempty"`
@@ -123,8 +127,12 @@ type CreateOpts struct {
 	// or false (DOWN).
 	AdminStateUp *bool `json:"admin_state_up,omitempty"`
 
-	// L7policies are the L7 policies which are part of this listener.
-	L7Policies []l7policies.CreateOpts `json:"l7policies,omitempty"`
+	// L7Policies is a slice of l7policies.CreateOpts which allows a set
+	// of policies to be created at the same time the listener is created.
+	//
+	// This is only possible to use when creating a fully populated
+	// Loadbalancer.
+	L7Policies []l7policies.CreateOpts `json:"l7policies,omitempty" xor:"LoadbalancerID"`
 
 	// Frontend client inactivity timeout in milliseconds
 	TimeoutClientData *int `json:"timeout_client_data,omitempty"`
@@ -189,9 +197,6 @@ type UpdateOpts struct {
 	// The ID of the default pool with which the Listener is associated.
 	DefaultPoolID *string `json:"default_pool_id,omitempty"`
 
-	// The default pool with which the Listener is associated.
-	DefaultPool *pools.UpdateOpts `json:"default_pool,omitempty"`
-
 	// Human-readable description for the Listener.
 	Description *string `json:"description,omitempty"`
 
@@ -207,9 +212,6 @@ type UpdateOpts struct {
 	// The administrative state of the Listener. A valid value is true (UP)
 	// or false (DOWN).
 	AdminStateUp *bool `json:"admin_state_up,omitempty"`
-
-	// L7policies are the L7 policies which are part of this listener.
-	L7Policies *[]l7policies.UpdateOpts `json:"l7policies,omitempty"`
 
 	// Frontend client inactivity timeout in milliseconds
 	TimeoutClientData *int `json:"timeout_client_data,omitempty"`

--- a/openstack/loadbalancer/v2/listeners/requests.go
+++ b/openstack/loadbalancer/v2/listeners/requests.go
@@ -2,6 +2,8 @@ package listeners
 
 import (
 	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/l7policies"
+	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/pools"
 	"github.com/gophercloud/gophercloud/pagination"
 )
 
@@ -84,7 +86,7 @@ type CreateOptsBuilder interface {
 // CreateOpts represents options for creating a listener.
 type CreateOpts struct {
 	// The load balancer on which to provision this listener.
-	LoadbalancerID string `json:"loadbalancer_id" required:"true"`
+	LoadbalancerID string `json:"loadbalancer_id,omitempty"`
 
 	// The protocol - can either be TCP, HTTP, HTTPS or TERMINATED_HTTPS.
 	Protocol Protocol `json:"protocol" required:"true"`
@@ -102,6 +104,9 @@ type CreateOpts struct {
 	// The ID of the default pool with which the Listener is associated.
 	DefaultPoolID string `json:"default_pool_id,omitempty"`
 
+	// The default pool with which the Listener is associated.
+	DefaultPool *pools.CreateOpts `json:"default_pool,omitempty"`
+
 	// Human-readable description for the Listener.
 	Description string `json:"description,omitempty"`
 
@@ -117,6 +122,9 @@ type CreateOpts struct {
 	// The administrative state of the Listener. A valid value is true (UP)
 	// or false (DOWN).
 	AdminStateUp *bool `json:"admin_state_up,omitempty"`
+
+	// L7policies are the L7 policies which are part of this listener.
+	L7Policies []l7policies.CreateOpts `json:"l7policies,omitempty"`
 
 	// Frontend client inactivity timeout in milliseconds
 	TimeoutClientData *int `json:"timeout_client_data,omitempty"`
@@ -181,6 +189,9 @@ type UpdateOpts struct {
 	// The ID of the default pool with which the Listener is associated.
 	DefaultPoolID *string `json:"default_pool_id,omitempty"`
 
+	// The default pool with which the Listener is associated.
+	DefaultPool *pools.UpdateOpts `json:"default_pool,omitempty"`
+
 	// Human-readable description for the Listener.
 	Description *string `json:"description,omitempty"`
 
@@ -196,6 +207,9 @@ type UpdateOpts struct {
 	// The administrative state of the Listener. A valid value is true (UP)
 	// or false (DOWN).
 	AdminStateUp *bool `json:"admin_state_up,omitempty"`
+
+	// L7policies are the L7 policies which are part of this listener.
+	L7Policies *[]l7policies.UpdateOpts `json:"l7policies,omitempty"`
 
 	// Frontend client inactivity timeout in milliseconds
 	TimeoutClientData *int `json:"timeout_client_data,omitempty"`

--- a/openstack/loadbalancer/v2/listeners/results.go
+++ b/openstack/loadbalancer/v2/listeners/results.go
@@ -37,6 +37,9 @@ type Listener struct {
 	// The UUID of default pool. Must have compatible protocol with listener.
 	DefaultPoolID string `json:"default_pool_id"`
 
+	// The default pool with which the Listener is associated.
+	DefaultPool *pools.Pool `json:"default_pool"`
+
 	// A list of load balancer IDs.
 	Loadbalancers []LoadBalancerID `json:"loadbalancers"`
 

--- a/openstack/loadbalancer/v2/loadbalancers/doc.go
+++ b/openstack/loadbalancer/v2/loadbalancers/doc.go
@@ -39,6 +39,54 @@ Example to Create a Load Balancer
 		panic(err)
 	}
 
+Example to Create a fully populated Load Balancer
+
+	createOpts := loadbalancers.CreateOpts{
+		Name:         "db_lb",
+		AdminStateUp: gophercloud.Enabled,
+		VipSubnetID:  "9cedb85d-0759-4898-8a4b-fa5a5ea10086",
+		VipAddress:   "10.30.176.48",
+		FlavorID:     "60df399a-ee85-11e9-81b4-2a2ae2dbcce4",
+		Provider:     "haproxy",
+		Tags:         []string{"test", "stage"},
+		Listeners: []listeners.CreateOpts{{
+			Protocol:     "HTTP",
+			ProtocolPort: 8080,
+			Name:         "redirect_listener",
+			L7Policies: []l7policies.CreateOpts{{
+				Name:        "redirect-example.com",
+				Action:      l7policies.ActionRedirectToURL,
+				RedirectURL: "http://www.example.com",
+				Rules: []l7policies.CreateRuleOpts{{
+					RuleType:    l7policies.TypePath,
+					CompareType: l7policies.CompareTypeRegex,
+					Value:       "/images*",
+				}},
+			}},
+			DefaultPool: &pools.CreateOpts{
+				LBMethod: pools.LBMethodRoundRobin,
+				Protocol: "HTTP",
+				Name:     "example pool",
+				Members: []pools.BatchUpdateMemberOpts{{
+					Address:      "192.0.2.51",
+					ProtocolPort: 80,
+				},},
+				Monitor: &monitors.CreateOpts{
+					Name:           "db",
+					Type:           "HTTP",
+					Delay:          3,
+					MaxRetries:     2,
+					Timeout:        1,
+				},
+			},
+		}},
+	}
+
+	lb, err := loadbalancers.Create(networkClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
 Example to Update a Load Balancer
 
 	lbID := "d67d56a6-4a86-4688-a282-f46444705c64"

--- a/openstack/loadbalancer/v2/loadbalancers/requests.go
+++ b/openstack/loadbalancer/v2/loadbalancers/requests.go
@@ -121,10 +121,18 @@ type CreateOpts struct {
 	// The name of the provider.
 	Provider string `json:"provider,omitempty"`
 
-	// Listeners are the listeners related to this Loadbalancer.
+	// Listeners is a slice of listeners.CreateOpts which allows a set
+	// of listeners to be created at the same time the Loadbalancer is created.
+	//
+	// This is only possible to use when creating a fully populated
+	// load balancer.
 	Listeners []listeners.CreateOpts `json:"listeners,omitempty"`
 
-	// Pools are the pools related to this Loadbalancer.
+	// Pools is a slice of pools.CreateOpts which allows a set of pools
+	// to be created at the same time the Loadbalancer is created.
+	//
+	// This is only possible to use when creating a fully populated
+	// load balancer.
 	Pools []pools.CreateOpts `json:"pools,omitempty"`
 
 	// Tags is a set of resource tags.
@@ -176,12 +184,6 @@ type UpdateOpts struct {
 	// The administrative state of the Loadbalancer. A valid value is true (UP)
 	// or false (DOWN).
 	AdminStateUp *bool `json:"admin_state_up,omitempty"`
-
-	// Listeners are the listeners related to this Loadbalancer.
-	Listeners *[]listeners.UpdateOpts `json:"listeners,omitempty"`
-
-	// Pools are the pools related to this Loadbalancer.
-	Pools *[]pools.UpdateOpts `json:"pools,omitempty"`
 
 	// Tags is a set of resource tags.
 	Tags *[]string `json:"tags,omitempty"`

--- a/openstack/loadbalancer/v2/loadbalancers/requests.go
+++ b/openstack/loadbalancer/v2/loadbalancers/requests.go
@@ -2,6 +2,8 @@ package loadbalancers
 
 import (
 	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/listeners"
+	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/pools"
 	"github.com/gophercloud/gophercloud/pagination"
 )
 
@@ -119,6 +121,12 @@ type CreateOpts struct {
 	// The name of the provider.
 	Provider string `json:"provider,omitempty"`
 
+	// Listeners are the listeners related to this Loadbalancer.
+	Listeners []listeners.CreateOpts `json:"listeners,omitempty"`
+
+	// Pools are the pools related to this Loadbalancer.
+	Pools []pools.CreateOpts `json:"pools,omitempty"`
+
 	// Tags is a set of resource tags.
 	Tags []string `json:"tags,omitempty"`
 }
@@ -168,6 +176,12 @@ type UpdateOpts struct {
 	// The administrative state of the Loadbalancer. A valid value is true (UP)
 	// or false (DOWN).
 	AdminStateUp *bool `json:"admin_state_up,omitempty"`
+
+	// Listeners are the listeners related to this Loadbalancer.
+	Listeners *[]listeners.UpdateOpts `json:"listeners,omitempty"`
+
+	// Pools are the pools related to this Loadbalancer.
+	Pools *[]pools.UpdateOpts `json:"pools,omitempty"`
 
 	// Tags is a set of resource tags.
 	Tags *[]string `json:"tags,omitempty"`

--- a/openstack/loadbalancer/v2/loadbalancers/testing/fixtures.go
+++ b/openstack/loadbalancer/v2/loadbalancers/testing/fixtures.go
@@ -108,103 +108,94 @@ const PostUpdateLoadbalancerBody = `
 // PostFullyPopulatedLoadbalancerBody is the canned response body of a Create request of an fully populated loadbalancer.
 const PostFullyPopulatedLoadbalancerBody = `
 {
-    "loadbalancer": {
-        "description": "My favorite load balancer",
-        "admin_state_up": true,
-        "project_id": "e3cd678b11784734bc366148aa37580e",
-        "provisioning_status": "ACTIVE",
-        "flavor_id": "",
+	"loadbalancer": {
+		"description": "My favorite load balancer",
+		"admin_state_up": true,
+		"project_id": "e3cd678b11784734bc366148aa37580e",
+		"provisioning_status": "ACTIVE",
+		"flavor_id": "",
 		"created_at": "2019-06-30T04:15:37",
 		"updated_at": "2019-06-30T05:18:49",
-        "listeners": [
-            {
-                "l7policies": [
-                    {
-                        "description": "",
-                        "admin_state_up": true,
-                        "rules": [],
-                        "project_id": "e3cd678b11784734bc366148aa37580e",
-                        "listener_id": "95de30ec-67f4-437b-b3f3-22c5d9ef9828",
-                        "redirect_url": "https://www.example.com/",
-                        "action": "REDIRECT_TO_URL",
-                        "position": 1,
-                        "id": "d0553837-f890-4981-b99a-f7cbd6a76577",
-                        "name": "redirect_policy"
-                    }
-                ],
-                "protocol": "HTTP",
-                "description": "",
-                "default_tls_container_ref": null,
-                "admin_state_up": true,
-                "default_pool_id": "c8cec227-410a-4a5b-af13-ecf38c2b0abb",
-                "project_id": "e3cd678b11784734bc366148aa37580e",
-                "default_tls_container_id": null,
-                "connection_limit": -1,
-                "sni_container_refs": [],
-                "protocol_port": 8080,
-                "id": "95de30ec-67f4-437b-b3f3-22c5d9ef9828",
-                "name": "redirect_listener"
-            }
-        ],
-        "vip_address": "203.0.113.50",
-        "vip_network_id": "d0d217df-3958-4fbf-a3c2-8dad2908c709",
-        "vip_subnet_id": "d4af86e1-0051-488c-b7a0-527f97490c9a",
-        "vip_port_id": "b4ca07d1-a31e-43e2-891a-7d14f419f342",
-        "provider": "octavia",
-        "pools": [
-            {
-                "lb_algorithm": "ROUND_ROBIN",
-                "protocol": "HTTP",
-                "description": "",
-                "admin_state_up": true,
-                "project_id": "e3cd678b11784734bc366148aa37580e",
-                "session_persistence": null,
-                "healthmonitor": {
-                    "name": "",
-                    "admin_state_up": true,
-                    "project_id": "e3cd678b11784734bc366148aa37580e",
-                    "delay": 3,
-                    "expected_codes": "200,201,202",
-                    "max_retries": 2,
-                    "http_method": "GET",
-                    "timeout": 1,
-                    "max_retries_down": 3,
-                    "url_path": "/index.html",
-                    "type": "HTTP",
-                    "id": "a8a2aa3f-d099-4752-8265-e6472f8147f9"
-                },
-                "members": [
-                    {
-                        "name": "",
-                        "weight": 1,
-                        "admin_state_up": true,
-                        "subnet_id": "bbb35f84-35cc-4b2f-84c2-a6a29bba68aa",
-                        "project_id": "e3cd678b11784734bc366148aa37580e",
-                        "address": "192.0.2.16",
-                        "protocol_port": 80,
-                        "id": "7d19ad6c-d549-453e-a5cd-05382c6be96a"
-                    },
-                    {
-                        "name": "",
-                        "weight": 1,
-                        "admin_state_up": true,
-                        "subnet_id": "bbb35f84-35cc-4b2f-84c2-a6a29bba68aa",
-                        "project_id": "e3cd678b11784734bc366148aa37580e",
-                        "address": "192.0.2.19",
-                        "protocol_port": 80,
-                        "id": "a167402b-caa6-41d5-b4d4-bde7f2cbfa5e"
-                    }
-                ],
-                "id": "c8cec227-410a-4a5b-af13-ecf38c2b0abb",
-                "name": "rr_pool"
-            }
-        ],
-        "id": "607226db-27ef-4d41-ae89-f2a800e9c2db",
-        "operating_status": "ONLINE",
-        "name": "best_load_balancer",
-        "availability_zone": "my_az",
-        "tags": ["test_tag"]
-    }
+		"listeners": [{
+			"l7policies": [{
+				"description": "",
+				"admin_state_up": true,
+				"rules": [],
+				"project_id": "e3cd678b11784734bc366148aa37580e",
+				"listener_id": "95de30ec-67f4-437b-b3f3-22c5d9ef9828",
+				"redirect_url": "https://www.example.com/",
+				"action": "REDIRECT_TO_URL",
+				"position": 1,
+				"id": "d0553837-f890-4981-b99a-f7cbd6a76577",
+				"name": "redirect_policy"
+			}],
+			"protocol": "HTTP",
+			"description": "",
+			"default_tls_container_ref": null,
+			"admin_state_up": true,
+			"default_pool_id": "c8cec227-410a-4a5b-af13-ecf38c2b0abb",
+			"project_id": "e3cd678b11784734bc366148aa37580e",
+			"default_tls_container_id": null,
+			"connection_limit": -1,
+			"sni_container_refs": [],
+			"protocol_port": 8080,
+			"id": "95de30ec-67f4-437b-b3f3-22c5d9ef9828",
+			"name": "redirect_listener"
+		}],
+		"vip_address": "203.0.113.50",
+		"vip_network_id": "d0d217df-3958-4fbf-a3c2-8dad2908c709",
+		"vip_subnet_id": "d4af86e1-0051-488c-b7a0-527f97490c9a",
+		"vip_port_id": "b4ca07d1-a31e-43e2-891a-7d14f419f342",
+		"provider": "octavia",
+		"pools": [{
+			"lb_algorithm": "ROUND_ROBIN",
+			"protocol": "HTTP",
+			"description": "",
+			"admin_state_up": true,
+			"project_id": "e3cd678b11784734bc366148aa37580e",
+			"session_persistence": null,
+			"healthmonitor": {
+				"name": "",
+				"admin_state_up": true,
+				"project_id": "e3cd678b11784734bc366148aa37580e",
+				"delay": 3,
+				"expected_codes": "200,201,202",
+				"max_retries": 2,
+				"http_method": "GET",
+				"timeout": 1,
+				"max_retries_down": 3,
+				"url_path": "/index.html",
+				"type": "HTTP",
+				"id": "a8a2aa3f-d099-4752-8265-e6472f8147f9"
+			},
+			"members": [{
+				"name": "",
+				"weight": 1,
+				"admin_state_up": true,
+				"subnet_id": "bbb35f84-35cc-4b2f-84c2-a6a29bba68aa",
+				"project_id": "e3cd678b11784734bc366148aa37580e",
+				"address": "192.0.2.16",
+				"protocol_port": 80,
+				"id": "7d19ad6c-d549-453e-a5cd-05382c6be96a"
+			},{
+				"name": "",
+				"weight": 1,
+				"admin_state_up": true,
+				"subnet_id": "bbb35f84-35cc-4b2f-84c2-a6a29bba68aa",
+				"project_id": "e3cd678b11784734bc366148aa37580e",
+				"address": "192.0.2.19",
+				"protocol_port": 80,
+				"id": "a167402b-caa6-41d5-b4d4-bde7f2cbfa5e"
+			}],
+			"id": "c8cec227-410a-4a5b-af13-ecf38c2b0abb",
+			"name": "rr_pool"
+		}],
+		"id": "607226db-27ef-4d41-ae89-f2a800e9c2db",
+		"operating_status": "ONLINE",
+		"name": "best_load_balancer",
+		"availability_zone": "my_az",
+		"tags": ["test_tag"]
+	}
 }
 `
 

--- a/openstack/loadbalancer/v2/loadbalancers/testing/fixtures.go
+++ b/openstack/loadbalancer/v2/loadbalancers/testing/fixtures.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/l7policies"
 	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/listeners"
 	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/loadbalancers"
 	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/monitors"
@@ -101,6 +102,109 @@ const PostUpdateLoadbalancerBody = `
 		"operating_status": "OFFLINE",
 		"tags": ["test"]
 	}
+}
+`
+
+// PostFullyPopulatedLoadbalancerBody is the canned response body of a Create request of an fully populated loadbalancer.
+const PostFullyPopulatedLoadbalancerBody = `
+{
+    "loadbalancer": {
+        "description": "My favorite load balancer",
+        "admin_state_up": true,
+        "project_id": "e3cd678b11784734bc366148aa37580e",
+        "provisioning_status": "ACTIVE",
+        "flavor_id": "",
+		"created_at": "2019-06-30T04:15:37",
+		"updated_at": "2019-06-30T05:18:49",
+        "listeners": [
+            {
+                "l7policies": [
+                    {
+                        "description": "",
+                        "admin_state_up": true,
+                        "rules": [],
+                        "project_id": "e3cd678b11784734bc366148aa37580e",
+                        "listener_id": "95de30ec-67f4-437b-b3f3-22c5d9ef9828",
+                        "redirect_url": "https://www.example.com/",
+                        "action": "REDIRECT_TO_URL",
+                        "position": 1,
+                        "id": "d0553837-f890-4981-b99a-f7cbd6a76577",
+                        "name": "redirect_policy"
+                    }
+                ],
+                "protocol": "HTTP",
+                "description": "",
+                "default_tls_container_ref": null,
+                "admin_state_up": true,
+                "default_pool_id": "c8cec227-410a-4a5b-af13-ecf38c2b0abb",
+                "project_id": "e3cd678b11784734bc366148aa37580e",
+                "default_tls_container_id": null,
+                "connection_limit": -1,
+                "sni_container_refs": [],
+                "protocol_port": 8080,
+                "id": "95de30ec-67f4-437b-b3f3-22c5d9ef9828",
+                "name": "redirect_listener"
+            }
+        ],
+        "vip_address": "203.0.113.50",
+        "vip_network_id": "d0d217df-3958-4fbf-a3c2-8dad2908c709",
+        "vip_subnet_id": "d4af86e1-0051-488c-b7a0-527f97490c9a",
+        "vip_port_id": "b4ca07d1-a31e-43e2-891a-7d14f419f342",
+        "provider": "octavia",
+        "pools": [
+            {
+                "lb_algorithm": "ROUND_ROBIN",
+                "protocol": "HTTP",
+                "description": "",
+                "admin_state_up": true,
+                "project_id": "e3cd678b11784734bc366148aa37580e",
+                "session_persistence": null,
+                "healthmonitor": {
+                    "name": "",
+                    "admin_state_up": true,
+                    "project_id": "e3cd678b11784734bc366148aa37580e",
+                    "delay": 3,
+                    "expected_codes": "200,201,202",
+                    "max_retries": 2,
+                    "http_method": "GET",
+                    "timeout": 1,
+                    "max_retries_down": 3,
+                    "url_path": "/index.html",
+                    "type": "HTTP",
+                    "id": "a8a2aa3f-d099-4752-8265-e6472f8147f9"
+                },
+                "members": [
+                    {
+                        "name": "",
+                        "weight": 1,
+                        "admin_state_up": true,
+                        "subnet_id": "bbb35f84-35cc-4b2f-84c2-a6a29bba68aa",
+                        "project_id": "e3cd678b11784734bc366148aa37580e",
+                        "address": "192.0.2.16",
+                        "protocol_port": 80,
+                        "id": "7d19ad6c-d549-453e-a5cd-05382c6be96a"
+                    },
+                    {
+                        "name": "",
+                        "weight": 1,
+                        "admin_state_up": true,
+                        "subnet_id": "bbb35f84-35cc-4b2f-84c2-a6a29bba68aa",
+                        "project_id": "e3cd678b11784734bc366148aa37580e",
+                        "address": "192.0.2.19",
+                        "protocol_port": 80,
+                        "id": "a167402b-caa6-41d5-b4d4-bde7f2cbfa5e"
+                    }
+                ],
+                "id": "c8cec227-410a-4a5b-af13-ecf38c2b0abb",
+                "name": "rr_pool"
+            }
+        ],
+        "id": "607226db-27ef-4d41-ae89-f2a800e9c2db",
+        "operating_status": "ONLINE",
+        "name": "best_load_balancer",
+        "availability_zone": "my_az",
+        "tags": ["test_tag"]
+    }
 }
 `
 
@@ -210,6 +314,91 @@ var (
 		OperatingStatus:    "OFFLINE",
 		Tags:               []string{"test"},
 	}
+	FullyPopulatedLoadBalancerDb = loadbalancers.LoadBalancer{
+		Description:        "My favorite load balancer",
+		AdminStateUp:       true,
+		ProjectID:          "e3cd678b11784734bc366148aa37580e",
+		UpdatedAt:          updatedTime,
+		CreatedAt:          createdTime,
+		ProvisioningStatus: "ACTIVE",
+		VipSubnetID:        "d4af86e1-0051-488c-b7a0-527f97490c9a",
+		VipNetworkID:       "d0d217df-3958-4fbf-a3c2-8dad2908c709",
+		VipAddress:         "203.0.113.50",
+		VipPortID:          "b4ca07d1-a31e-43e2-891a-7d14f419f342",
+		AvailabilityZone:   "my_az",
+		ID:                 "607226db-27ef-4d41-ae89-f2a800e9c2db",
+		OperatingStatus:    "ONLINE",
+		Name:               "best_load_balancer",
+		FlavorID:           "",
+		Provider:           "octavia",
+		Tags:               []string{"test_tag"},
+		Listeners: []listeners.Listener{{
+			ID:               "95de30ec-67f4-437b-b3f3-22c5d9ef9828",
+			ProjectID:        "e3cd678b11784734bc366148aa37580e",
+			Name:             "redirect_listener",
+			Description:      "",
+			Protocol:         "HTTP",
+			ProtocolPort:     8080,
+			DefaultPoolID:    "c8cec227-410a-4a5b-af13-ecf38c2b0abb",
+			AdminStateUp:     true,
+			ConnLimit:        -1,
+			SniContainerRefs: []string{},
+			L7Policies: []l7policies.L7Policy{{
+				ID:           "d0553837-f890-4981-b99a-f7cbd6a76577",
+				Name:         "redirect_policy",
+				ListenerID:   "95de30ec-67f4-437b-b3f3-22c5d9ef9828",
+				ProjectID:    "e3cd678b11784734bc366148aa37580e",
+				Description:  "",
+				Action:       "REDIRECT_TO_URL",
+				Position:     1,
+				RedirectURL:  "https://www.example.com/",
+				AdminStateUp: true,
+				Rules:        []l7policies.Rule{},
+			}},
+		}},
+		Pools: []pools.Pool{{
+			LBMethod:     "ROUND_ROBIN",
+			Protocol:     "HTTP",
+			Description:  "",
+			AdminStateUp: true,
+			Name:         "rr_pool",
+			ID:           "c8cec227-410a-4a5b-af13-ecf38c2b0abb",
+			ProjectID:    "e3cd678b11784734bc366148aa37580e",
+			Members: []pools.Member{{
+				Name:         "",
+				Address:      "192.0.2.16",
+				SubnetID:     "bbb35f84-35cc-4b2f-84c2-a6a29bba68aa",
+				AdminStateUp: true,
+				ProtocolPort: 80,
+				ID:           "7d19ad6c-d549-453e-a5cd-05382c6be96a",
+				ProjectID:    "e3cd678b11784734bc366148aa37580e",
+				Weight:       1,
+			}, {
+				Name:         "",
+				Address:      "192.0.2.19",
+				SubnetID:     "bbb35f84-35cc-4b2f-84c2-a6a29bba68aa",
+				AdminStateUp: true,
+				ProtocolPort: 80,
+				ID:           "a167402b-caa6-41d5-b4d4-bde7f2cbfa5e",
+				ProjectID:    "e3cd678b11784734bc366148aa37580e",
+				Weight:       1,
+			}},
+			Monitor: monitors.Monitor{
+				ID:             "a8a2aa3f-d099-4752-8265-e6472f8147f9",
+				ProjectID:      "e3cd678b11784734bc366148aa37580e",
+				Name:           "",
+				Type:           "HTTP",
+				Timeout:        1,
+				MaxRetries:     2,
+				Delay:          3,
+				MaxRetriesDown: 3,
+				HTTPMethod:     "GET",
+				URLPath:        "/index.html",
+				ExpectedCodes:  "200,201,202",
+				AdminStateUp:   true,
+			},
+		}},
+	}
 	LoadbalancerStatusesTree = loadbalancers.StatusTree{
 		Loadbalancer: &loadbalancers.LoadBalancer{
 			ID:                 "36e08a3e-a78f-4b40-a229-1e7e23eee1ab",
@@ -267,6 +456,81 @@ func HandleLoadbalancerListSuccessfully(t *testing.T) {
 		default:
 			t.Fatalf("/v2.0/lbaas/loadbalancers invoked with unexpected marker=[%s]", marker)
 		}
+	})
+}
+
+// HandleFullyPopulatedLoadbalancerCreationSuccessfully sets up the test server to respond to a
+// fully populated loadbalancer creation request with a given response.
+func HandleFullyPopulatedLoadbalancerCreationSuccessfully(t *testing.T, response string) {
+	th.Mux.HandleFunc("/v2.0/lbaas/loadbalancers", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, `{
+			"loadbalancer": {
+				"admin_state_up": true,
+				"flavor_id": "bba40eb2-ee8c-11e9-81b4-2a2ae2dbcce4",
+				"listeners": [
+					{
+						"default_pool": {
+							"healthmonitor": {
+								"delay": 3,
+								"expected_codes": "200",
+								"http_method": "GET",
+								"max_retries": 2,
+								"max_retries_down": 3,
+								"name": "db",
+								"timeout": 1,
+								"type": "HTTP",
+								"url_path": "/index.html"
+							},
+							"lb_algorithm": "ROUND_ROBIN",
+							"members": [
+								{
+									"address": "192.0.2.51",
+									"protocol_port": 80
+								},
+								{
+									"address": "192.0.2.52",
+									"protocol_port": 80
+								}
+							],
+							"name": "Example pool",
+							"protocol": "HTTP"
+						},
+						"l7policies": [
+							{
+								"action": "REDIRECT_TO_URL",
+								"name": "redirect-example.com",
+								"redirect_url": "http://www.example.com",
+								"rules": [
+									{
+										"compare_type": "REGEX",
+										"type": "PATH",
+										"value": "/images*"
+									}
+								]
+							}
+						],
+						"name": "redirect_listener",
+						"protocol": "HTTP",
+						"protocol_port": 8080
+					}
+				],
+				"name": "db_lb",
+				"provider": "octavia",
+				"tags": [
+					"test",
+					"stage"
+				],
+				"vip_address": "10.30.176.48",
+				"vip_port_id": "2bf413c8-41a9-4477-b505-333d5cbe8b55",
+				"vip_subnet_id": "9cedb85d-0759-4898-8a4b-fa5a5ea10086"
+			}
+		}`)
+
+		w.WriteHeader(http.StatusAccepted)
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprintf(w, response)
 	})
 }
 

--- a/openstack/loadbalancer/v2/monitors/requests.go
+++ b/openstack/loadbalancer/v2/monitors/requests.go
@@ -91,7 +91,7 @@ type CreateOptsBuilder interface {
 // operation.
 type CreateOpts struct {
 	// The Pool to Monitor.
-	PoolID string `json:"pool_id" required:"true"`
+	PoolID string `json:"pool_id,omitempty"`
 
 	// The type of probe, which is PING, TCP, HTTP, or HTTPS, that is
 	// sent by the load balancer to verify the member state.

--- a/openstack/loadbalancer/v2/pools/requests.go
+++ b/openstack/loadbalancer/v2/pools/requests.go
@@ -117,11 +117,19 @@ type CreateOpts struct {
 	// or false (DOWN).
 	AdminStateUp *bool `json:"admin_state_up,omitempty"`
 
-	// The updates for pool members
-	Members []BatchUpdateMemberOpts `json:"members,omitempty"`
+	// Members is a slice of BatchUpdateMemberOpts which allows a set of
+	// members to be created at the same time the pool is created.
+	//
+	// This is only possible to use when creating a fully populated
+	// Loadbalancer.
+	Members []BatchUpdateMemberOpts `json:"members,omitempty" xor:"ListenerID"`
 
-	// The Monitor associated with this Pool.
-	Monitor *monitors.CreateOpts `json:"healthmonitor,omitempty"`
+	// Monitor is an instance of monitors.CreateOpts which allows a monitor
+	// to be created at the same time the pool is created.
+	//
+	// This is only possible to use when creating a fully populated
+	// Loadbalancer.
+	Monitor *monitors.CreateOpts `json:"healthmonitor,omitempty" xor:"ListenerID"`
 }
 
 // ToPoolCreateMap builds a request body from CreateOpts.
@@ -172,16 +180,6 @@ type UpdateOpts struct {
 	// The administrative state of the Pool. A valid value is true (UP)
 	// or false (DOWN).
 	AdminStateUp *bool `json:"admin_state_up,omitempty"`
-
-	// Persistence is the session persistence of the pool.
-	// Omit this field to prevent session persistence.
-	Persistence *SessionPersistence `json:"session_persistence,omitempty"`
-
-	// The updates for pool members
-	Members *[]BatchUpdateMemberOpts `json:"members,omitempty"`
-
-	// The Monitor associated with this Pool.
-	Monitor *monitors.UpdateOpts `json:"healthmonitor,omitempty"`
 }
 
 // ToPoolUpdateMap builds a request body from UpdateOpts.

--- a/openstack/loadbalancer/v2/pools/requests.go
+++ b/openstack/loadbalancer/v2/pools/requests.go
@@ -122,14 +122,14 @@ type CreateOpts struct {
 	//
 	// This is only possible to use when creating a fully populated
 	// Loadbalancer.
-	Members []BatchUpdateMemberOpts `json:"members,omitempty" xor:"ListenerID"`
+	Members []BatchUpdateMemberOpts `json:"members,omitempty"`
 
 	// Monitor is an instance of monitors.CreateOpts which allows a monitor
 	// to be created at the same time the pool is created.
 	//
 	// This is only possible to use when creating a fully populated
 	// Loadbalancer.
-	Monitor *monitors.CreateOpts `json:"healthmonitor,omitempty" xor:"ListenerID"`
+	Monitor *monitors.CreateOpts `json:"healthmonitor,omitempty"`
 }
 
 // ToPoolCreateMap builds a request body from CreateOpts.

--- a/openstack/loadbalancer/v2/pools/requests.go
+++ b/openstack/loadbalancer/v2/pools/requests.go
@@ -2,6 +2,7 @@ package pools
 
 import (
 	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/monitors"
 	"github.com/gophercloud/gophercloud/pagination"
 )
 
@@ -92,11 +93,11 @@ type CreateOpts struct {
 
 	// The Loadbalancer on which the members of the pool will be associated with.
 	// Note: one of LoadbalancerID or ListenerID must be provided.
-	LoadbalancerID string `json:"loadbalancer_id,omitempty" xor:"ListenerID"`
+	LoadbalancerID string `json:"loadbalancer_id,omitempty"`
 
 	// The Listener on which the members of the pool will be associated with.
 	// Note: one of LoadbalancerID or ListenerID must be provided.
-	ListenerID string `json:"listener_id,omitempty" xor:"LoadbalancerID"`
+	ListenerID string `json:"listener_id,omitempty"`
 
 	// ProjectID is the UUID of the project who owns the Pool.
 	// Only administrative users can specify a project UUID other than their own.
@@ -115,6 +116,12 @@ type CreateOpts struct {
 	// The administrative state of the Pool. A valid value is true (UP)
 	// or false (DOWN).
 	AdminStateUp *bool `json:"admin_state_up,omitempty"`
+
+	// The updates for pool members
+	Members []BatchUpdateMemberOpts `json:"members,omitempty"`
+
+	// The Monitor associated with this Pool.
+	Monitor *monitors.CreateOpts `json:"healthmonitor,omitempty"`
 }
 
 // ToPoolCreateMap builds a request body from CreateOpts.
@@ -165,6 +172,16 @@ type UpdateOpts struct {
 	// The administrative state of the Pool. A valid value is true (UP)
 	// or false (DOWN).
 	AdminStateUp *bool `json:"admin_state_up,omitempty"`
+
+	// Persistence is the session persistence of the pool.
+	// Omit this field to prevent session persistence.
+	Persistence *SessionPersistence `json:"session_persistence,omitempty"`
+
+	// The updates for pool members
+	Members *[]BatchUpdateMemberOpts `json:"members,omitempty"`
+
+	// The Monitor associated with this Pool.
+	Monitor *monitors.UpdateOpts `json:"healthmonitor,omitempty"`
 }
 
 // ToPoolUpdateMap builds a request body from UpdateOpts.


### PR DESCRIPTION
This adds fully populated load balancer support for Octavia, thus enabling the user to create all entities (lb, pool, member, monitor etc) with a single API call. 

Prior to starting a PR, please make sure you have read our
[contributor tutorial](https://github.com/gophercloud/gophercloud/tree/master/docs/contributor-tutorial).

Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

For #1740

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/octavia/blob/master/octavia/api/v2/controllers/load_balancer.py#L500
https://docs.openstack.org/api-ref/load-balancer/v2/?expanded=create-a-load-balancer-detail#creating-a-fully-populated-load-balancer