### PR TITLE
Block storage: adding support of update snapshot api call

### DIFF
--- a/acceptance/openstack/blockstorage/v3/snapshots_test.go
+++ b/acceptance/openstack/blockstorage/v3/snapshots_test.go
@@ -28,8 +28,8 @@ func TestSnapshots(t *testing.T) {
 	defer DeleteSnapshot(t, client, snapshot1)
 
 	// Update snapshot
-	updatedSnapshotName := "ACPTTEST-002"
-	updatedSnapshotDescription := "ACPTTEST-002"
+	updatedSnapshotName := tools.RandomString("ACPTTEST", 16)
+	updatedSnapshotDescription := tools.RandomString("ACPTTEST", 16)
 	updateOpts := snapshots.UpdateOpts{
 		Name:        &updatedSnapshotName,
 		Description: &updatedSnapshotDescription,

--- a/acceptance/openstack/blockstorage/v3/snapshots_test.go
+++ b/acceptance/openstack/blockstorage/v3/snapshots_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/gophercloud/gophercloud/acceptance/clients"
+	"github.com/gophercloud/gophercloud/acceptance/tools"
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/snapshots"
 	"github.com/gophercloud/gophercloud/pagination"
 	th "github.com/gophercloud/gophercloud/testhelper"
@@ -25,6 +26,20 @@ func TestSnapshots(t *testing.T) {
 	snapshot1, err := CreateSnapshot(t, client, volume1)
 	th.AssertNoErr(t, err)
 	defer DeleteSnapshot(t, client, snapshot1)
+
+	// Update snapshot
+	updatedSnapshotName := "ACPTTEST-002"
+	updatedSnapshotDescription := "ACPTTEST-002"
+	updateOpts := snapshots.UpdateOpts{
+		Name:        &updatedSnapshotName,
+		Description: &updatedSnapshotDescription,
+	}
+	updatedSnapshot, err := snapshots.Update(client, snapshot1.ID, updateOpts).Extract()
+	th.AssertNoErr(t, err)
+
+	tools.PrintResource(t, updatedSnapshot)
+	th.AssertEquals(t, updatedSnapshot.Name, updatedSnapshotName)
+	th.AssertEquals(t, updatedSnapshot.Description, updatedSnapshotDescription)
 
 	volume2, err := CreateVolume(t, client)
 	th.AssertNoErr(t, err)

--- a/acceptance/openstack/blockstorage/v3/snapshots_test.go
+++ b/acceptance/openstack/blockstorage/v3/snapshots_test.go
@@ -34,6 +34,7 @@ func TestSnapshots(t *testing.T) {
 		Name:        &updatedSnapshotName,
 		Description: &updatedSnapshotDescription,
 	}
+	t.Logf("Attempting to update snapshot: %s", updatedSnapshotName)
 	updatedSnapshot, err := snapshots.Update(client, snapshot1.ID, updateOpts).Extract()
 	th.AssertNoErr(t, err)
 

--- a/openstack/blockstorage/v3/snapshots/doc.go
+++ b/openstack/blockstorage/v3/snapshots/doc.go
@@ -1,5 +1,62 @@
-// Package snapshots provides information and interaction with snapshots in the
-// OpenStack Block Storage service. A snapshot is a point in time copy of the
-// data contained in an external storage volume, and can be controlled
-// programmatically.
+/*
+Package snapshots provides information and interaction with snapshots in the
+OpenStack Block Storage service. A snapshot is a point in time copy of the
+data contained in an external storage volume, and can be controlled
+programmatically.
+
+
+Example to list Snapshots
+
+	allPages, err := snapshots.List(client, snapshots.ListOpts{}).AllPages()
+	if err != nil{
+		panic(err)
+	}
+	snapshots, err := snapshots.ExtractSnapshots(allPages)
+	if err != nil{
+		panic(err)
+	}
+	for _,s := range snapshots{
+		fmt.Println(s)
+	}
+
+Example to get a Snapshot
+
+	snapshotID := "4a584cae-e4ce-429b-9154-d4c9eb8fda4c"
+	snapshot, err := snapshots.Get(client, snapshotID).Extract()
+	if err != nil{
+		panic(err)
+	}
+	fmt.Println(snapshot)
+
+Example to create a Snapshot
+
+	snapshot, err := snapshots.Create(client, snapshots.CreateOpts{
+		Name:"snapshot_001",
+		VolumeID:"5aa119a8-d25b-45a7-8d1b-88e127885635",
+	}).Extract()
+	if err != nil{
+		panic(err)
+	}
+	fmt.Println(snapshot)
+
+Example to delete a Snapshot
+
+	snapshotID := "4a584cae-e4ce-429b-9154-d4c9eb8fda4c"
+	err := snapshots.Delete(client, snapshotID).ExtractErr()
+	if err != nil{
+		panic(err)
+	}
+
+Example to update a Snapshot
+
+	snapshotID := "4a584cae-e4ce-429b-9154-d4c9eb8fda4c"
+	snapshot, err = snapshots.Update(client, snapshotID, snapshots.UpdateOpts{
+		Name: "snapshot_002",
+		Description:"description_002",
+	}).Extract()
+	if err != nil{
+		panic(err)
+	}
+	fmt.Println(snapshot)
+*/
 package snapshots

--- a/openstack/blockstorage/v3/snapshots/results.go
+++ b/openstack/blockstorage/v3/snapshots/results.go
@@ -53,6 +53,11 @@ type DeleteResult struct {
 	gophercloud.ErrResult
 }
 
+// UpdateResult contains the response body and error from an Update request.
+type UpdateResult struct {
+	commonResult
+}
+
 // SnapshotPage is a pagination.Pager that is returned from a call to the List function.
 type SnapshotPage struct {
 	pagination.LinkedPageBase
@@ -84,11 +89,13 @@ func (r SnapshotPage) IsEmpty() (bool, error) {
 	return len(volumes) == 0, err
 }
 
-func (page SnapshotPage) NextPageURL() (string, error) {
+// NextPageURL uses the response's embedded link reference to navigate to the
+// next page of results.
+func (r SnapshotPage) NextPageURL() (string, error) {
 	var s struct {
 		Links []gophercloud.Link `json:"snapshots_links"`
 	}
-	err := page.ExtractInto(&s)
+	err := r.ExtractInto(&s)
 	if err != nil {
 		return "", err
 	}

--- a/openstack/blockstorage/v3/snapshots/testing/doc.go
+++ b/openstack/blockstorage/v3/snapshots/testing/doc.go
@@ -1,2 +1,2 @@
-// snapshots_v3
+// Package testing for snapshots_v3
 package testing

--- a/openstack/blockstorage/v3/snapshots/testing/fixtures.go
+++ b/openstack/blockstorage/v3/snapshots/testing/fixtures.go
@@ -9,6 +9,7 @@ import (
 	fake "github.com/gophercloud/gophercloud/testhelper/client"
 )
 
+// MockListResponse provides mock responce for list snapshot API call
 func MockListResponse(t *testing.T) {
 	th.Mux.HandleFunc("/snapshots", func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "GET")
@@ -58,6 +59,7 @@ func MockListResponse(t *testing.T) {
 	})
 }
 
+// MockGetResponse provides mock responce for get snapshot API call
 func MockGetResponse(t *testing.T) {
 	th.Mux.HandleFunc("/snapshots/d32019d3-bc6e-4319-9c1d-6722fc136a22", func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "GET")
@@ -81,6 +83,7 @@ func MockGetResponse(t *testing.T) {
 	})
 }
 
+// MockCreateResponse provides mock responce for create snapshot API call
 func MockCreateResponse(t *testing.T) {
 	th.Mux.HandleFunc("/snapshots", func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "POST")
@@ -116,6 +119,7 @@ func MockCreateResponse(t *testing.T) {
 	})
 }
 
+// MockUpdateMetadataResponse provides mock responce for update metadata snapshot API call
 func MockUpdateMetadataResponse(t *testing.T) {
 	th.Mux.HandleFunc("/snapshots/123/metadata", func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "PUT")
@@ -139,10 +143,36 @@ func MockUpdateMetadataResponse(t *testing.T) {
 	})
 }
 
+// MockDeleteResponse provides mock responce for delete snapshot API call
 func MockDeleteResponse(t *testing.T) {
 	th.Mux.HandleFunc("/snapshots/d32019d3-bc6e-4319-9c1d-6722fc136a22", func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "DELETE")
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 		w.WriteHeader(http.StatusNoContent)
+	})
+}
+
+// MockUpdateResponse provides mock responce for update snapshot API call
+func MockUpdateResponse(t *testing.T) {
+	th.Mux.HandleFunc("/snapshots/d32019d3-bc6e-4319-9c1d-6722fc136a22", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, `
+{
+    "snapshot": {
+        "id": "d32019d3-bc6e-4319-9c1d-6722fc136a22",
+        "name": "snapshot-002",
+        "description": "Daily backup 002",
+        "volume_id": "521752a6-acf6-4b2d-bc7a-119f9148cd8c",
+        "status": "available",
+        "size": 30,
+        "created_at": "2017-05-30T03:35:03.000000",
+        "updated_at": "2017-05-30T03:35:03.000000"
+    }
+}
+      `)
 	})
 }

--- a/openstack/blockstorage/v3/snapshots/testing/requests_test.go
+++ b/openstack/blockstorage/v3/snapshots/testing/requests_test.go
@@ -114,3 +114,18 @@ func TestDelete(t *testing.T) {
 	res := snapshots.Delete(client.ServiceClient(), "d32019d3-bc6e-4319-9c1d-6722fc136a22")
 	th.AssertNoErr(t, res.Err)
 }
+
+func TestUpdate(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockUpdateResponse(t)
+
+	var name = "snapshot-002"
+	var description = "Daily backup 002"
+	options := snapshots.UpdateOpts{Name: &name, Description: &description}
+	v, err := snapshots.Update(client.ServiceClient(), "d32019d3-bc6e-4319-9c1d-6722fc136a22", options).Extract()
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, "snapshot-002", v.Name)
+	th.CheckEquals(t, "Daily backup 002", v.Description)
+}

--- a/openstack/blockstorage/v3/snapshots/urls.go
+++ b/openstack/blockstorage/v3/snapshots/urls.go
@@ -18,6 +18,10 @@ func listURL(c *gophercloud.ServiceClient) string {
 	return createURL(c)
 }
 
+func updateURL(c *gophercloud.ServiceClient, id string) string {
+	return deleteURL(c, id)
+}
+
 func metadataURL(c *gophercloud.ServiceClient, id string) string {
 	return c.ServiceURL("snapshots", id, "metadata")
 }


### PR DESCRIPTION
For #2066 

- [x] code
- [x] unit tests
- [x] acceptance tests
- [x] documentation

Links to the line numbers/files in the OpenStack source code that support the code in this PR:

API:
https://docs.openstack.org/api-ref/block-storage/v3/index.html?expanded=update-a-snapshot-detail#update-a-snapshot

Schema:
https://github.com/openstack/cinder/blob/482e6a3cc5cca697b54ee1d853a4eca6e6f3cfc7/cinder/api/schemas/snapshots.py#L45

It seems that v3 uses the same method as v2 under the hood:
https://github.com/openstack/cinder/blob/482e6a3cc5cca697b54ee1d853a4eca6e6f3cfc7/cinder/api/v3/snapshots.py#L26

Update api:
https://github.com/openstack/cinder/blob/482e6a3cc5cca697b54ee1d853a4eca6e6f3cfc7/cinder/api/v2/snapshots.py#L148

Additional information:
Acceptance tests were ran against live OpenStack API(Ussuri). Here are logs from its run:
[AcceptanceTestsRun_logs.txt](https://github.com/gophercloud/gophercloud/files/5721502/AcceptanceTestsRun_logs.txt)
