### PR TITLE
Backups list detail #2083

### DIFF
--- a/openstack/blockstorage/extensions/backups/testing/fixtures.go
+++ b/openstack/blockstorage/extensions/backups/testing/fixtures.go
@@ -17,11 +17,11 @@ const ListResponse = `
   "backups": [
     {
       "id": "289da7f8-6440-407c-9fb4-7db01ec49164",
-      "name": "backup-001",
+      "name": "backup-001"
     },
     {
       "id": "96c3bda7-c82a-4f50-be73-ca7621794835",
-      "name": "backup-002",
+      "name": "backup-002"
     }
   ],
   "backups_links": [
@@ -57,7 +57,7 @@ const ListDetailResponse = `
   ],
   "backups_links": [
     {
-      "href": "%s/backups?marker=1",
+      "href": "%s/backups/detail?marker=1",
       "rel": "next"
     }
   ]

--- a/openstack/blockstorage/extensions/backups/testing/fixtures.go
+++ b/openstack/blockstorage/extensions/backups/testing/fixtures.go
@@ -18,6 +18,27 @@ const ListResponse = `
     {
       "id": "289da7f8-6440-407c-9fb4-7db01ec49164",
       "name": "backup-001",
+    },
+    {
+      "id": "96c3bda7-c82a-4f50-be73-ca7621794835",
+      "name": "backup-002",
+    }
+  ],
+  "backups_links": [
+    {
+      "href": "%s/backups?marker=1",
+      "rel": "next"
+    }
+  ]
+}
+`
+
+const ListDetailResponse = `
+{
+  "backups": [
+    {
+      "id": "289da7f8-6440-407c-9fb4-7db01ec49164",
+      "name": "backup-001",
       "volume_id": "521752a6-acf6-4b2d-bc7a-119f9148cd8c",
       "description": "Daily Backup",
       "status": "available",
@@ -172,6 +193,27 @@ func MockListResponse(t *testing.T) {
 		switch marker {
 		case "":
 			fmt.Fprintf(w, ListResponse, th.Server.URL)
+		case "1":
+			fmt.Fprintf(w, `{"backups": []}`)
+		default:
+			t.Fatalf("Unexpected marker: [%s]", marker)
+		}
+	})
+}
+
+func MockListDetailResponse(t *testing.T) {
+	th.Mux.HandleFunc("/backups/detail", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		r.ParseForm()
+		marker := r.Form.Get("marker")
+		switch marker {
+		case "":
+			fmt.Fprintf(w, ListDetailResponse, th.Server.URL)
 		case "1":
 			fmt.Fprintf(w, `{"backups": []}`)
 		default:

--- a/openstack/blockstorage/extensions/backups/testing/requests_test.go
+++ b/openstack/blockstorage/extensions/backups/testing/requests_test.go
@@ -29,6 +29,43 @@ func TestList(t *testing.T) {
 
 		expected := []backups.Backup{
 			{
+				ID:   "289da7f8-6440-407c-9fb4-7db01ec49164",
+				Name: "backup-001",
+			},
+			{
+				ID:   "96c3bda7-c82a-4f50-be73-ca7621794835",
+				Name: "backup-002",
+			},
+		}
+
+		th.CheckDeepEquals(t, expected, actual)
+
+		return true, nil
+	})
+
+	if count != 1 {
+		t.Errorf("Expected 1 page, got %d", count)
+	}
+}
+
+func TestListDetail(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockListResponse(t)
+
+	count := 0
+
+	backups.List(client.ServiceClient(), &backups.ListOpts{}).EachPage(func(page pagination.Page) (bool, error) {
+		count++
+		actual, err := backups.ExtractBackups(page)
+		if err != nil {
+			t.Errorf("Failed to extract backups: %v", err)
+			return false, err
+		}
+
+		expected := []backups.Backup{
+			{
 				ID:          "289da7f8-6440-407c-9fb4-7db01ec49164",
 				Name:        "backup-001",
 				VolumeID:    "521752a6-acf6-4b2d-bc7a-119f9148cd8c",

--- a/openstack/blockstorage/extensions/backups/testing/requests_test.go
+++ b/openstack/blockstorage/extensions/backups/testing/requests_test.go
@@ -19,7 +19,7 @@ func TestList(t *testing.T) {
 
 	count := 0
 
-	backups.List(client.ServiceClient(), &backups.ListOpts{}).EachPage(func(page pagination.Page) (bool, error) {
+	err := backups.List(client.ServiceClient(), &backups.ListOpts{}).EachPage(func(page pagination.Page) (bool, error) {
 		count++
 		actual, err := backups.ExtractBackups(page)
 		if err != nil {
@@ -42,6 +42,9 @@ func TestList(t *testing.T) {
 
 		return true, nil
 	})
+	if err != nil {
+		t.Errorf("EachPage returned error: %s", err)
+	}
 
 	if count != 1 {
 		t.Errorf("Expected 1 page, got %d", count)
@@ -52,11 +55,11 @@ func TestListDetail(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 
-	MockListResponse(t)
+	MockListDetailResponse(t)
 
 	count := 0
 
-	backups.List(client.ServiceClient(), &backups.ListOpts{}).EachPage(func(page pagination.Page) (bool, error) {
+	err := backups.ListDetail(client.ServiceClient(), &backups.ListDetailOpts{}).EachPage(func(page pagination.Page) (bool, error) {
 		count++
 		actual, err := backups.ExtractBackups(page)
 		if err != nil {
@@ -89,6 +92,9 @@ func TestListDetail(t *testing.T) {
 
 		return true, nil
 	})
+	if err != nil {
+		t.Errorf("EachPage returned error: %s", err)
+	}
 
 	if count != 1 {
 		t.Errorf("Expected 1 page, got %d", count)

--- a/openstack/blockstorage/extensions/backups/urls.go
+++ b/openstack/blockstorage/extensions/backups/urls.go
@@ -18,6 +18,10 @@ func listURL(c *gophercloud.ServiceClient) string {
 	return c.ServiceURL("backups")
 }
 
+func listDetailURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("backups", "detail")
+}
+
 func updateURL(c *gophercloud.ServiceClient, id string) string {
 	return c.ServiceURL("backups", id)
 }


### PR DESCRIPTION
For #2083 

Here's the API docs:

https://docs.openstack.org/api-ref/block-storage/v3/?expanded=list-backups-with-detail-detail#list-backups-with-detail

Sorry, I'm not sure where to find this in the openstack source.

Also I modified the List tests to not include additional information like `status` - this is what I observed against OVH, and appears to match the docs here: https://docs.openstack.org/api-ref/block-storage/v3/?expanded=list-backups-for-project-detail#list-backups-for-project