### PR TITLE
Fixes fully-populated loadbalancer creation without default_pool, l7policies or l7rules

### DIFF
--- a/openstack/loadbalancer/v2/l7policies/requests.go
+++ b/openstack/loadbalancer/v2/l7policies/requests.go
@@ -72,7 +72,7 @@ type CreateOpts struct {
 	//
 	// This is only possible to use when creating a fully populated
 	// Loadbalancer.
-	Rules []CreateRuleOpts `json:"rules,omitempty" xor:"ListenerID"`
+	Rules []CreateRuleOpts `json:"rules,omitempty"`
 }
 
 // ToL7PolicyCreateMap builds a request body from CreateOpts.

--- a/openstack/loadbalancer/v2/listeners/requests.go
+++ b/openstack/loadbalancer/v2/listeners/requests.go
@@ -109,7 +109,7 @@ type CreateOpts struct {
 	//
 	// This is only possible to use when creating a fully populated
 	// load balancer.
-	DefaultPool *pools.CreateOpts `json:"default_pool,omitempty" xor:"LoadbalancerID"`
+	DefaultPool *pools.CreateOpts `json:"default_pool,omitempty"`
 
 	// Human-readable description for the Listener.
 	Description string `json:"description,omitempty"`
@@ -132,7 +132,7 @@ type CreateOpts struct {
 	//
 	// This is only possible to use when creating a fully populated
 	// Loadbalancer.
-	L7Policies []l7policies.CreateOpts `json:"l7policies,omitempty" xor:"LoadbalancerID"`
+	L7Policies []l7policies.CreateOpts `json:"l7policies,omitempty"`
 
 	// Frontend client inactivity timeout in milliseconds
 	TimeoutClientData *int `json:"timeout_client_data,omitempty"`


### PR DESCRIPTION
Prior to starting a PR, please make sure you have read our
[contributor tutorial](https://github.com/gophercloud/gophercloud/tree/master/docs/contributor-tutorial).

Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

For #2086

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/octavia/blob/master/octavia/api/v2/controllers/load_balancer.py#L500
https://docs.openstack.org/api-ref/load-balancer/v2/?expanded=create-a-load-balancer-detail#creating-a-fully-populated-load-balancer