### PR TITLE
Return actionID for Node Remove API

### DIFF
--- a/acceptance/openstack/clustering/v1/clusters_test.go
+++ b/acceptance/openstack/clustering/v1/clusters_test.go
@@ -340,16 +340,14 @@ func TestClustersRemoveNodeFromCluster(t *testing.T) {
 	tools.PrintResource(t, cluster)
 
 	opt := clusters.RemoveNodesOpts{Nodes: cluster.Nodes}
-	res := clusters.RemoveNodes(client, cluster.ID, opt)
-	err = res.ExtractErr()
-	th.AssertNoErr(t, err)
+	actionID, err := clusters.RemoveNodes(client, cluster.ID, opt).Extract()
+	if err != nil {
+		t.Fatalf("Unable to remove nodes to cluster: %v", err)
+	}
 
 	for _, n := range cluster.Nodes {
 		defer DeleteNode(t, client, n)
 	}
-
-	actionID, err := GetActionID(res.Header)
-	th.AssertNoErr(t, err)
 
 	err = WaitForAction(client, actionID)
 	th.AssertNoErr(t, err)

--- a/openstack/clustering/v1/clusters/requests.go
+++ b/openstack/clustering/v1/clusters/requests.go
@@ -497,7 +497,7 @@ type RemoveNodesOpts struct {
 	Nodes []string `json:"nodes" required:"true"`
 }
 
-func RemoveNodes(client *gophercloud.ServiceClient, clusterID string, opts RemoveNodesOpts) (r DeleteResult) {
+func RemoveNodes(client *gophercloud.ServiceClient, clusterID string, opts RemoveNodesOpts) (r ActionResult) {
 	b, err := opts.ToClusterRemoveNodeMap()
 	if err != nil {
 		r.Err = err

--- a/openstack/clustering/v1/clusters/testing/requests_test.go
+++ b/openstack/clustering/v1/clusters/testing/requests_test.go
@@ -444,12 +444,15 @@ func TestAddNodes(t *testing.T) {
 func TestRemoveNodes(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
+
 	HandleRemoveNodesSuccessfully(t)
+
 	opts := clusters.RemoveNodesOpts{
 		Nodes: []string{"node1", "node2", "node3"},
 	}
-	err := clusters.RemoveNodes(fake.ServiceClient(), "7d85f602-a948-4a30-afd4-e84f47471c15", opts).ExtractErr()
+	result, err := clusters.RemoveNodes(fake.ServiceClient(), "7d85f602-a948-4a30-afd4-e84f47471c15", opts).Extract()
 	th.AssertNoErr(t, err)
+	th.AssertEquals(t, result, "2a0ff107-e789-4660-a122-3816c43af703")
 }
 
 func TestReplaceNodes(t *testing.T) {


### PR DESCRIPTION
For #2088 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/senlin/blob/master/senlin/conductor/service.py#L970
https://docs.openstack.org/api-ref/clustering/?expanded=remove-nodes-from-a-cluster-detail#remove-nodes-from-a-cluster
