### PR TITLE
[Identity v3] Add available project listing

### DIFF
--- a/acceptance/openstack/identity/v3/projects_test.go
+++ b/acceptance/openstack/identity/v3/projects_test.go
@@ -11,6 +11,23 @@ import (
 	th "github.com/gophercloud/gophercloud/testhelper"
 )
 
+func TestProjectsListAvailable(t *testing.T) {
+	clients.RequireNonAdmin(t)
+
+	client, err := clients.NewIdentityV3Client()
+	th.AssertNoErr(t, err)
+
+	allPages, err := projects.ListAvailable(client).AllPages()
+	th.AssertNoErr(t, err)
+
+	allProjects, err := projects.ExtractProjects(allPages)
+	th.AssertNoErr(t, err)
+
+	for _, project := range allProjects {
+		tools.PrintResource(t, project)
+	}
+}
+
 func TestProjectsList(t *testing.T) {
 	clients.RequireAdmin(t)
 

--- a/openstack/identity/v3/projects/requests.go
+++ b/openstack/identity/v3/projects/requests.go
@@ -85,6 +85,14 @@ func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pa
 	})
 }
 
+// ListAvailable enumerates the Projects which are available to a specific user.
+func ListAvailable(client *gophercloud.ServiceClient) pagination.Pager {
+	url := listAvailableURL(client)
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return ProjectPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
 // Get retrieves details on a single project, by ID.
 func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {
 	resp, err := client.Get(getURL(client, id), &r.Body, nil)

--- a/openstack/identity/v3/projects/testing/fixtures.go
+++ b/openstack/identity/v3/projects/testing/fixtures.go
@@ -10,6 +10,41 @@ import (
 	"github.com/gophercloud/gophercloud/testhelper/client"
 )
 
+// ListAvailableOutput provides a single page of available Project results.
+const ListAvailableOutput = `
+{
+  "projects": [
+    {
+      "description": "my first project",
+      "domain_id": "11111",
+      "enabled": true,
+      "id": "abcde",
+      "links": {
+        "self": "http://localhost:5000/identity/v3/projects/abcde"
+      },
+      "name": "project 1",
+      "parent_id": "11111"
+    },
+    {
+      "description": "my second project",
+      "domain_id": "22222",
+      "enabled": true,
+      "id": "bcdef",
+      "links": {
+        "self": "http://localhost:5000/identity/v3/projects/bcdef"
+      },
+      "name": "project 2",
+      "parent_id": "22222"
+    }
+  ],
+  "links": {
+    "next": null,
+    "previous": null,
+    "self": "http://localhost:5000/identity/v3/users/foobar/projects"
+  }
+}
+`
+
 // ListOutput provides a single page of Project results.
 const ListOutput = `
 {
@@ -103,6 +138,32 @@ const UpdateOutput = `
 }
 `
 
+// FirstProject is a Project fixture.
+var FirstProject = projects.Project{
+	Description: "my first project",
+	DomainID:    "11111",
+	Enabled:     true,
+	ID:          "abcde",
+	Name:        "project 1",
+	ParentID:    "11111",
+	Extra: map[string]interface{}{
+		"links": map[string]interface{}{"self": "http://localhost:5000/identity/v3/projects/abcde"},
+	},
+}
+
+// SecondProject is a Project fixture.
+var SecondProject = projects.Project{
+	Description: "my second project",
+	DomainID:    "22222",
+	Enabled:     true,
+	ID:          "bcdef",
+	Name:        "project 2",
+	ParentID:    "22222",
+	Extra: map[string]interface{}{
+		"links": map[string]interface{}{"self": "http://localhost:5000/identity/v3/projects/bcdef"},
+	},
+}
+
 // RedTeam is a Project fixture.
 var RedTeam = projects.Project{
 	IsDomain:    false,
@@ -144,8 +205,26 @@ var UpdatedRedTeam = projects.Project{
 	Extra:       map[string]interface{}{"test": "new"},
 }
 
+// ExpectedAvailableProjectsSlice is the slice of projects expected to be returned
+// from ListAvailableOutput.
+var ExpectedAvailableProjectsSlice = []projects.Project{FirstProject, SecondProject}
+
 // ExpectedProjectSlice is the slice of projects expected to be returned from ListOutput.
 var ExpectedProjectSlice = []projects.Project{RedTeam, BlueTeam}
+
+// HandleListAvailableProjectsSuccessfully creates an HTTP handler at `/auth/projects`
+// on the test handler mux that responds with a list of two tenants.
+func HandleListAvailableProjectsSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/auth/projects", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, ListAvailableOutput)
+	})
+}
 
 // HandleListProjectsSuccessfully creates an HTTP handler at `/projects` on the
 // test handler mux that responds with a list of two tenants.

--- a/openstack/identity/v3/projects/testing/requests_test.go
+++ b/openstack/identity/v3/projects/testing/requests_test.go
@@ -9,6 +9,26 @@ import (
 	"github.com/gophercloud/gophercloud/testhelper/client"
 )
 
+func TestListAvailableProjects(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleListAvailableProjectsSuccessfully(t)
+
+	count := 0
+	err := projects.ListAvailable(client.ServiceClient()).EachPage(func(page pagination.Page) (bool, error) {
+		count++
+
+		actual, err := projects.ExtractProjects(page)
+		th.AssertNoErr(t, err)
+
+		th.CheckDeepEquals(t, ExpectedAvailableProjectsSlice, actual)
+
+		return true, nil
+	})
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, count, 1)
+}
+
 func TestListProjects(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()

--- a/openstack/identity/v3/projects/urls.go
+++ b/openstack/identity/v3/projects/urls.go
@@ -2,6 +2,10 @@ package projects
 
 import "github.com/gophercloud/gophercloud"
 
+func listAvailableURL(client *gophercloud.ServiceClient) string {
+	return client.ServiceURL("auth", "projects")
+}
+
 func listURL(client *gophercloud.ServiceClient) string {
 	return client.ServiceURL("projects")
 }


### PR DESCRIPTION
For #1719

Refers

- API Documentation
  - https://docs.openstack.org/api-ref/identity/v3/#get-available-project-scopes
- OpenStack Source Code
  - https://github.com/openstack/keystone/blob/master/keystone/api/auth.py#L116-L145

### Changes

Add available project listing

### Open Questions

I'm not sure about word `available`, but if this PR is accepted, I think [ListCatalog](https://github.com/gophercloud/gophercloud/blob/master/openstack/identity/v3/catalog/requests.go#L9) should be renamed too 🤔