### PR TITLE
nova: support query hosts with availability-zone

### DIFF
--- a/openstack/compute/v2/servers/requests.go
+++ b/openstack/compute/v2/servers/requests.go
@@ -84,8 +84,8 @@ type ListOpts struct {
 	// NotTagsAny filters on specific server tags. At least one of the tags must be absent for the server.
 	NotTagsAny string `q:"not-tags-any"`
 
-        // Display servers based on their availability zone (Admin only until microversion 2.82).
-        AvailabilityZone string `q:"availability_zone"`
+	// Display servers based on their availability zone (Admin only until microversion 2.82).
+	AvailabilityZone string `q:"availability_zone"`
 }
 
 // ToServerListQuery formats a ListOpts into a query string.

--- a/openstack/compute/v2/servers/requests.go
+++ b/openstack/compute/v2/servers/requests.go
@@ -83,6 +83,9 @@ type ListOpts struct {
 	// This requires the client to be set to microversion 2.26 or later.
 	// NotTagsAny filters on specific server tags. At least one of the tags must be absent for the server.
 	NotTagsAny string `q:"not-tags-any"`
+
+        // Display servers based on their availability zone (Admin only until microversion 2.82).
+        AvailabilityZone string `q:"availability_zone"`
 }
 
 // ToServerListQuery formats a ListOpts into a query string.


### PR DESCRIPTION
For #2188 

nova: add support query hosts with availability-zone parameter

Filter the server list result by server availability zone.

This parameter is restricted to administrators until microversion 2.83. If non-admin users specify this parameter on a microversion less than 2.83, it will be ignored.