### PR TITLE
Add support for master_lb_enabled field for clusters

### DIFF
--- a/openstack/containerinfra/v1/clusters/doc.go
+++ b/openstack/containerinfra/v1/clusters/doc.go
@@ -6,7 +6,8 @@ Example to Create a Cluster
 	masterCount := 1
 	nodeCount := 1
 	createTimeout := 30
-	opts := clusters.CreateOpts{
+	masterLBEnabled := true
+	createOpts := clusters.CreateOpts{
 		ClusterTemplateID: "0562d357-8641-4759-8fed-8173f02c9633",
 		CreateTimeout:     &createTimeout,
 		DiscoveryURL:      "",
@@ -17,6 +18,7 @@ Example to Create a Cluster
 		MasterFlavorID:    "m1.small",
 		Name:              "k8s",
 		NodeCount:         &nodeCount,
+		MasterLBEnabled:   &masterLBEnabled,
 	}
 
 	cluster, err := clusters.Create(serviceClient, createOpts).Extract()

--- a/openstack/containerinfra/v1/clusters/requests.go
+++ b/openstack/containerinfra/v1/clusters/requests.go
@@ -24,6 +24,7 @@ type CreateOpts struct {
 	Name              string            `json:"name"`
 	NodeCount         *int              `json:"node_count,omitempty"`
 	FloatingIPEnabled *bool             `json:"floating_ip_enabled,omitempty"`
+	MasterLBEnabled   *bool             `json:"master_lb_enabled,omitempty"`
 	FixedNetwork      string            `json:"fixed_network,omitempty"`
 	FixedSubnet       string            `json:"fixed_subnet,omitempty"`
 	MergeLabels       *bool             `json:"merge_labels,omitempty"`

--- a/openstack/containerinfra/v1/clusters/testing/requests_test.go
+++ b/openstack/containerinfra/v1/clusters/testing/requests_test.go
@@ -19,6 +19,7 @@ func TestCreateCluster(t *testing.T) {
 	masterCount := 1
 	nodeCount := 1
 	createTimeout := 30
+	masterLBEnabled := true
 	opts := clusters.CreateOpts{
 		ClusterTemplateID: "0562d357-8641-4759-8fed-8173f02c9633",
 		CreateTimeout:     &createTimeout,
@@ -28,6 +29,7 @@ func TestCreateCluster(t *testing.T) {
 		Labels:            map[string]string{},
 		MasterCount:       &masterCount,
 		MasterFlavorID:    "m1.small",
+		MasterLBEnabled:   &masterLBEnabled,
 		Name:              "k8s",
 		NodeCount:         &nodeCount,
 		FloatingIPEnabled: gophercloud.Enabled,


### PR DESCRIPTION
Closes https://github.com/gophercloud/gophercloud/issues/2101

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

 * [magnum/api/controllers/v1/cluster.py#L205](https://github.com/openstack/magnum/blob/1cdc0628a28da32ef52324244a4c97b0794c2542/magnum/api/controllers/v1/cluster.py#L205)
 * https://github.com/openstack/magnum/commit/946c1d67c73a1b325dadd27018c38555acfee52f
