### PR TITLE
Add RaidLevel "JBOD"

### DIFF
--- a/openstack/baremetal/v1/nodes/requests.go
+++ b/openstack/baremetal/v1/nodes/requests.go
@@ -521,6 +521,7 @@ const (
 	RAID10 RAIDLevel = "1+0"
 	RAID50 RAIDLevel = "5+0"
 	RAID60 RAIDLevel = "6+0"
+	JBOD   RAIDLevel = "JBOD"
 )
 
 // DiskType is used to specify the disk type for a logical disk, e.g. hdd or ssd.


### PR DESCRIPTION
For #2105 

ironic now have "JBOD" in raid_config_schema.json. 
https://github.com/openstack/ironic/blob/master/ironic/drivers/raid_config_schema.json#L13
