### PR TITLE
swift: support modified-since for cache

### DIFF
--- a/openstack/objectstorage/v1/objects/requests.go
+++ b/openstack/objectstorage/v1/objects/requests.go
@@ -106,6 +106,12 @@ func (opts DownloadOpts) ToObjectDownloadParams() (map[string]string, string, er
 	if err != nil {
 		return nil, q.String(), err
 	}
+	if !opts.IfModifiedSince.IsZero() {
+		h["If-Modified-Since"] = opts.IfModifiedSince.Format(time.RFC1123)
+	}
+	if !opts.IfUnmodifiedSince.IsZero() {
+		h["If-Unmodified-Since"] = opts.IfUnmodifiedSince.Format(time.RFC1123)
+	}
 	return h, q.String(), nil
 }
 


### PR DESCRIPTION
For https://github.com/gophercloud/gophercloud/issues/2107

API doc: 
https://docs.openstack.org/api-ref/object-store/?expanded=get-object-content-and-metadata-detail,show-container-details-and-list-objects-detail#get-object-content-and-metadata

Source code: https://github.com/openstack/swift/blob/ed990999170e7789dc6e32f299c0a3818636d9ea/swift/common/swob.py#L903-L904