### PR TITLE
Add support for blockstorage volume_type quota

### DIFF
--- a/openstack/blockstorage/extensions/quotasets/doc.go
+++ b/openstack/blockstorage/extensions/quotasets/doc.go
@@ -32,6 +32,25 @@ Example to Update a Quota Set
 
 	fmt.Printf("%+v\n", quotaset)
 
+Example to Update a Quota set with volume_type quotas
+
+	updateOpts := quotasets.UpdateOpts{
+		Volumes: gophercloud.IntToPointer(100),
+		Extra: map[string]interface{}{
+			"gigabytes_foo": gophercloud.IntToPointer(100),
+			"snapshots_foo": gophercloud.IntToPointer(10),
+			"volumes_foo":   gophercloud.IntToPointer(10),
+		},
+	}
+
+	quotaset, err := quotasets.Update(blockStorageClient, "project-id", updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v\n", quotaset)
+
+
 Example to Delete a Quota Set
 
 	err := quotasets.Delete(blockStorageClient, "project-id").ExtractErr()

--- a/openstack/blockstorage/extensions/quotasets/requests.go
+++ b/openstack/blockstorage/extensions/quotasets/requests.go
@@ -43,7 +43,7 @@ func Update(client *gophercloud.ServiceClient, projectID string, opts UpdateOpts
 	return
 }
 
-// UpdateOptsBuilder enables extensins to add parameters to the update request.
+// UpdateOptsBuilder enables extensions to add parameters to the update request.
 type UpdateOptsBuilder interface {
 	// Extra specific name to prevent collisions with interfaces for other quotas
 	// (e.g. neutron)
@@ -53,7 +53,20 @@ type UpdateOptsBuilder interface {
 // ToBlockStorageQuotaUpdateMap builds the update options into a serializable
 // format.
 func (opts UpdateOpts) ToBlockStorageQuotaUpdateMap() (map[string]interface{}, error) {
-	return gophercloud.BuildRequestBody(opts, "quota_set")
+	b, err := gophercloud.BuildRequestBody(opts, "quota_set")
+	if err != nil {
+		return nil, err
+	}
+
+	if opts.Extra != nil {
+		if v, ok := b["quota_set"].(map[string]interface{}); ok {
+			for key, value := range opts.Extra {
+				v[key] = value
+			}
+		}
+	}
+
+	return b, nil
 }
 
 // Options for Updating the quotas of a Tenant.
@@ -87,6 +100,10 @@ type UpdateOpts struct {
 	// Force will update the quotaset even if the quota has already been used
 	// and the reserved quota exceeds the new quota.
 	Force bool `json:"force,omitempty"`
+
+	// Extra is a collection of miscellaneous key/values used to set
+	// quota per volume_type
+	Extra map[string]interface{} `json:"-"`
 }
 
 // Resets the quotas for the given tenant to their default values.

--- a/openstack/blockstorage/extensions/quotasets/testing/fixtures.go
+++ b/openstack/blockstorage/extensions/quotasets/testing/fixtures.go
@@ -34,6 +34,7 @@ var getExpectedQuotaSet = quotasets.QuotaSet{
 	Backups:            12,
 	BackupGigabytes:    13,
 	Groups:             14,
+	Extra:              make(map[string]interface{}),
 }
 
 var getUsageExpectedJSONBody = `
@@ -110,6 +111,7 @@ var fullUpdateOpts = quotasets.UpdateOpts{
 	Backups:            gophercloud.IntToPointer(12),
 	BackupGigabytes:    gophercloud.IntToPointer(13),
 	Groups:             gophercloud.IntToPointer(14),
+	Extra:              make(map[string]interface{}),
 }
 
 var fullUpdateExpectedQuotaSet = quotasets.QuotaSet{
@@ -120,6 +122,7 @@ var fullUpdateExpectedQuotaSet = quotasets.QuotaSet{
 	Backups:            12,
 	BackupGigabytes:    13,
 	Groups:             14,
+	Extra:              make(map[string]interface{}),
 }
 
 var partialUpdateExpectedJSONBody = `
@@ -141,9 +144,13 @@ var partialUpdateOpts = quotasets.UpdateOpts{
 	PerVolumeGigabytes: gophercloud.IntToPointer(0),
 	Backups:            gophercloud.IntToPointer(0),
 	BackupGigabytes:    gophercloud.IntToPointer(0),
+	Extra:              make(map[string]interface{}),
 }
 
-var partiualUpdateExpectedQuotaSet = quotasets.QuotaSet{Volumes: 200}
+var partiualUpdateExpectedQuotaSet = quotasets.QuotaSet{
+	Volumes: 200,
+	Extra:   make(map[string]interface{}),
+}
 
 // HandleSuccessfulRequest configures the test server to respond to an HTTP request.
 func HandleSuccessfulRequest(t *testing.T, httpMethod, uriPath, jsonOutput string, uriQueryParams map[string]string) {


### PR DESCRIPTION
For #2072 

Api docs:
- https://docs.openstack.org/api-ref/block-storage/v3/?expanded=update-quotas-for-a-project-detail#quota-sets-extension-os-quota-sets

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:
- https://github.com/openstack/cinder/blob/0fe910f130161edf5025d59020093ae163dfcba5/cinder/quota.py#L1157
- https://github.com/openstack/cinder/blob/0fe910f130161edf5025d59020093ae163dfcba5/cinder/quota.py#L1242
- https://github.com/openstack/cinder/blob/0fe910f130161edf5025d59020093ae163dfcba5/cinder/api/contrib/quotas.py#L31
- https://github.com/openstack/cinder/blob/0fe910f130161edf5025d59020093ae163dfcba5/cinder/api/contrib/quotas.py#L192-L275
