### PR TITLE
Add support for os-retype volumeaction

### DIFF
--- a/openstack/blockstorage/extensions/volumeactions/doc.go
+++ b/openstack/blockstorage/extensions/volumeactions/doc.go
@@ -93,5 +93,17 @@ Example of Setting a Volume's Bootable status
 	if err != nil {
 		panic(err)
 	}
+
+Example of Changing Type of a Volume
+
+	changeTypeOpts := volumeactions.ChangeTypeOpts{
+		NewType:         "ssd",
+		MigrationPolicy: volumeactions.MigrationPolicyOnDemand,
+	}
+
+	err = volumeactions.ChangeType(client, volumeID, changeTypeOpts).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
 */
 package volumeactions

--- a/openstack/blockstorage/extensions/volumeactions/requests.go
+++ b/openstack/blockstorage/extensions/volumeactions/requests.go
@@ -54,7 +54,7 @@ func Attach(client *gophercloud.ServiceClient, id string, opts AttachOptsBuilder
 	return
 }
 
-// BeginDetach will mark the volume as detaching.
+// BeginDetaching will mark the volume as detaching.
 func BeginDetaching(client *gophercloud.ServiceClient, id string) (r BeginDetachingResult) {
 	b := map[string]interface{}{"os-begin_detaching": make(map[string]interface{})}
 	resp, err := client.Post(actionURL(client, id), b, nil, &gophercloud.RequestOpts{
@@ -339,6 +339,54 @@ func SetBootable(client *gophercloud.ServiceClient, id string, opts BootableOpts
 	}
 	resp, err := client.Post(actionURL(client, id), b, nil, &gophercloud.RequestOpts{
 		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// MigrationPolicy type represents a migration_policy when changing types.
+type MigrationPolicy string
+
+// Supported attributes for MigrationPolicy attribute for changeType operations.
+const (
+	MigrationPolicyNever    MigrationPolicy = "never"
+	MigrationPolicyOnDemand MigrationPolicy = "on-demand"
+)
+
+// ChangeTypeOptsBuilder allows extensions to add additional parameters to the
+// ChangeType request.
+type ChangeTypeOptsBuilder interface {
+	ToVolumeChangeTypeMap() (map[string]interface{}, error)
+}
+
+// ChangeTypeOpts contains options for changing the type of an existing Volume.
+// This object is passed to the volumes.ChangeType function.
+type ChangeTypeOpts struct {
+	// NewType is the name of the new volume type of the volume.
+	NewType string `json:"new_type" required:"true"`
+
+	// MigrationPolicy specifies if the volume should be migrated when it is
+	// re-typed. Possible values are "on-demand" or "never". If not specified,
+	// the default is "never".
+	MigrationPolicy MigrationPolicy `json:"migration_policy,omitempty"`
+}
+
+// ToVolumeChangeTypeMap assembles a request body based on the contents of an
+// ChangeTypeOpts.
+func (opts ChangeTypeOpts) ToVolumeChangeTypeMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "os-retype")
+}
+
+// ChangeType will change the volume type of the volume based on the provided information.
+// This operation does not return a response body.
+func ChangeType(client *gophercloud.ServiceClient, id string, opts ChangeTypeOptsBuilder) (r ChangeTypeResult) {
+	b, err := opts.ToVolumeChangeTypeMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := client.Post(actionURL(client, id), b, nil, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
 	})
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/blockstorage/extensions/volumeactions/results.go
+++ b/openstack/blockstorage/extensions/volumeactions/results.go
@@ -209,3 +209,8 @@ func (r UploadImageResult) Extract() (VolumeImage, error) {
 type ForceDeleteResult struct {
 	gophercloud.ErrResult
 }
+
+// ChangeTypeResult contains the response body and error from an ChangeType request.
+type ChangeTypeResult struct {
+	gophercloud.ErrResult
+}

--- a/openstack/blockstorage/extensions/volumeactions/testing/fixtures.go
+++ b/openstack/blockstorage/extensions/volumeactions/testing/fixtures.go
@@ -326,3 +326,27 @@ func MockSetBootableResponse(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 }
+
+func MockChangeTypeResponse(t *testing.T) {
+	th.Mux.HandleFunc("/volumes/cd281d77-8217-4830-be95-9528227c105c/action",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "POST")
+			th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+			th.TestHeader(t, r, "Content-Type", "application/json")
+			th.TestHeader(t, r, "Accept", "application/json")
+			th.TestJSONRequest(t, r, `
+{
+    "os-retype":
+    {
+		"new_type": "ssd",
+		"migration_policy": "on-demand"
+    }
+}
+          `)
+
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusAccepted)
+
+			fmt.Fprintf(w, `{}`)
+		})
+}

--- a/openstack/blockstorage/extensions/volumeactions/testing/requests_test.go
+++ b/openstack/blockstorage/extensions/volumeactions/testing/requests_test.go
@@ -194,3 +194,18 @@ func TestSetBootable(t *testing.T) {
 	err := volumeactions.SetBootable(client.ServiceClient(), "cd281d77-8217-4830-be95-9528227c105c", options).ExtractErr()
 	th.AssertNoErr(t, err)
 }
+
+func TestChangeType(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockChangeTypeResponse(t)
+
+	options := &volumeactions.ChangeTypeOpts{
+		NewType:         "ssd",
+		MigrationPolicy: "on-demand",
+	}
+
+	err := volumeactions.ChangeType(client.ServiceClient(), "cd281d77-8217-4830-be95-9528227c105c", options).ExtractErr()
+	th.AssertNoErr(t, err)
+}


### PR DESCRIPTION
For #2110 

Add support for the "os-retype" volumeaction that changes the volume_type of a volume.

The lowe-level implementation of the os-retype is driver specific on cinder. The links below are blobs on the api level.
- [volumeaction](https://github.com/openstack/cinder/blob/876ac4e79fe14887ee3902ef833be5e2273d800b/cinder/api/contrib/volume_actions.py#L293-L303)
- [schema](https://github.com/openstack/cinder/blob/876ac4e79fe14887ee3902ef833be5e2273d800b/cinder/api/schemas/volume_actions.py#L87-L104)
- [volume-api](https://github.com/openstack/cinder/blob/876ac4e79fe14887ee3902ef833be5e2273d800b/cinder/volume/api.py#L1633)
