### PR TITLE
Change Microversion to 2.53

### DIFF
--- a/openstack/compute/v2/extensions/services/requests.go
+++ b/openstack/compute/v2/extensions/services/requests.go
@@ -25,6 +25,7 @@ func (opts ListOpts) ToServicesListQuery() (string, error) {
 
 // List makes a request against the API to list services.
 func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	client.Microversion = "2.53"
 	url := listURL(client)
 	if opts != nil {
 		query, err := opts.ToServicesListQuery()


### PR DESCRIPTION
When list nova services, we want to get uuid instead of id. It is
supported > 2.53
The id of the service as a uuid.
New in version 2.53

Prior to starting a PR, please make sure you have read our
[contributor tutorial](https://github.com/gophercloud/gophercloud/tree/master/docs/contributor-tutorial).

Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

For #[PUT ISSUE NUMBER HERE]

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

[PUT URLS HERE]
