### PR TITLE
blockstoragev3: support extra_spec for volumetypes

### DIFF
--- a/openstack/blockstorage/v3/volumetypes/doc.go
+++ b/openstack/blockstorage/v3/volumetypes/doc.go
@@ -58,6 +58,63 @@ Example to update a Volume Type
 		panic(err)
 	}
 	fmt.Println(volumetype)
-*/
 
+Example to Create Extra Specs for a Volume Type
+
+	typeID := "7ffaca22-f646-41d4-b79d-d7e4452ef8cc"
+
+	createOpts := volumetypes.ExtraSpecsOpts{
+		"capabilities": "gpu",
+	}
+	createdExtraSpecs, err := volumetypes.CreateExtraSpecs(client, typeID, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v", createdExtraSpecs)
+
+Example to Get Extra Specs for a Volume Type
+
+	typeID := "7ffaca22-f646-41d4-b79d-d7e4452ef8cc"
+
+	extraSpecs, err := volumetypes.ListExtraSpecs(client, typeID).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v", extraSpecs)
+
+Example to Get specific Extra Spec for a Volume Type
+
+	typeID := "7ffaca22-f646-41d4-b79d-d7e4452ef8cc"
+
+	extraSpec, err := volumetypes.GetExtraSpec(client, typeID, "capabilities").Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v", extraSpec)
+
+Example to Update Extra Specs for a Volume Type
+
+	typeID := "7ffaca22-f646-41d4-b79d-d7e4452ef8cc"
+
+	updateOpts := volumetypes.ExtraSpecsOpts{
+		"capabilities": "capabilities-updated",
+	}
+	updatedExtraSpec, err := volumetypes.UpdateExtraSpec(client, typeID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v", updatedExtraSpec)
+
+Example to Delete an Extra Spec for a Volume Type
+
+	typeID := "7ffaca22-f646-41d4-b79d-d7e4452ef8cc"
+	err := volumetypes.DeleteExtraSpec(client, typeID, "capabilities").ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+*/
 package volumetypes

--- a/openstack/blockstorage/v3/volumetypes/results.go
+++ b/openstack/blockstorage/v3/volumetypes/results.go
@@ -5,7 +5,7 @@ import (
 	"github.com/gophercloud/gophercloud/pagination"
 )
 
-// Volume Type contains all the information associated with an OpenStack Volume Type.
+// VolumeType contains all the information associated with an OpenStack Volume Type.
 type VolumeType struct {
 	// Unique identifier for the volume type.
 	ID string `json:"id"`
@@ -68,7 +68,7 @@ func (r commonResult) ExtractInto(v interface{}) error {
 	return r.Result.ExtractIntoStructPtr(v, "volume_type")
 }
 
-// ExtractVolumesInto similar to ExtractInto but operates on a `list` of volume types
+// ExtractVolumeTypesInto similar to ExtractInto but operates on a `list` of volume types
 func ExtractVolumeTypesInto(r pagination.Page, v interface{}) error {
 	return r.(VolumeTypePage).Result.ExtractIntoSlicePtr(v, "volume_types")
 }
@@ -91,4 +91,63 @@ type DeleteResult struct {
 // UpdateResult contains the response body and error from an Update request.
 type UpdateResult struct {
 	commonResult
+}
+
+// extraSpecsResult contains the result of a call for (potentially) multiple
+// key-value pairs. Call its Extract method to interpret it as a
+// map[string]interface.
+type extraSpecsResult struct {
+	gophercloud.Result
+}
+
+// ListExtraSpecsResult contains the result of a Get operation. Call its Extract
+// method to interpret it as a map[string]interface.
+type ListExtraSpecsResult struct {
+	extraSpecsResult
+}
+
+// CreateExtraSpecsResult contains the result of a Create operation. Call its
+// Extract method to interpret it as a map[string]interface.
+type CreateExtraSpecsResult struct {
+	extraSpecsResult
+}
+
+// Extract interprets any extraSpecsResult as ExtraSpecs, if possible.
+func (r extraSpecsResult) Extract() (map[string]string, error) {
+	var s struct {
+		ExtraSpecs map[string]string `json:"extra_specs"`
+	}
+	err := r.ExtractInto(&s)
+	return s.ExtraSpecs, err
+}
+
+// extraSpecResult contains the result of a call for individual a single
+// key-value pair.
+type extraSpecResult struct {
+	gophercloud.Result
+}
+
+// GetExtraSpecResult contains the result of a Get operation. Call its Extract
+// method to interpret it as a map[string]interface.
+type GetExtraSpecResult struct {
+	extraSpecResult
+}
+
+// UpdateExtraSpecResult contains the result of an Update operation. Call its
+// Extract method to interpret it as a map[string]interface.
+type UpdateExtraSpecResult struct {
+	extraSpecResult
+}
+
+// DeleteExtraSpecResult contains the result of a Delete operation. Call its
+// ExtractErr method to determine if the call succeeded or failed.
+type DeleteExtraSpecResult struct {
+	gophercloud.ErrResult
+}
+
+// Extract interprets any extraSpecResult as an ExtraSpec, if possible.
+func (r extraSpecResult) Extract() (map[string]string, error) {
+	var s map[string]string
+	err := r.ExtractInto(&s)
+	return s, err
 }

--- a/openstack/blockstorage/v3/volumetypes/testing/fixtures.go
+++ b/openstack/blockstorage/v3/volumetypes/testing/fixtures.go
@@ -152,3 +152,109 @@ func MockUpdateResponse(t *testing.T) {
 }`)
 	})
 }
+
+// ExtraSpecsGetBody provides a GET result of the extra_specs for a volume type
+const ExtraSpecsGetBody = `
+{
+    "extra_specs" : {
+        "capabilities": "gpu",
+        "volume_backend_name": "ssd"
+    }
+}
+`
+
+// GetExtraSpecBody provides a GET result of a particular extra_spec for a volume type
+const GetExtraSpecBody = `
+{
+    "capabilities": "gpu"
+}
+`
+
+// UpdatedExtraSpecBody provides an PUT result of a particular updated extra_spec for a volume type
+const UpdatedExtraSpecBody = `
+{
+    "capabilities": "gpu-2"
+}
+`
+
+// ExtraSpecs is the expected extra_specs returned from GET on a volume type's extra_specs
+var ExtraSpecs = map[string]string{
+	"capabilities":        "gpu",
+	"volume_backend_name": "ssd",
+}
+
+// ExtraSpec is the expected extra_spec returned from GET on a volume type's extra_specs
+var ExtraSpec = map[string]string{
+	"capabilities": "gpu",
+}
+
+// UpdatedExtraSpec is the expected extra_spec returned from PUT on a volume type's extra_specs
+var UpdatedExtraSpec = map[string]string{
+	"capabilities": "gpu-2",
+}
+
+func HandleExtraSpecsListSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/types/1/extra_specs", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, ExtraSpecsGetBody)
+	})
+}
+
+func HandleExtraSpecGetSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/types/1/extra_specs/capabilities", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, GetExtraSpecBody)
+	})
+}
+
+func HandleExtraSpecsCreateSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/types/1/extra_specs", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, `{
+				"extra_specs": {
+					"capabilities":        "gpu",
+                    "volume_backend_name": "ssd"
+				}
+			}`)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, ExtraSpecsGetBody)
+	})
+}
+
+func HandleExtraSpecUpdateSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/types/1/extra_specs/capabilities", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, `{
+				"capabilities":        "gpu-2"
+			}`)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, UpdatedExtraSpecBody)
+	})
+}
+
+func HandleExtraSpecDeleteSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/types/1/extra_specs/capabilities", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.WriteHeader(http.StatusAccepted)
+	})
+}

--- a/openstack/blockstorage/v3/volumetypes/testing/requests_test.go
+++ b/openstack/blockstorage/v3/volumetypes/testing/requests_test.go
@@ -117,3 +117,63 @@ func TestUpdate(t *testing.T) {
 	th.CheckEquals(t, "vol-type-002", v.Name)
 	th.CheckEquals(t, true, v.IsPublic)
 }
+
+func TestVolumeTypeExtraSpecsList(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleExtraSpecsListSuccessfully(t)
+
+	expected := ExtraSpecs
+	actual, err := volumetypes.ListExtraSpecs(client.ServiceClient(), "1").Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, expected, actual)
+}
+
+func TestVolumeTypeExtraSpecGet(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleExtraSpecGetSuccessfully(t)
+
+	expected := ExtraSpec
+	actual, err := volumetypes.GetExtraSpec(client.ServiceClient(), "1", "capabilities").Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, expected, actual)
+}
+
+func TestVolumeTypeExtraSpecsCreate(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleExtraSpecsCreateSuccessfully(t)
+
+	createOpts := volumetypes.ExtraSpecsOpts{
+		"capabilities":        "gpu",
+		"volume_backend_name": "ssd",
+	}
+	expected := ExtraSpecs
+	actual, err := volumetypes.CreateExtraSpecs(client.ServiceClient(), "1", createOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, expected, actual)
+}
+
+func TestVolumeTypeExtraSpecUpdate(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleExtraSpecUpdateSuccessfully(t)
+
+	updateOpts := volumetypes.ExtraSpecsOpts{
+		"capabilities": "gpu-2",
+	}
+	expected := UpdatedExtraSpec
+	actual, err := volumetypes.UpdateExtraSpec(client.ServiceClient(), "1", updateOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, expected, actual)
+}
+
+func TestVolumeTypeExtraSpecDelete(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleExtraSpecDeleteSuccessfully(t)
+
+	res := volumetypes.DeleteExtraSpec(client.ServiceClient(), "1", "capabilities")
+	th.AssertNoErr(t, res.Err)
+}

--- a/openstack/blockstorage/v3/volumetypes/urls.go
+++ b/openstack/blockstorage/v3/volumetypes/urls.go
@@ -21,3 +21,23 @@ func deleteURL(c *gophercloud.ServiceClient, id string) string {
 func updateURL(c *gophercloud.ServiceClient, id string) string {
 	return c.ServiceURL("types", id)
 }
+
+func extraSpecsListURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL("types", id, "extra_specs")
+}
+
+func extraSpecsGetURL(client *gophercloud.ServiceClient, id, key string) string {
+	return client.ServiceURL("types", id, "extra_specs", key)
+}
+
+func extraSpecsCreateURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL("types", id, "extra_specs")
+}
+
+func extraSpecUpdateURL(client *gophercloud.ServiceClient, id, key string) string {
+	return client.ServiceURL("types", id, "extra_specs", key)
+}
+
+func extraSpecDeleteURL(client *gophercloud.ServiceClient, id, key string) string {
+	return client.ServiceURL("types", id, "extra_specs", key)
+}


### PR DESCRIPTION
Add support for blockstoragev3 volumetype extra_spec operations
such as:
- create extra specs for volume type
- list all extra specs of volume type
- get specific extra spec of volume type
- update specific extra spec of volume type
- delete specific extra spec of volume type

For #649 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

CreateExtraSpecs:
- [api_docs](https://docs.openstack.org/api-ref/block-storage/v3/index.html?expanded=create-or-update-extra-specs-for-volume-type-detail#volume-types-types)
- [code](https://github.com/openstack/cinder/blob/8456d86c6b9f2f03de4b2b95d56d16d1884ce220/cinder/api/contrib/types_extra_specs.py#L82)

ListExtraSpecs:
- [api_docs](https://docs.openstack.org/api-ref/block-storage/v3/index.html?expanded=show-all-extra-specifications-for-volume-type-detail#volume-types-types)
- [code](https://github.com/openstack/cinder/blob/8456d86c6b9f2f03de4b2b95d56d16d1884ce220/cinder/api/contrib/types_extra_specs.py#L39)

GetExtraSpec:
- [api_docs](https://docs.openstack.org/api-ref/block-storage/v3/index.html?expanded=show-extra-specification-for-volume-type-detail#volume-types-types)
- [code](https://github.com/openstack/cinder/blob/8456d86c6b9f2f03de4b2b95d56d16d1884ce220/cinder/api/contrib/types_extra_specs.py#L144)

UpdateExtraSpec:
- [api_docs](https://docs.openstack.org/api-ref/block-storage/v3/index.html?expanded=update-extra-specification-for-volume-type-detail#volume-types-types)
- [code](https://github.com/openstack/cinder/blob/8456d86c6b9f2f03de4b2b95d56d16d1884ce220/cinder/api/contrib/types_extra_specs.py#L111)

DeleteExtraSpec:
- [api_docs](https://docs.openstack.org/api-ref/block-storage/v3/index.html?expanded=delete-extra-specification-for-volume-type-detail#volume-types-types)
- [code](https://github.com/openstack/cinder/blob/8456d86c6b9f2f03de4b2b95d56d16d1884ce220/cinder/api/contrib/types_extra_specs.py#L157)