### PR TITLE
Neutron quota: int-as-string workaround

### DIFF
--- a/openstack/networking/v2/extensions/quotas/testing/fixtures.go
+++ b/openstack/networking/v2/extensions/quotas/testing/fixtures.go
@@ -22,6 +22,11 @@ const GetResponseRaw = `
 `
 
 // GetDetailedResponseRaw is a sample response to a Get call with the detailed option.
+//
+// One "reserved" property is returned as a string to reflect a buggy behaviour
+// of Neutron.
+//
+// cf. https://bugs.launchpad.net/neutron/+bug/1918565
 const GetDetailedResponseRaw = `
 {
    "quota" : {
@@ -38,7 +43,7 @@ const GetDetailedResponseRaw = `
       "port" : {
           "used": 0,
           "limit": 25,
-          "reserved": 0
+          "reserved": "0"
       },
       "rbac_policy" : {
           "used": 0,


### PR DESCRIPTION
In some conditions, Neutron will JSON-encode quota values as strings
instead of integers.

With this patch, the unmarshaling method is overridden to accept
integers as strings.

See https://bugs.launchpad.net/neutron/+bug/1918565

Fixes #2125