### PR TITLE
blockstorage/v3/volumetypes Extra_specs omitempty

### DIFF
--- a/openstack/blockstorage/v3/volumetypes/requests.go
+++ b/openstack/blockstorage/v3/volumetypes/requests.go
@@ -22,7 +22,7 @@ type CreateOpts struct {
 	// the ID of the existing volume snapshot
 	IsPublic *bool `json:"os-volume-type-access:is_public,omitempty"`
 	// Extra spec key-value pairs defined by the user.
-	ExtraSpecs map[string]string `json:"extra_specs"`
+	ExtraSpecs map[string]string `json:"extra_specs,omitempty"`
 }
 
 // ToVolumeTypeCreateMap assembles a request body based on the contents of a


### PR DESCRIPTION
For #649 

Minor patch to volume_type CreateOpts for extra_specs.

[docs](https://docs.openstack.org/api-ref/block-storage/v3/index.html?expanded=create-a-volume-type-detail)