### PR TITLE
Compute: Handle Hypervisor request parameters

### DIFF
--- a/openstack/compute/v2/extensions/hypervisors/requests.go
+++ b/openstack/compute/v2/extensions/hypervisors/requests.go
@@ -5,9 +5,52 @@ import (
 	"github.com/gophercloud/gophercloud/pagination"
 )
 
+// ListOptsBuilder allows extensions to add additional parameters to the
+// List request.
+type ListOptsBuilder interface {
+	ToHypervisorListQuery() (string, error)
+}
+
+// ListOpts allows the filtering and sorting of paginated collections through
+// the API. Filtering is achieved by passing in struct field values that map to
+// the server attributes you want to see returned. Marker and Limit are used
+// for pagination.
+type ListOpts struct {
+	// Limit is an integer value for the limit of values to return.
+	// This requires microversion 2.33 or later.
+	Limit *int `q:"limit"`
+
+	// Marker is the ID of the last-seen item as a UUID.
+	// This requires microversion 2.53 or later.
+	Marker *string `q:"marker"`
+
+	// HypervisorHostnamePattern is the hypervisor hostname or a portion of it.
+	// This requires microversion 2.53 or later
+	HypervisorHostnamePattern *string `q:"hypervisor_hostname_pattern"`
+
+	// WithServers is a bool to include all servers which belong to each hypervisor
+	// This requires microversion 2.53 or later
+	WithServers *bool `q:"with_servers"`
+}
+
+// ToHypervisorListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToHypervisorListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
 // List makes a request against the API to list hypervisors.
-func List(client *gophercloud.ServiceClient) pagination.Pager {
-	return pagination.NewPager(client, hypervisorsListDetailURL(client), func(r pagination.PageResult) pagination.Page {
+func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := hypervisorsListDetailURL(client)
+	if opts != nil {
+		query, err := opts.ToHypervisorListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
 		return HypervisorPage{pagination.SinglePageBase(r)}
 	})
 }

--- a/openstack/compute/v2/extensions/hypervisors/results.go
+++ b/openstack/compute/v2/extensions/hypervisors/results.go
@@ -62,6 +62,12 @@ func (r *Service) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+// Server represents an instance running on the hypervisor
+type Server struct {
+	Name string `json:"name"`
+	UUID string `json:"uuid"`
+}
+
 // Hypervisor represents a hypervisor in the OpenStack cloud.
 type Hypervisor struct {
 	// A structure that contains cpu information like arch, model, vendor,
@@ -122,6 +128,10 @@ type Hypervisor struct {
 
 	// Service is the service this hypervisor represents.
 	Service Service `json:"service"`
+
+	// Servers is a list of Server object.
+	// The requires microversion 2.53 or later.
+	Servers []*Server `json:"servers"`
 
 	// VCPUs is the total number of vcpus on the hypervisor.
 	VCPUs int `json:"vcpus"`

--- a/openstack/compute/v2/extensions/hypervisors/testing/fixtures.go
+++ b/openstack/compute/v2/extensions/hypervisors/testing/fixtures.go
@@ -157,6 +157,98 @@ const HypervisorListBody = `
     ]
 }`
 
+// HypervisorListWithParametersBody represents a raw hypervisor list result with Pike+ release.
+const HypervisorListWithParametersBody = `
+{
+    "hypervisors": [
+        {
+            "cpu_info": {
+                "arch": "x86_64",
+                "model": "Nehalem",
+                "vendor": "Intel",
+                "features": [
+                    "pge",
+                    "clflush"
+                ],
+                "topology": {
+                    "cores": 1,
+                    "threads": 1,
+                    "sockets": 4
+                }
+            },
+            "current_workload": 0,
+            "status": "enabled",
+            "state": "up",
+            "disk_available_least": 0,
+            "host_ip": "1.1.1.1",
+            "free_disk_gb": 1028,
+            "free_ram_mb": 7680,
+            "hypervisor_hostname": "fake-mini",
+            "hypervisor_type": "fake",
+            "hypervisor_version": 2002000,
+            "id": "c48f6247-abe4-4a24-824e-ea39e108874f",
+            "local_gb": 1028,
+            "local_gb_used": 0,
+            "memory_mb": 8192,
+            "memory_mb_used": 512,
+            "running_vms": 0,
+            "service": {
+                "host": "e6a37ee802d74863ab8b91ade8f12a67",
+                "id": "9c2566e7-7a54-4777-a1ae-c2662f0c407c",
+                "disabled_reason": null
+            },
+            "servers": [
+                {
+                    "name": "instance-00000001",
+                    "uuid": "c42acc8d-eab3-4e4d-9d90-01b0791328f4"
+                },
+                {
+                    "name": "instance-00000002",
+                    "uuid": "8aaf2941-b774-41fc-921b-20c4757cc359"
+                }
+            ],
+            "vcpus": 1,
+            "vcpus_used": 0
+        },
+        {
+            "cpu_info": "{\"arch\": \"x86_64\", \"model\": \"Nehalem\", \"vendor\": \"Intel\", \"features\": [\"pge\", \"clflush\"], \"topology\": {\"cores\": 1, \"threads\": 1, \"sockets\": 4}}",
+            "current_workload": 0,
+            "status": "enabled",
+            "state": "up",
+            "disk_available_least": 0,
+            "host_ip": "1.1.1.1",
+            "free_disk_gb": 1028,
+            "free_ram_mb": 7680,
+            "hypervisor_hostname": "fake-mini",
+            "hypervisor_type": "fake",
+            "hypervisor_version": 2.002e+06,
+            "id": "c48f6247-abe4-4a24-824e-ea39e108874f",
+            "local_gb": 1028,
+            "local_gb_used": 0,
+            "memory_mb": 8192,
+            "memory_mb_used": 512,
+            "running_vms": 0,
+            "servers": [
+                {
+                    "name": "instance-00000001",
+                    "uuid": "c42acc8d-eab3-4e4d-9d90-01b0791328f4"
+                },
+                {
+                    "name": "instance-00000002",
+                    "uuid": "8aaf2941-b774-41fc-921b-20c4757cc359"
+                }
+            ],
+            "service": {
+                "host": "e6a37ee802d74863ab8b91ade8f12a67",
+                "id": "9c2566e7-7a54-4777-a1ae-c2662f0c407c",
+                "disabled_reason": null
+            },
+            "vcpus": 1,
+            "vcpus_used": 0
+        }
+    ]
+}`
+
 const HypervisorsStatisticsBody = `
 {
     "hypervisor_statistics": {
@@ -349,6 +441,56 @@ var (
 		VCPUsUsed: 0,
 	}
 
+	HypervisorFakeWithParameters = hypervisors.Hypervisor{
+		CPUInfo: hypervisors.CPUInfo{
+			Arch:   "x86_64",
+			Model:  "Nehalem",
+			Vendor: "Intel",
+			Features: []string{
+				"pge",
+				"clflush",
+			},
+			Topology: hypervisors.Topology{
+				Cores:   1,
+				Threads: 1,
+				Sockets: 4,
+			},
+		},
+		CurrentWorkload:    0,
+		Status:             "enabled",
+		State:              "up",
+		DiskAvailableLeast: 0,
+		HostIP:             "1.1.1.1",
+		FreeDiskGB:         1028,
+		FreeRamMB:          7680,
+		HypervisorHostname: "fake-mini",
+		HypervisorType:     "fake",
+		HypervisorVersion:  2002000,
+		ID:                 "c48f6247-abe4-4a24-824e-ea39e108874f",
+		LocalGB:            1028,
+		LocalGBUsed:        0,
+		MemoryMB:           8192,
+		MemoryMBUsed:       512,
+		RunningVMs:         0,
+		Service: hypervisors.Service{
+			Host:           "e6a37ee802d74863ab8b91ade8f12a67",
+			ID:             "9c2566e7-7a54-4777-a1ae-c2662f0c407c",
+			DisabledReason: "",
+		},
+		Servers: []*hypervisors.Server{
+			{
+				Name: "instance-00000001",
+				UUID: "c42acc8d-eab3-4e4d-9d90-01b0791328f4",
+			},
+			{
+				Name: "instance-00000002",
+				UUID: "8aaf2941-b774-41fc-921b-20c4757cc359",
+			},
+		},
+		VCPUs:     1,
+		VCPUsUsed: 0,
+	}
+
 	HypervisorEmptyCPUInfo = hypervisors.Hypervisor{
 		CurrentWorkload:    0,
 		Status:             "enabled",
@@ -426,6 +568,19 @@ func HandleHypervisorListSuccessfully(t *testing.T) {
 
 		w.Header().Add("Content-Type", "application/json")
 		fmt.Fprintf(w, HypervisorListBody)
+	})
+}
+
+func HandleHypervisorListWithParametersSuccessfully(t *testing.T) {
+	testhelper.Mux.HandleFunc("/os-hypervisors/detail", func(w http.ResponseWriter, r *http.Request) {
+		testhelper.TestMethod(t, r, "GET")
+		testhelper.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		testhelper.TestFormValues(t, r, map[string]string{
+			"with_servers": "true",
+		})
+
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprintf(w, HypervisorListWithParametersBody)
 	})
 }
 

--- a/openstack/compute/v2/extensions/hypervisors/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/hypervisors/testing/requests_test.go
@@ -15,7 +15,8 @@ func TestListHypervisorsPre253(t *testing.T) {
 	HandleHypervisorListPre253Successfully(t)
 
 	pages := 0
-	err := hypervisors.List(client.ServiceClient()).EachPage(func(page pagination.Page) (bool, error) {
+	err := hypervisors.List(client.ServiceClient(),
+		hypervisors.ListOpts{}).EachPage(func(page pagination.Page) (bool, error) {
 		pages++
 
 		actual, err := hypervisors.ExtractHypervisors(page)
@@ -44,7 +45,7 @@ func TestListAllHypervisorsPre253(t *testing.T) {
 	defer testhelper.TeardownHTTP()
 	HandleHypervisorListPre253Successfully(t)
 
-	allPages, err := hypervisors.List(client.ServiceClient()).AllPages()
+	allPages, err := hypervisors.List(client.ServiceClient(), hypervisors.ListOpts{}).AllPages()
 	testhelper.AssertNoErr(t, err)
 	actual, err := hypervisors.ExtractHypervisors(allPages)
 	testhelper.AssertNoErr(t, err)
@@ -58,7 +59,8 @@ func TestListHypervisors(t *testing.T) {
 	HandleHypervisorListSuccessfully(t)
 
 	pages := 0
-	err := hypervisors.List(client.ServiceClient()).EachPage(func(page pagination.Page) (bool, error) {
+	err := hypervisors.List(client.ServiceClient(),
+		hypervisors.ListOpts{}).EachPage(func(page pagination.Page) (bool, error) {
 		pages++
 
 		actual, err := hypervisors.ExtractHypervisors(page)
@@ -87,12 +89,26 @@ func TestListAllHypervisors(t *testing.T) {
 	defer testhelper.TeardownHTTP()
 	HandleHypervisorListSuccessfully(t)
 
-	allPages, err := hypervisors.List(client.ServiceClient()).AllPages()
+	allPages, err := hypervisors.List(client.ServiceClient(), hypervisors.ListOpts{}).AllPages()
 	testhelper.AssertNoErr(t, err)
 	actual, err := hypervisors.ExtractHypervisors(allPages)
 	testhelper.AssertNoErr(t, err)
 	testhelper.CheckDeepEquals(t, HypervisorFake, actual[0])
 	testhelper.CheckDeepEquals(t, HypervisorFake, actual[1])
+}
+
+func TestListAllHypervisorsWithParameters(t *testing.T) {
+	testhelper.SetupHTTP()
+	defer testhelper.TeardownHTTP()
+	HandleHypervisorListWithParametersSuccessfully(t)
+
+	with_servers := true
+	allPages, err := hypervisors.List(client.ServiceClient(), hypervisors.ListOpts{WithServers: &with_servers}).AllPages()
+	testhelper.AssertNoErr(t, err)
+	actual, err := hypervisors.ExtractHypervisors(allPages)
+	testhelper.AssertNoErr(t, err)
+	testhelper.CheckDeepEquals(t, HypervisorFakeWithParameters, actual[0])
+	testhelper.CheckDeepEquals(t, HypervisorFakeWithParameters, actual[1])
 }
 
 func TestHypervisorsStatistics(t *testing.T) {


### PR DESCRIPTION
Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/nova/blob/stable/victoria/nova/api/openstack/compute/hypervisors.py#L89

This field has become mandatory in microversion 2.75. If no servers is on hypervisor then empty list is returned.

Signed-off-by: Kien Nguyen <kiennt2609@gmail.com>