### PR TITLE
Identity: Support include_names query arg in /role_assignments

### DIFF
--- a/openstack/identity/v3/roles/requests.go
+++ b/openstack/identity/v3/roles/requests.go
@@ -204,6 +204,9 @@ type ListAssignmentsOpts struct {
 	// Effective lists effective assignments at the user, project, and domain
 	// level, allowing for the effects of group membership.
 	Effective *bool `q:"effective"`
+
+	// IncludeNames indicates whether to include names of any returned entities.
+	IncludeNames *bool `q:"include_names"`
 }
 
 // ToRolesListAssignmentsQuery formats a ListAssignmentsOpts into a query string.

--- a/openstack/identity/v3/roles/results.go
+++ b/openstack/identity/v3/roles/results.go
@@ -138,7 +138,8 @@ type RoleAssignment struct {
 
 // AssignedRole represents a Role in an assignment.
 type AssignedRole struct {
-	ID string `json:"id,omitempty"`
+	ID   string `json:"id,omitempty"`
+	Name string `json:"name,omitempty"`
 }
 
 // Scope represents a scope in a Role assignment.
@@ -149,22 +150,26 @@ type Scope struct {
 
 // Domain represents a domain in a role assignment scope.
 type Domain struct {
-	ID string `json:"id,omitempty"`
+	ID   string `json:"id,omitempty"`
+	Name string `json:"name,omitempty"`
 }
 
 // Project represents a project in a role assignment scope.
 type Project struct {
-	ID string `json:"id,omitempty"`
+	ID   string `json:"id,omitempty"`
+	Name string `json:"name,omitempty"`
 }
 
 // User represents a user in a role assignment scope.
 type User struct {
-	ID string `json:"id,omitempty"`
+	ID   string `json:"id,omitempty"`
+	Name string `json:"name,omitempty"`
 }
 
 // Group represents a group in a role assignment scope.
 type Group struct {
-	ID string `json:"id,omitempty"`
+	ID   string `json:"id,omitempty"`
+	Name string `json:"name,omitempty"`
 }
 
 // RoleAssignmentPage is a single page of RoleAssignments results.

--- a/openstack/identity/v3/roles/testing/fixtures.go
+++ b/openstack/identity/v3/roles/testing/fixtures.go
@@ -96,6 +96,7 @@ const UpdateOutput = `
 }
 `
 
+// ListAssignmentOutput provides a result of ListAssignment request.
 const ListAssignmentOutput = `
 {
     "role_assignments": [
@@ -135,6 +136,38 @@ const ListAssignmentOutput = `
     ],
     "links": {
         "self": "http://identity:35357/v3/role_assignments?effective",
+        "previous": null,
+        "next": null
+    }
+}
+`
+
+// ListAssignmentWithNamesOutput provides a result of ListAssignment request with IncludeNames option.
+const ListAssignmentWithNamesOutput = `
+{
+    "role_assignments": [
+        {
+            "links": {
+                "assignment": "http://identity:35357/v3/domains/161718/users/313233/roles/123456"
+            },
+            "role": {
+                "id": "123456",
+				"name": "include_names_role"
+            },
+            "scope": {
+                "domain": {
+                    "id": "161718",
+					"name": "52833"
+                }
+            },
+            "user": {
+                "id": "313233",
+				"name": "example-user-name"
+            }
+        }
+    ],
+    "links": {
+        "self": "http://identity:35357/v3/role_assignments?include_names=True",
         "previous": null,
         "next": null
     }
@@ -337,9 +370,21 @@ var SecondRoleAssignment = roles.RoleAssignment{
 	Group: roles.Group{},
 }
 
+// ThirdRoleAssignment is the third role assignment that has entity names in the List request.
+var ThirdRoleAssignment = roles.RoleAssignment{
+	Role:  roles.AssignedRole{ID: "123456", Name: "include_names_role"},
+	Scope: roles.Scope{Domain: roles.Domain{ID: "161718", Name: "52833"}},
+	User:  roles.User{ID: "313233", Name: "example-user-name"},
+	Group: roles.Group{},
+}
+
 // ExpectedRoleAssignmentsSlice is the slice of role assignments expected to be
 // returned from ListAssignmentOutput.
 var ExpectedRoleAssignmentsSlice = []roles.RoleAssignment{FirstRoleAssignment, SecondRoleAssignment}
+
+// ExpectedRoleAssignmentsWithNamesSlice is the slice of role assignments expected to be
+// returned from ListAssignmentWithNamesOutput.
+var ExpectedRoleAssignmentsWithNamesSlice = []roles.RoleAssignment{ThirdRoleAssignment}
 
 // HandleListRoleAssignmentsSuccessfully creates an HTTP handler at `/role_assignments` on the
 // test handler mux that responds with a list of two role assignments.
@@ -352,6 +397,21 @@ func HandleListRoleAssignmentsSuccessfully(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprintf(w, ListAssignmentOutput)
+	})
+}
+
+// HandleListRoleAssignmentsSuccessfully creates an HTTP handler at `/role_assignments` on the
+// test handler mux that responds with a list of two role assignments.
+func HandleListRoleAssignmentsWithNamesSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/role_assignments", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.AssertEquals(t, "include_names=true", r.URL.RawQuery)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, ListAssignmentWithNamesOutput)
 	})
 }
 

--- a/openstack/identity/v3/roles/testing/requests_test.go
+++ b/openstack/identity/v3/roles/testing/requests_test.go
@@ -147,6 +147,30 @@ func TestListAssignmentsSinglePage(t *testing.T) {
 	th.CheckEquals(t, count, 1)
 }
 
+func TestListAssignmentsWithNamesSinglePage(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleListRoleAssignmentsWithNamesSuccessfully(t)
+
+	var includeNames = true
+	listOpts := roles.ListAssignmentsOpts{
+		IncludeNames: &includeNames,
+	}
+
+	count := 0
+	err := roles.ListAssignments(client.ServiceClient(), listOpts).EachPage(func(page pagination.Page) (bool, error) {
+		count++
+		actual, err := roles.ExtractRoleAssignments(page)
+		th.AssertNoErr(t, err)
+
+		th.CheckDeepEquals(t, ExpectedRoleAssignmentsWithNamesSlice, actual)
+
+		return true, nil
+	})
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, count, 1)
+}
+
 func TestListAssignmentsOnResource_ProjectsUsers(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()


### PR DESCRIPTION
Keystone may include names into RoleAssignment entity, if provide include_names=true as query arguemnt

For #2124

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://docs.openstack.org/api-ref/identity/v3/index.html?expanded=id627-detail#id627
