### PR TITLE
Add availabilityzones extension for blockstorage

### DIFF
--- a/openstack/blockstorage/extensions/availabilityzones/doc.go
+++ b/openstack/blockstorage/extensions/availabilityzones/doc.go
@@ -1,0 +1,21 @@
+/*
+Package availabilityzones provides the ability to get lists of
+available volume availability zones.
+
+Example of Get Availability Zone Information
+
+	allPages, err := availabilityzones.List(volumeClient).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	availabilityZoneInfo, err := availabilityzones.ExtractAvailabilityZones(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, zoneInfo := range availabilityZoneInfo {
+  		fmt.Printf("%+v\n", zoneInfo)
+	}
+*/
+package availabilityzones

--- a/openstack/blockstorage/extensions/availabilityzones/requests.go
+++ b/openstack/blockstorage/extensions/availabilityzones/requests.go
@@ -1,0 +1,13 @@
+package availabilityzones
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// List will return the existing availability zones.
+func List(client *gophercloud.ServiceClient) pagination.Pager {
+	return pagination.NewPager(client, listURL(client), func(r pagination.PageResult) pagination.Page {
+		return AvailabilityZonePage{pagination.SinglePageBase(r)}
+	})
+}

--- a/openstack/blockstorage/extensions/availabilityzones/results.go
+++ b/openstack/blockstorage/extensions/availabilityzones/results.go
@@ -1,0 +1,33 @@
+package availabilityzones
+
+import (
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// ZoneState represents the current state of the availability zone.
+type ZoneState struct {
+	// Returns true if the availability zone is available
+	Available bool `json:"available"`
+}
+
+// AvailabilityZone contains all the information associated with an OpenStack
+// AvailabilityZone.
+type AvailabilityZone struct {
+	// The availability zone name
+	ZoneName  string    `json:"zoneName"`
+	ZoneState ZoneState `json:"zoneState"`
+}
+
+type AvailabilityZonePage struct {
+	pagination.SinglePageBase
+}
+
+// ExtractAvailabilityZones returns a slice of AvailabilityZones contained in a
+// single page of results.
+func ExtractAvailabilityZones(r pagination.Page) ([]AvailabilityZone, error) {
+	var s struct {
+		AvailabilityZoneInfo []AvailabilityZone `json:"availabilityZoneInfo"`
+	}
+	err := (r.(AvailabilityZonePage)).ExtractInto(&s)
+	return s.AvailabilityZoneInfo, err
+}

--- a/openstack/blockstorage/extensions/availabilityzones/testing/doc.go
+++ b/openstack/blockstorage/extensions/availabilityzones/testing/doc.go
@@ -1,0 +1,2 @@
+// availabilityzones unittests
+package testing

--- a/openstack/blockstorage/extensions/availabilityzones/testing/fixtures.go
+++ b/openstack/blockstorage/extensions/availabilityzones/testing/fixtures.go
@@ -1,0 +1,52 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	az "github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/availabilityzones"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+const GetOutput = `
+{
+    "availabilityZoneInfo": [
+        {
+            "zoneName": "internal",
+            "zoneState": {
+                "available": true
+            }
+        },
+        {
+            "zoneName": "nova",
+            "zoneState": {
+                "available": true
+            }
+        }
+    ]
+}`
+
+var AZResult = []az.AvailabilityZone{
+	{
+		ZoneName:  "internal",
+		ZoneState: az.ZoneState{Available: true},
+	},
+	{
+		ZoneName:  "nova",
+		ZoneState: az.ZoneState{Available: true},
+	},
+}
+
+// HandleGetSuccessfully configures the test server to respond to a Get request
+// for availability zone information.
+func HandleGetSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/os-availability-zone", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprintf(w, GetOutput)
+	})
+}

--- a/openstack/blockstorage/extensions/availabilityzones/testing/requests_test.go
+++ b/openstack/blockstorage/extensions/availabilityzones/testing/requests_test.go
@@ -1,0 +1,25 @@
+package testing
+
+import (
+	"testing"
+
+	az "github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/availabilityzones"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+// Verifies that availability zones can be listed correctly
+func TestList(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	HandleGetSuccessfully(t)
+
+	allPages, err := az.List(client.ServiceClient()).AllPages()
+	th.AssertNoErr(t, err)
+
+	actual, err := az.ExtractAvailabilityZones(allPages)
+	th.AssertNoErr(t, err)
+
+	th.CheckDeepEquals(t, AZResult, actual)
+}

--- a/openstack/blockstorage/extensions/availabilityzones/urls.go
+++ b/openstack/blockstorage/extensions/availabilityzones/urls.go
@@ -1,0 +1,7 @@
+package availabilityzones
+
+import "github.com/gophercloud/gophercloud"
+
+func listURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("os-availability-zone")
+}


### PR DESCRIPTION
For #2134

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/cinder/blob/master/cinder/api/contrib/availability_zones.py
https://github.com/openstack/cinder/blob/master/cinder/api/views/availability_zones.py
