### PR TITLE
apiversions: Fix documentation

### DIFF
--- a/openstack/baremetal/apiversions/doc.go
+++ b/openstack/baremetal/apiversions/doc.go
@@ -3,11 +3,21 @@ Package apiversions provides information about the versions supported by a speci
 
 	Example to list versions
 
-		allVersions, err := apiversions.List(client.ServiceClient()).AllPages()
+		allVersions, err := apiversions.List(baremetalClient).Extract()
+		if err != nil {
+			panic("unable to get API versions: " + err.Error())
+		}
+
+		for _, version := range allVersions.Versions {
+			fmt.Printf("%+v\n", version)
+		}
 
 	Example to get a specific version
 
-		actual, err := apiversions.Get(client.ServiceClient(), "v1").Extract()
+		actual, err := apiversions.Get(baremetalClient).Extract()
+		if err != nil {
+			panic("unable to get API version: " + err.Error())
+		}
 
 */
 package apiversions

--- a/openstack/blockstorage/apiversions/doc.go
+++ b/openstack/blockstorage/apiversions/doc.go
@@ -6,15 +6,15 @@ Example of Retrieving all API Versions
 
 	allPages, err := apiversions.List(client).AllPages()
 	if err != nil {
-		panic("Unable to get API versions: %s", err)
+		panic("unable to get API versions: " + err.Error())
 	}
 
 	allVersions, err := apiversions.ExtractAPIVersions(allPages)
 	if err != nil {
-		panic("Unable to extract API versions: %s", err)
+		panic("unable to extract API versions: " + err.Error())
 	}
 
-	for _, version := range versions {
+	for _, version := range allVersions {
 		fmt.Printf("%+v\n", version)
 	}
 
@@ -23,7 +23,7 @@ Example of Retrieving an API Version
 
 	version, err := apiversions.Get(client, "v3").Extract()
 	if err != nil {
-		panic("Unable to get API version: %s", err)
+		panic("unable to get API version: " + err.Error())
 	}
 
 	fmt.Printf("%+v\n", version)

--- a/openstack/sharedfilesystems/apiversions/doc.go
+++ b/openstack/sharedfilesystems/apiversions/doc.go
@@ -1,3 +1,30 @@
-// Package apiversions provides information and interaction with the different
-// API versions for the Shared File System service, code-named Manila.
+/*
+Package apiversions provides information and interaction with the different
+API versions for the Shared File System service, code-named Manila.
+
+Example to List API Versions
+
+	allPages, err := apiversions.List(client).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allVersions, err := apiversions.ExtractAPIVersions(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, version := range allVersions {
+		fmt.Printf("%+v\n", version)
+	}
+
+Example to Get an API Version
+
+	version, err := apiVersions.Get(client, "v2.1").Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v\n", version)
+*/
 package apiversions


### PR DESCRIPTION
For #2137 

This is a documentation-only patch.

* The **baremetal** apiversions `doc.go` documented a non-existant "AllPages" method of `ListResult`.
* The **blockstorage** apiversions `doc.go` called `panic` with multiple arguments.
* The **sharedfilesystem** apiversions `doc.go` did not provide an example call.