### PR TITLE
Add support for volume type access

### DIFF
--- a/acceptance/openstack/blockstorage/v3/blockstorage.go
+++ b/acceptance/openstack/blockstorage/v3/blockstorage.go
@@ -176,6 +176,37 @@ func CreateVolumeTypeNoExtraSpecs(t *testing.T, client *gophercloud.ServiceClien
 	return vt, nil
 }
 
+// CreatePrivateVolumeType will create a private volume type with a random
+// name and no extra specs. An error will be returned if the volume type was
+// unable to be created.
+func CreatePrivateVolumeType(t *testing.T, client *gophercloud.ServiceClient) (*volumetypes.VolumeType, error) {
+	name := tools.RandomString("ACPTTEST", 16)
+	description := "create_from_gophercloud"
+	isPublic := false
+	t.Logf("Attempting to create volume type: %s", name)
+
+	createOpts := volumetypes.CreateOpts{
+		Name:        name,
+		ExtraSpecs:  map[string]string{},
+		Description: description,
+		IsPublic:    &isPublic,
+	}
+
+	vt, err := volumetypes.Create(client, createOpts).Extract()
+	if err != nil {
+		return nil, err
+	}
+
+	tools.PrintResource(t, vt)
+	th.AssertEquals(t, vt.IsPublic, false)
+	th.AssertEquals(t, vt.Name, name)
+	th.AssertEquals(t, vt.Description, description)
+
+	t.Logf("Successfully created volume type: %s", vt.ID)
+
+	return vt, nil
+}
+
 // DeleteSnapshot will delete a snapshot. A fatal error will occur if the
 // snapshot failed to be deleted.
 func DeleteSnapshot(t *testing.T, client *gophercloud.ServiceClient, snapshot *snapshots.Snapshot) {

--- a/openstack/blockstorage/v3/volumetypes/doc.go
+++ b/openstack/blockstorage/v3/volumetypes/doc.go
@@ -116,5 +116,50 @@ Example to Delete an Extra Spec for a Volume Type
 	if err != nil {
 		panic(err)
 	}
+
+Example to List Volume Type Access
+
+	typeID := "e91758d6-a54a-4778-ad72-0c73a1cb695b"
+
+	allPages, err := volumetypes.ListAccesses(client, typeID).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allAccesses, err := volumetypes.ExtractAccesses(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, access := range allAccesses {
+		fmt.Printf("%+v", access)
+	}
+
+Example to Grant Access to a Volume Type
+
+	typeID := "e91758d6-a54a-4778-ad72-0c73a1cb695b"
+
+	accessOpts := volumetypes.AddAccessOpts{
+		Project: "15153a0979884b59b0592248ef947921",
+	}
+
+	err := volumetypes.AddAccess(client, typeID, accessOpts).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Remove/Revoke Access to a Volume Type
+
+	typeID := "e91758d6-a54a-4778-ad72-0c73a1cb695b"
+
+	accessOpts := volumetypes.RemoveAccessOpts{
+		Project: "15153a0979884b59b0592248ef947921",
+	}
+
+	err := volumetypes.RemoveAccess(client, typeID, accessOpts).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+
 */
 package volumetypes

--- a/openstack/blockstorage/v3/volumetypes/results.go
+++ b/openstack/blockstorage/v3/volumetypes/results.go
@@ -151,3 +151,44 @@ func (r extraSpecResult) Extract() (map[string]string, error) {
 	err := r.ExtractInto(&s)
 	return s, err
 }
+
+// VolumeTypeAccess represents an ACL of project access to a specific Volume Type.
+type VolumeTypeAccess struct {
+	// VolumeTypeID is the unique ID of the volume type.
+	VolumeTypeID string `json:"volume_type_id"`
+
+	// ProjectID is the unique ID of the project.
+	ProjectID string `json:"project_id"`
+}
+
+// AccessPage contains a single page of all VolumeTypeAccess entries for a volume type.
+type AccessPage struct {
+	pagination.SinglePageBase
+}
+
+// IsEmpty indicates whether an AccessPage is empty.
+func (page AccessPage) IsEmpty() (bool, error) {
+	v, err := ExtractAccesses(page)
+	return len(v) == 0, err
+}
+
+// ExtractAccesses interprets a page of results as a slice of VolumeTypeAccess.
+func ExtractAccesses(r pagination.Page) ([]VolumeTypeAccess, error) {
+	var s struct {
+		VolumeTypeAccesses []VolumeTypeAccess `json:"volume_type_access"`
+	}
+	err := (r.(AccessPage)).ExtractInto(&s)
+	return s.VolumeTypeAccesses, err
+}
+
+// AddAccessResult is the response from a AddAccess request. Call its
+// ExtractErr method to determine if the request succeeded or failed.
+type AddAccessResult struct {
+	gophercloud.ErrResult
+}
+
+// RemoveAccessResult is the response from a RemoveAccess request. Call its
+// ExtractErr method to determine if the request succeeded or failed.
+type RemoveAccessResult struct {
+	gophercloud.ErrResult
+}

--- a/openstack/blockstorage/v3/volumetypes/testing/requests_test.go
+++ b/openstack/blockstorage/v3/volumetypes/testing/requests_test.go
@@ -1,6 +1,9 @@
 package testing
 
 import (
+	"fmt"
+	"net/http"
+	"reflect"
 	"testing"
 
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumetypes"
@@ -176,4 +179,100 @@ func TestVolumeTypeExtraSpecDelete(t *testing.T) {
 
 	res := volumetypes.DeleteExtraSpec(client.ServiceClient(), "1", "capabilities")
 	th.AssertNoErr(t, res.Err)
+}
+
+func TestVolumeTypeListAccesses(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/types/a5082c24-2a27-43a4-b48e-fcec1240e36b/os-volume-type-access", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprintf(w, `
+			{
+			  "volume_type_access": [
+			    {
+            	  "project_id": "6f70656e737461636b20342065766572",
+            	  "volume_type_id": "a5082c24-2a27-43a4-b48e-fcec1240e36b"
+			    }
+			  ]
+			}
+		`)
+	})
+
+	expected := []volumetypes.VolumeTypeAccess{
+		{
+			VolumeTypeID: "a5082c24-2a27-43a4-b48e-fcec1240e36b",
+			ProjectID:    "6f70656e737461636b20342065766572",
+		},
+	}
+
+	allPages, err := volumetypes.ListAccesses(client.ServiceClient(), "a5082c24-2a27-43a4-b48e-fcec1240e36b").AllPages()
+	th.AssertNoErr(t, err)
+
+	actual, err := volumetypes.ExtractAccesses(allPages)
+	th.AssertNoErr(t, err)
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("Expected %#v, but was %#v", expected, actual)
+	}
+}
+
+func TestVolumeTypeAddAccess(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/types/a5082c24-2a27-43a4-b48e-fcec1240e36b/action", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestHeader(t, r, "accept", "application/json")
+		th.TestJSONRequest(t, r, `
+			{
+			  "addProjectAccess": {
+			    "project": "6f70656e737461636b20342065766572"
+			  }
+			}
+		`)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+	})
+
+	addAccessOpts := volumetypes.AddAccessOpts{
+		Project: "6f70656e737461636b20342065766572",
+	}
+
+	err := volumetypes.AddAccess(client.ServiceClient(), "a5082c24-2a27-43a4-b48e-fcec1240e36b", addAccessOpts).ExtractErr()
+	th.AssertNoErr(t, err)
+
+}
+
+func TestVolumeTypeRemoveAccess(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/types/a5082c24-2a27-43a4-b48e-fcec1240e36b/action", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestHeader(t, r, "accept", "application/json")
+		th.TestJSONRequest(t, r, `
+			{
+			  "removeProjectAccess": {
+			    "project": "6f70656e737461636b20342065766572"
+			  }
+			}
+		`)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+	})
+
+	removeAccessOpts := volumetypes.RemoveAccessOpts{
+		Project: "6f70656e737461636b20342065766572",
+	}
+
+	err := volumetypes.RemoveAccess(client.ServiceClient(), "a5082c24-2a27-43a4-b48e-fcec1240e36b", removeAccessOpts).ExtractErr()
+	th.AssertNoErr(t, err)
+
 }

--- a/openstack/blockstorage/v3/volumetypes/urls.go
+++ b/openstack/blockstorage/v3/volumetypes/urls.go
@@ -41,3 +41,11 @@ func extraSpecUpdateURL(client *gophercloud.ServiceClient, id, key string) strin
 func extraSpecDeleteURL(client *gophercloud.ServiceClient, id, key string) string {
 	return client.ServiceURL("types", id, "extra_specs", key)
 }
+
+func accessURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL("types", id, "os-volume-type-access")
+}
+
+func accessActionURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL("types", id, "action")
+}


### PR DESCRIPTION
ListAccesses: List accesses of private volume type
[api docs](https://docs.openstack.org/api-ref/block-storage/v3/index.html?expanded=list-private-volume-type-access-detail-detail#volume-type-access-types-action-types-os-volume-type-access)
[code](https://github.com/openstack/cinder/blob/facc1fc014a2f94a9e2767588da7e2f4ff73e3c5/cinder/api/contrib/volume_type_access.py#L41)

AddAccess: Add access of project to volume type
[api docs](https://docs.openstack.org/api-ref/block-storage/v3/index.html?expanded=add-private-volume-type-access-to-project-detail#volume-type-access-types-action-types-os-volume-type-access)
[code](https://github.com/openstack/cinder/blob/facc1fc014a2f94a9e2767588da7e2f4ff73e3c5/cinder/api/contrib/volume_type_access.py#L99)

RemoveAccess: Remove access of project from volume type
[api docs](https://docs.openstack.org/api-ref/block-storage/v3/index.html?expanded=remove-private-volume-type-access-from-project-detail#volume-type-access-types-action-types-os-volume-type-access)
[code](https://github.com/openstack/cinder/blob/facc1fc014a2f94a9e2767588da7e2f4ff73e3c5/cinder/api/contrib/volume_type_access.py#L113)

For #2129 
