### PR TITLE
blockstorage/v3: Add support for create/delete qos

### DIFF
--- a/acceptance/openstack/blockstorage/v3/qos_test.go
+++ b/acceptance/openstack/blockstorage/v3/qos_test.go
@@ -1,0 +1,20 @@
+package v3
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/acceptance/clients"
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestQoS(t *testing.T) {
+	clients.SkipRelease(t, "stable/mitaka")
+	clients.RequireAdmin(t)
+
+	client, err := clients.NewBlockStorageV3Client()
+	th.AssertNoErr(t, err)
+
+	qs, err := CreateQoS(t, client)
+	th.AssertNoErr(t, err)
+	defer DeleteQoS(t, client, qs)
+}

--- a/openstack/blockstorage/v3/qos/doc.go
+++ b/openstack/blockstorage/v3/qos/doc.go
@@ -1,0 +1,36 @@
+/*
+Package qos provides information and interaction with the QoS specifications
+for the Openstack Blockstorage service.
+
+Example to create a QoS specification
+
+	createOpts := qos.CreateOpts{
+		Name:     "test",
+		Consumer: qos.ConsumerFront,
+		Specs: map[string]string{
+			"read_iops_sec": "20000",
+		},
+	}
+
+	test, err := qos.Create(client, createOpts).Extract()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("QoS: %+v\n", test)
+
+Example to delete a QoS specification
+
+	qosID := "d6ae28ce-fcb5-4180-aa62-d260a27e09ae"
+
+	deleteOpts := qos.DeleteOpts{
+		Force: false,
+	}
+
+	err = qos.Delete(client, qosID, deleteOpts).ExtractErr()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+*/
+package qos

--- a/openstack/blockstorage/v3/qos/requests.go
+++ b/openstack/blockstorage/v3/qos/requests.go
@@ -1,0 +1,100 @@
+package qos
+
+import (
+	"github.com/gophercloud/gophercloud"
+)
+
+type CreateOptsBuilder interface {
+	ToQoSCreateMap() (map[string]interface{}, error)
+}
+
+type QoSConsumer string
+
+const (
+	ConsumerFront QoSConsumer = "front-end"
+	ConsumberBack QoSConsumer = "back-end"
+	ConsumerBoth  QoSConsumer = "both"
+)
+
+// CreateOpts contains options for creating a QoS specification.
+// This object is passed to the qos.Create function.
+type CreateOpts struct {
+	// The name of the QoS spec
+	Name string `json:"name"`
+	// The consumer of the QoS spec. Possible values are
+	// both, front-end, back-end.
+	Consumer QoSConsumer `json:"consumer,omitempty"`
+	// Specs is a collection of miscellaneous key/values used to set
+	// specifications for the QoS
+	Specs map[string]string `json:"-"`
+}
+
+// ToQoSCreateMap assembles a request body based on the contents of a
+// CreateOpts.
+func (opts CreateOpts) ToQoSCreateMap() (map[string]interface{}, error) {
+	b, err := gophercloud.BuildRequestBody(opts, "qos_specs")
+	if err != nil {
+		return nil, err
+	}
+
+	if opts.Specs != nil {
+		if v, ok := b["qos_specs"].(map[string]interface{}); ok {
+			for key, value := range opts.Specs {
+				v[key] = value
+			}
+		}
+	}
+
+	return b, nil
+}
+
+// Create will create a new QoS based on the values in CreateOpts. To extract
+// the QoS object from the response, call the Extract method on the
+// CreateResult.
+func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToQoSCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := client.Post(createURL(client), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// DeleteOptsBuilder allows extensions to add additional parameters to the
+// Delete request.
+type DeleteOptsBuilder interface {
+	ToQoSDeleteQuery() (string, error)
+}
+
+// DeleteOpts contains options for deleting a QoS. This object is passed to
+// the qos.Delete function.
+type DeleteOpts struct {
+	// Delete a QoS specification even if it is in-use
+	Force bool `q:"force"`
+}
+
+// ToQoSDeleteQuery formats a DeleteOpts into a query string.
+func (opts DeleteOpts) ToQoSDeleteQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// Delete will delete the existing QoS with the provided ID.
+func Delete(client *gophercloud.ServiceClient, id string, opts DeleteOptsBuilder) (r DeleteResult) {
+	url := deleteURL(client, id)
+	if opts != nil {
+		query, err := opts.ToQoSDeleteQuery()
+		if err != nil {
+			r.Err = err
+			return
+		}
+		url += query
+	}
+	resp, err := client.Delete(url, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}

--- a/openstack/blockstorage/v3/qos/results.go
+++ b/openstack/blockstorage/v3/qos/results.go
@@ -1,0 +1,41 @@
+package qos
+
+import "github.com/gophercloud/gophercloud"
+
+// QoS contains all the information associated with an OpenStack QoS specification.
+type QoS struct {
+	// Name is the name of the QoS.
+	Name string `json:"name"`
+	// Unique identifier for the QoS.
+	ID string `json:"id"`
+	// Consumer of QoS
+	Consumer string `json:"consumer"`
+	// Arbitrary key-value pairs defined by the user.
+	Specs map[string]string `json:"specs"`
+}
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// Extract will get the QoS object out of the commonResult object.
+func (r commonResult) Extract() (*QoS, error) {
+	var s QoS
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+// ExtractInto converts our response data into a QoS struct
+func (r commonResult) ExtractInto(qos interface{}) error {
+	return r.Result.ExtractIntoStructPtr(qos, "qos_specs")
+}
+
+// CreateResult contains the response body and error from a Create request.
+type CreateResult struct {
+	commonResult
+}
+
+// DeleteResult contains the response body and error from a Delete request.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}

--- a/openstack/blockstorage/v3/qos/testing/doc.go
+++ b/openstack/blockstorage/v3/qos/testing/doc.go
@@ -1,0 +1,2 @@
+// Package testing for qos_v3
+package testing

--- a/openstack/blockstorage/v3/qos/testing/fixtures.go
+++ b/openstack/blockstorage/v3/qos/testing/fixtures.go
@@ -1,0 +1,62 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/qos"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	fake "github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+var createQoSExpected = qos.QoS{
+	ID:       "d32019d3-bc6e-4319-9c1d-6722fc136a22",
+	Name:     "qos-001",
+	Consumer: "front-end",
+	Specs: map[string]string{
+		"read_iops_sec": "20000",
+	},
+}
+
+func MockCreateResponse(t *testing.T) {
+	th.Mux.HandleFunc("/qos-specs", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, `
+{
+    "qos_specs": {
+    	"name": "qos-001",
+		"consumer": "front-end",
+		"read_iops_sec": "20000"
+    }
+}
+      `)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, `
+{
+  "qos_specs": {
+    "id": "d32019d3-bc6e-4319-9c1d-6722fc136a22",
+	"name": "qos-001",
+	"consumer": "front-end",
+	"specs": {
+	  "read_iops_sec": "20000"
+	}
+  }
+}
+    `)
+	})
+}
+
+func MockDeleteResponse(t *testing.T) {
+	th.Mux.HandleFunc("/qos-specs/d32019d3-bc6e-4319-9c1d-6722fc136a22", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.WriteHeader(http.StatusAccepted)
+	})
+}

--- a/openstack/blockstorage/v3/qos/testing/requests_test.go
+++ b/openstack/blockstorage/v3/qos/testing/requests_test.go
@@ -1,0 +1,37 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/qos"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func TestCreate(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockCreateResponse(t)
+
+	options := qos.CreateOpts{
+		Name:     "qos-001",
+		Consumer: qos.ConsumerFront,
+		Specs: map[string]string{
+			"read_iops_sec": "20000",
+		},
+	}
+	actual, err := qos.Create(client.ServiceClient(), options).Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, &createQoSExpected, actual)
+}
+
+func TestDelete(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockDeleteResponse(t)
+
+	res := qos.Delete(client.ServiceClient(), "d32019d3-bc6e-4319-9c1d-6722fc136a22", qos.DeleteOpts{})
+	th.AssertNoErr(t, res.Err)
+}

--- a/openstack/blockstorage/v3/qos/urls.go
+++ b/openstack/blockstorage/v3/qos/urls.go
@@ -1,0 +1,11 @@
+package qos
+
+import "github.com/gophercloud/gophercloud"
+
+func createURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("qos-specs")
+}
+
+func deleteURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("qos-specs", id)
+}


### PR DESCRIPTION
For #2139 

Create:
Return code on doc is wrong, and parameters other than `name` are missing. Code showcases more how consumer and specs are used.
[docs](https://docs.openstack.org/api-ref/block-storage/v3/index.html?expanded=create-a-qos-specification-detail#quality-of-service-qos-specifications-qos-specs)
[code_schema](https://github.com/openstack/cinder/blob/393c2e4ad90c05ebf28cc3a2c65811d7e1e0bc18/cinder/api/schemas/qos_specs.py#L19) [code_api](https://github.com/openstack/cinder/blob/393c2e4ad90c05ebf28cc3a2c65811d7e1e0bc18/cinder/api/contrib/qos_specs_manage.py#L79) [code](https://github.com/openstack/cinder/blob/393c2e4ad90c05ebf28cc3a2c65811d7e1e0bc18/cinder/volume/qos_specs.py#L36)

Delete:
[docs](https://docs.openstack.org/api-ref/block-storage/v3/index.html?expanded=delete-a-qos-specification-detail#quality-of-service-qos-specifications-qos-specs)
[code_api](https://github.com/openstack/cinder/blob/393c2e4ad90c05ebf28cc3a2c65811d7e1e0bc18/cinder/api/contrib/qos_specs_manage.py#L161) [code](https://github.com/openstack/cinder/blob/393c2e4ad90c05ebf28cc3a2c65811d7e1e0bc18/cinder/volume/qos_specs.py#L107)