### PR TITLE
networking/v2: fix documentation for extensions/networkipavailabilities

### DIFF
--- a/openstack/networking/v2/extensions/networkipavailabilities/doc.go
+++ b/openstack/networking/v2/extensions/networkipavailabilities/doc.go
@@ -9,7 +9,7 @@ Example of Listing NetworkIPAvailabilities
     panic(err)
   }
 
-  allAvailabilities, err := subnetpools.ExtractSubnetPools(allPages)
+  allAvailabilities, err := networkipavailabilities.ExtractNetworkIPAvailabilities(allPages)
   if err != nil {
     panic(err)
   }


### PR DESCRIPTION
This is a documentation-only patch.

For #2144 