### PR TITLE
Add support for loadbalancer listener tls versions

### DIFF
--- a/acceptance/openstack/loadbalancer/v2/loadbalancer.go
+++ b/acceptance/openstack/loadbalancer/v2/loadbalancer.go
@@ -67,6 +67,9 @@ func CreateListenerHTTP(t *testing.T, client *gophercloud.ServiceClient, lb *loa
 		"X-Forwarded-For": "true",
 	}
 
+	tlsVersions := []listeners.TLSVersion{"TLSv1.2", "TLSv1.3"}
+	tlsVersionsExp := []string{"TLSv1.2", "TLSv1.3"}
+
 	createOpts := listeners.CreateOpts{
 		Name:           listenerName,
 		Description:    listenerDescription,
@@ -74,6 +77,7 @@ func CreateListenerHTTP(t *testing.T, client *gophercloud.ServiceClient, lb *loa
 		InsertHeaders:  headers,
 		Protocol:       listeners.ProtocolHTTP,
 		ProtocolPort:   listenerPort,
+		TLSVersions:    tlsVersions,
 	}
 
 	listener, err := listeners.Create(client, createOpts).Extract()
@@ -93,6 +97,7 @@ func CreateListenerHTTP(t *testing.T, client *gophercloud.ServiceClient, lb *loa
 	th.AssertEquals(t, listener.Protocol, string(listeners.ProtocolHTTP))
 	th.AssertEquals(t, listener.ProtocolPort, listenerPort)
 	th.AssertDeepEquals(t, listener.InsertHeaders, headers)
+	th.AssertDeepEquals(t, listener.TLSVersions, tlsVersionsExp)
 
 	return listener, nil
 }

--- a/openstack/loadbalancer/v2/listeners/requests.go
+++ b/openstack/loadbalancer/v2/listeners/requests.go
@@ -20,6 +20,17 @@ const (
 	ProtocolTerminatedHTTPS Protocol = "TERMINATED_HTTPS"
 )
 
+// Type TLSVersion represents a tls version
+type TLSVersion string
+
+const (
+	TLSVersionSSLv3   TLSVersion = "SSLv3"
+	TLSVersionTLSv1   TLSVersion = "TLSv1"
+	TLSVersionTLSv1_1 TLSVersion = "TLSv1.1"
+	TLSVersionTLSv1_2 TLSVersion = "TLSv1.2"
+	TLSVersionTLSv1_3 TLSVersion = "TLSv1.3"
+)
+
 // ListOptsBuilder allows extensions to add additional parameters to the
 // List request.
 type ListOptsBuilder interface {
@@ -151,6 +162,9 @@ type CreateOpts struct {
 
 	// A list of IPv4, IPv6 or mix of both CIDRs
 	AllowedCIDRs []string `json:"allowed_cidrs,omitempty"`
+
+	// A list of TLS protocol versions. Available from microversion 2.17
+	TLSVersions []TLSVersion `json:"tls_versions,omitempty"`
 }
 
 // ToListenerCreateMap builds a request body from CreateOpts.
@@ -230,6 +244,9 @@ type UpdateOpts struct {
 
 	// A list of IPv4, IPv6 or mix of both CIDRs
 	AllowedCIDRs *[]string `json:"allowed_cidrs,omitempty"`
+
+	// A list of TLS protocol versions. Available from microversion 2.17
+	TLSVersions *[]TLSVersion `json:"tls_versions,omitempty"`
 }
 
 // ToListenerUpdateMap builds a request body from UpdateOpts.

--- a/openstack/loadbalancer/v2/listeners/results.go
+++ b/openstack/loadbalancer/v2/listeners/results.go
@@ -83,6 +83,9 @@ type Listener struct {
 
 	// A list of IPv4, IPv6 or mix of both CIDRs
 	AllowedCIDRs []string `json:"allowed_cidrs"`
+
+	// A list of TLS protocol versions. Available from microversion 2.17
+	TLSVersions []string `json:"tls_versions"`
 }
 
 type Stats struct {

--- a/openstack/loadbalancer/v2/listeners/testing/fixtures.go
+++ b/openstack/loadbalancer/v2/listeners/testing/fixtures.go
@@ -29,7 +29,8 @@ const ListenersListBody = `
 			"allowed_cidrs": [
 				"192.0.2.0/24",
 				"198.51.100.0/24"
-			]
+			],
+			"tls_versions": ["TLSv1.2", "TLSv1.3"]
 		},
 		{
 			"id": "36e08a3e-a78f-4b40-a229-1e7e23eee1ab",
@@ -54,7 +55,8 @@ const ListenersListBody = `
 			"allowed_cidrs": [
 				"192.0.2.0/24",
 				"198.51.100.0/24"
-			]
+			],
+			"tls_versions": ["TLSv1.2"]
 		}
 	]
 }
@@ -86,7 +88,8 @@ const SingleListenerBody = `
 		"allowed_cidrs": [
 			"192.0.2.0/24",
 			"198.51.100.0/24"
-		]
+		],
+		"tls_versions": ["TLSv1.2"]
 	}
 }
 `
@@ -114,7 +117,8 @@ const PostUpdateListenerBody = `
 		"insert_headers": {
 			"X-Forwarded-For": "true",
 			"X-Forwarded-Port": "false"
-		}
+		},
+		"tls_versions": ["TLSv1.2", "TLSv1.3"]
 	}
 }
 `
@@ -146,6 +150,7 @@ var (
 		DefaultTlsContainerRef: "2c433435-20de-4411-84ae-9cc8917def76",
 		SniContainerRefs:       []string{"3d328d82-2547-4921-ac2f-61c3b452b5ff", "b3cfd7e3-8c19-455c-8ebb-d78dfd8f7e7d"},
 		AllowedCIDRs:           []string{"192.0.2.0/24", "198.51.100.0/24"},
+		TLSVersions:            []string{"TLSv1.2", "TLSv1.3"},
 	}
 	ListenerDb = listeners.Listener{
 		ID:                     "36e08a3e-a78f-4b40-a229-1e7e23eee1ab",
@@ -166,6 +171,7 @@ var (
 		TimeoutTCPInspect:      0,
 		InsertHeaders:          map[string]string{"X-Forwarded-For": "true"},
 		AllowedCIDRs:           []string{"192.0.2.0/24", "198.51.100.0/24"},
+		TLSVersions:            []string{"TLSv1.2"},
 	}
 	ListenerUpdated = listeners.Listener{
 		ID:                     "36e08a3e-a78f-4b40-a229-1e7e23eee1ab",
@@ -188,6 +194,7 @@ var (
 			"X-Forwarded-For":  "true",
 			"X-Forwarded-Port": "false",
 		},
+		TLSVersions: []string{"TLSv1.2", "TLSv1.3"},
 	}
 	ListenerStatsTree = listeners.Stats{
 		ActiveConnections: 0,
@@ -239,7 +246,8 @@ func HandleListenerCreationSuccessfully(t *testing.T, response string) {
 				"allowed_cidrs": [
 					"192.0.2.0/24",
 					"198.51.100.0/24"
-				]
+				],
+				"tls_versions": ["TLSv1.2"]
 			}
 		}`)
 
@@ -289,7 +297,8 @@ func HandleListenerUpdateSuccessfully(t *testing.T) {
 				"insert_headers": {
 					"X-Forwarded-For": "true",
 					"X-Forwarded-Port": "false"
-				}
+				},
+				"tls_versions": ["TLSv1.2", "TLSv1.3"]
 			}
 		}`)
 

--- a/openstack/loadbalancer/v2/listeners/testing/requests_test.go
+++ b/openstack/loadbalancer/v2/listeners/testing/requests_test.go
@@ -68,6 +68,7 @@ func TestCreateListener(t *testing.T) {
 		ProtocolPort:           3306,
 		InsertHeaders:          map[string]string{"X-Forwarded-For": "true"},
 		AllowedCIDRs:           []string{"192.0.2.0/24", "198.51.100.0/24"},
+		TLSVersions:            []listeners.TLSVersion{"TLSv1.2"},
 	}).Extract()
 	th.AssertNoErr(t, err)
 
@@ -134,6 +135,7 @@ func TestUpdateListener(t *testing.T) {
 		"X-Forwarded-For":  "true",
 		"X-Forwarded-Port": "false",
 	}
+	tlsVersions := []listeners.TLSVersion{"TLSv1.2", "TLSv1.3"}
 	actual, err := listeners.Update(client, "4ec89087-d057-4e2c-911f-60a3b47ee304", listeners.UpdateOpts{
 		Name:                 &name,
 		ConnLimit:            &i1001,
@@ -143,6 +145,7 @@ func TestUpdateListener(t *testing.T) {
 		TimeoutMemberConnect: &i181000,
 		TimeoutTCPInspect:    &i181000,
 		InsertHeaders:        &insertHeaders,
+		TLSVersions:          &tlsVersions,
 	}).Extract()
 	if err != nil {
 		t.Fatalf("Unexpected Update error: %v", err)


### PR DESCRIPTION
For #2128 

Update Create, Update to support tls_versions
[docs](https://docs.openstack.org/api-ref/load-balancer/v2/?expanded=create-listener-detail#create-listener)
[microversion](https://github.com/openstack/octavia/blob/4e53676b2a4f8e97b8c2412436813d890b67672f/octavia/api/root_controller.py#L118) 
[create type](https://github.com/openstack/octavia/blob/9389d5c0d94cb0575f34e800c5b77a982aac9546/octavia/api/v2/types/listener.py#L153) [update_type](https://github.com/openstack/octavia/blob/9389d5c0d94cb0575f34e800c5b77a982aac9546/octavia/api/v2/types/listener.py#L194)
[validate func](https://github.com/openstack/octavia/blob/9389d5c0d94cb0575f34e800c5b77a982aac9546/octavia/common/validate.py#L466) [validate const](https://github.com/openstack/octavia/blob/9389d5c0d94cb0575f34e800c5b77a982aac9546/octavia/common/constants.py#L872-L878) [validate const](https://github.com/openstack/octavia-lib/blob/3208f7fbcae31f84f0d8b0ff05ef63f5f7f2a075/octavia_lib/common/constants.py#L281-L285)