### PR TITLE
baremetal: add network_data to Node interface

### DIFF
--- a/openstack/baremetal/v1/nodes/requests.go
+++ b/openstack/baremetal/v1/nodes/requests.go
@@ -247,6 +247,9 @@ type CreateOpts struct {
 
 	// A string or UUID of the tenant who owns the baremetal node.
 	Owner string `json:"owner,omitempty"`
+
+	// Static network configuration to use during deployment and cleaning.
+	NetworkData map[string]interface{} `json:"network_data,omitempty"`
 }
 
 // ToNodeCreateMap assembles a request body based on the contents of a CreateOpts.

--- a/openstack/baremetal/v1/nodes/results.go
+++ b/openstack/baremetal/v1/nodes/results.go
@@ -192,6 +192,9 @@ type Node struct {
 
 	// A string or UUID of the tenant who owns the baremetal node.
 	Owner string `json:"owner"`
+
+	// Static network configuration to use during deployment and cleaning.
+	NetworkData map[string]interface{} `json:"network_data"`
 }
 
 // NodePage abstracts the raw results of making a List() request against


### PR DESCRIPTION
This field was added in microversion 1.66 and appears in the Victoria release.

For #2153

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://opendev.org/openstack/ironic/src/branch/master/ironic/api/controllers/v1/node.py#L161-L165
https://review.opendev.org/c/openstack/ironic/+/687910/