### PR TITLE
Add SCTP and PROXYV2 protocol for octavia pools

### DIFF
--- a/openstack/loadbalancer/v2/pools/requests.go
+++ b/openstack/loadbalancer/v2/pools/requests.go
@@ -71,6 +71,10 @@ const (
 	ProtocolPROXY Protocol = "PROXY"
 	ProtocolHTTP  Protocol = "HTTP"
 	ProtocolHTTPS Protocol = "HTTPS"
+	// Protocol PROXYV2 requires octavia microversion 2.22
+	ProtocolPROXYV2 Protocol = "PROXYV2"
+	// Protocol SCTP requires octavia microversion 2.23
+	ProtocolSCTP Protocol = "SCTP"
 )
 
 // CreateOptsBuilder allows extensions to add additional parameters to the
@@ -88,7 +92,8 @@ type CreateOpts struct {
 	LBMethod LBMethod `json:"lb_algorithm" required:"true"`
 
 	// The protocol used by the pool members, you can use either
-	// ProtocolTCP, ProtocolUDP, ProtocolPROXY, ProtocolHTTP, or ProtocolHTTPS.
+	// ProtocolTCP, ProtocolUDP, ProtocolPROXY, ProtocolHTTP, ProtocolHTTPS,
+	// ProtocolSCTP or ProtocolPROXYV2.
 	Protocol Protocol `json:"protocol" required:"true"`
 
 	// The Loadbalancer on which the members of the pool will be associated with.


### PR DESCRIPTION
For #2157 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

[docs](https://docs.openstack.org/api-ref/load-balancer/v2/?expanded=create-pool-detail#create-pool)
[code version](https://github.com/openstack/octavia/blob/16e83eef0154a30ef91fb09842bf009c540f1c66/octavia/api/root_controller.py#L133-L138)
[type check](https://github.com/openstack/octavia/blob/16e83eef0154a30ef91fb09842bf009c540f1c66/octavia/api/v2/types/pool.py#L207), [type check](https://github.com/openstack/octavia/blob/16e83eef0154a30ef91fb09842bf009c540f1c66/octavia/api/v2/types/pool.py#L153)
[const](https://github.com/openstack/octavia-lib/blob/3208f7fbcae31f84f0d8b0ff05ef63f5f7f2a075/octavia_lib/common/constants.py#L148-L150)
