### PR TITLE
Add resource provider allocations API for placement

### DIFF
--- a/acceptance/openstack/placement/v1/resourceproviders_test.go
+++ b/acceptance/openstack/placement/v1/resourceproviders_test.go
@@ -142,3 +142,33 @@ func TestResourceProviderTraits(t *testing.T) {
 
 	tools.PrintResource(t, usage)
 }
+
+func TestResourceProviderAllocations(t *testing.T) {
+	clients.SkipRelease(t, "stable/mitaka")
+	clients.SkipRelease(t, "stable/newton")
+	clients.SkipRelease(t, "stable/ocata")
+	clients.SkipRelease(t, "stable/pike")
+	clients.SkipRelease(t, "stable/queens")
+	clients.RequireAdmin(t)
+
+	client, err := clients.NewPlacementV1Client()
+	th.AssertNoErr(t, err)
+
+	// first create new resource provider
+	name := tools.RandomString("TESTACC-", 8)
+	t.Logf("Attempting to create resource provider: %s", name)
+
+	createOpts := resourceproviders.CreateOpts{
+		Name: name,
+	}
+
+	client.Microversion = "1.20"
+	resourceProvider, err := resourceproviders.Create(client, createOpts).Extract()
+	th.AssertNoErr(t, err)
+
+	// now get the allocations for the newly created resource provider
+	usage, err := resourceproviders.GetAllocations(client, resourceProvider.UUID).Extract()
+	th.AssertNoErr(t, err)
+
+	tools.PrintResource(t, usage)
+}

--- a/openstack/placement/v1/resourceproviders/doc.go
+++ b/openstack/placement/v1/resourceproviders/doc.go
@@ -50,5 +50,12 @@ Example to get resource providers traits
 		panic(err)
 	}
 
+Example to get resource providers allocations
+
+	rp, err := resourceproviders.GetAllocations(placementClient, resourceProviderID).Extract()
+	if err != nil {
+		panic(err)
+	}
+
 */
 package resourceproviders

--- a/openstack/placement/v1/resourceproviders/requests.go
+++ b/openstack/placement/v1/resourceproviders/requests.go
@@ -108,6 +108,12 @@ func GetInventories(client *gophercloud.ServiceClient, resourceProviderID string
 	return
 }
 
+func GetAllocations(client *gophercloud.ServiceClient, resourceProviderID string) (r GetAllocationsResult) {
+	resp, err := client.Get(getResourceProviderAllocationsURL(client, resourceProviderID), &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
 func GetTraits(client *gophercloud.ServiceClient, resourceProviderID string) (r GetTraitsResult) {
 	resp, err := client.Get(getResourceProviderTraitsURL(client, resourceProviderID), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)

--- a/openstack/placement/v1/resourceproviders/results.go
+++ b/openstack/placement/v1/resourceproviders/results.go
@@ -47,9 +47,18 @@ type Inventory struct {
 	Total           int     `json:"total"`
 }
 
+type Allocation struct {
+	Resources map[string]int `json:"resources"`
+}
+
 type ResourceProviderInventories struct {
 	ResourceProviderGeneration int                  `json:"resource_provider_generation"`
 	Inventories                map[string]Inventory `json:"inventories"`
+}
+
+type ResourceProviderAllocations struct {
+	ResourceProviderGeneration int                   `json:"resource_provider_generation"`
+	Allocations                map[string]Allocation `json:"allocations"`
 }
 
 type ResourceProviderTraits struct {
@@ -118,6 +127,19 @@ type GetInventoriesResult struct {
 // Extract interprets a GetInventoriesResult as a ResourceProviderInventories.
 func (r GetInventoriesResult) Extract() (*ResourceProviderInventories, error) {
 	var s ResourceProviderInventories
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+// GetAllocationsResult is the response of a Get allocations operations. Call its Extract method
+// to interpret it as a ResourceProviderAllocations.
+type GetAllocationsResult struct {
+	gophercloud.Result
+}
+
+// Extract interprets a GetAllocationsResult as a ResourceProviderAllocations.
+func (r GetAllocationsResult) Extract() (*ResourceProviderAllocations, error) {
+	var s ResourceProviderAllocations
 	err := r.ExtractInto(&s)
 	return &s, err
 }

--- a/openstack/placement/v1/resourceproviders/testing/fixtures.go
+++ b/openstack/placement/v1/resourceproviders/testing/fixtures.go
@@ -105,6 +105,32 @@ const InventoriesBody = `
 }
 `
 
+const AllocationsBody = `
+{
+    "allocations": {
+        "56785a3f-6f1c-4fec-af0b-0faf075b1fcb": {
+            "resources": {
+                "MEMORY_MB": 256,
+                "VCPU": 1
+            }
+        },
+        "9afd5aeb-d6b9-4dea-a588-1e6327a91834": {
+            "resources": {
+                "MEMORY_MB": 512,
+                "VCPU": 2
+            }
+        },
+        "9d16a611-e7f9-4ef3-be26-c61ed01ecefb": {
+            "resources": {
+                "MEMORY_MB": 1024,
+                "VCPU": 1
+            }
+        }
+    },
+    "resource_provider_generation": 12
+}
+`
+
 const TraitsBody = `
 {
     "resource_provider_generation": 1,
@@ -187,6 +213,30 @@ var ExpectedInventories = resourceproviders.ResourceProviderInventories{
 	},
 }
 
+var ExpectedAllocations = resourceproviders.ResourceProviderAllocations{
+	ResourceProviderGeneration: 12,
+	Allocations: map[string]resourceproviders.Allocation{
+		"56785a3f-6f1c-4fec-af0b-0faf075b1fcb": {
+			Resources: map[string]int{
+				"MEMORY_MB": 256,
+				"VCPU":      1,
+			},
+		},
+		"9afd5aeb-d6b9-4dea-a588-1e6327a91834": {
+			Resources: map[string]int{
+				"MEMORY_MB": 512,
+				"VCPU":      2,
+			},
+		},
+		"9d16a611-e7f9-4ef3-be26-c61ed01ecefb": {
+			Resources: map[string]int{
+				"MEMORY_MB": 1024,
+				"VCPU":      1,
+			},
+		},
+	},
+}
+
 var ExpectedTraits = resourceproviders.ResourceProviderTraits{
 	ResourceProviderGeneration: 1,
 	Traits: []string{
@@ -247,6 +297,21 @@ func HandleResourceProviderGetInventories(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 
 			fmt.Fprintf(w, InventoriesBody)
+		})
+}
+
+func HandleResourceProviderGetAllocations(t *testing.T) {
+	allocationsTestUrl := fmt.Sprintf("/resource_providers/%s/allocations", ResourceProviderTestID)
+
+	th.Mux.HandleFunc(allocationsTestUrl,
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "GET")
+			th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+
+			fmt.Fprintf(w, AllocationsBody)
 		})
 }
 

--- a/openstack/placement/v1/resourceproviders/testing/requests_test.go
+++ b/openstack/placement/v1/resourceproviders/testing/requests_test.go
@@ -78,6 +78,17 @@ func TestGetResourceProvidersInventories(t *testing.T) {
 	th.AssertDeepEquals(t, ExpectedInventories, *actual)
 }
 
+func TestGetResourceProvidersAllocations(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	HandleResourceProviderGetAllocations(t)
+
+	actual, err := resourceproviders.GetAllocations(fake.ServiceClient(), ResourceProviderTestID).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, ExpectedAllocations, *actual)
+}
+
 func TestGetResourceProvidersTraits(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()

--- a/openstack/placement/v1/resourceproviders/urls.go
+++ b/openstack/placement/v1/resourceproviders/urls.go
@@ -18,6 +18,10 @@ func getResourceProviderInventoriesURL(client *gophercloud.ServiceClient, resour
 	return client.ServiceURL(apiName, resourceProviderID, "inventories")
 }
 
+func getResourceProviderAllocationsURL(client *gophercloud.ServiceClient, resourceProviderID string) string {
+	return client.ServiceURL(apiName, resourceProviderID, "allocations")
+}
+
 func getResourceProviderTraitsURL(client *gophercloud.ServiceClient, resourceProviderID string) string {
 	return client.ServiceURL(apiName, resourceProviderID, "traits")
 }


### PR DESCRIPTION
For #526

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

API doc:
https://docs.openstack.org/api-ref/placement/?expanded=list-resource-provider-usages-detail#list-resource-provider-allocations

API code:
https://github.com/openstack/placement/blob/2150dbf6880c379b52035b604c51048743c446a5/placement/handlers/allocation.py#L271
