### PR TITLE
Add missing bios interface fields to Ironic API

### DIFF
--- a/openstack/baremetal/v1/nodes/requests.go
+++ b/openstack/baremetal/v1/nodes/requests.go
@@ -185,6 +185,9 @@ type CreateOpts struct {
 	// Requires microversion 1.47 or later.
 	AutomatedClean *bool `json:"automated_clean,omitempty"`
 
+	// The BIOS interface for a Node, e.g. “redfish”.
+	BIOSInterface string `json:"bios_interface,omitempty"`
+
 	// The boot interface for a Node, e.g. “pxe”.
 	BootInterface string `json:"boot_interface,omitempty"`
 

--- a/openstack/baremetal/v1/nodes/results.go
+++ b/openstack/baremetal/v1/nodes/results.go
@@ -145,6 +145,9 @@ type Node struct {
 	// For more details, see: https://docs.openstack.org/ironic/latest/install/configure-nova-flavors.html
 	ResourceClass string `json:"resource_class"`
 
+	// BIOS interface for a Node, e.g. “redfish”.
+	BIOSInterface string `json:"bios_interface"`
+
 	// Boot interface for a Node, e.g. “pxe”.
 	BootInterface string `json:"boot_interface"`
 
@@ -301,6 +304,7 @@ type DriverValidation struct {
 //  Ironic validates whether the Node’s driver has enough information to manage the Node. This polls each interface on
 //  the driver, and returns the status of that interface as an DriverValidation struct.
 type NodeValidation struct {
+	BIOS       DriverValidation `json:"bios"`
 	Boot       DriverValidation `json:"boot"`
 	Console    DriverValidation `json:"console"`
 	Deploy     DriverValidation `json:"deploy"`

--- a/openstack/baremetal/v1/nodes/testing/fixtures.go
+++ b/openstack/baremetal/v1/nodes/testing/fixtures.go
@@ -638,6 +638,7 @@ var (
 		CleanStep:           map[string]interface{}{},
 		DeployStep:          map[string]interface{}{},
 		ResourceClass:       "",
+		BIOSInterface:       "no-bios",
 		BootInterface:       "pxe",
 		ConsoleInterface:    "no-console",
 		DeployInterface:     "iscsi",
@@ -656,6 +657,10 @@ var (
 	}
 
 	NodeFooValidation = nodes.NodeValidation{
+		BIOS: nodes.DriverValidation{
+			Result: false,
+			Reason: "Driver ipmi does not support bios (disabled or not implemented).",
+		},
 		Boot: nodes.DriverValidation{
 			Result: false,
 			Reason: "Cannot validate image information for node a62b8495-52e2-407b-b3cb-62775d04c2b8 because one or more parameters are missing from its instance_info and insufficent information is present to boot from a remote volume. Missing are: ['ramdisk', 'kernel', 'image_source']",
@@ -730,6 +735,7 @@ var (
 		CleanStep:            map[string]interface{}{},
 		DeployStep:           map[string]interface{}{},
 		ResourceClass:        "",
+		BIOSInterface:        "no-bios",
 		BootInterface:        "pxe",
 		ConsoleInterface:     "no-console",
 		DeployInterface:      "iscsi",
@@ -773,6 +779,7 @@ var (
 		CleanStep:            map[string]interface{}{},
 		DeployStep:           map[string]interface{}{},
 		ResourceClass:        "",
+		BIOSInterface:        "no-bios",
 		BootInterface:        "pxe",
 		ConsoleInterface:     "no-console",
 		DeployInterface:      "iscsi",


### PR DESCRIPTION
A few bios interface fields are in the Ironic API but were missing from
the Ironic API documentation and not included in gophercloud. This
change adds in the bios interface to the node create, node list,
and node driver validation APIs.

For #[2163]

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:
https://github.com/openstack/ironic/blob/master/ironic/api/controllers/v1/node.py#L143
https://github.com/openstack/ironic/blob/master/ironic/api/controllers/v1/node.py#L1225
https://github.com/openstack/ironic/blob/master/ironic/api/controllers/v1/utils.py#L1262
