### PR TITLE
blockstorage/v3: Add support for list qos

### DIFF
--- a/acceptance/openstack/blockstorage/v3/qos_test.go
+++ b/acceptance/openstack/blockstorage/v3/qos_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/gophercloud/gophercloud/acceptance/clients"
+	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/qos"
+	"github.com/gophercloud/gophercloud/pagination"
 	th "github.com/gophercloud/gophercloud/testhelper"
 )
 
@@ -14,7 +16,35 @@ func TestQoS(t *testing.T) {
 	client, err := clients.NewBlockStorageV3Client()
 	th.AssertNoErr(t, err)
 
-	qs, err := CreateQoS(t, client)
+	qos1, err := CreateQoS(t, client)
 	th.AssertNoErr(t, err)
-	defer DeleteQoS(t, client, qs)
+	defer DeleteQoS(t, client, qos1)
+
+	qos2, err := CreateQoS(t, client)
+	th.AssertNoErr(t, err)
+	defer DeleteQoS(t, client, qos2)
+
+	listOpts := qos.ListOpts{
+		Limit: 1,
+	}
+
+	err = qos.List(client, listOpts).EachPage(func(page pagination.Page) (bool, error) {
+		actual, err := qos.ExtractQoS(page)
+		th.AssertNoErr(t, err)
+		th.AssertEquals(t, 1, len(actual))
+
+		var found bool
+		for _, q := range actual {
+			if q.ID == qos1.ID || q.ID == qos2.ID {
+				found = true
+			}
+		}
+
+		th.AssertEquals(t, found, true)
+
+		return true, nil
+	})
+
+	th.AssertNoErr(t, err)
+
 }

--- a/openstack/blockstorage/v3/qos/doc.go
+++ b/openstack/blockstorage/v3/qos/doc.go
@@ -32,5 +32,23 @@ Example to delete a QoS specification
 		log.Fatal(err)
 	}
 
+Example to list QoS specifications
+
+	listOpts := qos.ListOpts{}
+
+	allPages, err := qos.List(client, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allQoS, err := qos.ExtractQoS(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, qos := range allQoS {
+		fmt.Printf("List: %+v\n", qos)
+	}
+
 */
 package qos

--- a/openstack/blockstorage/v3/qos/testing/requests_test.go
+++ b/openstack/blockstorage/v3/qos/testing/requests_test.go
@@ -1,9 +1,11 @@
 package testing
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/qos"
+	"github.com/gophercloud/gophercloud/pagination"
 	th "github.com/gophercloud/gophercloud/testhelper"
 	"github.com/gophercloud/gophercloud/testhelper/client"
 )
@@ -34,4 +36,40 @@ func TestDelete(t *testing.T) {
 
 	res := qos.Delete(client.ServiceClient(), "d32019d3-bc6e-4319-9c1d-6722fc136a22", qos.DeleteOpts{})
 	th.AssertNoErr(t, res.Err)
+}
+
+func TestList(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockListResponse(t)
+
+	pages := 0
+	err := qos.List(client.ServiceClient(), nil).EachPage(func(page pagination.Page) (bool, error) {
+		pages++
+		actual, err := qos.ExtractQoS(page)
+		if err != nil {
+			return false, err
+		}
+
+		expected := []qos.QoS{
+			{ID: "1", Consumer: "back-end", Name: "foo", Specs: map[string]string{}},
+			{ID: "2", Consumer: "front-end", Name: "bar", Specs: map[string]string{
+				"read_iops_sec": "20000",
+			},
+			},
+		}
+
+		if !reflect.DeepEqual(expected, actual) {
+			t.Errorf("Expected %#v, but was %#v", expected, actual)
+		}
+
+		return true, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pages != 1 {
+		t.Errorf("Expected one page, got %d", pages)
+	}
 }

--- a/openstack/blockstorage/v3/qos/urls.go
+++ b/openstack/blockstorage/v3/qos/urls.go
@@ -6,6 +6,10 @@ func createURL(c *gophercloud.ServiceClient) string {
 	return c.ServiceURL("qos-specs")
 }
 
+func listURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("qos-specs")
+}
+
 func deleteURL(c *gophercloud.ServiceClient, id string) string {
 	return c.ServiceURL("qos-specs", id)
 }


### PR DESCRIPTION
For #2139 

[docs](https://docs.openstack.org/api-ref/block-storage/v3/index.html?expanded=list-qos-specifications-detail#quality-of-service-qos-specifications-qos-specs)

[code](https://github.com/openstack/cinder/blob/393c2e4ad90c05ebf28cc3a2c65811d7e1e0bc18/cinder/api/contrib/qos_specs_manage.py#L58) [code](https://github.com/openstack/cinder/blob/393c2e4ad90c05ebf28cc3a2c65811d7e1e0bc18/cinder/volume/qos_specs.py#L233)
