### PR TITLE
Add support for baremetal bios endpoint

### DIFF
--- a/openstack/baremetal/v1/nodes/requests.go
+++ b/openstack/baremetal/v1/nodes/requests.go
@@ -636,3 +636,21 @@ func SetRAIDConfig(client *gophercloud.ServiceClient, id string, raidConfigOptsB
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
+
+// Get the current BIOS Settings for the given Node.
+func ListBIOSSettings(client *gophercloud.ServiceClient, id string) (r ListBIOSSettingsResult) {
+	resp, err := client.Get(biosListSettingsURL(client, id), &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// Get one BIOS Setting for the given Node.
+func GetBIOSSetting(client *gophercloud.ServiceClient, id string, setting string) (r GetBIOSSettingResult) {
+	resp, err := client.Get(biosGetSettingURL(client, id, setting), &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}

--- a/openstack/baremetal/v1/nodes/results.go
+++ b/openstack/baremetal/v1/nodes/results.go
@@ -48,6 +48,23 @@ func ExtractNodesInto(r pagination.Page, v interface{}) error {
 	return r.(NodePage).Result.ExtractIntoSlicePtr(v, "nodes")
 }
 
+// Extract interprets a BIOSSettingsResult as an array of BIOSSetting structs, if possible.
+func (r ListBIOSSettingsResult) Extract() ([]BIOSSetting, error) {
+	var s struct {
+		Settings []BIOSSetting `json:"bios"`
+	}
+
+	err := r.ExtractInto(&s)
+	return s.Settings, err
+}
+
+// Extract interprets a SingleBIOSSettingResult as a BIOSSetting struct, if possible.
+func (r GetBIOSSettingResult) Extract() (*BIOSSetting, error) {
+	var s SingleBIOSSetting
+	err := r.ExtractInto(&s)
+	return &s.Setting, err
+}
+
 // Node represents a node in the OpenStack Bare Metal API.
 type Node struct {
 	// Whether automated cleaning is enabled or disabled on this node.
@@ -273,7 +290,7 @@ type BootDeviceResult struct {
 	gophercloud.Result
 }
 
-// BootDeviceResult is the response from a GetBootDevice operation. Call its Extract
+// SetBootDeviceResult is the response from a SetBootDevice operation. Call its Extract
 // method to interpret it as a BootDeviceOpts struct.
 type SetBootDeviceResult struct {
 	gophercloud.ErrResult
@@ -289,6 +306,18 @@ type SupportedBootDeviceResult struct {
 // method to determine if the call succeeded or failed.
 type ChangePowerStateResult struct {
 	gophercloud.ErrResult
+}
+
+// ListBIOSSettingsResult is the response from a ListBIOSSettings operation. Call its Extract
+// method to interpret it as an array of BIOSSetting structs.
+type ListBIOSSettingsResult struct {
+	gophercloud.Result
+}
+
+// GetBIOSSettingResult is the response from a GetBIOSSetting operation. Call its Extract
+// method to interpret it as a BIOSSetting struct.
+type GetBIOSSettingResult struct {
+	gophercloud.Result
 }
 
 // Each element in the response will contain a “result” variable, which will have a value of “true” or “false”, and
@@ -311,6 +340,20 @@ type NodeValidation struct {
 	RAID       DriverValidation `json:"raid"`
 	Rescue     DriverValidation `json:"rescue"`
 	Storage    DriverValidation `json:"storage"`
+}
+
+// A particular BIOS setting for a node in the OpenStack Bare Metal API.
+type BIOSSetting struct {
+
+	// Identifier for the BIOS setting.
+	Name string `json:"name"`
+
+	// Value of the BIOS setting.
+	Value string `json:"value"`
+}
+
+type SingleBIOSSetting struct {
+	Setting BIOSSetting
 }
 
 // ChangeStateResult is the response from any state change operation. Call its ExtractErr

--- a/openstack/baremetal/v1/nodes/testing/fixtures.go
+++ b/openstack/baremetal/v1/nodes/testing/fixtures.go
@@ -604,6 +604,33 @@ const NodeProvisionStateConfigDriveBody = `
 }
 `
 
+const NodeBIOSSettingsBody = `
+{
+  "bios": [
+   {
+      "name": "Proc1L2Cache",
+      "value": "10x256 KB"
+   },
+   {
+      "name": "Proc1NumCores",
+      "value": "10"
+   },
+   {
+      "name": "ProcVirtualization",
+      "value": "Enabled"
+   }
+   ]
+}
+`
+const NodeSingleBIOSSettingBody = `
+{
+  "Setting": {
+      "name": "ProcVirtualization",
+      "value": "Enabled"
+   }
+}
+`
+
 var (
 	NodeFoo = nodes.Node{
 		UUID:                 "d2630783-6ec8-4836-b556-ab427c4b581e",
@@ -803,6 +830,26 @@ var (
 				},
 			},
 		},
+	}
+
+	NodeBIOSSettings = []nodes.BIOSSetting{
+		{
+			Name:  "Proc1L2Cache",
+			Value: "10x256 KB",
+		},
+		{
+			Name:  "Proc1NumCores",
+			Value: "10",
+		},
+		{
+			Name:  "ProcVirtualization",
+			Value: "Enabled",
+		},
+	}
+
+	NodeSingleBIOSSetting = nodes.BIOSSetting{
+		Name:  "ProcVirtualization",
+		Value: "Enabled",
 	}
 )
 
@@ -1059,5 +1106,25 @@ func HandleSetRAIDConfigMaxSize(t *testing.T) {
 		`)
 
 		w.WriteHeader(http.StatusNoContent)
+	})
+}
+
+func HandleListBIOSSettingsSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/nodes/1234asdf/bios", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+
+		fmt.Fprintf(w, NodeBIOSSettingsBody)
+	})
+}
+
+func HandleGetBIOSSettingSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/nodes/1234asdf/bios/ProcVirtualization", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+
+		fmt.Fprintf(w, NodeSingleBIOSSettingBody)
 	})
 }

--- a/openstack/baremetal/v1/nodes/testing/requests_test.go
+++ b/openstack/baremetal/v1/nodes/testing/requests_test.go
@@ -545,3 +545,25 @@ func TestToRAIDConfigMap(t *testing.T) {
 		})
 	}
 }
+
+func TestListBIOSSettings(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleListBIOSSettingsSuccessfully(t)
+
+	c := client.ServiceClient()
+	actual, err := nodes.ListBIOSSettings(c, "1234asdf").Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, NodeBIOSSettings, actual)
+}
+
+func TestGetBIOSSetting(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleGetBIOSSettingSuccessfully(t)
+
+	c := client.ServiceClient()
+	actual, err := nodes.GetBIOSSetting(c, "1234asdf", "ProcVirtualization").Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, NodeSingleBIOSSetting, *actual)
+}

--- a/openstack/baremetal/v1/nodes/urls.go
+++ b/openstack/baremetal/v1/nodes/urls.go
@@ -57,3 +57,11 @@ func provisionStateURL(client *gophercloud.ServiceClient, id string) string {
 func raidConfigURL(client *gophercloud.ServiceClient, id string) string {
 	return statesResourceURL(client, id, "raid")
 }
+
+func biosListSettingsURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL("nodes", id, "bios")
+}
+
+func biosGetSettingURL(client *gophercloud.ServiceClient, id string, setting string) string {
+	return client.ServiceURL("nodes", id, "bios", setting)
+}


### PR DESCRIPTION
For #2165.

The baremetal bios endpoint has been available in the Ironic API since
version 1.40 and is documented in the API reference here -
https://docs.openstack.org/api-ref/baremetal/?expanded=#node-bios-nodes.
It provides a list of all bios settings by node or a particular setting on a node.

The ironic API code is here:
https://github.com/openstack/ironic/blob/master/ironic/api/controllers/v1/bios.py#L57
