### PR TITLE
Add support for additional bios settings fields in Ironic

### DIFF
--- a/openstack/baremetal/v1/nodes/results.go
+++ b/openstack/baremetal/v1/nodes/results.go
@@ -354,6 +354,37 @@ type BIOSSetting struct {
 
 	// Value of the BIOS setting.
 	Value string `json:"value"`
+
+	// The following fields are returned in microversion 1.74 or later
+	// when using the `details` option
+
+	// The type of setting - Enumeration, String, Integer, or Boolean.
+	AttributeType string `json:"attribute_type"`
+
+	// The allowable value for an Enumeration type setting.
+	AllowableValues []string `json:"allowable_values"`
+
+	// The lowest value for an Integer type setting.
+	LowerBound *int `json:"lower_bound"`
+
+	// The highest value for an Integer type setting.
+	UpperBound *int `json:"upper_bound"`
+
+	// Minimum length for a String type setting.
+	MinLength *int `json:"min_length"`
+
+	// Maximum length for a String type setting.
+	MaxLength *int `json:"max_length"`
+
+	// Whether or not this setting is read only.
+	ReadOnly *bool `json:"read_only"`
+
+	// Whether or not a reset is required after changing this setting.
+	ResetRequired *bool `json:"reset_required"`
+
+	// Whether or not this setting's value is unique to this node, e.g.
+	// a serial number.
+	Unique *bool `json:"unique"`
 }
 
 type SingleBIOSSetting struct {

--- a/openstack/baremetal/v1/nodes/testing/fixtures.go
+++ b/openstack/baremetal/v1/nodes/testing/fixtures.go
@@ -622,6 +622,92 @@ const NodeBIOSSettingsBody = `
    ]
 }
 `
+
+const NodeDetailBIOSSettingsBody = `
+{
+  "bios": [
+   {
+      "created_at": "2021-05-11T21:33:44+00:00",
+      "updated_at": null,
+      "name": "Proc1L2Cache",
+      "value": "10x256 KB",
+      "attribute_type": "String",
+      "allowable_values": [],
+      "lower_bound": null,
+      "max_length": 16,
+      "min_length": 0,
+      "read_only": true,
+      "reset_required": null,
+      "unique": null,
+      "upper_bound": null,
+      "links": [
+        {
+          "href": "http://ironic.example.com:6385/v1/nodes/d26115bf-1296-4ca8-8c86-6f310d8ec375/bios/Proc1L2Cache",
+          "rel": "self"
+        },
+        {
+          "href": "http://ironic.example.com:6385/nodes/d26115bf-1296-4ca8-8c86-6f310d8ec375/bios/Proc1L2Cache",
+          "rel": "bookmark"
+        }
+      ]
+   },
+   {
+      "created_at": "2021-05-11T21:33:44+00:00",
+      "updated_at": null,
+      "name": "Proc1NumCores",
+      "value": "10",
+      "attribute_type": "Integer",
+      "allowable_values": [],
+      "lower_bound": 0,
+      "max_length": null,
+      "min_length": null,
+      "read_only": true,
+      "reset_required": null,
+      "unique": null,
+      "upper_bound": 20,
+      "links": [
+        {
+          "href": "http://ironic.example.com:6385/v1/nodes/d26115bf-1296-4ca8-8c86-6f310d8ec375/bios/Proc1NumCores",
+          "rel": "self"
+        },
+        {
+          "href": "http://ironic.example.com:6385/nodes/d26115bf-1296-4ca8-8c86-6f310d8ec375/bios/Proc1NumCores",
+          "rel": "bookmark"
+        }
+      ]
+   },
+   {
+      "created_at": "2021-05-11T21:33:44+00:00",
+      "updated_at": null,
+      "name": "ProcVirtualization",
+      "value": "Enabled",
+      "attribute_type": "Enumeration",
+      "allowable_values": [
+        "Enabled",
+        "Disabled"
+      ],
+      "lower_bound": null,
+      "max_length": null,
+      "min_length": null,
+      "read_only": false,
+      "reset_required": null,
+      "unique": null,
+      "upper_bound": null,
+      "links": [
+        {
+          "href": "http://ironic.example.com:6385/v1/nodes/d26115bf-1296-4ca8-8c86-6f310d8ec375/bios/ProcVirtualization",
+          "rel": "self"
+        },
+        {
+          "href": "http://ironic.example.com:6385/nodes/d26115bf-1296-4ca8-8c86-6f310d8ec375/bios/ProcVirtualization",
+          "rel": "bookmark"
+        }
+      ]
+   }
+   ]
+}
+`
+
 const NodeSingleBIOSSettingBody = `
 {
   "Setting": {
@@ -851,6 +937,55 @@ var (
 		{
 			Name:  "ProcVirtualization",
 			Value: "Enabled",
+		},
+	}
+
+	iTrue      = true
+	iFalse     = false
+	minLength  = 0
+	maxLength  = 16
+	lowerBound = 0
+	upperBound = 20
+
+	NodeDetailBIOSSettings = []nodes.BIOSSetting{
+		{
+			Name:            "Proc1L2Cache",
+			Value:           "10x256 KB",
+			AttributeType:   "String",
+			AllowableValues: []string{},
+			LowerBound:      nil,
+			UpperBound:      nil,
+			MinLength:       &minLength,
+			MaxLength:       &maxLength,
+			ReadOnly:        &iTrue,
+			ResetRequired:   nil,
+			Unique:          nil,
+		},
+		{
+			Name:            "Proc1NumCores",
+			Value:           "10",
+			AttributeType:   "Integer",
+			AllowableValues: []string{},
+			LowerBound:      &lowerBound,
+			UpperBound:      &upperBound,
+			MinLength:       nil,
+			MaxLength:       nil,
+			ReadOnly:        &iTrue,
+			ResetRequired:   nil,
+			Unique:          nil,
+		},
+		{
+			Name:            "ProcVirtualization",
+			Value:           "Enabled",
+			AttributeType:   "Enumeration",
+			AllowableValues: []string{"Enabled", "Disabled"},
+			LowerBound:      nil,
+			UpperBound:      nil,
+			MinLength:       nil,
+			MaxLength:       nil,
+			ReadOnly:        &iFalse,
+			ResetRequired:   nil,
+			Unique:          nil,
 		},
 	}
 
@@ -1123,6 +1258,16 @@ func HandleListBIOSSettingsSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "Accept", "application/json")
 
 		fmt.Fprintf(w, NodeBIOSSettingsBody)
+	})
+}
+
+func HandleListDetailBIOSSettingsSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/nodes/1234asdf/bios", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+
+		fmt.Fprintf(w, NodeDetailBIOSSettingsBody)
 	})
 }
 

--- a/openstack/baremetal/v1/nodes/testing/requests_test.go
+++ b/openstack/baremetal/v1/nodes/testing/requests_test.go
@@ -552,9 +552,24 @@ func TestListBIOSSettings(t *testing.T) {
 	HandleListBIOSSettingsSuccessfully(t)
 
 	c := client.ServiceClient()
-	actual, err := nodes.ListBIOSSettings(c, "1234asdf").Extract()
+	actual, err := nodes.ListBIOSSettings(c, "1234asdf", nil).Extract()
 	th.AssertNoErr(t, err)
 	th.CheckDeepEquals(t, NodeBIOSSettings, actual)
+}
+
+func TestListDetailBIOSSettings(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleListDetailBIOSSettingsSuccessfully(t)
+
+	opts := nodes.ListBIOSSettingsOpts{
+		Detail: true,
+	}
+
+	c := client.ServiceClient()
+	actual, err := nodes.ListBIOSSettings(c, "1234asdf", opts).Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, NodeDetailBIOSSettings, actual)
 }
 
 func TestGetBIOSSetting(t *testing.T) {
@@ -566,4 +581,15 @@ func TestGetBIOSSetting(t *testing.T) {
 	actual, err := nodes.GetBIOSSetting(c, "1234asdf", "ProcVirtualization").Extract()
 	th.AssertNoErr(t, err)
 	th.CheckDeepEquals(t, NodeSingleBIOSSetting, *actual)
+}
+
+func TestListBIOSSettingsOpts(t *testing.T) {
+	// Detail cannot take Fields
+	opts := nodes.ListBIOSSettingsOpts{
+		Detail: true,
+		Fields: []string{"name", "value"},
+	}
+
+	_, err := opts.ToListBIOSSettingsOptsQuery()
+	th.AssertEquals(t, err.Error(), "cannot have both fields and detail options for BIOS settings")
 }


### PR DESCRIPTION
For #2166

A recent change to Ironic
(https://review.opendev.org/c/openstack/ironic/+/786707) has added
support for bios registry fields in the Ironic API for microversion 1.74. 
These can be retrieved using the `?detail=True` option when listing
all settings. The fields are also included when getting individual
settings without any options.

