### PR TITLE
Add tag and delete_on_termination for nova volumeattach

### DIFF
--- a/acceptance/openstack/compute/v2/compute.go
+++ b/acceptance/openstack/compute/v2/compute.go
@@ -802,8 +802,13 @@ func CreateServerWithPublicKey(t *testing.T, client *gophercloud.ServiceClient, 
 // CreateVolumeAttachment will attach a volume to a server. An error will be
 // returned if the volume failed to attach.
 func CreateVolumeAttachment(t *testing.T, client *gophercloud.ServiceClient, blockClient *gophercloud.ServiceClient, server *servers.Server, volume *volumes.Volume) (*volumeattach.VolumeAttachment, error) {
+	tag := tools.RandomString("ACPTTEST", 16)
+	dot := false
+
 	volumeAttachOptions := volumeattach.CreateOpts{
-		VolumeID: volume.ID,
+		VolumeID:            volume.ID,
+		Tag:                 tag,
+		DeleteOnTermination: dot,
 	}
 
 	t.Logf("Attempting to attach volume %s to server %s", volume.ID, server.ID)

--- a/acceptance/openstack/compute/v2/volumeattach_test.go
+++ b/acceptance/openstack/compute/v2/volumeattach_test.go
@@ -28,6 +28,7 @@ func TestVolumeAttachAttachment(t *testing.T) {
 	th.AssertNoErr(t, err)
 	defer bs.DeleteVolume(t, blockClient, volume)
 
+	client.Microversion = "2.79"
 	volumeAttachment, err := CreateVolumeAttachment(t, client, blockClient, server, volume)
 	th.AssertNoErr(t, err)
 	defer DeleteVolumeAttachment(t, client, blockClient, server, volumeAttachment)

--- a/openstack/compute/v2/extensions/volumeattach/requests.go
+++ b/openstack/compute/v2/extensions/volumeattach/requests.go
@@ -26,6 +26,14 @@ type CreateOpts struct {
 
 	// VolumeID is the ID of the volume to attach to the instance.
 	VolumeID string `json:"volumeId" required:"true"`
+
+	// Tag is a device role tag that can be applied to a volume when attaching
+	// it to the VM. Requires 2.49 microversion
+	Tag string `json:"tag,omitempty"`
+
+	// DeleteOnTermination specifies whether or not to delete the volume when the server
+	// is destroyed. Requires 2.79 microversion
+	DeleteOnTermination bool `json:"delete_on_termination,omitempty"`
 }
 
 // ToVolumeAttachmentCreateMap constructs a request body from CreateOpts.

--- a/openstack/compute/v2/extensions/volumeattach/results.go
+++ b/openstack/compute/v2/extensions/volumeattach/results.go
@@ -19,6 +19,14 @@ type VolumeAttachment struct {
 
 	// ServerID is the ID of the instance that has the volume attached.
 	ServerID string `json:"serverId"`
+
+	// Tag is a device role tag that can be applied to a volume when attaching
+	// it to the VM. Requires 2.70 microversion
+	Tag *string `json:"tag"`
+
+	// DeleteOnTermination specifies whether or not to delete the volume when the server
+	// is destroyed. Requires 2.79 microversion
+	DeleteOnTermination *bool `json:"delete_on_termination"`
 }
 
 // VolumeAttachmentPage stores a single page all of VolumeAttachment

--- a/openstack/compute/v2/extensions/volumeattach/testing/fixtures.go
+++ b/openstack/compute/v2/extensions/volumeattach/testing/fixtures.go
@@ -48,7 +48,9 @@ const CreateOutput = `
     "device": "/dev/vdc",
     "id": "a26887c6-c47b-4654-abb5-dfadf7d3f804",
     "serverId": "4d8c3732-a248-40ed-bebc-539a6ffd25c0",
-    "volumeId": "a26887c6-c47b-4654-abb5-dfadf7d3f804"
+    "volumeId": "a26887c6-c47b-4654-abb5-dfadf7d3f804",
+    "tag": "foo",
+    "delete_on_termination": true
   }
 }
 `
@@ -86,7 +88,9 @@ func HandleCreateSuccessfully(t *testing.T) {
 {
   "volumeAttachment": {
     "volumeId": "a26887c6-c47b-4654-abb5-dfadf7d3f804",
-    "device": "/dev/vdc"
+    "device": "/dev/vdc",
+    "tag": "foo",
+    "delete_on_termination": true
   }
 }
 `)

--- a/openstack/compute/v2/extensions/volumeattach/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/volumeattach/testing/requests_test.go
@@ -29,12 +29,17 @@ var SecondVolumeAttachment = volumeattach.VolumeAttachment{
 // from ListOutput, in the expected order.
 var ExpectedVolumeAttachmentSlice = []volumeattach.VolumeAttachment{FirstVolumeAttachment, SecondVolumeAttachment}
 
+var iTag = "foo"
+var iTrue = true
+
 //CreatedVolumeAttachment is the parsed result from CreatedOutput.
 var CreatedVolumeAttachment = volumeattach.VolumeAttachment{
-	Device:   "/dev/vdc",
-	ID:       "a26887c6-c47b-4654-abb5-dfadf7d3f804",
-	ServerID: "4d8c3732-a248-40ed-bebc-539a6ffd25c0",
-	VolumeID: "a26887c6-c47b-4654-abb5-dfadf7d3f804",
+	Device:              "/dev/vdc",
+	ID:                  "a26887c6-c47b-4654-abb5-dfadf7d3f804",
+	ServerID:            "4d8c3732-a248-40ed-bebc-539a6ffd25c0",
+	VolumeID:            "a26887c6-c47b-4654-abb5-dfadf7d3f804",
+	Tag:                 &iTag,
+	DeleteOnTermination: &iTrue,
 }
 
 func TestList(t *testing.T) {
@@ -67,8 +72,10 @@ func TestCreate(t *testing.T) {
 	serverID := "4d8c3732-a248-40ed-bebc-539a6ffd25c0"
 
 	actual, err := volumeattach.Create(client.ServiceClient(), serverID, volumeattach.CreateOpts{
-		Device:   "/dev/vdc",
-		VolumeID: "a26887c6-c47b-4654-abb5-dfadf7d3f804",
+		Device:              "/dev/vdc",
+		VolumeID:            "a26887c6-c47b-4654-abb5-dfadf7d3f804",
+		Tag:                 iTag,
+		DeleteOnTermination: iTrue,
 	}).Extract()
 	th.AssertNoErr(t, err)
 	th.CheckDeepEquals(t, &CreatedVolumeAttachment, actual)


### PR DESCRIPTION
For #2176 

Add 2 new request and respond fields for volumeattach.
tag => added on 2.49 =>https://docs.openstack.org/nova/latest/reference/api-microversion-history.html#id45
delete_on_termination => added on 2.79 => https://docs.openstack.org/nova/latest/reference/api-microversion-history.html#maximum-in-train


[docs](https://docs.openstack.org/api-ref/compute/?expanded=attach-a-volume-to-an-instance-detail#attach-a-volume-to-an-instance)

[schema](https://github.com/openstack/nova/blob/052cf963583ab7c6bbe4fcbf7bfe69f8f6733bdb/nova/api/openstack/compute/schemas/volumes.py#L87) [schema](https://github.com/openstack/nova/blob/052cf963583ab7c6bbe4fcbf7bfe69f8f6733bdb/nova/api/validation/parameter_types.py#L463)
[create](https://github.com/openstack/nova/blob/052cf963583ab7c6bbe4fcbf7bfe69f8f6733bdb/nova/api/openstack/compute/volumes.py#L343-L400) [get](https://github.com/openstack/nova/blob/052cf963583ab7c6bbe4fcbf7bfe69f8f6733bdb/nova/api/openstack/compute/volumes.py#L312-L335)

 

