### PR TITLE
Trove: Support to return Trove instance addresses

### DIFF
--- a/openstack/db/v1/instances/results.go
+++ b/openstack/db/v1/instances/results.go
@@ -39,6 +39,15 @@ type Fault struct {
 	Details string
 }
 
+// Address represents the IP address and its type to connect with the instance.
+type Address struct {
+	// The address type, e.g public
+	Type string
+
+	// The actual IP address
+	Address string
+}
+
 func (r *Fault) UnmarshalJSON(b []byte) error {
 	type tmp Fault
 	var s struct {
@@ -76,7 +85,8 @@ type Instance struct {
 	Hostname string
 
 	// The IP addresses associated with the database instance
-	// Is empty if the instance has a hostname
+	// Is empty if the instance has a hostname.
+	// Deprecated in favor of Addresses.
 	IP []string
 
 	// Indicates the unique identifier for the instance resource.
@@ -99,6 +109,9 @@ type Instance struct {
 
 	// Indicates how the instance stores data.
 	Datastore datastores.DatastorePartial
+
+	// The instance addresses
+	Addresses []Address
 }
 
 func (r *Instance) UnmarshalJSON(b []byte) error {

--- a/openstack/db/v1/instances/testing/fixtures.go
+++ b/openstack/db/v1/instances/testing/fixtures.go
@@ -53,6 +53,54 @@ var instance = `
 }
 `
 
+var instanceGet = `
+{
+  "created": "` + timestamp + `",
+  "datastore": {
+    "type": "mysql",
+    "version": "5.6"
+  },
+  "flavor": {
+    "id": "1",
+    "links": [
+      {
+        "href": "https://openstack.example.com/v1.0/1234/flavors/1",
+        "rel": "self"
+      },
+      {
+        "href": "https://openstack.example.com/v1.0/1234/flavors/1",
+        "rel": "bookmark"
+      }
+    ]
+  },
+  "links": [
+    {
+      "href": "https://openstack.example.com/v1.0/1234/instances/1",
+      "rel": "self"
+    }
+  ],
+  "id": "{instanceID}",
+  "name": "test",
+  "status": "ACTIVE",
+  "operating_status": "HEALTHY",
+  "updated": "` + timestamp + `",
+  "volume": {
+    "size": 1,
+    "used": 0.12
+  },
+  "addresses": [
+    {
+      "address": "10.1.0.62",
+      "type": "private"
+    },
+    {
+      "address": "172.24.5.114",
+      "type": "public"
+    }
+  ]
+}
+`
+
 var createReq = `
 {
 	"instance": {
@@ -149,7 +197,7 @@ var (
 	createResp          = fmt.Sprintf(`{"instance": %s}`, instance)
 	createWithFaultResp = fmt.Sprintf(`{"instance": %s}`, instanceWithFault)
 	listInstancesResp   = fmt.Sprintf(`{"instances":[%s]}`, instance)
-	getInstanceResp     = createResp
+	getInstanceResp     = fmt.Sprintf(`{"instance": %s}`, instanceGet)
 	enableUserResp      = `{"user":{"name":"root","password":"secretsecret"}}`
 	isUserEnabledResp   = `{"rootEnabled":true}`
 )
@@ -175,6 +223,33 @@ var expectedInstance = instances.Instance{
 	Datastore: datastores.DatastorePartial{
 		Type:    "mysql",
 		Version: "5.6",
+	},
+}
+
+var expectedGetInstance = instances.Instance{
+	Created: timeVal,
+	Updated: timeVal,
+	Flavor: instances.Flavor{
+		ID: "1",
+		Links: []gophercloud.Link{
+			{Href: "https://openstack.example.com/v1.0/1234/flavors/1", Rel: "self"},
+			{Href: "https://openstack.example.com/v1.0/1234/flavors/1", Rel: "bookmark"},
+		},
+	},
+	ID: instanceID,
+	Links: []gophercloud.Link{
+		{Href: "https://openstack.example.com/v1.0/1234/instances/1", Rel: "self"},
+	},
+	Name:   "test",
+	Status: "ACTIVE",
+	Volume: instances.Volume{Size: 1, Used: 0.12},
+	Datastore: datastores.DatastorePartial{
+		Type:    "mysql",
+		Version: "5.6",
+	},
+	Addresses: []instances.Address{
+		{Type: "private", Address: "10.1.0.62"},
+		{Type: "public", Address: "172.24.5.114"},
 	},
 }
 

--- a/openstack/db/v1/instances/testing/requests_test.go
+++ b/openstack/db/v1/instances/testing/requests_test.go
@@ -101,7 +101,7 @@ func TestGetInstance(t *testing.T) {
 	instance, err := instances.Get(fake.ServiceClient(), instanceID).Extract()
 
 	th.AssertNoErr(t, err)
-	th.AssertDeepEquals(t, &expectedInstance, instance)
+	th.AssertDeepEquals(t, &expectedGetInstance, instance)
 }
 
 func TestDeleteInstance(t *testing.T) {


### PR DESCRIPTION
Closes: #2178

- API response example for getting trove instance :
  https://docs.openstack.org/api-ref/database/?expanded=show-database-instance-details-detail#id52
- Trove code for getting instance addresses:
  https://github.com/openstack/trove/blob/b050996b9f6df738a0f68ac36a5b5f17f8bb2bc2/trove/instance/models.py#L170
