### PR TITLE
add `tag` attribute to servers.Network

### DIFF
--- a/openstack/compute/v2/servers/requests.go
+++ b/openstack/compute/v2/servers/requests.go
@@ -128,6 +128,13 @@ type Network struct {
 
 	// FixedIP specifies a fixed IPv4 address to be used on this network.
 	FixedIP string
+
+	// Tag may contain an optional device role tag for the server's virtual
+	// network interface. This can be used to identify network interfaces when
+	// multiple networks are connected to one server.
+	//
+	// Requires microversion 2.32 through 2.36 or 2.42 or later.
+	Tag string
 }
 
 // Personality is an array of files that are injected into the server at launch.
@@ -260,6 +267,9 @@ func (opts CreateOpts) ToServerCreateMap() (map[string]interface{}, error) {
 				}
 				if net.FixedIP != "" {
 					networks[i]["fixed_ip"] = net.FixedIP
+				}
+				if net.Tag != "" {
+					networks[i]["tag"] = net.Tag
 				}
 			}
 			b["networks"] = networks


### PR DESCRIPTION
Closes #2192.

Links to the line numbers/files in the OpenStack source code that support the
code in this PR: Links are given in the issue.

---

I was going to extend the tests to handle this attribute, but there are no tests at all that actually cover the `networks` attribute of server creation requests, so I hope this change is okay as-is.