### PR TITLE
Vendor Passthru support for Subscriptions

### DIFF
--- a/openstack/baremetal/v1/nodes/doc.go
+++ b/openstack/baremetal/v1/nodes/doc.go
@@ -126,5 +126,67 @@ Example to get boot device for a node
 	if err != nil {
 		panic(err)
 	}
+
+Example to list all vendor passthru methods
+
+	methods, err := nodes.GetVendorPassthruMethods(client, "a62b8495-52e2-407b-b3cb-62775d04c2b8").Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to list all subscriptions
+
+	method := nodes.CallVendorPassthruOpts{
+		Method: "get_all_subscriptions",
+	}
+	allSubscriptions, err := nodes.GetAllSubscriptions(client, "a62b8495-52e2-407b-b3cb-62775d04c2b8", method).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to get a subscription
+
+	method := nodes.CallVendorPassthruOpts{
+		Method: "get_subscription",
+	}
+	subscriptionOpt := nodes.GetSubscriptionOpts{
+		Id:     "subscription id",
+	}
+
+	subscription, err := nodes.GetSubscription(client, "a62b8495-52e2-407b-b3cb-62775d04c2b8", method, subscriptionOpt).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to delete a subscription
+
+	method := nodes.CallVendorPassthruOpts{
+		Method: "delete_subscription",
+	}
+	subscriptionDeleteOpt := nodes.DeleteSubscriptionOpts{
+		Id: "subscription id",
+	}
+
+	err := nodes.DeleteSubscription(client, "a62b8495-52e2-407b-b3cb-62775d04c2b8", method, subscriptionDeleteOpt).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+
+Example to create a subscription
+
+	method := nodes.CallVendorPassthruOpts{
+		Method: "create_subscription",
+	}
+	subscriptionCreateOpt := nodes.CreateSubscriptionOpts{
+		Destination: "https://subscription_destination_url"
+		Context:     "MyContext",
+		Protocol:    "Redfish",
+		EventTypes:  ["Alert"],
+	}
+
+	newSubscription, err := nodes.CreateSubscription(client, "a62b8495-52e2-407b-b3cb-62775d04c2b8", method, subscriptionCreateOpt).Extract()
+	if err != nil {
+		panic(err)
+	}
 */
 package nodes

--- a/openstack/baremetal/v1/nodes/results.go
+++ b/openstack/baremetal/v1/nodes/results.go
@@ -65,6 +65,25 @@ func (r GetBIOSSettingResult) Extract() (*BIOSSetting, error) {
 	return &s.Setting, err
 }
 
+// Extract interprets a VendorPassthruMethod as
+func (r VendorPassthruMethodsResult) Extract() (*VendorPassthruMethods, error) {
+	var s VendorPassthruMethods
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+func (r GetAllSubscriptionsVendorPassthruResult) Extract() (*GetAllSubscriptionsVendorPassthru, error) {
+	var s GetAllSubscriptionsVendorPassthru
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+func (r SubscriptionVendorPassthruResult) Extract() (*SubscriptionVendorPassthru, error) {
+	var s SubscriptionVendorPassthru
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
 // Node represents a node in the OpenStack Bare Metal API.
 type Node struct {
 	// Whether automated cleaning is enabled or disabled on this node.
@@ -323,6 +342,30 @@ type GetBIOSSettingResult struct {
 	gophercloud.Result
 }
 
+// VendorPassthruMethodsResult is the response from a GetVendorPassthruMethods operation. Call its Extract
+// method to interpret it as an array of allowed vendor methods.
+type VendorPassthruMethodsResult struct {
+	gophercloud.Result
+}
+
+// GetAllSubscriptionsVendorPassthruResult is the response from GetAllSubscriptions operation. Call its
+// Extract method to interpret it as a GetAllSubscriptionsVendorPassthru struct.
+type GetAllSubscriptionsVendorPassthruResult struct {
+	gophercloud.Result
+}
+
+// SubscriptionVendorPassthruResult is the response from GetSubscription and CreateSubscription operation. Call its Extract
+// method to interpret it as a SubscriptionVendorPassthru struct.
+type SubscriptionVendorPassthruResult struct {
+	gophercloud.Result
+}
+
+// DeleteSubscriptionVendorPassthruResult is the response from DeleteSubscription operation. Call its
+// ExtractErr method to determine if the call succeeded of failed.
+type DeleteSubscriptionVendorPassthruResult struct {
+	gophercloud.ErrResult
+}
+
 // Each element in the response will contain a “result” variable, which will have a value of “true” or “false”, and
 // also potentially a reason. A value of nil indicates that the Node’s driver does not support that interface.
 type DriverValidation struct {
@@ -395,4 +438,66 @@ type SingleBIOSSetting struct {
 // method to determine if the call succeeded or failed.
 type ChangeStateResult struct {
 	gophercloud.ErrResult
+}
+
+type VendorPassthruMethods struct {
+	CreateSubscription  CreateSubscriptionMethod  `json:"create_subscription,omitempty"`
+	DeleteSubscription  DeleteSubscriptionMethod  `json:"delete_subscription,omitempty"`
+	GetSubscription     GetSubscriptionMethod     `json:"get_subscription,omitempty"`
+	GetAllSubscriptions GetAllSubscriptionsMethod `json:"get_all_subscriptions,omitempty"`
+}
+
+// Below you can find all vendor passthru methods structs
+
+type CreateSubscriptionMethod struct {
+	HTTPMethods          []string `json:"http_methods"`
+	Async                bool     `json:"async"`
+	Description          string   `json:"description"`
+	Attach               bool     `json:"attach"`
+	RequireExclusiveLock bool     `json:"require_exclusive_lock"`
+}
+
+type DeleteSubscriptionMethod struct {
+	HTTPMethods          []string `json:"http_methods"`
+	Async                bool     `json:"async"`
+	Description          string   `json:"description"`
+	Attach               bool     `json:"attach"`
+	RequireExclusiveLock bool     `json:"require_exclusive_lock"`
+}
+
+type GetSubscriptionMethod struct {
+	HTTPMethods          []string `json:"http_methods"`
+	Async                bool     `json:"async"`
+	Description          string   `json:"description"`
+	Attach               bool     `json:"attach"`
+	RequireExclusiveLock bool     `json:"require_exclusive_lock"`
+}
+
+type GetAllSubscriptionsMethod struct {
+	HTTPMethods          []string `json:"http_methods"`
+	Async                bool     `json:"async"`
+	Description          string   `json:"description"`
+	Attach               bool     `json:"attach"`
+	RequireExclusiveLock bool     `json:"require_exclusive_lock"`
+}
+
+// A List of subscriptions from a node in the OpenStack Bare Metal API.
+type GetAllSubscriptionsVendorPassthru struct {
+	Context      string              `json:"@odata.context"`
+	Etag         string              `json:"@odata.etag"`
+	Id           string              `json:"@odata.id"`
+	Type         string              `json:"@odata.type"`
+	Description  string              `json:"Description"`
+	Name         string              `json:"Name"`
+	Members      []map[string]string `json:"Members"`
+	MembersCount int                 `json:"Members@odata.count"`
+}
+
+// A Subscription from a node in the OpenStack Bare Metal API.
+type SubscriptionVendorPassthru struct {
+	Id          string   `json:"Id"`
+	Context     string   `json:"Context"`
+	Destination string   `json:"Destination"`
+	EventTypes  []string `json:"EventTypes"`
+	Protocol    string   `json:"Protocol"`
 }

--- a/openstack/baremetal/v1/nodes/testing/fixtures.go
+++ b/openstack/baremetal/v1/nodes/testing/fixtures.go
@@ -717,6 +717,94 @@ const NodeSingleBIOSSettingBody = `
 }
 `
 
+const NodeVendorPassthruMethodsBody = `
+{
+  "create_subscription": {
+    "http_methods": [
+      "POST"
+    ],
+    "async": false,
+    "description": "",
+    "attach": false,
+    "require_exclusive_lock": true
+  },
+  "delete_subscription": {
+    "http_methods": [
+      "DELETE"
+    ],
+    "async": false,
+    "description": "",
+    "attach": false,
+    "require_exclusive_lock": true
+  },
+  "get_subscription": {
+    "http_methods": [
+      "GET"
+    ],
+    "async": false,
+    "description": "",
+    "attach": false,
+    "require_exclusive_lock": true
+  },
+  "get_all_subscriptions": {
+    "http_methods": [
+      "GET"
+    ],
+    "async": false,
+    "description": "",
+    "attach": false,
+    "require_exclusive_lock": true
+  }
+}
+`
+
+const NodeGetAllSubscriptionsVnedorPassthruBody = `
+{
+  "@odata.context": "/redfish/v1/$metadata#EventDestinationCollection.EventDestinationCollection",
+  "@odata.id": "/redfish/v1/EventService/Subscriptions",
+  "@odata.type": "#EventDestinationCollection.EventDestinationCollection",
+  "Description": "List of Event subscriptions",
+  "Members": [
+    {
+      "@odata.id": "/redfish/v1/EventService/Subscriptions/62dbd1b6-f637-11eb-b551-4cd98f20754c"
+    }
+  ],
+  "Members@odata.count": 1,
+  "Name": "Event Subscriptions Collection"
+}
+
+`
+
+const NodeGetSubscriptionVendorPassthruBody = `
+{
+  "Context": "Ironic",
+  "Destination": "https://192.168.0.1/EventReceiver.php",
+  "EventTypes": ["Alert"],
+  "Id": "62dbd1b6-f637-11eb-b551-4cd98f20754c",
+  "Protocol": "Redfish"
+}
+`
+
+const NodeCreateSubscriptionVendorPassthruAllParametersBody = `
+{
+  "Context": "gophercloud",
+  "Destination": "https://someurl",
+  "EventTypes": ["Alert"],
+  "Id": "eaa43e2-018a-424e-990a-cbf47c62ef80",
+  "Protocol": "Redfish"
+}
+`
+
+const NodeCreateSubscriptionVendorPassthruRequiredParametersBody = `
+{
+  "Context": "",
+  "Destination": "https://somedestinationurl",
+  "EventTypes": ["Alert"],
+  "Id": "344a3e2-978a-444e-990a-cbf47c62ef88",
+  "Protocol": "Redfish"
+}
+`
+
 var (
 	NodeFoo = nodes.Node{
 		UUID:                 "d2630783-6ec8-4836-b556-ab427c4b581e",
@@ -992,6 +1080,72 @@ var (
 	NodeSingleBIOSSetting = nodes.BIOSSetting{
 		Name:  "ProcVirtualization",
 		Value: "Enabled",
+	}
+
+	NodeVendorPassthruMethods = nodes.VendorPassthruMethods{
+		CreateSubscription: nodes.CreateSubscriptionMethod{
+			HTTPMethods:          []string{"POST"},
+			Async:                false,
+			Description:          "",
+			Attach:               false,
+			RequireExclusiveLock: true,
+		},
+		DeleteSubscription: nodes.DeleteSubscriptionMethod{
+			HTTPMethods:          []string{"DELETE"},
+			Async:                false,
+			Description:          "",
+			Attach:               false,
+			RequireExclusiveLock: true,
+		},
+		GetSubscription: nodes.GetSubscriptionMethod{
+			HTTPMethods:          []string{"GET"},
+			Async:                false,
+			Description:          "",
+			Attach:               false,
+			RequireExclusiveLock: true,
+		},
+		GetAllSubscriptions: nodes.GetAllSubscriptionsMethod{
+			HTTPMethods:          []string{"GET"},
+			Async:                false,
+			Description:          "",
+			Attach:               false,
+			RequireExclusiveLock: true,
+		},
+	}
+
+	NodeGetAllSubscriptions = nodes.GetAllSubscriptionsVendorPassthru{
+		Context:      "/redfish/v1/$metadata#EventDestinationCollection.EventDestinationCollection",
+		Etag:         "",
+		Id:           "/redfish/v1/EventService/Subscriptions",
+		Type:         "#EventDestinationCollection.EventDestinationCollection",
+		Description:  "List of Event subscriptions",
+		Name:         "Event Subscriptions Collection",
+		Members:      []map[string]string{{"@odata.id": "/redfish/v1/EventService/Subscriptions/62dbd1b6-f637-11eb-b551-4cd98f20754c"}},
+		MembersCount: 1,
+	}
+
+	NodeGetSubscription = nodes.SubscriptionVendorPassthru{
+		Id:          "62dbd1b6-f637-11eb-b551-4cd98f20754c",
+		Context:     "Ironic",
+		Destination: "https://192.168.0.1/EventReceiver.php",
+		EventTypes:  []string{"Alert"},
+		Protocol:    "Redfish",
+	}
+
+	NodeCreateSubscriptionRequiredParameters = nodes.SubscriptionVendorPassthru{
+		Id:          "344a3e2-978a-444e-990a-cbf47c62ef88",
+		Context:     "",
+		Destination: "https://somedestinationurl",
+		EventTypes:  []string{"Alert"},
+		Protocol:    "Redfish",
+	}
+
+	NodeCreateSubscriptionAllParameters = nodes.SubscriptionVendorPassthru{
+		Id:          "eaa43e2-018a-424e-990a-cbf47c62ef80",
+		Context:     "gophercloud",
+		Destination: "https://someurl",
+		EventTypes:  []string{"Alert"},
+		Protocol:    "Redfish",
 	}
 )
 
@@ -1278,5 +1432,93 @@ func HandleGetBIOSSettingSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "Accept", "application/json")
 
 		fmt.Fprintf(w, NodeSingleBIOSSettingBody)
+	})
+}
+
+func HandleGetVendorPassthruMethodsSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/nodes/1234asdf/vendor_passthru/methods", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+
+		fmt.Fprintf(w, NodeVendorPassthruMethodsBody)
+	})
+}
+
+func HandleGetAllSubscriptionsVendorPassthruSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/nodes/1234asdf/vendor_passthru", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestFormValues(t, r, map[string]string{"method": "get_all_subscriptions"})
+
+		fmt.Fprintf(w, NodeGetAllSubscriptionsVnedorPassthruBody)
+	})
+}
+
+func HandleGetSubscriptionVendorPassthruSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/nodes/1234asdf/vendor_passthru", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestFormValues(t, r, map[string]string{"method": "get_subscription"})
+		th.TestJSONRequest(t, r, `
+			{
+			   "id" : "62dbd1b6-f637-11eb-b551-4cd98f20754c"
+			}
+		`)
+
+		fmt.Fprintf(w, NodeGetSubscriptionVendorPassthruBody)
+	})
+}
+
+func HandleCreateSubscriptionVendorPassthruAllParametersSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/nodes/1234asdf/vendor_passthru", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestFormValues(t, r, map[string]string{"method": "create_subscription"})
+		th.TestJSONRequest(t, r, `
+			{
+         "Context":      "gophercloud",
+         "EventTypes":    ["Alert"],
+         "Protocol":     "Redfish",
+			   "Destination" : "https://someurl"
+			}
+		`)
+
+		fmt.Fprintf(w, NodeCreateSubscriptionVendorPassthruAllParametersBody)
+	})
+}
+
+func HandleCreateSubscriptionVendorPassthruRequiredParametersSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/nodes/1234asdf/vendor_passthru", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestFormValues(t, r, map[string]string{"method": "create_subscription"})
+		th.TestJSONRequest(t, r, `
+			{
+			   "Destination" : "https://somedestinationurl"
+			}
+		`)
+
+		fmt.Fprintf(w, NodeCreateSubscriptionVendorPassthruRequiredParametersBody)
+	})
+}
+
+func HandleDeleteSubscriptionVendorPassthruSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/nodes/1234asdf/vendor_passthru", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestFormValues(t, r, map[string]string{"method": "delete_subscription"})
+		th.TestJSONRequest(t, r, `
+			{
+			   "id" : "344a3e2-978a-444e-990a-cbf47c62ef88"
+			}
+		`)
+
+		w.WriteHeader(http.StatusNoContent)
 	})
 }

--- a/openstack/baremetal/v1/nodes/testing/requests_test.go
+++ b/openstack/baremetal/v1/nodes/testing/requests_test.go
@@ -593,3 +593,98 @@ func TestListBIOSSettingsOpts(t *testing.T) {
 	_, err := opts.ToListBIOSSettingsOptsQuery()
 	th.AssertEquals(t, err.Error(), "cannot have both fields and detail options for BIOS settings")
 }
+
+func TestGetVendorPassthruMethods(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleGetVendorPassthruMethodsSuccessfully(t)
+
+	c := client.ServiceClient()
+	actual, err := nodes.GetVendorPassthruMethods(c, "1234asdf").Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, NodeVendorPassthruMethods, *actual)
+}
+
+func TestGetAllSubscriptions(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleGetAllSubscriptionsVendorPassthruSuccessfully(t)
+
+	c := client.ServiceClient()
+	method := nodes.CallVendorPassthruOpts{
+		Method: "get_all_subscriptions",
+	}
+	actual, err := nodes.GetAllSubscriptions(c, "1234asdf", method).Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, NodeGetAllSubscriptions, *actual)
+}
+
+func TestGetSubscription(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleGetSubscriptionVendorPassthruSuccessfully(t)
+
+	c := client.ServiceClient()
+	method := nodes.CallVendorPassthruOpts{
+		Method: "get_subscription",
+	}
+	subscriptionOpt := nodes.GetSubscriptionOpts{
+		Id: "62dbd1b6-f637-11eb-b551-4cd98f20754c",
+	}
+	actual, err := nodes.GetSubscription(c, "1234asdf", method, subscriptionOpt).Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, NodeGetSubscription, *actual)
+}
+
+func TestCreateSubscriptionAllParameters(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleCreateSubscriptionVendorPassthruAllParametersSuccessfully(t)
+
+	c := client.ServiceClient()
+	method := nodes.CallVendorPassthruOpts{
+		Method: "create_subscription",
+	}
+	createOpt := nodes.CreateSubscriptionOpts{
+		Destination: "https://someurl",
+		Context:     "gophercloud",
+		Protocol:    "Redfish",
+		EventTypes:  []string{"Alert"},
+	}
+	actual, err := nodes.CreateSubscription(c, "1234asdf", method, createOpt).Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, NodeCreateSubscriptionAllParameters, *actual)
+}
+
+func TestCreateSubscriptionWithRequiredParameters(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleCreateSubscriptionVendorPassthruRequiredParametersSuccessfully(t)
+
+	c := client.ServiceClient()
+	method := nodes.CallVendorPassthruOpts{
+		Method: "create_subscription",
+	}
+	createOpt := nodes.CreateSubscriptionOpts{
+		Destination: "https://somedestinationurl",
+	}
+	actual, err := nodes.CreateSubscription(c, "1234asdf", method, createOpt).Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, NodeCreateSubscriptionRequiredParameters, *actual)
+}
+
+func TestDeleteSubscription(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleDeleteSubscriptionVendorPassthruSuccessfully(t)
+
+	c := client.ServiceClient()
+	method := nodes.CallVendorPassthruOpts{
+		Method: "delete_subscription",
+	}
+	deleteOpt := nodes.DeleteSubscriptionOpts{
+		Id: "344a3e2-978a-444e-990a-cbf47c62ef88",
+	}
+	err := nodes.DeleteSubscription(c, "1234asdf", method, deleteOpt).ExtractErr()
+	th.AssertNoErr(t, err)
+}

--- a/openstack/baremetal/v1/nodes/urls.go
+++ b/openstack/baremetal/v1/nodes/urls.go
@@ -65,3 +65,11 @@ func biosListSettingsURL(client *gophercloud.ServiceClient, id string) string {
 func biosGetSettingURL(client *gophercloud.ServiceClient, id string, setting string) string {
 	return client.ServiceURL("nodes", id, "bios", setting)
 }
+
+func vendorPassthruMethodsURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL("nodes", id, "vendor_passthru", "methods")
+}
+
+func vendorPassthruCallURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL("nodes", id, "vendor_passthru")
+}


### PR DESCRIPTION
For #1429 
This PR adds support for the following vendor passthru methods:
- create_subscription
- delete_subscription
- get_subscription
- get_all_subscriptions

This methods are only supported by redfish implementations in ironic
that are using the vendor passthru.

Introduced in Ironic in  [change 801064](https://review.opendev.org/c/openstack/ironic/+/801064)