### PR TITLE
Add block volume extension for os-vol-host-attr

### DIFF
--- a/openstack/blockstorage/extensions/volumehost/doc.go
+++ b/openstack/blockstorage/extensions/volumehost/doc.go
@@ -1,0 +1,26 @@
+/*
+Package volumehost provides the ability to extend a volume result with
+information about the Openstack host holding the volume. Example:
+
+	type VolumeWithHost struct {
+		volumes.Volume
+		volumehost.VolumeHostExt
+	}
+
+	var allVolumes []VolumeWithHost
+
+	allPages, err := volumes.List(client, nil).AllPages()
+	if err != nil {
+		panic("Unable to retrieve volumes: %s", err)
+	}
+
+	err = volumes.ExtractVolumesInto(allPages, &allVolumes)
+	if err != nil {
+		panic("Unable to extract volumes: %s", err)
+	}
+
+	for _, volume := range allVolumes {
+		fmt.Println(volume.Host)
+	}
+*/
+package volumehost

--- a/openstack/blockstorage/extensions/volumehost/results.go
+++ b/openstack/blockstorage/extensions/volumehost/results.go
@@ -1,0 +1,7 @@
+package volumehost
+
+// VolumeHostExt is an extension to the base Volume object
+type VolumeHostExt struct {
+	// Host is the identifier of the host holding the volume.
+	Host string `json:"os-vol-host-attr:host"`
+}

--- a/openstack/blockstorage/v3/volumes/testing/fixtures.go
+++ b/openstack/blockstorage/v3/volumes/testing/fixtures.go
@@ -38,7 +38,7 @@ func MockListResponse(t *testing.T) {
       "replication_status": "disabled",
       "os-volume-replication:extended_status": null,
       "encrypted": false,
-      "os-vol-host-attr:host": null,
+      "os-vol-host-attr:host": "host-001",
       "availability_zone": "nova",
       "attachments": [{
         "server_id": "83ec2e3b-4321-422b-8706-a84185f52a0a",
@@ -123,7 +123,6 @@ func MockGetResponse(t *testing.T) {
     "replication_status": "disabled",
     "os-volume-replication:extended_status": null,
     "encrypted": false,
-    "os-vol-host-attr:host": null,
     "availability_zone": "nova",
     "attachments": [{
       "server_id": "83ec2e3b-4321-422b-8706-a84185f52a0a",

--- a/openstack/blockstorage/v3/volumes/testing/requests_test.go
+++ b/openstack/blockstorage/v3/volumes/testing/requests_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/volumehost"
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/volumetenants"
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes"
 	"github.com/gophercloud/gophercloud/pagination"
@@ -103,6 +104,7 @@ func TestListAllWithExtensions(t *testing.T) {
 	type VolumeWithExt struct {
 		volumes.Volume
 		volumetenants.VolumeTenantExt
+		volumehost.VolumeHostExt
 	}
 
 	allPages, err := volumes.List(client.ServiceClient(), &volumes.ListOpts{}).AllPages()
@@ -112,6 +114,8 @@ func TestListAllWithExtensions(t *testing.T) {
 	err = volumes.ExtractVolumesInto(allPages, &actual)
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, 2, len(actual))
+	th.AssertEquals(t, "host-001", actual[0].Host)
+	th.AssertEquals(t, "", actual[1].Host)
 	th.AssertEquals(t, "304dc00909ac4d0da6c62d816bcb3459", actual[0].TenantID)
 }
 


### PR DESCRIPTION
The os-vol-host-attr is returned by OpenStack API;
let's add an extension to allow using this value.

Fixes #2211.