### PR TITLE
compute: Add ServerGroup property to Server

### DIFF
--- a/openstack/compute/v2/servers/results.go
+++ b/openstack/compute/v2/servers/results.go
@@ -221,6 +221,12 @@ type Server struct {
 	// Tags is a slice/list of string tags in a server.
 	// The requires microversion 2.26 or later.
 	Tags *[]string `json:"tags"`
+
+	// ServerGroups is a slice of strings containing the UUIDs of the
+	// server groups to which the server belongs. Currently this can
+	// contain at most one entry.
+	// New in microversion 2.71
+	ServerGroups *[]string `json:"server_groups"`
 }
 
 type AttachedVolume struct {


### PR DESCRIPTION
Add to the Server type the list of server groups the server is part of,
as exposed in microversions 1.71 and above as "server_groups".

For #2216

Here are the docs describing the property of the API object "server": https://docs.openstack.org/api-ref/compute/?expanded=show-server-details-detail#show-server-details

* https://github.com/openstack/nova/blob/d2a5fe5621d6ff1ae8ba5087049e0c4347592cf6/nova/api/openstack/compute/servers.py#L454-L455
* https://github.com/openstack/nova/blob/52cae8801de9229d6cfb7871c2073b83b3e41b81/nova/api/openstack/compute/views/servers.py#L420-L423