### PR TITLE
Image Service v2: Add Updating image.Protected field

### DIFF
--- a/acceptance/openstack/imageservice/v2/images_test.go
+++ b/acceptance/openstack/imageservice/v2/images_test.go
@@ -154,6 +154,7 @@ func TestImagesUpdate(t *testing.T) {
 		images.ReplaceImageName{NewName: image.Name + "foo"},
 		images.ReplaceImageTags{NewTags: newTags},
 		images.ReplaceImageMinDisk{NewMinDisk: 21},
+		images.ReplaceImageProtected{NewProtected: true},
 		images.UpdateImageProperty{
 			Op:    images.AddOp,
 			Name:  "hw_disk_bus",
@@ -172,6 +173,7 @@ func TestImagesUpdate(t *testing.T) {
 	tools.PrintResource(t, newImage.Properties)
 
 	th.AssertEquals(t, newImage.Name, image.Name+"foo")
+	th.AssertEquals(t, newImage.Protected, true)
 
 	sort.Strings(newTags)
 	sort.Strings(newImage.Tags)
@@ -184,4 +186,11 @@ func TestImagesUpdate(t *testing.T) {
 	if _, ok := newImage.Properties["architecture"]; ok {
 		t.Fatal("architecture property still exists")
 	}
+
+	// Now change image protection back to false or delete will fail
+	updateOpts = images.UpdateOpts{
+		images.ReplaceImageProtected{NewProtected: false},
+	}
+	_, err = images.Update(client, image.ID, updateOpts).Extract()
+	th.AssertNoErr(t, err)
 }

--- a/openstack/imageservice/v2/images/requests.go
+++ b/openstack/imageservice/v2/images/requests.go
@@ -373,6 +373,20 @@ func (r ReplaceImageMinRam) ToImagePatchMap() map[string]interface{} {
 	}
 }
 
+// ReplaceImageProtected represents an updated protected property request.
+type ReplaceImageProtected struct {
+	NewProtected bool
+}
+
+// ToImagePatchMap assembles a request body based on ReplaceImageProtected
+func (r ReplaceImageProtected) ToImagePatchMap() map[string]interface{} {
+	return map[string]interface{}{
+		"op":    "replace",
+		"path":  "/protected",
+		"value": r.NewProtected,
+	}
+}
+
 // UpdateOp represents a valid update operation.
 type UpdateOp string
 

--- a/openstack/imageservice/v2/images/testing/fixtures.go
+++ b/openstack/imageservice/v2/images/testing/fixtures.go
@@ -332,6 +332,11 @@ func HandleImageUpdateSuccessfully(t *testing.T) {
 				"value": false
 			},
 			{
+				"op": "replace",
+				"path": "/protected",
+				"value": true
+			},
+			{
 				"op": "add",
 				"path": "/empty_value",
 				"value": ""
@@ -348,6 +353,7 @@ func HandleImageUpdateSuccessfully(t *testing.T) {
 			"status": "active",
 			"visibility": "public",
 			"os_hidden": false,
+			"protected": true,
 			"size": 2254249,
 			"checksum": "2cec138d7dae2aa59038ef8c9aec2390",
 			"tags": [

--- a/openstack/imageservice/v2/images/testing/requests_test.go
+++ b/openstack/imageservice/v2/images/testing/requests_test.go
@@ -266,6 +266,7 @@ func TestUpdateImage(t *testing.T) {
 		images.ReplaceImageMinDisk{NewMinDisk: 21},
 		images.ReplaceImageMinRam{NewMinRam: 1024},
 		images.ReplaceImageHidden{NewHidden: false},
+		images.ReplaceImageProtected{NewProtected: true},
 		images.UpdateImageProperty{
 			Op:    images.AddOp,
 			Name:  "empty_value",
@@ -288,6 +289,7 @@ func TestUpdateImage(t *testing.T) {
 		Status:     images.ImageStatusActive,
 		Visibility: images.ImageVisibilityPublic,
 		Hidden:     false,
+		Protected:  true,
 
 		SizeBytes: sizebytes,
 		Checksum:  checksum,


### PR DESCRIPTION
Now we should be able to do something like:

```
updateOpts := images.UpdateOpts{
    images.ReplaceImageProtected{
        NewProtected: false,
    },
}
image, err = images.Update(client, imageID, updateOpts).Extract()
```

Fixes https://github.com/gophercloud/gophercloud/issues/2220