### PR TITLE
Support HttpHeaders in create_subscription

### DIFF
--- a/openstack/baremetal/v1/nodes/doc.go
+++ b/openstack/baremetal/v1/nodes/doc.go
@@ -182,6 +182,7 @@ Example to create a subscription
 		Context:     "MyContext",
 		Protocol:    "Redfish",
 		EventTypes:  ["Alert"],
+		HttpHeaders: [{"Key1":"Value1"}, {"Key2":"Value2"}],
 	}
 
 	newSubscription, err := nodes.CreateSubscription(client, "a62b8495-52e2-407b-b3cb-62775d04c2b8", method, subscriptionCreateOpt).Extract()

--- a/openstack/baremetal/v1/nodes/requests.go
+++ b/openstack/baremetal/v1/nodes/requests.go
@@ -801,10 +801,11 @@ func DeleteSubscription(client *gophercloud.ServiceClient, id string, method Cal
 
 // The desired subscription to be created from the baremetal node.
 type CreateSubscriptionOpts struct {
-	Destination string   `json:"Destination"`
-	EventTypes  []string `json:"EventTypes,omitempty"`
-	Context     string   `json:"Context,omitempty"`
-	Protocol    string   `json:"Protocol,omitempty"`
+	Destination string              `json:"Destination"`
+	EventTypes  []string            `json:"EventTypes,omitempty"`
+	HttpHeaders []map[string]string `json:"HttpHeaders,omitempty"`
+	Context     string              `json:"Context,omitempty"`
+	Protocol    string              `json:"Protocol,omitempty"`
 }
 
 // ToCreateSubscriptionMap assembles a query based on the contents of CallVendorPassthruOpts and a request body based on the contents of a CreateSubscriptionOpts

--- a/openstack/baremetal/v1/nodes/testing/fixtures.go
+++ b/openstack/baremetal/v1/nodes/testing/fixtures.go
@@ -790,6 +790,7 @@ const NodeCreateSubscriptionVendorPassthruAllParametersBody = `
   "Context": "gophercloud",
   "Destination": "https://someurl",
   "EventTypes": ["Alert"],
+  "HttpHeaders": [{"Context-Type":"application/json"}],
   "Id": "eaa43e2-018a-424e-990a-cbf47c62ef80",
   "Protocol": "Redfish"
 }
@@ -1481,7 +1482,8 @@ func HandleCreateSubscriptionVendorPassthruAllParametersSuccessfully(t *testing.
 		th.TestJSONRequest(t, r, `
 			{
          "Context":      "gophercloud",
-         "EventTypes":    ["Alert"],
+         "EventTypes":   ["Alert"],
+         "HttpHeaders":  [{"Content-Type":"application/json"}],
          "Protocol":     "Redfish",
 			   "Destination" : "https://someurl"
 			}

--- a/openstack/baremetal/v1/nodes/testing/requests_test.go
+++ b/openstack/baremetal/v1/nodes/testing/requests_test.go
@@ -650,6 +650,7 @@ func TestCreateSubscriptionAllParameters(t *testing.T) {
 		Context:     "gophercloud",
 		Protocol:    "Redfish",
 		EventTypes:  []string{"Alert"},
+		HttpHeaders: []map[string]string{{"Content-Type": "application/json"}},
 	}
 	actual, err := nodes.CreateSubscription(c, "1234asdf", method, createOpt).Extract()
 	th.AssertNoErr(t, err)


### PR DESCRIPTION
For #1429

This commit adds support for HttpHeaders in the create_subscription. (#2201)
It was added during the Xena release of Ironic in [1] after the
initial support for create subscriptions [2]

We don't need to modify the response of get_subscription because
redfish doesn't return the value of the HttpHeaders for the enduser.

[1] https://review.opendev.org/c/openstack/ironic/+/806859
[2] https://review.opendev.org/c/openstack/ironic/+/801064