### PR TITLE
Octavia: Add tags on pools

### DIFF
--- a/openstack/loadbalancer/v2/pools/doc.go
+++ b/openstack/loadbalancer/v2/pools/doc.go
@@ -28,6 +28,7 @@ Example to Create a Pool
 		LBMethod:       pools.LBMethodRoundRobin,
 		Protocol:       "HTTP",
 		Name:           "Example pool",
+		Tags:           []string{"test"},
 		LoadbalancerID: "79e05663-7f03-45d2-a092-8b94062f22ab",
 	}
 
@@ -40,8 +41,10 @@ Example to Update a Pool
 
 	poolID := "d67d56a6-4a86-4688-a282-f46444705c64"
 
+	newTags := []string{"prod"}
 	updateOpts := pools.UpdateOpts{
 		Name: "new-name",
+		Tags: &newTags,
 	}
 
 	pool, err := pools.Update(networkClient, poolID, updateOpts).Extract()

--- a/openstack/loadbalancer/v2/pools/requests.go
+++ b/openstack/loadbalancer/v2/pools/requests.go
@@ -135,6 +135,9 @@ type CreateOpts struct {
 	// This is only possible to use when creating a fully populated
 	// Loadbalancer.
 	Monitor *monitors.CreateOpts `json:"healthmonitor,omitempty"`
+
+	// Tags is a set of resource tags. New in version 2.5
+	Tags []string `json:"tags,omitempty"`
 }
 
 // ToPoolCreateMap builds a request body from CreateOpts.
@@ -185,6 +188,9 @@ type UpdateOpts struct {
 	// The administrative state of the Pool. A valid value is true (UP)
 	// or false (DOWN).
 	AdminStateUp *bool `json:"admin_state_up,omitempty"`
+
+	// Tags is a set of resource tags. New in version 2.5
+	Tags *[]string `json:"tags,omitempty"`
 }
 
 // ToPoolUpdateMap builds a request body from UpdateOpts.

--- a/openstack/loadbalancer/v2/pools/results.go
+++ b/openstack/loadbalancer/v2/pools/results.go
@@ -102,6 +102,10 @@ type Pool struct {
 
 	// The operating status of the pool.
 	OperatingStatus string `json:"operating_status"`
+
+	// Tags is a list of resource tags. Tags are arbitrarily defined strings
+	// attached to the resource. New in version 2.5
+	Tags []string `json:"tags"`
 }
 
 // PoolPage is the page returned by a pager when traversing over a


### PR DESCRIPTION
Add support for tags on octavia pools.
For #2236

[Code](https://github.com/openstack/octavia/blob/0b84631948bd3c5eb25a0921d5fbad657036304f/octavia/api/v2/types/pool.py#L82)
