### PR TITLE
Neutron v2: BGP Peer list / get

### DIFF
--- a/openstack/networking/v2/extensions/bgp/peers/doc.go
+++ b/openstack/networking/v2/extensions/bgp/peers/doc.go
@@ -1,0 +1,32 @@
+package peers
+
+/*
+Package peers contains the functionality for working with Neutron bgp peers.
+
+1. List BGP Peers, a.k.a. GET /bgp-peers
+
+Example:
+
+        pages, err := peers.List(c).AllPages()
+        if err != nil {
+                log.Panic(err)
+        }
+        allPeers, err := peers.ExtractBGPPeers(pages)
+        if err != nil {
+                log.Panic(err)
+        }
+
+        for _, peer := range allPeers {
+                log.Printf("%+v", peer)
+        }
+
+2. Get BGP Peer, a.k.a. GET /bgp-peers/{id}
+
+Example:
+        p, err := peers.Get(c, id).Extract()
+
+        if err != nil {
+                log.Panic(err)
+        }
+        log.Printf("%+v", *p)
+*/

--- a/openstack/networking/v2/extensions/bgp/peers/requests.go
+++ b/openstack/networking/v2/extensions/bgp/peers/requests.go
@@ -1,0 +1,21 @@
+package peers
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// List the bgp peers
+func List(c *gophercloud.ServiceClient) pagination.Pager {
+	url := listURL(c)
+	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		return BGPPeerPage{pagination.SinglePageBase(r)}
+	})
+}
+
+// Get retrieve the specific bgp peer by its uuid
+func Get(c *gophercloud.ServiceClient, id string) (r GetResult) {
+	resp, err := c.Get(getURL(c, id), &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}

--- a/openstack/networking/v2/extensions/bgp/peers/results.go
+++ b/openstack/networking/v2/extensions/bgp/peers/results.go
@@ -1,0 +1,78 @@
+package peers
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+const jroot = "bgp_peer"
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// Extract is a function that accepts a result and extracts a bgp peer resource.
+func (r commonResult) Extract() (*BGPPeer, error) {
+	var s BGPPeer
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+func (r commonResult) ExtractInto(v interface{}) error {
+	return r.Result.ExtractIntoStructPtr(v, jroot)
+}
+
+// BGP peer
+type BGPPeer struct {
+	// AuthType of the BGP Speaker
+	AuthType string `json:"auth_type"`
+
+	// UUID for the bgp peer
+	ID string `json:"id"`
+
+	// Human-readable name for the bgp peer. Might not be unique.
+	Name string `json:"name"`
+
+	// TenantID is the project owner of the bgp peer.
+	TenantID string `json:"tenant_id"`
+
+	// The IP addr of the BGP Peer
+	PeerIP string `json:"peer_ip"`
+
+	// ProjectID is the project owner of the bgp peer.
+	ProjectID string `json:"project_id"`
+
+	// Remote Autonomous System
+	RemoteAS int `json:"remote_as"`
+}
+
+// BGPPeerPage is the page returned by a pager when traversing over a
+// collection of bgp peers.
+type BGPPeerPage struct {
+	pagination.SinglePageBase
+}
+
+// IsEmpty checks whether a BGPPage struct is empty.
+func (r BGPPeerPage) IsEmpty() (bool, error) {
+	is, err := ExtractBGPPeers(r)
+	return len(is) == 0, err
+}
+
+// ExtractBGPPeers accepts a Page struct, specifically a BGPPeerPage struct,
+// and extracts the elements into a slice of BGPPeer structs. In other words,
+// a generic collection is mapped into a relevant slice.
+func ExtractBGPPeers(r pagination.Page) ([]BGPPeer, error) {
+	var s []BGPPeer
+	err := ExtractBGPPeersInto(r, &s)
+	return s, err
+}
+
+func ExtractBGPPeersInto(r pagination.Page, v interface{}) error {
+	return r.(BGPPeerPage).Result.ExtractIntoSlicePtr(v, "bgp_peers")
+}
+
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a BGPPeer.
+type GetResult struct {
+	commonResult
+}

--- a/openstack/networking/v2/extensions/bgp/peers/testing/doc.go
+++ b/openstack/networking/v2/extensions/bgp/peers/testing/doc.go
@@ -1,0 +1,2 @@
+// Package testing fro bgp peers
+package testing

--- a/openstack/networking/v2/extensions/bgp/peers/testing/fixture.go
+++ b/openstack/networking/v2/extensions/bgp/peers/testing/fixture.go
@@ -1,0 +1,62 @@
+package testing
+
+import "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/bgp/peers"
+
+const ListBGPPeersResult = `
+{
+  "bgp_peers": [
+    {
+      "auth_type": "none",
+      "remote_as": 4321,
+      "name": "testing-peer-1",
+      "tenant_id": "7fa3f96b-17ee-4d1b-8fbf-fe889bb1f1d0",
+      "peer_ip": "1.2.3.4",
+      "project_id": "7fa3f96b-17ee-4d1b-8fbf-fe889bb1f1d0",
+      "id": "afacc0e8-6b66-44e4-be53-a1ef16033ceb"
+    },
+    {
+      "auth_type": "none",
+      "remote_as": 4321,
+      "name": "testing-peer-2",
+      "tenant_id": "7fa3f96b-17ee-4d1b-8fbf-fe889bb1f1d0",
+      "peer_ip": "5.6.7.8",
+      "project_id": "7fa3f96b-17ee-4d1b-8fbf-fe889bb1f1d0",
+      "id": "acd7c4a1-e243-4fe5-80f9-eba8f143ac1d"
+    }
+  ]
+}
+`
+
+var BGPPeer1 = peers.BGPPeer{
+	ID:        "afacc0e8-6b66-44e4-be53-a1ef16033ceb",
+	AuthType:  "none",
+	Name:      "testing-peer-1",
+	TenantID:  "7fa3f96b-17ee-4d1b-8fbf-fe889bb1f1d0",
+	PeerIP:    "1.2.3.4",
+	ProjectID: "7fa3f96b-17ee-4d1b-8fbf-fe889bb1f1d0",
+	RemoteAS:  4321,
+}
+
+var BGPPeer2 = peers.BGPPeer{
+	AuthType:  "none",
+	ID:        "acd7c4a1-e243-4fe5-80f9-eba8f143ac1d",
+	Name:      "testing-peer-2",
+	TenantID:  "7fa3f96b-17ee-4d1b-8fbf-fe889bb1f1d0",
+	PeerIP:    "5.6.7.8",
+	ProjectID: "7fa3f96b-17ee-4d1b-8fbf-fe889bb1f1d0",
+	RemoteAS:  4321,
+}
+
+const GetBGPPeerResult = `
+{
+  "bgp_peer": {
+    "auth_type": "none",
+    "remote_as": 4321,
+    "name": "testing-peer-1",
+    "tenant_id": "7fa3f96b-17ee-4d1b-8fbf-fe889bb1f1d0",
+    "peer_ip": "1.2.3.4",
+    "project_id": "7fa3f96b-17ee-4d1b-8fbf-fe889bb1f1d0",
+    "id": "afacc0e8-6b66-44e4-be53-a1ef16033ceb"
+  }
+}
+`

--- a/openstack/networking/v2/extensions/bgp/peers/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/bgp/peers/testing/requests_test.go
@@ -1,0 +1,60 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	fake "github.com/gophercloud/gophercloud/openstack/networking/v2/common"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/bgp/peers"
+	"github.com/gophercloud/gophercloud/pagination"
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestList(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/bgp-peers",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "GET")
+			th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprintf(w, ListBGPPeersResult)
+		})
+	count := 0
+
+	peers.List(fake.ServiceClient()).EachPage(
+		func(page pagination.Page) (bool, error) {
+			count++
+			actual, err := peers.ExtractBGPPeers(page)
+
+			if err != nil {
+				t.Errorf("Failed to extract BGP Peers: %v", err)
+				return false, nil
+			}
+			expected := []peers.BGPPeer{BGPPeer1, BGPPeer2}
+			th.CheckDeepEquals(t, expected, actual)
+			return true, nil
+		})
+}
+
+func TestGet(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	bgpPeerID := "afacc0e8-6b66-44e4-be53-a1ef16033ceb"
+	th.Mux.HandleFunc("/v2.0/bgp-peers/"+bgpPeerID, func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, GetBGPPeerResult)
+	})
+
+	s, err := peers.Get(fake.ServiceClient(), bgpPeerID).Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, *s, BGPPeer1)
+}

--- a/openstack/networking/v2/extensions/bgp/peers/urls.go
+++ b/openstack/networking/v2/extensions/bgp/peers/urls.go
@@ -1,0 +1,25 @@
+package peers
+
+import "github.com/gophercloud/gophercloud"
+
+const urlBase = "bgp-peers"
+
+// return /v2.0/bgp-peers/{bgp-peer-id}
+func resourceURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL(urlBase, id)
+}
+
+// return /v2.0/bgp-peers
+func rootURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL(urlBase)
+}
+
+// return /v2.0/bgp-peers/{bgp-peer-id}
+func getURL(c *gophercloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
+}
+
+// return /v2.0/bgp-peers
+func listURL(c *gophercloud.ServiceClient) string {
+	return rootURL(c)
+}


### PR DESCRIPTION
Neutron V2: BGP VPNs
For #2209

Add List/Get method for bgp/peers
```
[CL-DESKTOP] 09:51:44 ~/src/github.com/shhgs/gophercloud $ git diff --stat official/master                                                                                                                         
 openstack/networking/v2/extensions/bgp/peers/doc.go                   | 32 ++++++++++++++++++++++++++++++++                                                                                                       
 openstack/networking/v2/extensions/bgp/peers/requests.go              | 21 +++++++++++++++++++++
 openstack/networking/v2/extensions/bgp/peers/results.go               | 78 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 openstack/networking/v2/extensions/bgp/peers/testing/doc.go           |  2 ++
 openstack/networking/v2/extensions/bgp/peers/testing/fixture.go       | 62 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 openstack/networking/v2/extensions/bgp/peers/testing/requests_test.go | 59 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 openstack/networking/v2/extensions/bgp/peers/urls.go                  | 25 +++++++++++++++++++++++++
 7 files changed, 279 insertions(+)
```