### PR TITLE
Fix openstack/common/extension doc examples

### DIFF
--- a/openstack/clustering/v1/actions/doc.go
+++ b/openstack/clustering/v1/actions/doc.go
@@ -15,7 +15,7 @@ Example to List Actions
 		}
 
 		for _, actionInfo := range actionInfos {
-			fmt.Println("%+v\n", actionInfo)
+			fmt.Printf("%+v\n", actionInfo)
 		}
 		return true, nil
 	})

--- a/openstack/clustering/v1/events/doc.go
+++ b/openstack/clustering/v1/events/doc.go
@@ -15,7 +15,7 @@ Example to List Events
 		}
 
 		for _, eventInfo := range eventInfos {
-			fmt.Println("%+v\n", eventInfo)
+			fmt.Printf("%+v\n", eventInfo)
 		}
 		return true, nil
 	})

--- a/openstack/clustering/v1/profiletypes/doc.go
+++ b/openstack/clustering/v1/profiletypes/doc.go
@@ -11,7 +11,7 @@ Example to List ProfileType
 		}
 
 		for _, profileType := range profileTypes {
-			fmt.Println("%+v\n", profileType)
+			fmt.Printf("%+v\n", profileType)
 		}
 		return true, nil
 	})

--- a/openstack/common/extensions/doc.go
+++ b/openstack/common/extensions/doc.go
@@ -30,7 +30,7 @@ Example of Retrieving Compute Extensions
 	allExtensions, err := extensions.ExtractExtensions(allPages)
 
 	for _, extension := range allExtensions{
-		fmt.Println("%+v\n", extension)
+		fmt.Printf("%+v\n", extension)
 	}
 
 
@@ -46,7 +46,7 @@ Example of Retrieving Network Extensions
 	allExtensions, err := extensions.ExtractExtensions(allPages)
 
 	for _, extension := range allExtensions{
-		fmt.Println("%+v\n", extension)
+		fmt.Printf("%+v\n", extension)
 	}
 */
 package extensions

--- a/openstack/networking/v2/extensions/external/doc.go
+++ b/openstack/networking/v2/extensions/external/doc.go
@@ -29,7 +29,7 @@ Example to List Networks with External Information
 	}
 
 	for _, network := range allNetworks {
-		fmt.Println("%+v\n", network)
+		fmt.Printf("%+v\n", network)
 	}
 
 Example to Create a Network with External Information

--- a/openstack/networking/v2/extensions/portsecurity/doc.go
+++ b/openstack/networking/v2/extensions/portsecurity/doc.go
@@ -26,7 +26,7 @@ Example to List Networks with Port Security Information
 	}
 
 	for _, network := range allNetworks {
-		fmt.Println("%+v\n", network)
+		fmt.Printf("%+v\n", network)
 	}
 
 Example to Create a Network without Port Security
@@ -51,7 +51,7 @@ Example to Create a Network without Port Security
 		panic(err)
 	}
 
-	fmt.Println("%+v\n", networkWithPortSecurityExt)
+	fmt.Printf("%+v\n", networkWithPortSecurityExt)
 
 Example to Disable Port Security on an Existing Network
 
@@ -73,7 +73,7 @@ Example to Disable Port Security on an Existing Network
 		panic(err)
 	}
 
-	fmt.Println("%+v\n", networkWithPortSecurityExt)
+	fmt.Printf("%+v\n", networkWithPortSecurityExt)
 
 Example to Get a Port with Port Security Information
 
@@ -89,7 +89,7 @@ Example to Get a Port with Port Security Information
 		panic(err)
 	}
 
-	fmt.Println("%+v\n", portWithPortSecurityExtensions)
+	fmt.Printf("%+v\n", portWithPortSecurityExtensions)
 
 Example to Create a Port Without Port Security
 
@@ -117,7 +117,7 @@ Example to Create a Port Without Port Security
 		panic(err)
 	}
 
-	fmt.Println("%+v\n", portWithPortSecurityExtensions)
+	fmt.Printf("%+v\n", portWithPortSecurityExtensions)
 
 Example to Disable Port Security on an Existing Port
 
@@ -140,6 +140,6 @@ Example to Disable Port Security on an Existing Port
 		panic(err)
 	}
 
-	fmt.Println("%+v\n", portWithPortSecurityExtensions)
+	fmt.Printf("%+v\n", portWithPortSecurityExtensions)
 */
 package portsecurity

--- a/openstack/networking/v2/extensions/vlantransparent/doc.go
+++ b/openstack/networking/v2/extensions/vlantransparent/doc.go
@@ -29,7 +29,7 @@ Example of Listing Networks with the vlan-transparent extension
     }
 
     for _, network := range allNetworks {
-        fmt.Println("%+v\n", network)
+        fmt.Printf("%+v\n", network)
 	}
 
 Example of Getting a Network with the vlan-transparent extension
@@ -44,7 +44,7 @@ Example of Getting a Network with the vlan-transparent extension
 		panic(err)
 	}
 
-	fmt.Println("%+v\n", network)
+	fmt.Printf("%+v\n", network)
 
 Example of Creating Network with the vlan-transparent extension
 
@@ -68,7 +68,7 @@ Example of Creating Network with the vlan-transparent extension
 		panic(err)
 	}
 
-	fmt.Println("%+v\n", network)
+	fmt.Printf("%+v\n", network)
 
 Example of Updating Network with the vlan-transparent extension
 
@@ -92,6 +92,6 @@ Example of Updating Network with the vlan-transparent extension
 		panic(err)
 	}
 
-	fmt.Println("%+v\n", network)
+	fmt.Printf("%+v\n", network)
 */
 package vlantransparent


### PR DESCRIPTION
Fix calls to pagination.Pager.AllPages() in `openstack/common/extension` doc examples and also fix formatting error with `fmt.Println()`.

For #2242