### PR TITLE
Add ability to handle 502 and 504 errors

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -156,7 +156,7 @@ type ErrDefault500 struct {
 	ErrUnexpectedResponseCode
 }
 
-// ErrDefault500 is the default error type returned on a 502 HTTP response code.
+// ErrDefault502 is the default error type returned on a 502 HTTP response code.
 type ErrDefault502 struct {
 	ErrUnexpectedResponseCode
 }

--- a/errors.go
+++ b/errors.go
@@ -156,8 +156,18 @@ type ErrDefault500 struct {
 	ErrUnexpectedResponseCode
 }
 
+// ErrDefault500 is the default error type returned on a 502 HTTP response code.
+type ErrDefault502 struct {
+	ErrUnexpectedResponseCode
+}
+
 // ErrDefault503 is the default error type returned on a 503 HTTP response code.
 type ErrDefault503 struct {
+	ErrUnexpectedResponseCode
+}
+
+// ErrDefault504 is the default error type returned on a 504 HTTP response code.
+type ErrDefault504 struct {
 	ErrUnexpectedResponseCode
 }
 
@@ -198,9 +208,15 @@ func (e ErrDefault429) Error() string {
 func (e ErrDefault500) Error() string {
 	return "Internal Server Error"
 }
+func (e ErrDefault502) Error() string {
+	return "Bad Gateway"
+}
 func (e ErrDefault503) Error() string {
 	return "The service is currently unable to handle the request due to a temporary" +
 		" overloading or maintenance. This is a temporary condition. Try again later."
+}
+func (e ErrDefault504) Error() string {
+	return "Gateway Timeout"
 }
 
 // Err400er is the interface resource error types implement to override the error message
@@ -257,10 +273,22 @@ type Err500er interface {
 	Error500(ErrUnexpectedResponseCode) error
 }
 
+// Err502er is the interface resource error types implement to override the error message
+// from a 502 error.
+type Err502er interface {
+	Error502(ErrUnexpectedResponseCode) error
+}
+
 // Err503er is the interface resource error types implement to override the error message
 // from a 503 error.
 type Err503er interface {
 	Error503(ErrUnexpectedResponseCode) error
+}
+
+// Err504er is the interface resource error types implement to override the error message
+// from a 504 error.
+type Err504er interface {
+	Error504(ErrUnexpectedResponseCode) error
 }
 
 // ErrTimeOut is the error type returned when an operations times out.

--- a/provider_client.go
+++ b/provider_client.go
@@ -556,10 +556,20 @@ func (client *ProviderClient) doRequest(method, url string, options *RequestOpts
 			if error500er, ok := errType.(Err500er); ok {
 				err = error500er.Error500(respErr)
 			}
+		case http.StatusBadGateway:
+			err = ErrDefault502{respErr}
+			if error502er, ok := errType.(Err502er); ok {
+				err = error502er.Error502(respErr)
+			}
 		case http.StatusServiceUnavailable:
 			err = ErrDefault503{respErr}
 			if error503er, ok := errType.(Err503er); ok {
 				err = error503er.Error503(respErr)
+			}
+		case http.StatusGatewayTimeout:
+			err = ErrDefault504{respErr}
+			if error504er, ok := errType.(Err504er); ok {
+				err = error504er.Error504(respErr)
 			}
 		}
 

--- a/testing/errors_test.go
+++ b/testing/errors_test.go
@@ -7,19 +7,37 @@ import (
 	th "github.com/gophercloud/gophercloud/testhelper"
 )
 
-func TestGetResponseCode(t *testing.T) {
-	respErr := gophercloud.ErrUnexpectedResponseCode{
+func returnsUnexpectedResp(code int) gophercloud.ErrUnexpectedResponseCode {
+	return gophercloud.ErrUnexpectedResponseCode{
 		URL:            "http://example.com",
 		Method:         "GET",
 		Expected:       []int{200},
-		Actual:         404,
+		Actual:         code,
 		Body:           nil,
 		ResponseHeader: nil,
 	}
+}
 
-	var err404 error = gophercloud.ErrDefault404{ErrUnexpectedResponseCode: respErr}
+func TestGetResponseCode404(t *testing.T) {
+	var err404 error = gophercloud.ErrDefault404{ErrUnexpectedResponseCode: returnsUnexpectedResp(404)}
 
 	err, ok := err404.(gophercloud.StatusCodeError)
 	th.AssertEquals(t, true, ok)
 	th.AssertEquals(t, err.GetStatusCode(), 404)
+}
+
+func TestGetResponseCode502(t *testing.T) {
+	var err502 error = gophercloud.ErrDefault502{ErrUnexpectedResponseCode: returnsUnexpectedResp(502)}
+
+	err, ok := err502.(gophercloud.StatusCodeError)
+	th.AssertEquals(t, true, ok)
+	th.AssertEquals(t, err.GetStatusCode(), 502)
+}
+
+func TestGetResponseCode504(t *testing.T) {
+	var err504 error = gophercloud.ErrDefault504{ErrUnexpectedResponseCode: returnsUnexpectedResp(504)}
+
+	err, ok := err504.(gophercloud.StatusCodeError)
+	th.AssertEquals(t, true, ok)
+	th.AssertEquals(t, err.GetStatusCode(), 504)
 }


### PR DESCRIPTION
This change introduces additional types to handle 502 Bad Gateway and 504 Gateway Timeout http errors

For #2244 
Related terraform-provider-openstack/terraform-provider-openstack#1303
