### PR TITLE
fix(octavia): PUT l7policy success response code is 202, not 200 (closes #2254)

### DIFF
--- a/openstack/loadbalancer/v2/l7policies/requests.go
+++ b/openstack/loadbalancer/v2/l7policies/requests.go
@@ -219,7 +219,7 @@ func Update(c *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r 
 		return
 	}
 	resp, err := c.Put(resourceURL(c, id), b, &r.Body, &gophercloud.RequestOpts{
-		OkCodes: []int{200},
+		OkCodes: []int{202},
 	})
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/loadbalancer/v2/l7policies/testing/fixtures.go
+++ b/openstack/loadbalancer/v2/l7policies/testing/fixtures.go
@@ -261,6 +261,7 @@ func HandleL7PolicyUpdateSuccessfully(t *testing.T) {
 			}
 		}`)
 
+		w.WriteHeader(http.StatusAccepted)
 		fmt.Fprintf(w, PostUpdateL7PolicyBody)
 	})
 }
@@ -279,6 +280,7 @@ func HandleL7PolicyUpdateNullRedirectURLSuccessfully(t *testing.T) {
 			}
 		}`)
 
+		w.WriteHeader(http.StatusAccepted)
 		fmt.Fprintf(w, PostUpdateL7PolicyNullRedirectURLBody)
 	})
 }


### PR DESCRIPTION
For #2254

Links to the line numbers/files in the OpenStack source code that support the code in this PR:

https://docs.openstack.org/api-ref/load-balancer/v2/index.html?expanded=update-a-l7-policy-detail#update-a-l7-policy
