### PR TITLE
Use keyword to automatically close related issue

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -4,7 +4,7 @@ Prior to starting a PR, please make sure you have read our
 Prior to a PR being reviewed, there needs to be a Github issue that the PR
 addresses. Replace the brackets and text below with that issue number.
 
-For #[PUT ISSUE NUMBER HERE]
+Fixes #[PUT ISSUE NUMBER HERE]
 
 Links to the line numbers/files in the OpenStack source code that support the
 code in this PR:


### PR DESCRIPTION
There are multiple keywords to close related issue when merging a pull
request [1], and `For` wasn't one of them.

[1] https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

Fixes #2269