### PR TITLE
zuul/networking job: enable Neutron Dynamic Routing service

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -76,8 +76,10 @@
         - acceptance/openstack/networking/v2/extensions/subnetpools
         - acceptance/openstack/networking/v2/extensions/trunks
         - acceptance/openstack/networking/v2/extensions/vlantransparent
+      devstack_projects: 'openstack/neutron-dynamic-routing'
       devstack_services:
         - designate
+        - neutron-dynamic-routing
         - neutron-ext
         - octavia
 


### PR DESCRIPTION
It'll be useful when we'll start testing
https://github.com/gophercloud/gophercloud/pull/2241.

This patch will install devstack with dynamic routing on the networking
job.
