### PR TITLE
service_client: Accept per-call Context

### DIFF
--- a/context.go
+++ b/context.go
@@ -1,0 +1,100 @@
+package gophercloud
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+type mergeContext struct {
+	child  context.Context
+	parent context.Context
+	ch     chan struct{}
+
+	sync.Mutex
+	err error
+}
+
+func idempotentlyClose(ch chan struct{}) {
+	select {
+	case <-ch:
+	default:
+		close(ch)
+	}
+}
+
+// MergeContext returns a copy of ctx that also obeys a second parent.
+// MergeContext always returns a non-nil context.Context.
+func MergeContext(child, parent context.Context) (context.Context, context.CancelFunc) {
+	if child == nil {
+		if parent == nil {
+			return context.WithCancel(context.Background())
+		}
+		return context.WithCancel(parent)
+	}
+	if parent == nil {
+		return context.WithCancel(child)
+	}
+
+	ch := make(chan struct{})
+	cancelCh := make(chan struct{})
+
+	go func() {
+		select {
+		case <-child.Done():
+		case <-parent.Done():
+		case <-cancelCh:
+		}
+		close(ch)
+	}()
+
+	return &mergeContext{
+		child:  child,
+		parent: parent,
+		ch:     ch,
+	}, func() { idempotentlyClose(cancelCh) }
+}
+
+// Value returns Context's value for the key, or parent's if nil.
+func (ctx *mergeContext) Value(key interface{}) interface{} {
+	if v := ctx.child.Value(key); v != nil {
+		return v
+	}
+	return ctx.parent.Value(key)
+}
+
+// Done returns a channel that is closed when either Context's or parent's is.
+func (ctx *mergeContext) Done() <-chan struct{} {
+	return ctx.ch
+}
+
+// Err returns Context's Err(), or parent's if nil. After Err returns a
+// non-nil error, successive calls to Err return the same error.
+func (ctx *mergeContext) Err() error {
+	ctx.Lock()
+	defer ctx.Unlock()
+
+	if ctx.err == nil {
+		if err := ctx.child.Err(); err != nil {
+			ctx.err = err
+		} else {
+			ctx.err = ctx.parent.Err()
+		}
+	}
+	return ctx.err
+}
+
+// Deadline returns the closest deadline, if any.
+func (ctx *mergeContext) Deadline() (deadline time.Time, ok bool) {
+	if d1, ok := ctx.child.Deadline(); ok {
+		if d2, ok := ctx.parent.Deadline(); ok {
+			if d1.Before(d2) {
+				return d1, ok
+			} else {
+				return d2, ok
+			}
+		}
+		return d1, ok
+	}
+	return ctx.parent.Deadline()
+}

--- a/testing/context_test.go
+++ b/testing/context_test.go
@@ -1,0 +1,364 @@
+package testing
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gophercloud/gophercloud"
+)
+
+func TestContext(t *testing.T) {
+	t.Run("cancellation", func(t *testing.T) {
+		t.Run("cancel is idempotent", func(t *testing.T) {
+			ctx1, cancel1 := context.WithCancel(context.Background())
+			defer cancel1()
+			ctx2, cancel2 := context.WithCancel(context.Background())
+			defer cancel2()
+			mergedCtx, cancelMergedCtx := gophercloud.MergeContext(ctx1, ctx2)
+			defer cancelMergedCtx()
+
+			cancelMergedCtx()
+			cancel1()
+			cancel2()
+			cancelMergedCtx()
+
+			time.Sleep(time.Millisecond)
+
+			cancelMergedCtx()
+
+			select {
+			case <-mergedCtx.Done():
+			default:
+				t.Errorf("expected mergedCtx to have been cancelled")
+			}
+		})
+
+		t.Run("nothing cancelled", func(t *testing.T) {
+			ctx1, cancel1 := context.WithCancel(context.Background())
+			defer cancel1()
+			ctx2, cancel2 := context.WithCancel(context.Background())
+			defer cancel2()
+			mergedCtx, cancelMergedCtx := gophercloud.MergeContext(ctx1, ctx2)
+			defer cancelMergedCtx()
+
+			time.Sleep(time.Millisecond)
+
+			select {
+			case <-mergedCtx.Done():
+				t.Errorf("expected mergedCtx to not have been cancelled")
+			default:
+			}
+		})
+
+		t.Run("cancel ctx1", func(t *testing.T) {
+			ctx1, cancel1 := context.WithCancel(context.Background())
+			defer cancel1()
+			ctx2, cancel2 := context.WithCancel(context.Background())
+			defer cancel2()
+			mergedCtx, cancelMergedCtx := gophercloud.MergeContext(ctx1, ctx2)
+			defer cancelMergedCtx()
+
+			cancel1()
+			time.Sleep(time.Millisecond)
+
+			select {
+			case <-mergedCtx.Done():
+			default:
+				t.Errorf("expected mergedCtx to have been cancelled")
+			}
+		})
+
+		t.Run("cancel ctx2", func(t *testing.T) {
+			ctx1, cancel1 := context.WithCancel(context.Background())
+			defer cancel1()
+			ctx2, cancel2 := context.WithCancel(context.Background())
+			defer cancel2()
+			mergedCtx, cancelMergedCtx := gophercloud.MergeContext(ctx1, ctx2)
+			defer cancelMergedCtx()
+
+			cancel2()
+			time.Sleep(time.Millisecond)
+
+			select {
+			case <-mergedCtx.Done():
+			default:
+				t.Errorf("expected mergedCtx to have been cancelled")
+			}
+		})
+
+		t.Run("cancel mergeCtx", func(t *testing.T) {
+			ctx1, cancel1 := context.WithCancel(context.Background())
+			defer cancel1()
+			ctx2, cancel2 := context.WithCancel(context.Background())
+			defer cancel2()
+			mergedCtx, cancelMergedCtx := gophercloud.MergeContext(ctx1, ctx2)
+			defer cancelMergedCtx()
+
+			cancelMergedCtx()
+			time.Sleep(time.Millisecond)
+
+			select {
+			case <-mergedCtx.Done():
+			default:
+				t.Errorf("expected mergedCtx to have been cancelled")
+			}
+		})
+	})
+
+	t.Run("deadline", func(t *testing.T) {
+		t.Run("no deadline", func(t *testing.T) {
+			ctx1, cancel1 := context.WithCancel(context.Background())
+			defer cancel1()
+			ctx2, cancel2 := context.WithCancel(context.Background())
+			defer cancel2()
+			mergedCtx, cancelMergedCtx := gophercloud.MergeContext(ctx1, ctx2)
+			defer cancelMergedCtx()
+
+			if d, ok := mergedCtx.Deadline(); ok {
+				t.Errorf("expected mergedCtx to not have deadline, found %q", d)
+			}
+		})
+
+		t.Run("ctx1 has deadline", func(t *testing.T) {
+			t1 := time.Date(1955, time.November, 5, 1, 21, 0, 0, time.Local)
+
+			ctx1, cancel1 := context.WithDeadline(context.Background(), t1)
+			defer cancel1()
+			ctx2, cancel2 := context.WithCancel(context.Background())
+			defer cancel2()
+			mergedCtx, cancelMergedCtx := gophercloud.MergeContext(ctx1, ctx2)
+			defer cancelMergedCtx()
+
+			if d, ok := mergedCtx.Deadline(); ok {
+				if d != t1 {
+					t.Errorf("expected mergedCtx to have deadline %q, found %q", t1, d)
+				}
+			} else {
+				t.Errorf("expected mergedCtx to have deadline, found %q", d)
+			}
+		})
+
+		t.Run("ctx2 has deadline", func(t *testing.T) {
+			t1 := time.Date(1955, time.November, 5, 1, 21, 0, 0, time.Local)
+
+			ctx1, cancel1 := context.WithCancel(context.Background())
+			defer cancel1()
+			ctx2, cancel2 := context.WithDeadline(context.Background(), t1)
+			defer cancel2()
+			mergedCtx, cancelMergedCtx := gophercloud.MergeContext(ctx1, ctx2)
+			defer cancelMergedCtx()
+
+			if d, ok := mergedCtx.Deadline(); ok {
+				if d != t1 {
+					t.Errorf("expected mergedCtx to have deadline %q, found %q", t1, d)
+				}
+			} else {
+				t.Errorf("expected mergedCtx to have deadline, found %q", d)
+			}
+		})
+
+		t.Run("two deadlines, closer is 1", func(t *testing.T) {
+			t1 := time.Date(1955, time.November, 5, 1, 21, 0, 0, time.Local)
+			t2 := time.Date(2015, time.November, 5, 1, 21, 0, 0, time.Local)
+
+			ctx1, cancel1 := context.WithDeadline(context.Background(), t1)
+			defer cancel1()
+			ctx2, cancel2 := context.WithDeadline(context.Background(), t2)
+			defer cancel2()
+			mergedCtx, cancelMergedCtx := gophercloud.MergeContext(ctx1, ctx2)
+			defer cancelMergedCtx()
+
+			if d, ok := mergedCtx.Deadline(); ok {
+				if d != t1 {
+					t.Errorf("expected mergedCtx to have deadline %q, found %q", t1, d)
+				}
+			} else {
+				t.Errorf("expected mergedCtx to have deadline, found %q", d)
+			}
+		})
+
+		t.Run("two deadlines, closer is 2", func(t *testing.T) {
+			t1 := time.Date(1955, time.November, 5, 1, 21, 0, 0, time.Local)
+			t2 := time.Date(2015, time.November, 5, 1, 21, 0, 0, time.Local)
+
+			ctx1, cancel1 := context.WithDeadline(context.Background(), t2)
+			defer cancel1()
+			ctx2, cancel2 := context.WithDeadline(context.Background(), t1)
+			defer cancel2()
+			mergedCtx, cancelMergedCtx := gophercloud.MergeContext(ctx1, ctx2)
+			defer cancelMergedCtx()
+
+			if d, ok := mergedCtx.Deadline(); ok {
+				if d != t1 {
+					t.Errorf("expected mergedCtx to have deadline %q, found %q", t1, d)
+				}
+			} else {
+				t.Errorf("expected mergedCtx to have deadline, found %q", d)
+			}
+		})
+	})
+
+	t.Run("errors", func(t *testing.T) {
+		t.Run("consistently returns the first error, ctx1", func(t *testing.T) {
+			ctx1, cancel1 := context.WithDeadline(context.Background(), time.Now())
+			defer cancel1()
+			ctx2, cancel2 := context.WithCancel(context.Background())
+			defer cancel2()
+			mergedCtx, cancelMergedCtx := gophercloud.MergeContext(ctx1, ctx2)
+			defer cancelMergedCtx()
+
+			timer := time.NewTimer(time.Millisecond)
+			defer timer.Stop()
+
+			select {
+			case <-mergedCtx.Done():
+			case <-timer.C:
+				t.Fatal("mergedCtx did not stop")
+			}
+
+			if want, have := context.DeadlineExceeded, mergedCtx.Err(); want != have {
+				t.Errorf("expected error %q, found %q", want, have)
+			}
+
+			cancel2()
+			if want, have := context.DeadlineExceeded, mergedCtx.Err(); want != have {
+				t.Errorf("expected error to stay %q after the second context is done, found %q", want, have)
+			}
+		})
+
+		t.Run("consistently returns the first error, ctx2", func(t *testing.T) {
+			ctx1, cancel1 := context.WithCancel(context.Background())
+			defer cancel1()
+			ctx2, cancel2 := context.WithDeadline(context.Background(), time.Now())
+			defer cancel2()
+			mergedCtx, cancelMergedCtx := gophercloud.MergeContext(ctx1, ctx2)
+			defer cancelMergedCtx()
+
+			timer := time.NewTimer(time.Millisecond)
+			defer timer.Stop()
+
+			select {
+			case <-mergedCtx.Done():
+			case <-timer.C:
+				t.Fatal("mergedCtx did not stop")
+			}
+
+			if want, have := context.DeadlineExceeded, mergedCtx.Err(); want != have {
+				t.Errorf("expected error %q, found %q", want, have)
+			}
+
+			cancel1()
+			if want, have := context.DeadlineExceeded, mergedCtx.Err(); want != have {
+				t.Errorf("expected error to stay %q after the second context is done, found %q", want, have)
+			}
+		})
+	})
+
+	t.Run("merge", func(t *testing.T) {
+		t.Run("ctx2 nil", func(t *testing.T) {
+			ctx2, cancel2 := context.WithCancel(context.Background())
+			defer cancel2()
+			mergedCtx, cancelMergedCtx := gophercloud.MergeContext(nil, ctx2)
+			defer cancelMergedCtx()
+
+			cancel2()
+			time.Sleep(time.Millisecond)
+
+			select {
+			case <-mergedCtx.Done():
+			default:
+				t.Errorf("expected mergedCtx to have been cancelled")
+			}
+		})
+
+		t.Run("ctx1 nil", func(t *testing.T) {
+			ctx1, cancel1 := context.WithCancel(context.Background())
+			defer cancel1()
+			mergedCtx, cancelMergedCtx := gophercloud.MergeContext(ctx1, nil)
+			defer cancelMergedCtx()
+
+			cancel1()
+			time.Sleep(time.Millisecond)
+
+			select {
+			case <-mergedCtx.Done():
+			default:
+				t.Errorf("expected mergedCtx to have been cancelled")
+			}
+		})
+
+		t.Run("nil nil", func(t *testing.T) {
+			mergedCtx, cancelMergedCtx := gophercloud.MergeContext(nil, nil)
+			defer cancelMergedCtx()
+
+			cancelMergedCtx()
+
+			select {
+			case <-mergedCtx.Done():
+			default:
+				t.Errorf("expected mergedCtx to have been cancelled")
+			}
+		})
+	})
+
+	t.Run("value", func(t *testing.T) {
+		type key string
+		type value string
+		var (
+			key1 key = "this is a key"
+			key2 key = "this is another key"
+			key3 key = "this key is for testing precedence"
+
+			value1           value = "this is a value"
+			value2           value = "this is another value"
+			value3a, value3b value = "this value should be returned", "this value will be overwritten"
+		)
+
+		ctxA := context.WithValue(context.Background(), key1, value1)
+		ctxA = context.WithValue(ctxA, key3, value3a)
+
+		ctxB := context.WithValue(context.Background(), key2, value2)
+		ctxB = context.WithValue(ctxB, key3, value3b)
+
+		mergedCtx, cancelMergedCtx := gophercloud.MergeContext(ctxA, ctxB)
+		defer cancelMergedCtx()
+
+		{
+			var key, want = key1, value1
+			v := mergedCtx.Value(key)
+			if have, ok := v.(value); ok {
+				if want != have {
+					t.Errorf("expected value from child context %q, found %q", want, have)
+				}
+			} else {
+				t.Errorf("expected value from child context %q, found %q", want, v)
+			}
+		}
+
+		{
+			var key, want = key2, value2
+			v := mergedCtx.Value(key)
+			if have, ok := v.(value); ok {
+				if want != have {
+					t.Errorf("expected value from parent context %q, found %q", want, have)
+				}
+			} else {
+				t.Errorf("expected value from parent context %q, found %q", want, v)
+			}
+		}
+
+		{
+			var key, want = key3, value3a
+
+			v := mergedCtx.Value(key)
+			if have, ok := v.(value); ok {
+				if want != have {
+					t.Errorf("expected value from child context %q, found %q", want, have)
+				}
+			} else {
+				t.Errorf("expected value from child context %q, found %q", want, v)
+			}
+		}
+	})
+}

--- a/testing/service_client_test.go
+++ b/testing/service_client_test.go
@@ -1,6 +1,7 @@
 package testing
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -31,4 +32,88 @@ func TestMoreHeaders(t *testing.T) {
 	resp, err := c.Get(fmt.Sprintf("%s/route", th.Endpoint()), nil, nil)
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, resp.Request.Header.Get("custom"), "header")
+}
+
+func TestServiceContext(t *testing.T) {
+	t.Run("copied ServiceClient has original MoreHeaders", func(t *testing.T) {
+		th.SetupHTTP()
+		defer th.TeardownHTTP()
+		th.Mux.HandleFunc("/route", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+
+		var c *gophercloud.ServiceClient
+		{
+			original := new(gophercloud.ServiceClient)
+			original.MoreHeaders = map[string]string{
+				"custom": "header",
+			}
+
+			c = original.WithContext(context.Background())
+		}
+		c.ProviderClient = new(gophercloud.ProviderClient)
+
+		resp, err := c.Get(fmt.Sprintf("%s/route", th.Endpoint()), nil, nil)
+		th.AssertNoErr(t, err)
+		th.AssertEquals(t, resp.Request.Header.Get("custom"), "header")
+	})
+
+	t.Run("original ServiceClient is untouched", func(t *testing.T) {
+		t.Run("context", func(t *testing.T) {
+			th.SetupHTTP()
+			defer th.TeardownHTTP()
+			th.Mux.HandleFunc("/route", func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			})
+
+			original := new(gophercloud.ServiceClient)
+			original.MoreHeaders = map[string]string{
+				"custom": "header",
+			}
+			original.ProviderClient = new(gophercloud.ProviderClient)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+			c := original.WithContext(ctx)
+
+			{
+				_, err := c.Get(fmt.Sprintf("%s/route", th.Endpoint()), nil, nil)
+				th.AssertErr(t, err)
+			}
+
+			{
+				_, err := original.Get(fmt.Sprintf("%s/route", th.Endpoint()), nil, nil)
+				th.AssertNoErr(t, err)
+			}
+		})
+
+		t.Run("headers", func(t *testing.T) {
+			th.SetupHTTP()
+			defer th.TeardownHTTP()
+			th.Mux.HandleFunc("/route", func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			})
+
+			original := new(gophercloud.ServiceClient)
+			original.MoreHeaders = map[string]string{
+				"custom": "header",
+			}
+			original.ProviderClient = new(gophercloud.ProviderClient)
+
+			c := original.WithContext(context.Background())
+			delete(c.MoreHeaders, "custom")
+
+			{
+				resp, err := c.Get(fmt.Sprintf("%s/route", th.Endpoint()), nil, nil)
+				th.AssertNoErr(t, err)
+				th.AssertEquals(t, resp.Request.Header.Get("custom"), "")
+			}
+
+			{
+				resp, err := original.Get(fmt.Sprintf("%s/route", th.Endpoint()), nil, nil)
+				th.AssertNoErr(t, err)
+				th.AssertEquals(t, resp.Request.Header.Get("custom"), "header")
+			}
+		})
+	})
 }


### PR DESCRIPTION
Adds the ability to pass per-call context.Context.
Adds a WithContext method to the ServiceClient, which will return a new
ServiceClient.

The context added to ServiceClient will be used in addition to the
ProviderClient's Context to make HTTP calls.

Example use:

```Go
	ctx := context.Background()
	allPages, err := servers.List(client.WithContext(ctx), servers.ListOpts{}).AllPages()
```

Most of the complexity of this patch is a consequence of the choice to merge the ServiceClient context with the ProviderClient's, instead of just overwriting it. This is another choice that is up for debate.

---

## Alternative B:

```Go
	ctx := context.Background()
	allPages, err := servers.List(client, servers.ListOpts{Context: ctx}).AllPages()
```

However I see one issue with this alternative: not all verbs currently accept an "options". See for example [`servers.Get(client *gophercloud.ServiceClient, id string)`](https://github.com/gophercloud/gophercloud/blob/1069770c51f3c757c6fc065ce3a43414b9db6825/openstack/compute/v2/servers/requests.go#L324). Such a change would not then be backwards-compatible.

---

## Alternative C:

Duplicate every user-facing function with a `WithContext` version

---

## Alternative D:

Wait until the next Major release to change every single user-facing function to accept a Context as the first argument.

---

Any more ideas?

For #1987