### PR TITLE
blockstorage/v3/qos Add Get, Update and Delete Keys

### DIFF
--- a/acceptance/openstack/blockstorage/v3/qos_test.go
+++ b/acceptance/openstack/blockstorage/v3/qos_test.go
@@ -28,6 +28,24 @@ func TestQoS(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.AssertDeepEquals(t, qos2, getQoS2)
 
+	updateOpts := qos.UpdateOpts{
+		Consumer: qos.ConsumerBack,
+		Specs: map[string]string{
+			"read_iops_sec":  "40000",
+			"write_iops_sec": "40000",
+		},
+	}
+
+	expectedQosSpecs := map[string]string{
+		"consumer":       "back-end",
+		"read_iops_sec":  "40000",
+		"write_iops_sec": "40000",
+	}
+
+	updatedQosSpecs, err := qos.Update(client, qos2.ID, updateOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, updatedQosSpecs, expectedQosSpecs)
+
 	listOpts := qos.ListOpts{
 		Limit: 1,
 	}

--- a/acceptance/openstack/blockstorage/v3/qos_test.go
+++ b/acceptance/openstack/blockstorage/v3/qos_test.go
@@ -24,6 +24,10 @@ func TestQoS(t *testing.T) {
 	th.AssertNoErr(t, err)
 	defer DeleteQoS(t, client, qos2)
 
+	getQoS2, err := qos.Get(client, qos2.ID).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, qos2, getQoS2)
+
 	listOpts := qos.ListOpts{
 		Limit: 1,
 	}

--- a/acceptance/openstack/blockstorage/v3/qos_test.go
+++ b/acceptance/openstack/blockstorage/v3/qos_test.go
@@ -28,6 +28,9 @@ func TestQoS(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.AssertDeepEquals(t, qos2, getQoS2)
 
+	err = qos.DeleteKeys(client, qos2.ID, qos.DeleteKeysOpts{"read_iops_sec"}).ExtractErr()
+	th.AssertNoErr(t, err)
+
 	updateOpts := qos.UpdateOpts{
 		Consumer: qos.ConsumerBack,
 		Specs: map[string]string{

--- a/openstack/blockstorage/v3/qos/doc.go
+++ b/openstack/blockstorage/v3/qos/doc.go
@@ -50,5 +50,16 @@ Example to list QoS specifications
 		fmt.Printf("List: %+v\n", qos)
 	}
 
+Example to get a single QoS specification
+
+	qosID := "de075d5e-8afc-4e23-9388-b84a5183d1c0"
+
+	singleQos, err := qos.Get(client, test.ID).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Get: %+v\n", singleQos)
+
 */
 package qos

--- a/openstack/blockstorage/v3/qos/doc.go
+++ b/openstack/blockstorage/v3/qos/doc.go
@@ -72,11 +72,22 @@ Example of updating QoSSpec
 		},
 	}
 
-	specs, err := qos.Update(client, qosID, qosSpecs).Extract()
+	specs, err := qos.Update(client, qosID, updateOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
 	fmt.Printf("%+v\n", specs)
+
+
+Example of deleting specific keys/specs from a QoS
+
+	qosID := "de075d5e-8afc-4e23-9388-b84a5183d1c0"
+
+	keysToDelete := qos.DeleteKeysOpts{"read_iops_sec"}
+	err = qos.DeleteKeys(client, qosID, keysToDelete).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
 
 */
 package qos

--- a/openstack/blockstorage/v3/qos/doc.go
+++ b/openstack/blockstorage/v3/qos/doc.go
@@ -61,5 +61,22 @@ Example to get a single QoS specification
 
 	fmt.Printf("Get: %+v\n", singleQos)
 
+Example of updating QoSSpec
+
+	qosID := "de075d5e-8afc-4e23-9388-b84a5183d1c0"
+
+	updateOpts := qos.UpdateOpts{
+		Consumer: qos.ConsumerBack,
+		Specs: map[string]string{
+			"read_iops_sec": "40000",
+		},
+	}
+
+	specs, err := qos.Update(client, qosID, qosSpecs).Extract()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("%+v\n", specs)
+
 */
 package qos

--- a/openstack/blockstorage/v3/qos/requests.go
+++ b/openstack/blockstorage/v3/qos/requests.go
@@ -209,3 +209,32 @@ func Update(client *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
+
+// DeleteKeysOptsBuilder allows extensions to add additional parameters to the
+// CreateExtraSpecs requests.
+type DeleteKeysOptsBuilder interface {
+	ToDeleteKeysCreateMap() (map[string]interface{}, error)
+}
+
+// DeleteKeysOpts is a string slice that contains keys to be deleted.
+type DeleteKeysOpts []string
+
+// ToDeleteKeysCreateMap assembles a body for a Create request based on
+// the contents of ExtraSpecsOpts.
+func (opts DeleteKeysOpts) ToDeleteKeysCreateMap() (map[string]interface{}, error) {
+	return map[string]interface{}{"keys": opts}, nil
+}
+
+// DeleteKeys will delete the keys/specs from the specified QoS
+func DeleteKeys(client *gophercloud.ServiceClient, qosID string, opts DeleteKeysOptsBuilder) (r DeleteResult) {
+	b, err := opts.ToDeleteKeysCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := client.Put(deleteKeysURL(client, qosID), b, nil, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}

--- a/openstack/blockstorage/v3/qos/requests.go
+++ b/openstack/blockstorage/v3/qos/requests.go
@@ -143,3 +143,13 @@ func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pa
 		return QoSPage{pagination.LinkedPageBase{PageResult: r}}
 	})
 }
+
+// Get retrieves details of a single qos. Use Extract to convert its
+// result into a QoS.
+func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {
+	resp, err := client.Get(getURL(client, id), &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}

--- a/openstack/blockstorage/v3/qos/results.go
+++ b/openstack/blockstorage/v3/qos/results.go
@@ -81,3 +81,19 @@ func ExtractQoS(r pagination.Page) ([]QoS, error) {
 type GetResult struct {
 	commonResult
 }
+
+// Extract interprets any updateResult as qosSpecs, if possible.
+func (r updateResult) Extract() (map[string]string, error) {
+	var s struct {
+		QosSpecs map[string]string `json:"qos_specs"`
+	}
+	err := r.ExtractInto(&s)
+	return s.QosSpecs, err
+}
+
+// updateResult contains the result of a call for (potentially) multiple
+// key-value pairs. Call its Extract method to interpret it as a
+// map[string]interface.
+type updateResult struct {
+	gophercloud.Result
+}

--- a/openstack/blockstorage/v3/qos/results.go
+++ b/openstack/blockstorage/v3/qos/results.go
@@ -75,3 +75,9 @@ func ExtractQoS(r pagination.Page) ([]QoS, error) {
 	err := (r.(QoSPage)).ExtractInto(&s)
 	return s.QoSs, err
 }
+
+// GetResult is the response of a Get operations. Call its Extract method to
+// interpret it as a Flavor.
+type GetResult struct {
+	commonResult
+}

--- a/openstack/blockstorage/v3/qos/testing/fixtures.go
+++ b/openstack/blockstorage/v3/qos/testing/fixtures.go
@@ -173,3 +173,17 @@ func MockUpdateResponse(t *testing.T) {
 		fmt.Fprintf(w, UpdateBody)
 	})
 }
+
+func MockDeleteKeysResponse(t *testing.T) {
+	th.Mux.HandleFunc("/qos-specs/d32019d3-bc6e-4319-9c1d-6722fc136a22/delete_keys", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestJSONRequest(t, r, `{
+			"keys": [
+				"read_iops_sec"
+			]
+		}`)
+
+		w.WriteHeader(http.StatusAccepted)
+	})
+}

--- a/openstack/blockstorage/v3/qos/testing/fixtures.go
+++ b/openstack/blockstorage/v3/qos/testing/fixtures.go
@@ -19,6 +19,15 @@ var createQoSExpected = qos.QoS{
 	},
 }
 
+var getQoSExpected = qos.QoS{
+	ID:       "d32019d3-bc6e-4319-9c1d-6722fc136a22",
+	Name:     "qos-001",
+	Consumer: "front-end",
+	Specs: map[string]string{
+		"read_iops_sec": "20000",
+	},
+}
+
 func MockCreateResponse(t *testing.T) {
 	th.Mux.HandleFunc("/qos-specs", func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "POST")
@@ -103,5 +112,27 @@ func MockListResponse(t *testing.T) {
 		default:
 			t.Fatalf("Unexpected marker: [%s]", marker)
 		}
+	})
+}
+
+func MockGetResponse(t *testing.T) {
+	th.Mux.HandleFunc("/qos-specs/d32019d3-bc6e-4319-9c1d-6722fc136a22", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.Header().Add("Content-Type", "application/json")
+//		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, `
+{
+  "qos_specs": {
+    "id": "d32019d3-bc6e-4319-9c1d-6722fc136a22",
+	"name": "qos-001",
+	"consumer": "front-end",
+	"specs": {
+	  "read_iops_sec": "20000"
+	}
+  }
+}
+    `)
 	})
 }

--- a/openstack/blockstorage/v3/qos/testing/fixtures.go
+++ b/openstack/blockstorage/v3/qos/testing/fixtures.go
@@ -120,7 +120,7 @@ func MockGetResponse(t *testing.T) {
 		th.TestMethod(t, r, "GET")
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 		w.Header().Add("Content-Type", "application/json")
-//		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusOK)
 
 		fmt.Fprintf(w, `
 {
@@ -134,5 +134,42 @@ func MockGetResponse(t *testing.T) {
   }
 }
     `)
+	})
+}
+
+// UpdateBody provides a PUT result of the qos_specs for a QoS
+const UpdateBody = `
+{
+    "qos_specs" : {
+		"consumer": "back-end",
+		"read_iops_sec":  "40000",
+		"write_iops_sec": "40000"
+    }
+}
+`
+
+// UpdateQos is the expected qos_specs returned from PUT on a qos's qos_specs
+var UpdateQos = map[string]string{
+	"consumer":       "back-end",
+	"read_iops_sec":  "40000",
+	"write_iops_sec": "40000",
+}
+
+func MockUpdateResponse(t *testing.T) {
+	th.Mux.HandleFunc("/qos-specs/d32019d3-bc6e-4319-9c1d-6722fc136a22", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, `{
+				"qos_specs": {
+					"consumer": "back-end",
+					"read_iops_sec":  "40000",
+					"write_iops_sec": "40000"
+				}
+			}`)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, UpdateBody)
 	})
 }

--- a/openstack/blockstorage/v3/qos/testing/requests_test.go
+++ b/openstack/blockstorage/v3/qos/testing/requests_test.go
@@ -73,3 +73,14 @@ func TestList(t *testing.T) {
 		t.Errorf("Expected one page, got %d", pages)
 	}
 }
+
+func TestGet(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockGetResponse(t)
+
+	actual, err := qos.Get(client.ServiceClient(), "d32019d3-bc6e-4319-9c1d-6722fc136a22").Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, &createQoSExpected, actual)
+}

--- a/openstack/blockstorage/v3/qos/testing/requests_test.go
+++ b/openstack/blockstorage/v3/qos/testing/requests_test.go
@@ -82,5 +82,24 @@ func TestGet(t *testing.T) {
 
 	actual, err := qos.Get(client.ServiceClient(), "d32019d3-bc6e-4319-9c1d-6722fc136a22").Extract()
 	th.AssertNoErr(t, err)
-	th.CheckDeepEquals(t, &createQoSExpected, actual)
+	th.CheckDeepEquals(t, &getQoSExpected, actual)
+}
+
+func TestUpdate(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	MockUpdateResponse(t)
+
+	updateOpts := qos.UpdateOpts{
+		Consumer: qos.ConsumerBack,
+		Specs: map[string]string{
+			"read_iops_sec":  "40000",
+			"write_iops_sec": "40000",
+		},
+	}
+
+	expected := UpdateQos
+	actual, err := qos.Update(client.ServiceClient(), "d32019d3-bc6e-4319-9c1d-6722fc136a22", updateOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, expected, actual)
 }

--- a/openstack/blockstorage/v3/qos/testing/requests_test.go
+++ b/openstack/blockstorage/v3/qos/testing/requests_test.go
@@ -103,3 +103,13 @@ func TestUpdate(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.CheckDeepEquals(t, expected, actual)
 }
+
+func TestDeleteKeys(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockDeleteKeysResponse(t)
+
+	res := qos.DeleteKeys(client.ServiceClient(), "d32019d3-bc6e-4319-9c1d-6722fc136a22", qos.DeleteKeysOpts{"read_iops_sec"})
+	th.AssertNoErr(t, res.Err)
+}

--- a/openstack/blockstorage/v3/qos/urls.go
+++ b/openstack/blockstorage/v3/qos/urls.go
@@ -2,6 +2,10 @@ package qos
 
 import "github.com/gophercloud/gophercloud"
 
+func getURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL("qos-specs", id)
+}
+
 func createURL(c *gophercloud.ServiceClient) string {
 	return c.ServiceURL("qos-specs")
 }

--- a/openstack/blockstorage/v3/qos/urls.go
+++ b/openstack/blockstorage/v3/qos/urls.go
@@ -21,3 +21,7 @@ func deleteURL(c *gophercloud.ServiceClient, id string) string {
 func updateURL(client *gophercloud.ServiceClient, id string) string {
 	return client.ServiceURL("qos-specs", id)
 }
+
+func deleteKeysURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL("qos-specs", id, "delete_keys")
+}

--- a/openstack/blockstorage/v3/qos/urls.go
+++ b/openstack/blockstorage/v3/qos/urls.go
@@ -17,3 +17,7 @@ func listURL(c *gophercloud.ServiceClient) string {
 func deleteURL(c *gophercloud.ServiceClient, id string) string {
 	return c.ServiceURL("qos-specs", id)
 }
+
+func updateURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL("qos-specs", id)
+}


### PR DESCRIPTION
Partially implements: #2139 

Implements `Get`, `Update` and `DeleteKeys`

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

`Get`: [api docs](https://docs.openstack.org/api-ref/block-storage/v3/?expanded=show-a-qos-specification-details-detail#quality-of-service-qos-specifications-qos-specs), [code](https://github.com/openstack/cinder/blob/393c2e4ad90c05ebf28cc3a2c65811d7e1e0bc18/cinder/volume/qos_specs.py#L241)

`Update`: [api docs](https://docs.openstack.org/api-ref/block-storage/v3/?expanded=set-keys-in-a-qos-specification-detail#quality-of-service-qos-specifications-qos-specs) [schema](https://github.com/openstack/cinder/blob/393c2e4ad90c05ebf28cc3a2c65811d7e1e0bc18/cinder/api/schemas/qos_specs.py#L40), [code](https://github.com/openstack/cinder/blob/393c2e4ad90c05ebf28cc3a2c65811d7e1e0bc18/cinder/volume/qos_specs.py#L70)

`DeleteKeys`: [api docs](https://docs.openstack.org/api-ref/block-storage/v3/?expanded=unset-keys-in-a-qos-specification-detail#quality-of-service-qos-specifications-qos-specs), [schema](https://github.com/openstack/cinder/blob/393c2e4ad90c05ebf28cc3a2c65811d7e1e0bc18/cinder/api/schemas/qos_specs.py#L50), [code](https://github.com/openstack/cinder/blob/393c2e4ad90c05ebf28cc3a2c65811d7e1e0bc18/cinder/volume/qos_specs.py#L127)
