### PR TITLE
Associate, Disassociate, Disassociate_all and ListAssociations for blockstorage/v3/qos

### DIFF
--- a/openstack/blockstorage/v3/qos/doc.go
+++ b/openstack/blockstorage/v3/qos/doc.go
@@ -126,6 +126,23 @@ if err != nil {
 	panic(err)
 }
 
+Example of listing all associations of a QoS
+
+qosID := "de075d5e-8afc-4e23-9388-b84a5183d1c0"
+
+allQosAssociations, err := qos.ListAssociations(client, qosID).AllPages()
+if err != nil {
+	panic(err)
+}
+
+allAssociations, err := qos.ExtractAssociations(allQosAssociations)
+if err != nil {
+	panic(err)
+}
+
+for _, association := range allAssociations {
+	fmt.Printf("Association: %+v\n", association)
+}
 
 */
 package qos

--- a/openstack/blockstorage/v3/qos/doc.go
+++ b/openstack/blockstorage/v3/qos/doc.go
@@ -103,5 +103,20 @@ if err != nil {
 	panic(err)
 }
 
+Example of disassociating a QoS from a volume type
+
+qosID := "de075d5e-8afc-4e23-9388-b84a5183d1c0"
+volID := "b596be6a-0ce9-43fa-804a-5c5e181ede76"
+
+disassociateOpts := qos.DisassociateOpts{
+	VolumeTypeID: volID,
+}
+
+err = qos.Disassociate(client, qosID, disassociateOpts).ExtractErr()
+if err != nil {
+	panic(err)
+}
+
+
 */
 package qos

--- a/openstack/blockstorage/v3/qos/doc.go
+++ b/openstack/blockstorage/v3/qos/doc.go
@@ -89,5 +89,19 @@ Example of deleting specific keys/specs from a QoS
 		panic(err)
 	}
 
+	Example of associating a QoS with a volume type
+
+qosID := "de075d5e-8afc-4e23-9388-b84a5183d1c0"
+volID := "b596be6a-0ce9-43fa-804a-5c5e181ede76"
+
+associateOpts := qos.AssociateOpts{
+	VolumeTypeID: volID,
+}
+
+err = qos.Associate(client, qosID, associateOpts).ExtractErr()
+if err != nil {
+	panic(err)
+}
+
 */
 package qos

--- a/openstack/blockstorage/v3/qos/doc.go
+++ b/openstack/blockstorage/v3/qos/doc.go
@@ -117,6 +117,15 @@ if err != nil {
 	panic(err)
 }
 
+Example of disaassociating a Qos from all volume types
+
+qosID := "de075d5e-8afc-4e23-9388-b84a5183d1c0"
+
+err = qos.DisassociateAll(client, qosID).ExtractErr()
+if err != nil {
+	panic(err)
+}
+
 
 */
 package qos

--- a/openstack/blockstorage/v3/qos/requests.go
+++ b/openstack/blockstorage/v3/qos/requests.go
@@ -238,3 +238,38 @@ func DeleteKeys(client *gophercloud.ServiceClient, qosID string, opts DeleteKeys
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
+
+// AssociateOpitsBuilder allows extensions to define volume type id
+// to the associate query
+type AssociateOptsBuilder interface {
+	ToQosAssociateQuery() (string, error)
+}
+
+// AssociateOpts contains options for associating a QoS with a
+// volume type
+type AssociateOpts struct {
+	VolumeTypeID string `q:"vol_type_id" required:"true"`
+}
+
+// ToQosAssociateQuery formats an AssociateOpts into a query string
+func (opts AssociateOpts) ToQosAssociateQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// Associate will associate a qos with a volute type
+func Associate(client *gophercloud.ServiceClient, qosID string, opts AssociateOptsBuilder) (r AssociateResult) {
+	url := associateURL(client, qosID)
+	query, err := opts.ToQosAssociateQuery()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	url += query
+
+	resp, err := client.Get(url, nil, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}

--- a/openstack/blockstorage/v3/qos/requests.go
+++ b/openstack/blockstorage/v3/qos/requests.go
@@ -308,3 +308,12 @@ func Disassociate(client *gophercloud.ServiceClient, qosID string, opts Disassoc
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
+
+// DisassociateAll will disassociate a qos from all volute types
+func DisassociateAll(client *gophercloud.ServiceClient, qosID string) (r DisassociateAllResult) {
+	resp, err := client.Get(disassociateAllURL(client, qosID), nil, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}

--- a/openstack/blockstorage/v3/qos/requests.go
+++ b/openstack/blockstorage/v3/qos/requests.go
@@ -273,3 +273,38 @@ func Associate(client *gophercloud.ServiceClient, qosID string, opts AssociateOp
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
+
+// DisassociateOpitsBuilder allows extensions to define volume type id
+// to the disassociate query
+type DisassociateOptsBuilder interface {
+	ToQosDisassociateQuery() (string, error)
+}
+
+// DisassociateOpts contains options for disassociating a QoS from a
+// volume type
+type DisassociateOpts struct {
+	VolumeTypeID string `q:"vol_type_id" required:"true"`
+}
+
+// ToQosDisassociateQuery formats a DisassociateOpts into a query string
+func (opts DisassociateOpts) ToQosDisassociateQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// Disassociate will disassociate a qos from a volute type
+func Disassociate(client *gophercloud.ServiceClient, qosID string, opts DisassociateOptsBuilder) (r DisassociateResult) {
+	url := disassociateURL(client, qosID)
+	query, err := opts.ToQosDisassociateQuery()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	url += query
+
+	resp, err := client.Get(url, nil, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}

--- a/openstack/blockstorage/v3/qos/requests.go
+++ b/openstack/blockstorage/v3/qos/requests.go
@@ -317,3 +317,12 @@ func DisassociateAll(client *gophercloud.ServiceClient, qosID string) (r Disasso
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
+
+// ListAssociations retrieves the associations of a QoS.
+func ListAssociations(client *gophercloud.ServiceClient, qosID string) pagination.Pager {
+	url := listAssociationsURL(client, qosID)
+
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return AssociationPage{pagination.SinglePageBase(r)}
+	})
+}

--- a/openstack/blockstorage/v3/qos/results.go
+++ b/openstack/blockstorage/v3/qos/results.go
@@ -97,3 +97,8 @@ func (r updateResult) Extract() (map[string]string, error) {
 type updateResult struct {
 	gophercloud.Result
 }
+
+// AssociateResult contains the response body and error from a Associate request.
+type AssociateResult struct {
+	gophercloud.ErrResult
+}

--- a/openstack/blockstorage/v3/qos/results.go
+++ b/openstack/blockstorage/v3/qos/results.go
@@ -102,3 +102,8 @@ type updateResult struct {
 type AssociateResult struct {
 	gophercloud.ErrResult
 }
+
+// DisassociateResult contains the response body and error from a Disassociate request.
+type DisassociateResult struct {
+	gophercloud.ErrResult
+}

--- a/openstack/blockstorage/v3/qos/results.go
+++ b/openstack/blockstorage/v3/qos/results.go
@@ -107,3 +107,8 @@ type AssociateResult struct {
 type DisassociateResult struct {
 	gophercloud.ErrResult
 }
+
+// DisassociateAllResult contains the response body and error from a DisassociateAll request.
+type DisassociateAllResult struct {
+	gophercloud.ErrResult
+}

--- a/openstack/blockstorage/v3/qos/results.go
+++ b/openstack/blockstorage/v3/qos/results.go
@@ -112,3 +112,33 @@ type DisassociateResult struct {
 type DisassociateAllResult struct {
 	gophercloud.ErrResult
 }
+
+// QoS contains all the information associated with an OpenStack QoS specification.
+type QosAssociation struct {
+	// Name is the name of the associated resource
+	Name string `json:"name"`
+	// Unique identifier of the associated resources
+	ID string `json:"id"`
+	// AssociationType of the QoS Association
+	AssociationType string `json:"association_type"`
+}
+
+// AssociationPage contains a single page of all Associations of a QoS
+type AssociationPage struct {
+	pagination.SinglePageBase
+}
+
+// IsEmpty indicates whether an Association page is empty.
+func (page AssociationPage) IsEmpty() (bool, error) {
+	v, err := ExtractAssociations(page)
+	return len(v) == 0, err
+}
+
+// ExtractAssociations interprets a page of results as a slice of QosAssociations
+func ExtractAssociations(r pagination.Page) ([]QosAssociation, error) {
+	var s struct {
+		QosAssociations []QosAssociation `json:"qos_associations"`
+	}
+	err := (r.(AssociationPage)).ExtractInto(&s)
+	return s.QosAssociations, err
+}

--- a/openstack/blockstorage/v3/qos/testing/fixtures.go
+++ b/openstack/blockstorage/v3/qos/testing/fixtures.go
@@ -195,3 +195,11 @@ func MockAssociateResponse(t *testing.T) {
 		w.WriteHeader(http.StatusAccepted)
 	})
 }
+
+func MockDisassociateResponse(t *testing.T) {
+	th.Mux.HandleFunc("/qos-specs/d32019d3-bc6e-4319-9c1d-6722fc136a22/disassociate", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.WriteHeader(http.StatusAccepted)
+	})
+}

--- a/openstack/blockstorage/v3/qos/testing/fixtures.go
+++ b/openstack/blockstorage/v3/qos/testing/fixtures.go
@@ -211,3 +211,22 @@ func MockDisassociateAllResponse(t *testing.T) {
 		w.WriteHeader(http.StatusAccepted)
 	})
 }
+
+func MockListAssociationsResponse(t *testing.T) {
+	th.Mux.HandleFunc("/qos-specs/d32019d3-bc6e-4319-9c1d-6722fc136a22/associations", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprintf(w, `
+			{
+			  "qos_associations": [
+			    {
+			      "name": 			  "foo",
+				  "id": 			  "2f954bcf047c4ee9b09a37d49ae6db54",
+				  "association_type": "volume_type"
+			    }
+			  ]
+			}
+		`)
+	})
+}

--- a/openstack/blockstorage/v3/qos/testing/fixtures.go
+++ b/openstack/blockstorage/v3/qos/testing/fixtures.go
@@ -187,3 +187,11 @@ func MockDeleteKeysResponse(t *testing.T) {
 		w.WriteHeader(http.StatusAccepted)
 	})
 }
+
+func MockAssociateResponse(t *testing.T) {
+	th.Mux.HandleFunc("/qos-specs/d32019d3-bc6e-4319-9c1d-6722fc136a22/associate", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.WriteHeader(http.StatusAccepted)
+	})
+}

--- a/openstack/blockstorage/v3/qos/testing/fixtures.go
+++ b/openstack/blockstorage/v3/qos/testing/fixtures.go
@@ -203,3 +203,11 @@ func MockDisassociateResponse(t *testing.T) {
 		w.WriteHeader(http.StatusAccepted)
 	})
 }
+
+func MockDisassociateAllResponse(t *testing.T) {
+	th.Mux.HandleFunc("/qos-specs/d32019d3-bc6e-4319-9c1d-6722fc136a22/disassociate_all", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.WriteHeader(http.StatusAccepted)
+	})
+}

--- a/openstack/blockstorage/v3/qos/testing/requests_test.go
+++ b/openstack/blockstorage/v3/qos/testing/requests_test.go
@@ -127,3 +127,17 @@ func TestAssociate(t *testing.T) {
 	res := qos.Associate(client.ServiceClient(), "d32019d3-bc6e-4319-9c1d-6722fc136a22", associateOpts)
 	th.AssertNoErr(t, res.Err)
 }
+
+func TestDisssociate(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockDisassociateResponse(t)
+
+	disassociateOpts := qos.DisassociateOpts{
+		VolumeTypeID: "b596be6a-0ce9-43fa-804a-5c5e181ede76",
+	}
+
+	res := qos.Disassociate(client.ServiceClient(), "d32019d3-bc6e-4319-9c1d-6722fc136a22", disassociateOpts)
+	th.AssertNoErr(t, res.Err)
+}

--- a/openstack/blockstorage/v3/qos/testing/requests_test.go
+++ b/openstack/blockstorage/v3/qos/testing/requests_test.go
@@ -151,3 +151,28 @@ func TestDissasociateAll(t *testing.T) {
 	res := qos.DisassociateAll(client.ServiceClient(), "d32019d3-bc6e-4319-9c1d-6722fc136a22")
 	th.AssertNoErr(t, res.Err)
 }
+
+func TestQosAssociationsList(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockListAssociationsResponse(t)
+
+	expected := []qos.QosAssociation{
+		{
+			Name:            "foo",
+			ID:              "2f954bcf047c4ee9b09a37d49ae6db54",
+			AssociationType: "volume_type",
+		},
+	}
+
+	allPages, err := qos.ListAssociations(client.ServiceClient(), "d32019d3-bc6e-4319-9c1d-6722fc136a22").AllPages()
+	th.AssertNoErr(t, err)
+
+	actual, err := qos.ExtractAssociations(allPages)
+	th.AssertNoErr(t, err)
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("Expected %#v, but was %#v", expected, actual)
+	}
+}

--- a/openstack/blockstorage/v3/qos/testing/requests_test.go
+++ b/openstack/blockstorage/v3/qos/testing/requests_test.go
@@ -141,3 +141,13 @@ func TestDisssociate(t *testing.T) {
 	res := qos.Disassociate(client.ServiceClient(), "d32019d3-bc6e-4319-9c1d-6722fc136a22", disassociateOpts)
 	th.AssertNoErr(t, res.Err)
 }
+
+func TestDissasociateAll(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockDisassociateAllResponse(t)
+
+	res := qos.DisassociateAll(client.ServiceClient(), "d32019d3-bc6e-4319-9c1d-6722fc136a22")
+	th.AssertNoErr(t, res.Err)
+}

--- a/openstack/blockstorage/v3/qos/testing/requests_test.go
+++ b/openstack/blockstorage/v3/qos/testing/requests_test.go
@@ -113,3 +113,17 @@ func TestDeleteKeys(t *testing.T) {
 	res := qos.DeleteKeys(client.ServiceClient(), "d32019d3-bc6e-4319-9c1d-6722fc136a22", qos.DeleteKeysOpts{"read_iops_sec"})
 	th.AssertNoErr(t, res.Err)
 }
+
+func TestAssociate(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockAssociateResponse(t)
+
+	associateOpts := qos.AssociateOpts{
+		VolumeTypeID: "b596be6a-0ce9-43fa-804a-5c5e181ede76",
+	}
+
+	res := qos.Associate(client.ServiceClient(), "d32019d3-bc6e-4319-9c1d-6722fc136a22", associateOpts)
+	th.AssertNoErr(t, res.Err)
+}

--- a/openstack/blockstorage/v3/qos/urls.go
+++ b/openstack/blockstorage/v3/qos/urls.go
@@ -29,3 +29,7 @@ func deleteKeysURL(client *gophercloud.ServiceClient, id string) string {
 func associateURL(client *gophercloud.ServiceClient, id string) string {
 	return client.ServiceURL("qos-specs", id, "associate")
 }
+
+func disassociateURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL("qos-specs", id, "disassociate")
+}

--- a/openstack/blockstorage/v3/qos/urls.go
+++ b/openstack/blockstorage/v3/qos/urls.go
@@ -25,3 +25,7 @@ func updateURL(client *gophercloud.ServiceClient, id string) string {
 func deleteKeysURL(client *gophercloud.ServiceClient, id string) string {
 	return client.ServiceURL("qos-specs", id, "delete_keys")
 }
+
+func associateURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL("qos-specs", id, "associate")
+}

--- a/openstack/blockstorage/v3/qos/urls.go
+++ b/openstack/blockstorage/v3/qos/urls.go
@@ -37,3 +37,7 @@ func disassociateURL(client *gophercloud.ServiceClient, id string) string {
 func disassociateAllURL(client *gophercloud.ServiceClient, id string) string {
 	return client.ServiceURL("qos-specs", id, "disassociate_all")
 }
+
+func listAssociationsURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL("qos-specs", id, "associations")
+}

--- a/openstack/blockstorage/v3/qos/urls.go
+++ b/openstack/blockstorage/v3/qos/urls.go
@@ -33,3 +33,7 @@ func associateURL(client *gophercloud.ServiceClient, id string) string {
 func disassociateURL(client *gophercloud.ServiceClient, id string) string {
 	return client.ServiceURL("qos-specs", id, "disassociate")
 }
+
+func disassociateAllURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL("qos-specs", id, "disassociate_all")
+}


### PR DESCRIPTION
Fixes #2139 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

- [docs](https://docs.openstack.org/api-ref/block-storage/v3/index.html?expanded=create-attachment-detail,associate-qos-specification-with-a-volume-type-detail#quality-of-service-qos-specifications-qos-specs)
- [code](https://github.com/openstack/cinder/blob/393c2e4ad90c05ebf28cc3a2c65811d7e1e0bc18/cinder/volume/qos_specs.py#L150-L230) => Note: Docs are wrong on the return type of ListAssociations, its `association_type` instead of `type` as shown [here](https://github.com/openstack/cinder/blob/393c2e4ad90c05ebf28cc3a2c65811d7e1e0bc18/cinder/volume/qos_specs.py#L165)
