### PR TITLE
Add support for container-infra services

### DIFF
--- a/acceptance/openstack/containerinfra/v1/services_test.go
+++ b/acceptance/openstack/containerinfra/v1/services_test.go
@@ -1,0 +1,30 @@
+//go:build acceptance || containerinfra
+// +build acceptance containerinfra
+
+package v1
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/acceptance/clients"
+	"github.com/gophercloud/gophercloud/acceptance/tools"
+	"github.com/gophercloud/gophercloud/openstack/containerinfra/v1/services"
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestServicesList(t *testing.T) {
+	clients.RequireAdmin(t)
+
+	client, err := clients.NewContainerInfraV1Client()
+	th.AssertNoErr(t, err)
+
+	allPages, err := services.List(client).AllPages()
+	th.AssertNoErr(t, err)
+
+	allServices, err := services.ExtractServices(allPages)
+	th.AssertNoErr(t, err)
+
+	for _, service := range allServices {
+		tools.PrintResource(t, service)
+	}
+}

--- a/openstack/containerinfra/v1/services/doc.go
+++ b/openstack/containerinfra/v1/services/doc.go
@@ -1,0 +1,22 @@
+/*
+Package services returns information about the Magnum services in the
+OpenStack cloud.
+
+Example of Retrieving list of all services
+
+	allPages, err := services.List(serviceClient).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allServices, err := services.ExtractServices(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, service := range allServices {
+		fmt.Printf("%+v\n", service)
+	}
+*/
+
+package services

--- a/openstack/containerinfra/v1/services/requests.go
+++ b/openstack/containerinfra/v1/services/requests.go
@@ -1,0 +1,13 @@
+package services
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+func List(client *gophercloud.ServiceClient) pagination.Pager {
+	url := listURL(client)
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return ServicePage{pagination.SinglePageBase(r)}
+	})
+}

--- a/openstack/containerinfra/v1/services/requests.go
+++ b/openstack/containerinfra/v1/services/requests.go
@@ -5,6 +5,7 @@ import (
 	"github.com/gophercloud/gophercloud/pagination"
 )
 
+// List makes a request against the API to list services.
 func List(client *gophercloud.ServiceClient) pagination.Pager {
 	url := listURL(client)
 	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {

--- a/openstack/containerinfra/v1/services/results.go
+++ b/openstack/containerinfra/v1/services/results.go
@@ -1,0 +1,36 @@
+package services
+
+import (
+	"time"
+
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+type Service struct {
+	Binary         string    `json:"binary"`
+	CreatedAt      time.Time `json:"created_at"`
+	State          string    `json:"state"`
+	ReportCount    int       `json:"report_count"`
+	UpdatedAt      time.Time `json:"updated_at"`
+	Host           string    `json:"host"`
+	Disabled       bool      `json:"disabled"`
+	DisabledReason string    `json:"disabled_reason"`
+	ID             int       `json:"id"`
+}
+
+type ServicePage struct {
+	pagination.SinglePageBase
+}
+
+func (page ServicePage) IsEmpty() (bool, error) {
+	services, err := ExtractServices(page)
+	return len(services) == 0, err
+}
+
+func ExtractServices(r pagination.Page) ([]Service, error) {
+	var s struct {
+		Service []Service `json:"mservices"`
+	}
+	err := (r.(ServicePage)).ExtractInto(&s)
+	return s.Service, err
+}

--- a/openstack/containerinfra/v1/services/testing/fixtures.go
+++ b/openstack/containerinfra/v1/services/testing/fixtures.go
@@ -1,0 +1,104 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gophercloud/gophercloud/openstack/containerinfra/v1/services"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+const ServiceListBody = `
+{
+    "mservices": [
+        {
+            "host": "magnum-conductor-2",
+            "binary": "magnum-conductor",
+            "state": "up",
+            "id": 25,
+            "report_count": 499402,
+            "disabled": false,
+            "disabled_reason": null,
+            "created_at": "2020-11-16T23:35:25+00:00",
+            "updated_at": "2021-12-04T09:28:02+00:00"
+        },
+        {
+            "host": "magnum-conductor-0",
+            "binary": "magnum-conductor",
+            "state": "up",
+            "id": 28,
+            "report_count": 498163,
+            "disabled": false,
+            "disabled_reason": null,
+            "created_at": "2020-11-16T23:35:32+00:00",
+            "updated_at": "2021-12-04T09:28:40+00:00"
+        },
+        {
+            "host": "magnum-conductor-1",
+            "binary": "magnum-conductor",
+            "state": "up",
+            "id": 31,
+            "report_count": 499668,
+            "disabled": false,
+            "disabled_reason": null,
+            "created_at": "2020-11-16T23:35:33+00:00",
+            "updated_at": "2021-12-04T09:28:00+00:00"
+        }
+    ]
+}
+`
+
+var firstCreated, _ = time.Parse(time.RFC3339, "2020-11-16T23:35:25+00:00")
+var firstUpdated, _ = time.Parse(time.RFC3339, "2021-12-04T09:28:02+00:00")
+var FirstFakeService = services.Service{
+	Binary:         "magnum-conductor",
+	Host:           "magnum-conductor-2",
+	State:          "up",
+	ID:             25,
+	ReportCount:    499402,
+	Disabled:       false,
+	DisabledReason: "",
+	CreatedAt:      firstCreated,
+	UpdatedAt:      firstUpdated,
+}
+
+var secondCreated, _ = time.Parse(time.RFC3339, "2020-11-16T23:35:32+00:00")
+var secondUpdated, _ = time.Parse(time.RFC3339, "2021-12-04T09:28:40+00:00")
+var SecondFakeService = services.Service{
+	Host:           "magnum-conductor-0",
+	Binary:         "magnum-conductor",
+	State:          "up",
+	ID:             28,
+	ReportCount:    498163,
+	Disabled:       false,
+	DisabledReason: "",
+	CreatedAt:      secondCreated,
+	UpdatedAt:      secondUpdated,
+}
+
+var thirdCreated, _ = time.Parse(time.RFC3339, "2020-11-16T23:35:33+00:00")
+var thirdUpdated, _ = time.Parse(time.RFC3339, "2021-12-04T09:28:00+00:00")
+var ThirdFakeService = services.Service{
+	Host:           "magnum-conductor-1",
+	Binary:         "magnum-conductor",
+	State:          "up",
+	ID:             31,
+	ReportCount:    499668,
+	Disabled:       false,
+	DisabledReason: "",
+	CreatedAt:      thirdCreated,
+	UpdatedAt:      thirdUpdated,
+}
+
+func HandleListSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/mservices", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprint(w, ServiceListBody)
+	})
+}

--- a/openstack/containerinfra/v1/services/testing/requests_test.go
+++ b/openstack/containerinfra/v1/services/testing/requests_test.go
@@ -1,0 +1,41 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/containerinfra/v1/services"
+	"github.com/gophercloud/gophercloud/pagination"
+	"github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func TestListServices(t *testing.T) {
+	testhelper.SetupHTTP()
+	defer testhelper.TeardownHTTP()
+	HandleListSuccessfully(t)
+
+	pages := 0
+	err := services.List(client.ServiceClient()).EachPage(func(page pagination.Page) (bool, error) {
+		pages++
+
+		actual, err := services.ExtractServices(page)
+		if err != nil {
+			return false, err
+		}
+
+		if len(actual) != 3 {
+			t.Fatalf("Expected 3 services, got %d", len(actual))
+		}
+		testhelper.CheckDeepEquals(t, FirstFakeService, actual[0])
+		testhelper.CheckDeepEquals(t, SecondFakeService, actual[1])
+		testhelper.CheckDeepEquals(t, ThirdFakeService, actual[2])
+
+		return true, nil
+	})
+
+	testhelper.AssertNoErr(t, err)
+
+	if pages != 1 {
+		t.Errorf("Expected 1 page, saw %d", pages)
+	}
+}

--- a/openstack/containerinfra/v1/services/urls.go
+++ b/openstack/containerinfra/v1/services/urls.go
@@ -1,0 +1,7 @@
+package services
+
+import "github.com/gophercloud/gophercloud"
+
+func listURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("mservices")
+}


### PR DESCRIPTION
This patch adds support to be able to list all of the container-infra
sevices over the API.  The unit tests are passing locally as well as
running acceptance tests as well locally.

Fixes #2286 