### PR TITLE
Bump Go to 1.14

### DIFF
--- a/.github/workflows/reauth-retests.yaml
+++ b/.github/workflows/reauth-retests.yaml
@@ -1,0 +1,22 @@
+on: [push, pull_request]
+name: Reauth retests
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version:
+          - "1"
+
+    steps:
+      - name: Setup Go ${{ matrix.go-version }}
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - uses: actions/checkout@v2
+
+      - name: Run reauth retests
+        run: |
+          ./script/unittest

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -7,7 +7,7 @@ jobs:
       fail-fast: false
       matrix:
         go-version:
-          - "1.13"
+          - "1.14"
           - "1"
 
     env:

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -23,7 +23,6 @@ jobs:
 
       - name: Setup environment
         run: |
-          go get golang.org/x/crypto/ssh
           go get github.com/wadey/gocovmerge
           go get golang.org/x/tools/cmd/goimports
 

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -7,7 +7,8 @@ jobs:
       fail-fast: false
       matrix:
         go-version:
-          - "1.15"
+          - "1.13"
+          - "1"
 
     env:
       GO111MODULE: "on"
@@ -24,7 +25,6 @@ jobs:
         run: |
           go get golang.org/x/crypto/ssh
           go get github.com/wadey/gocovmerge
-          go get github.com/mattn/goveralls
           go get golang.org/x/tools/cmd/goimports
 
       - name: Run go vet
@@ -40,3 +40,13 @@ jobs:
       - uses: shogo82148/actions-goveralls@v1
         with:
           path-to-profile: cover.out
+          flag-name: Go-${{ matrix.go-version }}
+          parallel: true
+
+  finish:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: shogo82148/actions-goveralls@v1
+        with:
+          parallel-finished: true

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -2,7 +2,7 @@ on: [push, pull_request]
 name: Unit Testing
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -33,7 +33,6 @@ jobs:
       - name: Run unit tests
         run: |
           ./script/coverage
-          ./script/unittest
           ./script/format
 
       - uses: shogo82148/actions-goveralls@v1

--- a/acceptance/openstack/baremetal/httpbasic/allocations_test.go
+++ b/acceptance/openstack/baremetal/httpbasic/allocations_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || baremetal || allocations
 // +build acceptance baremetal allocations
 
 package httpbasic

--- a/acceptance/openstack/baremetal/httpbasic/ports_test.go
+++ b/acceptance/openstack/baremetal/httpbasic/ports_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || baremetal || ports
 // +build acceptance baremetal ports
 
 package httpbasic

--- a/acceptance/openstack/baremetal/noauth/allocations_test.go
+++ b/acceptance/openstack/baremetal/noauth/allocations_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || baremetal || allocations
 // +build acceptance baremetal allocations
 
 package noauth

--- a/acceptance/openstack/baremetal/noauth/ports_test.go
+++ b/acceptance/openstack/baremetal/noauth/ports_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || baremetal || ports
 // +build acceptance baremetal ports
 
 package noauth

--- a/acceptance/openstack/baremetal/v1/allocations_test.go
+++ b/acceptance/openstack/baremetal/v1/allocations_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || baremetal || allocations
 // +build acceptance baremetal allocations
 
 package v1

--- a/acceptance/openstack/baremetal/v1/nodes_test.go
+++ b/acceptance/openstack/baremetal/v1/nodes_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || baremetal || nodes
 // +build acceptance baremetal nodes
 
 package v1

--- a/acceptance/openstack/baremetal/v1/ports_test.go
+++ b/acceptance/openstack/baremetal/v1/ports_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || baremetal || ports
 // +build acceptance baremetal ports
 
 package v1

--- a/acceptance/openstack/blockstorage/apiversions_test.go
+++ b/acceptance/openstack/blockstorage/apiversions_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || blockstorage
 // +build acceptance blockstorage
 
 package blockstorage

--- a/acceptance/openstack/blockstorage/extensions/backups_test.go
+++ b/acceptance/openstack/blockstorage/extensions/backups_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || blockstorage
 // +build acceptance blockstorage
 
 package extensions

--- a/acceptance/openstack/blockstorage/extensions/schedulerhints_test.go
+++ b/acceptance/openstack/blockstorage/extensions/schedulerhints_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || blockstorage
 // +build acceptance blockstorage
 
 package extensions

--- a/acceptance/openstack/blockstorage/extensions/schedulerstats_test.go
+++ b/acceptance/openstack/blockstorage/extensions/schedulerstats_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || blockstorage
 // +build acceptance blockstorage
 
 package extensions

--- a/acceptance/openstack/blockstorage/extensions/services_test.go
+++ b/acceptance/openstack/blockstorage/extensions/services_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || blockstorage
 // +build acceptance blockstorage
 
 package extensions

--- a/acceptance/openstack/blockstorage/extensions/volumeactions_test.go
+++ b/acceptance/openstack/blockstorage/extensions/volumeactions_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || blockstorage
 // +build acceptance blockstorage
 
 package extensions

--- a/acceptance/openstack/blockstorage/extensions/volumetenants_test.go
+++ b/acceptance/openstack/blockstorage/extensions/volumetenants_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || blockstorage
 // +build acceptance blockstorage
 
 package extensions

--- a/acceptance/openstack/blockstorage/noauth/snapshots_test.go
+++ b/acceptance/openstack/blockstorage/noauth/snapshots_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || blockstorage
 // +build acceptance blockstorage
 
 package noauth

--- a/acceptance/openstack/blockstorage/noauth/volumes_test.go
+++ b/acceptance/openstack/blockstorage/noauth/volumes_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || blockstorage
 // +build acceptance blockstorage
 
 package noauth

--- a/acceptance/openstack/blockstorage/v1/snapshots_test.go
+++ b/acceptance/openstack/blockstorage/v1/snapshots_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || blockstorage
 // +build acceptance blockstorage
 
 package v1

--- a/acceptance/openstack/blockstorage/v1/volumes_test.go
+++ b/acceptance/openstack/blockstorage/v1/volumes_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || blockstorage
 // +build acceptance blockstorage
 
 package v1

--- a/acceptance/openstack/blockstorage/v1/volumetypes_test.go
+++ b/acceptance/openstack/blockstorage/v1/volumetypes_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || blockstorage
 // +build acceptance blockstorage
 
 package v1

--- a/acceptance/openstack/blockstorage/v2/snapshots_test.go
+++ b/acceptance/openstack/blockstorage/v2/snapshots_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || blockstorage
 // +build acceptance blockstorage
 
 package v2

--- a/acceptance/openstack/blockstorage/v2/volumes_test.go
+++ b/acceptance/openstack/blockstorage/v2/volumes_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || blockstorage
 // +build acceptance blockstorage
 
 package v2

--- a/acceptance/openstack/blockstorage/v3/quotaset_test.go
+++ b/acceptance/openstack/blockstorage/v3/quotaset_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || quotasets
 // +build acceptance quotasets
 
 package v3

--- a/acceptance/openstack/blockstorage/v3/snapshots_test.go
+++ b/acceptance/openstack/blockstorage/v3/snapshots_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || blockstorage
 // +build acceptance blockstorage
 
 package v3

--- a/acceptance/openstack/blockstorage/v3/volumeattachments_test.go
+++ b/acceptance/openstack/blockstorage/v3/volumeattachments_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || blockstorage
 // +build acceptance blockstorage
 
 package v3

--- a/acceptance/openstack/blockstorage/v3/volumes_test.go
+++ b/acceptance/openstack/blockstorage/v3/volumes_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || blockstorage
 // +build acceptance blockstorage
 
 package v3

--- a/acceptance/openstack/blockstorage/v3/volumetypes_test.go
+++ b/acceptance/openstack/blockstorage/v3/volumetypes_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || blockstorage
 // +build acceptance blockstorage
 
 package v3

--- a/acceptance/openstack/client_test.go
+++ b/acceptance/openstack/client_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance
 // +build acceptance
 
 package openstack

--- a/acceptance/openstack/clustering/v1/actions_test.go
+++ b/acceptance/openstack/clustering/v1/actions_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || clustering || actions
 // +build acceptance clustering actions
 
 package v1

--- a/acceptance/openstack/clustering/v1/clusters_test.go
+++ b/acceptance/openstack/clustering/v1/clusters_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || clustering || policies
 // +build acceptance clustering policies
 
 package v1

--- a/acceptance/openstack/clustering/v1/events_test.go
+++ b/acceptance/openstack/clustering/v1/events_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || clustering || events
 // +build acceptance clustering events
 
 package v1

--- a/acceptance/openstack/clustering/v1/nodes_test.go
+++ b/acceptance/openstack/clustering/v1/nodes_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || clustering || policies
 // +build acceptance clustering policies
 
 package v1

--- a/acceptance/openstack/clustering/v1/policies_test.go
+++ b/acceptance/openstack/clustering/v1/policies_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || clustering || policies
 // +build acceptance clustering policies
 
 package v1

--- a/acceptance/openstack/clustering/v1/policytypes_test.go
+++ b/acceptance/openstack/clustering/v1/policytypes_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || clustering || policytypes
 // +build acceptance clustering policytypes
 
 package v1

--- a/acceptance/openstack/clustering/v1/profiles_test.go
+++ b/acceptance/openstack/clustering/v1/profiles_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || clustering || policies
 // +build acceptance clustering policies
 
 package v1

--- a/acceptance/openstack/clustering/v1/profiletypes_test.go
+++ b/acceptance/openstack/clustering/v1/profiletypes_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || clustering || profiletypes
 // +build acceptance clustering profiletypes
 
 package v1

--- a/acceptance/openstack/clustering/v1/receivers_test.go
+++ b/acceptance/openstack/clustering/v1/receivers_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || clustering || policies
 // +build acceptance clustering policies
 
 package v1

--- a/acceptance/openstack/clustering/v1/webhooktrigger_test.go
+++ b/acceptance/openstack/clustering/v1/webhooktrigger_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || clustering || webhooks
 // +build acceptance clustering webhooks
 
 package v1

--- a/acceptance/openstack/compute/v2/aggregates_test.go
+++ b/acceptance/openstack/compute/v2/aggregates_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || compute || aggregates
 // +build acceptance compute aggregates
 
 package v2

--- a/acceptance/openstack/compute/v2/attachinterfaces_test.go
+++ b/acceptance/openstack/compute/v2/attachinterfaces_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || compute || servers
 // +build acceptance compute servers
 
 package v2

--- a/acceptance/openstack/compute/v2/availabilityzones_test.go
+++ b/acceptance/openstack/compute/v2/availabilityzones_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || compute || availabilityzones
 // +build acceptance compute availabilityzones
 
 package v2

--- a/acceptance/openstack/compute/v2/bootfromvolume_test.go
+++ b/acceptance/openstack/compute/v2/bootfromvolume_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || compute || bootfromvolume
 // +build acceptance compute bootfromvolume
 
 package v2

--- a/acceptance/openstack/compute/v2/defsecrules_test.go
+++ b/acceptance/openstack/compute/v2/defsecrules_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || compute || defsecrules
 // +build acceptance compute defsecrules
 
 package v2

--- a/acceptance/openstack/compute/v2/diagnostics_test.go
+++ b/acceptance/openstack/compute/v2/diagnostics_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || compute || limits
 // +build acceptance compute limits
 
 package v2

--- a/acceptance/openstack/compute/v2/extension_test.go
+++ b/acceptance/openstack/compute/v2/extension_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || compute || extensions
 // +build acceptance compute extensions
 
 package v2

--- a/acceptance/openstack/compute/v2/flavors_test.go
+++ b/acceptance/openstack/compute/v2/flavors_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || compute || flavors
 // +build acceptance compute flavors
 
 package v2

--- a/acceptance/openstack/compute/v2/floatingip_test.go
+++ b/acceptance/openstack/compute/v2/floatingip_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || compute || servers
 // +build acceptance compute servers
 
 package v2

--- a/acceptance/openstack/compute/v2/hypervisors_test.go
+++ b/acceptance/openstack/compute/v2/hypervisors_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || compute || hypervisors
 // +build acceptance compute hypervisors
 
 package v2

--- a/acceptance/openstack/compute/v2/images_test.go
+++ b/acceptance/openstack/compute/v2/images_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || compute || images
 // +build acceptance compute images
 
 package v2

--- a/acceptance/openstack/compute/v2/instance_actions_test.go
+++ b/acceptance/openstack/compute/v2/instance_actions_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || compute || limits
 // +build acceptance compute limits
 
 package v2

--- a/acceptance/openstack/compute/v2/keypairs_test.go
+++ b/acceptance/openstack/compute/v2/keypairs_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || compute || keypairs
 // +build acceptance compute keypairs
 
 package v2

--- a/acceptance/openstack/compute/v2/limits_test.go
+++ b/acceptance/openstack/compute/v2/limits_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || compute || limits
 // +build acceptance compute limits
 
 package v2

--- a/acceptance/openstack/compute/v2/migrate_test.go
+++ b/acceptance/openstack/compute/v2/migrate_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || compute || servers
 // +build acceptance compute servers
 
 package v2

--- a/acceptance/openstack/compute/v2/network_test.go
+++ b/acceptance/openstack/compute/v2/network_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || compute || servers
 // +build acceptance compute servers
 
 package v2

--- a/acceptance/openstack/compute/v2/quotaset_test.go
+++ b/acceptance/openstack/compute/v2/quotaset_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || compute || quotasets
 // +build acceptance compute quotasets
 
 package v2

--- a/acceptance/openstack/compute/v2/remoteconsoles_test.go
+++ b/acceptance/openstack/compute/v2/remoteconsoles_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || compute || remoteconsoles
 // +build acceptance compute remoteconsoles
 
 package v2

--- a/acceptance/openstack/compute/v2/rescueunrescue_test.go
+++ b/acceptance/openstack/compute/v2/rescueunrescue_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || compute || rescueunrescue
 // +build acceptance compute rescueunrescue
 
 package v2

--- a/acceptance/openstack/compute/v2/secgroup_test.go
+++ b/acceptance/openstack/compute/v2/secgroup_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || compute || secgroups
 // +build acceptance compute secgroups
 
 package v2

--- a/acceptance/openstack/compute/v2/servergroup_test.go
+++ b/acceptance/openstack/compute/v2/servergroup_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || compute || servergroups
 // +build acceptance compute servergroups
 
 package v2

--- a/acceptance/openstack/compute/v2/servers_test.go
+++ b/acceptance/openstack/compute/v2/servers_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || compute || servers
 // +build acceptance compute servers
 
 package v2

--- a/acceptance/openstack/compute/v2/services_test.go
+++ b/acceptance/openstack/compute/v2/services_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || compute || services
 // +build acceptance compute services
 
 package v2

--- a/acceptance/openstack/compute/v2/tenantnetworks_test.go
+++ b/acceptance/openstack/compute/v2/tenantnetworks_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || compute || servers
 // +build acceptance compute servers
 
 package v2

--- a/acceptance/openstack/compute/v2/usage_test.go
+++ b/acceptance/openstack/compute/v2/usage_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || compute || usage
 // +build acceptance compute usage
 
 package v2

--- a/acceptance/openstack/compute/v2/volumeattach_test.go
+++ b/acceptance/openstack/compute/v2/volumeattach_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || compute || volumeattach
 // +build acceptance compute volumeattach
 
 package v2

--- a/acceptance/openstack/container/v1/capsules_test.go
+++ b/acceptance/openstack/container/v1/capsules_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || containers || capsules
 // +build acceptance containers capsules
 
 package v1

--- a/acceptance/openstack/containerinfra/v1/certificates_test.go
+++ b/acceptance/openstack/containerinfra/v1/certificates_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || containerinfra
 // +build acceptance containerinfra
 
 package v1

--- a/acceptance/openstack/containerinfra/v1/clusters_test.go
+++ b/acceptance/openstack/containerinfra/v1/clusters_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || containerinfra
 // +build acceptance containerinfra
 
 package v1

--- a/acceptance/openstack/containerinfra/v1/clustertemplates_test.go
+++ b/acceptance/openstack/containerinfra/v1/clustertemplates_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || containerinfra
 // +build acceptance containerinfra
 
 package v1

--- a/acceptance/openstack/containerinfra/v1/nodegroups_test.go
+++ b/acceptance/openstack/containerinfra/v1/nodegroups_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || containerinfra
 // +build acceptance containerinfra
 
 package v1

--- a/acceptance/openstack/containerinfra/v1/quotas_test.go
+++ b/acceptance/openstack/containerinfra/v1/quotas_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || containerinfra
 // +build acceptance containerinfra
 
 package v1

--- a/acceptance/openstack/db/v1/configurations_test.go
+++ b/acceptance/openstack/db/v1/configurations_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || db
 // +build acceptance db
 
 package v1

--- a/acceptance/openstack/db/v1/databases_test.go
+++ b/acceptance/openstack/db/v1/databases_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || db
 // +build acceptance db
 
 package v1

--- a/acceptance/openstack/db/v1/flavors_test.go
+++ b/acceptance/openstack/db/v1/flavors_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || db
 // +build acceptance db
 
 package v1

--- a/acceptance/openstack/db/v1/instances_test.go
+++ b/acceptance/openstack/db/v1/instances_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || db
 // +build acceptance db
 
 package v1

--- a/acceptance/openstack/db/v1/users_test.go
+++ b/acceptance/openstack/db/v1/users_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || db
 // +build acceptance db
 
 package v1

--- a/acceptance/openstack/dns/v2/recordsets_test.go
+++ b/acceptance/openstack/dns/v2/recordsets_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance
 // +build acceptance
 
 package v2

--- a/acceptance/openstack/dns/v2/transfers_test.go
+++ b/acceptance/openstack/dns/v2/transfers_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || dns || transfers
 // +build acceptance dns transfers
 
 package v2

--- a/acceptance/openstack/dns/v2/zones_test.go
+++ b/acceptance/openstack/dns/v2/zones_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || dns || zones
 // +build acceptance dns zones
 
 package v2

--- a/acceptance/openstack/identity/v2/extension_test.go
+++ b/acceptance/openstack/identity/v2/extension_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || identity
 // +build acceptance identity
 
 package v2

--- a/acceptance/openstack/identity/v2/role_test.go
+++ b/acceptance/openstack/identity/v2/role_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || identity || roles
 // +build acceptance identity roles
 
 package v2

--- a/acceptance/openstack/identity/v2/tenant_test.go
+++ b/acceptance/openstack/identity/v2/tenant_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || identity
 // +build acceptance identity
 
 package v2

--- a/acceptance/openstack/identity/v2/token_test.go
+++ b/acceptance/openstack/identity/v2/token_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || identity
 // +build acceptance identity
 
 package v2

--- a/acceptance/openstack/identity/v2/user_test.go
+++ b/acceptance/openstack/identity/v2/user_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || identity
 // +build acceptance identity
 
 package v2

--- a/acceptance/openstack/identity/v3/applicationcredentials_test.go
+++ b/acceptance/openstack/identity/v3/applicationcredentials_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance
 // +build acceptance
 
 package v3

--- a/acceptance/openstack/identity/v3/credentials_test.go
+++ b/acceptance/openstack/identity/v3/credentials_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance
 // +build acceptance
 
 package v3

--- a/acceptance/openstack/identity/v3/domains_test.go
+++ b/acceptance/openstack/identity/v3/domains_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance
 // +build acceptance
 
 package v3

--- a/acceptance/openstack/identity/v3/ec2credentials_test.go
+++ b/acceptance/openstack/identity/v3/ec2credentials_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance
 // +build acceptance
 
 package v3

--- a/acceptance/openstack/identity/v3/endpoint_test.go
+++ b/acceptance/openstack/identity/v3/endpoint_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance
 // +build acceptance
 
 package v3

--- a/acceptance/openstack/identity/v3/groups_test.go
+++ b/acceptance/openstack/identity/v3/groups_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance
 // +build acceptance
 
 package v3

--- a/acceptance/openstack/identity/v3/oauth1_test.go
+++ b/acceptance/openstack/identity/v3/oauth1_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance
 // +build acceptance
 
 package v3

--- a/acceptance/openstack/identity/v3/policies_test.go
+++ b/acceptance/openstack/identity/v3/policies_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance
 // +build acceptance
 
 package v3

--- a/acceptance/openstack/identity/v3/projects_test.go
+++ b/acceptance/openstack/identity/v3/projects_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance
 // +build acceptance
 
 package v3

--- a/acceptance/openstack/identity/v3/reauth_test.go
+++ b/acceptance/openstack/identity/v3/reauth_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance
 // +build acceptance
 
 package v3

--- a/acceptance/openstack/identity/v3/regions_test.go
+++ b/acceptance/openstack/identity/v3/regions_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance
 // +build acceptance
 
 package v3

--- a/acceptance/openstack/identity/v3/roles_test.go
+++ b/acceptance/openstack/identity/v3/roles_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance
 // +build acceptance
 
 package v3

--- a/acceptance/openstack/identity/v3/service_test.go
+++ b/acceptance/openstack/identity/v3/service_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance
 // +build acceptance
 
 package v3

--- a/acceptance/openstack/identity/v3/token_test.go
+++ b/acceptance/openstack/identity/v3/token_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance
 // +build acceptance
 
 package v3

--- a/acceptance/openstack/identity/v3/trusts_test.go
+++ b/acceptance/openstack/identity/v3/trusts_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || identity || trusts
 // +build acceptance identity trusts
 
 package v3

--- a/acceptance/openstack/identity/v3/users_test.go
+++ b/acceptance/openstack/identity/v3/users_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance
 // +build acceptance
 
 package v3

--- a/acceptance/openstack/imageservice/v2/imageimport_test.go
+++ b/acceptance/openstack/imageservice/v2/imageimport_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || imageservice || imageimport
 // +build acceptance imageservice imageimport
 
 package v2

--- a/acceptance/openstack/imageservice/v2/images_test.go
+++ b/acceptance/openstack/imageservice/v2/images_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || imageservice || images
 // +build acceptance imageservice images
 
 package v2

--- a/acceptance/openstack/imageservice/v2/tasks_test.go
+++ b/acceptance/openstack/imageservice/v2/tasks_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || imageservice || tasks
 // +build acceptance imageservice tasks
 
 package v2

--- a/acceptance/openstack/keymanager/v1/acls_test.go
+++ b/acceptance/openstack/keymanager/v1/acls_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || keymanager || acls
 // +build acceptance keymanager acls
 
 package v1

--- a/acceptance/openstack/keymanager/v1/containers_test.go
+++ b/acceptance/openstack/keymanager/v1/containers_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || keymanager || containers
 // +build acceptance keymanager containers
 
 package v1

--- a/acceptance/openstack/keymanager/v1/orders_test.go
+++ b/acceptance/openstack/keymanager/v1/orders_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || keymanager || orders
 // +build acceptance keymanager orders
 
 package v1

--- a/acceptance/openstack/keymanager/v1/secrets_test.go
+++ b/acceptance/openstack/keymanager/v1/secrets_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || keymanager || secrets
 // +build acceptance keymanager secrets
 
 package v1

--- a/acceptance/openstack/loadbalancer/v2/amphorae_test.go
+++ b/acceptance/openstack/loadbalancer/v2/amphorae_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || containers || capsules
 // +build acceptance containers capsules
 
 package v2

--- a/acceptance/openstack/loadbalancer/v2/l7policies_test.go
+++ b/acceptance/openstack/loadbalancer/v2/l7policies_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || networking || loadbalancer || l7policies
 // +build acceptance networking loadbalancer l7policies
 
 package v2

--- a/acceptance/openstack/loadbalancer/v2/listeners_test.go
+++ b/acceptance/openstack/loadbalancer/v2/listeners_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || networking || loadbalancer || listeners
 // +build acceptance networking loadbalancer listeners
 
 package v2

--- a/acceptance/openstack/loadbalancer/v2/loadbalancers_test.go
+++ b/acceptance/openstack/loadbalancer/v2/loadbalancers_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || networking || loadbalancer || loadbalancers
 // +build acceptance networking loadbalancer loadbalancers
 
 package v2

--- a/acceptance/openstack/loadbalancer/v2/monitors_test.go
+++ b/acceptance/openstack/loadbalancer/v2/monitors_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || networking || loadbalancer || monitors
 // +build acceptance networking loadbalancer monitors
 
 package v2

--- a/acceptance/openstack/loadbalancer/v2/pools_test.go
+++ b/acceptance/openstack/loadbalancer/v2/pools_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || networking || loadbalancer || pools
 // +build acceptance networking loadbalancer pools
 
 package v2

--- a/acceptance/openstack/loadbalancer/v2/providers_test.go
+++ b/acceptance/openstack/loadbalancer/v2/providers_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || networking || loadbalancer || providers
 // +build acceptance networking loadbalancer providers
 
 package v2

--- a/acceptance/openstack/loadbalancer/v2/quotas_test.go
+++ b/acceptance/openstack/loadbalancer/v2/quotas_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || networking || loadbalancer || quotas
 // +build acceptance networking loadbalancer quotas
 
 package v2

--- a/acceptance/openstack/messaging/v2/claims_test.go
+++ b/acceptance/openstack/messaging/v2/claims_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || messaging || claims
 // +build acceptance messaging claims
 
 package v2

--- a/acceptance/openstack/messaging/v2/message_test.go
+++ b/acceptance/openstack/messaging/v2/message_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || messaging || messages
 // +build acceptance messaging messages
 
 package v2

--- a/acceptance/openstack/messaging/v2/queue_test.go
+++ b/acceptance/openstack/messaging/v2/queue_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || messaging || queues
 // +build acceptance messaging queues
 
 package v2

--- a/acceptance/openstack/networking/v2/apiversion_test.go
+++ b/acceptance/openstack/networking/v2/apiversion_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || networking
 // +build acceptance networking
 
 package v2

--- a/acceptance/openstack/networking/v2/extension_test.go
+++ b/acceptance/openstack/networking/v2/extension_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || networking || extensions
 // +build acceptance networking extensions
 
 package v2

--- a/acceptance/openstack/networking/v2/extensions/agents/agents_test.go
+++ b/acceptance/openstack/networking/v2/extensions/agents/agents_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || networking || agents
 // +build acceptance networking agents
 
 package agents

--- a/acceptance/openstack/networking/v2/extensions/attributestags_test.go
+++ b/acceptance/openstack/networking/v2/extensions/attributestags_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || networking || tags
 // +build acceptance networking tags
 
 package extensions

--- a/acceptance/openstack/networking/v2/extensions/dns/dns_test.go
+++ b/acceptance/openstack/networking/v2/extensions/dns/dns_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || networking
 // +build acceptance networking
 
 package dns

--- a/acceptance/openstack/networking/v2/extensions/fwaas/firewall_test.go
+++ b/acceptance/openstack/networking/v2/extensions/fwaas/firewall_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || networking || fwaas
 // +build acceptance networking fwaas
 
 package fwaas

--- a/acceptance/openstack/networking/v2/extensions/fwaas/policy_test.go
+++ b/acceptance/openstack/networking/v2/extensions/fwaas/policy_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || networking || fwaas
 // +build acceptance networking fwaas
 
 package fwaas

--- a/acceptance/openstack/networking/v2/extensions/fwaas/rule_test.go
+++ b/acceptance/openstack/networking/v2/extensions/fwaas/rule_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || networking || fwaas
 // +build acceptance networking fwaas
 
 package fwaas

--- a/acceptance/openstack/networking/v2/extensions/fwaas_v2/groups_test.go
+++ b/acceptance/openstack/networking/v2/extensions/fwaas_v2/groups_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || networking || fwaas_v2
 // +build acceptance networking fwaas_v2
 
 package fwaas_v2

--- a/acceptance/openstack/networking/v2/extensions/fwaas_v2/policy_test.go
+++ b/acceptance/openstack/networking/v2/extensions/fwaas_v2/policy_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || networking || fwaas_v2
 // +build acceptance networking fwaas_v2
 
 package fwaas_v2

--- a/acceptance/openstack/networking/v2/extensions/fwaas_v2/rule_test.go
+++ b/acceptance/openstack/networking/v2/extensions/fwaas_v2/rule_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || networking || fwaas_v2
 // +build acceptance networking fwaas_v2
 
 package fwaas_v2

--- a/acceptance/openstack/networking/v2/extensions/layer3/addressscopes_test.go
+++ b/acceptance/openstack/networking/v2/extensions/layer3/addressscopes_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || networking || layer3 || addressscopes
 // +build acceptance networking layer3 addressscopes
 
 package layer3

--- a/acceptance/openstack/networking/v2/extensions/layer3/floatingips_test.go
+++ b/acceptance/openstack/networking/v2/extensions/layer3/floatingips_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || networking || layer3 || floatingips
 // +build acceptance networking layer3 floatingips
 
 package layer3

--- a/acceptance/openstack/networking/v2/extensions/layer3/routers_test.go
+++ b/acceptance/openstack/networking/v2/extensions/layer3/routers_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || networking || layer3 || router
 // +build acceptance networking layer3 router
 
 package layer3

--- a/acceptance/openstack/networking/v2/extensions/lbaas/members_test.go
+++ b/acceptance/openstack/networking/v2/extensions/lbaas/members_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || networking || lbaas || member
 // +build acceptance networking lbaas member
 
 package lbaas

--- a/acceptance/openstack/networking/v2/extensions/lbaas/monitors_test.go
+++ b/acceptance/openstack/networking/v2/extensions/lbaas/monitors_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || networking || lbaas || monitors
 // +build acceptance networking lbaas monitors
 
 package lbaas

--- a/acceptance/openstack/networking/v2/extensions/lbaas/pools_test.go
+++ b/acceptance/openstack/networking/v2/extensions/lbaas/pools_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || networking || lbaas || pool
 // +build acceptance networking lbaas pool
 
 package lbaas

--- a/acceptance/openstack/networking/v2/extensions/lbaas/vips_test.go
+++ b/acceptance/openstack/networking/v2/extensions/lbaas/vips_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || networking || lbaas || vip
 // +build acceptance networking lbaas vip
 
 package lbaas

--- a/acceptance/openstack/networking/v2/extensions/lbaas_v2/l7policies_test.go
+++ b/acceptance/openstack/networking/v2/extensions/lbaas_v2/l7policies_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || networking || loadbalancer || l7policies
 // +build acceptance networking loadbalancer l7policies
 
 package lbaas_v2

--- a/acceptance/openstack/networking/v2/extensions/lbaas_v2/listeners_test.go
+++ b/acceptance/openstack/networking/v2/extensions/lbaas_v2/listeners_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || networking || loadbalancer || listeners
 // +build acceptance networking loadbalancer listeners
 
 package lbaas_v2

--- a/acceptance/openstack/networking/v2/extensions/lbaas_v2/loadbalancers_test.go
+++ b/acceptance/openstack/networking/v2/extensions/lbaas_v2/loadbalancers_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || networking || lbaas_v2 || loadbalancers
 // +build acceptance networking lbaas_v2 loadbalancers
 
 package lbaas_v2

--- a/acceptance/openstack/networking/v2/extensions/lbaas_v2/monitors_test.go
+++ b/acceptance/openstack/networking/v2/extensions/lbaas_v2/monitors_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || networking || loadbalancer || monitors
 // +build acceptance networking loadbalancer monitors
 
 package lbaas_v2

--- a/acceptance/openstack/networking/v2/extensions/lbaas_v2/pools_test.go
+++ b/acceptance/openstack/networking/v2/extensions/lbaas_v2/pools_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || networking || loadbalancer || pools
 // +build acceptance networking loadbalancer pools
 
 package lbaas_v2

--- a/acceptance/openstack/networking/v2/extensions/mtu/mtu_test.go
+++ b/acceptance/openstack/networking/v2/extensions/mtu/mtu_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || networking
 // +build acceptance networking
 
 package mtu

--- a/acceptance/openstack/networking/v2/extensions/networkipavailabilities/networkipavailabilities_test.go
+++ b/acceptance/openstack/networking/v2/extensions/networkipavailabilities/networkipavailabilities_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || networking || networkipavailabilities
 // +build acceptance networking networkipavailabilities
 
 package networkipavailabilities

--- a/acceptance/openstack/networking/v2/extensions/portsbinding/portsbinding_test.go
+++ b/acceptance/openstack/networking/v2/extensions/portsbinding/portsbinding_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || networking
 // +build acceptance networking
 
 package portsbinding

--- a/acceptance/openstack/networking/v2/extensions/provider_test.go
+++ b/acceptance/openstack/networking/v2/extensions/provider_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || networking || provider
 // +build acceptance networking provider
 
 package extensions

--- a/acceptance/openstack/networking/v2/extensions/qos/policies/policies_test.go
+++ b/acceptance/openstack/networking/v2/extensions/qos/policies/policies_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || networking || qos || policies
 // +build acceptance networking qos policies
 
 package policies

--- a/acceptance/openstack/networking/v2/extensions/quotas/quotas_test.go
+++ b/acceptance/openstack/networking/v2/extensions/quotas/quotas_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || networking || quotas
 // +build acceptance networking quotas
 
 package quotas

--- a/acceptance/openstack/networking/v2/extensions/rbacpolicies/rbacpolicies_test.go
+++ b/acceptance/openstack/networking/v2/extensions/rbacpolicies/rbacpolicies_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance
 // +build acceptance
 
 package rbacpolicies

--- a/acceptance/openstack/networking/v2/extensions/security_test.go
+++ b/acceptance/openstack/networking/v2/extensions/security_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || networking || security
 // +build acceptance networking security
 
 package extensions

--- a/acceptance/openstack/networking/v2/extensions/subnetpools/subnetpools_test.go
+++ b/acceptance/openstack/networking/v2/extensions/subnetpools/subnetpools_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || networking || subnetpools
 // +build acceptance networking subnetpools
 
 package v2

--- a/acceptance/openstack/networking/v2/extensions/trunks/trunks_test.go
+++ b/acceptance/openstack/networking/v2/extensions/trunks/trunks_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || trunks
 // +build acceptance trunks
 
 package trunks

--- a/acceptance/openstack/networking/v2/extensions/vlantransparent/vlantransparent_test.go
+++ b/acceptance/openstack/networking/v2/extensions/vlantransparent/vlantransparent_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || networking || vlantransparent
 // +build acceptance networking vlantransparent
 
 package v2

--- a/acceptance/openstack/networking/v2/extensions/vpnaas/group_test.go
+++ b/acceptance/openstack/networking/v2/extensions/vpnaas/group_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || networking || vpnaas
 // +build acceptance networking vpnaas
 
 package vpnaas

--- a/acceptance/openstack/networking/v2/extensions/vpnaas/ikepolicy_test.go
+++ b/acceptance/openstack/networking/v2/extensions/vpnaas/ikepolicy_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || networking || vpnaas
 // +build acceptance networking vpnaas
 
 package vpnaas

--- a/acceptance/openstack/networking/v2/extensions/vpnaas/ipsecpolicy_test.go
+++ b/acceptance/openstack/networking/v2/extensions/vpnaas/ipsecpolicy_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || networking || vpnaas
 // +build acceptance networking vpnaas
 
 package vpnaas

--- a/acceptance/openstack/networking/v2/extensions/vpnaas/service_test.go
+++ b/acceptance/openstack/networking/v2/extensions/vpnaas/service_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || networking || fwaas
 // +build acceptance networking fwaas
 
 package vpnaas

--- a/acceptance/openstack/networking/v2/extensions/vpnaas/siteconnection_test.go
+++ b/acceptance/openstack/networking/v2/extensions/vpnaas/siteconnection_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || networking || vpnaas
 // +build acceptance networking vpnaas
 
 package vpnaas

--- a/acceptance/openstack/networking/v2/networks_test.go
+++ b/acceptance/openstack/networking/v2/networks_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || networking
 // +build acceptance networking
 
 package v2

--- a/acceptance/openstack/networking/v2/ports_test.go
+++ b/acceptance/openstack/networking/v2/ports_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || networking
 // +build acceptance networking
 
 package v2

--- a/acceptance/openstack/networking/v2/subnets_test.go
+++ b/acceptance/openstack/networking/v2/subnets_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance || networking
 // +build acceptance networking
 
 package v2

--- a/acceptance/openstack/objectstorage/v1/accounts_test.go
+++ b/acceptance/openstack/objectstorage/v1/accounts_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance
 // +build acceptance
 
 package v1

--- a/acceptance/openstack/objectstorage/v1/containers_test.go
+++ b/acceptance/openstack/objectstorage/v1/containers_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance
 // +build acceptance
 
 package v1

--- a/acceptance/openstack/objectstorage/v1/objects_test.go
+++ b/acceptance/openstack/objectstorage/v1/objects_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance
 // +build acceptance
 
 package v1

--- a/acceptance/openstack/orchestration/v1/buildinfo_test.go
+++ b/acceptance/openstack/orchestration/v1/buildinfo_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance
 // +build acceptance
 
 package v1

--- a/acceptance/openstack/orchestration/v1/stackevents_test.go
+++ b/acceptance/openstack/orchestration/v1/stackevents_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance
 // +build acceptance
 
 package v1

--- a/acceptance/openstack/orchestration/v1/stackresources_test.go
+++ b/acceptance/openstack/orchestration/v1/stackresources_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance
 // +build acceptance
 
 package v1

--- a/acceptance/openstack/orchestration/v1/stacks_test.go
+++ b/acceptance/openstack/orchestration/v1/stacks_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance
 // +build acceptance
 
 package v1

--- a/acceptance/openstack/orchestration/v1/stacktemplates_test.go
+++ b/acceptance/openstack/orchestration/v1/stacktemplates_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance
 // +build acceptance
 
 package v1

--- a/acceptance/openstack/pkg.go
+++ b/acceptance/openstack/pkg.go
@@ -1,3 +1,4 @@
+//go:build acceptance
 // +build acceptance
 
 package openstack

--- a/acceptance/openstack/sharedfilesystems/v2/availabilityzones_test.go
+++ b/acceptance/openstack/sharedfilesystems/v2/availabilityzones_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance
 // +build acceptance
 
 package v2

--- a/acceptance/openstack/sharedfilesystems/v2/securityservices_test.go
+++ b/acceptance/openstack/sharedfilesystems/v2/securityservices_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance
 // +build acceptance
 
 package v2

--- a/acceptance/openstack/sharedfilesystems/v2/sharenetworks_test.go
+++ b/acceptance/openstack/sharedfilesystems/v2/sharenetworks_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance
 // +build acceptance
 
 package v2

--- a/acceptance/openstack/sharedfilesystems/v2/shares_test.go
+++ b/acceptance/openstack/sharedfilesystems/v2/shares_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance
 // +build acceptance
 
 package v2

--- a/acceptance/openstack/sharedfilesystems/v2/sharetypes_test.go
+++ b/acceptance/openstack/sharedfilesystems/v2/sharetypes_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance
 // +build acceptance
 
 package v2

--- a/acceptance/openstack/sharedfilesystems/v2/snapshots_test.go
+++ b/acceptance/openstack/sharedfilesystems/v2/snapshots_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance
 // +build acceptance
 
 package v2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gophercloud/gophercloud
 
-go 1.13
+go 1.14
 
 require (
 	golang.org/x/crypto v0.0.0-20211202192323-5770296d904e


### PR DESCRIPTION
This PR contains several little changes to the test definitions:

* Test against Go 1.14 (the oldest supported version) and Go tip
* Let the Goveralls GH action deal with the Goveralls installation
* Use ubuntu-latest in tests instead of pinning to an arbitrary version
* Remove a (probably) unneeded explicit install of `crypto/ssh`
* Run scripts/unittest in a separate workflow, to increase readability and parallelise work

Additionally, it turns out that we are using in `testhelper` a method that was introduced in Go 1.14. With this PR, I propose to bump the minimum acceptable version of Go to v1.14 in `go.mod`.