### PR TITLE
Add SOURCE_IP_PORT as lb_algorithm

### DIFF
--- a/openstack/loadbalancer/v2/pools/requests.go
+++ b/openstack/loadbalancer/v2/pools/requests.go
@@ -65,6 +65,7 @@ const (
 	LBMethodRoundRobin       LBMethod = "ROUND_ROBIN"
 	LBMethodLeastConnections LBMethod = "LEAST_CONNECTIONS"
 	LBMethodSourceIp         LBMethod = "SOURCE_IP"
+	LBMethodSourceIpPort     LBMethod = "SOURCE_IP_PORT"
 
 	ProtocolTCP   Protocol = "TCP"
 	ProtocolUDP   Protocol = "UDP"
@@ -87,8 +88,8 @@ type CreateOptsBuilder interface {
 // operation.
 type CreateOpts struct {
 	// The algorithm used to distribute load between the members of the pool. The
-	// current specification supports LBMethodRoundRobin, LBMethodLeastConnections
-	// and LBMethodSourceIp as valid values for this attribute.
+	// current specification supports LBMethodRoundRobin, LBMethodLeastConnections,
+	// LBMethodSourceIp and LBMethodSourceIpPort as valid values for this attribute.
 	LBMethod LBMethod `json:"lb_algorithm" required:"true"`
 
 	// The protocol used by the pool members, you can use either
@@ -181,8 +182,8 @@ type UpdateOpts struct {
 	Description *string `json:"description,omitempty"`
 
 	// The algorithm used to distribute load between the members of the pool. The
-	// current specification supports LBMethodRoundRobin, LBMethodLeastConnections
-	// and LBMethodSourceIp as valid values for this attribute.
+	// current specification supports LBMethodRoundRobin, LBMethodLeastConnections,
+	// LBMethodSourceIp and LBMethodSourceIpPort as valid values for this attribute.
 	LBMethod LBMethod `json:"lb_algorithm,omitempty"`
 
 	// The administrative state of the Pool. A valid value is true (UP)


### PR DESCRIPTION
This commit added SOURCE_IP_PORT to lb_algorithm options. It is the only
load balancer algorithm supported by OVN.

Fixes https://github.com/gophercloud/gophercloud/issues/2299

[Reference Doc](https://docs.openstack.org/ovn-octavia-provider/latest/admin/driver.html)
