### PR TITLE
Identity v3: add support for OS-EP-FILTER (endpoint) extension #2303

### DIFF
--- a/acceptance/openstack/identity/v3/projectendpoint_test.go
+++ b/acceptance/openstack/identity/v3/projectendpoint_test.go
@@ -1,0 +1,56 @@
+//go:build acceptance
+// +build acceptance
+
+package v3
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/acceptance/clients"
+	"github.com/gophercloud/gophercloud/acceptance/tools"
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/endpoints"
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/extensions/projectendpoints"
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestProjectEndpoints(t *testing.T) {
+	clients.RequireAdmin(t)
+
+	client, err := clients.NewIdentityV3Client()
+	th.AssertNoErr(t, err)
+
+	// Create a project to assign endpoints.
+	project, err := CreateProject(t, client, nil)
+	th.AssertNoErr(t, err)
+	defer DeleteProject(t, client, project.ID)
+
+	tools.PrintResource(t, project)
+
+	// Get an endpoint
+	allEndpointsPages, err := endpoints.List(client, nil).AllPages()
+	th.AssertNoErr(t, err)
+
+	allEndpoints, err := endpoints.ExtractEndpoints(allEndpointsPages)
+	th.AssertNoErr(t, err)
+	th.AssertIntGreaterOrEqual(t, len(allEndpoints), 1)
+	endpoint := allEndpoints[0]
+
+	// Attach endpoint
+	err = projectendpoints.Create(client, project.ID, endpoint.ID).Err
+	th.AssertNoErr(t, err)
+
+	// List endpoints
+	allProjectEndpointsPages, err := projectendpoints.List(client, project.ID).AllPages()
+	th.AssertNoErr(t, err)
+
+	allProjectEndpoints, err := projectendpoints.ExtractEndpoints(allProjectEndpointsPages)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, 1, len(allProjectEndpoints))
+
+	tools.PrintResource(t, allProjectEndpoints[0])
+
+	// Detach endpoint
+	err = projectendpoints.Delete(client, project.ID, endpoint.ID).Err
+	th.AssertNoErr(t, err)
+
+}

--- a/openstack/identity/v3/extensions/projectendpoints/doc.go
+++ b/openstack/identity/v3/extensions/projectendpoints/doc.go
@@ -1,0 +1,27 @@
+/*
+Package endpoints provides information and interaction with the service
+OS-EP-FILTER/endpoints API resource in the OpenStack Identity service.
+
+For more information, see:
+https://docs.openstack.org/api-ref/identity/v3-ext/#list-associations-by-project
+
+Example to List Project Endpoints
+
+	projectD := "e629d6e599d9489fb3ae5d9cc12eaea3"
+
+	allPages, err := projectendpoints.List(identityClient, projectID).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allEndpoints, err := projectendpoints.ExtractEndpoints(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, endpoint := range allEndpoints {
+		fmt.Printf("%+v\n", endpoint)
+	}
+
+*/
+package projectendpoints

--- a/openstack/identity/v3/extensions/projectendpoints/requests.go
+++ b/openstack/identity/v3/extensions/projectendpoints/requests.go
@@ -1,0 +1,33 @@
+package projectendpoints
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+type CreateOptsBuilder interface {
+	ToEndpointCreateMap() (map[string]interface{}, error)
+}
+
+// Create inserts a new Endpoint association to a project.
+func Create(client *gophercloud.ServiceClient, projectID, endpointID string) (r CreateResult) {
+	resp, err := client.Put(createURL(client, projectID, endpointID), nil, nil, &gophercloud.RequestOpts{OkCodes: []int{204}})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// List enumerates endpoints in a paginated collection, optionally filtered
+// by ListOpts criteria.
+func List(client *gophercloud.ServiceClient, projectID string) pagination.Pager {
+	u := listURL(client, projectID)
+	return pagination.NewPager(client, u, func(r pagination.PageResult) pagination.Page {
+		return EndpointPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// Delete removes an endpoint from the service catalog.
+func Delete(client *gophercloud.ServiceClient, projectID string, endpointID string) (r DeleteResult) {
+	resp, err := client.Delete(deleteURL(client, projectID, endpointID), &gophercloud.RequestOpts{OkCodes: []int{204}})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}

--- a/openstack/identity/v3/extensions/projectendpoints/results.go
+++ b/openstack/identity/v3/extensions/projectendpoints/results.go
@@ -1,0 +1,57 @@
+package projectendpoints
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// CreateResult is the response from a Create operation. Call its Extract
+// method to interpret it as an Endpoint.
+type CreateResult struct {
+	gophercloud.ErrResult
+}
+
+// DeleteResult is the response from a Delete operation. Call its ExtractErr
+// method to determine if the call succeeded or failed.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
+// Endpoint describes the entry point for another service's API.
+type Endpoint struct {
+	// ID is the unique ID of the endpoint.
+	ID string `json:"id"`
+
+	// Availability is the interface type of the Endpoint (admin, internal,
+	// or public), referenced by the gophercloud.Availability type.
+	Availability gophercloud.Availability `json:"interface"`
+
+	// Region is the region the Endpoint is located in.
+	Region string `json:"region"`
+
+	// ServiceID is the ID of the service the Endpoint refers to.
+	ServiceID string `json:"service_id"`
+
+	// URL is the url of the Endpoint.
+	URL string `json:"url"`
+}
+
+// EndpointPage is a single page of Endpoint results.
+type EndpointPage struct {
+	pagination.LinkedPageBase
+}
+
+// IsEmpty returns true if no Endpoints were returned.
+func (r EndpointPage) IsEmpty() (bool, error) {
+	es, err := ExtractEndpoints(r)
+	return len(es) == 0, err
+}
+
+// ExtractEndpoints extracts an Endpoint slice from a Page.
+func ExtractEndpoints(r pagination.Page) ([]Endpoint, error) {
+	var s struct {
+		Endpoints []Endpoint `json:"endpoints"`
+	}
+	err := (r.(EndpointPage)).ExtractInto(&s)
+	return s.Endpoints, err
+}

--- a/openstack/identity/v3/extensions/projectendpoints/testing/doc.go
+++ b/openstack/identity/v3/extensions/projectendpoints/testing/doc.go
@@ -1,0 +1,2 @@
+// projectendpoints unit tests
+package testing

--- a/openstack/identity/v3/extensions/projectendpoints/urls.go
+++ b/openstack/identity/v3/extensions/projectendpoints/urls.go
@@ -1,0 +1,15 @@
+package projectendpoints
+
+import "github.com/gophercloud/gophercloud"
+
+func listURL(client *gophercloud.ServiceClient, projectID string) string {
+	return client.ServiceURL("OS-EP-FILTER", "projects", projectID, "endpoints")
+}
+
+func createURL(client *gophercloud.ServiceClient, projectID, endpointID string) string {
+	return client.ServiceURL("OS-EP-FILTER", "projects", projectID, "endpoints", endpointID)
+}
+
+func deleteURL(client *gophercloud.ServiceClient, projectID, endpointID string) string {
+	return client.ServiceURL("OS-EP-FILTER", "projects", projectID, "endpoints", endpointID)
+}


### PR DESCRIPTION
Fixes #2303

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://docs.openstack.org/api-ref/identity/v3-ext/?expanded=list-associations-by-project-detail#list-associations-by-project
https://github.com/openstack/keystone/blob/ba2e4b83e88d5c1576e9d2cd6a760367deef3a62/keystone/api/os_ep_filter.py#L145-L154
