### PR TITLE
[CI-v2] Replace baremetal job with Github Action

### DIFF
--- a/.github/workflows/functional-baremetal.yaml
+++ b/.github/workflows/functional-baremetal.yaml
@@ -1,0 +1,93 @@
+name: functional-baremetal
+on:
+  pull_request:
+    paths:
+      - '^.*baremetal.*$'
+      - '.github/workflows/functional-baremetal.yaml'
+  schedule:
+    - cron: '0 0 * * *'
+jobs:
+  functional-baremetal:
+    strategy:
+      fail-fast: false
+      matrix:
+        name: ["master"]
+        openstack_version: ["master"]
+        ubuntu_version: ["20.04"]
+        include:
+          - name: "xena"
+            openstack_version: "stable/xena"
+            ubuntu_version: "20.04"
+          - name: "wallaby"
+            openstack_version: "stable/wallaby"
+            ubuntu_version: "20.04"
+          - name: "victoria"
+            openstack_version: "stable/victoria"
+            ubuntu_version: "20.04"
+          - name: "ussuri"
+            openstack_version: "stable/ussuri"
+            ubuntu_version: "18.04"
+          - name: "train"
+            openstack_version: "stable/train"
+            ubuntu_version: "18.04"
+    runs-on: ubuntu-${{ matrix.ubuntu_version }}
+    name: Deploy OpenStack ${{ matrix.name }} with Ironic and run baremetal acceptance tests
+    steps:
+      - name: Checkout Gophercloud
+        uses: actions/checkout@v2
+      - name: Deploy devstack
+        uses: EmilienM/devstack-action@v0.6
+        with:
+          branch: ${{ matrix.openstack_version }}
+          conf_overrides: |
+            enable_plugin ironic https://opendev.org/openstack/ironic ${{ matrix.openstack_version }}
+            LIBS_FROM_GIT=pyghmi,virtualbmc
+            FORCE_CONFIG_DRIVE=True
+            Q_AGENT=openvswitch
+            Q_ML2_TENANT_NETWORK_TYPE=vxlan
+            Q_ML2_PLUGIN_MECHANISM_DRIVERS=openvswitch
+            DEFAULT_INSTANCE_TYPE=baremetal
+            OVERRIDE_PUBLIC_BRIDGE_MTU=1400
+            VIRT_DRIVER=ironic
+            BUILD_TIMEOUT=1800
+            SERVICE_TIMEOUT=90
+            GLANCE_LIMIT_IMAGE_SIZE_TOTAL=5000
+            Q_USE_SECGROUP=False
+            API_WORKERS=1
+            IRONIC_BAREMETAL_BASIC_OPS=True
+            IRONIC_BUILD_DEPLOY_RAMDISK=False
+            IRONIC_AUTOMATED_CLEAN_ENABLED=False
+            IRONIC_CALLBACK_TIMEOUT=600
+            IRONIC_DEPLOY_DRIVER=ipmi
+            IRONIC_INSPECTOR_BUILD_RAMDISK=False
+            IRONIC_RAMDISK_TYPE=tinyipa
+            IRONIC_TEMPEST_BUILD_TIMEOUT=720
+            IRONIC_TEMPEST_WHOLE_DISK_IMAGE=False
+            IRONIC_VM_COUNT=1
+            IRONIC_VM_EPHEMERAL_DISK=1
+            IRONIC_VM_LOG_DIR=/opt/stack/new/ironic-bm-logs
+            IRONIC_VM_SPECS_RAM=1024
+            IRONIC_DEFAULT_DEPLOY_INTERFACE=direct
+            IRONIC_ENABLED_DEPLOY_INTERFACES=direct
+            SWIFT_ENABLE_TEMPURLS=True
+            SWIFT_TEMPURL_KEY=secretkey
+          enabled_services: 'ir-api,ir-cond,s-account,s-container,s-object,s-proxy,q-svc,q-agt,q-dhcp,q-l3,q-meta,-cinder,-c-sch,-c-api,-c-vol,-c-bak,-ovn,-ovn-controller,-ovn-northd,-q-ovn-metadata-agent'
+      - name: Checkout go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '^1.15'
+      - name: Run Gophercloud acceptance tests
+        run: ./script/acceptancetest
+        env:
+          DEVSTACK_PATH: ${{ github.workspace }}/devstack
+          ACCEPTANCE_TESTS_FILTER: '^.*baremetal(.(?!noauth).*)?$'
+          OS_BRANCH: ${{ matrix.openstack_version }}
+      - name: Generate logs on failure
+        run: ./script/collectlogs
+        if: failure()
+      - name: Upload logs artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+          name: functional-baremetal-${{ matrix.name }}
+          path: /tmp/devstack-logs/*

--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -106,21 +106,6 @@
         - manila
 
 - job:
-    name: gophercloud-acceptance-test-ironic
-    parent: gophercloud-acceptance-test-base
-    description: |
-      Run gophercloud ironic acceptance test on master branch
-    files:
-      - ^.*baremetal.*$
-    vars:
-      devstack_services:
-        - ironic
-      devstack_override_enabled_services: 'g-api,g-reg,q-agt,q-dhcp,q-l3,q-svc,key,mysql,rabbit,ir-api,ir-cond,s-account,s-container,s-object,s-proxy'
-      devstack_projects: 'openstack/ironic-python-agent-builder openstack/ironic'
-      acceptance_tests:
-        - acceptance/openstack/baremetal/v1
-
-- job:
     name: gophercloud-acceptance-test-compute-ussuri
     parent: gophercloud-acceptance-test-compute
     nodeset: ubuntu-bionic
@@ -490,7 +475,6 @@
         - gophercloud-acceptance-test-compute
         - gophercloud-acceptance-test-networking
         - gophercloud-acceptance-test-storage
-        - gophercloud-acceptance-test-ironic
     recheck-newton:
       jobs:
         - gophercloud-acceptance-test-compute-newton

--- a/acceptance/clients/conditions.go
+++ b/acceptance/clients/conditions.go
@@ -89,3 +89,13 @@ func SkipRelease(t *testing.T, release string) {
 		t.Skipf("this is not supported in %s", release)
 	}
 }
+
+// SkipReleasesBelow will have the test be skipped on releases below a certain
+// one. Releases are named such as 'stable/mitaka', master, etc.
+func SkipReleasesBelow(t *testing.T, release string) {
+	current_branch := os.Getenv("OS_BRANCH")
+
+	if current_branch != "master" && current_branch < release {
+		t.Skipf("this is not supported below %s, testing in %s", release, current_branch)
+	}
+}

--- a/acceptance/openstack/baremetal/httpbasic/nodes_test.go
+++ b/acceptance/openstack/baremetal/httpbasic/nodes_test.go
@@ -69,6 +69,7 @@ func TestNodesUpdate(t *testing.T) {
 }
 
 func TestNodesRAIDConfig(t *testing.T) {
+	clients.SkipReleasesBelow(t, "stable/ussuri")
 	clients.RequireLong(t)
 	clients.RequireIronicHTTPBasic(t)
 

--- a/acceptance/openstack/baremetal/noauth/nodes_test.go
+++ b/acceptance/openstack/baremetal/noauth/nodes_test.go
@@ -67,6 +67,7 @@ func TestNodesUpdate(t *testing.T) {
 }
 
 func TestNodesRAIDConfig(t *testing.T) {
+	clients.SkipReleasesBelow(t, "stable/ussuri")
 	clients.RequireLong(t)
 
 	client, err := clients.NewBareMetalV1NoAuthClient()

--- a/acceptance/openstack/baremetal/v1/nodes_test.go
+++ b/acceptance/openstack/baremetal/v1/nodes_test.go
@@ -69,6 +69,7 @@ func TestNodesUpdate(t *testing.T) {
 }
 
 func TestNodesRAIDConfig(t *testing.T) {
+	clients.SkipReleasesBelow(t, "stable/ussuri")
 	clients.RequireLong(t)
 
 	client, err := clients.NewBareMetalV1Client()


### PR DESCRIPTION
This runs a Github Action to:

* Deploy Devstack with Ironic
* Run acceptance/openstack/baremetal
* Post logs if we encounter a failure
* Replace the previous CI job managed in Zuul
