### PR TITLE
Add Missing Neutron v2 Protocol Constant "any"

### DIFF
--- a/openstack/networking/v2/extensions/security/rules/requests.go
+++ b/openstack/networking/v2/extensions/security/rules/requests.go
@@ -74,7 +74,7 @@ const (
 	ProtocolUDP       RuleProtocol  = "udp"
 	ProtocolUDPLite   RuleProtocol  = "udplite"
 	ProtocolVRRP      RuleProtocol  = "vrrp"
-	ProtocolANY       RuleProtocol  = "any"
+	ProtocolAny       RuleProtocol  = "any"
 )
 
 // CreateOptsBuilder allows extensions to add additional parameters to the

--- a/openstack/networking/v2/extensions/security/rules/requests.go
+++ b/openstack/networking/v2/extensions/security/rules/requests.go
@@ -74,6 +74,7 @@ const (
 	ProtocolUDP       RuleProtocol  = "udp"
 	ProtocolUDPLite   RuleProtocol  = "udplite"
 	ProtocolVRRP      RuleProtocol  = "vrrp"
+	ProtocolANY       RuleProtocol  = "any"
 )
 
 // CreateOptsBuilder allows extensions to add additional parameters to the


### PR DESCRIPTION
Add option "Any" in security group rules, according the [documentation](https://docs.openstack.org/python-openstackclient/latest/cli/command-objects/security-group-rule.html#cmdoption-openstack-security-group-rule-create-protocol):

```bash
Network version 2:
IP protocol (ah, dccp, egp, esp, gre, icmp, igmp, ipv6-encap, ipv6-frag, ipv6-icmp, ipv6-nonxt, ipv6-opts, ipv6-route, ospf, pgm, rsvp, sctp, tcp, udp, udplite, vrrp and integer representations [0-255] or any; default: any (all protocols))
```

Fixes #2309

In code neutron `None` - wildcard, but in documentation it mention as  `any`
Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/python-openstackclient/commit/82f45d9bd203aee77914c1f9e300f7dbedf673c8
https://github.com/openstack/neutron/blob/1ad9ca56b07ffdc9f7e0bc6a62af61961b9128eb/neutron/extensions/securitygroup.py#L211
https://github.com/openstack/neutron/blob/1ad9ca56b07ffdc9f7e0bc6a62af61961b9128eb/neutron/extensions/securitygroup.py#L151