### PR TITLE
[CI-v2] Add compute job with Github Action

### DIFF
--- a/.github/workflows/functional-compute.yaml
+++ b/.github/workflows/functional-compute.yaml
@@ -1,0 +1,61 @@
+name: functional-compute
+on:
+  pull_request:
+    paths:
+      - '^.*compute.*$'
+      - '.github/workflows/functional-compute.yaml'
+  schedule:
+    - cron: '0 0 * * *'
+jobs:
+  functional-compute:
+    strategy:
+      fail-fast: false
+      matrix:
+        name: ["master"]
+        openstack_version: ["master"]
+        ubuntu_version: ["20.04"]
+        include:
+          - name: "xena"
+            openstack_version: "stable/xena"
+            ubuntu_version: "20.04"
+          - name: "wallaby"
+            openstack_version: "stable/wallaby"
+            ubuntu_version: "20.04"
+          - name: "victoria"
+            openstack_version: "stable/victoria"
+            ubuntu_version: "20.04"
+          - name: "ussuri"
+            openstack_version: "stable/ussuri"
+            ubuntu_version: "18.04"
+          - name: "train"
+            openstack_version: "stable/train"
+            ubuntu_version: "18.04"
+    runs-on: ubuntu-${{ matrix.ubuntu_version }}
+    name: Deploy OpenStack ${{ matrix.name }} with Nova and run compute acceptance tests
+    steps:
+      - name: Checkout Gophercloud
+        uses: actions/checkout@v2
+      - name: Deploy devstack
+        uses: EmilienM/devstack-action@v0.6
+        with:
+          branch: ${{ matrix.openstack_version }}
+          conf_overrides: |
+            CINDER_ISCSI_HELPER=tgtadm
+      - name: Checkout go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '^1.15'
+      - name: Run Gophercloud acceptance tests
+        run: ./script/acceptancetest
+        env:
+          DEVSTACK_PATH: ${{ github.workspace }}/devstack
+          ACCEPTANCE_TESTS_FILTER: "^.*compute.*$"
+      - name: Generate logs on failure
+        run: ./script/collectlogs
+        if: failure()
+      - name: Upload logs artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+          name: functional-compute-${{ matrix.name }}
+          path: /tmp/devstack-logs/*

--- a/acceptance/openstack/compute/v2/instance_actions_test.go
+++ b/acceptance/openstack/compute/v2/instance_actions_test.go
@@ -44,12 +44,6 @@ func TestInstanceActions(t *testing.T) {
 
 func TestInstanceActionsMicroversions(t *testing.T) {
 	clients.RequireLong(t)
-	clients.SkipRelease(t, "stable/mitaka")
-	clients.SkipRelease(t, "stable/newton")
-	clients.SkipRelease(t, "stable/ocata")
-	clients.SkipRelease(t, "stable/pike")
-	clients.SkipRelease(t, "stable/queens")
-	clients.SkipRelease(t, "stable/rocky")
 
 	now := time.Now()
 

--- a/acceptance/openstack/compute/v2/keypairs_test.go
+++ b/acceptance/openstack/compute/v2/keypairs_test.go
@@ -18,9 +18,6 @@ import (
 const keyName = "gophercloud_test_key_pair"
 
 func TestKeyPairsParse(t *testing.T) {
-	clients.SkipRelease(t, "stable/mitaka")
-	clients.SkipRelease(t, "stable/newton")
-
 	client, err := clients.NewComputeV2Client()
 	th.AssertNoErr(t, err)
 

--- a/acceptance/openstack/compute/v2/migrate_test.go
+++ b/acceptance/openstack/compute/v2/migrate_test.go
@@ -12,8 +12,6 @@ import (
 )
 
 func TestMigrate(t *testing.T) {
-	t.Skip("This is not passing in OpenLab. Works locally")
-
 	clients.RequireLong(t)
 	clients.RequireAdmin(t)
 

--- a/acceptance/openstack/compute/v2/servergroup_test.go
+++ b/acceptance/openstack/compute/v2/servergroup_test.go
@@ -72,12 +72,6 @@ func TestServergroupsAffinityPolicy(t *testing.T) {
 }
 
 func TestServergroupsMicroversionCreateDelete(t *testing.T) {
-	clients.SkipRelease(t, "stable/mitaka")
-	clients.SkipRelease(t, "stable/newton")
-	clients.SkipRelease(t, "stable/ocata")
-	clients.SkipRelease(t, "stable/pike")
-	clients.SkipRelease(t, "stable/queens")
-
 	client, err := clients.NewComputeV2Client()
 	th.AssertNoErr(t, err)
 

--- a/acceptance/openstack/compute/v2/servers_test.go
+++ b/acceptance/openstack/compute/v2/servers_test.go
@@ -87,8 +87,6 @@ func TestServersCreateDestroy(t *testing.T) {
 }
 
 func TestServersWithExtensionsCreateDestroy(t *testing.T) {
-	clients.SkipRelease(t, "stable/mitaka")
-
 	clients.RequireLong(t)
 
 	var extendedServer struct {
@@ -491,9 +489,6 @@ func TestServersConsoleOutput(t *testing.T) {
 
 func TestServersTags(t *testing.T) {
 	clients.RequireLong(t)
-	clients.SkipRelease(t, "stable/mitaka")
-	clients.SkipRelease(t, "stable/newton")
-	clients.SkipRelease(t, "stable/ocata")
 
 	choices, err := clients.AcceptanceTestChoicesFromEnv()
 	th.AssertNoErr(t, err)
@@ -567,9 +562,6 @@ func TestServersTags(t *testing.T) {
 func TestServersWithExtendedAttributesCreateDestroy(t *testing.T) {
 	clients.RequireLong(t)
 	clients.RequireAdmin(t)
-	clients.SkipRelease(t, "stable/mitaka")
-	clients.SkipRelease(t, "stable/newton")
-	clients.SkipRelease(t, "stable/ocata")
 
 	client, err := clients.NewComputeV2Client()
 	th.AssertNoErr(t, err)

--- a/acceptance/openstack/compute/v2/services_test.go
+++ b/acceptance/openstack/compute/v2/services_test.go
@@ -66,7 +66,6 @@ func TestServicesListWithOpts(t *testing.T) {
 }
 
 func TestServicesUpdate(t *testing.T) {
-	clients.SkipRelease(t, "stable/ocata")
 	clients.RequireAdmin(t)
 
 	client, err := clients.NewComputeV2Client()

--- a/acceptance/openstack/compute/v2/usage_test.go
+++ b/acceptance/openstack/compute/v2/usage_test.go
@@ -16,7 +16,8 @@ import (
 )
 
 func TestUsageSingleTenant(t *testing.T) {
-	t.Skip("This is not passing in OpenLab. Works locally")
+	// TODO(emilien): This test is failing for now
+	t.Skip("This is not passing now, will fix later")
 
 	clients.RequireLong(t)
 


### PR DESCRIPTION
This runs a Github Action to:

* Deploy Devstack with Nova and Cinder
* Run acceptance/openstack/compute
* Post logs if we encounter a failure
* Fix aggregate test to a hostname instead of the FQDN. Nova takes
  hostname: https://github.com/openstack/nova/blob/master/nova/compute/api.py#L6454
* Skip UsageTest and will fix later. The test doesn't pass for now, the
  usage is null everywhere we need to figure out why.
* Switch QuotaSet tests to use API v3 of Keystone instead of v2, which
  was removed in previous versions of OpenStack.
* Unskip all tests except `TestUsageSingleTenant` which seems complicated and potentially broken at API level, so we test almost everything :-)