### PR TITLE
Identity v3: OS-EP-FILTERS endpoint groups list/get

### DIFF
--- a/acceptance/openstack/identity/v3/endpointgroups_test.go
+++ b/acceptance/openstack/identity/v3/endpointgroups_test.go
@@ -1,0 +1,31 @@
+//go:build acceptance || identity || endpointgroups
+// +build acceptance identity endpointgroups
+
+package v3
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/acceptance/clients"
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/extensions/endpointgroups"
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestEndpointGroupsList(t *testing.T) {
+	clients.SkipRelease(t, "stable/mitaka")
+	clients.SkipRelease(t, "stable/newton")
+	clients.SkipRelease(t, "stable/ocata")
+	clients.SkipRelease(t, "stable/pike")
+	clients.SkipRelease(t, "stable/queens")
+	clients.RequireAdmin(t)
+
+	client, err := clients.NewIdentityV3Client()
+	th.AssertNoErr(t, err)
+
+	allPages, err := endpointgroups.List(client, nil).AllPages()
+	th.AssertNoErr(t, err)
+
+	allEndpointGroups, err := endpointgroups.ExtractEndpointGroups(allPages)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, len(allEndpointGroups), 0)
+}

--- a/openstack/identity/v3/extensions/endpointgroups/doc.go
+++ b/openstack/identity/v3/extensions/endpointgroups/doc.go
@@ -1,0 +1,32 @@
+/*
+Package endpointgroups enables management of OpenStack Identity Endpoint Groups
+and Endpoint associations.
+
+Example to Get an Endpoint Group
+
+	err := endpointgroups.Get(identityClient, endpointGroupID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+
+Example to List all Endpoint Groups by name
+
+	listOpts := endpointgropus.ListOpts{
+		Name: "mygroup",
+	}
+
+	allPages, err := endpointgroups.List(identityClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allGroups, err := endpointgroups.ExtractEndpointGroups(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, endpointgroup := range allGroups {
+		fmt.Printf("%+v\n", endpointgroup)
+	}
+*/
+package endpointgroups

--- a/openstack/identity/v3/extensions/endpointgroups/requests.go
+++ b/openstack/identity/v3/extensions/endpointgroups/requests.go
@@ -1,0 +1,46 @@
+package endpointgroups
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// Get retrieves details on a single endpoint group, by ID.
+func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {
+	_, r.Err = client.Get(resourceURL(client, id), &r.Body, nil)
+	return
+}
+
+// ListOptsBuilder allows extensions to add additional parameters to
+// the List request
+type ListOptsBuilder interface {
+	ToEndpointGroupListQuery() (string, error)
+}
+
+// ListOpts provides options to filter the List results.
+type ListOpts struct {
+	// Name filters the response by endpoint group name.
+	Name string `q:"name"`
+}
+
+// ToEndpointGroupListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToEndpointGroupListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List enumerates the endpoint groups
+func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := rootURL(client)
+	if opts != nil {
+		query, err := opts.ToEndpointGroupListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return EndpointGroupPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}

--- a/openstack/identity/v3/extensions/endpointgroups/results.go
+++ b/openstack/identity/v3/extensions/endpointgroups/results.go
@@ -1,0 +1,63 @@
+package endpointgroups
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// Extract interprets a GetResult, CreateResult or UpdateResult as a concrete
+// EndpointGroup. An error is returned if the original call or the extraction
+// failed.
+func (r commonResult) Extract() (*EndpointGroup, error) {
+	var s struct {
+		EndpointGroup *EndpointGroup `json:"endpoint_group"`
+	}
+	err := r.ExtractInto(&s)
+	return s.EndpointGroup, err
+}
+
+// GetResult is the response from a Get operation. Call its Extract method
+// to interpret it as an EndpointGroup.
+type GetResult struct {
+	commonResult
+}
+
+// EndpointGroup represents a group of endpoints matching one or several filter
+// criteria.
+type EndpointGroup struct {
+	// ID is the unique ID of the endpoint group.
+	ID string `json:"id"`
+
+	// Name is the name of the new endpoint group.
+	Name string `json:"name"`
+
+	// Filters is a map type describing the filter criteria
+	Filters map[string]interface{} `json:"filters"`
+
+	// Description is the description of the endpoint group
+	Description string `json:"description"`
+}
+
+// EndpointGroupPage is a single page of EndpointGroup results.
+type EndpointGroupPage struct {
+	pagination.LinkedPageBase
+}
+
+// IsEmpty returns true if no EndpointGroups were returned.
+func (r EndpointGroupPage) IsEmpty() (bool, error) {
+	es, err := ExtractEndpointGroups(r)
+	return len(es) == 0, err
+}
+
+// ExtractEndpointGroups extracts an EndpointGroup slice from a Page.
+func ExtractEndpointGroups(r pagination.Page) ([]EndpointGroup, error) {
+	var s struct {
+		EndpointGroups []EndpointGroup `json:"endpoint_groups"`
+	}
+	err := (r.(EndpointGroupPage)).ExtractInto(&s)
+	return s.EndpointGroups, err
+}

--- a/openstack/identity/v3/extensions/endpointgroups/testing/requests_test.go
+++ b/openstack/identity/v3/extensions/endpointgroups/testing/requests_test.go
@@ -1,0 +1,132 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/extensions/endpointgroups"
+	"github.com/gophercloud/gophercloud/pagination"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func TestGetEndpointGroup(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/OS-EP-FILTER/endpoint_groups/24", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		fmt.Fprintf(w, `
+		{
+			"endpoint_group": {
+			    "id": "24",
+			    "filters": {
+				    "interface": "public",
+					"service_id": "1234",
+					"region_id": "5678"
+			    },
+			    "name": "endpointgroup1",
+			    "description": "public endpoint group 1",
+			    "links": {
+					"self": "https://localhost:5000/v3/OS-EP-FILTER/endpoint_groups/24"
+			    }
+			}
+		}
+		`)
+	})
+
+	actual, err := endpointgroups.Get(client.ServiceClient(), "24").Extract()
+	if err != nil {
+		t.Fatalf("Failed to extract EndpointGroup: %v", err)
+	}
+
+	expected := &endpointgroups.EndpointGroup{
+		ID: "24",
+		Filters: map[string]interface{}{
+			"interface":  "public",
+			"service_id": "1234",
+			"region_id":  "5678",
+		},
+		Name:        "endpointgroup1",
+		Description: "public endpoint group 1",
+	}
+	th.AssertDeepEquals(t, expected, actual)
+}
+
+func TestListEndpointGroups(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/OS-EP-FILTER/endpoint_groups", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprintf(w, `
+		{
+			"endpoint_groups": [
+				{
+				    "id": "24",
+				    "filters": {
+						"interface": "public",
+						"service_id": "1234",
+						"region_id": "5678",
+				    },
+				    "name": "endpointgroup1",
+				    "description": "public endpoint group 1",
+				    "links": {
+						"self": "https://localhost:5000/v3/OS-EP-FILTER/endpoint_groups/24"
+				    }
+				},
+				{
+				    "id": "25",
+				    "filters": {
+						"interface": "internal"
+				    },
+				    "name": "endpointgroup2",
+				    "description": "internal endpoint group 1",
+				    "links": {
+						"self": "https://localhost:5000/v3/OS-EP-FILTER/endpoint_groups/25"
+				    }
+				}
+			]
+		}
+		`)
+	})
+
+	count := 0
+	endpointgroups.List(client.ServiceClient(), endpointgroups.ListOpts{}).EachPage(func(page pagination.Page) (bool, error) {
+		count++
+		actual, err := endpointgroups.ExtractEndpointGroups(page)
+		if err != nil {
+			t.Errorf("Failed to extract EndpointGroups: %v", err)
+			return false, err
+		}
+
+		expected := []endpointgroups.EndpointGroup{
+			{
+				ID: "24",
+				Filters: map[string]interface{}{
+					"interface":  "public",
+					"service_id": "1234",
+					"region_id":  "5678",
+				},
+				Name:        "endpointgroup1",
+				Description: "public endpoint group 1",
+			},
+			{
+				ID: "25",
+				Filters: map[string]interface{}{
+					"interface": "internal",
+				},
+				Name:        "endpointgroup2",
+				Description: "internal endpoint group 1",
+			},
+		}
+		th.AssertDeepEquals(t, expected, actual)
+		return true, nil
+	})
+}

--- a/openstack/identity/v3/extensions/endpointgroups/urls.go
+++ b/openstack/identity/v3/extensions/endpointgroups/urls.go
@@ -1,0 +1,15 @@
+package endpointgroups
+
+import "github.com/gophercloud/gophercloud"
+
+const (
+	endpointGroupPath = "OS-EP-FILTER/endpoint_groups"
+)
+
+func rootURL(client *gophercloud.ServiceClient) string {
+	return client.ServiceURL(endpointGroupPath)
+}
+
+func resourceURL(client *gophercloud.ServiceClient, endointGroupID string) string {
+	return client.ServiceURL(endpointGroupPath, endointGroupID)
+}


### PR DESCRIPTION
For #1889

API doc:
https://docs.openstack.org/api-ref/identity/v3-ext/index.html#os-ep-filter-api

API calls:
https://github.com/openstack/keystone/blob/ba2e4b83e88d5c1576e9d2cd6a760367deef3a62/keystone/api/os_ep_filter.py#L68-L79

Structures: https://github.com/openstack/keystone/blob/ba2e4b83e88d5c1576e9d2cd6a760367deef3a62/keystone/catalog/backends/sql.py#L605

EndpointGroupFilter structure: https://github.com/openstack/keystone/blob/ba2e4b83e88d5c1576e9d2cd6a760367deef3a62/keystone/api/os_ep_filter.py#L54

Note: this is a new proposal based on this PR: https://github.com/gophercloud/gophercloud/pull/1893 
I took care of the latests comments to move forward on this topic.
If there are better ways to do it, feel free to share it and close this PR. Thanks !