### PR TITLE
[CI-v2] Add identity job with Github Action

### DIFF
--- a/.github/workflows/functional-identity.yaml
+++ b/.github/workflows/functional-identity.yaml
@@ -1,0 +1,59 @@
+name: functional-identity
+on:
+  pull_request:
+    paths:
+      - '^.*identity.*$'
+      - '.github/workflows/functional-identity.yaml'
+  schedule:
+    - cron: '0 0 * * *'
+jobs:
+  functional-identity:
+    strategy:
+      fail-fast: false
+      matrix:
+        name: ["master"]
+        openstack_version: ["master"]
+        ubuntu_version: ["20.04"]
+        include:
+          - name: "xena"
+            openstack_version: "stable/xena"
+            ubuntu_version: "20.04"
+          - name: "wallaby"
+            openstack_version: "stable/wallaby"
+            ubuntu_version: "20.04"
+          - name: "victoria"
+            openstack_version: "stable/victoria"
+            ubuntu_version: "20.04"
+          - name: "ussuri"
+            openstack_version: "stable/ussuri"
+            ubuntu_version: "18.04"
+          - name: "train"
+            openstack_version: "stable/train"
+            ubuntu_version: "18.04"
+    runs-on: ubuntu-${{ matrix.ubuntu_version }}
+    name: Deploy OpenStack ${{ matrix.name }} with Keystone and run identity acceptance tests
+    steps:
+      - name: Checkout Gophercloud
+        uses: actions/checkout@v2
+      - name: Deploy devstack
+        uses: EmilienM/devstack-action@v0.6
+        with:
+          branch: ${{ matrix.openstack_version }}
+      - name: Checkout go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '^1.15'
+      - name: Run Gophercloud acceptance tests
+        run: ./script/acceptancetest
+        env:
+          DEVSTACK_PATH: ${{ github.workspace }}/devstack
+          ACCEPTANCE_TESTS_FILTER: "^.*identity.*$"
+      - name: Generate logs on failure
+        run: ./script/collectlogs
+        if: failure()
+      - name: Upload logs artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+          name: functional-identity-${{ matrix.name }}
+          path: /tmp/devstack-logs/*

--- a/acceptance/openstack/identity/v3/applicationcredentials_test.go
+++ b/acceptance/openstack/identity/v3/applicationcredentials_test.go
@@ -16,11 +16,6 @@ import (
 )
 
 func TestApplicationCredentialsCRD(t *testing.T) {
-	clients.SkipRelease(t, "stable/mitaka")
-	clients.SkipRelease(t, "stable/newton")
-	clients.SkipRelease(t, "stable/ocata")
-	clients.SkipRelease(t, "stable/pike")
-
 	// maps are required, because Application Credential roles are returned in a random order
 	rolesToMap := func(roles []applicationcredentials.Role) map[string]string {
 		rolesMap := map[string]string{}
@@ -174,13 +169,6 @@ func TestApplicationCredentialsCRD(t *testing.T) {
 
 func TestApplicationCredentialsAccessRules(t *testing.T) {
 	clients.RequireAdmin(t)
-	clients.SkipRelease(t, "stable/mitaka")
-	clients.SkipRelease(t, "stable/newton")
-	clients.SkipRelease(t, "stable/ocata")
-	clients.SkipRelease(t, "stable/pike")
-	clients.SkipRelease(t, "stable/queens")
-	clients.SkipRelease(t, "stable/rocky")
-	clients.SkipRelease(t, "stable/stein")
 
 	client, err := clients.NewIdentityV3Client()
 	th.AssertNoErr(t, err)

--- a/acceptance/openstack/identity/v3/identity.go
+++ b/acceptance/openstack/identity/v3/identity.go
@@ -140,7 +140,13 @@ func CreateDomain(t *testing.T, client *gophercloud.ServiceClient, c *domains.Cr
 // has so many options. An error will be returned if the role was
 // unable to be created.
 func CreateRole(t *testing.T, client *gophercloud.ServiceClient, c *roles.CreateOpts) (*roles.Role, error) {
-	name := tools.RandomString("ACPTTEST", 8)
+	var name string
+	if c.Name == "" {
+		name = tools.RandomString("ACPTTEST", 8)
+	} else {
+		name = c.Name
+	}
+
 	t.Logf("Attempting to create role: %s", name)
 
 	var createOpts roles.CreateOpts
@@ -149,7 +155,6 @@ func CreateRole(t *testing.T, client *gophercloud.ServiceClient, c *roles.Create
 	} else {
 		createOpts = roles.CreateOpts{}
 	}
-
 	createOpts.Name = name
 
 	role, err := roles.Create(client, createOpts).Extract()

--- a/acceptance/openstack/identity/v3/oauth1_test.go
+++ b/acceptance/openstack/identity/v3/oauth1_test.go
@@ -16,10 +16,6 @@ import (
 )
 
 func TestOAuth1CRUD(t *testing.T) {
-	clients.SkipRelease(t, "stable/mitaka")
-	clients.SkipRelease(t, "stable/newton")
-	clients.SkipRelease(t, "stable/ocata")
-
 	client, err := clients.NewIdentityV3Client()
 	th.AssertNoErr(t, err)
 

--- a/acceptance/openstack/identity/v3/projects_test.go
+++ b/acceptance/openstack/identity/v3/projects_test.go
@@ -214,9 +214,6 @@ func TestProjectsNested(t *testing.T) {
 }
 
 func TestProjectsTags(t *testing.T) {
-	clients.SkipRelease(t, "stable/mitaka")
-	clients.SkipRelease(t, "stable/newton")
-	clients.SkipRelease(t, "stable/ocata")
 	clients.RequireAdmin(t)
 
 	client, err := clients.NewIdentityV3Client()

--- a/acceptance/openstack/identity/v3/roles_test.go
+++ b/acceptance/openstack/identity/v3/roles_test.go
@@ -58,8 +58,7 @@ func TestRolesCRUD(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	createOpts := roles.CreateOpts{
-		Name:     "testrole",
-		DomainID: "default",
+		Name: "testrole",
 		Extra: map[string]interface{}{
 			"description": "test role description",
 		},
@@ -73,9 +72,7 @@ func TestRolesCRUD(t *testing.T) {
 	tools.PrintResource(t, role)
 	tools.PrintResource(t, role.Extra)
 
-	listOpts := roles.ListOpts{
-		DomainID: "default",
-	}
+	listOpts := roles.ListOpts{}
 	allPages, err := roles.List(client, listOpts).AllPages()
 	th.AssertNoErr(t, err)
 
@@ -112,24 +109,11 @@ func TestRolesCRUD(t *testing.T) {
 func TestRolesFilterList(t *testing.T) {
 	clients.RequireAdmin(t)
 
-	// For some reason this is not longer working.
-	clients.SkipRelease(t, "master")
-	clients.SkipRelease(t, "stable/mitaka")
-	clients.SkipRelease(t, "stable/newton")
-	clients.SkipRelease(t, "stable/ocata")
-	clients.SkipRelease(t, "stable/pike")
-	clients.SkipRelease(t, "stable/queens")
-	clients.SkipRelease(t, "stable/rocky")
-	clients.SkipRelease(t, "stable/stein")
-	clients.SkipRelease(t, "stable/train")
-	clients.SkipRelease(t, "stable/ussuri")
-
 	client, err := clients.NewIdentityV3Client()
 	th.AssertNoErr(t, err)
 
 	createOpts := roles.CreateOpts{
-		Name:     "testrole",
-		DomainID: "default",
+		Name: "testrole",
 		Extra: map[string]interface{}{
 			"description": "test role description",
 		},
@@ -142,7 +126,7 @@ func TestRolesFilterList(t *testing.T) {
 
 	var listOpts roles.ListOpts
 	listOpts.Filters = map[string]string{
-		"name__contains": "TEST",
+		"name__contains": "test",
 	}
 
 	allPages, err := roles.List(client, listOpts).AllPages()

--- a/acceptance/openstack/identity/v3/trusts_test.go
+++ b/acceptance/openstack/identity/v3/trusts_test.go
@@ -18,11 +18,6 @@ import (
 )
 
 func TestTrustCRUD(t *testing.T) {
-	clients.SkipRelease(t, "stable/mitaka")
-	clients.SkipRelease(t, "stable/newton")
-	clients.SkipRelease(t, "stable/ocata")
-	clients.SkipRelease(t, "stable/pike")
-	clients.SkipRelease(t, "stable/queens")
 	clients.RequireAdmin(t)
 
 	client, err := clients.NewIdentityV3Client()


### PR DESCRIPTION
This runs a Github Action to:
* Deploy Devstack with Keystone
* Run acceptance/openstack/identity/v3
* Fix test for roles: we were creating a role with a random name and not
  taking in consideration that CreateOpts could contain a Name. Also, we
  were creating the role in the default domain but this is problematic
  because right now Gophercloud is not able to delete a role in a
  specific domain. This is a feature that will need to be added (issue
  #2321)
* Post logs if we encounter a failure

Note: we don't have CI coverage for v2 API because it was removed long
time ago (in Pike): https://docs.openstack.org/releasenotes/keystone/pike.html#deprecation-notes