### PR TITLE
[CI-v2] Add networking job with Github Action

### DIFF
--- a/.github/workflows/functional-networking.yaml
+++ b/.github/workflows/functional-networking.yaml
@@ -1,0 +1,72 @@
+name: functional-networking
+on:
+  pull_request:
+    paths:
+      - '**networking**'
+  schedule:
+    - cron: '0 0 * * *'
+jobs:
+  functional-networking:
+    strategy:
+      fail-fast: false
+      matrix:
+        name: ["master"]
+        openstack_version: ["master"]
+        ubuntu_version: ["20.04"]
+        devstack_conf_overrides: [""]
+        include:
+          - name: "xena"
+            openstack_version: "stable/xena"
+            ubuntu_version: "20.04"
+            devstack_conf_overrides: ""
+          - name: "wallaby"
+            openstack_version: "stable/wallaby"
+            ubuntu_version: "20.04"
+            devstack_conf_overrides: ""
+          - name: "victoria"
+            openstack_version: "stable/victoria"
+            ubuntu_version: "20.04"
+            devstack_conf_overrides: ""
+          - name: "ussuri"
+            openstack_version: "stable/ussuri"
+            ubuntu_version: "18.04"
+            devstack_conf_overrides: |
+              enable_plugin neutron-fwaas https://git.openstack.org/openstack/neutron-fwaas stable/ussuri
+          - name: "train"
+            openstack_version: "stable/train"
+            ubuntu_version: "18.04"
+            devstack_conf_overrides: |
+              enable_plugin neutron-fwaas https://git.openstack.org/openstack/neutron-fwaas stable/train
+    runs-on: ubuntu-${{ matrix.ubuntu_version }}
+    name: Deploy OpenStack ${{ matrix.name }} with Neutron and run networking acceptance tests
+    steps:
+      - name: Checkout Gophercloud
+        uses: actions/checkout@v2
+      - name: Deploy devstack
+        uses: EmilienM/devstack-action@v0.6
+        with:
+          branch: ${{ matrix.openstack_version }}
+          conf_overrides: |
+            Q_ML2_PLUGIN_EXT_DRIVERS=qos,port_security,dns_domain_keywords
+            enable_plugin neutron-vpnaas https://opendev.org/openstack/neutron-vpnaas ${{ matrix.openstack_version }}
+            ${{ matrix.devstack_conf_overrides }}
+          enabled_services: 'neutron-dns,neutron-qos,neutron-segments,neutron-trunk,neutron-uplink-status-propagation,neutron-network-segment-range,neutron-port-forwarding'
+      - name: Checkout go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '^1.15'
+      - name: Run Gophercloud acceptance tests
+        run: ./script/acceptancetest
+        env:
+          DEVSTACK_PATH: ${{ github.workspace }}/devstack
+          ACCEPTANCE_TESTS_FILTER: "^.*networking.*$"
+          OS_BRANCH: ${{ matrix.openstack_version }}
+      - name: Generate logs on failure
+        run: ./script/collectlogs
+        if: failure()
+      - name: Upload logs artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+          name: functional-networking-${{ matrix.name }}
+          path: /tmp/devstack-logs/*

--- a/acceptance/openstack/networking/v2/extensions/agents/agents_test.go
+++ b/acceptance/openstack/networking/v2/extensions/agents/agents_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestAgentsRUD(t *testing.T) {
+	t.Skip("TestAgentsRUD needs to be re-worked to work with both ML2/OVS and OVN")
 	clients.RequireAdmin(t)
 
 	client, err := clients.NewNetworkV2Client()
@@ -69,9 +70,6 @@ func TestAgentsRUD(t *testing.T) {
 	agent, err = agents.Update(client, allAgents[0].ID, &agents.UpdateOpts{Description: &allAgents[0].Description}).Extract()
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, agent.Description, allAgents[0].Description)
-
-	// skip this part
-	// t.Skip("Skip DHCP agent network scheduling")
 
 	// Assign a new network to a DHCP agent
 	network, err := networking.CreateNetwork(t, client)

--- a/acceptance/openstack/networking/v2/extensions/attributestags_test.go
+++ b/acceptance/openstack/networking/v2/extensions/attributestags_test.go
@@ -89,8 +89,6 @@ func listNetworkWithTagOpts(t *testing.T, client *gophercloud.ServiceClient, lis
 }
 
 func TestQueryByTags(t *testing.T) {
-	clients.SkipRelease(t, "stable/mitaka")
-
 	client, err := clients.NewNetworkV2Client()
 	th.AssertNoErr(t, err)
 

--- a/acceptance/openstack/networking/v2/extensions/dns/dns.go
+++ b/acceptance/openstack/networking/v2/extensions/dns/dns.go
@@ -105,7 +105,7 @@ func CreateFloatingIPDNS(t *testing.T, client *gophercloud.ServiceClient, networ
 
 // CreateNetworkDNS will create a network with a DNS domain set.
 // An error will be returned if the network could not be created.
-func CreateNetworkDNS(t *testing.T, client *gophercloud.ServiceClient, dnsDomanin string) (*NetworkWithDNSExt, error) {
+func CreateNetworkDNS(t *testing.T, client *gophercloud.ServiceClient, dnsDomain string) (*NetworkWithDNSExt, error) {
 	networkName := tools.RandomString("TESTACC-", 8)
 	networkCreateOpts := networks.CreateOpts{
 		Name:         networkName,
@@ -114,7 +114,7 @@ func CreateNetworkDNS(t *testing.T, client *gophercloud.ServiceClient, dnsDomani
 
 	createOpts := dns.NetworkCreateOptsExt{
 		CreateOptsBuilder: networkCreateOpts,
-		DNSDomain:         dnsDomanin,
+		DNSDomain:         dnsDomain,
 	}
 
 	t.Logf("Attempting to create network: %s", networkName)
@@ -129,7 +129,7 @@ func CreateNetworkDNS(t *testing.T, client *gophercloud.ServiceClient, dnsDomani
 	t.Logf("Successfully created network.")
 
 	th.AssertEquals(t, network.Name, networkName)
-	th.AssertEquals(t, network.DNSDomain, dnsDomanin)
+	th.AssertEquals(t, network.DNSDomain, dnsDomain)
 
 	return &network, nil
 }

--- a/acceptance/openstack/networking/v2/extensions/dns/dns_test.go
+++ b/acceptance/openstack/networking/v2/extensions/dns/dns_test.go
@@ -147,6 +147,7 @@ func TestDNSPortCRUDL(t *testing.T) {
 }
 
 func TestDNSFloatingIPCRDL(t *testing.T) {
+	t.Skip("Skipping TestDNSFloatingIPCRDL for now, as it doesn't work with ML2/OVN.")
 	clients.RequireAdmin(t)
 
 	client, err := clients.NewNetworkV2Client()

--- a/acceptance/openstack/networking/v2/extensions/fwaas/firewall_test.go
+++ b/acceptance/openstack/networking/v2/extensions/fwaas/firewall_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestFirewallCRUD(t *testing.T) {
+	t.Skip("Skip this test, FWAAS v1 is old and will be removed from Gophercloud")
 	client, err := clients.NewNetworkV2Client()
 	th.AssertNoErr(t, err)
 
@@ -76,6 +77,7 @@ func TestFirewallCRUD(t *testing.T) {
 }
 
 func TestFirewallCRUDRouter(t *testing.T) {
+	t.Skip("Skip this test, FWAAS v1 is old and will be removed from Gophercloud")
 	client, err := clients.NewNetworkV2Client()
 	th.AssertNoErr(t, err)
 
@@ -126,6 +128,7 @@ func TestFirewallCRUDRouter(t *testing.T) {
 }
 
 func TestFirewallCRUDRemoveRouter(t *testing.T) {
+	t.Skip("Skip this test, FWAAS v1 is old and will be removed from Gophercloud")
 	client, err := clients.NewNetworkV2Client()
 	th.AssertNoErr(t, err)
 

--- a/acceptance/openstack/networking/v2/extensions/fwaas/policy_test.go
+++ b/acceptance/openstack/networking/v2/extensions/fwaas/policy_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestPolicyCRUD(t *testing.T) {
+	t.Skip("Skip this test, FWAAS v1 is old and will be removed from Gophercloud")
 	client, err := clients.NewNetworkV2Client()
 	th.AssertNoErr(t, err)
 

--- a/acceptance/openstack/networking/v2/extensions/fwaas/rule_test.go
+++ b/acceptance/openstack/networking/v2/extensions/fwaas/rule_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestRuleCRUD(t *testing.T) {
+	t.Skip("Skip this test, FWAAS v1 is old and will be removed from Gophercloud")
 	client, err := clients.NewNetworkV2Client()
 	th.AssertNoErr(t, err)
 

--- a/acceptance/openstack/networking/v2/extensions/fwaas_v2/fwaas_v2.go
+++ b/acceptance/openstack/networking/v2/extensions/fwaas_v2/fwaas_v2.go
@@ -74,9 +74,11 @@ func CreatePolicy(t *testing.T, client *gophercloud.ServiceClient, ruleID string
 func CreateRule(t *testing.T, client *gophercloud.ServiceClient) (*rules.Rule, error) {
 	ruleName := tools.RandomString("TESTACC-", 8)
 	sourceAddress := fmt.Sprintf("192.168.1.%d", tools.RandomInt(1, 100))
-	sourcePort := strconv.Itoa(tools.RandomInt(1, 100))
+	sourcePortInt := strconv.Itoa(tools.RandomInt(1, 100))
+	sourcePort := fmt.Sprintf("%s:%s", sourcePortInt, sourcePortInt)
 	destinationAddress := fmt.Sprintf("192.168.2.%d", tools.RandomInt(1, 100))
-	destinationPort := strconv.Itoa(tools.RandomInt(1, 100))
+	destinationPortInt := strconv.Itoa(tools.RandomInt(1, 100))
+	destinationPort := fmt.Sprintf("%s:%s", destinationPortInt, destinationPortInt)
 
 	t.Logf("Attempting to create rule %s with source %s:%s and destination %s:%s",
 		ruleName, sourceAddress, sourcePort, destinationAddress, destinationPort)
@@ -102,9 +104,9 @@ func CreateRule(t *testing.T, client *gophercloud.ServiceClient) (*rules.Rule, e
 	th.AssertEquals(t, rule.Protocol, string(rules.ProtocolTCP))
 	th.AssertEquals(t, rule.Action, string(rules.ActionAllow))
 	th.AssertEquals(t, rule.SourceIPAddress, sourceAddress)
-	th.AssertEquals(t, rule.SourcePort, sourcePort)
+	th.AssertEquals(t, rule.SourcePort, sourcePortInt)
 	th.AssertEquals(t, rule.DestinationIPAddress, destinationAddress)
-	th.AssertEquals(t, rule.DestinationPort, destinationPort)
+	th.AssertEquals(t, rule.DestinationPort, destinationPortInt)
 
 	return rule, nil
 }

--- a/acceptance/openstack/networking/v2/extensions/fwaas_v2/groups_test.go
+++ b/acceptance/openstack/networking/v2/extensions/fwaas_v2/groups_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestGroupCRUD(t *testing.T) {
+	clients.SkipReleasesAbove(t, "stable/ussuri")
 
 	client, err := clients.NewNetworkV2Client()
 	th.AssertNoErr(t, err)

--- a/acceptance/openstack/networking/v2/extensions/fwaas_v2/policy_test.go
+++ b/acceptance/openstack/networking/v2/extensions/fwaas_v2/policy_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestPolicyCRUD(t *testing.T) {
+	clients.SkipReleasesAbove(t, "stable/ussuri")
+
 	client, err := clients.NewNetworkV2Client()
 	th.AssertNoErr(t, err)
 

--- a/acceptance/openstack/networking/v2/extensions/fwaas_v2/rule_test.go
+++ b/acceptance/openstack/networking/v2/extensions/fwaas_v2/rule_test.go
@@ -4,6 +4,8 @@
 package fwaas_v2
 
 import (
+	"fmt"
+	"strconv"
 	"testing"
 
 	"github.com/gophercloud/gophercloud/acceptance/clients"
@@ -13,6 +15,7 @@ import (
 )
 
 func TestRuleCRUD(t *testing.T) {
+	clients.SkipReleasesAbove(t, "stable/ussuri")
 
 	client, err := clients.NewNetworkV2Client()
 	th.AssertNoErr(t, err)
@@ -24,15 +27,19 @@ func TestRuleCRUD(t *testing.T) {
 	tools.PrintResource(t, rule)
 
 	ruleDescription := "Some rule description"
-	ruleProtocol := rules.ProtocolICMP
+	ruleSourcePortInt := strconv.Itoa(tools.RandomInt(1, 100))
+	ruleSourcePort := fmt.Sprintf("%s:%s", ruleSourcePortInt, ruleSourcePortInt)
+	ruleProtocol := rules.ProtocolTCP
 	updateOpts := rules.UpdateOpts{
 		Description: &ruleDescription,
 		Protocol:    &ruleProtocol,
+		SourcePort:  &ruleSourcePort,
 	}
 
 	ruleUpdated, err := rules.Update(client, rule.ID, updateOpts).Extract()
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, ruleUpdated.Description, ruleDescription)
+	th.AssertEquals(t, ruleUpdated.SourcePort, ruleSourcePortInt)
 	th.AssertEquals(t, ruleUpdated.Protocol, string(ruleProtocol))
 
 	newRule, err := rules.Get(client, rule.ID).Extract()

--- a/acceptance/openstack/networking/v2/extensions/layer3/routers_test.go
+++ b/acceptance/openstack/networking/v2/extensions/layer3/routers_test.go
@@ -167,6 +167,7 @@ func TestLayer3RouterInterface(t *testing.T) {
 }
 
 func TestLayer3RouterAgents(t *testing.T) {
+	t.Skip("TestLayer3RouterAgents needs to be re-worked to work with both ML2/OVS and OVN")
 	clients.RequireAdmin(t)
 
 	client, err := clients.NewNetworkV2Client()

--- a/acceptance/openstack/networking/v2/extensions/lbaas/members_test.go
+++ b/acceptance/openstack/networking/v2/extensions/lbaas/members_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestMembersList(t *testing.T) {
+	t.Skip("Neutron LBaaS was replaced by Octavia and the API will be removed in a future release")
 	client, err := clients.NewNetworkV2Client()
 	if err != nil {
 		t.Fatalf("Unable to create a network client: %v", err)
@@ -35,6 +36,7 @@ func TestMembersList(t *testing.T) {
 }
 
 func TestMembersCRUD(t *testing.T) {
+	t.Skip("Neutron LBaaS was replaced by Octavia and the API will be removed in a future release")
 	client, err := clients.NewNetworkV2Client()
 	if err != nil {
 		t.Fatalf("Unable to create a network client: %v", err)

--- a/acceptance/openstack/networking/v2/extensions/lbaas/monitors_test.go
+++ b/acceptance/openstack/networking/v2/extensions/lbaas/monitors_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestMonitorsList(t *testing.T) {
+	t.Skip("Neutron LBaaS was replaced by Octavia and the API will be removed in a future release")
 	client, err := clients.NewNetworkV2Client()
 	if err != nil {
 		t.Fatalf("Unable to create a network client: %v", err)
@@ -33,6 +34,7 @@ func TestMonitorsList(t *testing.T) {
 }
 
 func TestMonitorsCRUD(t *testing.T) {
+	t.Skip("Neutron LBaaS was replaced by Octavia and the API will be removed in a future release")
 	client, err := clients.NewNetworkV2Client()
 	if err != nil {
 		t.Fatalf("Unable to create a network client: %v", err)

--- a/acceptance/openstack/networking/v2/extensions/lbaas/pools_test.go
+++ b/acceptance/openstack/networking/v2/extensions/lbaas/pools_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestPoolsList(t *testing.T) {
+	t.Skip("Neutron LBaaS was replaced by Octavia and the API will be removed in a future release")
 	client, err := clients.NewNetworkV2Client()
 	if err != nil {
 		t.Fatalf("Unable to create a network client: %v", err)
@@ -34,6 +35,7 @@ func TestPoolsList(t *testing.T) {
 }
 
 func TestPoolsCRUD(t *testing.T) {
+	t.Skip("Neutron LBaaS was replaced by Octavia and the API will be removed in a future release")
 	client, err := clients.NewNetworkV2Client()
 	if err != nil {
 		t.Fatalf("Unable to create a network client: %v", err)
@@ -77,6 +79,7 @@ func TestPoolsCRUD(t *testing.T) {
 }
 
 func TestPoolsMonitors(t *testing.T) {
+	t.Skip("Neutron LBaaS was replaced by Octavia and the API will be removed in a future release")
 	client, err := clients.NewNetworkV2Client()
 	if err != nil {
 		t.Fatalf("Unable to create a network client: %v", err)

--- a/acceptance/openstack/networking/v2/extensions/lbaas/vips_test.go
+++ b/acceptance/openstack/networking/v2/extensions/lbaas/vips_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestVIPsList(t *testing.T) {
+	t.Skip("Neutron LBaaS was replaced by Octavia and the API will be removed in a future release")
 	client, err := clients.NewNetworkV2Client()
 	if err != nil {
 		t.Fatalf("Unable to create a network client: %v", err)
@@ -34,6 +35,7 @@ func TestVIPsList(t *testing.T) {
 }
 
 func TestVIPsCRUD(t *testing.T) {
+	t.Skip("Neutron LBaaS was replaced by Octavia and the API will be removed in a future release")
 	client, err := clients.NewNetworkV2Client()
 	if err != nil {
 		t.Fatalf("Unable to create a network client: %v", err)

--- a/acceptance/openstack/networking/v2/extensions/lbaas_v2/l7policies_test.go
+++ b/acceptance/openstack/networking/v2/extensions/lbaas_v2/l7policies_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestL7PoliciesList(t *testing.T) {
+	t.Skip("Neutron LBaaS v2 was replaced by Octavia and the API will be removed in a future release")
 	client, err := clients.NewNetworkV2Client()
 	if err != nil {
 		t.Fatalf("Unable to create a loadbalancer client: %v", err)

--- a/acceptance/openstack/networking/v2/extensions/lbaas_v2/listeners_test.go
+++ b/acceptance/openstack/networking/v2/extensions/lbaas_v2/listeners_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestListenersList(t *testing.T) {
+	t.Skip("Neutron LBaaS v2 was replaced by Octavia and the API will be removed in a future release")
 	client, err := clients.NewNetworkV2Client()
 	if err != nil {
 		t.Fatalf("Unable to create a loadbalancer client: %v", err)

--- a/acceptance/openstack/networking/v2/extensions/lbaas_v2/loadbalancers_test.go
+++ b/acceptance/openstack/networking/v2/extensions/lbaas_v2/loadbalancers_test.go
@@ -18,6 +18,7 @@ import (
 )
 
 func TestLoadbalancersList(t *testing.T) {
+	t.Skip("Neutron LBaaS v2 was replaced by Octavia and the API will be removed in a future release")
 	client, err := clients.NewNetworkV2Client()
 	th.AssertNoErr(t, err)
 
@@ -33,6 +34,7 @@ func TestLoadbalancersList(t *testing.T) {
 }
 
 func TestLoadbalancersCRUD(t *testing.T) {
+	t.Skip("Neutron LBaaS v2 was replaced by Octavia and the API will be removed in a future release")
 	client, err := clients.NewNetworkV2Client()
 	th.AssertNoErr(t, err)
 

--- a/acceptance/openstack/networking/v2/extensions/lbaas_v2/monitors_test.go
+++ b/acceptance/openstack/networking/v2/extensions/lbaas_v2/monitors_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestMonitorsList(t *testing.T) {
+	t.Skip("Neutron LBaaS v2 was replaced by Octavia and the API will be removed in a future release")
 	client, err := clients.NewNetworkV2Client()
 	if err != nil {
 		t.Fatalf("Unable to create a loadbalancer client: %v", err)

--- a/acceptance/openstack/networking/v2/extensions/lbaas_v2/pools_test.go
+++ b/acceptance/openstack/networking/v2/extensions/lbaas_v2/pools_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestPoolsList(t *testing.T) {
+	t.Skip("Neutron LBaaS v2 was replaced by Octavia and the API will be removed in a future release")
 	client, err := clients.NewNetworkV2Client()
 	if err != nil {
 		t.Fatalf("Unable to create a loadbalancer client: %v", err)

--- a/acceptance/openstack/networking/v2/extensions/mtu/mtu_test.go
+++ b/acceptance/openstack/networking/v2/extensions/mtu/mtu_test.go
@@ -18,9 +18,6 @@ import (
 
 func TestMTUNetworkCRUDL(t *testing.T) {
 	clients.RequireAdmin(t)
-	clients.SkipRelease(t, "stable/mitaka")
-	clients.SkipRelease(t, "stable/newton")
-	clients.SkipRelease(t, "stable/ocata")
 
 	client, err := clients.NewNetworkV2Client()
 	th.AssertNoErr(t, err)
@@ -37,7 +34,7 @@ func TestMTUNetworkCRUDL(t *testing.T) {
 	// Create Network
 	var networkMTU int
 	if mtuWritable != nil {
-		networkMTU = 1449
+		networkMTU = 1440
 	}
 	network, err := CreateNetworkWithMTU(t, client, &networkMTU)
 	th.AssertNoErr(t, err)

--- a/acceptance/openstack/networking/v2/extensions/qos/policies/policies_test.go
+++ b/acceptance/openstack/networking/v2/extensions/qos/policies/policies_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gophercloud/gophercloud/acceptance/clients"
 	"github.com/gophercloud/gophercloud/acceptance/tools"
+	"github.com/gophercloud/gophercloud/openstack/common/extensions"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/qos/policies"
 	th "github.com/gophercloud/gophercloud/testhelper"
 )
@@ -15,6 +16,12 @@ import (
 func TestPoliciesCRUD(t *testing.T) {
 	client, err := clients.NewNetworkV2Client()
 	th.AssertNoErr(t, err)
+
+	extension, err := extensions.Get(client, "qos").Extract()
+	if err != nil {
+		t.Skip("This test requires qos Neutron extension")
+	}
+	tools.PrintResource(t, extension)
 
 	// Create a QoS policy.
 	policy, err := CreateQoSPolicy(t, client)

--- a/acceptance/openstack/networking/v2/extensions/qos/rules/rules_test.go
+++ b/acceptance/openstack/networking/v2/extensions/qos/rules/rules_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gophercloud/gophercloud/acceptance/clients"
 	accpolicies "github.com/gophercloud/gophercloud/acceptance/openstack/networking/v2/extensions/qos/policies"
 	"github.com/gophercloud/gophercloud/acceptance/tools"
+	"github.com/gophercloud/gophercloud/openstack/common/extensions"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/qos/policies"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/qos/rules"
 	th "github.com/gophercloud/gophercloud/testhelper"
@@ -14,6 +15,12 @@ import (
 func TestBandwidthLimitRulesCRUD(t *testing.T) {
 	client, err := clients.NewNetworkV2Client()
 	th.AssertNoErr(t, err)
+
+	extension, err := extensions.Get(client, "qos").Extract()
+	if err != nil {
+		t.Skip("This test requires qos Neutron extension")
+	}
+	tools.PrintResource(t, extension)
 
 	// Create a QoS policy
 	policy, err := accpolicies.CreateQoSPolicy(t, client)
@@ -55,10 +62,14 @@ func TestBandwidthLimitRulesCRUD(t *testing.T) {
 }
 
 func TestDSCPMarkingRulesCRUD(t *testing.T) {
-	clients.SkipRelease(t, "stable/mitaka")
-
 	client, err := clients.NewNetworkV2Client()
 	th.AssertNoErr(t, err)
+
+	extension, err := extensions.Get(client, "qos").Extract()
+	if err != nil {
+		t.Skip("This test requires qos Neutron extension")
+	}
+	tools.PrintResource(t, extension)
 
 	// Create a QoS policy
 	policy, err := accpolicies.CreateQoSPolicy(t, client)
@@ -100,10 +111,14 @@ func TestDSCPMarkingRulesCRUD(t *testing.T) {
 }
 
 func TestMinimumBandwidthRulesCRUD(t *testing.T) {
-	clients.SkipRelease(t, "stable/mitaka")
-
 	client, err := clients.NewNetworkV2Client()
 	th.AssertNoErr(t, err)
+
+	extension, err := extensions.Get(client, "qos").Extract()
+	if err != nil {
+		t.Skip("This test requires qos Neutron extension")
+	}
+	tools.PrintResource(t, extension)
 
 	// Create a QoS policy
 	policy, err := accpolicies.CreateQoSPolicy(t, client)

--- a/acceptance/openstack/networking/v2/extensions/qos/ruletypes/ruletypes_test.go
+++ b/acceptance/openstack/networking/v2/extensions/qos/ruletypes/ruletypes_test.go
@@ -5,19 +5,22 @@ import (
 
 	"github.com/gophercloud/gophercloud/acceptance/clients"
 	"github.com/gophercloud/gophercloud/acceptance/tools"
+	"github.com/gophercloud/gophercloud/openstack/common/extensions"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/qos/ruletypes"
 )
 
 func TestRuleTypes(t *testing.T) {
-	clients.SkipRelease(t, "stable/mitaka")
-	clients.SkipRelease(t, "stable/newton")
-	clients.SkipRelease(t, "stable/ocata")
-
 	client, err := clients.NewNetworkV2Client()
 	if err != nil {
 		t.Fatalf("Unable to create a network client: %v", err)
 		return
 	}
+
+	extension, err := extensions.Get(client, "qos").Extract()
+	if err != nil {
+		t.Skip("This test requires qos Neutron extension")
+	}
+	tools.PrintResource(t, extension)
 
 	page, err := ruletypes.ListRuleTypes(client).AllPages()
 	if err != nil {

--- a/acceptance/openstack/networking/v2/extensions/trunks/trunks_test.go
+++ b/acceptance/openstack/networking/v2/extensions/trunks/trunks_test.go
@@ -10,19 +10,23 @@ import (
 	"github.com/gophercloud/gophercloud/acceptance/clients"
 	v2 "github.com/gophercloud/gophercloud/acceptance/openstack/networking/v2"
 	"github.com/gophercloud/gophercloud/acceptance/tools"
+	"github.com/gophercloud/gophercloud/openstack/common/extensions"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/attributestags"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/trunks"
 	th "github.com/gophercloud/gophercloud/testhelper"
 )
 
 func TestTrunkCRUD(t *testing.T) {
-	clients.SkipRelease(t, "stable/mitaka")
-	t.Skip("Currently failing in OpenLab")
-
 	client, err := clients.NewNetworkV2Client()
 	if err != nil {
 		t.Fatalf("Unable to create a network client: %v", err)
 	}
+
+	extension, err := extensions.Get(client, "trunk").Extract()
+	if err != nil {
+		t.Skip("This test requires trunk Neutron extension")
+	}
+	tools.PrintResource(t, extension)
 
 	// Create Network
 	network, err := v2.CreateNetwork(t, client)
@@ -103,13 +107,16 @@ func TestTrunkCRUD(t *testing.T) {
 }
 
 func TestTrunkList(t *testing.T) {
-	clients.SkipRelease(t, "stable/mitaka")
-	t.Skip("Currently failing in OpenLab")
-
 	client, err := clients.NewNetworkV2Client()
 	if err != nil {
 		t.Fatalf("Unable to create a network client: %v", err)
 	}
+
+	extension, err := extensions.Get(client, "trunk").Extract()
+	if err != nil {
+		t.Skip("This test requires trunk Neutron extension")
+	}
+	tools.PrintResource(t, extension)
 
 	allPages, err := trunks.List(client, nil).AllPages()
 	if err != nil {
@@ -127,13 +134,16 @@ func TestTrunkList(t *testing.T) {
 }
 
 func TestTrunkSubportOperation(t *testing.T) {
-	clients.SkipRelease(t, "stable/mitaka")
-	t.Skip("Currently failing in OpenLab")
-
 	client, err := clients.NewNetworkV2Client()
 	if err != nil {
 		t.Fatalf("Unable to create a network client: %v", err)
 	}
+
+	extension, err := extensions.Get(client, "trunk").Extract()
+	if err != nil {
+		t.Skip("This test requires trunk Neutron extension")
+	}
+	tools.PrintResource(t, extension)
 
 	// Create Network
 	network, err := v2.CreateNetwork(t, client)
@@ -212,15 +222,16 @@ func TestTrunkSubportOperation(t *testing.T) {
 }
 
 func TestTrunkTags(t *testing.T) {
-	clients.SkipRelease(t, "stable/mitaka")
-	clients.SkipRelease(t, "stable/newton")
-	clients.SkipRelease(t, "stable/ocata")
-	t.Skip("Currently failing in OpenLab")
-
 	client, err := clients.NewNetworkV2Client()
 	if err != nil {
 		t.Fatalf("Unable to create a network client: %v", err)
 	}
+
+	extension, err := extensions.Get(client, "trunk").Extract()
+	if err != nil {
+		t.Skip("This test requires trunk Neutron extension")
+	}
+	tools.PrintResource(t, extension)
 
 	// Create Network
 	network, err := v2.CreateNetwork(t, client)

--- a/acceptance/openstack/networking/v2/extensions/vlantransparent/vlantransparent_test.go
+++ b/acceptance/openstack/networking/v2/extensions/vlantransparent/vlantransparent_test.go
@@ -9,14 +9,19 @@ import (
 	"github.com/gophercloud/gophercloud/acceptance/clients"
 	networkingv2 "github.com/gophercloud/gophercloud/acceptance/openstack/networking/v2"
 	"github.com/gophercloud/gophercloud/acceptance/tools"
+	"github.com/gophercloud/gophercloud/openstack/common/extensions"
 	th "github.com/gophercloud/gophercloud/testhelper"
 )
 
 func TestVLANTransparentCRUD(t *testing.T) {
-	t.Skip("We don't have VLAN transparent extension in OpenLab.")
-
 	client, err := clients.NewNetworkV2Client()
 	th.AssertNoErr(t, err)
+
+	extension, err := extensions.Get(client, "vlan-transparent").Extract()
+	if err != nil {
+		t.Skip("This test requires vlan-transparent Neutron extension")
+	}
+	tools.PrintResource(t, extension)
 
 	// Create a VLAN transparent network.
 	network, err := CreateVLANTransparentNetwork(t, client)

--- a/acceptance/openstack/networking/v2/extensions/vpnaas/service_test.go
+++ b/acceptance/openstack/networking/v2/extensions/vpnaas/service_test.go
@@ -29,6 +29,7 @@ func TestServiceList(t *testing.T) {
 }
 
 func TestServiceCRUD(t *testing.T) {
+	clients.SkipReleasesAbove(t, "stable/wallaby")
 	client, err := clients.NewNetworkV2Client()
 	th.AssertNoErr(t, err)
 

--- a/acceptance/openstack/networking/v2/extensions/vpnaas/siteconnection_test.go
+++ b/acceptance/openstack/networking/v2/extensions/vpnaas/siteconnection_test.go
@@ -31,6 +31,7 @@ func TestConnectionList(t *testing.T) {
 }
 
 func TestConnectionCRUD(t *testing.T) {
+	clients.SkipReleasesAbove(t, "stable/wallaby")
 	client, err := clients.NewNetworkV2Client()
 	th.AssertNoErr(t, err)
 


### PR DESCRIPTION
This runs a Github Action to:

* Deploy Devstack with Neutron
* Run acceptance/openstack/networking
* Unskip a lot of tests
* Do not test FWaaS v1, too old and will be removed from Gophercloud via #2320
* Skip FWAAS v2 testing after Ussuri (service was removed); and deploy it only on
  Ussuri and Train, so it can still be tested.
* Fix a test for FWAAS, where ICMP rule can't have a port in source
* Skip TestAgentsRUD because it can't work with OVN (default in devstack
  now). This test will have to be reworked in the future.
* Fix TestDNSPortCRUDL test (some typos)
* Skip TestLayer3RouterAgents because it can't work with OVN (default
  in devstack now). This test will have to be rewored in the future.
* Skip TestDNSFloatingIPCRDL which doesn't work with ML2/OVN
* Skip LBAAS (v1 and v2) from Neutron API, it was removed and replaced by Octavia.
  We'll need to deprecate and remove it from Gophercloud as well.
* In TestMTUNetworkCRUDL, reduce the MTU to 1440. With OVN + Geneve, we
  can't go above 1442, so let's set 1440 for the test to be safe.
* Skip VlanTransparent, Trunk and QoS testing if the extension is not there.
* Post logs if we encounter a failure