### PR TITLE
acceptance: add pipefail to `acceptancetest` script

### DIFF
--- a/script/acceptancetest
+++ b/script/acceptancetest
@@ -1,6 +1,7 @@
 #!/bin/bash
 #
 set -x
+set -o pipefail
 
 source `dirname $0`/stackenv
 


### PR DESCRIPTION
Since we now redirect the output to a log file, we need to enable
pipefail otherwise RC will always be 0 which is wrong if tests fail.
