### PR TITLE
Update loadbalancer/v2/l7policies create and update

### DIFF
--- a/openstack/loadbalancer/v2/l7policies/requests.go
+++ b/openstack/loadbalancer/v2/l7policies/requests.go
@@ -16,6 +16,7 @@ type RuleType string
 type CompareType string
 
 const (
+	ActionRedirectPrefix Action = "REDIRECT_PREFIX"
 	ActionRedirectToPool Action = "REDIRECT_TO_POOL"
 	ActionRedirectToURL  Action = "REDIRECT_TO_URL"
 	ActionReject         Action = "REJECT"
@@ -42,7 +43,7 @@ type CreateOpts struct {
 	// The ID of the listener.
 	ListenerID string `json:"listener_id,omitempty"`
 
-	// The L7 policy action. One of REDIRECT_TO_POOL, REDIRECT_TO_URL, or REJECT.
+	// The L7 policy action. One of REDIRECT_PREFIX, REDIRECT_TO_POOL, REDIRECT_TO_URL, or REJECT.
 	Action Action `json:"action" required:"true"`
 
 	// The position of this policy on the listener.
@@ -55,6 +56,10 @@ type CreateOpts struct {
 	// Only administrative users can specify a project UUID other than their own.
 	ProjectID string `json:"project_id,omitempty"`
 
+	// Requests matching this policy will be redirected to this Prefix URL.
+	// Only valid if action is REDIRECT_PREFIX.
+	RedirectPrefix string `json:"redirect_prefix,omitempty"`
+
 	// Requests matching this policy will be redirected to the pool with this ID.
 	// Only valid if action is REDIRECT_TO_POOL.
 	RedirectPoolID string `json:"redirect_pool_id,omitempty"`
@@ -62,6 +67,11 @@ type CreateOpts struct {
 	// Requests matching this policy will be redirected to this URL.
 	// Only valid if action is REDIRECT_TO_URL.
 	RedirectURL string `json:"redirect_url,omitempty"`
+
+	// Requests matching this policy will be redirected to the specified URL or Prefix URL
+	// with the HTTP response code. Valid if action is REDIRECT_TO_URL or REDIRECT_PREFIX.
+	// Valid options are: 301, 302, 303, 307, or 308. Default is 302. Requires version 2.9
+	RedirectHttpCode int32 `json:"redirect_http_code,omitempty"`
 
 	// The administrative state of the Loadbalancer. A valid value is true (UP)
 	// or false (DOWN).
@@ -169,7 +179,7 @@ type UpdateOpts struct {
 	// Name of the L7 policy, empty string is allowed.
 	Name *string `json:"name,omitempty"`
 
-	// The L7 policy action. One of REDIRECT_TO_POOL, REDIRECT_TO_URL, or REJECT.
+	// The L7 policy action. One of REDIRECT_PREFIX, REDIRECT_TO_POOL, REDIRECT_TO_URL, or REJECT.
 	Action Action `json:"action,omitempty"`
 
 	// The position of this policy on the listener.
@@ -178,6 +188,10 @@ type UpdateOpts struct {
 	// A human-readable description for the resource, empty string is allowed.
 	Description *string `json:"description,omitempty"`
 
+	// Requests matching this policy will be redirected to this Prefix URL.
+	// Only valid if action is REDIRECT_PREFIX.
+	RedirectPrefix *string `json:"redirect_prefix,omitempty"`
+
 	// Requests matching this policy will be redirected to the pool with this ID.
 	// Only valid if action is REDIRECT_TO_POOL.
 	RedirectPoolID *string `json:"redirect_pool_id,omitempty"`
@@ -185,6 +199,11 @@ type UpdateOpts struct {
 	// Requests matching this policy will be redirected to this URL.
 	// Only valid if action is REDIRECT_TO_URL.
 	RedirectURL *string `json:"redirect_url,omitempty"`
+
+	// Requests matching this policy will be redirected to the specified URL or Prefix URL
+	// with the HTTP response code. Valid if action is REDIRECT_TO_URL or REDIRECT_PREFIX.
+	// Valid options are: 301, 302, 303, 307, or 308. Default is 302. Requires version 2.9
+	RedirectHttpCode int32 `json:"redirect_http_code,omitempty"`
 
 	// The administrative state of the Loadbalancer. A valid value is true (UP)
 	// or false (DOWN).
@@ -206,6 +225,14 @@ func (opts UpdateOpts) ToL7PolicyUpdateMap() (map[string]interface{}, error) {
 
 	if m["redirect_url"] == "" {
 		m["redirect_url"] = nil
+	}
+
+	if m["redirect_prefix"] == "" {
+		m["redirect_prefix"] = nil
+	}
+
+	if m["redirect_http_code"] == 0 {
+		m["redirect_http_code"] = nil
 	}
 
 	return b, nil

--- a/openstack/loadbalancer/v2/l7policies/results.go
+++ b/openstack/loadbalancer/v2/l7policies/results.go
@@ -17,7 +17,7 @@ type L7Policy struct {
 	// The ID of the listener.
 	ListenerID string `json:"listener_id"`
 
-	// The L7 policy action. One of REDIRECT_TO_POOL, REDIRECT_TO_URL, or REJECT.
+	// The L7 policy action. One of REDIRECT_PREFIX, REDIRECT_TO_POOL, REDIRECT_TO_URL, or REJECT.
 	Action string `json:"action"`
 
 	// The position of this policy on the listener.
@@ -34,9 +34,17 @@ type L7Policy struct {
 	// Only valid if action is REDIRECT_TO_POOL.
 	RedirectPoolID string `json:"redirect_pool_id"`
 
+	// Requests matching this policy will be redirected to this Prefix URL.
+	// Only valid if action is REDIRECT_PREFIX.
+	RedirectPrefix string `json:"redirect_prefix"`
+
 	// Requests matching this policy will be redirected to this URL.
 	// Only valid if action is REDIRECT_TO_URL.
 	RedirectURL string `json:"redirect_url"`
+
+	// Requests matching this policy will be redirected to the specified URL or Prefix URL
+	// with the HTTP response code. Valid if action is REDIRECT_TO_URL or REDIRECT_PREFIX.
+	RedirectHttpCode int32 `json:"redirect_http_code"`
 
 	// The administrative state of the L7 policy, which is up (true) or down (false).
 	AdminStateUp bool `json:"admin_state_up"`


### PR DESCRIPTION
Add REDIRECT_PREFIX and REDIRECT_HTTP_CODE to l7policy
CreateOpts and UpdateOpts.
Docs: https://docs.openstack.org/api-ref/load-balancer/v2/?expanded=create-an-l7-policy-detail,update-a-l7-policy-detail#create-an-l7-policy
Fixes: #2322

