### PR TITLE
Github workflows: update REGEX to trigger jobs

### DIFF
--- a/.github/workflows/functional-baremetal.yaml
+++ b/.github/workflows/functional-baremetal.yaml
@@ -2,8 +2,7 @@ name: functional-baremetal
 on:
   pull_request:
     paths:
-      - '^.*baremetal.*$'
-      - '.github/workflows/functional-baremetal.yaml'
+      - '**baremetal**'
   schedule:
     - cron: '0 0 * * *'
 jobs:

--- a/.github/workflows/functional-blockstorage.yaml
+++ b/.github/workflows/functional-blockstorage.yaml
@@ -2,8 +2,7 @@ name: functional-blockstorage
 on:
   pull_request:
     paths:
-      - '^.*blockstorage.*$'
-      - '.github/workflows/functional-blockstorage.yaml'
+      - '**blockstorage**'
   schedule:
     - cron: '0 0 * * *'
 jobs:

--- a/.github/workflows/functional-compute.yaml
+++ b/.github/workflows/functional-compute.yaml
@@ -2,8 +2,7 @@ name: functional-compute
 on:
   pull_request:
     paths:
-      - '^.*compute.*$'
-      - '.github/workflows/functional-compute.yaml'
+      - '**compute**'
   schedule:
     - cron: '0 0 * * *'
 jobs:

--- a/.github/workflows/functional-identity.yaml
+++ b/.github/workflows/functional-identity.yaml
@@ -2,8 +2,7 @@ name: functional-identity
 on:
   pull_request:
     paths:
-      - '^.*identity.*$'
-      - '.github/workflows/functional-identity.yaml'
+      - '**identity**'
   schedule:
     - cron: '0 0 * * *'
 jobs:

--- a/.github/workflows/functional-imageservice.yaml
+++ b/.github/workflows/functional-imageservice.yaml
@@ -2,8 +2,7 @@ name: functional-imageservice
 on:
   pull_request:
     paths:
-      - '^.*imageservice.*$'
-      - '.github/workflows/functional-imageservice.yaml'
+      - '**imageservice**'
   schedule:
     - cron: '0 0 * * *'
 jobs:

--- a/.github/workflows/functional-keymanager.yaml
+++ b/.github/workflows/functional-keymanager.yaml
@@ -2,8 +2,7 @@ name: functional-keymanager
 on:
   pull_request:
     paths:
-      - '^.*keymanager.*$'
-      - '.github/workflows/functional-keymanager.yaml'
+      - '**keymanager**'
   schedule:
     - cron: '0 0 * * *'
 jobs:


### PR DESCRIPTION
We thought Github supported usual REGEX syntax but it's not, see:
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet

So we update the functional workflows so the jobs run when the right
files are modified.
