### PR TITLE
Fix triggers for basic and dns functional workflows

### DIFF
--- a/.github/workflows/functional-basic.yaml
+++ b/.github/workflows/functional-basic.yaml
@@ -2,7 +2,10 @@ name: functional-basic
 on:
   pull_request:
     paths-ignore:
-      - '^docs/|\.md$|^(?:.*/)?(?:\.gitignore|LICENSE)$'
+      - 'docs/**'
+      - '**.md'
+      - '**.gitignore'
+      - '**LICENSE'
   schedule:
     - cron: '0 0 * * *'
 jobs:

--- a/.github/workflows/functional-dns.yaml
+++ b/.github/workflows/functional-dns.yaml
@@ -2,8 +2,8 @@ name: functional-dns
 on:
   pull_request:
     paths:
-      - '^acceptance/openstack/dns.*$'
-      - '.github/workflows/functional-dns.yaml'
+      - 'acceptance/openstack/dns**'
+      - '**functional-dns.yaml'
   schedule:
     - cron: '0 0 * * *'
 jobs:


### PR DESCRIPTION
It's not using regex but instead bash style globbing [1].

Follow-up to #2334.

[1] https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#patterns-to-match-file-paths