### PR TITLE
Add disk/by_id to introspection data

### DIFF
--- a/openstack/baremetalintrospection/v1/introspection/results.go
+++ b/openstack/baremetalintrospection/v1/introspection/results.go
@@ -236,6 +236,7 @@ type RootDiskType struct {
 	Model              string `json:"model"`
 	Name               string `json:"name"`
 	ByPath             string `json:"by_path"`
+	ById               string `json:"by_id"`
 	Rotational         bool   `json:"rotational"`
 	Serial             string `json:"serial"`
 	Size               int64  `json:"size"`


### PR DESCRIPTION
Disk by-id (e.g. /dev/disk/by-id/nvme-eui.0134314821d7dd35)

ById is most reliable way to identify disk because disk Name and
ByPath may be changed after reboot. At the same time ById is
always the same for same disk because it based on device serial
number.
