### PR TITLE
Add allocated_capacity_gb to blockstorage/extensions/schedulerstats

### DIFF
--- a/openstack/blockstorage/extensions/schedulerstats/results.go
+++ b/openstack/blockstorage/extensions/schedulerstats/results.go
@@ -32,6 +32,7 @@ type Capabilities struct {
 	GoodnessFuction          string  `json:"goodness_function"`
 	Multiattach              bool    `json:"multiattach"`
 	SparseCopyVolume         bool    `json:"sparse_copy_volume"`
+	AllocatedCapacityGB      float64 `json:"-"`
 }
 
 // StoragePool represents an individual StoragePool retrieved from the
@@ -45,6 +46,7 @@ func (r *Capabilities) UnmarshalJSON(b []byte) error {
 	type tmp Capabilities
 	var s struct {
 		tmp
+		AllocatedCapacityGB      interface{} `json:"allocated_capacity_gb"`
 		FreeCapacityGB           interface{} `json:"free_capacity_gb"`
 		MaxOverSubscriptionRatio interface{} `json:"max_over_subscription_ratio"`
 		TotalCapacityGB          interface{} `json:"total_capacity_gb"`
@@ -71,6 +73,7 @@ func (r *Capabilities) UnmarshalJSON(b []byte) error {
 		return 0.0
 	}
 
+	r.AllocatedCapacityGB = parseCapacity(s.AllocatedCapacityGB)
 	r.FreeCapacityGB = parseCapacity(s.FreeCapacityGB)
 	r.TotalCapacityGB = parseCapacity(s.TotalCapacityGB)
 


### PR DESCRIPTION
Fixes #2347

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://docs.openstack.org/cinder/xena/admin/blockstorage-driver-filter-weighing.html#host-stats-for-a-back-end
https://docs.openstack.org/cinder/latest/contributor/api/cinder.scheduler.host_manager.html#cinder.scheduler.host_manager.BackendState.update_from_volume_capability
https://github.com/openstack/cinder/blob/master/cinder/scheduler/host_manager.py#L126