### PR TITLE
Add support for shared-file-system `/v2/services` and `/v2/scheduler-stats/pools`

### DIFF
--- a/acceptance/openstack/sharedfilesystems/v2/schedulerstats_test.go
+++ b/acceptance/openstack/sharedfilesystems/v2/schedulerstats_test.go
@@ -1,0 +1,29 @@
+//go:build acceptance
+// +build acceptance
+
+package v2
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/acceptance/clients"
+	"github.com/gophercloud/gophercloud/acceptance/tools"
+	"github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/schedulerstats"
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestSchedulerStatsList(t *testing.T) {
+	client, err := clients.NewSharedFileSystemV2Client()
+	client.Microversion = "2.23"
+	th.AssertNoErr(t, err)
+
+	allPages, err := schedulerstats.List(client, nil).AllPages()
+	th.AssertNoErr(t, err)
+
+	allPools, err := schedulerstats.ExtractPools(allPages)
+	th.AssertNoErr(t, err)
+
+	for _, recordset := range allPools {
+		tools.PrintResource(t, &recordset)
+	}
+}

--- a/acceptance/openstack/sharedfilesystems/v2/services_test.go
+++ b/acceptance/openstack/sharedfilesystems/v2/services_test.go
@@ -1,0 +1,32 @@
+//go:build acceptance
+// +build acceptance
+
+package v2
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/acceptance/clients"
+	"github.com/gophercloud/gophercloud/acceptance/tools"
+	"github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/services"
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestServicesList(t *testing.T) {
+	client, err := clients.NewSharedFileSystemV2Client()
+	th.AssertNoErr(t, err)
+
+	client.Microversion = "2.7"
+	allPages, err := services.List(client, nil).AllPages()
+	th.AssertNoErr(t, err)
+
+	allServices, err := services.ExtractServices(allPages)
+	th.AssertNoErr(t, err)
+
+	th.AssertIntGreaterOrEqual(t, len(allServices), 1)
+
+	for _, s := range allServices {
+		tools.PrintResource(t, &s)
+		th.AssertEquals(t, s.Status, "enabled")
+	}
+}

--- a/acceptance/openstack/sharedfilesystems/v2/shares.go
+++ b/acceptance/openstack/sharedfilesystems/v2/shares.go
@@ -16,7 +16,7 @@ import (
 // error will be returned if the share could not be created
 func CreateShare(t *testing.T, client *gophercloud.ServiceClient) (*shares.Share, error) {
 	if testing.Short() {
-		t.Skip("Skipping test that requres share creation in short mode.")
+		t.Skip("Skipping test that requires share creation in short mode.")
 	}
 
 	iTrue := true

--- a/openstack/sharedfilesystems/v2/schedulerstats/doc.go
+++ b/openstack/sharedfilesystems/v2/schedulerstats/doc.go
@@ -1,0 +1,22 @@
+/*
+Package schedulerstats returns information about shared file systems capacity
+and utilisation. Example:
+
+	listOpts := schedulerstats.ListOpts{
+	}
+
+	allPages, err := schedulerstats.List(client, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allStats, err := schedulerstats.ExtractPools(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, stat := range allStats {
+		fmt.Printf("%+v\n", stat)
+	}
+*/
+package schedulerstats

--- a/openstack/sharedfilesystems/v2/schedulerstats/requests.go
+++ b/openstack/sharedfilesystems/v2/schedulerstats/requests.go
@@ -1,0 +1,92 @@
+package schedulerstats
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// ListOptsBuilder allows extensions to add additional parameters to the
+// List request.
+type ListOptsBuilder interface {
+	ToPoolsListQuery() (string, error)
+}
+
+// ListOpts controls the view of data returned (e.g globally or per project).
+type ListOpts struct {
+	// The pool name for the back end.
+	ProjectID string `json:"project_id,omitempty"`
+	// The pool name for the back end.
+	PoolName string `json:"pool_name"`
+	// The host name for the back end.
+	HostName string `json:"host_name"`
+	// The name of the back end.
+	BackendName string `json:"backend_name"`
+	// The capabilities for the storage back end.
+	Capabilities string `json:"capabilities"`
+	// The share type name or UUID. Allows filtering back end pools based on the extra-specs in the share type.
+	ShareType string `json:"share_type,omitempty"`
+}
+
+// ToPoolsListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToPoolsListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List makes a request against the API to list pool information.
+func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := poolsListURL(client)
+	if opts != nil {
+		query, err := opts.ToPoolsListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return PoolPage{pagination.SinglePageBase(r)}
+	})
+}
+
+// ListDetailOptsBuilder allows extensions to add additional parameters to the
+// ListDetail request.
+type ListDetailOptsBuilder interface {
+	ToPoolsListQuery() (string, error)
+}
+
+// ListOpts controls the view of data returned (e.g globally or per project).
+type ListDetailOpts struct {
+	// The pool name for the back end.
+	ProjectID string `json:"project_id,omitempty"`
+	// The pool name for the back end.
+	PoolName string `json:"pool_name"`
+	// The host name for the back end.
+	HostName string `json:"host_name"`
+	// The name of the back end.
+	BackendName string `json:"backend_name"`
+	// The capabilities for the storage back end.
+	Capabilities string `json:"capabilities"`
+	// The share type name or UUID. Allows filtering back end pools based on the extra-specs in the share type.
+	ShareType string `json:"share_type,omitempty"`
+}
+
+// ToPoolsListQuery formats a ListDetailOpts into a query string.
+func (opts ListDetailOpts) ToPoolsListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// ListDetail makes a request against the API to list detailed pool information.
+func ListDetail(client *gophercloud.ServiceClient, opts ListDetailOptsBuilder) pagination.Pager {
+	url := poolsListDetailURL(client)
+	if opts != nil {
+		query, err := opts.ToPoolsListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return PoolPage{pagination.SinglePageBase(r)}
+	})
+}

--- a/openstack/sharedfilesystems/v2/schedulerstats/results.go
+++ b/openstack/sharedfilesystems/v2/schedulerstats/results.go
@@ -1,0 +1,116 @@
+package schedulerstats
+
+import (
+	"encoding/json"
+	"math"
+
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// Capabilities represents the information of an individual Pool.
+type Capabilities struct {
+	// The following fields should be present in all storage drivers.
+
+	// The quality of service (QoS) support.
+	Qos bool `json:"qos"`
+	// The date and time stamp when the API request was issued.
+	Timestamp string `json:"timestamp"`
+	// The name of the share back end.
+	ShareBackendName string `json:"share_backend_name"`
+	// Share server is usually a storage virtual machine or a lightweight container that is used to export shared file systems.
+	DriverHandlesShareServers bool `json:"driver_handles_share_servers"`
+	// The driver version of the back end.
+	DriverVersion string `json:"driver_version"`
+	// The amount of free capacity for the back end, in GiBs. A valid value is a string, such as unknown, or an integer.
+	FreeCapacityGB float64 `json:"-"`
+	// The storage protocol for the back end. For example, NFS_CIFS, glusterfs, HDFS, etc.
+	StorageProtocol string `json:"storage_protocol"`
+	// The total capacity for the back end, in GiBs. A valid value is a string, such as unknown, or an integer.
+	TotalCapacityGB float64 `json:"-"`
+	// The specification that filters back ends by whether they do or do not support share snapshots.
+	SnapshotSupport bool `json:"snapshot_support"`
+	// The back end replication domain.
+	ReplicationDomain string `json:"replication_domain"`
+	// The name of the vendor for the back end.
+	VendorName string `json:"vendor_name"`
+
+	// The following fields are optional and may have empty values depending
+
+	// on the storage driver in use.
+	ReservedPercentage  int64   `json:"reserved_percentage"`
+	AllocatedCapacityGB float64 `json:"-"`
+}
+
+// Pool represents an individual Pool retrieved from the
+// schedulerstats API.
+type Pool struct {
+	// The name of the back end.
+	Name string `json:"name"`
+	// The name of the back end.
+	Backend string `json:"backend"`
+	// The pool name for the back end.
+	Pool string `json:"pool"`
+	// The host name for the back end.
+	Host string `json:"host"`
+	// The back end capabilities which include qos, total_capacity_gb, etc.
+	Capabilities Capabilities `json:"capabilities,omitempty"`
+}
+
+func (r *Capabilities) UnmarshalJSON(b []byte) error {
+	type tmp Capabilities
+	var s struct {
+		tmp
+		AllocatedCapacityGB interface{} `json:"allocated_capacity_gb"`
+		FreeCapacityGB      interface{} `json:"free_capacity_gb"`
+		TotalCapacityGB     interface{} `json:"total_capacity_gb"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	*r = Capabilities(s.tmp)
+
+	// Generic function to parse a capacity value which may be a numeric
+	// value, "unknown", or "infinite"
+	parseCapacity := func(capacity interface{}) float64 {
+		if capacity != nil {
+			switch capacity.(type) {
+			case float64:
+				return capacity.(float64)
+			case string:
+				if capacity.(string) == "infinite" {
+					return math.Inf(1)
+				}
+			}
+		}
+		return 0.0
+	}
+
+	r.AllocatedCapacityGB = parseCapacity(s.AllocatedCapacityGB)
+	r.FreeCapacityGB = parseCapacity(s.FreeCapacityGB)
+	r.TotalCapacityGB = parseCapacity(s.TotalCapacityGB)
+
+	return nil
+}
+
+// PoolPage is a single page of all List results.
+type PoolPage struct {
+	pagination.SinglePageBase
+}
+
+// IsEmpty satisfies the IsEmpty method of the Page interface. It returns true
+// if a List contains no results.
+func (page PoolPage) IsEmpty() (bool, error) {
+	va, err := ExtractPools(page)
+	return len(va) == 0, err
+}
+
+// ExtractPools takes a List result and extracts the collection of
+// Pools returned by the API.
+func ExtractPools(p pagination.Page) ([]Pool, error) {
+	var s struct {
+		Pools []Pool `json:"pools"`
+	}
+	err := (p.(PoolPage)).ExtractInto(&s)
+	return s.Pools, err
+}

--- a/openstack/sharedfilesystems/v2/schedulerstats/testing/fixtures.go
+++ b/openstack/sharedfilesystems/v2/schedulerstats/testing/fixtures.go
@@ -14,16 +14,28 @@ const PoolsListBody = `
 {
     "pools": [
         {
-            "name": "opencloud@alpha#ALPHA_pool"
+            "name": "opencloud@alpha#ALPHA_pool",
+            "host": "opencloud",
+            "backend": "alpha",
+            "pool": "ALPHA_pool"
         },
         {
-            "name": "opencloud@beta#BETA_pool"
+            "name": "opencloud@beta#BETA_pool",
+            "host": "opencloud",
+            "backend": "beta",
+            "pool": "BETA_pool"
         },
         {
-            "name": "opencloud@gamma#GAMMA_pool"
+            "name": "opencloud@gamma#GAMMA_pool",
+            "host": "opencloud",
+            "backend": "gamma",
+            "pool": "GAMMA_pool"
         },
         {
-            "name": "opencloud@delta#DELTA_pool"
+            "name": "opencloud@delta#DELTA_pool",
+            "host": "opencloud",
+            "backend": "delta",
+            "pool": "DELTA_pool"
         }
     ]
 }
@@ -113,7 +125,6 @@ const PoolsListBodyDetail = `
                 "mount_snapshot_support": true,
                 "dedupe": false,
                 "compression": false,
-                "replication_domain": "replica_domain_store1",
                 "sg_consistent_snapshot_support": "pool",
                 "ipv4_support": true,
                 "ipv6_support": false
@@ -142,7 +153,6 @@ const PoolsListBodyDetail = `
                 "mount_snapshot_support": true,
                 "dedupe": false,
                 "compression": false,
-                "replication_domain": "replica_domain_store1",
                 "sg_consistent_snapshot_support": "pool",
                 "ipv4_support": true,
                 "ipv6_support": false
@@ -154,66 +164,102 @@ const PoolsListBodyDetail = `
 
 var (
 	PoolFake1 = schedulerstats.Pool{
-		Name: "opencloud@alpha#ALPHA_pool",
+		Name:    "opencloud@alpha#ALPHA_pool",
+		Host:    "opencloud",
+		Backend: "alpha",
+		Pool:    "ALPHA_pool",
 	}
 
 	PoolFake2 = schedulerstats.Pool{
-		Name: "opencloud@beta#BETA_pool",
+		Name:    "opencloud@beta#BETA_pool",
+		Host:    "opencloud",
+		Backend: "beta",
+		Pool:    "BETA_pool",
 	}
 
 	PoolFake3 = schedulerstats.Pool{
-		Name: "opencloud@gamma#GAMMA_pool",
+		Name:    "opencloud@gamma#GAMMA_pool",
+		Host:    "opencloud",
+		Backend: "gamma",
+		Pool:    "GAMMA_pool",
 	}
 
 	PoolFake4 = schedulerstats.Pool{
-		Name: "opencloud@delta#DELTA_pool",
+		Name:    "opencloud@delta#DELTA_pool",
+		Host:    "opencloud",
+		Backend: "delta",
+		Pool:    "DELTA_pool",
 	}
 
 	PoolDetailFake1 = schedulerstats.Pool{
-		Name: "opencloud@alpha#ALPHA_pool",
-		Host: "opencloud",
+		Name:    "opencloud@alpha#ALPHA_pool",
+		Host:    "opencloud",
+		Backend: "alpha",
+		Pool:    "ALPHA_pool",
 		Capabilities: schedulerstats.Capabilities{
-			DriverVersion:   "1.0",
-			FreeCapacityGB:  1210,
-			StorageProtocol: "NFS_CIFS",
-			TotalCapacityGB: 1230,
-			VendorName:      "Open Source",
+			DriverVersion:             "1.0",
+			FreeCapacityGB:            1210,
+			StorageProtocol:           "NFS_CIFS",
+			TotalCapacityGB:           1230,
+			VendorName:                "Open Source",
+			ShareBackendName:          "ALPHA",
+			Timestamp:                 "2019-05-07T00:28:02.935569",
+			DriverHandlesShareServers: true,
+			SnapshotSupport:           true,
 		},
 	}
 
 	PoolDetailFake2 = schedulerstats.Pool{
-		Name: "opencloud@beta#BETA_pool",
-		Host: "opencloud",
+		Name:    "opencloud@beta#BETA_pool",
+		Host:    "opencloud",
+		Backend: "beta",
+		Pool:    "BETA_pool",
 		Capabilities: schedulerstats.Capabilities{
-			DriverVersion:   "1.0",
-			FreeCapacityGB:  1210,
-			StorageProtocol: "NFS_CIFS",
-			TotalCapacityGB: 1230,
-			VendorName:      "Open Source",
+			DriverVersion:             "1.0",
+			FreeCapacityGB:            1210,
+			StorageProtocol:           "NFS_CIFS",
+			TotalCapacityGB:           1230,
+			VendorName:                "Open Source",
+			ShareBackendName:          "BETA",
+			Timestamp:                 "2019-05-07T00:28:02.817309",
+			DriverHandlesShareServers: true,
+			SnapshotSupport:           true,
 		},
 	}
 
 	PoolDetailFake3 = schedulerstats.Pool{
-		Name: "opencloud@gamma#GAMMA_pool",
-		Host: "opencloud",
+		Name:    "opencloud@gamma#GAMMA_pool",
+		Host:    "opencloud",
+		Backend: "gamma",
+		Pool:    "GAMMA_pool",
 		Capabilities: schedulerstats.Capabilities{
-			DriverVersion:   "1.0",
-			FreeCapacityGB:  1210,
-			StorageProtocol: "NFS_CIFS",
-			TotalCapacityGB: 1230,
-			VendorName:      "Open Source",
+			DriverVersion:             "1.0",
+			FreeCapacityGB:            1210,
+			StorageProtocol:           "NFS_CIFS",
+			TotalCapacityGB:           1230,
+			VendorName:                "Open Source",
+			ShareBackendName:          "GAMMA",
+			Timestamp:                 "2019-05-07T00:28:02.899888",
+			DriverHandlesShareServers: false,
+			SnapshotSupport:           true,
 		},
 	}
 
 	PoolDetailFake4 = schedulerstats.Pool{
-		Name: "opencloud@delta#DELTA_pool",
-		Host: "opencloud",
+		Name:    "opencloud@delta#DELTA_pool",
+		Host:    "opencloud",
+		Backend: "delta",
+		Pool:    "DELTA_pool",
 		Capabilities: schedulerstats.Capabilities{
-			DriverVersion:   "1.0",
-			FreeCapacityGB:  1210,
-			StorageProtocol: "NFS_CIFS",
-			TotalCapacityGB: 1230,
-			VendorName:      "Open Source",
+			DriverVersion:             "1.0",
+			FreeCapacityGB:            1210,
+			StorageProtocol:           "NFS_CIFS",
+			TotalCapacityGB:           1230,
+			VendorName:                "Open Source",
+			ShareBackendName:          "DELTA",
+			Timestamp:                 "2019-05-07T00:28:02.963660",
+			DriverHandlesShareServers: false,
+			SnapshotSupport:           true,
 		},
 	}
 )

--- a/openstack/sharedfilesystems/v2/schedulerstats/testing/fixtures.go
+++ b/openstack/sharedfilesystems/v2/schedulerstats/testing/fixtures.go
@@ -1,0 +1,241 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/schedulerstats"
+	"github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+const PoolsListBody = `
+{
+    "pools": [
+        {
+            "name": "opencloud@alpha#ALPHA_pool"
+        },
+        {
+            "name": "opencloud@beta#BETA_pool"
+        },
+        {
+            "name": "opencloud@gamma#GAMMA_pool"
+        },
+        {
+            "name": "opencloud@delta#DELTA_pool"
+        }
+    ]
+}
+`
+
+const PoolsListBodyDetail = `
+{
+    "pools": [
+        {
+            "name": "opencloud@alpha#ALPHA_pool",
+            "host": "opencloud",
+            "backend": "alpha",
+            "pool": "ALPHA_pool",
+            "capabilities": {
+                "pool_name": "ALPHA_pool",
+                "total_capacity_gb": 1230.0,
+                "free_capacity_gb": 1210.0,
+                "reserved_percentage": 0,
+                "share_backend_name": "ALPHA",
+                "storage_protocol": "NFS_CIFS",
+                "vendor_name": "Open Source",
+                "driver_version": "1.0",
+                "timestamp": "2019-05-07T00:28:02.935569",
+                "driver_handles_share_servers": true,
+                "snapshot_support": true,
+                "create_share_from_snapshot_support": true,
+                "revert_to_snapshot_support": true,
+                "mount_snapshot_support": true,
+                "dedupe": false,
+                "compression": false,
+                "replication_type": null,
+                "replication_domain": null,
+                "sg_consistent_snapshot_support": "pool",
+                "ipv4_support": true,
+                "ipv6_support": false
+            }
+        },
+        {
+            "name": "opencloud@beta#BETA_pool",
+            "host": "opencloud",
+            "backend": "beta",
+            "pool": "BETA_pool",
+            "capabilities": {
+                "pool_name": "BETA_pool",
+                "total_capacity_gb": 1230.0,
+                "free_capacity_gb": 1210.0,
+                "reserved_percentage": 0,
+                "share_backend_name": "BETA",
+                "storage_protocol": "NFS_CIFS",
+                "vendor_name": "Open Source",
+                "driver_version": "1.0",
+                "timestamp": "2019-05-07T00:28:02.817309",
+                "driver_handles_share_servers": true,
+                "snapshot_support": true,
+                "create_share_from_snapshot_support": true,
+                "revert_to_snapshot_support": true,
+                "mount_snapshot_support": true,
+                "dedupe": false,
+                "compression": false,
+                "replication_type": null,
+                "replication_domain": null,
+                "sg_consistent_snapshot_support": "pool",
+                "ipv4_support": true,
+                "ipv6_support": false
+            }
+        },
+        {
+            "name": "opencloud@gamma#GAMMA_pool",
+            "host": "opencloud",
+            "backend": "gamma",
+            "pool": "GAMMA_pool",
+            "capabilities": {
+                "pool_name": "GAMMA_pool",
+                "total_capacity_gb": 1230.0,
+                "free_capacity_gb": 1210.0,
+                "reserved_percentage": 0,
+                "replication_type": "readable",
+                "share_backend_name": "GAMMA",
+                "storage_protocol": "NFS_CIFS",
+                "vendor_name": "Open Source",
+                "driver_version": "1.0",
+                "timestamp": "2019-05-07T00:28:02.899888",
+                "driver_handles_share_servers": false,
+                "snapshot_support": true,
+                "create_share_from_snapshot_support": true,
+                "revert_to_snapshot_support": true,
+                "mount_snapshot_support": true,
+                "dedupe": false,
+                "compression": false,
+                "replication_domain": "replica_domain_store1",
+                "sg_consistent_snapshot_support": "pool",
+                "ipv4_support": true,
+                "ipv6_support": false
+            }
+        },
+        {
+            "name": "opencloud@delta#DELTA_pool",
+            "host": "opencloud",
+            "backend": "delta",
+            "pool": "DELTA_pool",
+            "capabilities": {
+                "pool_name": "DELTA_pool",
+                "total_capacity_gb": 1230.0,
+                "free_capacity_gb": 1210.0,
+                "reserved_percentage": 0,
+                "replication_type": "readable",
+                "share_backend_name": "DELTA",
+                "storage_protocol": "NFS_CIFS",
+                "vendor_name": "Open Source",
+                "driver_version": "1.0",
+                "timestamp": "2019-05-07T00:28:02.963660",
+                "driver_handles_share_servers": false,
+                "snapshot_support": true,
+                "create_share_from_snapshot_support": true,
+                "revert_to_snapshot_support": true,
+                "mount_snapshot_support": true,
+                "dedupe": false,
+                "compression": false,
+                "replication_domain": "replica_domain_store1",
+                "sg_consistent_snapshot_support": "pool",
+                "ipv4_support": true,
+                "ipv6_support": false
+            }
+        }
+    ]
+}
+`
+
+var (
+	PoolFake1 = schedulerstats.Pool{
+		Name: "opencloud@alpha#ALPHA_pool",
+	}
+
+	PoolFake2 = schedulerstats.Pool{
+		Name: "opencloud@beta#BETA_pool",
+	}
+
+	PoolFake3 = schedulerstats.Pool{
+		Name: "opencloud@gamma#GAMMA_pool",
+	}
+
+	PoolFake4 = schedulerstats.Pool{
+		Name: "opencloud@delta#DELTA_pool",
+	}
+
+	PoolDetailFake1 = schedulerstats.Pool{
+		Name: "opencloud@alpha#ALPHA_pool",
+		Host: "opencloud",
+		Capabilities: schedulerstats.Capabilities{
+			DriverVersion:   "1.0",
+			FreeCapacityGB:  1210,
+			StorageProtocol: "NFS_CIFS",
+			TotalCapacityGB: 1230,
+			VendorName:      "Open Source",
+		},
+	}
+
+	PoolDetailFake2 = schedulerstats.Pool{
+		Name: "opencloud@beta#BETA_pool",
+		Host: "opencloud",
+		Capabilities: schedulerstats.Capabilities{
+			DriverVersion:   "1.0",
+			FreeCapacityGB:  1210,
+			StorageProtocol: "NFS_CIFS",
+			TotalCapacityGB: 1230,
+			VendorName:      "Open Source",
+		},
+	}
+
+	PoolDetailFake3 = schedulerstats.Pool{
+		Name: "opencloud@gamma#GAMMA_pool",
+		Host: "opencloud",
+		Capabilities: schedulerstats.Capabilities{
+			DriverVersion:   "1.0",
+			FreeCapacityGB:  1210,
+			StorageProtocol: "NFS_CIFS",
+			TotalCapacityGB: 1230,
+			VendorName:      "Open Source",
+		},
+	}
+
+	PoolDetailFake4 = schedulerstats.Pool{
+		Name: "opencloud@delta#DELTA_pool",
+		Host: "opencloud",
+		Capabilities: schedulerstats.Capabilities{
+			DriverVersion:   "1.0",
+			FreeCapacityGB:  1210,
+			StorageProtocol: "NFS_CIFS",
+			TotalCapacityGB: 1230,
+			VendorName:      "Open Source",
+		},
+	}
+)
+
+func HandlePoolsListSuccessfully(t *testing.T) {
+	testhelper.Mux.HandleFunc("/scheduler-stats/pools", func(w http.ResponseWriter, r *http.Request) {
+		testhelper.TestMethod(t, r, "GET")
+		testhelper.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+
+		r.ParseForm()
+		fmt.Fprintf(w, PoolsListBody)
+
+	})
+	testhelper.Mux.HandleFunc("/scheduler-stats/pools/detail", func(w http.ResponseWriter, r *http.Request) {
+		testhelper.TestMethod(t, r, "GET")
+		testhelper.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+
+		r.ParseForm()
+		fmt.Fprintf(w, PoolsListBodyDetail)
+	})
+}

--- a/openstack/sharedfilesystems/v2/schedulerstats/testing/requests_test.go
+++ b/openstack/sharedfilesystems/v2/schedulerstats/testing/requests_test.go
@@ -1,0 +1,64 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/schedulerstats"
+	"github.com/gophercloud/gophercloud/pagination"
+	"github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func TestListPoolsDetail(t *testing.T) {
+	testhelper.SetupHTTP()
+	defer testhelper.TeardownHTTP()
+	HandlePoolsListSuccessfully(t)
+
+	pages := 0
+	err := schedulerstats.List(client.ServiceClient(), schedulerstats.ListOpts{}).EachPage(func(page pagination.Page) (bool, error) {
+		pages++
+
+		actual, err := schedulerstats.ExtractPools(page)
+		testhelper.AssertNoErr(t, err)
+
+		if len(actual) != 4 {
+			t.Fatalf("Expected 4 backends, got %d", len(actual))
+		}
+		testhelper.CheckDeepEquals(t, PoolFake1, actual[0])
+		testhelper.CheckDeepEquals(t, PoolFake2, actual[1])
+		testhelper.CheckDeepEquals(t, PoolFake3, actual[2])
+		testhelper.CheckDeepEquals(t, PoolFake4, actual[3])
+
+		return true, nil
+	})
+
+	testhelper.AssertNoErr(t, err)
+
+	if pages != 1 {
+		t.Errorf("Expected 1 page, saw %d", pages)
+	}
+
+	pages = 0
+	err = schedulerstats.ListDetail(client.ServiceClient(), schedulerstats.ListDetailOpts{}).EachPage(func(page pagination.Page) (bool, error) {
+		pages++
+
+		actual, err := schedulerstats.ExtractPools(page)
+		testhelper.AssertNoErr(t, err)
+
+		if len(actual) != 4 {
+			t.Fatalf("Expected 4 backends, got %d", len(actual))
+		}
+		testhelper.CheckDeepEquals(t, PoolDetailFake1, actual[0])
+		testhelper.CheckDeepEquals(t, PoolDetailFake2, actual[1])
+		testhelper.CheckDeepEquals(t, PoolDetailFake3, actual[2])
+		testhelper.CheckDeepEquals(t, PoolDetailFake4, actual[3])
+
+		return true, nil
+	})
+
+	testhelper.AssertNoErr(t, err)
+
+	if pages != 1 {
+		t.Errorf("Expected 1 page, saw %d", pages)
+	}
+}

--- a/openstack/sharedfilesystems/v2/schedulerstats/urls.go
+++ b/openstack/sharedfilesystems/v2/schedulerstats/urls.go
@@ -1,0 +1,11 @@
+package schedulerstats
+
+import "github.com/gophercloud/gophercloud"
+
+func poolsListURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("scheduler-stats", "pools")
+}
+
+func poolsListDetailURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("scheduler-stats", "pools", "detail")
+}

--- a/openstack/sharedfilesystems/v2/services/doc.go
+++ b/openstack/sharedfilesystems/v2/services/doc.go
@@ -1,0 +1,22 @@
+/*
+Package services returns information about the sharedfilesystems services in the
+OpenStack cloud.
+
+Example of Retrieving list of all services
+
+	allPages, err := services.List(sharedFileSystemV2, services.ListOpts{}).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allServices, err := services.ExtractServices(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, service := range allServices {
+		fmt.Printf("%+v\n", service)
+	}
+*/
+
+package services

--- a/openstack/sharedfilesystems/v2/services/requests.go
+++ b/openstack/sharedfilesystems/v2/services/requests.go
@@ -1,0 +1,49 @@
+package services
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// ListOptsBuilder allows extensions to add additional parameters to the List
+// request.
+type ListOptsBuilder interface {
+	ToServiceListQuery() (string, error)
+}
+
+// ListOpts holds options for listing Services.
+type ListOpts struct {
+	// The pool name for the back end.
+	ProjectID string `json:"project_id,omitempty"`
+	// The service host name.
+	Host string `json:"host"`
+	// The service binary name. Default is the base name of the executable.
+	Binary string `json:"binary"`
+	// The availability zone.
+	Zone string `json:"zone"`
+	// The current state of the service. A valid value is up or down.
+	State string `json:"state"`
+	// The service status, which is enabled or disabled.
+	Status string `json:"status"`
+}
+
+// ToServiceListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToServiceListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List makes a request against the API to list services.
+func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(client)
+	if opts != nil {
+		query, err := opts.ToServiceListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return ServicePage{pagination.SinglePageBase(r)}
+	})
+}

--- a/openstack/sharedfilesystems/v2/services/results.go
+++ b/openstack/sharedfilesystems/v2/services/results.go
@@ -1,0 +1,70 @@
+package services
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// Service represents a Shared File System service in the OpenStack cloud.
+type Service struct {
+	// The binary name of the service.
+	Binary string `json:"binary"`
+
+	// The name of the host.
+	Host string `json:"host"`
+
+	// The ID of the service.
+	ID int `json:"id"`
+
+	// The state of the service. One of up or down.
+	State string `json:"state"`
+
+	// The status of the service. One of available or unavailable.
+	Status string `json:"status"`
+
+	// The date and time stamp when the extension was last updated.
+	UpdatedAt time.Time `json:"-"`
+
+	// The availability zone name.
+	Zone string `json:"zone"`
+}
+
+// UnmarshalJSON to override default
+func (r *Service) UnmarshalJSON(b []byte) error {
+	type tmp Service
+	var s struct {
+		tmp
+		UpdatedAt gophercloud.JSONRFC3339MilliNoZ `json:"updated_at"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	*r = Service(s.tmp)
+
+	r.UpdatedAt = time.Time(s.UpdatedAt)
+
+	return nil
+}
+
+// ServicePage represents a single page of all Services from a List request.
+type ServicePage struct {
+	pagination.SinglePageBase
+}
+
+// IsEmpty determines whether or not a page of Services contains any results.
+func (page ServicePage) IsEmpty() (bool, error) {
+	services, err := ExtractServices(page)
+	return len(services) == 0, err
+}
+
+func ExtractServices(r pagination.Page) ([]Service, error) {
+	var s struct {
+		Service []Service `json:"services"`
+	}
+	err := (r.(ServicePage)).ExtractInto(&s)
+	return s.Service, err
+}

--- a/openstack/sharedfilesystems/v2/services/testing/fixtures.go
+++ b/openstack/sharedfilesystems/v2/services/testing/fixtures.go
@@ -1,0 +1,71 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/services"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+// ServiceListBody is sample response to the List call
+const ServiceListBody = `
+{
+	"services": [
+			{
+					"status": "enabled",
+					"binary": "manila-share",
+					"zone": "manila",
+					"host": "manila2@generic1",
+					"updated_at": "2015-09-07T13:03:57.000000",
+					"state": "up",
+					"id": 1
+			},
+			{
+					"status": "enabled",
+					"binary": "manila-scheduler",
+					"zone": "manila",
+					"host": "manila2",
+					"updated_at": "2015-09-07T13:03:57.000000",
+					"state": "up",
+					"id": 2
+			}
+	]
+}
+`
+
+// First service from the ServiceListBody
+var FirstFakeService = services.Service{
+	Binary:    "manila-share",
+	Host:      "manila2@generic1",
+	ID:        1,
+	State:     "up",
+	Status:    "enabled",
+	UpdatedAt: time.Date(2015, 9, 7, 13, 3, 57, 0, time.UTC),
+	Zone:      "manila",
+}
+
+// Second service from the ServiceListBody
+var SecondFakeService = services.Service{
+	Binary:    "manila-scheduler",
+	Host:      "manila2",
+	ID:        2,
+	State:     "up",
+	Status:    "enabled",
+	UpdatedAt: time.Date(2015, 9, 7, 13, 3, 57, 0, time.UTC),
+	Zone:      "manila",
+}
+
+// HandleListSuccessfully configures the test server to respond to a List request.
+func HandleListSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/services", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprintf(w, ServiceListBody)
+	})
+}

--- a/openstack/sharedfilesystems/v2/services/testing/requests_test.go
+++ b/openstack/sharedfilesystems/v2/services/testing/requests_test.go
@@ -1,0 +1,40 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/services"
+	"github.com/gophercloud/gophercloud/pagination"
+	"github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func TestListServices(t *testing.T) {
+	testhelper.SetupHTTP()
+	defer testhelper.TeardownHTTP()
+	HandleListSuccessfully(t)
+
+	pages := 0
+	err := services.List(client.ServiceClient(), services.ListOpts{}).EachPage(func(page pagination.Page) (bool, error) {
+		pages++
+
+		actual, err := services.ExtractServices(page)
+		if err != nil {
+			return false, err
+		}
+
+		if len(actual) != 2 {
+			t.Fatalf("Expected 2 services, got %d", len(actual))
+		}
+		testhelper.CheckDeepEquals(t, FirstFakeService, actual[0])
+		testhelper.CheckDeepEquals(t, SecondFakeService, actual[1])
+
+		return true, nil
+	})
+
+	testhelper.AssertNoErr(t, err)
+
+	if pages != 1 {
+		t.Errorf("Expected 1 page, saw %d", pages)
+	}
+}

--- a/openstack/sharedfilesystems/v2/services/urls.go
+++ b/openstack/sharedfilesystems/v2/services/urls.go
@@ -1,0 +1,7 @@
+package services
+
+import "github.com/gophercloud/gophercloud"
+
+func listURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("services")
+}


### PR DESCRIPTION
Fixes #2349

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://docs.openstack.org/api-ref/shared-file-system/?expanded=#list-back-end-storage-pools
https://docs.openstack.org/api-ref/shared-file-system/?expanded=#list-services
