### PR TITLE
dns/v2/recordsets: add missing metadata field

### DIFF
--- a/openstack/dns/v2/recordsets/results.go
+++ b/openstack/dns/v2/recordsets/results.go
@@ -112,6 +112,11 @@ type RecordSet struct {
 	// useful for passing along to other APIs that might want a recordset
 	// reference.
 	Links []gophercloud.Link `json:"-"`
+
+	// Metadata contains the total_count of resources matching the filter
+	Metadata struct {
+		TotalCount int `json:"total_count"`
+	} `json:"metadata"`
 }
 
 func (r *RecordSet) UnmarshalJSON(b []byte) error {


### PR DESCRIPTION
Fixes #2352

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://docs.openstack.org/api-ref/dns/?expanded=list-recordsets-in-a-zone-detail#id81
