### PR TITLE
Add ParentProviderUUID to resourceProvider

### DIFF
--- a/acceptance/openstack/placement/v1/placement.go
+++ b/acceptance/openstack/placement/v1/placement.go
@@ -1,0 +1,56 @@
+package v1
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/acceptance/tools"
+	"github.com/gophercloud/gophercloud/openstack/placement/v1/resourceproviders"
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func CreateResourceProvider(t *testing.T, client *gophercloud.ServiceClient) (*resourceproviders.ResourceProvider, error) {
+	name := tools.RandomString("TESTACC-", 8)
+	t.Logf("Attempting to create resource provider: %s", name)
+
+	createOpts := resourceproviders.CreateOpts{
+		Name: name,
+	}
+
+	client.Microversion = "1.20"
+	resourceProvider, err := resourceproviders.Create(client, createOpts).Extract()
+	if err != nil {
+		return resourceProvider, err
+	}
+
+	t.Logf("Successfully created resourceProvider: %s.", resourceProvider.Name)
+	tools.PrintResource(t, resourceProvider)
+
+	th.AssertEquals(t, resourceProvider.Name, name)
+
+	return resourceProvider, nil
+}
+
+func CreateResourceProviderWithParent(t *testing.T, client *gophercloud.ServiceClient, parentUUID string) (*resourceproviders.ResourceProvider, error) {
+	name := tools.RandomString("TESTACC-", 8)
+	t.Logf("Attempting to create resource provider: %s", name)
+
+	createOpts := resourceproviders.CreateOpts{
+		Name:               name,
+		ParentProviderUUID: parentUUID,
+	}
+
+	client.Microversion = "1.20"
+	resourceProvider, err := resourceproviders.Create(client, createOpts).Extract()
+	if err != nil {
+		return resourceProvider, err
+	}
+
+	t.Logf("Successfully created resourceProvider: %s.", resourceProvider.Name)
+	tools.PrintResource(t, resourceProvider)
+
+	th.AssertEquals(t, resourceProvider.Name, name)
+	th.AssertEquals(t, resourceProvider.ParentProviderUUID, parentUUID)
+
+	return resourceProvider, nil
+}

--- a/acceptance/openstack/placement/v1/resourceproviders_test.go
+++ b/acceptance/openstack/placement/v1/resourceproviders_test.go
@@ -32,18 +32,11 @@ func TestResourceProviderCreate(t *testing.T) {
 	client, err := clients.NewPlacementV1Client()
 	th.AssertNoErr(t, err)
 
-	name := tools.RandomString("TESTACC-", 8)
-	t.Logf("Attempting to create resource provider: %s", name)
-
-	createOpts := resourceproviders.CreateOpts{
-		Name: name,
-	}
-
-	client.Microversion = "1.20"
-	resourceProvider, err := resourceproviders.Create(client, createOpts).Extract()
+	resourceProvider, err := CreateResourceProvider(t, client)
 	th.AssertNoErr(t, err)
 
-	tools.PrintResource(t, resourceProvider)
+	resourceProvider, err = CreateResourceProviderWithParent(t, client, resourceProvider.UUID)
+	th.AssertNoErr(t, err)
 }
 
 func TestResourceProviderUsages(t *testing.T) {
@@ -55,15 +48,7 @@ func TestResourceProviderUsages(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	// first create new resource provider
-	name := tools.RandomString("TESTACC-", 8)
-	t.Logf("Attempting to create resource provider: %s", name)
-
-	createOpts := resourceproviders.CreateOpts{
-		Name: name,
-	}
-
-	client.Microversion = "1.20"
-	resourceProvider, err := resourceproviders.Create(client, createOpts).Extract()
+	resourceProvider, err := CreateResourceProvider(t, client)
 	th.AssertNoErr(t, err)
 
 	// now get the usages for the newly created resource provider
@@ -80,15 +65,7 @@ func TestResourceProviderInventories(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	// first create new resource provider
-	name := tools.RandomString("TESTACC-", 8)
-	t.Logf("Attempting to create resource provider: %s", name)
-
-	createOpts := resourceproviders.CreateOpts{
-		Name: name,
-	}
-
-	client.Microversion = "1.20"
-	resourceProvider, err := resourceproviders.Create(client, createOpts).Extract()
+	resourceProvider, err := CreateResourceProvider(t, client)
 	th.AssertNoErr(t, err)
 
 	// now get the inventories for the newly created resource provider
@@ -105,15 +82,7 @@ func TestResourceProviderTraits(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	// first create new resource provider
-	name := tools.RandomString("TESTACC-", 8)
-	t.Logf("Attempting to create resource provider: %s", name)
-
-	createOpts := resourceproviders.CreateOpts{
-		Name: name,
-	}
-
-	client.Microversion = "1.20"
-	resourceProvider, err := resourceproviders.Create(client, createOpts).Extract()
+	resourceProvider, err := CreateResourceProvider(t, client)
 	th.AssertNoErr(t, err)
 
 	// now get the traits for the newly created resource provider
@@ -130,15 +99,7 @@ func TestResourceProviderAllocations(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	// first create new resource provider
-	name := tools.RandomString("TESTACC-", 8)
-	t.Logf("Attempting to create resource provider: %s", name)
-
-	createOpts := resourceproviders.CreateOpts{
-		Name: name,
-	}
-
-	client.Microversion = "1.20"
-	resourceProvider, err := resourceproviders.Create(client, createOpts).Extract()
+	resourceProvider, err := CreateResourceProvider(t, client)
 	th.AssertNoErr(t, err)
 
 	// now get the allocations for the newly created resource provider

--- a/openstack/placement/v1/resourceproviders/doc.go
+++ b/openstack/placement/v1/resourceproviders/doc.go
@@ -22,6 +22,7 @@ Example to create resource providers
 	createOpts := resourceproviders.CreateOpts{
 		Name: "new-rp",
 		UUID: "b99b3ab4-3aa6-4fba-b827-69b88b9c544a",
+		ParentProvider: "c7f50b40-6f32-4d7a-9f32-9384057be83b"
 	}
 
 	rp, err := resourceproviders.Create(placementClient, createOpts).Extract()

--- a/openstack/placement/v1/resourceproviders/requests.go
+++ b/openstack/placement/v1/resourceproviders/requests.go
@@ -69,6 +69,9 @@ type CreateOptsBuilder interface {
 type CreateOpts struct {
 	Name string `json:"name"`
 	UUID string `json:"uuid,omitempty"`
+	// The UUID of the immediate parent of the resource provider.
+	// Available in version >= 1.14
+	ParentProviderUUID string `json:"parent_provider_uuid,omitempty"`
 }
 
 // ToResourceProviderCreateMap constructs a request body from CreateOpts.

--- a/openstack/placement/v1/resourceproviders/testing/requests_test.go
+++ b/openstack/placement/v1/resourceproviders/testing/requests_test.go
@@ -46,8 +46,9 @@ func TestCreateResourceProvider(t *testing.T) {
 	expected := ExpectedResourceProvider1
 
 	opts := resourceproviders.CreateOpts{
-		Name: ExpectedResourceProvider1.Name,
-		UUID: ExpectedResourceProvider1.UUID,
+		Name:               ExpectedResourceProvider1.Name,
+		UUID:               ExpectedResourceProvider1.UUID,
+		ParentProviderUUID: ExpectedResourceProvider1.ParentProviderUUID,
 	}
 
 	actual, err := resourceproviders.Create(fake.ServiceClient(), opts).Extract()


### PR DESCRIPTION
Add ParentProviderUUID to placement/v1/resourceproviders createOpts.
Moreover restructure acceptance tests for consistency and for future
additions.

[Docs](https://docs.openstack.org/api-ref/placement/?expanded=create-resource-provider-detail)

Relates to: #526
