### PR TITLE
zuul: drop storage jobs

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -43,43 +43,11 @@
         - zun
 
 - job:
-    name: gophercloud-acceptance-test-storage
-    parent: gophercloud-acceptance-test-base
-    description: |
-      Run gophercloud storage acceptance test on master branch
-    files:
-      - ^.*blockstorage.*$
-      - ^.*imageservice.*$
-      - ^.*objectstorage.*$
-      - ^.*sharedfilesystems.*$
-    vars:
-      acceptance_tests:
-        - acceptance/openstack/blockstorage
-        - acceptance/openstack/blockstorage/extensions
-        - acceptance/openstack/blockstorage/v3
-        - acceptance/openstack/imageservice/v2
-        - acceptance/openstack/objectstorage/v1
-        - acceptance/openstack/sharedfilesystems/v2
-        - acceptance/openstack/sharedfilesystems/v2/messages
-      devstack_services:
-        - manila
-
-- job:
     name: gophercloud-acceptance-test-compute-ussuri
     parent: gophercloud-acceptance-test-compute
     nodeset: ubuntu-bionic
     description: |
       Run gophercloud compute acceptance test on ussuri branch
-    vars:
-      global_env:
-        OS_BRANCH: stable/ussuri
-
-- job:
-    name: gophercloud-acceptance-test-storage-ussuri
-    parent: gophercloud-acceptance-test-storage
-    nodeset: ubuntu-bionic
-    description: |
-      Run gophercloud storage test on ussuri branch
     vars:
       global_env:
         OS_BRANCH: stable/ussuri
@@ -95,31 +63,11 @@
         OS_BRANCH: stable/train
 
 - job:
-    name: gophercloud-acceptance-test-storage-train
-    parent: gophercloud-acceptance-test-storage
-    nodeset: ubuntu-xenial
-    description: |
-      Run gophercloud storage acceptance test on train branch
-    vars:
-      global_env:
-        OS_BRANCH: stable/train
-
-- job:
     name: gophercloud-acceptance-test-compute-stein
     parent: gophercloud-acceptance-test-compute
     nodeset: ubuntu-xenial
     description: |
       Run gophercloud compute acceptance test on stein branch
-    vars:
-      global_env:
-        OS_BRANCH: stable/stein
-
-- job:
-    name: gophercloud-acceptance-test-storage-stein
-    parent: gophercloud-acceptance-test-storage
-    nodeset: ubuntu-xenial
-    description: |
-      Run gophercloud storage acceptance test on stein branch
     vars:
       global_env:
         OS_BRANCH: stable/stein
@@ -135,30 +83,10 @@
         OS_BRANCH: stable/rocky
 
 - job:
-    name: gophercloud-acceptance-test-storage-rocky
-    parent: gophercloud-acceptance-test-storage
-    nodeset: ubuntu-xenial
-    description: |
-      Run gophercloud storage acceptance test on rocky branch
-    vars:
-      global_env:
-        OS_BRANCH: stable/rocky
-
-- job:
     name: gophercloud-acceptance-test-compute-queens
     parent: gophercloud-acceptance-test-compute
     description: |
       Run gophercloud compute acceptance test on queens branch
-    nodeset: ubuntu-xenial
-    vars:
-      global_env:
-        OS_BRANCH: stable/queens
-
-- job:
-    name: gophercloud-acceptance-test-storage-queens
-    parent: gophercloud-acceptance-test-storage
-    description: |
-      Run gophercloud storage acceptance test on queens branch
     nodeset: ubuntu-xenial
     vars:
       global_env:
@@ -177,30 +105,10 @@
         OS_BRANCH: stable/pike
 
 - job:
-    name: gophercloud-acceptance-test-storage-pike
-    parent: gophercloud-acceptance-test-storage
-    description: |
-      Run gophercloud storage acceptance test on pike branch
-    nodeset: ubuntu-xenial
-    vars:
-      global_env:
-        OS_BRANCH: stable/pike
-
-- job:
     name: gophercloud-acceptance-test-compute-ocata
     parent: gophercloud-acceptance-test-compute
     description: |
       Run gophercloud compute acceptance test on ocata branch
-    nodeset: ubuntu-xenial
-    vars:
-      global_env:
-        OS_BRANCH: stable/ocata
-
-- job:
-    name: gophercloud-acceptance-test-storage-ocata
-    parent: gophercloud-acceptance-test-storage
-    description: |
-      Run gophercloud storage acceptance test on ocata branch
     nodeset: ubuntu-xenial
     vars:
       global_env:
@@ -213,16 +121,6 @@
     parent: gophercloud-acceptance-test-compute
     description: |
       Run gophercloud compute acceptance test on newton branch
-    nodeset: ubuntu-xenial
-    vars:
-      global_env:
-        OS_BRANCH: stable/newton
-
-- job:
-    name: gophercloud-acceptance-test-storage-newton
-    parent: gophercloud-acceptance-test-storage
-    description: |
-      Run gophercloud storage acceptance test on newton branch
     nodeset: ubuntu-xenial
     vars:
       global_env:
@@ -244,8 +142,6 @@
         - acceptance/openstack/container/v1
         - acceptance/openstack/orchestration/v1
         - acceptance/openstack/placement/v1
-        - acceptance/openstack/sharedfilesystems/v2
-        - acceptance/openstack/sharedfilesystems/v2/messages
       devstack_services:
         - manila
         - zun
@@ -320,36 +216,27 @@
       jobs:
         - gophercloud-unittest
         - gophercloud-acceptance-test-compute
-        - gophercloud-acceptance-test-storage
     recheck-newton:
       jobs:
         - gophercloud-acceptance-test-compute-newton
-        - gophercloud-acceptance-test-storage-newton
     recheck-ocata:
       jobs:
         - gophercloud-acceptance-test-compute-ocata
-        - gophercloud-acceptance-test-storage-ocata
     recheck-pike:
       jobs:
         - gophercloud-acceptance-test-compute-pike
-        - gophercloud-acceptance-test-storage-pike
     recheck-queens:
       jobs:
         - gophercloud-acceptance-test-compute-queens
-        - gophercloud-acceptance-test-storage-queens
     recheck-rocky:
       jobs:
         - gophercloud-acceptance-test-compute-rocky
-        - gophercloud-acceptance-test-storage-rocky
     recheck-stein:
       jobs:
         - gophercloud-acceptance-test-compute-stein
-        - gophercloud-acceptance-test-storage-stein
     recheck-train:
       jobs:
         - gophercloud-acceptance-test-compute-train
-        - gophercloud-acceptance-test-storage-train
     recheck-ussuri:
       jobs:
         - gophercloud-acceptance-test-compute-ussuri
-        - gophercloud-acceptance-test-storage-ussuri


### PR DESCRIPTION
We've replaced all of the storage jobs with github actions.