### PR TITLE
Fix trigger of functional-dns job

### DIFF
--- a/.github/workflows/functional-dns.yaml
+++ b/.github/workflows/functional-dns.yaml
@@ -2,7 +2,7 @@ name: functional-dns
 on:
   pull_request:
     paths:
-      - 'acceptance/openstack/dns**'
+      - '**openstack/dns**'
       - '**functional-dns.yaml'
   schedule:
     - cron: '0 0 * * *'


### PR DESCRIPTION
The previous filter would not run the functional-dns job when files
touching the DNS service, under the openstack/dns path, were modified.
This commit fixes it.

We can't use the simpler `**dns**` filter as this would match the files
for the neutron DNS extension which is a different thing.