### PR TITLE
Stop using `go get` as required by latest golang

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -23,8 +23,8 @@ jobs:
 
       - name: Setup environment
         run: |
-          go get github.com/wadey/gocovmerge
-          go get golang.org/x/tools/cmd/goimports
+          go install github.com/wadey/gocovmerge@master || go get github.com/wadey/gocovmerge
+          go install golang.org/x/tools/cmd/goimports@latest || go get golang.org/x/tools/cmd/goimports
 
       - name: Run go vet
         run: |


### PR DESCRIPTION
See release notes: https://go.dev/doc/go1.18
```
go get no longer builds or installs packages in module-aware mode.
go get is now dedicated to adjusting dependencies in go.mod.
Effectively, the -d flag is always enabled.
To install the latest version of an executable outside the context of the current module,
use go install example.com/cmd@latest.
```

Note: we fallback to `go get` if `go install` didn't work as expected,
since we still run it on Go 1.14.