### PR TITLE
containerinfra: add a few missing labels fields

### DIFF
--- a/openstack/containerinfra/v1/clusters/results.go
+++ b/openstack/containerinfra/v1/clusters/results.go
@@ -94,6 +94,9 @@ type Cluster struct {
 	FlavorID           string                 `json:"flavor_id"`
 	KeyPair            string                 `json:"keypair"`
 	Labels             map[string]string      `json:"labels"`
+	LabelsAdded        map[string]string      `json:"labels_added"`
+	LabelsOverridden   map[string]string      `json:"labels_overridden"`
+	LabelsSkipped      map[string]string      `json:"labels_skipped"`
 	Links              []gophercloud.Link     `json:"links"`
 	MasterFlavorID     string                 `json:"master_flavor_id"`
 	MasterAddresses    []string               `json:"master_addresses"`

--- a/openstack/containerinfra/v1/nodegroups/requests.go
+++ b/openstack/containerinfra/v1/nodegroups/requests.go
@@ -87,7 +87,8 @@ type CreateOpts struct {
 	// Node image ID. Defaults to cluster template image if unset.
 	ImageID string `json:"image_id,omitempty"`
 	// Node machine flavor ID. Defaults to cluster minion flavor if unset.
-	FlavorID string `json:"flavor_id,omitempty"`
+	FlavorID    string `json:"flavor_id,omitempty"`
+	MergeLabels *bool  `json:"merge_labels,omitempty"`
 }
 
 func (opts CreateOpts) ToNodeGroupCreateMap() (map[string]interface{}, error) {

--- a/openstack/containerinfra/v1/nodegroups/results.go
+++ b/openstack/containerinfra/v1/nodegroups/results.go
@@ -50,6 +50,9 @@ type NodeGroup struct {
 	ProjectID        string             `json:"project_id"`
 	DockerVolumeSize *int               `json:"docker_volume_size"`
 	Labels           map[string]string  `json:"labels"`
+	LabelsAdded      map[string]string  `json:"labels_added"`
+	LabelsOverridden map[string]string  `json:"labels_overridden"`
+	LabelsSkipped    map[string]string  `json:"labels_skipped"`
 	Links            []gophercloud.Link `json:"links"`
 	FlavorID         string             `json:"flavor_id"`
 	ImageID          string             `json:"image_id"`

--- a/openstack/containerinfra/v1/nodegroups/testing/requests_test.go
+++ b/openstack/containerinfra/v1/nodegroups/testing/requests_test.go
@@ -132,7 +132,8 @@ func TestCreateNodeGroupSuccess(t *testing.T) {
 	sc.Endpoint = sc.Endpoint + "v1/"
 
 	createOpts := nodegroups.CreateOpts{
-		Name: "test-ng",
+		Name:        "test-ng",
+		MergeLabels: gophercloud.Enabled,
 	}
 
 	ng, err := nodegroups.Create(sc, clusterUUID, createOpts).Extract()


### PR DESCRIPTION
Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

Fixes #2376

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/magnum/blob/20413d0c45dc7a6426072bd889bfb71c73fa62b1/magnum/api/controllers/v1/nodegroup.py#L129-L145
https://github.com/openstack/magnum/blob/20413d0c45dc7a6426072bd889bfb71c73fa62b1/magnum/api/controllers/v1/cluster.py#L187-L203

