### PR TITLE
Fix greetings workflow on PRs

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -1,6 +1,6 @@
 name: Greetings
 
-on: [pull_request, issues]
+on: [pull_request_target, issues]
 
 jobs:
   greeting:


### PR DESCRIPTION
The greetings workflow template for github action didn't have the
permission to comment when the PR originated from a fork [1].

It would return a `Resource not accessible by integration` error as seen
in [2].

We need to use the `pull_request_target` [3] trigger rather than
`pull_request` to allow the workflow to execute in the context of the
target repository.

[1] https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
[2] https://github.com/gophercloud/gophercloud/runs/5881926600?check_suite_focus=true
[3] https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target