### PR TITLE
add support restoring a soft-deleted server and tests

### DIFF
--- a/openstack/compute/v2/servers/requests.go
+++ b/openstack/compute/v2/servers/requests.go
@@ -320,6 +320,13 @@ func ForceDelete(client *gophercloud.ServiceClient, id string) (r ActionResult) 
 	return
 }
 
+// Restore  a soft-deleted server.
+func Restore(client *gophercloud.ServiceClient, id string) (r ActionResult) {
+	resp, err := client.Post(actionURL(client, id), map[string]interface{}{"restore": ""}, nil, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
 // Get requests details on a single server, by ID.
 func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {
 	resp, err := client.Get(getURL(client, id), &r.Body, &gophercloud.RequestOpts{

--- a/openstack/compute/v2/servers/testing/fixtures.go
+++ b/openstack/compute/v2/servers/testing/fixtures.go
@@ -935,6 +935,18 @@ func HandleServerForceDeletionSuccessfully(t *testing.T) {
 	})
 }
 
+// HandleServerRestoreSuccessfully sets up the test server to respond to a server restore
+// request.
+func HandleServerRestoreSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/servers/asdfasdfasdf/action", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, `{ "restore": "" }`)
+
+		w.WriteHeader(http.StatusAccepted)
+	})
+}
+
 // HandleServerGetSuccessfully sets up the test server to respond to a server Get request.
 func HandleServerGetSuccessfully(t *testing.T) {
 	th.Mux.HandleFunc("/servers/1234asdf", func(w http.ResponseWriter, r *http.Request) {

--- a/openstack/compute/v2/servers/testing/requests_test.go
+++ b/openstack/compute/v2/servers/testing/requests_test.go
@@ -221,6 +221,15 @@ func TestForceDeleteServer(t *testing.T) {
 	th.AssertNoErr(t, res.Err)
 }
 
+func TestRestoreServer(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleServerRestoreSuccessfully(t)
+
+	res := servers.Restore(client.ServiceClient(), "asdfasdfasdf")
+	th.AssertNoErr(t, res.Err)
+}
+
 func TestGetServer(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()


### PR DESCRIPTION
Fixes https://github.com/gophercloud/gophercloud/issues/2368

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://docs.openstack.org/api-ref/compute/?expanded=restore-soft-deleted-instance-restore-action-detail