### PR TITLE
Add missing fields in Objectstorage and compute API

### DIFF
--- a/openstack/compute/v2/servers/results.go
+++ b/openstack/compute/v2/servers/results.go
@@ -279,6 +279,10 @@ type Server struct {
 
 	// AvailabilityZone is the availabilty zone the server is in.
 	AvailabilityZone string `json:"OS-EXT-AZ:availability_zone"`
+
+	// Locked indicates the lock status of the server
+	// This requires microversion 2.9 or later
+	Locked *bool `json:"locked"`
 }
 
 type AttachedVolume struct {

--- a/openstack/compute/v2/servers/testing/fixtures_test.go
+++ b/openstack/compute/v2/servers/testing/fixtures_test.go
@@ -158,7 +158,8 @@ const ServerListBody = `
 			"progress": 0,
 			"OS-EXT-STS:power_state": 1,
 			"config_drive": "",
-			"metadata": {}
+			"metadata": {},
+			"locked": true
 		},
 		{
 		"status": "ACTIVE",
@@ -297,7 +298,8 @@ const SingleServerBody = `
 		"progress": 0,
 		"OS-EXT-STS:power_state": 1,
 		"config_drive": "",
-		"metadata": {}
+		"metadata": {},
+		"locked": true
 	}
 }
 `
@@ -631,6 +633,7 @@ var (
 		TerminatedAt:       time.Time{},
 		DiskConfig:         servers.Manual,
 		AvailabilityZone:   "nova",
+		Locked:             func() *bool { b := true; return &b }(),
 	}
 
 	ConsoleOutput = "abc"

--- a/openstack/compute/v2/servers/testing/requests_test.go
+++ b/openstack/compute/v2/servers/testing/requests_test.go
@@ -774,6 +774,7 @@ func TestGetFaultyServer(t *testing.T) {
 
 	FaultyServer := ServerDerp
 	FaultyServer.Fault = DerpFault
+	FaultyServer.Locked = nil
 	th.CheckDeepEquals(t, FaultyServer, *actual)
 }
 
@@ -1145,6 +1146,7 @@ func TestCreateServerWithTags(t *testing.T) {
 	tags := []string{"foo", "bar"}
 	ServerDerpTags := ServerDerp
 	ServerDerpTags.Tags = &tags
+	ServerDerpTags.Locked = nil
 
 	createOpts := servers.CreateOpts{
 		Name:      "derp",

--- a/openstack/objectstorage/v1/containers/results.go
+++ b/openstack/objectstorage/v1/containers/results.go
@@ -111,6 +111,8 @@ type GetHeader struct {
 	TempURLKey2      string    `json:"X-Container-Meta-Temp-URL-Key-2"`
 	Timestamp        float64   `json:"X-Timestamp,string"`
 	VersionsEnabled  bool      `json:"-"`
+	SyncKey          string    `json:"X-Sync-Key"`
+	SyncTo           string    `json:"X-Sync-To"`
 }
 
 func (r *GetHeader) UnmarshalJSON(b []byte) error {

--- a/openstack/objectstorage/v1/containers/testing/fixtures.go
+++ b/openstack/objectstorage/v1/containers/testing/fixtures.go
@@ -258,6 +258,8 @@ func HandleGetContainerSuccessfully(t *testing.T, options ...option) {
 		w.Header().Set("X-Trans-Id", "tx554ed59667a64c61866f1-0057b4ba37")
 		w.Header().Set("X-Storage-Policy", "test_policy")
 		w.Header().Set("X-Versions-Enabled", "True")
+		w.Header().Set("X-Sync-Key", "272465181849")
+		w.Header().Set("X-Sync-To", "anotherContainer")
 		w.WriteHeader(http.StatusNoContent)
 	})
 }

--- a/openstack/objectstorage/v1/containers/testing/requests_test.go
+++ b/openstack/objectstorage/v1/containers/testing/requests_test.go
@@ -244,6 +244,8 @@ func TestGetContainer(t *testing.T) {
 		StoragePolicy:   "test_policy",
 		Timestamp:       1471298837.95721,
 		VersionsEnabled: true,
+		SyncKey:         "272465181849",
+		SyncTo:          "anotherContainer",
 	}
 	actual, err := res.Extract()
 	th.AssertNoErr(t, err)


### PR DESCRIPTION
Fixes https://github.com/gophercloud/gophercloud/issues/2386 and https://github.com/gophercloud/gophercloud/issues/1958

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://docs.openstack.org/api-ref/compute/?expanded=show-server-details-detail#:~:text=security%20group%20name.-,locked,-body
https://docs.openstack.org/api-ref/object-store/?expanded=create-container-detail#:~:text=X%2DContainer%2DSync%2DTo%20(Optional)
