### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/gomod.yml
+++ b/.github/workflows/gomod.yml
@@ -1,5 +1,8 @@
 on: [push, pull_request]
 name: go mod
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/reauth-retests.yaml
+++ b/.github/workflows/reauth-retests.yaml
@@ -1,5 +1,8 @@
 on: [push, pull_request]
 name: Reauth retests
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -1,7 +1,13 @@
 on: [push, pull_request]
 name: Unit Testing
+permissions:
+  contents: read
+
 jobs:
   test:
+    permissions:
+      checks: write  # for shogo82148/actions-goveralls to create a new check based on the results
+      contents: read  # for actions/checkout to fetch code
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -43,6 +49,8 @@ jobs:
           parallel: true
 
   finish:
+    permissions:
+      checks: write  # for shogo82148/actions-goveralls to create a new check based on the results
     needs: test
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
