### PR TITLE
Neutron v2: BGP Speaker create / delete 

### DIFF
--- a/acceptance/openstack/networking/v2/extensions/bgp/speakers/bgpspeakers_test.go
+++ b/acceptance/openstack/networking/v2/extensions/bgp/speakers/bgpspeakers_test.go
@@ -1,0 +1,76 @@
+package speakers
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/acceptance/clients"
+	"github.com/gophercloud/gophercloud/acceptance/tools"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/bgp/speakers"
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func CreateBGPSpeaker(t *testing.T, client *gophercloud.ServiceClient) (*speakers.BGPSpeaker, error) {
+	opts := speakers.CreateOpts{
+		IPVersion:                     4,
+		AdvertiseFloatingIPHostRoutes: false,
+		AdvertiseTenantNetworks:       true,
+		Name:                          tools.RandomString("TESTACC-BGPSPEAKER-", 8),
+		LocalAS:                       "3000",
+		Networks:                      []string{},
+	}
+
+	t.Logf("Attempting to create BGP Speaker: %s", opts.Name)
+	bgpSpeaker, err := speakers.Create(client, opts).Extract()
+	if err != nil {
+		return bgpSpeaker, err
+	}
+
+	localas, err := strconv.Atoi(opts.LocalAS)
+	t.Logf("Successfully created BGP Speaker")
+	th.AssertEquals(t, bgpSpeaker.Name, opts.Name)
+	th.AssertEquals(t, bgpSpeaker.LocalAS, localas)
+	th.AssertEquals(t, bgpSpeaker.IPVersion, opts.IPVersion)
+	th.AssertEquals(t, bgpSpeaker.AdvertiseTenantNetworks, opts.AdvertiseTenantNetworks)
+	th.AssertEquals(t, bgpSpeaker.AdvertiseFloatingIPHostRoutes, opts.AdvertiseFloatingIPHostRoutes)
+	return bgpSpeaker, err
+}
+
+func TestBGPSpeakerCRD(t *testing.T) {
+	clients.RequireAdmin(t)
+
+	client, err := clients.NewNetworkV2Client()
+	th.AssertNoErr(t, err)
+
+	// Create a BGP Speaker
+	bgpSpeakerCreated, err := CreateBGPSpeaker(t, client)
+	th.AssertNoErr(t, err)
+	tools.PrintResource(t, bgpSpeakerCreated)
+
+	// Get a BGP Speaker
+	bgpSpeakerGot, err := speakers.Get(client, bgpSpeakerCreated.ID).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, bgpSpeakerCreated.ID, bgpSpeakerGot.ID)
+	th.AssertEquals(t, bgpSpeakerCreated.Name, bgpSpeakerGot.Name)
+
+	// List BGP Speakers
+	allPages, err := speakers.List(client).AllPages()
+	th.AssertNoErr(t, err)
+	allSpeakers, err := speakers.ExtractBGPSpeakers(allPages)
+	th.AssertNoErr(t, err)
+
+	t.Logf("Retrieved BGP Speakers")
+	tools.PrintResource(t, allSpeakers)
+	th.AssertIntGreaterOrEqual(t, len(allSpeakers), 1)
+
+	// Delete a BGP Speaker
+	t.Logf("Attempting to delete BGP Speaker: %s", bgpSpeakerGot.Name)
+	err = speakers.Delete(client, bgpSpeakerGot.ID).ExtractErr()
+	th.AssertNoErr(t, err)
+
+	// Confirm the BGP Speaker is deleted
+	bgpSpeakerGot, err = speakers.Get(client, bgpSpeakerGot.ID).Extract()
+	th.AssertErr(t, err)
+	t.Logf("BGP Speaker %s deleted", bgpSpeakerCreated.Name)
+}

--- a/acceptance/openstack/networking/v2/extensions/bgp/speakers/doc.go
+++ b/acceptance/openstack/networking/v2/extensions/bgp/speakers/doc.go
@@ -1,0 +1,2 @@
+// BGP Peer acceptance tests
+package speakers

--- a/openstack/networking/v2/extensions/bgp/speakers/doc.go
+++ b/openstack/networking/v2/extensions/bgp/speakers/doc.go
@@ -31,4 +31,34 @@ Example:
                 log.Panic(nil)
         }
         log.Printf("%+v", *speaker)
+
+
+3. Create BGP Speaker, a.k.a. POST /bgp-speakers
+
+Example:
+
+	opts := speakers.CreateOpts{
+		IPVersion:                     6,
+		AdvertiseFloatingIPHostRoutes: false,
+		AdvertiseTenantNetworks:       true,
+		Name:                          "gophercloud-testing-bgp-speaker",
+		LocalAS:                       "2000",
+		Networks:                      []string{},
+	}
+        r, err := speaker.Create(c, opts).Extract()
+        if err != nil {
+                log.Panic(err)
+        }
+        log.Printf("%+v", *r)
+
+
+5. Delete BGP Speaker, a.k.a. DELETE /bgp-speakers/{id}
+
+Example:
+
+        err := speaker.Delete(auth, speakerID).ExtractErr()
+        if err != nil {
+                log.Panic(err)
+        }
+        log.Printf("Speaker Deleted")
 */

--- a/openstack/networking/v2/extensions/bgp/speakers/requests.go
+++ b/openstack/networking/v2/extensions/bgp/speakers/requests.go
@@ -19,3 +19,43 @@ func Get(c *gophercloud.ServiceClient, id string) (r GetResult) {
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
+
+// CreateOpts represents options used to create a network.
+type CreateOpts struct {
+	Name                          string   `json:"name"`
+	IPVersion                     int      `json:"ip_version"`
+	AdvertiseFloatingIPHostRoutes bool     `json:"advertise_floating_ip_host_routes"`
+	AdvertiseTenantNetworks       bool     `json:"advertise_tenant_networks"`
+	LocalAS                       string   `json:"local_as"`
+	Networks                      []string `json:"networks,omitempty"`
+}
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToSpeakerCreateMap() (map[string]interface{}, error)
+}
+
+// ToSpeakerCreateMap builds a request body from CreateOpts.
+func (opts CreateOpts) ToSpeakerCreateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, jroot)
+}
+
+// Create accepts a CreateOpts and create a BGP Speaker.
+func Create(c *gophercloud.ServiceClient, opts CreateOpts) (r CreateResult) {
+	b, err := opts.ToSpeakerCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := c.Post(createURL(c), b, &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// Delete accepts a unique ID and deletes the bgp speaker associated with it.
+func Delete(c *gophercloud.ServiceClient, speakerID string) (r DeleteResult) {
+	resp, err := c.Delete(deleteURL(c, speakerID), nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}

--- a/openstack/networking/v2/extensions/bgp/speakers/results.go
+++ b/openstack/networking/v2/extensions/bgp/speakers/results.go
@@ -85,3 +85,15 @@ func ExtractBGPSpeakersInto(r pagination.Page, v interface{}) error {
 type GetResult struct {
 	commonResult
 }
+
+// CreateResult represents the result of a create operation. Call its Extract
+// method to interpret it as a BGPSpeaker.
+type CreateResult struct {
+	commonResult
+}
+
+// DeleteResult represents the result of a delete operation. Call its
+// ExtractErr method to determine if the request succeeded or failed.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}

--- a/openstack/networking/v2/extensions/bgp/speakers/testing/fixture.go
+++ b/openstack/networking/v2/extensions/bgp/speakers/testing/fixture.go
@@ -61,3 +61,31 @@ const GetBGPSpeakerResult = `
   }
 }
 `
+const CreateRequest = `
+{
+  "bgp_speaker": {
+    "advertise_floating_ip_host_routes": false,
+    "advertise_tenant_networks": true,
+    "ip_version": 6,
+    "local_as": "2000",
+    "name": "gophercloud-testing-bgp-speaker"
+  }
+}
+`
+
+const CreateResponse = `
+{
+  "bgp_speaker": {
+    "peers": [],
+    "project_id": "7fa3f96b-17ee-4d1b-8fbf-fe889bb1f1d0",
+    "name": "gophercloud-testing-bgp-speaker",
+    "tenant_id": "7fa3f96b-17ee-4d1b-8fbf-fe889bb1f1d0",
+    "local_as": 2000,
+    "advertise_tenant_networks": true,
+    "networks": [],
+    "ip_version": 6,
+    "advertise_floating_ip_host_routes": false,
+    "id": "26e98af2-4dc7-452a-91b0-65ee45f3e7c1"
+  }
+}
+`

--- a/openstack/networking/v2/extensions/bgp/speakers/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/bgp/speakers/testing/requests_test.go
@@ -58,3 +58,54 @@ func TestGet(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.CheckDeepEquals(t, *s, BGPSpeaker1)
 }
+
+func TestCreate(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/bgp-speakers", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, CreateRequest)
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprintf(w, CreateResponse)
+	})
+
+	opts := speakers.CreateOpts{
+		IPVersion:                     6,
+		AdvertiseFloatingIPHostRoutes: false,
+		AdvertiseTenantNetworks:       true,
+		Name:                          "gophercloud-testing-bgp-speaker",
+		LocalAS:                       "2000",
+		Networks:                      []string{},
+	}
+	r, err := speakers.Create(fake.ServiceClient(), opts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, r.Name, opts.Name)
+	th.AssertEquals(t, r.LocalAS, 2000)
+	th.AssertEquals(t, len(r.Networks), 0)
+	th.AssertEquals(t, r.IPVersion, opts.IPVersion)
+	th.AssertEquals(t, r.AdvertiseFloatingIPHostRoutes, opts.AdvertiseFloatingIPHostRoutes)
+	th.AssertEquals(t, r.AdvertiseTenantNetworks, opts.AdvertiseTenantNetworks)
+}
+
+func TestDelete(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	bgpSpeakerID := "ab01ade1-ae62-43c9-8a1f-3c24225b96d8"
+	th.Mux.HandleFunc("/v2.0/bgp-speakers/"+bgpSpeakerID, func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	err := speakers.Delete(fake.ServiceClient(), bgpSpeakerID).ExtractErr()
+	th.AssertNoErr(t, err)
+}

--- a/openstack/networking/v2/extensions/bgp/speakers/urls.go
+++ b/openstack/networking/v2/extensions/bgp/speakers/urls.go
@@ -23,3 +23,13 @@ func getURL(c *gophercloud.ServiceClient, id string) string {
 func listURL(c *gophercloud.ServiceClient) string {
 	return rootURL(c)
 }
+
+// return /v2.0/bgp-speakers
+func createURL(c *gophercloud.ServiceClient) string {
+	return rootURL(c)
+}
+
+// return /v2.0/bgp-speakers/{bgp-peer-id}
+func deleteURL(c *gophercloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
+}


### PR DESCRIPTION
Neutron V2: BGP Dynamic Routing 
For #2208

```
$ git diff --stat HEAD^                                                                    
 acceptance/openstack/networking/v2/extensions/bgp/speakers/bgpspeakers_test.go | 72 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++                                                      
 acceptance/openstack/networking/v2/extensions/bgp/speakers/doc.go              |  2 ++
 openstack/networking/v2/extensions/bgp/speakers/doc.go                         | 30 ++++++++++++++++++++++++++++++
 openstack/networking/v2/extensions/bgp/speakers/requests.go                    | 40 ++++++++++++++++++++++++++++++++++++++++
 openstack/networking/v2/extensions/bgp/speakers/results.go                     | 12 ++++++++++++
 openstack/networking/v2/extensions/bgp/speakers/testing/fixture.go             | 28 ++++++++++++++++++++++++++++
 openstack/networking/v2/extensions/bgp/speakers/testing/requests_test.go       | 51 +++++++++++++++++++++++++++++++++++++++++++++++++++
 openstack/networking/v2/extensions/bgp/speakers/urls.go                        | 10 ++++++++++
 8 files changed, 245 insertions(+)
```
