### PR TITLE
Neutron v2: BGP Peer Update

### DIFF
--- a/acceptance/openstack/networking/v2/extensions/bgp/peers/bgppeers_test.go
+++ b/acceptance/openstack/networking/v2/extensions/bgp/peers/bgppeers_test.go
@@ -31,31 +31,44 @@ func CreateBGPPeer(t *testing.T, client *gophercloud.ServiceClient) (*peers.BGPP
 	return bgpPeer, err
 }
 
-func TestBGPPeerCRD(t *testing.T) {
+func TestBGPPeerCRUD(t *testing.T) {
 	clients.RequireAdmin(t)
 
 	client, err := clients.NewNetworkV2Client()
 	th.AssertNoErr(t, err)
 
-	allPages, err := peers.List(client).AllPages()
-	th.AssertNoErr(t, err)
-
-	allPeers, err := peers.ExtractBGPPeers(allPages)
-	th.AssertNoErr(t, err)
-
-	t.Logf("Retrieved BGP Peers")
-	tools.PrintResource(t, allPeers)
-
+	// Create a BGP Peer
 	bgpPeerCreated, err := CreateBGPPeer(t, client)
 	th.AssertNoErr(t, err)
-
 	tools.PrintResource(t, bgpPeerCreated)
 
+	// Get a BGP Peer
 	bgpPeerGot, err := peers.Get(client, bgpPeerCreated.ID).Extract()
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, bgpPeerCreated.ID, bgpPeerGot.ID)
 	th.AssertEquals(t, bgpPeerCreated.Name, bgpPeerGot.Name)
 
+	// Update a BGP Peer
+	newBGPPeerName := tools.RandomString("TESTACC-BGPPEER-", 10)
+	updateBGPOpts := peers.UpdateOpts{
+		Name:     newBGPPeerName,
+		Password: tools.MakeNewPassword(""),
+	}
+	bgpPeerUpdated, err := peers.Update(client, bgpPeerGot.ID, updateBGPOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, bgpPeerUpdated.Name, newBGPPeerName)
+
+	// List all BGP Peers
+	allPages, err := peers.List(client).AllPages()
+	th.AssertNoErr(t, err)
+	allPeers, err := peers.ExtractBGPPeers(allPages)
+	th.AssertNoErr(t, err)
+
+	t.Logf("Retrieved BGP Peers")
+	tools.PrintResource(t, allPeers)
+	th.AssertIntGreaterOrEqual(t, len(allPeers), 1)
+
+	// Delete a BGP Peer
 	t.Logf("Attempting to delete BGP Peer: %s", bgpPeerGot.Name)
 	err = peers.Delete(client, bgpPeerGot.ID).ExtractErr()
 	th.AssertNoErr(t, err)

--- a/openstack/networking/v2/extensions/bgp/peers/doc.go
+++ b/openstack/networking/v2/extensions/bgp/peers/doc.go
@@ -54,4 +54,18 @@ Example:
                 log.Panic(err)
         }
         log.Printf("BGP Peer deleted")
+
+
+5. Update BGP Peer, a.k.a. PUT /bgp-peers/{id}
+
+Example:
+
+        var opt peers.UpdateOpts
+        opt.Name = "peer-name-updated"
+        opt.Password = "superStrong"
+        p, err := peers.Update(c, id, opts).Extract()
+        if err != nil {
+                log.Panic(err)
+        }
+        log.Printf("%+v", p)
 */

--- a/openstack/networking/v2/extensions/bgp/peers/requests.go
+++ b/openstack/networking/v2/extensions/bgp/peers/requests.go
@@ -26,7 +26,7 @@ type CreateOptsBuilder interface {
 	ToPeerCreateMap() (map[string]interface{}, error)
 }
 
-// CreateOpts represents options used to create a network.
+// CreateOpts represents options used to create a BGP Peer.
 type CreateOpts struct {
 	AuthType string `json:"auth_type"`
 	RemoteAS int    `json:"remote_as"`
@@ -55,6 +55,37 @@ func Create(c *gophercloud.ServiceClient, opts CreateOpts) (r CreateResult) {
 // Delete accepts a unique ID and deletes the bgp Peer associated with it.
 func Delete(c *gophercloud.ServiceClient, bgpPeerID string) (r DeleteResult) {
 	resp, err := c.Delete(deleteURL(c, bgpPeerID), nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
+type UpdateOptsBuilder interface {
+	ToPeerUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts represents options used to update a BGP Peer.
+type UpdateOpts struct {
+	Name     string `json:"name,omitempty"`
+	Password string `json:"password,omitempty"`
+}
+
+// ToPeerUpdateMap builds a request body from UpdateOpts.
+func (opts UpdateOpts) ToPeerUpdateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, jroot)
+}
+
+// Update accept a BGP Peer ID and an UpdateOpts and update the BGP Peer
+func Update(c *gophercloud.ServiceClient, bgpPeerID string, opts UpdateOpts) (r UpdateResult) {
+	b, err := opts.ToPeerUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := c.Put(updateURL(c, bgpPeerID), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }

--- a/openstack/networking/v2/extensions/bgp/peers/results.go
+++ b/openstack/networking/v2/extensions/bgp/peers/results.go
@@ -88,3 +88,9 @@ type CreateResult struct {
 type DeleteResult struct {
 	gophercloud.ErrResult
 }
+
+// UpdateResult represents the result of an update operation. Call its Extract
+// method to interpret it as a BGPPeer.
+type UpdateResult struct {
+	commonResult
+}

--- a/openstack/networking/v2/extensions/bgp/peers/testing/fixture.go
+++ b/openstack/networking/v2/extensions/bgp/peers/testing/fixture.go
@@ -86,3 +86,26 @@ const CreateResponse = `
   }
 }
 `
+
+const UpdateBGPPeerRequest = `
+{
+  "bgp_peer": {
+    "name": "test-rename-bgp-peer",
+    "password": "superStrong"
+  }
+}
+`
+
+const UpdateBGPPeerResponse = `
+{
+  "bgp_peer": {
+    "auth_type": "md5",
+    "remote_as": 20000,
+    "name": "test-rename-bgp-peer",
+    "tenant_id": "52a9d4ff-81b6-4b16-a7fa-5325d3bc1c5d",
+    "peer_ip": "192.168.0.1",
+    "project_id": "52a9d4ff-81b6-4b16-a7fa-5325d3bc1c5d",
+    "id": "b7ad63ea-b803-496a-ad59-f9ef513a5cb9"
+  }
+}
+`

--- a/openstack/networking/v2/extensions/bgp/peers/urls.go
+++ b/openstack/networking/v2/extensions/bgp/peers/urls.go
@@ -33,3 +33,8 @@ func createURL(c *gophercloud.ServiceClient) string {
 func deleteURL(c *gophercloud.ServiceClient, id string) string {
 	return resourceURL(c, id)
 }
+
+// return /v2.0/bgp-peers/{bgp-peer-id}
+func updateURL(c *gophercloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
+}


### PR DESCRIPTION
Neutron V2: BGP Dynamic Routing
For #2208

```
$ git diff --stat official/master                                                                                                                      
 acceptance/openstack/networking/v2/extensions/bgp/peers/bgppeers_test.go | 35 ++++++++++++++++++++++++-----------                                                                                                 
 openstack/networking/v2/extensions/bgp/peers/doc.go                      | 14 ++++++++++++++
 openstack/networking/v2/extensions/bgp/peers/requests.go                 | 33 ++++++++++++++++++++++++++++++++-
 openstack/networking/v2/extensions/bgp/peers/results.go                  |  6 ++++++
 openstack/networking/v2/extensions/bgp/peers/testing/fixture.go          | 23 +++++++++++++++++++++++
 openstack/networking/v2/extensions/bgp/peers/testing/requests_test.go    | 27 +++++++++++++++++++++++++++
 openstack/networking/v2/extensions/bgp/peers/urls.go                     |  5 +++++
 7 files changed, 131 insertions(+), 12 deletions(-)
```