### PR TITLE
Neutron v2: BGP Speaker Update and Add/Remove BGP Peer

### DIFF
--- a/acceptance/openstack/networking/v2/extensions/bgp/peers/bgppeers_test.go
+++ b/acceptance/openstack/networking/v2/extensions/bgp/peers/bgppeers_test.go
@@ -3,33 +3,11 @@ package peers
 import (
 	"testing"
 
-	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/acceptance/clients"
 	"github.com/gophercloud/gophercloud/acceptance/tools"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/bgp/peers"
 	th "github.com/gophercloud/gophercloud/testhelper"
 )
-
-func CreateBGPPeer(t *testing.T, client *gophercloud.ServiceClient) (*peers.BGPPeer, error) {
-	var opts peers.CreateOpts
-	opts.AuthType = "md5"
-	opts.Password = tools.MakeNewPassword("")
-	opts.RemoteAS = tools.RandomInt(1000, 2000)
-	opts.Name = tools.RandomString("TESTACC-BGPPEER-", 8)
-	opts.PeerIP = "192.168.0.1"
-
-	t.Logf("Attempting to create BGP Peer: %s", opts.Name)
-	bgpPeer, err := peers.Create(client, opts).Extract()
-	if err != nil {
-		return bgpPeer, err
-	}
-
-	t.Logf("Successfully created BGP Peer")
-	th.AssertEquals(t, bgpPeer.Name, opts.Name)
-	th.AssertEquals(t, bgpPeer.RemoteAS, opts.RemoteAS)
-	th.AssertEquals(t, bgpPeer.PeerIP, opts.PeerIP)
-	return bgpPeer, err
-}
 
 func TestBGPPeerCRUD(t *testing.T) {
 	clients.RequireAdmin(t)
@@ -40,7 +18,6 @@ func TestBGPPeerCRUD(t *testing.T) {
 	// Create a BGP Peer
 	bgpPeerCreated, err := CreateBGPPeer(t, client)
 	th.AssertNoErr(t, err)
-	tools.PrintResource(t, bgpPeerCreated)
 
 	// Get a BGP Peer
 	bgpPeerGot, err := peers.Get(client, bgpPeerCreated.ID).Extract()
@@ -57,6 +34,7 @@ func TestBGPPeerCRUD(t *testing.T) {
 	bgpPeerUpdated, err := peers.Update(client, bgpPeerGot.ID, updateBGPOpts).Extract()
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, bgpPeerUpdated.Name, newBGPPeerName)
+	t.Logf("Update BGP Peer, renamed from %s to %s", bgpPeerGot.Name, bgpPeerUpdated.Name)
 
 	// List all BGP Peers
 	allPages, err := peers.List(client).AllPages()
@@ -69,11 +47,11 @@ func TestBGPPeerCRUD(t *testing.T) {
 	th.AssertIntGreaterOrEqual(t, len(allPeers), 1)
 
 	// Delete a BGP Peer
-	t.Logf("Attempting to delete BGP Peer: %s", bgpPeerGot.Name)
+	t.Logf("Attempting to delete BGP Peer: %s", bgpPeerUpdated.Name)
 	err = peers.Delete(client, bgpPeerGot.ID).ExtractErr()
 	th.AssertNoErr(t, err)
 
 	bgpPeerGot, err = peers.Get(client, bgpPeerGot.ID).Extract()
 	th.AssertErr(t, err)
-	t.Logf("BGP Peer %s deleted", bgpPeerCreated.Name)
+	t.Logf("BGP Peer %s deleted", bgpPeerUpdated.Name)
 }

--- a/acceptance/openstack/networking/v2/extensions/bgp/peers/peers.go
+++ b/acceptance/openstack/networking/v2/extensions/bgp/peers/peers.go
@@ -1,0 +1,32 @@
+package peers
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/acceptance/tools"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/bgp/peers"
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func CreateBGPPeer(t *testing.T, client *gophercloud.ServiceClient) (*peers.BGPPeer, error) {
+	var opts peers.CreateOpts
+	opts.AuthType = "md5"
+	opts.Password = tools.MakeNewPassword("")
+	opts.RemoteAS = tools.RandomInt(1000, 2000)
+	opts.Name = tools.RandomString("TESTACC-BGPPEER-", 8)
+	opts.PeerIP = "192.168.0.1"
+
+	t.Logf("Attempting to create BGP Peer: %s", opts.Name)
+	bgpPeer, err := peers.Create(client, opts).Extract()
+	if err != nil {
+		return bgpPeer, err
+	}
+
+	th.AssertEquals(t, bgpPeer.Name, opts.Name)
+	th.AssertEquals(t, bgpPeer.RemoteAS, opts.RemoteAS)
+	th.AssertEquals(t, bgpPeer.PeerIP, opts.PeerIP)
+	t.Logf("Successfully created BGP Peer")
+	tools.PrintResource(t, bgpPeer)
+	return bgpPeer, err
+}

--- a/acceptance/openstack/networking/v2/extensions/bgp/speakers/speakers.go
+++ b/acceptance/openstack/networking/v2/extensions/bgp/speakers/speakers.go
@@ -1,0 +1,38 @@
+package speakers
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/acceptance/tools"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/bgp/speakers"
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func CreateBGPSpeaker(t *testing.T, client *gophercloud.ServiceClient) (*speakers.BGPSpeaker, error) {
+	opts := speakers.CreateOpts{
+		IPVersion:                     4,
+		AdvertiseFloatingIPHostRoutes: false,
+		AdvertiseTenantNetworks:       true,
+		Name:                          tools.RandomString("TESTACC-BGPSPEAKER-", 8),
+		LocalAS:                       "3000",
+		Networks:                      []string{},
+	}
+
+	t.Logf("Attempting to create BGP Speaker: %s", opts.Name)
+	bgpSpeaker, err := speakers.Create(client, opts).Extract()
+	if err != nil {
+		return bgpSpeaker, err
+	}
+
+	localas, err := strconv.Atoi(opts.LocalAS)
+	th.AssertEquals(t, bgpSpeaker.Name, opts.Name)
+	th.AssertEquals(t, bgpSpeaker.LocalAS, localas)
+	th.AssertEquals(t, bgpSpeaker.IPVersion, opts.IPVersion)
+	th.AssertEquals(t, bgpSpeaker.AdvertiseTenantNetworks, opts.AdvertiseTenantNetworks)
+	th.AssertEquals(t, bgpSpeaker.AdvertiseFloatingIPHostRoutes, opts.AdvertiseFloatingIPHostRoutes)
+	t.Logf("Successfully created BGP Speaker")
+	tools.PrintResource(t, bgpSpeaker)
+	return bgpSpeaker, err
+}

--- a/openstack/networking/v2/extensions/bgp/speakers/doc.go
+++ b/openstack/networking/v2/extensions/bgp/speakers/doc.go
@@ -45,7 +45,7 @@ Example:
 		LocalAS:                       "2000",
 		Networks:                      []string{},
 	}
-        r, err := speaker.Create(c, opts).Extract()
+        r, err := speakers.Create(c, opts).Extract()
         if err != nil {
                 log.Panic(err)
         }
@@ -56,9 +56,49 @@ Example:
 
 Example:
 
-        err := speaker.Delete(auth, speakerID).ExtractErr()
+        err := speakers.Delete(auth, speakerID).ExtractErr()
         if err != nil {
                 log.Panic(err)
         }
         log.Printf("Speaker Deleted")
+
+
+6. Update BGP Speaker
+
+Example:
+
+	opts := speakers.UpdateOpts{
+		Name:                          "testing-bgp-speaker",
+		AdvertiseTenantNetworks:       false,
+		AdvertiseFloatingIPHostRoutes: true,
+	}
+	spk, err := speakers.Update(c, bgpSpeakerID, opts).Extract()
+	if err != nil {
+		log.Panic(err)
+	}
+	log.Printf("%+v", spk)
+
+
+7. Add BGP Peer, a.k.a. PUT /bgp-speakers/{id}/add_bgp_peer
+
+Example:
+
+	opts := speakers.AddBGPPeerOpts{BGPPeerID: bgpPeerID}
+        r, err := speakers.AddBGPPeer(c, bgpSpeakerID, opts).Extract()
+        if err != nil {
+                log.Panic(err)
+        }
+        log.Printf("%+v", r)
+
+
+8. Remove BGP Peer, a.k.a. PUT /bgp-speakers/{id}/remove_bgp_peer
+
+Example:
+
+	opts := speakers.RemoveBGPPeerOpts{BGPPeerID: bgpPeerID}
+        err := speakers.RemoveBGPPeer(c, bgpSpeakerID, opts).ExtractErr()
+        if err != nil {
+                log.Panic(err)
+        }
+        log.Printf("Successfully removed BGP Peer")
 */

--- a/openstack/networking/v2/extensions/bgp/speakers/requests.go
+++ b/openstack/networking/v2/extensions/bgp/speakers/requests.go
@@ -20,7 +20,7 @@ func Get(c *gophercloud.ServiceClient, id string) (r GetResult) {
 	return
 }
 
-// CreateOpts represents options used to create a network.
+// CreateOpts represents options used to create a BGP Speaker.
 type CreateOpts struct {
 	Name                          string   `json:"name"`
 	IPVersion                     int      `json:"ip_version"`
@@ -30,8 +30,7 @@ type CreateOpts struct {
 	Networks                      []string `json:"networks,omitempty"`
 }
 
-// CreateOptsBuilder allows extensions to add additional parameters to the
-// Create request.
+// CreateOptsBuilder declare a function that build CreateOpts into a Create request body.
 type CreateOptsBuilder interface {
 	ToSpeakerCreateMap() (map[string]interface{}, error)
 }
@@ -56,6 +55,94 @@ func Create(c *gophercloud.ServiceClient, opts CreateOpts) (r CreateResult) {
 // Delete accepts a unique ID and deletes the bgp speaker associated with it.
 func Delete(c *gophercloud.ServiceClient, speakerID string) (r DeleteResult) {
 	resp, err := c.Delete(deleteURL(c, speakerID), nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// UpdateOpts represents options used to update a BGP Speaker.
+type UpdateOpts struct {
+	Name                          string `json:"name,omitempty"`
+	AdvertiseFloatingIPHostRoutes bool   `json:"advertise_floating_ip_host_routes"`
+	AdvertiseTenantNetworks       bool   `json:"advertise_tenant_networks"`
+}
+
+// ToSpeakerUpdateMap build a request body from UpdateOpts
+func (opts UpdateOpts) ToSpeakerUpdateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, jroot)
+}
+
+// UpdateOptsBuilder allow the extensions to add additional parameters to the
+// Update request.
+type UpdateOptsBuilder interface {
+	ToSpeakerUpdateMap() (map[string]interface{}, error)
+}
+
+// Update accepts a UpdateOpts and update the BGP Speaker.
+func Update(c *gophercloud.ServiceClient, speakerID string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToSpeakerUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := c.Put(updateURL(c, speakerID), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// AddBGPPeerOpts represents options used to add a BGP Peer to a BGP Speaker
+type AddBGPPeerOpts struct {
+	BGPPeerID string `json:"bgp_peer_id"`
+}
+
+// AddBGPPeerOptsBuilder declare a funtion that encode AddBGPPeerOpts into a request body
+type AddBGPPeerOptsBuilder interface {
+	ToBGPSpeakerAddBGPPeerMap() (map[string]interface{}, error)
+}
+
+// ToBGPSpeakerAddBGPPeerMap build a request body from AddBGPPeerOpts
+func (opts AddBGPPeerOpts) ToBGPSpeakerAddBGPPeerMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "")
+}
+
+// AddBGPPeer add the BGP peer to the speaker a.k.a. PUT /v2.0/bgp-speakers/{bgp-speaker-id}/add_bgp_peer
+func AddBGPPeer(c *gophercloud.ServiceClient, bgpSpeakerID string, opts AddBGPPeerOptsBuilder) (r AddBGPPeerResult) {
+	b, err := opts.ToBGPSpeakerAddBGPPeerMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := c.Put(addBGPPeerURL(c, bgpSpeakerID), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// RemoveBGPPeerOpts represents options used to remove a BGP Peer to a BGP Speaker
+type RemoveBGPPeerOpts AddBGPPeerOpts
+
+// RemoveBGPPeerOptsBuilder declare a funtion that encode RemoveBGPPeerOpts into a request body
+type RemoveBGPPeerOptsBuilder interface {
+	ToBGPSpeakerRemoveBGPPeerMap() (map[string]interface{}, error)
+}
+
+// ToBGPSpeakerRemoveBGPPeerMap build a request body from RemoveBGPPeerOpts
+func (opts RemoveBGPPeerOpts) ToBGPSpeakerRemoveBGPPeerMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "")
+}
+
+// RemoveBGPPeer remove the BGP peer from the speaker, a.k.a. PUT /v2.0/bgp-speakers/{bgp-speaker-id}/add_bgp_peer
+func RemoveBGPPeer(c *gophercloud.ServiceClient, bgpSpeakerID string, opts RemoveBGPPeerOptsBuilder) (r RemoveBGPPeerResult) {
+	b, err := opts.ToBGPSpeakerRemoveBGPPeerMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := c.Put(removeBGPPeerURL(c, bgpSpeakerID), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }

--- a/openstack/networking/v2/extensions/bgp/speakers/results.go
+++ b/openstack/networking/v2/extensions/bgp/speakers/results.go
@@ -76,6 +76,9 @@ func ExtractBGPSpeakers(r pagination.Page) ([]BGPSpeaker, error) {
 	return s, err
 }
 
+// ExtractBGPSpeakersInto accepts a Page struct and an interface{}. The former contains
+// a list of BGPSpeaker and the later should be used to store the result that would be
+// extracted from the former.
 func ExtractBGPSpeakersInto(r pagination.Page, v interface{}) error {
 	return r.(BGPSpeakerPage).Result.ExtractIntoSlicePtr(v, "bgp_speakers")
 }
@@ -95,5 +98,33 @@ type CreateResult struct {
 // DeleteResult represents the result of a delete operation. Call its
 // ExtractErr method to determine if the request succeeded or failed.
 type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
+// UpdateResult represents the result of an update operation. Call its Extract
+// method to interpret it as a BGPSpeaker.
+type UpdateResult struct {
+	commonResult
+}
+
+// AddBGPPeerResult represent the response of the PUT /v2.0/bgp-speakers/{bgp-speaker-id}/add-bgp-peer
+type AddBGPPeerResult struct {
+	gophercloud.Result
+}
+
+// Extract is a function that accepts a result and extracts a AddBGPPeerResult resource
+func (r AddBGPPeerResult) Extract() (*AddBGPPeerOpts, error) {
+	var s AddBGPPeerOpts
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+func (r AddBGPPeerResult) ExtractInto(v interface{}) error {
+	return r.Result.ExtractIntoStructPtr(v, "")
+}
+
+// RemoveBGPPeerResult represent the response of the PUT /v2.0/bgp-speakers/{bgp-speaker-id}/remove-bgp-peer
+// There is no body content for the response of a successful DELETE request.
+type RemoveBGPPeerResult struct {
 	gophercloud.ErrResult
 }

--- a/openstack/networking/v2/extensions/bgp/speakers/testing/fixture.go
+++ b/openstack/networking/v2/extensions/bgp/speakers/testing/fixture.go
@@ -89,3 +89,36 @@ const CreateResponse = `
   }
 }
 `
+
+const UpdateBGPSpeakerRequest = `
+{
+  "bgp_speaker": {
+    "advertise_floating_ip_host_routes": true,
+    "advertise_tenant_networks": false,
+    "name": "testing-bgp-speaker"
+  }
+}
+`
+
+const UpdateBGPSpeakerResponse = `
+{
+  "bgp_speaker": {
+    "peers": [],
+    "project_id": "7fa3f96b-17ee-4d1b-8fbf-fe889bb1f1d0",
+    "name": "testing-bgp-speaker",
+    "tenant_id": "7fa3f96b-17ee-4d1b-8fbf-fe889bb1f1d0",
+    "local_as": 2000,
+    "advertise_tenant_networks": false,
+    "networks": [],
+    "ip_version": 4,
+    "advertise_floating_ip_host_routes": true,
+    "id": "d25d0036-7f17-49d7-8d02-4bf9dd49d5a9"
+  }
+}
+`
+
+const AddRemoveBGPPeerJSON = `
+{
+  "bgp_peer_id": "f5884c7c-71d5-43a3-88b4-1742e97674aa"
+}
+`

--- a/openstack/networking/v2/extensions/bgp/speakers/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/bgp/speakers/testing/requests_test.go
@@ -2,6 +2,7 @@ package testing
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 	"testing"
 
@@ -108,4 +109,88 @@ func TestDelete(t *testing.T) {
 
 	err := speakers.Delete(fake.ServiceClient(), bgpSpeakerID).ExtractErr()
 	th.AssertNoErr(t, err)
+}
+
+func TestUpdate(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	bgpSpeakerID := "ab01ade1-ae62-43c9-8a1f-3c24225b96d8"
+	th.Mux.HandleFunc("/v2.0/bgp-speakers/"+bgpSpeakerID, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" {
+			th.TestMethod(t, r, "GET")
+			th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprintf(w, GetBGPSpeakerResult)
+		} else if r.Method == "PUT" {
+			th.TestMethod(t, r, "PUT")
+			th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+			th.TestHeader(t, r, "Content-Type", "application/json")
+			th.TestHeader(t, r, "Accept", "application/json")
+			th.TestJSONRequest(t, r, UpdateBGPSpeakerRequest)
+
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprintf(w, UpdateBGPSpeakerResponse)
+		} else {
+			panic("Unexpected Request")
+		}
+	})
+
+	opts := speakers.UpdateOpts{
+		Name:                          "testing-bgp-speaker",
+		AdvertiseTenantNetworks:       false,
+		AdvertiseFloatingIPHostRoutes: true,
+	}
+
+	r, err := speakers.Update(fake.ServiceClient(), bgpSpeakerID, opts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, r.Name, opts.Name)
+	th.AssertEquals(t, r.AdvertiseTenantNetworks, opts.AdvertiseTenantNetworks)
+	th.AssertEquals(t, r.AdvertiseFloatingIPHostRoutes, opts.AdvertiseFloatingIPHostRoutes)
+}
+
+func TestAddBGPPeer(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	bgpSpeakerID := "ab01ade1-ae62-43c9-8a1f-3c24225b96d8"
+	bgpPeerID := "f5884c7c-71d5-43a3-88b4-1742e97674aa"
+	th.Mux.HandleFunc("/v2.0/bgp-speakers/"+bgpSpeakerID+"/add_bgp_peer", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, AddRemoveBGPPeerJSON)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, AddRemoveBGPPeerJSON)
+	})
+
+	opts := speakers.AddBGPPeerOpts{BGPPeerID: bgpPeerID}
+	r, err := speakers.AddBGPPeer(fake.ServiceClient(), bgpSpeakerID, opts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, bgpPeerID, r.BGPPeerID)
+}
+
+func TestRemoveBGPPeer(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	bgpSpeakerID := "ab01ade1-ae62-43c9-8a1f-3c24225b96d8"
+	bgpPeerID := "f5884c7c-71d5-43a3-88b4-1742e97674aa"
+	th.Mux.HandleFunc("/v2.0/bgp-speakers/"+bgpSpeakerID+"/remove_bgp_peer", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, AddRemoveBGPPeerJSON)
+		w.WriteHeader(http.StatusOK)
+	})
+
+	opts := speakers.RemoveBGPPeerOpts{BGPPeerID: bgpPeerID}
+	err := speakers.RemoveBGPPeer(fake.ServiceClient(), bgpSpeakerID, opts).ExtractErr()
+	th.AssertEquals(t, err, io.EOF)
 }

--- a/openstack/networking/v2/extensions/bgp/speakers/urls.go
+++ b/openstack/networking/v2/extensions/bgp/speakers/urls.go
@@ -33,3 +33,18 @@ func createURL(c *gophercloud.ServiceClient) string {
 func deleteURL(c *gophercloud.ServiceClient, id string) string {
 	return resourceURL(c, id)
 }
+
+// return /v2.0/bgp-speakers/{bgp-peer-id}
+func updateURL(c *gophercloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
+}
+
+// return /v2.0/bgp-speakers/{bgp-speaker-id}/add_bgp_peer
+func addBGPPeerURL(c *gophercloud.ServiceClient, speakerID string) string {
+	return c.ServiceURL(urlBase, speakerID, "add_bgp_peer")
+}
+
+// return /v2.0/bgp-speakers/{bgp-speaker-id}/remove_bgp_peer
+func removeBGPPeerURL(c *gophercloud.ServiceClient, speakerID string) string {
+	return c.ServiceURL(urlBase, speakerID, "remove_bgp_peer")
+}


### PR DESCRIPTION
Neutron V2: BGP Dynamic Routing
For #2208

```
$ git diff --stat HEAD^ 
 acceptance/openstack/networking/v2/extensions/bgp/peers/bgppeers_test.go       | 28 +++-------------------------
 acceptance/openstack/networking/v2/extensions/bgp/peers/peers.go               | 32 ++++++++++++++++++++++++++++++++
 acceptance/openstack/networking/v2/extensions/bgp/speakers/bgpspeakers_test.go | 89 +++++++++++++++++++++++++++++++++++++++++------------------------------------------------
 acceptance/openstack/networking/v2/extensions/bgp/speakers/speakers.go         | 38 ++++++++++++++++++++++++++++++++++++++
 openstack/networking/v2/extensions/bgp/speakers/doc.go                         | 42 ++++++++++++++++++++++++++++++++++++++++--
 openstack/networking/v2/extensions/bgp/speakers/requests.go                    | 91 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++---
 openstack/networking/v2/extensions/bgp/speakers/results.go                     | 41 +++++++++++++++++++++++++++++++++++++++++
 openstack/networking/v2/extensions/bgp/speakers/testing/fixture.go             | 33 +++++++++++++++++++++++++++++++++
 openstack/networking/v2/extensions/bgp/speakers/testing/requests_test.go       | 83 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 openstack/networking/v2/extensions/bgp/speakers/urls.go                        | 15 +++++++++++++++
 10 files changed, 414 insertions(+), 78 deletions(-)
```
