### PR TITLE
Adjusted Blockstorage V3 Snapshot List Endpoint

### DIFF
--- a/openstack/blockstorage/v3/snapshots/testing/fixtures.go
+++ b/openstack/blockstorage/v3/snapshots/testing/fixtures.go
@@ -11,7 +11,7 @@ import (
 
 // MockListResponse provides mock responce for list snapshot API call
 func MockListResponse(t *testing.T) {
-	th.Mux.HandleFunc("/snapshots", func(w http.ResponseWriter, r *http.Request) {
+	th.Mux.HandleFunc("/snapshots/detail", func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "GET")
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 

--- a/openstack/blockstorage/v3/snapshots/urls.go
+++ b/openstack/blockstorage/v3/snapshots/urls.go
@@ -15,7 +15,7 @@ func getURL(c *gophercloud.ServiceClient, id string) string {
 }
 
 func listURL(c *gophercloud.ServiceClient) string {
-	return createURL(c)
+	return c.ServiceURL("snapshots", "detail")
 }
 
 func updateURL(c *gophercloud.ServiceClient, id string) string {


### PR DESCRIPTION
Replaced the normal list snapshots with the detailed list endpoint url.

Fixes #2403

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

[https://docs.openstack.org/api-ref/block-storage/v3/index.html?expanded=list-accessible-snapshots-detail,list-snapshots-and-details-detail#list-snapshots-and-details](https://docs.openstack.org/api-ref/block-storage/v3/index.html?expanded=list-accessible-snapshots-detail,list-snapshots-and-details-detail#list-snapshots-and-details)
