### PR TITLE
Identity v3: add role assignments list param include_subtree

### DIFF
--- a/openstack/identity/v3/roles/requests.go
+++ b/openstack/identity/v3/roles/requests.go
@@ -208,6 +208,11 @@ type ListAssignmentsOpts struct {
 	// IncludeNames indicates whether to include names of any returned entities.
 	// Requires microversion 3.6 or later.
 	IncludeNames *bool `q:"include_names"`
+
+	// IncludeSubtree indicates whether to include relevant assignments in the project hierarchy below the project
+	// specified in the ScopeProjectID. Specify DomainID in ScopeProjectID to get a list for all projects in the domain.
+	// Requires microversion 3.6 or later.
+	IncludeSubtree *bool `q:"include_subtree"`
 }
 
 // ToRolesListAssignmentsQuery formats a ListAssignmentsOpts into a query string.

--- a/openstack/identity/v3/roles/testing/fixtures.go
+++ b/openstack/identity/v3/roles/testing/fixtures.go
@@ -428,6 +428,21 @@ func HandleListRoleAssignmentsWithNamesSuccessfully(t *testing.T) {
 	})
 }
 
+// HandleListRoleAssignmentsWithSubtreeSuccessfully creates an HTTP handler at `/role_assignments` on the
+// test handler mux that responds with a list of two role assignments.
+func HandleListRoleAssignmentsWithSubtreeSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/role_assignments", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.AssertEquals(t, "include_subtree=true", r.URL.RawQuery)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, ListAssignmentOutput)
+	})
+}
+
 // RoleOnResource is the role in the ListAssignmentsOnResource request.
 var RoleOnResource = roles.Role{
 	ID: "9fe1d3",

--- a/openstack/identity/v3/roles/testing/requests_test.go
+++ b/openstack/identity/v3/roles/testing/requests_test.go
@@ -171,6 +171,30 @@ func TestListAssignmentsWithNamesSinglePage(t *testing.T) {
 	th.CheckEquals(t, count, 1)
 }
 
+func TestListAssignmentsWithSubtreeSinglePage(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleListRoleAssignmentsWithSubtreeSuccessfully(t)
+
+	var includeSubtree = true
+	listOpts := roles.ListAssignmentsOpts{
+		IncludeSubtree: &includeSubtree,
+	}
+
+	count := 0
+	err := roles.ListAssignments(client.ServiceClient(), listOpts).EachPage(func(page pagination.Page) (bool, error) {
+		count++
+		actual, err := roles.ExtractRoleAssignments(page)
+		th.AssertNoErr(t, err)
+
+		th.CheckDeepEquals(t, ExpectedRoleAssignmentsSlice, actual)
+
+		return true, nil
+	})
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, count, 1)
+}
+
 func TestListAssignmentsOnResource_ProjectsUsers(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()


### PR DESCRIPTION
Add to Identity v3 role assignments list request `include_subtree` parameter, which allows to get a list of assignments for all projects in the project hierarchy below specified projectID or domainID.

`scope.project.id` is required if `include_subtree` is specified.

[Keystone code with include_subtree query parameter](https://github.com/openstack/keystone/blob/stable/yoga/keystone/api/role_assignments.py#L43) .

[API documentation](https://docs.openstack.org/api-ref/identity/v3/?expanded=id627-detail#id627).