### PR TITLE
CI: Bump devstack-action to v0.7

### DIFF
--- a/.github/workflows/functional-baremetal.yaml
+++ b/.github/workflows/functional-baremetal.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Checkout Gophercloud
         uses: actions/checkout@v3
       - name: Deploy devstack
-        uses: EmilienM/devstack-action@v0.6
+        uses: EmilienM/devstack-action@v0.7
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |

--- a/.github/workflows/functional-basic.yaml
+++ b/.github/workflows/functional-basic.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Checkout Gophercloud
         uses: actions/checkout@v3
       - name: Deploy devstack
-        uses: EmilienM/devstack-action@v0.6
+        uses: EmilienM/devstack-action@v0.7
         with:
           branch: ${{ matrix.openstack_version }}
           enabled_services: 's-account,s-container,s-object,s-proxy'

--- a/.github/workflows/functional-blockstorage.yaml
+++ b/.github/workflows/functional-blockstorage.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Checkout Gophercloud
         uses: actions/checkout@v3
       - name: Deploy devstack
-        uses: EmilienM/devstack-action@v0.6
+        uses: EmilienM/devstack-action@v0.7
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |

--- a/.github/workflows/functional-clustering.yaml
+++ b/.github/workflows/functional-clustering.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Checkout Gophercloud
         uses: actions/checkout@v3
       - name: Deploy devstack
-        uses: EmilienM/devstack-action@v0.6
+        uses: EmilienM/devstack-action@v0.7
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |

--- a/.github/workflows/functional-compute.yaml
+++ b/.github/workflows/functional-compute.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Checkout Gophercloud
         uses: actions/checkout@v3
       - name: Deploy devstack
-        uses: EmilienM/devstack-action@v0.6
+        uses: EmilienM/devstack-action@v0.7
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |

--- a/.github/workflows/functional-containerinfra.yaml
+++ b/.github/workflows/functional-containerinfra.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Checkout Gophercloud
         uses: actions/checkout@v3
       - name: Deploy devstack
-        uses: EmilienM/devstack-action@v0.6
+        uses: EmilienM/devstack-action@v0.7
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |

--- a/.github/workflows/functional-dns.yaml
+++ b/.github/workflows/functional-dns.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Checkout Gophercloud
         uses: actions/checkout@v3
       - name: Deploy devstack
-        uses: EmilienM/devstack-action@v0.6
+        uses: EmilienM/devstack-action@v0.7
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |

--- a/.github/workflows/functional-identity.yaml
+++ b/.github/workflows/functional-identity.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Checkout Gophercloud
         uses: actions/checkout@v3
       - name: Deploy devstack
-        uses: EmilienM/devstack-action@v0.6
+        uses: EmilienM/devstack-action@v0.7
         with:
           branch: ${{ matrix.openstack_version }}
       - name: Checkout go

--- a/.github/workflows/functional-imageservice.yaml
+++ b/.github/workflows/functional-imageservice.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Checkout Gophercloud
         uses: actions/checkout@v3
       - name: Deploy devstack
-        uses: EmilienM/devstack-action@v0.6
+        uses: EmilienM/devstack-action@v0.7
         with:
           branch: ${{ matrix.openstack_version }}
       - name: Checkout go

--- a/.github/workflows/functional-keymanager.yaml
+++ b/.github/workflows/functional-keymanager.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Checkout Gophercloud
         uses: actions/checkout@v3
       - name: Deploy devstack
-        uses: EmilienM/devstack-action@v0.6
+        uses: EmilienM/devstack-action@v0.7
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |

--- a/.github/workflows/functional-loadbalancer.yaml
+++ b/.github/workflows/functional-loadbalancer.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Checkout Gophercloud
         uses: actions/checkout@v3
       - name: Deploy devstack
-        uses: EmilienM/devstack-action@v0.6
+        uses: EmilienM/devstack-action@v0.7
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |

--- a/.github/workflows/functional-messaging.yaml
+++ b/.github/workflows/functional-messaging.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Checkout Gophercloud
         uses: actions/checkout@v3
       - name: Deploy devstack
-        uses: EmilienM/devstack-action@v0.6
+        uses: EmilienM/devstack-action@v0.7
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |

--- a/.github/workflows/functional-networking.yaml
+++ b/.github/workflows/functional-networking.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Checkout Gophercloud
         uses: actions/checkout@v3
       - name: Deploy devstack
-        uses: EmilienM/devstack-action@v0.6
+        uses: EmilienM/devstack-action@v0.7
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |

--- a/.github/workflows/functional-objectstorage.yaml
+++ b/.github/workflows/functional-objectstorage.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Checkout Gophercloud
         uses: actions/checkout@v3
       - name: Deploy devstack
-        uses: EmilienM/devstack-action@v0.6
+        uses: EmilienM/devstack-action@v0.7
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |

--- a/.github/workflows/functional-orchestration.yaml
+++ b/.github/workflows/functional-orchestration.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Checkout Gophercloud
         uses: actions/checkout@v3
       - name: Deploy devstack
-        uses: EmilienM/devstack-action@v0.6
+        uses: EmilienM/devstack-action@v0.7
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |

--- a/.github/workflows/functional-placement.yaml
+++ b/.github/workflows/functional-placement.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Checkout Gophercloud
         uses: actions/checkout@v3
       - name: Deploy devstack
-        uses: EmilienM/devstack-action@v0.6
+        uses: EmilienM/devstack-action@v0.7
         with:
           branch: ${{ matrix.openstack_version }}
       - name: Checkout go

--- a/.github/workflows/functional-sharedfilesystems.yaml
+++ b/.github/workflows/functional-sharedfilesystems.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Checkout Gophercloud
         uses: actions/checkout@v3
       - name: Deploy devstack
-        uses: EmilienM/devstack-action@v0.6
+        uses: EmilienM/devstack-action@v0.7
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |


### PR DESCRIPTION
That will help to disable Tempest (not needed in our jobs) and therefore
bring back the Ussuri job in good shape.

Issue #2408