### PR TITLE
CI: fix networking job for train release

### DIFF
--- a/.github/workflows/functional-networking.yaml
+++ b/.github/workflows/functional-networking.yaml
@@ -53,7 +53,8 @@ jobs:
           conf_overrides: |
             Q_ML2_PLUGIN_EXT_DRIVERS=qos,port_security,dns_domain_keywords
             enable_plugin neutron-vpnaas https://opendev.org/openstack/neutron-vpnaas ${{ matrix.openstack_version }}
-            enable_plugin neutron-dynamic-routing https://opendev.org/openstack/neutron-dynamic-routing  ${{ matrix.openstack_version }}
+            # Use github mirroring as stable/train branch no longer exists on opendev git repo
+            enable_plugin neutron-dynamic-routing https://github.com/openstack/neutron-dynamic-routing ${{ matrix.openstack_version }}
             ${{ matrix.devstack_conf_overrides }}
           enabled_services: 'neutron-dns,neutron-qos,neutron-segments,neutron-trunk,neutron-uplink-status-propagation,neutron-network-segment-range,neutron-port-forwarding'
       - name: Checkout go


### PR DESCRIPTION
The `stable/train` branch no longer exist on opendev's
neutron-dynamic-routing repository, and it caused devstack to fail
installing. Use the github mirror instead that still has the desired
branch.