### PR TITLE
CI: Fix train networking job

### DIFF
--- a/.github/workflows/functional-networking.yaml
+++ b/.github/workflows/functional-networking.yaml
@@ -41,6 +41,7 @@ jobs:
             ubuntu_version: "18.04"
             devstack_conf_overrides: |
               enable_plugin neutron-fwaas https://git.openstack.org/openstack/neutron-fwaas stable/train
+              enable_plugin neutron-dynamic-routing https://opendev.org/openstack/neutron-dynamic-routing train-eol
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with Neutron and run networking acceptance tests
     steps:
@@ -53,8 +54,7 @@ jobs:
           conf_overrides: |
             Q_ML2_PLUGIN_EXT_DRIVERS=qos,port_security,dns_domain_keywords
             enable_plugin neutron-vpnaas https://opendev.org/openstack/neutron-vpnaas ${{ matrix.openstack_version }}
-            # Use github mirroring as stable/train branch no longer exists on opendev git repo
-            enable_plugin neutron-dynamic-routing https://github.com/openstack/neutron-dynamic-routing ${{ matrix.openstack_version }}
+            enable_plugin neutron-dynamic-routing https://opendev.org/openstack/neutron-dynamic-routing ${{ matrix.openstack_version }}
             ${{ matrix.devstack_conf_overrides }}
           enabled_services: 'neutron-dns,neutron-qos,neutron-segments,neutron-trunk,neutron-uplink-status-propagation,neutron-network-segment-range,neutron-port-forwarding'
       - name: Checkout go

--- a/.github/workflows/functional-networking.yaml
+++ b/.github/workflows/functional-networking.yaml
@@ -13,29 +13,34 @@ jobs:
         name: ["master"]
         openstack_version: ["master"]
         ubuntu_version: ["20.04"]
-        devstack_conf_overrides: [""]
+        devstack_conf_overrides: ["enable_plugin neutron-dynamic-routing https://opendev.org/openstack/neutron-dynamic-routing master"]
         include:
           - name: "yoga"
             openstack_version: "stable/yoga"
             ubuntu_version: "20.04"
-            devstack_conf_overrides: ""
+            devstack_conf_overrides: |
+              enable_plugin neutron-dynamic-routing https://opendev.org/openstack/neutron-dynamic-routing stable/yoga
           - name: "xena"
             openstack_version: "stable/xena"
             ubuntu_version: "20.04"
-            devstack_conf_overrides: ""
+            devstack_conf_overrides: |
+              enable_plugin neutron-dynamic-routing https://opendev.org/openstack/neutron-dynamic-routing stable/xena
           - name: "wallaby"
             openstack_version: "stable/wallaby"
             ubuntu_version: "20.04"
-            devstack_conf_overrides: ""
+            devstack_conf_overrides: |
+              enable_plugin neutron-dynamic-routing https://opendev.org/openstack/neutron-dynamic-routing stable/wallaby
           - name: "victoria"
             openstack_version: "stable/victoria"
             ubuntu_version: "20.04"
-            devstack_conf_overrides: ""
+            devstack_conf_overrides: |
+              enable_plugin neutron-dynamic-routing https://opendev.org/openstack/neutron-dynamic-routing stable/victoria
           - name: "ussuri"
             openstack_version: "stable/ussuri"
             ubuntu_version: "18.04"
             devstack_conf_overrides: |
               enable_plugin neutron-fwaas https://opendev.org/openstack/neutron-fwaas stable/ussuri
+              enable_plugin neutron-dynamic-routing https://opendev.org/openstack/neutron-dynamic-routing stable/ussuri
           - name: "train"
             openstack_version: "stable/train"
             ubuntu_version: "18.04"
@@ -54,7 +59,6 @@ jobs:
           conf_overrides: |
             Q_ML2_PLUGIN_EXT_DRIVERS=qos,port_security,dns_domain_keywords
             enable_plugin neutron-vpnaas https://opendev.org/openstack/neutron-vpnaas ${{ matrix.openstack_version }}
-            enable_plugin neutron-dynamic-routing https://opendev.org/openstack/neutron-dynamic-routing ${{ matrix.openstack_version }}
             ${{ matrix.devstack_conf_overrides }}
           enabled_services: 'neutron-dns,neutron-qos,neutron-segments,neutron-trunk,neutron-uplink-status-propagation,neutron-network-segment-range,neutron-port-forwarding'
       - name: Checkout go

--- a/.github/workflows/functional-networking.yaml
+++ b/.github/workflows/functional-networking.yaml
@@ -35,12 +35,12 @@ jobs:
             openstack_version: "stable/ussuri"
             ubuntu_version: "18.04"
             devstack_conf_overrides: |
-              enable_plugin neutron-fwaas https://git.openstack.org/openstack/neutron-fwaas stable/ussuri
+              enable_plugin neutron-fwaas https://opendev.org/openstack/neutron-fwaas stable/ussuri
           - name: "train"
             openstack_version: "stable/train"
             ubuntu_version: "18.04"
             devstack_conf_overrides: |
-              enable_plugin neutron-fwaas https://git.openstack.org/openstack/neutron-fwaas stable/train
+              enable_plugin neutron-fwaas https://opendev.org/openstack/neutron-fwaas stable/train
               enable_plugin neutron-dynamic-routing https://opendev.org/openstack/neutron-dynamic-routing train-eol
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with Neutron and run networking acceptance tests


### PR DESCRIPTION
A follow-up to https://github.com/gophercloud/gophercloud/pull/2413.

It was only a matter of time before the branch sync happened on github
and stable/train disappeared. Let's use the train-eol tag instead.