### PR TITLE
Add Support for User Domain Name/ID/Default Domain

### DIFF
--- a/openstack/auth_env.go
+++ b/openstack/auth_env.go
@@ -43,6 +43,9 @@ func AuthOptionsFromEnv() (gophercloud.AuthOptions, error) {
 	tenantName := os.Getenv("OS_TENANT_NAME")
 	domainID := os.Getenv("OS_DOMAIN_ID")
 	domainName := os.Getenv("OS_DOMAIN_NAME")
+	userDomainName := os.Getenv("OS_USER_DOMAIN_NAME")
+	userDomainID := os.Getenv("OS_USER_DOMAIN_ID")
+	defaultDomain := os.Getenv("OS_DEFAULT_DOMAIN")
 	applicationCredentialID := os.Getenv("OS_APPLICATION_CREDENTIAL_ID")
 	applicationCredentialName := os.Getenv("OS_APPLICATION_CREDENTIAL_NAME")
 	applicationCredentialSecret := os.Getenv("OS_APPLICATION_CREDENTIAL_SECRET")
@@ -103,8 +106,16 @@ func AuthOptionsFromEnv() (gophercloud.AuthOptions, error) {
 			}
 		}
 		if username != "" && domainID == "" && domainName == "" {
-			return nilOptions, gophercloud.ErrMissingAnyoneOfEnvironmentVariables{
-				EnvironmentVariables: []string{"OS_DOMAIN_ID", "OS_DOMAIN_NAME"},
+			if userDomainID == "" && userDomainName == "" && defaultDomain == "" {
+				return nilOptions, gophercloud.ErrMissingAnyoneOfEnvironmentVariables{
+					EnvironmentVariables: []string{"OS_DOMAIN_ID", "OS_DOMAIN_NAME"},
+				}
+			}
+			if defaultDomain == "" {
+				domainID = userDomainID
+				domainName = userDomainName
+			} else {
+				domainID = defaultDomain
 			}
 		}
 	}


### PR DESCRIPTION
users should be able to use OS_USER_DOMAIN_NAME, OS_USER_DOMAIN_ID or
OS_DEFAULT_DOMAIN to specify the DOMAIN of user.

Fixes: #2418

Reference:
https://docs.openstack.org/python-openstackclient/latest/cli/authentication.html#authenticating-using-identity-server-api-v3