### PR TITLE
Use newer OS images for train and ussuri LB jobs

### DIFF
--- a/.github/workflows/functional-loadbalancer.yaml
+++ b/.github/workflows/functional-loadbalancer.yaml
@@ -28,10 +28,10 @@ jobs:
             ubuntu_version: "20.04"
           - name: "ussuri"
             openstack_version: "stable/ussuri"
-            ubuntu_version: "18.04"
+            ubuntu_version: "20.04"
           - name: "train"
             openstack_version: "stable/train"
-            ubuntu_version: "18.04"
+            ubuntu_version: "20.04"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with Octavia and run loadbalancer acceptance tests
     steps:
@@ -44,6 +44,7 @@ jobs:
           conf_overrides: |
             enable_plugin octavia https://opendev.org/openstack/octavia ${{ matrix.openstack_version }}
             enable_plugin neutron https://opendev.org/openstack/neutron ${{ matrix.openstack_version }}
+            FORCE=yes
           enabled_services: 'octavia,o-api,o-cw,o-hk,o-hm,o-da'
       - name: Checkout go
         uses: actions/setup-go@v3


### PR DESCRIPTION
Diskimage-builder now requires at least python 3.8.

Unfortunately the amphora image building in octavia's devstack plugin
doesn't respect the python version set via devstack's PYTHON3_VERSION
environment variable. Instead, let's switch to Ubunto 20.04 that ships
with python 3.8 as the default python interpreter.

https://github.com/openstack/diskimage-builder/commit/fe0e5324d4248d114660ec35111ae9601e05b95b