### PR TITLE
Add support for deleting nova service

### DIFF
--- a/acceptance/openstack/compute/v2/services_test.go
+++ b/acceptance/openstack/compute/v2/services_test.go
@@ -121,3 +121,27 @@ func TestServicesUpdate(t *testing.T) {
 		th.AssertEquals(t, updated.ID, service.ID)
 	}
 }
+
+func TestDeleteService(t *testing.T) {
+	clients.RequireAdmin(t)
+
+	client, err := clients.NewComputeV2Client()
+	th.AssertNoErr(t, err)
+
+	listOpts := services.ListOpts{
+		Binary: "nova-compute",
+	}
+
+	client.Microversion = "2.53"
+	allPages, err := services.List(client, listOpts).AllPages()
+	th.AssertNoErr(t, err)
+
+	allServices, err := services.ExtractServices(allPages)
+	th.AssertNoErr(t, err)
+
+	// delete all services
+	for _, service := range allServices {
+		updated, err := services.Delete(client, service.ID).Extract()
+		th.AssertNoErr(t, err)
+	}
+}

--- a/openstack/compute/v2/extensions/services/doc.go
+++ b/openstack/compute/v2/extensions/services/doc.go
@@ -32,6 +32,13 @@ Example of updating a service
 	if err != nil {
 		panic(err)
 	}
+
+Example of delete a service
+
+	updated, err := services.Delete(client, serviceID).Extract()
+	if err != nil {
+		panic(err)
+	}
 */
 
 package services

--- a/openstack/compute/v2/extensions/services/requests.go
+++ b/openstack/compute/v2/extensions/services/requests.go
@@ -80,3 +80,12 @@ func Update(client *gophercloud.ServiceClient, id string, opts UpdateOpts) (r Up
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
+
+// Delete will delete the existing service with the provided ID.
+func Delete(client *gophercloud.ServiceClient, id string) (r UpdateResult) {
+	resp, err := client.Delete(updateURL(client, id), &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}


### PR DESCRIPTION
Add support for deleting nova service

Fixes https://github.com/gophercloud/gophercloud/issues/2421

Reference:
https://docs.openstack.org/python-openstackclient/latest/cli/command-objects/compute-service.html