### PR TITLE
Credit the Gophercloud authors

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,5 @@
 Copyright 2012-2013 Rackspace, Inc.
+Copyright Gophercloud authors
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.  You may obtain a copy of the


### PR DESCRIPTION
for post-2013 contributions.