### PR TITLE
Add support for baremetal v1 volume connectors and targets

### DIFF
--- a/openstack/baremetal/v1/volume/doc.go
+++ b/openstack/baremetal/v1/volume/doc.go
@@ -1,0 +1,7 @@
+/*
+ Package bmvolume contains the functionality to Listing, Searching, Creating, Updating,
+ and Deleting of bare metal volume connectors or targets resources
+
+ API reference: https://docs.openstack.org/api-ref/baremetal/?expanded=#volume-volume
+*/
+package bmvolume

--- a/openstack/baremetal/v1/volume/requests.go
+++ b/openstack/baremetal/v1/volume/requests.go
@@ -1,0 +1,237 @@
+package bmvolume
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+type ListOpts struct {
+}
+
+func List(client *gophercloud.ServiceClient, opts ListOpts) (r ListResult) {
+	resp, err := client.Get(listURL(client), &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+type ListConnectorsOptsBuilder interface {
+	ToConnectorsListQuery() (string, error)
+}
+type ListConnectorsOpts struct {
+	// node uuid
+	Node string `q:node`
+	// One or more fields to be returned in the response.
+	Fields []string `q:"fields"`
+	// Requests a page size of items.
+	Limit int `q:"limit"`
+	// The ID of the last-seen item
+	Marker string `q:"marker"`
+	// Sorts the response by the requested sort direction.
+	// Valid value is asc (ascending) or desc (descending). Default is asc.
+	SortDir string `q:"sort_dir"`
+	// Sorts the response by the this attribute value. Default is id.
+	SortKey string `q:"sort_key"`
+}
+
+func (opts ListConnectorsOpts) ToConnectorsListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+func ListConnectors(client *gophercloud.ServiceClient, opts ListConnectorsOptsBuilder) pagination.Pager {
+	url := listConnectorsURL(client)
+	if opts != nil {
+		query, err := opts.ToConnectorsListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return ConnectorPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+type CreateConnectorOptsBuilder interface {
+	ToConnectorCreateMap() (map[string]interface{}, error)
+}
+
+type CreateConnectorOpts struct {
+	NodeUUID      string                 `json:"node_uuid,omitempty"`
+	ConnectorType string                 `json:"type,omitempty"`
+	ConnectorId   string                 `json:"connector_id,omitempty"`
+	Extra         map[string]interface{} `json:"Extra,omitempty"`
+	UUID          string                 `json:"uuid,omitempty"`
+}
+
+func (opts CreateConnectorOpts) ToConnectorCreateMap() (map[string]interface{}, error) {
+	body, err := gophercloud.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+	return body, nil
+}
+
+func CreateConnector(client *gophercloud.ServiceClient, opts CreateConnectorOptsBuilder) (r CreateConnectorResult) {
+	reqBody, err := opts.ToConnectorCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := client.Post(createConnectorsURL(client), reqBody, &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+type Patch interface {
+	ToUpdateMap() map[string]interface{}
+}
+
+type UpdateOpts []Patch
+
+type UpdateOp string
+
+const (
+	ReplaceOp UpdateOp = "replace"
+	AddOp     UpdateOp = "add"
+	RemoveOp  UpdateOp = "remove"
+)
+
+type UpdateOperation struct {
+	Op    UpdateOp    `json:"op" required:"true"`
+	Path  string      `json:"path" required:"true"`
+	Value interface{} `json:"value,omitempty"`
+}
+
+func (opts UpdateOperation) ToUpdateMap() map[string]interface{} {
+	return map[string]interface{}{
+		"op":    opts.Op,
+		"path":  opts.Path,
+		"value": opts.Value,
+	}
+}
+
+func UpdateConnector(client *gophercloud.ServiceClient, id string, opts UpdateOpts) (r UpdateConnectorResult) {
+	body := make([]map[string]interface{}, len(opts))
+	for i, patch := range opts {
+		body[i] = patch.ToUpdateMap()
+	}
+	resp, err := client.Patch(patchConnectorsURL(client, id), body, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+func DeleteConnector(client *gophercloud.ServiceClient, id string) (r DeleteConnectorResult) {
+	resp, err := client.Delete(deleteConnectorsURL(client, id), nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+func GetConnector(client *gophercloud.ServiceClient, id string) (r GetConnectorResult) {
+	resp, err := client.Get(getConnectorsURL(client, id), &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+type ListTargetsOptsBuilder interface {
+	ToTargetsListQuery() (string, error)
+}
+type ListTargetsOpts struct {
+	// node uuid
+	Node string `q:node`
+	// One or more fields to be returned in the response.
+	Fields []string `q:"fields"`
+	// Requests a page size of items.
+	Limit int `q:"limit"`
+	// The ID of the last-seen item
+	Marker string `q:"marker"`
+	// Sorts the response by the requested sort direction.
+	// Valid value is asc (ascending) or desc (descending). Default is asc.
+	SortDir string `q:"sort_dir"`
+	// Sorts the response by the this attribute value. Default is id.
+	SortKey string `q:"sort_key"`
+}
+
+func (opts ListTargetsOpts) ToTargetsListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+func ListTargets(client *gophercloud.ServiceClient, opts ListTargetsOptsBuilder) pagination.Pager {
+	url := listTargetsURL(client)
+	if opts != nil {
+		query, err := opts.ToTargetsListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return TargetPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+type CreateTargetOptsBuilder interface {
+	ToTargetCreateMap() (map[string]interface{}, error)
+}
+
+type CreateTargetOpts struct {
+	NodeUUID   string                 `json:"node_uuid,omitempty"`
+	VolumeType string                 `json:"volume_type,omitempty"` //iscsi, fibre_channel
+	Properties map[string]interface{} `json:"properties,omitempty"`
+	BootIndex  string                 `json:"boot_index,omitempty"`
+	VolumeId   string                 `json:"volume_id,omitempty"`
+	Extra      map[string]interface{} `json:"Extra,omitempty"`
+	UUID       string                 `json:"uuid,omitempty"`
+}
+
+func (opts CreateTargetOpts) ToTargetCreateMap() (map[string]interface{}, error) {
+	body, err := gophercloud.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+	return body, nil
+}
+
+func CreateTarget(client *gophercloud.ServiceClient, opts CreateTargetOptsBuilder) (r CreateTargetResult) {
+	reqBody, err := opts.ToTargetCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := client.Post(createTargetsURL(client), reqBody, &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+func UpdateTarget(client *gophercloud.ServiceClient, id string, opts UpdateOpts) (r UpdateTargetResult) {
+	body := make([]map[string]interface{}, len(opts))
+	for i, patch := range opts {
+		body[i] = patch.ToUpdateMap()
+	}
+	resp, err := client.Patch(patchTargetsURL(client, id), body, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+func DeleteTarget(client *gophercloud.ServiceClient, id string) (r DeleteTargetResult) {
+	resp, err := client.Delete(deleteTargetsURL(client, id), nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+func GetTarget(client *gophercloud.ServiceClient, id string) (r GetTargetResult) {
+	resp, err := client.Get(getTargetsURL(client, id), &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}

--- a/openstack/baremetal/v1/volume/results.go
+++ b/openstack/baremetal/v1/volume/results.go
@@ -1,0 +1,190 @@
+package bmvolume
+
+import (
+	//"encoding/json"
+	//"fmt"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+type volumeResult struct {
+	gophercloud.Result
+}
+
+type ListResult struct {
+	volumeResult
+}
+
+func (r ListResult) Extract() (*Volume, error) {
+	var s Volume
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+type Volume struct {
+	Connectors []interface{} `json:"connectors"`
+	Targets    []interface{} `json:"targets"`
+	Links      []interface{} `json:"links"`
+}
+
+type Connector struct {
+	UUID          string                 `json:"uuid"`
+	ConnectorType string                 `json:"type"`
+	ConnectorId   string                 `json:"connector_id"`
+	NodeUUID      string                 `json:"node_uuid"`
+	Extra         map[string]interface{} `json:"extra"`
+	Links         []interface{}          `json:"links"`
+}
+
+type connectorResult struct {
+	gophercloud.Result
+}
+
+type ConnectorPage struct {
+	pagination.LinkedPageBase
+}
+
+type Connectors struct {
+	Connectors []Connector `json:"connectors"`
+}
+
+func ExtractConnectorsInto(r pagination.Page, v interface{}) error {
+	//var c Connectors
+	//j := json.Unmarshal(r.(ConnectorPage).Result.Body.([]byte), &c)
+	//fmt.Println(c)
+	//return j
+	return r.(ConnectorPage).Result.ExtractIntoSlicePtr(v, "connectors")
+}
+func ExtractConnectors(r pagination.Page) ([]Connector, error) {
+	var s []Connector
+	err := ExtractConnectorsInto(r, &s)
+	return s, err
+}
+
+func (r ConnectorPage) IsEmpty() (bool, error) {
+	s, err := ExtractConnectors(r)
+	return len(s) == 0, err
+}
+
+func (r ConnectorPage) NextPageURL() (string, error) {
+	var s struct {
+		Links []gophercloud.Link `json:"connector_links"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return gophercloud.ExtractNextURL(s.Links)
+}
+
+type CreateConnectorResult struct {
+	connectorResult
+}
+
+func (r CreateConnectorResult) Extract() (*Connector, error) {
+	var c Connector
+	err := r.ExtractInto(&c)
+	return &c, err
+}
+
+type UpdateConnectorResult struct {
+	connectorResult
+}
+
+func (r UpdateConnectorResult) Extract() (*Connector, error) {
+	var c Connector
+	err := r.ExtractInto(&c)
+	return &c, err
+}
+
+type DeleteConnectorResult struct {
+	connectorResult
+}
+
+type GetConnectorResult struct {
+	connectorResult
+}
+
+func (r GetConnectorResult) Extract() (*Connector, error) {
+	var c Connector
+	err := r.ExtractInto(&c)
+	return &c, err
+}
+
+type targetResult struct {
+	gophercloud.Result
+}
+
+type Target struct {
+	UUID       string                 `json:"uuid"`
+	VolumeType string                 `json:"volume_type"`
+	Properties map[string]interface{} `json:"properties"`
+	BootIndex  string                 `json:"boot_index"`
+	VolumeId   string                 `json:"volume_id"`
+	Extra      map[string]interface{} `json:"extra"`
+	NodeUUID   string                 `json:"node_uuid"`
+	Links      []interface{}          `json:"links"`
+}
+type TargetPage struct {
+	pagination.LinkedPageBase
+}
+
+func ExtractTargetsInto(r pagination.Page, v interface{}) error {
+	return r.(TargetPage).Result.ExtractIntoSlicePtr(v, "targets")
+}
+func ExtractTargets(r pagination.Page) ([]Target, error) {
+	var s []Target
+	err := ExtractTargetsInto(r, &s)
+	return s, err
+}
+
+func (r TargetPage) IsEmpty() (bool, error) {
+	s, err := ExtractTargets(r)
+	return len(s) == 0, err
+}
+
+func (r TargetPage) NextPageURL() (string, error) {
+	var s struct {
+		Links []gophercloud.Link `json:"target_links"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return gophercloud.ExtractNextURL(s.Links)
+}
+
+type CreateTargetResult struct {
+	targetResult
+}
+
+func (r CreateTargetResult) Extract() (*Target, error) {
+	var t Target
+	err := r.ExtractInto(&t)
+	return &t, err
+}
+
+type UpdateTargetResult struct {
+	targetResult
+}
+
+func (r UpdateTargetResult) Extract() (*Target, error) {
+	var t Target
+	err := r.ExtractInto(&t)
+	return &t, err
+}
+
+type DeleteTargetResult struct {
+	targetResult
+}
+
+type GetTargetResult struct {
+	targetResult
+}
+
+func (r GetTargetResult) Extract() (*Target, error) {
+	var t Target
+	err := r.ExtractInto(&t)
+	return &t, err
+}

--- a/openstack/baremetal/v1/volume/testing/doc.go
+++ b/openstack/baremetal/v1/volume/testing/doc.go
@@ -1,0 +1,2 @@
+// bmvolume unit tests
+package testing

--- a/openstack/baremetal/v1/volume/testing/fixtures.go
+++ b/openstack/baremetal/v1/volume/testing/fixtures.go
@@ -1,0 +1,249 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+const VolumeListBody = `
+	{
+  "connectors": [
+    {
+      "href": "http://127.0.0.1:6385/v1/volume/connectors",
+      "rel": "self"
+    },
+    {
+      "href": "http://127.0.0.1:6385/volume/connectors",
+      "rel": "bookmark"
+    }
+  ],
+  "links": [
+    {
+      "href": "http://127.0.0.1:6385/v1/volume/",
+      "rel": "self"
+    },
+    {
+      "href": "http://127.0.0.1:6385/volume/",
+      "rel": "bookmark"
+    }
+  ],
+  "targets": [
+    {
+      "href": "http://127.0.0.1:6385/v1/volume/targets",
+      "rel": "self"
+    },
+    {
+      "href": "http://127.0.0.1:6385/volume/targets",
+      "rel": "bookmark"
+    }
+  ]
+}
+`
+
+const ConnectorListBody = `{
+  "connectors": [
+    {
+      "connector_id": "iqn.2017-07.org.openstack:01:d9a51732c3f",
+      "links": [
+        {
+          "href": "http://127.0.0.1:6385/v1/volume/connectors/9bf93e01-d728-47a3-ad4b-5e66a835037c",
+          "rel": "self"
+        },
+        {
+          "href": "http://127.0.0.1:6385/volume/connectors/9bf93e01-d728-47a3-ad4b-5e66a835037c",
+          "rel": "bookmark"
+        }
+      ],
+      "node_uuid": "6d85703a-565d-469a-96ce-30b6de53079d",
+      "type": "iqn",
+      "uuid": "9bf93e01-d728-47a3-ad4b-5e66a835037c"
+    }
+  ]
+}`
+
+const TargetListBody = `
+	{
+  "targets": [
+    {
+      "boot_index": "0",
+      "links": [
+        {
+          "href": "http://127.0.0.1:6385/v1/volume/targets/bd4d008c-7d31-463d-abf9-6c23d9d55f7f",
+          "rel": "self"
+        },
+        {
+          "href": "http://127.0.0.1:6385/volume/targets/bd4d008c-7d31-463d-abf9-6c23d9d55f7f",
+          "rel": "bookmark"
+        }
+      ],
+      "node_uuid": "6d85703a-565d-469a-96ce-30b6de53079d",
+      "uuid": "bd4d008c-7d31-463d-abf9-6c23d9d55f7f",
+      "volume_id": "04452bed-5367-4202-8bf5-de4335ac56d2",
+      "volume_type": "iscsi"
+    }
+  ]
+}
+`
+
+const SingleConnectorBody = `
+	{
+  "connector_id": "iqn.2017-07.org.openstack:01:d9a51732c3f",
+  "created_at": "2016-08-18T22:28:48.643434+11:11",
+  "extra": {},
+  "links": [
+    {
+      "href": "http://127.0.0.1:6385/v1/volume/connectors/9bf93e01-d728-47a3-ad4b-5e66a835037c",
+      "rel": "self"
+    },
+    {
+      "href": "http://127.0.0.1:6385/volume/connectors/9bf93e01-d728-47a3-ad4b-5e66a835037c",
+      "rel": "bookmark"
+    }
+  ],
+  "node_uuid": "6d85703a-565d-469a-96ce-30b6de53079d",
+  "type": "iqn",
+  "updated_at": null,
+  "uuid": "9bf93e01-d728-47a3-ad4b-5e66a835037c"
+}
+`
+
+const SingleTargetBody = `
+	{
+  "boot_index": "0",
+  "created_at": "2016-08-18T22:28:48.643434+11:11",
+  "extra": {},
+  "links": [
+    {
+      "href": "http://127.0.0.1:6385/v1/volume/targets/bd4d008c-7d31-463d-abf9-6c23d9d55f7f",
+      "rel": "self"
+    },
+    {
+      "href": "http://127.0.0.1:6385/volume/targets/bd4d008c-7d31-463d-abf9-6c23d9d55f7f",
+      "rel": "bookmark"
+    }
+  ],
+  "node_uuid": "6d85703a-565d-469a-96ce-30b6de53079d",
+  "properties": {},
+  "updated_at": null,
+  "uuid": "bd4d008c-7d31-463d-abf9-6c23d9d55f7f",
+  "volume_id": "04452bed-5367-4202-8bf5-de4335ac56d2",
+  "volume_type": "iscsi"
+}
+`
+
+func HandleVolumeListSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/volume", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		w.Header().Add("Content-Type", "appliction/json")
+		fmt.Fprintf(w, VolumeListBody)
+	})
+}
+
+func HandleConnectorListSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/volume/connectors", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		w.Header().Add("Content-Type", "appliction/json")
+		fmt.Fprintf(w, ConnectorListBody)
+	})
+}
+
+func HandleConnectorCreationSuccessfully(t *testing.T, response string) {
+	th.Mux.HandleFunc("/volume/connectors", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, `{
+          "node_uuid": "6d85703a-565d-469a-96ce-30b6de53079d",
+          "type": "iqn",
+          "connector_id": "iqn.2017-07.org.openstack:01:d9a51732c3f"
+        }`)
+
+		w.WriteHeader(http.StatusAccepted)
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprintf(w, response)
+	})
+}
+
+func HandleConnectorDeletionSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/volume/connectors/9bf93e01-d728-47a3-ad4b-5e66a835037c", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		w.WriteHeader(http.StatusNoContent)
+	})
+}
+func HandleConnectorGetSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/volume/connectors/9bf93e01-d728-47a3-ad4b-5e66a835037c", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+		fmt.Fprintf(w, SingleConnectorBody)
+	})
+}
+
+func HandleConnectorUpdateSuccessfully(t *testing.T, response string) {
+	th.Mux.HandleFunc("/volume/connectors/9bf93e01-d728-47a3-ad4b-5e66a835037c", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PATCH")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestJSONRequest(t, r, `[{"op": "replace", "path": "/connector_id", "value": "iqn.2017-07.org.openstack:01:66666666666"}]`)
+		fmt.Fprintf(w, response)
+	})
+}
+
+func HandleTargetListSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/volume/targets", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		w.Header().Add("Content-Type", "appliction/json")
+		fmt.Fprintf(w, TargetListBody)
+	})
+}
+
+func HandleTargetCreationSuccessfully(t *testing.T, response string) {
+	th.Mux.HandleFunc("/volume/targets", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, `{
+          "boot_index": "0",
+          "node_uuid": "6d85703a-565d-469a-96ce-30b6de53079d",
+          "volume_id": "04452bed-5367-4202-8bf5-de4335ac56d2",
+          "volume_type":"iscsi"
+        }`)
+		w.WriteHeader(http.StatusAccepted)
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprintf(w, response)
+	})
+}
+
+func HandleTargetDeletionSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/volume/targets/bd4d008c-7d31-463d-abf9-6c23d9d55f7f", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		w.WriteHeader(http.StatusNoContent)
+	})
+}
+func HandleTargetGetSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/volume/targets/bd4d008c-7d31-463d-abf9-6c23d9d55f7f", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+		fmt.Fprintf(w, SingleTargetBody)
+	})
+}
+
+func HandleTargetUpdateSuccessfully(t *testing.T, response string) {
+	th.Mux.HandleFunc("/volume/targets/bd4d008c-7d31-463d-abf9-6c23d9d55f7f", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PATCH")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestJSONRequest(t, r, `[{"op": "replace", "path": "/volume_id", "value": "06666bed-5367-4202-8bf5-de4335ac56d2"}]`)
+		fmt.Fprintf(w, response)
+	})
+}

--- a/openstack/baremetal/v1/volume/testing/requests_test.go
+++ b/openstack/baremetal/v1/volume/testing/requests_test.go
@@ -1,0 +1,191 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/baremetal/v1/volume"
+	"github.com/gophercloud/gophercloud/pagination"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func TestListVolumes(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleVolumeListSuccessfully(t)
+	actual, err := bmvolume.List(client.ServiceClient(), bmvolume.ListOpts{}).Extract()
+	th.AssertNoErr(t, err)
+	if len(actual.Connectors) <= 0 || len(actual.Targets) <= 0 || len(actual.Links) <= 0 {
+		t.Fatalf("Expected Connectors Targets Links, but got not all!")
+	}
+	th.AssertEquals(t, "http://127.0.0.1:6385/v1/volume/connectors", actual.Connectors[0].(map[string]interface{})["href"].(string))
+	th.AssertEquals(t, "http://127.0.0.1:6385/v1/volume/targets", actual.Targets[0].(map[string]interface{})["href"].(string))
+	th.AssertEquals(t, "http://127.0.0.1:6385/v1/volume/", actual.Links[0].(map[string]interface{})["href"].(string))
+}
+
+func TestListConnectors(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleConnectorListSuccessfully(t)
+	pages := 0
+	connectorListOpts := bmvolume.ListConnectorsOpts{}
+	connectorListOpts.Node = "6d85703a-565d-469a-96ce-30b6de53079d"
+	err := bmvolume.ListConnectors(client.ServiceClient(), connectorListOpts).EachPage(func(page pagination.Page) (bool, error) {
+		pages++
+		actual, err := bmvolume.ExtractConnectors(page)
+		if err != nil {
+			return false, err
+		}
+		if len(actual) != 1 {
+			t.Fatalf("Expected 1 connectors, but got not!")
+		}
+		th.AssertEquals(t, "iqn.2017-07.org.openstack:01:d9a51732c3f", actual[0].ConnectorId)
+		th.AssertEquals(t, "6d85703a-565d-469a-96ce-30b6de53079d", actual[0].NodeUUID)
+		return true, nil
+	})
+	th.AssertNoErr(t, err)
+	if pages != 1 {
+		t.Errorf("Expected 1 page, saw %d", pages)
+	}
+}
+
+func TestCreateConnector(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleConnectorCreationSuccessfully(t, SingleConnectorBody)
+	connectorCreateOpts := bmvolume.CreateConnectorOpts{}
+	connectorCreateOpts.NodeUUID = "6d85703a-565d-469a-96ce-30b6de53079d"
+	connectorCreateOpts.ConnectorType = "iqn"
+	connectorCreateOpts.ConnectorId = "iqn.2017-07.org.openstack:01:d9a51732c3f"
+	actual, err := bmvolume.CreateConnector(client.ServiceClient(), connectorCreateOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, "6d85703a-565d-469a-96ce-30b6de53079d", actual.NodeUUID)
+	th.AssertEquals(t, "iqn", actual.ConnectorType)
+	th.AssertEquals(t, "iqn.2017-07.org.openstack:01:d9a51732c3f", actual.ConnectorId)
+	th.AssertEquals(t, "9bf93e01-d728-47a3-ad4b-5e66a835037c", actual.UUID)
+}
+
+func TestDeleteConnector(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleConnectorDeletionSuccessfully(t)
+	res := bmvolume.DeleteConnector(client.ServiceClient(), "9bf93e01-d728-47a3-ad4b-5e66a835037c")
+	th.AssertNoErr(t, res.Err)
+}
+func TestGetConnector(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleConnectorGetSuccessfully(t)
+	actual, err := bmvolume.GetConnector(client.ServiceClient(), "9bf93e01-d728-47a3-ad4b-5e66a835037c").Extract()
+	if err != nil {
+		t.Fatalf("Unexpected Get Connector error: %v", err)
+	}
+	th.AssertEquals(t, "6d85703a-565d-469a-96ce-30b6de53079d", actual.NodeUUID)
+	th.AssertEquals(t, "iqn", actual.ConnectorType)
+	th.AssertEquals(t, "iqn.2017-07.org.openstack:01:d9a51732c3f", actual.ConnectorId)
+	th.AssertEquals(t, "9bf93e01-d728-47a3-ad4b-5e66a835037c", actual.UUID)
+}
+
+func TestUpdateConnector(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleConnectorUpdateSuccessfully(t, SingleConnectorBody)
+	actual, err := bmvolume.UpdateConnector(client.ServiceClient(), "9bf93e01-d728-47a3-ad4b-5e66a835037c", bmvolume.UpdateOpts{
+		bmvolume.UpdateOperation{
+			Op:    bmvolume.ReplaceOp,
+			Path:  "/connector_id",
+			Value: "iqn.2017-07.org.openstack:01:66666666666",
+		},
+	}).Extract()
+	if err != nil {
+		t.Fatalf("Unexpected Update Connector error: %v", err)
+	}
+	th.AssertEquals(t, "6d85703a-565d-469a-96ce-30b6de53079d", actual.NodeUUID)
+	th.AssertEquals(t, "iqn", actual.ConnectorType)
+	th.AssertEquals(t, "iqn.2017-07.org.openstack:01:d9a51732c3f", actual.ConnectorId)
+	th.AssertEquals(t, "9bf93e01-d728-47a3-ad4b-5e66a835037c", actual.UUID)
+}
+
+func TestListTargets(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleTargetListSuccessfully(t)
+	pages := 0
+	targetListOpts := bmvolume.ListTargetsOpts{}
+	targetListOpts.Node = "6d85703a-565d-469a-96ce-30b6de53079d"
+	err := bmvolume.ListTargets(client.ServiceClient(), targetListOpts).EachPage(func(page pagination.Page) (bool, error) {
+		pages++
+		actual, err := bmvolume.ExtractTargets(page)
+		if err != nil {
+			return false, err
+		}
+		if len(actual) != 1 {
+			t.Fatalf("Expected 1 targets, but got not!")
+		}
+		th.AssertEquals(t, "bd4d008c-7d31-463d-abf9-6c23d9d55f7f", actual[0].UUID)
+		th.AssertEquals(t, "6d85703a-565d-469a-96ce-30b6de53079d", actual[0].NodeUUID)
+		return true, nil
+	})
+	th.AssertNoErr(t, err)
+	if pages != 1 {
+		t.Errorf("Expected 1 page, saw %d", pages)
+	}
+}
+
+func TestCreateTarget(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleTargetCreationSuccessfully(t, SingleTargetBody)
+	targetCreateOpts := bmvolume.CreateTargetOpts{}
+	targetCreateOpts.BootIndex = "0"
+	targetCreateOpts.NodeUUID = "6d85703a-565d-469a-96ce-30b6de53079d"
+	targetCreateOpts.VolumeType = "iscsi"
+	targetCreateOpts.VolumeId = "04452bed-5367-4202-8bf5-de4335ac56d2"
+	actual, err := bmvolume.CreateTarget(client.ServiceClient(), targetCreateOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, "6d85703a-565d-469a-96ce-30b6de53079d", actual.NodeUUID)
+	th.AssertEquals(t, "iscsi", actual.VolumeType)
+	th.AssertEquals(t, "04452bed-5367-4202-8bf5-de4335ac56d2", actual.VolumeId)
+	th.AssertEquals(t, "bd4d008c-7d31-463d-abf9-6c23d9d55f7f", actual.UUID)
+}
+
+func TestDeleteTarget(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleTargetDeletionSuccessfully(t)
+	res := bmvolume.DeleteTarget(client.ServiceClient(), "bd4d008c-7d31-463d-abf9-6c23d9d55f7f")
+	th.AssertNoErr(t, res.Err)
+}
+func TestGetTarget(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleTargetGetSuccessfully(t)
+	actual, err := bmvolume.GetTarget(client.ServiceClient(), "bd4d008c-7d31-463d-abf9-6c23d9d55f7f").Extract()
+	if err != nil {
+		t.Fatalf("Unexpected Get Target error: %v", err)
+	}
+	th.AssertEquals(t, "6d85703a-565d-469a-96ce-30b6de53079d", actual.NodeUUID)
+	th.AssertEquals(t, "iscsi", actual.VolumeType)
+	th.AssertEquals(t, "04452bed-5367-4202-8bf5-de4335ac56d2", actual.VolumeId)
+	th.AssertEquals(t, "bd4d008c-7d31-463d-abf9-6c23d9d55f7f", actual.UUID)
+}
+
+func TestUpdateTarget(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleTargetUpdateSuccessfully(t, SingleTargetBody)
+	actual, err := bmvolume.UpdateTarget(client.ServiceClient(), "bd4d008c-7d31-463d-abf9-6c23d9d55f7f", bmvolume.UpdateOpts{
+		bmvolume.UpdateOperation{
+			Op:    bmvolume.ReplaceOp,
+			Path:  "/volume_id",
+			Value: "06666bed-5367-4202-8bf5-de4335ac56d2",
+		},
+	}).Extract()
+	if err != nil {
+		t.Fatalf("Unexpected Update Target error: %v", err)
+	}
+	th.AssertEquals(t, "6d85703a-565d-469a-96ce-30b6de53079d", actual.NodeUUID)
+	th.AssertEquals(t, "iscsi", actual.VolumeType)
+	th.AssertEquals(t, "04452bed-5367-4202-8bf5-de4335ac56d2", actual.VolumeId)
+	th.AssertEquals(t, "bd4d008c-7d31-463d-abf9-6c23d9d55f7f", actual.UUID)
+}

--- a/openstack/baremetal/v1/volume/urls.go
+++ b/openstack/baremetal/v1/volume/urls.go
@@ -1,0 +1,47 @@
+package bmvolume
+
+import "github.com/gophercloud/gophercloud"
+
+func listURL(client *gophercloud.ServiceClient) string {
+	return client.ServiceURL("volume")
+}
+
+func createConnectorsURL(client *gophercloud.ServiceClient) string {
+	return client.ServiceURL("volume", "connectors")
+}
+
+func listConnectorsURL(client *gophercloud.ServiceClient) string {
+	return createConnectorsURL(client)
+}
+
+func getConnectorsURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL("volume", "connectors", id)
+}
+
+func patchConnectorsURL(client *gophercloud.ServiceClient, id string) string {
+	return getConnectorsURL(client, id)
+}
+
+func deleteConnectorsURL(client *gophercloud.ServiceClient, id string) string {
+	return getConnectorsURL(client, id)
+}
+
+func createTargetsURL(client *gophercloud.ServiceClient) string {
+	return client.ServiceURL("volume", "targets")
+}
+
+func listTargetsURL(client *gophercloud.ServiceClient) string {
+	return createTargetsURL(client)
+}
+
+func getTargetsURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL("volume", "targets", id)
+}
+
+func patchTargetsURL(client *gophercloud.ServiceClient, id string) string {
+	return getTargetsURL(client, id)
+}
+
+func deleteTargetsURL(client *gophercloud.ServiceClient, id string) string {
+	return getTargetsURL(client, id)
+}

--- a/results.go
+++ b/results.go
@@ -53,9 +53,13 @@ func (r Result) ExtractInto(to interface{}) error {
 		return json.NewDecoder(reader).Decode(to)
 	}
 
-	b, err := json.Marshal(r.Body)
-	if err != nil {
-		return err
+	var err error
+	b, bok := r.Body.([]byte)
+	if !bok {
+		b, err = json.Marshal(r.Body)
+		if err != nil {
+			return err
+		}
 	}
 	err = json.Unmarshal(b, to)
 


### PR DESCRIPTION
There is no interfaces in baremetal v1 for volume connectors and targets, while volume connectors and targets setting is necessary when baremetal is boot from remote volume, **so we should add some volume client api in baremetal v1 directory**. 
In the process of adding these apis,  i find when i  use ExtractInto function in results.go to json.unmarshal pagination.LinkedPageBase.PageResult body to some structure, it will throw exception like "**json: cannot unmarshal string into Go value of type map[string]interface {}**", when i change codes blow, the exception will disappear.