### PR TITLE
Apply gofmt to comments

### DIFF
--- a/acceptance/openstack/compute/v2/compute.go
+++ b/acceptance/openstack/compute/v2/compute.go
@@ -1140,7 +1140,7 @@ func WaitForComputeStatus(client *gophercloud.ServiceClient, server *servers.Ser
 	})
 }
 
-//Convenience method to fill an QuotaSet-UpdateOpts-struct from a QuotaSet-struct
+// Convenience method to fill an QuotaSet-UpdateOpts-struct from a QuotaSet-struct
 func FillUpdateOptsFromQuotaSet(src quotasets.QuotaSet, dest *quotasets.UpdateOpts) {
 	dest.FixedIPs = &src.FixedIPs
 	dest.FloatingIPs = &src.FloatingIPs

--- a/acceptance/openstack/networking/v2/extensions/fwaas/fwaas.go
+++ b/acceptance/openstack/networking/v2/extensions/fwaas/fwaas.go
@@ -117,7 +117,7 @@ func CreatePolicy(t *testing.T, client *gophercloud.ServiceClient, ruleID string
 }
 
 // CreateRule will create a Firewall Rule with a random source address and
-//source port, destination address and port. An error will be returned if
+// source port, destination address and port. An error will be returned if
 // the rule could not be created.
 func CreateRule(t *testing.T, client *gophercloud.ServiceClient) (*rules.Rule, error) {
 	ruleName := tools.RandomString("TESTACC-", 8)

--- a/acceptance/openstack/networking/v2/extensions/fwaas_v2/fwaas_v2.go
+++ b/acceptance/openstack/networking/v2/extensions/fwaas_v2/fwaas_v2.go
@@ -69,7 +69,7 @@ func CreatePolicy(t *testing.T, client *gophercloud.ServiceClient, ruleID string
 }
 
 // CreateRule will create a Firewall Rule with a random source address and
-//source port, destination address and port. An error will be returned if
+// source port, destination address and port. An error will be returned if
 // the rule could not be created.
 func CreateRule(t *testing.T, client *gophercloud.ServiceClient) (*rules.Rule, error) {
 	ruleName := tools.RandomString("TESTACC-", 8)

--- a/auth_options.go
+++ b/auth_options.go
@@ -12,20 +12,20 @@ provider.
 
 An example of manually providing authentication information:
 
-  opts := gophercloud.AuthOptions{
-    IdentityEndpoint: "https://openstack.example.com:5000/v2.0",
-    Username: "{username}",
-    Password: "{password}",
-    TenantID: "{tenant_id}",
-  }
+	opts := gophercloud.AuthOptions{
+	  IdentityEndpoint: "https://openstack.example.com:5000/v2.0",
+	  Username: "{username}",
+	  Password: "{password}",
+	  TenantID: "{tenant_id}",
+	}
 
-  provider, err := openstack.AuthenticatedClient(opts)
+	provider, err := openstack.AuthenticatedClient(opts)
 
 An example of using AuthOptionsFromEnv(), where the environment variables can
 be read from a file, such as a standard openrc file:
 
-  opts, err := openstack.AuthOptionsFromEnv()
-  provider, err := openstack.AuthenticatedClient(opts)
+	opts, err := openstack.AuthOptionsFromEnv()
+	provider, err := openstack.AuthenticatedClient(opts)
 */
 type AuthOptions struct {
 	// IdentityEndpoint specifies the HTTP endpoint that is required to work with

--- a/doc.go
+++ b/doc.go
@@ -3,7 +3,7 @@ Package gophercloud provides a multi-vendor interface to OpenStack-compatible
 clouds. The library has a three-level hierarchy: providers, services, and
 resources.
 
-Authenticating with Providers
+# Authenticating with Providers
 
 Provider structs represent the cloud providers that offer and manage a
 collection of services. You will generally want to create one Provider
@@ -49,7 +49,7 @@ instead of "project".
 	opts, err := openstack.AuthOptionsFromEnv()
 	provider, err := openstack.AuthenticatedClient(opts)
 
-Service Clients
+# Service Clients
 
 Service structs are specific to a provider and handle all of the logic and
 operations for a particular OpenStack service. Examples of services include:
@@ -60,7 +60,7 @@ pass in the parent provider, like so:
 
 	client, err := openstack.NewComputeV2(provider, opts)
 
-Resources
+# Resources
 
 Resource structs are the domain models that services make use of in order
 to work with and represent the state of API resources:
@@ -144,6 +144,5 @@ An example retry backoff function, which respects the 429 HTTP response code and
 
 		return nil
 	}
-
 */
 package gophercloud

--- a/docs/contributor-tutorial/.template/doc.go
+++ b/docs/contributor-tutorial/.template/doc.go
@@ -1,13 +1,12 @@
 /*
 Package NAME manages and retrieves RESOURCE in the OpenStack SERVICE Service.
 
-Example to List RESOURCE
+# Example to List RESOURCE
 
-Example to Create a RESOURCE
+# Example to Create a RESOURCE
 
-Example to Update a RESOURCE
+# Example to Update a RESOURCE
 
 Example to Delete a RESOURCE
-
 */
 package RESOURCE

--- a/openstack/baremetal/apiversions/doc.go
+++ b/openstack/baremetal/apiversions/doc.go
@@ -18,6 +18,5 @@ Package apiversions provides information about the versions supported by a speci
 		if err != nil {
 			panic("unable to get API version: " + err.Error())
 		}
-
 */
 package apiversions

--- a/openstack/baremetal/httpbasic/doc.go
+++ b/openstack/baremetal/httpbasic/doc.go
@@ -3,16 +3,16 @@ Package httpbasic provides support for http_basic bare metal endpoints.
 
 Example of obtaining and using a client:
 
-      client, err := httpbasic.NewBareMetalHTTPBasic(httpbasic.Endpoints{
-		IronicEndpoing:     "http://localhost:6385/v1/",
-		IronicUser:         "myUser",
-		IronicUserPassword: "myPassword",
-	})
-	if err != nil {
-		panic(err)
-	}
+	      client, err := httpbasic.NewBareMetalHTTPBasic(httpbasic.Endpoints{
+			IronicEndpoing:     "http://localhost:6385/v1/",
+			IronicUser:         "myUser",
+			IronicUserPassword: "myPassword",
+		})
+		if err != nil {
+			panic(err)
+		}
 
-	client.Microversion = "1.50"
-	nodes.ListDetail(client, nodes.listOpts{})
+		client.Microversion = "1.50"
+		nodes.ListDetail(client, nodes.listOpts{})
 */
 package httpbasic

--- a/openstack/baremetal/v1/nodes/results.go
+++ b/openstack/baremetal/v1/nodes/results.go
@@ -373,8 +373,8 @@ type DriverValidation struct {
 	Reason string `json:"reason"`
 }
 
-//  Ironic validates whether the Node’s driver has enough information to manage the Node. This polls each interface on
-//  the driver, and returns the status of that interface as an DriverValidation struct.
+// Ironic validates whether the Node’s driver has enough information to manage the Node. This polls each interface on
+// the driver, and returns the status of that interface as an DriverValidation struct.
 type NodeValidation struct {
 	BIOS       DriverValidation `json:"bios"`
 	Boot       DriverValidation `json:"boot"`

--- a/openstack/baremetal/v1/ports/doc.go
+++ b/openstack/baremetal/v1/ports/doc.go
@@ -1,85 +1,83 @@
 /*
- Package ports contains the functionality to Listing, Searching, Creating, Updating,
- and Deleting of bare metal Port resources
+	Package ports contains the functionality to Listing, Searching, Creating, Updating,
+	and Deleting of bare metal Port resources
 
- API reference: https://developer.openstack.org/api-ref/baremetal/#ports-ports
-
+	API reference: https://developer.openstack.org/api-ref/baremetal/#ports-ports
 
 Example to List Ports with Detail
 
- 	ports.ListDetail(client, nil).EachPage(func(page pagination.Page) (bool, error) {
- 		portList, err := ports.ExtractPorts(page)
- 		if err != nil {
- 			return false, err
- 		}
+	ports.ListDetail(client, nil).EachPage(func(page pagination.Page) (bool, error) {
+		portList, err := ports.ExtractPorts(page)
+		if err != nil {
+			return false, err
+		}
 
- 		for _, n := range portList {
- 			// Do something
- 		}
+		for _, n := range portList {
+			// Do something
+		}
 
- 		return true, nil
- 	})
+		return true, nil
+	})
 
 Example to List Ports
 
-	listOpts := ports.ListOpts{
- 		Limit: 10,
-	}
+		listOpts := ports.ListOpts{
+	 		Limit: 10,
+		}
 
- 	ports.List(client, listOpts).EachPage(func(page pagination.Page) (bool, error) {
- 		portList, err := ports.ExtractPorts(page)
- 		if err != nil {
- 			return false, err
- 		}
+	 	ports.List(client, listOpts).EachPage(func(page pagination.Page) (bool, error) {
+	 		portList, err := ports.ExtractPorts(page)
+	 		if err != nil {
+	 			return false, err
+	 		}
 
- 		for _, n := range portList {
- 			// Do something
- 		}
+	 		for _, n := range portList {
+	 			// Do something
+	 		}
 
- 		return true, nil
- 	})
+	 		return true, nil
+	 	})
 
 Example to Create a Port
 
-	createOpts := ports.CreateOpts{
- 		NodeUUID: "e8920409-e07e-41bb-8cc1-72acb103e2dd",
-		Address: "00:1B:63:84:45:E6",
-    PhysicalNetwork: "my-network",
-	}
+		createOpts := ports.CreateOpts{
+	 		NodeUUID: "e8920409-e07e-41bb-8cc1-72acb103e2dd",
+			Address: "00:1B:63:84:45:E6",
+	    PhysicalNetwork: "my-network",
+		}
 
- 	createPort, err := ports.Create(client, createOpts).Extract()
- 	if err != nil {
- 		panic(err)
- 	}
+	 	createPort, err := ports.Create(client, createOpts).Extract()
+	 	if err != nil {
+	 		panic(err)
+	 	}
 
 Example to Get a Port
 
- 	showPort, err := ports.Get(client, "c9afd385-5d89-4ecb-9e1c-68194da6b474").Extract()
- 	if err != nil {
- 		panic(err)
- 	}
+	showPort, err := ports.Get(client, "c9afd385-5d89-4ecb-9e1c-68194da6b474").Extract()
+	if err != nil {
+		panic(err)
+	}
 
 Example to Update a Port
 
-	updateOpts := ports.UpdateOpts{
- 		ports.UpdateOperation{
- 			Op:    ReplaceOp,
- 			Path:  "/address",
- 			Value: "22:22:22:22:22:22",
- 		},
-	}
+		updateOpts := ports.UpdateOpts{
+	 		ports.UpdateOperation{
+	 			Op:    ReplaceOp,
+	 			Path:  "/address",
+	 			Value: "22:22:22:22:22:22",
+	 		},
+		}
 
- 	updatePort, err := ports.Update(client, "c9afd385-5d89-4ecb-9e1c-68194da6b474", updateOpts).Extract()
- 	if err != nil {
- 		panic(err)
- 	}
+	 	updatePort, err := ports.Update(client, "c9afd385-5d89-4ecb-9e1c-68194da6b474", updateOpts).Extract()
+	 	if err != nil {
+	 		panic(err)
+	 	}
 
 Example to Delete a Port
 
- 	err = ports.Delete(client, "c9afd385-5d89-4ecb-9e1c-68194da6b474").ExtractErr()
- 	if err != nil {
- 		panic(err)
-	}
-
+	 	err = ports.Delete(client, "c9afd385-5d89-4ecb-9e1c-68194da6b474").ExtractErr()
+	 	if err != nil {
+	 		panic(err)
+		}
 */
 package ports

--- a/openstack/blockstorage/apiversions/doc.go
+++ b/openstack/blockstorage/apiversions/doc.go
@@ -18,7 +18,6 @@ Example of Retrieving all API Versions
 		fmt.Printf("%+v\n", version)
 	}
 
-
 Example of Retrieving an API Version
 
 	version, err := apiversions.Get(client, "v3").Extract()

--- a/openstack/blockstorage/extensions/availabilityzones/doc.go
+++ b/openstack/blockstorage/extensions/availabilityzones/doc.go
@@ -4,18 +4,18 @@ available volume availability zones.
 
 Example of Get Availability Zone Information
 
-	allPages, err := availabilityzones.List(volumeClient).AllPages()
-	if err != nil {
-		panic(err)
-	}
+		allPages, err := availabilityzones.List(volumeClient).AllPages()
+		if err != nil {
+			panic(err)
+		}
 
-	availabilityZoneInfo, err := availabilityzones.ExtractAvailabilityZones(allPages)
-	if err != nil {
-		panic(err)
-	}
+		availabilityZoneInfo, err := availabilityzones.ExtractAvailabilityZones(allPages)
+		if err != nil {
+			panic(err)
+		}
 
-	for _, zoneInfo := range availabilityZoneInfo {
-  		fmt.Printf("%+v\n", zoneInfo)
-	}
+		for _, zoneInfo := range availabilityZoneInfo {
+	  		fmt.Printf("%+v\n", zoneInfo)
+		}
 */
 package availabilityzones

--- a/openstack/blockstorage/extensions/limits/doc.go
+++ b/openstack/blockstorage/extensions/limits/doc.go
@@ -3,11 +3,11 @@ Package limits shows rate and limit information for a project you authorized for
 
 Example to Retrieve Limits
 
-    limits, err := limits.Get(blockStorageClient).Extract()
-    if err != nil {
-        panic(err)
-    }
+	limits, err := limits.Get(blockStorageClient).Extract()
+	if err != nil {
+	    panic(err)
+	}
 
-    fmt.Printf("%+v\n", limits)
+	fmt.Printf("%+v\n", limits)
 */
 package limits

--- a/openstack/blockstorage/extensions/quotasets/doc.go
+++ b/openstack/blockstorage/extensions/quotasets/doc.go
@@ -50,7 +50,6 @@ Example to Update a Quota set with volume_type quotas
 
 	fmt.Printf("%+v\n", quotaset)
 
-
 Example to Delete a Quota Set
 
 	err := quotasets.Delete(blockStorageClient, "project-id").ExtractErr()

--- a/openstack/blockstorage/extensions/volumeactions/doc.go
+++ b/openstack/blockstorage/extensions/volumeactions/doc.go
@@ -25,7 +25,6 @@ Example of Attaching a Volume to an Instance
 		panic(err)
 	}
 
-
 Example of Creating an Image from a Volume
 
 	uploadImageOpts := volumeactions.UploadImageOpts{

--- a/openstack/blockstorage/v3/attachments/doc.go
+++ b/openstack/blockstorage/v3/attachments/doc.go
@@ -82,6 +82,5 @@ Example to Delete Attachment
 	if err != nil {
 		panic(err)
 	}
-
 */
 package attachments

--- a/openstack/blockstorage/v3/attachments/requests.go
+++ b/openstack/blockstorage/v3/attachments/requests.go
@@ -12,7 +12,7 @@ type CreateOptsBuilder interface {
 }
 
 // CreateOpts contains options for creating a Volume attachment. This object is
-//passed to the Create function. For more information about these parameters,
+// passed to the Create function. For more information about these parameters,
 // see the Attachment object.
 type CreateOpts struct {
 	// VolumeUUID is the UUID of the Cinder volume to create the attachment

--- a/openstack/blockstorage/v3/qos/doc.go
+++ b/openstack/blockstorage/v3/qos/doc.go
@@ -78,7 +78,6 @@ Example of updating QoSSpec
 	}
 	fmt.Printf("%+v\n", specs)
 
-
 Example of deleting specific keys/specs from a QoS
 
 	qosID := "de075d5e-8afc-4e23-9388-b84a5183d1c0"
@@ -143,6 +142,5 @@ Example of listing all associations of a QoS
 	for _, association := range allAssociations {
 		fmt.Printf("Association: %+v\n", association)
 	}
-
 */
 package qos

--- a/openstack/blockstorage/v3/snapshots/doc.go
+++ b/openstack/blockstorage/v3/snapshots/doc.go
@@ -4,7 +4,6 @@ OpenStack Block Storage service. A snapshot is a point in time copy of the
 data contained in an external storage volume, and can be controlled
 programmatically.
 
-
 Example to list Snapshots
 
 	allPages, err := snapshots.List(client, snapshots.ListOpts{}).AllPages()

--- a/openstack/blockstorage/v3/volumetypes/doc.go
+++ b/openstack/blockstorage/v3/volumetypes/doc.go
@@ -160,6 +160,5 @@ Example to Remove/Revoke Access to a Volume Type
 	if err != nil {
 		panic(err)
 	}
-
 */
 package volumetypes

--- a/openstack/clustering/v1/clusters/doc.go
+++ b/openstack/clustering/v1/clusters/doc.go
@@ -225,15 +225,15 @@ Example to Complete Life Cycle
 
 Example to add nodes to a cluster
 
-	addNodesOpts := clusters.AddNodesOpts{
-		Nodes: []string{"node-123"},
-	}
-	clusterID := "b7b870e3-d3c5-4a93-b9d7-846c53b2c2da"
-	actionID, err := clusters.AddNodes(serviceClient, clusterID, addNodesOpts).Extract()
-	if err != nil {
-		panic(err)
-	}
-    fmt.Println("action=", actionID)
+		addNodesOpts := clusters.AddNodesOpts{
+			Nodes: []string{"node-123"},
+		}
+		clusterID := "b7b870e3-d3c5-4a93-b9d7-846c53b2c2da"
+		actionID, err := clusters.AddNodes(serviceClient, clusterID, addNodesOpts).Extract()
+		if err != nil {
+			panic(err)
+		}
+	    fmt.Println("action=", actionID)
 
 Example to remove nodes from a cluster
 
@@ -282,6 +282,5 @@ Example to perform an operation on a cluster
 	if err != nil {
 		panic(err)
 	}
-
 */
 package clusters

--- a/openstack/clustering/v1/nodes/doc.go
+++ b/openstack/clustering/v1/nodes/doc.go
@@ -106,6 +106,5 @@ Example to Check a Node
 		panic(err)
 	}
 	fmt.Println("action=", actionID)
-
 */
 package nodes

--- a/openstack/clustering/v1/policies/doc.go
+++ b/openstack/clustering/v1/policies/doc.go
@@ -22,7 +22,6 @@ Example to List Policies
 		fmt.Printf("%+v\n", policy)
 	}
 
-
 Example to Create a Policy
 
 	createOpts := policies.CreateOpts{
@@ -50,13 +49,13 @@ Example to Create a Policy
 
 Example to Get a Policy
 
-    policyName := "get_policy"
-    policyDetail, err := policies.Get(clusteringClient, policyName).Extract()
-    if err != nil {
-        panic(err)
-    }
+	policyName := "get_policy"
+	policyDetail, err := policies.Get(clusteringClient, policyName).Extract()
+	if err != nil {
+	    panic(err)
+	}
 
-    fmt.Printf("%+v\n", policyDetail)
+	fmt.Printf("%+v\n", policyDetail)
 
 Example to Update a Policy
 

--- a/openstack/clustering/v1/policytypes/doc.go
+++ b/openstack/clustering/v1/policytypes/doc.go
@@ -4,28 +4,28 @@ from the OpenStack Clustering Service.
 
 Example to List Policy Types
 
-    allPages, err := policytypes.List(clusteringClient).AllPages()
-    if err != nil {
-        panic(err)
-    }
+	allPages, err := policytypes.List(clusteringClient).AllPages()
+	if err != nil {
+	    panic(err)
+	}
 
-    allPolicyTypes, err := actions.ExtractPolicyTypes(allPages)
-    if err != nil {
-        panic(err)
-    }
+	allPolicyTypes, err := actions.ExtractPolicyTypes(allPages)
+	if err != nil {
+	    panic(err)
+	}
 
-    for _, policyType := range allPolicyTypes {
-        fmt.Printf("%+v\n", policyType)
-    }
+	for _, policyType := range allPolicyTypes {
+	    fmt.Printf("%+v\n", policyType)
+	}
 
 Example to Get a Policy Type
 
-    policyTypeName := "senlin.policy.affinity-1.0"
-    policyTypeDetail, err := policyTypes.Get(clusteringClient, policyTypeName).Extract()
-    if err != nil {
-        panic(err)
-    }
+	policyTypeName := "senlin.policy.affinity-1.0"
+	policyTypeDetail, err := policyTypes.Get(clusteringClient, policyTypeName).Extract()
+	if err != nil {
+	    panic(err)
+	}
 
-    fmt.Printf("%+v\n", policyTypeDetail)
+	fmt.Printf("%+v\n", policyTypeDetail)
 */
 package policytypes

--- a/openstack/clustering/v1/profiles/doc.go
+++ b/openstack/clustering/v1/profiles/doc.go
@@ -41,7 +41,6 @@ Example to Get a Profile
 
 	fmt.Print("profile", profile)
 
-
 Example to List Profiles
 
 	listOpts := profiles.ListOpts{
@@ -105,6 +104,5 @@ Example to Validate a profile
 	if err != nil {
 		panic(err)
 	}
-
 */
 package profiles

--- a/openstack/clustering/v1/profiletypes/doc.go
+++ b/openstack/clustering/v1/profiletypes/doc.go
@@ -26,6 +26,7 @@ Example to Get a ProfileType
 	fmt.Printf("%+v\n", profileType)
 
 Example of list operations supported by a profile type
+
 	serviceClient.Microversion = "1.5"
 
 	profileTypeName := "os.nova.server-1.0"
@@ -42,6 +43,5 @@ Example of list operations supported by a profile type
 	for _, op := range ops {
 		fmt.Printf("%+v\n", op)
 	}
-
 */
 package profiletypes

--- a/openstack/clustering/v1/receivers/doc.go
+++ b/openstack/clustering/v1/receivers/doc.go
@@ -76,6 +76,5 @@ Example to Notify a Receiver
 	if err != nil {
 		panic(err)
 	}
-
 */
 package receivers

--- a/openstack/clustering/v1/webhooks/doc.go
+++ b/openstack/clustering/v1/webhooks/doc.go
@@ -10,6 +10,5 @@ Example to Trigger webhook action
 	}
 
 	fmt.Println("result", result)
-
 */
 package webhooks

--- a/openstack/common/extensions/doc.go
+++ b/openstack/common/extensions/doc.go
@@ -33,7 +33,6 @@ Example of Retrieving Compute Extensions
 		fmt.Printf("%+v\n", extension)
 	}
 
-
 Example of Retrieving Network Extensions
 
 	ao, err := openstack.AuthOptionsFromEnv()

--- a/openstack/compute/v2/extensions/aggregates/doc.go
+++ b/openstack/compute/v2/extensions/aggregates/doc.go
@@ -100,6 +100,5 @@ Example of Create or Update Metadata
 		panic(err)
 	}
 	fmt.Printf("%+v\n", aggregate)
-
 */
 package aggregates

--- a/openstack/compute/v2/extensions/availabilityzones/doc.go
+++ b/openstack/compute/v2/extensions/availabilityzones/doc.go
@@ -28,34 +28,34 @@ Example of Extend server result with Availability Zone Information:
 
 Example of Get Availability Zone Information
 
-	allPages, err := availabilityzones.List(computeClient).AllPages()
-	if err != nil {
-		panic(err)
-	}
+		allPages, err := availabilityzones.List(computeClient).AllPages()
+		if err != nil {
+			panic(err)
+		}
 
-	availabilityZoneInfo, err := availabilityzones.ExtractAvailabilityZones(allPages)
-	if err != nil {
-		panic(err)
-	}
+		availabilityZoneInfo, err := availabilityzones.ExtractAvailabilityZones(allPages)
+		if err != nil {
+			panic(err)
+		}
 
-	for _, zoneInfo := range availabilityZoneInfo {
-  		fmt.Printf("%+v\n", zoneInfo)
-	}
+		for _, zoneInfo := range availabilityZoneInfo {
+	  		fmt.Printf("%+v\n", zoneInfo)
+		}
 
 Example of Get Detailed Availability Zone Information
 
-	allPages, err := availabilityzones.ListDetail(computeClient).AllPages()
-	if err != nil {
-		panic(err)
-	}
+		allPages, err := availabilityzones.ListDetail(computeClient).AllPages()
+		if err != nil {
+			panic(err)
+		}
 
-	availabilityZoneInfo, err := availabilityzones.ExtractAvailabilityZones(allPages)
-	if err != nil {
-		panic(err)
-	}
+		availabilityZoneInfo, err := availabilityzones.ExtractAvailabilityZones(allPages)
+		if err != nil {
+			panic(err)
+		}
 
-	for _, zoneInfo := range availabilityZoneInfo {
-  		fmt.Printf("%+v\n", zoneInfo)
-	}
+		for _, zoneInfo := range availabilityZoneInfo {
+	  		fmt.Printf("%+v\n", zoneInfo)
+		}
 */
 package availabilityzones

--- a/openstack/compute/v2/extensions/bootfromvolume/doc.go
+++ b/openstack/compute/v2/extensions/bootfromvolume/doc.go
@@ -10,7 +10,7 @@ https://docs.openstack.org/nova/latest/user/block-device-mapping.html
 
 Note that this package implements `block_device_mapping_v2`.
 
-Example of Creating a Server From an Image
+# Example of Creating a Server From an Image
 
 This example will boot a server from an image and use a standard ephemeral
 disk as the server's root disk. This is virtually no different than creating
@@ -42,7 +42,7 @@ a server without using block device mappings.
 		panic(err)
 	}
 
-Example of Creating a Server From a New Volume
+# Example of Creating a Server From a New Volume
 
 This example will create a block storage volume based on the given Image. The
 server will use this volume as its root disk.
@@ -72,7 +72,7 @@ server will use this volume as its root disk.
 		panic(err)
 	}
 
-Example of Creating a Server From an Existing Volume
+# Example of Creating a Server From an Existing Volume
 
 This example will create a server with an existing volume as its root disk.
 
@@ -100,7 +100,7 @@ This example will create a server with an existing volume as its root disk.
 		panic(err)
 	}
 
-Example of Creating a Server with Multiple Ephemeral Disks
+# Example of Creating a Server with Multiple Ephemeral Disks
 
 This example will create a server with multiple ephemeral disks. The first
 block device will be based off of an existing Image. Each additional

--- a/openstack/compute/v2/extensions/diagnostics/doc.go
+++ b/openstack/compute/v2/extensions/diagnostics/doc.go
@@ -9,6 +9,5 @@ Example of Show Diagnostics
 	}
 
 	fmt.Printf("%+v\n", diags)
-
 */
 package diagnostics

--- a/openstack/compute/v2/extensions/evacuate/results.go
+++ b/openstack/compute/v2/extensions/evacuate/results.go
@@ -5,8 +5,8 @@ import (
 )
 
 // EvacuateResult is the response from an Evacuate operation.
-//Call its ExtractAdminPass method to retrieve the admin password of the instance.
-//The admin password will be an empty string if the cloud is not configured to inject admin passwords..
+// Call its ExtractAdminPass method to retrieve the admin password of the instance.
+// The admin password will be an empty string if the cloud is not configured to inject admin passwords..
 type EvacuateResult struct {
 	gophercloud.Result
 }

--- a/openstack/compute/v2/extensions/extendedserverattributes/doc.go
+++ b/openstack/compute/v2/extensions/extendedserverattributes/doc.go
@@ -4,64 +4,64 @@ server result with the extended usage information.
 
 Example to Get basic extended information:
 
-  type serverAttributesExt struct {
-    servers.Server
-    extendedserverattributes.ServerAttributesExt
-  }
-  var serverWithAttributesExt serverAttributesExt
+	type serverAttributesExt struct {
+	  servers.Server
+	  extendedserverattributes.ServerAttributesExt
+	}
+	var serverWithAttributesExt serverAttributesExt
 
-  err := servers.Get(computeClient, "d650a0ce-17c3-497d-961a-43c4af80998a").ExtractInto(&serverWithAttributesExt)
-  if err != nil {
-    panic(err)
-  }
+	err := servers.Get(computeClient, "d650a0ce-17c3-497d-961a-43c4af80998a").ExtractInto(&serverWithAttributesExt)
+	if err != nil {
+	  panic(err)
+	}
 
-  fmt.Printf("%+v\n", serverWithAttributesExt)
+	fmt.Printf("%+v\n", serverWithAttributesExt)
 
 Example to get additional fields with microversion 2.3 or later
 
-  computeClient.Microversion = "2.3"
-  result := servers.Get(computeClient, "d650a0ce-17c3-497d-961a-43c4af80998a")
+	computeClient.Microversion = "2.3"
+	result := servers.Get(computeClient, "d650a0ce-17c3-497d-961a-43c4af80998a")
 
-  reservationID, err := extendedserverattributes.ExtractReservationID(result.Result)
-  if err != nil {
-    panic(err)
-  }
-  fmt.Printf("%s\n", reservationID)
+	reservationID, err := extendedserverattributes.ExtractReservationID(result.Result)
+	if err != nil {
+	  panic(err)
+	}
+	fmt.Printf("%s\n", reservationID)
 
-  launchIndex, err := extendedserverattributes.ExtractLaunchIndex(result.Result)
-  if err != nil {
-    panic(err)
-  }
-  fmt.Printf("%d\n", launchIndex)
+	launchIndex, err := extendedserverattributes.ExtractLaunchIndex(result.Result)
+	if err != nil {
+	  panic(err)
+	}
+	fmt.Printf("%d\n", launchIndex)
 
-  ramdiskID, err := extendedserverattributes.ExtractRamdiskID(result.Result)
-  if err != nil {
-    panic(err)
-  }
-  fmt.Printf("%s\n", ramdiskID)
+	ramdiskID, err := extendedserverattributes.ExtractRamdiskID(result.Result)
+	if err != nil {
+	  panic(err)
+	}
+	fmt.Printf("%s\n", ramdiskID)
 
-  kernelID, err := extendedserverattributes.ExtractKernelID(result.Result)
-  if err != nil {
-    panic(err)
-  }
-  fmt.Printf("%s\n", kernelID)
+	kernelID, err := extendedserverattributes.ExtractKernelID(result.Result)
+	if err != nil {
+	  panic(err)
+	}
+	fmt.Printf("%s\n", kernelID)
 
-  hostname, err := extendedserverattributes.ExtractHostname(result.Result)
-  if err != nil {
-    panic(err)
-  }
-  fmt.Printf("%s\n", hostname)
+	hostname, err := extendedserverattributes.ExtractHostname(result.Result)
+	if err != nil {
+	  panic(err)
+	}
+	fmt.Printf("%s\n", hostname)
 
-  rootDeviceName, err := extendedserverattributes.ExtractRootDeviceName(result.Result)
-  if err != nil {
-    panic(err)
-  }
-  fmt.Printf("%s\n", rootDeviceName)
+	rootDeviceName, err := extendedserverattributes.ExtractRootDeviceName(result.Result)
+	if err != nil {
+	  panic(err)
+	}
+	fmt.Printf("%s\n", rootDeviceName)
 
-  userData, err := extendedserverattributes.ExtractUserData(result.Result)
-  if err != nil {
-    panic(err)
-  }
-  fmt.Printf("%s\n", userData)
+	userData, err := extendedserverattributes.ExtractUserData(result.Result)
+	if err != nil {
+	  panic(err)
+	}
+	fmt.Printf("%s\n", userData)
 */
 package extendedserverattributes

--- a/openstack/compute/v2/extensions/keypairs/doc.go
+++ b/openstack/compute/v2/extensions/keypairs/doc.go
@@ -115,6 +115,5 @@ Example to Get a Key Pair owned by a certain user using microversion 2.10 or gre
 	if err != nil {
 		panic(err)
 	}
-
 */
 package keypairs

--- a/openstack/compute/v2/extensions/migrate/doc.go
+++ b/openstack/compute/v2/extensions/migrate/doc.go
@@ -25,6 +25,5 @@ Example of Live-Migrate Server (os-migrateLive Action)
 	if err != nil {
 		panic(err)
 	}
-
 */
 package migrate

--- a/openstack/compute/v2/extensions/quotasets/testing/fixtures.go
+++ b/openstack/compute/v2/extensions/quotasets/testing/fixtures.go
@@ -136,13 +136,13 @@ var FirstQuotaDetailsSet = quotasets.QuotaDetailSet{
 	ServerGroupMembers:       quotasets.QuotaDetail{InUse: 0, Reserved: 0, Limit: 3},
 }
 
-//The expected update Body. Is also returned by PUT request
+// The expected update Body. Is also returned by PUT request
 const UpdateOutput = `{"quota_set":{"cores":200,"fixed_ips":0,"floating_ips":0,"injected_file_content_bytes":10240,"injected_file_path_bytes":255,"injected_files":5,"instances":25,"key_pairs":10,"metadata_items":128,"ram":9216000,"security_group_rules":20,"security_groups":10,"server_groups":2,"server_group_members":3}}`
 
-//The expected partialupdate Body. Is also returned by PUT request
+// The expected partialupdate Body. Is also returned by PUT request
 const PartialUpdateBody = `{"quota_set":{"cores":200, "force":true}}`
 
-//Result of Quota-update
+// Result of Quota-update
 var UpdatedQuotaSet = quotasets.UpdateOpts{
 	FixedIPs:                 gophercloud.IntToPointer(0),
 	FloatingIPs:              gophercloud.IntToPointer(0),

--- a/openstack/compute/v2/extensions/remoteconsoles/doc.go
+++ b/openstack/compute/v2/extensions/remoteconsoles/doc.go
@@ -6,20 +6,20 @@ that API.
 
 Example of Creating a new RemoteConsole
 
-  computeClient, err := openstack.NewComputeV2(providerClient, endpointOptions)
-  computeClient.Microversion = "2.6"
+	computeClient, err := openstack.NewComputeV2(providerClient, endpointOptions)
+	computeClient.Microversion = "2.6"
 
-  createOpts := remoteconsoles.CreateOpts{
-    Protocol: remoteconsoles.ConsoleProtocolVNC,
-    Type:     remoteconsoles.ConsoleTypeNoVNC,
-  }
-  serverID := "b16ba811-199d-4ffd-8839-ba96c1185a67"
+	createOpts := remoteconsoles.CreateOpts{
+	  Protocol: remoteconsoles.ConsoleProtocolVNC,
+	  Type:     remoteconsoles.ConsoleTypeNoVNC,
+	}
+	serverID := "b16ba811-199d-4ffd-8839-ba96c1185a67"
 
-  remtoteConsole, err := remoteconsoles.Create(computeClient, serverID, createOpts).Extract()
-  if err != nil {
-    panic(err)
-  }
+	remtoteConsole, err := remoteconsoles.Create(computeClient, serverID, createOpts).Extract()
+	if err != nil {
+	  panic(err)
+	}
 
-  fmt.Printf("Console URL: %s\n", remtoteConsole.URL)
+	fmt.Printf("Console URL: %s\n", remtoteConsole.URL)
 */
 package remoteconsoles

--- a/openstack/compute/v2/extensions/rescueunrescue/doc.go
+++ b/openstack/compute/v2/extensions/rescueunrescue/doc.go
@@ -4,25 +4,25 @@ and to return it back.
 
 Example to Rescue a server
 
-  rescueOpts := rescueunrescue.RescueOpts{
-    AdminPass:      "aUPtawPzE9NU",
-    RescueImageRef: "115e5c5b-72f0-4a0a-9067-60706545248c",
-  }
-  serverID := "3f54d05f-3430-4d80-aa07-63e6af9e2488"
+	rescueOpts := rescueunrescue.RescueOpts{
+	  AdminPass:      "aUPtawPzE9NU",
+	  RescueImageRef: "115e5c5b-72f0-4a0a-9067-60706545248c",
+	}
+	serverID := "3f54d05f-3430-4d80-aa07-63e6af9e2488"
 
-  adminPass, err := rescueunrescue.Rescue(computeClient, serverID, rescueOpts).Extract()
-  if err != nil {
-    panic(err)
-  }
+	adminPass, err := rescueunrescue.Rescue(computeClient, serverID, rescueOpts).Extract()
+	if err != nil {
+	  panic(err)
+	}
 
-  fmt.Printf("adminPass of the rescued server %s: %s\n", serverID, adminPass)
+	fmt.Printf("adminPass of the rescued server %s: %s\n", serverID, adminPass)
 
 Example to Unrescue a server
 
-  serverID := "3f54d05f-3430-4d80-aa07-63e6af9e2488"
+	serverID := "3f54d05f-3430-4d80-aa07-63e6af9e2488"
 
-  if err := rescueunrescue.Unrescue(computeClient, serverID).ExtractErr(); err != nil {
-    panic(err)
-  }
+	if err := rescueunrescue.Unrescue(computeClient, serverID).ExtractErr(); err != nil {
+	  panic(err)
+	}
 */
 package rescueunrescue

--- a/openstack/compute/v2/extensions/secgroups/doc.go
+++ b/openstack/compute/v2/extensions/secgroups/doc.go
@@ -92,8 +92,7 @@ Example to Remove a Security Group from a Server
 		panic(err)
 	}
 
-Example to Delete a Security Group
-
+# Example to Delete a Security Group
 
 	sgID := "37d94f8a-d136-465c-ae46-144f0d8ef141"
 	err := secgroups.Delete(computeClient, sgID).ExtractErr()

--- a/openstack/compute/v2/extensions/servergroups/doc.go
+++ b/openstack/compute/v2/extensions/servergroups/doc.go
@@ -31,21 +31,21 @@ Example to Create a Server Group
 
 Example to Create a Server Group with additional microversion 2.64 fields
 
-	createOpts := servergroups.CreateOpts{
-		Name:   "my_sg",
-		Policy: "anti-affinity",
-        	Rules: &servergroups.Rules{
-            		MaxServerPerHost: 3,
-        	},
-	}
+		createOpts := servergroups.CreateOpts{
+			Name:   "my_sg",
+			Policy: "anti-affinity",
+	        	Rules: &servergroups.Rules{
+	            		MaxServerPerHost: 3,
+	        	},
+		}
 
-	computeClient.Microversion = "2.64"
-	result := servergroups.Create(computeClient, createOpts)
+		computeClient.Microversion = "2.64"
+		result := servergroups.Create(computeClient, createOpts)
 
-	serverGroup, err := result.Extract()
-	if err != nil {
-		panic(err)
-	}
+		serverGroup, err := result.Extract()
+		if err != nil {
+			panic(err)
+		}
 
 Example to Delete a Server Group
 

--- a/openstack/compute/v2/extensions/serverusage/doc.go
+++ b/openstack/compute/v2/extensions/serverusage/doc.go
@@ -4,17 +4,17 @@ with the extended usage information.
 
 Example to Get an extended information:
 
-  type serverUsageExt struct {
-    servers.Server
-    serverusage.UsageExt
-  }
-  var serverWithUsageExt serverUsageExt
+	type serverUsageExt struct {
+	  servers.Server
+	  serverusage.UsageExt
+	}
+	var serverWithUsageExt serverUsageExt
 
-  err := servers.Get(computeClient, "d650a0ce-17c3-497d-961a-43c4af80998a").ExtractInto(&serverWithUsageExt)
-  if err != nil {
-    panic(err)
-  }
+	err := servers.Get(computeClient, "d650a0ce-17c3-497d-961a-43c4af80998a").ExtractInto(&serverWithUsageExt)
+	if err != nil {
+	  panic(err)
+	}
 
-  fmt.Printf("%+v\n", serverWithUsageExt)
+	fmt.Printf("%+v\n", serverWithUsageExt)
 */
 package serverusage

--- a/openstack/compute/v2/extensions/services/testing/fixtures.go
+++ b/openstack/compute/v2/extensions/services/testing/fixtures.go
@@ -238,7 +238,7 @@ const ServiceUpdate = `
 }
 `
 
-//FakeServiceUpdateBody represents the updated service
+// FakeServiceUpdateBody represents the updated service
 var FakeServiceUpdateBody = services.Service{
 	Binary:         "nova-scheduler",
 	DisabledReason: "test1",

--- a/openstack/compute/v2/extensions/tags/doc.go
+++ b/openstack/compute/v2/extensions/tags/doc.go
@@ -5,66 +5,66 @@ This extension is available since 2.26 Compute V2 API microversion.
 
 Example to List all server Tags
 
-	client.Microversion = "2.26"
+		client.Microversion = "2.26"
 
-    serverTags, err := tags.List(client, serverID).Extract()
-    if err != nil {
-        log.Fatal(err)
-    }
+	    serverTags, err := tags.List(client, serverID).Extract()
+	    if err != nil {
+	        log.Fatal(err)
+	    }
 
-    fmt.Printf("Tags: %v\n", serverTags)
+	    fmt.Printf("Tags: %v\n", serverTags)
 
 Example to Check if the specific Tag exists on a server
 
-    client.Microversion = "2.26"
+	client.Microversion = "2.26"
 
-    exists, err := tags.Check(client, serverID, tag).Extract()
-    if err != nil {
-        log.Fatal(err)
-    }
+	exists, err := tags.Check(client, serverID, tag).Extract()
+	if err != nil {
+	    log.Fatal(err)
+	}
 
-    if exists {
-        log.Printf("Tag %s is set\n", tag)
-    } else {
-        log.Printf("Tag %s is not set\n", tag)
-    }
+	if exists {
+	    log.Printf("Tag %s is set\n", tag)
+	} else {
+	    log.Printf("Tag %s is not set\n", tag)
+	}
 
 Example to Replace all Tags on a server
 
-    client.Microversion = "2.26"
+	client.Microversion = "2.26"
 
-    newTags, err := tags.ReplaceAll(client, serverID, tags.ReplaceAllOpts{Tags: []string{"foo", "bar"}}).Extract()
-    if err != nil {
-        log.Fatal(err)
-    }
+	newTags, err := tags.ReplaceAll(client, serverID, tags.ReplaceAllOpts{Tags: []string{"foo", "bar"}}).Extract()
+	if err != nil {
+	    log.Fatal(err)
+	}
 
-    fmt.Printf("New tags: %v\n", newTags)
+	fmt.Printf("New tags: %v\n", newTags)
 
 Example to Add a new Tag on a server
 
-    client.Microversion = "2.26"
+	client.Microversion = "2.26"
 
-    err := tags.Add(client, serverID, "foo").ExtractErr()
-    if err != nil {
-        log.Fatal(err)
-    }
+	err := tags.Add(client, serverID, "foo").ExtractErr()
+	if err != nil {
+	    log.Fatal(err)
+	}
 
 Example to Delete a Tag on a server
 
-    client.Microversion = "2.26"
+	client.Microversion = "2.26"
 
-    err := tags.Delete(client, serverID, "foo").ExtractErr()
-    if err != nil {
-        log.Fatal(err)
-    }
+	err := tags.Delete(client, serverID, "foo").ExtractErr()
+	if err != nil {
+	    log.Fatal(err)
+	}
 
 Example to Delete all Tags on a server
 
-    client.Microversion = "2.26"
+	client.Microversion = "2.26"
 
-    err := tags.DeleteAll(client, serverID).ExtractErr()
-    if err != nil {
-        log.Fatal(err)
-    }
+	err := tags.DeleteAll(client, serverID).ExtractErr()
+	if err != nil {
+	    log.Fatal(err)
+	}
 */
 package tags

--- a/openstack/compute/v2/extensions/usage/doc.go
+++ b/openstack/compute/v2/extensions/usage/doc.go
@@ -54,6 +54,5 @@ Example to Retrieve Usage for All Tenants:
 	if err != nil {
 		panic(err)
 	}
-
 */
 package usage

--- a/openstack/compute/v2/extensions/volumeattach/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/volumeattach/testing/requests_test.go
@@ -32,7 +32,7 @@ var ExpectedVolumeAttachmentSlice = []volumeattach.VolumeAttachment{FirstVolumeA
 var iTag = "foo"
 var iTrue = true
 
-//CreatedVolumeAttachment is the parsed result from CreatedOutput.
+// CreatedVolumeAttachment is the parsed result from CreatedOutput.
 var CreatedVolumeAttachment = volumeattach.VolumeAttachment{
 	Device:              "/dev/vdc",
 	ID:                  "a26887c6-c47b-4654-abb5-dfadf7d3f804",

--- a/openstack/compute/v2/flavors/requests.go
+++ b/openstack/compute/v2/flavors/requests.go
@@ -12,12 +12,12 @@ type ListOptsBuilder interface {
 }
 
 /*
-	AccessType maps to OpenStack's Flavor.is_public field. Although the is_public
-	field is boolean, the request options are ternary, which is why AccessType is
-	a string. The following values are allowed:
+AccessType maps to OpenStack's Flavor.is_public field. Although the is_public
+field is boolean, the request options are ternary, which is why AccessType is
+a string. The following values are allowed:
 
-	The AccessType arguement is optional, and if it is not supplied, OpenStack
-	returns the PublicAccess flavors.
+The AccessType arguement is optional, and if it is not supplied, OpenStack
+returns the PublicAccess flavors.
 */
 type AccessType string
 
@@ -35,12 +35,12 @@ const (
 )
 
 /*
-	ListOpts filters the results returned by the List() function.
-	For example, a flavor with a minDisk field of 10 will not be returned if you
-	specify MinDisk set to 20.
+ListOpts filters the results returned by the List() function.
+For example, a flavor with a minDisk field of 10 will not be returned if you
+specify MinDisk set to 20.
 
-	Typically, software will use the last ID of the previous call to List to set
-	the Marker for the current call.
+Typically, software will use the last ID of the previous call to List to set
+the Marker for the current call.
 */
 type ListOpts struct {
 	// ChangesSince, if provided, instructs List to return only those things which

--- a/openstack/compute/v2/servers/requests.go
+++ b/openstack/compute/v2/servers/requests.go
@@ -412,19 +412,19 @@ func (opts RebootOpts) ToServerRebootMap() (map[string]interface{}, error) {
 }
 
 /*
-	Reboot requests that a given server reboot.
+Reboot requests that a given server reboot.
 
-	Two methods exist for rebooting a server:
+Two methods exist for rebooting a server:
 
-	HardReboot (aka PowerCycle) starts the server instance by physically cutting
-	power to the machine, or if a VM, terminating it at the hypervisor level.
-	It's done. Caput. Full stop.
-	Then, after a brief while, power is restored or the VM instance restarted.
+HardReboot (aka PowerCycle) starts the server instance by physically cutting
+power to the machine, or if a VM, terminating it at the hypervisor level.
+It's done. Caput. Full stop.
+Then, after a brief while, power is restored or the VM instance restarted.
 
-	SoftReboot (aka OSReboot) simply tells the OS to restart under its own
-	procedure.
-	E.g., in Linux, asking it to enter runlevel 6, or executing
-	"sudo shutdown -r now", or by asking Windows to rtart the machine.
+SoftReboot (aka OSReboot) simply tells the OS to restart under its own
+procedure.
+E.g., in Linux, asking it to enter runlevel 6, or executing
+"sudo shutdown -r now", or by asking Windows to rtart the machine.
 */
 func Reboot(client *gophercloud.ServiceClient, id string, opts RebootOptsBuilder) (r ActionResult) {
 	b, err := opts.ToServerRebootMap()

--- a/openstack/compute/v2/servers/results.go
+++ b/openstack/compute/v2/servers/results.go
@@ -99,7 +99,8 @@ type GetPasswordResult struct {
 // If privateKey != nil the password is decrypted with the private key.
 // If privateKey == nil the encrypted password is returned and can be decrypted
 // with:
-//   echo '<pwd>' | base64 -D | openssl rsautl -decrypt -inkey <private_key>
+//
+//	echo '<pwd>' | base64 -D | openssl rsautl -decrypt -inkey <private_key>
 func (r GetPasswordResult) ExtractPassword(privateKey *rsa.PrivateKey) (string, error) {
 	var s struct {
 		Password string `json:"password"`

--- a/openstack/compute/v2/servers/testing/results_test.go
+++ b/openstack/compute/v2/servers/testing/results_test.go
@@ -48,7 +48,8 @@ func TestExtractPassword_encrypted_pwd(t *testing.T) {
 
 // Ok - return decrypted password when private key is given.
 // Decrytion can be verified by:
-//   echo "<enc_pwd>" | base64 -D | openssl rsautl -decrypt -inkey <privateKey.pem>
+//
+//	echo "<enc_pwd>" | base64 -D | openssl rsautl -decrypt -inkey <privateKey.pem>
 func TestExtractPassword_decrypted_pwd(t *testing.T) {
 
 	privateKey, err := ssh.ParseRawPrivateKey([]byte(`

--- a/openstack/containerinfra/v1/clusters/doc.go
+++ b/openstack/containerinfra/v1/clusters/doc.go
@@ -57,19 +57,19 @@ Example to List Clusters
 
 Example to List Clusters with detailed information
 
-    allPagesDetail, err := clusters.ListDetail(serviceClient, clusters.ListOpts{}).AllPages()
-    if err != nil {
-        panic(err)
-    }
+	allPagesDetail, err := clusters.ListDetail(serviceClient, clusters.ListOpts{}).AllPages()
+	if err != nil {
+	    panic(err)
+	}
 
-    allClustersDetail, err := clusters.ExtractClusters(allPagesDetail)
-    if err != nil {
-        panic(err)
-    }
+	allClustersDetail, err := clusters.ExtractClusters(allPagesDetail)
+	if err != nil {
+	    panic(err)
+	}
 
-    for _, clusterDetail := range allClustersDetail {
-        fmt.Printf("%+v\n", clusterDetail)
-    }
+	for _, clusterDetail := range allClustersDetail {
+	    fmt.Printf("%+v\n", clusterDetail)
+	}
 
 Example to Update a Cluster
 
@@ -109,6 +109,5 @@ Example to Delete a Cluster
 	if err != nil {
 		panic(err)
 	}
-
 */
 package clusters

--- a/openstack/containerinfra/v1/nodegroups/doc.go
+++ b/openstack/containerinfra/v1/nodegroups/doc.go
@@ -4,115 +4,109 @@ Package nodegroups provides methods for interacting with the Magnum node group A
 All node group actions must be performed on a specific cluster,
 so the cluster UUID/name is required as a parameter in each method.
 
-
 Create a client to use:
 
-    opts, err := openstack.AuthOptionsFromEnv()
-    if err != nil {
-        panic(err)
-    }
+	opts, err := openstack.AuthOptionsFromEnv()
+	if err != nil {
+	    panic(err)
+	}
 
-    provider, err := openstack.AuthenticatedClient(opts)
-    if err != nil {
-        panic(err)
-    }
+	provider, err := openstack.AuthenticatedClient(opts)
+	if err != nil {
+	    panic(err)
+	}
 
-    client, err := openstack.NewContainerInfraV1(provider, gophercloud.EndpointOpts{Region: os.Getenv("OS_REGION_NAME")})
-    if err != nil {
-        panic(err)
-    }
+	client, err := openstack.NewContainerInfraV1(provider, gophercloud.EndpointOpts{Region: os.Getenv("OS_REGION_NAME")})
+	if err != nil {
+	    panic(err)
+	}
 
-    client.Microversion = "1.9"
-
+	client.Microversion = "1.9"
 
 Example of Getting a node group:
 
-    ng, err := nodegroups.Get(client, clusterUUID, nodeGroupUUID).Extract()
-    if err != nil {
-        panic(err)
-    }
-    fmt.Printf("%#v\n", ng)
-
+	ng, err := nodegroups.Get(client, clusterUUID, nodeGroupUUID).Extract()
+	if err != nil {
+	    panic(err)
+	}
+	fmt.Printf("%#v\n", ng)
 
 Example of Listing node groups:
 
-    listOpts := nodegroup.ListOpts{
-        Role: "worker",
-    }
+	listOpts := nodegroup.ListOpts{
+	    Role: "worker",
+	}
 
-    allPages, err := nodegroups.List(client, clusterUUID, listOpts).AllPages()
-    if err != nil {
-        panic(err)
-    }
+	allPages, err := nodegroups.List(client, clusterUUID, listOpts).AllPages()
+	if err != nil {
+	    panic(err)
+	}
 
-    ngs, err := nodegroups.ExtractNodeGroups(allPages)
-    if err != nil {
-        panic(err)
-    }
+	ngs, err := nodegroups.ExtractNodeGroups(allPages)
+	if err != nil {
+	    panic(err)
+	}
 
-    for _, ng := range ngs {
-        fmt.Printf("%#v\n", ng)
-    }
-
+	for _, ng := range ngs {
+	    fmt.Printf("%#v\n", ng)
+	}
 
 Example of Creating a node group:
 
-    // Labels, node image and node flavor will be inherited from the cluster value if not set.
-    // Role will default to "worker" if not set.
+	// Labels, node image and node flavor will be inherited from the cluster value if not set.
+	// Role will default to "worker" if not set.
 
-    // To add a label to the new node group, need to know the cluster labels
-    cluster, err := clusters.Get(client, clusterUUID).Extract()
-    if err != nil {
-        panic(err)
-    }
+	// To add a label to the new node group, need to know the cluster labels
+	cluster, err := clusters.Get(client, clusterUUID).Extract()
+	if err != nil {
+	    panic(err)
+	}
 
-    // Add the new label
-    labels := cluster.Labels
-    labels["availability_zone"] = "A"
+	// Add the new label
+	labels := cluster.Labels
+	labels["availability_zone"] = "A"
 
-    maxNodes := 5
-    createOpts := nodegroups.CreateOpts{
-        Name:         "new-nodegroup",
-        MinNodeCount: 2,
-        MaxNodeCount: &maxNodes,
-        Labels: labels,
-    }
+	maxNodes := 5
+	createOpts := nodegroups.CreateOpts{
+	    Name:         "new-nodegroup",
+	    MinNodeCount: 2,
+	    MaxNodeCount: &maxNodes,
+	    Labels: labels,
+	}
 
-    ng, err := nodegroups.Create(client, clusterUUID, createOpts).Extract()
-    if err != nil {
-        panic(err)
-    }
+	ng, err := nodegroups.Create(client, clusterUUID, createOpts).Extract()
+	if err != nil {
+	    panic(err)
+	}
 
-    fmt.Printf("%#v\n", ng)
-
+	fmt.Printf("%#v\n", ng)
 
 Example of Updating a node group:
 
-    // Valid paths are "/min_node_count" and "/max_node_count".
-    // Max node count can be unset with the "remove" op to have
-    // no enforced maximum node count.
+	// Valid paths are "/min_node_count" and "/max_node_count".
+	// Max node count can be unset with the "remove" op to have
+	// no enforced maximum node count.
 
-    updateOpts := []nodegroups.UpdateOptsBuilder{
-        nodegroups.UpdateOpts{
-            Op:    nodegroups.ReplaceOp,
-            Path:  "/max_node_count",
-            Value: 10,
-        },
-    }
+	updateOpts := []nodegroups.UpdateOptsBuilder{
+	    nodegroups.UpdateOpts{
+	        Op:    nodegroups.ReplaceOp,
+	        Path:  "/max_node_count",
+	        Value: 10,
+	    },
+	}
 
-    ng, err = nodegroups.Update(client, clusterUUID, nodeGroupUUID, updateOpts).Extract()
-    if err != nil {
-        panic(err)
-    }
+	ng, err = nodegroups.Update(client, clusterUUID, nodeGroupUUID, updateOpts).Extract()
+	if err != nil {
+	    panic(err)
+	}
 
-    fmt.Printf("%#v\n", ng)
-
+	fmt.Printf("%#v\n", ng)
 
 Example of Deleting a node group:
 
-     err = nodegroups.Delete(client, clusterUUID, nodeGroupUUID).ExtractErr()
-     if err != nil {
-         panic(err)
-     }
+	err = nodegroups.Delete(client, clusterUUID, nodeGroupUUID).ExtractErr()
+	if err != nil {
+	    panic(err)
+	}
 */
 package nodegroups

--- a/openstack/containerinfra/v1/quotas/doc.go
+++ b/openstack/containerinfra/v1/quotas/doc.go
@@ -13,6 +13,5 @@ Example to Create a Quota
 	if err != nil {
 		panic(err)
 	}
-
 */
 package quotas

--- a/openstack/dns/v2/transfer/accept/doc.go
+++ b/openstack/dns/v2/transfer/accept/doc.go
@@ -4,40 +4,40 @@ resource for the OpenStack DNS service.
 
 Example to List Zone Transfer Accepts
 
-        // Optionaly you can provide Status as query parameter for filtering the result.
-        allPages, err := transferAccepts.List(dnsClient, nil).AllPages()
-        if err != nil {
-        	panic(err)
-        }
+	// Optionaly you can provide Status as query parameter for filtering the result.
+	allPages, err := transferAccepts.List(dnsClient, nil).AllPages()
+	if err != nil {
+		panic(err)
+	}
 
-        allTransferAccepts, err := transferAccepts.ExtractTransferAccepts(allPages)
-        if err != nil {
-        	panic(err)
-        }
+	allTransferAccepts, err := transferAccepts.ExtractTransferAccepts(allPages)
+	if err != nil {
+		panic(err)
+	}
 
-        for _, transferAccept := range allTransferAccepts {
-        	fmt.Printf("%+v\n", transferAccept)
-        }
+	for _, transferAccept := range allTransferAccepts {
+		fmt.Printf("%+v\n", transferAccept)
+	}
 
 Example to Create a Zone Transfer Accept
 
-        zoneTransferRequestID := "99d10f68-5623-4491-91a0-6daafa32b60e"
-        key := "JKHGD2F7"
-        createOpts := transferAccepts.CreateOpts{
-        	ZoneTransferRequestID: zoneTransferRequestID,
-        	Key: key,
-        }
-        transferAccept, err := transferAccepts.Create(dnsClient, createOpts).Extract()
-        if err != nil {
-        	panic(err)
-        }
+	zoneTransferRequestID := "99d10f68-5623-4491-91a0-6daafa32b60e"
+	key := "JKHGD2F7"
+	createOpts := transferAccepts.CreateOpts{
+		ZoneTransferRequestID: zoneTransferRequestID,
+		Key: key,
+	}
+	transferAccept, err := transferAccepts.Create(dnsClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
 
 Example to Get a Zone Transfer Accept
 
-        transferAcceptID := "99d10f68-5623-4491-91a0-6daafa32b60e"
-        transferAccept, err := transferAccepts.Get(dnsClient, transferAcceptID).Extract()
-        if err != nil {
-        	panic(err)
-        }
+	transferAcceptID := "99d10f68-5623-4491-91a0-6daafa32b60e"
+	transferAccept, err := transferAccepts.Get(dnsClient, transferAcceptID).Extract()
+	if err != nil {
+		panic(err)
+	}
 */
 package accept

--- a/openstack/dns/v2/transfer/request/doc.go
+++ b/openstack/dns/v2/transfer/request/doc.go
@@ -4,39 +4,39 @@ resource for the OpenStack DNS service.
 
 Example to List Zone Transfer Requests
 
-        allPages, err := transferRequests.List(dnsClient, nil).AllPages()
-        if err != nil {
-        	panic(err)
-        }
+	allPages, err := transferRequests.List(dnsClient, nil).AllPages()
+	if err != nil {
+		panic(err)
+	}
 
-        allTransferRequests, err := transferRequests.ExtractTransferRequests(allPages)
-        if err != nil {
-        	panic(err)
-        }
+	allTransferRequests, err := transferRequests.ExtractTransferRequests(allPages)
+	if err != nil {
+		panic(err)
+	}
 
-        for _, transferRequest := range allTransferRequests {
-        	fmt.Printf("%+v\n", transferRequest)
-        }
+	for _, transferRequest := range allTransferRequests {
+		fmt.Printf("%+v\n", transferRequest)
+	}
 
 Example to Create a Zone Transfer Request
 
-        zoneID := "99d10f68-5623-4491-91a0-6daafa32b60e"
-        targetProjectID := "f977bd7c-6485-4385-b04f-b5af0d186fcc"
-        createOpts := transferRequests.CreateOpts{
-                TargetProjectID: targetProjectID,
-        	Description: "This is a zone transfer request.",
-        }
-        transferRequest, err := transferRequests.Create(dnsClient, zoneID, createOpts).Extract()
-        if err != nil {
-        	panic(err)
-        }
+	zoneID := "99d10f68-5623-4491-91a0-6daafa32b60e"
+	targetProjectID := "f977bd7c-6485-4385-b04f-b5af0d186fcc"
+	createOpts := transferRequests.CreateOpts{
+	        TargetProjectID: targetProjectID,
+		Description: "This is a zone transfer request.",
+	}
+	transferRequest, err := transferRequests.Create(dnsClient, zoneID, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
 
 Example to Delete a Zone Transfer Request
 
-        transferID := "99d10f68-5623-4491-91a0-6daafa32b60e"
-        err := transferRequests.Delete(dnsClient, transferID).ExtractErr()
-        if err != nil {
-        	panic(err)
-        }
+	transferID := "99d10f68-5623-4491-91a0-6daafa32b60e"
+	err := transferRequests.Delete(dnsClient, transferID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
 */
 package request

--- a/openstack/identity/v3/endpoints/doc.go
+++ b/openstack/identity/v3/endpoints/doc.go
@@ -44,7 +44,6 @@ Example to Create an Endpoint
 		panic(err)
 	}
 
-
 Example to Update an Endpoint
 
 	endpointID := "ad59deeec5154d1fa0dcff518596f499"

--- a/openstack/identity/v3/extensions/ec2credentials/doc.go
+++ b/openstack/identity/v3/extensions/ec2credentials/doc.go
@@ -16,6 +16,5 @@ Example to Create an EC2 credential
 	if err != nil {
 		panic(err)
 	}
-
 */
 package ec2credentials

--- a/openstack/identity/v3/extensions/ec2tokens/doc.go
+++ b/openstack/identity/v3/extensions/ec2tokens/doc.go
@@ -36,6 +36,5 @@ Example to auth a client using EC2 access and secret keys
 	if err != nil {
 		panic(err)
 	}
-
 */
 package ec2tokens

--- a/openstack/identity/v3/extensions/oauth1/doc.go
+++ b/openstack/identity/v3/extensions/oauth1/doc.go
@@ -118,6 +118,5 @@ Example to Create a Token using OAuth1 method
 	if err != nil {
 		panic(err)
 	}
-
 */
 package oauth1

--- a/openstack/identity/v3/extensions/projectendpoints/doc.go
+++ b/openstack/identity/v3/extensions/projectendpoints/doc.go
@@ -22,6 +22,5 @@ Example to List Project Endpoints
 	for _, endpoint := range allEndpoints {
 		fmt.Printf("%+v\n", endpoint)
 	}
-
 */
 package projectendpoints

--- a/openstack/identity/v3/extensions/trusts/doc.go
+++ b/openstack/identity/v3/extensions/trusts/doc.go
@@ -25,43 +25,43 @@ Example to Create a Token with Username, Password, and Trust ID
 
 Example to Create a Trust
 
-    expiresAt := time.Date(2019, 12, 1, 14, 0, 0, 999999999, time.UTC)
-    createOpts := trusts.CreateOpts{
-        ExpiresAt:         &expiresAt,
-        Impersonation:     true,
-        AllowRedelegation: true,
-        ProjectID:         "9b71012f5a4a4aef9193f1995fe159b2",
-        Roles: []trusts.Role{
-            {
-                Name: "member",
-            },
-        },
-        TrusteeUserID: "ecb37e88cc86431c99d0332208cb6fbf",
-        TrustorUserID: "959ed913a32c4ec88c041c98e61cbbc3",
-    }
+	expiresAt := time.Date(2019, 12, 1, 14, 0, 0, 999999999, time.UTC)
+	createOpts := trusts.CreateOpts{
+	    ExpiresAt:         &expiresAt,
+	    Impersonation:     true,
+	    AllowRedelegation: true,
+	    ProjectID:         "9b71012f5a4a4aef9193f1995fe159b2",
+	    Roles: []trusts.Role{
+	        {
+	            Name: "member",
+	        },
+	    },
+	    TrusteeUserID: "ecb37e88cc86431c99d0332208cb6fbf",
+	    TrustorUserID: "959ed913a32c4ec88c041c98e61cbbc3",
+	}
 
-    trust, err := trusts.Create(identityClient, createOpts).Extract()
-    if err != nil {
-        panic(err)
-    }
+	trust, err := trusts.Create(identityClient, createOpts).Extract()
+	if err != nil {
+	    panic(err)
+	}
 
-    fmt.Printf("Trust: %+v\n", trust)
+	fmt.Printf("Trust: %+v\n", trust)
 
 Example to Delete a Trust
 
-    trustID := "3422b7c113894f5d90665e1a79655e23"
-    err := trusts.Delete(identityClient, trustID).ExtractErr()
-    if err != nil {
-        panic(err)
-    }
+	trustID := "3422b7c113894f5d90665e1a79655e23"
+	err := trusts.Delete(identityClient, trustID).ExtractErr()
+	if err != nil {
+	    panic(err)
+	}
 
 Example to Get a Trust
 
-    trustID := "3422b7c113894f5d90665e1a79655e23"
-    err := trusts.Get(identityClient, trustID).ExtractErr()
-    if err != nil {
-        panic(err)
-    }
+	trustID := "3422b7c113894f5d90665e1a79655e23"
+	err := trusts.Get(identityClient, trustID).ExtractErr()
+	if err != nil {
+	    panic(err)
+	}
 
 Example to List a Trust
 

--- a/openstack/identity/v3/limits/doc.go
+++ b/openstack/identity/v3/limits/doc.go
@@ -17,6 +17,5 @@ Example to List Limits
 	if err != nil {
 		panic(err)
 	}
-
 */
 package limits

--- a/openstack/identity/v3/services/doc.go
+++ b/openstack/identity/v3/services/doc.go
@@ -61,6 +61,5 @@ Example to Delete a Service
 	if err != nil {
 		panic(err)
 	}
-
 */
 package services

--- a/openstack/identity/v3/tokens/doc.go
+++ b/openstack/identity/v3/tokens/doc.go
@@ -103,6 +103,5 @@ Example to Create a Token from a Username and Password with Project Name Scope
 	if err != nil {
 		panic(err)
 	}
-
 */
 package tokens

--- a/openstack/identity/v3/users/doc.go
+++ b/openstack/identity/v3/users/doc.go
@@ -167,6 +167,5 @@ Example to List Users in a Group
 	for _, user := range allUsers {
 		fmt.Printf("%+v\n", user)
 	}
-
 */
 package users

--- a/openstack/imageservice/v2/imagedata/doc.go
+++ b/openstack/imageservice/v2/imagedata/doc.go
@@ -18,18 +18,18 @@ Example to Upload Image Data
 
 Example to Stage Image Data
 
-  imageID := "da3b75d9-3f4a-40e7-8a2c-bfab23927dea"
+	imageID := "da3b75d9-3f4a-40e7-8a2c-bfab23927dea"
 
-  imageData, err := os.Open("/path/to/image/file")
-  if err != nil {
-    panic(err)
-  }
-  defer imageData.Close()
+	imageData, err := os.Open("/path/to/image/file")
+	if err != nil {
+	  panic(err)
+	}
+	defer imageData.Close()
 
-  err = imagedata.Stage(imageClient, imageID, imageData).ExtractErr()
-  if err != nil {
-    panic(err)
-  }
+	err = imagedata.Stage(imageClient, imageID, imageData).ExtractErr()
+	if err != nil {
+	  panic(err)
+	}
 
 Example to Download Image Data
 

--- a/openstack/imageservice/v2/imageimport/doc.go
+++ b/openstack/imageservice/v2/imageimport/doc.go
@@ -4,24 +4,24 @@ Imageservice Import API information.
 
 Example to Get an information about the Import API
 
-  importInfo, err := imageimport.Get(imagesClient).Extract()
-  if err != nil {
-    panic(err)
-  }
+	importInfo, err := imageimport.Get(imagesClient).Extract()
+	if err != nil {
+	  panic(err)
+	}
 
-  fmt.Printf("%+v\n", importInfo)
+	fmt.Printf("%+v\n", importInfo)
 
 Example to Create a new image import
 
-  createOpts := imageimport.CreateOpts{
-    Name: imageimport.WebDownloadMethod,
-    URI:  "http://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img",
-  }
-  imageID := "da3b75d9-3f4a-40e7-8a2c-bfab23927dea"
+	createOpts := imageimport.CreateOpts{
+	  Name: imageimport.WebDownloadMethod,
+	  URI:  "http://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img",
+	}
+	imageID := "da3b75d9-3f4a-40e7-8a2c-bfab23927dea"
 
-  err := imageimport.Create(imagesClient, imageID, createOpts).ExtractErr()
-  if err != nil {
-    panic(err)
-  }
+	err := imageimport.Create(imagesClient, imageID, createOpts).ExtractErr()
+	if err != nil {
+	  panic(err)
+	}
 */
 package imageimport

--- a/openstack/imageservice/v2/members/requests.go
+++ b/openstack/imageservice/v2/members/requests.go
@@ -6,22 +6,22 @@ import (
 )
 
 /*
-	Create member for specific image
+Create member for specific image
 
-	Preconditions
+# Preconditions
 
-	* The specified images must exist.
-	* You can only add a new member to an image which 'visibility' attribute is
-		private.
-	* You must be the owner of the specified image.
+  - The specified images must exist.
+  - You can only add a new member to an image which 'visibility' attribute is
+    private.
+  - You must be the owner of the specified image.
 
-	Synchronous Postconditions
+# Synchronous Postconditions
 
-	With correct permissions, you can see the member status of the image as
-	pending through API calls.
+With correct permissions, you can see the member status of the image as
+pending through API calls.
 
-	More details here:
-	http://developer.openstack.org/api-ref-image-v2.html#createImageMember-v2
+More details here:
+http://developer.openstack.org/api-ref-image-v2.html#createImageMember-v2
 */
 func Create(client *gophercloud.ServiceClient, id string, member string) (r CreateResult) {
 	b := map[string]interface{}{"member": member}

--- a/openstack/imageservice/v2/tasks/doc.go
+++ b/openstack/imageservice/v2/tasks/doc.go
@@ -4,52 +4,52 @@ Imageservice.
 
 Example to List Tasks
 
-  listOpts := tasks.ListOpts{
-    Owner: "424e7cf0243c468ca61732ba45973b3e",
-  }
+	listOpts := tasks.ListOpts{
+	  Owner: "424e7cf0243c468ca61732ba45973b3e",
+	}
 
-  allPages, err := tasks.List(imagesClient, listOpts).AllPages()
-  if err != nil {
-    panic(err)
-  }
+	allPages, err := tasks.List(imagesClient, listOpts).AllPages()
+	if err != nil {
+	  panic(err)
+	}
 
-  allTasks, err := tasks.ExtractTasks(allPages)
-  if err != nil {
-    panic(err)
-  }
+	allTasks, err := tasks.ExtractTasks(allPages)
+	if err != nil {
+	  panic(err)
+	}
 
-  for _, task := range allTasks {
-    fmt.Printf("%+v\n", task)
-  }
+	for _, task := range allTasks {
+	  fmt.Printf("%+v\n", task)
+	}
 
 Example to Get a Task
 
-  task, err := tasks.Get(imagesClient, "1252f636-1246-4319-bfba-c47cde0efbe0").Extract()
-  if err != nil {
-    panic(err)
-  }
+	task, err := tasks.Get(imagesClient, "1252f636-1246-4319-bfba-c47cde0efbe0").Extract()
+	if err != nil {
+	  panic(err)
+	}
 
-  fmt.Printf("%+v\n", task)
+	fmt.Printf("%+v\n", task)
 
 Example to Create a Task
 
-  createOpts := tasks.CreateOpts{
-    Type: "import",
-    Input: map[string]interface{}{
-      "image_properties": map[string]interface{}{
-        "container_format": "bare",
-        "disk_format":      "raw",
-      },
-      "import_from_format": "raw",
-      "import_from":        "https://cloud-images.ubuntu.com/bionic/current/bionic-server-cloudimg-amd64.img",
-    },
-  }
+	createOpts := tasks.CreateOpts{
+	  Type: "import",
+	  Input: map[string]interface{}{
+	    "image_properties": map[string]interface{}{
+	      "container_format": "bare",
+	      "disk_format":      "raw",
+	    },
+	    "import_from_format": "raw",
+	    "import_from":        "https://cloud-images.ubuntu.com/bionic/current/bionic-server-cloudimg-amd64.img",
+	  },
+	}
 
-  task, err := tasks.Create(imagesClient, createOpts).Extract()
-  if err != nil {
-    panic(err)
-  }
+	task, err := tasks.Create(imagesClient, createOpts).Extract()
+	if err != nil {
+	  panic(err)
+	}
 
-  fmt.Printf("%+v\n", task)
+	fmt.Printf("%+v\n", task)
 */
 package tasks

--- a/openstack/loadbalancer/v2/monitors/requests.go
+++ b/openstack/loadbalancer/v2/monitors/requests.go
@@ -149,19 +149,19 @@ func (opts CreateOpts) ToMonitorCreateMap() (map[string]interface{}, error) {
 }
 
 /*
- Create is an operation which provisions a new Health Monitor. There are
- different types of Monitor you can provision: PING, TCP or HTTP(S). Below
- are examples of how to create each one.
+Create is an operation which provisions a new Health Monitor. There are
+different types of Monitor you can provision: PING, TCP or HTTP(S). Below
+are examples of how to create each one.
 
- Here is an example config struct to use when creating a PING or TCP Monitor:
+Here is an example config struct to use when creating a PING or TCP Monitor:
 
- CreateOpts{Type: TypePING, Delay: 20, Timeout: 10, MaxRetries: 3}
- CreateOpts{Type: TypeTCP, Delay: 20, Timeout: 10, MaxRetries: 3}
+CreateOpts{Type: TypePING, Delay: 20, Timeout: 10, MaxRetries: 3}
+CreateOpts{Type: TypeTCP, Delay: 20, Timeout: 10, MaxRetries: 3}
 
- Here is an example config struct to use when creating a HTTP(S) Monitor:
+Here is an example config struct to use when creating a HTTP(S) Monitor:
 
- CreateOpts{Type: TypeHTTP, Delay: 20, Timeout: 10, MaxRetries: 3,
- HttpMethod: "HEAD", ExpectedCodes: "200", PoolID: "2c946bfc-1804-43ab-a2ff-58f6a762b505"}
+CreateOpts{Type: TypeHTTP, Delay: 20, Timeout: 10, MaxRetries: 3,
+HttpMethod: "HEAD", ExpectedCodes: "200", PoolID: "2c946bfc-1804-43ab-a2ff-58f6a762b505"}
 */
 func Create(c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToMonitorCreateMap()

--- a/openstack/loadbalancer/v2/pools/results.go
+++ b/openstack/loadbalancer/v2/pools/results.go
@@ -15,15 +15,20 @@ import (
 // types of persistence are supported:
 //
 // SOURCE_IP:   With this mode, all connections originating from the same source
-//              IP address, will be handled by the same Member of the Pool.
+//
+//	IP address, will be handled by the same Member of the Pool.
+//
 // HTTP_COOKIE: With this persistence mode, the load balancing function will
-//              create a cookie on the first request from a client. Subsequent
-//              requests containing the same cookie value will be handled by
-//              the same Member of the Pool.
+//
+//	create a cookie on the first request from a client. Subsequent
+//	requests containing the same cookie value will be handled by
+//	the same Member of the Pool.
+//
 // APP_COOKIE:  With this persistence mode, the load balancing function will
-//              rely on a cookie established by the backend application. All
-//              requests carrying the same cookie value will be handled by the
-//              same Member of the Pool.
+//
+//	rely on a cookie established by the backend application. All
+//	requests carrying the same cookie value will be handled by the
+//	same Member of the Pool.
 type SessionPersistence struct {
 	// The type of persistence mode.
 	Type string `json:"type"`

--- a/openstack/loadbalancer/v2/providers/doc.go
+++ b/openstack/loadbalancer/v2/providers/doc.go
@@ -17,6 +17,5 @@ Example to List Providers
 	for _, p := range allProviders {
 		fmt.Printf("%+v\n", p)
 	}
-
 */
 package providers

--- a/openstack/loadbalancer/v2/quotas/doc.go
+++ b/openstack/loadbalancer/v2/quotas/doc.go
@@ -3,32 +3,32 @@ Package quotas provides the ability to retrieve and manage Load Balancer quotas
 
 Example to Get project quotas
 
-    projectID = "23d5d3f79dfa4f73b72b8b0b0063ec55"
-    quotasInfo, err := quotas.Get(networkClient, projectID).Extract()
-    if err != nil {
-        log.Fatal(err)
-    }
+	projectID = "23d5d3f79dfa4f73b72b8b0b0063ec55"
+	quotasInfo, err := quotas.Get(networkClient, projectID).Extract()
+	if err != nil {
+	    log.Fatal(err)
+	}
 
-    fmt.Printf("quotas: %#v\n", quotasInfo)
+	fmt.Printf("quotas: %#v\n", quotasInfo)
 
 Example to Update project quotas
 
-    projectID = "23d5d3f79dfa4f73b72b8b0b0063ec55"
+	    projectID = "23d5d3f79dfa4f73b72b8b0b0063ec55"
 
-    updateOpts := quotas.UpdateOpts{
-		Loadbalancer:  gophercloud.IntToPointer(20),
-		Listener:      gophercloud.IntToPointer(40),
-		Member:        gophercloud.IntToPointer(200),
-		Pool:          gophercloud.IntToPointer(20),
-		Healthmonitor: gophercloud.IntToPointer(1),
-		L7Policy:      gophercloud.IntToPointer(50),
-		L7Rule:        gophercloud.IntToPointer(100),
-    }
-    quotasInfo, err := quotas.Update(networkClient, projectID)
-    if err != nil {
-        log.Fatal(err)
-    }
+	    updateOpts := quotas.UpdateOpts{
+			Loadbalancer:  gophercloud.IntToPointer(20),
+			Listener:      gophercloud.IntToPointer(40),
+			Member:        gophercloud.IntToPointer(200),
+			Pool:          gophercloud.IntToPointer(20),
+			Healthmonitor: gophercloud.IntToPointer(1),
+			L7Policy:      gophercloud.IntToPointer(50),
+			L7Rule:        gophercloud.IntToPointer(100),
+	    }
+	    quotasInfo, err := quotas.Update(networkClient, projectID)
+	    if err != nil {
+	        log.Fatal(err)
+	    }
 
-    fmt.Printf("quotas: %#v\n", quotasInfo)
+	    fmt.Printf("quotas: %#v\n", quotasInfo)
 */
 package quotas

--- a/openstack/messaging/v2/queues/doc.go
+++ b/openstack/messaging/v2/queues/doc.go
@@ -6,24 +6,24 @@ Lists all queues and creates, shows information for updates, deletes, and action
 
 Example to List Queues
 
-	listOpts := queues.ListOpts{
-		Limit: 10,
-	}
-
-	pager := queues.List(client, listOpts)
-
-    err = pager.EachPage(func(page pagination.Page) (bool, error) {
-		queues, err := queues.ExtractQueues(page)
-		if err != nil {
-			panic(err)
+		listOpts := queues.ListOpts{
+			Limit: 10,
 		}
 
-		for _, queue := range queues {
-			fmt.Printf("%+v\n", queue)
-		}
+		pager := queues.List(client, listOpts)
 
-		return true, nil
-	})
+	    err = pager.EachPage(func(page pagination.Page) (bool, error) {
+			queues, err := queues.ExtractQueues(page)
+			if err != nil {
+				panic(err)
+			}
+
+			for _, queue := range queues {
+				fmt.Printf("%+v\n", queue)
+			}
+
+			return true, nil
+		})
 
 Example to Create a Queue
 

--- a/openstack/networking/v2/extensions/attributestags/doc.go
+++ b/openstack/networking/v2/extensions/attributestags/doc.go
@@ -7,12 +7,12 @@ See https://developer.openstack.org/api-ref/network/v2/#standard-attributes-tag-
 
 Example to ReplaceAll Resource Tags
 
-    network, err := networks.Create(conn, createOpts).Extract()
+	network, err := networks.Create(conn, createOpts).Extract()
 
-    tagReplaceAllOpts := attributestags.ReplaceAllOpts{
-        Tags:         []string{"abc", "123"},
-    }
-    attributestags.ReplaceAll(conn, "networks", network.ID, tagReplaceAllOpts)
+	tagReplaceAllOpts := attributestags.ReplaceAllOpts{
+	    Tags:         []string{"abc", "123"},
+	}
+	attributestags.ReplaceAll(conn, "networks", network.ID, tagReplaceAllOpts)
 
 Example to List all Resource Tags
 
@@ -24,11 +24,11 @@ Example to Delete all Resource Tags
 
 Example to Add a tag to a Resource
 
-    err = attributestags.Add(client, "networks", network.ID, "atag").ExtractErr()
+	err = attributestags.Add(client, "networks", network.ID, "atag").ExtractErr()
 
 Example to Delete a tag from a Resource
 
-    err = attributestags.Delete(client, "networks", network.ID, "atag").ExtractErr()
+	err = attributestags.Delete(client, "networks", network.ID, "atag").ExtractErr()
 
 Example to confirm if a tag exists on a resource
 

--- a/openstack/networking/v2/extensions/layer3/addressscopes/doc.go
+++ b/openstack/networking/v2/extensions/layer3/addressscopes/doc.go
@@ -3,62 +3,62 @@ Package addressscopes provides the ability to retrieve and manage Address scopes
 
 Example of Listing Address scopes
 
-    listOpts := addressscopes.ListOpts{
-        IPVersion: 6,
-    }
+	listOpts := addressscopes.ListOpts{
+	    IPVersion: 6,
+	}
 
-    allPages, err := addressscopes.List(networkClient, listOpts).AllPages()
-    if err != nil {
-        panic(err)
-    }
+	allPages, err := addressscopes.List(networkClient, listOpts).AllPages()
+	if err != nil {
+	    panic(err)
+	}
 
-    allAddressScopes, err := addressscopes.ExtractAddressScopes(allPages)
-    if err != nil {
-        panic(err)
-    }
+	allAddressScopes, err := addressscopes.ExtractAddressScopes(allPages)
+	if err != nil {
+	    panic(err)
+	}
 
-    for _, addressScope := range allAddressScopes {
-        fmt.Printf("%+v\n", addressScope)
-    }
+	for _, addressScope := range allAddressScopes {
+	    fmt.Printf("%+v\n", addressScope)
+	}
 
 Example to Get an Address scope
 
-    addressScopeID = "9cc35860-522a-4d35-974d-51d4b011801e"
-    addressScope, err := addressscopes.Get(networkClient, addressScopeID).Extract()
-    if err != nil {
-        panic(err)
-    }
+	addressScopeID = "9cc35860-522a-4d35-974d-51d4b011801e"
+	addressScope, err := addressscopes.Get(networkClient, addressScopeID).Extract()
+	if err != nil {
+	    panic(err)
+	}
 
 Example to Create a new Address scope
 
-    addressScopeOpts := addressscopes.CreateOpts{
-        Name: "my_address_scope",
-        IPVersion: 6,
-    }
-    addressScope, err := addressscopes.Create(networkClient, addressScopeOpts).Extract()
-    if err != nil {
-        panic(err)
-    }
+	addressScopeOpts := addressscopes.CreateOpts{
+	    Name: "my_address_scope",
+	    IPVersion: 6,
+	}
+	addressScope, err := addressscopes.Create(networkClient, addressScopeOpts).Extract()
+	if err != nil {
+	    panic(err)
+	}
 
 Example to Update an Address scope
 
-    addressScopeID = "9cc35860-522a-4d35-974d-51d4b011801e"
-    newName := "awesome_name"
-    updateOpts := addressscopes.UpdateOpts{
-        Name: &newName,
-    }
+	addressScopeID = "9cc35860-522a-4d35-974d-51d4b011801e"
+	newName := "awesome_name"
+	updateOpts := addressscopes.UpdateOpts{
+	    Name: &newName,
+	}
 
-    addressScope, err := addressscopes.Update(networkClient, addressScopeID, updateOpts).Extract()
-    if err != nil {
-        panic(err)
-    }
+	addressScope, err := addressscopes.Update(networkClient, addressScopeID, updateOpts).Extract()
+	if err != nil {
+	    panic(err)
+	}
 
 Example to Delete an Address scope
 
-    addressScopeID = "9cc35860-522a-4d35-974d-51d4b011801e"
-    err := addressscopes.Delete(networkClient, addressScopeID).ExtractErr()
-    if err != nil {
-        panic(err)
-    }
+	addressScopeID = "9cc35860-522a-4d35-974d-51d4b011801e"
+	err := addressscopes.Delete(networkClient, addressScopeID).ExtractErr()
+	if err != nil {
+	    panic(err)
+	}
 */
 package addressscopes

--- a/openstack/networking/v2/extensions/layer3/portforwarding/doc.go
+++ b/openstack/networking/v2/extensions/layer3/portforwarding/doc.go
@@ -28,7 +28,6 @@ Example to Get a Port Forwarding with a certain ID
 		panic(err)
 	}
 
-
 Example to Create a Port Forwarding for a floating IP
 
 	createOpts := &portforwarding.CreateOpts{

--- a/openstack/networking/v2/extensions/lbaas/monitors/requests.go
+++ b/openstack/networking/v2/extensions/lbaas/monitors/requests.go
@@ -138,8 +138,8 @@ func (opts CreateOpts) ToLBMonitorCreateMap() (map[string]interface{}, error) {
 // Here is an example config struct to use when creating a HTTP(S) monitor:
 //
 // CreateOpts{Type: TypeHTTP, Delay: 20, Timeout: 10, MaxRetries: 3,
-//  HttpMethod: "HEAD", ExpectedCodes: "200"}
 //
+//	HttpMethod: "HEAD", ExpectedCodes: "200"}
 func Create(c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToLBMonitorCreateMap()
 	if err != nil {

--- a/openstack/networking/v2/extensions/lbaas/vips/results.go
+++ b/openstack/networking/v2/extensions/lbaas/vips/results.go
@@ -11,15 +11,20 @@ import (
 // types of persistence are supported:
 //
 // SOURCE_IP:   With this mode, all connections originating from the same source
-//              IP address, will be handled by the same member of the pool.
+//
+//	IP address, will be handled by the same member of the pool.
+//
 // HTTP_COOKIE: With this persistence mode, the load balancing function will
-//              create a cookie on the first request from a client. Subsequent
-//              requests containing the same cookie value will be handled by
-//              the same member of the pool.
+//
+//	create a cookie on the first request from a client. Subsequent
+//	requests containing the same cookie value will be handled by
+//	the same member of the pool.
+//
 // APP_COOKIE:  With this persistence mode, the load balancing function will
-//              rely on a cookie established by the backend application. All
-//              requests carrying the same cookie value will be handled by the
-//              same member of the pool.
+//
+//	rely on a cookie established by the backend application. All
+//	requests carrying the same cookie value will be handled by the
+//	same member of the pool.
 type SessionPersistence struct {
 	// Type is the type of persistence mode.
 	Type string `json:"type"`

--- a/openstack/networking/v2/extensions/lbaas_v2/monitors/requests.go
+++ b/openstack/networking/v2/extensions/lbaas_v2/monitors/requests.go
@@ -159,19 +159,19 @@ func (opts CreateOpts) ToMonitorCreateMap() (map[string]interface{}, error) {
 }
 
 /*
- Create is an operation which provisions a new Health Monitor. There are
- different types of Monitor you can provision: PING, TCP or HTTP(S). Below
- are examples of how to create each one.
+Create is an operation which provisions a new Health Monitor. There are
+different types of Monitor you can provision: PING, TCP or HTTP(S). Below
+are examples of how to create each one.
 
- Here is an example config struct to use when creating a PING or TCP Monitor:
+Here is an example config struct to use when creating a PING or TCP Monitor:
 
- CreateOpts{Type: TypePING, Delay: 20, Timeout: 10, MaxRetries: 3}
- CreateOpts{Type: TypeTCP, Delay: 20, Timeout: 10, MaxRetries: 3}
+CreateOpts{Type: TypePING, Delay: 20, Timeout: 10, MaxRetries: 3}
+CreateOpts{Type: TypeTCP, Delay: 20, Timeout: 10, MaxRetries: 3}
 
- Here is an example config struct to use when creating a HTTP(S) Monitor:
+Here is an example config struct to use when creating a HTTP(S) Monitor:
 
- CreateOpts{Type: TypeHTTP, Delay: 20, Timeout: 10, MaxRetries: 3,
- HttpMethod: "HEAD", ExpectedCodes: "200", PoolID: "2c946bfc-1804-43ab-a2ff-58f6a762b505"}
+CreateOpts{Type: TypeHTTP, Delay: 20, Timeout: 10, MaxRetries: 3,
+HttpMethod: "HEAD", ExpectedCodes: "200", PoolID: "2c946bfc-1804-43ab-a2ff-58f6a762b505"}
 */
 func Create(c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToMonitorCreateMap()

--- a/openstack/networking/v2/extensions/lbaas_v2/pools/results.go
+++ b/openstack/networking/v2/extensions/lbaas_v2/pools/results.go
@@ -12,15 +12,20 @@ import (
 // types of persistence are supported:
 //
 // SOURCE_IP:   With this mode, all connections originating from the same source
-//              IP address, will be handled by the same Member of the Pool.
+//
+//	IP address, will be handled by the same Member of the Pool.
+//
 // HTTP_COOKIE: With this persistence mode, the load balancing function will
-//              create a cookie on the first request from a client. Subsequent
-//              requests containing the same cookie value will be handled by
-//              the same Member of the Pool.
+//
+//	create a cookie on the first request from a client. Subsequent
+//	requests containing the same cookie value will be handled by
+//	the same Member of the Pool.
+//
 // APP_COOKIE:  With this persistence mode, the load balancing function will
-//              rely on a cookie established by the backend application. All
-//              requests carrying the same cookie value will be handled by the
-//              same Member of the Pool.
+//
+//	rely on a cookie established by the backend application. All
+//	requests carrying the same cookie value will be handled by the
+//	same Member of the Pool.
 type SessionPersistence struct {
 	// The type of persistence mode.
 	Type string `json:"type"`

--- a/openstack/networking/v2/extensions/networkipavailabilities/doc.go
+++ b/openstack/networking/v2/extensions/networkipavailabilities/doc.go
@@ -4,27 +4,27 @@ networkipavailabilities through the Neutron API.
 
 Example of Listing NetworkIPAvailabilities
 
-  allPages, err := networkipavailabilities.List(networkClient, networkipavailabilities.ListOpts{}).AllPages()
-  if err != nil {
-    panic(err)
-  }
+	allPages, err := networkipavailabilities.List(networkClient, networkipavailabilities.ListOpts{}).AllPages()
+	if err != nil {
+	  panic(err)
+	}
 
-  allAvailabilities, err := networkipavailabilities.ExtractNetworkIPAvailabilities(allPages)
-  if err != nil {
-    panic(err)
-  }
+	allAvailabilities, err := networkipavailabilities.ExtractNetworkIPAvailabilities(allPages)
+	if err != nil {
+	  panic(err)
+	}
 
-  for _, availability := range allAvailabilities {
-    fmt.Printf("%+v\n", availability)
-  }
+	for _, availability := range allAvailabilities {
+	  fmt.Printf("%+v\n", availability)
+	}
 
 Example of Getting a single NetworkIPAvailability
 
-  availability, err := networkipavailabilities.Get(networkClient, "cf11ab78-2302-49fa-870f-851a08c7afb8").Extract()
-  if err != nil {
-    panic(err)
-  }
+	availability, err := networkipavailabilities.Get(networkClient, "cf11ab78-2302-49fa-870f-851a08c7afb8").Extract()
+	if err != nil {
+	  panic(err)
+	}
 
-  fmt.Printf("%+v\n", availability)
+	fmt.Printf("%+v\n", availability)
 */
 package networkipavailabilities

--- a/openstack/networking/v2/extensions/qos/policies/doc.go
+++ b/openstack/networking/v2/extensions/qos/policies/doc.go
@@ -4,254 +4,254 @@ for the OpenStack Networking service.
 
 Example to Get a Port with a QoS policy
 
-    var portWithQoS struct {
-        ports.Port
-        policies.QoSPolicyExt
-    }
+	var portWithQoS struct {
+	    ports.Port
+	    policies.QoSPolicyExt
+	}
 
-    portID := "46d4bfb9-b26e-41f3-bd2e-e6dcc1ccedb2"
+	portID := "46d4bfb9-b26e-41f3-bd2e-e6dcc1ccedb2"
 
-    err = ports.Get(client, portID).ExtractInto(&portWithQoS)
-    if err != nil {
-        log.Fatal(err)
-    }
+	err = ports.Get(client, portID).ExtractInto(&portWithQoS)
+	if err != nil {
+	    log.Fatal(err)
+	}
 
-    fmt.Printf("Port: %+v\n", portWithQoS)
+	fmt.Printf("Port: %+v\n", portWithQoS)
 
 Example to Create a Port with a QoS policy
 
-    var portWithQoS struct {
-        ports.Port
-        policies.QoSPolicyExt
-    }
+	var portWithQoS struct {
+	    ports.Port
+	    policies.QoSPolicyExt
+	}
 
-    policyID := "d6ae28ce-fcb5-4180-aa62-d260a27e09ae"
-    networkID := "7069db8d-e817-4b39-a654-d2dd76e73d36"
+	policyID := "d6ae28ce-fcb5-4180-aa62-d260a27e09ae"
+	networkID := "7069db8d-e817-4b39-a654-d2dd76e73d36"
 
-    portCreateOpts := ports.CreateOpts{
-        NetworkID: networkID,
-    }
+	portCreateOpts := ports.CreateOpts{
+	    NetworkID: networkID,
+	}
 
-    createOpts := policies.PortCreateOptsExt{
-        CreateOptsBuilder: portCreateOpts,
-        QoSPolicyID:       policyID,
-    }
+	createOpts := policies.PortCreateOptsExt{
+	    CreateOptsBuilder: portCreateOpts,
+	    QoSPolicyID:       policyID,
+	}
 
-    err = ports.Create(client, createOpts).ExtractInto(&portWithQoS)
-    if err != nil {
-        panic(err)
-    }
+	err = ports.Create(client, createOpts).ExtractInto(&portWithQoS)
+	if err != nil {
+	    panic(err)
+	}
 
-    fmt.Printf("Port: %+v\n", portWithQoS)
+	fmt.Printf("Port: %+v\n", portWithQoS)
 
 Example to Add a QoS policy to an existing Port
 
-    var portWithQoS struct {
-        ports.Port
-        policies.QoSPolicyExt
-    }
+	var portWithQoS struct {
+	    ports.Port
+	    policies.QoSPolicyExt
+	}
 
-    portUpdateOpts := ports.UpdateOpts{}
+	portUpdateOpts := ports.UpdateOpts{}
 
-    policyID := "d6ae28ce-fcb5-4180-aa62-d260a27e09ae"
+	policyID := "d6ae28ce-fcb5-4180-aa62-d260a27e09ae"
 
-    updateOpts := policies.PortUpdateOptsExt{
-        UpdateOptsBuilder: portUpdateOpts,
-        QoSPolicyID:       &policyID,
-    }
+	updateOpts := policies.PortUpdateOptsExt{
+	    UpdateOptsBuilder: portUpdateOpts,
+	    QoSPolicyID:       &policyID,
+	}
 
-    err := ports.Update(client, "65c0ee9f-d634-4522-8954-51021b570b0d", updateOpts).ExtractInto(&portWithQoS)
-    if err != nil {
-        panic(err)
-    }
+	err := ports.Update(client, "65c0ee9f-d634-4522-8954-51021b570b0d", updateOpts).ExtractInto(&portWithQoS)
+	if err != nil {
+	    panic(err)
+	}
 
-    fmt.Printf("Port: %+v\n", portWithQoS)
+	fmt.Printf("Port: %+v\n", portWithQoS)
 
 Example to Delete a QoS policy from the existing Port
 
-    var portWithQoS struct {
-        ports.Port
-        policies.QoSPolicyExt
-    }
+	var portWithQoS struct {
+	    ports.Port
+	    policies.QoSPolicyExt
+	}
 
-    portUpdateOpts := ports.UpdateOpts{}
+	portUpdateOpts := ports.UpdateOpts{}
 
-    policyID := ""
+	policyID := ""
 
-    updateOpts := policies.PortUpdateOptsExt{
-        UpdateOptsBuilder: portUpdateOpts,
-        QoSPolicyID:       &policyID,
-    }
+	updateOpts := policies.PortUpdateOptsExt{
+	    UpdateOptsBuilder: portUpdateOpts,
+	    QoSPolicyID:       &policyID,
+	}
 
-    err := ports.Update(client, "65c0ee9f-d634-4522-8954-51021b570b0d", updateOpts).ExtractInto(&portWithQoS)
-    if err != nil {
-        panic(err)
-    }
+	err := ports.Update(client, "65c0ee9f-d634-4522-8954-51021b570b0d", updateOpts).ExtractInto(&portWithQoS)
+	if err != nil {
+	    panic(err)
+	}
 
-    fmt.Printf("Port: %+v\n", portWithQoS)
+	fmt.Printf("Port: %+v\n", portWithQoS)
 
 Example to Get a Network with a QoS policy
 
-    var networkWithQoS struct {
-        networks.Network
-        policies.QoSPolicyExt
-    }
+	var networkWithQoS struct {
+	    networks.Network
+	    policies.QoSPolicyExt
+	}
 
-    networkID := "46d4bfb9-b26e-41f3-bd2e-e6dcc1ccedb2"
+	networkID := "46d4bfb9-b26e-41f3-bd2e-e6dcc1ccedb2"
 
-    err = networks.Get(client, networkID).ExtractInto(&networkWithQoS)
-    if err != nil {
-        log.Fatal(err)
-    }
+	err = networks.Get(client, networkID).ExtractInto(&networkWithQoS)
+	if err != nil {
+	    log.Fatal(err)
+	}
 
-    fmt.Printf("Network: %+v\n", networkWithQoS)
+	fmt.Printf("Network: %+v\n", networkWithQoS)
 
 Example to Create a Network with a QoS policy
 
-    var networkWithQoS struct {
-        networks.Network
-        policies.QoSPolicyExt
-    }
+	var networkWithQoS struct {
+	    networks.Network
+	    policies.QoSPolicyExt
+	}
 
-    policyID := "d6ae28ce-fcb5-4180-aa62-d260a27e09ae"
-    networkID := "7069db8d-e817-4b39-a654-d2dd76e73d36"
+	policyID := "d6ae28ce-fcb5-4180-aa62-d260a27e09ae"
+	networkID := "7069db8d-e817-4b39-a654-d2dd76e73d36"
 
-    networkCreateOpts := networks.CreateOpts{
-        NetworkID: networkID,
-    }
+	networkCreateOpts := networks.CreateOpts{
+	    NetworkID: networkID,
+	}
 
-    createOpts := policies.NetworkCreateOptsExt{
-        CreateOptsBuilder: networkCreateOpts,
-        QoSPolicyID:       policyID,
-    }
+	createOpts := policies.NetworkCreateOptsExt{
+	    CreateOptsBuilder: networkCreateOpts,
+	    QoSPolicyID:       policyID,
+	}
 
-    err = networks.Create(client, createOpts).ExtractInto(&networkWithQoS)
-    if err != nil {
-        panic(err)
-    }
+	err = networks.Create(client, createOpts).ExtractInto(&networkWithQoS)
+	if err != nil {
+	    panic(err)
+	}
 
-    fmt.Printf("Network: %+v\n", networkWithQoS)
+	fmt.Printf("Network: %+v\n", networkWithQoS)
 
 Example to add a QoS policy to an existing Network
 
-    var networkWithQoS struct {
-        networks.Network
-        policies.QoSPolicyExt
-    }
+	var networkWithQoS struct {
+	    networks.Network
+	    policies.QoSPolicyExt
+	}
 
-    networkUpdateOpts := networks.UpdateOpts{}
+	networkUpdateOpts := networks.UpdateOpts{}
 
-    policyID := "d6ae28ce-fcb5-4180-aa62-d260a27e09ae"
+	policyID := "d6ae28ce-fcb5-4180-aa62-d260a27e09ae"
 
-    updateOpts := policies.NetworkUpdateOptsExt{
-        UpdateOptsBuilder: networkUpdateOpts,
-        QoSPolicyID:       &policyID,
-    }
+	updateOpts := policies.NetworkUpdateOptsExt{
+	    UpdateOptsBuilder: networkUpdateOpts,
+	    QoSPolicyID:       &policyID,
+	}
 
-    err := networks.Update(client, "65c0ee9f-d634-4522-8954-51021b570b0d", updateOpts).ExtractInto(&networkWithQoS)
-    if err != nil {
-        panic(err)
-    }
+	err := networks.Update(client, "65c0ee9f-d634-4522-8954-51021b570b0d", updateOpts).ExtractInto(&networkWithQoS)
+	if err != nil {
+	    panic(err)
+	}
 
-    fmt.Printf("Network: %+v\n", networkWithQoS)
+	fmt.Printf("Network: %+v\n", networkWithQoS)
 
 Example to delete a QoS policy from the existing Network
 
-    var networkWithQoS struct {
-        networks.Network
-        policies.QoSPolicyExt
-    }
+	var networkWithQoS struct {
+	    networks.Network
+	    policies.QoSPolicyExt
+	}
 
-    networkUpdateOpts := networks.UpdateOpts{}
+	networkUpdateOpts := networks.UpdateOpts{}
 
-    policyID := ""
+	policyID := ""
 
-    updateOpts := policies.NetworkUpdateOptsExt{
-        UpdateOptsBuilder: networkUpdateOpts,
-        QoSPolicyID:       &policyID,
-    }
+	updateOpts := policies.NetworkUpdateOptsExt{
+	    UpdateOptsBuilder: networkUpdateOpts,
+	    QoSPolicyID:       &policyID,
+	}
 
-    err := networks.Update(client, "65c0ee9f-d634-4522-8954-51021b570b0d", updateOpts).ExtractInto(&networkWithQoS)
-    if err != nil {
-        panic(err)
-    }
+	err := networks.Update(client, "65c0ee9f-d634-4522-8954-51021b570b0d", updateOpts).ExtractInto(&networkWithQoS)
+	if err != nil {
+	    panic(err)
+	}
 
-    fmt.Printf("Network: %+v\n", networkWithQoS)
+	fmt.Printf("Network: %+v\n", networkWithQoS)
 
 Example to List QoS policies
 
-    shared := true
-    listOpts := policies.ListOpts{
-        Name:   "shared-policy",
-        Shared: &shared,
-    }
+	    shared := true
+	    listOpts := policies.ListOpts{
+	        Name:   "shared-policy",
+	        Shared: &shared,
+	    }
 
-    allPages, err := policies.List(networkClient, listOpts).AllPages()
-    if err != nil {
-        panic(err)
-    }
+	    allPages, err := policies.List(networkClient, listOpts).AllPages()
+	    if err != nil {
+	        panic(err)
+	    }
 
-	allPolicies, err := policies.ExtractPolicies(allPages)
-    if err != nil {
-        panic(err)
-    }
+		allPolicies, err := policies.ExtractPolicies(allPages)
+	    if err != nil {
+	        panic(err)
+	    }
 
-    for _, policy := range allPolicies {
-        fmt.Printf("%+v\n", policy)
-    }
+	    for _, policy := range allPolicies {
+	        fmt.Printf("%+v\n", policy)
+	    }
 
 Example to Get a specific QoS policy
 
-    policyID := "30a57f4a-336b-4382-8275-d708babd2241"
+	policyID := "30a57f4a-336b-4382-8275-d708babd2241"
 
-    policy, err := policies.Get(networkClient, policyID).Extract()
-    if err != nil {
-        panic(err)
-    }
+	policy, err := policies.Get(networkClient, policyID).Extract()
+	if err != nil {
+	    panic(err)
+	}
 
-    fmt.Printf("%+v\n", policy)
+	fmt.Printf("%+v\n", policy)
 
 Example to Create a QoS policy
 
-    createOpts := policies.CreateOpts{
-        Name:      "shared-default-policy",
-        Shared:    true,
-        IsDefault: true,
-    }
+	createOpts := policies.CreateOpts{
+	    Name:      "shared-default-policy",
+	    Shared:    true,
+	    IsDefault: true,
+	}
 
-    policy, err := policies.Create(networkClient, createOpts).Extract()
-    if err != nil {
-        panic(err)
-    }
+	policy, err := policies.Create(networkClient, createOpts).Extract()
+	if err != nil {
+	    panic(err)
+	}
 
-    fmt.Printf("%+v\n", policy)
+	fmt.Printf("%+v\n", policy)
 
 Example to Update a QoS policy
 
-    shared := true
-    isDefault := false
-    opts := policies.UpdateOpts{
-        Name:      "new-name",
-        Shared:    &shared,
-        IsDefault: &isDefault,
-    }
+	shared := true
+	isDefault := false
+	opts := policies.UpdateOpts{
+	    Name:      "new-name",
+	    Shared:    &shared,
+	    IsDefault: &isDefault,
+	}
 
-    policyID := "30a57f4a-336b-4382-8275-d708babd2241"
+	policyID := "30a57f4a-336b-4382-8275-d708babd2241"
 
-    policy, err := policies.Update(networkClient, policyID, opts).Extract()
-    if err != nil {
-        panic(err)
-    }
+	policy, err := policies.Update(networkClient, policyID, opts).Extract()
+	if err != nil {
+	    panic(err)
+	}
 
-    fmt.Printf("%+v\n", policy)
+	fmt.Printf("%+v\n", policy)
 
 Example to Delete a QoS policy
 
-    policyID := "30a57f4a-336b-4382-8275-d708babd2241"
+	policyID := "30a57f4a-336b-4382-8275-d708babd2241"
 
-    err := policies.Delete(networkClient, policyID).ExtractErr()
-    if err != nil {
-        panic(err)
-    }
+	err := policies.Delete(networkClient, policyID).ExtractErr()
+	if err != nil {
+	    panic(err)
+	}
 */
 package policies

--- a/openstack/networking/v2/extensions/qos/rules/doc.go
+++ b/openstack/networking/v2/extensions/qos/rules/doc.go
@@ -3,234 +3,234 @@ Package rules provides the ability to retrieve and manage QoS policy rules throu
 
 Example of Listing BandwidthLimitRules
 
-    listOpts := rules.BandwidthLimitRulesListOpts{
-        MaxKBps: 3000,
-    }
+	listOpts := rules.BandwidthLimitRulesListOpts{
+	    MaxKBps: 3000,
+	}
 
-    policyID := "501005fa-3b56-4061-aaca-3f24995112e1"
+	policyID := "501005fa-3b56-4061-aaca-3f24995112e1"
 
-    allPages, err := rules.ListBandwidthLimitRules(networkClient, policyID, listOpts).AllPages()
-    if err != nil {
-        panic(err)
-    }
+	allPages, err := rules.ListBandwidthLimitRules(networkClient, policyID, listOpts).AllPages()
+	if err != nil {
+	    panic(err)
+	}
 
-    allBandwidthLimitRules, err := rules.ExtractBandwidthLimitRules(allPages)
-    if err != nil {
-        panic(err)
-    }
+	allBandwidthLimitRules, err := rules.ExtractBandwidthLimitRules(allPages)
+	if err != nil {
+	    panic(err)
+	}
 
-    for _, bandwidthLimitRule := range allBandwidthLimitRules {
-        fmt.Printf("%+v\n", bandwidthLimitRule)
-    }
+	for _, bandwidthLimitRule := range allBandwidthLimitRules {
+	    fmt.Printf("%+v\n", bandwidthLimitRule)
+	}
 
 Example of Getting a single BandwidthLimitRule
 
-    policyID := "501005fa-3b56-4061-aaca-3f24995112e1"
-    ruleID   := "30a57f4a-336b-4382-8275-d708babd2241"
+	policyID := "501005fa-3b56-4061-aaca-3f24995112e1"
+	ruleID   := "30a57f4a-336b-4382-8275-d708babd2241"
 
-    rule, err := rules.GetBandwidthLimitRule(networkClient, policyID, ruleID).ExtractBandwidthLimitRule()
-    if err != nil {
-        panic(err)
-    }
+	rule, err := rules.GetBandwidthLimitRule(networkClient, policyID, ruleID).ExtractBandwidthLimitRule()
+	if err != nil {
+	    panic(err)
+	}
 
-    fmt.Printf("Rule: %+v\n", rule)
+	fmt.Printf("Rule: %+v\n", rule)
 
 Example of Creating a single BandwidthLimitRule
 
-    opts := rules.CreateBandwidthLimitRuleOpts{
-        MaxKBps:      2000,
-        MaxBurstKBps: 200,
-    }
+	opts := rules.CreateBandwidthLimitRuleOpts{
+	    MaxKBps:      2000,
+	    MaxBurstKBps: 200,
+	}
 
-    policyID := "501005fa-3b56-4061-aaca-3f24995112e1"
+	policyID := "501005fa-3b56-4061-aaca-3f24995112e1"
 
-    rule, err := rules.CreateBandwidthLimitRule(networkClient, policyID, opts).ExtractBandwidthLimitRule()
-    if err != nil {
-        panic(err)
-    }
+	rule, err := rules.CreateBandwidthLimitRule(networkClient, policyID, opts).ExtractBandwidthLimitRule()
+	if err != nil {
+	    panic(err)
+	}
 
-    fmt.Printf("Rule: %+v\n", rule)
+	fmt.Printf("Rule: %+v\n", rule)
 
 Example of Updating a single BandwidthLimitRule
 
-    maxKBps := 500
-    maxBurstKBps := 0
+	maxKBps := 500
+	maxBurstKBps := 0
 
-    opts := rules.UpdateBandwidthLimitRuleOpts{
-        MaxKBps:      &maxKBps,
-        MaxBurstKBps: &maxBurstKBps,
-    }
+	opts := rules.UpdateBandwidthLimitRuleOpts{
+	    MaxKBps:      &maxKBps,
+	    MaxBurstKBps: &maxBurstKBps,
+	}
 
-    policyID := "501005fa-3b56-4061-aaca-3f24995112e1"
-    ruleID   := "30a57f4a-336b-4382-8275-d708babd2241"
+	policyID := "501005fa-3b56-4061-aaca-3f24995112e1"
+	ruleID   := "30a57f4a-336b-4382-8275-d708babd2241"
 
-    rule, err := rules.UpdateBandwidthLimitRule(networkClient, policyID, ruleID, opts).ExtractBandwidthLimitRule()
-    if err != nil {
-        panic(err)
-    }
+	rule, err := rules.UpdateBandwidthLimitRule(networkClient, policyID, ruleID, opts).ExtractBandwidthLimitRule()
+	if err != nil {
+	    panic(err)
+	}
 
-    fmt.Printf("Rule: %+v\n", rule)
+	fmt.Printf("Rule: %+v\n", rule)
 
 Example of Deleting a single BandwidthLimitRule
 
-    policyID := "501005fa-3b56-4061-aaca-3f24995112e1"
-    ruleID   := "30a57f4a-336b-4382-8275-d708babd2241"
+	policyID := "501005fa-3b56-4061-aaca-3f24995112e1"
+	ruleID   := "30a57f4a-336b-4382-8275-d708babd2241"
 
-    err := rules.DeleteBandwidthLimitRule(fake.ServiceClient(), "501005fa-3b56-4061-aaca-3f24995112e1", "30a57f4a-336b-4382-8275-d708babd2241").ExtractErr()
-    if err != nil {
-        panic(err)
-    }
+	err := rules.DeleteBandwidthLimitRule(fake.ServiceClient(), "501005fa-3b56-4061-aaca-3f24995112e1", "30a57f4a-336b-4382-8275-d708babd2241").ExtractErr()
+	if err != nil {
+	    panic(err)
+	}
 
 Example of Listing DSCP marking rules
 
-    listOpts := rules.DSCPMarkingRulesListOpts{}
+	listOpts := rules.DSCPMarkingRulesListOpts{}
 
-    policyID := "501005fa-3b56-4061-aaca-3f24995112e1"
+	policyID := "501005fa-3b56-4061-aaca-3f24995112e1"
 
-    allPages, err := rules.ListDSCPMarkingRules(networkClient, policyID, listOpts).AllPages()
-    if err != nil {
-        panic(err)
-    }
+	allPages, err := rules.ListDSCPMarkingRules(networkClient, policyID, listOpts).AllPages()
+	if err != nil {
+	    panic(err)
+	}
 
-    allDSCPMarkingRules, err := rules.ExtractDSCPMarkingRules(allPages)
-    if err != nil {
-        panic(err)
-    }
+	allDSCPMarkingRules, err := rules.ExtractDSCPMarkingRules(allPages)
+	if err != nil {
+	    panic(err)
+	}
 
-    for _, dscpMarkingRule := range allDSCPMarkingRules {
-        fmt.Printf("%+v\n", dscpMarkingRule)
-    }
+	for _, dscpMarkingRule := range allDSCPMarkingRules {
+	    fmt.Printf("%+v\n", dscpMarkingRule)
+	}
 
 Example of Getting a single DSCPMarkingRule
 
-    policyID := "501005fa-3b56-4061-aaca-3f24995112e1"
-    ruleID   := "30a57f4a-336b-4382-8275-d708babd2241"
+	policyID := "501005fa-3b56-4061-aaca-3f24995112e1"
+	ruleID   := "30a57f4a-336b-4382-8275-d708babd2241"
 
-    rule, err := rules.GetDSCPMarkingRule(networkClient, policyID, ruleID).ExtractDSCPMarkingRule()
-    if err != nil {
-        panic(err)
-    }
+	rule, err := rules.GetDSCPMarkingRule(networkClient, policyID, ruleID).ExtractDSCPMarkingRule()
+	if err != nil {
+	    panic(err)
+	}
 
-    fmt.Printf("Rule: %+v\n", rule)
+	fmt.Printf("Rule: %+v\n", rule)
 
 Example of Creating a single DSCPMarkingRule
 
-    opts := rules.CreateDSCPMarkingRuleOpts{
-        DSCPMark: 20,
-    }
+	opts := rules.CreateDSCPMarkingRuleOpts{
+	    DSCPMark: 20,
+	}
 
-    policyID := "501005fa-3b56-4061-aaca-3f24995112e1"
+	policyID := "501005fa-3b56-4061-aaca-3f24995112e1"
 
-    rule, err := rules.CreateDSCPMarkingRule(networkClient, policyID, opts).ExtractDSCPMarkingRule()
-    if err != nil {
-        panic(err)
-    }
+	rule, err := rules.CreateDSCPMarkingRule(networkClient, policyID, opts).ExtractDSCPMarkingRule()
+	if err != nil {
+	    panic(err)
+	}
 
-    fmt.Printf("Rule: %+v\n", rule)
+	fmt.Printf("Rule: %+v\n", rule)
 
 Example of Updating a single DSCPMarkingRule
 
-    dscpMark := 26
+	dscpMark := 26
 
-    opts := rules.UpdateDSCPMarkingRuleOpts{
-        DSCPMark: &dscpMark,
-    }
+	opts := rules.UpdateDSCPMarkingRuleOpts{
+	    DSCPMark: &dscpMark,
+	}
 
-    policyID := "501005fa-3b56-4061-aaca-3f24995112e1"
-    ruleID   := "30a57f4a-336b-4382-8275-d708babd2241"
+	policyID := "501005fa-3b56-4061-aaca-3f24995112e1"
+	ruleID   := "30a57f4a-336b-4382-8275-d708babd2241"
 
-    rule, err := rules.UpdateDSCPMarkingRule(networkClient, policyID, ruleID, opts).ExtractDSCPMarkingRule()
-    if err != nil {
-        panic(err)
-    }
+	rule, err := rules.UpdateDSCPMarkingRule(networkClient, policyID, ruleID, opts).ExtractDSCPMarkingRule()
+	if err != nil {
+	    panic(err)
+	}
 
-    fmt.Printf("Rule: %+v\n", rule)
+	fmt.Printf("Rule: %+v\n", rule)
 
 Example of Deleting a single DSCPMarkingRule
 
-    policyID := "501005fa-3b56-4061-aaca-3f24995112e1"
-    ruleID   := "30a57f4a-336b-4382-8275-d708babd2241"
+	policyID := "501005fa-3b56-4061-aaca-3f24995112e1"
+	ruleID   := "30a57f4a-336b-4382-8275-d708babd2241"
 
-    err := rules.DeleteDSCPMarkingRule(fake.ServiceClient(), "501005fa-3b56-4061-aaca-3f24995112e1", "30a57f4a-336b-4382-8275-d708babd2241").ExtractErr()
-    if err != nil {
-        panic(err)
-    }
+	err := rules.DeleteDSCPMarkingRule(fake.ServiceClient(), "501005fa-3b56-4061-aaca-3f24995112e1", "30a57f4a-336b-4382-8275-d708babd2241").ExtractErr()
+	if err != nil {
+	    panic(err)
+	}
 
 Example of Listing MinimumBandwidthRules
 
-    listOpts := rules.MinimumBandwidthRulesListOpts{
-        MinKBps: 3000,
-    }
+	listOpts := rules.MinimumBandwidthRulesListOpts{
+	    MinKBps: 3000,
+	}
 
-    policyID := "501005fa-3b56-4061-aaca-3f24995112e1"
+	policyID := "501005fa-3b56-4061-aaca-3f24995112e1"
 
-    allPages, err := rules.ListMinimumBandwidthRules(networkClient, policyID, listOpts).AllPages()
-    if err != nil {
-        panic(err)
-    }
+	allPages, err := rules.ListMinimumBandwidthRules(networkClient, policyID, listOpts).AllPages()
+	if err != nil {
+	    panic(err)
+	}
 
-    allMinimumBandwidthRules, err := rules.ExtractMinimumBandwidthRules(allPages)
-    if err != nil {
-        panic(err)
-    }
+	allMinimumBandwidthRules, err := rules.ExtractMinimumBandwidthRules(allPages)
+	if err != nil {
+	    panic(err)
+	}
 
-    for _, bandwidthLimitRule := range allMinimumBandwidthRules {
-        fmt.Printf("%+v\n", bandwidthLimitRule)
-    }
+	for _, bandwidthLimitRule := range allMinimumBandwidthRules {
+	    fmt.Printf("%+v\n", bandwidthLimitRule)
+	}
 
 Example of Getting a single MinimumBandwidthRule
 
-    policyID := "501005fa-3b56-4061-aaca-3f24995112e1"
-    ruleID   := "30a57f4a-336b-4382-8275-d708babd2241"
+	policyID := "501005fa-3b56-4061-aaca-3f24995112e1"
+	ruleID   := "30a57f4a-336b-4382-8275-d708babd2241"
 
-    rule, err := rules.GetMinimumBandwidthRule(networkClient, policyID, ruleID).ExtractMinimumBandwidthRule()
-    if err != nil {
-        panic(err)
-    }
+	rule, err := rules.GetMinimumBandwidthRule(networkClient, policyID, ruleID).ExtractMinimumBandwidthRule()
+	if err != nil {
+	    panic(err)
+	}
 
-    fmt.Printf("Rule: %+v\n", rule)
+	fmt.Printf("Rule: %+v\n", rule)
 
 Example of Creating a single MinimumBandwidthRule
 
-    opts := rules.CreateMinimumBandwidthRuleOpts{
-        MinKBps: 2000,
-    }
+	opts := rules.CreateMinimumBandwidthRuleOpts{
+	    MinKBps: 2000,
+	}
 
-    policyID := "501005fa-3b56-4061-aaca-3f24995112e1"
+	policyID := "501005fa-3b56-4061-aaca-3f24995112e1"
 
-    rule, err := rules.CreateMinimumBandwidthRule(networkClient, policyID, opts).ExtractMinimumBandwidthRule()
-    if err != nil {
-        panic(err)
-    }
+	rule, err := rules.CreateMinimumBandwidthRule(networkClient, policyID, opts).ExtractMinimumBandwidthRule()
+	if err != nil {
+	    panic(err)
+	}
 
-    fmt.Printf("Rule: %+v\n", rule)
+	fmt.Printf("Rule: %+v\n", rule)
 
 Example of Updating a single MinimumBandwidthRule
 
-    minKBps := 500
+	minKBps := 500
 
-    opts := rules.UpdateMinimumBandwidthRuleOpts{
-        MinKBps: &minKBps,
-    }
+	opts := rules.UpdateMinimumBandwidthRuleOpts{
+	    MinKBps: &minKBps,
+	}
 
-    policyID := "501005fa-3b56-4061-aaca-3f24995112e1"
-    ruleID   := "30a57f4a-336b-4382-8275-d708babd2241"
+	policyID := "501005fa-3b56-4061-aaca-3f24995112e1"
+	ruleID   := "30a57f4a-336b-4382-8275-d708babd2241"
 
-    rule, err := rules.UpdateMinimumBandwidthRule(networkClient, policyID, ruleID, opts).ExtractMinimumBandwidthRule()
-    if err != nil {
-        panic(err)
-    }
+	rule, err := rules.UpdateMinimumBandwidthRule(networkClient, policyID, ruleID, opts).ExtractMinimumBandwidthRule()
+	if err != nil {
+	    panic(err)
+	}
 
-    fmt.Printf("Rule: %+v\n", rule)
+	fmt.Printf("Rule: %+v\n", rule)
 
 Example of Deleting a single MinimumBandwidthRule
 
-    policyID := "501005fa-3b56-4061-aaca-3f24995112e1"
-    ruleID   := "30a57f4a-336b-4382-8275-d708babd2241"
+	policyID := "501005fa-3b56-4061-aaca-3f24995112e1"
+	ruleID   := "30a57f4a-336b-4382-8275-d708babd2241"
 
-    err := rules.DeleteMinimumBandwidthRule(fake.ServiceClient(), "501005fa-3b56-4061-aaca-3f24995112e1", "30a57f4a-336b-4382-8275-d708babd2241").ExtractErr()
-    if err != nil {
-        panic(err)
-    }
+	err := rules.DeleteMinimumBandwidthRule(fake.ServiceClient(), "501005fa-3b56-4061-aaca-3f24995112e1", "30a57f4a-336b-4382-8275-d708babd2241").ExtractErr()
+	if err != nil {
+	    panic(err)
+	}
 */
 package rules

--- a/openstack/networking/v2/extensions/qos/ruletypes/doc.go
+++ b/openstack/networking/v2/extensions/qos/ruletypes/doc.go
@@ -17,13 +17,13 @@ Example of Listing QoS rule types
 
 Example of Getting a single QoS rule type by it's name
 
-    ruleTypeName := "bandwidth_limit"
+	ruleTypeName := "bandwidth_limit"
 
-    ruleType, err := ruletypes.Get(networkClient, ruleTypeName).Extract()
-    if err != nil {
-        panic(err)
-    }
+	ruleType, err := ruletypes.Get(networkClient, ruleTypeName).Extract()
+	if err != nil {
+	    panic(err)
+	}
 
-    fmt.Printf("%+v\n", ruleTypeName)
+	fmt.Printf("%+v\n", ruleTypeName)
 */
 package ruletypes

--- a/openstack/networking/v2/extensions/quotas/doc.go
+++ b/openstack/networking/v2/extensions/quotas/doc.go
@@ -3,45 +3,45 @@ Package quotas provides the ability to retrieve and manage Networking quotas thr
 
 Example to Get project quotas
 
-    projectID = "23d5d3f79dfa4f73b72b8b0b0063ec55"
-    quotasInfo, err := quotas.Get(networkClient, projectID).Extract()
-    if err != nil {
-        log.Fatal(err)
-    }
+	projectID = "23d5d3f79dfa4f73b72b8b0b0063ec55"
+	quotasInfo, err := quotas.Get(networkClient, projectID).Extract()
+	if err != nil {
+	    log.Fatal(err)
+	}
 
-    fmt.Printf("quotas: %#v\n", quotasInfo)
+	fmt.Printf("quotas: %#v\n", quotasInfo)
 
 Example to Get a Detailed Quota Set
 
-    projectID = "23d5d3f79dfa4f73b72b8b0b0063ec55"
-    quotasInfo, err := quotas.GetDetail(networkClient, projectID).Extract()
-    if err != nil {
-        log.Fatal(err)
-    }
+	projectID = "23d5d3f79dfa4f73b72b8b0b0063ec55"
+	quotasInfo, err := quotas.GetDetail(networkClient, projectID).Extract()
+	if err != nil {
+	    log.Fatal(err)
+	}
 
-    fmt.Printf("quotas: %#v\n", quotasInfo)
+	fmt.Printf("quotas: %#v\n", quotasInfo)
 
 Example to Update project quotas
 
-    projectID = "23d5d3f79dfa4f73b72b8b0b0063ec55"
+	projectID = "23d5d3f79dfa4f73b72b8b0b0063ec55"
 
-    updateOpts := quotas.UpdateOpts{
-        FloatingIP:        gophercloud.IntToPointer(0),
-        Network:           gophercloud.IntToPointer(-1),
-        Port:              gophercloud.IntToPointer(5),
-        RBACPolicy:        gophercloud.IntToPointer(10),
-        Router:            gophercloud.IntToPointer(15),
-        SecurityGroup:     gophercloud.IntToPointer(20),
-        SecurityGroupRule: gophercloud.IntToPointer(-1),
-        Subnet:            gophercloud.IntToPointer(25),
-        SubnetPool:        gophercloud.IntToPointer(0),
-        Trunk:             gophercloud.IntToPointer(0),
-    }
-    quotasInfo, err := quotas.Update(networkClient, projectID)
-    if err != nil {
-        log.Fatal(err)
-    }
+	updateOpts := quotas.UpdateOpts{
+	    FloatingIP:        gophercloud.IntToPointer(0),
+	    Network:           gophercloud.IntToPointer(-1),
+	    Port:              gophercloud.IntToPointer(5),
+	    RBACPolicy:        gophercloud.IntToPointer(10),
+	    Router:            gophercloud.IntToPointer(15),
+	    SecurityGroup:     gophercloud.IntToPointer(20),
+	    SecurityGroupRule: gophercloud.IntToPointer(-1),
+	    Subnet:            gophercloud.IntToPointer(25),
+	    SubnetPool:        gophercloud.IntToPointer(0),
+	    Trunk:             gophercloud.IntToPointer(0),
+	}
+	quotasInfo, err := quotas.Update(networkClient, projectID)
+	if err != nil {
+	    log.Fatal(err)
+	}
 
-    fmt.Printf("quotas: %#v\n", quotasInfo)
+	fmt.Printf("quotas: %#v\n", quotasInfo)
 */
 package quotas

--- a/openstack/networking/v2/extensions/rbacpolicies/doc.go
+++ b/openstack/networking/v2/extensions/rbacpolicies/doc.go
@@ -15,17 +15,17 @@ before this feature was added.
 
 Example to Create a RBAC Policy
 
-	createOpts := rbacpolicies.CreateOpts{
-		Action:       rbacpolicies.ActionAccessShared,
-		ObjectType:   "network",
-                TargetTenant: "6e547a3bcfe44702889fdeff3c3520c3",
-                ObjectID:     "240d22bf-bd17-4238-9758-25f72610ecdc"
-	}
+		createOpts := rbacpolicies.CreateOpts{
+			Action:       rbacpolicies.ActionAccessShared,
+			ObjectType:   "network",
+	                TargetTenant: "6e547a3bcfe44702889fdeff3c3520c3",
+	                ObjectID:     "240d22bf-bd17-4238-9758-25f72610ecdc"
+		}
 
-	rbacPolicy, err := rbacpolicies.Create(rbacClient, createOpts).Extract()
-	if err != nil {
-		panic(err)
-	}
+		rbacPolicy, err := rbacpolicies.Create(rbacClient, createOpts).Extract()
+		if err != nil {
+			panic(err)
+		}
 
 Example to List RBAC Policies
 
@@ -74,6 +74,5 @@ Example to Update a RBAC Policy
 	if err != nil {
 		panic(err)
 	}
-
 */
 package rbacpolicies

--- a/openstack/networking/v2/extensions/security/doc.go
+++ b/openstack/networking/v2/extensions/security/doc.go
@@ -14,19 +14,19 @@
 // The basic characteristics of Neutron Security Groups are:
 //
 // For ingress traffic (to an instance)
-//  - Only traffic matched with security group rules are allowed.
-//  - When there is no rule defined, all traffic is dropped.
+//   - Only traffic matched with security group rules are allowed.
+//   - When there is no rule defined, all traffic is dropped.
 //
 // For egress traffic (from an instance)
-//  - Only traffic matched with security group rules are allowed.
-//  - When there is no rule defined, all egress traffic are dropped.
-//  - When a new security group is created, rules to allow all egress traffic
-//    is automatically added.
+//   - Only traffic matched with security group rules are allowed.
+//   - When there is no rule defined, all egress traffic are dropped.
+//   - When a new security group is created, rules to allow all egress traffic
+//     is automatically added.
 //
 // "default security group" is defined for each tenant.
-//  - For the default security group a rule which allows intercommunication
-//    among hosts associated with the default security group is defined by default.
-//  - As a result, all egress traffic and intercommunication in the default
-//    group are allowed and all ingress from outside of the default group is
-//    dropped by default (in the default security group).
+//   - For the default security group a rule which allows intercommunication
+//     among hosts associated with the default security group is defined by default.
+//   - As a result, all egress traffic and intercommunication in the default
+//     group are allowed and all ingress from outside of the default group is
+//     dropped by default (in the default security group).
 package security

--- a/openstack/networking/v2/extensions/vlantransparent/doc.go
+++ b/openstack/networking/v2/extensions/vlantransparent/doc.go
@@ -4,33 +4,33 @@ with the vlan-transparent extension through the Neutron API.
 
 Example of Listing Networks with the vlan-transparent extension
 
-    iTrue := true
-    networkListOpts := networks.ListOpts{}
-    listOpts := vlantransparent.ListOptsExt{
-        ListOptsBuilder: networkListOpts,
-        VLANTransparent: &iTrue,
-    }
+	    iTrue := true
+	    networkListOpts := networks.ListOpts{}
+	    listOpts := vlantransparent.ListOptsExt{
+	        ListOptsBuilder: networkListOpts,
+	        VLANTransparent: &iTrue,
+	    }
 
-    type NetworkWithVLANTransparentExt struct {
-        networks.Network
-        vlantransparent.NetworkVLANTransparentExt
-    }
+	    type NetworkWithVLANTransparentExt struct {
+	        networks.Network
+	        vlantransparent.NetworkVLANTransparentExt
+	    }
 
-    var allNetworks []NetworkWithVLANTransparentExt
+	    var allNetworks []NetworkWithVLANTransparentExt
 
-    allPages, err := networks.List(networkClient, listOpts).AllPages()
-    if err != nil {
-        panic(err)
-    }
+	    allPages, err := networks.List(networkClient, listOpts).AllPages()
+	    if err != nil {
+	        panic(err)
+	    }
 
-    err = networks.ExtractNetworksInto(allPages, &allNetworks)
-    if err != nil {
-        panic(err)
-    }
+	    err = networks.ExtractNetworksInto(allPages, &allNetworks)
+	    if err != nil {
+	        panic(err)
+	    }
 
-    for _, network := range allNetworks {
-        fmt.Printf("%+v\n", network)
-	}
+	    for _, network := range allNetworks {
+	        fmt.Printf("%+v\n", network)
+		}
 
 Example of Getting a Network with the vlan-transparent extension
 

--- a/openstack/networking/v2/extensions/vpnaas/ikepolicies/doc.go
+++ b/openstack/networking/v2/extensions/vpnaas/ikepolicies/doc.go
@@ -2,7 +2,6 @@
 Package ikepolicies allows management and retrieval of IKE policies in the
 OpenStack Networking Service.
 
-
 Example to Create an IKE policy
 
 	createOpts := ikepolicies.CreateOpts{
@@ -23,7 +22,6 @@ Example to Show the details of a specific IKE policy by ID
 	if err != nil {
 		panic(err)
 	}
-
 
 Example to Delete a Policy
 
@@ -47,7 +45,6 @@ Example to Update an IKE policy
 		panic(err)
 	}
 
-
 Example to List IKE policies
 
 	allPages, err := ikepolicies.List(client, nil).AllPages()
@@ -59,6 +56,5 @@ Example to List IKE policies
 	if err != nil {
 		panic(err)
 	}
-
 */
 package ikepolicies

--- a/openstack/networking/v2/extensions/vpnaas/ipsecpolicies/doc.go
+++ b/openstack/networking/v2/extensions/vpnaas/ipsecpolicies/doc.go
@@ -51,6 +51,5 @@ Example to List IPSec policies
 	if err != nil {
 		panic(err)
 	}
-
 */
 package ipsecpolicies

--- a/openstack/networking/v2/extensions/vpnaas/services/doc.go
+++ b/openstack/networking/v2/extensions/vpnaas/services/doc.go
@@ -63,6 +63,5 @@ Example to Show the details of a specific Service by ID
 	if err != nil {
 		panic(err)
 	}
-
 */
 package services

--- a/openstack/networking/v2/extensions/vpnaas/siteconnections/doc.go
+++ b/openstack/networking/v2/extensions/vpnaas/siteconnections/doc.go
@@ -2,27 +2,26 @@
 Package siteconnections allows management and retrieval of IPSec site connections in the
 OpenStack Networking Service.
 
+# Example to create an IPSec site connection
 
-Example to create an IPSec site connection
-
-createOpts := siteconnections.CreateOpts{
-		Name:           "Connection1",
-		PSK:            "secret",
-		Initiator:      siteconnections.InitiatorBiDirectional,
-		AdminStateUp:   gophercloud.Enabled,
-		IPSecPolicyID:  "4ab0a72e-64ef-4809-be43-c3f7e0e5239b",
-		PeerEPGroupID:  "5f5801b1-b383-4cf0-bf61-9e85d4044b2d",
-		IKEPolicyID:    "47a880f9-1da9-468c-b289-219c9eca78f0",
-		VPNServiceID:   "692c1ec8-a7cd-44d9-972b-8ed3fe4cc476",
-		LocalEPGroupID: "498bb96a-1517-47ea-b1eb-c4a53db46a16",
-		PeerAddress:    "172.24.4.233",
-		PeerID:         "172.24.4.233",
-		MTU:            1500,
-	}
-	connection, err := siteconnections.Create(client, createOpts).Extract()
-	if err != nil {
-		panic(err)
-	}
+	createOpts := siteconnections.CreateOpts{
+			Name:           "Connection1",
+			PSK:            "secret",
+			Initiator:      siteconnections.InitiatorBiDirectional,
+			AdminStateUp:   gophercloud.Enabled,
+			IPSecPolicyID:  "4ab0a72e-64ef-4809-be43-c3f7e0e5239b",
+			PeerEPGroupID:  "5f5801b1-b383-4cf0-bf61-9e85d4044b2d",
+			IKEPolicyID:    "47a880f9-1da9-468c-b289-219c9eca78f0",
+			VPNServiceID:   "692c1ec8-a7cd-44d9-972b-8ed3fe4cc476",
+			LocalEPGroupID: "498bb96a-1517-47ea-b1eb-c4a53db46a16",
+			PeerAddress:    "172.24.4.233",
+			PeerID:         "172.24.4.233",
+			MTU:            1500,
+		}
+		connection, err := siteconnections.Create(client, createOpts).Extract()
+		if err != nil {
+			panic(err)
+		}
 
 Example to Show the details of a specific IPSec site connection by ID
 
@@ -63,6 +62,5 @@ Example to Update an IPSec site connection
 	if err != nil {
 		panic(err)
 	}
-
 */
 package siteconnections

--- a/openstack/objectstorage/v1/accounts/doc.go
+++ b/openstack/objectstorage/v1/accounts/doc.go
@@ -24,6 +24,5 @@ Example to Update an Account
 
 	updateResult, err := accounts.Update(objectStorageClient, updateOpts).Extract()
 	fmt.Printf("%+v\n", updateResult)
-
 */
 package accounts

--- a/openstack/orchestration/v1/resourcetypes/doc.go
+++ b/openstack/orchestration/v1/resourcetypes/doc.go
@@ -5,17 +5,17 @@ customised to use as provider templates.
 
 Example of listing available resource types:
 
-    listOpts := resourcetypes.ListOpts{
-        SupportStatus: resourcetypes.SupportStatusSupported,
-    }
+	listOpts := resourcetypes.ListOpts{
+	    SupportStatus: resourcetypes.SupportStatusSupported,
+	}
 
-    resourceTypes, err := resourcetypes.List(client, listOpts).Extract()
-    if err != nil {
-        panic(err)
-    }
-    fmt.Println("Get Resource Type List")
-    for _, rt := range resTypes {
-        fmt.Println(rt.ResourceType)
-    }
+	resourceTypes, err := resourcetypes.List(client, listOpts).Extract()
+	if err != nil {
+	    panic(err)
+	}
+	fmt.Println("Get Resource Type List")
+	for _, rt := range resTypes {
+	    fmt.Println(rt.ResourceType)
+	}
 */
 package resourcetypes

--- a/openstack/orchestration/v1/stackevents/doc.go
+++ b/openstack/orchestration/v1/stackevents/doc.go
@@ -5,15 +5,15 @@ updating and abandoning.
 
 Example for list events for a stack
 
-    pages, err := stackevents.List(client, stack.Name, stack.ID, nil).AllPages()
-    if err != nil {
-        panic(err)
-    }
-    events, err := stackevents.ExtractEvents(pages)
-    if err != nil {
-        panic(err)
-    }
-    fmt.Println("Get Event List")
-    fmt.Println(events)
+	pages, err := stackevents.List(client, stack.Name, stack.ID, nil).AllPages()
+	if err != nil {
+	    panic(err)
+	}
+	events, err := stackevents.ExtractEvents(pages)
+	if err != nil {
+	    panic(err)
+	}
+	fmt.Println("Get Event List")
+	fmt.Println(events)
 */
 package stackevents

--- a/openstack/orchestration/v1/stackresources/doc.go
+++ b/openstack/orchestration/v1/stackresources/doc.go
@@ -6,66 +6,65 @@ balancer, some configuration management system, and so forth).
 
 Example of get resource information in stack
 
-    rsrc_result := stackresources.Get(client, stack.Name, stack.ID, rsrc.Name)
-    if rsrc_result.Err != nil {
-        panic(rsrc_result.Err)
-    }
-    rsrc, err := rsrc_result.Extract()
-    if err != nil {
-        panic(err)
-    }
+	rsrc_result := stackresources.Get(client, stack.Name, stack.ID, rsrc.Name)
+	if rsrc_result.Err != nil {
+	    panic(rsrc_result.Err)
+	}
+	rsrc, err := rsrc_result.Extract()
+	if err != nil {
+	    panic(err)
+	}
 
 Example for list stack resources
 
-    all_stack_rsrc_pages, err := stackresources.List(client, stack.Name, stack.ID, nil).AllPages()
-    if err != nil {
-        panic(err)
-    }
+	all_stack_rsrc_pages, err := stackresources.List(client, stack.Name, stack.ID, nil).AllPages()
+	if err != nil {
+	    panic(err)
+	}
 
-    all_stack_rsrcs, err := stackresources.ExtractResources(all_stack_rsrc_pages)
-    if err != nil {
-        panic(err)
-    }
+	all_stack_rsrcs, err := stackresources.ExtractResources(all_stack_rsrc_pages)
+	if err != nil {
+	    panic(err)
+	}
 
-    fmt.Println("Resource List:")
-    for _, rsrc := range all_stack_rsrcs {
-        // Get information of a resource in stack
-        rsrc_result := stackresources.Get(client, stack.Name, stack.ID, rsrc.Name)
-        if rsrc_result.Err != nil {
-            panic(rsrc_result.Err)
-        }
-        rsrc, err := rsrc_result.Extract()
-        if err != nil {
-            panic(err)
-        }
-        fmt.Println("Resource Name: ", rsrc.Name, ", Physical ID: ", rsrc.PhysicalID, ", Status: ", rsrc.Status)
-    }
-
+	fmt.Println("Resource List:")
+	for _, rsrc := range all_stack_rsrcs {
+	    // Get information of a resource in stack
+	    rsrc_result := stackresources.Get(client, stack.Name, stack.ID, rsrc.Name)
+	    if rsrc_result.Err != nil {
+	        panic(rsrc_result.Err)
+	    }
+	    rsrc, err := rsrc_result.Extract()
+	    if err != nil {
+	        panic(err)
+	    }
+	    fmt.Println("Resource Name: ", rsrc.Name, ", Physical ID: ", rsrc.PhysicalID, ", Status: ", rsrc.Status)
+	}
 
 Example for get resource type schema
 
-    schema_result := stackresources.Schema(client, "OS::Heat::Stack")
-    if schema_result.Err != nil {
-        panic(schema_result.Err)
-    }
-    schema, err := schema_result.Extract()
-    if err != nil {
-        panic(err)
-    }
-    fmt.Println("Schema for resource type OS::Heat::Stack")
-    fmt.Println(schema.SupportStatus)
+	schema_result := stackresources.Schema(client, "OS::Heat::Stack")
+	if schema_result.Err != nil {
+	    panic(schema_result.Err)
+	}
+	schema, err := schema_result.Extract()
+	if err != nil {
+	    panic(err)
+	}
+	fmt.Println("Schema for resource type OS::Heat::Stack")
+	fmt.Println(schema.SupportStatus)
 
 Example for get resource type Template
 
-    tmp_result := stackresources.Template(client, "OS::Heat::Stack")
-    if tmp_result.Err != nil {
-        panic(tmp_result.Err)
-    }
-    tmp, err := tmp_result.Extract()
-    if err != nil {
-        panic(err)
-    }
-    fmt.Println("Template for resource type OS::Heat::Stack")
-    fmt.Println(string(tmp))
+	tmp_result := stackresources.Template(client, "OS::Heat::Stack")
+	if tmp_result.Err != nil {
+	    panic(tmp_result.Err)
+	}
+	tmp, err := tmp_result.Extract()
+	if err != nil {
+	    panic(err)
+	}
+	fmt.Println("Template for resource type OS::Heat::Stack")
+	fmt.Println(string(tmp))
 */
 package stackresources

--- a/openstack/orchestration/v1/stacks/doc.go
+++ b/openstack/orchestration/v1/stacks/doc.go
@@ -7,109 +7,111 @@ application framework or component specified (in the template). A stack is a
 running instance of a template. The result of creating a stack is a deployment
 of the application framework or component.
 
-Prepare required import packages
+# Prepare required import packages
 
 import (
-  "fmt"
-  "github.com/gophercloud/gophercloud"
-  "github.com/gophercloud/gophercloud/openstack"
-  "github.com/gophercloud/gophercloud/openstack/orchestration/v1/stacks"
+
+	"fmt"
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack"
+	"github.com/gophercloud/gophercloud/openstack/orchestration/v1/stacks"
+
 )
 
 Example of Preparing Orchestration client:
 
-    client, err := openstack.NewOrchestrationV1(provider,  gophercloud.EndpointOpts{Region: "RegionOne"})
+	client, err := openstack.NewOrchestrationV1(provider,  gophercloud.EndpointOpts{Region: "RegionOne"})
 
 Example of List Stack:
-    all_stack_pages, err := stacks.List(client, nil).AllPages()
-    if err != nil {
-        panic(err)
-    }
 
-    all_stacks, err := stacks.ExtractStacks(all_stack_pages)
-    if err != nil {
-        panic(err)
-    }
+	all_stack_pages, err := stacks.List(client, nil).AllPages()
+	if err != nil {
+	    panic(err)
+	}
 
-    for _, stack := range all_stacks {
-        fmt.Printf("%+v\n", stack)
-    }
+	all_stacks, err := stacks.ExtractStacks(all_stack_pages)
+	if err != nil {
+	    panic(err)
+	}
 
+	for _, stack := range all_stacks {
+	    fmt.Printf("%+v\n", stack)
+	}
 
 Example to Create an Stack
 
-    // Create Template
-    t := make(map[string]interface{})
-    f, err := ioutil.ReadFile("template.yaml")
-    if err != nil {
-        panic(err)
-    }
-    err = yaml.Unmarshal(f, t)
-    if err != nil {
-        panic(err)
-    }
+	// Create Template
+	t := make(map[string]interface{})
+	f, err := ioutil.ReadFile("template.yaml")
+	if err != nil {
+	    panic(err)
+	}
+	err = yaml.Unmarshal(f, t)
+	if err != nil {
+	    panic(err)
+	}
 
-    template := &stacks.Template{}
-    template.TE = stacks.TE{
-        Bin: f,
-    }
-    // Create Environment if needed
-    t_env := make(map[string]interface{})
-    f_env, err := ioutil.ReadFile("env.yaml")
-    if err != nil {
-        panic(err)
-    }
-    err = yaml.Unmarshal(f_env, t_env)
-    if err != nil {
-        panic(err)
-    }
+	template := &stacks.Template{}
+	template.TE = stacks.TE{
+	    Bin: f,
+	}
+	// Create Environment if needed
+	t_env := make(map[string]interface{})
+	f_env, err := ioutil.ReadFile("env.yaml")
+	if err != nil {
+	    panic(err)
+	}
+	err = yaml.Unmarshal(f_env, t_env)
+	if err != nil {
+	    panic(err)
+	}
 
-    env := &stacks.Environment{}
-    env.TE = stacks.TE{
-        Bin: f_env,
-    }
+	env := &stacks.Environment{}
+	env.TE = stacks.TE{
+	    Bin: f_env,
+	}
 
-    // Remember, the priority of parameters you given through
-    // Parameters is higher than the parameters you provided in EnvironmentOpts.
-    params := make(map[string]string)
-    params["number_of_nodes"] = 1
-    tags := []string{"example-stack"}
-    createOpts := &stacks.CreateOpts{
-        // The name of the stack. It must start with an alphabetic character.
-        Name:       "testing_group",
-        // A structure that contains either the template file or url. Call the
-        // associated methods to extract the information relevant to send in a create request.
-        TemplateOpts: template,
-        // A structure that contains details for the environment of the stack.
-        EnvironmentOpts: env,
-        // User-defined parameters to pass to the template.
-        Parameters: params,
-        // A list of tags to assosciate with the Stack
-        Tags: tags,
-    }
+	// Remember, the priority of parameters you given through
+	// Parameters is higher than the parameters you provided in EnvironmentOpts.
+	params := make(map[string]string)
+	params["number_of_nodes"] = 1
+	tags := []string{"example-stack"}
+	createOpts := &stacks.CreateOpts{
+	    // The name of the stack. It must start with an alphabetic character.
+	    Name:       "testing_group",
+	    // A structure that contains either the template file or url. Call the
+	    // associated methods to extract the information relevant to send in a create request.
+	    TemplateOpts: template,
+	    // A structure that contains details for the environment of the stack.
+	    EnvironmentOpts: env,
+	    // User-defined parameters to pass to the template.
+	    Parameters: params,
+	    // A list of tags to assosciate with the Stack
+	    Tags: tags,
+	}
 
-    r := stacks.Create(client, createOpts)
-    //dcreated_stack := stacks.CreatedStack()
-    if r.Err != nil {
-        panic(r.Err)
-    }
-    created_stack, err := r.Extract()
-    if err != nil {
-        panic(err)
-    }
-    fmt.Printf("Created Stack: %v", created_stack.ID)
+	r := stacks.Create(client, createOpts)
+	//dcreated_stack := stacks.CreatedStack()
+	if r.Err != nil {
+	    panic(r.Err)
+	}
+	created_stack, err := r.Extract()
+	if err != nil {
+	    panic(err)
+	}
+	fmt.Printf("Created Stack: %v", created_stack.ID)
 
 Example for Get Stack
 
-    get_result := stacks.Get(client, stackName, created_stack.ID)
-    if get_result.Err != nil {
-        panic(get_result.Err)
-    }
-    stack, err := get_result.Extract()
-    if err != nil {
-        panic(err)
-    }
-    fmt.Println("Get Stack: Name: ", stack.Name, ", ID: ", stack.ID, ", Status: ", stack.Status)
+	get_result := stacks.Get(client, stackName, created_stack.ID)
+	if get_result.Err != nil {
+	    panic(get_result.Err)
+	}
+	stack, err := get_result.Extract()
+	if err != nil {
+	    panic(err)
+	}
+	fmt.Println("Get Stack: Name: ", stack.Name, ", ID: ", stack.ID, ", Status: ", stack.Status)
 
 Example for Find Stack
 
@@ -125,15 +127,15 @@ Example for Find Stack
 
 Example for Delete Stack
 
-    del_r := stacks.Delete(client, stackName, created_stack.ID)
-    if del_r.Err != nil {
-        panic(del_r.Err)
-    }
-    fmt.Println("Deleted Stack: ", stackName)
+	del_r := stacks.Delete(client, stackName, created_stack.ID)
+	if del_r.Err != nil {
+	    panic(del_r.Err)
+	}
+	fmt.Println("Deleted Stack: ", stackName)
 
 Summary of  Behavior Between Stack Update and UpdatePatch Methods :
 
-Function | Test Case | Result
+# Function | Test Case | Result
 
 Update()	| Template AND Parameters WITH Conflict | Parameter takes priority, parameters are set in raw_template.environment overlay
 Update()	| Template ONLY | Template updates, raw_template.environment overlay is removed

--- a/openstack/orchestration/v1/stacks/requests.go
+++ b/openstack/orchestration/v1/stacks/requests.go
@@ -404,7 +404,8 @@ func toStackUpdateMap(opts UpdateOpts) (map[string]interface{}, error) {
 }
 
 // Update accepts an UpdateOpts struct and updates an existing stack using the
-//  http PUT verb with the values provided. opts.TemplateOpts is required.
+//
+//	http PUT verb with the values provided. opts.TemplateOpts is required.
 func Update(c *gophercloud.ServiceClient, stackName, stackID string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToStackUpdateMap()
 	if err != nil {
@@ -417,7 +418,8 @@ func Update(c *gophercloud.ServiceClient, stackName, stackID string, opts Update
 }
 
 // Update accepts an UpdateOpts struct and updates an existing stack using the
-//  http PATCH verb with the values provided. opts.TemplateOpts is not required.
+//
+//	http PATCH verb with the values provided. opts.TemplateOpts is not required.
 func UpdatePatch(c *gophercloud.ServiceClient, stackName, stackID string, opts UpdatePatchOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToStackUpdatePatchMap()
 	if err != nil {

--- a/openstack/orchestration/v1/stacktemplates/doc.go
+++ b/openstack/orchestration/v1/stacktemplates/doc.go
@@ -9,30 +9,29 @@ specific application stack.
 
 Example to get stack template
 
-    temp, err := stacktemplates.Get(client, stack.Name, stack.ID).Extract()
-    if err != nil {
-        panic(err)
-    }
-    fmt.Println("Get Stack Template for Stack ", stack.Name)
-    fmt.Println(string(temp))
+	temp, err := stacktemplates.Get(client, stack.Name, stack.ID).Extract()
+	if err != nil {
+	    panic(err)
+	}
+	fmt.Println("Get Stack Template for Stack ", stack.Name)
+	fmt.Println(string(temp))
 
 Example to validate stack template
 
-    f2, err := ioutil.ReadFile("template.err.yaml")
-    if err != nil {
-        panic(err)
-    }
-    fmt.Println(string(f2))
-    validateOpts := &stacktemplates.ValidateOpts{
-        Template: string(f2),
-    }
-    validate_result, err := stacktemplates.Validate(client, validateOpts).Extract()
-    if err != nil {
-        // If validate failed, you will get error message here
-        fmt.Println("Validate failed: ", err.Error())
-    } else {
-        fmt.Println(validate_result.Parameters)
-    }
-
+	f2, err := ioutil.ReadFile("template.err.yaml")
+	if err != nil {
+	    panic(err)
+	}
+	fmt.Println(string(f2))
+	validateOpts := &stacktemplates.ValidateOpts{
+	    Template: string(f2),
+	}
+	validate_result, err := stacktemplates.Validate(client, validateOpts).Extract()
+	if err != nil {
+	    // If validate failed, you will get error message here
+	    fmt.Println("Validate failed: ", err.Error())
+	} else {
+	    fmt.Println(validate_result.Parameters)
+	}
 */
 package stacktemplates

--- a/openstack/placement/v1/resourceproviders/doc.go
+++ b/openstack/placement/v1/resourceproviders/doc.go
@@ -88,6 +88,5 @@ Example to get resource providers allocations
 	if err != nil {
 		panic(err)
 	}
-
 */
 package resourceproviders

--- a/openstack/sharedfilesystems/v2/shares/doc.go
+++ b/openstack/sharedfilesystems/v2/shares/doc.go
@@ -6,6 +6,7 @@ For more information, see:
 https://docs.openstack.org/api-ref/shared-file-system/
 
 Example to Revert a Share to a Snapshot ID
+
 	opts := &shares.RevertOpts{
 		// snapshot ID to revert to
 		SnapshotID: "ddeac769-9742-497f-b985-5bcfa94a3fd6",
@@ -17,6 +18,7 @@ Example to Revert a Share to a Snapshot ID
 	}
 
 Example to Reset a Share Status
+
 	opts := &shares.ResetStatusOpts{
 		// a new Share Status
 		Status: "available",
@@ -28,6 +30,7 @@ Example to Reset a Share Status
 	}
 
 Example to Force Delete a Share
+
 	manilaClient.Microversion = "2.7"
 	err := shares.ForceDelete(manilaClient, shareID).ExtractErr()
 	if err != nil {
@@ -35,11 +38,11 @@ Example to Force Delete a Share
 	}
 
 Example to Unmanage a Share
+
 	manilaClient.Microversion = "2.7"
 	err := shares.Unmanage(manilaClient, shareID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
-
 */
 package shares

--- a/openstack/utils/testing/doc.go
+++ b/openstack/utils/testing/doc.go
@@ -1,2 +1,2 @@
-//utils
+// utils
 package testing

--- a/openstack/workflow/v2/crontriggers/doc.go
+++ b/openstack/workflow/v2/crontriggers/doc.go
@@ -4,7 +4,7 @@ Package crontriggers provides interaction with the cron triggers API in the Open
 Cron trigger is an object that allows to run Mistral workflows according to a time pattern (Unix crontab patterns format).
 Once a trigger is created it will run a specified workflow according to its properties: pattern, first_execution_time and remaining_executions.
 
-List cron triggers
+# List cron triggers
 
 To filter cron triggers from a list request, you can use advanced filters with special FilterType to check for equality, non equality, values greater or lower, etc.
 Default Filter checks equality, but you can override it with provided filter type.
@@ -68,6 +68,5 @@ Delete a cron trigger
 	if res.Err != nil {
 		panic(res.Err)
 	}
-
 */
 package crontriggers

--- a/openstack/workflow/v2/executions/doc.go
+++ b/openstack/workflow/v2/executions/doc.go
@@ -5,7 +5,7 @@ An execution is a one-shot execution of a specific workflow. Each execution cont
 
 An execution represents also the execution of a cron trigger. Each run of a cron trigger will generate an execution.
 
-List executions
+# List executions
 
 To filter executions from a list request, you can use advanced filters with special FilterType to check for equality, non equality, values greater or lower, etc.
 Default Filter checks equality, but you can override it with provided filter type.
@@ -65,6 +65,5 @@ Delete an execution
 	if res.Err != nil {
 		panic(res.Err)
 	}
-
 */
 package executions

--- a/openstack/workflow/v2/workflows/doc.go
+++ b/openstack/workflow/v2/workflows/doc.go
@@ -37,31 +37,31 @@ Get a workflow
 
 Create a workflow
 
-	workflowDefinition := `---
-      version: '2.0'
+		workflowDefinition := `---
+	      version: '2.0'
 
-      workflow_echo:
-        description: Simple workflow example
-        type: direct
-        input:
-          - msg
+	      workflow_echo:
+	        description: Simple workflow example
+	        type: direct
+	        input:
+	          - msg
 
-        tasks:
-          test:
-            action: std.echo output="<% $.msg %>"`
+	        tasks:
+	          test:
+	            action: std.echo output="<% $.msg %>"`
 
-	createOpts := &workflows.CreateOpts{
-		Definition: strings.NewReader(workflowDefinition),
-		Scope: "private",
-		Namespace: "some-namespace",
-	}
+		createOpts := &workflows.CreateOpts{
+			Definition: strings.NewReader(workflowDefinition),
+			Scope: "private",
+			Namespace: "some-namespace",
+		}
 
-	workflow, err := workflows.Create(mistralClient, createOpts).Extract()
-	if err != nil {
-		panic(err)
-	}
+		workflow, err := workflows.Create(mistralClient, createOpts).Extract()
+		if err != nil {
+			panic(err)
+		}
 
-	fmt.Printf("%+v\n", workflow)
+		fmt.Printf("%+v\n", workflow)
 
 Delete a workflow
 

--- a/params.go
+++ b/params.go
@@ -15,17 +15,17 @@ BuildRequestBody builds a map[string]interface from the given `struct`. If
 parent is not an empty string, the final map[string]interface returned will
 encapsulate the built one. For example:
 
-  disk := 1
-  createOpts := flavors.CreateOpts{
-    ID:         "1",
-    Name:       "m1.tiny",
-    Disk:       &disk,
-    RAM:        512,
-    VCPUs:      1,
-    RxTxFactor: 1.0,
-  }
+	disk := 1
+	createOpts := flavors.CreateOpts{
+	  ID:         "1",
+	  Name:       "m1.tiny",
+	  Disk:       &disk,
+	  RAM:        512,
+	  VCPUs:      1,
+	  RxTxFactor: 1.0,
+	}
 
-  body, err := gophercloud.BuildRequestBody(createOpts, "flavor")
+	body, err := gophercloud.BuildRequestBody(createOpts, "flavor")
 
 The above example can be run as-is, however it is recommended to look at how
 BuildRequestBody is used within Gophercloud to more fully understand how it
@@ -401,22 +401,22 @@ It accepts an arbitrary tagged structure and produces a string map that's
 suitable for use as the HTTP headers of an outgoing request. Field names are
 mapped to header names based in "h" tags.
 
-  type struct Something {
-    Bar string `h:"x_bar"`
-    Baz int    `h:"lorem_ipsum"`
-  }
+	type struct Something {
+	  Bar string `h:"x_bar"`
+	  Baz int    `h:"lorem_ipsum"`
+	}
 
-  instance := Something{
-    Bar: "AAA",
-    Baz: "BBB",
-  }
+	instance := Something{
+	  Bar: "AAA",
+	  Baz: "BBB",
+	}
 
 will be converted into:
 
-  map[string]string{
-    "x_bar": "AAA",
-    "lorem_ipsum": "BBB",
-  }
+	map[string]string{
+	  "x_bar": "AAA",
+	  "lorem_ipsum": "BBB",
+	}
 
 Untagged fields and fields left at their zero values are skipped. Integers,
 booleans and string values are supported.


### PR DESCRIPTION
With go 1.19, automated go formatting with `go fmt` applies to comments
as well. This caused the unit test job to fail on new PRs. Let's apply
the go 1.19 formatting to the whole code base.

Fixes #2449 