### PR TITLE
Add description to flavor

### DIFF
--- a/acceptance/openstack/compute/v2/compute.go
+++ b/acceptance/openstack/compute/v2/compute.go
@@ -208,15 +208,20 @@ func CreateDefaultRule(t *testing.T, client *gophercloud.ServiceClient) (dsr.Def
 // An error will be returned if the flavor could not be created.
 func CreateFlavor(t *testing.T, client *gophercloud.ServiceClient) (*flavors.Flavor, error) {
 	flavorName := tools.RandomString("flavor_", 5)
+	flavorDescription := fmt.Sprintf("I am %s and i am a yummy flavor", flavorName)
+
+	// Microversion 2.55 is required to add description to flavor
+	client.Microversion = "2.55"
 	t.Logf("Attempting to create flavor %s", flavorName)
 
 	isPublic := true
 	createOpts := flavors.CreateOpts{
-		Name:     flavorName,
-		RAM:      1,
-		VCPUs:    1,
-		Disk:     gophercloud.IntToPointer(1),
-		IsPublic: &isPublic,
+		Name:        flavorName,
+		RAM:         1,
+		VCPUs:       1,
+		Disk:        gophercloud.IntToPointer(1),
+		IsPublic:    &isPublic,
+		Description: flavorDescription,
 	}
 
 	flavor, err := flavors.Create(client, createOpts).Extract()
@@ -231,6 +236,7 @@ func CreateFlavor(t *testing.T, client *gophercloud.ServiceClient) (*flavors.Fla
 	th.AssertEquals(t, flavor.Disk, 1)
 	th.AssertEquals(t, flavor.VCPUs, 1)
 	th.AssertEquals(t, flavor.IsPublic, true)
+	th.AssertEquals(t, flavor.Description, flavorDescription)
 
 	return flavor, nil
 }

--- a/openstack/compute/v2/flavors/requests.go
+++ b/openstack/compute/v2/flavors/requests.go
@@ -128,6 +128,11 @@ type CreateOpts struct {
 
 	// Ephemeral is the amount of ephemeral disk space, measured in GB.
 	Ephemeral *int `json:"OS-FLV-EXT-DATA:ephemeral,omitempty"`
+
+	// Description is a free form description of the flavor. Limited to
+	// 65535 characters in length. Only printable characters are allowed.
+	// New in version 2.55
+	Description string `json:"description,omitempty"`
 }
 
 // ToFlavorCreateMap constructs a request body from CreateOpts.

--- a/openstack/compute/v2/flavors/results.go
+++ b/openstack/compute/v2/flavors/results.go
@@ -69,6 +69,11 @@ type Flavor struct {
 
 	// Ephemeral is the amount of ephemeral disk space, measured in GB.
 	Ephemeral int `json:"OS-FLV-EXT-DATA:ephemeral"`
+
+	// Description is a free form description of the flavor. Limited to
+	// 65535 characters in length. Only printable characters are allowed.
+	// New in version 2.55
+	Description string `json:"description"`
 }
 
 func (r *Flavor) UnmarshalJSON(b []byte) error {

--- a/openstack/compute/v2/flavors/testing/requests_test.go
+++ b/openstack/compute/v2/flavors/testing/requests_test.go
@@ -38,7 +38,8 @@ func TestListFlavors(t *testing.T) {
 								"ram": 9216000,
 								"swap":"",
 								"os-flavor-access:is_public": true,
-								"OS-FLV-EXT-DATA:ephemeral": 10
+								"OS-FLV-EXT-DATA:ephemeral": 10,
+								"description": "foo"
 							},
 							{
 								"id": "2",
@@ -87,7 +88,7 @@ func TestListFlavors(t *testing.T) {
 		}
 
 		expected := []flavors.Flavor{
-			{ID: "1", Name: "m1.tiny", VCPUs: 1, Disk: 1, RAM: 9216000, Swap: 0, IsPublic: true, Ephemeral: 10},
+			{ID: "1", Name: "m1.tiny", VCPUs: 1, Disk: 1, RAM: 9216000, Swap: 0, IsPublic: true, Ephemeral: 10, Description: "foo"},
 			{ID: "2", Name: "m1.small", VCPUs: 1, Disk: 20, RAM: 2048, Swap: 1000, IsPublic: true, Ephemeral: 0},
 			{ID: "3", Name: "m1.medium", VCPUs: 2, Disk: 40, RAM: 4096, Swap: 1000, IsPublic: false, Ephemeral: 0},
 		}
@@ -124,7 +125,8 @@ func TestGetFlavor(t *testing.T) {
 					"ram": 512,
 					"vcpus": 1,
 					"rxtx_factor": 1,
-					"swap": ""
+					"swap": "",
+					"description": "foo"
 				}
 			}
 		`)
@@ -136,13 +138,14 @@ func TestGetFlavor(t *testing.T) {
 	}
 
 	expected := &flavors.Flavor{
-		ID:         "1",
-		Name:       "m1.tiny",
-		Disk:       1,
-		RAM:        512,
-		VCPUs:      1,
-		RxTxFactor: 1,
-		Swap:       0,
+		ID:          "1",
+		Name:        "m1.tiny",
+		Disk:        1,
+		RAM:         512,
+		VCPUs:       1,
+		RxTxFactor:  1,
+		Swap:        0,
+		Description: "foo",
 	}
 	if !reflect.DeepEqual(expected, actual) {
 		t.Errorf("Expected %#v, but was %#v", expected, actual)
@@ -167,7 +170,8 @@ func TestCreateFlavor(t *testing.T) {
 					"ram": 512,
 					"vcpus": 1,
 					"rxtx_factor": 1,
-					"swap": ""
+					"swap": "",
+					"description": "foo"
 				}
 			}
 		`)
@@ -175,12 +179,13 @@ func TestCreateFlavor(t *testing.T) {
 
 	disk := 1
 	opts := &flavors.CreateOpts{
-		ID:         "1",
-		Name:       "m1.tiny",
-		Disk:       &disk,
-		RAM:        512,
-		VCPUs:      1,
-		RxTxFactor: 1.0,
+		ID:          "1",
+		Name:        "m1.tiny",
+		Disk:        &disk,
+		RAM:         512,
+		VCPUs:       1,
+		RxTxFactor:  1.0,
+		Description: "foo",
 	}
 	actual, err := flavors.Create(fake.ServiceClient(), opts).Extract()
 	if err != nil {
@@ -188,13 +193,14 @@ func TestCreateFlavor(t *testing.T) {
 	}
 
 	expected := &flavors.Flavor{
-		ID:         "1",
-		Name:       "m1.tiny",
-		Disk:       1,
-		RAM:        512,
-		VCPUs:      1,
-		RxTxFactor: 1,
-		Swap:       0,
+		ID:          "1",
+		Name:        "m1.tiny",
+		Disk:        1,
+		RAM:         512,
+		VCPUs:       1,
+		RxTxFactor:  1,
+		Swap:        0,
+		Description: "foo",
 	}
 	if !reflect.DeepEqual(expected, actual) {
 		t.Errorf("Expected %#v, but was %#v", expected, actual)


### PR DESCRIPTION
Add description to flavors which has been added as an optional
attribute since nova 2.55 (Queens).

Fixes #2452 

[Docs](https://docs.openstack.org/api-ref/compute/#create-flavor)