### PR TITLE
keystone: add v3 limits create operation

### DIFF
--- a/acceptance/openstack/identity/v3/limits_test.go
+++ b/acceptance/openstack/identity/v3/limits_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gophercloud/gophercloud/acceptance/clients"
 	"github.com/gophercloud/gophercloud/acceptance/tools"
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/limits"
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/services"
 	th "github.com/gophercloud/gophercloud/testhelper"
 )
 
@@ -37,4 +38,45 @@ func TestLimitsList(t *testing.T) {
 
 	_, err = limits.ExtractLimits(allPages)
 	th.AssertNoErr(t, err)
+}
+
+func TestCreateLimits(t *testing.T) {
+	limitDescription := tools.RandomString("TESTLIMITS-DESC-", 8)
+	resourceLimit := tools.RandomInt(1, 100)
+	resourceName := "volume"
+
+	clients.RequireAdmin(t)
+
+	client, err := clients.NewIdentityV3Client()
+	th.AssertNoErr(t, err)
+
+	project, err := CreateProject(t, client, nil)
+	th.AssertNoErr(t, err)
+
+	createServiceOpts := &services.CreateOpts{
+		Type:  resourceName,
+		Extra: map[string]interface{}{},
+	}
+
+	service, err := CreateService(t, client, createServiceOpts)
+	th.AssertNoErr(t, err)
+
+	createOpts := limits.BatchCreateOpts{
+		limits.CreateOpts{
+			ServiceID:     service.ID,
+			ProjectID:     project.ID,
+			ResourceName:  resourceName,
+			ResourceLimit: resourceLimit,
+			Description:   limitDescription,
+		},
+	}
+
+	createdLimits, err := limits.BatchCreate(client, createOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertIntGreaterOrEqual(t, 1, len(createdLimits))
+	th.AssertEquals(t, limitDescription, createdLimits[0].Description)
+	th.AssertEquals(t, resourceLimit, createdLimits[0].ResourceLimit)
+	th.AssertEquals(t, resourceName, createdLimits[0].ResourceName)
+	th.AssertEquals(t, service.ID, createdLimits[0].ServiceID)
+	th.AssertEquals(t, project.ID, createdLimits[0].ProjectID)
 }

--- a/acceptance/openstack/identity/v3/limits_test.go
+++ b/acceptance/openstack/identity/v3/limits_test.go
@@ -42,6 +42,11 @@ func TestLimitsList(t *testing.T) {
 }
 
 func TestCreateLimits(t *testing.T) {
+	// TODO: After https://github.com/gophercloud/gophercloud/issues/2290 is implemented
+	// use registered limits API to create global registered limit and then overwrite it with limit.
+	// Current solution (using glance limit) only works with Openstack Xena and above.
+	clients.SkipReleasesBelow(t, "stable/xena")
+
 	err := os.Setenv("OS_SYSTEM_SCOPE", "all")
 	th.AssertNoErr(t, err)
 	defer os.Unsetenv("OS_SYSTEM_SCOPE")
@@ -59,7 +64,6 @@ func TestCreateLimits(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	// Find image service (glance on Devstack) which has precreated registered limits.
-	// TODO: Use registered limits API to create global limit and then overwrite it with limit.
 	allPages, err := services.List(client, nil).AllPages()
 	th.AssertNoErr(t, err)
 

--- a/acceptance/openstack/identity/v3/limits_test.go
+++ b/acceptance/openstack/identity/v3/limits_test.go
@@ -4,6 +4,7 @@
 package v3
 
 import (
+	"os"
 	"testing"
 
 	"github.com/gophercloud/gophercloud/acceptance/clients"
@@ -41,6 +42,10 @@ func TestLimitsList(t *testing.T) {
 }
 
 func TestCreateLimits(t *testing.T) {
+	err := os.Setenv("OS_SYSTEM_SCOPE", "all")
+	th.AssertNoErr(t, err)
+	defer os.Unsetenv("OS_SYSTEM_SCOPE")
+
 	limitDescription := tools.RandomString("TESTLIMITS-DESC-", 8)
 	resourceLimit := tools.RandomInt(1, 100)
 	resourceName := "image_size_total"
@@ -87,4 +92,5 @@ func TestCreateLimits(t *testing.T) {
 	th.AssertEquals(t, resourceName, createdLimits[0].ResourceName)
 	th.AssertEquals(t, serviceID, createdLimits[0].ServiceID)
 	th.AssertEquals(t, project.ID, createdLimits[0].ProjectID)
+
 }

--- a/openstack/auth_env.go
+++ b/openstack/auth_env.go
@@ -46,6 +46,7 @@ func AuthOptionsFromEnv() (gophercloud.AuthOptions, error) {
 	applicationCredentialID := os.Getenv("OS_APPLICATION_CREDENTIAL_ID")
 	applicationCredentialName := os.Getenv("OS_APPLICATION_CREDENTIAL_NAME")
 	applicationCredentialSecret := os.Getenv("OS_APPLICATION_CREDENTIAL_SECRET")
+	systemScope := os.Getenv("OS_SYSTEM_SCOPE")
 
 	// If OS_PROJECT_ID is set, overwrite tenantID with the value.
 	if v := os.Getenv("OS_PROJECT_ID"); v != "" {
@@ -109,6 +110,13 @@ func AuthOptionsFromEnv() (gophercloud.AuthOptions, error) {
 		}
 	}
 
+	var scope *gophercloud.AuthScope
+	if systemScope == "all" {
+		scope = &gophercloud.AuthScope{
+			System: true,
+		}
+	}
+
 	ao := gophercloud.AuthOptions{
 		IdentityEndpoint:            authURL,
 		UserID:                      userID,
@@ -122,6 +130,7 @@ func AuthOptionsFromEnv() (gophercloud.AuthOptions, error) {
 		ApplicationCredentialID:     applicationCredentialID,
 		ApplicationCredentialName:   applicationCredentialName,
 		ApplicationCredentialSecret: applicationCredentialSecret,
+		Scope:                       scope,
 	}
 
 	return ao, nil

--- a/openstack/identity/v3/limits/doc.go
+++ b/openstack/identity/v3/limits/doc.go
@@ -24,5 +24,29 @@ Example to List Limits
 	if err != nil {
 		panic(err)
 	}
+
+Example to Create Limits
+
+	batchCreateOpts := limits.BatchCreateOpts{
+		limits.CreateOpts{
+			ServiceID:     "9408080f1970482aa0e38bc2d4ea34b7",
+			ProjectID:     "3a705b9f56bb439381b43c4fe59dccce",
+			RegionID:      "RegionOne",
+			ResourceName:  "snapshot",
+			ResourceLimit: 5,
+		},
+		limits.CreateOpts{
+			ServiceID:     "9408080f1970482aa0e38bc2d4ea34b7",
+			DomainID:      "edbafc92be354ffa977c58aa79c7bdb2",
+			ResourceName:  "volume",
+			ResourceLimit: 10,
+			Description:   "Number of volumes for project 3a705b9f56bb439381b43c4fe59dccce",
+		},
+	}
+
+	createdLimits, err := limits.Create(identityClient, batchCreateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
 */
 package limits

--- a/openstack/identity/v3/limits/requests.go
+++ b/openstack/identity/v3/limits/requests.go
@@ -44,7 +44,7 @@ func (opts ListOpts) ToLimitListQuery() (string, error) {
 
 // List enumerates the limits.
 func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
-	url := listURL(client)
+	url := rootURL(client)
 	if opts != nil {
 		query, err := opts.ToLimitListQuery()
 		if err != nil {
@@ -55,4 +55,67 @@ func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pa
 	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
 		return LimitPage{pagination.LinkedPageBase{PageResult: r}}
 	})
+}
+
+// BatchCreateOptsBuilder allows extensions to add additional parameters to
+// the Create request.
+type BatchCreateOptsBuilder interface {
+	ToLimitsCreateMap() (map[string]interface{}, error)
+}
+
+type CreateOpts struct {
+	// RegionID is the ID of the region where the limit is applied.
+	RegionID string `json:"region_id,omitempty"`
+
+	// ProjectID is the ID of the project where the limit is applied.
+	ProjectID string `json:"project_id,omitempty"`
+
+	// DomainID is the ID of the domain where the limit is applied.
+	DomainID string `json:"domain_id,omitempty"`
+
+	// ServiceID is the ID of the service where the limit is applied.
+	ServiceID string `json:"service_id" required:"true"`
+
+	// Description of the limit.
+	Description string `json:"description,omitempty"`
+
+	// ResourceName is the name of the resource that the limit is applied to.
+	ResourceName string `json:"resource_name" required:"true"`
+
+	// ResourceLimit is the override limit.
+	ResourceLimit int `json:"resource_limit"`
+}
+
+// BatchCreateOpts provides options used to create limits.
+type BatchCreateOpts []CreateOpts
+
+// ToLimitsCreateMap formats a BatchCreateOpts into a create request.
+func (opts BatchCreateOpts) ToLimitsCreateMap() (map[string]interface{}, error) {
+	limits := make([]map[string]interface{}, len(opts))
+	for i, limit := range opts {
+		limitMap, err := limit.ToMap()
+		if err != nil {
+			return nil, err
+		}
+		limits[i] = limitMap
+	}
+	return map[string]interface{}{"limits": limits}, nil
+}
+
+func (opts CreateOpts) ToMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "")
+}
+
+// BatchCreate creates new Limits.
+func BatchCreate(client *gophercloud.ServiceClient, opts BatchCreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToLimitsCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := client.Post(rootURL(client), &b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{201},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
 }

--- a/openstack/identity/v3/limits/results.go
+++ b/openstack/identity/v3/limits/results.go
@@ -59,9 +59,20 @@ type Limit struct {
 	Links map[string]interface{} `json:"links"`
 }
 
+// A LimitsOutput is an array of limits returned by List and BatchCreate operations
+type LimitsOutput struct {
+	Limits []Limit `json:"limits"`
+}
+
 // LimitPage is a single page of Limit results.
 type LimitPage struct {
 	pagination.LinkedPageBase
+}
+
+// CreateResult is the response from a Create operation. Call its Extract method
+// to interpret it as a Limits.
+type CreateResult struct {
+	gophercloud.Result
 }
 
 // IsEmpty determines whether or not a page of Limits contains any results.
@@ -88,9 +99,14 @@ func (r LimitPage) NextPageURL() (string, error) {
 // ExtractLimits returns a slice of Limits contained in a single page of
 // results.
 func ExtractLimits(r pagination.Page) ([]Limit, error) {
-	var s struct {
-		Limits []Limit `json:"limits"`
-	}
-	err := (r.(LimitPage)).ExtractInto(&s)
-	return s.Limits, err
+	var out LimitsOutput
+	err := (r.(LimitPage)).ExtractInto(&out)
+	return out.Limits, err
+}
+
+// Extract interprets CreateResult as slice of Limits.
+func (r CreateResult) Extract() ([]Limit, error) {
+	var out LimitsOutput
+	err := r.ExtractInto(&out)
+	return out.Limits, err
 }

--- a/openstack/identity/v3/limits/testing/fixtures.go
+++ b/openstack/identity/v3/limits/testing/fixtures.go
@@ -58,11 +58,34 @@ const ListOutput = `
 }
 `
 
+const CreateRequest = `
+{
+    "limits":[
+        {
+            "service_id": "9408080f1970482aa0e38bc2d4ea34b7",
+            "project_id": "3a705b9f56bb439381b43c4fe59dccce",
+            "region_id": "RegionOne",
+            "resource_name": "snapshot",
+            "resource_limit": 5
+        },
+        {
+            "service_id": "9408080f1970482aa0e38bc2d4ea34b7",
+            "domain_id": "edbafc92be354ffa977c58aa79c7bdb2",
+            "resource_name": "volume",
+            "resource_limit": 11,
+            "description": "Number of volumes for project 3a705b9f56bb439381b43c4fe59dccce"
+        }
+    ]
+}
+`
+
 // Model is the enforcement model in the GetEnforcementModel request.
 var Model = limits.EnforcementModel{
 	Name:        "flat",
 	Description: "Limit enforcement and validation does not take project hierarchy into consideration.",
 }
+
+const CreateOutput = ListOutput
 
 // FirstLimit is the first limit in the List request.
 var FirstLimit = limits.Limit{
@@ -118,5 +141,18 @@ func HandleListLimitsSuccessfully(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprintf(w, ListOutput)
+	})
+}
+
+// HandleCreateLimitSuccessfully creates an HTTP handler at `/limits` on the
+// test handler mux that tests limit creation.
+func HandleCreateLimitSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/limits", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, CreateRequest)
+
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprintf(w, CreateOutput)
 	})
 }

--- a/openstack/identity/v3/limits/testing/requests_test.go
+++ b/openstack/identity/v3/limits/testing/requests_test.go
@@ -50,3 +50,30 @@ func TestListLimitsAllPages(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.CheckDeepEquals(t, ExpectedLimitsSlice, actual)
 }
+
+func TestCreateLimits(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleCreateLimitSuccessfully(t)
+
+	createOpts := limits.BatchCreateOpts{
+		limits.CreateOpts{
+			ServiceID:     "9408080f1970482aa0e38bc2d4ea34b7",
+			ProjectID:     "3a705b9f56bb439381b43c4fe59dccce",
+			RegionID:      "RegionOne",
+			ResourceName:  "snapshot",
+			ResourceLimit: 5,
+		},
+		limits.CreateOpts{
+			ServiceID:     "9408080f1970482aa0e38bc2d4ea34b7",
+			DomainID:      "edbafc92be354ffa977c58aa79c7bdb2",
+			ResourceName:  "volume",
+			ResourceLimit: 11,
+			Description:   "Number of volumes for project 3a705b9f56bb439381b43c4fe59dccce",
+		},
+	}
+
+	actual, err := limits.BatchCreate(client.ServiceClient(), createOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, ExpectedLimitsSlice, actual)
+}

--- a/openstack/identity/v3/limits/urls.go
+++ b/openstack/identity/v3/limits/urls.go
@@ -2,10 +2,15 @@ package limits
 
 import "github.com/gophercloud/gophercloud"
 
+const (
+	rootPath             = "limits"
+	enforcementModelPath = "model"
+)
+
 func enforcementModelURL(client *gophercloud.ServiceClient) string {
-	return client.ServiceURL("limits", "model")
+	return client.ServiceURL(rootPath, enforcementModelPath)
 }
 
-func listURL(client *gophercloud.ServiceClient) string {
-	return client.ServiceURL("limits")
+func rootURL(client *gophercloud.ServiceClient) string {
+	return client.ServiceURL(rootPath)
 }


### PR DESCRIPTION
For #2289

[docs](https://docs.openstack.org/api-ref/identity/v3/#create-limits)
[code](https://github.com/openstack/keystone/blob/stable/yoga/keystone/api/limits.py#L103)