### PR TITLE
keystone: add v3 limits update operation

### DIFF
--- a/acceptance/openstack/identity/v3/limits_test.go
+++ b/acceptance/openstack/identity/v3/limits_test.go
@@ -102,4 +102,16 @@ func TestLimitsCRUD(t *testing.T) {
 	limit, err := limits.Get(client, limitID).Extract()
 	th.AssertNoErr(t, err)
 	th.AssertDeepEquals(t, createdLimits[0], *limit)
+
+	newLimitDescription := tools.RandomString("TESTLIMITS-DESC-CHNGD-", 8)
+	newResourceLimit := tools.RandomInt(1, 100)
+	updateOpts := limits.UpdateOpts{
+		Description:   &newLimitDescription,
+		ResourceLimit: &newResourceLimit,
+	}
+
+	updatedLimit, err := limits.Update(client, limitID, updateOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, newLimitDescription, updatedLimit.Description)
+	th.AssertEquals(t, newResourceLimit, updatedLimit.ResourceLimit)
 }

--- a/openstack/identity/v3/limits/doc.go
+++ b/openstack/identity/v3/limits/doc.go
@@ -55,5 +55,21 @@ Example to Get a Limit
 	if err != nil {
 		panic(err)
 	}
+
+Example to Update a Limit
+
+	limitID := "0fe36e73809d46aeae6705c39077b1b3"
+
+	description := "Number of snapshots for project 3a705b9f56bb439381b43c4fe59dccce"
+	resourceLimit := 5
+	updateOpts := limits.UpdateOpts{
+	  Description:   &description,
+	  ResourceLimit: &resourceLimit,
+	}
+
+	limit, err := limits.Update(identityClient, limitID, updateOpts).Extract()
+	if err != nil {
+	  panic(err)
+	}
 */
 package limits

--- a/openstack/identity/v3/limits/requests.go
+++ b/openstack/identity/v3/limits/requests.go
@@ -126,3 +126,37 @@ func Get(client *gophercloud.ServiceClient, limitID string) (r GetResult) {
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
+
+// UpdateOptsBuilder allows extensions to add additional parameters to
+// the Update request.
+type UpdateOptsBuilder interface {
+	ToLimitUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts represents parameters to update a domain.
+type UpdateOpts struct {
+	// Description of the limit.
+	Description *string `json:"description,omitempty"`
+
+	// ResourceLimit is the override limit.
+	ResourceLimit *int `json:"resource_limit,omitempty"`
+}
+
+// ToLimitUpdateMap formats UpdateOpts into an update request.
+func (opts UpdateOpts) ToLimitUpdateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "limit")
+}
+
+// Update modifies the attributes of a limit.
+func Update(client *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToLimitUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := client.Patch(resourceURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}

--- a/openstack/identity/v3/limits/results.go
+++ b/openstack/identity/v3/limits/results.go
@@ -90,6 +90,12 @@ type GetResult struct {
 	commonResult
 }
 
+// UpdateResult is the result of an Update request. Call its Extract method to
+// interpret it as a Limit.
+type UpdateResult struct {
+	commonResult
+}
+
 // IsEmpty determines whether or not a page of Limits contains any results.
 func (r LimitPage) IsEmpty() (bool, error) {
 	if r.StatusCode == 204 {

--- a/openstack/identity/v3/limits/testing/fixtures.go
+++ b/openstack/identity/v3/limits/testing/fixtures.go
@@ -96,6 +96,32 @@ const GetOutput = `
 }
 `
 
+const UpdateRequest = `
+{
+    "limit": {
+        "resource_limit": 5,
+        "description": "Number of snapshots for project 3a705b9f56bb439381b43c4fe59dccce"
+    }
+}
+`
+
+const UpdateOutput = `
+{
+    "limit": {
+        "resource_name": "snapshot",
+        "region_id": "RegionOne",
+        "links": {
+            "self": "http://10.3.150.25/identity/v3/limits/3229b3849f584faea483d6851f7aab05"
+        },
+        "service_id": "9408080f1970482aa0e38bc2d4ea34b7",
+        "project_id": "3a705b9f56bb439381b43c4fe59dccce",
+        "id": "3229b3849f584faea483d6851f7aab05",
+        "resource_limit": 5,
+        "description": "Number of snapshots for project 3a705b9f56bb439381b43c4fe59dccce"
+    }
+}
+`
+
 // Model is the enforcement model in the GetEnforcementModel request.
 var Model = limits.EnforcementModel{
 	Name:        "flat",
@@ -128,6 +154,20 @@ var SecondLimit = limits.Limit{
 	ProjectID:     "3a705b9f56bb439381b43c4fe59dccce",
 	ID:            "3229b3849f584faea483d6851f7aab05",
 	ResourceLimit: 5,
+}
+
+// SecondLimitUpdated is the updated limit in the Update request.
+var SecondLimitUpdated = limits.Limit{
+	ResourceName: "snapshot",
+	RegionID:     "RegionOne",
+	Links: map[string]interface{}{
+		"self": "http://10.3.150.25/identity/v3/limits/3229b3849f584faea483d6851f7aab05",
+	},
+	ServiceID:     "9408080f1970482aa0e38bc2d4ea34b7",
+	ProjectID:     "3a705b9f56bb439381b43c4fe59dccce",
+	ID:            "3229b3849f584faea483d6851f7aab05",
+	ResourceLimit: 5,
+	Description:   "Number of snapshots for project 3a705b9f56bb439381b43c4fe59dccce",
 }
 
 // ExpectedLimitsSlice is the slice of limits expected to be returned from ListOutput.
@@ -185,5 +225,18 @@ func HandleGetLimitSuccessfully(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprintf(w, GetOutput)
+	})
+}
+
+// HandleUpdateLimitSuccessfully creates an HTTP handler at `/limits` on the
+// test handler mux that tests limit update.
+func HandleUpdateLimitSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/limits/3229b3849f584faea483d6851f7aab05", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PATCH")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, UpdateRequest)
+
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, UpdateOutput)
 	})
 }

--- a/openstack/identity/v3/limits/testing/requests_test.go
+++ b/openstack/identity/v3/limits/testing/requests_test.go
@@ -87,3 +87,20 @@ func TestGetLimit(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.CheckDeepEquals(t, FirstLimit, *actual)
 }
+
+func TestUpdateLimit(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleUpdateLimitSuccessfully(t)
+
+	var description = "Number of snapshots for project 3a705b9f56bb439381b43c4fe59dccce"
+	var resourceLimit = 5
+	updateOpts := limits.UpdateOpts{
+		Description:   &description,
+		ResourceLimit: &resourceLimit,
+	}
+
+	actual, err := limits.Update(client.ServiceClient(), "3229b3849f584faea483d6851f7aab05", updateOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, SecondLimitUpdated, *actual)
+}


### PR DESCRIPTION
For #2289

[docs](https://docs.openstack.org/api-ref/identity/v3/#update-limit)
[code](https://github.com/openstack/keystone/blob/stable/yoga/keystone/api/limits.py#L115)

This is a base for detail and delete operations code I prepared.