### PR TITLE
keystone: add v3 OS-FEDERATION extension List Mappings

### DIFF
--- a/acceptance/openstack/identity/v3/federation_test.go
+++ b/acceptance/openstack/identity/v3/federation_test.go
@@ -8,18 +8,18 @@ import (
 
 	"github.com/gophercloud/gophercloud/acceptance/clients"
 	"github.com/gophercloud/gophercloud/acceptance/tools"
-	th "github.com/gophercloud/gophercloud/testhelper"
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/extensions/federation"
+	th "github.com/gophercloud/gophercloud/testhelper"
 )
 
 func TestListMappings(t *testing.T) {
 	client, err := clients.NewIdentityV3Client()
 	th.AssertNoErr(t, err)
 
-  allPages, err := federation.ListMappings(client).AllPages()
+	allPages, err := federation.ListMappings(client).AllPages()
 	th.AssertNoErr(t, err)
 
-  mappings, err := federation.ExtractMappings(allPages)
+	mappings, err := federation.ExtractMappings(allPages)
 	th.AssertNoErr(t, err)
 
 	tools.PrintResource(t, mappings)

--- a/acceptance/openstack/identity/v3/federation_test.go
+++ b/acceptance/openstack/identity/v3/federation_test.go
@@ -1,0 +1,26 @@
+//go:build acceptance
+// +build acceptance
+
+package v3
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/acceptance/clients"
+	"github.com/gophercloud/gophercloud/acceptance/tools"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/extensions/federation"
+)
+
+func TestListMappings(t *testing.T) {
+	client, err := clients.NewIdentityV3Client()
+	th.AssertNoErr(t, err)
+
+  allPages, err := federation.ListMappings(client).AllPages()
+	th.AssertNoErr(t, err)
+
+  mappings, err := federation.ExtractMappings(allPages)
+	th.AssertNoErr(t, err)
+
+	tools.PrintResource(t, mappings)
+}

--- a/openstack/identity/v3/extensions/federation/doc.go
+++ b/openstack/identity/v3/extensions/federation/doc.go
@@ -1,0 +1,16 @@
+/*
+Package federation provides information and interaction with OS-FEDERATION API for the
+Openstack Identity service.
+
+Example to List Mappings
+
+	allPages, err := federation.ListMappings(identityClient).AllPages()
+	if err != nil {
+		panic(err)
+	}
+	allMappings, err := federation.ExtractMappings(allPages)
+	if err != nil {
+		panic(err)
+	}
+*/
+package federation

--- a/openstack/identity/v3/extensions/federation/requests.go
+++ b/openstack/identity/v3/extensions/federation/requests.go
@@ -1,0 +1,13 @@
+package federation
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// ListMappings enumerates the mappings.
+func ListMappings(client *gophercloud.ServiceClient) pagination.Pager {
+	return pagination.NewPager(client, mappingsRootURL(client), func(r pagination.PageResult) pagination.Page {
+		return MappingsPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}

--- a/openstack/identity/v3/extensions/federation/results.go
+++ b/openstack/identity/v3/extensions/federation/results.go
@@ -1,0 +1,167 @@
+package federation
+
+import (
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+type UserType string
+
+const (
+	UserTypeEphemeral UserType = "ephemeral"
+	UserTypeLocal     UserType = "local"
+)
+
+// Mapping a set of rules to map federation protocol attributes to
+// Identity API objects.
+type Mapping struct {
+	// The Federation Mapping unique ID
+	ID string `json:"id"`
+
+	// Links contains referencing links to the limit.
+	Links map[string]interface{} `json:"links"`
+
+	// The list of rules used to map remote users into local users
+	Rules []MappingRule `json:"rules"`
+}
+
+type MappingRule struct {
+	// References a local Identity API resource, such as a group or user to which the remote attributes will be mapped.
+	Local []RuleLocal `json:"local"`
+
+	// Each object contains a rule for mapping remote attributes to Identity API concepts.
+	Remote []RuleRemote `json:"remote"`
+}
+
+type RuleRemote struct {
+	// Type represents an assertion type keyword.
+	Type string `json:"type"`
+
+	// If true, then each string will be evaluated as a regular expression search against the remote attribute type.
+	Regex *bool `json:"regex,omitempty"`
+
+	// The rule is matched only if any of the specified strings appear in the remote attribute type.
+	// This is mutually exclusive with NotAnyOf.
+	AnyOneOf []string `json:"any_one_of,omitempty"`
+
+	// The rule is not matched if any of the specified strings appear in the remote attribute type.
+	// This is mutually exclusive with AnyOneOf.
+	NotAnyOf []string `json:"not_any_of,omitempty"`
+
+	// The rule works as a filter, removing any specified strings that are listed there from the remote attribute type.
+	// This is mutually exclusive with Whitelist.
+	Blacklist []string `json:"blacklist,omitempty"`
+
+	// The rule works as a filter, allowing only the specified strings in the remote attribute type to be passed ahead.
+	// This is mutually exclusive with Blacklist.
+	Whitelist []string `json:"whitelist,omitempty"`
+}
+
+type RuleLocal struct {
+	// Domain to which the remote attributes will be matched.
+	Domain *Domain `json:"domain,omitempty"`
+
+	// Group to which the remote attributes will be matched.
+	Group *Group `json:"group,omitempty"`
+
+	// Group IDs to which the remote attributes will be matched.
+	GroupIDs string `json:"group_ids,omitempty"`
+
+	// Groups to which the remote attributes will be matched.
+	Groups string `json:"groups,omitempty"`
+
+	// Projects to which the remote attributes will be matched.
+	Projects []RuleProject `json:"projects,omitempty"`
+
+	// User to which the remote attributes will be matched.
+	User *RuleUser `json:"user,omitempty"`
+}
+
+type Domain struct {
+	// Domain ID
+	// This is mutually exclusive with Name.
+	ID string `json:"id,omitempty"`
+
+	// Domain Name
+	// This is mutually exclusive with ID.
+	Name string `json:"name,omitempty"`
+}
+
+type Group struct {
+	// Group ID to which the rule should match.
+	// This is mutually exclusive with Name and Domain.
+	ID string `json:"id,omitempty"`
+
+	// Group Name to which the rule should match.
+	// This is mutually exclusive with ID.
+	Name string `json:"name,omitempty"`
+
+	// Group Domain to which the rule should match.
+	// This is mutually exclusive with ID.
+	Domain *Domain `json:"domain,omitempty"`
+}
+
+type RuleProject struct {
+	// Project name
+	Name string `json:"name,omitempty"`
+
+	// Project roles
+	Roles []RuleProjectRole `json:"roles,omitempty"`
+}
+
+type RuleProjectRole struct {
+	// Role name
+	Name string `json:"name,omitempty"`
+}
+
+type RuleUser struct {
+	// User domain
+	Domain *Domain `json:"domain,omitempty"`
+
+	// User email
+	Email string `json:"email,omitempty"`
+
+	// User ID
+	ID string `json:"id,omitempty"`
+
+	// User name
+	Name string `json:"name,omitempty"`
+
+	// User type
+	Type *UserType `json:"type,omitempty"`
+}
+
+// MappingsPage is a single page of Mapping results.
+type MappingsPage struct {
+	pagination.LinkedPageBase
+}
+
+// IsEmpty determines whether or not a page of Mappings contains any results.
+func (c MappingsPage) IsEmpty() (bool, error) {
+	mappings, err := ExtractMappings(c)
+	return len(mappings) == 0, err
+}
+
+// NextPageURL extracts the "next" link from the links section of the result.
+func (c MappingsPage) NextPageURL() (string, error) {
+	var s struct {
+		Links struct {
+			Next     string `json:"next"`
+			Previous string `json:"previous"`
+		} `json:"links"`
+	}
+	err := c.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return s.Links.Next, err
+}
+
+// ExtractMappings returns a slice of Mappings contained in a single page of
+// results.
+func ExtractMappings(r pagination.Page) ([]Mapping, error) {
+	var s struct {
+		Mappings []Mapping `json:"mappings"`
+	}
+	err := (r.(MappingsPage)).ExtractInto(&s)
+	return s.Mappings, err
+}

--- a/openstack/identity/v3/extensions/federation/testing/fixtures.go
+++ b/openstack/identity/v3/extensions/federation/testing/fixtures.go
@@ -1,0 +1,109 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/extensions/federation"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+const ListOutput = `
+{
+    "links": {
+        "next": null,
+        "previous": null,
+        "self": "http://example.com/identity/v3/OS-FEDERATION/mappings"
+    },
+    "mappings": [
+        {
+            "id": "ACME",
+            "links": {
+                "self": "http://example.com/identity/v3/OS-FEDERATION/mappings/ACME"
+            },
+            "rules": [
+                {
+                    "local": [
+                        {
+                            "user": {
+                                "name": "{0}"
+                            }
+                        },
+                        {
+                            "group": {
+                                "id": "0cd5e9"
+                            }
+                        }
+                    ],
+                    "remote": [
+                        {
+                            "type": "UserName"
+                        },
+                        {
+                            "type": "orgPersonType",
+                            "not_any_of": [
+                                "Contractor",
+                                "Guest"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}
+`
+
+var MappingACME = federation.Mapping{
+	ID: "ACME",
+	Links: map[string]interface{}{
+		"self": "http://example.com/identity/v3/OS-FEDERATION/mappings/ACME",
+	},
+	Rules: []federation.MappingRule{
+		{
+			Local: []federation.RuleLocal{
+				{
+					User: &federation.RuleUser{
+						Name: "{0}",
+					},
+				},
+				{
+					Group: &federation.Group{
+						ID: "0cd5e9",
+					},
+				},
+			},
+			Remote: []federation.RuleRemote{
+				{
+					Type: "UserName",
+				},
+				{
+					Type: "orgPersonType",
+					NotAnyOf: []string{
+						"Contractor",
+						"Guest",
+					},
+				},
+			},
+		},
+	},
+}
+
+// ExpectedMappingsSlice is the slice of mappings expected to be returned from ListOutput.
+var ExpectedMappingsSlice = []federation.Mapping{MappingACME}
+
+// HandleListMappingsSuccessfully creates an HTTP handler at `/mappings` on the
+// test handler mux that responds with a list of two mappings.
+func HandleListMappingsSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/OS-FEDERATION/mappings", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, ListOutput)
+	})
+}

--- a/openstack/identity/v3/extensions/federation/testing/requests_test.go
+++ b/openstack/identity/v3/extensions/federation/testing/requests_test.go
@@ -1,0 +1,42 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/extensions/federation"
+	"github.com/gophercloud/gophercloud/pagination"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func TestListMappings(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleListMappingsSuccessfully(t)
+
+	count := 0
+	err := federation.ListMappings(client.ServiceClient()).EachPage(func(page pagination.Page) (bool, error) {
+		count++
+
+		actual, err := federation.ExtractMappings(page)
+		th.AssertNoErr(t, err)
+
+		th.CheckDeepEquals(t, ExpectedMappingsSlice, actual)
+
+		return true, nil
+	})
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, count, 1)
+}
+
+func TestListMappingsAllPages(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleListMappingsSuccessfully(t)
+
+	allPages, err := federation.ListMappings(client.ServiceClient()).AllPages()
+	th.AssertNoErr(t, err)
+	actual, err := federation.ExtractMappings(allPages)
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, ExpectedMappingsSlice, actual)
+}

--- a/openstack/identity/v3/extensions/federation/urls.go
+++ b/openstack/identity/v3/extensions/federation/urls.go
@@ -1,0 +1,12 @@
+package federation
+
+import "github.com/gophercloud/gophercloud"
+
+const (
+	rootPath     = "OS-FEDERATION"
+	mappingsPath = "mappings"
+)
+
+func mappingsRootURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL(rootPath, mappingsPath)
+}


### PR DESCRIPTION
For #2461

[docs](https://docs.openstack.org/api-ref/identity/v3-ext/index.html#list-mappings)
[code](https://github.com/openstack/keystone/blob/stable/yoga/keystone/api/os_federation.py#L267)

After this is reviewed and merged other operations will follow.