### PR TITLE
keystone: add v3 limits GetEnforcementModel operation

### DIFF
--- a/acceptance/openstack/identity/v3/limits_test.go
+++ b/acceptance/openstack/identity/v3/limits_test.go
@@ -7,9 +7,22 @@ import (
 	"testing"
 
 	"github.com/gophercloud/gophercloud/acceptance/clients"
+	"github.com/gophercloud/gophercloud/acceptance/tools"
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/limits"
 	th "github.com/gophercloud/gophercloud/testhelper"
 )
+
+func TestGetEnforcementModel(t *testing.T) {
+	clients.RequireAdmin(t)
+
+	client, err := clients.NewIdentityV3Client()
+	th.AssertNoErr(t, err)
+
+	model, err := limits.GetEnforcementModel(client).Extract()
+	th.AssertNoErr(t, err)
+
+	tools.PrintResource(t, model)
+}
 
 func TestLimitsList(t *testing.T) {
 	clients.RequireAdmin(t)

--- a/openstack/identity/v3/limits/doc.go
+++ b/openstack/identity/v3/limits/doc.go
@@ -2,6 +2,13 @@
 Package limits provides information and interaction with limits for the
 Openstack Identity service.
 
+Example to Get EnforcementModel
+
+	model, err := limits.GetEnforcementModel(identityClient).Extract()
+	if err != nil {
+		panic(err)
+	}
+
 Example to List Limits
 
 	listOpts := limits.ListOpts{

--- a/openstack/identity/v3/limits/requests.go
+++ b/openstack/identity/v3/limits/requests.go
@@ -5,6 +5,13 @@ import (
 	"github.com/gophercloud/gophercloud/pagination"
 )
 
+// Get retrieves details on a single limit, by ID.
+func GetEnforcementModel(client *gophercloud.ServiceClient) (r EnforcementModelResult) {
+	resp, err := client.Get(enforcementModelURL(client), &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
 // ListOptsBuilder allows extensions to add additional parameters to
 // the List request
 type ListOptsBuilder interface {

--- a/openstack/identity/v3/limits/results.go
+++ b/openstack/identity/v3/limits/results.go
@@ -1,8 +1,33 @@
 package limits
 
 import (
+	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/pagination"
 )
+
+// A model describing the configured enforcement model used by the deployment.
+type EnforcementModel struct {
+	// The name of the enforcement model.
+	Name string `json:"name"`
+
+	// A short description of the enforcement model used.
+	Description string `json:"description"`
+}
+
+// EnforcementModelResult is the response from a GetEnforcementModel operation. Call its Extract method
+// to interpret it as a EnforcementModel.
+type EnforcementModelResult struct {
+	gophercloud.Result
+}
+
+// Extract interprets EnforcementModelResult as a EnforcementModel.
+func (r EnforcementModelResult) Extract() (*EnforcementModel, error) {
+	var out struct {
+		Model *EnforcementModel `json:"model"`
+	}
+	err := r.ExtractInto(&out)
+	return out.Model, err
+}
 
 // A limit is the limit that override the registered limit for each project.
 type Limit struct {

--- a/openstack/identity/v3/limits/testing/fixtures.go
+++ b/openstack/identity/v3/limits/testing/fixtures.go
@@ -10,6 +10,15 @@ import (
 	"github.com/gophercloud/gophercloud/testhelper/client"
 )
 
+const GetEnforcementModelOutput = `
+{
+    "model": {
+        "description": "Limit enforcement and validation does not take project hierarchy into consideration.",
+        "name": "flat"
+    }
+}
+`
+
 // ListOutput provides a single page of List results.
 const ListOutput = `
 {
@@ -49,6 +58,12 @@ const ListOutput = `
 }
 `
 
+// Model is the enforcement model in the GetEnforcementModel request.
+var Model = limits.EnforcementModel{
+	Name:        "flat",
+	Description: "Limit enforcement and validation does not take project hierarchy into consideration.",
+}
+
 // FirstLimit is the first limit in the List request.
 var FirstLimit = limits.Limit{
 	ResourceName: "volume",
@@ -77,6 +92,20 @@ var SecondLimit = limits.Limit{
 
 // ExpectedLimitsSlice is the slice of limits expected to be returned from ListOutput.
 var ExpectedLimitsSlice = []limits.Limit{FirstLimit, SecondLimit}
+
+// HandleGetEnforcementModelSuccessfully creates an HTTP handler at `/limits/model` on the
+// test handler mux that responds with a enforcement model.
+func HandleGetEnforcementModelSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/limits/model", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, GetEnforcementModelOutput)
+	})
+}
 
 // HandleListLimitsSuccessfully creates an HTTP handler at `/limits` on the
 // test handler mux that responds with a list of two limits.

--- a/openstack/identity/v3/limits/testing/requests_test.go
+++ b/openstack/identity/v3/limits/testing/requests_test.go
@@ -9,6 +9,16 @@ import (
 	"github.com/gophercloud/gophercloud/testhelper/client"
 )
 
+func TestGetEnforcementModel(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleGetEnforcementModelSuccessfully(t)
+
+	actual, err := limits.GetEnforcementModel(client.ServiceClient()).Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, Model, *actual)
+}
+
 func TestListLimits(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()

--- a/openstack/identity/v3/limits/urls.go
+++ b/openstack/identity/v3/limits/urls.go
@@ -2,6 +2,10 @@ package limits
 
 import "github.com/gophercloud/gophercloud"
 
+func enforcementModelURL(client *gophercloud.ServiceClient) string {
+	return client.ServiceURL("limits", "model")
+}
+
 func listURL(client *gophercloud.ServiceClient) string {
 	return client.ServiceURL("limits")
 }


### PR DESCRIPTION
For #2289

[docs](https://docs.openstack.org/api-ref/identity/v3/#get-enforcement-model)
[code](https://github.com/openstack/keystone/blob/stable/yoga/keystone/api/limits.py#L131)
