### PR TITLE
Implementing re-image volumeaction

### DIFF
--- a/acceptance/openstack/blockstorage/extensions/volumeactions_test.go
+++ b/acceptance/openstack/blockstorage/extensions/volumeactions_test.go
@@ -145,6 +145,26 @@ func TestVolumeActionsChangeType(t *testing.T) {
 	tools.PrintResource(t, newVolume)
 }
 
+func TestVolumeActionsReImage(t *testing.T) {
+	clients.SkipReleasesBelow(t, "stable/yoga")
+
+	choices, err := clients.AcceptanceTestChoicesFromEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	blockClient, err := clients.NewBlockStorageV3Client()
+	th.AssertNoErr(t, err)
+	blockClient.Microversion = "3.68"
+
+	volume, err := blockstorage.CreateVolume(t, blockClient)
+	th.AssertNoErr(t, err)
+	defer blockstorage.DeleteVolume(t, blockClient, volume)
+
+	err = ReImage(t, blockClient, volume, choices.ImageID)
+	th.AssertNoErr(t, err)
+}
+
 // Note(jtopjian): I plan to work on this at some point, but it requires
 // setting up a server with iscsi utils.
 /*

--- a/openstack/blockstorage/extensions/volumeactions/requests.go
+++ b/openstack/blockstorage/extensions/volumeactions/requests.go
@@ -391,3 +391,30 @@ func ChangeType(client *gophercloud.ServiceClient, id string, opts ChangeTypeOpt
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
+
+// ReImageOpts contains options for Re-image a volume.
+type ReImageOpts struct {
+	// New image id
+	ImageID string `json:"image_id"`
+	// set true to re-image volumes in reserved state
+	ReImageReserved bool `json:"reimage_reserved"`
+}
+
+// ToReImageMap assembles a request body based on the contents of a ReImageOpts.
+func (opts ReImageOpts) ToReImageMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "os-reimage")
+}
+
+// ReImage will re-image a volume based on the values in ReImageOpts
+func ReImage(client *gophercloud.ServiceClient, id string, opts ReImageOpts) (r ReImageResult) {
+	b, err := opts.ToReImageMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := client.Post(actionURL(client, id), b, nil, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}

--- a/openstack/blockstorage/extensions/volumeactions/results.go
+++ b/openstack/blockstorage/extensions/volumeactions/results.go
@@ -214,3 +214,8 @@ type ForceDeleteResult struct {
 type ChangeTypeResult struct {
 	gophercloud.ErrResult
 }
+
+// ReImageResult contains the response body and error from a ReImage request.
+type ReImageResult struct {
+	gophercloud.ErrResult
+}

--- a/openstack/blockstorage/extensions/volumeactions/testing/fixtures.go
+++ b/openstack/blockstorage/extensions/volumeactions/testing/fixtures.go
@@ -327,6 +327,26 @@ func MockSetBootableResponse(t *testing.T) {
 	})
 }
 
+func MockReImageResponse(t *testing.T) {
+	th.Mux.HandleFunc("/volumes/cd281d77-8217-4830-be95-9528227c105c/action", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, `
+{
+	"os-reimage": {
+		"image_id": "71543ced-a8af-45b6-a5c4-a46282108a90",
+		"reimage_reserved": false
+	}
+}
+		`)
+		w.Header().Add("Content-Type", "application/json")
+		w.Header().Add("Content-Length", "0")
+		w.WriteHeader(http.StatusAccepted)
+	})
+}
+
 func MockChangeTypeResponse(t *testing.T) {
 	th.Mux.HandleFunc("/volumes/cd281d77-8217-4830-be95-9528227c105c/action",
 		func(w http.ResponseWriter, r *http.Request) {

--- a/openstack/blockstorage/extensions/volumeactions/testing/requests_test.go
+++ b/openstack/blockstorage/extensions/volumeactions/testing/requests_test.go
@@ -195,6 +195,21 @@ func TestSetBootable(t *testing.T) {
 	th.AssertNoErr(t, err)
 }
 
+func TestReImage(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockReImageResponse(t)
+
+	options := volumeactions.ReImageOpts{
+		ImageID:         "71543ced-a8af-45b6-a5c4-a46282108a90",
+		ReImageReserved: false,
+	}
+
+	err := volumeactions.ReImage(client.ServiceClient(), "cd281d77-8217-4830-be95-9528227c105c", options).ExtractErr()
+	th.AssertNoErr(t, err)
+}
+
 func TestChangeType(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()


### PR DESCRIPTION
Fixes #2473

https://github.com/openstack/cinder/blob/d69e89ea3ba63d305f2a344f6c43b83a74d731fc/cinder/api/schemas/volume_actions.py#L206

Support for re-image volume action added.