### PR TITLE
Support old time format for port CreatedAt and UpdatedAt

### DIFF
--- a/openstack/networking/v2/extensions/dns/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/dns/testing/requests_test.go
@@ -57,6 +57,8 @@ func TestPortList(t *testing.T) {
 				ID:             "d80b1a3b-4fc1-49f3-952e-1e2ab7081d8b",
 				SecurityGroups: []string{},
 				DeviceID:       "9ae135f4-b6e0-4dad-9e91-3c223e385824",
+				CreatedAt:      time.Date(2019, time.June, 30, 4, 15, 37, 0, time.UTC),
+				UpdatedAt:      time.Date(2019, time.June, 30, 5, 18, 49, 0, time.UTC),
 			},
 			PortDNSExt: dns.PortDNSExt{
 				DNSName: "test-port",

--- a/openstack/networking/v2/extensions/portsbinding/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/portsbinding/testing/requests_test.go
@@ -2,6 +2,7 @@ package testing
 
 import (
 	"testing"
+	"time"
 
 	fake "github.com/gophercloud/gophercloud/openstack/networking/v2/common"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/portsbinding"
@@ -40,6 +41,8 @@ func TestList(t *testing.T) {
 				ID:             "d80b1a3b-4fc1-49f3-952e-1e2ab7081d8b",
 				SecurityGroups: []string{},
 				DeviceID:       "9ae135f4-b6e0-4dad-9e91-3c223e385824",
+				CreatedAt:      time.Date(2019, time.June, 30, 4, 15, 37, 0, time.UTC),
+				UpdatedAt:      time.Date(2019, time.June, 30, 5, 18, 49, 0, time.UTC),
 			},
 			PortsBindingExt: portsbinding.PortsBindingExt{
 				VNICType: "normal",

--- a/openstack/networking/v2/ports/results.go
+++ b/openstack/networking/v2/ports/results.go
@@ -1,6 +1,7 @@
 package ports
 
 import (
+	"encoding/json"
 	"time"
 
 	"github.com/gophercloud/gophercloud"
@@ -114,10 +115,48 @@ type Port struct {
 	RevisionNumber int `json:"revision_number"`
 
 	// Timestamp when the port was created
-	CreatedAt time.Time `json:"created_at"`
+	CreatedAt time.Time `json:"-"`
 
 	// Timestamp when the port was last updated
-	UpdatedAt time.Time `json:"updated_at"`
+	UpdatedAt time.Time `json:"-"`
+}
+
+func (r *Port) UnmarshalJSON(b []byte) error {
+	type tmp Port
+
+	// Support for older neutron time format
+	var s1 struct {
+		tmp
+		CreatedAt gophercloud.JSONRFC3339NoZ `json:"created_at"`
+		UpdatedAt gophercloud.JSONRFC3339NoZ `json:"updated_at"`
+	}
+
+	err := json.Unmarshal(b, &s1)
+	if err == nil {
+		*r = Port(s1.tmp)
+		r.CreatedAt = time.Time(s1.CreatedAt)
+		r.UpdatedAt = time.Time(s1.UpdatedAt)
+
+		return nil
+	}
+
+	// Support for newer neutron time format
+	var s2 struct {
+		tmp
+		CreatedAt time.Time `json:"created_at"`
+		UpdatedAt time.Time `json:"updated_at"`
+	}
+
+	err = json.Unmarshal(b, &s2)
+	if err != nil {
+		return err
+	}
+
+	*r = Port(s2.tmp)
+	r.CreatedAt = time.Time(s2.CreatedAt)
+	r.UpdatedAt = time.Time(s2.UpdatedAt)
+
+	return nil
 }
 
 // PortPage is the page returned by a pager when traversing over a collection

--- a/openstack/networking/v2/ports/testing/fixtures.go
+++ b/openstack/networking/v2/ports/testing/fixtures.go
@@ -30,7 +30,9 @@ const ListResponse = `
               }
             ],
             "device_id": "9ae135f4-b6e0-4dad-9e91-3c223e385824",
-            "port_security_enabled": false
+            "port_security_enabled": false,
+            "created_at": "2019-06-30T04:15:37",
+            "updated_at": "2019-06-30T05:18:49"
         }
     ]
 }
@@ -73,7 +75,9 @@ const GetResponse = `
             "fqdn": "test-port.openstack.local."
           }
         ],
-        "device_id": "5e3898d7-11be-483e-9732-b2f5eccd2b2e"
+        "device_id": "5e3898d7-11be-483e-9732-b2f5eccd2b2e",
+        "created_at": "2019-06-30T04:15:37Z",
+        "updated_at": "2019-06-30T05:18:49Z"
     }
 }
 `

--- a/openstack/networking/v2/ports/testing/requests_test.go
+++ b/openstack/networking/v2/ports/testing/requests_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/url"
 	"testing"
+	"time"
 
 	fake "github.com/gophercloud/gophercloud/openstack/networking/v2/common"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/extradhcpopts"
@@ -30,7 +31,7 @@ func TestList(t *testing.T) {
 
 	count := 0
 
-	ports.List(fake.ServiceClient(), ports.ListOpts{}).EachPage(func(page pagination.Page) (bool, error) {
+	err := ports.List(fake.ServiceClient(), ports.ListOpts{}).EachPage(func(page pagination.Page) (bool, error) {
 		count++
 		actual, err := ports.ExtractPorts(page)
 		if err != nil {
@@ -56,6 +57,8 @@ func TestList(t *testing.T) {
 				ID:             "d80b1a3b-4fc1-49f3-952e-1e2ab7081d8b",
 				SecurityGroups: []string{},
 				DeviceID:       "9ae135f4-b6e0-4dad-9e91-3c223e385824",
+				CreatedAt:      time.Date(2019, time.June, 30, 4, 15, 37, 0, time.UTC),
+				UpdatedAt:      time.Date(2019, time.June, 30, 5, 18, 49, 0, time.UTC),
 			},
 		}
 
@@ -63,6 +66,8 @@ func TestList(t *testing.T) {
 
 		return true, nil
 	})
+
+	th.AssertNoErr(t, err)
 
 	if count != 1 {
 		t.Errorf("Expected 1 page, got %d", count)
@@ -131,6 +136,8 @@ func TestGet(t *testing.T) {
 	th.AssertDeepEquals(t, n.SecurityGroups, []string{})
 	th.AssertEquals(t, n.Status, "ACTIVE")
 	th.AssertEquals(t, n.DeviceID, "5e3898d7-11be-483e-9732-b2f5eccd2b2e")
+	th.AssertEquals(t, n.CreatedAt, time.Date(2019, time.June, 30, 4, 15, 37, 0, time.UTC))
+	th.AssertEquals(t, n.UpdatedAt, time.Date(2019, time.June, 30, 5, 18, 49, 0, time.UTC))
 }
 
 func TestGetWithExtensions(t *testing.T) {


### PR DESCRIPTION
Older versions of neutron returned times as RFC 3339 "no Z" format. While gophercloud currently supports OpenStack versions from Train and above, all returning the new RFC 3339 time format, there's no reasons to be hostile against older OpenStack releases.

This commit makes the Port.CreatedAt and Port.UpdatedAt fields compatible with older OpenStack releases.

Fixes #2469