### PR TITLE
Port CreatedAt and UpdatedAt: add back JSON tags

### DIFF
--- a/openstack/networking/v2/ports/results.go
+++ b/openstack/networking/v2/ports/results.go
@@ -115,10 +115,10 @@ type Port struct {
 	RevisionNumber int `json:"revision_number"`
 
 	// Timestamp when the port was created
-	CreatedAt time.Time `json:"-"`
+	CreatedAt time.Time `json:"created_at"`
 
 	// Timestamp when the port was last updated
-	UpdatedAt time.Time `json:"-"`
+	UpdatedAt time.Time `json:"updated_at"`
 }
 
 func (r *Port) UnmarshalJSON(b []byte) error {


### PR DESCRIPTION
Removing them in 48581dacb7ec726e2ea5ed5094e0bf91db20751b was not necessary. Removing them might break client-side serialisation.