### PR TITLE
Add createdAt, updatedAt and provisionUpdatedAt fields in Baremetal V1 nodes

### DIFF
--- a/openstack/baremetal/v1/nodes/results.go
+++ b/openstack/baremetal/v1/nodes/results.go
@@ -1,6 +1,8 @@
 package nodes
 
 import (
+	"time"
+
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/pagination"
 )
@@ -234,6 +236,12 @@ type Node struct {
 
 	// Static network configuration to use during deployment and cleaning.
 	NetworkData map[string]interface{} `json:"network_data"`
+
+	// The UTC date and time when the resource was created, ISO 8601 format.
+	CreatedAt time.Time `json:"created_at"`
+
+	// The UTC date and time when the resource was updated, ISO 8601 format. May be “null”.
+	UpdatedAt time.Time `json:"updated_at"`
 }
 
 // NodePage abstracts the raw results of making a List() request against

--- a/openstack/baremetal/v1/nodes/results.go
+++ b/openstack/baremetal/v1/nodes/results.go
@@ -242,6 +242,9 @@ type Node struct {
 
 	// The UTC date and time when the resource was updated, ISO 8601 format. May be “null”.
 	UpdatedAt time.Time `json:"updated_at"`
+
+	// The UTC date and time when the provision state was updated, ISO 8601 format. May be “null”.
+	ProvisionUpdatedAt time.Time `json:"provision_updated_at"`
 }
 
 // NodePage abstracts the raw results of making a List() request against

--- a/openstack/baremetal/v1/nodes/testing/fixtures.go
+++ b/openstack/baremetal/v1/nodes/testing/fixtures.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/gophercloud/gophercloud/openstack/baremetal/v1/nodes"
 	th "github.com/gophercloud/gophercloud/testhelper"
@@ -164,7 +165,7 @@ const NodeListDetailBody = `
       "target_provision_state": null,
       "target_raid_config": {},
       "traits": [],
-      "updated_at": null,
+      "updated_at": "2019-02-15T19:59:29+00:00",
       "uuid": "d2630783-6ec8-4836-b556-ab427c4b581e",
       "vendor_interface": "ipmitool",
       "volume": [
@@ -261,7 +262,7 @@ const NodeListDetailBody = `
       "target_provision_state": null,
       "target_raid_config": {},
       "traits": [],
-      "updated_at": null,
+      "updated_at": "2019-02-15T19:59:29+00:00",
       "uuid": "08c84581-58f5-4ea2-a0c6-dd2e5d2b3662",
       "vendor_interface": "ipmitool",
       "volume": [
@@ -358,7 +359,7 @@ const NodeListDetailBody = `
       "target_provision_state": null,
       "target_raid_config": {},
       "traits": [],
-      "updated_at": null,
+      "updated_at": "2019-02-15T19:59:29+00:00",
       "uuid": "c9afd385-5d89-4ecb-9e1c-68194da6b474",
       "vendor_interface": "ipmitool",
       "volume": [
@@ -468,7 +469,7 @@ const SingleNodeBody = `
   "target_provision_state": null,
   "target_raid_config": {},
   "traits": [],
-  "updated_at": null,
+  "updated_at": "2019-02-15T19:59:29+00:00",
   "uuid": "d2630783-6ec8-4836-b556-ab427c4b581e",
   "vendor_interface": "ipmitool",
   "volume": [
@@ -813,6 +814,11 @@ const NodeSetMaintenanceBody = `
 `
 
 var (
+	createdAtFoo, _ = time.Parse(time.RFC3339, "2019-01-31T19:59:28+00:00")
+	createdAtBar, _ = time.Parse(time.RFC3339, "2019-01-31T19:59:29+00:00")
+	createdAtBaz, _ = time.Parse(time.RFC3339, "2019-01-31T19:59:30+00:00")
+	updatedAt, _    = time.Parse(time.RFC3339, "2019-02-15T19:59:29+00:00")
+
 	NodeFoo = nodes.Node{
 		UUID:                 "d2630783-6ec8-4836-b556-ab427c4b581e",
 		Name:                 "foo",
@@ -862,6 +868,8 @@ var (
 		ConductorGroup:      "",
 		Protected:           false,
 		ProtectedReason:     "",
+		CreatedAt:           createdAtFoo,
+		UpdatedAt:           updatedAt,
 	}
 
 	NodeFooValidation = nodes.NodeValidation{
@@ -959,6 +967,8 @@ var (
 		ConductorGroup:       "",
 		Protected:            false,
 		ProtectedReason:      "",
+		CreatedAt:            createdAtBar,
+		UpdatedAt:            updatedAt,
 	}
 
 	NodeBaz = nodes.Node{
@@ -1003,6 +1013,8 @@ var (
 		ConductorGroup:       "",
 		Protected:            false,
 		ProtectedReason:      "",
+		CreatedAt:            createdAtBaz,
+		UpdatedAt:            updatedAt,
 	}
 
 	ConfigDriveMap = nodes.ConfigDrive{

--- a/openstack/baremetal/v1/nodes/testing/fixtures.go
+++ b/openstack/baremetal/v1/nodes/testing/fixtures.go
@@ -144,7 +144,7 @@ const NodeListDetailBody = `
       "power_state": null,
       "properties": {},
       "provision_state": "enroll",
-      "provision_updated_at": null,
+      "provision_updated_at": "2019-02-15T17:21:29+00:00",
       "raid_config": {},
       "raid_interface": "no-raid",
       "rescue_interface": "no-rescue",
@@ -448,7 +448,7 @@ const SingleNodeBody = `
   "power_state": null,
   "properties": {},
   "provision_state": "enroll",
-  "provision_updated_at": null,
+  "provision_updated_at": "2019-02-15T17:21:29+00:00",
   "raid_config": {},
   "raid_interface": "no-raid",
   "rescue_interface": "no-rescue",
@@ -814,10 +814,11 @@ const NodeSetMaintenanceBody = `
 `
 
 var (
-	createdAtFoo, _ = time.Parse(time.RFC3339, "2019-01-31T19:59:28+00:00")
-	createdAtBar, _ = time.Parse(time.RFC3339, "2019-01-31T19:59:29+00:00")
-	createdAtBaz, _ = time.Parse(time.RFC3339, "2019-01-31T19:59:30+00:00")
-	updatedAt, _    = time.Parse(time.RFC3339, "2019-02-15T19:59:29+00:00")
+	createdAtFoo, _      = time.Parse(time.RFC3339, "2019-01-31T19:59:28+00:00")
+	createdAtBar, _      = time.Parse(time.RFC3339, "2019-01-31T19:59:29+00:00")
+	createdAtBaz, _      = time.Parse(time.RFC3339, "2019-01-31T19:59:30+00:00")
+	updatedAt, _         = time.Parse(time.RFC3339, "2019-02-15T19:59:29+00:00")
+	provisonUpdatedAt, _ = time.Parse(time.RFC3339, "2019-02-15T17:21:29+00:00")
 
 	NodeFoo = nodes.Node{
 		UUID:                 "d2630783-6ec8-4836-b556-ab427c4b581e",
@@ -870,6 +871,7 @@ var (
 		ProtectedReason:     "",
 		CreatedAt:           createdAtFoo,
 		UpdatedAt:           updatedAt,
+		ProvisionUpdatedAt:  provisonUpdatedAt,
 	}
 
 	NodeFooValidation = nodes.NodeValidation{


### PR DESCRIPTION
Fixes #2481

Links to the line numbers/files in the OpenStack source code that support the code in this PR:

- https://github.com/openstack/ironic/blob/9e9a23ef0c06dda467fc275c00c6988e4bcb5ba2/ironic/objects/base.py#L80
- https://github.com/openstack/ironic/blob/master/ironic/objects/node.py#L128
