### PR TITLE
Add AvailabilityZone field to DBaaS instance

### DIFF
--- a/openstack/db/v1/instances/requests.go
+++ b/openstack/db/v1/instances/requests.go
@@ -56,6 +56,8 @@ type CreateOpts struct {
 	// Name of the instance to create. The length of the name is limited to
 	// 255 characters and any characters are permitted. Optional.
 	Name string
+	// The availability zone of the instance.
+	AvailabilityZone string
 	// A slice of database information options.
 	Databases db.CreateOptsBuilder
 	// A slice of user information options.
@@ -88,6 +90,9 @@ func (opts CreateOpts) ToInstanceCreateMap() (map[string]interface{}, error) {
 
 	if opts.Name != "" {
 		instance["name"] = opts.Name
+	}
+	if opts.AvailabilityZone != "" {
+		instance["availability_zone"] = opts.AvailabilityZone
 	}
 	if opts.Databases != nil {
 		dbs, err := opts.Databases.ToDBCreateMap()

--- a/openstack/db/v1/instances/testing/fixtures.go
+++ b/openstack/db/v1/instances/testing/fixtures.go
@@ -129,7 +129,8 @@ var createReq = `
 		],
 		"volume": {
 			"size": 2
-		}
+		},
+		"availability_zone": "nova"
 	}
 }
 `

--- a/openstack/db/v1/instances/testing/requests_test.go
+++ b/openstack/db/v1/instances/testing/requests_test.go
@@ -17,8 +17,9 @@ func TestCreate(t *testing.T) {
 	HandleCreate(t)
 
 	opts := instances.CreateOpts{
-		Name:      "json_rack_instance",
-		FlavorRef: "1",
+		Name:             "json_rack_instance",
+		AvailabilityZone: "nova",
+		FlavorRef:        "1",
 		Databases: db.BatchCreateOpts{
 			{CharSet: "utf8", Collate: "utf8_general_ci", Name: "sampledb"},
 			{Name: "nextround"},
@@ -47,8 +48,9 @@ func TestCreateWithFault(t *testing.T) {
 	HandleCreateWithFault(t)
 
 	opts := instances.CreateOpts{
-		Name:      "json_rack_instance",
-		FlavorRef: "1",
+		Name:             "json_rack_instance",
+		AvailabilityZone: "nova",
+		FlavorRef:        "1",
 		Databases: db.BatchCreateOpts{
 			{CharSet: "utf8", Collate: "utf8_general_ci", Name: "sampledb"},
 			{Name: "nextround"},


### PR DESCRIPTION
Fixes https://github.com/gophercloud/gophercloud/issues/2483

Openstack API Ref:
https://docs.openstack.org/api-ref/database/?expanded=create-database-instance-detail#create-database-instance