### PR TITLE
Add Prometheus protocol for octavia listeners

### DIFF
--- a/openstack/loadbalancer/v2/listeners/requests.go
+++ b/openstack/loadbalancer/v2/listeners/requests.go
@@ -18,7 +18,9 @@ const (
 	ProtocolHTTP  Protocol = "HTTP"
 	ProtocolHTTPS Protocol = "HTTPS"
 	// Protocol SCTP requires octavia microversion 2.23
-	ProtocolSCTP            Protocol = "SCTP"
+	ProtocolSCTP Protocol = "SCTP"
+	// Protocol Prometheus requires octavia microversion 2.25
+	ProtocolPrometheus      Protocol = "PROMETHEUS"
 	ProtocolTerminatedHTTPS Protocol = "TERMINATED_HTTPS"
 )
 


### PR DESCRIPTION
Prometheus protocol was added for octavia listeners on 2.25

[docs](https://docs.openstack.org/api-ref/load-balancer/v2/#create-listener)
[code](https://github.com/openstack/octavia/blob/master/octavia/api/root_controller.py#L142)
