### PR TITLE
Add Persistance for octavia pools.UpdateOpts

### DIFF
--- a/openstack/loadbalancer/v2/pools/requests.go
+++ b/openstack/loadbalancer/v2/pools/requests.go
@@ -190,6 +190,9 @@ type UpdateOpts struct {
 	// or false (DOWN).
 	AdminStateUp *bool `json:"admin_state_up,omitempty"`
 
+	// Persistence is the session persistence of the pool.
+	Persistence *SessionPersistence `json:"session_persistence,omitempty"`
+
 	// Tags is a set of resource tags. New in version 2.5
 	Tags *[]string `json:"tags,omitempty"`
 }


### PR DESCRIPTION
Session persistance can be updated on Octavia. Add it to UpdateOpts
[Docs](https://docs.openstack.org/api-ref/load-balancer/v2/?expanded=update-a-pool-detail#update-a-pool)