### PR TITLE
Update github workflow for Openstack Zed

### DIFF
--- a/.github/workflows/functional-baremetal.yaml
+++ b/.github/workflows/functional-baremetal.yaml
@@ -14,6 +14,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["20.04"]
         include:
+          - name: "zed"
+            openstack_version: "stable/zed"
+            ubuntu_version: "20.04"
           - name: "yoga"
             openstack_version: "stable/yoga"
             ubuntu_version: "20.04"

--- a/.github/workflows/functional-basic.yaml
+++ b/.github/workflows/functional-basic.yaml
@@ -17,6 +17,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["20.04"]
         include:
+          - name: "zed"
+            openstack_version: "stable/zed"
+            ubuntu_version: "20.04"        
           - name: "yoga"
             openstack_version: "stable/yoga"
             ubuntu_version: "20.04"

--- a/.github/workflows/functional-blockstorage.yaml
+++ b/.github/workflows/functional-blockstorage.yaml
@@ -14,6 +14,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["20.04"]
         include:
+          - name: "zed"
+            openstack_version: "stable/zed"
+            ubuntu_version: "20.04"
           - name: "yoga"
             openstack_version: "stable/yoga"
             ubuntu_version: "20.04"

--- a/.github/workflows/functional-clustering.yaml
+++ b/.github/workflows/functional-clustering.yaml
@@ -14,6 +14,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["20.04"]
         include:
+          - name: "zed"
+            openstack_version: "stable/zed"
+            ubuntu_version: "20.04"
           - name: "yoga"
             openstack_version: "stable/yoga"
             ubuntu_version: "20.04"

--- a/.github/workflows/functional-compute.yaml
+++ b/.github/workflows/functional-compute.yaml
@@ -14,6 +14,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["20.04"]
         include:
+          - name: "zed"
+            openstack_version: "stable/zed"
+            ubuntu_version: "20.04"
           - name: "yoga"
             openstack_version: "stable/yoga"
             ubuntu_version: "20.04"

--- a/.github/workflows/functional-containerinfra.yaml
+++ b/.github/workflows/functional-containerinfra.yaml
@@ -14,6 +14,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["20.04"]
         include:
+          - name: "zed"
+            openstack_version: "stable/zed"
+            ubuntu_version: "20.04"
           - name: "yoga"
             openstack_version: "stable/yoga"
             ubuntu_version: "20.04"

--- a/.github/workflows/functional-containerinfra.yaml
+++ b/.github/workflows/functional-containerinfra.yaml
@@ -10,31 +10,63 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        name: ["master"]
-        openstack_version: ["master"]
-        ubuntu_version: ["20.04"]
         include:
+          - name: "master"
+            openstack_version: "master"
+            ubuntu_version: "20.04"
+            devstack_conf_overrides: |
+              enable_plugin barbican https://opendev.org/openstack/barbican master
+              enable_plugin heat https://opendev.org/openstack/heat master
+              enable_plugin magnum https://opendev.org/openstack/magnum master
           - name: "zed"
             openstack_version: "stable/zed"
             ubuntu_version: "20.04"
+            devstack_conf_overrides: |
+              enable_plugin barbican https://opendev.org/openstack/barbican stable/zed
+              enable_plugin heat https://opendev.org/openstack/heat stable/zed
+              enable_plugin magnum https://opendev.org/openstack/magnum stable/zed
           - name: "yoga"
             openstack_version: "stable/yoga"
             ubuntu_version: "20.04"
+            devstack_conf_overrides: |
+              enable_plugin barbican https://opendev.org/openstack/barbican stable/yoga
+              enable_plugin heat https://opendev.org/openstack/heat stable/yoga
+              enable_plugin magnum https://opendev.org/openstack/magnum stable/yoga
           - name: "xena"
             openstack_version: "stable/xena"
             ubuntu_version: "20.04"
+            devstack_conf_overrides: |
+              enable_plugin barbican https://opendev.org/openstack/barbican stable/xena
+              enable_plugin heat https://opendev.org/openstack/heat stable/xena
+              enable_plugin magnum https://opendev.org/openstack/magnum stable/xena
           - name: "wallaby"
             openstack_version: "stable/wallaby"
             ubuntu_version: "20.04"
+            devstack_conf_overrides: |
+              enable_plugin barbican https://opendev.org/openstack/barbican stable/wallaby
+              enable_plugin heat https://opendev.org/openstack/heat stable/wallaby
+              enable_plugin magnum https://opendev.org/openstack/magnum stable/wallaby
           - name: "victoria"
             openstack_version: "stable/victoria"
             ubuntu_version: "20.04"
+            devstack_conf_overrides: |
+              enable_plugin barbican https://opendev.org/openstack/barbican stable/victoria
+              enable_plugin heat https://opendev.org/openstack/heat stable/victoria
+              enable_plugin magnum https://opendev.org/openstack/magnum stable/victoria
           - name: "ussuri"
             openstack_version: "stable/ussuri"
             ubuntu_version: "18.04"
+            devstack_conf_overrides: |
+              enable_plugin barbican https://opendev.org/openstack/barbican stable/ussuri
+              enable_plugin heat https://opendev.org/openstack/heat stable/ussuri
+              enable_plugin magnum https://opendev.org/openstack/magnum ussuri-eol
           - name: "train"
             openstack_version: "stable/train"
             ubuntu_version: "18.04"
+            devstack_conf_overrides: |
+              enable_plugin barbican https://opendev.org/openstack/barbican stable/train
+              enable_plugin heat https://opendev.org/openstack/heat stable/train
+              enable_plugin magnum https://opendev.org/openstack/magnum train-eol
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with Magnum and run containerinfra acceptance tests
     steps:
@@ -45,9 +77,7 @@ jobs:
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |
-            enable_plugin barbican https://opendev.org/openstack/barbican ${{ matrix.openstack_version }}
-            enable_plugin heat https://opendev.org/openstack/heat ${{ matrix.openstack_version }}
-            enable_plugin magnum https://opendev.org/openstack/magnum ${{ matrix.openstack_version }}
+            ${{ matrix.devstack_conf_overrides }}
             GLANCE_LIMIT_IMAGE_SIZE_TOTAL=5000
             SWIFT_MAX_FILE_SIZE=5368709122
             KEYSTONE_ADMIN_ENDPOINT=true

--- a/.github/workflows/functional-dns.yaml
+++ b/.github/workflows/functional-dns.yaml
@@ -11,31 +11,47 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        name: ["master"]
-        openstack_version: ["master"]
-        ubuntu_version: ["20.04"]
         include:
+          - name: "master"
+            openstack_version: "master"
+            ubuntu_version: "20.04"
+            devstack_conf_overrides: |
+              enable_plugin designate https://opendev.org/openstack/designate master
           - name: "zed"
             openstack_version: "stable/zed"
             ubuntu_version: "20.04"
+            devstack_conf_overrides: |
+              enable_plugin designate https://opendev.org/openstack/designate stable/zed
           - name: "yoga"
             openstack_version: "stable/yoga"
             ubuntu_version: "20.04"
+            devstack_conf_overrides: |
+              enable_plugin designate https://opendev.org/openstack/designate stable/yoga
           - name: "xena"
             openstack_version: "stable/xena"
             ubuntu_version: "20.04"
+            devstack_conf_overrides: |
+              enable_plugin designate https://opendev.org/openstack/designate stable/xena
           - name: "wallaby"
             openstack_version: "stable/wallaby"
             ubuntu_version: "20.04"
+            devstack_conf_overrides: |
+              enable_plugin designate https://opendev.org/openstack/designate stable/wallaby
           - name: "victoria"
             openstack_version: "stable/victoria"
             ubuntu_version: "20.04"
+            devstack_conf_overrides: |
+              enable_plugin designate https://opendev.org/openstack/designate stable/victoria
           - name: "ussuri"
             openstack_version: "stable/ussuri"
             ubuntu_version: "18.04"
+            devstack_conf_overrides: |
+              enable_plugin designate https://opendev.org/openstack/designate stable/ussuri
           - name: "train"
             openstack_version: "stable/train"
             ubuntu_version: "18.04"
+            devstack_conf_overrides: |
+              enable_plugin designate https://opendev.org/openstack/designate train-eol
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with Designate and run dns acceptance tests
     steps:
@@ -46,7 +62,7 @@ jobs:
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |
-            enable_plugin designate https://opendev.org/openstack/designate ${{ matrix.openstack_version }}
+            ${{ matrix.devstack_conf_overrides }}
           enabled_services: 'designate,designate-central,designate-api,designate-worker,designate-producer,designate-mdns'
       - name: Checkout go
         uses: actions/setup-go@v3

--- a/.github/workflows/functional-dns.yaml
+++ b/.github/workflows/functional-dns.yaml
@@ -15,6 +15,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["20.04"]
         include:
+          - name: "zed"
+            openstack_version: "stable/zed"
+            ubuntu_version: "20.04"
           - name: "yoga"
             openstack_version: "stable/yoga"
             ubuntu_version: "20.04"

--- a/.github/workflows/functional-identity.yaml
+++ b/.github/workflows/functional-identity.yaml
@@ -14,6 +14,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["20.04"]
         include:
+          - name: "zed"
+            openstack_version: "stable/zed"
+            ubuntu_version: "20.04"
           - name: "yoga"
             openstack_version: "stable/yoga"
             ubuntu_version: "20.04"

--- a/.github/workflows/functional-imageservice.yaml
+++ b/.github/workflows/functional-imageservice.yaml
@@ -14,6 +14,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["20.04"]
         include:
+          - name: "zed"
+            openstack_version: "stable/zed"
+            ubuntu_version: "20.04"
           - name: "yoga"
             openstack_version: "stable/yoga"
             ubuntu_version: "20.04"

--- a/.github/workflows/functional-keymanager.yaml
+++ b/.github/workflows/functional-keymanager.yaml
@@ -14,6 +14,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["20.04"]
         include:
+          - name: "zed"
+            openstack_version: "stable/zed"
+            ubuntu_version: "20.04"
           - name: "yoga"
             openstack_version: "stable/yoga"
             ubuntu_version: "20.04"

--- a/.github/workflows/functional-loadbalancer.yaml
+++ b/.github/workflows/functional-loadbalancer.yaml
@@ -14,6 +14,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["20.04"]
         include:
+          - name: "zed"
+            openstack_version: "stable/zed"
+            ubuntu_version: "20.04"
           - name: "yoga"
             openstack_version: "stable/yoga"
             ubuntu_version: "20.04"

--- a/.github/workflows/functional-messaging.yaml
+++ b/.github/workflows/functional-messaging.yaml
@@ -14,6 +14,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["20.04"]
         include:
+          - name: "zed"
+            openstack_version: "stable/zed"
+            ubuntu_version: "20.04"
           - name: "yoga"
             openstack_version: "stable/yoga"
             ubuntu_version: "20.04"

--- a/.github/workflows/functional-networking.yaml
+++ b/.github/workflows/functional-networking.yaml
@@ -17,6 +17,12 @@ jobs:
             devstack_conf_overrides: |
               enable_plugin neutron-dynamic-routing https://opendev.org/openstack/neutron-dynamic-routing master
               enable_plugin neutron-vpnaas https://opendev.org/openstack/neutron-vpnaas master
+          - name: "zed"
+            openstack_version: "stable/zed"
+            ubuntu_version: "20.04"
+            devstack_conf_overrides: |
+              enable_plugin neutron-dynamic-routing https://opendev.org/openstack/neutron-dynamic-routing stable/zed
+              enable_plugin neutron-vpnaas https://opendev.org/openstack/neutron-vpnaas stable/zed
           - name: "yoga"
             openstack_version: "stable/yoga"
             ubuntu_version: "20.04"

--- a/.github/workflows/functional-objectstorage.yaml
+++ b/.github/workflows/functional-objectstorage.yaml
@@ -14,6 +14,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["20.04"]
         include:
+          - name: "zed"
+            openstack_version: "stable/zed"
+            ubuntu_version: "20.04"
           - name: "yoga"
             openstack_version: "stable/yoga"
             ubuntu_version: "20.04"

--- a/.github/workflows/functional-orchestration.yaml
+++ b/.github/workflows/functional-orchestration.yaml
@@ -14,6 +14,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["20.04"]
         include:
+          - name: "zed"
+            openstack_version: "stable/zed"
+            ubuntu_version: "20.04"
           - name: "yoga"
             openstack_version: "stable/yoga"
             ubuntu_version: "20.04"

--- a/.github/workflows/functional-placement.yaml
+++ b/.github/workflows/functional-placement.yaml
@@ -14,6 +14,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["20.04"]
         include:
+          - name: "zed"
+            openstack_version: "stable/zed"
+            ubuntu_version: "20.04"
           - name: "yoga"
             openstack_version: "stable/yoga"
             ubuntu_version: "20.04"

--- a/.github/workflows/functional-sharedfilesystems.yaml
+++ b/.github/workflows/functional-sharedfilesystems.yaml
@@ -14,6 +14,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["20.04"]
         include:
+          - name: "zed"
+            openstack_version: "stable/zed"
+            ubuntu_version: "20.04"
           - name: "yoga"
             openstack_version: "stable/yoga"
             ubuntu_version: "20.04"


### PR DESCRIPTION
Openstack Zed was released recently. Update github workflows to include testing for the stable/zed verson. ~~Furthermore remove stable/train from the versions that are tested.~~

I was updating today the ci on TPO and thought to push it here as well. I "assumed" that removing stable/train was the way to go, but maybe i was wrong