### PR TITLE
Add VipQosPolicyID to loadbalancer Create and Update

### DIFF
--- a/.github/workflows/functional-loadbalancer.yaml
+++ b/.github/workflows/functional-loadbalancer.yaml
@@ -44,7 +44,7 @@ jobs:
           conf_overrides: |
             enable_plugin octavia https://opendev.org/openstack/octavia ${{ matrix.openstack_version }}
             enable_plugin neutron https://opendev.org/openstack/neutron ${{ matrix.openstack_version }}
-          enabled_services: 'octavia,o-api,o-cw,o-hk,o-hm,o-da'
+          enabled_services: 'octavia,o-api,o-cw,o-hk,o-hm,o-da,neutron-qos'
       - name: Checkout go
         uses: actions/setup-go@v3
         with:

--- a/acceptance/openstack/loadbalancer/v2/loadbalancer.go
+++ b/acceptance/openstack/loadbalancer/v2/loadbalancer.go
@@ -110,7 +110,7 @@ func CreateListenerHTTP(t *testing.T, client *gophercloud.ServiceClient, lb *loa
 
 // CreateLoadBalancer will create a load balancer with a random name on a given
 // subnet. An error will be returned if the loadbalancer could not be created.
-func CreateLoadBalancer(t *testing.T, client *gophercloud.ServiceClient, subnetID string, tags []string) (*loadbalancers.LoadBalancer, error) {
+func CreateLoadBalancer(t *testing.T, client *gophercloud.ServiceClient, subnetID string, tags []string, policyID string) (*loadbalancers.LoadBalancer, error) {
 	lbName := tools.RandomString("TESTACCT-", 8)
 	lbDescription := tools.RandomString("TESTACCT-DESC-", 8)
 
@@ -124,6 +124,10 @@ func CreateLoadBalancer(t *testing.T, client *gophercloud.ServiceClient, subnetI
 	}
 	if len(tags) > 0 {
 		createOpts.Tags = tags
+	}
+
+	if len(policyID) > 0 {
+		createOpts.VipQosPolicyID = policyID
 	}
 
 	lb, err := loadbalancers.Create(client, createOpts).Extract()
@@ -147,6 +151,10 @@ func CreateLoadBalancer(t *testing.T, client *gophercloud.ServiceClient, subnetI
 
 	if len(tags) > 0 {
 		th.AssertDeepEquals(t, lb.Tags, tags)
+	}
+
+	if len(policyID) > 0 {
+		th.AssertEquals(t, lb.VipQosPolicyID, policyID)
 	}
 
 	return lb, nil

--- a/openstack/loadbalancer/v2/loadbalancers/requests.go
+++ b/openstack/loadbalancer/v2/loadbalancers/requests.go
@@ -107,6 +107,9 @@ type CreateOpts struct {
 	// The IP address of the Loadbalancer.
 	VipAddress string `json:"vip_address,omitempty"`
 
+	// The ID of the QoS Policy which will apply to the Virtual IP
+	VipQosPolicyID string `json:"vip_qos_policy_id,omitempty"`
+
 	// The administrative state of the Loadbalancer. A valid value is true (UP)
 	// or false (DOWN).
 	AdminStateUp *bool `json:"admin_state_up,omitempty"`
@@ -184,6 +187,9 @@ type UpdateOpts struct {
 	// The administrative state of the Loadbalancer. A valid value is true (UP)
 	// or false (DOWN).
 	AdminStateUp *bool `json:"admin_state_up,omitempty"`
+
+	// The ID of the QoS Policy which will apply to the Virtual IP
+	VipQosPolicyID *string `json:"vip_qos_policy_id,omitempty"`
 
 	// Tags is a set of resource tags.
 	Tags *[]string `json:"tags,omitempty"`

--- a/openstack/loadbalancer/v2/loadbalancers/results.go
+++ b/openstack/loadbalancer/v2/loadbalancers/results.go
@@ -47,6 +47,9 @@ type LoadBalancer struct {
 	// Loadbalancer address.
 	VipNetworkID string `json:"vip_network_id"`
 
+	// The ID of the QoS Policy which will apply to the Virtual IP
+	VipQosPolicyID string `json:"vip_qos_policy_id"`
+
 	// The unique ID for the LoadBalancer.
 	ID string `json:"id"`
 


### PR DESCRIPTION
VipQosPolicyID can be defined for loadbalancers during creation and update. Moreover add the `neutron-qos` service to loadbalancer workflow.
[Docs](https://docs.openstack.org/api-ref/load-balancer/v2/?expanded=create-a-load-balancer-detail,update-a-load-balancer-detail#create-a-load-balancer)

