### PR TITLE
Add tags for loadbalancer l7policy and l7rule

### DIFF
--- a/acceptance/openstack/loadbalancer/v2/loadbalancer.go
+++ b/acceptance/openstack/loadbalancer/v2/loadbalancer.go
@@ -419,7 +419,7 @@ func CreatePoolHTTP(t *testing.T, client *gophercloud.ServiceClient, lb *loadbal
 // CreateL7Policy will create a l7 policy with a random name with a specified listener
 // and loadbalancer. An error will be returned if the l7 policy could not be
 // created.
-func CreateL7Policy(t *testing.T, client *gophercloud.ServiceClient, listener *listeners.Listener, lb *loadbalancers.LoadBalancer) (*l7policies.L7Policy, error) {
+func CreateL7Policy(t *testing.T, client *gophercloud.ServiceClient, listener *listeners.Listener, lb *loadbalancers.LoadBalancer, tags []string) (*l7policies.L7Policy, error) {
 	policyName := tools.RandomString("TESTACCT-", 8)
 	policyDescription := tools.RandomString("TESTACCT-DESC-", 8)
 
@@ -431,6 +431,7 @@ func CreateL7Policy(t *testing.T, client *gophercloud.ServiceClient, listener *l
 		ListenerID:  listener.ID,
 		Action:      l7policies.ActionRedirectToURL,
 		RedirectURL: "http://www.example.com",
+		Tags:        tags,
 	}
 
 	policy, err := l7policies.Create(client, createOpts).Extract()
@@ -449,18 +450,20 @@ func CreateL7Policy(t *testing.T, client *gophercloud.ServiceClient, listener *l
 	th.AssertEquals(t, policy.ListenerID, listener.ID)
 	th.AssertEquals(t, policy.Action, string(l7policies.ActionRedirectToURL))
 	th.AssertEquals(t, policy.RedirectURL, "http://www.example.com")
+	th.AssertDeepEquals(t, policy.Tags, tags)
 
 	return policy, nil
 }
 
 // CreateL7Rule creates a l7 rule for specified l7 policy.
-func CreateL7Rule(t *testing.T, client *gophercloud.ServiceClient, policyID string, lb *loadbalancers.LoadBalancer) (*l7policies.Rule, error) {
+func CreateL7Rule(t *testing.T, client *gophercloud.ServiceClient, policyID string, lb *loadbalancers.LoadBalancer, tags []string) (*l7policies.Rule, error) {
 	t.Logf("Attempting to create l7 rule for policy %s", policyID)
 
 	createOpts := l7policies.CreateRuleOpts{
 		RuleType:    l7policies.TypePath,
 		CompareType: l7policies.CompareTypeStartWith,
 		Value:       "/api",
+		Tags:        tags,
 	}
 
 	rule, err := l7policies.CreateRule(client, policyID, createOpts).Extract()
@@ -477,6 +480,7 @@ func CreateL7Rule(t *testing.T, client *gophercloud.ServiceClient, policyID stri
 	th.AssertEquals(t, rule.RuleType, string(l7policies.TypePath))
 	th.AssertEquals(t, rule.CompareType, string(l7policies.CompareTypeStartWith))
 	th.AssertEquals(t, rule.Value, "/api")
+	th.AssertDeepEquals(t, rule.Tags, tags)
 
 	return rule, nil
 }

--- a/acceptance/openstack/loadbalancer/v2/loadbalancers_test.go
+++ b/acceptance/openstack/loadbalancer/v2/loadbalancers_test.go
@@ -120,13 +120,16 @@ func TestLoadbalancerHTTPCRUD(t *testing.T) {
 	defer DeleteListener(t, lbClient, lb.ID, listener.ID)
 
 	// L7 policy
-	policy, err := CreateL7Policy(t, lbClient, listener, lb)
+	tags := []string{"test"}
+	policy, err := CreateL7Policy(t, lbClient, listener, lb, tags)
 	th.AssertNoErr(t, err)
 	defer DeleteL7Policy(t, lbClient, lb.ID, policy.ID)
 
+	tags = []string{"test", "test1"}
 	newDescription := ""
 	updateL7policyOpts := l7policies.UpdateOpts{
 		Description: &newDescription,
+		Tags:        &tags,
 	}
 	_, err = l7policies.Update(lbClient, policy.ID, updateL7policyOpts).Extract()
 	th.AssertNoErr(t, err)
@@ -141,9 +144,11 @@ func TestLoadbalancerHTTPCRUD(t *testing.T) {
 	tools.PrintResource(t, newPolicy)
 
 	th.AssertEquals(t, newPolicy.Description, newDescription)
+	th.AssertDeepEquals(t, newPolicy.Tags, tags)
 
 	// L7 rule
-	rule, err := CreateL7Rule(t, lbClient, newPolicy.ID, lb)
+	tags = []string{"test"}
+	rule, err := CreateL7Rule(t, lbClient, newPolicy.ID, lb, tags)
 	th.AssertNoErr(t, err)
 	defer DeleteL7Rule(t, lbClient, lb.ID, policy.ID, rule.ID)
 
@@ -155,10 +160,12 @@ func TestLoadbalancerHTTPCRUD(t *testing.T) {
 		tools.PrintResource(t, rule)
 	}
 
+	tags = []string{"test", "test1"}
 	updateL7ruleOpts := l7policies.UpdateRuleOpts{
 		RuleType:    l7policies.TypePath,
 		CompareType: l7policies.CompareTypeRegex,
 		Value:       "/images/special*",
+		Tags:        &tags,
 	}
 	_, err = l7policies.UpdateRule(lbClient, policy.ID, rule.ID, updateL7ruleOpts).Extract()
 	th.AssertNoErr(t, err)
@@ -171,6 +178,8 @@ func TestLoadbalancerHTTPCRUD(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	tools.PrintResource(t, newRule)
+
+	th.AssertDeepEquals(t, newRule.Tags, tags)
 
 	// Pool
 	pool, err := CreatePoolHTTP(t, lbClient, lb)

--- a/openstack/loadbalancer/v2/l7policies/requests.go
+++ b/openstack/loadbalancer/v2/l7policies/requests.go
@@ -83,6 +83,9 @@ type CreateOpts struct {
 	// This is only possible to use when creating a fully populated
 	// Loadbalancer.
 	Rules []CreateRuleOpts `json:"rules,omitempty"`
+
+	// Tags is a set of resource tags. Requires version 2.5.
+	Tags []string `json:"tags,omitempty"`
 }
 
 // ToL7PolicyCreateMap builds a request body from CreateOpts.
@@ -208,6 +211,9 @@ type UpdateOpts struct {
 	// The administrative state of the Loadbalancer. A valid value is true (UP)
 	// or false (DOWN).
 	AdminStateUp *bool `json:"admin_state_up,omitempty"`
+
+	// Tags is a set of resource tags. Requires version 2.5.
+	Tags *[]string `json:"tags,omitempty"`
 }
 
 // ToL7PolicyUpdateMap builds a request body from UpdateOpts.
@@ -278,6 +284,9 @@ type CreateRuleOpts struct {
 	// The administrative state of the Loadbalancer. A valid value is true (UP)
 	// or false (DOWN).
 	AdminStateUp *bool `json:"admin_state_up,omitempty"`
+
+	// Tags is a set of resource tags. Requires version 2.5.
+	Tags []string `json:"tags,omitempty"`
 }
 
 // ToRuleCreateMap builds a request body from CreateRuleOpts.
@@ -387,6 +396,9 @@ type UpdateRuleOpts struct {
 	// The administrative state of the Loadbalancer. A valid value is true (UP)
 	// or false (DOWN).
 	AdminStateUp *bool `json:"admin_state_up,omitempty"`
+
+	// Tags is a set of resource tags. Requires version 2.5.
+	Tags *[]string `json:"tags,omitempty"`
 }
 
 // ToRuleUpdateMap builds a request body from UpdateRuleOpts.

--- a/openstack/loadbalancer/v2/l7policies/results.go
+++ b/openstack/loadbalancer/v2/l7policies/results.go
@@ -58,6 +58,10 @@ type L7Policy struct {
 
 	// Rules are List of associated L7 rule IDs.
 	Rules []Rule `json:"rules"`
+
+	// Tags is a list of resource tags. Tags are arbitrarily defined strings
+	// attached to the resource.
+	Tags []string `json:"tags"`
 }
 
 // Rule represents layer 7 load balancing rule.
@@ -94,6 +98,10 @@ type Rule struct {
 
 	// The operating status of the L7 policy.
 	OperatingStatus string `json:"operating_status"`
+
+	// Tags is a list of resource tags. Tags are arbitrarily defined strings
+	// attached to the resource.
+	Tags []string `json:"tags"`
 }
 
 type commonResult struct {


### PR DESCRIPTION
Tags are supported for octavia l7policy and l7rules since version 2.5. Add support for Create and Update.
[Docs](https://docs.openstack.org/api-ref/load-balancer/v2/?expanded=create-an-l7-policy-detail,update-a-l7-policy-detail,create-an-l7-rule-detail,update-a-l7-rule-detail#create-an-l7-policy)

partially implemets: #2381 