### PR TITLE
Manila: add Get for share-access-rules API

### DIFF
--- a/acceptance/openstack/sharedfilesystems/v2/shareaccessrules.go
+++ b/acceptance/openstack/sharedfilesystems/v2/shareaccessrules.go
@@ -1,0 +1,18 @@
+package v2
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/shareaccessrules"
+)
+
+func ShareAccessRuleGet(t *testing.T, client *gophercloud.ServiceClient, accessID string) (*shareaccessrules.ShareAccess, error) {
+	accessRule, err := shareaccessrules.Get(client, accessID).Extract()
+	if err != nil {
+		t.Logf("Failed to get share access rule %s: %v", accessID, err)
+		return nil, err
+	}
+
+	return accessRule, nil
+}

--- a/acceptance/openstack/sharedfilesystems/v2/shareaccessrules_test.go
+++ b/acceptance/openstack/sharedfilesystems/v2/shareaccessrules_test.go
@@ -1,0 +1,48 @@
+//go:build acceptance
+// +build acceptance
+
+package v2
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/acceptance/clients"
+	"github.com/gophercloud/gophercloud/acceptance/tools"
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestShareAccessRulesGet(t *testing.T) {
+	client, err := clients.NewSharedFileSystemV2Client()
+	if err != nil {
+		t.Fatalf("Unable to create a shared file system client: %v", err)
+	}
+
+	client.Microversion = "2.49"
+
+	share, err := CreateShare(t, client)
+	if err != nil {
+		t.Fatalf("Unable to create a share: %v", err)
+	}
+
+	defer DeleteShare(t, client, share)
+
+	shareAccessRight, err := GrantAccess(t, client, share)
+	if err != nil {
+		t.Fatalf("Unable to grant access to share %s: %v", share.ID, err)
+	}
+
+	accessRule, err := ShareAccessRuleGet(t, client, shareAccessRight.ID)
+	if err != nil {
+		t.Logf("Unable to get share access rule for share %s: %v", share.ID, err)
+	}
+
+	tools.PrintResource(t, accessRule)
+
+	th.AssertEquals(t, shareAccessRight.ID, accessRule.ID)
+	th.AssertEquals(t, shareAccessRight.ShareID, accessRule.ShareID)
+	th.AssertEquals(t, shareAccessRight.AccessType, accessRule.AccessType)
+	th.AssertEquals(t, shareAccessRight.AccessLevel, accessRule.AccessLevel)
+	th.AssertEquals(t, shareAccessRight.AccessTo, accessRule.AccessTo)
+	th.AssertEquals(t, shareAccessRight.AccessKey, accessRule.AccessKey)
+	th.AssertEquals(t, shareAccessRight.State, accessRule.State)
+}

--- a/openstack/sharedfilesystems/v2/shareaccessrules/requests.go
+++ b/openstack/sharedfilesystems/v2/shareaccessrules/requests.go
@@ -1,0 +1,12 @@
+package shareaccessrules
+
+import (
+	"github.com/gophercloud/gophercloud"
+)
+
+// Get retrieves details about a share access rule.
+func Get(client *gophercloud.ServiceClient, accessID string) (r GetResult) {
+	resp, err := client.Get(getURL(client, accessID), &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}

--- a/openstack/sharedfilesystems/v2/shareaccessrules/results.go
+++ b/openstack/sharedfilesystems/v2/shareaccessrules/results.go
@@ -1,0 +1,65 @@
+package shareaccessrules
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/gophercloud/gophercloud"
+)
+
+// ShareAccess contains information associated with an OpenStack share access rule.
+type ShareAccess struct {
+	// The UUID of the share to which you are granted or denied access.
+	ShareID string `json:"share_id"`
+	// The date and time stamp when the resource was created within the service’s database.
+	CreatedAt time.Time `json:"-"`
+	// The date and time stamp when the resource was last updated within the service’s database.
+	UpdatedAt time.Time `json:"-"`
+	// The access rule type.
+	AccessType string `json:"access_type"`
+	// The value that defines the access. The back end grants or denies the access to it.
+	AccessTo string `json:"access_to"`
+	// The access credential of the entity granted share access.
+	AccessKey string `json:"access_key"`
+	// The state of the access rule.
+	State string `json:"state"`
+	// The access level to the share.
+	AccessLevel string `json:"access_level"`
+	// The access rule ID.
+	ID string `json:"id"`
+	// Access rule metadata.
+	Metadata map[string]interface{} `json:"metadata"`
+}
+
+func (r *ShareAccess) UnmarshalJSON(b []byte) error {
+	type tmp ShareAccess
+	var s struct {
+		tmp
+		CreatedAt gophercloud.JSONRFC3339MilliNoZ `json:"created_at"`
+		UpdatedAt gophercloud.JSONRFC3339MilliNoZ `json:"updated_at"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	*r = ShareAccess(s.tmp)
+
+	r.CreatedAt = time.Time(s.CreatedAt)
+	r.UpdatedAt = time.Time(s.UpdatedAt)
+
+	return nil
+}
+
+// GetResult contains the response body and error from a Get request.
+type GetResult struct {
+	gophercloud.Result
+}
+
+// Extract will get the ShareAccess object from the GetResult.
+func (r GetResult) Extract() (*ShareAccess, error) {
+	var s struct {
+		ShareAccess *ShareAccess `json:"access"`
+	}
+	err := r.ExtractInto(&s)
+	return s.ShareAccess, err
+}

--- a/openstack/sharedfilesystems/v2/shareaccessrules/testing/fixtures.go
+++ b/openstack/sharedfilesystems/v2/shareaccessrules/testing/fixtures.go
@@ -1,0 +1,45 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	th "github.com/gophercloud/gophercloud/testhelper"
+	fake "github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+const (
+	shareAccessRulesEndpoint = "/share-access-rules"
+	shareAccessRuleID        = "507bf114-36f2-4f56-8cf4-857985ca87c1"
+	shareID                  = "fb213952-2352-41b4-ad7b-2c4c69d13eef"
+)
+
+var getResponse = `{
+    "access": {
+        "access_level": "rw",
+        "state": "error",
+        "id": "507bf114-36f2-4f56-8cf4-857985ca87c1",
+        "share_id": "fb213952-2352-41b4-ad7b-2c4c69d13eef",
+        "access_type": "cert",
+        "access_to": "example.com",
+        "access_key": null,
+        "created_at": "2018-07-17T02:01:04.000000",
+        "updated_at": "2018-07-17T02:01:04.000000",
+        "metadata": {
+            "key1": "value1",
+            "key2": "value2"
+        }
+    }
+}`
+
+func MockGetResponse(t *testing.T) {
+	th.Mux.HandleFunc(shareAccessRulesEndpoint+"/"+shareAccessRuleID, func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, getResponse)
+	})
+}

--- a/openstack/sharedfilesystems/v2/shareaccessrules/testing/requests_test.go
+++ b/openstack/sharedfilesystems/v2/shareaccessrules/testing/requests_test.go
@@ -1,0 +1,39 @@
+package testing
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/shareaccessrules"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func TestGet(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockGetResponse(t)
+
+	resp := shareaccessrules.Get(client.ServiceClient(), "507bf114-36f2-4f56-8cf4-857985ca87c1")
+	th.AssertNoErr(t, resp.Err)
+
+	accessRule, err := resp.Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertDeepEquals(t, &shareaccessrules.ShareAccess{
+		ShareID:     "fb213952-2352-41b4-ad7b-2c4c69d13eef",
+		CreatedAt:   time.Date(2018, 7, 17, 2, 1, 4, 0, time.UTC),
+		UpdatedAt:   time.Date(2018, 7, 17, 2, 1, 4, 0, time.UTC),
+		AccessType:  "cert",
+		AccessTo:    "example.com",
+		AccessKey:   "",
+		State:       "error",
+		AccessLevel: "rw",
+		ID:          "507bf114-36f2-4f56-8cf4-857985ca87c1",
+		Metadata: map[string]interface{}{
+			"key1": "value1",
+			"key2": "value2",
+		},
+	}, accessRule)
+}

--- a/openstack/sharedfilesystems/v2/shareaccessrules/urls.go
+++ b/openstack/sharedfilesystems/v2/shareaccessrules/urls.go
@@ -1,0 +1,11 @@
+package shareaccessrules
+
+import (
+	"github.com/gophercloud/gophercloud"
+)
+
+const shareAccessRulesEndpoint = "share-access-rules"
+
+func getURL(c *gophercloud.ServiceClient, accessID string) string {
+	return c.ServiceURL(shareAccessRulesEndpoint, accessID)
+}


### PR DESCRIPTION
This PR adds `Get` for `share-access-rules` Manila API.

Part of https://github.com/gophercloud/gophercloud/issues/2495

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/manila/blob/stable/yoga/manila/db/sqlalchemy/api.py#L2591-L2601
https://github.com/openstack/manila/blob/stable/yoga/manila/api/v2/share_accesses.py#L39-L45
https://github.com/openstack/manila/blob/stable/yoga/manila/api/views/share_accesses.py#L50-L62
