### PR TITLE
Staskraev/l3 agent scheduler

### DIFF
--- a/acceptance/openstack/networking/v2/extensions/layer3/l3_scheduling_test.go
+++ b/acceptance/openstack/networking/v2/extensions/layer3/l3_scheduling_test.go
@@ -1,0 +1,76 @@
+//go:build acceptance || networking || layer3 || router
+// +build acceptance networking layer3 router
+
+package layer3
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/acceptance/clients"
+	networking "github.com/gophercloud/gophercloud/acceptance/openstack/networking/v2"
+	"github.com/gophercloud/gophercloud/acceptance/tools"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/agents"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers"
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestLayer3RouterScheduling(t *testing.T) {
+	client, err := clients.NewNetworkV2Client()
+	th.AssertNoErr(t, err)
+
+	network, err := networking.CreateNetwork(t, client)
+	th.AssertNoErr(t, err)
+	defer networking.DeleteNetwork(t, client, network.ID)
+
+	subnet, err := networking.CreateSubnet(t, client, network.ID)
+	th.AssertNoErr(t, err)
+	defer networking.DeleteSubnet(t, client, subnet.ID)
+
+	router, err := CreateRouter(t, client, network.ID)
+	th.AssertNoErr(t, err)
+	defer DeleteRouter(t, client, router.ID)
+	tools.PrintResource(t, router)
+
+	routerInterface, err := CreateRouterInterfaceOnSubnet(t, client, subnet.ID, router.ID)
+	tools.PrintResource(t, routerInterface)
+	th.AssertNoErr(t, err)
+	defer DeleteRouterInterface(t, client, routerInterface.PortID, router.ID)
+
+	// List hosting agent
+	allPages, err := routers.ListL3Agents(client, router.ID).AllPages()
+	th.AssertNoErr(t, err)
+	hostingAgents, err := routers.ExtractL3Agents(allPages)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, len(hostingAgents) > 0, true)
+	hostingAgent := hostingAgents[0]
+	t.Logf("Router %s is scheduled on %s", router.ID, hostingAgent.ID)
+
+	// remove from hosting agent
+	err = agents.RemoveL3Router(client, hostingAgent.ID, router.ID).ExtractErr()
+	th.AssertNoErr(t, err)
+
+	containsRouterFunc := func(rs []routers.Router, routerID string) bool {
+		for _, r := range rs {
+			if r.ID == router.ID {
+				return true
+			}
+		}
+		return false
+	}
+
+	// List routers on hosting agent
+	routersOnHostingAgent, err := agents.ListL3Routers(client, hostingAgent.ID).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, containsRouterFunc(routersOnHostingAgent, router.ID), false)
+	t.Logf("Router %s is not scheduled on %s", router.ID, hostingAgent.ID)
+
+	// schedule back
+	err = agents.ScheduleL3Router(client, hostingAgents[0].ID, agents.ScheduleL3RouterOpts{RouterID: router.ID}).ExtractErr()
+	th.AssertNoErr(t, err)
+
+	// List hosting agent after readding
+	routersOnHostingAgent, err = agents.ListL3Routers(client, hostingAgent.ID).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, containsRouterFunc(routersOnHostingAgent, router.ID), true)
+	t.Logf("Router %s is scheduled on %s", router.ID, hostingAgent.ID)
+}

--- a/acceptance/openstack/networking/v2/extensions/layer3/l3_scheduling_test.go
+++ b/acceptance/openstack/networking/v2/extensions/layer3/l3_scheduling_test.go
@@ -47,7 +47,7 @@ func TestLayer3RouterScheduling(t *testing.T) {
 	th.AssertNoErr(t, err)
 	hostingAgents, err := routers.ExtractL3Agents(allPages)
 	th.AssertNoErr(t, err)
-	th.AssertIntGreaterOrEqual(t, len(hostingAgents), 0)
+	th.AssertIntGreaterOrEqual(t, len(hostingAgents), 1)
 	hostingAgent := hostingAgents[0]
 	t.Logf("Router %s is scheduled on %s", router.ID, hostingAgent.ID)
 

--- a/acceptance/openstack/networking/v2/extensions/layer3/l3_scheduling_test.go
+++ b/acceptance/openstack/networking/v2/extensions/layer3/l3_scheduling_test.go
@@ -47,7 +47,7 @@ func TestLayer3RouterScheduling(t *testing.T) {
 	th.AssertNoErr(t, err)
 	hostingAgents, err := routers.ExtractL3Agents(allPages)
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, len(hostingAgents) > 0, true)
+	th.AssertIntGreaterOrEqual(t, len(hostingAgents), 0)
 	hostingAgent := hostingAgents[0]
 	t.Logf("Router %s is scheduled on %s", router.ID, hostingAgent.ID)
 

--- a/acceptance/openstack/networking/v2/extensions/layer3/l3_scheduling_test.go
+++ b/acceptance/openstack/networking/v2/extensions/layer3/l3_scheduling_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gophercloud/gophercloud/acceptance/clients"
 	networking "github.com/gophercloud/gophercloud/acceptance/openstack/networking/v2"
 	"github.com/gophercloud/gophercloud/acceptance/tools"
+	"github.com/gophercloud/gophercloud/openstack/common/extensions"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/agents"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers"
 	th "github.com/gophercloud/gophercloud/testhelper"
@@ -17,6 +18,11 @@ import (
 func TestLayer3RouterScheduling(t *testing.T) {
 	client, err := clients.NewNetworkV2Client()
 	th.AssertNoErr(t, err)
+
+	_, err = extensions.Get(client, "l3_agent_scheduler").Extract()
+	if err != nil {
+		t.Skip("Extension l3_agent_scheduler not present")
+	}
 
 	network, err := networking.CreateNetwork(t, client)
 	th.AssertNoErr(t, err)

--- a/openstack/networking/v2/extensions/agents/doc.go
+++ b/openstack/networking/v2/extensions/agents/doc.go
@@ -142,7 +142,7 @@ Example to remove router from L3 agent
 
 	agentID := "0e1095ae-6f36-40f3-8322-8e1c9a5e68ca"
 	routerID := "e6fa0457-efc2-491d-ac12-17ab60417efd"
-        err = agents.RemoveL3Router(neutron, "0e1095ae-6f36-40f3-8322-8e1c9a5e68ca", "e6fa0457-efc2-491d-ac12-17ab60417efd").ExtractErr()
+        err = agents.RemoveL3Router(neutron, agentID, routerID).ExtractErr()
         if err != nil {
             log.Panic(err)
         }
@@ -151,7 +151,7 @@ Example to schedule router to L3 agent
 
 	agentID := "0e1095ae-6f36-40f3-8322-8e1c9a5e68ca"
 	routerID := "e6fa0457-efc2-491d-ac12-17ab60417efd"
-	err = agents.ScheduleL3Router(neutron, agentID, agents.ScheduleL3RouterOpts{routerID}).ExtractErr()
+	err = agents.ScheduleL3Router(neutron, agentID, agents.ScheduleL3RouterOpts{RouterID: routerID}).ExtractErr()
         if err != nil {
             log.Panic(err)
         }

--- a/openstack/networking/v2/extensions/agents/doc.go
+++ b/openstack/networking/v2/extensions/agents/doc.go
@@ -126,6 +126,37 @@ Example to list dragents hosting specific bgp speaker
 	for _, a := range allAgents {
 		log.Printf("%+v", a)
 	}
+
+Example to list routers scheduled to L3 agent
+
+        routers, err := agents.ListL3Routers(neutron, "655967f5-d6f3-4732-88f5-617b0ff5c356").Extract()
+        if err != nil {
+            log.Panic(err)
+        }
+
+        for _, r := range routers {
+            log.Printf("%+v", r)
+        }
+
+Example to remove router from L3 agent
+
+	agentID := "0e1095ae-6f36-40f3-8322-8e1c9a5e68ca"
+	routerID := "e6fa0457-efc2-491d-ac12-17ab60417efd"
+        err = agents.RemoveL3Router(neutron, "0e1095ae-6f36-40f3-8322-8e1c9a5e68ca", "e6fa0457-efc2-491d-ac12-17ab60417efd").ExtractErr()
+        if err != nil {
+            log.Panic(err)
+        }
+
+Example to schedule router to L3 agent
+
+	agentID := "0e1095ae-6f36-40f3-8322-8e1c9a5e68ca"
+	routerID := "e6fa0457-efc2-491d-ac12-17ab60417efd"
+	err = agents.ScheduleL3Router(neutron, agentID, agents.ScheduleL3RouterOpts{routerID}).ExtractErr()
+        if err != nil {
+            log.Panic(err)
+        }
+
+
 */
 
 package agents

--- a/openstack/networking/v2/extensions/agents/requests.go
+++ b/openstack/networking/v2/extensions/agents/requests.go
@@ -205,3 +205,49 @@ func ListDRAgentHostingBGPSpeakers(c *gophercloud.ServiceClient, bgpSpeakerID st
 		return AgentPage{pagination.LinkedPageBase{PageResult: r}}
 	})
 }
+
+// ListL3Routers returns a list of routers scheduled to a specific
+// L3 agent.
+func ListL3Routers(c *gophercloud.ServiceClient, id string) (r ListL3RoutersResult) {
+	resp, err := c.Get(listL3RoutersURL(c, id), &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// ScheduleL3RouterOptsBuilder allows extensions to add additional parameters
+// to the ScheduleL3Router request.
+type ScheduleL3RouterOptsBuilder interface {
+	ToAgentScheduleL3RouterMap() (map[string]interface{}, error)
+}
+
+// ScheduleL3RouterOpts represents the attributes used when scheduling a
+// router to a L3 agent.
+type ScheduleL3RouterOpts struct {
+	RouterID string `json:"router_id" required:"true"`
+}
+
+// ToAgentScheduleL3RouterMap builds a request body from ScheduleL3RouterOpts.
+func (opts ScheduleL3RouterOpts) ToAgentScheduleL3RouterMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "")
+}
+
+// ScheduleL3Router schedule a router to a L3 agent.
+func ScheduleL3Router(c *gophercloud.ServiceClient, id string, opts ScheduleL3RouterOptsBuilder) (r ScheduleL3RouterResult) {
+	b, err := opts.ToAgentScheduleL3RouterMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := c.Post(scheduleL3RouterURL(c, id), b, nil, &gophercloud.RequestOpts{
+		OkCodes: []int{201},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// RemoveL3Router removes a router from a L3 agent.
+func RemoveL3Router(c *gophercloud.ServiceClient, id string, routerID string) (r RemoveL3RouterResult) {
+	resp, err := c.Delete(removeL3RouterURL(c, id, routerID), nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}

--- a/openstack/networking/v2/extensions/agents/results.go
+++ b/openstack/networking/v2/extensions/agents/results.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/bgp/speakers"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
 	"github.com/gophercloud/gophercloud/pagination"
 )
@@ -207,4 +208,34 @@ func ExtractBGPSpeakers(r pagination.Page) ([]speakers.BGPSpeaker, error) {
 
 	err := (r.(ListBGPSpeakersResult)).ExtractInto(&s)
 	return s.Speakers, err
+}
+
+// ListL3RoutersResult is the response from a List operation.
+// Call its Extract method to interpret it as routers.
+type ListL3RoutersResult struct {
+	gophercloud.Result
+}
+
+// ScheduleL3RouterResult represents the result of a schedule a router to
+// a L3 agent operation. ExtractErr method to determine if the request
+// succeeded or failed.
+type ScheduleL3RouterResult struct {
+	gophercloud.ErrResult
+}
+
+// RemoveL3RouterResult represents the result of a remove a router from a
+// L3 agent operation. ExtractErr method to determine if the request succeeded
+// or failed.
+type RemoveL3RouterResult struct {
+	gophercloud.ErrResult
+}
+
+// Extract interprets any ListL3RoutesResult as an array of routers.
+func (r ListL3RoutersResult) Extract() ([]routers.Router, error) {
+	var s struct {
+		Routers []routers.Router `json:"routers"`
+	}
+
+	err := r.ExtractInto(&s)
+	return s.Routers, err
 }

--- a/openstack/networking/v2/extensions/agents/testing/fixtures.go
+++ b/openstack/networking/v2/extensions/agents/testing/fixtures.go
@@ -345,3 +345,89 @@ const ListDRAgentHostingBGPSpeakersResult = `
   ]
 }
 `
+
+// AgentL3ListListResult represents raw response for the ListL3Routers request.
+const AgentL3RoutersListResult = `
+{
+    "routers": [
+        {
+            "admin_state_up": true,
+            "availability_zone_hints": [],
+            "availability_zones": [
+                "nova"
+            ],
+            "description": "",
+            "distributed": false,
+            "external_gateway_info": {
+                "enable_snat": true,
+                "external_fixed_ips": [
+                    {
+                        "ip_address": "172.24.4.3",
+                        "subnet_id": "b930d7f6-ceb7-40a0-8b81-a425dd994ccf"
+                    },
+                    {
+                        "ip_address": "2001:db8::c",
+                        "subnet_id": "0c56df5d-ace5-46c8-8f4c-45fa4e334d18"
+                    }
+                ],
+                "network_id": "ae34051f-aa6c-4c75-abf5-50dc9ac99ef3"
+            },
+            "flavor_id": "f7b14d9a-b0dc-4fbe-bb14-a0f4970a69e0",
+            "ha": false,
+            "id": "915a14a6-867b-4af7-83d1-70efceb146f9",
+            "name": "router2",
+            "revision_number": 1,
+            "routes": [
+                {
+                    "destination": "179.24.1.0/24",
+                    "nexthop": "172.24.3.99"
+                }
+            ],
+            "status": "ACTIVE",
+            "project_id": "0bd18306d801447bb457a46252d82d13",
+            "tenant_id": "0bd18306d801447bb457a46252d82d13",
+            "service_type_id": null
+        },
+        {
+            "admin_state_up": true,
+            "availability_zone_hints": [],
+            "availability_zones": [
+                "nova"
+            ],
+            "description": "",
+            "distributed": false,
+            "external_gateway_info": {
+                "enable_snat": true,
+                "external_fixed_ips": [
+                    {
+                        "ip_address": "172.24.4.6",
+                        "subnet_id": "b930d7f6-ceb7-40a0-8b81-a425dd994ccf"
+                    },
+                    {
+                        "ip_address": "2001:db8::9",
+                        "subnet_id": "0c56df5d-ace5-46c8-8f4c-45fa4e334d18"
+                    }
+                ],
+                "network_id": "ae34051f-aa6c-4c75-abf5-50dc9ac99ef3"
+            },
+            "flavor_id": "f7b14d9a-b0dc-4fbe-bb14-a0f4970a69e0",
+            "ha": false,
+            "id": "f8a44de0-fc8e-45df-93c7-f79bf3b01c95",
+            "name": "router1",
+            "revision_number": 1,
+            "routes": [],
+            "status": "ACTIVE",
+            "project_id": "0bd18306d801447bb457a46252d82d13",
+            "tenant_id": "0bd18306d801447bb457a46252d82d13",
+            "service_type_id": null
+        }
+    ]
+}
+`
+
+// ScheduleL3RouterRequest represents raw request for the ScheduleL3Router request.
+const ScheduleL3RouterRequest = `
+{
+    "router_id": "43e66290-79a4-415d-9eb9-7ff7919839e1"
+}
+`

--- a/openstack/networking/v2/extensions/agents/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/agents/testing/requests_test.go
@@ -344,8 +344,8 @@ func TestListL3Routers(t *testing.T) {
 
 	routes := []routers.Route{
 		{
-			"172.24.3.99",
-			"179.24.1.0/24",
+			NextHop:         "172.24.3.99",
+			DestinationCIDR: "179.24.1.0/24",
 		},
 	}
 

--- a/openstack/networking/v2/extensions/agents/urls.go
+++ b/openstack/networking/v2/extensions/agents/urls.go
@@ -46,8 +46,6 @@ func listDHCPNetworksURL(c *gophercloud.ServiceClient, id string) string {
 }
 
 func listL3RoutersURL(c *gophercloud.ServiceClient, id string) string {
-	// TODO
-	// hmm list should be the plain l3RoutersURL but dhcp example tell otherwise
 	return l3RoutersURL(c, id)
 }
 

--- a/openstack/networking/v2/extensions/agents/urls.go
+++ b/openstack/networking/v2/extensions/agents/urls.go
@@ -4,6 +4,7 @@ import "github.com/gophercloud/gophercloud"
 
 const resourcePath = "agents"
 const dhcpNetworksResourcePath = "dhcp-networks"
+const l3RoutersResourcePath = "l3-routers"
 const bgpSpeakersResourcePath = "bgp-drinstances"
 const bgpDRAgentSpeakersResourcePath = "bgp-speakers"
 const bgpDRAgentAgentResourcePath = "bgp-dragents"
@@ -36,16 +37,34 @@ func dhcpNetworksURL(c *gophercloud.ServiceClient, id string) string {
 	return c.ServiceURL(resourcePath, id, dhcpNetworksResourcePath)
 }
 
+func l3RoutersURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL(resourcePath, id, l3RoutersResourcePath)
+}
+
 func listDHCPNetworksURL(c *gophercloud.ServiceClient, id string) string {
 	return dhcpNetworksURL(c, id)
+}
+
+func listL3RoutersURL(c *gophercloud.ServiceClient, id string) string {
+	// TODO
+	// hmm list should be the plain l3RoutersURL but dhcp example tell otherwise
+	return l3RoutersURL(c, id)
 }
 
 func scheduleDHCPNetworkURL(c *gophercloud.ServiceClient, id string) string {
 	return dhcpNetworksURL(c, id)
 }
 
+func scheduleL3RouterURL(c *gophercloud.ServiceClient, id string) string {
+	return l3RoutersURL(c, id)
+}
+
 func removeDHCPNetworkURL(c *gophercloud.ServiceClient, id string, networkID string) string {
 	return c.ServiceURL(resourcePath, id, dhcpNetworksResourcePath, networkID)
+}
+
+func removeL3RouterURL(c *gophercloud.ServiceClient, id string, routerID string) string {
+	return c.ServiceURL(resourcePath, id, l3RoutersResourcePath, routerID)
 }
 
 // return /v2.0/agents/{agent-id}/bgp-drinstances


### PR DESCRIPTION
Fixes #2500

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

* [remove_router_from_l3_agent](https://github.com/openstack/neutron/blob/fefd9a6bb1e5b685d56c75e7a538b0dfc0a959ec/neutron/db/l3_agentschedulers_db.py#L191-L223)

* [list_routers_on_l3_agent](https://github.com/openstack/neutron/blob/fefd9a6bb1e5b685d56c75e7a538b0dfc0a959ec/neutron/db/l3_agentschedulers_db.py#L284-L295)

* [add_router_to_l3_agent](https://github.com/openstack/neutron/blob/fefd9a6bb1e5b685d56c75e7a538b0dfc0a959ec/neutron/db/l3_agentschedulers_db.py#L158-L175)


* Acceptance test can't be run in CI because necessary extension is disabled, I am able to run it locally just fine.