### PR TITLE
tests: Fix Go v1.14 "go vet"

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -29,6 +29,10 @@ jobs:
 
       - name: Setup environment
         run: |
+          # Changing into a different directory to avoid polluting go.sum with "go get"
+          cd "$(mktemp -d)"
+
+          # we use "go get" for Go v1.14
           go install github.com/wadey/gocovmerge@master || go get github.com/wadey/gocovmerge
           go install golang.org/x/tools/cmd/goimports@latest || go get golang.org/x/tools/cmd/goimports
 


### PR DESCRIPTION
We use "go get" to install test dependencies in Go v1.14. As a side
effect, `go.sum` was polluted and `golang.org/x/crypto` was bumped to a
version that is incompatible with Go v1.14.

With this change, installing test dependencies no longer changes the
state of the checked-out repository.