### PR TITLE
[Identity v3] Add available domain listing

### DIFF
--- a/acceptance/openstack/identity/v3/domains_test.go
+++ b/acceptance/openstack/identity/v3/domains_test.go
@@ -12,6 +12,23 @@ import (
 	th "github.com/gophercloud/gophercloud/testhelper"
 )
 
+func TestDomainsListAvailable(t *testing.T) {
+	clients.RequireAdmin(t)
+
+	client, err := clients.NewIdentityV3Client()
+	th.AssertNoErr(t, err)
+
+	allPages, err := domains.ListAvailable(client).AllPages()
+	th.AssertNoErr(t, err)
+
+	allDomains, err := domains.ExtractDomains(allPages)
+	th.AssertNoErr(t, err)
+
+	for _, domain := range allDomains {
+		tools.PrintResource(t, domain)
+	}
+}
+
 func TestDomainsList(t *testing.T) {
 	clients.RequireAdmin(t)
 

--- a/openstack/identity/v3/domains/requests.go
+++ b/openstack/identity/v3/domains/requests.go
@@ -41,6 +41,14 @@ func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pa
 	})
 }
 
+// ListAvailable enumerates the domains which are available to a specific user.
+func ListAvailable(client *gophercloud.ServiceClient) pagination.Pager {
+	url := listAvailableURL(client)
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return DomainPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
 // Get retrieves details on a single domain, by ID.
 func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {
 	resp, err := client.Get(getURL(client, id), &r.Body, nil)

--- a/openstack/identity/v3/domains/testing/fixtures.go
+++ b/openstack/identity/v3/domains/testing/fixtures.go
@@ -10,6 +10,37 @@ import (
 	"github.com/gophercloud/gophercloud/testhelper/client"
 )
 
+// ListAvailableOutput provides a single page of available domain results.
+const ListAvailableOutput = `
+{
+    "domains": [
+        {
+            "id": "52af04aec5f84182b06959d2775d2000",
+            "name": "TestDomain",
+            "description": "Testing domain",
+            "enabled": false,
+            "links": {
+                "self": "https://example.com/v3/domains/52af04aec5f84182b06959d2775d2000"
+            }
+        },
+        {
+            "id": "a720688fb87f4575a4c000d818061eae",
+            "name": "ProdDomain",
+            "description": "Production domain",
+            "enabled": true,
+            "links": {
+                "self": "https://example.com/v3/domains/a720688fb87f4575a4c000d818061eae"
+            }
+        }
+    ],
+    "links": {
+        "next": null,
+        "self": "https://example.com/v3/auth/domains",
+        "previous": null
+    }
+}
+`
+
 // ListOutput provides a single page of Domain results.
 const ListOutput = `
 {
@@ -87,6 +118,28 @@ const UpdateOutput = `
 }
 `
 
+// ProdDomain is a domain fixture.
+var ProdDomain = domains.Domain{
+	Enabled: true,
+	ID:      "a720688fb87f4575a4c000d818061eae",
+	Links: map[string]interface{}{
+		"self": "https://example.com/v3/domains/a720688fb87f4575a4c000d818061eae",
+	},
+	Name:        "ProdDomain",
+	Description: "Production domain",
+}
+
+// TestDomain is a domain fixture.
+var TestDomain = domains.Domain{
+	Enabled: false,
+	ID:      "52af04aec5f84182b06959d2775d2000",
+	Links: map[string]interface{}{
+		"self": "https://example.com/v3/domains/52af04aec5f84182b06959d2775d2000",
+	},
+	Name:        "TestDomain",
+	Description: "Testing domain",
+}
+
 // FirstDomain is the first domain in the List request.
 var FirstDomain = domains.Domain{
 	Enabled: true,
@@ -119,8 +172,26 @@ var SecondDomainUpdated = domains.Domain{
 	Description: "Staging Domain",
 }
 
+// ExpectedAvailableDomainsSlice is the slice of domains expected to be returned
+// from ListAvailableOutput.
+var ExpectedAvailableDomainsSlice = []domains.Domain{TestDomain, ProdDomain}
+
 // ExpectedDomainsSlice is the slice of domains expected to be returned from ListOutput.
 var ExpectedDomainsSlice = []domains.Domain{FirstDomain, SecondDomain}
+
+// HandleListAvailableDomainsSuccessfully creates an HTTP handler at `/auth/domains`
+// on the test handler mux that responds with a list of two domains.
+func HandleListAvailableDomainsSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/auth/domains", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, ListAvailableOutput)
+	})
+}
 
 // HandleListDomainsSuccessfully creates an HTTP handler at `/domains` on the
 // test handler mux that responds with a list of two domains.

--- a/openstack/identity/v3/domains/testing/requests_test.go
+++ b/openstack/identity/v3/domains/testing/requests_test.go
@@ -9,6 +9,26 @@ import (
 	"github.com/gophercloud/gophercloud/testhelper/client"
 )
 
+func TestListAvailableDomains(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleListAvailableDomainsSuccessfully(t)
+
+	count := 0
+	err := domains.ListAvailable(client.ServiceClient()).EachPage(func(page pagination.Page) (bool, error) {
+		count++
+
+		actual, err := domains.ExtractDomains(page)
+		th.AssertNoErr(t, err)
+
+		th.CheckDeepEquals(t, ExpectedAvailableDomainsSlice, actual)
+
+		return true, nil
+	})
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, count, 1)
+}
+
 func TestListDomains(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()

--- a/openstack/identity/v3/domains/urls.go
+++ b/openstack/identity/v3/domains/urls.go
@@ -2,6 +2,10 @@ package domains
 
 import "github.com/gophercloud/gophercloud"
 
+func listAvailableURL(client *gophercloud.ServiceClient) string {
+	return client.ServiceURL("auth", "domains")
+}
+
 func listURL(client *gophercloud.ServiceClient) string {
 	return client.ServiceURL("domains")
 }


### PR DESCRIPTION
For #1719

Add support to list available domains for user.

API reference:
https://docs.openstack.org/api-ref/identity/v3/#get-available-domain-scopes

Implementation:
https://github.com/openstack/keystone/blob/master/keystone/api/auth.py#L148-L178