### PR TITLE
objectstorage: Do not parse NoContent responses

### DIFF
--- a/openstack/objectstorage/v1/containers/results.go
+++ b/openstack/objectstorage/v1/containers/results.go
@@ -30,6 +30,10 @@ type ContainerPage struct {
 
 // IsEmpty returns true if a ListResult contains no container names.
 func (r ContainerPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	names, err := ExtractNames(r)
 	return len(names) == 0, err
 }

--- a/openstack/objectstorage/v1/containers/testing/fixtures.go
+++ b/openstack/objectstorage/v1/containers/testing/fixtures.go
@@ -94,6 +94,19 @@ func HandleListContainerNamesSuccessfully(t *testing.T) {
 	})
 }
 
+// HandleListZeroContainerNames204 creates an HTTP handler at `/` on the test handler mux that
+// responds with "204 No Content" when container names are requested. This happens on some, but not all,
+// objectstorage instances. This case is peculiar in that the server sends no `content-type` header.
+func HandleListZeroContainerNames204(t *testing.T) {
+	th.Mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Accept", "text/plain")
+
+		w.WriteHeader(http.StatusNoContent)
+	})
+}
+
 // HandleCreateContainerSuccessfully creates an HTTP handler at `/testContainer` on the test handler mux that
 // responds with a `Create` response.
 func HandleCreateContainerSuccessfully(t *testing.T) {

--- a/openstack/objectstorage/v1/containers/testing/requests_test.go
+++ b/openstack/objectstorage/v1/containers/testing/requests_test.go
@@ -79,6 +79,18 @@ func TestListAllContainerNames(t *testing.T) {
 	th.CheckDeepEquals(t, ExpectedListNames, actual)
 }
 
+func TestListZeroContainerNames(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleListZeroContainerNames204(t)
+
+	allPages, err := containers.List(fake.ServiceClient(), &containers.ListOpts{Full: false}).AllPages()
+	th.AssertNoErr(t, err)
+	actual, err := containers.ExtractNames(allPages)
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, []string{}, actual)
+}
+
 func TestCreateContainer(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()

--- a/openstack/objectstorage/v1/objects/results.go
+++ b/openstack/objectstorage/v1/objects/results.go
@@ -70,6 +70,10 @@ type ObjectPage struct {
 
 // IsEmpty returns true if a ListResult contains no object names.
 func (r ObjectPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	names, err := ExtractNames(r)
 	return len(names) == 0, err
 }

--- a/openstack/objectstorage/v1/objects/testing/fixtures.go
+++ b/openstack/objectstorage/v1/objects/testing/fixtures.go
@@ -162,6 +162,19 @@ func HandleListObjectNamesSuccessfully(t *testing.T) {
 	})
 }
 
+// HandleListZeroObjectNames204 creates an HTTP handler at `/testContainer` on the test handler mux that
+// responds with "204 No Content" when object names are requested. This happens on some, but not all, objectstorage
+// instances. This case is peculiar in that the server sends no `content-type` header.
+func HandleListZeroObjectNames204(t *testing.T) {
+	th.Mux.HandleFunc("/testContainer", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Accept", "text/plain")
+
+		w.WriteHeader(http.StatusNoContent)
+	})
+}
+
 // HandleCreateTextObjectSuccessfully creates an HTTP handler at `/testContainer/testObject` on the test handler mux
 // that responds with a `Create` response. A Content-Type of "text/plain" is expected.
 func HandleCreateTextObjectSuccessfully(t *testing.T, content string) {

--- a/openstack/objectstorage/v1/objects/testing/requests_test.go
+++ b/openstack/objectstorage/v1/objects/testing/requests_test.go
@@ -160,6 +160,29 @@ func TestListObjectNames(t *testing.T) {
 	th.CheckEquals(t, count, 1)
 }
 
+func TestListZeroObjectNames204(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleListZeroObjectNames204(t)
+
+	count := 0
+	options := &objects.ListOpts{Full: false}
+	err := objects.List(fake.ServiceClient(), "testContainer", options).EachPage(func(page pagination.Page) (bool, error) {
+		count++
+		actual, err := objects.ExtractNames(page)
+		if err != nil {
+			t.Errorf("Failed to extract container names: %v", err)
+			return false, err
+		}
+
+		th.CheckDeepEquals(t, []string{}, actual)
+
+		return true, nil
+	})
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, 0, count)
+}
+
 func TestCreateObject(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()

--- a/pagination/http.go
+++ b/pagination/http.go
@@ -44,8 +44,9 @@ func PageResultFrom(resp *http.Response) (PageResult, error) {
 func PageResultFromParsed(resp *http.Response, body interface{}) PageResult {
 	return PageResult{
 		Result: gophercloud.Result{
-			Body:   body,
-			Header: resp.Header,
+			Body:       body,
+			StatusCode: resp.StatusCode,
+			Header:     resp.Header,
 		},
 		URL: *resp.Request.URL,
 	}

--- a/results.go
+++ b/results.go
@@ -30,6 +30,11 @@ type Result struct {
 	// this will be the deserialized JSON structure.
 	Body interface{}
 
+	// StatusCode is the HTTP status code of the original response. Will be
+	// one of the OkCodes defined on the gophercloud.RequestOpts that was
+	// used in the request.
+	StatusCode int
+
 	// Header contains the HTTP header structure from the original response.
 	Header http.Header
 


### PR DESCRIPTION
Some Swift instances respond with HTTP status code 204 when asked to list containers and there are no containers, or when asked to list objects on an empty container. Before this patch, Gophercloud would error because the header `content-type` is absent on the response.

With this patch, objectstorage responses with HTTP status code 204 are immediately recognised as empty and their body is not read.

Potentially supersedes https://github.com/gophercloud/gophercloud/pull/2510