### PR TITLE
Modify user-agent header to ensure current gophercloud version is provided

### DIFF
--- a/provider_client.go
+++ b/provider_client.go
@@ -14,7 +14,7 @@ import (
 
 // DefaultUserAgent is the default User-Agent string set in the request header.
 const (
-	DefaultUserAgent         = "gophercloud/2.0.0"
+	DefaultUserAgent         = "gophercloud/v1.1.1"
 	DefaultMaxBackoffRetries = 60
 )
 

--- a/testing/provider_client_test.go
+++ b/testing/provider_client_test.go
@@ -32,17 +32,17 @@ func TestUserAgent(t *testing.T) {
 	p := &gophercloud.ProviderClient{}
 
 	p.UserAgent.Prepend("custom-user-agent/2.4.0")
-	expected := "custom-user-agent/2.4.0 gophercloud/2.0.0"
+	expected := "custom-user-agent/2.4.0 " + gophercloud.DefaultUserAgent
 	actual := p.UserAgent.Join()
 	th.CheckEquals(t, expected, actual)
 
 	p.UserAgent.Prepend("another-custom-user-agent/0.3.0", "a-third-ua/5.9.0")
-	expected = "another-custom-user-agent/0.3.0 a-third-ua/5.9.0 custom-user-agent/2.4.0 gophercloud/2.0.0"
+	expected = "another-custom-user-agent/0.3.0 a-third-ua/5.9.0 custom-user-agent/2.4.0 " + gophercloud.DefaultUserAgent
 	actual = p.UserAgent.Join()
 	th.CheckEquals(t, expected, actual)
 
 	p.UserAgent = gophercloud.UserAgent{}
-	expected = "gophercloud/2.0.0"
+	expected = gophercloud.DefaultUserAgent
 	actual = p.UserAgent.Join()
 	th.CheckEquals(t, expected, actual)
 }


### PR DESCRIPTION
Fixes #2511

In addition to this change a new github action will be required to ensure there is no version drift.
This version should stay in-line with the current release of gophercloud