### PR TITLE
CI: cleanup some jobs for containerinfra & dns

### DIFF
--- a/.github/workflows/functional-containerinfra.yaml
+++ b/.github/workflows/functional-containerinfra.yaml
@@ -26,12 +26,6 @@ jobs:
           - name: "victoria"
             openstack_version: "stable/victoria"
             ubuntu_version: "20.04"
-          - name: "ussuri"
-            openstack_version: "stable/ussuri"
-            ubuntu_version: "18.04"
-          - name: "train"
-            openstack_version: "stable/train"
-            ubuntu_version: "18.04"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with Magnum and run containerinfra acceptance tests
     steps:

--- a/.github/workflows/functional-dns.yaml
+++ b/.github/workflows/functional-dns.yaml
@@ -30,9 +30,6 @@ jobs:
           - name: "ussuri"
             openstack_version: "stable/ussuri"
             ubuntu_version: "18.04"
-          - name: "train"
-            openstack_version: "stable/train"
-            ubuntu_version: "18.04"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with Designate and run dns acceptance tests
     steps:


### PR DESCRIPTION
* containerinfra: train and ussuri aren't supported anymore in upstream.
* dns: train isn't supported anymore in upstream.

Let's remove these jobs, since they can't work anyway.
