### PR TITLE
keystone: add v3 OS-FEDERATION mappings create operation

### DIFF
--- a/acceptance/openstack/identity/v3/federation_test.go
+++ b/acceptance/openstack/identity/v3/federation_test.go
@@ -25,7 +25,9 @@ func TestListMappings(t *testing.T) {
 	tools.PrintResource(t, mappings)
 }
 
-func TestCreateMapping(t *testing.T) {
+func TestMappingsCRUD(t *testing.T) {
+	mappingName := tools.RandomString("TESTMAPPING-", 8)
+
 	clients.RequireAdmin(t)
 
 	client, err := clients.NewIdentityV3Client()
@@ -62,7 +64,7 @@ func TestCreateMapping(t *testing.T) {
 		},
 	}
 
-	actual, err := federation.CreateMapping(client, "ACME", createOpts).Extract()
+	actual, err := federation.CreateMapping(client, mappingName, createOpts).Extract()
 	th.AssertNoErr(t, err)
 	th.CheckDeepEquals(t, createOpts.Rules[0], actual.Rules[0])
 }

--- a/acceptance/openstack/identity/v3/federation_test.go
+++ b/acceptance/openstack/identity/v3/federation_test.go
@@ -24,3 +24,45 @@ func TestListMappings(t *testing.T) {
 
 	tools.PrintResource(t, mappings)
 }
+
+func TestCreateMapping(t *testing.T) {
+	clients.RequireAdmin(t)
+
+	client, err := clients.NewIdentityV3Client()
+	th.AssertNoErr(t, err)
+
+	createOpts := federation.CreateMappingOpts{
+		Rules: []federation.MappingRule{
+			{
+				Local: []federation.RuleLocal{
+					{
+						User: &federation.RuleUser{
+							Name: "{0}",
+						},
+					},
+					{
+						Group: &federation.Group{
+							ID: "0cd5e9",
+						},
+					},
+				},
+				Remote: []federation.RuleRemote{
+					{
+						Type: "UserName",
+					},
+					{
+						Type: "orgPersonType",
+						NotAnyOf: []string{
+							"Contractor",
+							"Guest",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	actual, err := federation.CreateMapping(client, "ACME", createOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, createOpts.Rules[0], actual.Rules[0])
+}

--- a/openstack/identity/v3/extensions/federation/doc.go
+++ b/openstack/identity/v3/extensions/federation/doc.go
@@ -12,5 +12,38 @@ Example to List Mappings
 	if err != nil {
 		panic(err)
 	}
+
+Example to Create Mappings
+
+	createOpts := federation.CreateMappingOpts{
+		Rules: []federation.MappingRule{
+			{
+				Local: []federation.RuleLocal{
+					{
+						User: &federation.RuleUser{
+							Name: "{0}",
+						},
+					},
+					{
+						Group: &federation.Group{
+							ID: "0cd5e9",
+						},
+					},
+				},
+				Remote: []federation.RuleRemote{
+					{
+						Type: "UserName",
+					},
+					{
+						Type: "orgPersonType",
+						NotAnyOf: []string{
+							"Contractor",
+							"Guest",
+						},
+					},
+				},
+			},
+		},
+	}
 */
 package federation

--- a/openstack/identity/v3/extensions/federation/doc.go
+++ b/openstack/identity/v3/extensions/federation/doc.go
@@ -45,5 +45,10 @@ Example to Create Mappings
 			},
 		},
 	}
+
+	createdMapping, err := federation.CreateMapping(identityClient, "ACME", createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
 */
 package federation

--- a/openstack/identity/v3/extensions/federation/requests.go
+++ b/openstack/identity/v3/extensions/federation/requests.go
@@ -11,3 +11,34 @@ func ListMappings(client *gophercloud.ServiceClient) pagination.Pager {
 		return MappingsPage{pagination.LinkedPageBase{PageResult: r}}
 	})
 }
+
+// CreateMappingOptsBuilder allows extensions to add additional parameters to
+// the Create request.
+type CreateMappingOptsBuilder interface {
+	ToMappingCreateMap() (map[string]interface{}, error)
+}
+
+// UpdateMappingOpts provides options for creating a mapping.
+type CreateMappingOpts struct {
+	// The list of rules used to map remote users into local users
+	Rules []MappingRule `json:"rules"`
+}
+
+// ToMappingCreateMap formats a CreateMappingOpts into a create request.
+func (opts CreateMappingOpts) ToMappingCreateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "mapping")
+}
+
+// CreateMapping creates a new Mapping.
+func CreateMapping(client *gophercloud.ServiceClient, mappingID string, opts CreateMappingOptsBuilder) (r CreateMappingResult) {
+	b, err := opts.ToMappingCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := client.Put(mappingsResourceURL(client, mappingID), &b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{201},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}

--- a/openstack/identity/v3/extensions/federation/results.go
+++ b/openstack/identity/v3/extensions/federation/results.go
@@ -1,6 +1,7 @@
 package federation
 
 import (
+	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/pagination"
 )
 
@@ -128,6 +129,25 @@ type RuleUser struct {
 
 	// User type
 	Type *UserType `json:"type,omitempty"`
+}
+
+type mappingResult struct {
+	gophercloud.Result
+}
+
+// Extract interprets any mappingResult as a Mapping.
+func (c mappingResult) Extract() (*Mapping, error) {
+	var s struct {
+		Mapping *Mapping `json:"mapping"`
+	}
+	err := c.ExtractInto(&s)
+	return s.Mapping, err
+}
+
+// CreateMappingResult is the response from a CreateMapping operation.
+// Call its Extract method to interpret it as a Mapping.
+type CreateMappingResult struct {
+	mappingResult
 }
 
 // MappingsPage is a single page of Mapping results.

--- a/openstack/identity/v3/extensions/federation/testing/fixtures.go
+++ b/openstack/identity/v3/extensions/federation/testing/fixtures.go
@@ -56,6 +56,80 @@ const ListOutput = `
 }
 `
 
+const CreateRequest = `
+  {
+    "mapping": {
+        "rules": [
+            {
+                "local": [
+                    {
+                        "user": {
+                            "name": "{0}"
+                        }
+                    },
+                    {
+                        "group": {
+                            "id": "0cd5e9"
+                        }
+                    }
+                ],
+                "remote": [
+                    {
+                        "type": "UserName"
+                    },
+                    {
+                        "type": "orgPersonType",
+                        "not_any_of": [
+                            "Contractor",
+                            "Guest"
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}
+`
+
+const CreateOutput = `
+{
+    "mapping": {
+        "id": "ACME",
+        "links": {
+            "self": "http://example.com/identity/v3/OS-FEDERATION/mappings/ACME"
+        },
+        "rules": [
+            {
+                "local": [
+                    {
+                        "user": {
+                            "name": "{0}"
+                        }
+                    },
+                    {
+                        "group": {
+                            "id": "0cd5e9"
+                        }
+                    }
+                ],
+                "remote": [
+                    {
+                        "type": "UserName"
+                    },
+                    {
+                        "type": "orgPersonType",
+                        "not_any_of": [
+                            "Contractor",
+                            "Guest"
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}
+`
+
 var MappingACME = federation.Mapping{
 	ID: "ACME",
 	Links: map[string]interface{}{
@@ -105,5 +179,18 @@ func HandleListMappingsSuccessfully(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprintf(w, ListOutput)
+	})
+}
+
+// HandleCreateMappingSuccessfully creates an HTTP handler at `/mappings` on the
+// test handler mux that tests mapping creation.
+func HandleCreateMappingSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/OS-FEDERATION/mappings/ACME", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, CreateRequest)
+
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprintf(w, CreateOutput)
 	})
 }

--- a/openstack/identity/v3/extensions/federation/testing/requests_test.go
+++ b/openstack/identity/v3/extensions/federation/testing/requests_test.go
@@ -40,3 +40,44 @@ func TestListMappingsAllPages(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.CheckDeepEquals(t, ExpectedMappingsSlice, actual)
 }
+
+func TestCreateMappings(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleCreateMappingSuccessfully(t)
+
+	createOpts := federation.CreateMappingOpts{
+		Rules: []federation.MappingRule{
+			{
+				Local: []federation.RuleLocal{
+					{
+						User: &federation.RuleUser{
+							Name: "{0}",
+						},
+					},
+					{
+						Group: &federation.Group{
+							ID: "0cd5e9",
+						},
+					},
+				},
+				Remote: []federation.RuleRemote{
+					{
+						Type: "UserName",
+					},
+					{
+						Type: "orgPersonType",
+						NotAnyOf: []string{
+							"Contractor",
+							"Guest",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	actual, err := federation.CreateMapping(client.ServiceClient(), "ACME", createOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, MappingACME, *actual)
+}

--- a/openstack/identity/v3/extensions/federation/urls.go
+++ b/openstack/identity/v3/extensions/federation/urls.go
@@ -10,3 +10,7 @@ const (
 func mappingsRootURL(c *gophercloud.ServiceClient) string {
 	return c.ServiceURL(rootPath, mappingsPath)
 }
+
+func mappingsResourceURL(c *gophercloud.ServiceClient, mappingID string) string {
+	return c.ServiceURL(rootPath, mappingsPath, mappingID)
+}


### PR DESCRIPTION
For https://github.com/gophercloud/gophercloud/issues/2461

[docs](https://docs.openstack.org/api-ref/identity/v3-ext/index.html#create-a-mapping)
[code](https://github.com/openstack/keystone/blob/stable/yoga/keystone/api/os_federation.py#L275)