### PR TITLE
Support value_specs for Ports

### DIFF
--- a/openstack/networking/v2/ports/requests.go
+++ b/openstack/networking/v2/ports/requests.go
@@ -110,18 +110,19 @@ type CreateOptsBuilder interface {
 
 // CreateOpts represents the attributes used when creating a new port.
 type CreateOpts struct {
-	NetworkID           string        `json:"network_id" required:"true"`
-	Name                string        `json:"name,omitempty"`
-	Description         string        `json:"description,omitempty"`
-	AdminStateUp        *bool         `json:"admin_state_up,omitempty"`
-	MACAddress          string        `json:"mac_address,omitempty"`
-	FixedIPs            interface{}   `json:"fixed_ips,omitempty"`
-	DeviceID            string        `json:"device_id,omitempty"`
-	DeviceOwner         string        `json:"device_owner,omitempty"`
-	TenantID            string        `json:"tenant_id,omitempty"`
-	ProjectID           string        `json:"project_id,omitempty"`
-	SecurityGroups      *[]string     `json:"security_groups,omitempty"`
-	AllowedAddressPairs []AddressPair `json:"allowed_address_pairs,omitempty"`
+	NetworkID           string            `json:"network_id" required:"true"`
+	Name                string            `json:"name,omitempty"`
+	Description         string            `json:"description,omitempty"`
+	AdminStateUp        *bool             `json:"admin_state_up,omitempty"`
+	MACAddress          string            `json:"mac_address,omitempty"`
+	FixedIPs            interface{}       `json:"fixed_ips,omitempty"`
+	DeviceID            string            `json:"device_id,omitempty"`
+	DeviceOwner         string            `json:"device_owner,omitempty"`
+	TenantID            string            `json:"tenant_id,omitempty"`
+	ProjectID           string            `json:"project_id,omitempty"`
+	SecurityGroups      *[]string         `json:"security_groups,omitempty"`
+	AllowedAddressPairs []AddressPair     `json:"allowed_address_pairs,omitempty"`
+	ValueSpecs          map[string]string `json:"value_specs,omitempty"`
 }
 
 // ToPortCreateMap builds a request body from CreateOpts.
@@ -150,14 +151,15 @@ type UpdateOptsBuilder interface {
 
 // UpdateOpts represents the attributes used when updating an existing port.
 type UpdateOpts struct {
-	Name                *string        `json:"name,omitempty"`
-	Description         *string        `json:"description,omitempty"`
-	AdminStateUp        *bool          `json:"admin_state_up,omitempty"`
-	FixedIPs            interface{}    `json:"fixed_ips,omitempty"`
-	DeviceID            *string        `json:"device_id,omitempty"`
-	DeviceOwner         *string        `json:"device_owner,omitempty"`
-	SecurityGroups      *[]string      `json:"security_groups,omitempty"`
-	AllowedAddressPairs *[]AddressPair `json:"allowed_address_pairs,omitempty"`
+	Name                *string           `json:"name,omitempty"`
+	Description         *string           `json:"description,omitempty"`
+	AdminStateUp        *bool             `json:"admin_state_up,omitempty"`
+	FixedIPs            interface{}       `json:"fixed_ips,omitempty"`
+	DeviceID            *string           `json:"device_id,omitempty"`
+	DeviceOwner         *string           `json:"device_owner,omitempty"`
+	SecurityGroups      *[]string         `json:"security_groups,omitempty"`
+	AllowedAddressPairs *[]AddressPair    `json:"allowed_address_pairs,omitempty"`
+	ValueSpecs          map[string]string `json:"value_specs,omitempty"`
 
 	// RevisionNumber implements extension:standard-attr-revisions. If != "" it
 	// will set revision_number=%s. If the revision number does not match, the

--- a/openstack/networking/v2/ports/results.go
+++ b/openstack/networking/v2/ports/results.go
@@ -111,6 +111,9 @@ type Port struct {
 	// Tags optionally set via extensions/attributestags
 	Tags []string `json:"tags"`
 
+	// Extra parameters to include in the request.
+	ValueSpecs map[string]string `json:"value_specs"`
+
 	// RevisionNumber optionally set via extensions/standard-attr-revisions
 	RevisionNumber int `json:"revision_number"`
 

--- a/openstack/networking/v2/ports/testing/fixtures.go
+++ b/openstack/networking/v2/ports/testing/fixtures.go
@@ -240,6 +240,66 @@ const CreateOmitSecurityGroupsResponse = `
 }
 `
 
+const CreateValueSpecRequest = `
+{
+    "port": {
+        "network_id": "a87cc70a-3e15-4acf-8205-9b711a3531b7",
+        "name": "private-port",
+        "admin_state_up": true,
+        "fixed_ips": [
+            {
+                "subnet_id": "a0304c3a-4f08-4c43-88af-d796509c97d2",
+                "ip_address": "10.0.0.2"
+            }
+        ],
+        "security_groups": ["foo"],
+        "allowed_address_pairs": [
+          {
+            "ip_address": "10.0.0.4",
+            "mac_address": "fa:16:3e:c9:cb:f0"
+          }
+        ],
+        "value_specs": {
+            "key": "value"
+        }
+    }
+}
+`
+
+const CreateValueSpecResponse = `
+{
+    "port": {
+        "status": "DOWN",
+        "name": "private-port",
+        "admin_state_up": true,
+        "network_id": "a87cc70a-3e15-4acf-8205-9b711a3531b7",
+        "tenant_id": "d6700c0c9ffa4f1cb322cd4a1f3906fa",
+        "device_owner": "",
+        "mac_address": "fa:16:3e:c9:cb:f0",
+        "fixed_ips": [
+            {
+                "subnet_id": "a0304c3a-4f08-4c43-88af-d796509c97d2",
+                "ip_address": "10.0.0.2"
+            }
+        ],
+        "id": "65c0ee9f-d634-4522-8954-51021b570b0d",
+        "security_groups": [
+            "f0ac4394-7e4a-4409-9701-ba8be283dbc3"
+        ],
+        "allowed_address_pairs": [
+          {
+            "ip_address": "10.0.0.4",
+            "mac_address": "fa:16:3e:c9:cb:f0"
+          }
+        ],
+        "value_specs": {
+            "key": "value"
+        },
+        "device_id": ""
+    }
+}
+`
+
 const CreatePortSecurityRequest = `
 {
     "port": {

--- a/openstack/networking/v2/ports/testing/requests_test.go
+++ b/openstack/networking/v2/ports/testing/requests_test.go
@@ -314,6 +314,60 @@ func TestCreateWithNoSecurityGroup(t *testing.T) {
 	})
 }
 
+func TestCreateWithValueSpecs(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/ports", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, CreateValueSpecRequest)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+
+		fmt.Fprintf(w, CreateValueSpecResponse)
+	})
+
+	asu := true
+	options := ports.CreateOpts{
+		Name:         "private-port",
+		AdminStateUp: &asu,
+		NetworkID:    "a87cc70a-3e15-4acf-8205-9b711a3531b7",
+		FixedIPs: []ports.IP{
+			{SubnetID: "a0304c3a-4f08-4c43-88af-d796509c97d2", IPAddress: "10.0.0.2"},
+		},
+		SecurityGroups: &[]string{"foo"},
+		AllowedAddressPairs: []ports.AddressPair{
+			{IPAddress: "10.0.0.4", MACAddress: "fa:16:3e:c9:cb:f0"},
+		},
+		ValueSpecs: map[string]string{
+			"key": "value",
+		},
+	}
+	n, err := ports.Create(fake.ServiceClient(), options).Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, n.Status, "DOWN")
+	th.AssertEquals(t, n.Name, "private-port")
+	th.AssertEquals(t, n.AdminStateUp, true)
+	th.AssertEquals(t, n.NetworkID, "a87cc70a-3e15-4acf-8205-9b711a3531b7")
+	th.AssertEquals(t, n.TenantID, "d6700c0c9ffa4f1cb322cd4a1f3906fa")
+	th.AssertEquals(t, n.DeviceOwner, "")
+	th.AssertEquals(t, n.MACAddress, "fa:16:3e:c9:cb:f0")
+	th.AssertDeepEquals(t, n.FixedIPs, []ports.IP{
+		{SubnetID: "a0304c3a-4f08-4c43-88af-d796509c97d2", IPAddress: "10.0.0.2"},
+	})
+	th.AssertEquals(t, n.ID, "65c0ee9f-d634-4522-8954-51021b570b0d")
+	th.AssertDeepEquals(t, n.SecurityGroups, []string{"f0ac4394-7e4a-4409-9701-ba8be283dbc3"})
+	th.AssertDeepEquals(t, n.AllowedAddressPairs, []ports.AddressPair{
+		{IPAddress: "10.0.0.4", MACAddress: "fa:16:3e:c9:cb:f0"},
+	})
+	th.AssertDeepEquals(t, n.ValueSpecs, map[string]string{"key": "value"})
+}
+
 func TestRequiredCreateOpts(t *testing.T) {
 	res := ports.Create(fake.ServiceClient(), ports.CreateOpts{})
 	if res.Err == nil {


### PR DESCRIPTION
Fixes #2532

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

Docs: https://docs.openstack.org/heat/zed/template_guide/openstack.html#OS::Neutron::Port-prop-value_specs
