### PR TITLE
README: remove some notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,19 +138,3 @@ See the [contributing guide](./.github/CONTRIBUTING.md).
 
 If you're struggling with something or have spotted a potential bug, feel free
 to submit an issue to our [bug tracker](https://github.com/gophercloud/gophercloud/issues).
-
-## Thank You
-
-We'd like to extend special thanks and appreciation to the following:
-
-### OpenLab
-
-<a href="http://openlabtesting.org/"><img src="./docs/assets/openlab.png" width="600px"></a>
-
-OpenLab is providing a full CI environment to test each PR and merge for a variety of OpenStack releases.
-
-### VEXXHOST
-
-<a href="https://vexxhost.com/"><img src="./docs/assets/vexxhost.png" width="600px"></a>
-
-VEXXHOST is providing their services to assist with the development and testing of Gophercloud.


### PR DESCRIPTION
Some notes are outdated, we don't use openlab nor vexxhost anymore, we
can remove the notes here to avoid confusion on where our CI is located
now.