### PR TITLE
[all] IsEmpty to check for HTTP status 204

### DIFF
--- a/docs/contributor-tutorial/.template/results.go
+++ b/docs/contributor-tutorial/.template/results.go
@@ -44,6 +44,10 @@ type ResourcePage struct {
 
 // IsEmpty determines whether or not a page of RESOURCES contains any results.
 func (r ResourcePage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	resources, err := ExtractResources(r)
 	return len(resources) == 0, err
 }

--- a/openstack/baremetal/v1/allocations/results.go
+++ b/openstack/baremetal/v1/allocations/results.go
@@ -71,6 +71,10 @@ type AllocationPage struct {
 
 // IsEmpty returns true if a page contains no Allocation results.
 func (r AllocationPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	s, err := ExtractAllocations(r)
 	return len(s) == 0, err
 }

--- a/openstack/baremetal/v1/drivers/results.go
+++ b/openstack/baremetal/v1/drivers/results.go
@@ -134,6 +134,10 @@ type DriverPage struct {
 
 // IsEmpty returns true if a page contains no Driver results.
 func (r DriverPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	s, err := ExtractDrivers(r)
 	return len(s) == 0, err
 }

--- a/openstack/baremetal/v1/nodes/results.go
+++ b/openstack/baremetal/v1/nodes/results.go
@@ -263,6 +263,10 @@ type NodePage struct {
 
 // IsEmpty returns true if a page contains no Node results.
 func (r NodePage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	s, err := ExtractNodes(r)
 	return len(s) == 0, err
 }

--- a/openstack/baremetal/v1/ports/results.go
+++ b/openstack/baremetal/v1/ports/results.go
@@ -82,6 +82,10 @@ type PortPage struct {
 
 // IsEmpty returns true if a page contains no Port results.
 func (r PortPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	s, err := ExtractPorts(r)
 	return len(s) == 0, err
 }

--- a/openstack/baremetalintrospection/v1/introspection/results.go
+++ b/openstack/baremetalintrospection/v1/introspection/results.go
@@ -73,6 +73,10 @@ type Introspection struct {
 
 // IsEmpty returns true if a page contains no Introspection results.
 func (r IntrospectionPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	s, err := ExtractIntrospections(r)
 	return len(s) == 0, err
 }

--- a/openstack/blockstorage/apiversions/results.go
+++ b/openstack/blockstorage/apiversions/results.go
@@ -32,6 +32,10 @@ type APIVersionPage struct {
 
 // IsEmpty checks whether an APIVersionPage struct is empty.
 func (r APIVersionPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractAPIVersions(r)
 	return len(is) == 0, err
 }

--- a/openstack/blockstorage/extensions/backups/results.go
+++ b/openstack/blockstorage/extensions/backups/results.go
@@ -113,6 +113,10 @@ func (r *Backup) UnmarshalJSON(b []byte) error {
 
 // IsEmpty returns true if a BackupPage contains no Backups.
 func (r BackupPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	volumes, err := ExtractBackups(r)
 	return len(volumes) == 0, err
 }

--- a/openstack/blockstorage/extensions/quotasets/results.go
+++ b/openstack/blockstorage/extensions/quotasets/results.go
@@ -139,6 +139,10 @@ type QuotaSetPage struct {
 
 // IsEmpty determines whether or not a QuotaSetsetPage is empty.
 func (r QuotaSetPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	ks, err := ExtractQuotaSets(r)
 	return len(ks) == 0, err
 }

--- a/openstack/blockstorage/extensions/schedulerstats/results.go
+++ b/openstack/blockstorage/extensions/schedulerstats/results.go
@@ -97,6 +97,10 @@ type StoragePoolPage struct {
 // IsEmpty satisfies the IsEmpty method of the Page interface. It returns true
 // if a List contains no results.
 func (page StoragePoolPage) IsEmpty() (bool, error) {
+	if page.StatusCode == 204 {
+		return true, nil
+	}
+
 	va, err := ExtractStoragePools(page)
 	return len(va) == 0, err
 }

--- a/openstack/blockstorage/extensions/services/results.go
+++ b/openstack/blockstorage/extensions/services/results.go
@@ -71,6 +71,10 @@ type ServicePage struct {
 
 // IsEmpty determines whether or not a page of Services contains any results.
 func (page ServicePage) IsEmpty() (bool, error) {
+	if page.StatusCode == 204 {
+		return true, nil
+	}
+
 	services, err := ExtractServices(page)
 	return len(services) == 0, err
 }

--- a/openstack/blockstorage/extensions/volumetransfers/results.go
+++ b/openstack/blockstorage/extensions/volumetransfers/results.go
@@ -86,6 +86,10 @@ type TransferPage struct {
 
 // IsEmpty returns true if a ListResult contains no Transfers.
 func (r TransferPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	transfers, err := ExtractTransfers(r)
 	return len(transfers) == 0, err
 }

--- a/openstack/blockstorage/v1/apiversions/results.go
+++ b/openstack/blockstorage/v1/apiversions/results.go
@@ -20,6 +20,10 @@ type APIVersionPage struct {
 
 // IsEmpty checks whether an APIVersionPage struct is empty.
 func (r APIVersionPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractAPIVersions(r)
 	return len(is) == 0, err
 }

--- a/openstack/blockstorage/v1/snapshots/results.go
+++ b/openstack/blockstorage/v1/snapshots/results.go
@@ -89,6 +89,10 @@ type SnapshotPage struct {
 
 // IsEmpty returns true if a SnapshotPage contains no Snapshots.
 func (r SnapshotPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	volumes, err := ExtractSnapshots(r)
 	return len(volumes) == 0, err
 }

--- a/openstack/blockstorage/v1/volumes/results.go
+++ b/openstack/blockstorage/v1/volumes/results.go
@@ -77,6 +77,10 @@ type VolumePage struct {
 
 // IsEmpty returns true if a VolumePage contains no Volumes.
 func (r VolumePage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	volumes, err := ExtractVolumes(r)
 	return len(volumes) == 0, err
 }

--- a/openstack/blockstorage/v1/volumetypes/results.go
+++ b/openstack/blockstorage/v1/volumetypes/results.go
@@ -34,6 +34,10 @@ type VolumeTypePage struct {
 
 // IsEmpty returns true if a VolumeTypePage contains no Volume Types.
 func (r VolumeTypePage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	volumeTypes, err := ExtractVolumeTypes(r)
 	return len(volumeTypes) == 0, err
 }

--- a/openstack/blockstorage/v2/snapshots/results.go
+++ b/openstack/blockstorage/v2/snapshots/results.go
@@ -79,6 +79,10 @@ func (r *Snapshot) UnmarshalJSON(b []byte) error {
 
 // IsEmpty returns true if a SnapshotPage contains no Snapshots.
 func (r SnapshotPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	volumes, err := ExtractSnapshots(r)
 	return len(volumes) == 0, err
 }

--- a/openstack/blockstorage/v2/volumes/results.go
+++ b/openstack/blockstorage/v2/volumes/results.go
@@ -103,6 +103,10 @@ type VolumePage struct {
 
 // IsEmpty returns true if a ListResult contains no Volumes.
 func (r VolumePage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	volumes, err := ExtractVolumes(r)
 	return len(volumes) == 0, err
 }

--- a/openstack/blockstorage/v3/attachments/results.go
+++ b/openstack/blockstorage/v3/attachments/results.go
@@ -60,6 +60,10 @@ type AttachmentPage struct {
 
 // IsEmpty returns true if a ListResult contains no Attachments.
 func (r AttachmentPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	attachments, err := ExtractAttachments(r)
 	return len(attachments) == 0, err
 }

--- a/openstack/blockstorage/v3/qos/results.go
+++ b/openstack/blockstorage/v3/qos/results.go
@@ -49,6 +49,10 @@ type QoSPage struct {
 
 // IsEmpty determines if a QoSPage contains any results.
 func (page QoSPage) IsEmpty() (bool, error) {
+	if page.StatusCode == 204 {
+		return true, nil
+	}
+
 	qos, err := ExtractQoS(page)
 	return len(qos) == 0, err
 }
@@ -130,6 +134,10 @@ type AssociationPage struct {
 
 // IsEmpty indicates whether an Association page is empty.
 func (page AssociationPage) IsEmpty() (bool, error) {
+	if page.StatusCode == 204 {
+		return true, nil
+	}
+
 	v, err := ExtractAssociations(page)
 	return len(v) == 0, err
 }

--- a/openstack/blockstorage/v3/snapshots/results.go
+++ b/openstack/blockstorage/v3/snapshots/results.go
@@ -85,6 +85,10 @@ func (r *Snapshot) UnmarshalJSON(b []byte) error {
 
 // IsEmpty returns true if a SnapshotPage contains no Snapshots.
 func (r SnapshotPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	volumes, err := ExtractSnapshots(r)
 	return len(volumes) == 0, err
 }

--- a/openstack/blockstorage/v3/volumes/results.go
+++ b/openstack/blockstorage/v3/volumes/results.go
@@ -111,6 +111,10 @@ type VolumePage struct {
 
 // IsEmpty returns true if a ListResult contains no Volumes.
 func (r VolumePage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	volumes, err := ExtractVolumes(r)
 	return len(volumes) == 0, err
 }

--- a/openstack/blockstorage/v3/volumetypes/results.go
+++ b/openstack/blockstorage/v3/volumetypes/results.go
@@ -30,6 +30,10 @@ type VolumeTypePage struct {
 
 // IsEmpty returns true if a ListResult contains no Volume Types.
 func (r VolumeTypePage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	volumetypes, err := ExtractVolumeTypes(r)
 	return len(volumetypes) == 0, err
 }
@@ -168,6 +172,10 @@ type AccessPage struct {
 
 // IsEmpty indicates whether an AccessPage is empty.
 func (page AccessPage) IsEmpty() (bool, error) {
+	if page.StatusCode == 204 {
+		return true, nil
+	}
+
 	v, err := ExtractAccesses(page)
 	return len(v) == 0, err
 }

--- a/openstack/cdn/v1/flavors/results.go
+++ b/openstack/cdn/v1/flavors/results.go
@@ -33,6 +33,10 @@ type FlavorPage struct {
 
 // IsEmpty returns true if a FlavorPage contains no Flavors.
 func (r FlavorPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	flavors, err := ExtractFlavors(r)
 	return len(flavors) == 0, err
 }

--- a/openstack/cdn/v1/services/results.go
+++ b/openstack/cdn/v1/services/results.go
@@ -229,6 +229,10 @@ type ServicePage struct {
 
 // IsEmpty returns true if a ListResult contains no services.
 func (r ServicePage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	services, err := ExtractServices(r)
 	return len(services) == 0, err
 }

--- a/openstack/clustering/v1/actions/results.go
+++ b/openstack/clustering/v1/actions/results.go
@@ -92,6 +92,10 @@ type ActionPage struct {
 
 // IsEmpty determines if a ActionPage contains any results.
 func (r ActionPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	actions, err := ExtractActions(r)
 	return len(actions) == 0, err
 }

--- a/openstack/clustering/v1/clusters/results.go
+++ b/openstack/clustering/v1/clusters/results.go
@@ -155,6 +155,10 @@ type ClusterPage struct {
 
 // IsEmpty determines whether or not a page of Clusters contains any results.
 func (page ClusterPage) IsEmpty() (bool, error) {
+	if page.StatusCode == 204 {
+		return true, nil
+	}
+
 	clusters, err := ExtractClusters(page)
 	return len(clusters) == 0, err
 }
@@ -167,6 +171,10 @@ type ClusterPolicyPage struct {
 // IsEmpty determines whether or not a page of ClusterPolicies contains any
 // results.
 func (page ClusterPolicyPage) IsEmpty() (bool, error) {
+	if page.StatusCode == 204 {
+		return true, nil
+	}
+
 	clusterPolicies, err := ExtractClusterPolicies(page)
 	return len(clusterPolicies) == 0, err
 }

--- a/openstack/clustering/v1/events/results.go
+++ b/openstack/clustering/v1/events/results.go
@@ -52,6 +52,10 @@ type EventPage struct {
 
 // IsEmpty determines if a EventPage contains any results.
 func (r EventPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	events, err := ExtractEvents(r)
 	return len(events) == 0, err
 }

--- a/openstack/clustering/v1/nodes/results.go
+++ b/openstack/clustering/v1/nodes/results.go
@@ -115,6 +115,10 @@ type NodePage struct {
 
 // IsEmpty determines if a NodePage contains any results.
 func (page NodePage) IsEmpty() (bool, error) {
+	if page.StatusCode == 204 {
+		return true, nil
+	}
+
 	nodes, err := ExtractNodes(page)
 	return len(nodes) == 0, err
 }

--- a/openstack/clustering/v1/policies/results.go
+++ b/openstack/clustering/v1/policies/results.go
@@ -159,6 +159,10 @@ type PolicyPage struct {
 
 // IsEmpty determines if a PolicyPage contains any results.
 func (page PolicyPage) IsEmpty() (bool, error) {
+	if page.StatusCode == 204 {
+		return true, nil
+	}
+
 	policies, err := ExtractPolicies(page)
 	return len(policies) == 0, err
 }

--- a/openstack/clustering/v1/policytypes/results.go
+++ b/openstack/clustering/v1/policytypes/results.go
@@ -54,6 +54,10 @@ type PolicyTypePage struct {
 
 // IsEmpty determines if a PolicyType contains any results.
 func (page PolicyTypePage) IsEmpty() (bool, error) {
+	if page.StatusCode == 204 {
+		return true, nil
+	}
+
 	policyTypes, err := ExtractPolicyTypes(page)
 	return len(policyTypes) == 0, err
 }

--- a/openstack/clustering/v1/profiles/results.go
+++ b/openstack/clustering/v1/profiles/results.go
@@ -152,6 +152,10 @@ type ProfilePage struct {
 
 // IsEmpty determines if a ProfilePage contains any results.
 func (page ProfilePage) IsEmpty() (bool, error) {
+	if page.StatusCode == 204 {
+		return true, nil
+	}
+
 	profiles, err := ExtractProfiles(page)
 	return len(profiles) == 0, err
 }

--- a/openstack/clustering/v1/profiletypes/results.go
+++ b/openstack/clustering/v1/profiletypes/results.go
@@ -48,6 +48,10 @@ type ProfileTypePage struct {
 
 // IsEmpty determines if ExtractProfileTypes contains any results.
 func (page ProfileTypePage) IsEmpty() (bool, error) {
+	if page.StatusCode == 204 {
+		return true, nil
+	}
+
 	profileTypes, err := ExtractProfileTypes(page)
 	return len(profileTypes) == 0, err
 }

--- a/openstack/clustering/v1/receivers/results.go
+++ b/openstack/clustering/v1/receivers/results.go
@@ -106,6 +106,10 @@ type ReceiverPage struct {
 
 // IsEmpty determines if a ReceiverPage contains any results.
 func (page ReceiverPage) IsEmpty() (bool, error) {
+	if page.StatusCode == 204 {
+		return true, nil
+	}
+
 	receivers, err := ExtractReceivers(page)
 	return len(receivers) == 0, err
 }

--- a/openstack/common/extensions/results.go
+++ b/openstack/common/extensions/results.go
@@ -37,6 +37,10 @@ type ExtensionPage struct {
 
 // IsEmpty checks whether an ExtensionPage struct is empty.
 func (r ExtensionPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractExtensions(r)
 	return len(is) == 0, err
 }

--- a/openstack/compute/apiversions/results.go
+++ b/openstack/compute/apiversions/results.go
@@ -33,6 +33,10 @@ type APIVersionPage struct {
 
 // IsEmpty checks whether an APIVersionPage struct is empty.
 func (r APIVersionPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractAPIVersions(r)
 	return len(is) == 0, err
 }

--- a/openstack/compute/v2/extensions/aggregates/results.go
+++ b/openstack/compute/v2/extensions/aggregates/results.go
@@ -71,6 +71,10 @@ type AggregatesPage struct {
 
 // IsEmpty determines whether or not a page of Aggregates contains any results.
 func (page AggregatesPage) IsEmpty() (bool, error) {
+	if page.StatusCode == 204 {
+		return true, nil
+	}
+
 	aggregates, err := ExtractAggregates(page)
 	return len(aggregates) == 0, err
 }

--- a/openstack/compute/v2/extensions/attachinterfaces/results.go
+++ b/openstack/compute/v2/extensions/attachinterfaces/results.go
@@ -65,6 +65,10 @@ type InterfacePage struct {
 
 // IsEmpty returns true if an InterfacePage contains no interfaces.
 func (r InterfacePage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	interfaces, err := ExtractInterfaces(r)
 	return len(interfaces) == 0, err
 }

--- a/openstack/compute/v2/extensions/defsecrules/results.go
+++ b/openstack/compute/v2/extensions/defsecrules/results.go
@@ -29,6 +29,10 @@ type DefaultRulePage struct {
 
 // IsEmpty determines whether or not a page of default rules contains any results.
 func (page DefaultRulePage) IsEmpty() (bool, error) {
+	if page.StatusCode == 204 {
+		return true, nil
+	}
+
 	users, err := ExtractDefaultRules(page)
 	return len(users) == 0, err
 }

--- a/openstack/compute/v2/extensions/floatingips/results.go
+++ b/openstack/compute/v2/extensions/floatingips/results.go
@@ -56,6 +56,10 @@ type FloatingIPPage struct {
 
 // IsEmpty determines whether or not a FloatingIPsPage is empty.
 func (page FloatingIPPage) IsEmpty() (bool, error) {
+	if page.StatusCode == 204 {
+		return true, nil
+	}
+
 	va, err := ExtractFloatingIPs(page)
 	return len(va) == 0, err
 }

--- a/openstack/compute/v2/extensions/hypervisors/results.go
+++ b/openstack/compute/v2/extensions/hypervisors/results.go
@@ -235,6 +235,10 @@ type HypervisorPage struct {
 
 // IsEmpty determines whether or not a HypervisorPage is empty.
 func (page HypervisorPage) IsEmpty() (bool, error) {
+	if page.StatusCode == 204 {
+		return true, nil
+	}
+
 	va, err := ExtractHypervisors(page)
 	return len(va) == 0, err
 }

--- a/openstack/compute/v2/extensions/instanceactions/results.go
+++ b/openstack/compute/v2/extensions/instanceactions/results.go
@@ -60,6 +60,10 @@ type InstanceActionPage struct {
 
 // IsEmpty returns true if an InstanceActionPage contains no instance actions.
 func (r InstanceActionPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	instanceactions, err := ExtractInstanceActions(r)
 	return len(instanceactions) == 0, err
 }

--- a/openstack/compute/v2/extensions/keypairs/results.go
+++ b/openstack/compute/v2/extensions/keypairs/results.go
@@ -41,6 +41,10 @@ type KeyPairPage struct {
 
 // IsEmpty determines whether or not a KeyPairPage is empty.
 func (page KeyPairPage) IsEmpty() (bool, error) {
+	if page.StatusCode == 204 {
+		return true, nil
+	}
+
 	ks, err := ExtractKeyPairs(page)
 	return len(ks) == 0, err
 }

--- a/openstack/compute/v2/extensions/networks/results.go
+++ b/openstack/compute/v2/extensions/networks/results.go
@@ -99,6 +99,10 @@ type NetworkPage struct {
 
 // IsEmpty determines whether or not a NetworkPage is empty.
 func (page NetworkPage) IsEmpty() (bool, error) {
+	if page.StatusCode == 204 {
+		return true, nil
+	}
+
 	va, err := ExtractNetworks(page)
 	return len(va) == 0, err
 }

--- a/openstack/compute/v2/extensions/quotasets/results.go
+++ b/openstack/compute/v2/extensions/quotasets/results.go
@@ -128,6 +128,10 @@ type QuotaSetPage struct {
 
 // IsEmpty determines whether or not a QuotaSetsetPage is empty.
 func (page QuotaSetPage) IsEmpty() (bool, error) {
+	if page.StatusCode == 204 {
+		return true, nil
+	}
+
 	ks, err := ExtractQuotaSets(page)
 	return len(ks) == 0, err
 }

--- a/openstack/compute/v2/extensions/secgroups/results.go
+++ b/openstack/compute/v2/extensions/secgroups/results.go
@@ -129,6 +129,10 @@ type SecurityGroupPage struct {
 // IsEmpty determines whether or not a page of Security Groups contains any
 // results.
 func (page SecurityGroupPage) IsEmpty() (bool, error) {
+	if page.StatusCode == 204 {
+		return true, nil
+	}
+
 	users, err := ExtractSecurityGroups(page)
 	return len(users) == 0, err
 }

--- a/openstack/compute/v2/extensions/servergroups/results.go
+++ b/openstack/compute/v2/extensions/servergroups/results.go
@@ -64,6 +64,10 @@ type ServerGroupPage struct {
 
 // IsEmpty determines whether or not a ServerGroupsPage is empty.
 func (page ServerGroupPage) IsEmpty() (bool, error) {
+	if page.StatusCode == 204 {
+		return true, nil
+	}
+
 	va, err := ExtractServerGroups(page)
 	return len(va) == 0, err
 }

--- a/openstack/compute/v2/extensions/services/results.go
+++ b/openstack/compute/v2/extensions/services/results.go
@@ -98,6 +98,10 @@ type ServicePage struct {
 
 // IsEmpty determines whether or not a page of Services contains any results.
 func (page ServicePage) IsEmpty() (bool, error) {
+	if page.StatusCode == 204 {
+		return true, nil
+	}
+
 	services, err := ExtractServices(page)
 	return len(services) == 0, err
 }

--- a/openstack/compute/v2/extensions/tenantnetworks/results.go
+++ b/openstack/compute/v2/extensions/tenantnetworks/results.go
@@ -24,6 +24,10 @@ type NetworkPage struct {
 
 // IsEmpty determines whether or not a NetworkPage is empty.
 func (page NetworkPage) IsEmpty() (bool, error) {
+	if page.StatusCode == 204 {
+		return true, nil
+	}
+
 	va, err := ExtractNetworks(page)
 	return len(va) == 0, err
 }

--- a/openstack/compute/v2/extensions/usage/results.go
+++ b/openstack/compute/v2/extensions/usage/results.go
@@ -122,6 +122,10 @@ type SingleTenantPage struct {
 
 // IsEmpty determines whether or not a SingleTenantPage is empty.
 func (r SingleTenantPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	ks, err := ExtractSingleTenant(r)
 	return ks == nil, err
 }
@@ -165,6 +169,10 @@ func ExtractAllTenants(page pagination.Page) ([]TenantUsage, error) {
 
 // IsEmpty determines whether or not an AllTenantsPage is empty.
 func (r AllTenantsPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	usages, err := ExtractAllTenants(r)
 	return len(usages) == 0, err
 }

--- a/openstack/compute/v2/extensions/volumeattach/results.go
+++ b/openstack/compute/v2/extensions/volumeattach/results.go
@@ -37,6 +37,10 @@ type VolumeAttachmentPage struct {
 
 // IsEmpty determines whether or not a VolumeAttachmentPage is empty.
 func (page VolumeAttachmentPage) IsEmpty() (bool, error) {
+	if page.StatusCode == 204 {
+		return true, nil
+	}
+
 	va, err := ExtractVolumeAttachments(page)
 	return len(va) == 0, err
 }

--- a/openstack/compute/v2/flavors/results.go
+++ b/openstack/compute/v2/flavors/results.go
@@ -121,6 +121,10 @@ type FlavorPage struct {
 
 // IsEmpty determines if a FlavorPage contains any results.
 func (page FlavorPage) IsEmpty() (bool, error) {
+	if page.StatusCode == 204 {
+		return true, nil
+	}
+
 	flavors, err := ExtractFlavors(page)
 	return len(flavors) == 0, err
 }
@@ -155,6 +159,10 @@ type AccessPage struct {
 
 // IsEmpty indicates whether an AccessPage is empty.
 func (page AccessPage) IsEmpty() (bool, error) {
+	if page.StatusCode == 204 {
+		return true, nil
+	}
+
 	v, err := ExtractAccesses(page)
 	return len(v) == 0, err
 }

--- a/openstack/compute/v2/images/results.go
+++ b/openstack/compute/v2/images/results.go
@@ -67,6 +67,10 @@ type ImagePage struct {
 
 // IsEmpty returns true if an ImagePage contains no Image results.
 func (page ImagePage) IsEmpty() (bool, error) {
+	if page.StatusCode == 204 {
+		return true, nil
+	}
+
 	images, err := ExtractImages(page)
 	return len(images) == 0, err
 }

--- a/openstack/compute/v2/servers/results.go
+++ b/openstack/compute/v2/servers/results.go
@@ -277,6 +277,10 @@ type ServerPage struct {
 
 // IsEmpty returns true if a page contains no Server results.
 func (r ServerPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	s, err := ExtractServers(r)
 	return len(s) == 0, err
 }
@@ -385,6 +389,10 @@ type AddressPage struct {
 
 // IsEmpty returns true if an AddressPage contains no networks.
 func (r AddressPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	addresses, err := ExtractAddresses(r)
 	return len(addresses) == 0, err
 }
@@ -410,6 +418,10 @@ type NetworkAddressPage struct {
 
 // IsEmpty returns true if a NetworkAddressPage contains no addresses.
 func (r NetworkAddressPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	addresses, err := ExtractNetworkAddresses(r)
 	return len(addresses) == 0, err
 }

--- a/openstack/container/v1/capsules/results.go
+++ b/openstack/container/v1/capsules/results.go
@@ -241,6 +241,10 @@ func (r CapsulePage) NextPageURL() (string, error) {
 
 // IsEmpty checks whether a CapsulePage struct is empty.
 func (r CapsulePage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractCapsules(r)
 	if err != nil {
 		return false, err

--- a/openstack/containerinfra/apiversions/results.go
+++ b/openstack/containerinfra/apiversions/results.go
@@ -28,6 +28,10 @@ type APIVersionPage struct {
 
 // IsEmpty checks whether an APIVersionPage struct is empty.
 func (r APIVersionPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractAPIVersions(r)
 	return len(is) == 0, err
 }

--- a/openstack/containerinfra/v1/clusters/results.go
+++ b/openstack/containerinfra/v1/clusters/results.go
@@ -135,6 +135,10 @@ func (r ClusterPage) NextPageURL() (string, error) {
 
 // IsEmpty checks whether a ClusterPage struct is empty.
 func (r ClusterPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractClusters(r)
 	return len(is) == 0, err
 }

--- a/openstack/containerinfra/v1/clustertemplates/results.go
+++ b/openstack/containerinfra/v1/clustertemplates/results.go
@@ -99,6 +99,10 @@ func (r ClusterTemplatePage) NextPageURL() (string, error) {
 
 // IsEmpty checks whether a ClusterTemplatePage struct is empty.
 func (r ClusterTemplatePage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractClusterTemplates(r)
 	return len(is) == 0, err
 }

--- a/openstack/containerinfra/v1/nodegroups/results.go
+++ b/openstack/containerinfra/v1/nodegroups/results.go
@@ -86,6 +86,10 @@ func (r NodeGroupPage) NextPageURL() (string, error) {
 }
 
 func (r NodeGroupPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	s, err := ExtractNodeGroups(r)
 	return len(s) == 0, err
 }

--- a/openstack/db/v1/configurations/results.go
+++ b/openstack/db/v1/configurations/results.go
@@ -47,6 +47,10 @@ type ConfigPage struct {
 
 // IsEmpty indicates whether a ConfigPage is empty.
 func (r ConfigPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractConfigs(r)
 	return len(is) == 0, err
 }
@@ -114,6 +118,10 @@ type ParamPage struct {
 
 // IsEmpty indicates whether a ParamPage is empty.
 func (r ParamPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractParams(r)
 	return len(is) == 0, err
 }

--- a/openstack/db/v1/databases/results.go
+++ b/openstack/db/v1/databases/results.go
@@ -35,6 +35,10 @@ type DBPage struct {
 
 // IsEmpty checks to see whether the collection is empty.
 func (page DBPage) IsEmpty() (bool, error) {
+	if page.StatusCode == 204 {
+		return true, nil
+	}
+
 	dbs, err := ExtractDBs(page)
 	return len(dbs) == 0, err
 }

--- a/openstack/db/v1/datastores/results.go
+++ b/openstack/db/v1/datastores/results.go
@@ -47,6 +47,10 @@ type DatastorePage struct {
 
 // IsEmpty indicates whether a Datastore collection is empty.
 func (r DatastorePage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractDatastores(r)
 	return len(is) == 0, err
 }
@@ -77,6 +81,10 @@ type VersionPage struct {
 
 // IsEmpty indicates whether a collection of version resources is empty.
 func (r VersionPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractVersions(r)
 	return len(is) == 0, err
 }

--- a/openstack/db/v1/flavors/results.go
+++ b/openstack/db/v1/flavors/results.go
@@ -45,6 +45,10 @@ type FlavorPage struct {
 
 // IsEmpty determines if a page contains any results.
 func (page FlavorPage) IsEmpty() (bool, error) {
+	if page.StatusCode == 204 {
+		return true, nil
+	}
+
 	flavors, err := ExtractFlavors(page)
 	return len(flavors) == 0, err
 }

--- a/openstack/db/v1/instances/results.go
+++ b/openstack/db/v1/instances/results.go
@@ -173,6 +173,10 @@ type InstancePage struct {
 
 // IsEmpty checks to see whether the collection is empty.
 func (page InstancePage) IsEmpty() (bool, error) {
+	if page.StatusCode == 204 {
+		return true, nil
+	}
+
 	instances, err := ExtractInstances(page)
 	return len(instances) == 0, err
 }

--- a/openstack/db/v1/users/results.go
+++ b/openstack/db/v1/users/results.go
@@ -35,6 +35,10 @@ type UserPage struct {
 
 // IsEmpty checks to see whether the collection is empty.
 func (page UserPage) IsEmpty() (bool, error) {
+	if page.StatusCode == 204 {
+		return true, nil
+	}
+
 	users, err := ExtractUsers(page)
 	return len(users) == 0, err
 }

--- a/openstack/dns/v2/recordsets/results.go
+++ b/openstack/dns/v2/recordsets/results.go
@@ -51,6 +51,10 @@ type DeleteResult struct {
 
 // IsEmpty returns true if the page contains no results.
 func (r RecordSetPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	s, err := ExtractRecordSets(r)
 	return len(s) == 0, err
 }

--- a/openstack/dns/v2/transfer/accept/results.go
+++ b/openstack/dns/v2/transfer/accept/results.go
@@ -39,6 +39,10 @@ type TransferAcceptPage struct {
 
 // IsEmpty returns true if the page contains no results.
 func (r TransferAcceptPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	s, err := ExtractTransferAccepts(r)
 	return len(s) == 0, err
 }

--- a/openstack/dns/v2/transfer/request/results.go
+++ b/openstack/dns/v2/transfer/request/results.go
@@ -51,6 +51,10 @@ type TransferRequestPage struct {
 
 // IsEmpty returns true if the page contains no results.
 func (r TransferRequestPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	s, err := ExtractTransferRequests(r)
 	return len(s) == 0, err
 }

--- a/openstack/dns/v2/zones/results.go
+++ b/openstack/dns/v2/zones/results.go
@@ -52,6 +52,10 @@ type ZonePage struct {
 
 // IsEmpty returns true if the page contains no results.
 func (r ZonePage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	s, err := ExtractZones(r)
 	return len(s) == 0, err
 }

--- a/openstack/identity/v2/extensions/admin/roles/results.go
+++ b/openstack/identity/v2/extensions/admin/roles/results.go
@@ -27,6 +27,10 @@ type RolePage struct {
 
 // IsEmpty determines whether or not a page of Roles contains any results.
 func (r RolePage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	users, err := ExtractRoles(r)
 	return len(users) == 0, err
 }

--- a/openstack/identity/v2/tenants/results.go
+++ b/openstack/identity/v2/tenants/results.go
@@ -27,6 +27,10 @@ type TenantPage struct {
 
 // IsEmpty determines whether or not a page of Tenants contains any results.
 func (r TenantPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	tenants, err := ExtractTenants(r)
 	return len(tenants) == 0, err
 }

--- a/openstack/identity/v2/users/results.go
+++ b/openstack/identity/v2/users/results.go
@@ -48,6 +48,10 @@ type RolePage struct {
 
 // IsEmpty determines whether or not a page of Users contains any results.
 func (r UserPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	users, err := ExtractUsers(r)
 	return len(users) == 0, err
 }
@@ -63,6 +67,10 @@ func ExtractUsers(r pagination.Page) ([]User, error) {
 
 // IsEmpty determines whether or not a page of Roles contains any results.
 func (r RolePage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	users, err := ExtractRoles(r)
 	return len(users) == 0, err
 }

--- a/openstack/identity/v3/applicationcredentials/results.go
+++ b/openstack/identity/v3/applicationcredentials/results.go
@@ -105,6 +105,10 @@ type ApplicationCredentialPage struct {
 
 // IsEmpty determines whether or not a an ApplicationCredentialPage contains any results.
 func (r ApplicationCredentialPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	applicationCredentials, err := ExtractApplicationCredentials(r)
 	return len(applicationCredentials) == 0, err
 }
@@ -155,6 +159,10 @@ type AccessRulePage struct {
 
 // IsEmpty determines whether or not a an AccessRulePage contains any results.
 func (r AccessRulePage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	accessRules, err := ExtractAccessRules(r)
 	return len(accessRules) == 0, err
 }

--- a/openstack/identity/v3/catalog/results.go
+++ b/openstack/identity/v3/catalog/results.go
@@ -12,6 +12,10 @@ type ServiceCatalogPage struct {
 
 // IsEmpty returns true if the ServiceCatalogPage contains no results.
 func (r ServiceCatalogPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	services, err := ExtractServiceCatalog(r)
 	return len(services) == 0, err
 }

--- a/openstack/identity/v3/credentials/results.go
+++ b/openstack/identity/v3/credentials/results.go
@@ -56,6 +56,10 @@ type CredentialPage struct {
 
 // IsEmpty determines whether or not a CredentialPage contains any results.
 func (r CredentialPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	credentials, err := ExtractCredentials(r)
 	return len(credentials) == 0, err
 }

--- a/openstack/identity/v3/domains/results.go
+++ b/openstack/identity/v3/domains/results.go
@@ -58,6 +58,10 @@ type DomainPage struct {
 
 // IsEmpty determines whether or not a page of Domains contains any results.
 func (r DomainPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	domains, err := ExtractDomains(r)
 	return len(domains) == 0, err
 }

--- a/openstack/identity/v3/endpoints/results.go
+++ b/openstack/identity/v3/endpoints/results.go
@@ -69,6 +69,10 @@ type EndpointPage struct {
 
 // IsEmpty returns true if no Endpoints were returned.
 func (r EndpointPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	es, err := ExtractEndpoints(r)
 	return len(es) == 0, err
 }

--- a/openstack/identity/v3/extensions/ec2credentials/results.go
+++ b/openstack/identity/v3/extensions/ec2credentials/results.go
@@ -50,6 +50,10 @@ type CredentialPage struct {
 
 // IsEmpty determines whether or not a an CredentialPage contains any results.
 func (r CredentialPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	ec2Credentials, err := ExtractCredentials(r)
 	return len(ec2Credentials) == 0, err
 }

--- a/openstack/identity/v3/extensions/federation/results.go
+++ b/openstack/identity/v3/extensions/federation/results.go
@@ -175,6 +175,10 @@ type MappingsPage struct {
 
 // IsEmpty determines whether or not a page of Mappings contains any results.
 func (c MappingsPage) IsEmpty() (bool, error) {
+	if c.StatusCode == 204 {
+		return true, nil
+	}
+
 	mappings, err := ExtractMappings(c)
 	return len(mappings) == 0, err
 }

--- a/openstack/identity/v3/extensions/oauth1/results.go
+++ b/openstack/identity/v3/extensions/oauth1/results.go
@@ -52,6 +52,10 @@ type GetConsumerResult struct {
 
 // IsEmpty determines whether or not a page of Consumers contains any results.
 func (c ConsumersPage) IsEmpty() (bool, error) {
+	if c.StatusCode == 204 {
+		return true, nil
+	}
+
 	consumers, err := ExtractConsumers(c)
 	return len(consumers) == 0, err
 }
@@ -208,6 +212,10 @@ type AccessTokensPage struct {
 
 // IsEmpty determines whether or not a an AccessTokensPage contains any results.
 func (r AccessTokensPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	accessTokens, err := ExtractAccessTokens(r)
 	return len(accessTokens) == 0, err
 }
@@ -251,6 +259,10 @@ type AccessTokenRolesPage struct {
 
 // IsEmpty determines whether or not a an AccessTokensPage contains any results.
 func (r AccessTokenRolesPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	accessTokenRoles, err := ExtractAccessTokenRoles(r)
 	return len(accessTokenRoles) == 0, err
 }

--- a/openstack/identity/v3/extensions/projectendpoints/results.go
+++ b/openstack/identity/v3/extensions/projectendpoints/results.go
@@ -43,6 +43,10 @@ type EndpointPage struct {
 
 // IsEmpty returns true if no Endpoints were returned.
 func (r EndpointPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	es, err := ExtractEndpoints(r)
 	return len(es) == 0, err
 }

--- a/openstack/identity/v3/extensions/trusts/results.go
+++ b/openstack/identity/v3/extensions/trusts/results.go
@@ -36,6 +36,10 @@ type GetResult struct {
 
 // IsEmpty determines whether or not a page of Trusts contains any results.
 func (t TrustPage) IsEmpty() (bool, error) {
+	if t.StatusCode == 204 {
+		return true, nil
+	}
+
 	roles, err := ExtractTrusts(t)
 	return len(roles) == 0, err
 }
@@ -109,6 +113,10 @@ type RolesPage struct {
 
 // IsEmpty determines whether or not a a Page contains any results.
 func (r RolesPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	accessTokenRoles, err := ExtractRoles(r)
 	return len(accessTokenRoles) == 0, err
 }

--- a/openstack/identity/v3/groups/results.go
+++ b/openstack/identity/v3/groups/results.go
@@ -93,6 +93,10 @@ type GroupPage struct {
 
 // IsEmpty determines whether or not a page of Groups contains any results.
 func (r GroupPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	groups, err := ExtractGroups(r)
 	return len(groups) == 0, err
 }

--- a/openstack/identity/v3/limits/results.go
+++ b/openstack/identity/v3/limits/results.go
@@ -66,6 +66,10 @@ type LimitPage struct {
 
 // IsEmpty determines whether or not a page of Limits contains any results.
 func (r LimitPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	limits, err := ExtractLimits(r)
 	return len(limits) == 0, err
 }

--- a/openstack/identity/v3/policies/results.go
+++ b/openstack/identity/v3/policies/results.go
@@ -91,6 +91,10 @@ type PolicyPage struct {
 
 // IsEmpty determines whether or not a page of Policies contains any results.
 func (r PolicyPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	policies, err := ExtractPolicies(r)
 	return len(policies) == 0, err
 }

--- a/openstack/identity/v3/projects/results.go
+++ b/openstack/identity/v3/projects/results.go
@@ -113,6 +113,10 @@ type ProjectPage struct {
 
 // IsEmpty determines whether or not a page of Projects contains any results.
 func (r ProjectPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	projects, err := ExtractProjects(r)
 	return len(projects) == 0, err
 }

--- a/openstack/identity/v3/regions/results.go
+++ b/openstack/identity/v3/regions/results.go
@@ -90,6 +90,10 @@ type RegionPage struct {
 
 // IsEmpty determines whether or not a page of Regions contains any results.
 func (r RegionPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	regions, err := ExtractRegions(r)
 	return len(regions) == 0, err
 }

--- a/openstack/identity/v3/roles/results.go
+++ b/openstack/identity/v3/roles/results.go
@@ -90,6 +90,10 @@ type RolePage struct {
 
 // IsEmpty determines whether or not a page of Roles contains any results.
 func (r RolePage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	roles, err := ExtractRoles(r)
 	return len(roles) == 0, err
 }
@@ -182,6 +186,10 @@ type RoleAssignmentPage struct {
 
 // IsEmpty returns true if the RoleAssignmentPage contains no results.
 func (r RoleAssignmentPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	roleAssignments, err := ExtractRoleAssignments(r)
 	return len(roleAssignments) == 0, err
 }

--- a/openstack/identity/v3/services/results.go
+++ b/openstack/identity/v3/services/results.go
@@ -100,6 +100,10 @@ type ServicePage struct {
 
 // IsEmpty returns true if the ServicePage contains no results.
 func (p ServicePage) IsEmpty() (bool, error) {
+	if p.StatusCode == 204 {
+		return true, nil
+	}
+
 	services, err := ExtractServices(p)
 	return len(services) == 0, err
 }

--- a/openstack/identity/v3/users/results.go
+++ b/openstack/identity/v3/users/results.go
@@ -135,6 +135,10 @@ type UserPage struct {
 
 // IsEmpty determines whether or not a UserPage contains any results.
 func (r UserPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	users, err := ExtractUsers(r)
 	return len(users) == 0, err
 }

--- a/openstack/imageservice/v2/images/results.go
+++ b/openstack/imageservice/v2/images/results.go
@@ -204,6 +204,10 @@ type ImagePage struct {
 
 // IsEmpty returns true if an ImagePage contains no Images results.
 func (r ImagePage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	images, err := ExtractImages(r)
 	return len(images) == 0, err
 }

--- a/openstack/imageservice/v2/members/results.go
+++ b/openstack/imageservice/v2/members/results.go
@@ -41,6 +41,10 @@ func ExtractMembers(r pagination.Page) ([]Member, error) {
 
 // IsEmpty determines whether or not a MemberPage contains any results.
 func (r MemberPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	members, err := ExtractMembers(r)
 	return len(members) == 0, err
 }

--- a/openstack/imageservice/v2/tasks/results.go
+++ b/openstack/imageservice/v2/tasks/results.go
@@ -81,6 +81,10 @@ type TaskPage struct {
 
 // IsEmpty returns true if a TaskPage contains no Tasks results.
 func (r TaskPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	tasks, err := ExtractTasks(r)
 	return len(tasks) == 0, err
 }

--- a/openstack/keymanager/v1/containers/results.go
+++ b/openstack/keymanager/v1/containers/results.go
@@ -108,6 +108,10 @@ type ContainerPage struct {
 
 // IsEmpty determines whether or not a page of Container contains any results.
 func (r ContainerPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	containers, err := ExtractContainers(r)
 	return len(containers) == 0, err
 }
@@ -204,6 +208,10 @@ type ConsumerPage struct {
 
 // IsEmpty determines whether or not a page of consumers contains any results.
 func (r ConsumerPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	consumers, err := ExtractConsumers(r)
 	return len(consumers) == 0, err
 }

--- a/openstack/keymanager/v1/orders/results.go
+++ b/openstack/keymanager/v1/orders/results.go
@@ -135,6 +135,10 @@ type OrderPage struct {
 
 // IsEmpty determines whether or not a page of ordersS contains any results.
 func (r OrderPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	orders, err := ExtractOrders(r)
 	return len(orders) == 0, err
 }

--- a/openstack/keymanager/v1/secrets/results.go
+++ b/openstack/keymanager/v1/secrets/results.go
@@ -136,6 +136,10 @@ type SecretPage struct {
 
 // IsEmpty determines whether or not a page of secrets contains any results.
 func (r SecretPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	secrets, err := ExtractSecrets(r)
 	return len(secrets) == 0, err
 }

--- a/openstack/loadbalancer/v2/amphorae/results.go
+++ b/openstack/loadbalancer/v2/amphorae/results.go
@@ -113,6 +113,10 @@ func (r AmphoraPage) NextPageURL() (string, error) {
 
 // IsEmpty checks whether a AmphoraPage struct is empty.
 func (r AmphoraPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractAmphorae(r)
 	return len(is) == 0, err
 }

--- a/openstack/loadbalancer/v2/apiversions/results.go
+++ b/openstack/loadbalancer/v2/apiversions/results.go
@@ -17,6 +17,10 @@ type APIVersionPage struct {
 
 // IsEmpty checks whether an APIVersionPage struct is empty.
 func (r APIVersionPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractAPIVersions(r)
 	return len(is) == 0, err
 }

--- a/openstack/loadbalancer/v2/l7policies/results.go
+++ b/openstack/loadbalancer/v2/l7policies/results.go
@@ -137,6 +137,10 @@ func (r L7PolicyPage) NextPageURL() (string, error) {
 
 // IsEmpty checks whether a L7PolicyPage struct is empty.
 func (r L7PolicyPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractL7Policies(r)
 	return len(is) == 0, err
 }
@@ -211,6 +215,10 @@ func (r RulePage) NextPageURL() (string, error) {
 
 // IsEmpty checks whether a RulePage struct is empty.
 func (r RulePage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractRules(r)
 	return len(is) == 0, err
 }

--- a/openstack/loadbalancer/v2/listeners/results.go
+++ b/openstack/loadbalancer/v2/listeners/results.go
@@ -157,6 +157,10 @@ func (r ListenerPage) NextPageURL() (string, error) {
 
 // IsEmpty checks whether a ListenerPage struct is empty.
 func (r ListenerPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractListeners(r)
 	return len(is) == 0, err
 }

--- a/openstack/loadbalancer/v2/loadbalancers/results.go
+++ b/openstack/loadbalancer/v2/loadbalancers/results.go
@@ -161,6 +161,10 @@ func (r LoadBalancerPage) NextPageURL() (string, error) {
 
 // IsEmpty checks whether a LoadBalancerPage struct is empty.
 func (r LoadBalancerPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractLoadBalancers(r)
 	return len(is) == 0, err
 }

--- a/openstack/loadbalancer/v2/monitors/results.go
+++ b/openstack/loadbalancer/v2/monitors/results.go
@@ -110,6 +110,10 @@ func (r MonitorPage) NextPageURL() (string, error) {
 
 // IsEmpty checks whether a MonitorPage struct is empty.
 func (r MonitorPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractMonitors(r)
 	return len(is) == 0, err
 }

--- a/openstack/loadbalancer/v2/pools/results.go
+++ b/openstack/loadbalancer/v2/pools/results.go
@@ -135,6 +135,10 @@ func (r PoolPage) NextPageURL() (string, error) {
 
 // IsEmpty checks whether a PoolPage struct is empty.
 func (r PoolPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractPools(r)
 	return len(is) == 0, err
 }
@@ -265,6 +269,10 @@ func (r MemberPage) NextPageURL() (string, error) {
 
 // IsEmpty checks whether a MemberPage struct is empty.
 func (r MemberPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractMembers(r)
 	return len(is) == 0, err
 }

--- a/openstack/loadbalancer/v2/providers/results.go
+++ b/openstack/loadbalancer/v2/providers/results.go
@@ -36,6 +36,10 @@ func (r ProviderPage) NextPageURL() (string, error) {
 
 // IsEmpty checks whether a ProviderPage struct is empty.
 func (r ProviderPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractProviders(r)
 	return len(is) == 0, err
 }

--- a/openstack/messaging/v2/messages/results.go
+++ b/openstack/messaging/v2/messages/results.go
@@ -109,6 +109,10 @@ func ExtractMessages(r pagination.Page) ([]Message, error) {
 
 // IsEmpty determines if a MessagePage contains any results.
 func (r MessagePage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	s, err := ExtractMessages(r)
 	return len(s) == 0, err
 }

--- a/openstack/messaging/v2/queues/results.go
+++ b/openstack/messaging/v2/queues/results.go
@@ -150,6 +150,10 @@ func ExtractQueues(r pagination.Page) ([]Queue, error) {
 
 // IsEmpty determines if a QueuesPage contains any results.
 func (r QueuePage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	s, err := ExtractQueues(r)
 	return len(s) == 0, err
 }

--- a/openstack/networking/v2/apiversions/results.go
+++ b/openstack/networking/v2/apiversions/results.go
@@ -19,6 +19,10 @@ type APIVersionPage struct {
 
 // IsEmpty checks whether an APIVersionPage struct is empty.
 func (r APIVersionPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractAPIVersions(r)
 	return len(is) == 0, err
 }
@@ -49,6 +53,10 @@ type APIVersionResourcePage struct {
 // IsEmpty is a concrete function which indicates whether an
 // APIVersionResourcePage is empty or not.
 func (r APIVersionResourcePage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractVersionResources(r)
 	return len(is) == 0, err
 }

--- a/openstack/networking/v2/extensions/agents/results.go
+++ b/openstack/networking/v2/extensions/agents/results.go
@@ -160,6 +160,10 @@ func (r AgentPage) NextPageURL() (string, error) {
 
 // IsEmpty determines whether or not a AgentPage is empty.
 func (r AgentPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	agents, err := ExtractAgents(r)
 	return len(agents) == 0, err
 }
@@ -196,6 +200,10 @@ type ListBGPSpeakersResult struct {
 }
 
 func (r ListBGPSpeakersResult) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	speakers, err := ExtractBGPSpeakers(r)
 	return 0 == len(speakers), err
 }

--- a/openstack/networking/v2/extensions/bgp/peers/results.go
+++ b/openstack/networking/v2/extensions/bgp/peers/results.go
@@ -54,6 +54,10 @@ type BGPPeerPage struct {
 
 // IsEmpty checks whether a BGPPage struct is empty.
 func (r BGPPeerPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractBGPPeers(r)
 	return len(is) == 0, err
 }

--- a/openstack/networking/v2/extensions/bgp/speakers/results.go
+++ b/openstack/networking/v2/extensions/bgp/speakers/results.go
@@ -63,6 +63,10 @@ type BGPSpeakerPage struct {
 
 // IsEmpty checks whether a BGPSpeakerPage struct is empty.
 func (r BGPSpeakerPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractBGPSpeakers(r)
 	return len(is) == 0, err
 }
@@ -145,6 +149,10 @@ type AdvertisedRoutePage struct {
 
 // IsEmpty checks whether a AdvertisedRoutePage struct is empty.
 func (r AdvertisedRoutePage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractAdvertisedRoutes(r)
 	return len(is) == 0, err
 }

--- a/openstack/networking/v2/extensions/fwaas/firewalls/results.go
+++ b/openstack/networking/v2/extensions/fwaas/firewalls/results.go
@@ -58,6 +58,10 @@ func (r FirewallPage) NextPageURL() (string, error) {
 
 // IsEmpty checks whether a FirewallPage struct is empty.
 func (r FirewallPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractFirewalls(r)
 	return len(is) == 0, err
 }

--- a/openstack/networking/v2/extensions/fwaas/policies/results.go
+++ b/openstack/networking/v2/extensions/fwaas/policies/results.go
@@ -52,6 +52,10 @@ func (r PolicyPage) NextPageURL() (string, error) {
 
 // IsEmpty checks whether a PolicyPage struct is empty.
 func (r PolicyPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractPolicies(r)
 	return len(is) == 0, err
 }

--- a/openstack/networking/v2/extensions/fwaas/rules/results.go
+++ b/openstack/networking/v2/extensions/fwaas/rules/results.go
@@ -47,6 +47,10 @@ func (r RulePage) NextPageURL() (string, error) {
 
 // IsEmpty checks whether a RulePage struct is empty.
 func (r RulePage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractRules(r)
 	return len(is) == 0, err
 }

--- a/openstack/networking/v2/extensions/fwaas_v2/groups/results.go
+++ b/openstack/networking/v2/extensions/fwaas_v2/groups/results.go
@@ -55,6 +55,10 @@ func (r GroupPage) NextPageURL() (string, error) {
 
 // IsEmpty checks whether a GroupPage struct is empty.
 func (r GroupPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractGroups(r)
 	return len(is) == 0, err
 }

--- a/openstack/networking/v2/extensions/fwaas_v2/policies/results.go
+++ b/openstack/networking/v2/extensions/fwaas_v2/policies/results.go
@@ -62,6 +62,10 @@ func (r PolicyPage) NextPageURL() (string, error) {
 
 // IsEmpty checks whether a PolicyPage struct is empty.
 func (r PolicyPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractPolicies(r)
 	return len(is) == 0, err
 }

--- a/openstack/networking/v2/extensions/fwaas_v2/rules/results.go
+++ b/openstack/networking/v2/extensions/fwaas_v2/rules/results.go
@@ -46,6 +46,10 @@ func (r RulePage) NextPageURL() (string, error) {
 
 // IsEmpty checks whether a RulePage struct is empty.
 func (r RulePage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractRules(r)
 	return len(is) == 0, err
 }

--- a/openstack/networking/v2/extensions/layer3/addressscopes/results.go
+++ b/openstack/networking/v2/extensions/layer3/addressscopes/results.go
@@ -84,6 +84,10 @@ func (r AddressScopePage) NextPageURL() (string, error) {
 
 // IsEmpty determines whether or not a AddressScopePage is empty.
 func (r AddressScopePage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	addressScopes, err := ExtractAddressScopes(r)
 	return len(addressScopes) == 0, err
 }

--- a/openstack/networking/v2/extensions/layer3/floatingips/results.go
+++ b/openstack/networking/v2/extensions/layer3/floatingips/results.go
@@ -157,6 +157,10 @@ func (r FloatingIPPage) NextPageURL() (string, error) {
 
 // IsEmpty checks whether a FloatingIPPage struct is empty.
 func (r FloatingIPPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractFloatingIPs(r)
 	return len(is) == 0, err
 }

--- a/openstack/networking/v2/extensions/layer3/portforwarding/results.go
+++ b/openstack/networking/v2/extensions/layer3/portforwarding/results.go
@@ -88,6 +88,10 @@ func (r PortForwardingPage) NextPageURL() (string, error) {
 
 // IsEmpty checks whether a PortForwardingPage struct is empty.
 func (r PortForwardingPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractPortForwardings(r)
 	return len(is) == 0, err
 }

--- a/openstack/networking/v2/extensions/layer3/routers/results.go
+++ b/openstack/networking/v2/extensions/layer3/routers/results.go
@@ -100,6 +100,10 @@ func (r RouterPage) NextPageURL() (string, error) {
 
 // IsEmpty checks whether a RouterPage struct is empty.
 func (r RouterPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractRouters(r)
 	return len(is) == 0, err
 }
@@ -263,6 +267,10 @@ type ListL3AgentsPage struct {
 }
 
 func (r ListL3AgentsPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	v, err := ExtractL3Agents(r)
 	return len(v) == 0, err
 }

--- a/openstack/networking/v2/extensions/lbaas/members/results.go
+++ b/openstack/networking/v2/extensions/lbaas/members/results.go
@@ -56,6 +56,10 @@ func (r MemberPage) NextPageURL() (string, error) {
 
 // IsEmpty checks whether a MemberPage struct is empty.
 func (r MemberPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractMembers(r)
 	return len(is) == 0, err
 }

--- a/openstack/networking/v2/extensions/lbaas/monitors/results.go
+++ b/openstack/networking/v2/extensions/lbaas/monitors/results.go
@@ -88,6 +88,10 @@ func (r MonitorPage) NextPageURL() (string, error) {
 
 // IsEmpty checks whether a PoolPage struct is empty.
 func (r MonitorPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractMonitors(r)
 	return len(is) == 0, err
 }

--- a/openstack/networking/v2/extensions/lbaas/pools/results.go
+++ b/openstack/networking/v2/extensions/lbaas/pools/results.go
@@ -78,6 +78,10 @@ func (r PoolPage) NextPageURL() (string, error) {
 
 // IsEmpty checks whether a PoolPage struct is empty.
 func (r PoolPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractPools(r)
 	return len(is) == 0, err
 }

--- a/openstack/networking/v2/extensions/lbaas/vips/results.go
+++ b/openstack/networking/v2/extensions/lbaas/vips/results.go
@@ -108,6 +108,10 @@ func (r VIPPage) NextPageURL() (string, error) {
 
 // IsEmpty checks whether a VIPPage struct is empty.
 func (r VIPPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractVIPs(r)
 	return len(is) == 0, err
 }

--- a/openstack/networking/v2/extensions/lbaas_v2/l7policies/results.go
+++ b/openstack/networking/v2/extensions/lbaas_v2/l7policies/results.go
@@ -137,6 +137,10 @@ func (r L7PolicyPage) NextPageURL() (string, error) {
 
 // IsEmpty checks whether a L7PolicyPage struct is empty.
 func (r L7PolicyPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractL7Policies(r)
 	return len(is) == 0, err
 }
@@ -211,6 +215,10 @@ func (r RulePage) NextPageURL() (string, error) {
 
 // IsEmpty checks whether a RulePage struct is empty.
 func (r RulePage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractRules(r)
 	return len(is) == 0, err
 }

--- a/openstack/networking/v2/extensions/lbaas_v2/listeners/results.go
+++ b/openstack/networking/v2/extensions/lbaas_v2/listeners/results.go
@@ -88,6 +88,10 @@ func (r ListenerPage) NextPageURL() (string, error) {
 
 // IsEmpty checks whether a ListenerPage struct is empty.
 func (r ListenerPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractListeners(r)
 	return len(is) == 0, err
 }

--- a/openstack/networking/v2/extensions/lbaas_v2/loadbalancers/results.go
+++ b/openstack/networking/v2/extensions/lbaas_v2/loadbalancers/results.go
@@ -101,6 +101,10 @@ func (r LoadBalancerPage) NextPageURL() (string, error) {
 
 // IsEmpty checks whether a LoadBalancerPage struct is empty.
 func (r LoadBalancerPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractLoadBalancers(r)
 	return len(is) == 0, err
 }

--- a/openstack/networking/v2/extensions/lbaas_v2/monitors/results.go
+++ b/openstack/networking/v2/extensions/lbaas_v2/monitors/results.go
@@ -100,6 +100,10 @@ func (r MonitorPage) NextPageURL() (string, error) {
 
 // IsEmpty checks whether a MonitorPage struct is empty.
 func (r MonitorPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractMonitors(r)
 	return len(is) == 0, err
 }

--- a/openstack/networking/v2/extensions/lbaas_v2/pools/results.go
+++ b/openstack/networking/v2/extensions/lbaas_v2/pools/results.go
@@ -130,6 +130,10 @@ func (r PoolPage) NextPageURL() (string, error) {
 
 // IsEmpty checks whether a PoolPage struct is empty.
 func (r PoolPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractPools(r)
 	return len(is) == 0, err
 }
@@ -243,6 +247,10 @@ func (r MemberPage) NextPageURL() (string, error) {
 
 // IsEmpty checks whether a MemberPage struct is empty.
 func (r MemberPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractMembers(r)
 	return len(is) == 0, err
 }

--- a/openstack/networking/v2/extensions/networkipavailabilities/results.go
+++ b/openstack/networking/v2/extensions/networkipavailabilities/results.go
@@ -121,6 +121,10 @@ type NetworkIPAvailabilityPage struct {
 
 // IsEmpty determines whether or not a NetworkIPAvailability is empty.
 func (r NetworkIPAvailabilityPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	networkipavailabilities, err := ExtractNetworkIPAvailabilities(r)
 	return len(networkipavailabilities) == 0, err
 }

--- a/openstack/networking/v2/extensions/qos/policies/results.go
+++ b/openstack/networking/v2/extensions/qos/policies/results.go
@@ -110,6 +110,10 @@ func (r PolicyPage) NextPageURL() (string, error) {
 
 // IsEmpty checks whether a PolicyPage is empty.
 func (r PolicyPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractPolicies(r)
 	return len(is) == 0, err
 }

--- a/openstack/networking/v2/extensions/qos/rules/results.go
+++ b/openstack/networking/v2/extensions/qos/rules/results.go
@@ -70,6 +70,10 @@ type BandwidthLimitRulePage struct {
 
 // IsEmpty checks whether a BandwidthLimitRulePage is empty.
 func (r BandwidthLimitRulePage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractBandwidthLimitRules(r)
 	return len(is) == 0, err
 }
@@ -142,6 +146,10 @@ type DSCPMarkingRulePage struct {
 
 // IsEmpty checks whether a DSCPMarkingRulePage is empty.
 func (r DSCPMarkingRulePage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractDSCPMarkingRules(r)
 	return len(is) == 0, err
 }
@@ -217,6 +225,10 @@ type MinimumBandwidthRulePage struct {
 
 // IsEmpty checks whether a MinimumBandwidthRulePage is empty.
 func (r MinimumBandwidthRulePage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractMinimumBandwidthRules(r)
 	return len(is) == 0, err
 }

--- a/openstack/networking/v2/extensions/qos/ruletypes/results.go
+++ b/openstack/networking/v2/extensions/qos/ruletypes/results.go
@@ -47,6 +47,10 @@ type ListRuleTypesPage struct {
 }
 
 func (r ListRuleTypesPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	v, err := ExtractRuleTypes(r)
 	return len(v) == 0, err
 }

--- a/openstack/networking/v2/extensions/rbacpolicies/results.go
+++ b/openstack/networking/v2/extensions/rbacpolicies/results.go
@@ -82,6 +82,10 @@ type RBACPolicyPage struct {
 
 // IsEmpty checks whether a RBACPolicyPage struct is empty.
 func (r RBACPolicyPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractRBACPolicies(r)
 	return len(is) == 0, err
 }

--- a/openstack/networking/v2/extensions/security/groups/results.go
+++ b/openstack/networking/v2/extensions/security/groups/results.go
@@ -101,6 +101,10 @@ func (r SecGroupPage) NextPageURL() (string, error) {
 
 // IsEmpty checks whether a SecGroupPage struct is empty.
 func (r SecGroupPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractGroups(r)
 	return len(is) == 0, err
 }

--- a/openstack/networking/v2/extensions/security/rules/results.go
+++ b/openstack/networking/v2/extensions/security/rules/results.go
@@ -80,6 +80,10 @@ func (r SecGroupRulePage) NextPageURL() (string, error) {
 
 // IsEmpty checks whether a SecGroupRulePage struct is empty.
 func (r SecGroupRulePage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractRules(r)
 	return len(is) == 0, err
 }

--- a/openstack/networking/v2/extensions/subnetpools/results.go
+++ b/openstack/networking/v2/extensions/subnetpools/results.go
@@ -251,6 +251,10 @@ func (r SubnetPoolPage) NextPageURL() (string, error) {
 
 // IsEmpty determines whether or not a SubnetPoolPage is empty.
 func (r SubnetPoolPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	subnetpools, err := ExtractSubnetPools(r)
 	return len(subnetpools) == 0, err
 }

--- a/openstack/networking/v2/extensions/trunks/results.go
+++ b/openstack/networking/v2/extensions/trunks/results.go
@@ -111,6 +111,10 @@ type TrunkPage struct {
 }
 
 func (page TrunkPage) IsEmpty() (bool, error) {
+	if page.StatusCode == 204 {
+		return true, nil
+	}
+
 	trunks, err := ExtractTrunks(page)
 	return len(trunks) == 0, err
 }

--- a/openstack/networking/v2/extensions/vpnaas/endpointgroups/results.go
+++ b/openstack/networking/v2/extensions/vpnaas/endpointgroups/results.go
@@ -64,6 +64,10 @@ func (r EndpointGroupPage) NextPageURL() (string, error) {
 
 // IsEmpty checks whether an EndpointGroupPage struct is empty.
 func (r EndpointGroupPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractEndpointGroups(r)
 	return len(is) == 0, err
 }

--- a/openstack/networking/v2/extensions/vpnaas/ikepolicies/results.go
+++ b/openstack/networking/v2/extensions/vpnaas/ikepolicies/results.go
@@ -85,6 +85,10 @@ func (r PolicyPage) NextPageURL() (string, error) {
 
 // IsEmpty checks whether a PolicyPage struct is empty.
 func (r PolicyPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractPolicies(r)
 	return len(is) == 0, err
 }

--- a/openstack/networking/v2/extensions/vpnaas/ipsecpolicies/results.go
+++ b/openstack/networking/v2/extensions/vpnaas/ipsecpolicies/results.go
@@ -104,6 +104,10 @@ func (r PolicyPage) NextPageURL() (string, error) {
 
 // IsEmpty checks whether a PolicyPage struct is empty.
 func (r PolicyPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractPolicies(r)
 	return len(is) == 0, err
 }

--- a/openstack/networking/v2/extensions/vpnaas/services/results.go
+++ b/openstack/networking/v2/extensions/vpnaas/services/results.go
@@ -72,6 +72,10 @@ func (r ServicePage) NextPageURL() (string, error) {
 
 // IsEmpty checks whether a ServicePage struct is empty.
 func (r ServicePage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractServices(r)
 	return len(is) == 0, err
 }

--- a/openstack/networking/v2/extensions/vpnaas/siteconnections/results.go
+++ b/openstack/networking/v2/extensions/vpnaas/siteconnections/results.go
@@ -114,6 +114,10 @@ func (r ConnectionPage) NextPageURL() (string, error) {
 
 // IsEmpty checks whether a ConnectionPage struct is empty.
 func (r ConnectionPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractConnections(r)
 	return len(is) == 0, err
 }

--- a/openstack/networking/v2/networks/results.go
+++ b/openstack/networking/v2/networks/results.go
@@ -155,6 +155,10 @@ func (r NetworkPage) NextPageURL() (string, error) {
 
 // IsEmpty checks whether a NetworkPage struct is empty.
 func (r NetworkPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractNetworks(r)
 	return len(is) == 0, err
 }

--- a/openstack/networking/v2/ports/results.go
+++ b/openstack/networking/v2/ports/results.go
@@ -187,6 +187,10 @@ func (r PortPage) NextPageURL() (string, error) {
 
 // IsEmpty checks whether a PortPage struct is empty.
 func (r PortPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractPorts(r)
 	return len(is) == 0, err
 }

--- a/openstack/networking/v2/subnets/results.go
+++ b/openstack/networking/v2/subnets/results.go
@@ -142,6 +142,10 @@ func (r SubnetPage) NextPageURL() (string, error) {
 
 // IsEmpty checks whether a SubnetPage struct is empty.
 func (r SubnetPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractSubnets(r)
 	return len(is) == 0, err
 }

--- a/openstack/orchestration/v1/apiversions/results.go
+++ b/openstack/orchestration/v1/apiversions/results.go
@@ -21,6 +21,10 @@ type APIVersionPage struct {
 
 // IsEmpty checks whether an APIVersionPage struct is empty.
 func (r APIVersionPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractAPIVersions(r)
 	return len(is) == 0, err
 }

--- a/openstack/orchestration/v1/stackevents/results.go
+++ b/openstack/orchestration/v1/stackevents/results.go
@@ -82,6 +82,10 @@ type EventPage struct {
 
 // IsEmpty returns true if a page contains no Server results.
 func (r EventPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	events, err := ExtractEvents(r)
 	return len(events) == 0, err
 }

--- a/openstack/orchestration/v1/stackresources/results.go
+++ b/openstack/orchestration/v1/stackresources/results.go
@@ -89,6 +89,10 @@ type ResourcePage struct {
 
 // IsEmpty returns true if a page contains no Server results.
 func (r ResourcePage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	resources, err := ExtractResources(r)
 	return len(resources) == 0, err
 }
@@ -141,6 +145,10 @@ type ResourceTypePage struct {
 
 // IsEmpty returns true if a ResourceTypePage contains no resource types.
 func (r ResourceTypePage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	rts, err := ExtractResourceTypes(r)
 	return len(rts) == 0, err
 }

--- a/openstack/orchestration/v1/stacks/results.go
+++ b/openstack/orchestration/v1/stacks/results.go
@@ -42,6 +42,10 @@ type StackPage struct {
 
 // IsEmpty returns true if a ListResult contains no Stacks.
 func (r StackPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	stacks, err := ExtractStacks(r)
 	return len(stacks) == 0, err
 }

--- a/openstack/placement/v1/resourceproviders/results.go
+++ b/openstack/placement/v1/resourceproviders/results.go
@@ -110,6 +110,10 @@ type ResourceProvidersPage struct {
 
 // IsEmpty determines if a ResourceProvidersPage contains any results.
 func (page ResourceProvidersPage) IsEmpty() (bool, error) {
+	if page.StatusCode == 204 {
+		return true, nil
+	}
+
 	resourceProviders, err := ExtractResourceProviders(page)
 	return len(resourceProviders) == 0, err
 }

--- a/openstack/sharedfilesystems/apiversions/results.go
+++ b/openstack/sharedfilesystems/apiversions/results.go
@@ -33,6 +33,10 @@ type APIVersionPage struct {
 
 // IsEmpty checks whether an APIVersionPage struct is empty.
 func (r APIVersionPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	is, err := ExtractAPIVersions(r)
 	return len(is) == 0, err
 }

--- a/openstack/sharedfilesystems/v2/messages/results.go
+++ b/openstack/sharedfilesystems/v2/messages/results.go
@@ -65,6 +65,10 @@ type MessagePage struct {
 
 // IsEmpty returns true if a ListResult contains no Messages.
 func (r MessagePage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	messages, err := ExtractMessages(r)
 	return len(messages) == 0, err
 }

--- a/openstack/sharedfilesystems/v2/schedulerstats/results.go
+++ b/openstack/sharedfilesystems/v2/schedulerstats/results.go
@@ -101,6 +101,10 @@ type PoolPage struct {
 // IsEmpty satisfies the IsEmpty method of the Page interface. It returns true
 // if a List contains no results.
 func (page PoolPage) IsEmpty() (bool, error) {
+	if page.StatusCode == 204 {
+		return true, nil
+	}
+
 	va, err := ExtractPools(page)
 	return len(va) == 0, err
 }

--- a/openstack/sharedfilesystems/v2/securityservices/results.go
+++ b/openstack/sharedfilesystems/v2/securityservices/results.go
@@ -71,6 +71,10 @@ type SecurityServicePage struct {
 
 // IsEmpty returns true if a ListResult contains no SecurityServices.
 func (r SecurityServicePage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	securityServices, err := ExtractSecurityServices(r)
 	return len(securityServices) == 0, err
 }

--- a/openstack/sharedfilesystems/v2/services/results.go
+++ b/openstack/sharedfilesystems/v2/services/results.go
@@ -57,6 +57,10 @@ type ServicePage struct {
 
 // IsEmpty determines whether or not a page of Services contains any results.
 func (page ServicePage) IsEmpty() (bool, error) {
+	if page.StatusCode == 204 {
+		return true, nil
+	}
+
 	services, err := ExtractServices(page)
 	return len(services) == 0, err
 }

--- a/openstack/sharedfilesystems/v2/sharenetworks/results.go
+++ b/openstack/sharedfilesystems/v2/sharenetworks/results.go
@@ -126,6 +126,10 @@ func (r ShareNetworkPage) LastMarker() (string, error) {
 
 // IsEmpty satisifies the IsEmpty method of the Page interface
 func (r ShareNetworkPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	shareNetworks, err := ExtractShareNetworks(r)
 	return len(shareNetworks) == 0, err
 }

--- a/openstack/sharedfilesystems/v2/shares/results.go
+++ b/openstack/sharedfilesystems/v2/shares/results.go
@@ -178,6 +178,10 @@ func (r SharePage) LastMarker() (string, error) {
 
 // IsEmpty satisifies the IsEmpty method of the Page interface
 func (r SharePage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	shares, err := ExtractShares(r)
 	return len(shares) == 0, err
 }

--- a/openstack/sharedfilesystems/v2/sharetypes/results.go
+++ b/openstack/sharedfilesystems/v2/sharetypes/results.go
@@ -50,6 +50,10 @@ type ShareTypePage struct {
 
 // IsEmpty returns true if a ListResult contains no ShareTypes.
 func (r ShareTypePage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	shareTypes, err := ExtractShareTypes(r)
 	return len(shareTypes) == 0, err
 }

--- a/openstack/sharedfilesystems/v2/snapshots/results.go
+++ b/openstack/sharedfilesystems/v2/snapshots/results.go
@@ -139,6 +139,10 @@ func (r SnapshotPage) LastMarker() (string, error) {
 
 // IsEmpty satisifies the IsEmpty method of the Page interface
 func (r SnapshotPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	snapshots, err := ExtractSnapshots(r)
 	return len(snapshots) == 0, err
 }

--- a/openstack/workflow/v2/crontriggers/results.go
+++ b/openstack/workflow/v2/crontriggers/results.go
@@ -130,6 +130,10 @@ type CronTriggerPage struct {
 
 // IsEmpty checks if an CronTriggerPage contains any results.
 func (r CronTriggerPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	exec, err := ExtractCronTriggers(r)
 	return len(exec) == 0, err
 }

--- a/openstack/workflow/v2/executions/results.go
+++ b/openstack/workflow/v2/executions/results.go
@@ -132,6 +132,10 @@ type ExecutionPage struct {
 
 // IsEmpty checks if an ExecutionPage contains any results.
 func (r ExecutionPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	exec, err := ExtractExecutions(r)
 	return len(exec) == 0, err
 }

--- a/openstack/workflow/v2/workflows/results.go
+++ b/openstack/workflow/v2/workflows/results.go
@@ -106,6 +106,10 @@ type WorkflowPage struct {
 
 // IsEmpty checks if an WorkflowPage contains any results.
 func (r WorkflowPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
 	exec, err := ExtractWorkflows(r)
 	return len(exec) == 0, err
 }


### PR DESCRIPTION
With this commit, all `IsEmpty() (bool, error)` functions now check the status code of the result. If it's `204`, they immediately confirm that the page is empty.

This change was introduced in commit 64ed1bc1 in `objectstorage` to support Swift instances running behind a reverse proxy that was truncating `content-type` headers from `204 Empty` responses. With this change, the same check is applied to all services.

While no functional impact is expected on non-proxied OpenStack modules, this patch will prevent issues on proxied clouds. In general, it also seems reasonable to expect `204 Empty` responses to be empty.

---

This change is the result of running:

```shell
find -name 'results.go' -exec sed -i 's|^\(func (\(.\+\) .\+) IsEmpty() (bool, error) {\)$|\1\nif \2.StatusCode==204 {\nreturn true,nil\n}\n|' {} \;
go fmt ./...
```