### PR TITLE
keystone: add v3 OS-FEDERATION mappings get operation

### DIFF
--- a/acceptance/openstack/identity/v3/federation_test.go
+++ b/acceptance/openstack/identity/v3/federation_test.go
@@ -64,7 +64,13 @@ func TestMappingsCRUD(t *testing.T) {
 		},
 	}
 
-	actual, err := federation.CreateMapping(client, mappingName, createOpts).Extract()
+	createdMapping, err := federation.CreateMapping(client, mappingName, createOpts).Extract()
 	th.AssertNoErr(t, err)
-	th.CheckDeepEquals(t, createOpts.Rules[0], actual.Rules[0])
+	th.AssertEquals(t, len(createOpts.Rules), len(createdMapping.Rules))
+	th.CheckDeepEquals(t, createOpts.Rules[0], createdMapping.Rules[0])
+
+	mapping, err := federation.GetMapping(client, mappingName).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, len(createOpts.Rules), len(mapping.Rules))
+	th.CheckDeepEquals(t, createOpts.Rules[0], mapping.Rules[0])
 }

--- a/openstack/identity/v3/extensions/federation/doc.go
+++ b/openstack/identity/v3/extensions/federation/doc.go
@@ -50,5 +50,12 @@ Example to Create Mappings
 	if err != nil {
 		panic(err)
 	}
+
+Example to Get a Mapping
+
+	mapping, err := federation.GetMapping(identityClient, "ACME").Extract()
+	if err != nil {
+		panic(err)
+	}
 */
 package federation

--- a/openstack/identity/v3/extensions/federation/requests.go
+++ b/openstack/identity/v3/extensions/federation/requests.go
@@ -42,3 +42,10 @@ func CreateMapping(client *gophercloud.ServiceClient, mappingID string, opts Cre
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
+
+// GetMapping retrieves details on a single mapping, by ID.
+func GetMapping(client *gophercloud.ServiceClient, mappingID string) (r GetMappingResult) {
+	resp, err := client.Get(mappingsResourceURL(client, mappingID), &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}

--- a/openstack/identity/v3/extensions/federation/results.go
+++ b/openstack/identity/v3/extensions/federation/results.go
@@ -150,6 +150,12 @@ type CreateMappingResult struct {
 	mappingResult
 }
 
+// GetMappingResult is the response from a GetMapping operation.
+// Call its Extract method to interpret it as a Mapping.
+type GetMappingResult struct {
+	mappingResult
+}
+
 // MappingsPage is a single page of Mapping results.
 type MappingsPage struct {
 	pagination.LinkedPageBase

--- a/openstack/identity/v3/extensions/federation/testing/fixtures.go
+++ b/openstack/identity/v3/extensions/federation/testing/fixtures.go
@@ -130,6 +130,8 @@ const CreateOutput = `
 }
 `
 
+const GetOutput = CreateOutput
+
 var MappingACME = federation.Mapping{
 	ID: "ACME",
 	Links: map[string]interface{}{
@@ -192,5 +194,19 @@ func HandleCreateMappingSuccessfully(t *testing.T) {
 
 		w.WriteHeader(http.StatusCreated)
 		fmt.Fprintf(w, CreateOutput)
+	})
+}
+
+// HandleGetMappingSuccessfully creates an HTTP handler at `/mappings` on the
+// test handler mux that responds with a single mapping.
+func HandleGetMappingSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/OS-FEDERATION/mappings/ACME", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, GetOutput)
 	})
 }

--- a/openstack/identity/v3/extensions/federation/testing/requests_test.go
+++ b/openstack/identity/v3/extensions/federation/testing/requests_test.go
@@ -81,3 +81,13 @@ func TestCreateMappings(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.CheckDeepEquals(t, MappingACME, *actual)
 }
+
+func TestGetMapping(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleGetMappingSuccessfully(t)
+
+	actual, err := federation.GetMapping(client.ServiceClient(), "ACME").Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, MappingACME, *actual)
+}


### PR DESCRIPTION
For https://github.com/gophercloud/gophercloud/issues/2461

[docs](https://docs.openstack.org/api-ref/identity/v3-ext/index.html#get-a-mapping)
[code](https://github.com/openstack/keystone/blob/stable/yoga/keystone/api/os_federation.py#L258)