### PR TITLE
Drop train job for baremetal

### DIFF
--- a/.github/workflows/functional-baremetal.yaml
+++ b/.github/workflows/functional-baremetal.yaml
@@ -29,9 +29,6 @@ jobs:
           - name: "ussuri"
             openstack_version: "stable/ussuri"
             ubuntu_version: "18.04"
-          - name: "train"
-            openstack_version: "stable/train"
-            ubuntu_version: "18.04"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with Ironic and run baremetal acceptance tests
     steps:


### PR DESCRIPTION
Upstream had EOL-ed the train branch and is no longer accepting fixes. Our patch to fix the installation of virtualbmc with python 3.6 [1] was abandoned. We have no choice than dropping our train job as it's going to permafail and we can't fix it.

[1] https://review.opendev.org/c/openstack/ironic/+/847436

Close #2439