### PR TITLE
keystone: add v3 OS-FEDERATION mappings update operation

### DIFF
--- a/acceptance/openstack/identity/v3/federation_test.go
+++ b/acceptance/openstack/identity/v3/federation_test.go
@@ -107,6 +107,6 @@ func TestMappingsCRUD(t *testing.T) {
 
 	updatedMapping, err := federation.UpdateMapping(client, mappingName, updateOpts).Extract()
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, len(createOpts.Rules), len(mapping.Rules))
+	th.AssertEquals(t, len(updateOpts.Rules), len(updatedMapping.Rules))
 	th.CheckDeepEquals(t, updateOpts.Rules[0], updatedMapping.Rules[0])
 }

--- a/acceptance/openstack/identity/v3/federation_test.go
+++ b/acceptance/openstack/identity/v3/federation_test.go
@@ -73,4 +73,40 @@ func TestMappingsCRUD(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, len(createOpts.Rules), len(mapping.Rules))
 	th.CheckDeepEquals(t, createOpts.Rules[0], mapping.Rules[0])
+
+	updateOpts := federation.UpdateMappingOpts{
+		Rules: []federation.MappingRule{
+			{
+				Local: []federation.RuleLocal{
+					{
+						User: &federation.RuleUser{
+							Name: "{0}",
+						},
+					},
+					{
+						Group: &federation.Group{
+							ID: "0cd5e9",
+						},
+					},
+				},
+				Remote: []federation.RuleRemote{
+					{
+						Type: "UserName",
+					},
+					{
+						Type: "orgPersonType",
+						AnyOneOf: []string{
+							"Contractor",
+							"SubContractor",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	updatedMapping, err := federation.UpdateMapping(client, mappingName, updateOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, len(createOpts.Rules), len(mapping.Rules))
+	th.CheckDeepEquals(t, updateOpts.Rules[0], updatedMapping.Rules[0])
 }

--- a/openstack/identity/v3/extensions/federation/doc.go
+++ b/openstack/identity/v3/extensions/federation/doc.go
@@ -57,5 +57,42 @@ Example to Get a Mapping
 	if err != nil {
 		panic(err)
 	}
+
+Example to Update a Mapping
+
+	updateOpts := federation.UpdateMappingOpts{
+		Rules: []federation.MappingRule{
+			{
+				Local: []federation.RuleLocal{
+					{
+						User: &federation.RuleUser{
+							Name: "{0}",
+						},
+					},
+					{
+						Group: &federation.Group{
+							ID: "0cd5e9",
+						},
+					},
+				},
+				Remote: []federation.RuleRemote{
+					{
+						Type: "UserName",
+					},
+					{
+						Type: "orgPersonType",
+						AnyOneOf: []string{
+							"Contractor",
+							"SubContractor",
+						},
+					},
+				},
+			},
+		},
+	}
+	updatedMapping, err := federation.UpdateMapping(identityClient, "ACME", updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
 */
 package federation

--- a/openstack/identity/v3/extensions/federation/requests.go
+++ b/openstack/identity/v3/extensions/federation/requests.go
@@ -49,3 +49,34 @@ func GetMapping(client *gophercloud.ServiceClient, mappingID string) (r GetMappi
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
+
+// UpdateMappingOptsBuilder allows extensions to add additional parameters to
+// the Update request.
+type UpdateMappingOptsBuilder interface {
+	ToMappingUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateMappingOpts provides options for updating a mapping.
+type UpdateMappingOpts struct {
+	// The list of rules used to map remote users into local users
+	Rules []MappingRule `json:"rules"`
+}
+
+// ToMappingUpdateMap formats a UpdateOpts into an update request.
+func (opts UpdateMappingOpts) ToMappingUpdateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "mapping")
+}
+
+// UpdateMapping updates an existing mapping.
+func UpdateMapping(client *gophercloud.ServiceClient, mappingID string, opts UpdateMappingOptsBuilder) (r UpdateMappingResult) {
+	b, err := opts.ToMappingUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := client.Patch(mappingsResourceURL(client, mappingID), &b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}

--- a/openstack/identity/v3/extensions/federation/results.go
+++ b/openstack/identity/v3/extensions/federation/results.go
@@ -156,6 +156,12 @@ type GetMappingResult struct {
 	mappingResult
 }
 
+// UpdateMappingResult is the response from a UpdateMapping operation.
+// Call its Extract method to interpret it as a Mapping.
+type UpdateMappingResult struct {
+	mappingResult
+}
+
 // MappingsPage is a single page of Mapping results.
 type MappingsPage struct {
 	pagination.LinkedPageBase

--- a/openstack/identity/v3/extensions/federation/testing/fixtures.go
+++ b/openstack/identity/v3/extensions/federation/testing/fixtures.go
@@ -132,6 +132,80 @@ const CreateOutput = `
 
 const GetOutput = CreateOutput
 
+const UpdateRequest = `
+{
+    "mapping": {
+        "rules": [
+            {
+                "local": [
+                    {
+                        "user": {
+                            "name": "{0}"
+                        }
+                    },
+                    {
+                        "group": {
+                            "id": "0cd5e9"
+                        }
+                    }
+                ],
+                "remote": [
+                    {
+                        "type": "UserName"
+                    },
+                    {
+                        "type": "orgPersonType",
+                        "any_one_of": [
+                            "Contractor",
+                            "SubContractor"
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}
+`
+
+const UpdateOutput = `
+{
+    "mapping": {
+        "id": "ACME",
+        "links": {
+            "self": "http://example.com/identity/v3/OS-FEDERATION/mappings/ACME"
+        },
+        "rules": [
+            {
+                "local": [
+                    {
+                        "user": {
+                            "name": "{0}"
+                        }
+                    },
+                    {
+                        "group": {
+                            "id": "0cd5e9"
+                        }
+                    }
+                ],
+                "remote": [
+                    {
+                        "type": "UserName"
+                    },
+                    {
+                        "type": "orgPersonType",
+                        "any_one_of": [
+                            "Contractor",
+                            "SubContractor"
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}
+`
+
 var MappingACME = federation.Mapping{
 	ID: "ACME",
 	Links: map[string]interface{}{
@@ -160,6 +234,41 @@ var MappingACME = federation.Mapping{
 					NotAnyOf: []string{
 						"Contractor",
 						"Guest",
+					},
+				},
+			},
+		},
+	},
+}
+
+var MappingUpdated = federation.Mapping{
+	ID: "ACME",
+	Links: map[string]interface{}{
+		"self": "http://example.com/identity/v3/OS-FEDERATION/mappings/ACME",
+	},
+	Rules: []federation.MappingRule{
+		{
+			Local: []federation.RuleLocal{
+				{
+					User: &federation.RuleUser{
+						Name: "{0}",
+					},
+				},
+				{
+					Group: &federation.Group{
+						ID: "0cd5e9",
+					},
+				},
+			},
+			Remote: []federation.RuleRemote{
+				{
+					Type: "UserName",
+				},
+				{
+					Type: "orgPersonType",
+					AnyOneOf: []string{
+						"Contractor",
+						"SubContractor",
 					},
 				},
 			},
@@ -208,5 +317,18 @@ func HandleGetMappingSuccessfully(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprintf(w, GetOutput)
+	})
+}
+
+// HandleUpdateMappingSuccessfully creates an HTTP handler at `/mappings` on the
+// test handler mux that tests mapping update.
+func HandleUpdateMappingSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/OS-FEDERATION/mappings/ACME", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PATCH")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, UpdateRequest)
+
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, UpdateOutput)
 	})
 }

--- a/openstack/identity/v3/extensions/federation/testing/requests_test.go
+++ b/openstack/identity/v3/extensions/federation/testing/requests_test.go
@@ -91,3 +91,44 @@ func TestGetMapping(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.CheckDeepEquals(t, MappingACME, *actual)
 }
+
+func TestUpdateMapping(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleUpdateMappingSuccessfully(t)
+
+	updateOpts := federation.UpdateMappingOpts{
+		Rules: []federation.MappingRule{
+			{
+				Local: []federation.RuleLocal{
+					{
+						User: &federation.RuleUser{
+							Name: "{0}",
+						},
+					},
+					{
+						Group: &federation.Group{
+							ID: "0cd5e9",
+						},
+					},
+				},
+				Remote: []federation.RuleRemote{
+					{
+						Type: "UserName",
+					},
+					{
+						Type: "orgPersonType",
+						AnyOneOf: []string{
+							"Contractor",
+							"SubContractor",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	actual, err := federation.UpdateMapping(client.ServiceClient(), "ACME", updateOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, MappingUpdated, *actual)
+}


### PR DESCRIPTION
For https://github.com/gophercloud/gophercloud/issues/2461

[docs](https://docs.openstack.org/api-ref/identity/v3-ext/index.html#update-a-mapping)
[code](https://github.com/openstack/keystone/blob/stable/yoga/keystone/api/os_federation.py#L275)