### PR TITLE
objectstorage: Reject container names with a slash

### DIFF
--- a/openstack/objectstorage/v1/containers/errors.go
+++ b/openstack/objectstorage/v1/containers/errors.go
@@ -1,0 +1,13 @@
+package containers
+
+import "github.com/gophercloud/gophercloud"
+
+// ErrInvalidContainerName signals a container name containing an illegal
+// character.
+type ErrInvalidContainerName struct {
+	gophercloud.BaseError
+}
+
+func (e ErrInvalidContainerName) Error() string {
+	return "A container name must not contain: " + forbiddenContainerRunes
+}

--- a/openstack/objectstorage/v1/containers/requests.go
+++ b/openstack/objectstorage/v1/containers/requests.go
@@ -96,6 +96,11 @@ func (opts CreateOpts) ToContainerCreateMap() (map[string]string, error) {
 
 // Create is a function that creates a new container.
 func Create(c *gophercloud.ServiceClient, containerName string, opts CreateOptsBuilder) (r CreateResult) {
+	url, err := createURL(c, containerName)
+	if err != nil {
+		r.Err = err
+		return
+	}
 	h := make(map[string]string)
 	if opts != nil {
 		headers, err := opts.ToContainerCreateMap()
@@ -107,7 +112,7 @@ func Create(c *gophercloud.ServiceClient, containerName string, opts CreateOptsB
 			h[k] = v
 		}
 	}
-	resp, err := c.Request("PUT", createURL(c, containerName), &gophercloud.RequestOpts{
+	resp, err := c.Request("PUT", url, &gophercloud.RequestOpts{
 		MoreHeaders: h,
 		OkCodes:     []int{201, 202, 204},
 	})
@@ -138,7 +143,12 @@ func BulkDelete(c *gophercloud.ServiceClient, containers []string) (r BulkDelete
 
 // Delete is a function that deletes a container.
 func Delete(c *gophercloud.ServiceClient, containerName string) (r DeleteResult) {
-	resp, err := c.Delete(deleteURL(c, containerName), nil)
+	url, err := deleteURL(c, containerName)
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := c.Delete(url, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
@@ -189,6 +199,11 @@ func (opts UpdateOpts) ToContainerUpdateMap() (map[string]string, error) {
 // Update is a function that creates, updates, or deletes a container's
 // metadata.
 func Update(c *gophercloud.ServiceClient, containerName string, opts UpdateOptsBuilder) (r UpdateResult) {
+	url, err := updateURL(c, containerName)
+	if err != nil {
+		r.Err = err
+		return
+	}
 	h := make(map[string]string)
 	if opts != nil {
 		headers, err := opts.ToContainerUpdateMap()
@@ -201,7 +216,7 @@ func Update(c *gophercloud.ServiceClient, containerName string, opts UpdateOptsB
 			h[k] = v
 		}
 	}
-	resp, err := c.Request("POST", updateURL(c, containerName), &gophercloud.RequestOpts{
+	resp, err := c.Request("POST", url, &gophercloud.RequestOpts{
 		MoreHeaders: h,
 		OkCodes:     []int{201, 202, 204},
 	})
@@ -229,6 +244,11 @@ func (opts GetOpts) ToContainerGetMap() (map[string]string, error) {
 // the custom metadata, pass the GetResult response to the ExtractMetadata
 // function.
 func Get(c *gophercloud.ServiceClient, containerName string, opts GetOptsBuilder) (r GetResult) {
+	url, err := getURL(c, containerName)
+	if err != nil {
+		r.Err = err
+		return
+	}
 	h := make(map[string]string)
 	if opts != nil {
 		headers, err := opts.ToContainerGetMap()
@@ -241,7 +261,7 @@ func Get(c *gophercloud.ServiceClient, containerName string, opts GetOptsBuilder
 			h[k] = v
 		}
 	}
-	resp, err := c.Head(getURL(c, containerName), &gophercloud.RequestOpts{
+	resp, err := c.Head(url, &gophercloud.RequestOpts{
 		MoreHeaders: h,
 		OkCodes:     []int{200, 204},
 	})

--- a/openstack/objectstorage/v1/containers/testing/fixtures.go
+++ b/openstack/objectstorage/v1/containers/testing/fixtures.go
@@ -10,6 +10,18 @@ import (
 	fake "github.com/gophercloud/gophercloud/testhelper/client"
 )
 
+type handlerOptions struct {
+	path string
+}
+
+type option func(*handlerOptions)
+
+func WithPath(s string) option {
+	return func(h *handlerOptions) {
+		h.path = s
+	}
+}
+
 // ExpectedListInfo is the result expected from a call to `List` when full
 // info is requested.
 var ExpectedListInfo = []containers.Container{
@@ -127,8 +139,15 @@ func HandleCreateContainerSuccessfully(t *testing.T) {
 
 // HandleDeleteContainerSuccessfully creates an HTTP handler at `/testContainer` on the test handler mux that
 // responds with a `Delete` response.
-func HandleDeleteContainerSuccessfully(t *testing.T) {
-	th.Mux.HandleFunc("/testContainer", func(w http.ResponseWriter, r *http.Request) {
+func HandleDeleteContainerSuccessfully(t *testing.T, options ...option) {
+	ho := handlerOptions{
+		path: "/testContainer",
+	}
+	for _, apply := range options {
+		apply(&ho)
+	}
+
+	th.Mux.HandleFunc(ho.path, func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "DELETE")
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 		th.TestHeader(t, r, "Accept", "application/json")
@@ -167,8 +186,15 @@ func HandleBulkDeleteSuccessfully(t *testing.T) {
 
 // HandleUpdateContainerSuccessfully creates an HTTP handler at `/testContainer` on the test handler mux that
 // responds with a `Update` response.
-func HandleUpdateContainerSuccessfully(t *testing.T) {
-	th.Mux.HandleFunc("/testContainer", func(w http.ResponseWriter, r *http.Request) {
+func HandleUpdateContainerSuccessfully(t *testing.T, options ...option) {
+	ho := handlerOptions{
+		path: "/testContainer",
+	}
+	for _, apply := range options {
+		apply(&ho)
+	}
+
+	th.Mux.HandleFunc(ho.path, func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "POST")
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 		th.TestHeader(t, r, "Accept", "application/json")
@@ -183,8 +209,15 @@ func HandleUpdateContainerSuccessfully(t *testing.T) {
 
 // HandleGetContainerSuccessfully creates an HTTP handler at `/testContainer` on the test handler mux that
 // responds with a `Get` response.
-func HandleGetContainerSuccessfully(t *testing.T) {
-	th.Mux.HandleFunc("/testContainer", func(w http.ResponseWriter, r *http.Request) {
+func HandleGetContainerSuccessfully(t *testing.T, options ...option) {
+	ho := handlerOptions{
+		path: "/testContainer",
+	}
+	for _, apply := range options {
+		apply(&ho)
+	}
+
+	th.Mux.HandleFunc(ho.path, func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "HEAD")
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 		th.TestHeader(t, r, "Accept", "application/json")

--- a/openstack/objectstorage/v1/containers/urls.go
+++ b/openstack/objectstorage/v1/containers/urls.go
@@ -1,24 +1,51 @@
 package containers
 
-import "github.com/gophercloud/gophercloud"
+import (
+	"fmt"
+	"strings"
+
+	"github.com/gophercloud/gophercloud"
+)
+
+const forbiddenContainerRunes = "/"
+
+func CheckContainerName(s string) error {
+	if strings.ContainsAny(s, forbiddenContainerRunes) {
+		return ErrInvalidContainerName{}
+	}
+
+	// The input could (and should) already have been escaped. This cycle
+	// checks for the escaped versions of the forbidden characters. Note
+	// that a simple "contains" is sufficient, because Go's http library
+	// won't accept invalid escape sequences (e.g. "%%2F").
+	for _, r := range forbiddenContainerRunes {
+		if strings.Contains(strings.ToLower(s), fmt.Sprintf("%%%x", r)) {
+			return ErrInvalidContainerName{}
+		}
+	}
+	return nil
+}
 
 func listURL(c *gophercloud.ServiceClient) string {
 	return c.Endpoint
 }
 
-func createURL(c *gophercloud.ServiceClient, container string) string {
-	return c.ServiceURL(container)
+func createURL(c *gophercloud.ServiceClient, container string) (string, error) {
+	if err := CheckContainerName(container); err != nil {
+		return "", err
+	}
+	return c.ServiceURL(container), nil
 }
 
-func getURL(c *gophercloud.ServiceClient, container string) string {
+func getURL(c *gophercloud.ServiceClient, container string) (string, error) {
 	return createURL(c, container)
 }
 
-func deleteURL(c *gophercloud.ServiceClient, container string) string {
+func deleteURL(c *gophercloud.ServiceClient, container string) (string, error) {
 	return createURL(c, container)
 }
 
-func updateURL(c *gophercloud.ServiceClient, container string) string {
+func updateURL(c *gophercloud.ServiceClient, container string) (string, error) {
 	return createURL(c, container)
 }
 

--- a/openstack/objectstorage/v1/objects/testing/fixtures.go
+++ b/openstack/objectstorage/v1/objects/testing/fixtures.go
@@ -13,10 +13,29 @@ import (
 	fake "github.com/gophercloud/gophercloud/testhelper/client"
 )
 
+type handlerOptions struct {
+	path string
+}
+
+type option func(*handlerOptions)
+
+func WithPath(s string) option {
+	return func(h *handlerOptions) {
+		h.path = s
+	}
+}
+
 // HandleDownloadObjectSuccessfully creates an HTTP handler at `/testContainer/testObject` on the test handler mux that
 // responds with a `Download` response.
-func HandleDownloadObjectSuccessfully(t *testing.T) {
-	th.Mux.HandleFunc("/testContainer/testObject", func(w http.ResponseWriter, r *http.Request) {
+func HandleDownloadObjectSuccessfully(t *testing.T, options ...option) {
+	ho := handlerOptions{
+		path: "/testContainer/testObject",
+	}
+	for _, apply := range options {
+		apply(&ho)
+	}
+
+	th.Mux.HandleFunc(ho.path, func(w http.ResponseWriter, r *http.Request) {
 		date := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
 		th.TestMethod(t, r, "GET")
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
@@ -79,8 +98,15 @@ var ExpectedListNames = []string{"hello", "goodbye"}
 
 // HandleListObjectsInfoSuccessfully creates an HTTP handler at `/testContainer` on the test handler mux that
 // responds with a `List` response when full info is requested.
-func HandleListObjectsInfoSuccessfully(t *testing.T) {
-	th.Mux.HandleFunc("/testContainer", func(w http.ResponseWriter, r *http.Request) {
+func HandleListObjectsInfoSuccessfully(t *testing.T, options ...option) {
+	ho := handlerOptions{
+		path: "/testContainer",
+	}
+	for _, apply := range options {
+		apply(&ho)
+	}
+
+	th.Mux.HandleFunc(ho.path, func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "GET")
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 		th.TestHeader(t, r, "Accept", "application/json")
@@ -177,8 +203,15 @@ func HandleListZeroObjectNames204(t *testing.T) {
 
 // HandleCreateTextObjectSuccessfully creates an HTTP handler at `/testContainer/testObject` on the test handler mux
 // that responds with a `Create` response. A Content-Type of "text/plain" is expected.
-func HandleCreateTextObjectSuccessfully(t *testing.T, content string) {
-	th.Mux.HandleFunc("/testContainer/testObject", func(w http.ResponseWriter, r *http.Request) {
+func HandleCreateTextObjectSuccessfully(t *testing.T, content string, options ...option) {
+	ho := handlerOptions{
+		path: "/testContainer/testObject",
+	}
+	for _, apply := range options {
+		apply(&ho)
+	}
+
+	th.Mux.HandleFunc(ho.path, func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "PUT")
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 		th.TestHeader(t, r, "Content-Type", "text/plain")
@@ -250,8 +283,15 @@ func HandleCopyObjectSuccessfully(t *testing.T) {
 
 // HandleDeleteObjectSuccessfully creates an HTTP handler at `/testContainer/testObject` on the test handler mux that
 // responds with a `Delete` response.
-func HandleDeleteObjectSuccessfully(t *testing.T) {
-	th.Mux.HandleFunc("/testContainer/testObject", func(w http.ResponseWriter, r *http.Request) {
+func HandleDeleteObjectSuccessfully(t *testing.T, options ...option) {
+	ho := handlerOptions{
+		path: "/testContainer/testObject",
+	}
+	for _, apply := range options {
+		apply(&ho)
+	}
+
+	th.Mux.HandleFunc(ho.path, func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "DELETE")
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 		th.TestHeader(t, r, "Accept", "application/json")
@@ -290,8 +330,15 @@ func HandleBulkDeleteSuccessfully(t *testing.T) {
 
 // HandleUpdateObjectSuccessfully creates an HTTP handler at `/testContainer/testObject` on the test handler mux that
 // responds with a `Update` response.
-func HandleUpdateObjectSuccessfully(t *testing.T) {
-	th.Mux.HandleFunc("/testContainer/testObject", func(w http.ResponseWriter, r *http.Request) {
+func HandleUpdateObjectSuccessfully(t *testing.T, options ...option) {
+	ho := handlerOptions{
+		path: "/testContainer/testObject",
+	}
+	for _, apply := range options {
+		apply(&ho)
+	}
+
+	th.Mux.HandleFunc(ho.path, func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "POST")
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 		th.TestHeader(t, r, "Accept", "application/json")
@@ -309,8 +356,15 @@ func HandleUpdateObjectSuccessfully(t *testing.T) {
 
 // HandleGetObjectSuccessfully creates an HTTP handler at `/testContainer/testObject` on the test handler mux that
 // responds with a `Get` response.
-func HandleGetObjectSuccessfully(t *testing.T) {
-	th.Mux.HandleFunc("/testContainer/testObject", func(w http.ResponseWriter, r *http.Request) {
+func HandleGetObjectSuccessfully(t *testing.T, options ...option) {
+	ho := handlerOptions{
+		path: "/testContainer/testObject",
+	}
+	for _, apply := range options {
+		apply(&ho)
+	}
+
+	th.Mux.HandleFunc(ho.path, func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "HEAD")
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 		th.TestHeader(t, r, "Accept", "application/json")

--- a/openstack/objectstorage/v1/objects/urls.go
+++ b/openstack/objectstorage/v1/objects/urls.go
@@ -2,33 +2,40 @@ package objects
 
 import (
 	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/objectstorage/v1/containers"
 )
 
-func listURL(c *gophercloud.ServiceClient, container string) string {
-	return c.ServiceURL(container)
+func listURL(c *gophercloud.ServiceClient, container string) (string, error) {
+	if err := containers.CheckContainerName(container); err != nil {
+		return "", err
+	}
+	return c.ServiceURL(container), nil
 }
 
-func copyURL(c *gophercloud.ServiceClient, container, object string) string {
-	return c.ServiceURL(container, object)
+func copyURL(c *gophercloud.ServiceClient, container, object string) (string, error) {
+	if err := containers.CheckContainerName(container); err != nil {
+		return "", err
+	}
+	return c.ServiceURL(container, object), nil
 }
 
-func createURL(c *gophercloud.ServiceClient, container, object string) string {
+func createURL(c *gophercloud.ServiceClient, container, object string) (string, error) {
 	return copyURL(c, container, object)
 }
 
-func getURL(c *gophercloud.ServiceClient, container, object string) string {
+func getURL(c *gophercloud.ServiceClient, container, object string) (string, error) {
 	return copyURL(c, container, object)
 }
 
-func deleteURL(c *gophercloud.ServiceClient, container, object string) string {
+func deleteURL(c *gophercloud.ServiceClient, container, object string) (string, error) {
 	return copyURL(c, container, object)
 }
 
-func downloadURL(c *gophercloud.ServiceClient, container, object string) string {
+func downloadURL(c *gophercloud.ServiceClient, container, object string) (string, error) {
 	return copyURL(c, container, object)
 }
 
-func updateURL(c *gophercloud.ServiceClient, container, object string) string {
+func updateURL(c *gophercloud.ServiceClient, container, object string) (string, error) {
 	return copyURL(c, container, object)
 }
 

--- a/pagination/pager.go
+++ b/pagination/pager.go
@@ -134,6 +134,9 @@ func (p Pager) EachPage(handler func(Page) (bool, error)) error {
 // AllPages returns all the pages from a `List` operation in a single page,
 // allowing the user to retrieve all the pages at once.
 func (p Pager) AllPages() (Page, error) {
+	if p.Err != nil {
+		return nil, p.Err
+	}
 	// pagesSlice holds all the pages until they get converted into as Page Body.
 	var pagesSlice []interface{}
 	// body will contain the final concatenated Page body.

--- a/testhelper/convenience.go
+++ b/testhelper/convenience.go
@@ -3,6 +3,7 @@ package testhelper
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"reflect"
@@ -351,6 +352,29 @@ func AssertErr(t *testing.T, e error) {
 // CheckNoErr is similar to AssertNoErr, except with a non-fatal error
 func CheckNoErr(t *testing.T, e error) {
 	if e != nil {
+		logError(t, fmt.Sprintf("unexpected error %s", yellow(e.Error())))
+	}
+}
+
+// CheckErr is similar to AssertErr, except with a non-fatal error. If expected
+// errors are passed, this function also checks that an error in e's tree is
+// assignable to one of them. The tree consists of e itself, followed by the
+// errors obtained by repeatedly calling Unwrap.
+//
+// CheckErr panics if expected contains anything other than non-nil pointers to
+// either a type that implements error, or to any interface type.
+func CheckErr(t *testing.T, e error, expected ...interface{}) {
+	if e == nil {
+		logError(t, "expected error, got nil")
+		return
+	}
+
+	if len(expected) > 0 {
+		for _, expectedError := range expected {
+			if errors.As(e, expectedError) {
+				return
+			}
+		}
 		logError(t, fmt.Sprintf("unexpected error %s", yellow(e.Error())))
 	}
 }


### PR DESCRIPTION
As per the [OpenStack object-storage docs](https://docs.openstack.org/api-ref/object-store/#create-container), container names must not contain a slash (`/`).

By accepting them, some functions change their meaning. For example, by passing a container name with a slash to `containers.Create`, it is possible to actually create an object (if the container exists already).

With this patch, objectstorage functions error when called with a containerName containing a slash.

Fixes #2551