### PR TITLE
loadbalancer: Use CreateMemberOpts instead of BatchUpdateMemberOpts in PoolCreateOpts

### DIFF
--- a/acceptance/openstack/loadbalancer/v2/loadbalancer.go
+++ b/acceptance/openstack/loadbalancer/v2/loadbalancer.go
@@ -195,7 +195,7 @@ func CreateLoadBalancerFullyPopulated(t *testing.T, client *gophercloud.ServiceC
 				Description: poolDescription,
 				Protocol:    pools.ProtocolHTTP,
 				LBMethod:    pools.LBMethodLeastConnections,
-				Members: []pools.BatchUpdateMemberOpts{{
+				Members: []pools.CreateMemberOpts{{
 					Name:         &memberName,
 					ProtocolPort: memberPort,
 					Weight:       &memberWeight,

--- a/acceptance/openstack/loadbalancer/v2/loadbalancer.go
+++ b/acceptance/openstack/loadbalancer/v2/loadbalancer.go
@@ -196,11 +196,11 @@ func CreateLoadBalancerFullyPopulated(t *testing.T, client *gophercloud.ServiceC
 				Protocol:    pools.ProtocolHTTP,
 				LBMethod:    pools.LBMethodLeastConnections,
 				Members: []pools.CreateMemberOpts{{
-					Name:         &memberName,
+					Name:         memberName,
 					ProtocolPort: memberPort,
 					Weight:       &memberWeight,
 					Address:      "1.2.3.4",
-					SubnetID:     &subnetID,
+					SubnetID:     subnetID,
 				}},
 				Monitor: &monitors.CreateOpts{
 					Delay:          10,

--- a/openstack/loadbalancer/v2/loadbalancers/testing/requests_test.go
+++ b/openstack/loadbalancer/v2/loadbalancers/testing/requests_test.go
@@ -110,7 +110,7 @@ func TestCreateFullyPopulatedLoadbalancer(t *testing.T) {
 				LBMethod: pools.LBMethodRoundRobin,
 				Protocol: "HTTP",
 				Name:     "Example pool",
-				Members: []pools.BatchUpdateMemberOpts{{
+				Members: []pools.CreateMemberOpts{{
 					Address:      "192.0.2.51",
 					ProtocolPort: 80,
 				}, {

--- a/openstack/loadbalancer/v2/pools/requests.go
+++ b/openstack/loadbalancer/v2/pools/requests.go
@@ -123,12 +123,12 @@ type CreateOpts struct {
 	// or false (DOWN).
 	AdminStateUp *bool `json:"admin_state_up,omitempty"`
 
-	// Members is a slice of BatchUpdateMemberOpts which allows a set of
+	// Members is a slice of CreateMemberOpts which allows a set of
 	// members to be created at the same time the pool is created.
 	//
 	// This is only possible to use when creating a fully populated
 	// Loadbalancer.
-	Members []BatchUpdateMemberOpts `json:"members,omitempty"`
+	Members []CreateMemberOpts `json:"members,omitempty"`
 
 	// Monitor is an instance of monitors.CreateOpts which allows a monitor
 	// to be created at the same time the pool is created.


### PR DESCRIPTION
In order to support members without any subnet, the struct for the pool members need to be CreateMemberOpts.


Fixes #2559

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:
API validation for UUID in octavia:
https://opendev.org/openstack/octavia/src/commit/c2c59f4c9eb9f9ef6081e386bf2bc1badc145241/octavia/api/v2/types/member.py#L127
