### PR TITLE
compute: add ext_specs to flavor

### DIFF
--- a/openstack/compute/v2/flavors/results.go
+++ b/openstack/compute/v2/flavors/results.go
@@ -80,6 +80,12 @@ type Flavor struct {
 	// 65535 characters in length. Only printable characters are allowed.
 	// New in version 2.55
 	Description string `json:"description"`
+
+	// Properties is a dictionary of the flavor’s extra-specs key-and-value
+	// pairs. This will only be included if the user is allowed by policy to
+	// index flavor extra_specs
+	// New in version 2.61
+	ExtraSpecs map[string]string `json:"extra_specs"`
 }
 
 func (r *Flavor) UnmarshalJSON(b []byte) error {

--- a/openstack/compute/v2/flavors/testing/requests_test.go
+++ b/openstack/compute/v2/flavors/testing/requests_test.go
@@ -39,7 +39,11 @@ func TestListFlavors(t *testing.T) {
 								"swap":"",
 								"os-flavor-access:is_public": true,
 								"OS-FLV-EXT-DATA:ephemeral": 10,
-								"description": "foo"
+								"description": "foo",
+								"extra_specs":
+									{
+										"foo": "bar"
+									}
 							},
 							{
 								"id": "2",
@@ -88,7 +92,7 @@ func TestListFlavors(t *testing.T) {
 		}
 
 		expected := []flavors.Flavor{
-			{ID: "1", Name: "m1.tiny", VCPUs: 1, Disk: 1, RAM: 9216000, Swap: 0, IsPublic: true, Ephemeral: 10, Description: "foo"},
+			{ID: "1", Name: "m1.tiny", VCPUs: 1, Disk: 1, RAM: 9216000, Swap: 0, IsPublic: true, Ephemeral: 10, Description: "foo", ExtraSpecs: map[string]string{"foo": "bar"}},
 			{ID: "2", Name: "m1.small", VCPUs: 1, Disk: 20, RAM: 2048, Swap: 1000, IsPublic: true, Ephemeral: 0},
 			{ID: "3", Name: "m1.medium", VCPUs: 2, Disk: 40, RAM: 4096, Swap: 1000, IsPublic: false, Ephemeral: 0},
 		}
@@ -126,7 +130,10 @@ func TestGetFlavor(t *testing.T) {
 					"vcpus": 1,
 					"rxtx_factor": 1,
 					"swap": "",
-					"description": "foo"
+					"description": "foo",
+					"extra_specs": {
+						"foo": "bar"
+					}
 				}
 			}
 		`)
@@ -146,6 +153,7 @@ func TestGetFlavor(t *testing.T) {
 		RxTxFactor:  1,
 		Swap:        0,
 		Description: "foo",
+		ExtraSpecs:  map[string]string{"foo": "bar"},
 	}
 	if !reflect.DeepEqual(expected, actual) {
 		t.Errorf("Expected %#v, but was %#v", expected, actual)


### PR DESCRIPTION
Fixes #2497 

Openstack API Ref:
[flavor get](https://docs.openstack.org/api-ref/compute/?expanded=resize-server-resize-action-detail,start-server-os-start-action-detail,create-server-back-up-createbackup-action-detail,show-details-of-specific-api-version-detail,show-flavor-details-detail#show-flavor-details)

nova code Ref:
https://github.com/openstack/nova/blob/5c32d5efe1e1aece48b680474617113c61a248d5/nova/objects/flavor.py#L220

As there is no extra_spec in flavor create's parameter,for acceptance test, I write a test which create extra_spec for a already existed flavor, then compare the get result's extra_spec.  [nova create flavor code](https://github.com/openstack/nova/blob/5c32d5efe1e1aece48b680474617113c61a248d5/nova/api/openstack/compute/flavor_manage.py#L55).


