### PR TITLE
Support propagate_uplink_status for Ports

### DIFF
--- a/openstack/networking/v2/ports/requests.go
+++ b/openstack/networking/v2/ports/requests.go
@@ -110,19 +110,20 @@ type CreateOptsBuilder interface {
 
 // CreateOpts represents the attributes used when creating a new port.
 type CreateOpts struct {
-	NetworkID           string             `json:"network_id" required:"true"`
-	Name                string             `json:"name,omitempty"`
-	Description         string             `json:"description,omitempty"`
-	AdminStateUp        *bool              `json:"admin_state_up,omitempty"`
-	MACAddress          string             `json:"mac_address,omitempty"`
-	FixedIPs            interface{}        `json:"fixed_ips,omitempty"`
-	DeviceID            string             `json:"device_id,omitempty"`
-	DeviceOwner         string             `json:"device_owner,omitempty"`
-	TenantID            string             `json:"tenant_id,omitempty"`
-	ProjectID           string             `json:"project_id,omitempty"`
-	SecurityGroups      *[]string          `json:"security_groups,omitempty"`
-	AllowedAddressPairs []AddressPair      `json:"allowed_address_pairs,omitempty"`
-	ValueSpecs          *map[string]string `json:"value_specs,omitempty"`
+	NetworkID             string             `json:"network_id" required:"true"`
+	Name                  string             `json:"name,omitempty"`
+	Description           string             `json:"description,omitempty"`
+	AdminStateUp          *bool              `json:"admin_state_up,omitempty"`
+	MACAddress            string             `json:"mac_address,omitempty"`
+	FixedIPs              interface{}        `json:"fixed_ips,omitempty"`
+	DeviceID              string             `json:"device_id,omitempty"`
+	DeviceOwner           string             `json:"device_owner,omitempty"`
+	TenantID              string             `json:"tenant_id,omitempty"`
+	ProjectID             string             `json:"project_id,omitempty"`
+	SecurityGroups        *[]string          `json:"security_groups,omitempty"`
+	AllowedAddressPairs   []AddressPair      `json:"allowed_address_pairs,omitempty"`
+	PropagateUplinkStatus *bool              `json:"propagate_uplink_status,omitempty"`
+	ValueSpecs            *map[string]string `json:"value_specs,omitempty"`
 }
 
 // ToPortCreateMap builds a request body from CreateOpts.
@@ -151,15 +152,16 @@ type UpdateOptsBuilder interface {
 
 // UpdateOpts represents the attributes used when updating an existing port.
 type UpdateOpts struct {
-	Name                *string            `json:"name,omitempty"`
-	Description         *string            `json:"description,omitempty"`
-	AdminStateUp        *bool              `json:"admin_state_up,omitempty"`
-	FixedIPs            interface{}        `json:"fixed_ips,omitempty"`
-	DeviceID            *string            `json:"device_id,omitempty"`
-	DeviceOwner         *string            `json:"device_owner,omitempty"`
-	SecurityGroups      *[]string          `json:"security_groups,omitempty"`
-	AllowedAddressPairs *[]AddressPair     `json:"allowed_address_pairs,omitempty"`
-	ValueSpecs          *map[string]string `json:"value_specs,omitempty"`
+	Name                  *string            `json:"name,omitempty"`
+	Description           *string            `json:"description,omitempty"`
+	AdminStateUp          *bool              `json:"admin_state_up,omitempty"`
+	FixedIPs              interface{}        `json:"fixed_ips,omitempty"`
+	DeviceID              *string            `json:"device_id,omitempty"`
+	DeviceOwner           *string            `json:"device_owner,omitempty"`
+	SecurityGroups        *[]string          `json:"security_groups,omitempty"`
+	AllowedAddressPairs   *[]AddressPair     `json:"allowed_address_pairs,omitempty"`
+	PropagateUplinkStatus *bool              `json:"propagate_uplink_status,omitempty"`
+	ValueSpecs            *map[string]string `json:"value_specs,omitempty"`
 
 	// RevisionNumber implements extension:standard-attr-revisions. If != "" it
 	// will set revision_number=%s. If the revision number does not match, the

--- a/openstack/networking/v2/ports/results.go
+++ b/openstack/networking/v2/ports/results.go
@@ -111,6 +111,9 @@ type Port struct {
 	// Tags optionally set via extensions/attributestags
 	Tags []string `json:"tags"`
 
+	// PropagateUplinkStatus enables/disables propagate uplink status on the port.
+	PropagateUplinkStatus bool `json:"propagate_uplink_status"`
+
 	// Extra parameters to include in the request.
 	ValueSpecs map[string]string `json:"value_specs"`
 

--- a/openstack/networking/v2/ports/testing/fixtures.go
+++ b/openstack/networking/v2/ports/testing/fixtures.go
@@ -240,6 +240,46 @@ const CreateOmitSecurityGroupsResponse = `
 }
 `
 
+const CreatePropagateUplinkStatusRequest = `
+{
+    "port": {
+        "network_id": "a87cc70a-3e15-4acf-8205-9b711a3531b7",
+        "name": "private-port",
+        "admin_state_up": true,
+        "fixed_ips": [
+            {
+                "subnet_id": "a0304c3a-4f08-4c43-88af-d796509c97d2",
+                "ip_address": "10.0.0.2"
+            }
+        ],
+        "propagate_uplink_status": true
+    }
+}
+`
+
+const CreatePropagateUplinkStatusResponse = `
+{
+    "port": {
+        "status": "DOWN",
+        "name": "private-port",
+        "admin_state_up": true,
+        "network_id": "a87cc70a-3e15-4acf-8205-9b711a3531b7",
+        "tenant_id": "d6700c0c9ffa4f1cb322cd4a1f3906fa",
+        "device_owner": "",
+        "mac_address": "fa:16:3e:c9:cb:f0",
+        "fixed_ips": [
+            {
+                "subnet_id": "a0304c3a-4f08-4c43-88af-d796509c97d2",
+                "ip_address": "10.0.0.2"
+            }
+        ],
+        "id": "65c0ee9f-d634-4522-8954-51021b570b0d",
+        "propagate_uplink_status": true,
+        "device_id": ""
+    }
+}
+`
+
 const CreateValueSpecRequest = `
 {
     "port": {
@@ -456,6 +496,46 @@ const UpdateOmitSecurityGroupsResponse = `
         "security_groups": [
             "f0ac4394-7e4a-4409-9701-ba8be283dbc3"
         ],
+        "device_id": ""
+    }
+}
+`
+
+const UpdatePropagateUplinkStatusRequest = `
+{
+    "port": {
+        "propagate_uplink_status": true
+    }
+}
+`
+
+const UpdatePropagateUplinkStatusResponse = `
+{
+    "port": {
+        "status": "DOWN",
+        "name": "new_port_name",
+        "admin_state_up": true,
+        "network_id": "a87cc70a-3e15-4acf-8205-9b711a3531b7",
+        "tenant_id": "d6700c0c9ffa4f1cb322cd4a1f3906fa",
+        "device_owner": "",
+        "mac_address": "fa:16:3e:c9:cb:f0",
+        "fixed_ips": [
+            {
+                "subnet_id": "a0304c3a-4f08-4c43-88af-d796509c97d2",
+                "ip_address": "10.0.0.3"
+            }
+        ],
+        "allowed_address_pairs": [
+          {
+            "ip_address": "10.0.0.4",
+            "mac_address": "fa:16:3e:c9:cb:f0"
+          }
+        ],
+        "id": "65c0ee9f-d634-4522-8954-51021b570b0d",
+        "security_groups": [
+            "f0ac4394-7e4a-4409-9701-ba8be283dbc3"
+        ],
+        "propagate_uplink_status": true,
         "device_id": ""
     }
 }


### PR DESCRIPTION
Fixes #2562 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

Docs: https://docs.openstack.org/heat/zed/template_guide/openstack.html#OS::Neutron::Port-prop-propagate_uplink_status
