### PR TITLE
Prefer github mirrors over opendev repos

### DIFF
--- a/.github/workflows/functional-baremetal.yaml
+++ b/.github/workflows/functional-baremetal.yaml
@@ -39,6 +39,8 @@ jobs:
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |
+            # pyghmi is not mirrored on github
+            PYGHMI_REPO=https://opendev.org/x/pyghmi
             enable_plugin ironic https://github.com/openstack/ironic ${{ matrix.openstack_version }}
             LIBS_FROM_GIT=pyghmi,virtualbmc
             FORCE_CONFIG_DRIVE=True

--- a/.github/workflows/functional-baremetal.yaml
+++ b/.github/workflows/functional-baremetal.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Checkout Gophercloud
         uses: actions/checkout@v3
       - name: Deploy devstack
-        uses: EmilienM/devstack-action@v0.9
+        uses: EmilienM/devstack-action@v0.10
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |

--- a/.github/workflows/functional-baremetal.yaml
+++ b/.github/workflows/functional-baremetal.yaml
@@ -39,7 +39,7 @@ jobs:
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |
-            enable_plugin ironic https://opendev.org/openstack/ironic ${{ matrix.openstack_version }}
+            enable_plugin ironic https://github.com/openstack/ironic ${{ matrix.openstack_version }}
             LIBS_FROM_GIT=pyghmi,virtualbmc
             FORCE_CONFIG_DRIVE=True
             Q_AGENT=openvswitch

--- a/.github/workflows/functional-basic.yaml
+++ b/.github/workflows/functional-basic.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Checkout Gophercloud
         uses: actions/checkout@v3
       - name: Deploy devstack
-        uses: EmilienM/devstack-action@v0.9
+        uses: EmilienM/devstack-action@v0.10
         with:
           branch: ${{ matrix.openstack_version }}
           enabled_services: 's-account,s-container,s-object,s-proxy'

--- a/.github/workflows/functional-blockstorage.yaml
+++ b/.github/workflows/functional-blockstorage.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Checkout Gophercloud
         uses: actions/checkout@v3
       - name: Deploy devstack
-        uses: EmilienM/devstack-action@v0.9
+        uses: EmilienM/devstack-action@v0.10
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |

--- a/.github/workflows/functional-clustering.yaml
+++ b/.github/workflows/functional-clustering.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Checkout Gophercloud
         uses: actions/checkout@v3
       - name: Deploy devstack
-        uses: EmilienM/devstack-action@v0.9
+        uses: EmilienM/devstack-action@v0.10
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |

--- a/.github/workflows/functional-clustering.yaml
+++ b/.github/workflows/functional-clustering.yaml
@@ -42,8 +42,8 @@ jobs:
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |
-            enable_plugin senlin https://opendev.org/openstack/senlin ${{ matrix.openstack_version }}
-            enable_plugin zaqar https://opendev.org/openstack/zaqar ${{ matrix.openstack_version }}
+            enable_plugin senlin https://github.com/openstack/senlin ${{ matrix.openstack_version }}
+            enable_plugin zaqar https://github.com/openstack/zaqar ${{ matrix.openstack_version }}
             ZAQARCLIENT_BRANCH=${{ matrix.openstack_version }}
       - name: Checkout go
         uses: actions/setup-go@v3

--- a/.github/workflows/functional-compute.yaml
+++ b/.github/workflows/functional-compute.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Checkout Gophercloud
         uses: actions/checkout@v3
       - name: Deploy devstack
-        uses: EmilienM/devstack-action@v0.9
+        uses: EmilienM/devstack-action@v0.10
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |

--- a/.github/workflows/functional-containerinfra.yaml
+++ b/.github/workflows/functional-containerinfra.yaml
@@ -52,7 +52,7 @@ jobs:
       - name: Checkout Gophercloud
         uses: actions/checkout@v3
       - name: Deploy devstack
-        uses: EmilienM/devstack-action@v0.9
+        uses: EmilienM/devstack-action@v0.10
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |

--- a/.github/workflows/functional-containerinfra.yaml
+++ b/.github/workflows/functional-containerinfra.yaml
@@ -15,37 +15,37 @@ jobs:
             openstack_version: "master"
             ubuntu_version: "20.04"
             devstack_conf_overrides: |
-              enable_plugin magnum https://opendev.org/openstack/magnum master
+              enable_plugin magnum https://github.com/openstack/magnum master
           - name: "yoga"
             openstack_version: "stable/yoga"
             ubuntu_version: "20.04"
             devstack_conf_overrides: |
-              enable_plugin magnum https://opendev.org/openstack/magnum stable/yoga
+              enable_plugin magnum https://github.com/openstack/magnum stable/yoga
           - name: "xena"
             openstack_version: "stable/xena"
             ubuntu_version: "20.04"
             devstack_conf_overrides: |
-              enable_plugin magnum https://opendev.org/openstack/magnum stable/xena
+              enable_plugin magnum https://github.com/openstack/magnum stable/xena
           - name: "wallaby"
             openstack_version: "stable/wallaby"
             ubuntu_version: "20.04"
             devstack_conf_overrides: |
-              enable_plugin magnum https://opendev.org/openstack/magnum stable/wallaby
+              enable_plugin magnum https://github.com/openstack/magnum stable/wallaby
           - name: "victoria"
             openstack_version: "stable/victoria"
             ubuntu_version: "20.04"
             devstack_conf_overrides: |
-              enable_plugin magnum https://opendev.org/openstack/magnum stable/victoria
+              enable_plugin magnum https://github.com/openstack/magnum stable/victoria
           - name: "ussuri"
             openstack_version: "stable/ussuri"
             ubuntu_version: "18.04"
             devstack_conf_overrides: |
-              enable_plugin magnum https://opendev.org/openstack/magnum ussuri-eol
+              enable_plugin magnum https://github.com/openstack/magnum ussuri-eol
           - name: "train"
             openstack_version: "stable/train"
             ubuntu_version: "18.04"
             devstack_conf_overrides: |
-              enable_plugin magnum https://opendev.org/openstack/magnum train-eol
+              enable_plugin magnum https://github.com/openstack/magnum train-eol
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with Magnum and run containerinfra acceptance tests
     steps:
@@ -56,8 +56,8 @@ jobs:
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |
-            enable_plugin barbican https://opendev.org/openstack/barbican ${{ matrix.openstack_version }}
-            enable_plugin heat https://opendev.org/openstack/heat ${{ matrix.openstack_version }}
+            enable_plugin barbican https://github.com/openstack/barbican ${{ matrix.openstack_version }}
+            enable_plugin heat https://github.com/openstack/heat ${{ matrix.openstack_version }}
             GLANCE_LIMIT_IMAGE_SIZE_TOTAL=5000
             SWIFT_MAX_FILE_SIZE=5368709122
             KEYSTONE_ADMIN_ENDPOINT=true

--- a/.github/workflows/functional-dns.yaml
+++ b/.github/workflows/functional-dns.yaml
@@ -53,7 +53,7 @@ jobs:
       - name: Checkout Gophercloud
         uses: actions/checkout@v3
       - name: Deploy devstack
-        uses: EmilienM/devstack-action@v0.9
+        uses: EmilienM/devstack-action@v0.10
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |

--- a/.github/workflows/functional-dns.yaml
+++ b/.github/workflows/functional-dns.yaml
@@ -16,37 +16,37 @@ jobs:
             openstack_version: "master"
             ubuntu_version: "20.04"
             devstack_conf_overrides: |
-              enable_plugin designate https://opendev.org/openstack/designate master
+              enable_plugin designate https://github.com/openstack/designate master
           - name: "yoga"
             openstack_version: "stable/yoga"
             ubuntu_version: "20.04"
             devstack_conf_overrides: |
-              enable_plugin designate https://opendev.org/openstack/designate stable/yoga
+              enable_plugin designate https://github.com/openstack/designate stable/yoga
           - name: "xena"
             openstack_version: "stable/xena"
             ubuntu_version: "20.04"
             devstack_conf_overrides: |
-              enable_plugin designate https://opendev.org/openstack/designate stable/xena
+              enable_plugin designate https://github.com/openstack/designate stable/xena
           - name: "wallaby"
             openstack_version: "stable/wallaby"
             ubuntu_version: "20.04"
             devstack_conf_overrides: |
-              enable_plugin designate https://opendev.org/openstack/designate stable/wallaby
+              enable_plugin designate https://github.com/openstack/designate stable/wallaby
           - name: "victoria"
             openstack_version: "stable/victoria"
             ubuntu_version: "20.04"
             devstack_conf_overrides: |
-              enable_plugin designate https://opendev.org/openstack/designate stable/victoria
+              enable_plugin designate https://github.com/openstack/designate stable/victoria
           - name: "ussuri"
             openstack_version: "stable/ussuri"
             ubuntu_version: "18.04"
             devstack_conf_overrides: |
-              enable_plugin designate https://opendev.org/openstack/designate stable/ussuri
+              enable_plugin designate https://github.com/openstack/designate stable/ussuri
           - name: "train"
             openstack_version: "stable/train"
             ubuntu_version: "18.04"
             devstack_conf_overrides: |
-              enable_plugin designate https://opendev.org/openstack/designate train-eol
+              enable_plugin designate https://github.com/openstack/designate train-eol
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with Designate and run dns acceptance tests
     steps:

--- a/.github/workflows/functional-identity.yaml
+++ b/.github/workflows/functional-identity.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Checkout Gophercloud
         uses: actions/checkout@v3
       - name: Deploy devstack
-        uses: EmilienM/devstack-action@v0.9
+        uses: EmilienM/devstack-action@v0.10
         with:
           branch: ${{ matrix.openstack_version }}
       - name: Checkout go

--- a/.github/workflows/functional-imageservice.yaml
+++ b/.github/workflows/functional-imageservice.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Checkout Gophercloud
         uses: actions/checkout@v3
       - name: Deploy devstack
-        uses: EmilienM/devstack-action@v0.9
+        uses: EmilienM/devstack-action@v0.10
         with:
           branch: ${{ matrix.openstack_version }}
       - name: Checkout go

--- a/.github/workflows/functional-keymanager.yaml
+++ b/.github/workflows/functional-keymanager.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Checkout Gophercloud
         uses: actions/checkout@v3
       - name: Deploy devstack
-        uses: EmilienM/devstack-action@v0.9
+        uses: EmilienM/devstack-action@v0.10
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |

--- a/.github/workflows/functional-keymanager.yaml
+++ b/.github/workflows/functional-keymanager.yaml
@@ -42,7 +42,7 @@ jobs:
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |
-            enable_plugin barbican https://opendev.org/openstack/barbican ${{ matrix.openstack_version }}
+            enable_plugin barbican https://github.com/openstack/barbican ${{ matrix.openstack_version }}
           enabled_services: 'barbican-svc,barbican-retry,barbican-keystone-listener'
       - name: Checkout go
         uses: actions/setup-go@v3

--- a/.github/workflows/functional-loadbalancer.yaml
+++ b/.github/workflows/functional-loadbalancer.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Checkout Gophercloud
         uses: actions/checkout@v3
       - name: Deploy devstack
-        uses: EmilienM/devstack-action@v0.9
+        uses: EmilienM/devstack-action@v0.10
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |

--- a/.github/workflows/functional-loadbalancer.yaml
+++ b/.github/workflows/functional-loadbalancer.yaml
@@ -42,8 +42,8 @@ jobs:
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |
-            enable_plugin octavia https://opendev.org/openstack/octavia ${{ matrix.openstack_version }}
-            enable_plugin neutron https://opendev.org/openstack/neutron ${{ matrix.openstack_version }}
+            enable_plugin octavia https://github.com/openstack/octavia ${{ matrix.openstack_version }}
+            enable_plugin neutron https://github.com/openstack/neutron ${{ matrix.openstack_version }}
           enabled_services: 'octavia,o-api,o-cw,o-hk,o-hm,o-da,neutron-qos'
       - name: Checkout go
         uses: actions/setup-go@v3

--- a/.github/workflows/functional-messaging.yaml
+++ b/.github/workflows/functional-messaging.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Checkout Gophercloud
         uses: actions/checkout@v3
       - name: Deploy devstack
-        uses: EmilienM/devstack-action@v0.9
+        uses: EmilienM/devstack-action@v0.10
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |

--- a/.github/workflows/functional-messaging.yaml
+++ b/.github/workflows/functional-messaging.yaml
@@ -42,7 +42,7 @@ jobs:
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |
-            enable_plugin zaqar https://opendev.org/openstack/zaqar ${{ matrix.openstack_version }}
+            enable_plugin zaqar https://github.com/openstack/zaqar ${{ matrix.openstack_version }}
             ZAQARCLIENT_BRANCH=${{ matrix.openstack_version }}
       - name: Checkout go
         uses: actions/setup-go@v3

--- a/.github/workflows/functional-networking.yaml
+++ b/.github/workflows/functional-networking.yaml
@@ -61,7 +61,7 @@ jobs:
       - name: Checkout Gophercloud
         uses: actions/checkout@v3
       - name: Deploy devstack
-        uses: EmilienM/devstack-action@v0.9
+        uses: EmilienM/devstack-action@v0.10
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |

--- a/.github/workflows/functional-networking.yaml
+++ b/.github/workflows/functional-networking.yaml
@@ -15,46 +15,46 @@ jobs:
             openstack_version: "master"
             ubuntu_version: "20.04"
             devstack_conf_overrides: |
-              enable_plugin neutron-dynamic-routing https://opendev.org/openstack/neutron-dynamic-routing master
-              enable_plugin neutron-vpnaas https://opendev.org/openstack/neutron-vpnaas master
+              enable_plugin neutron-dynamic-routing https://github.com/openstack/neutron-dynamic-routing master
+              enable_plugin neutron-vpnaas https://github.com/openstack/neutron-vpnaas master
           - name: "yoga"
             openstack_version: "stable/yoga"
             ubuntu_version: "20.04"
             devstack_conf_overrides: |
-              enable_plugin neutron-dynamic-routing https://opendev.org/openstack/neutron-dynamic-routing stable/yoga
-              enable_plugin neutron-vpnaas https://opendev.org/openstack/neutron-vpnaas stable/yoga
+              enable_plugin neutron-dynamic-routing https://github.com/openstack/neutron-dynamic-routing stable/yoga
+              enable_plugin neutron-vpnaas https://github.com/openstack/neutron-vpnaas stable/yoga
           - name: "xena"
             openstack_version: "stable/xena"
             ubuntu_version: "20.04"
             devstack_conf_overrides: |
-              enable_plugin neutron-dynamic-routing https://opendev.org/openstack/neutron-dynamic-routing stable/xena
-              enable_plugin neutron-vpnaas https://opendev.org/openstack/neutron-vpnaas stable/xena
+              enable_plugin neutron-dynamic-routing https://github.com/openstack/neutron-dynamic-routing stable/xena
+              enable_plugin neutron-vpnaas https://github.com/openstack/neutron-vpnaas stable/xena
           - name: "wallaby"
             openstack_version: "stable/wallaby"
             ubuntu_version: "20.04"
             devstack_conf_overrides: |
-              enable_plugin neutron-dynamic-routing https://opendev.org/openstack/neutron-dynamic-routing stable/wallaby
-              enable_plugin neutron-vpnaas https://opendev.org/openstack/neutron-vpnaas stable/wallaby
+              enable_plugin neutron-dynamic-routing https://github.com/openstack/neutron-dynamic-routing stable/wallaby
+              enable_plugin neutron-vpnaas https://github.com/openstack/neutron-vpnaas stable/wallaby
           - name: "victoria"
             openstack_version: "stable/victoria"
             ubuntu_version: "20.04"
             devstack_conf_overrides: |
-              enable_plugin neutron-dynamic-routing https://opendev.org/openstack/neutron-dynamic-routing stable/victoria
-              enable_plugin neutron-vpnaas https://opendev.org/openstack/neutron-vpnaas stable/victoria
+              enable_plugin neutron-dynamic-routing https://github.com/openstack/neutron-dynamic-routing stable/victoria
+              enable_plugin neutron-vpnaas https://github.com/openstack/neutron-vpnaas stable/victoria
           - name: "ussuri"
             openstack_version: "stable/ussuri"
             ubuntu_version: "18.04"
             devstack_conf_overrides: |
-              enable_plugin neutron-fwaas https://opendev.org/openstack/neutron-fwaas stable/ussuri
-              enable_plugin neutron-dynamic-routing https://opendev.org/openstack/neutron-dynamic-routing stable/ussuri
-              enable_plugin neutron-vpnaas https://opendev.org/openstack/neutron-vpnaas ussuri-eol
+              enable_plugin neutron-fwaas https://github.com/openstack/neutron-fwaas stable/ussuri
+              enable_plugin neutron-dynamic-routing https://github.com/openstack/neutron-dynamic-routing stable/ussuri
+              enable_plugin neutron-vpnaas https://github.com/openstack/neutron-vpnaas ussuri-eol
           - name: "train"
             openstack_version: "stable/train"
             ubuntu_version: "18.04"
             devstack_conf_overrides: |
-              enable_plugin neutron-fwaas https://opendev.org/openstack/neutron-fwaas stable/train
-              enable_plugin neutron-dynamic-routing https://opendev.org/openstack/neutron-dynamic-routing train-eol
-              enable_plugin neutron-vpnaas https://opendev.org/openstack/neutron-vpnaas train-eol
+              enable_plugin neutron-fwaas https://github.com/openstack/neutron-fwaas stable/train
+              enable_plugin neutron-dynamic-routing https://github.com/openstack/neutron-dynamic-routing train-eol
+              enable_plugin neutron-vpnaas https://github.com/openstack/neutron-vpnaas train-eol
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with Neutron and run networking acceptance tests
     steps:

--- a/.github/workflows/functional-objectstorage.yaml
+++ b/.github/workflows/functional-objectstorage.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Checkout Gophercloud
         uses: actions/checkout@v3
       - name: Deploy devstack
-        uses: EmilienM/devstack-action@v0.9
+        uses: EmilienM/devstack-action@v0.10
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |

--- a/.github/workflows/functional-orchestration.yaml
+++ b/.github/workflows/functional-orchestration.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Checkout Gophercloud
         uses: actions/checkout@v3
       - name: Deploy devstack
-        uses: EmilienM/devstack-action@v0.9
+        uses: EmilienM/devstack-action@v0.10
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |

--- a/.github/workflows/functional-orchestration.yaml
+++ b/.github/workflows/functional-orchestration.yaml
@@ -42,7 +42,7 @@ jobs:
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |
-            enable_plugin heat https://opendev.org/openstack/heat ${{ matrix.openstack_version }}
+            enable_plugin heat https://github.com/openstack/heat ${{ matrix.openstack_version }}
           enabled_services: 'h-eng,h-api,h-api-cfn,h-api-cw'
       - name: Checkout go
         uses: actions/setup-go@v3

--- a/.github/workflows/functional-placement.yaml
+++ b/.github/workflows/functional-placement.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Checkout Gophercloud
         uses: actions/checkout@v3
       - name: Deploy devstack
-        uses: EmilienM/devstack-action@v0.9
+        uses: EmilienM/devstack-action@v0.10
         with:
           branch: ${{ matrix.openstack_version }}
       - name: Checkout go

--- a/.github/workflows/functional-sharedfilesystems.yaml
+++ b/.github/workflows/functional-sharedfilesystems.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Checkout Gophercloud
         uses: actions/checkout@v3
       - name: Deploy devstack
-        uses: EmilienM/devstack-action@v0.9
+        uses: EmilienM/devstack-action@v0.10
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |

--- a/.github/workflows/functional-sharedfilesystems.yaml
+++ b/.github/workflows/functional-sharedfilesystems.yaml
@@ -42,7 +42,7 @@ jobs:
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |
-            enable_plugin manila https://opendev.org/openstack/manila ${{ matrix.openstack_version }}
+            enable_plugin manila https://github.com/openstack/manila ${{ matrix.openstack_version }}
             # LVM Backend config options
             MANILA_SERVICE_IMAGE_ENABLED=False
             SHARE_DRIVER=manila.share.drivers.lvm.LVMShareDriver


### PR DESCRIPTION
The jobs are running in the Github infra and we should prefer github repos when possible.

Bump devstack-action to v0.10 that changes the default GIT_BASE to point to github repos rather than opendev.
Also change the URL of devstack-plugins to prefer github mirrors over opendev repos.

Hopefully mitigates #2565.