### PR TITLE
Swift V1: support object versioning

### DIFF
--- a/acceptance/openstack/objectstorage/v1/versioning_test.go
+++ b/acceptance/openstack/objectstorage/v1/versioning_test.go
@@ -1,0 +1,189 @@
+//go:build acceptance
+// +build acceptance
+
+package v1
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/acceptance/clients"
+	"github.com/gophercloud/gophercloud/acceptance/tools"
+	"github.com/gophercloud/gophercloud/openstack/objectstorage/v1/containers"
+	"github.com/gophercloud/gophercloud/openstack/objectstorage/v1/objects"
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestObjectsVersioning(t *testing.T) {
+	t.Skip("Skip this test, versioning is not yet supported by test env")
+
+	client, err := clients.NewObjectStorageV1Client()
+	if err != nil {
+		t.Fatalf("Unable to create client: %v", err)
+	}
+
+	// Make a slice of length numObjects to hold the random object names.
+	oNames := make([]string, numObjects)
+	for i := 0; i < len(oNames); i++ {
+		oNames[i] = tools.RandomString("test-object-", 8)
+	}
+
+	// Create a container to hold the test objects.
+	cName := tools.RandomString("test-container-", 8)
+	opts := containers.CreateOpts{
+		VersionsEnabled: true,
+	}
+	header, err := containers.Create(client, cName, opts).Extract()
+	th.AssertNoErr(t, err)
+	t.Logf("Create container headers: %+v\n", header)
+
+	// Defer deletion of the container until after testing.
+	defer func() {
+		res := containers.Delete(client, cName)
+		th.AssertNoErr(t, res.Err)
+	}()
+
+	// ensure versioning is enabled
+	get, err := containers.Get(client, cName, nil).Extract()
+	th.AssertNoErr(t, err)
+	t.Logf("Get container headers: %+v\n", get)
+	th.AssertEquals(t, true, get.VersionsEnabled)
+
+	// Create a slice of buffers to hold the test object content.
+	oContents := make([]string, numObjects)
+	oContentVersionIDs := make([]string, numObjects)
+	for i := 0; i < numObjects; i++ {
+		oContents[i] = tools.RandomString("", 10)
+		createOpts := objects.CreateOpts{
+			Content: strings.NewReader(oContents[i]),
+		}
+		obj, err := objects.Create(client, cName, oNames[i], createOpts).Extract()
+		th.AssertNoErr(t, err)
+		oContentVersionIDs[i] = obj.ObjectVersionID
+	}
+	oNewContents := make([]string, numObjects)
+	for i := 0; i < numObjects; i++ {
+		oNewContents[i] = tools.RandomString("", 10)
+		createOpts := objects.CreateOpts{
+			Content: strings.NewReader(oNewContents[i]),
+		}
+		_, err := objects.Create(client, cName, oNames[i], createOpts).Extract()
+		th.AssertNoErr(t, err)
+	}
+	// Delete the objects after testing two times.
+	defer func() {
+		// disable object versioning
+		opts := containers.UpdateOpts{
+			VersionsEnabled: new(bool),
+		}
+		header, err := containers.Update(client, cName, opts).Extract()
+		th.AssertNoErr(t, err)
+
+		t.Logf("Update container headers: %+v\n", header)
+
+		// ensure versioning is disabled
+		get, err := containers.Get(client, cName, nil).Extract()
+		th.AssertNoErr(t, err)
+		t.Logf("Get container headers: %+v\n", get)
+		th.AssertEquals(t, false, get.VersionsEnabled)
+
+		// delete all object versions before deleting the container
+		currentVersionIDs := make([]string, numObjects)
+		for i := 0; i < numObjects; i++ {
+			opts := objects.DeleteOpts{
+				ObjectVersionID: oContentVersionIDs[i],
+			}
+			obj, err := objects.Delete(client, cName, oNames[i], opts).Extract()
+			th.AssertNoErr(t, err)
+			currentVersionIDs[i] = obj.ObjectCurrentVersionID
+		}
+		for i := 0; i < numObjects; i++ {
+			opts := objects.DeleteOpts{
+				ObjectVersionID: currentVersionIDs[i],
+			}
+			res := objects.Delete(client, cName, oNames[i], opts)
+			th.AssertNoErr(t, res.Err)
+		}
+	}()
+
+	// List created objects
+	listOpts := objects.ListOpts{
+		Full:   true,
+		Prefix: "test-object-",
+	}
+
+	allPages, err := objects.List(client, cName, listOpts).AllPages()
+	if err != nil {
+		t.Fatalf("Unable to list objects: %v", err)
+	}
+
+	ons, err := objects.ExtractNames(allPages)
+	if err != nil {
+		t.Fatalf("Unable to extract objects: %v", err)
+	}
+	th.AssertEquals(t, len(ons), len(oNames))
+
+	ois, err := objects.ExtractInfo(allPages)
+	if err != nil {
+		t.Fatalf("Unable to extract object info: %v", err)
+	}
+	th.AssertEquals(t, len(ois), len(oNames))
+
+	// List all created objects
+	listOpts = objects.ListOpts{
+		Full:     true,
+		Prefix:   "test-object-",
+		Versions: true,
+	}
+
+	allPages, err = objects.List(client, cName, listOpts).AllPages()
+	if err != nil {
+		t.Fatalf("Unable to list objects: %v", err)
+	}
+
+	ons, err = objects.ExtractNames(allPages)
+	if err != nil {
+		t.Fatalf("Unable to extract objects: %v", err)
+	}
+	th.AssertEquals(t, len(ons), 2*len(oNames))
+
+	ois, err = objects.ExtractInfo(allPages)
+	if err != nil {
+		t.Fatalf("Unable to extract object info: %v", err)
+	}
+	th.AssertEquals(t, len(ois), 2*len(oNames))
+
+	// ensure proper versioning attributes are set
+	for i, obj := range ois {
+		if i%2 == 0 {
+			th.AssertEquals(t, true, obj.IsLatest)
+		} else {
+			th.AssertEquals(t, false, obj.IsLatest)
+		}
+		if obj.VersionID == "" {
+			t.Fatalf("Unexpected empty version_id for the %s object", obj.Name)
+		}
+	}
+
+	// Download one of the objects that was created above.
+	downloadres := objects.Download(client, cName, oNames[0], nil)
+	th.AssertNoErr(t, downloadres.Err)
+
+	o1Content, err := downloadres.ExtractContent()
+	th.AssertNoErr(t, err)
+
+	// Compare the two object's contents to test that the copy worked.
+	th.AssertEquals(t, oNewContents[0], string(o1Content))
+
+	// Download the another object that was create above.
+	downloadOpts := objects.DownloadOpts{
+		Newest: true,
+	}
+	downloadres = objects.Download(client, cName, oNames[1], downloadOpts)
+	th.AssertNoErr(t, downloadres.Err)
+	o2Content, err := downloadres.ExtractContent()
+	th.AssertNoErr(t, err)
+
+	// Compare the two object's contents to test that the copy worked.
+	th.AssertEquals(t, oNewContents[1], string(o2Content))
+}

--- a/openstack/objectstorage/v1/containers/requests.go
+++ b/openstack/objectstorage/v1/containers/requests.go
@@ -80,6 +80,7 @@ type CreateOpts struct {
 	TempURLKey        string `h:"X-Container-Meta-Temp-URL-Key"`
 	TempURLKey2       string `h:"X-Container-Meta-Temp-URL-Key-2"`
 	StoragePolicy     string `h:"X-Storage-Policy"`
+	VersionsEnabled   bool   `h:"X-Versions-Enabled"`
 }
 
 // ToContainerCreateMap formats a CreateOpts into a map of headers.
@@ -176,6 +177,7 @@ type UpdateOpts struct {
 	HistoryLocation        string  `h:"X-History-Location"`
 	TempURLKey             string  `h:"X-Container-Meta-Temp-URL-Key"`
 	TempURLKey2            string  `h:"X-Container-Meta-Temp-URL-Key-2"`
+	VersionsEnabled        *bool   `h:"X-Versions-Enabled"`
 }
 
 // ToContainerUpdateMap formats a UpdateOpts into a map of headers.

--- a/openstack/objectstorage/v1/containers/results.go
+++ b/openstack/objectstorage/v1/containers/results.go
@@ -3,6 +3,7 @@ package containers
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -109,15 +110,17 @@ type GetHeader struct {
 	TempURLKey       string    `json:"X-Container-Meta-Temp-URL-Key"`
 	TempURLKey2      string    `json:"X-Container-Meta-Temp-URL-Key-2"`
 	Timestamp        float64   `json:"X-Timestamp,string"`
+	VersionsEnabled  bool      `json:"-"`
 }
 
 func (r *GetHeader) UnmarshalJSON(b []byte) error {
 	type tmp GetHeader
 	var s struct {
 		tmp
-		Write string                  `json:"X-Container-Write"`
-		Read  string                  `json:"X-Container-Read"`
-		Date  gophercloud.JSONRFC1123 `json:"Date"`
+		Write           string                  `json:"X-Container-Write"`
+		Read            string                  `json:"X-Container-Read"`
+		Date            gophercloud.JSONRFC1123 `json:"Date"`
+		VersionsEnabled string                  `json:"X-Versions-Enabled"`
 	}
 
 	err := json.Unmarshal(b, &s)
@@ -131,6 +134,12 @@ func (r *GetHeader) UnmarshalJSON(b []byte) error {
 	r.Write = strings.Split(s.Write, ",")
 
 	r.Date = time.Time(s.Date)
+
+	if s.VersionsEnabled != "" {
+		// custom unmarshaller here is required to handle boolean value
+		// that starts with a capital letter
+		r.VersionsEnabled, err = strconv.ParseBool(s.VersionsEnabled)
+	}
 
 	return err
 }

--- a/openstack/objectstorage/v1/containers/testing/fixtures.go
+++ b/openstack/objectstorage/v1/containers/testing/fixtures.go
@@ -207,6 +207,54 @@ func HandleUpdateContainerSuccessfully(t *testing.T, options ...option) {
 	})
 }
 
+// HandleUpdateContainerVersioningOn creates an HTTP handler at `/testVersioning` on the test handler mux that
+// responds with a `Update` response.
+func HandleUpdateContainerVersioningOn(t *testing.T, options ...option) {
+	ho := handlerOptions{
+		path: "/testVersioning",
+	}
+	for _, apply := range options {
+		apply(&ho)
+	}
+
+	th.Mux.HandleFunc(ho.path, func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestHeader(t, r, "X-Container-Write", "")
+		th.TestHeader(t, r, "X-Container-Read", "")
+		th.TestHeader(t, r, "X-Container-Sync-To", "")
+		th.TestHeader(t, r, "X-Container-Sync-Key", "")
+		th.TestHeader(t, r, "Content-Type", "text/plain")
+		th.TestHeader(t, r, "X-Versions-Enabled", "true")
+		w.WriteHeader(http.StatusNoContent)
+	})
+}
+
+// HandleUpdateContainerVersioningOff creates an HTTP handler at `/testVersioning` on the test handler mux that
+// responds with a `Update` response.
+func HandleUpdateContainerVersioningOff(t *testing.T, options ...option) {
+	ho := handlerOptions{
+		path: "/testVersioning",
+	}
+	for _, apply := range options {
+		apply(&ho)
+	}
+
+	th.Mux.HandleFunc(ho.path, func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestHeader(t, r, "X-Container-Write", "")
+		th.TestHeader(t, r, "X-Container-Read", "")
+		th.TestHeader(t, r, "X-Container-Sync-To", "")
+		th.TestHeader(t, r, "X-Container-Sync-Key", "")
+		th.TestHeader(t, r, "Content-Type", "text/plain")
+		th.TestHeader(t, r, "X-Versions-Enabled", "false")
+		w.WriteHeader(http.StatusNoContent)
+	})
+}
+
 // HandleGetContainerSuccessfully creates an HTTP handler at `/testContainer` on the test handler mux that
 // responds with a `Get` response.
 func HandleGetContainerSuccessfully(t *testing.T, options ...option) {
@@ -231,6 +279,7 @@ func HandleGetContainerSuccessfully(t *testing.T, options ...option) {
 		w.Header().Set("X-Timestamp", "1471298837.95721")
 		w.Header().Set("X-Trans-Id", "tx554ed59667a64c61866f1-0057b4ba37")
 		w.Header().Set("X-Storage-Policy", "test_policy")
+		w.Header().Set("X-Versions-Enabled", "True")
 		w.WriteHeader(http.StatusNoContent)
 	})
 }

--- a/openstack/objectstorage/v1/containers/testing/requests_test.go
+++ b/openstack/objectstorage/v1/containers/testing/requests_test.go
@@ -236,18 +236,58 @@ func TestGetContainer(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	expected := &containers.GetHeader{
-		AcceptRanges:  "bytes",
-		BytesUsed:     100,
-		ContentType:   "application/json; charset=utf-8",
-		Date:          time.Date(2016, time.August, 17, 19, 25, 43, 0, time.UTC),
-		ObjectCount:   4,
-		Read:          []string{"test"},
-		TransID:       "tx554ed59667a64c61866f1-0057b4ba37",
-		Write:         []string{"test2", "user4"},
-		StoragePolicy: "test_policy",
-		Timestamp:     1471298837.95721,
+		AcceptRanges:    "bytes",
+		BytesUsed:       100,
+		ContentType:     "application/json; charset=utf-8",
+		Date:            time.Date(2016, time.August, 17, 19, 25, 43, 0, time.UTC),
+		ObjectCount:     4,
+		Read:            []string{"test"},
+		TransID:         "tx554ed59667a64c61866f1-0057b4ba37",
+		Write:           []string{"test2", "user4"},
+		StoragePolicy:   "test_policy",
+		Timestamp:       1471298837.95721,
+		VersionsEnabled: true,
 	}
 	actual, err := res.Extract()
 	th.AssertNoErr(t, err)
 	th.AssertDeepEquals(t, expected, actual)
+}
+
+func TestUpdateContainerVersioningOff(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleUpdateContainerVersioningOff(t)
+
+	contentType := "text/plain"
+	options := &containers.UpdateOpts{
+		Metadata:         map[string]string{"foo": "bar"},
+		ContainerWrite:   new(string),
+		ContainerRead:    new(string),
+		ContainerSyncTo:  new(string),
+		ContainerSyncKey: new(string),
+		ContentType:      &contentType,
+		VersionsEnabled:  new(bool),
+	}
+	_, err := containers.Update(fake.ServiceClient(), "testVersioning", options).Extract()
+	th.AssertNoErr(t, err)
+}
+
+func TestUpdateContainerVersioningOn(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleUpdateContainerVersioningOn(t)
+
+	iTrue := true
+	contentType := "text/plain"
+	options := &containers.UpdateOpts{
+		Metadata:         map[string]string{"foo": "bar"},
+		ContainerWrite:   new(string),
+		ContainerRead:    new(string),
+		ContainerSyncTo:  new(string),
+		ContainerSyncKey: new(string),
+		ContentType:      &contentType,
+		VersionsEnabled:  &iTrue,
+	}
+	_, err := containers.Update(fake.ServiceClient(), "testVersioning", options).Extract()
+	th.AssertNoErr(t, err)
 }

--- a/openstack/objectstorage/v1/objects/results.go
+++ b/openstack/objectstorage/v1/objects/results.go
@@ -32,6 +32,13 @@ type Object struct {
 
 	// Subdir denotes if the result contains a subdir.
 	Subdir string `json:"subdir"`
+
+	// IsLatest indicates whether the object version is the latest one.
+	IsLatest bool `json:"is_latest"`
+
+	// VersionID contains a version ID of the object, when container
+	// versioning is enabled.
+	VersionID string `json:"version_id"`
 }
 
 func (r *Object) UnmarshalJSON(b []byte) error {
@@ -146,6 +153,7 @@ type DownloadHeader struct {
 	ObjectManifest     string    `json:"X-Object-Manifest"`
 	StaticLargeObject  bool      `json:"-"`
 	TransID            string    `json:"X-Trans-Id"`
+	ObjectVersionID    string    `json:"X-Object-Version-Id"`
 }
 
 func (r *DownloadHeader) UnmarshalJSON(b []byte) error {
@@ -224,6 +232,7 @@ type GetHeader struct {
 	ObjectManifest     string    `json:"X-Object-Manifest"`
 	StaticLargeObject  bool      `json:"-"`
 	TransID            string    `json:"X-Trans-Id"`
+	ObjectVersionID    string    `json:"X-Object-Version-Id"`
 }
 
 func (r *GetHeader) UnmarshalJSON(b []byte) error {
@@ -290,12 +299,13 @@ func (r GetResult) ExtractMetadata() (map[string]string, error) {
 // CreateHeader represents the headers returned in the response from a
 // Create request.
 type CreateHeader struct {
-	ContentLength int64     `json:"Content-Length,string"`
-	ContentType   string    `json:"Content-Type"`
-	Date          time.Time `json:"-"`
-	ETag          string    `json:"Etag"`
-	LastModified  time.Time `json:"-"`
-	TransID       string    `json:"X-Trans-Id"`
+	ContentLength   int64     `json:"Content-Length,string"`
+	ContentType     string    `json:"Content-Type"`
+	Date            time.Time `json:"-"`
+	ETag            string    `json:"Etag"`
+	LastModified    time.Time `json:"-"`
+	TransID         string    `json:"X-Trans-Id"`
+	ObjectVersionID string    `json:"X-Object-Version-Id"`
 }
 
 func (r *CreateHeader) UnmarshalJSON(b []byte) error {
@@ -337,10 +347,11 @@ func (r CreateResult) Extract() (*CreateHeader, error) {
 // UpdateHeader represents the headers returned in the response from a
 // Update request.
 type UpdateHeader struct {
-	ContentLength int64     `json:"Content-Length,string"`
-	ContentType   string    `json:"Content-Type"`
-	Date          time.Time `json:"-"`
-	TransID       string    `json:"X-Trans-Id"`
+	ContentLength   int64     `json:"Content-Length,string"`
+	ContentType     string    `json:"Content-Type"`
+	Date            time.Time `json:"-"`
+	TransID         string    `json:"X-Trans-Id"`
+	ObjectVersionID string    `json:"X-Object-Version-Id"`
 }
 
 func (r *UpdateHeader) UnmarshalJSON(b []byte) error {
@@ -376,10 +387,12 @@ func (r UpdateResult) Extract() (*UpdateHeader, error) {
 // DeleteHeader represents the headers returned in the response from a
 // Delete request.
 type DeleteHeader struct {
-	ContentLength int64     `json:"Content-Length,string"`
-	ContentType   string    `json:"Content-Type"`
-	Date          time.Time `json:"-"`
-	TransID       string    `json:"X-Trans-Id"`
+	ContentLength          int64     `json:"Content-Length,string"`
+	ContentType            string    `json:"Content-Type"`
+	Date                   time.Time `json:"-"`
+	TransID                string    `json:"X-Trans-Id"`
+	ObjectVersionID        string    `json:"X-Object-Version-Id"`
+	ObjectCurrentVersionID string    `json:"X-Object-Current-Version-Id"`
 }
 
 func (r *DeleteHeader) UnmarshalJSON(b []byte) error {
@@ -423,6 +436,7 @@ type CopyHeader struct {
 	ETag                   string    `json:"Etag"`
 	LastModified           time.Time `json:"-"`
 	TransID                string    `json:"X-Trans-Id"`
+	ObjectVersionID        string    `json:"X-Object-Version-Id"`
 }
 
 func (r *CopyHeader) UnmarshalJSON(b []byte) error {

--- a/openstack/objectstorage/v1/objects/testing/fixtures.go
+++ b/openstack/objectstorage/v1/objects/testing/fixtures.go
@@ -281,6 +281,20 @@ func HandleCopyObjectSuccessfully(t *testing.T) {
 	})
 }
 
+// HandleCopyObjectSuccessfully creates an HTTP handler at `/testContainer/testObject` on the test handler mux that
+// responds with a `Copy` response.
+func HandleCopyObjectVersionSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/testContainer/testObject", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "COPY")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestHeader(t, r, "Destination", "/newTestContainer/newTestObject")
+		th.TestFormValues(t, r, map[string]string{"version-id": "123456788"})
+		w.Header().Set("X-Object-Version-Id", "123456789")
+		w.WriteHeader(http.StatusCreated)
+	})
+}
+
 // HandleDeleteObjectSuccessfully creates an HTTP handler at `/testContainer/testObject` on the test handler mux that
 // responds with a `Delete` response.
 func HandleDeleteObjectSuccessfully(t *testing.T, options ...option) {

--- a/openstack/objectstorage/v1/objects/testing/requests_test.go
+++ b/openstack/objectstorage/v1/objects/testing/requests_test.go
@@ -351,6 +351,17 @@ func TestCopyObject(t *testing.T) {
 	th.AssertNoErr(t, res.Err)
 }
 
+func TestCopyObjectVersion(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleCopyObjectVersionSuccessfully(t)
+
+	options := &objects.CopyOpts{Destination: "/newTestContainer/newTestObject", ObjectVersionID: "123456788"}
+	res, err := objects.Copy(fake.ServiceClient(), "testContainer", "testObject", options).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, "123456789", res.ObjectVersionID)
+}
+
 func TestDeleteObject(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()


### PR DESCRIPTION
Fixes #2181

I focused on functional tests for objects versioning checks, since it requires a lot of duplicate checks in objects unit tests. Hope this is fine.