### PR TITLE
Enable tests for object versioning

### DIFF
--- a/.github/workflows/functional-objectstorage.yaml
+++ b/.github/workflows/functional-objectstorage.yaml
@@ -44,6 +44,9 @@ jobs:
           conf_overrides: |
             SWIFT_ENABLE_TEMPURLS=True
             SWIFT_TEMPURL_KEY=secretkey
+            [[post-config|\$SWIFT_CONFIG_PROXY_SERVER]]
+            [filter:versioned_writes]
+            allow_object_versioning = true
           enabled_services: 's-account,s-container,s-object,s-proxy'
       - name: Checkout go
         uses: actions/setup-go@v3

--- a/acceptance/openstack/objectstorage/v1/versioning_test.go
+++ b/acceptance/openstack/objectstorage/v1/versioning_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestObjectsVersioning(t *testing.T) {
-	t.Skip("Skip this test, versioning is not yet supported by test env")
+	clients.SkipReleasesBelow(t, "stable/ussuri")
 
 	client, err := clients.NewObjectStorageV1Client()
 	if err != nil {

--- a/script/collectlogs
+++ b/script/collectlogs
@@ -4,8 +4,10 @@ set -x
 LOG_DIR=${LOG_DIR:-/tmp/devstack-logs}
 mkdir -p $LOG_DIR
 sudo journalctl -o short-precise --no-pager &> $LOG_DIR/journal.log
+sudo systemctl status "devstack@*" &> $LOG_DIR/devstack-services.txt
 free -m > $LOG_DIR/free.txt
 dpkg -l > $LOG_DIR/dpkg-l.txt
 pip freeze > $LOG_DIR/pip-freeze.txt
+cp ./devstack/local.conf $LOG_DIR
 sudo find $LOG_DIR -type d -exec chmod 0755 {} \;
 sudo find $LOG_DIR -type f -exec chmod 0644 {} \;


### PR DESCRIPTION
The devstack environment was not setup properly to enable acceptance tests developed for https://github.com/gophercloud/gophercloud/pull/2571.