### PR TITLE
Add support of Flavors and FlavorProfiles for Octavia

### DIFF
--- a/internal/acceptance/openstack/loadbalancer/v2/flavorprofiles_test.go
+++ b/internal/acceptance/openstack/loadbalancer/v2/flavorprofiles_test.go
@@ -1,0 +1,53 @@
+//go:build acceptance || networking || loadbalancer || flavorprofiles
+// +build acceptance networking loadbalancer flavorprofiles
+
+package v2
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/internal/acceptance/clients"
+	"github.com/gophercloud/gophercloud/internal/acceptance/tools"
+	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/flavorprofiles"
+
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestFlavorProfilesList(t *testing.T) {
+	client, err := clients.NewLoadBalancerV2Client()
+	th.AssertNoErr(t, err)
+
+	allPages, err := flavorprofiles.List(client, nil).AllPages()
+	th.AssertNoErr(t, err)
+
+	allFlavorProfiles, err := flavorprofiles.ExtractFlavorProfiles(allPages)
+	th.AssertNoErr(t, err)
+
+	for _, flavorprofile := range allFlavorProfiles {
+		tools.PrintResource(t, flavorprofile)
+	}
+}
+
+func TestFlavorProfilesCRUD(t *testing.T) {
+	lbClient, err := clients.NewLoadBalancerV2Client()
+	th.AssertNoErr(t, err)
+
+	flavorProfile, err := CreateFlavorProfile(t, lbClient)
+	th.AssertNoErr(t, err)
+	defer DeleteFlavorProfile(t, lbClient, flavorProfile)
+
+	tools.PrintResource(t, flavorProfile)
+
+	th.AssertEquals(t, "amphora", flavorProfile.ProviderName)
+
+	flavorProfileUpdateOpts := flavorprofiles.UpdateOpts{
+		Name: tools.RandomString("TESTACCTUP-", 8),
+	}
+
+	flavorProfileUpdated, err := flavorprofiles.Update(lbClient, flavorProfile.ID, flavorProfileUpdateOpts).Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, flavorProfileUpdateOpts.Name, flavorProfileUpdated.Name)
+
+	t.Logf("Successfully updated flavorprofile %s", flavorProfileUpdated.Name)
+}

--- a/internal/acceptance/openstack/loadbalancer/v2/flavors_test.go
+++ b/internal/acceptance/openstack/loadbalancer/v2/flavors_test.go
@@ -1,0 +1,66 @@
+//go:build acceptance || networking || loadbalancer || flavors
+// +build acceptance networking loadbalancer flavors
+
+package v2
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/internal/acceptance/clients"
+	"github.com/gophercloud/gophercloud/internal/acceptance/tools"
+	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/flavors"
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestFlavorsList(t *testing.T) {
+	client, err := clients.NewLoadBalancerV2Client()
+	if err != nil {
+		t.Fatalf("Unable to create a loadbalancer client: %v", err)
+	}
+
+	allPages, err := flavors.List(client, nil).AllPages()
+	if err != nil {
+		t.Fatalf("Unable to list flavors: %v", err)
+	}
+
+	allFlavors, err := flavors.ExtractFlavors(allPages)
+	if err != nil {
+		t.Fatalf("Unable to extract flavors: %v", err)
+	}
+
+	for _, flavor := range allFlavors {
+		tools.PrintResource(t, flavor)
+	}
+}
+
+func TestFlavorsCRUD(t *testing.T) {
+	lbClient, err := clients.NewLoadBalancerV2Client()
+	th.AssertNoErr(t, err)
+
+	flavorProfile, err := CreateFlavorProfile(t, lbClient)
+	th.AssertNoErr(t, err)
+	defer DeleteFlavorProfile(t, lbClient, flavorProfile)
+
+	tools.PrintResource(t, flavorProfile)
+
+	th.AssertEquals(t, "amphora", flavorProfile.ProviderName)
+
+	flavor, err := CreateFlavor(t, lbClient, flavorProfile)
+	th.AssertNoErr(t, err)
+	defer DeleteFlavor(t, lbClient, flavor)
+
+	tools.PrintResource(t, flavor)
+
+	th.AssertEquals(t, flavor.FlavorProfileId, flavorProfile.ID)
+
+	flavorUpdateOpts := flavors.UpdateOpts{
+		Name: tools.RandomString("TESTACCTUP-", 8),
+	}
+
+	flavorUpdated, err := flavors.Update(lbClient, flavor.ID, flavorUpdateOpts).Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, flavorUpdateOpts.Name, flavorUpdated.Name)
+
+	t.Logf("Successfully updated flavor %s", flavorUpdated.Name)
+}

--- a/internal/acceptance/openstack/loadbalancer/v2/loadbalancer.go
+++ b/internal/acceptance/openstack/loadbalancer/v2/loadbalancer.go
@@ -8,6 +8,8 @@ import (
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/internal/acceptance/clients"
 	"github.com/gophercloud/gophercloud/internal/acceptance/tools"
+	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/flavorprofiles"
+	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/flavors"
 	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/l7policies"
 	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/listeners"
 	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/loadbalancers"
@@ -679,4 +681,73 @@ func WaitForLoadBalancerState(client *gophercloud.ServiceClient, lbID, status st
 
 		return false, nil
 	})
+}
+
+func CreateFlavorProfile(t *testing.T, client *gophercloud.ServiceClient) (*flavorprofiles.FlavorProfile, error) {
+	flavorProfileName := tools.RandomString("TESTACCT-", 8)
+	flavorProfileDriver := "amphora"
+	flavorProfileData := "{\"loadbalancer_topology\": \"SINGLE\"}"
+
+	createOpts := flavorprofiles.CreateOpts{
+		Name:         flavorProfileName,
+		ProviderName: flavorProfileDriver,
+		FlavorData:   flavorProfileData,
+	}
+
+	flavorProfile, err := flavorprofiles.Create(client, createOpts).Extract()
+	if err != nil {
+		return flavorProfile, err
+	}
+
+	t.Logf("Successfully created flavorprofile %s", flavorProfileName)
+
+	th.AssertEquals(t, flavorProfileName, flavorProfile.Name)
+	th.AssertEquals(t, flavorProfileDriver, flavorProfile.ProviderName)
+	th.AssertEquals(t, flavorProfileData, flavorProfile.FlavorData)
+
+	return flavorProfile, nil
+}
+
+func DeleteFlavorProfile(t *testing.T, client *gophercloud.ServiceClient, flavorProfile *flavorprofiles.FlavorProfile) {
+	err := flavorprofiles.Delete(client, flavorProfile.ID).ExtractErr()
+	if err != nil {
+		t.Fatalf("Unable to delete flavorprofile: %v", err)
+	}
+
+	t.Logf("Successfully deleted flavorprofile %s", flavorProfile.Name)
+}
+
+func CreateFlavor(t *testing.T, client *gophercloud.ServiceClient, flavorProfile *flavorprofiles.FlavorProfile) (*flavors.Flavor, error) {
+	flavorName := tools.RandomString("TESTACCT-", 8)
+	description := tools.RandomString("TESTACCT-desc-", 32)
+
+	createOpts := flavors.CreateOpts{
+		Name:            flavorName,
+		Description:     description,
+		FlavorProfileId: flavorProfile.ID,
+		Enabled:         true,
+	}
+
+	flavor, err := flavors.Create(client, createOpts).Extract()
+	if err != nil {
+		return flavor, err
+	}
+
+	t.Logf("Successfully created flavor %s with flavorprofile %s", flavor.Name, flavorProfile.Name)
+
+	th.AssertEquals(t, flavorName, flavor.Name)
+	th.AssertEquals(t, description, flavor.Description)
+	th.AssertEquals(t, flavorProfile.ID, flavor.FlavorProfileId)
+	th.AssertEquals(t, true, flavor.Enabled)
+
+	return flavor, nil
+}
+
+func DeleteFlavor(t *testing.T, client *gophercloud.ServiceClient, flavor *flavors.Flavor) {
+	err := flavors.Delete(client, flavor.ID).ExtractErr()
+	if err != nil {
+		t.Fatalf("Unable to delete flavor: %v", err)
+	}
+
+	t.Logf("Successfully deleted flavor %s", flavor.Name)
 }

--- a/openstack/loadbalancer/v2/flavorprofiles/doc.go
+++ b/openstack/loadbalancer/v2/flavorprofiles/doc.go
@@ -1,0 +1,57 @@
+/*
+Package flavorprofiles provides information and interaction
+with FlavorProfiles for the OpenStack Load-balancing service.
+
+Example to List FlavorProfiles
+
+	listOpts := flavorprofiles.ListOpts{}
+
+	allPages, err := flavorprofiles.List(octaviaClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allFlavorProfiles, err := flavorprofiles.ExtractFlavorProfiles(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, flavorProfile := range allFlavorProfiles {
+		fmt.Printf("%+v\n", flavorProfile)
+	}
+
+Example to Create a FlavorProfile
+
+	createOpts := flavorprofiles.CreateOpts{
+		Name:         "amphora-single",
+		ProviderName: "amphora",
+		FlavorData:   "{\"loadbalancer_topology\": \"SINGLE\"}",
+	}
+
+	flavorProfile, err := flavorprofiles.Create(octaviaClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Update a FlavorProfile
+
+	flavorProfileID := "dd6a26af-8085-4047-a62b-3080f4c76521"
+
+	updateOpts := flavorprofiles.UpdateOpts{
+		Name: "amphora-single-updated",
+	}
+
+	flavorProfile, err := flavorprofiles.Update(octaviaClient, flavorProfileID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete a FlavorProfile
+
+	flavorProfileID := "dd6a26af-8085-4047-a62b-3080f4c76521"
+	err := flavorprofiles.Delete(octaviaClient, flavorProfileID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+*/
+package flavorprofiles

--- a/openstack/loadbalancer/v2/flavorprofiles/requests.go
+++ b/openstack/loadbalancer/v2/flavorprofiles/requests.go
@@ -1,4 +1,4 @@
-package flavors
+package flavorprofiles
 
 import (
 	"github.com/gophercloud/gophercloud"
@@ -8,7 +8,7 @@ import (
 // ListOptsBuilder allows extensions to add additional parameters to the
 // List request.
 type ListOptsBuilder interface {
-	ToFlavorListQuery() (string, error)
+	ToFlavorProfileListQuery() (string, error)
 }
 
 // ListOpts allows to manage the output of the request.
@@ -17,33 +17,33 @@ type ListOpts struct {
 	Fields []string `q:"fields"`
 }
 
-// ToFlavorListQuery formats a ListOpts into a query string.
-func (opts ListOpts) ToFlavorListQuery() (string, error) {
+// ToFlavorProfileListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToFlavorProfileListQuery() (string, error) {
 	q, err := gophercloud.BuildQueryString(opts)
 	return q.String(), err
 }
 
 // List returns a Pager which allows you to iterate over a collection of
-// Flavor. It accepts a ListOpts struct, which allows you to filter
+// FlavorProfiles. It accepts a ListOpts struct, which allows you to filter
 // and sort the returned collection for greater efficiency.
 func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 	url := rootURL(c)
 	if opts != nil {
-		query, err := opts.ToFlavorListQuery()
+		query, err := opts.ToFlavorProfileListQuery()
 		if err != nil {
 			return pagination.Pager{Err: err}
 		}
 		url += query
 	}
 	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
-		return FlavorPage{pagination.LinkedPageBase{PageResult: r}}
+		return FlavorProfilePage{pagination.LinkedPageBase{PageResult: r}}
 	})
 }
 
 // CreateOptsBuilder allows extensions to add additional parameters to the
 // Create request.
 type CreateOptsBuilder interface {
-	ToFlavorCreateMap() (map[string]interface{}, error)
+	ToFlavorProfileCreateMap() (map[string]interface{}, error)
 }
 
 // CreateOpts is the common options struct used in this package's Create
@@ -52,26 +52,22 @@ type CreateOpts struct {
 	// Human-readable name for the Loadbalancer. Does not have to be unique.
 	Name string `json:"name" required:"true"`
 
-	// Human-readable description for the Flavor.
-	Description string `json:"description,omitempty"`
+	// Providing the name of the provider supported by the Octavia installation.
+	ProviderName string `json:"provider_name" required:"true"`
 
-	// The ID of the FlavorProfile which give the metadata for the creation of
-	// a LoadBalancer.
-	FlavorProfileId string `json:"flavor_profile_id" required:"true"`
-
-	// If the resource is available for use. The default is True.
-	Enabled bool `json:"enabled,omitempty"`
+	// Providing the json string containing the flavor metadata.
+	FlavorData string `json:"flavor_data" required:"true"`
 }
 
-// ToFlavorCreateMap builds a request body from CreateOpts.
-func (opts CreateOpts) ToFlavorCreateMap() (map[string]interface{}, error) {
-	return gophercloud.BuildRequestBody(opts, "flavor")
+// ToFlavorProfileCreateMap builds a request body from CreateOpts.
+func (opts CreateOpts) ToFlavorProfileCreateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "flavorprofile")
 }
 
-// Create is and operation which add a new Flavor into the database.
+// Create is and operation which add a new FlavorProfile into the database.
 // CreateResult will be returned.
 func Create(c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
-	b, err := opts.ToFlavorCreateMap()
+	b, err := opts.ToFlavorProfileCreateMap()
 	if err != nil {
 		r.Err = err
 		return
@@ -81,7 +77,7 @@ func Create(c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResul
 	return
 }
 
-// Get retrieves a particular Flavor based on its unique ID.
+// Get retrieves a particular FlavorProfile based on its unique ID.
 func Get(c *gophercloud.ServiceClient, id string) (r GetResult) {
 	resp, err := c.Get(resourceURL(c, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
@@ -91,7 +87,7 @@ func Get(c *gophercloud.ServiceClient, id string) (r GetResult) {
 // UpdateOptsBuilder allows extensions to add additional parameters to the
 // Update request.
 type UpdateOptsBuilder interface {
-	ToFlavorUpdateMap() (map[string]interface{}, error)
+	ToFlavorProfileUpdateMap() (map[string]interface{}, error)
 }
 
 // UpdateOpts is the common options struct used in this package's Update
@@ -100,16 +96,16 @@ type UpdateOpts struct {
 	// Human-readable name for the Loadbalancer. Does not have to be unique.
 	Name string `json:"name,omitempty"`
 
-	// Human-readable description for the Flavor.
-	Description string `json:"description,omitempty"`
+	// Providing the name of the provider supported by the Octavia installation.
+	ProviderName string `json:"provider_name,omitempty"`
 
-	// If the resource is available for use.
-	Enabled bool `json:"enabled,omitempty"`
+	// Providing the json string containing the flavor metadata.
+	FlavorData string `json:"flavor_data,omitempty"`
 }
 
-// ToFlavorUpdateMap builds a request body from UpdateOpts.
-func (opts UpdateOpts) ToFlavorUpdateMap() (map[string]interface{}, error) {
-	b, err := gophercloud.BuildRequestBody(opts, "flavor")
+// ToFlavorProfileUpdateMap builds a request body from UpdateOpts.
+func (opts UpdateOpts) ToFlavorProfileUpdateMap() (map[string]interface{}, error) {
+	b, err := gophercloud.BuildRequestBody(opts, "flavorprofile")
 	if err != nil {
 		return nil, err
 	}
@@ -118,21 +114,21 @@ func (opts UpdateOpts) ToFlavorUpdateMap() (map[string]interface{}, error) {
 }
 
 // Update is an operation which modifies the attributes of the specified
-// Flavor.
+// FlavorProfile.
 func Update(c *gophercloud.ServiceClient, id string, opts UpdateOpts) (r UpdateResult) {
-	b, err := opts.ToFlavorUpdateMap()
+	b, err := opts.ToFlavorProfileUpdateMap()
 	if err != nil {
 		r.Err = err
 		return
 	}
 	resp, err := c.Put(resourceURL(c, id), b, &r.Body, &gophercloud.RequestOpts{
-		OkCodes: []int{200},
+		OkCodes: []int{200, 202},
 	})
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
-// Delete will permanently delete a particular Flavor based on its
+// Delete will permanently delete a particular FlavorProfile based on its
 // unique ID.
 func Delete(c *gophercloud.ServiceClient, id string) (r DeleteResult) {
 	resp, err := c.Delete(resourceURL(c, id), nil)

--- a/openstack/loadbalancer/v2/flavorprofiles/results.go
+++ b/openstack/loadbalancer/v2/flavorprofiles/results.go
@@ -1,0 +1,95 @@
+package flavorprofiles
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// FlavorProfile provide metadata such as provider, toplogy and instance flavor.
+type FlavorProfile struct {
+	// The unique ID for the Flavor
+	ID string `json:"id"`
+
+	// Human-readable name for the Flavor. Does not have to be unique.
+	Name string `json:"name"`
+
+	// Name of the provider
+	ProviderName string `json:"provider_name"`
+
+	// Flavor data
+	FlavorData string `json:"flavor_data"`
+}
+
+// FlavorProfilePage is the page returned by a pager when traversing over a
+// collection of flavor profiles.
+type FlavorProfilePage struct {
+	pagination.LinkedPageBase
+}
+
+// NextPageURL is invoked when a paginated collection of flavor profiles has
+// reached the end of a page and the pager seeks to traverse over a new one.
+// In order to do this, it needs to construct the next page's URL.
+func (r FlavorProfilePage) NextPageURL() (string, error) {
+	var s struct {
+		Links []gophercloud.Link `json:"flavorprofiles_links"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return gophercloud.ExtractNextURL(s.Links)
+}
+
+// IsEmpty checks whether a FlavorProfilePage struct is empty.
+func (r FlavorProfilePage) IsEmpty() (bool, error) {
+	is, err := ExtractFlavorProfiles(r)
+	return len(is) == 0, err
+}
+
+// ExtractFlavorProfiles accepts a Page struct, specifically a FlavorProfilePage
+// struct, and extracts the elements into a slice of FlavorProfile structs. In
+// other words, a generic collection is mapped into a relevant slice.
+func ExtractFlavorProfiles(r pagination.Page) ([]FlavorProfile, error) {
+	var s struct {
+		FlavorProfiles []FlavorProfile `json:"flavorprofiles"`
+	}
+	err := (r.(FlavorProfilePage)).ExtractInto(&s)
+	return s.FlavorProfiles, err
+}
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// Extract is a function that accepts a result and extracts a flavor profile.
+func (r commonResult) Extract() (*FlavorProfile, error) {
+	var s struct {
+		FlavorProfile *FlavorProfile `json:"flavorprofile"`
+	}
+	err := r.ExtractInto(&s)
+	return s.FlavorProfile, err
+}
+
+// CreateResult represents the result of a create operation. Call its Extract
+// method to interpret it as a FlavorProfile.
+type CreateResult struct {
+	commonResult
+}
+
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a FlavorProfile.
+type GetResult struct {
+	commonResult
+}
+
+// UpdateResult represents the result of an update operation. Call its Extract
+// method to interpret it as a FlavorProfile.
+type UpdateResult struct {
+	commonResult
+}
+
+// DeleteResult represents the result of a delete operation. Call its
+// ExtractErr method to determine if the request succeeded or failed.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}

--- a/openstack/loadbalancer/v2/flavorprofiles/testing/doc.go
+++ b/openstack/loadbalancer/v2/flavorprofiles/testing/doc.go
@@ -1,0 +1,1 @@
+package testing

--- a/openstack/loadbalancer/v2/flavorprofiles/testing/fixtures.go
+++ b/openstack/loadbalancer/v2/flavorprofiles/testing/fixtures.go
@@ -1,0 +1,157 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/flavorprofiles"
+
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+const FlavorProfilesListBody = `
+{
+	"flavorprofiles": [
+        {
+            "id": "c55d080d-af45-47ee-b48c-4caa5e87724f",
+            "name": "amphora-single",
+            "provider_name": "amphora",
+            "flavor_data": "{\"loadbalancer_topology\": \"SINGLE\"}"
+        },
+		{
+            "id": "f78d2815-3714-4b6e-91d8-cf821ba01017",
+            "name": "amphora-act-stdby",
+            "provider_name": "amphora",
+            "flavor_data": "{\"loadbalancer_topology\": \"ACTIVE_STANDBY\"}"
+        }
+    ]
+}
+`
+
+const SingleFlavorProfileBody = `
+{
+	"flavorprofile": {
+		"id": "dcd65be5-f117-4260-ab3d-b32cc5bd1272",
+		"name": "amphora-test",
+		"provider_name": "amphora",
+		"flavor_data": "{\"loadbalancer_topology\": \"ACTIVE_STANDBY\"}"
+	}
+}
+`
+
+const PostUpdateFlavorBody = `
+{
+	"flavorprofile": {
+		"id": "dcd65be5-f117-4260-ab3d-b32cc5bd1272",
+		"name": "amphora-test-updated",
+		"provider_name": "amphora",
+		"flavor_data": "{\"loadbalancer_topology\": \"SINGLE\"}"
+	}
+}
+`
+
+var (
+	FlavorProfileSingle = flavorprofiles.FlavorProfile{
+		ID:           "c55d080d-af45-47ee-b48c-4caa5e87724f",
+		Name:         "amphora-single",
+		ProviderName: "amphora",
+		FlavorData:   "{\"loadbalancer_topology\": \"SINGLE\"}",
+	}
+
+	FlavorProfileAct = flavorprofiles.FlavorProfile{
+		ID:           "f78d2815-3714-4b6e-91d8-cf821ba01017",
+		Name:         "amphora-act-stdby",
+		ProviderName: "amphora",
+		FlavorData:   "{\"loadbalancer_topology\": \"ACTIVE_STANDBY\"}",
+	}
+
+	FlavorDb = flavorprofiles.FlavorProfile{
+		ID:           "dcd65be5-f117-4260-ab3d-b32cc5bd1272",
+		Name:         "amphora-test",
+		ProviderName: "amphora",
+		FlavorData:   "{\"loadbalancer_topology\": \"ACTIVE_STANDBY\"}",
+	}
+
+	FlavorUpdated = flavorprofiles.FlavorProfile{
+		ID:           "dcd65be5-f117-4260-ab3d-b32cc5bd1272",
+		Name:         "amphora-test-updated",
+		ProviderName: "amphora",
+		FlavorData:   "{\"loadbalancer_topology\": \"SINGLE\"}",
+	}
+)
+
+func HandleFlavorProfileListSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/v2.0/lbaas/flavorprofiles", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		r.ParseForm()
+		marker := r.Form.Get("marker")
+		switch marker {
+		case "":
+			fmt.Fprintf(w, FlavorProfilesListBody)
+		case "3a0d060b-fcec-4250-9ab6-940b806a12dd":
+			fmt.Fprintf(w, `{ "flavors": [] }`)
+		default:
+			t.Fatalf("/v2.0/lbaas/flavors invoked with unexpected marker=[%s]", marker)
+		}
+	})
+}
+
+func HandleFlavorProfileCreationSuccessfully(t *testing.T, response string) {
+	th.Mux.HandleFunc("/v2.0/lbaas/flavorprofiles", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, `{
+			"flavorprofile": {
+				"name": "amphora-test",
+				"provider_name": "amphora",
+				"flavor_data": "{\"loadbalancer_topology\": \"ACTIVE_STANDBY\"}"
+			}
+		}`)
+
+		w.WriteHeader(http.StatusAccepted)
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprintf(w, response)
+	})
+}
+
+func HandleFlavorProfileGetSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/v2.0/lbaas/flavorprofiles/dcd65be5-f117-4260-ab3d-b32cc5bd1272", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+
+		fmt.Fprintf(w, SingleFlavorProfileBody)
+	})
+}
+
+func HandleFlavorProfileDeletionSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/v2.0/lbaas/flavorprofiles/dcd65be5-f117-4260-ab3d-b32cc5bd1272", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.WriteHeader(http.StatusNoContent)
+	})
+}
+
+func HandleFlavorProfileUpdateSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/v2.0/lbaas/flavorprofiles/dcd65be5-f117-4260-ab3d-b32cc5bd1272", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestJSONRequest(t, r, `{
+			"flavorprofile": {
+				"name": "amphora-test-updated",
+				"provider_name": "amphora",
+				"flavor_data": "{\"loadbalancer_topology\": \"SINGLE\"}"
+			}
+		}`)
+
+		fmt.Fprintf(w, PostUpdateFlavorBody)
+	})
+}

--- a/openstack/loadbalancer/v2/flavorprofiles/testing/requests_test.go
+++ b/openstack/loadbalancer/v2/flavorprofiles/testing/requests_test.go
@@ -1,0 +1,117 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/flavorprofiles"
+	"github.com/gophercloud/gophercloud/pagination"
+
+	fake "github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/testhelper"
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestListFlavorProfiles(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleFlavorProfileListSuccessfully(t)
+
+	pages := 0
+	err := flavorprofiles.List(fake.ServiceClient(), flavorprofiles.ListOpts{}).EachPage(func(page pagination.Page) (bool, error) {
+		pages++
+
+		actual, err := flavorprofiles.ExtractFlavorProfiles(page)
+		if err != nil {
+			return false, err
+		}
+
+		if len(actual) != 2 {
+			t.Fatalf("Expected 2 flavors, got %d", len(actual))
+		}
+		th.CheckDeepEquals(t, FlavorProfileSingle, actual[0])
+		th.CheckDeepEquals(t, FlavorProfileAct, actual[1])
+
+		return true, nil
+	})
+
+	th.AssertNoErr(t, err)
+
+	if pages != 1 {
+		t.Errorf("Expected 1 page, saw %d", pages)
+	}
+}
+
+func TestListAllFlavorProfiles(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleFlavorProfileListSuccessfully(t)
+
+	allPages, err := flavorprofiles.List(fake.ServiceClient(), flavorprofiles.ListOpts{}).AllPages()
+	th.AssertNoErr(t, err)
+	actual, err := flavorprofiles.ExtractFlavorProfiles(allPages)
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, FlavorProfileSingle, actual[0])
+	th.CheckDeepEquals(t, FlavorProfileAct, actual[1])
+}
+
+func TestCreateFlavorProfile(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleFlavorProfileCreationSuccessfully(t, SingleFlavorProfileBody)
+
+	actual, err := flavorprofiles.Create(fake.ServiceClient(), flavorprofiles.CreateOpts{
+		Name:         "amphora-test",
+		ProviderName: "amphora",
+		FlavorData:   "{\"loadbalancer_topology\": \"ACTIVE_STANDBY\"}",
+	}).Extract()
+	th.AssertNoErr(t, err)
+
+	th.CheckDeepEquals(t, FlavorDb, *actual)
+}
+
+func TestRequiredCreateOpts(t *testing.T) {
+	res := flavorprofiles.Create(fake.ServiceClient(), flavorprofiles.CreateOpts{})
+	if res.Err == nil {
+		t.Fatalf("Expected error, got none")
+	}
+}
+
+func TestGetFlavorProfiles(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleFlavorProfileGetSuccessfully(t)
+
+	client := fake.ServiceClient()
+	actual, err := flavorprofiles.Get(client, "dcd65be5-f117-4260-ab3d-b32cc5bd1272").Extract()
+	if err != nil {
+		t.Fatalf("Unexpected Get error: %v", err)
+	}
+
+	th.CheckDeepEquals(t, FlavorDb, *actual)
+}
+
+func TestDeleteFlavorProfile(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleFlavorProfileDeletionSuccessfully(t)
+
+	res := flavorprofiles.Delete(fake.ServiceClient(), "dcd65be5-f117-4260-ab3d-b32cc5bd1272")
+	th.AssertNoErr(t, res.Err)
+}
+
+func TestUpdateFlavorProfile(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleFlavorProfileUpdateSuccessfully(t)
+
+	client := fake.ServiceClient()
+	actual, err := flavorprofiles.Update(client, "dcd65be5-f117-4260-ab3d-b32cc5bd1272", flavorprofiles.UpdateOpts{
+		Name:         "amphora-test-updated",
+		ProviderName: "amphora",
+		FlavorData:   "{\"loadbalancer_topology\": \"SINGLE\"}",
+	}).Extract()
+	if err != nil {
+		t.Fatalf("Unexpected Update error: %v", err)
+	}
+
+	th.CheckDeepEquals(t, FlavorUpdated, *actual)
+}

--- a/openstack/loadbalancer/v2/flavorprofiles/urls.go
+++ b/openstack/loadbalancer/v2/flavorprofiles/urls.go
@@ -1,0 +1,16 @@
+package flavorprofiles
+
+import "github.com/gophercloud/gophercloud"
+
+const (
+	rootPath     = "lbaas"
+	resourcePath = "flavorprofiles"
+)
+
+func rootURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL(rootPath, resourcePath)
+}
+
+func resourceURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL(rootPath, resourcePath, id)
+}

--- a/openstack/loadbalancer/v2/flavors/doc.go
+++ b/openstack/loadbalancer/v2/flavors/doc.go
@@ -1,0 +1,58 @@
+/*
+Package flavors provides information and interaction with Flavors
+for the OpenStack Load-balancing service.
+
+Example to List Flavors
+
+	listOpts := flavors.ListOpts{}
+
+	allPages, err := flavors.List(octaviaClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allFlavors, err := flavors.ExtractFlavors(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, flavor := range allFlavors {
+		fmt.Printf("%+v\n", flavor)
+	}
+
+Example to Create a Flavor
+
+	createOpts := flavors.CreateOpts{
+		Name:            "Flavor name",
+		Description:     "My flavor description",
+		Enable:          true,
+		FlavorProfileId: "9daa2768-74e7-4d13-bf5d-1b8e0dc239e1",
+	}
+
+	flavor, err := flavors.Create(octaviaClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Update a Flavor
+
+	flavorID := "d67d56a6-4a86-4688-a282-f46444705c64"
+
+	updateOpts := flavors.UpdateOpts{
+		Name: "New name",
+	}
+
+	flavor, err := flavors.Update(octaviaClient, flavorID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete a Flavor
+
+	flavorID := "d67d56a6-4a86-4688-a282-f46444705c64"
+	err := flavors.Delete(octaviaClient, flavorID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+*/
+package flavors

--- a/openstack/loadbalancer/v2/flavors/requests.go
+++ b/openstack/loadbalancer/v2/flavors/requests.go
@@ -1,0 +1,112 @@
+package flavors
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// LIST
+
+type ListOptsBuilder interface {
+	ToFlavorListQuery() (string, error)
+}
+
+type ListOpts struct {
+	ID   string `q:"id"`
+	Name string `q:"name"`
+}
+
+func (opts ListOpts) ToFlavorListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := rootURL(c)
+	if opts != nil {
+		query, err := opts.ToFlavorListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		return FlavorPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// CREATE
+
+type CreateOptsBuilder interface {
+	ToFlavorCreateMap() (map[string]interface{}, error)
+}
+
+type CreateOpts struct {
+	Name            string `json:"name,omitempty"`
+	Description     string `json:"description,omitempty"`
+	FlavorProfileId string `json:"flavor_profile_id,required:"true""`
+	Enabled         bool   `json:"enabled,default:"true""`
+}
+
+func (opts CreateOpts) ToFlavorCreateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "flavor")
+}
+
+func Create(c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToFlavorCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := c.Post(rootURL(c), b, &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// GET
+
+func Get(c *gophercloud.ServiceClient, id string) (r GetResult) {
+	resp, err := c.Get(resourceURL(c, id), &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// UPDATE
+
+type UpdateOptsBuilder interface {
+	ToFlavorUpdateMap() (map[string]interface{}, error)
+}
+
+type UpdateOpts struct {
+	Name        string `json:"name,omitempty"`
+	Description string `json:"description,omitempty"`
+	Enabled     bool   `json:"enabled" default:"true"`
+}
+
+func (opts UpdateOpts) ToFlavorUpdateMap() (map[string]interface{}, error) {
+	b, err := gophercloud.BuildRequestBody(opts, "flavor")
+	if err != nil {
+		return nil, err
+	}
+
+	return b, nil
+}
+
+func Update(c *gophercloud.ServiceClient, id string, opts UpdateOpts) (r UpdateResult) {
+	b, err := opts.ToFlavorUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := c.Put(resourceURL(c, id), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200, 202},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+func Delete(c *gophercloud.ServiceClient, id string) (r DeleteResult) {
+	resp, err := c.Delete(resourceURL(c, id), nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}

--- a/openstack/loadbalancer/v2/flavors/results.go
+++ b/openstack/loadbalancer/v2/flavors/results.go
@@ -1,0 +1,79 @@
+package flavors
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+type Flavor struct {
+	// The unique ID for the Flavor
+	ID string `json:"id"`
+
+	// Human-readable name for the Flavor. Does not have to be unique.
+	Name string `json:"name"`
+
+	// Human-readable description for the Flavor.
+	Description string `json:"description"`
+
+	// Status of the Flavor.
+	Enabled bool `json:"enabled"`
+
+	// Flavor Profile apply to this Flavor.
+	FlavorProfileId string `json:"flavor_profile_id"`
+}
+
+type FlavorPage struct {
+	pagination.LinkedPageBase
+}
+
+func (r FlavorPage) NextPageURL() (string, error) {
+	var s struct {
+		Links []gophercloud.Link `json:"flavors_links"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return gophercloud.ExtractNextURL(s.Links)
+}
+
+func (r FlavorPage) IsEmpty() (bool, error) {
+	is, err := ExtractFlavors(r)
+	return len(is) == 0, err
+}
+
+func ExtractFlavors(r pagination.Page) ([]Flavor, error) {
+	var s struct {
+		Flavors []Flavor `json:"flavors"`
+	}
+	err := (r.(FlavorPage)).ExtractInto(&s)
+	return s.Flavors, err
+}
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+func (r commonResult) Extract() (*Flavor, error) {
+	var s struct {
+		Flavor *Flavor `json:"flavor"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Flavor, err
+}
+
+type CreateResult struct {
+	commonResult
+}
+
+type GetResult struct {
+	commonResult
+}
+
+type UpdateResult struct {
+	commonResult
+}
+
+type DeleteResult struct {
+	gophercloud.ErrResult
+}

--- a/openstack/loadbalancer/v2/flavors/results.go
+++ b/openstack/loadbalancer/v2/flavors/results.go
@@ -5,6 +5,7 @@ import (
 	"github.com/gophercloud/gophercloud/pagination"
 )
 
+// Flavor provide specs for the creation of a load balancer.
 type Flavor struct {
 	// The unique ID for the Flavor
 	ID string `json:"id"`
@@ -22,10 +23,15 @@ type Flavor struct {
 	FlavorProfileId string `json:"flavor_profile_id"`
 }
 
+// FlavorPage is the page returned by a pager when traversing over a
+// collection of flavors.
 type FlavorPage struct {
 	pagination.LinkedPageBase
 }
 
+// NextPageURL is invoked when a paginated collection of flavors has
+// reached the end of a page and the pager seeks to traverse over a new one.
+// In order to do this, it needs to construct the next page's URL.
 func (r FlavorPage) NextPageURL() (string, error) {
 	var s struct {
 		Links []gophercloud.Link `json:"flavors_links"`
@@ -37,11 +43,15 @@ func (r FlavorPage) NextPageURL() (string, error) {
 	return gophercloud.ExtractNextURL(s.Links)
 }
 
+// IsEmpty checks whether a FlavorPage struct is empty.
 func (r FlavorPage) IsEmpty() (bool, error) {
 	is, err := ExtractFlavors(r)
 	return len(is) == 0, err
 }
 
+// ExtractFlavors accepts a Page struct, specifically a FlavorPage
+// struct, and extracts the elements into a slice of Flavor structs. In
+// other words, a generic collection is mapped into a relevant slice.
 func ExtractFlavors(r pagination.Page) ([]Flavor, error) {
 	var s struct {
 		Flavors []Flavor `json:"flavors"`
@@ -54,6 +64,7 @@ type commonResult struct {
 	gophercloud.Result
 }
 
+// Extract is a function that accepts a result and extracts a flavor.
 func (r commonResult) Extract() (*Flavor, error) {
 	var s struct {
 		Flavor *Flavor `json:"flavor"`
@@ -62,18 +73,26 @@ func (r commonResult) Extract() (*Flavor, error) {
 	return s.Flavor, err
 }
 
+// CreateResult represents the result of a create operation. Call its Extract
+// method to interpret it as a Flavor.
 type CreateResult struct {
 	commonResult
 }
 
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a Flavor.
 type GetResult struct {
 	commonResult
 }
 
+// UpdateResult represents the result of an update operation. Call its Extract
+// method to interpret it as a Flavor.
 type UpdateResult struct {
 	commonResult
 }
 
+// DeleteResult represents the result of a delete operation. Call its
+// ExtractErr method to determine if the request succeeded or failed.
 type DeleteResult struct {
 	gophercloud.ErrResult
 }

--- a/openstack/loadbalancer/v2/flavors/testing/doc.go
+++ b/openstack/loadbalancer/v2/flavors/testing/doc.go
@@ -1,0 +1,1 @@
+package testing

--- a/openstack/loadbalancer/v2/flavors/testing/fixtures.go
+++ b/openstack/loadbalancer/v2/flavors/testing/fixtures.go
@@ -157,7 +157,7 @@ func HandleFlavorUpdateSuccessfully(t *testing.T) {
 			"flavor": {
 				"name": "Basic v2",
 				"description": "Rename flavor",
-				"enabled": false
+				"enabled": true
 			}
 		}`)
 

--- a/openstack/loadbalancer/v2/flavors/testing/fixutres.go
+++ b/openstack/loadbalancer/v2/flavors/testing/fixutres.go
@@ -1,0 +1,166 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/flavors"
+
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+const FlavorsListBody = `
+{
+	"flavors": [
+        {
+            "id": "4c82a610-8c7f-4a72-8cca-42f584e3f6d1",
+            "name": "Basic",
+            "description": "A basic standalone Octavia load balancer.",
+            "enabled": true,
+            "flavor_profile_id": "bdba88c7-beab-4fc9-a5dd-3635de59185b"
+        },
+		{
+            "id": "0af3b9cc-9284-44c2-9494-0ec337fa31bb",
+            "name": "Advance",
+            "description": "A advance standalone Octavia load balancer.",
+            "enabled": false,
+            "flavor_profile_id": "c221abc6-a845-45a0-925c-27110c9d7bdc"
+        }
+    ]
+}
+`
+
+const SingleFlavorBody = `
+{
+	"flavor": {
+		"id": "5548c807-e6e8-43d7-9ea4-b38d34dd74a0",
+		"name": "Basic",
+		"description": "A basic standalone Octavia load balancer.",
+		"enabled": true,
+		"flavor_profile_id": "9daa2768-74e7-4d13-bf5d-1b8e0dc239e1"
+	}
+}
+`
+
+const PostUpdateFlavorBody = `
+{
+	"flavor": {
+		"id": "5548c807-e6e8-43d7-9ea4-b38d34dd74a0",
+		"name": "Basic v2",
+		"description": "Rename flavor",
+		"enabled": false,
+		"flavor_profile_id": "9daa2768-74e7-4d13-bf5d-1b8e0dc239e1"
+	}
+}
+`
+
+var (
+	FlavorBasic = flavors.Flavor{
+		ID:              "4c82a610-8c7f-4a72-8cca-42f584e3f6d1",
+		Name:            "Basic",
+		Description:     "A basic standalone Octavia load balancer.",
+		Enabled:         true,
+		FlavorProfileId: "bdba88c7-beab-4fc9-a5dd-3635de59185b",
+	}
+
+	FlavorAdvance = flavors.Flavor{
+		ID:              "0af3b9cc-9284-44c2-9494-0ec337fa31bb",
+		Name:            "Advance",
+		Description:     "A advance standalone Octavia load balancer.",
+		Enabled:         false,
+		FlavorProfileId: "c221abc6-a845-45a0-925c-27110c9d7bdc",
+	}
+
+	FlavorDb = flavors.Flavor{
+		ID:              "5548c807-e6e8-43d7-9ea4-b38d34dd74a0",
+		Name:            "Basic",
+		Description:     "A basic standalone Octavia load balancer.",
+		Enabled:         true,
+		FlavorProfileId: "9daa2768-74e7-4d13-bf5d-1b8e0dc239e1",
+	}
+
+	FlavorUpdated = flavors.Flavor{
+		ID:              "5548c807-e6e8-43d7-9ea4-b38d34dd74a0",
+		Name:            "Basic v2",
+		Description:     "Rename flavor",
+		Enabled:         false,
+		FlavorProfileId: "9daa2768-74e7-4d13-bf5d-1b8e0dc239e1",
+	}
+)
+
+func HandleFlavorListSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/v2.0/lbaas/flavors", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		r.ParseForm()
+		marker := r.Form.Get("marker")
+		switch marker {
+		case "":
+			fmt.Fprintf(w, FlavorsListBody)
+		case "3a0d060b-fcec-4250-9ab6-940b806a12dd":
+			fmt.Fprintf(w, `{ "flavors": [] }`)
+		default:
+			t.Fatalf("/v2.0/lbaas/flavors invoked with unexpected marker=[%s]", marker)
+		}
+	})
+}
+
+func HandleFlavorCreationSuccessfully(t *testing.T, response string) {
+	th.Mux.HandleFunc("/v2.0/lbaas/flavors", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, `{
+			"flavor": {
+				"name": "Basic",
+				"description": "A basic standalone Octavia load balancer.",
+				"enabled": true,
+				"flavor_profile_id": "9daa2768-74e7-4d13-bf5d-1b8e0dc239e1"
+			}
+		}`)
+
+		w.WriteHeader(http.StatusAccepted)
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprintf(w, response)
+	})
+}
+
+func HandleFlavorGetSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/v2.0/lbaas/flavors/5548c807-e6e8-43d7-9ea4-b38d34dd74a0", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+
+		fmt.Fprintf(w, SingleFlavorBody)
+	})
+}
+
+func HandleFlavorDeletionSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/v2.0/lbaas/flavors/5548c807-e6e8-43d7-9ea4-b38d34dd74a0", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.WriteHeader(http.StatusNoContent)
+	})
+}
+
+func HandleFlavorUpdateSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/v2.0/lbaas/flavors/5548c807-e6e8-43d7-9ea4-b38d34dd74a0", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestJSONRequest(t, r, `{
+			"flavor": {
+				"name": "Basic v2",
+				"description": "Rename flavor",
+				"enabled": false
+			}
+		}`)
+
+		fmt.Fprintf(w, PostUpdateFlavorBody)
+	})
+}

--- a/openstack/loadbalancer/v2/flavors/testing/requests_test.go
+++ b/openstack/loadbalancer/v2/flavors/testing/requests_test.go
@@ -108,7 +108,7 @@ func TestUpdateFlavor(t *testing.T) {
 	actual, err := flavors.Update(client, "5548c807-e6e8-43d7-9ea4-b38d34dd74a0", flavors.UpdateOpts{
 		Name:        "Basic v2",
 		Description: "Rename flavor",
-		Enabled:     false,
+		Enabled:     true,
 	}).Extract()
 	if err != nil {
 		t.Fatalf("Unexpected Update error: %v", err)

--- a/openstack/loadbalancer/v2/flavors/testing/requests_test.go
+++ b/openstack/loadbalancer/v2/flavors/testing/requests_test.go
@@ -1,0 +1,118 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/flavors"
+	"github.com/gophercloud/gophercloud/pagination"
+
+	fake "github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/testhelper"
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestListFlavors(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleFlavorListSuccessfully(t)
+
+	pages := 0
+	err := flavors.List(fake.ServiceClient(), flavors.ListOpts{}).EachPage(func(page pagination.Page) (bool, error) {
+		pages++
+
+		actual, err := flavors.ExtractFlavors(page)
+		if err != nil {
+			return false, err
+		}
+
+		if len(actual) != 2 {
+			t.Fatalf("Expected 2 flavors, got %d", len(actual))
+		}
+		th.CheckDeepEquals(t, FlavorBasic, actual[0])
+		th.CheckDeepEquals(t, FlavorAdvance, actual[1])
+
+		return true, nil
+	})
+
+	th.AssertNoErr(t, err)
+
+	if pages != 1 {
+		t.Errorf("Expected 1 page, saw %d", pages)
+	}
+}
+
+func TestListAllFlavors(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleFlavorListSuccessfully(t)
+
+	allPages, err := flavors.List(fake.ServiceClient(), flavors.ListOpts{}).AllPages()
+	th.AssertNoErr(t, err)
+	actual, err := flavors.ExtractFlavors(allPages)
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, FlavorBasic, actual[0])
+	th.CheckDeepEquals(t, FlavorAdvance, actual[1])
+}
+
+func TestCreateFlavor(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleFlavorCreationSuccessfully(t, SingleFlavorBody)
+
+	actual, err := flavors.Create(fake.ServiceClient(), flavors.CreateOpts{
+		Name:            "Basic",
+		Description:     "A basic standalone Octavia load balancer.",
+		Enabled:         true,
+		FlavorProfileId: "9daa2768-74e7-4d13-bf5d-1b8e0dc239e1",
+	}).Extract()
+	th.AssertNoErr(t, err)
+
+	th.CheckDeepEquals(t, FlavorDb, *actual)
+}
+
+func TestRequiredCreateOpts(t *testing.T) {
+	res := flavors.Create(fake.ServiceClient(), flavors.CreateOpts{})
+	if res.Err == nil {
+		t.Fatalf("Expected error, got none")
+	}
+}
+
+func TestGetFlavor(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleFlavorGetSuccessfully(t)
+
+	client := fake.ServiceClient()
+	actual, err := flavors.Get(client, "5548c807-e6e8-43d7-9ea4-b38d34dd74a0").Extract()
+	if err != nil {
+		t.Fatalf("Unexpected Get error: %v", err)
+	}
+
+	th.CheckDeepEquals(t, FlavorDb, *actual)
+}
+
+func TestDeleteFlavor(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleFlavorDeletionSuccessfully(t)
+
+	res := flavors.Delete(fake.ServiceClient(), "5548c807-e6e8-43d7-9ea4-b38d34dd74a0")
+	th.AssertNoErr(t, res.Err)
+}
+
+func TestUpdateFlavor(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleFlavorUpdateSuccessfully(t)
+
+	client := fake.ServiceClient()
+	actual, err := flavors.Update(client, "5548c807-e6e8-43d7-9ea4-b38d34dd74a0", flavors.UpdateOpts{
+		Name:        "Basic v2",
+		Description: "Rename flavor",
+		Enabled:     false,
+	}).Extract()
+	if err != nil {
+		t.Fatalf("Unexpected Update error: %v", err)
+	}
+
+	th.CheckDeepEquals(t, FlavorUpdated, *actual)
+}

--- a/openstack/loadbalancer/v2/flavors/urls.go
+++ b/openstack/loadbalancer/v2/flavors/urls.go
@@ -1,0 +1,16 @@
+package flavors
+
+import "github.com/gophercloud/gophercloud"
+
+const (
+	rootPath     = "lbaas"
+	resourcePath = "flavors"
+)
+
+func rootURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL(rootPath, resourcePath)
+}
+
+func resourceURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL(rootPath, resourcePath, id)
+}


### PR DESCRIPTION
Add support of Flavors and FlavorProfiles for Octavia

Fixes #2574 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/octavia/blob/master/octavia/api/v2/controllers/flavors.py
https://github.com/openstack/octavia/blob/master/octavia/api/v2/controllers/flavor_profiles.py
