### PR TITLE
keystone: add v3 OS-FEDERATION mappings delete operation

### DIFF
--- a/acceptance/openstack/identity/v3/federation_test.go
+++ b/acceptance/openstack/identity/v3/federation_test.go
@@ -6,6 +6,7 @@ package v3
 import (
 	"testing"
 
+	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/acceptance/clients"
 	"github.com/gophercloud/gophercloud/acceptance/tools"
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/extensions/federation"
@@ -112,4 +113,9 @@ func TestMappingsCRUD(t *testing.T) {
 
 	err = federation.DeleteMapping(client, mappingName).ExtractErr()
 	th.AssertNoErr(t, err)
+
+	resp := federation.GetMapping(client, mappingName)
+	th.AssertErr(t, resp.Err)
+	_, ok := resp.Err.(gophercloud.ErrDefault404)
+	th.AssertEquals(t, true, ok)
 }

--- a/acceptance/openstack/identity/v3/federation_test.go
+++ b/acceptance/openstack/identity/v3/federation_test.go
@@ -109,4 +109,7 @@ func TestMappingsCRUD(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, len(updateOpts.Rules), len(updatedMapping.Rules))
 	th.CheckDeepEquals(t, updateOpts.Rules[0], updatedMapping.Rules[0])
+
+	err = federation.DeleteMapping(client, mappingName).ExtractErr()
+	th.AssertNoErr(t, err)
 }

--- a/openstack/identity/v3/extensions/federation/doc.go
+++ b/openstack/identity/v3/extensions/federation/doc.go
@@ -94,5 +94,12 @@ Example to Update a Mapping
 	if err != nil {
 		panic(err)
 	}
+
+Example to Delete a Mapping
+
+	err := federation.DeleteMapping(identityClient, "ACME").ExtractErr()
+	if err != nil {
+		panic(err)
+	}
 */
 package federation

--- a/openstack/identity/v3/extensions/federation/requests.go
+++ b/openstack/identity/v3/extensions/federation/requests.go
@@ -80,3 +80,10 @@ func UpdateMapping(client *gophercloud.ServiceClient, mappingID string, opts Upd
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
+
+// DeleteMapping deletes a mapping.
+func DeleteMapping(client *gophercloud.ServiceClient, mappingID string) (r DeleteMappingResult) {
+	resp, err := client.Delete(mappingsResourceURL(client, mappingID), nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}

--- a/openstack/identity/v3/extensions/federation/results.go
+++ b/openstack/identity/v3/extensions/federation/results.go
@@ -162,6 +162,12 @@ type UpdateMappingResult struct {
 	mappingResult
 }
 
+// DeleteMappingResult is the response from a DeleteMapping operation.
+// Call its ExtractErr to determine if the request succeeded or failed.
+type DeleteMappingResult struct {
+	gophercloud.ErrResult
+}
+
 // MappingsPage is a single page of Mapping results.
 type MappingsPage struct {
 	pagination.LinkedPageBase

--- a/openstack/identity/v3/extensions/federation/testing/fixtures.go
+++ b/openstack/identity/v3/extensions/federation/testing/fixtures.go
@@ -332,3 +332,14 @@ func HandleUpdateMappingSuccessfully(t *testing.T) {
 		fmt.Fprintf(w, UpdateOutput)
 	})
 }
+
+// HandleDeleteMappingSuccessfully creates an HTTP handler at `/mappings` on the
+// test handler mux that tests mapping deletion.
+func HandleDeleteMappingSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/OS-FEDERATION/mappings/ACME", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.WriteHeader(http.StatusNoContent)
+	})
+}

--- a/openstack/identity/v3/extensions/federation/testing/requests_test.go
+++ b/openstack/identity/v3/extensions/federation/testing/requests_test.go
@@ -132,3 +132,12 @@ func TestUpdateMapping(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.CheckDeepEquals(t, MappingUpdated, *actual)
 }
+
+func TestDeleteMapping(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleDeleteMappingSuccessfully(t)
+
+	res := federation.DeleteMapping(client.ServiceClient(), "ACME")
+	th.AssertNoErr(t, res.Err)
+}


### PR DESCRIPTION
For https://github.com/gophercloud/gophercloud/issues/2461

[docs](https://docs.openstack.org/api-ref/identity/v3-ext/index.html#delete-a-mapping)
[code](https://github.com/openstack/keystone/blob/stable/yoga/keystone/api/os_federation.py#L301)