### PR TITLE
Add periodic jobs for OpenStack zed release and reduce periodic jobs frequency

### DIFF
--- a/.github/workflows/functional-baremetal.yaml
+++ b/.github/workflows/functional-baremetal.yaml
@@ -14,6 +14,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["20.04"]
         include:
+          - name: "zed"
+            openstack_version: "stable/zed"
+            ubuntu_version: "20.04"
           - name: "yoga"
             openstack_version: "stable/yoga"
             ubuntu_version: "20.04"

--- a/.github/workflows/functional-baremetal.yaml
+++ b/.github/workflows/functional-baremetal.yaml
@@ -4,7 +4,7 @@ on:
     paths:
       - '**baremetal**'
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 0 */3 * *'
 jobs:
   functional-baremetal:
     strategy:

--- a/.github/workflows/functional-basic.yaml
+++ b/.github/workflows/functional-basic.yaml
@@ -7,7 +7,7 @@ on:
       - '**.gitignore'
       - '**LICENSE'
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 0 */3 * *'
 jobs:
   functional-basic:
     strategy:

--- a/.github/workflows/functional-basic.yaml
+++ b/.github/workflows/functional-basic.yaml
@@ -17,6 +17,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["20.04"]
         include:
+          - name: "zed"
+            openstack_version: "stable/zed"
+            ubuntu_version: "20.04"
           - name: "yoga"
             openstack_version: "stable/yoga"
             ubuntu_version: "20.04"

--- a/.github/workflows/functional-blockstorage.yaml
+++ b/.github/workflows/functional-blockstorage.yaml
@@ -4,7 +4,7 @@ on:
     paths:
       - '**blockstorage**'
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 0 */3 * *'
 jobs:
   functional-blockstorage:
     strategy:

--- a/.github/workflows/functional-blockstorage.yaml
+++ b/.github/workflows/functional-blockstorage.yaml
@@ -14,6 +14,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["20.04"]
         include:
+          - name: "zed"
+            openstack_version: "stable/zed"
+            ubuntu_version: "20.04"
           - name: "yoga"
             openstack_version: "stable/yoga"
             ubuntu_version: "20.04"

--- a/.github/workflows/functional-clustering.yaml
+++ b/.github/workflows/functional-clustering.yaml
@@ -14,6 +14,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["20.04"]
         include:
+          - name: "zed"
+            openstack_version: "stable/zed"
+            ubuntu_version: "20.04"
           - name: "yoga"
             openstack_version: "stable/yoga"
             ubuntu_version: "20.04"

--- a/.github/workflows/functional-clustering.yaml
+++ b/.github/workflows/functional-clustering.yaml
@@ -4,7 +4,7 @@ on:
     paths:
       - '**clustering**'
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 0 */3 * *'
 jobs:
   functional-clustering:
     strategy:

--- a/.github/workflows/functional-compute.yaml
+++ b/.github/workflows/functional-compute.yaml
@@ -14,6 +14,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["20.04"]
         include:
+          - name: "zed"
+            openstack_version: "stable/zed"
+            ubuntu_version: "20.04"
           - name: "yoga"
             openstack_version: "stable/yoga"
             ubuntu_version: "20.04"

--- a/.github/workflows/functional-compute.yaml
+++ b/.github/workflows/functional-compute.yaml
@@ -4,7 +4,7 @@ on:
     paths:
       - '**compute**'
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 0 */3 * *'
 jobs:
   functional-compute:
     strategy:

--- a/.github/workflows/functional-containerinfra.yaml
+++ b/.github/workflows/functional-containerinfra.yaml
@@ -4,7 +4,7 @@ on:
     paths:
       - '**containerinfra**'
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 0 */3 * *'
 jobs:
   functional-containerinfra:
     strategy:

--- a/.github/workflows/functional-containerinfra.yaml
+++ b/.github/workflows/functional-containerinfra.yaml
@@ -16,6 +16,11 @@ jobs:
             ubuntu_version: "20.04"
             devstack_conf_overrides: |
               enable_plugin magnum https://github.com/openstack/magnum master
+          - name: "zed"
+            openstack_version: "stable/zed"
+            ubuntu_version: "20.04"
+            devstack_conf_overrides: |
+              enable_plugin magnum https://github.com/openstack/magnum stable/zed
           - name: "yoga"
             openstack_version: "stable/yoga"
             ubuntu_version: "20.04"

--- a/.github/workflows/functional-dns.yaml
+++ b/.github/workflows/functional-dns.yaml
@@ -5,7 +5,7 @@ on:
       - '**openstack/dns**'
       - '**functional-dns.yaml'
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 0 */3 * *'
 jobs:
   functional-dns:
     strategy:

--- a/.github/workflows/functional-dns.yaml
+++ b/.github/workflows/functional-dns.yaml
@@ -17,6 +17,11 @@ jobs:
             ubuntu_version: "20.04"
             devstack_conf_overrides: |
               enable_plugin designate https://github.com/openstack/designate master
+          - name: "zed"
+            openstack_version: "stable/zed"
+            ubuntu_version: "20.04"
+            devstack_conf_overrides: |
+              enable_plugin designate https://github.com/openstack/designate stable/zed
           - name: "yoga"
             openstack_version: "stable/yoga"
             ubuntu_version: "20.04"

--- a/.github/workflows/functional-identity.yaml
+++ b/.github/workflows/functional-identity.yaml
@@ -14,6 +14,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["20.04"]
         include:
+          - name: "zed"
+            openstack_version: "stable/zed"
+            ubuntu_version: "20.04"
           - name: "yoga"
             openstack_version: "stable/yoga"
             ubuntu_version: "20.04"

--- a/.github/workflows/functional-identity.yaml
+++ b/.github/workflows/functional-identity.yaml
@@ -4,7 +4,7 @@ on:
     paths:
       - '**identity**'
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 0 */3 * *'
 jobs:
   functional-identity:
     strategy:

--- a/.github/workflows/functional-imageservice.yaml
+++ b/.github/workflows/functional-imageservice.yaml
@@ -4,7 +4,7 @@ on:
     paths:
       - '**imageservice**'
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 0 */3 * *'
 jobs:
   functional-imageservice:
     strategy:

--- a/.github/workflows/functional-imageservice.yaml
+++ b/.github/workflows/functional-imageservice.yaml
@@ -14,6 +14,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["20.04"]
         include:
+          - name: "zed"
+            openstack_version: "stable/zed"
+            ubuntu_version: "20.04"
           - name: "yoga"
             openstack_version: "stable/yoga"
             ubuntu_version: "20.04"

--- a/.github/workflows/functional-keymanager.yaml
+++ b/.github/workflows/functional-keymanager.yaml
@@ -14,6 +14,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["20.04"]
         include:
+          - name: "zed"
+            openstack_version: "stable/zed"
+            ubuntu_version: "20.04"
           - name: "yoga"
             openstack_version: "stable/yoga"
             ubuntu_version: "20.04"

--- a/.github/workflows/functional-keymanager.yaml
+++ b/.github/workflows/functional-keymanager.yaml
@@ -4,7 +4,7 @@ on:
     paths:
       - '**keymanager**'
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 0 */3 * *'
 jobs:
   functional-keymanager:
     strategy:

--- a/.github/workflows/functional-loadbalancer.yaml
+++ b/.github/workflows/functional-loadbalancer.yaml
@@ -14,6 +14,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["20.04"]
         include:
+          - name: "zed"
+            openstack_version: "stable/zed"
+            ubuntu_version: "20.04"
           - name: "yoga"
             openstack_version: "stable/yoga"
             ubuntu_version: "20.04"

--- a/.github/workflows/functional-loadbalancer.yaml
+++ b/.github/workflows/functional-loadbalancer.yaml
@@ -4,7 +4,7 @@ on:
     paths:
       - '**loadbalancer**'
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 0 */3 * *'
 jobs:
   functional-loadbalancer:
     strategy:

--- a/.github/workflows/functional-messaging.yaml
+++ b/.github/workflows/functional-messaging.yaml
@@ -4,7 +4,7 @@ on:
     paths:
       - '**messaging**'
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 0 */3 * *'
 jobs:
   functional-messaging:
     strategy:

--- a/.github/workflows/functional-messaging.yaml
+++ b/.github/workflows/functional-messaging.yaml
@@ -14,6 +14,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["20.04"]
         include:
+          - name: "zed"
+            openstack_version: "stable/zed"
+            ubuntu_version: "20.04"
           - name: "yoga"
             openstack_version: "stable/yoga"
             ubuntu_version: "20.04"

--- a/.github/workflows/functional-networking.yaml
+++ b/.github/workflows/functional-networking.yaml
@@ -4,7 +4,7 @@ on:
     paths:
       - '**networking**'
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 0 */3 * *'
 jobs:
   functional-networking:
     strategy:

--- a/.github/workflows/functional-networking.yaml
+++ b/.github/workflows/functional-networking.yaml
@@ -17,6 +17,12 @@ jobs:
             devstack_conf_overrides: |
               enable_plugin neutron-dynamic-routing https://github.com/openstack/neutron-dynamic-routing master
               enable_plugin neutron-vpnaas https://github.com/openstack/neutron-vpnaas master
+          - name: "zed"
+            openstack_version: "stable/zed"
+            ubuntu_version: "20.04"
+            devstack_conf_overrides: |
+              enable_plugin neutron-dynamic-routing https://github.com/openstack/neutron-dynamic-routing stable/zed
+              enable_plugin neutron-vpnaas https://github.com/openstack/neutron-vpnaas stable/zed
           - name: "yoga"
             openstack_version: "stable/yoga"
             ubuntu_version: "20.04"

--- a/.github/workflows/functional-objectstorage.yaml
+++ b/.github/workflows/functional-objectstorage.yaml
@@ -14,6 +14,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["20.04"]
         include:
+          - name: "zed"
+            openstack_version: "stable/zed"
+            ubuntu_version: "20.04"
           - name: "yoga"
             openstack_version: "stable/yoga"
             ubuntu_version: "20.04"

--- a/.github/workflows/functional-objectstorage.yaml
+++ b/.github/workflows/functional-objectstorage.yaml
@@ -4,7 +4,7 @@ on:
     paths:
       - '**objectstorage**'
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 0 */3 * *'
 jobs:
   functional-objectstorage:
     strategy:

--- a/.github/workflows/functional-orchestration.yaml
+++ b/.github/workflows/functional-orchestration.yaml
@@ -14,6 +14,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["20.04"]
         include:
+          - name: "zed"
+            openstack_version: "stable/zed"
+            ubuntu_version: "20.04"
           - name: "yoga"
             openstack_version: "stable/yoga"
             ubuntu_version: "20.04"

--- a/.github/workflows/functional-orchestration.yaml
+++ b/.github/workflows/functional-orchestration.yaml
@@ -4,7 +4,7 @@ on:
     paths:
       - '**orchestration**'
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 0 */3 * *'
 jobs:
   functional-orchestration:
     strategy:

--- a/.github/workflows/functional-placement.yaml
+++ b/.github/workflows/functional-placement.yaml
@@ -14,6 +14,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["20.04"]
         include:
+          - name: "zed"
+            openstack_version: "stable/zed"
+            ubuntu_version: "20.04"
           - name: "yoga"
             openstack_version: "stable/yoga"
             ubuntu_version: "20.04"

--- a/.github/workflows/functional-placement.yaml
+++ b/.github/workflows/functional-placement.yaml
@@ -4,7 +4,7 @@ on:
     paths:
       - '**placement**'
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 0 */3 * *'
 jobs:
   functional-placement:
     strategy:

--- a/.github/workflows/functional-sharedfilesystems.yaml
+++ b/.github/workflows/functional-sharedfilesystems.yaml
@@ -14,6 +14,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["20.04"]
         include:
+          - name: "zed"
+            openstack_version: "stable/zed"
+            ubuntu_version: "20.04"
           - name: "yoga"
             openstack_version: "stable/yoga"
             ubuntu_version: "20.04"

--- a/.github/workflows/functional-sharedfilesystems.yaml
+++ b/.github/workflows/functional-sharedfilesystems.yaml
@@ -4,7 +4,7 @@ on:
     paths:
       - '**sharedfilesystems**'
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 0 */3 * *'
 jobs:
   functional-sharedfilesystems:
     strategy:


### PR DESCRIPTION
This PR adds periodic jobs for the zed release that came out in oct 22. It also reduce the frequency of periodic jobs to run once every 3 days rather than every day.