### PR TITLE
CI: workaround mongodb dependency for messaging and clustering master jobs

### DIFF
--- a/.github/workflows/functional-clustering.yaml
+++ b/.github/workflows/functional-clustering.yaml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         name: ["master"]
         openstack_version: ["master"]
-        ubuntu_version: ["20.04"]
+        ubuntu_version: ["22.04"]
         include:
           - name: "yoga"
             openstack_version: "stable/yoga"

--- a/.github/workflows/functional-messaging.yaml
+++ b/.github/workflows/functional-messaging.yaml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         name: ["master"]
         openstack_version: ["master"]
-        ubuntu_version: ["20.04"]
+        ubuntu_version: ["22.04"]
         include:
           - name: "yoga"
             openstack_version: "stable/yoga"


### PR DESCRIPTION
The zaqar devstack plugin has a workaround for the failing dependency
for ubuntu version 22.04. Let's use this as the runner in those jobs.