### PR TITLE
fix: Incorrect Documentation

### DIFF
--- a/openstack/networking/v2/extensions/provider/doc.go
+++ b/openstack/networking/v2/extensions/provider/doc.go
@@ -60,7 +60,7 @@ Example to Create a Provider Network
 		Shared:       &iTrue,
 	}
 
-	createOpts : provider.CreateOptsExt{
+	createOpts := provider.CreateOptsExt{
 		CreateOptsBuilder: networkCreateOpts,
 		Segments:          segments,
 	}


### PR DESCRIPTION
fix
[issue link](https://github.com/gophercloud/gophercloud/issues/2586)

`Example` are currently missing [Equal sign](https://pkg.go.dev/github.com/gophercloud/gophercloud@v1.2.0/openstack/networking/v2/extensions/provider) in the CreateOpts.
```
	createOpts : provider.CreateOptsExt{
		CreateOptsBuilder: networkCreateOpts,
		Segments:          segments,
	}
```
Thank you for your attention to this matter.


