### PR TITLE
Add support for block storage v3 AZs

### DIFF
--- a/acceptance/openstack/blockstorage/v3/availabilityzones_test.go
+++ b/acceptance/openstack/blockstorage/v3/availabilityzones_test.go
@@ -1,0 +1,29 @@
+//go:build acceptance || blockstorage
+// +build acceptance blockstorage
+
+package v3
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/acceptance/clients"
+	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/availabilityzones"
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestAvailabilityZonesList(t *testing.T) {
+	clients.RequireLong(t)
+
+	client, err := clients.NewBlockStorageV3Client()
+	th.AssertNoErr(t, err)
+
+	allPages, err := availabilityzones.List(client).AllPages()
+	th.AssertNoErr(t, err)
+
+	zones, err := availabilityzones.ExtractAvailabilityZones(allPages)
+	th.AssertNoErr(t, err)
+
+	if len(zones) == 0 {
+		t.Fatal("At least one availability zone was expected to be found")
+	}
+}

--- a/openstack/blockstorage/v3/availabilityzones/doc.go
+++ b/openstack/blockstorage/v3/availabilityzones/doc.go
@@ -1,0 +1,21 @@
+/*
+Package availabilityzones provides information and interaction with the
+availability zone API in the Openstack Block Storage service.
+
+Example to list availability zones
+
+	allPages, err := availabilityzones.List(client).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allAavailabilityZones, err := availabilityzones.ExtractAvailabilityZone(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, availabilityZone := range allAvailabilityZones{
+		fmt.Printf("List: %+v\n", availabilityZone)
+	}
+*/
+package availabilityzones

--- a/openstack/blockstorage/v3/availabilityzones/requests.go
+++ b/openstack/blockstorage/v3/availabilityzones/requests.go
@@ -1,0 +1,13 @@
+package availabilityzones
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// List will return the existing availability zones.
+func List(client *gophercloud.ServiceClient) pagination.Pager {
+	return pagination.NewPager(client, listURL(client), func(r pagination.PageResult) pagination.Page {
+		return AvailabilityZonePage{pagination.SinglePageBase(r)}
+	})
+}

--- a/openstack/blockstorage/v3/availabilityzones/results.go
+++ b/openstack/blockstorage/v3/availabilityzones/results.go
@@ -1,0 +1,36 @@
+package availabilityzones
+
+import (
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// AvailabilityZoneState contains the state information associated with an
+// OpenStack Block Storage AvailabilityZone.
+type AvailabilityZoneState struct {
+	// Whether the availability zone is available.
+	Available bool `json:"available"`
+}
+
+// AvailabilityZone contains all the information associated with an OpenStack
+// Block Storage AvailabilityZone.
+type AvailabilityZone struct {
+	// The name of the availability zone.
+	Name string `json:"zoneName"`
+	// The state of the availability zone.
+	State AvailabilityZoneState `json:"zoneState"`
+}
+
+// AvailabilityZonePage contains a single page of all Availability Zones.
+type AvailabilityZonePage struct {
+	pagination.SinglePageBase
+}
+
+// ExtractAvailabilityZones will remove the envelope from the response and get
+// the AvailabilityZone objects.
+func ExtractAvailabilityZones(r pagination.Page) ([]AvailabilityZone, error) {
+	var a struct {
+		AvailabilityZones []AvailabilityZone `json:"availabilityZoneInfo"`
+	}
+	err := (r.(AvailabilityZonePage)).ExtractInto(&a)
+	return a.AvailabilityZones, err
+}

--- a/openstack/blockstorage/v3/availabilityzones/testing/doc.go
+++ b/openstack/blockstorage/v3/availabilityzones/testing/doc.go
@@ -1,0 +1,2 @@
+// Package testing for availabilityzones_v3
+package testing

--- a/openstack/blockstorage/v3/availabilityzones/testing/fixtures.go
+++ b/openstack/blockstorage/v3/availabilityzones/testing/fixtures.go
@@ -1,0 +1,32 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	th "github.com/gophercloud/gophercloud/testhelper"
+	fake "github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func MockListResponse(t *testing.T) {
+	th.Mux.HandleFunc("/os-availability-zone", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, `
+        {
+            "availabilityZoneInfo": [
+                {
+                    "zoneName": "nova",
+                    "zoneState": {
+                        "available": true
+                    }
+                }
+           ]
+        }`)
+	})
+}

--- a/openstack/blockstorage/v3/availabilityzones/testing/requests_test.go
+++ b/openstack/blockstorage/v3/availabilityzones/testing/requests_test.go
@@ -1,0 +1,30 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/availabilityzones"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+// Verifies that availability zones can be listed correctly
+func TestList(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockListResponse(t)
+
+	allPages, err := availabilityzones.List(client.ServiceClient()).AllPages()
+	th.AssertNoErr(t, err)
+	actual, err := availabilityzones.ExtractAvailabilityZones(allPages)
+	th.AssertNoErr(t, err)
+	expected := []availabilityzones.AvailabilityZone{
+		{
+			Name:  "nova",
+			State: availabilityzones.AvailabilityZoneState{Available: true},
+		},
+	}
+
+	th.CheckDeepEquals(t, expected, actual)
+}

--- a/openstack/blockstorage/v3/availabilityzones/urls.go
+++ b/openstack/blockstorage/v3/availabilityzones/urls.go
@@ -1,0 +1,7 @@
+package availabilityzones
+
+import "github.com/gophercloud/gophercloud"
+
+func listURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("os-availability-zone")
+}


### PR DESCRIPTION
Fixes #2590

- [python-cinderclient](https://github.com/openstack/python-cinderclient/blob/master/cinderclient/v3/availability_zones.py)
- [openstacksdk](https://github.com/openstack/openstacksdk/blob/master/openstack/block_storage/v3/availability_zone.py)
