### PR TITLE
Make TestMTUNetworkCRUDL deterministic

### DIFF
--- a/acceptance/openstack/networking/v2/extensions/mtu/mtu_test.go
+++ b/acceptance/openstack/networking/v2/extensions/mtu/mtu_test.go
@@ -129,6 +129,7 @@ func TestMTUNetworkCRUDL(t *testing.T) {
 		th.AssertNoErr(t, err)
 
 		tools.PrintResource(t, getNewNetwork)
-		th.AssertDeepEquals(t, newNetwork, getNewNetwork)
+		th.AssertEquals(t, getNewNetwork.Description, newNetworkDescription)
+		th.AssertEquals(t, getNewNetwork.MTU, newNetworkMTU)
 	}
 }


### PR DESCRIPTION
It seems the MTU update API does not returned an object with the `updated_at` field to it's new value. This can cause our test to fail if we check the return of the Update function against the same object retrieved from a Get call, as the `updated_at` field can differ.

Instead, just checked for the fields we change in this test.

Fix #2592