### PR TITLE
keystone: add v3 limits get operation

### DIFF
--- a/acceptance/openstack/identity/v3/limits_test.go
+++ b/acceptance/openstack/identity/v3/limits_test.go
@@ -41,7 +41,7 @@ func TestLimitsList(t *testing.T) {
 	th.AssertNoErr(t, err)
 }
 
-func TestCreateLimits(t *testing.T) {
+func TestLimitsCRUD(t *testing.T) {
 	// TODO: After https://github.com/gophercloud/gophercloud/issues/2290 is implemented
 	// use registered limits API to create global registered limit and then overwrite it with limit.
 	// Current solution (using glance limit) only works with Openstack Xena and above.
@@ -97,4 +97,9 @@ func TestCreateLimits(t *testing.T) {
 	th.AssertEquals(t, serviceID, createdLimits[0].ServiceID)
 	th.AssertEquals(t, project.ID, createdLimits[0].ProjectID)
 
+	limitID := createdLimits[0].ID
+
+	limit, err := limits.Get(client, limitID).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, createdLimits[0], *limit)
 }

--- a/openstack/identity/v3/limits/doc.go
+++ b/openstack/identity/v3/limits/doc.go
@@ -48,5 +48,12 @@ Example to Create Limits
 	if err != nil {
 		panic(err)
 	}
+
+Example to Get a Limit
+
+	limit, err := limits.Get(identityClient, "25a04c7a065c430590881c646cdcdd58").Extract()
+	if err != nil {
+		panic(err)
+	}
 */
 package limits

--- a/openstack/identity/v3/limits/requests.go
+++ b/openstack/identity/v3/limits/requests.go
@@ -119,3 +119,10 @@ func BatchCreate(client *gophercloud.ServiceClient, opts BatchCreateOptsBuilder)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
+
+// Get retrieves details on a single limit, by ID.
+func Get(client *gophercloud.ServiceClient, limitID string) (r GetResult) {
+	resp, err := client.Get(resourceURL(client, limitID), &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}

--- a/openstack/identity/v3/limits/results.go
+++ b/openstack/identity/v3/limits/results.go
@@ -64,6 +64,11 @@ type LimitsOutput struct {
 	Limits []Limit `json:"limits"`
 }
 
+// A LimitOutput is an encapsulated Limit returned by Get and Update operations
+type LimitOutput struct {
+	Limit *Limit `json:"limit"`
+}
+
 // LimitPage is a single page of Limit results.
 type LimitPage struct {
 	pagination.LinkedPageBase
@@ -73,6 +78,16 @@ type LimitPage struct {
 // to interpret it as a Limits.
 type CreateResult struct {
 	gophercloud.Result
+}
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// GetResult is the response from a Get operation. Call its Extract method
+// to interpret it as a Limit.
+type GetResult struct {
+	commonResult
 }
 
 // IsEmpty determines whether or not a page of Limits contains any results.
@@ -113,4 +128,11 @@ func (r CreateResult) Extract() ([]Limit, error) {
 	var out LimitsOutput
 	err := r.ExtractInto(&out)
 	return out.Limits, err
+}
+
+// Extract interprets any commonResult as a Limit.
+func (r commonResult) Extract() (*Limit, error) {
+	var out LimitOutput
+	err := r.ExtractInto(&out)
+	return out.Limit, err
 }

--- a/openstack/identity/v3/limits/testing/fixtures.go
+++ b/openstack/identity/v3/limits/testing/fixtures.go
@@ -79,6 +79,23 @@ const CreateRequest = `
 }
 `
 
+const GetOutput = `
+{
+    "limit": {
+        "resource_name": "volume",
+        "region_id": null,
+        "links": {
+            "self": "http://10.3.150.25/identity/v3/limits/25a04c7a065c430590881c646cdcdd58"
+        },
+        "service_id": "9408080f1970482aa0e38bc2d4ea34b7",
+        "project_id": "3a705b9f56bb439381b43c4fe59dccce",
+        "id": "25a04c7a065c430590881c646cdcdd58",
+        "resource_limit": 11,
+        "description": "Number of volumes for project 3a705b9f56bb439381b43c4fe59dccce"
+    }
+}
+`
+
 // Model is the enforcement model in the GetEnforcementModel request.
 var Model = limits.EnforcementModel{
 	Name:        "flat",
@@ -154,5 +171,19 @@ func HandleCreateLimitSuccessfully(t *testing.T) {
 
 		w.WriteHeader(http.StatusCreated)
 		fmt.Fprintf(w, CreateOutput)
+	})
+}
+
+// HandleGetLimitSuccessfully creates an HTTP handler at `/limits` on the
+// test handler mux that responds with a single limit.
+func HandleGetLimitSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/limits/25a04c7a065c430590881c646cdcdd58", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, GetOutput)
 	})
 }

--- a/openstack/identity/v3/limits/testing/requests_test.go
+++ b/openstack/identity/v3/limits/testing/requests_test.go
@@ -77,3 +77,13 @@ func TestCreateLimits(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.CheckDeepEquals(t, ExpectedLimitsSlice, actual)
 }
+
+func TestGetLimit(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleGetLimitSuccessfully(t)
+
+	actual, err := limits.Get(client.ServiceClient(), "25a04c7a065c430590881c646cdcdd58").Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, FirstLimit, *actual)
+}

--- a/openstack/identity/v3/limits/urls.go
+++ b/openstack/identity/v3/limits/urls.go
@@ -14,3 +14,7 @@ func enforcementModelURL(client *gophercloud.ServiceClient) string {
 func rootURL(client *gophercloud.ServiceClient) string {
 	return client.ServiceURL(rootPath)
 }
+
+func resourceURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL(rootPath, id)
+}


### PR DESCRIPTION
For https://github.com/gophercloud/gophercloud/issues/2289

[docs](https://docs.openstack.org/api-ref/identity/v3/#show-limit-details)
[code](https://github.com/openstack/keystone/blob/stable/yoga/keystone/api/limits.py#L92)