### PR TITLE
Drop train and ussuri jobs

### DIFF
--- a/.github/workflows/functional-baremetal.yaml
+++ b/.github/workflows/functional-baremetal.yaml
@@ -29,9 +29,6 @@ jobs:
           - name: "victoria"
             openstack_version: "stable/victoria"
             ubuntu_version: "20.04"
-          - name: "ussuri"
-            openstack_version: "stable/ussuri"
-            ubuntu_version: "18.04"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with Ironic and run baremetal acceptance tests
     steps:

--- a/.github/workflows/functional-basic.yaml
+++ b/.github/workflows/functional-basic.yaml
@@ -32,12 +32,6 @@ jobs:
           - name: "victoria"
             openstack_version: "stable/victoria"
             ubuntu_version: "20.04"
-          - name: "ussuri"
-            openstack_version: "stable/ussuri"
-            ubuntu_version: "18.04"
-          - name: "train"
-            openstack_version: "stable/train"
-            ubuntu_version: "18.04"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with defaults and run basic acceptance tests
     steps:

--- a/.github/workflows/functional-blockstorage.yaml
+++ b/.github/workflows/functional-blockstorage.yaml
@@ -29,12 +29,6 @@ jobs:
           - name: "victoria"
             openstack_version: "stable/victoria"
             ubuntu_version: "20.04"
-          - name: "ussuri"
-            openstack_version: "stable/ussuri"
-            ubuntu_version: "18.04"
-          - name: "train"
-            openstack_version: "stable/train"
-            ubuntu_version: "18.04"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with Cinder and run blockstorage acceptance tests
     steps:

--- a/.github/workflows/functional-clustering.yaml
+++ b/.github/workflows/functional-clustering.yaml
@@ -29,12 +29,6 @@ jobs:
           - name: "victoria"
             openstack_version: "stable/victoria"
             ubuntu_version: "20.04"
-          - name: "ussuri"
-            openstack_version: "stable/ussuri"
-            ubuntu_version: "18.04"
-          - name: "train"
-            openstack_version: "stable/train"
-            ubuntu_version: "18.04"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with Senlin and run clustering acceptance tests
     steps:

--- a/.github/workflows/functional-compute.yaml
+++ b/.github/workflows/functional-compute.yaml
@@ -29,12 +29,6 @@ jobs:
           - name: "victoria"
             openstack_version: "stable/victoria"
             ubuntu_version: "20.04"
-          - name: "ussuri"
-            openstack_version: "stable/ussuri"
-            ubuntu_version: "18.04"
-          - name: "train"
-            openstack_version: "stable/train"
-            ubuntu_version: "18.04"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with Nova and run compute acceptance tests
     steps:

--- a/.github/workflows/functional-containerinfra.yaml
+++ b/.github/workflows/functional-containerinfra.yaml
@@ -41,16 +41,6 @@ jobs:
             ubuntu_version: "20.04"
             devstack_conf_overrides: |
               enable_plugin magnum https://github.com/openstack/magnum stable/victoria
-          - name: "ussuri"
-            openstack_version: "stable/ussuri"
-            ubuntu_version: "18.04"
-            devstack_conf_overrides: |
-              enable_plugin magnum https://github.com/openstack/magnum ussuri-eol
-          - name: "train"
-            openstack_version: "stable/train"
-            ubuntu_version: "18.04"
-            devstack_conf_overrides: |
-              enable_plugin magnum https://github.com/openstack/magnum train-eol
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with Magnum and run containerinfra acceptance tests
     steps:

--- a/.github/workflows/functional-dns.yaml
+++ b/.github/workflows/functional-dns.yaml
@@ -42,16 +42,6 @@ jobs:
             ubuntu_version: "20.04"
             devstack_conf_overrides: |
               enable_plugin designate https://github.com/openstack/designate stable/victoria
-          - name: "ussuri"
-            openstack_version: "stable/ussuri"
-            ubuntu_version: "18.04"
-            devstack_conf_overrides: |
-              enable_plugin designate https://github.com/openstack/designate stable/ussuri
-          - name: "train"
-            openstack_version: "stable/train"
-            ubuntu_version: "18.04"
-            devstack_conf_overrides: |
-              enable_plugin designate https://github.com/openstack/designate train-eol
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with Designate and run dns acceptance tests
     steps:

--- a/.github/workflows/functional-identity.yaml
+++ b/.github/workflows/functional-identity.yaml
@@ -29,12 +29,6 @@ jobs:
           - name: "victoria"
             openstack_version: "stable/victoria"
             ubuntu_version: "20.04"
-          - name: "ussuri"
-            openstack_version: "stable/ussuri"
-            ubuntu_version: "18.04"
-          - name: "train"
-            openstack_version: "stable/train"
-            ubuntu_version: "18.04"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with Keystone and run identity acceptance tests
     steps:

--- a/.github/workflows/functional-imageservice.yaml
+++ b/.github/workflows/functional-imageservice.yaml
@@ -29,12 +29,6 @@ jobs:
           - name: "victoria"
             openstack_version: "stable/victoria"
             ubuntu_version: "20.04"
-          - name: "ussuri"
-            openstack_version: "stable/ussuri"
-            ubuntu_version: "18.04"
-          - name: "train"
-            openstack_version: "stable/train"
-            ubuntu_version: "18.04"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with Glance and run imageservice acceptance tests
     steps:

--- a/.github/workflows/functional-keymanager.yaml
+++ b/.github/workflows/functional-keymanager.yaml
@@ -29,12 +29,6 @@ jobs:
           - name: "victoria"
             openstack_version: "stable/victoria"
             ubuntu_version: "20.04"
-          - name: "ussuri"
-            openstack_version: "stable/ussuri"
-            ubuntu_version: "18.04"
-          - name: "train"
-            openstack_version: "stable/train"
-            ubuntu_version: "18.04"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with Barbican and run keymanager acceptance tests
     steps:

--- a/.github/workflows/functional-loadbalancer.yaml
+++ b/.github/workflows/functional-loadbalancer.yaml
@@ -29,12 +29,6 @@ jobs:
           - name: "victoria"
             openstack_version: "stable/victoria"
             ubuntu_version: "20.04"
-          - name: "ussuri"
-            openstack_version: "stable/ussuri"
-            ubuntu_version: "18.04"
-          - name: "train"
-            openstack_version: "stable/train"
-            ubuntu_version: "18.04"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with Octavia and run loadbalancer acceptance tests
     steps:

--- a/.github/workflows/functional-messaging.yaml
+++ b/.github/workflows/functional-messaging.yaml
@@ -29,12 +29,6 @@ jobs:
           - name: "victoria"
             openstack_version: "stable/victoria"
             ubuntu_version: "20.04"
-          - name: "ussuri"
-            openstack_version: "stable/ussuri"
-            ubuntu_version: "18.04"
-          - name: "train"
-            openstack_version: "stable/train"
-            ubuntu_version: "18.04"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with Zaqar and run messaging acceptance tests
     steps:

--- a/.github/workflows/functional-networking.yaml
+++ b/.github/workflows/functional-networking.yaml
@@ -47,20 +47,6 @@ jobs:
             devstack_conf_overrides: |
               enable_plugin neutron-dynamic-routing https://github.com/openstack/neutron-dynamic-routing stable/victoria
               enable_plugin neutron-vpnaas https://github.com/openstack/neutron-vpnaas stable/victoria
-          - name: "ussuri"
-            openstack_version: "stable/ussuri"
-            ubuntu_version: "18.04"
-            devstack_conf_overrides: |
-              enable_plugin neutron-fwaas https://github.com/openstack/neutron-fwaas stable/ussuri
-              enable_plugin neutron-dynamic-routing https://github.com/openstack/neutron-dynamic-routing stable/ussuri
-              enable_plugin neutron-vpnaas https://github.com/openstack/neutron-vpnaas ussuri-eol
-          - name: "train"
-            openstack_version: "stable/train"
-            ubuntu_version: "18.04"
-            devstack_conf_overrides: |
-              enable_plugin neutron-fwaas https://github.com/openstack/neutron-fwaas stable/train
-              enable_plugin neutron-dynamic-routing https://github.com/openstack/neutron-dynamic-routing train-eol
-              enable_plugin neutron-vpnaas https://github.com/openstack/neutron-vpnaas train-eol
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with Neutron and run networking acceptance tests
     steps:

--- a/.github/workflows/functional-objectstorage.yaml
+++ b/.github/workflows/functional-objectstorage.yaml
@@ -29,12 +29,6 @@ jobs:
           - name: "victoria"
             openstack_version: "stable/victoria"
             ubuntu_version: "20.04"
-          - name: "ussuri"
-            openstack_version: "stable/ussuri"
-            ubuntu_version: "18.04"
-          - name: "train"
-            openstack_version: "stable/train"
-            ubuntu_version: "18.04"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with Swift and run objectstorage acceptance tests
     steps:

--- a/.github/workflows/functional-orchestration.yaml
+++ b/.github/workflows/functional-orchestration.yaml
@@ -29,12 +29,6 @@ jobs:
           - name: "victoria"
             openstack_version: "stable/victoria"
             ubuntu_version: "20.04"
-          - name: "ussuri"
-            openstack_version: "stable/ussuri"
-            ubuntu_version: "18.04"
-          - name: "train"
-            openstack_version: "stable/train"
-            ubuntu_version: "18.04"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with Heat and run orchestration acceptance tests
     steps:

--- a/.github/workflows/functional-placement.yaml
+++ b/.github/workflows/functional-placement.yaml
@@ -29,12 +29,6 @@ jobs:
           - name: "victoria"
             openstack_version: "stable/victoria"
             ubuntu_version: "20.04"
-          - name: "ussuri"
-            openstack_version: "stable/ussuri"
-            ubuntu_version: "18.04"
-          - name: "train"
-            openstack_version: "stable/train"
-            ubuntu_version: "18.04"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with Placement and run placement acceptance tests
     steps:

--- a/.github/workflows/functional-sharedfilesystems.yaml
+++ b/.github/workflows/functional-sharedfilesystems.yaml
@@ -29,12 +29,6 @@ jobs:
           - name: "victoria"
             openstack_version: "stable/victoria"
             ubuntu_version: "20.04"
-          - name: "ussuri"
-            openstack_version: "stable/ussuri"
-            ubuntu_version: "18.04"
-          - name: "train"
-            openstack_version: "stable/train"
-            ubuntu_version: "18.04"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with Manila and run sharedfilesystems acceptance tests
     steps:


### PR DESCRIPTION
The Ubuntu 18.04 image for github action runner was deprecated [1]. Ubuntu is is unfortunately the only linux image available as a github action runner and using a more recent version of ubuntu to run the train and ussuri jobs proved to be impracticable [2]. We're forced to retire those jobs.

[1] https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/
[2] https://github.com/gophercloud/gophercloud/pull/2585
