### PR TITLE
Add PUT/HEAD/DELETE for indentity/v3/OS-INHERIT

### DIFF
--- a/acceptance/openstack/identity/v3/osinherit_test.go
+++ b/acceptance/openstack/identity/v3/osinherit_test.go
@@ -1,0 +1,171 @@
+//go:build acceptance
+// +build acceptance
+
+package v3
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/acceptance/clients"
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/domains"
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/groups"
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/osinherit"
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/roles"
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestInheritRolesAssignToUserOnProject(t *testing.T) {
+	clients.RequireAdmin(t)
+
+	client, err := clients.NewIdentityV3Client()
+	th.AssertNoErr(t, err)
+
+	project, err := CreateProject(t, client, nil)
+	th.AssertNoErr(t, err)
+	defer DeleteProject(t, client, project.ID)
+
+	roleCreateOpts := roles.CreateOpts{
+		DomainID: "default",
+	}
+	role, err := CreateRole(t, client, &roleCreateOpts)
+	th.AssertNoErr(t, err)
+	defer DeleteRole(t, client, role.ID)
+
+	user, err := CreateUser(t, client, nil)
+	th.AssertNoErr(t, err)
+	defer DeleteUser(t, client, user.ID)
+
+	t.Logf("Attempting to assign an inherited role %s to a user %s on a project %s",
+		role.Name, user.Name, project.Name)
+
+	assignOpts := osinherit.AssignOpts{
+		UserID:    user.ID,
+		ProjectID: project.ID,
+	}
+	err = osinherit.Assign(client, role.ID, assignOpts).ExtractErr()
+	th.AssertNoErr(t, err)
+
+	t.Logf("Successfully assigned a role %s to a user %s on a project %s",
+		role.Name, user.Name, project.Name)
+
+}
+
+func TestInheritRolesAssignToUserOnDomain(t *testing.T) {
+	clients.RequireAdmin(t)
+
+	client, err := clients.NewIdentityV3Client()
+	th.AssertNoErr(t, err)
+
+	domain, err := CreateDomain(t, client, &domains.CreateOpts{
+		Enabled: gophercloud.Disabled,
+	})
+	th.AssertNoErr(t, err)
+	defer DeleteDomain(t, client, domain.ID)
+
+	roleCreateOpts := roles.CreateOpts{
+		DomainID: "default",
+	}
+	role, err := CreateRole(t, client, &roleCreateOpts)
+	th.AssertNoErr(t, err)
+	defer DeleteRole(t, client, role.ID)
+
+	user, err := CreateUser(t, client, nil)
+	th.AssertNoErr(t, err)
+	defer DeleteUser(t, client, user.ID)
+
+	t.Logf("Attempting to assign a role %s to a user %s on a domain %s",
+		role.Name, user.Name, domain.Name)
+
+	assignOpts := osinherit.AssignOpts{
+		UserID:   user.ID,
+		DomainID: domain.ID,
+	}
+
+	err = osinherit.Assign(client, role.ID, assignOpts).ExtractErr()
+	th.AssertNoErr(t, err)
+
+	t.Logf("Successfully assigned a role %s to a user %s on a domain %s",
+		role.Name, user.Name, domain.Name)
+
+}
+
+func TestInheritRolesAssignToGroupOnDomain(t *testing.T) {
+	clients.RequireAdmin(t)
+
+	client, err := clients.NewIdentityV3Client()
+	th.AssertNoErr(t, err)
+
+	domain, err := CreateDomain(t, client, &domains.CreateOpts{
+		Enabled: gophercloud.Disabled,
+	})
+	th.AssertNoErr(t, err)
+	defer DeleteDomain(t, client, domain.ID)
+
+	roleCreateOpts := roles.CreateOpts{
+		DomainID: "default",
+	}
+	role, err := CreateRole(t, client, &roleCreateOpts)
+	th.AssertNoErr(t, err)
+	defer DeleteRole(t, client, role.ID)
+
+	groupCreateOpts := &groups.CreateOpts{
+		DomainID: "default",
+	}
+	group, err := CreateGroup(t, client, groupCreateOpts)
+	th.AssertNoErr(t, err)
+	defer DeleteGroup(t, client, group.ID)
+
+	t.Logf("Attempting to assign a role %s to a group %s on a domain %s",
+		role.Name, group.Name, domain.Name)
+
+	assignOpts := osinherit.AssignOpts{
+		GroupID:  group.ID,
+		DomainID: domain.ID,
+	}
+
+	err = osinherit.Assign(client, role.ID, assignOpts).ExtractErr()
+	th.AssertNoErr(t, err)
+
+	t.Logf("Successfully assigned a role %s to a group %s on a domain %s",
+		role.Name, group.Name, domain.Name)
+}
+
+func TestInheritRolesAssignToGroupOnProject(t *testing.T) {
+	clients.RequireAdmin(t)
+
+	client, err := clients.NewIdentityV3Client()
+	th.AssertNoErr(t, err)
+
+	project, err := CreateProject(t, client, nil)
+	th.AssertNoErr(t, err)
+	defer DeleteProject(t, client, project.ID)
+
+	roleCreateOpts := roles.CreateOpts{
+		DomainID: "default",
+	}
+	role, err := CreateRole(t, client, &roleCreateOpts)
+	th.AssertNoErr(t, err)
+	defer DeleteRole(t, client, role.ID)
+
+	groupCreateOpts := &groups.CreateOpts{
+		DomainID: "default",
+	}
+	group, err := CreateGroup(t, client, groupCreateOpts)
+	th.AssertNoErr(t, err)
+	defer DeleteGroup(t, client, group.ID)
+
+	t.Logf("Attempting to assign a role %s to a group %s on a project %s",
+		role.Name, group.Name, project.Name)
+
+	assignOpts := osinherit.AssignOpts{
+		GroupID:   group.ID,
+		ProjectID: project.ID,
+	}
+	err = osinherit.Assign(client, role.ID, assignOpts).ExtractErr()
+	th.AssertNoErr(t, err)
+
+	t.Logf("Successfully assigned a role %s to a group %s on a project %s",
+		role.Name, group.Name, project.Name)
+
+}

--- a/acceptance/openstack/identity/v3/osinherit_test.go
+++ b/acceptance/openstack/identity/v3/osinherit_test.go
@@ -59,6 +59,16 @@ func TestInheritRolesAssignToUserOnProject(t *testing.T) {
 	t.Logf("Successfully validated inherited role %s to a user %s on a project %s",
 		role.Name, user.Name, project.Name)
 
+	unassignOpts := osinherit.UnassignOpts{
+		UserID:    user.ID,
+		ProjectID: project.ID,
+	}
+	err = osinherit.Unassign(client, role.ID, unassignOpts).ExtractErr()
+	th.AssertNoErr(t, err)
+
+	t.Logf("Successfully unassgined inherited role %s to a user %s on a project %s",
+		role.Name, user.Name, project.Name)
+
 }
 
 func TestInheritRolesAssignToUserOnDomain(t *testing.T) {
@@ -107,6 +117,17 @@ func TestInheritRolesAssignToUserOnDomain(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	t.Logf("Successfully validated inherited role %s to a user %s on a domain %s",
+		role.Name, user.Name, domain.Name)
+
+	unassignOpts := osinherit.UnassignOpts{
+		UserID:   user.ID,
+		DomainID: domain.ID,
+	}
+
+	err = osinherit.Unassign(client, role.ID, unassignOpts).ExtractErr()
+	th.AssertNoErr(t, err)
+
+	t.Logf("Successfully unassigned inherited role %s to a user %s on a domain %s",
 		role.Name, user.Name, domain.Name)
 
 }
@@ -162,6 +183,17 @@ func TestInheritRolesAssignToGroupOnDomain(t *testing.T) {
 	t.Logf("Successfully validated inherited role %s to a group %s on a domain %s",
 		role.Name, group.Name, domain.Name)
 
+	unassignOpts := osinherit.UnassignOpts{
+		GroupID:  group.ID,
+		DomainID: domain.ID,
+	}
+
+	err = osinherit.Unassign(client, role.ID, unassignOpts).ExtractErr()
+	th.AssertNoErr(t, err)
+
+	t.Logf("Successfully unassigned inherited role %s to a group %s on a domain %s",
+		role.Name, group.Name, domain.Name)
+
 }
 
 func TestInheritRolesAssignToGroupOnProject(t *testing.T) {
@@ -209,6 +241,16 @@ func TestInheritRolesAssignToGroupOnProject(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	t.Logf("Successfully validated inherited role %s to a group %s on a project %s",
+		role.Name, group.Name, project.Name)
+
+	unassignOpts := osinherit.UnassignOpts{
+		GroupID:   group.ID,
+		ProjectID: project.ID,
+	}
+	err = osinherit.Unassign(client, role.ID, unassignOpts).ExtractErr()
+	th.AssertNoErr(t, err)
+
+	t.Logf("Successfully unassgined inherited role %s to a group %s on a project %s",
 		role.Name, group.Name, project.Name)
 
 }

--- a/acceptance/openstack/identity/v3/osinherit_test.go
+++ b/acceptance/openstack/identity/v3/osinherit_test.go
@@ -66,7 +66,7 @@ func TestInheritRolesAssignToUserOnProject(t *testing.T) {
 	err = osinherit.Unassign(client, role.ID, unassignOpts).ExtractErr()
 	th.AssertNoErr(t, err)
 
-	t.Logf("Successfully unassgined inherited role %s to a user %s on a project %s",
+	t.Logf("Successfully unassigned inherited role %s to a user %s on a project %s",
 		role.Name, user.Name, project.Name)
 
 }
@@ -250,7 +250,7 @@ func TestInheritRolesAssignToGroupOnProject(t *testing.T) {
 	err = osinherit.Unassign(client, role.ID, unassignOpts).ExtractErr()
 	th.AssertNoErr(t, err)
 
-	t.Logf("Successfully unassgined inherited role %s to a group %s on a project %s",
+	t.Logf("Successfully unassigned inherited role %s to a group %s on a project %s",
 		role.Name, group.Name, project.Name)
 
 }

--- a/acceptance/openstack/identity/v3/osinherit_test.go
+++ b/acceptance/openstack/identity/v3/osinherit_test.go
@@ -49,6 +49,16 @@ func TestInheritRolesAssignToUserOnProject(t *testing.T) {
 	t.Logf("Successfully assigned a role %s to a user %s on a project %s",
 		role.Name, user.Name, project.Name)
 
+	validateOpts := osinherit.ValidateOpts{
+		UserID:    user.ID,
+		ProjectID: project.ID,
+	}
+	err = osinherit.Validate(client, role.ID, validateOpts).ExtractErr()
+	th.AssertNoErr(t, err)
+
+	t.Logf("Successfully validated inherited role %s to a user %s on a project %s",
+		role.Name, user.Name, project.Name)
+
 }
 
 func TestInheritRolesAssignToUserOnDomain(t *testing.T) {
@@ -86,6 +96,17 @@ func TestInheritRolesAssignToUserOnDomain(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	t.Logf("Successfully assigned a role %s to a user %s on a domain %s",
+		role.Name, user.Name, domain.Name)
+
+	validateOpts := osinherit.ValidateOpts{
+		UserID:   user.ID,
+		DomainID: domain.ID,
+	}
+
+	err = osinherit.Validate(client, role.ID, validateOpts).ExtractErr()
+	th.AssertNoErr(t, err)
+
+	t.Logf("Successfully validated inherited role %s to a user %s on a domain %s",
 		role.Name, user.Name, domain.Name)
 
 }
@@ -129,6 +150,18 @@ func TestInheritRolesAssignToGroupOnDomain(t *testing.T) {
 
 	t.Logf("Successfully assigned a role %s to a group %s on a domain %s",
 		role.Name, group.Name, domain.Name)
+
+	validateOpts := osinherit.ValidateOpts{
+		GroupID:  group.ID,
+		DomainID: domain.ID,
+	}
+
+	err = osinherit.Validate(client, role.ID, validateOpts).ExtractErr()
+	th.AssertNoErr(t, err)
+
+	t.Logf("Successfully validated inherited role %s to a group %s on a domain %s",
+		role.Name, group.Name, domain.Name)
+
 }
 
 func TestInheritRolesAssignToGroupOnProject(t *testing.T) {
@@ -166,6 +199,16 @@ func TestInheritRolesAssignToGroupOnProject(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	t.Logf("Successfully assigned a role %s to a group %s on a project %s",
+		role.Name, group.Name, project.Name)
+
+	validateOpts := osinherit.ValidateOpts{
+		GroupID:   group.ID,
+		ProjectID: project.ID,
+	}
+	err = osinherit.Validate(client, role.ID, validateOpts).ExtractErr()
+	th.AssertNoErr(t, err)
+
+	t.Logf("Successfully validated inherited role %s to a group %s on a project %s",
 		role.Name, group.Name, project.Name)
 
 }

--- a/openstack/identity/v3/osinherit/doc.go
+++ b/openstack/identity/v3/osinherit/doc.go
@@ -31,5 +31,20 @@ Example to Assign a Inherited Role to a User to a Project's subtree
 	if err != nil {
 		panic(err)
 	}
+
+Example to validate a Inherited Role to a User to a Project's subtree
+
+	projectID := "a99e9b4e620e4db09a2dfb6e42a01e66"
+	userID := "9df1a02f5eb2416a9781e8b0c022d3ae"
+	roleID := "9fe2ff9ee4384b1894a90878d3e92bab"
+
+	err := osinherit.Assign(identityClient, roleID, osinherit.AssignOpts{
+		UserID:    userID,
+		ProjectID: projectID,
+	}).ExtractErr()
+
+	if err != nil {
+		panic(err)
+	}
 */
 package osinherit

--- a/openstack/identity/v3/osinherit/doc.go
+++ b/openstack/identity/v3/osinherit/doc.go
@@ -38,7 +38,22 @@ Example to validate a Inherited Role to a User to a Project's subtree
 	userID := "9df1a02f5eb2416a9781e8b0c022d3ae"
 	roleID := "9fe2ff9ee4384b1894a90878d3e92bab"
 
-	err := osinherit.Assign(identityClient, roleID, osinherit.AssignOpts{
+	err := osinherit.Validate(identityClient, roleID, osinherit.validateOpts{
+		UserID:    userID,
+		ProjectID: projectID,
+	}).ExtractErr()
+
+	if err != nil {
+		panic(err)
+	}
+
+Example to unassign a Inherited Role to a User to a Project's subtree
+
+	projectID := "a99e9b4e620e4db09a2dfb6e42a01e66"
+	userID := "9df1a02f5eb2416a9781e8b0c022d3ae"
+	roleID := "9fe2ff9ee4384b1894a90878d3e92bab"
+
+	err := osinherit.Unassign(identityClient, roleID, osinherit.UnassignOpts{
 		UserID:    userID,
 		ProjectID: projectID,
 	}).ExtractErr()

--- a/openstack/identity/v3/osinherit/doc.go
+++ b/openstack/identity/v3/osinherit/doc.go
@@ -1,0 +1,35 @@
+/*
+Package osinherit enables projects to inherit role assignments from
+either their owning domain or projects that are higher in the hierarchy.
+
+Example to Assign a Inherited Role to a User to a Domain
+
+	domainID := "a99e9b4e620e4db09a2dfb6e42a01e66"
+	userID := "9df1a02f5eb2416a9781e8b0c022d3ae"
+	roleID := "9fe2ff9ee4384b1894a90878d3e92bab"
+
+	err := osinherit.Assign(identityClient, roleID, osinherit.AssignOpts{
+		UserID:   userID,
+		domainID: domainID,
+	}).ExtractErr()
+
+	if err != nil {
+		panic(err)
+	}
+
+Example to Assign a Inherited Role to a User to a Project's subtree
+
+	projectID := "a99e9b4e620e4db09a2dfb6e42a01e66"
+	userID := "9df1a02f5eb2416a9781e8b0c022d3ae"
+	roleID := "9fe2ff9ee4384b1894a90878d3e92bab"
+
+	err := osinherit.Assign(identityClient, roleID, osinherit.AssignOpts{
+		UserID:    userID,
+		ProjectID: projectID,
+	}).ExtractErr()
+
+	if err != nil {
+		panic(err)
+	}
+*/
+package osinherit

--- a/openstack/identity/v3/osinherit/requests.go
+++ b/openstack/identity/v3/osinherit/requests.go
@@ -1,0 +1,60 @@
+package osinherit
+
+import "github.com/gophercloud/gophercloud"
+
+// AssignOpts provides options to assign a role
+type AssignOpts struct {
+	// UserID is the ID of a user to assign a inherited role
+	// Note: exactly one of UserID or GroupID must be provided
+	UserID string `xor:"GroupID"`
+
+	// GroupID is the ID of a group to assign a inherited role
+	// Note: exactly one of UserID or GroupID must be provided
+	GroupID string `xor:"UserID"`
+
+	// ProjectID is the ID of a project to assign a inherited role on
+	// Note: exactly one of ProjectID or DomainID must be provided
+	ProjectID string `xor:"DomainID"`
+
+	// DomainID is the ID of a domain to assign a inherited role on
+	// Note: exactly one of ProjectID or DomainID must be provided
+	DomainID string `xor:"ProjectID"`
+}
+
+// Assign is the operation responsible for assigning a inherited role
+// to a user/group on a project/domain.
+func Assign(client *gophercloud.ServiceClient, roleID string, opts AssignOpts) (r AssignmentResult) {
+	// Check xor conditions
+	_, err := gophercloud.BuildRequestBody(opts, "")
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	// Get corresponding URL
+	var targetID string
+	var targetType string
+	if opts.ProjectID != "" {
+		targetID = opts.ProjectID
+		targetType = "projects"
+	} else {
+		targetID = opts.DomainID
+		targetType = "domains"
+	}
+
+	var actorID string
+	var actorType string
+	if opts.UserID != "" {
+		actorID = opts.UserID
+		actorType = "users"
+	} else {
+		actorID = opts.GroupID
+		actorType = "groups"
+	}
+
+	resp, err := client.Put(assignURL(client, targetType, targetID, actorType, actorID, roleID), nil, nil, &gophercloud.RequestOpts{
+		OkCodes: []int{204},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}

--- a/openstack/identity/v3/osinherit/requests.go
+++ b/openstack/identity/v3/osinherit/requests.go
@@ -21,6 +21,25 @@ type AssignOpts struct {
 	DomainID string `xor:"ProjectID"`
 }
 
+// ValidateOpts provides options to which role to validate
+type ValidateOpts struct {
+	// UserID is the ID of a user to validate an inherited role
+	// Note: exactly one of UserID or GroupID must be provided
+	UserID string `xor:"GroupID"`
+
+	// GroupID is the ID of a group to validate an inherited role
+	// Note: exactly one of UserID or GroupID must be provided
+	GroupID string `xor:"UserID"`
+
+	// ProjectID is the ID of a project to validate an inherited role on
+	// Note: exactly one of ProjectID or DomainID must be provided
+	ProjectID string `xor:"DomainID"`
+
+	// DomainID is the ID of a domain to validate an inherited role on
+	// Note: exactly one of ProjectID or DomainID must be provided
+	DomainID string `xor:"ProjectID"`
+}
+
 // Assign is the operation responsible for assigning a inherited role
 // to a user/group on a project/domain.
 func Assign(client *gophercloud.ServiceClient, roleID string, opts AssignOpts) (r AssignmentResult) {
@@ -53,6 +72,44 @@ func Assign(client *gophercloud.ServiceClient, roleID string, opts AssignOpts) (
 	}
 
 	resp, err := client.Put(assignURL(client, targetType, targetID, actorType, actorID, roleID), nil, nil, &gophercloud.RequestOpts{
+		OkCodes: []int{204},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// Validate is the operation responsible for validating an inherited role
+// of a user/group on a project/domain.
+func Validate(client *gophercloud.ServiceClient, roleID string, opts ValidateOpts) (r ValidateResult) {
+	// Check xor conditions
+	_, err := gophercloud.BuildRequestBody(opts, "")
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	// Get corresponding URL
+	var targetID string
+	var targetType string
+	if opts.ProjectID != "" {
+		targetID = opts.ProjectID
+		targetType = "projects"
+	} else {
+		targetID = opts.DomainID
+		targetType = "domains"
+	}
+
+	var actorID string
+	var actorType string
+	if opts.UserID != "" {
+		actorID = opts.UserID
+		actorType = "users"
+	} else {
+		actorID = opts.GroupID
+		actorType = "groups"
+	}
+
+	resp, err := client.Head(assignURL(client, targetType, targetID, actorType, actorID, roleID), &gophercloud.RequestOpts{
 		OkCodes: []int{204},
 	})
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)

--- a/openstack/identity/v3/osinherit/requests.go
+++ b/openstack/identity/v3/osinherit/requests.go
@@ -2,21 +2,21 @@ package osinherit
 
 import "github.com/gophercloud/gophercloud"
 
-// AssignOpts provides options to assign a role
+// AssignOpts provides options to assign an inherited role
 type AssignOpts struct {
-	// UserID is the ID of a user to assign a inherited role
+	// UserID is the ID of a user to assign an inherited role
 	// Note: exactly one of UserID or GroupID must be provided
 	UserID string `xor:"GroupID"`
 
-	// GroupID is the ID of a group to assign a inherited role
+	// GroupID is the ID of a group to assign an inherited role
 	// Note: exactly one of UserID or GroupID must be provided
 	GroupID string `xor:"UserID"`
 
-	// ProjectID is the ID of a project to assign a inherited role on
+	// ProjectID is the ID of a project to assign an inherited role on
 	// Note: exactly one of ProjectID or DomainID must be provided
 	ProjectID string `xor:"DomainID"`
 
-	// DomainID is the ID of a domain to assign a inherited role on
+	// DomainID is the ID of a domain to assign an inherited role on
 	// Note: exactly one of ProjectID or DomainID must be provided
 	DomainID string `xor:"ProjectID"`
 }
@@ -40,7 +40,26 @@ type ValidateOpts struct {
 	DomainID string `xor:"ProjectID"`
 }
 
-// Assign is the operation responsible for assigning a inherited role
+// UnassignOpts provides options to unassign an inherited role
+type UnassignOpts struct {
+	// UserID is the ID of a user to unassign an inherited role
+	// Note: exactly one of UserID or GroupID must be provided
+	UserID string `xor:"GroupID"`
+
+	// GroupID is the ID of a group to unassign an inherited role
+	// Note: exactly one of UserID or GroupID must be provided
+	GroupID string `xor:"UserID"`
+
+	// ProjectID is the ID of a project to assign an inherited role on
+	// Note: exactly one of ProjectID or DomainID must be provided
+	ProjectID string `xor:"DomainID"`
+
+	// DomainID is the ID of a domain to assign an inherited role on
+	// Note: exactly one of ProjectID or DomainID must be provided
+	DomainID string `xor:"ProjectID"`
+}
+
+// Assign is the operation responsible for assigning an inherited role
 // to a user/group on a project/domain.
 func Assign(client *gophercloud.ServiceClient, roleID string, opts AssignOpts) (r AssignmentResult) {
 	// Check xor conditions
@@ -110,6 +129,44 @@ func Validate(client *gophercloud.ServiceClient, roleID string, opts ValidateOpt
 	}
 
 	resp, err := client.Head(assignURL(client, targetType, targetID, actorType, actorID, roleID), &gophercloud.RequestOpts{
+		OkCodes: []int{204},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// Unassign is the operation responsible for unassigning an inherited
+// role to a user/group on a project/domain.
+func Unassign(client *gophercloud.ServiceClient, roleID string, opts UnassignOpts) (r UnassignmentResult) {
+	// Check xor conditions
+	_, err := gophercloud.BuildRequestBody(opts, "")
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	// Get corresponding URL
+	var targetID string
+	var targetType string
+	if opts.ProjectID != "" {
+		targetID = opts.ProjectID
+		targetType = "projects"
+	} else {
+		targetID = opts.DomainID
+		targetType = "domains"
+	}
+
+	var actorID string
+	var actorType string
+	if opts.UserID != "" {
+		actorID = opts.UserID
+		actorType = "users"
+	} else {
+		actorID = opts.GroupID
+		actorType = "groups"
+	}
+
+	resp, err := client.Delete(assignURL(client, targetType, targetID, actorType, actorID, roleID), &gophercloud.RequestOpts{
 		OkCodes: []int{204},
 	})
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)

--- a/openstack/identity/v3/osinherit/results.go
+++ b/openstack/identity/v3/osinherit/results.go
@@ -7,3 +7,9 @@ import "github.com/gophercloud/gophercloud"
 type AssignmentResult struct {
 	gophercloud.ErrResult
 }
+
+// ValidateResult represents the result of an validate operation.
+// Call ExtractErr method to determine if the request succeeded or failed.
+type ValidateResult struct {
+	gophercloud.ErrResult
+}

--- a/openstack/identity/v3/osinherit/results.go
+++ b/openstack/identity/v3/osinherit/results.go
@@ -1,0 +1,9 @@
+package osinherit
+
+import "github.com/gophercloud/gophercloud"
+
+// AssignmentResult represents the result of an assign operation.
+// Call ExtractErr method to determine if the request succeeded or failed.
+type AssignmentResult struct {
+	gophercloud.ErrResult
+}

--- a/openstack/identity/v3/osinherit/results.go
+++ b/openstack/identity/v3/osinherit/results.go
@@ -13,3 +13,9 @@ type AssignmentResult struct {
 type ValidateResult struct {
 	gophercloud.ErrResult
 }
+
+// UnassignmentResult represents the result of an unassign operation.
+// Call ExtractErr method to determine if the request succeeded or failed.
+type UnassignmentResult struct {
+	gophercloud.ErrResult
+}

--- a/openstack/identity/v3/osinherit/testing/doc.go
+++ b/openstack/identity/v3/osinherit/testing/doc.go
@@ -1,0 +1,2 @@
+// osinherit unit tests
+package testing

--- a/openstack/identity/v3/osinherit/testing/fixtures.go
+++ b/openstack/identity/v3/osinherit/testing/fixtures.go
@@ -1,0 +1,35 @@
+package testing
+
+import (
+	"net/http"
+	"testing"
+
+	th "github.com/gophercloud/gophercloud/testhelper"
+	fake "github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func HandleAssignSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/OS-INHERIT/projects/{project_id}/users/{user_id}/roles/{role_id}/inherited_to_projects", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	th.Mux.HandleFunc("/OS-INHERIT/projects/{project_id}/groups/{group_id}/roles/{role_id}/inherited_to_projects", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	th.Mux.HandleFunc("/OS-INHERIT/domains/{domain_id}/users/{user_id}/roles/{role_id}/inherited_to_projects", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	th.Mux.HandleFunc("/OS-INHERIT/domains/{domain_id}/groups/{group_id}/roles/{role_id}/inherited_to_projects", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.WriteHeader(http.StatusNoContent)
+	})
+}

--- a/openstack/identity/v3/osinherit/testing/fixtures.go
+++ b/openstack/identity/v3/osinherit/testing/fixtures.go
@@ -33,3 +33,29 @@ func HandleAssignSuccessfully(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 }
+
+func HandleValidateSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/OS-INHERIT/projects/{project_id}/users/{user_id}/roles/{role_id}/inherited_to_projects", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "HEAD")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	th.Mux.HandleFunc("/OS-INHERIT/projects/{project_id}/groups/{group_id}/roles/{role_id}/inherited_to_projects", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "HEAD")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	th.Mux.HandleFunc("/OS-INHERIT/domains/{domain_id}/users/{user_id}/roles/{role_id}/inherited_to_projects", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "HEAD")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	th.Mux.HandleFunc("/OS-INHERIT/domains/{domain_id}/groups/{group_id}/roles/{role_id}/inherited_to_projects", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "HEAD")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.WriteHeader(http.StatusNoContent)
+	})
+}

--- a/openstack/identity/v3/osinherit/testing/fixtures.go
+++ b/openstack/identity/v3/osinherit/testing/fixtures.go
@@ -59,3 +59,29 @@ func HandleValidateSuccessfully(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 }
+
+func HandleUnassignSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/OS-INHERIT/projects/{project_id}/users/{user_id}/roles/{role_id}/inherited_to_projects", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	th.Mux.HandleFunc("/OS-INHERIT/projects/{project_id}/groups/{group_id}/roles/{role_id}/inherited_to_projects", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	th.Mux.HandleFunc("/OS-INHERIT/domains/{domain_id}/users/{user_id}/roles/{role_id}/inherited_to_projects", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	th.Mux.HandleFunc("/OS-INHERIT/domains/{domain_id}/groups/{group_id}/roles/{role_id}/inherited_to_projects", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.WriteHeader(http.StatusNoContent)
+	})
+}

--- a/openstack/identity/v3/osinherit/testing/requests_test.go
+++ b/openstack/identity/v3/osinherit/testing/requests_test.go
@@ -67,3 +67,33 @@ func TestValidate(t *testing.T) {
 	}).ExtractErr()
 	th.AssertNoErr(t, err)
 }
+
+func TestUnassign(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleUnassignSuccessfully(t)
+
+	err := osinherit.Unassign(client.ServiceClient(), "{role_id}", osinherit.UnassignOpts{
+		UserID:    "{user_id}",
+		ProjectID: "{project_id}",
+	}).ExtractErr()
+	th.AssertNoErr(t, err)
+
+	err = osinherit.Unassign(client.ServiceClient(), "{role_id}", osinherit.UnassignOpts{
+		UserID:   "{user_id}",
+		DomainID: "{domain_id}",
+	}).ExtractErr()
+	th.AssertNoErr(t, err)
+
+	err = osinherit.Unassign(client.ServiceClient(), "{role_id}", osinherit.UnassignOpts{
+		GroupID:   "{group_id}",
+		ProjectID: "{project_id}",
+	}).ExtractErr()
+	th.AssertNoErr(t, err)
+
+	err = osinherit.Unassign(client.ServiceClient(), "{role_id}", osinherit.UnassignOpts{
+		GroupID:  "{group_id}",
+		DomainID: "{domain_id}",
+	}).ExtractErr()
+	th.AssertNoErr(t, err)
+}

--- a/openstack/identity/v3/osinherit/testing/requests_test.go
+++ b/openstack/identity/v3/osinherit/testing/requests_test.go
@@ -1,0 +1,39 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/osinherit"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func TestAssign(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleAssignSuccessfully(t)
+
+	err := osinherit.Assign(client.ServiceClient(), "{role_id}", osinherit.AssignOpts{
+		UserID:    "{user_id}",
+		ProjectID: "{project_id}",
+	}).ExtractErr()
+	th.AssertNoErr(t, err)
+
+	err = osinherit.Assign(client.ServiceClient(), "{role_id}", osinherit.AssignOpts{
+		UserID:   "{user_id}",
+		DomainID: "{domain_id}",
+	}).ExtractErr()
+	th.AssertNoErr(t, err)
+
+	err = osinherit.Assign(client.ServiceClient(), "{role_id}", osinherit.AssignOpts{
+		GroupID:   "{group_id}",
+		ProjectID: "{project_id}",
+	}).ExtractErr()
+	th.AssertNoErr(t, err)
+
+	err = osinherit.Assign(client.ServiceClient(), "{role_id}", osinherit.AssignOpts{
+		GroupID:  "{group_id}",
+		DomainID: "{domain_id}",
+	}).ExtractErr()
+	th.AssertNoErr(t, err)
+}

--- a/openstack/identity/v3/osinherit/testing/requests_test.go
+++ b/openstack/identity/v3/osinherit/testing/requests_test.go
@@ -36,6 +36,18 @@ func TestAssign(t *testing.T) {
 		DomainID: "{domain_id}",
 	}).ExtractErr()
 	th.AssertNoErr(t, err)
+
+	err = osinherit.Assign(client.ServiceClient(), "{role_id}", osinherit.AssignOpts{
+		GroupID: "{group_id}",
+		UserID:  "{user_id}",
+	}).ExtractErr()
+	th.AssertErr(t, err)
+
+	err = osinherit.Assign(client.ServiceClient(), "{role_id}", osinherit.AssignOpts{
+		ProjectID: "{project_id}",
+		DomainID:  "{domain_id}",
+	}).ExtractErr()
+	th.AssertErr(t, err)
 }
 
 func TestValidate(t *testing.T) {
@@ -66,6 +78,18 @@ func TestValidate(t *testing.T) {
 		DomainID: "{domain_id}",
 	}).ExtractErr()
 	th.AssertNoErr(t, err)
+
+	err = osinherit.Validate(client.ServiceClient(), "{role_id}", osinherit.ValidateOpts{
+		GroupID: "{group_id}",
+		UserID:  "{user_id}",
+	}).ExtractErr()
+	th.AssertErr(t, err)
+
+	err = osinherit.Validate(client.ServiceClient(), "{role_id}", osinherit.ValidateOpts{
+		ProjectID: "{project_id}",
+		DomainID:  "{domain_id}",
+	}).ExtractErr()
+	th.AssertErr(t, err)
 }
 
 func TestUnassign(t *testing.T) {
@@ -96,4 +120,16 @@ func TestUnassign(t *testing.T) {
 		DomainID: "{domain_id}",
 	}).ExtractErr()
 	th.AssertNoErr(t, err)
+
+	err = osinherit.Unassign(client.ServiceClient(), "{role_id}", osinherit.UnassignOpts{
+		GroupID: "{group_id}",
+		UserID:  "{user_id}",
+	}).ExtractErr()
+	th.AssertErr(t, err)
+
+	err = osinherit.Unassign(client.ServiceClient(), "{role_id}", osinherit.UnassignOpts{
+		ProjectID: "{project_id}",
+		DomainID:  "{domain_id}",
+	}).ExtractErr()
+	th.AssertErr(t, err)
 }

--- a/openstack/identity/v3/osinherit/testing/requests_test.go
+++ b/openstack/identity/v3/osinherit/testing/requests_test.go
@@ -37,3 +37,33 @@ func TestAssign(t *testing.T) {
 	}).ExtractErr()
 	th.AssertNoErr(t, err)
 }
+
+func TestValidate(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleValidateSuccessfully(t)
+
+	err := osinherit.Validate(client.ServiceClient(), "{role_id}", osinherit.ValidateOpts{
+		UserID:    "{user_id}",
+		ProjectID: "{project_id}",
+	}).ExtractErr()
+	th.AssertNoErr(t, err)
+
+	err = osinherit.Validate(client.ServiceClient(), "{role_id}", osinherit.ValidateOpts{
+		UserID:   "{user_id}",
+		DomainID: "{domain_id}",
+	}).ExtractErr()
+	th.AssertNoErr(t, err)
+
+	err = osinherit.Validate(client.ServiceClient(), "{role_id}", osinherit.ValidateOpts{
+		GroupID:   "{group_id}",
+		ProjectID: "{project_id}",
+	}).ExtractErr()
+	th.AssertNoErr(t, err)
+
+	err = osinherit.Validate(client.ServiceClient(), "{role_id}", osinherit.ValidateOpts{
+		GroupID:  "{group_id}",
+		DomainID: "{domain_id}",
+	}).ExtractErr()
+	th.AssertNoErr(t, err)
+}

--- a/openstack/identity/v3/osinherit/urls.go
+++ b/openstack/identity/v3/osinherit/urls.go
@@ -1,0 +1,11 @@
+package osinherit
+
+import "github.com/gophercloud/gophercloud"
+
+const (
+	inheritPath = "OS-INHERIT"
+)
+
+func assignURL(client *gophercloud.ServiceClient, targetType, targetID, actorType, actorID, roleID string) string {
+	return client.ServiceURL(inheritPath, targetType, targetID, actorType, actorID, "roles", roleID, "inherited_to_projects")
+}


### PR DESCRIPTION
Add PUT/HEAD/DELETE for indentity/v3/OS-INHERIT. Follow the same pattern as normal role assignments for consistency. 

This adds PUT/HEAD/DELETE for all combinations of domain/project and user/group.

[DOCS](https://docs.openstack.org/api-ref/identity/v3/index.html?&#os-inherit)
Fixes #2205 

Each commit adds one API call, thus it is a bit easier to review by reviewing one commit each time