### PR TITLE
Migrate baremetal inventory to a common location

### DIFF
--- a/openstack/baremetal/inventory/testing/fixtures.go
+++ b/openstack/baremetal/inventory/testing/fixtures.go
@@ -40,7 +40,6 @@ const InventorySample = `{
 	    "client_id": null,
 	    "has_carrier": true,
 	    "ipv4_address": "172.24.42.101",
-	    "lldp": [],
 	    "mac_address": "52:54:00:47:20:4d",
 	    "name": "eth1",
 	    "product": "0x0001",
@@ -50,16 +49,6 @@ const InventorySample = `{
 	    "client_id": null,
 	    "has_carrier": true,
 	    "ipv4_address": "172.24.42.100",
-	    "lldp": [
-		[
-		    1,
-		    "04112233aabbcc"
-		],
-		[
-		    5,
-		    "737730312d646973742d31622d623132"
-		]
-	    ],
 	    "mac_address": "52:54:00:4e:3d:30",
 	    "name": "eth0",
 	    "product": "0x0001",
@@ -118,7 +107,6 @@ var Inventory = inventory.InventoryType{
 			Name:        "eth1",
 			Product:     "0x0001",
 			IPV4Address: "172.24.42.101",
-			LLDP:        []inventory.LLDPTLVType{},
 		},
 		{
 			IPV4Address: "172.24.42.100",
@@ -127,17 +115,7 @@ var Inventory = inventory.InventoryType{
 			Product:     "0x0001",
 			HasCarrier:  true,
 			Vendor:      "0x1af4",
-			LLDP: []inventory.LLDPTLVType{
-				{
-					Type:  1,
-					Value: "04112233aabbcc",
-				},
-				{
-					Type:  5,
-					Value: "737730312d646973742d31622d623132",
-				},
-			},
-			SpeedMbps: 1000,
+			SpeedMbps:   1000,
 		},
 	},
 	Memory: inventory.MemoryType{

--- a/openstack/baremetal/inventory/testing/fixtures.go
+++ b/openstack/baremetal/inventory/testing/fixtures.go
@@ -1,0 +1,148 @@
+package testing
+
+import "github.com/gophercloud/gophercloud/openstack/baremetal/inventory"
+
+const InventorySample = `{
+    "bmc_address": "192.167.2.134",
+    "boot": {
+	"current_boot_mode": "bios",
+	"pxe_interface": "52:54:00:4e:3d:30"
+    },
+    "cpu": {
+	"architecture": "x86_64",
+	"count": 2,
+	"flags": [
+	    "fpu",
+	    "mmx",
+	    "fxsr",
+	    "sse",
+	    "sse2"
+	],
+	"frequency": "2100.084"
+    },
+    "disks": [
+	{
+	    "hctl": null,
+	    "model": "",
+	    "name": "/dev/vda",
+	    "rotational": true,
+	    "serial": null,
+	    "size": 13958643712,
+	    "vendor": "0x1af4",
+	    "wwn": null,
+	    "wwn_vendor_extension": null,
+	    "wwn_with_extension": null
+	}
+    ],
+    "hostname": "myawesomehost",
+    "interfaces": [
+	{
+	    "client_id": null,
+	    "has_carrier": true,
+	    "ipv4_address": "172.24.42.101",
+	    "lldp": [],
+	    "mac_address": "52:54:00:47:20:4d",
+	    "name": "eth1",
+	    "product": "0x0001",
+	    "vendor": "0x1af4"
+	},
+	{
+	    "client_id": null,
+	    "has_carrier": true,
+	    "ipv4_address": "172.24.42.100",
+	    "lldp": [
+		[
+		    1,
+		    "04112233aabbcc"
+		],
+		[
+		    5,
+		    "737730312d646973742d31622d623132"
+		]
+	    ],
+	    "mac_address": "52:54:00:4e:3d:30",
+	    "name": "eth0",
+	    "product": "0x0001",
+	    "vendor": "0x1af4",
+	    "speed_mbps": 1000
+	}
+    ],
+    "memory": {
+	"physical_mb": 2048,
+	"total": 2105864192
+    },
+    "system_vendor": {
+	"manufacturer": "Bochs",
+	"product_name": "Bochs",
+	"serial_number": "Not Specified",
+	"firmware": {
+	    "version": "1.2.3.4"
+	}
+    }
+}`
+
+var Inventory = inventory.InventoryType{
+	SystemVendor: inventory.SystemVendorType{
+		Manufacturer: "Bochs",
+		ProductName:  "Bochs",
+		SerialNumber: "Not Specified",
+		Firmware: inventory.SystemFirmwareType{
+			Version: "1.2.3.4",
+		},
+	},
+	BmcAddress: "192.167.2.134",
+	Boot: inventory.BootInfoType{
+		CurrentBootMode: "bios",
+		PXEInterface:    "52:54:00:4e:3d:30",
+	},
+	CPU: inventory.CPUType{
+		Count:        2,
+		Flags:        []string{"fpu", "mmx", "fxsr", "sse", "sse2"},
+		Frequency:    "2100.084",
+		Architecture: "x86_64",
+	},
+	Disks: []inventory.RootDiskType{
+		{
+			Rotational: true,
+			Model:      "",
+			Name:       "/dev/vda",
+			Size:       13958643712,
+			Vendor:     "0x1af4",
+		},
+	},
+	Interfaces: []inventory.InterfaceType{
+		{
+			Vendor:      "0x1af4",
+			HasCarrier:  true,
+			MACAddress:  "52:54:00:47:20:4d",
+			Name:        "eth1",
+			Product:     "0x0001",
+			IPV4Address: "172.24.42.101",
+			LLDP:        []inventory.LLDPTLVType{},
+		},
+		{
+			IPV4Address: "172.24.42.100",
+			MACAddress:  "52:54:00:4e:3d:30",
+			Name:        "eth0",
+			Product:     "0x0001",
+			HasCarrier:  true,
+			Vendor:      "0x1af4",
+			LLDP: []inventory.LLDPTLVType{
+				{
+					Type:  1,
+					Value: "04112233aabbcc",
+				},
+				{
+					Type:  5,
+					Value: "737730312d646973742d31622d623132",
+				},
+			},
+			SpeedMbps: 1000,
+		},
+	},
+	Memory: inventory.MemoryType{
+		PhysicalMb: 2048.0,
+		Total:      2.105864192e+09,
+	},
+	Hostname: "myawesomehost",
+}

--- a/openstack/baremetal/inventory/testing/types_test.go
+++ b/openstack/baremetal/inventory/testing/types_test.go
@@ -1,0 +1,40 @@
+package testing
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/baremetal/inventory"
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestIntrospectionNUMA(t *testing.T) {
+	var output inventory.InventoryType
+	err := json.Unmarshal([]byte(InventorySample), &output)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal inventory: %s", err)
+	}
+
+	th.CheckDeepEquals(t, Inventory, output)
+}
+
+func TestLLDPTLVErrors(t *testing.T) {
+	badInputs := []string{
+		"[1]",
+		"[1, 2]",
+		"[\"foo\", \"bar\"]",
+	}
+
+	for _, input := range badInputs {
+		var output inventory.LLDPTLVType
+		err := json.Unmarshal([]byte(input), &output)
+		if err == nil {
+			t.Fatalf("No JSON parse error for invalid LLDP TLV %s", input)
+		}
+
+		if !strings.Contains(err.Error(), "LLDP TLV") {
+			t.Fatalf("Unexpected JSON parse error \"%s\" for invalid LLDP TLV %s", err, input)
+		}
+	}
+}

--- a/openstack/baremetal/inventory/types.go
+++ b/openstack/baremetal/inventory/types.go
@@ -24,13 +24,11 @@ type InterfaceType struct {
 	HasCarrier  bool   `json:"has_carrier"`
 	IPV4Address string `json:"ipv4_address"`
 	IPV6Address string `json:"ipv6_address"`
-	// Deprecated, see Data.RawLLDP
-	LLDP       []LLDPTLVType `json:"lldp"`
-	MACAddress string        `json:"mac_address"`
-	Name       string        `json:"name"`
-	Product    string        `json:"product"`
-	SpeedMbps  int           `json:"speed_mbps"`
-	Vendor     string        `json:"vendor"`
+	MACAddress  string `json:"mac_address"`
+	Name        string `json:"name"`
+	Product     string `json:"product"`
+	SpeedMbps   int    `json:"speed_mbps"`
+	Vendor      string `json:"vendor"`
 }
 
 type LLDPTLVType struct {

--- a/openstack/baremetal/inventory/types.go
+++ b/openstack/baremetal/inventory/types.go
@@ -1,0 +1,108 @@
+package inventory
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type BootInfoType struct {
+	CurrentBootMode string `json:"current_boot_mode"`
+	PXEInterface    string `json:"pxe_interface"`
+}
+
+type CPUType struct {
+	Architecture string   `json:"architecture"`
+	Count        int      `json:"count"`
+	Flags        []string `json:"flags"`
+	Frequency    string   `json:"frequency"`
+	ModelName    string   `json:"model_name"`
+}
+
+type InterfaceType struct {
+	BIOSDevName string `json:"biosdevname"`
+	ClientID    string `json:"client_id"`
+	HasCarrier  bool   `json:"has_carrier"`
+	IPV4Address string `json:"ipv4_address"`
+	IPV6Address string `json:"ipv6_address"`
+	// Deprecated, see Data.RawLLDP
+	LLDP       []LLDPTLVType `json:"lldp"`
+	MACAddress string        `json:"mac_address"`
+	Name       string        `json:"name"`
+	Product    string        `json:"product"`
+	SpeedMbps  int           `json:"speed_mbps"`
+	Vendor     string        `json:"vendor"`
+}
+
+type LLDPTLVType struct {
+	Type  int
+	Value string
+}
+
+type MemoryType struct {
+	PhysicalMb int `json:"physical_mb"`
+	Total      int `json:"total"`
+}
+
+type RootDiskType struct {
+	Hctl               string `json:"hctl"`
+	Model              string `json:"model"`
+	Name               string `json:"name"`
+	ByPath             string `json:"by_path"`
+	Rotational         bool   `json:"rotational"`
+	Serial             string `json:"serial"`
+	Size               int64  `json:"size"`
+	Vendor             string `json:"vendor"`
+	Wwn                string `json:"wwn"`
+	WwnVendorExtension string `json:"wwn_vendor_extension"`
+	WwnWithExtension   string `json:"wwn_with_extension"`
+}
+
+type SystemFirmwareType struct {
+	Version   string `json:"version"`
+	BuildDate string `json:"build_date"`
+	Vendor    string `json:"vendor"`
+}
+
+type SystemVendorType struct {
+	Manufacturer string             `json:"manufacturer"`
+	ProductName  string             `json:"product_name"`
+	SerialNumber string             `json:"serial_number"`
+	Firmware     SystemFirmwareType `json:"firmware"`
+}
+
+type InventoryType struct {
+	BmcAddress   string           `json:"bmc_address"`
+	Boot         BootInfoType     `json:"boot"`
+	CPU          CPUType          `json:"cpu"`
+	Disks        []RootDiskType   `json:"disks"`
+	Interfaces   []InterfaceType  `json:"interfaces"`
+	Memory       MemoryType       `json:"memory"`
+	SystemVendor SystemVendorType `json:"system_vendor"`
+	Hostname     string           `json:"hostname"`
+}
+
+// UnmarshalJSON interprets an LLDP TLV [key, value] pair as an LLDPTLVType structure
+func (r *LLDPTLVType) UnmarshalJSON(data []byte) error {
+	var list []interface{}
+	if err := json.Unmarshal(data, &list); err != nil {
+		return err
+	}
+
+	if len(list) != 2 {
+		return fmt.Errorf("Invalid LLDP TLV key-value pair")
+	}
+
+	fieldtype, ok := list[0].(float64)
+	if !ok {
+		return fmt.Errorf("LLDP TLV key is not number")
+	}
+
+	value, ok := list[1].(string)
+	if !ok {
+		return fmt.Errorf("LLDP TLV value is not string")
+	}
+
+	r.Type = int(fieldtype)
+	r.Value = value
+	return nil
+}

--- a/openstack/baremetalintrospection/v1/introspection/results.go
+++ b/openstack/baremetalintrospection/v1/introspection/results.go
@@ -2,10 +2,10 @@ package introspection
 
 import (
 	"encoding/json"
-	"fmt"
 	"time"
 
 	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/baremetal/inventory"
 	"github.com/gophercloud/gophercloud/pagination"
 )
 
@@ -162,21 +162,21 @@ type AbortResult struct {
 // This structure has been provided for basic compatibility but it
 // will need extensions
 type Data struct {
-	AllInterfaces map[string]BaseInterfaceType `json:"all_interfaces"`
-	BootInterface string                       `json:"boot_interface"`
-	CPUArch       string                       `json:"cpu_arch"`
-	CPUs          int                          `json:"cpus"`
-	Error         string                       `json:"error"`
-	Interfaces    map[string]BaseInterfaceType `json:"interfaces"`
-	Inventory     InventoryType                `json:"inventory"`
-	IPMIAddress   string                       `json:"ipmi_address"`
-	LocalGB       int                          `json:"local_gb"`
-	MACs          []string                     `json:"macs"`
-	MemoryMB      int                          `json:"memory_mb"`
-	RootDisk      RootDiskType                 `json:"root_disk"`
-	Extra         ExtraHardwareDataType        `json:"extra"`
-	NUMATopology  NUMATopology                 `json:"numa_topology"`
-	RawLLDP       map[string][]LLDPTLVType     `json:"lldp_raw"`
+	AllInterfaces map[string]BaseInterfaceType       `json:"all_interfaces"`
+	BootInterface string                             `json:"boot_interface"`
+	CPUArch       string                             `json:"cpu_arch"`
+	CPUs          int                                `json:"cpus"`
+	Error         string                             `json:"error"`
+	Interfaces    map[string]BaseInterfaceType       `json:"interfaces"`
+	Inventory     inventory.InventoryType            `json:"inventory"`
+	IPMIAddress   string                             `json:"ipmi_address"`
+	LocalGB       int                                `json:"local_gb"`
+	MACs          []string                           `json:"macs"`
+	MemoryMB      int                                `json:"memory_mb"`
+	RootDisk      inventory.RootDiskType             `json:"root_disk"`
+	Extra         ExtraHardwareDataType              `json:"extra"`
+	NUMATopology  NUMATopology                       `json:"numa_topology"`
+	RawLLDP       map[string][]inventory.LLDPTLVType `json:"lldp_raw"`
 }
 
 // Sub Types defined under Data and deeper in the structure
@@ -187,82 +187,6 @@ type BaseInterfaceType struct {
 	MAC           string                 `json:"mac"`
 	PXE           bool                   `json:"pxe"`
 	LLDPProcessed map[string]interface{} `json:"lldp_processed"`
-}
-
-type BootInfoType struct {
-	CurrentBootMode string `json:"current_boot_mode"`
-	PXEInterface    string `json:"pxe_interface"`
-}
-
-type CPUType struct {
-	Architecture string   `json:"architecture"`
-	Count        int      `json:"count"`
-	Flags        []string `json:"flags"`
-	Frequency    string   `json:"frequency"`
-	ModelName    string   `json:"model_name"`
-}
-
-type LLDPTLVType struct {
-	Type  int
-	Value string
-}
-
-type InterfaceType struct {
-	BIOSDevName string `json:"biosdevname"`
-	ClientID    string `json:"client_id"`
-	HasCarrier  bool   `json:"has_carrier"`
-	IPV4Address string `json:"ipv4_address"`
-	IPV6Address string `json:"ipv6_address"`
-	// Deprecated, see Data.RawLLDP
-	LLDP       []LLDPTLVType `json:"lldp"`
-	MACAddress string        `json:"mac_address"`
-	Name       string        `json:"name"`
-	Product    string        `json:"product"`
-	SpeedMbps  int           `json:"speed_mbps"`
-	Vendor     string        `json:"vendor"`
-}
-
-type InventoryType struct {
-	BmcAddress   string           `json:"bmc_address"`
-	Boot         BootInfoType     `json:"boot"`
-	CPU          CPUType          `json:"cpu"`
-	Disks        []RootDiskType   `json:"disks"`
-	Interfaces   []InterfaceType  `json:"interfaces"`
-	Memory       MemoryType       `json:"memory"`
-	SystemVendor SystemVendorType `json:"system_vendor"`
-	Hostname     string           `json:"hostname"`
-}
-
-type MemoryType struct {
-	PhysicalMb int `json:"physical_mb"`
-	Total      int `json:"total"`
-}
-
-type RootDiskType struct {
-	Hctl               string `json:"hctl"`
-	Model              string `json:"model"`
-	Name               string `json:"name"`
-	ByPath             string `json:"by_path"`
-	Rotational         bool   `json:"rotational"`
-	Serial             string `json:"serial"`
-	Size               int64  `json:"size"`
-	Vendor             string `json:"vendor"`
-	Wwn                string `json:"wwn"`
-	WwnVendorExtension string `json:"wwn_vendor_extension"`
-	WwnWithExtension   string `json:"wwn_with_extension"`
-}
-
-type SystemFirmwareType struct {
-	Version   string `json:"version"`
-	BuildDate string `json:"build_date"`
-	Vendor    string `json:"vendor"`
-}
-
-type SystemVendorType struct {
-	Manufacturer string             `json:"manufacturer"`
-	ProductName  string             `json:"product_name"`
-	SerialNumber string             `json:"serial_number"`
-	Firmware     SystemFirmwareType `json:"firmware"`
 }
 
 type ExtraHardwareData map[string]interface{}
@@ -299,32 +223,6 @@ type NUMANIC struct {
 type NUMARAM struct {
 	NUMANode int `json:"numa_node"`
 	SizeKB   int `json:"size_kb"`
-}
-
-// UnmarshalJSON interprets an LLDP TLV [key, value] pair as an LLDPTLVType structure
-func (r *LLDPTLVType) UnmarshalJSON(data []byte) error {
-	var list []interface{}
-	if err := json.Unmarshal(data, &list); err != nil {
-		return err
-	}
-
-	if len(list) != 2 {
-		return fmt.Errorf("Invalid LLDP TLV key-value pair")
-	}
-
-	fieldtype, ok := list[0].(float64)
-	if !ok {
-		return fmt.Errorf("LLDP TLV key is not number")
-	}
-
-	value, ok := list[1].(string)
-	if !ok {
-		return fmt.Errorf("LLDP TLV value is not string")
-	}
-
-	r.Type = int(fieldtype)
-	r.Value = value
-	return nil
 }
 
 // Extract interprets any IntrospectionDataResult as IntrospectionData, if possible.

--- a/openstack/baremetalintrospection/v1/introspection/testing/fixtures.go
+++ b/openstack/baremetalintrospection/v1/introspection/testing/fixtures.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/baremetal/inventory"
+	inventorytesting "github.com/gophercloud/gophercloud/openstack/baremetal/inventory/testing"
 	"github.com/gophercloud/gophercloud/openstack/baremetalintrospection/v1/introspection"
 	th "github.com/gophercloud/gophercloud/testhelper"
 	"github.com/gophercloud/gophercloud/testhelper/client"
@@ -67,7 +69,7 @@ const IntrospectionStatus = `
 `
 
 // IntrospectionDataJSONSample contains sample data reported by the introspection process.
-const IntrospectionDataJSONSample = `
+var IntrospectionDataJSONSample = fmt.Sprintf(`
 {
     "all_interfaces": {
         "eth0": {
@@ -99,84 +101,7 @@ const IntrospectionDataJSONSample = `
             "pxe": true
         }
     },
-    "inventory": {
-        "bmc_address": "192.167.2.134",
-        "boot": {
-            "current_boot_mode": "bios",
-            "pxe_interface": "52:54:00:4e:3d:30"
-        },
-        "cpu": {
-            "architecture": "x86_64",
-            "count": 2,
-            "flags": [
-                "fpu",
-                "mmx",
-                "fxsr",
-                "sse",
-                "sse2"
-            ],
-            "frequency": "2100.084"
-        },
-        "disks": [
-            {
-                "hctl": null,
-                "model": "",
-                "name": "/dev/vda",
-                "rotational": true,
-                "serial": null,
-                "size": 13958643712,
-                "vendor": "0x1af4",
-                "wwn": null,
-                "wwn_vendor_extension": null,
-                "wwn_with_extension": null
-            }
-        ],
-        "hostname": "myawesomehost",
-        "interfaces": [
-            {
-                "client_id": null,
-                "has_carrier": true,
-                "ipv4_address": "172.24.42.101",
-                "lldp": [],
-                "mac_address": "52:54:00:47:20:4d",
-                "name": "eth1",
-                "product": "0x0001",
-                "vendor": "0x1af4"
-            },
-            {
-                "client_id": null,
-                "has_carrier": true,
-                "ipv4_address": "172.24.42.100",
-                "lldp": [
-                    [
-                        1,
-                        "04112233aabbcc"
-                    ],
-                    [
-                        5,
-                        "737730312d646973742d31622d623132"
-                    ]
-                ],
-                "mac_address": "52:54:00:4e:3d:30",
-                "name": "eth0",
-                "product": "0x0001",
-                "vendor": "0x1af4",
-		"speed_mbps": 1000
-            }
-        ],
-        "memory": {
-            "physical_mb": 2048,
-            "total": 2105864192
-        },
-        "system_vendor": {
-            "manufacturer": "Bochs",
-            "product_name": "Bochs",
-            "serial_number": "Not Specified",
-	    "firmware": {
-		"version": "1.2.3.4"
-	    }
-        }
-    },
+    "inventory": %s,
     "ipmi_address": "192.167.2.134",
     "lldp_raw": {
 	"eth0": [
@@ -208,7 +133,7 @@ const IntrospectionDataJSONSample = `
         "wwn_with_extension": null
     }
 }
-`
+`, inventorytesting.InventorySample)
 
 // IntrospectionExtraHardwareJSONSample contains extra hardware sample data
 // reported by the introspection process.
@@ -370,7 +295,7 @@ var (
 	IntrospectionDataRes = introspection.Data{
 		CPUArch: "x86_64",
 		MACs:    []string{"52:54:00:4e:3d:30"},
-		RootDisk: introspection.RootDiskType{
+		RootDisk: inventory.RootDiskType{
 			Rotational: true,
 			Model:      "",
 			Name:       "/dev/vda",
@@ -388,73 +313,9 @@ var (
 		BootInterface: "52:54:00:4e:3d:30",
 		MemoryMB:      2048,
 		IPMIAddress:   "192.167.2.134",
-		Inventory: introspection.InventoryType{
-			SystemVendor: introspection.SystemVendorType{
-				Manufacturer: "Bochs",
-				ProductName:  "Bochs",
-				SerialNumber: "Not Specified",
-				Firmware: introspection.SystemFirmwareType{
-					Version: "1.2.3.4",
-				},
-			},
-			BmcAddress: "192.167.2.134",
-			Boot: introspection.BootInfoType{
-				CurrentBootMode: "bios",
-				PXEInterface:    "52:54:00:4e:3d:30",
-			},
-			CPU: introspection.CPUType{
-				Count:        2,
-				Flags:        []string{"fpu", "mmx", "fxsr", "sse", "sse2"},
-				Frequency:    "2100.084",
-				Architecture: "x86_64",
-			},
-			Disks: []introspection.RootDiskType{
-				{
-					Rotational: true,
-					Model:      "",
-					Name:       "/dev/vda",
-					Size:       13958643712,
-					Vendor:     "0x1af4",
-				},
-			},
-			Interfaces: []introspection.InterfaceType{
-				{
-					Vendor:      "0x1af4",
-					HasCarrier:  true,
-					MACAddress:  "52:54:00:47:20:4d",
-					Name:        "eth1",
-					Product:     "0x0001",
-					IPV4Address: "172.24.42.101",
-					LLDP:        []introspection.LLDPTLVType{},
-				},
-				{
-					IPV4Address: "172.24.42.100",
-					MACAddress:  "52:54:00:4e:3d:30",
-					Name:        "eth0",
-					Product:     "0x0001",
-					HasCarrier:  true,
-					Vendor:      "0x1af4",
-					LLDP: []introspection.LLDPTLVType{
-						{
-							Type:  1,
-							Value: "04112233aabbcc",
-						},
-						{
-							Type:  5,
-							Value: "737730312d646973742d31622d623132",
-						},
-					},
-					SpeedMbps: 1000,
-				},
-			},
-			Memory: introspection.MemoryType{
-				PhysicalMb: 2048.0,
-				Total:      2.105864192e+09,
-			},
-			Hostname: "myawesomehost",
-		},
-		Error:   "",
-		LocalGB: 12,
+		Inventory:     inventorytesting.Inventory,
+		Error:         "",
+		LocalGB:       12,
 		AllInterfaces: map[string]introspection.BaseInterfaceType{
 			"eth1": {
 				IP:  "172.24.42.101",
@@ -471,7 +332,7 @@ var (
 				},
 			},
 		},
-		RawLLDP: map[string][]introspection.LLDPTLVType{
+		RawLLDP: map[string][]inventory.LLDPTLVType{
 			"eth0": {
 				{
 					Type:  1,

--- a/openstack/baremetalintrospection/v1/introspection/testing/results_test.go
+++ b/openstack/baremetalintrospection/v1/introspection/testing/results_test.go
@@ -2,32 +2,11 @@ package testing
 
 import (
 	"encoding/json"
-	"strings"
 	"testing"
 
 	"github.com/gophercloud/gophercloud/openstack/baremetalintrospection/v1/introspection"
 	th "github.com/gophercloud/gophercloud/testhelper"
 )
-
-func TestLLDPTLVErrors(t *testing.T) {
-	badInputs := []string{
-		"[1]",
-		"[1, 2]",
-		"[\"foo\", \"bar\"]",
-	}
-
-	for _, input := range badInputs {
-		var output introspection.LLDPTLVType
-		err := json.Unmarshal([]byte(input), &output)
-		if err == nil {
-			t.Fatalf("No JSON parse error for invalid LLDP TLV %s", input)
-		}
-
-		if !strings.Contains(err.Error(), "LLDP TLV") {
-			t.Fatalf("Unexpected JSON parse error \"%s\" for invalid LLDP TLV %s", err, input)
-		}
-	}
-}
 
 func TestExtraHardware(t *testing.T) {
 	var output introspection.ExtraHardwareDataType


### PR DESCRIPTION
With the introduction of the Ironic inventory API, these types are now shared between Ironic and Inspector. No new functionality here yet, posting it to get the refactoring out of my way. Only the documented parts of the introspection data is migrated, not the Inspector-specific ones.

This change is technically breaking since the code is moved around and can no longer be imported at the old locations.

Part of #2612 