### PR TITLE
keystone: add v3 limits delete operation

### DIFF
--- a/acceptance/openstack/identity/v3/limits_test.go
+++ b/acceptance/openstack/identity/v3/limits_test.go
@@ -117,4 +117,7 @@ func TestLimitsCRUD(t *testing.T) {
 
 	err = limits.Delete(client, limitID).ExtractErr()
 	th.AssertNoErr(t, err)
+
+	_, err = limits.Get(client, limitID).Extract()
+	th.AssertErr(t, err)
 }

--- a/acceptance/openstack/identity/v3/limits_test.go
+++ b/acceptance/openstack/identity/v3/limits_test.go
@@ -114,4 +114,7 @@ func TestLimitsCRUD(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, newLimitDescription, updatedLimit.Description)
 	th.AssertEquals(t, newResourceLimit, updatedLimit.ResourceLimit)
+
+	err = limits.Delete(client, limitID).ExtractErr()
+	th.AssertNoErr(t, err)
 }

--- a/openstack/identity/v3/limits/doc.go
+++ b/openstack/identity/v3/limits/doc.go
@@ -71,5 +71,13 @@ Example to Update a Limit
 	if err != nil {
 	  panic(err)
 	}
+
+Example to Delete a Limit
+
+	limitID := "0fe36e73809d46aeae6705c39077b1b3"
+	err := limits.Delete(identityClient, limitID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
 */
 package limits

--- a/openstack/identity/v3/limits/requests.go
+++ b/openstack/identity/v3/limits/requests.go
@@ -160,3 +160,10 @@ func Update(client *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
+
+// Delete deletes a limit.
+func Delete(client *gophercloud.ServiceClient, limitID string) (r DeleteResult) {
+	resp, err := client.Delete(resourceURL(client, limitID), nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}

--- a/openstack/identity/v3/limits/results.go
+++ b/openstack/identity/v3/limits/results.go
@@ -96,6 +96,12 @@ type UpdateResult struct {
 	commonResult
 }
 
+// DeleteResult is the response from a Delete operation. Call its ExtractErr to
+// determine if the request succeeded or failed.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
 // IsEmpty determines whether or not a page of Limits contains any results.
 func (r LimitPage) IsEmpty() (bool, error) {
 	if r.StatusCode == 204 {

--- a/openstack/identity/v3/limits/testing/fixtures.go
+++ b/openstack/identity/v3/limits/testing/fixtures.go
@@ -240,3 +240,14 @@ func HandleUpdateLimitSuccessfully(t *testing.T) {
 		fmt.Fprintf(w, UpdateOutput)
 	})
 }
+
+// HandleDeleteLimitSuccessfully creates an HTTP handler at `/limits` on the
+// test handler mux that tests limit deletion.
+func HandleDeleteLimitSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/limits/3229b3849f584faea483d6851f7aab05", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.WriteHeader(http.StatusNoContent)
+	})
+}

--- a/openstack/identity/v3/limits/testing/requests_test.go
+++ b/openstack/identity/v3/limits/testing/requests_test.go
@@ -104,3 +104,12 @@ func TestUpdateLimit(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.CheckDeepEquals(t, SecondLimitUpdated, *actual)
 }
+
+func TestDeleteLimit(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleDeleteLimitSuccessfully(t)
+
+	err := limits.Delete(client.ServiceClient(), "3229b3849f584faea483d6851f7aab05").ExtractErr()
+	th.AssertNoErr(t, err)
+}


### PR DESCRIPTION
For https://github.com/gophercloud/gophercloud/issues/2289

[docs](https://docs.openstack.org/api-ref/identity/v3/#delete-limit)
[code](https://github.com/openstack/keystone/blob/stable/yoga/keystone/api/limits.py#L124)