### PR TITLE
Fix version comparison for acceptance tests

### DIFF
--- a/.github/workflows/functional-basic.yaml
+++ b/.github/workflows/functional-basic.yaml
@@ -51,6 +51,7 @@ jobs:
         env:
           DEVSTACK_PATH: ${{ github.workspace }}/devstack
           ACCEPTANCE_TESTS_FILTER: '^acceptance/openstack$'
+          OS_BRANCH: ${{ matrix.openstack_version }}
       - name: Generate logs on failure
         run: ./script/collectlogs
         if: failure()

--- a/.github/workflows/functional-clustering.yaml
+++ b/.github/workflows/functional-clustering.yaml
@@ -51,6 +51,7 @@ jobs:
         env:
           DEVSTACK_PATH: ${{ github.workspace }}/devstack
           ACCEPTANCE_TESTS_FILTER: "^.*clustering.*$"
+          OS_BRANCH: ${{ matrix.openstack_version }}
       - name: Generate logs on failure
         run: ./script/collectlogs
         if: failure()

--- a/.github/workflows/functional-compute.yaml
+++ b/.github/workflows/functional-compute.yaml
@@ -49,6 +49,7 @@ jobs:
         env:
           DEVSTACK_PATH: ${{ github.workspace }}/devstack
           ACCEPTANCE_TESTS_FILTER: "^.*compute.*$"
+          OS_BRANCH: ${{ matrix.openstack_version }}
       - name: Generate logs on failure
         run: ./script/collectlogs
         if: failure()

--- a/.github/workflows/functional-containerinfra.yaml
+++ b/.github/workflows/functional-containerinfra.yaml
@@ -68,6 +68,7 @@ jobs:
         env:
           DEVSTACK_PATH: ${{ github.workspace }}/devstack
           ACCEPTANCE_TESTS_FILTER: "^.*containerinfra.*$"
+          OS_BRANCH: ${{ matrix.openstack_version }}
       - name: Generate logs on failure
         run: ./script/collectlogs
         if: failure()

--- a/.github/workflows/functional-dns.yaml
+++ b/.github/workflows/functional-dns.yaml
@@ -63,6 +63,7 @@ jobs:
         env:
           DEVSTACK_PATH: ${{ github.workspace }}/devstack
           ACCEPTANCE_TESTS_FILTER: "^acceptance/openstack/dns.*$"
+          OS_BRANCH: ${{ matrix.openstack_version }}
       - name: Generate logs on failure
         run: ./script/collectlogs
         if: failure()

--- a/.github/workflows/functional-identity.yaml
+++ b/.github/workflows/functional-identity.yaml
@@ -47,6 +47,7 @@ jobs:
         env:
           DEVSTACK_PATH: ${{ github.workspace }}/devstack
           ACCEPTANCE_TESTS_FILTER: "^.*identity.*$"
+          OS_BRANCH: ${{ matrix.openstack_version }}
       - name: Generate logs on failure
         run: ./script/collectlogs
         if: failure()

--- a/.github/workflows/functional-imageservice.yaml
+++ b/.github/workflows/functional-imageservice.yaml
@@ -47,6 +47,7 @@ jobs:
         env:
           DEVSTACK_PATH: ${{ github.workspace }}/devstack
           ACCEPTANCE_TESTS_FILTER: "^.*imageservice.*$"
+          OS_BRANCH: ${{ matrix.openstack_version }}
       - name: Generate logs on failure
         run: ./script/collectlogs
         if: failure()

--- a/.github/workflows/functional-keymanager.yaml
+++ b/.github/workflows/functional-keymanager.yaml
@@ -50,6 +50,7 @@ jobs:
         env:
           DEVSTACK_PATH: ${{ github.workspace }}/devstack
           ACCEPTANCE_TESTS_FILTER: "^.*keymanager.*$"
+          OS_BRANCH: ${{ matrix.openstack_version }}
       - name: Generate logs on failure
         run: ./script/collectlogs
         if: failure()

--- a/.github/workflows/functional-messaging.yaml
+++ b/.github/workflows/functional-messaging.yaml
@@ -50,6 +50,7 @@ jobs:
         env:
           DEVSTACK_PATH: ${{ github.workspace }}/devstack
           ACCEPTANCE_TESTS_FILTER: "^.*messaging.*$"
+          OS_BRANCH: ${{ matrix.openstack_version }}
       - name: Generate logs on failure
         run: ./script/collectlogs
         if: failure()

--- a/.github/workflows/functional-objectstorage.yaml
+++ b/.github/workflows/functional-objectstorage.yaml
@@ -54,6 +54,7 @@ jobs:
         env:
           DEVSTACK_PATH: ${{ github.workspace }}/devstack
           ACCEPTANCE_TESTS_FILTER: '^.*objectstorage.*$'
+          OS_BRANCH: ${{ matrix.openstack_version }}
       - name: Generate logs on failure
         run: ./script/collectlogs
         if: failure()

--- a/.github/workflows/functional-orchestration.yaml
+++ b/.github/workflows/functional-orchestration.yaml
@@ -50,6 +50,7 @@ jobs:
         env:
           DEVSTACK_PATH: ${{ github.workspace }}/devstack
           ACCEPTANCE_TESTS_FILTER: ^.*orchestration.*$
+          OS_BRANCH: ${{ matrix.openstack_version }}
       - name: Generate logs on failure
         run: ./script/collectlogs
         if: failure()

--- a/.github/workflows/functional-placement.yaml
+++ b/.github/workflows/functional-placement.yaml
@@ -47,6 +47,7 @@ jobs:
         env:
           DEVSTACK_PATH: ${{ github.workspace }}/devstack
           ACCEPTANCE_TESTS_FILTER: ^.*placement.*$
+          OS_BRANCH: ${{ matrix.openstack_version }}
       - name: Generate logs on failure
         run: ./script/collectlogs
         if: failure()

--- a/.github/workflows/functional-sharedfilesystems.yaml
+++ b/.github/workflows/functional-sharedfilesystems.yaml
@@ -63,6 +63,7 @@ jobs:
         env:
           DEVSTACK_PATH: ${{ github.workspace }}/devstack
           ACCEPTANCE_TESTS_FILTER: "^.*sharedfilesystems.*$"
+          OS_BRANCH: ${{ matrix.openstack_version }}
       - name: Generate logs on failure
         run: ./script/collectlogs
         if: failure()

--- a/acceptance/clients/conditions.go
+++ b/acceptance/clients/conditions.go
@@ -74,10 +74,19 @@ func RequireIronicHTTPBasic(t *testing.T) {
 	}
 }
 
+func getReleaseFromEnv(t *testing.T) string {
+	current_branch := os.Getenv("OS_BRANCH")
+	if current_branch == "" {
+		t.Fatal("this test requires OS_BRANCH to be set but it wasn't")
+	}
+	return current_branch
+}
+
 // SkipRelease will have the test be skipped on a certain
 // release. Releases are named such as 'stable/mitaka', master, etc.
 func SkipRelease(t *testing.T, release string) {
-	if os.Getenv("OS_BRANCH") == release {
+	current_branch := getReleaseFromEnv(t)
+	if current_branch == release {
 		t.Skipf("this is not supported in %s", release)
 	}
 }
@@ -85,7 +94,7 @@ func SkipRelease(t *testing.T, release string) {
 // SkipReleasesBelow will have the test be skipped on releases below a certain
 // one. Releases are named such as 'stable/mitaka', master, etc.
 func SkipReleasesBelow(t *testing.T, release string) {
-	current_branch := os.Getenv("OS_BRANCH")
+	current_branch := getReleaseFromEnv(t)
 
 	if IsReleasesBelow(t, release) {
 		t.Skipf("this is not supported below %s, testing in %s", release, current_branch)
@@ -96,7 +105,7 @@ func SkipReleasesBelow(t *testing.T, release string) {
 // one. The test is always skipped on master release. Releases are named such
 // as 'stable/mitaka', master, etc.
 func SkipReleasesAbove(t *testing.T, release string) {
-	current_branch := os.Getenv("OS_BRANCH")
+	current_branch := getReleaseFromEnv(t)
 
 	// Assume master is always too new
 	if IsReleasesAbove(t, release) {
@@ -108,7 +117,7 @@ func SkipReleasesAbove(t *testing.T, release string) {
 // one. The result is always true on master release. Releases are named such
 // as 'stable/mitaka', master, etc.
 func IsReleasesAbove(t *testing.T, release string) bool {
-	current_branch := os.Getenv("OS_BRANCH")
+	current_branch := getReleaseFromEnv(t)
 
 	// Assume master is always too new
 	if current_branch == "master" || current_branch > release {
@@ -121,7 +130,7 @@ func IsReleasesAbove(t *testing.T, release string) bool {
 // IsReleasesBelow will return true on releases below a certain
 // one. Releases are named such as 'stable/mitaka', master, etc.
 func IsReleasesBelow(t *testing.T, release string) bool {
-	current_branch := os.Getenv("OS_BRANCH")
+	current_branch := getReleaseFromEnv(t)
 
 	if current_branch != "master" && current_branch < release {
 		return true


### PR DESCRIPTION
Some acceptance tests rely on a version comparison to conditionally skip tests. It turns out we were not consistently setting the relevant `OS_BRANCH` environment variable in all the jobs, meaning the version comparison would fail and skip the test.

This PR does two things:
- consistently set the `OS_BRANCH` variable for all our acceptance jobs
- fail the test when the required `OS_BRANCH` variable is not set