### PR TITLE
Pin goimport dep to a version that works with go 1.14

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -31,10 +31,11 @@ jobs:
         run: |
           # Changing into a different directory to avoid polluting go.sum with "go get"
           cd "$(mktemp -d)"
+          go mod init unit_tests
 
           # we use "go get" for Go v1.14
           go install github.com/wadey/gocovmerge@master || go get github.com/wadey/gocovmerge
-          go install golang.org/x/tools/cmd/goimports@latest || go get golang.org/x/tools/cmd/goimports
+          go install golang.org/x/tools/cmd/goimports@latest || go get golang.org/x/tools/cmd/goimports@v0.8.0
 
       - name: Run go vet
         run: |


### PR DESCRIPTION
Fixes the unit tests when running with go 1.14.