### PR TITLE
neutron: Support trunk_details extension

### DIFF
--- a/acceptance/openstack/networking/v2/extensions/trunk_details/trunks_test.go
+++ b/acceptance/openstack/networking/v2/extensions/trunk_details/trunks_test.go
@@ -1,0 +1,123 @@
+//go:build acceptance || trunks
+// +build acceptance trunks
+
+package trunk_details
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/acceptance/clients"
+	v2 "github.com/gophercloud/gophercloud/acceptance/openstack/networking/v2"
+	v2Trunks "github.com/gophercloud/gophercloud/acceptance/openstack/networking/v2/extensions/trunks"
+	"github.com/gophercloud/gophercloud/openstack/common/extensions"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/trunk_details"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/trunks"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+type portWithTrunkDetails struct {
+	ports.Port
+	trunk_details.TrunkDetailsExt
+}
+
+func TestListPortWithSubports(t *testing.T) {
+	client, err := clients.NewNetworkV2Client()
+	if err != nil {
+		t.Fatalf("Unable to create a network client: %v", err)
+	}
+
+	_, err = extensions.Get(client, "trunk-details").Extract()
+	if err != nil {
+		t.Skip("This test requires trunk-details Neutron extension")
+	}
+
+	// Create Network
+	network, err := v2.CreateNetwork(t, client)
+	if err != nil {
+		t.Fatalf("Unable to create network: %v", err)
+	}
+	defer v2.DeleteNetwork(t, client, network.ID)
+
+	// Create Subnet
+	subnet, err := v2.CreateSubnet(t, client, network.ID)
+	if err != nil {
+		t.Fatalf("Unable to create subnet: %v", err)
+	}
+	defer v2.DeleteSubnet(t, client, subnet.ID)
+
+	// Create port
+	parentPort, err := v2.CreatePort(t, client, network.ID, subnet.ID)
+	if err != nil {
+		t.Fatalf("Unable to create port: %v", err)
+	}
+	defer v2.DeletePort(t, client, parentPort.ID)
+
+	subport1, err := v2.CreatePort(t, client, network.ID, subnet.ID)
+	if err != nil {
+		t.Fatalf("Unable to create port: %v", err)
+	}
+	defer v2.DeletePort(t, client, subport1.ID)
+
+	subport2, err := v2.CreatePort(t, client, network.ID, subnet.ID)
+	if err != nil {
+		t.Fatalf("Unable to create port: %v", err)
+	}
+	defer v2.DeletePort(t, client, subport2.ID)
+
+	trunk, err := v2Trunks.CreateTrunk(t, client, parentPort.ID, subport1.ID, subport2.ID)
+	if err != nil {
+		t.Fatalf("Unable to create trunk: %v", err)
+	}
+	defer v2Trunks.DeleteTrunk(t, client, trunk.ID)
+
+	// Test LIST ports with trunk details
+	allPages, err := ports.List(client, ports.ListOpts{ID: parentPort.ID}).AllPages()
+	th.AssertNoErr(t, err)
+
+	var allPorts []portWithTrunkDetails
+	err = ports.ExtractPortsInto(allPages, &allPorts)
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, 1, len(allPorts))
+	port := allPorts[0]
+
+	th.AssertEquals(t, trunk.ID, port.TrunkDetails.TrunkID)
+	th.AssertEquals(t, 2, len(port.TrunkDetails.SubPorts))
+
+	// Note that MAC address is not (currently) returned in list queries. We
+	// exclude it from the comparison here in case it's ever added. MAC
+	// address is returned in GET queries, so we do assert that in the GET
+	// test below.
+	th.AssertDeepEquals(t, trunks.Subport{
+		SegmentationID:   1,
+		SegmentationType: "vlan",
+		PortID:           subport1.ID,
+	}, port.TrunkDetails.SubPorts[0].Subport)
+	th.AssertDeepEquals(t, trunks.Subport{
+		SegmentationID:   2,
+		SegmentationType: "vlan",
+		PortID:           subport2.ID,
+	}, port.TrunkDetails.SubPorts[1].Subport)
+
+	// Test GET port with trunk details
+	err = ports.Get(client, parentPort.ID).ExtractInto(&port)
+	th.AssertEquals(t, trunk.ID, port.TrunkDetails.TrunkID)
+	th.AssertEquals(t, 2, len(port.TrunkDetails.SubPorts))
+	th.AssertDeepEquals(t, trunk_details.Subport{
+		Subport: trunks.Subport{
+			SegmentationID:   1,
+			SegmentationType: "vlan",
+			PortID:           subport1.ID,
+		},
+		MACAddress: subport1.MACAddress,
+	}, port.TrunkDetails.SubPorts[0])
+	th.AssertDeepEquals(t, trunk_details.Subport{
+		Subport: trunks.Subport{
+			SegmentationID:   2,
+			SegmentationType: "vlan",
+			PortID:           subport2.ID,
+		},
+		MACAddress: subport2.MACAddress,
+	}, port.TrunkDetails.SubPorts[1])
+}

--- a/openstack/networking/v2/extensions/trunk_details/doc.go
+++ b/openstack/networking/v2/extensions/trunk_details/doc.go
@@ -1,0 +1,20 @@
+/*
+Package trunk_details provides the ability to extend a ports result with
+additional information about any trunk and subports associated with the port.
+
+Example:
+
+	type portExt struct {
+	  ports.Port
+	  trunk_details.TrunkDetailsExt
+	}
+	var portExt portExt
+
+	err := ports.Get(networkClient, "2ba3a709-e40e-462c-a541-85e99de589bf").ExtractInto(&portExt)
+	if err != nil {
+	  panic(err)
+	}
+
+	fmt.Printf("%+v\n", portExt)
+*/
+package trunk_details

--- a/openstack/networking/v2/extensions/trunk_details/results.go
+++ b/openstack/networking/v2/extensions/trunk_details/results.go
@@ -1,0 +1,30 @@
+package trunk_details
+
+import (
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/trunks"
+)
+
+// TrunkDetailsExt represents additional trunking information returned in a
+// ports query.
+type TrunkDetailsExt struct {
+	// trunk_details contains details of any trunk associated with the port
+	TrunkDetails `json:"trunk_details,omitempty"`
+}
+
+// TrunkDetails contains additional trunking information returned in a
+// ports query.
+type TrunkDetails struct {
+	// trunk_id contains the UUID of the trunk
+	TrunkID string `json:"trunk_id"`
+
+	// sub_ports contains a list of subports associated with the trunk
+	SubPorts []Subport `json:"sub_ports,omitempty"`
+}
+
+type Subport struct {
+	trunks.Subport
+
+	// mac_address contains the MAC address of the subport.
+	// Note that MACAddress may not be returned in list queries
+	MACAddress string `json:"mac_address,omitempty"`
+}

--- a/openstack/networking/v2/extensions/trunk_details/testing/doc.go
+++ b/openstack/networking/v2/extensions/trunk_details/testing/doc.go
@@ -1,0 +1,1 @@
+package testing

--- a/openstack/networking/v2/extensions/trunk_details/testing/fixtures.go
+++ b/openstack/networking/v2/extensions/trunk_details/testing/fixtures.go
@@ -1,0 +1,52 @@
+package testing
+
+// PortWithTrunkDetailsResult represents a raw server response from the
+// Neutron API with trunk_details enabled.
+// Some fields have been deleted from the response.
+const PortWithTrunkDetailsResult = `
+{
+  "port": {
+    "id": "dc3e8758-ee96-402d-94b0-4be5e9396c82",
+    "name": "test-port-with-subports",
+    "network_id": "42e996cb-6c9e-4cb1-8665-c62aa1610249",
+    "tenant_id": "d4aa8944-e8be-4f46-bf93-74331af9c49e",
+    "mac_address": "fa:16:3e:1f:de:6d",
+    "admin_state_up": true,
+    "status": "ACTIVE",
+    "device_id": "935f1d9c-1888-457e-98d7-cb57405086cf",
+    "device_owner": "compute:nova",
+    "fixed_ips": [
+      {
+        "subnet_id": "f7aea11b-a649-4d23-995f-dcd4f2513f7e",
+        "ip_address": "172.16.0.225"
+      }
+    ],
+    "allowed_address_pairs": [],
+    "extra_dhcp_opts": [],
+    "security_groups": [
+      "614f6c36-50b8-4dde-ab59-a46783befeec"
+    ],
+    "description": "",
+    "binding:vnic_type": "normal",
+    "qos_policy_id": null,
+    "port_security_enabled": true,
+    "trunk_details": {
+      "trunk_id": "f170c831-8c55-4ceb-ad13-75eab4a121e5",
+      "sub_ports": [
+        {
+          "segmentation_id": 100,
+          "segmentation_type": "vlan",
+          "port_id": "20c673d8-7f9d-4570-b662-148d9ddcc5bd",
+          "mac_address": "fa:16:3e:88:29:a0"
+        }
+      ]
+    },
+    "ip_allocation": "immediate",
+    "tags": [],
+    "created_at": "2023-05-05T10:54:51Z",
+    "updated_at": "2023-05-05T16:26:01Z",
+    "revision_number": 4,
+    "project_id": "d4aa8944-e8be-4f46-bf93-74331af9c49e"
+  }
+}
+`

--- a/openstack/networking/v2/extensions/trunk_details/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/trunk_details/testing/requests_test.go
@@ -1,0 +1,44 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/trunk_details"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	fake "github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func TestServerWithUsageExt(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	const portIDFixture = "dc3e8758-ee96-402d-94b0-4be5e9396c82"
+
+	th.Mux.HandleFunc("/ports/"+portIDFixture, func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+
+		fmt.Fprint(w, PortWithTrunkDetailsResult)
+	})
+
+	var portExt struct {
+		ports.Port
+		trunk_details.TrunkDetailsExt
+	}
+
+	// Extract basic fields.
+	err := ports.Get(fake.ServiceClient(), portIDFixture).ExtractInto(&portExt)
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, portExt.TrunkDetails.TrunkID, "f170c831-8c55-4ceb-ad13-75eab4a121e5")
+	th.AssertEquals(t, len(portExt.TrunkDetails.SubPorts), 1)
+	subPort := portExt.TrunkDetails.SubPorts[0]
+	th.AssertEquals(t, subPort.SegmentationID, 100)
+	th.AssertEquals(t, subPort.SegmentationType, "vlan")
+	th.AssertEquals(t, subPort.PortID, "20c673d8-7f9d-4570-b662-148d9ddcc5bd")
+	th.AssertEquals(t, subPort.MACAddress, "fa:16:3e:88:29:a0")
+}


### PR DESCRIPTION
Fixes https://github.com/gophercloud/gophercloud/issues/2624

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/neutron-lib/blob/c5ca1ddf420b827e4684dee6a6495475014a91e3/api-ref/source/v2/samples/trunks/trunk-details-show-response.json#L14-L30