### PR TITLE
Add upstream neutron bug for trunk_details

### DIFF
--- a/acceptance/openstack/networking/v2/extensions/trunk_details/trunks_test.go
+++ b/acceptance/openstack/networking/v2/extensions/trunk_details/trunks_test.go
@@ -89,6 +89,8 @@ func TestListPortWithSubports(t *testing.T) {
 	// exclude it from the comparison here in case it's ever added. MAC
 	// address is returned in GET queries, so we do assert that in the GET
 	// test below.
+	// Tracked in https://bugs.launchpad.net/neutron/+bug/2020552
+	// TODO: Remove this workaround when the bug is resolved
 	th.AssertDeepEquals(t, trunks.Subport{
 		SegmentationID:   1,
 		SegmentationType: "vlan",


### PR DESCRIPTION
This simply adds a comment pointing to an upstream tracking bug for a workaround in https://github.com/gophercloud/gophercloud/pull/2625.

The bug is https://bugs.launchpad.net/neutron/+bug/2020552

The trunk_details acceptance test works around the bug. The tracking bug should allow somebody to confidently remove the workaround in the future.