### PR TITLE
[manila]: Add Share Replicas support

### DIFF
--- a/acceptance/clients/conditions.go
+++ b/acceptance/clients/conditions.go
@@ -12,6 +12,14 @@ func RequiredSystemScope(t *testing.T) {
 	}
 }
 
+// RequireManilaReplicas will restrict a test to only be run with enabled
+// manila replicas.
+func RequireManilaReplicas(t *testing.T) {
+	if os.Getenv("OS_MANILA_REPLICAS") != "true" {
+		t.Skip("manila replicas must be enabled to run this test")
+	}
+}
+
 // RequireAdmin will restrict a test to only be run by admin users.
 func RequireAdmin(t *testing.T) {
 	if os.Getenv("OS_USERNAME") != "admin" {

--- a/acceptance/openstack/sharedfilesystems/v2/replicas_test.go
+++ b/acceptance/openstack/sharedfilesystems/v2/replicas_test.go
@@ -1,0 +1,308 @@
+//go:build acceptance
+// +build acceptance
+
+package v2
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gophercloud/gophercloud/acceptance/clients"
+	"github.com/gophercloud/gophercloud/acceptance/tools"
+	"github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/replicas"
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+// otherwise we need to set "X-OpenStack-Manila-API-Experimental: true"
+const replicasMicroversion = "2.60"
+
+func TestReplicaCreate(t *testing.T) {
+	clients.RequireManilaReplicas(t)
+
+	client, err := clients.NewSharedFileSystemV2Client()
+	if err != nil {
+		t.Fatalf("Unable to create a shared file system client: %v", err)
+	}
+	client.Microversion = replicasMicroversion
+
+	share, err := CreateShare(t, client)
+	if err != nil {
+		t.Fatalf("Unable to create a share: %v", err)
+	}
+
+	defer DeleteShare(t, client, share)
+
+	replica, err := CreateReplica(t, client, share)
+	if err != nil {
+		t.Fatalf("Unable to create a replica: %v", err)
+	}
+
+	defer DeleteReplica(t, client, replica)
+
+	created, err := replicas.Get(client, replica.ID).Extract()
+	if err != nil {
+		t.Errorf("Unable to retrieve replica: %v", err)
+	}
+	tools.PrintResource(t, created)
+
+	allReplicas, err := ListShareReplicas(t, client, share.ID)
+	th.AssertNoErr(t, err)
+
+	if len(allReplicas) != 2 {
+		t.Errorf("Unable to list all two replicas")
+	}
+}
+
+func TestReplicaPromote(t *testing.T) {
+	clients.RequireManilaReplicas(t)
+
+	client, err := clients.NewSharedFileSystemV2Client()
+	if err != nil {
+		t.Fatalf("Unable to create a shared file system client: %v", err)
+	}
+	client.Microversion = replicasMicroversion
+
+	share, err := CreateShare(t, client)
+	if err != nil {
+		t.Fatalf("Unable to create a share: %v", err)
+	}
+
+	defer DeleteShare(t, client, share)
+
+	replica, err := CreateReplica(t, client, share)
+	if err != nil {
+		t.Fatalf("Unable to create a replica: %v", err)
+	}
+
+	defer DeleteReplica(t, client, replica)
+
+	created, err := replicas.Get(client, replica.ID).Extract()
+	if err != nil {
+		t.Fatalf("Unable to retrieve replica: %v", err)
+	}
+	tools.PrintResource(t, created)
+
+	// sync new replica
+	err = replicas.Resync(client, created.ID).ExtractErr()
+	th.AssertNoErr(t, err)
+	_, err = waitForReplicaState(t, client, created.ID, "in_sync")
+	if err != nil {
+		t.Fatalf("Replica status error: %v", err)
+	}
+
+	// promote new replica
+	err = replicas.Promote(client, created.ID, &replicas.PromoteOpts{}).ExtractErr()
+	th.AssertNoErr(t, err)
+
+	_, err = waitForReplicaState(t, client, created.ID, "active")
+	if err != nil {
+		t.Fatalf("Replica status error: %v", err)
+	}
+
+	// promote old replica
+	allReplicas, err := ListShareReplicas(t, client, share.ID)
+	th.AssertNoErr(t, err)
+	var oldReplicaID string
+	for _, v := range allReplicas {
+		if v.ID == created.ID {
+			// These are not the droids you are looking for
+			continue
+		}
+		oldReplicaID = v.ID
+	}
+	if oldReplicaID == "" {
+		t.Errorf("Unable to get old replica")
+	}
+	// sync old replica
+	err = replicas.Resync(client, oldReplicaID).ExtractErr()
+	th.AssertNoErr(t, err)
+	_, err = waitForReplicaState(t, client, oldReplicaID, "in_sync")
+	if err != nil {
+		t.Fatalf("Replica status error: %v", err)
+	}
+	err = replicas.Promote(client, oldReplicaID, &replicas.PromoteOpts{}).ExtractErr()
+	th.AssertNoErr(t, err)
+
+	_, err = waitForReplicaState(t, client, oldReplicaID, "active")
+	if err != nil {
+		t.Fatalf("Replica status error: %v", err)
+	}
+}
+
+func TestReplicaExportLocations(t *testing.T) {
+	clients.RequireManilaReplicas(t)
+
+	client, err := clients.NewSharedFileSystemV2Client()
+	if err != nil {
+		t.Fatalf("Unable to create a shared file system client: %v", err)
+	}
+	client.Microversion = replicasMicroversion
+
+	share, err := CreateShare(t, client)
+	if err != nil {
+		t.Fatalf("Unable to create a share: %v", err)
+	}
+
+	defer DeleteShare(t, client, share)
+
+	replica, err := CreateReplica(t, client, share)
+	if err != nil {
+		t.Fatalf("Unable to create a replica: %v", err)
+	}
+
+	defer DeleteReplica(t, client, replica)
+
+	// this call should return empty list, since replica is not yet active
+	exportLocations, err := replicas.ListExportLocations(client, replica.ID).Extract()
+	if err != nil {
+		t.Errorf("Unable to list replica export locations: %v", err)
+	}
+	tools.PrintResource(t, exportLocations)
+
+	opts := replicas.ListOpts{
+		ShareID: share.ID,
+	}
+	pages, err := replicas.List(client, opts).AllPages()
+	th.AssertNoErr(t, err)
+
+	allReplicas, err := replicas.ExtractReplicas(pages)
+	th.AssertNoErr(t, err)
+
+	var activeReplicaID string
+	for _, v := range allReplicas {
+		if v.State == "active" && v.Status == "available" {
+			activeReplicaID = v.ID
+		}
+	}
+
+	if activeReplicaID == "" {
+		t.Errorf("Unable to get active replica")
+	}
+
+	exportLocations, err = replicas.ListExportLocations(client, activeReplicaID).Extract()
+	if err != nil {
+		t.Errorf("Unable to list replica export locations: %v", err)
+	}
+	tools.PrintResource(t, exportLocations)
+
+	exportLocation, err := replicas.GetExportLocation(client, activeReplicaID, exportLocations[0].ID).Extract()
+	if err != nil {
+		t.Errorf("Unable to get replica export location: %v", err)
+	}
+	tools.PrintResource(t, exportLocation)
+	// unset CreatedAt and UpdatedAt
+	exportLocation.CreatedAt = time.Time{}
+	exportLocation.UpdatedAt = time.Time{}
+	th.AssertEquals(t, exportLocations[0], *exportLocation)
+}
+
+func TestReplicaListDetail(t *testing.T) {
+	clients.RequireManilaReplicas(t)
+
+	client, err := clients.NewSharedFileSystemV2Client()
+	if err != nil {
+		t.Fatalf("Unable to create a shared file system client: %v", err)
+	}
+	client.Microversion = replicasMicroversion
+
+	share, err := CreateShare(t, client)
+	if err != nil {
+		t.Fatalf("Unable to create a share: %v", err)
+	}
+
+	defer DeleteShare(t, client, share)
+
+	replica, err := CreateReplica(t, client, share)
+	if err != nil {
+		t.Fatalf("Unable to create a replica: %v", err)
+	}
+
+	defer DeleteReplica(t, client, replica)
+
+	ss, err := ListShareReplicas(t, client, share.ID)
+	if err != nil {
+		t.Fatalf("Unable to list replicas: %v", err)
+	}
+
+	for i := range ss {
+		tools.PrintResource(t, &ss[i])
+	}
+}
+
+func TestReplicaResetStatus(t *testing.T) {
+	clients.RequireManilaReplicas(t)
+
+	client, err := clients.NewSharedFileSystemV2Client()
+	if err != nil {
+		t.Fatalf("Unable to create a shared file system client: %v", err)
+	}
+	client.Microversion = replicasMicroversion
+
+	share, err := CreateShare(t, client)
+	if err != nil {
+		t.Fatalf("Unable to create a share: %v", err)
+	}
+
+	defer DeleteShare(t, client, share)
+
+	replica, err := CreateReplica(t, client, share)
+	if err != nil {
+		t.Fatalf("Unable to create a replica: %v", err)
+	}
+
+	defer DeleteReplica(t, client, replica)
+
+	resetStatusOpts := &replicas.ResetStatusOpts{
+		Status: "error",
+	}
+	err = replicas.ResetStatus(client, replica.ID, resetStatusOpts).ExtractErr()
+	if err != nil {
+		t.Fatalf("Unable to reset a replica status: %v", err)
+	}
+
+	// We need to wait till the Extend operation is done
+	_, err = waitForReplicaStatus(t, client, replica.ID, "error")
+	if err != nil {
+		t.Fatalf("Replica status error: %v", err)
+	}
+
+	t.Logf("Replica %s status successfuly reset", replica.ID)
+}
+
+// This test available only for cloud admins
+func TestReplicaForceDelete(t *testing.T) {
+	clients.RequireManilaReplicas(t)
+	clients.RequireAdmin(t)
+
+	client, err := clients.NewSharedFileSystemV2Client()
+	if err != nil {
+		t.Fatalf("Unable to create a shared file system client: %v", err)
+	}
+	client.Microversion = replicasMicroversion
+
+	share, err := CreateShare(t, client)
+	if err != nil {
+		t.Fatalf("Unable to create a share: %v", err)
+	}
+
+	defer DeleteShare(t, client, share)
+
+	replica, err := CreateReplica(t, client, share)
+	if err != nil {
+		t.Fatalf("Unable to create a replica: %v", err)
+	}
+
+	defer DeleteReplica(t, client, replica)
+
+	err = replicas.ForceDelete(client, replica.ID).ExtractErr()
+	if err != nil {
+		t.Fatalf("Unable to force delete a replica: %v", err)
+	}
+
+	_, err = waitForReplicaStatus(t, client, replica.ID, "deleted")
+	if err != nil {
+		t.Fatalf("Replica status error: %v", err)
+	}
+
+	t.Logf("Replica %s was successfuly deleted", replica.ID)
+}

--- a/acceptance/openstack/sharedfilesystems/v2/schedulerstats_test.go
+++ b/acceptance/openstack/sharedfilesystems/v2/schedulerstats_test.go
@@ -14,8 +14,8 @@ import (
 
 func TestSchedulerStatsList(t *testing.T) {
 	client, err := clients.NewSharedFileSystemV2Client()
-	client.Microversion = "2.23"
 	th.AssertNoErr(t, err)
+	client.Microversion = "2.23"
 
 	allPages, err := schedulerstats.List(client, nil).AllPages()
 	th.AssertNoErr(t, err)

--- a/openstack/sharedfilesystems/v2/replicas/requests.go
+++ b/openstack/sharedfilesystems/v2/replicas/requests.go
@@ -1,0 +1,271 @@
+package replicas
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToReplicaCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts contains the options for create a Share Replica. This object is
+// passed to replicas.Create function. For more information about these parameters,
+// please refer to the Replica object, or the shared file systems API v2
+// documentation.
+type CreateOpts struct {
+	// The UUID of the share from which to create a share replica.
+	ShareID string `json:"share_id" required:"true"`
+	// The UUID of the share network to which the share replica should
+	// belong to.
+	ShareNetworkID string `json:"share_network_id,omitempty"`
+	// The availability zone of the share replica.
+	AvailabilityZone string `json:"availability_zone,omitempty"`
+	// One or more scheduler hints key and value pairs as a dictionary of
+	// strings. Minimum supported microversion for SchedulerHints is 2.67.
+	SchedulerHints map[string]string `json:"scheduler_hints,omitempty"`
+}
+
+// ToReplicaCreateMap assembles a request body based on the contents of a
+// CreateOpts.
+func (opts CreateOpts) ToReplicaCreateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "share_replica")
+}
+
+// Create will create a new Share Replica based on the values in CreateOpts. To extract
+// the Replica object from the response, call the Extract method on the
+// CreateResult.
+func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToReplicaCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := client.Post(createURL(client), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// ListOpts holds options for listing Share Replicas. This object is passed to the
+// replicas.List function.
+type ListOpts struct {
+	// The UUID of the share.
+	ShareID string `q:"share_id"`
+	// Per page limit for share replicas
+	Limit int `q:"limit"`
+	// Used in conjunction with limit to return a slice of items.
+	Offset int `q:"offset"`
+	// The ID of the last-seen item.
+	Marker string `q:"marker"`
+}
+
+// ListOptsBuilder allows extensions to add additional parameters to the List
+// request.
+type ListOptsBuilder interface {
+	ToReplicaListQuery() (string, error)
+}
+
+// ToReplicaListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToReplicaListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List returns []Replica optionally limited by the conditions provided in ListOpts.
+func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(client)
+	if opts != nil {
+		query, err := opts.ToReplicaListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		p := ReplicaPage{pagination.MarkerPageBase{PageResult: r}}
+		p.MarkerPageBase.Owner = p
+		return p
+	})
+}
+
+// ListDetail returns []Replica optionally limited by the conditions provided in ListOpts.
+func ListDetail(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listDetailURL(client)
+	if opts != nil {
+		query, err := opts.ToReplicaListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		p := ReplicaPage{pagination.MarkerPageBase{PageResult: r}}
+		p.MarkerPageBase.Owner = p
+		return p
+	})
+}
+
+// Delete will delete an existing Replica with the given UUID.
+func Delete(client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+	resp, err := client.Delete(deleteURL(client, id), nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// Get will get a single share with given UUID
+func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {
+	resp, err := client.Get(getURL(client, id), &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// ListExportLocations will list replicaID's export locations.
+// Minimum supported microversion for ListExportLocations is 2.47.
+func ListExportLocations(client *gophercloud.ServiceClient, id string) (r ListExportLocationsResult) {
+	resp, err := client.Get(listExportLocationsURL(client, id), &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// GetExportLocation will get replicaID's export location by an ID.
+// Minimum supported microversion for GetExportLocation is 2.47.
+func GetExportLocation(client *gophercloud.ServiceClient, replicaID string, id string) (r GetExportLocationResult) {
+	resp, err := client.Get(getExportLocationURL(client, replicaID, id), &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// PromoteOptsBuilder allows extensions to add additional parameters to the
+// Promote request.
+type PromoteOptsBuilder interface {
+	ToReplicaPromoteMap() (map[string]interface{}, error)
+}
+
+// PromoteOpts contains options for promoteing a Replica to active replica state.
+// This object is passed to the replicas.Promote function.
+type PromoteOpts struct {
+	// The quiesce wait time in seconds used during replica promote.
+	// Minimum supported microversion for QuiesceWaitTime is 2.75.
+	QuiesceWaitTime int `json:"quiesce_wait_time,omitempty"`
+}
+
+// ToReplicaPromoteMap assembles a request body based on the contents of a
+// PromoteOpts.
+func (opts PromoteOpts) ToReplicaPromoteMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "promote")
+}
+
+// Promote will promote an existing Replica to active state. PromoteResult contains only the error.
+// To extract it, call the ExtractErr method on the PromoteResult.
+func Promote(client *gophercloud.ServiceClient, id string, opts PromoteOptsBuilder) (r PromoteResult) {
+	b, err := opts.ToReplicaPromoteMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	resp, err := client.Post(actionURL(client, id), b, nil, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// Resync a replica with its active mirror. ResyncResult contains only the error.
+// To extract it, call the ExtractErr method on the ResyncResult.
+func Resync(client *gophercloud.ServiceClient, id string) (r ResyncResult) {
+	resp, err := client.Post(actionURL(client, id), map[string]interface{}{"resync": nil}, nil, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// ResetStatusOptsBuilder allows extensions to add additional parameters to the
+// ResetStatus request.
+type ResetStatusOptsBuilder interface {
+	ToReplicaResetStatusMap() (map[string]interface{}, error)
+}
+
+// ResetStatusOpts contain options for updating a Share Replica status. This object is passed
+// to the replicas.ResetStatus function. Administrator only.
+type ResetStatusOpts struct {
+	// The status of a share replica. List of possible values: "available",
+	// "error", "creating", "deleting" or "error_deleting".
+	Status string `json:"status" required:"true"`
+}
+
+// ToReplicaResetStatusMap assembles a request body based on the contents of an
+// ResetStatusOpts.
+func (opts ResetStatusOpts) ToReplicaResetStatusMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "reset_status")
+}
+
+// ResetStatus will reset the Share Replica status with provided information.
+// ResetStatusResult contains only the error. To extract it, call the ExtractErr
+// method on the ResetStatusResult.
+func ResetStatus(client *gophercloud.ServiceClient, id string, opts ResetStatusOptsBuilder) (r ResetStatusResult) {
+	b, err := opts.ToReplicaResetStatusMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := client.Post(actionURL(client, id), b, nil, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// ResetStateOptsBuilder allows extensions to add additional parameters to the
+// ResetState request.
+type ResetStateOptsBuilder interface {
+	ToReplicaResetStateMap() (map[string]interface{}, error)
+}
+
+// ResetStateOpts contain options for updating a Share Replica state. This object is passed
+// to the replicas.ResetState function. Administrator only.
+type ResetStateOpts struct {
+	// The state of a share replica. List of possible values: "active",
+	// "in_sync", "out_of_sync" or "error".
+	State string `json:"replica_state" required:"true"`
+}
+
+// ToReplicaResetStateMap assembles a request body based on the contents of an
+// ResetStateOpts.
+func (opts ResetStateOpts) ToReplicaResetStateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "reset_replica_state")
+}
+
+// ResetState will reset the Share Replica state with provided information.
+// ResetStateResult contains only the error. To extract it, call the ExtractErr
+// method on the ResetStateResult.
+func ResetState(client *gophercloud.ServiceClient, id string, opts ResetStateOptsBuilder) (r ResetStateResult) {
+	b, err := opts.ToReplicaResetStateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := client.Post(actionURL(client, id), b, nil, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// ForceDelete force-deletes a Share Replica in any state. ForceDeleteResult
+// contains only the error. To extract it, call the ExtractErr method on the
+// ForceDeleteResult. Administrator only.
+func ForceDelete(client *gophercloud.ServiceClient, id string) (r ForceDeleteResult) {
+	resp, err := client.Post(actionURL(client, id), map[string]interface{}{"force_delete": nil}, nil, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}

--- a/openstack/sharedfilesystems/v2/replicas/results.go
+++ b/openstack/sharedfilesystems/v2/replicas/results.go
@@ -1,0 +1,272 @@
+package replicas
+
+import (
+	"encoding/json"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+const (
+	invalidMarker = "-1"
+)
+
+// Replica contains all information associated with an OpenStack Share Replica.
+type Replica struct {
+	// ID of the share replica
+	ID string `json:"id"`
+	// The availability zone of the share replica.
+	AvailabilityZone string `json:"availability_zone"`
+	// Indicates whether existing access rules will be cast to read/only.
+	CastRulesToReadonly bool `json:"cast_rules_to_readonly"`
+	// The host name of the share replica.
+	Host string `json:"host"`
+	// The UUID of the share to which a share replica belongs.
+	ShareID string `json:"share_id"`
+	// The UUID of the share network where the resource is exported to.
+	ShareNetworkID string `json:"share_network_id"`
+	// The UUID of the share server.
+	ShareServerID string `json:"share_server_id"`
+	// The share replica status.
+	Status string `json:"status"`
+	// The share replica state.
+	State string `json:"replica_state"`
+	// Timestamp when the replica was created.
+	CreatedAt time.Time `json:"-"`
+	// Timestamp when the replica was updated.
+	UpdatedAt time.Time `json:"-"`
+}
+
+func (r *Replica) UnmarshalJSON(b []byte) error {
+	type tmp Replica
+	var s struct {
+		tmp
+		CreatedAt gophercloud.JSONRFC3339MilliNoZ `json:"created_at"`
+		UpdatedAt gophercloud.JSONRFC3339MilliNoZ `json:"updated_at"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	*r = Replica(s.tmp)
+
+	r.CreatedAt = time.Time(s.CreatedAt)
+	r.UpdatedAt = time.Time(s.UpdatedAt)
+
+	return nil
+}
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// Extract will get the Replica object from the commonResul.t
+func (r commonResult) Extract() (*Replica, error) {
+	var s struct {
+		Replica *Replica `json:"share_replica"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Replica, err
+}
+
+// CreateResult contains the response body and error from a Create request.
+type CreateResult struct {
+	commonResult
+}
+
+// ReplicaPage is a pagination.pager that is returned from a call to the List function.
+type ReplicaPage struct {
+	pagination.MarkerPageBase
+}
+
+// NextPageURL generates the URL for the page of results after this one.
+func (r ReplicaPage) NextPageURL() (string, error) {
+	currentURL := r.URL
+	mark, err := r.Owner.LastMarker()
+	if err != nil {
+		return "", err
+	}
+	if mark == invalidMarker {
+		return "", nil
+	}
+
+	q := currentURL.Query()
+	q.Set("offset", mark)
+	currentURL.RawQuery = q.Encode()
+	return currentURL.String(), nil
+}
+
+// LastMarker returns the last offset in a ListResult.
+func (r ReplicaPage) LastMarker() (string, error) {
+	replicas, err := ExtractReplicas(r)
+	if err != nil {
+		return invalidMarker, err
+	}
+	if len(replicas) == 0 {
+		return invalidMarker, nil
+	}
+
+	u, err := url.Parse(r.URL.String())
+	if err != nil {
+		return invalidMarker, err
+	}
+	queryParams := u.Query()
+	offset := queryParams.Get("offset")
+	limit := queryParams.Get("limit")
+
+	// Limit is not present, only one page required
+	if limit == "" {
+		return invalidMarker, nil
+	}
+
+	iOffset := 0
+	if offset != "" {
+		iOffset, err = strconv.Atoi(offset)
+		if err != nil {
+			return invalidMarker, err
+		}
+	}
+	iLimit, err := strconv.Atoi(limit)
+	if err != nil {
+		return invalidMarker, err
+	}
+	iOffset = iOffset + iLimit
+	offset = strconv.Itoa(iOffset)
+
+	return offset, nil
+}
+
+// IsEmpty satisifies the IsEmpty method of the Page interface.
+func (r ReplicaPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
+	replicas, err := ExtractReplicas(r)
+	return len(replicas) == 0, err
+}
+
+// ExtractReplicas extracts and returns a Replica slice. It is used while
+// iterating over a replicas.List call.
+func ExtractReplicas(r pagination.Page) ([]Replica, error) {
+	var s struct {
+		Replicas []Replica `json:"share_replicas"`
+	}
+
+	err := (r.(ReplicaPage)).ExtractInto(&s)
+
+	return s.Replicas, err
+}
+
+// DeleteResult contains the response body and error from a Delete request.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
+// GetResult contains the response body and error from a Get request.
+type GetResult struct {
+	commonResult
+}
+
+// ListExportLocationsResult contains the result body and error from a
+// ListExportLocations request.
+type ListExportLocationsResult struct {
+	gophercloud.Result
+}
+
+// GetExportLocationResult contains the result body and error from a
+// GetExportLocation request.
+type GetExportLocationResult struct {
+	gophercloud.Result
+}
+
+// ExportLocation contains all information associated with a share export location
+type ExportLocation struct {
+	// The share replica export location UUID.
+	ID string `json:"id"`
+	// The export location path that should be used for mount operation.
+	Path string `json:"path"`
+	// The UUID of the share instance that this export location belongs to.
+	ShareInstanceID string `json:"share_instance_id"`
+	// Defines purpose of an export location. If set to true, then it is
+	// expected to be used for service needs and by administrators only. If
+	// it is set to false, then this export location can be used by end users.
+	IsAdminOnly bool `json:"is_admin_only"`
+	// Drivers may use this field to identify which export locations are
+	// most efficient and should be used preferentially by clients.
+	// By default it is set to false value. New in version 2.14.
+	Preferred bool `json:"preferred"`
+	// The availability zone of the share replica.
+	AvailabilityZone string `json:"availability_zone"`
+	// The share replica state.
+	State string `json:"replica_state"`
+	// Timestamp when the export location was created.
+	CreatedAt time.Time `json:"-"`
+	// Timestamp when the export location was updated.
+	UpdatedAt time.Time `json:"-"`
+}
+
+func (r *ExportLocation) UnmarshalJSON(b []byte) error {
+	type tmp ExportLocation
+	var s struct {
+		tmp
+		CreatedAt gophercloud.JSONRFC3339MilliNoZ `json:"created_at"`
+		UpdatedAt gophercloud.JSONRFC3339MilliNoZ `json:"updated_at"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	*r = ExportLocation(s.tmp)
+
+	r.CreatedAt = time.Time(s.CreatedAt)
+	r.UpdatedAt = time.Time(s.UpdatedAt)
+
+	return nil
+}
+
+// Extract will get the Export Locations from the ListExportLocationsResult
+func (r ListExportLocationsResult) Extract() ([]ExportLocation, error) {
+	var s struct {
+		ExportLocations []ExportLocation `json:"export_locations"`
+	}
+	err := r.ExtractInto(&s)
+	return s.ExportLocations, err
+}
+
+// Extract will get the Export Location from the GetExportLocationResult
+func (r GetExportLocationResult) Extract() (*ExportLocation, error) {
+	var s struct {
+		ExportLocation *ExportLocation `json:"export_location"`
+	}
+	err := r.ExtractInto(&s)
+	return s.ExportLocation, err
+}
+
+// PromoteResult contains the error from an Promote request.
+type PromoteResult struct {
+	gophercloud.ErrResult
+}
+
+// ResyncResult contains the error from a Resync request.
+type ResyncResult struct {
+	gophercloud.ErrResult
+}
+
+// ResetStatusResult contains the error from a ResetStatus request.
+type ResetStatusResult struct {
+	gophercloud.ErrResult
+}
+
+// ResetStateResult contains the error from a ResetState request.
+type ResetStateResult struct {
+	gophercloud.ErrResult
+}
+
+// ForceDeleteResult contains the error from a ForceDelete request.
+type ForceDeleteResult struct {
+	gophercloud.ErrResult
+}

--- a/openstack/sharedfilesystems/v2/replicas/testing/fixtures.go
+++ b/openstack/sharedfilesystems/v2/replicas/testing/fixtures.go
@@ -1,0 +1,356 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	th "github.com/gophercloud/gophercloud/testhelper"
+	fake "github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+const (
+	shareEndpoint = "/share-replicas"
+	replicaID     = "3b9c33e8-b136-45c6-84a6-019c8db1d550"
+)
+
+var createRequest = `{
+  "share_replica": {
+    "share_id": "65a34695-f9e5-4eea-b48d-a0b261d82943",
+    "availability_zone": "zone-1"
+  }
+}
+`
+
+var createResponse = `{
+  "share_replica": {
+    "id": "3b9c33e8-b136-45c6-84a6-019c8db1d550",
+    "share_id": "65a34695-f9e5-4eea-b48d-a0b261d82943",
+    "availability_zone": "zone-1",
+    "created_at": "2023-05-26T12:32:56.391337",
+    "status": "creating",
+    "share_network_id": "ca0163c8-3941-4420-8b01-41517e19e366",
+    "share_server_id": null,
+    "replica_state": null,
+    "updated_at": null
+  }
+}
+`
+
+// MockCreateResponse creates a mock response
+func MockCreateResponse(t *testing.T) {
+	th.Mux.HandleFunc(shareEndpoint, func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestHeader(t, r, "X-OpenStack-Manila-API-Version", "2.11")
+		th.TestJSONRequest(t, r, createRequest)
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		fmt.Fprintf(w, createResponse)
+	})
+}
+
+// MockDeleteResponse creates a mock delete response
+func MockDeleteResponse(t *testing.T) {
+	th.Mux.HandleFunc(shareEndpoint+"/"+replicaID, func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "X-OpenStack-Manila-API-Version", "2.11")
+		w.WriteHeader(http.StatusAccepted)
+	})
+}
+
+var promoteRequest = `{
+  "promote": {
+    "quiesce_wait_time": 30
+  }
+}
+`
+
+func MockPromoteResponse(t *testing.T) {
+	th.Mux.HandleFunc(shareEndpoint+"/"+replicaID+"/action", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestHeader(t, r, "X-OpenStack-Manila-API-Version", "2.11")
+		th.TestJSONRequest(t, r, promoteRequest)
+		w.WriteHeader(http.StatusAccepted)
+	})
+}
+
+var resyncRequest = `{
+  "resync": null
+}
+`
+
+func MockResyncResponse(t *testing.T) {
+	th.Mux.HandleFunc(shareEndpoint+"/"+replicaID+"/action", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestHeader(t, r, "X-OpenStack-Manila-API-Version", "2.11")
+		th.TestJSONRequest(t, r, resyncRequest)
+		w.WriteHeader(http.StatusAccepted)
+	})
+}
+
+var resetStatusRequest = `{
+  "reset_status": {
+    "status": "available"
+  }
+}
+`
+
+func MockResetStatusResponse(t *testing.T) {
+	th.Mux.HandleFunc(shareEndpoint+"/"+replicaID+"/action", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestHeader(t, r, "X-OpenStack-Manila-API-Version", "2.11")
+		th.TestJSONRequest(t, r, resetStatusRequest)
+		w.WriteHeader(http.StatusAccepted)
+	})
+}
+
+var resetStateRequest = `{
+  "reset_replica_state": {
+    "replica_state": "active"
+  }
+}
+`
+
+func MockResetStateResponse(t *testing.T) {
+	th.Mux.HandleFunc(shareEndpoint+"/"+replicaID+"/action", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestHeader(t, r, "X-OpenStack-Manila-API-Version", "2.11")
+		th.TestJSONRequest(t, r, resetStateRequest)
+		w.WriteHeader(http.StatusAccepted)
+	})
+}
+
+var deleteRequest = `{
+  "force_delete": null
+}
+`
+
+func MockForceDeleteResponse(t *testing.T) {
+	th.Mux.HandleFunc(shareEndpoint+"/"+replicaID+"/action", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestHeader(t, r, "X-OpenStack-Manila-API-Version", "2.11")
+		th.TestJSONRequest(t, r, deleteRequest)
+		w.WriteHeader(http.StatusAccepted)
+	})
+}
+
+var getResponse = `{
+  "share_replica": {
+    "id": "3b9c33e8-b136-45c6-84a6-019c8db1d550",
+    "share_id": "65a34695-f9e5-4eea-b48d-a0b261d82943",
+    "availability_zone": "zone-1",
+    "created_at": "2023-05-26T12:32:56.391337",
+    "status": "available",
+    "share_network_id": "ca0163c8-3941-4420-8b01-41517e19e366",
+    "share_server_id": "5ccc1b0c-334a-4e46-81e6-b52e03223060",
+    "replica_state": "active",
+    "updated_at": "2023-05-26T12:33:28.265716"
+  }
+}
+`
+
+// MockGetResponse creates a mock get response
+func MockGetResponse(t *testing.T) {
+	th.Mux.HandleFunc(shareEndpoint+"/"+replicaID, func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "X-OpenStack-Manila-API-Version", "2.11")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, getResponse)
+	})
+}
+
+var listResponse = `{
+  "share_replicas": [
+    {
+      "id": "3b9c33e8-b136-45c6-84a6-019c8db1d550",
+      "share_id": "65a34695-f9e5-4eea-b48d-a0b261d82943",
+      "status": "available",
+      "replica_state": "active"
+    },
+    {
+      "id": "4b70c2e2-eec7-4699-880d-4da9051ca162",
+      "share_id": "65a34695-f9e5-4eea-b48d-a0b261d82943",
+      "status": "available",
+      "replica_state": "out_of_sync"
+    },
+    {
+      "id": "920bb037-bdd7-48a1-98f0-1aa1787ca3eb",
+      "share_id": "65a34695-f9e5-4eea-b48d-a0b261d82943",
+      "status": "available",
+      "replica_state": "in_sync"
+    }
+  ]
+}
+`
+
+var listEmptyResponse = `{"share_replicas": []}`
+
+// MockListResponse creates a mock detailed-list response
+func MockListResponse(t *testing.T) {
+	th.Mux.HandleFunc(shareEndpoint, func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "X-OpenStack-Manila-API-Version", "2.11")
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		r.ParseForm()
+		marker := r.Form.Get("offset")
+		shareID := r.Form.Get("share_id")
+		if shareID != "65a34695-f9e5-4eea-b48d-a0b261d82943" {
+			th.AssertNoErr(t, fmt.Errorf("unexpected share_id"))
+		}
+
+		switch marker {
+		case "":
+			fmt.Fprint(w, listResponse)
+		default:
+			fmt.Fprint(w, listEmptyResponse)
+		}
+	})
+}
+
+var listDetailResponse = `{
+  "share_replicas": [
+    {
+      "id": "3b9c33e8-b136-45c6-84a6-019c8db1d550",
+      "share_id": "65a34695-f9e5-4eea-b48d-a0b261d82943",
+      "availability_zone": "zone-1",
+      "created_at": "2023-05-26T12:32:56.391337",
+      "status": "available",
+      "share_network_id": "ca0163c8-3941-4420-8b01-41517e19e366",
+      "share_server_id": "5ccc1b0c-334a-4e46-81e6-b52e03223060",
+      "replica_state": "active",
+      "updated_at": "2023-05-26T12:33:28.265716"
+    },
+    {
+      "id": "4b70c2e2-eec7-4699-880d-4da9051ca162",
+      "share_id": "65a34695-f9e5-4eea-b48d-a0b261d82943",
+      "availability_zone": "zone-2",
+      "created_at": "2023-05-26T11:59:38.313089",
+      "status": "available",
+      "share_network_id": "ca0163c8-3941-4420-8b01-41517e19e366",
+      "share_server_id": "81aa586e-3a03-4f92-98bd-807d87a61c1a",
+      "replica_state": "out_of_sync",
+      "updated_at": "2023-05-26T12:00:04.321081"
+    },
+    {
+      "id": "920bb037-bdd7-48a1-98f0-1aa1787ca3eb",
+      "share_id": "65a34695-f9e5-4eea-b48d-a0b261d82943",
+      "availability_zone": "zone-1",
+      "created_at": "2023-05-26T12:32:45.751834",
+      "status": "available",
+      "share_network_id": "ca0163c8-3941-4420-8b01-41517e19e366",
+      "share_server_id": "b87ea601-7d4c-47f3-8956-6876b7a6b6db",
+      "replica_state": "in_sync",
+      "updated_at": "2023-05-26T12:36:04.110328"
+    }
+  ]
+}
+`
+
+var listDetailEmptyResponse = `{"share_replicas": []}`
+
+// MockListDetailResponse creates a mock detailed-list response
+func MockListDetailResponse(t *testing.T) {
+	th.Mux.HandleFunc(shareEndpoint+"/detail", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "X-OpenStack-Manila-API-Version", "2.11")
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		r.ParseForm()
+		marker := r.Form.Get("offset")
+		shareID := r.Form.Get("share_id")
+		if shareID != "65a34695-f9e5-4eea-b48d-a0b261d82943" {
+			th.AssertNoErr(t, fmt.Errorf("unexpected share_id"))
+		}
+
+		switch marker {
+		case "":
+			fmt.Fprint(w, listDetailResponse)
+		default:
+			fmt.Fprint(w, listDetailEmptyResponse)
+		}
+	})
+}
+
+var listExportLocationsResponse = `{
+  "export_locations": [
+    {
+      "id": "3fc02d3c-da47-42a2-88b8-2d48f8c276bd",
+      "path": "192.168.1.123:/var/lib/manila/mnt/share-3b9c33e8-b136-45c6-84a6-019c8db1d550",
+      "preferred": true,
+      "replica_state": "active",
+      "availability_zone": "zone-1"
+    },
+    {
+      "id": "ae73e762-e8b9-4aad-aad3-23afb7cd6825",
+      "path": "192.168.1.124:/var/lib/manila/mnt/share-3b9c33e8-b136-45c6-84a6-019c8db1d550",
+      "preferred": false,
+      "replica_state": "active",
+      "availability_zone": "zone-1"
+    }
+  ]
+}
+`
+
+// MockListExportLocationsResponse creates a mock get export locations response
+func MockListExportLocationsResponse(t *testing.T) {
+	th.Mux.HandleFunc(shareEndpoint+"/"+replicaID+"/export-locations", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.Header().Add("Content-Type", "application/json")
+		th.TestHeader(t, r, "X-OpenStack-Manila-API-Version", "2.47")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, listExportLocationsResponse)
+	})
+}
+
+var getExportLocationResponse = `{
+  "export_location": {
+    "id": "ae73e762-e8b9-4aad-aad3-23afb7cd6825",
+    "path": "192.168.1.124:/var/lib/manila/mnt/share-3b9c33e8-b136-45c6-84a6-019c8db1d550",
+    "preferred": false,
+    "created_at": "2023-05-26T12:44:33.987960",
+    "updated_at": "2023-05-26T12:44:33.958363",
+    "replica_state": "active",
+    "availability_zone": "zone-1"
+  }
+}
+`
+
+// MockGetExportLocationResponse creates a mock get export location response
+func MockGetExportLocationResponse(t *testing.T) {
+	th.Mux.HandleFunc(shareEndpoint+"/"+replicaID+"/export-locations/ae73e762-e8b9-4aad-aad3-23afb7cd6825", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.Header().Add("Content-Type", "application/json")
+		th.TestHeader(t, r, "X-OpenStack-Manila-API-Version", "2.47")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, getExportLocationResponse)
+	})
+}

--- a/openstack/sharedfilesystems/v2/replicas/testing/request_test.go
+++ b/openstack/sharedfilesystems/v2/replicas/testing/request_test.go
@@ -1,0 +1,269 @@
+package testing
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/replicas"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+func getClient(microVersion string) *gophercloud.ServiceClient {
+	c := client.ServiceClient()
+	c.Type = "sharev2"
+	c.Microversion = microVersion
+	return c
+}
+
+func TestCreate(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockCreateResponse(t)
+
+	options := &replicas.CreateOpts{
+		ShareID:          "65a34695-f9e5-4eea-b48d-a0b261d82943",
+		AvailabilityZone: "zone-1",
+	}
+	actual, err := replicas.Create(getClient("2.11"), options).Extract()
+
+	expected := &replicas.Replica{
+		ID:               "3b9c33e8-b136-45c6-84a6-019c8db1d550",
+		ShareID:          "65a34695-f9e5-4eea-b48d-a0b261d82943",
+		AvailabilityZone: "zone-1",
+		Status:           "creating",
+		ShareNetworkID:   "ca0163c8-3941-4420-8b01-41517e19e366",
+		CreatedAt:        time.Date(2023, time.May, 26, 12, 32, 56, 391337000, time.UTC), //"2023-05-26T12:32:56.391337",
+	}
+
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expected, actual)
+}
+
+func TestDelete(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockDeleteResponse(t)
+
+	result := replicas.Delete(getClient("2.11"), replicaID)
+	th.AssertNoErr(t, result.Err)
+}
+
+func TestForceDeleteSuccess(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockForceDeleteResponse(t)
+
+	err := replicas.ForceDelete(getClient("2.11"), replicaID).ExtractErr()
+	th.AssertNoErr(t, err)
+}
+
+func TestGet(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockGetResponse(t)
+
+	actual, err := replicas.Get(getClient("2.11"), replicaID).Extract()
+
+	expected := &replicas.Replica{
+		AvailabilityZone: "zone-1",
+		ShareNetworkID:   "ca0163c8-3941-4420-8b01-41517e19e366",
+		ShareServerID:    "5ccc1b0c-334a-4e46-81e6-b52e03223060",
+		ShareID:          "65a34695-f9e5-4eea-b48d-a0b261d82943",
+		ID:               replicaID,
+		Status:           "available",
+		State:            "active",
+		CreatedAt:        time.Date(2023, time.May, 26, 12, 32, 56, 391337000, time.UTC),
+		UpdatedAt:        time.Date(2023, time.May, 26, 12, 33, 28, 265716000, time.UTC),
+	}
+
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expected, actual)
+}
+
+func TestList(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockListResponse(t)
+
+	listOpts := &replicas.ListOpts{
+		ShareID: "65a34695-f9e5-4eea-b48d-a0b261d82943",
+	}
+	allPages, err := replicas.List(getClient("2.11"), listOpts).AllPages()
+	th.AssertNoErr(t, err)
+
+	actual, err := replicas.ExtractReplicas(allPages)
+	th.AssertNoErr(t, err)
+
+	expected := []replicas.Replica{
+		{
+			ID:      replicaID,
+			ShareID: "65a34695-f9e5-4eea-b48d-a0b261d82943",
+			Status:  "available",
+			State:   "active",
+		},
+		{
+			ID:      "4b70c2e2-eec7-4699-880d-4da9051ca162",
+			ShareID: "65a34695-f9e5-4eea-b48d-a0b261d82943",
+			Status:  "available",
+			State:   "out_of_sync",
+		},
+		{
+			ID:      "920bb037-bdd7-48a1-98f0-1aa1787ca3eb",
+			ShareID: "65a34695-f9e5-4eea-b48d-a0b261d82943",
+			Status:  "available",
+			State:   "in_sync",
+		},
+	}
+
+	th.AssertDeepEquals(t, expected, actual)
+}
+
+func TestListDetail(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockListDetailResponse(t)
+
+	listOpts := &replicas.ListOpts{
+		ShareID: "65a34695-f9e5-4eea-b48d-a0b261d82943",
+	}
+	allPages, err := replicas.ListDetail(getClient("2.11"), listOpts).AllPages()
+	th.AssertNoErr(t, err)
+
+	actual, err := replicas.ExtractReplicas(allPages)
+	th.AssertNoErr(t, err)
+
+	expected := []replicas.Replica{
+		{
+			AvailabilityZone: "zone-1",
+			ShareNetworkID:   "ca0163c8-3941-4420-8b01-41517e19e366",
+			ShareServerID:    "5ccc1b0c-334a-4e46-81e6-b52e03223060",
+			ShareID:          "65a34695-f9e5-4eea-b48d-a0b261d82943",
+			ID:               replicaID,
+			Status:           "available",
+			State:            "active",
+			CreatedAt:        time.Date(2023, time.May, 26, 12, 32, 56, 391337000, time.UTC),
+			UpdatedAt:        time.Date(2023, time.May, 26, 12, 33, 28, 265716000, time.UTC),
+		},
+		{
+			AvailabilityZone: "zone-2",
+			ShareNetworkID:   "ca0163c8-3941-4420-8b01-41517e19e366",
+			ShareServerID:    "81aa586e-3a03-4f92-98bd-807d87a61c1a",
+			ShareID:          "65a34695-f9e5-4eea-b48d-a0b261d82943",
+			ID:               "4b70c2e2-eec7-4699-880d-4da9051ca162",
+			Status:           "available",
+			State:            "out_of_sync",
+			CreatedAt:        time.Date(2023, time.May, 26, 11, 59, 38, 313089000, time.UTC),
+			UpdatedAt:        time.Date(2023, time.May, 26, 12, 00, 04, 321081000, time.UTC),
+		},
+		{
+			AvailabilityZone: "zone-1",
+			ShareNetworkID:   "ca0163c8-3941-4420-8b01-41517e19e366",
+			ShareServerID:    "b87ea601-7d4c-47f3-8956-6876b7a6b6db",
+			ShareID:          "65a34695-f9e5-4eea-b48d-a0b261d82943",
+			ID:               "920bb037-bdd7-48a1-98f0-1aa1787ca3eb",
+			Status:           "available",
+			State:            "in_sync",
+			CreatedAt:        time.Date(2023, time.May, 26, 12, 32, 45, 751834000, time.UTC),
+			UpdatedAt:        time.Date(2023, time.May, 26, 12, 36, 04, 110328000, time.UTC),
+		},
+	}
+
+	th.AssertDeepEquals(t, expected, actual)
+}
+
+func TestListExportLocationsSuccess(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockListExportLocationsResponse(t)
+
+	actual, err := replicas.ListExportLocations(getClient("2.47"), replicaID).Extract()
+
+	expected := []replicas.ExportLocation{
+		{
+			ID:               "3fc02d3c-da47-42a2-88b8-2d48f8c276bd",
+			Path:             "192.168.1.123:/var/lib/manila/mnt/share-3b9c33e8-b136-45c6-84a6-019c8db1d550",
+			Preferred:        true,
+			State:            "active",
+			AvailabilityZone: "zone-1",
+		},
+		{
+			ID:               "ae73e762-e8b9-4aad-aad3-23afb7cd6825",
+			Path:             "192.168.1.124:/var/lib/manila/mnt/share-3b9c33e8-b136-45c6-84a6-019c8db1d550",
+			Preferred:        false,
+			State:            "active",
+			AvailabilityZone: "zone-1",
+		},
+	}
+
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expected, actual)
+}
+
+func TestGetExportLocationSuccess(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockGetExportLocationResponse(t)
+
+	s, err := replicas.GetExportLocation(getClient("2.47"), replicaID, "ae73e762-e8b9-4aad-aad3-23afb7cd6825").Extract()
+
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, s, &replicas.ExportLocation{
+		Path:             "192.168.1.124:/var/lib/manila/mnt/share-3b9c33e8-b136-45c6-84a6-019c8db1d550",
+		ID:               "ae73e762-e8b9-4aad-aad3-23afb7cd6825",
+		Preferred:        false,
+		State:            "active",
+		AvailabilityZone: "zone-1",
+		CreatedAt:        time.Date(2023, time.May, 26, 12, 44, 33, 987960000, time.UTC),
+		UpdatedAt:        time.Date(2023, time.May, 26, 12, 44, 33, 958363000, time.UTC),
+	})
+}
+
+func TestResetStatusSuccess(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockResetStatusResponse(t)
+
+	err := replicas.ResetStatus(getClient("2.11"), replicaID, &replicas.ResetStatusOpts{Status: "available"}).ExtractErr()
+	th.AssertNoErr(t, err)
+}
+
+func TestResetStateSuccess(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockResetStateResponse(t)
+
+	err := replicas.ResetState(getClient("2.11"), replicaID, &replicas.ResetStateOpts{State: "active"}).ExtractErr()
+	th.AssertNoErr(t, err)
+}
+
+func TestResyncSuccess(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockResyncResponse(t)
+
+	err := replicas.Resync(getClient("2.11"), replicaID).ExtractErr()
+	th.AssertNoErr(t, err)
+}
+
+func TestPromoteSuccess(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockPromoteResponse(t)
+
+	err := replicas.Promote(getClient("2.11"), replicaID, &replicas.PromoteOpts{QuiesceWaitTime: 30}).ExtractErr()
+	th.AssertNoErr(t, err)
+}

--- a/openstack/sharedfilesystems/v2/replicas/urls.go
+++ b/openstack/sharedfilesystems/v2/replicas/urls.go
@@ -1,0 +1,35 @@
+package replicas
+
+import "github.com/gophercloud/gophercloud"
+
+func createURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("share-replicas")
+}
+
+func listURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("share-replicas")
+}
+
+func listDetailURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("share-replicas", "detail")
+}
+
+func deleteURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("share-replicas", id)
+}
+
+func getURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("share-replicas", id)
+}
+
+func listExportLocationsURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("share-replicas", id, "export-locations")
+}
+
+func getExportLocationURL(c *gophercloud.ServiceClient, replicaID, id string) string {
+	return c.ServiceURL("share-replicas", replicaID, "export-locations", id)
+}
+
+func actionURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("share-replicas", id, "action")
+}


### PR DESCRIPTION
Fixes #2633 

Looks like devstack doesn't support replicas. Here is the output of local tests:

```
$ go test -run TestReplica -v ./*.go
=== RUN   TestReplicaCreate
    tools.go:80: {
          "id": "125d64dd-aab9-4e24-8ccb-39dd455d1ba7",
          "availability_zone": "zone-1b",
          "cast_rules_to_readonly": false,
          "host": "",
          "share_id": "72a37fa6-20c9-43dc-a463-b802e96044d0",
          "share_network_id": "ca0163c8-3941-4420-8b01-41517e19e366",
          "share_server_id": "ed15ae66-af5d-4d72-8db2-a1f90a93a260",
          "status": "available",
          "replica_state": "out_of_sync"
        }
    replicas.go:54: Deleted replica: 125d64dd-aab9-4e24-8ccb-39dd455d1ba7
    shares.go:103: Deleted share: 72a37fa6-20c9-43dc-a463-b802e96044d0
--- PASS: TestReplicaCreate (66.88s)
=== RUN   TestReplicaPromote
    tools.go:80: {
          "id": "6a39a458-b2ee-468f-b1d9-261db50eec8c",
          "availability_zone": "zone-1b",
          "cast_rules_to_readonly": false,
          "host": "",
          "share_id": "fe52148b-3a24-4a19-84aa-08f1b2eeafd8",
          "share_network_id": "ca0163c8-3941-4420-8b01-41517e19e366",
          "share_server_id": "ed15ae66-af5d-4d72-8db2-a1f90a93a260",
          "status": "available",
          "replica_state": "out_of_sync"
        }
    replicas.go:54: Deleted replica: 6a39a458-b2ee-468f-b1d9-261db50eec8c
    shares.go:103: Deleted share: fe52148b-3a24-4a19-84aa-08f1b2eeafd8
--- PASS: TestReplicaPromote (126.09s)
=== RUN   TestReplicaExportLocations
    tools.go:80: []
    tools.go:80: [
          {
            "id": "c0cee115-28fc-43f0-bb42-5eba7f09d5dc",
            "path": "10.180.66.129:/share_5b891aba_b9a9_4582_8fb3_e14ab0dc2b6c",
            "share_instance_id": "",
            "is_admin_only": false,
            "preferred": true,
            "availability_zone": "zone-1b",
            "replica_state": "active"
          },
          {
            "id": "97bcdc70-ca37-45e9-b02b-3918b035c69b",
            "path": "10.180.66.22:/share_5b891aba_b9a9_4582_8fb3_e14ab0dc2b6c",
            "share_instance_id": "",
            "is_admin_only": false,
            "preferred": false,
            "availability_zone": "zone-1b",
            "replica_state": "active"
          }
        ]
    tools.go:80: {
          "id": "c0cee115-28fc-43f0-bb42-5eba7f09d5dc",
          "path": "10.180.66.129:/share_5b891aba_b9a9_4582_8fb3_e14ab0dc2b6c",
          "share_instance_id": "",
          "is_admin_only": false,
          "preferred": true,
          "availability_zone": "zone-1b",
          "replica_state": "active"
        }
    replicas.go:54: Deleted replica: 53661add-3fa1-49a2-b482-45c8c16a3e0a
    shares.go:103: Deleted share: 66c839d2-b083-4cb7-a4f8-eab71e43c908
--- PASS: TestReplicaExportLocations (54.36s)
=== RUN   TestReplicaListDetail
    tools.go:80: {
          "id": "65fe1244-ac6f-4e73-80e4-597a95ec6520",
          "availability_zone": "",
          "cast_rules_to_readonly": false,
          "host": "",
          "share_id": "e836fc36-62ef-4c82-b873-7c9fac061819",
          "share_network_id": "",
          "share_server_id": "",
          "status": "available",
          "replica_state": "out_of_sync"
        }
    tools.go:80: {
          "id": "f2e24517-87e5-4b35-b594-f69c2bb09ab4",
          "availability_zone": "",
          "cast_rules_to_readonly": false,
          "host": "",
          "share_id": "e836fc36-62ef-4c82-b873-7c9fac061819",
          "share_network_id": "",
          "share_server_id": "",
          "status": "available",
          "replica_state": "active"
        }
    replicas.go:54: Deleted replica: 65fe1244-ac6f-4e73-80e4-597a95ec6520
    shares.go:103: Deleted share: e836fc36-62ef-4c82-b873-7c9fac061819
--- PASS: TestReplicaListDetail (66.38s)
=== RUN   TestReplicaResetStatus
    replicas_test.go:278: Replica bf6d605c-3773-4178-8ae1-3b177540ffd0 status successfuly reset
    replicas.go:54: Deleted replica: bf6d605c-3773-4178-8ae1-3b177540ffd0
    shares.go:103: Deleted share: ef9fe330-4a4f-4703-ba97-a853d70a8314
--- PASS: TestReplicaResetStatus (80.83s)
=== RUN   TestReplicaForceDelete
    replicas_test.go:23: Skipping cloud admin tests.
--- SKIP: TestReplicaForceDelete (0.00s)
PASS
ok      command-line-arguments  394.539s
```