### PR TITLE
[FWaaS_v2]: Add FWaaS_V2 workflow and enable tests

### DIFF
--- a/.github/workflows/functional-fwaas_v2.yaml
+++ b/.github/workflows/functional-fwaas_v2.yaml
@@ -38,8 +38,6 @@ jobs:
             Q_ML2_PLUGIN_TYPE_DRIVERS=flat,gre,vlan,vxlan
             Q_ML2_TENANT_NETWORK_TYPE=vxlan
             Q_TUNNEL_TYPES=vxlan,gre
-            enable_plugin neutron-fwaas https://opendev.org/openstack/neutron-fwaas stable/zed
-            enable_plugin neutron-fwaas-dashboard https://opendev.org/openstack/neutron-fwaas-dashboard stable/zed
           enabled_services: 'q-svc,q-agt,q-dhcp,q-l3,q-meta,q-fwaas-v2'
           disabled_services: 'ovn,ovn-controller,ovn-northd,q-ovn-metadata-agent,cinder,c-sch,c-api,c-vol,horizon,tempest,swift'
       - name: Checkout go

--- a/.github/workflows/functional-fwaas_v2.yaml
+++ b/.github/workflows/functional-fwaas_v2.yaml
@@ -31,7 +31,6 @@ jobs:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |
             enable_plugin neutron-fwaas https://opendev.org/openstack/neutron-fwaas ${{ matrix.openstack_version }}
-            enable_plugin neutron-fwaas-dashboard https://opendev.org/openstack/neutron-fwaas-dashboard ${{ matrix.openstack_version }}
             Q_AGENT=openvswitch
             Q_ML2_PLUGIN_MECHANISM_DRIVERS=openvswitch,l2population
             Q_ML2_PLUGIN_TYPE_DRIVERS=flat,gre,vlan,vxlan

--- a/.github/workflows/functional-fwaas_v2.yaml
+++ b/.github/workflows/functional-fwaas_v2.yaml
@@ -38,8 +38,7 @@ jobs:
             Q_ML2_PLUGIN_TYPE_DRIVERS=flat,gre,vlan,vxlan
             Q_ML2_TENANT_NETWORK_TYPE=vxlan
             Q_TUNNEL_TYPES=vxlan,gre
-          enabled_services: 'q-svc,q-agt,q-dhcp,q-l3,q-meta,q-fwaas-v2'
-          disabled_services: 'ovn,ovn-controller,ovn-northd,q-ovn-metadata-agent,cinder,c-sch,c-api,c-vol,horizon,tempest,swift'
+          enabled_services: 'q-svc,q-agt,q-dhcp,q-l3,q-meta,q-fwaas-v2,-cinder,-horizon,-tempest,-swift,-c-sch,-c-api,-c-vol,-c-bak,-ovn,-ovn-controller,-ovn-northd,-q-ovn-metadata-agent'
       - name: Checkout go
         uses: actions/setup-go@v4
         with:

--- a/.github/workflows/functional-fwaas_v2.yaml
+++ b/.github/workflows/functional-fwaas_v2.yaml
@@ -1,12 +1,12 @@
-name: functional-networking
+name: functional-fwaas_v2
 on:
   pull_request:
     paths:
-      - '**networking**'
+      - '**networking/extensions/fwaas_v2**'
   schedule:
     - cron: '0 0 */3 * *'
 jobs:
-  functional-networking:
+  functional-fwaas_v2:
     strategy:
       fail-fast: false
       matrix:
@@ -57,5 +57,5 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v3
         with:
-          name: functional-networking-${{ matrix.name }}
+          name: functional-fwaas_v2-${{ matrix.name }}
           path: /tmp/devstack-logs/*

--- a/.github/workflows/functional-fwaas_v2.yaml
+++ b/.github/workflows/functional-fwaas_v2.yaml
@@ -1,0 +1,63 @@
+name: functional-networking
+on:
+  pull_request:
+    paths:
+      - '**networking**'
+  schedule:
+    - cron: '0 0 */3 * *'
+jobs:
+  functional-networking:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: "master"
+            openstack_version: "master"
+            ubuntu_version: "22.04"
+            devstack_conf_overrides: |
+              enable_plugin neutron-fwaas https://opendev.org/openstack/neutron-fwaas master
+              enable_plugin neutron-fwaas-dashboard https://opendev.org/openstack/neutron-fwaas-dashboard master
+          - name: "zed"
+            openstack_version: "stable/zed"
+            ubuntu_version: "22.04"
+            devstack_conf_overrides: |
+              enable_plugin neutron-fwaas https://opendev.org/openstack/neutron-fwaas stable/zed
+              enable_plugin neutron-fwaas-dashboard https://opendev.org/openstack/neutron-fwaas-dashboard stable/zed
+    runs-on: ubuntu-${{ matrix.ubuntu_version }}
+    name: Deploy OpenStack ${{ matrix.name }} with enabled FWaaS_v2 and run networking acceptance tests
+    steps:
+      - name: Checkout Gophercloud
+        uses: actions/checkout@v3
+      - name: Deploy devstack
+        uses: EmilienM/devstack-action@v0.11
+        with:
+          branch: ${{ matrix.openstack_version }}
+          conf_overrides: |
+            Q_AGENT=openvswitch
+            Q_ML2_PLUGIN_MECHANISM_DRIVERS=openvswitch,l2population
+            Q_ML2_PLUGIN_TYPE_DRIVERS=flat,gre,vlan,vxlan
+            Q_ML2_TENANT_NETWORK_TYPE=vxlan
+            Q_TUNNEL_TYPES=vxlan,gre
+            enable_plugin neutron-fwaas https://opendev.org/openstack/neutron-fwaas stable/zed
+            enable_plugin neutron-fwaas-dashboard https://opendev.org/openstack/neutron-fwaas-dashboard stable/zed
+          enabled_services: 'q-svc,q-agt,q-dhcp,q-l3,q-meta,q-fwaas-v2'
+          disabled_services: 'ovn,ovn-controller,ovn-northd,q-ovn-metadata-agent,cinder,c-sch,c-api,c-vol,horizon,tempest,swift'
+      - name: Checkout go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '^1.15'
+      - name: Run Gophercloud acceptance tests
+        run: ./script/acceptancetest
+        env:
+          DEVSTACK_PATH: ${{ github.workspace }}/devstack
+          ACCEPTANCE_TESTS_FILTER: "^.*fwaas_v2.*$"
+          OS_BRANCH: ${{ matrix.openstack_version }}
+      - name: Generate logs on failure
+        run: ./script/collectlogs
+        if: failure()
+      - name: Upload logs artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: functional-networking-${{ matrix.name }}
+          path: /tmp/devstack-logs/*

--- a/.github/workflows/functional-fwaas_v2.yaml
+++ b/.github/workflows/functional-fwaas_v2.yaml
@@ -10,19 +10,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        name: ["master"]
+        openstack_version: ["master"]
+        ubuntu_version: ["22.04"]
         include:
-          - name: "master"
-            openstack_version: "master"
+          - name: "antelope"
+            openstack_version: "stable/2023.1"
             ubuntu_version: "22.04"
-            devstack_conf_overrides: |
-              enable_plugin neutron-fwaas https://opendev.org/openstack/neutron-fwaas master
-              enable_plugin neutron-fwaas-dashboard https://opendev.org/openstack/neutron-fwaas-dashboard master
           - name: "zed"
             openstack_version: "stable/zed"
             ubuntu_version: "22.04"
-            devstack_conf_overrides: |
-              enable_plugin neutron-fwaas https://opendev.org/openstack/neutron-fwaas stable/zed
-              enable_plugin neutron-fwaas-dashboard https://opendev.org/openstack/neutron-fwaas-dashboard stable/zed
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with enabled FWaaS_v2 and run networking acceptance tests
     steps:
@@ -33,6 +30,8 @@ jobs:
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |
+            enable_plugin neutron-fwaas https://opendev.org/openstack/neutron-fwaas ${{ matrix.openstack_version }}
+            enable_plugin neutron-fwaas-dashboard https://opendev.org/openstack/neutron-fwaas-dashboard ${{ matrix.openstack_version }}
             Q_AGENT=openvswitch
             Q_ML2_PLUGIN_MECHANISM_DRIVERS=openvswitch,l2population
             Q_ML2_PLUGIN_TYPE_DRIVERS=flat,gre,vlan,vxlan

--- a/.github/workflows/functional-networking.yaml
+++ b/.github/workflows/functional-networking.yaml
@@ -68,7 +68,7 @@ jobs:
         run: ./script/acceptancetest
         env:
           DEVSTACK_PATH: ${{ github.workspace }}/devstack
-          ACCEPTANCE_TESTS_FILTER: "^.*networking.*$"
+          ACCEPTANCE_TESTS_FILTER: "^(?!.*fwaas_v2.*).*networking.*$"
           OS_BRANCH: ${{ matrix.openstack_version }}
       - name: Generate logs on failure
         run: ./script/collectlogs

--- a/acceptance/openstack/networking/v2/extensions/fwaas_v2/groups_test.go
+++ b/acceptance/openstack/networking/v2/extensions/fwaas_v2/groups_test.go
@@ -13,7 +13,9 @@ import (
 )
 
 func TestGroupCRUD(t *testing.T) {
-	clients.SkipReleasesAbove(t, "stable/ussuri")
+	// Releases below Victoria are not maintained.
+	// FWaaS_v2 is not compatible with releases below Zed.
+	clients.SkipReleasesBelow(t, "stable/zed")
 
 	client, err := clients.NewNetworkV2Client()
 	th.AssertNoErr(t, err)
@@ -48,21 +50,21 @@ func TestGroupCRUD(t *testing.T) {
 		EgressFirewallPolicyID:  &firewall_policy_id,
 	}
 
-	groupUpdated, err := groups.Update(client, createdGroup.ID, updateOpts).Extract()
+	updatedGroup, err := groups.Update(client, createdGroup.ID, updateOpts).Extract()
 	if err != nil {
 		t.Fatalf("Unable to update firewall group %s: %v", createdGroup.ID, err)
 	}
 
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, groupUpdated.Name, groupName)
-	th.AssertEquals(t, groupUpdated.Description, description)
-	th.AssertEquals(t, groupUpdated.AdminStateUp, adminStateUp)
-	th.AssertEquals(t, groupUpdated.IngressFirewallPolicyID, firewall_policy_id)
-	th.AssertEquals(t, groupUpdated.EgressFirewallPolicyID, firewall_policy_id)
+	th.AssertEquals(t, updatedGroup.Name, groupName)
+	th.AssertEquals(t, updatedGroup.Description, description)
+	th.AssertEquals(t, updatedGroup.AdminStateUp, adminStateUp)
+	th.AssertEquals(t, updatedGroup.IngressFirewallPolicyID, firewall_policy_id)
+	th.AssertEquals(t, updatedGroup.EgressFirewallPolicyID, firewall_policy_id)
 
-	t.Logf("Updated firewall group %s", groupUpdated.ID)
+	t.Logf("Updated firewall group %s", updatedGroup.ID)
 
-	removeIngressPolicy, err := groups.RemoveIngressPolicy(client, groupUpdated.ID).Extract()
+	removeIngressPolicy, err := groups.RemoveIngressPolicy(client, updatedGroup.ID).Extract()
 	if err != nil {
 		t.Fatalf("Unable to remove ingress firewall policy from firewall group %s: %v", removeIngressPolicy.ID, err)
 	}
@@ -70,16 +72,16 @@ func TestGroupCRUD(t *testing.T) {
 	th.AssertEquals(t, removeIngressPolicy.IngressFirewallPolicyID, "")
 	th.AssertEquals(t, removeIngressPolicy.EgressFirewallPolicyID, firewall_policy_id)
 
-	t.Logf("Ingress policy removed from firewall group %s", groupUpdated.ID)
+	t.Logf("Ingress policy removed from firewall group %s", updatedGroup.ID)
 
-	removeEgressPolicy, err := groups.RemoveEgressPolicy(client, groupUpdated.ID).Extract()
+	removeEgressPolicy, err := groups.RemoveEgressPolicy(client, updatedGroup.ID).Extract()
 	if err != nil {
 		t.Fatalf("Unable to remove egress firewall policy from firewall group %s: %v", removeEgressPolicy.ID, err)
 	}
 
 	th.AssertEquals(t, removeEgressPolicy.EgressFirewallPolicyID, "")
 
-	t.Logf("Egress policy removed from firewall group %s", groupUpdated.ID)
+	t.Logf("Egress policy removed from firewall group %s", updatedGroup.ID)
 
 	allPages, err := groups.List(client, nil).AllPages()
 	th.AssertNoErr(t, err)

--- a/acceptance/openstack/networking/v2/extensions/fwaas_v2/policy_test.go
+++ b/acceptance/openstack/networking/v2/extensions/fwaas_v2/policy_test.go
@@ -13,7 +13,9 @@ import (
 )
 
 func TestPolicyCRUD(t *testing.T) {
-	clients.SkipReleasesAbove(t, "stable/ussuri")
+	// Releases below Victoria are not maintained.
+	// FWaaS_v2 is not compatible with releases below Zed.
+	clients.SkipReleasesBelow(t, "stable/zed")
 
 	client, err := clients.NewNetworkV2Client()
 	th.AssertNoErr(t, err)

--- a/acceptance/openstack/networking/v2/extensions/fwaas_v2/rule_test.go
+++ b/acceptance/openstack/networking/v2/extensions/fwaas_v2/rule_test.go
@@ -15,7 +15,9 @@ import (
 )
 
 func TestRuleCRUD(t *testing.T) {
-	clients.SkipReleasesAbove(t, "stable/ussuri")
+	// Releases below Victoria are not maintained.
+	// FWaaS_v2 is not compatible with releases below Zed.
+	clients.SkipReleasesBelow(t, "stable/zed")
 
 	client, err := clients.NewNetworkV2Client()
 	th.AssertNoErr(t, err)


### PR DESCRIPTION
Releases below Victoria are deprecated and not testing.
FWaaS_v2 is not compatible with releases below Zed.
FWaaS_v2 has no support for OVN currently and require openvswitch, Q_ML2_PLUGIN_MECHANISM_DRIVERS, Q_ML2_PLUGIN_TYPE_DRIVERS, Q_ML2_TENANT_NETWORK_TYPE and other custom variables.

Add only FWaaS_V2 workflow.
Skip tests for releases below Zed.
Small fix FWaaS_V2 test variable.
Exclude FWaaS_V2 tests from networking workflow acceptance tests filter.

Fixes #2636
