### PR TITLE
Add CRUD support for encryption in volume v3 types

### DIFF
--- a/acceptance/openstack/blockstorage/v3/volumetypes_test.go
+++ b/acceptance/openstack/blockstorage/v3/volumetypes_test.go
@@ -174,34 +174,33 @@ func TestEncryptionVolumeTypes(t *testing.T) {
 	th.AssertNoErr(t, err)
 	defer DeleteVolumeType(t, client, vt)
 
-  createEncryptionOpts := volumetypes.CreateEncryptionOpts{
-    KeySize: 256,
-    Provider: "luks",
-    ControlLocation: "front-end",
-    Cipher: "aes-xts-plain64",
-  }
+	createEncryptionOpts := volumetypes.CreateEncryptionOpts{
+		KeySize:         256,
+		Provider:        "luks",
+		ControlLocation: "front-end",
+		Cipher:          "aes-xts-plain64",
+	}
 
-  eVT, err := volumetypes.CreateEncryption(client, vt.ID, createEncryptionOpts).Extract()
-  th.AssertNoErr(t, err)
-  defer volumetypes.DeleteEncryption(client, eVT.VolumeTypeID, eVT.EncryptionID)
+	eVT, err := volumetypes.CreateEncryption(client, vt.ID, createEncryptionOpts).Extract()
+	th.AssertNoErr(t, err)
+	defer volumetypes.DeleteEncryption(client, eVT.VolumeTypeID, eVT.EncryptionID)
 
 	geVT, err := volumetypes.GetEncryption(client, vt.ID).Extract()
 	th.AssertNoErr(t, err)
-  tools.PrintResource(t, geVT)
+	tools.PrintResource(t, geVT)
 
-  key := "cipher"
+	key := "cipher"
 	gesVT, err := volumetypes.GetEncryptionSpec(client, vt.ID, key).Extract()
 	th.AssertNoErr(t, err)
-  tools.PrintResource(t, gesVT)
-
+	tools.PrintResource(t, gesVT)
 
 	updateEncryptionOpts := volumetypes.UpdateEncryptionOpts{
-		ControlLocation:    "back-end",
+		ControlLocation: "back-end",
 	}
 
 	newEVT, err := volumetypes.UpdateEncryption(client, vt.ID, eVT.EncryptionID, updateEncryptionOpts).Extract()
-  tools.PrintResource(t, newEVT)
+	tools.PrintResource(t, newEVT)
 	th.AssertNoErr(t, err)
 
-		th.AssertEquals(t, "back-end", newEVT.ControlLocation)
+	th.AssertEquals(t, "back-end", newEVT.ControlLocation)
 }

--- a/acceptance/openstack/blockstorage/v3/volumetypes_test.go
+++ b/acceptance/openstack/blockstorage/v3/volumetypes_test.go
@@ -174,16 +174,16 @@ func TestEncryptionVolumeTypes(t *testing.T) {
 	th.AssertNoErr(t, err)
 	defer DeleteVolumeType(t, client, vt)
 
-  createEncryptionOpts := volumetypes.EncryptionOptions{
+  createEncryptionOpts := volumetypes.CreateEncryptionOpts{
     KeySize: 256,
     Provider: "luks",
     ControlLocation: "front-end",
     Cipher: "aes-xts-plain64",
   }
 
-  eVT, err := volumetypes.CreateEncryption(client, vt.ID, createEncryptionOpts)
+  eVT, err := volumetypes.CreateEncryption(client, vt.ID, createEncryptionOpts).Extract()
   th.AssertNoErr(t, err)
-  defer DeleteEncryption(t, client, evt)
+  defer volumetypes.DeleteEncryption(client, eVT.VolumeTypeID, eVT.EncryptionID)
 
 	geVT, err := volumetypes.GetEncryption(client, vt.ID).Extract()
 	th.AssertNoErr(t, err)
@@ -195,13 +195,13 @@ func TestEncryptionVolumeTypes(t *testing.T) {
   tools.PrintResource(t, gesVT)
 
 
-	updateEncryptionOpts := volumetypes.EncryptionUpdateOpts{
+	updateEncryptionOpts := volumetypes.UpdateEncryptionOpts{
 		ControlLocation:    "back-end",
 	}
 
-	newEVT, err := volumetypes.Update(client, vt.ID, updateEncryptionOpts).Extract()
+	newEVT, err := volumetypes.UpdateEncryption(client, vt.ID, eVT.EncryptionID, updateEncryptionOpts).Extract()
+  tools.PrintResource(t, newEVT)
 	th.AssertNoErr(t, err)
 
-	tools.PrintResource(t, newEVT)
-	th.AssertEquals(t, "back-end", newEVT.ControlLocation)
+		th.AssertEquals(t, "back-end", newEVT.ControlLocation)
 }

--- a/openstack/blockstorage/v3/volumetypes/doc.go
+++ b/openstack/blockstorage/v3/volumetypes/doc.go
@@ -162,26 +162,27 @@ Example to Remove/Revoke Access to a Volume Type
 	}
 
 Example to Create the Encryption of a Volume Type
-  typeID := "7ffaca22-f646-41d4-b79d-d7e4452ef8cc"
-	volumeType, err := volumetypes.CreateEncryption(client, typeID, .CreateEncryptionOpts{
-		KeySize:      256,
-		Provider:    "luks",
-		ControlLocation: "front-end",
-		Cipher:  "aes-xts-plain64",
-	}).Extract()
-	if err != nil{
-		panic(err)
-	}
-	fmt.Println(volumeType)
+
+	  typeID := "7ffaca22-f646-41d4-b79d-d7e4452ef8cc"
+		volumeType, err := volumetypes.CreateEncryption(client, typeID, .CreateEncryptionOpts{
+			KeySize:      256,
+			Provider:    "luks",
+			ControlLocation: "front-end",
+			Cipher:  "aes-xts-plain64",
+		}).Extract()
+		if err != nil{
+			panic(err)
+		}
+		fmt.Println(volumeType)
 
 Example to Delete the Encryption of a Volume Type
 
-	typeID := "7ffaca22-f646-41d4-b79d-d7e4452ef8cc"
-  encryptionID := ""81e069c6-7394-4856-8df7-3b237ca61f74
-	err := volumetypes.DeleteEncryption(client, typeID, encryptionID).ExtractErr()
-	if err != nil{
-		panic(err)
-	}
+		typeID := "7ffaca22-f646-41d4-b79d-d7e4452ef8cc"
+	  encryptionID := ""81e069c6-7394-4856-8df7-3b237ca61f74
+		err := volumetypes.DeleteEncryption(client, typeID, encryptionID).ExtractErr()
+		if err != nil{
+			panic(err)
+		}
 
 Example to Update the Encryption of a Volume Type
 
@@ -208,15 +209,12 @@ Example to Show an Encryption of a Volume Type
 
 Example to Show an Encryption Spec of a Volume Type
 
-	typeID := "7ffaca22-f646-41d4-b79d-d7e4452ef8cc"
-  key := "cipher"
-	volumeType, err := volumetypes.GetEncrytpionSpec(client, typeID).Extract()
-	if err != nil{
-		panic(err)
-	}
-	fmt.Println(volumeType)
-
-
-
+		typeID := "7ffaca22-f646-41d4-b79d-d7e4452ef8cc"
+	  key := "cipher"
+		volumeType, err := volumetypes.GetEncrytpionSpec(client, typeID).Extract()
+		if err != nil{
+			panic(err)
+		}
+		fmt.Println(volumeType)
 */
 package volumetypes

--- a/openstack/blockstorage/v3/volumetypes/doc.go
+++ b/openstack/blockstorage/v3/volumetypes/doc.go
@@ -160,5 +160,63 @@ Example to Remove/Revoke Access to a Volume Type
 	if err != nil {
 		panic(err)
 	}
+
+Example to Create the Encryption of a Volume Type
+  typeID := "7ffaca22-f646-41d4-b79d-d7e4452ef8cc"
+	volumeType, err := volumetypes.CreateEncryption(client, typeID, .CreateEncryptionOpts{
+		KeySize:      256,
+		Provider:    "luks",
+		ControlLocation: "front-end",
+		Cipher:  "aes-xts-plain64",
+	}).Extract()
+	if err != nil{
+		panic(err)
+	}
+	fmt.Println(volumeType)
+
+Example to Delete the Encryption of a Volume Type
+
+	typeID := "7ffaca22-f646-41d4-b79d-d7e4452ef8cc"
+  encryptionID := ""81e069c6-7394-4856-8df7-3b237ca61f74
+	err := volumetypes.DeleteEncryption(client, typeID, encryptionID).ExtractErr()
+	if err != nil{
+		panic(err)
+	}
+
+Example to Update the Encryption of a Volume Type
+
+	typeID := "7ffaca22-f646-41d4-b79d-d7e4452ef8cc"
+	volumetype, err = volumetypes.UpdateEncryption(client, typeID, volumetypes.UpdateEncryptionOpts{
+		KeySize:      256,
+		Provider:    "luks",
+		ControlLocation: "front-end",
+		Cipher:  "aes-xts-plain64",
+	}).Extract()
+	if err != nil{
+		panic(err)
+	}
+	fmt.Println(volumetype)
+
+Example to Show an Encryption of a Volume Type
+
+	typeID := "7ffaca22-f646-41d4-b79d-d7e4452ef8cc"
+	volumeType, err := volumetypes.GetEncrytpion(client, typeID).Extract()
+	if err != nil{
+		panic(err)
+	}
+	fmt.Println(volumeType)
+
+Example to Show an Encryption Spec of a Volume Type
+
+	typeID := "7ffaca22-f646-41d4-b79d-d7e4452ef8cc"
+  key := "cipher"
+	volumeType, err := volumetypes.GetEncrytpionSpec(client, typeID).Extract()
+	if err != nil{
+		panic(err)
+	}
+	fmt.Println(volumeType)
+
+
+
 */
 package volumetypes

--- a/openstack/blockstorage/v3/volumetypes/requests.go
+++ b/openstack/blockstorage/v3/volumetypes/requests.go
@@ -304,3 +304,108 @@ func RemoveAccess(client *gophercloud.ServiceClient, id string, opts RemoveAcces
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
+
+// CreateEncryptionOptsBuilder allows extensions to add additional parameters to the
+// Create Encryption request.
+type CreateEncryptionOptsBuilder interface {
+	ToEncryptionCreateMap() (map[string]interface{}, error)
+}
+
+// CreateEncryptionOpts contains options for creating an Encryption Type object.
+// This object is passed to the volumetypes.CreateEncryption function.
+// For more information about these parameters,see the Encryption Type object.
+type CreateEncryptionOpts struct {
+  // The size of the encryption key.
+  KeySize int `json:"key_size"`
+  // The class of that provides the encryption support.
+  Provider string `json:"provider" required:"true"`
+  // Notional service where encryption is performed.
+  ControlLocation string `json:"control_location"`
+  // The encryption algorithm or mode.
+  Cipher string `json:"cipher"`
+}
+
+// ToEncryptionCreateMap assembles a request body based on the contents of a
+// CreateEncryptionOpts.
+func (opts CreateEncryptionOpts) ToEncryptionCreateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "encryption")
+}
+
+// CreateEncryption will creates an Encryption Type object based on the CreateEncryptionOpts.
+// To extract the Encryption Type object from the response, call the Extract method on the
+// EncryptionCreateResult.
+func CreateEncryption(client *gophercloud.ServiceClient, id string, opts CreateEncryptionOptsBuilder) (r CreateEncryptionResult) {
+	b, err := opts.ToEncryptionCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := client.Post(createEncryptionURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// Delete will delete an encryption type for an existing Volume Type with the provided ID.
+func DeleteEncryption(client *gophercloud.ServiceClient, id, encryptionID string) (r DeleteEncryptionResult) {
+	resp, err := client.Delete(deleteEncryptionURL(client, id, encryptionID), nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// GetEncryption retrieves the encryption type for an existing VolumeType with the provided ID.
+func GetEncryption(client *gophercloud.ServiceClient, id string) (r GetEncryptionResult){
+	resp, err := client.Get(getEncryptionURL(client, id), &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// GetEncryptionSpecs retrieves the encryption type specs for an existing VolumeType with the provided ID.
+func GetEncryptionSpec(client *gophercloud.ServiceClient, id, key string) (r GetEncryptionSpecResult) {
+	resp, err := client.Get(getEncryptionSpecURL(client, id, key), &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// UpdateEncryptionOptsBuilder allows extensions to add additional parameters to the
+// Update encryption request.
+type UpdateEncryptionOptsBuilder interface {
+	ToUpdateEncryptionMap() (map[string]interface{}, error)
+}
+
+// Update Encryption Opts contains options for creating an Update Encryption Type. This object is passed to
+// the volumetypes.UpdateEncryption function. For more information about these parameters,
+// see the Update Encryption Type object.
+type UpdateEncryptionOpts struct {
+  // The size of the encryption key.
+  KeySize int `json:"key_size"`
+  // The class of that provides the encryption support.
+  Provider string `json:"provider"`
+  // Notional service where encryption is performed.
+  ControlLocation string `json:"control_location"`
+  // The encryption algorithm or mode.
+  Cipher string `json:"cipher"`
+}
+
+// ToEncryptionCreateMap assembles a request body based on the contents of a
+// UpdateEncryptionOpts.
+func (opts UpdateEncryptionOpts) ToUpdateEncryptionMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "encryption")
+}
+
+// Update will update an existing encryption for a Volume Type based on the values in UpdateEncryptionOpts.
+// To extract the UpdateEncryption Type object from the response, call the Extract method on the
+// UpdateEncryptionResult.
+func UpdateEncryption(client *gophercloud.ServiceClient, id,encryptionID string, opts UpdateEncryptionOptsBuilder) (r UpdateEncryptionResult) {
+	b, err := opts.ToUpdateEncryptionMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := client.Put(updateEncryptionURL(client, id, encryptionID), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}

--- a/openstack/blockstorage/v3/volumetypes/requests.go
+++ b/openstack/blockstorage/v3/volumetypes/requests.go
@@ -315,14 +315,14 @@ type CreateEncryptionOptsBuilder interface {
 // This object is passed to the volumetypes.CreateEncryption function.
 // For more information about these parameters,see the Encryption Type object.
 type CreateEncryptionOpts struct {
-  // The size of the encryption key.
-  KeySize int `json:"key_size"`
-  // The class of that provides the encryption support.
-  Provider string `json:"provider" required:"true"`
-  // Notional service where encryption is performed.
-  ControlLocation string `json:"control_location"`
-  // The encryption algorithm or mode.
-  Cipher string `json:"cipher"`
+	// The size of the encryption key.
+	KeySize int `json:"key_size"`
+	// The class of that provides the encryption support.
+	Provider string `json:"provider" required:"true"`
+	// Notional service where encryption is performed.
+	ControlLocation string `json:"control_location"`
+	// The encryption algorithm or mode.
+	Cipher string `json:"cipher"`
 }
 
 // ToEncryptionCreateMap assembles a request body based on the contents of a
@@ -355,7 +355,7 @@ func DeleteEncryption(client *gophercloud.ServiceClient, id, encryptionID string
 }
 
 // GetEncryption retrieves the encryption type for an existing VolumeType with the provided ID.
-func GetEncryption(client *gophercloud.ServiceClient, id string) (r GetEncryptionResult){
+func GetEncryption(client *gophercloud.ServiceClient, id string) (r GetEncryptionResult) {
 	resp, err := client.Get(getEncryptionURL(client, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -378,14 +378,14 @@ type UpdateEncryptionOptsBuilder interface {
 // the volumetypes.UpdateEncryption function. For more information about these parameters,
 // see the Update Encryption Type object.
 type UpdateEncryptionOpts struct {
-  // The size of the encryption key.
-  KeySize int `json:"key_size"`
-  // The class of that provides the encryption support.
-  Provider string `json:"provider"`
-  // Notional service where encryption is performed.
-  ControlLocation string `json:"control_location"`
-  // The encryption algorithm or mode.
-  Cipher string `json:"cipher"`
+	// The size of the encryption key.
+	KeySize int `json:"key_size"`
+	// The class of that provides the encryption support.
+	Provider string `json:"provider"`
+	// Notional service where encryption is performed.
+	ControlLocation string `json:"control_location"`
+	// The encryption algorithm or mode.
+	Cipher string `json:"cipher"`
 }
 
 // ToEncryptionCreateMap assembles a request body based on the contents of a
@@ -397,7 +397,7 @@ func (opts UpdateEncryptionOpts) ToUpdateEncryptionMap() (map[string]interface{}
 // Update will update an existing encryption for a Volume Type based on the values in UpdateEncryptionOpts.
 // To extract the UpdateEncryption Type object from the response, call the Extract method on the
 // UpdateEncryptionResult.
-func UpdateEncryption(client *gophercloud.ServiceClient, id,encryptionID string, opts UpdateEncryptionOptsBuilder) (r UpdateEncryptionResult) {
+func UpdateEncryption(client *gophercloud.ServiceClient, id, encryptionID string, opts UpdateEncryptionOptsBuilder) (r UpdateEncryptionResult) {
 	b, err := opts.ToUpdateEncryptionMap()
 	if err != nil {
 		r.Err = err

--- a/openstack/blockstorage/v3/volumetypes/results.go
+++ b/openstack/blockstorage/v3/volumetypes/results.go
@@ -200,3 +200,102 @@ type AddAccessResult struct {
 type RemoveAccessResult struct {
 	gophercloud.ErrResult
 }
+
+
+type EncryptionType struct {
+	// Unique identifier for the volume type.
+  VolumeTypeID string `json:"volume_type_id"`
+	// Notional service where encryption is performed.
+	ControlLocation string `json:"control_location"`
+	// Unique identifier for encryption type.
+  EncryptionID string `json:"encryption_id"`
+	// Size of encryption key.
+	KeySize int `json:"key_size"`
+	// Class that provides encryption support.
+	Provider string `json:"provider"`
+	// The encryption algorithm or mode.
+	Cipher string `json:"cipher"`
+}
+
+type encryptionResult struct {
+	gophercloud.Result
+}
+
+func (r encryptionResult) Extract() (*EncryptionType, error) {
+	var s EncryptionType
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+// ExtractInto converts our response data into a volume type struct
+func (r encryptionResult) ExtractInto(v interface{}) error {
+	return r.Result.ExtractIntoStructPtr(v, "encryption")
+}
+
+type CreateEncryptionResult struct {
+	encryptionResult
+}
+
+// UpdateResult contains the response body and error from an UpdateEncryption request.
+type UpdateEncryptionResult struct {
+	encryptionResult
+}
+
+// DeleteEncryptionResult contains the response body and error from a DeleteEncryprion request.
+type DeleteEncryptionResult struct {
+	gophercloud.ErrResult
+}
+
+type GetEncryptionType struct {
+  // Unique identifier for the volume type.
+  VolumeTypeID string `json:"volume_type_id"`
+	// Notional service where encryption is performed.
+	ControlLocation string `json:"control_location"`
+  // Shows if the resource is deleted or Notional
+  Deleted bool `json:"deleted"`
+  // Shows the date and time the resource was created.
+  CreatedAt string `json:"created_at"`
+  // Shows the date and time when resource was updated.
+  UpdatedAt string `json:"updated_at"`
+  // Unique identifier for encryption type.
+  EncryptionID string `json:"encryption_id"`
+	// Size of encryption key.
+	KeySize int `json:"key_size"`
+	// Class that provides encryption support.
+	Provider string `json:"provider"`
+  // Shows the date and time the reousrce was deleted.
+  DeletedAt string `json:"deleted_at"`
+  // The encryption algorithm or mode.
+	Cipher string `json:"cipher"`
+}
+
+type encryptionShowResult struct {
+	gophercloud.Result
+}
+
+// Extract interprets any extraSpecResult as an ExtraSpec, if possible.
+func (r encryptionShowResult) Extract() (* GetEncryptionType, error) {
+	var s GetEncryptionType
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+type GetEncryptionResult struct {
+	encryptionShowResult
+}
+
+type encryptionShowSpecResult struct{
+  gophercloud.Result
+}
+
+// Extract interprets any empty interface Result as an empty interface.
+func (r encryptionShowSpecResult) Extract() (map[string]interface{}, error) {
+	var s map[string]interface{}
+	err := r.ExtractInto(&s)
+	return s, err
+}
+
+type GetEncryptionSpecResult struct{
+  encryptionShowSpecResult
+}
+

--- a/openstack/blockstorage/v3/volumetypes/results.go
+++ b/openstack/blockstorage/v3/volumetypes/results.go
@@ -201,14 +201,13 @@ type RemoveAccessResult struct {
 	gophercloud.ErrResult
 }
 
-
 type EncryptionType struct {
 	// Unique identifier for the volume type.
-  VolumeTypeID string `json:"volume_type_id"`
+	VolumeTypeID string `json:"volume_type_id"`
 	// Notional service where encryption is performed.
 	ControlLocation string `json:"control_location"`
 	// Unique identifier for encryption type.
-  EncryptionID string `json:"encryption_id"`
+	EncryptionID string `json:"encryption_id"`
 	// Size of encryption key.
 	KeySize int `json:"key_size"`
 	// Class that provides encryption support.
@@ -247,25 +246,25 @@ type DeleteEncryptionResult struct {
 }
 
 type GetEncryptionType struct {
-  // Unique identifier for the volume type.
-  VolumeTypeID string `json:"volume_type_id"`
+	// Unique identifier for the volume type.
+	VolumeTypeID string `json:"volume_type_id"`
 	// Notional service where encryption is performed.
 	ControlLocation string `json:"control_location"`
-  // Shows if the resource is deleted or Notional
-  Deleted bool `json:"deleted"`
-  // Shows the date and time the resource was created.
-  CreatedAt string `json:"created_at"`
-  // Shows the date and time when resource was updated.
-  UpdatedAt string `json:"updated_at"`
-  // Unique identifier for encryption type.
-  EncryptionID string `json:"encryption_id"`
+	// Shows if the resource is deleted or Notional
+	Deleted bool `json:"deleted"`
+	// Shows the date and time the resource was created.
+	CreatedAt string `json:"created_at"`
+	// Shows the date and time when resource was updated.
+	UpdatedAt string `json:"updated_at"`
+	// Unique identifier for encryption type.
+	EncryptionID string `json:"encryption_id"`
 	// Size of encryption key.
 	KeySize int `json:"key_size"`
 	// Class that provides encryption support.
 	Provider string `json:"provider"`
-  // Shows the date and time the reousrce was deleted.
-  DeletedAt string `json:"deleted_at"`
-  // The encryption algorithm or mode.
+	// Shows the date and time the reousrce was deleted.
+	DeletedAt string `json:"deleted_at"`
+	// The encryption algorithm or mode.
 	Cipher string `json:"cipher"`
 }
 
@@ -274,7 +273,7 @@ type encryptionShowResult struct {
 }
 
 // Extract interprets any extraSpecResult as an ExtraSpec, if possible.
-func (r encryptionShowResult) Extract() (* GetEncryptionType, error) {
+func (r encryptionShowResult) Extract() (*GetEncryptionType, error) {
 	var s GetEncryptionType
 	err := r.ExtractInto(&s)
 	return &s, err
@@ -284,8 +283,8 @@ type GetEncryptionResult struct {
 	encryptionShowResult
 }
 
-type encryptionShowSpecResult struct{
-  gophercloud.Result
+type encryptionShowSpecResult struct {
+	gophercloud.Result
 }
 
 // Extract interprets any empty interface Result as an empty interface.
@@ -295,7 +294,6 @@ func (r encryptionShowSpecResult) Extract() (map[string]interface{}, error) {
 	return s, err
 }
 
-type GetEncryptionSpecResult struct{
-  encryptionShowSpecResult
+type GetEncryptionSpecResult struct {
+	encryptionShowSpecResult
 }
-

--- a/openstack/blockstorage/v3/volumetypes/testing/fixtures.go
+++ b/openstack/blockstorage/v3/volumetypes/testing/fixtures.go
@@ -340,7 +340,7 @@ func MockEncryptionGetResponse(t *testing.T) {
 		th.TestMethod(t, r, "GET")
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 
-    w.Header().Add("Content-Type", "application/json")
+		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
 		fmt.Fprintf(w, `
@@ -365,7 +365,7 @@ func MockEncryptionGetSpecResponse(t *testing.T) {
 		th.TestMethod(t, r, "GET")
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 
-    w.Header().Add("Content-Type", "application/json")
+		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
 		fmt.Fprintf(w, `

--- a/openstack/blockstorage/v3/volumetypes/testing/fixtures.go
+++ b/openstack/blockstorage/v3/volumetypes/testing/fixtures.go
@@ -258,3 +258,120 @@ func HandleExtraSpecDeleteSuccessfully(t *testing.T) {
 		w.WriteHeader(http.StatusAccepted)
 	})
 }
+
+func MockEncryptionCreateResponse(t *testing.T) {
+	th.Mux.HandleFunc("/types/a5082c24-2a27-43a4-b48e-fcec1240e36b/encryption", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, `
+{
+    "encryption": {
+        "key_size": 256,
+        "provider": "luks",
+        "control_location": "front-end",
+        "cipher": "aes-xts-plain64"
+   }
+}
+      `)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, `
+{
+    "encryption": {
+        "volume_type_id": "a5082c24-2a27-43a4-b48e-fcec1240e36b",
+        "control_location": "front-end",
+        "encryption_id": "81e069c6-7394-4856-8df7-3b237ca61f74",
+        "key_size": 256,
+        "provider": "luks",
+        "cipher": "aes-xts-plain64"
+    }
+}
+    `)
+	})
+}
+
+func MockDeleteEncryptionResponse(t *testing.T) {
+	th.Mux.HandleFunc("/types/a5082c24-2a27-43a4-b48e-fcec1240e36b/encryption/81e069c6-7394-4856-8df7-3b237ca61f74", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.WriteHeader(http.StatusAccepted)
+	})
+}
+
+func MockEncryptionUpdateResponse(t *testing.T) {
+	th.Mux.HandleFunc("/types/a5082c24-2a27-43a4-b48e-fcec1240e36b/encryption/81e069c6-7394-4856-8df7-3b237ca61f74", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, `
+{
+    "encryption": {
+        "key_size": 256,
+        "provider": "luks",
+        "control_location": "front-end",
+        "cipher": "aes-xts-plain64"
+   }
+}
+      `)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, `
+{
+    "encryption": {
+        "control_location": "front-end",
+        "key_size": 256,
+        "provider": "luks",
+        "cipher": "aes-xts-plain64"
+    }
+}
+    `)
+	})
+}
+
+func MockEncryptionGetResponse(t *testing.T) {
+	th.Mux.HandleFunc("/types/a5082c24-2a27-43a4-b48e-fcec1240e36b/encryption", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+    w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, `
+{
+    "volume_type_id": "a5082c24-2a27-43a4-b48e-fcec1240e36b",
+    "control_location": "front-end",
+    "deleted": false,
+    "created_at": "2016-12-28T02:32:25.000000",
+    "updated_at": null,
+    "encryption_id": "81e069c6-7394-4856-8df7-3b237ca61f74",
+    "key_size": 256,
+    "provider": "luks",
+    "deleted_at": null,
+    "cipher": "aes-xts-plain64"
+}
+    `)
+	})
+}
+
+func MockEncryptionGetSpecResponse(t *testing.T) {
+	th.Mux.HandleFunc("/types/a5082c24-2a27-43a4-b48e-fcec1240e36b/encryption/cipher", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+    w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, `
+{
+    "cipher": "aes-xts-plain64"
+}
+    `)
+	})
+}

--- a/openstack/blockstorage/v3/volumetypes/testing/requests_test.go
+++ b/openstack/blockstorage/v3/volumetypes/testing/requests_test.go
@@ -284,13 +284,13 @@ func TestCreateEncryption(t *testing.T) {
 	MockEncryptionCreateResponse(t)
 
 	options := &volumetypes.CreateEncryptionOpts{
-		KeySize:      256,
-		Provider:    "luks",
+		KeySize:         256,
+		Provider:        "luks",
 		ControlLocation: "front-end",
-		Cipher:  "aes-xts-plain64",
+		Cipher:          "aes-xts-plain64",
 	}
-  id := "a5082c24-2a27-43a4-b48e-fcec1240e36b"
-  n, err := volumetypes.CreateEncryption(client.ServiceClient(), id, options).Extract()
+	id := "a5082c24-2a27-43a4-b48e-fcec1240e36b"
+	n, err := volumetypes.CreateEncryption(client.ServiceClient(), id, options).Extract()
 	th.AssertNoErr(t, err)
 
 	th.AssertEquals(t, "a5082c24-2a27-43a4-b48e-fcec1240e36b", n.VolumeTypeID)
@@ -298,7 +298,7 @@ func TestCreateEncryption(t *testing.T) {
 	th.AssertEquals(t, "81e069c6-7394-4856-8df7-3b237ca61f74", n.EncryptionID)
 	th.AssertEquals(t, 256, n.KeySize)
 	th.AssertEquals(t, "luks", n.Provider)
-  th.AssertEquals(t, "aes-xts-plain64", n.Cipher)
+	th.AssertEquals(t, "aes-xts-plain64", n.Cipher)
 }
 
 func TestDeleteEncryption(t *testing.T) {
@@ -307,7 +307,7 @@ func TestDeleteEncryption(t *testing.T) {
 
 	MockDeleteEncryptionResponse(t)
 
-	res := volumetypes.DeleteEncryption(client.ServiceClient(), "a5082c24-2a27-43a4-b48e-fcec1240e36b", "81e069c6-7394-4856-8df7-3b237ca61f74" )
+	res := volumetypes.DeleteEncryption(client.ServiceClient(), "a5082c24-2a27-43a4-b48e-fcec1240e36b", "81e069c6-7394-4856-8df7-3b237ca61f74")
 	th.AssertNoErr(t, res.Err)
 }
 
@@ -318,20 +318,20 @@ func TestUpdateEncryption(t *testing.T) {
 	MockEncryptionUpdateResponse(t)
 
 	options := &volumetypes.UpdateEncryptionOpts{
-		KeySize:      256,
-		Provider:    "luks",
+		KeySize:         256,
+		Provider:        "luks",
 		ControlLocation: "front-end",
-		Cipher:  "aes-xts-plain64",
+		Cipher:          "aes-xts-plain64",
 	}
-  id := "a5082c24-2a27-43a4-b48e-fcec1240e36b"
-  encryptionID := "81e069c6-7394-4856-8df7-3b237ca61f74"
-  n, err := volumetypes.UpdateEncryption(client.ServiceClient(), id, encryptionID, options).Extract()
+	id := "a5082c24-2a27-43a4-b48e-fcec1240e36b"
+	encryptionID := "81e069c6-7394-4856-8df7-3b237ca61f74"
+	n, err := volumetypes.UpdateEncryption(client.ServiceClient(), id, encryptionID, options).Extract()
 	th.AssertNoErr(t, err)
 
 	th.AssertEquals(t, "front-end", n.ControlLocation)
 	th.AssertEquals(t, 256, n.KeySize)
 	th.AssertEquals(t, "luks", n.Provider)
-  th.AssertEquals(t, "aes-xts-plain64", n.Cipher)
+	th.AssertEquals(t, "aes-xts-plain64", n.Cipher)
 }
 
 func TestGetEncryption(t *testing.T) {
@@ -339,20 +339,20 @@ func TestGetEncryption(t *testing.T) {
 	defer th.TeardownHTTP()
 
 	MockEncryptionGetResponse(t)
-  id := "a5082c24-2a27-43a4-b48e-fcec1240e36b"
-  n, err := volumetypes.GetEncryption(client.ServiceClient(), id).Extract()
+	id := "a5082c24-2a27-43a4-b48e-fcec1240e36b"
+	n, err := volumetypes.GetEncryption(client.ServiceClient(), id).Extract()
 	th.AssertNoErr(t, err)
 
-  th.AssertEquals(t, "a5082c24-2a27-43a4-b48e-fcec1240e36b", n.VolumeTypeID)
+	th.AssertEquals(t, "a5082c24-2a27-43a4-b48e-fcec1240e36b", n.VolumeTypeID)
 	th.AssertEquals(t, "front-end", n.ControlLocation)
 	th.AssertEquals(t, false, n.Deleted)
-  th.AssertEquals(t, "2016-12-28T02:32:25.000000", n.CreatedAt)
-  th.AssertEquals(t, "", n.UpdatedAt)
-  th.AssertEquals(t, "81e069c6-7394-4856-8df7-3b237ca61f74", n.EncryptionID)
+	th.AssertEquals(t, "2016-12-28T02:32:25.000000", n.CreatedAt)
+	th.AssertEquals(t, "", n.UpdatedAt)
+	th.AssertEquals(t, "81e069c6-7394-4856-8df7-3b237ca61f74", n.EncryptionID)
 	th.AssertEquals(t, 256, n.KeySize)
 	th.AssertEquals(t, "luks", n.Provider)
-  th.AssertEquals(t, "", n.DeletedAt)
-  th.AssertEquals(t, "aes-xts-plain64", n.Cipher)
+	th.AssertEquals(t, "", n.DeletedAt)
+	th.AssertEquals(t, "aes-xts-plain64", n.Cipher)
 }
 
 func TestGetEncryptionSpec(t *testing.T) {
@@ -360,15 +360,15 @@ func TestGetEncryptionSpec(t *testing.T) {
 	defer th.TeardownHTTP()
 
 	MockEncryptionGetSpecResponse(t)
-  id := "a5082c24-2a27-43a4-b48e-fcec1240e36b"
-  n, err := volumetypes.GetEncryptionSpec(client.ServiceClient(), id, "cipher").Extract()
+	id := "a5082c24-2a27-43a4-b48e-fcec1240e36b"
+	n, err := volumetypes.GetEncryptionSpec(client.ServiceClient(), id, "cipher").Extract()
 	th.AssertNoErr(t, err)
 
-  key := "cipher"
-  testVar, exists := n[key]
-  if exists {
-    th.AssertEquals(t, "aes-xts-plain64", testVar)
-  } else  {
-    t.Fatalf("Key %s does not exist in map.", key)
-  }
+	key := "cipher"
+	testVar, exists := n[key]
+	if exists {
+		th.AssertEquals(t, "aes-xts-plain64", testVar)
+	} else {
+		t.Fatalf("Key %s does not exist in map.", key)
+	}
 }

--- a/openstack/blockstorage/v3/volumetypes/testing/requests_test.go
+++ b/openstack/blockstorage/v3/volumetypes/testing/requests_test.go
@@ -276,3 +276,99 @@ func TestVolumeTypeRemoveAccess(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 }
+
+func TestCreateEncryption(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockEncryptionCreateResponse(t)
+
+	options := &volumetypes.CreateEncryptionOpts{
+		KeySize:      256,
+		Provider:    "luks",
+		ControlLocation: "front-end",
+		Cipher:  "aes-xts-plain64",
+	}
+  id := "a5082c24-2a27-43a4-b48e-fcec1240e36b"
+  n, err := volumetypes.CreateEncryption(client.ServiceClient(), id, options).Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, "a5082c24-2a27-43a4-b48e-fcec1240e36b", n.VolumeTypeID)
+	th.AssertEquals(t, "front-end", n.ControlLocation)
+	th.AssertEquals(t, "81e069c6-7394-4856-8df7-3b237ca61f74", n.EncryptionID)
+	th.AssertEquals(t, 256, n.KeySize)
+	th.AssertEquals(t, "luks", n.Provider)
+  th.AssertEquals(t, "aes-xts-plain64", n.Cipher)
+}
+
+func TestDeleteEncryption(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockDeleteEncryptionResponse(t)
+
+	res := volumetypes.DeleteEncryption(client.ServiceClient(), "a5082c24-2a27-43a4-b48e-fcec1240e36b", "81e069c6-7394-4856-8df7-3b237ca61f74" )
+	th.AssertNoErr(t, res.Err)
+}
+
+func TestUpdateEncryption(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockEncryptionUpdateResponse(t)
+
+	options := &volumetypes.UpdateEncryptionOpts{
+		KeySize:      256,
+		Provider:    "luks",
+		ControlLocation: "front-end",
+		Cipher:  "aes-xts-plain64",
+	}
+  id := "a5082c24-2a27-43a4-b48e-fcec1240e36b"
+  encryptionID := "81e069c6-7394-4856-8df7-3b237ca61f74"
+  n, err := volumetypes.UpdateEncryption(client.ServiceClient(), id, encryptionID, options).Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, "front-end", n.ControlLocation)
+	th.AssertEquals(t, 256, n.KeySize)
+	th.AssertEquals(t, "luks", n.Provider)
+  th.AssertEquals(t, "aes-xts-plain64", n.Cipher)
+}
+
+func TestGetEncryption(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockEncryptionGetResponse(t)
+  id := "a5082c24-2a27-43a4-b48e-fcec1240e36b"
+  n, err := volumetypes.GetEncryption(client.ServiceClient(), id).Extract()
+	th.AssertNoErr(t, err)
+
+  th.AssertEquals(t, "a5082c24-2a27-43a4-b48e-fcec1240e36b", n.VolumeTypeID)
+	th.AssertEquals(t, "front-end", n.ControlLocation)
+	th.AssertEquals(t, false, n.Deleted)
+  th.AssertEquals(t, "2016-12-28T02:32:25.000000", n.CreatedAt)
+  th.AssertEquals(t, "", n.UpdatedAt)
+  th.AssertEquals(t, "81e069c6-7394-4856-8df7-3b237ca61f74", n.EncryptionID)
+	th.AssertEquals(t, 256, n.KeySize)
+	th.AssertEquals(t, "luks", n.Provider)
+  th.AssertEquals(t, "", n.DeletedAt)
+  th.AssertEquals(t, "aes-xts-plain64", n.Cipher)
+}
+
+func TestGetEncryptionSpec(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockEncryptionGetSpecResponse(t)
+  id := "a5082c24-2a27-43a4-b48e-fcec1240e36b"
+  n, err := volumetypes.GetEncryptionSpec(client.ServiceClient(), id, "cipher").Extract()
+	th.AssertNoErr(t, err)
+
+  key := "cipher"
+  testVar, exists := n[key]
+  if exists {
+    th.AssertEquals(t, "aes-xts-plain64", testVar)
+  } else  {
+    t.Fatalf("Key %s does not exist in map.", key)
+  }
+}

--- a/openstack/blockstorage/v3/volumetypes/urls.go
+++ b/openstack/blockstorage/v3/volumetypes/urls.go
@@ -55,17 +55,17 @@ func createEncryptionURL(client *gophercloud.ServiceClient, id string) string {
 }
 
 func deleteEncryptionURL(client *gophercloud.ServiceClient, id, encryptionID string) string {
-  return client.ServiceURL("types", id, "encryption", encryptionID)
+	return client.ServiceURL("types", id, "encryption", encryptionID)
 }
 
 func getEncryptionURL(client *gophercloud.ServiceClient, id string) string {
-  return client.ServiceURL("types", id, "encryption")
+	return client.ServiceURL("types", id, "encryption")
 }
 
 func getEncryptionSpecURL(client *gophercloud.ServiceClient, id, key string) string {
-  return client.ServiceURL("types", id, "encryption", key)
+	return client.ServiceURL("types", id, "encryption", key)
 }
 
 func updateEncryptionURL(client *gophercloud.ServiceClient, id, encryptionID string) string {
-  return client.ServiceURL("types", id, "encryption", encryptionID)
+	return client.ServiceURL("types", id, "encryption", encryptionID)
 }

--- a/openstack/blockstorage/v3/volumetypes/urls.go
+++ b/openstack/blockstorage/v3/volumetypes/urls.go
@@ -49,3 +49,23 @@ func accessURL(client *gophercloud.ServiceClient, id string) string {
 func accessActionURL(client *gophercloud.ServiceClient, id string) string {
 	return client.ServiceURL("types", id, "action")
 }
+
+func createEncryptionURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL("types", id, "encryption")
+}
+
+func deleteEncryptionURL(client *gophercloud.ServiceClient, id, encryptionID string) string {
+  return client.ServiceURL("types", id, "encryption", encryptionID)
+}
+
+func getEncryptionURL(client *gophercloud.ServiceClient, id string) string {
+  return client.ServiceURL("types", id, "encryption")
+}
+
+func getEncryptionSpecURL(client *gophercloud.ServiceClient, id, key string) string {
+  return client.ServiceURL("types", id, "encryption", key)
+}
+
+func updateEncryptionURL(client *gophercloud.ServiceClient, id, encryptionID string) string {
+  return client.ServiceURL("types", id, "encryption", encryptionID)
+}


### PR DESCRIPTION
Add Create/Delete/Update/Get support for encryption of volume types.

Fixes #2641

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

1.  Create an encryption for a volume type:

    * [API Docs](https://docs.openstack.org/api-ref/block-storage/v3/index.html?expanded=list-private-volume-type-access-detail-detail#create-an-encryption-type)
    * [Code](https://github.com/openstack/cinder/blob/facc1fc014a2f94a9e2767588da7e2f4ff73e3c5/cinder/api/contrib/volume_type_encryption.py#L68)
    
2.  Update an encryption for a volume type:

    * [API Docs](https://docs.openstack.org/api-ref/block-storage/v3/index.html?expanded=list-private-volume-type-access-detail-detail#update-an-encryption-type)
    * [Code](https://github.com/openstack/cinder/blob/facc1fc014a2f94a9e2767588da7e2f4ff73e3c5/cinder/api/contrib/volume_type_encryption.py#L96)
    
3.  Delete an encryption for a volume type:

    * [API Docs](https://docs.openstack.org/api-ref/block-storage/v3/index.html?expanded=list-private-volume-type-access-detail-detail#delete-an-encryption-type)
    * [Code](https://github.com/openstack/cinder/blob/facc1fc014a2f94a9e2767588da7e2f4ff73e3c5/cinder/api/contrib/volume_type_encryption.py#L134)
    
4.  Show an encryption for a volume type:

    * [API Docs](https://docs.openstack.org/api-ref/block-storage/v3/index.html?expanded=#show-an-encryption-type)
    * [Code](https://github.com/openstack/cinder/blob/facc1fc014a2f94a9e2767588da7e2f4ff73e3c5/cinder/api/contrib/volume_type_encryption.py#L59)
    
5.  Show an encryption spec for a volume type:

    * [API Docs](https://docs.openstack.org/api-ref/block-storage/v3/index.html?expanded=#show-encryption-specs-item)
    * [Code](https://github.com/openstack/cinder/blob/facc1fc014a2f94a9e2767588da7e2f4ff73e3c5/cinder/api/contrib/volume_type_encryption.py#L120)
     