### PR TITLE
identity: use AuthOptionsBuilder for v2 auth

### DIFF
--- a/openstack/client_test.go
+++ b/openstack/client_test.go
@@ -1,0 +1,5 @@
+package openstack
+
+import tokens2 "github.com/gophercloud/gophercloud/v2/openstack/identity/v2/tokens"
+
+var _ tokens2.AuthOptionsBuilder = &v2TokenNoReauth{}

--- a/openstack/identity/v2/tokens/requests.go
+++ b/openstack/identity/v2/tokens/requests.go
@@ -42,6 +42,7 @@ type AuthOptionsBuilder interface {
 	// ToTokenCreateMap assembles the Create request body, returning an error
 	// if parameters are missing or inconsistent.
 	ToTokenV2CreateMap() (map[string]any, error)
+	CanReauth() bool
 }
 
 // AuthOptions are the valid options for Openstack Identity v2 authentication.
@@ -79,6 +80,10 @@ func (opts AuthOptions) ToTokenV2CreateMap() (map[string]any, error) {
 		return nil, err
 	}
 	return b, nil
+}
+
+func (opts AuthOptions) CanReauth() bool {
+	return opts.AllowReauth
 }
 
 // Create authenticates to the identity service and attempts to acquire a Token.


### PR DESCRIPTION
Rather than creating a tokens2.AuthOptions inside the authentication flow for identity v2, allow any structure that implements the tokens2.AuthBuilderOptions interface to be used. The interface is modified to add a CanReauth function like the v3 version has but provides a default implementation. The gophercloud.AuthOptions already implements this interface so there is no change to its API. Lastly add an AuthenticateV2Ext function which will allow an out of tree identity v2 auth mechanism to be implemented. fixes #2651. ref #1330.
