### PR TITLE
Instrument backporting to v1

### DIFF
--- a/.github/backport-labels.yaml
+++ b/.github/backport-labels.yaml
@@ -1,0 +1,3 @@
+- name: backport-v1
+  description: This PR will be backported to v1
+  color: '30ABB9'

--- a/.github/workflows/backport_v1.yaml
+++ b/.github/workflows/backport_v1.yaml
@@ -1,0 +1,31 @@
+name: Pull Request backporting
+
+on:
+  pull_request_target:
+    types:
+      - closed
+      - labeled
+
+jobs:
+  backporting:
+    name: "Backporting"
+    # Only react to merged PRs for security reasons.
+    # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target.
+    if: >
+      github.event.pull_request.merged
+      && (
+        github.event.action == 'closed'
+          && contains(github.event.pull_request.labels.*.name, 'backport-v1')
+        || (
+          github.event.action == 'labeled'
+          && contains(github.event.label.name, 'backport-v1')
+        )
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - name: Backporting
+        uses: pierreprinetti/backport@v1
+        with:
+          target-branch: v1
+          pull-request: ${{ github.event.pull_request.url }}
+          auth: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ensure-labels.yaml
+++ b/.github/workflows/ensure-labels.yaml
@@ -4,7 +4,8 @@ on:
     branches:
       - master
     paths:
-      - .github/semver-labels.yaml
+      - .github/ensure-labels.yaml
+      - .github/backport-labels.yaml
       - .github/workflows/semver-labels.yaml
 jobs:
   semver:
@@ -16,3 +17,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           manifest: .github/semver-labels.yaml
+  backport:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: micnncim/action-label-syncer@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          manifest: .github/backport-labels.yaml

--- a/README.md
+++ b/README.md
@@ -1,13 +1,11 @@
 # Gophercloud: an OpenStack SDK for Go
-[![Build Status](https://travis-ci.org/gophercloud/gophercloud.svg?branch=master)](https://travis-ci.org/gophercloud/gophercloud)
 [![Coverage Status](https://coveralls.io/repos/github/gophercloud/gophercloud/badge.svg?branch=master)](https://coveralls.io/github/gophercloud/gophercloud?branch=master)
 
-Gophercloud is an OpenStack Go SDK.
+[Reference documentation](http://godoc.org/github.com/gophercloud/gophercloud)
 
-## Useful links
+Gophercloud is a Go SDK for OpenStack.
 
-* [Reference documentation](http://godoc.org/github.com/gophercloud/gophercloud)
-* [Effective Go](https://golang.org/doc/effective_go.html)
+This is the development branch of Gophercloud; stable releases are cut from the branch `v1`.
 
 ## How to install
 


### PR DESCRIPTION
The stable branch is now `v1`. Non-breaking changes will be backported by applying a `backport-v1` label.