### PR TITLE
chore: Fix labels

### DIFF
--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -1,0 +1,15 @@
+- color: '9E1957'
+  description: Breaking change
+  name: semver:major
+- color: 'FBCA04'
+  description: Backwards-compatible change
+  name: semver:minor
+- color: '6E7624'
+  description: No API change
+  name: semver:patch
+- color: '30ABB9'
+  description: This PR will be backported to v1
+  name: backport-v1
+- color: 'BCF611'
+  description: A good issue for first-time contributors
+  name: good first issue

--- a/.github/semver-labels.yaml
+++ b/.github/semver-labels.yaml
@@ -1,9 +1,0 @@
-- name: semver:major
-  description: Breaking change
-  color: '9E1957'
-- name: semver:minor
-  description: Backwards-compatible change
-  color: 'FBCA04'
-- name: semver:patch
-  description: No API change
-  color: '6E7624'

--- a/.github/workflows/ensure-labels.yaml
+++ b/.github/workflows/ensure-labels.yaml
@@ -1,14 +1,13 @@
-name: Ensure labels
+name: Apply labels in .github/labels.yaml
 on:
   push:
     branches:
       - master
     paths:
-      - .github/ensure-labels.yaml
-      - .github/backport-labels.yaml
-      - .github/workflows/semver-labels.yaml
+      - .github/labels.yaml
+      - .github/workflows/ensure-labels.yaml
 jobs:
-  semver:
+  ensure:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -16,13 +15,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          manifest: .github/semver-labels.yaml
-  backport:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: micnncim/action-label-syncer@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          manifest: .github/backport-labels.yaml
+          manifest: .github/labels.yaml


### PR DESCRIPTION
The PR https://github.com/gophercloud/gophercloud/pull/2656 caused all labels to be removed, because each run of the action eliminates all labels that aren't listed.

This PR reintroduces our semver labels and the `good first issue` label in the repository.