### PR TITLE
Cinder: Remove multiatttach request parameter

### DIFF
--- a/openstack/blockstorage/v3/volumes/requests.go
+++ b/openstack/blockstorage/v3/volumes/requests.go
@@ -41,8 +41,6 @@ type CreateOpts struct {
 	BackupID string `json:"backup_id,omitempty"`
 	// The associated volume type
 	VolumeType string `json:"volume_type,omitempty"`
-	// Multiattach denotes if the volume is multi-attach capable.
-	Multiattach bool `json:"multiattach,omitempty"`
 }
 
 // ToVolumeCreateMap assembles a request body based on the contents of a


### PR DESCRIPTION
The multiattach request parameter is no longer part of the API [1]. Starting with microversion 3.50 (Queens), you need to use a volume type with multiattach capability instead.

Depends on https://github.com/gophercloud/gophercloud/pull/2658.

[1] https://github.com/openstack/cinder/commit/d4535c77493a7b362091b962f42f2613dea65dbe