### PR TITLE
CI/semver: only run on master

### DIFF
--- a/.github/workflows/semver-require.yaml
+++ b/.github/workflows/semver-require.yaml
@@ -1,6 +1,8 @@
 name: Verify PR Labels
 on:
   pull_request:
+    branches:
+      - master
     types:
       - opened
       - labeled

--- a/.github/workflows/semver-unlabel.yaml
+++ b/.github/workflows/semver-unlabel.yaml
@@ -6,6 +6,8 @@ name: Reset PR labels on push
 
 on:
   pull_request_target:
+    branches:
+      - master
     types:
       - synchronize
 


### PR DESCRIPTION
We don't want these workflows to run on other branches than master.
