### PR TITLE
[CI] Drop branch filters for 'Ensure Labels' and 'CodeQL' jobs

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,13 +1,6 @@
 name: "CodeQL"
 
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ master ]
-  schedule:
-    - cron: '18 8 * * 6'
+on: [push, pull_request]
 
 jobs:
   analyze:

--- a/.github/workflows/ensure-labels.yaml
+++ b/.github/workflows/ensure-labels.yaml
@@ -1,8 +1,6 @@
 name: Apply labels in .github/labels.yaml
 on:
   push:
-    branches:
-      - master
     paths:
       - .github/labels.yaml
       - .github/workflows/ensure-labels.yaml


### PR DESCRIPTION
These jobs should run on all branches, so drop the branch filter that were in place.

For the CodeQL job, it seems like the github action syntax does not allow for a simplified `on` syntax, while at the same time using a `on.schedule`, so drop the periodic that we weren't paying attention to anyway. We have enough signal with just the PR jobs.