### PR TITLE
[v1][CI] Drop periodic jobs from stable branch

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -6,8 +6,6 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ master ]
-  schedule:
-    - cron: '18 8 * * 6'
 
 jobs:
   analyze:

--- a/.github/workflows/functional-baremetal.yaml
+++ b/.github/workflows/functional-baremetal.yaml
@@ -3,8 +3,6 @@ on:
   pull_request:
     paths:
       - '**baremetal**'
-  schedule:
-    - cron: '0 0 */3 * *'
 jobs:
   functional-baremetal:
     strategy:

--- a/.github/workflows/functional-basic.yaml
+++ b/.github/workflows/functional-basic.yaml
@@ -6,8 +6,6 @@ on:
       - '**.md'
       - '**.gitignore'
       - '**LICENSE'
-  schedule:
-    - cron: '0 0 */3 * *'
 jobs:
   functional-basic:
     strategy:

--- a/.github/workflows/functional-blockstorage.yaml
+++ b/.github/workflows/functional-blockstorage.yaml
@@ -3,8 +3,6 @@ on:
   pull_request:
     paths:
       - '**blockstorage**'
-  schedule:
-    - cron: '0 0 */3 * *'
 jobs:
   functional-blockstorage:
     strategy:

--- a/.github/workflows/functional-clustering.yaml
+++ b/.github/workflows/functional-clustering.yaml
@@ -3,8 +3,6 @@ on:
   pull_request:
     paths:
       - '**clustering**'
-  schedule:
-    - cron: '0 0 */3 * *'
 jobs:
   functional-clustering:
     strategy:

--- a/.github/workflows/functional-compute.yaml
+++ b/.github/workflows/functional-compute.yaml
@@ -3,8 +3,6 @@ on:
   pull_request:
     paths:
       - '**compute**'
-  schedule:
-    - cron: '0 0 */3 * *'
 jobs:
   functional-compute:
     strategy:

--- a/.github/workflows/functional-containerinfra.yaml
+++ b/.github/workflows/functional-containerinfra.yaml
@@ -3,8 +3,6 @@ on:
   pull_request:
     paths:
       - '**containerinfra**'
-  schedule:
-    - cron: '0 0 */3 * *'
 jobs:
   functional-containerinfra:
     strategy:

--- a/.github/workflows/functional-dns.yaml
+++ b/.github/workflows/functional-dns.yaml
@@ -4,8 +4,6 @@ on:
     paths:
       - '**openstack/dns**'
       - '**functional-dns.yaml'
-  schedule:
-    - cron: '0 0 */3 * *'
 jobs:
   functional-dns:
     strategy:

--- a/.github/workflows/functional-fwaas_v2.yaml
+++ b/.github/workflows/functional-fwaas_v2.yaml
@@ -3,8 +3,6 @@ on:
   pull_request:
     paths:
       - '**networking/extensions/fwaas_v2**'
-  schedule:
-    - cron: '0 0 */3 * *'
 jobs:
   functional-fwaas_v2:
     strategy:

--- a/.github/workflows/functional-identity.yaml
+++ b/.github/workflows/functional-identity.yaml
@@ -3,8 +3,6 @@ on:
   pull_request:
     paths:
       - '**identity**'
-  schedule:
-    - cron: '0 0 */3 * *'
 jobs:
   functional-identity:
     strategy:

--- a/.github/workflows/functional-imageservice.yaml
+++ b/.github/workflows/functional-imageservice.yaml
@@ -3,8 +3,6 @@ on:
   pull_request:
     paths:
       - '**imageservice**'
-  schedule:
-    - cron: '0 0 */3 * *'
 jobs:
   functional-imageservice:
     strategy:

--- a/.github/workflows/functional-keymanager.yaml
+++ b/.github/workflows/functional-keymanager.yaml
@@ -3,8 +3,6 @@ on:
   pull_request:
     paths:
       - '**keymanager**'
-  schedule:
-    - cron: '0 0 */3 * *'
 jobs:
   functional-keymanager:
     strategy:

--- a/.github/workflows/functional-loadbalancer.yaml
+++ b/.github/workflows/functional-loadbalancer.yaml
@@ -3,8 +3,6 @@ on:
   pull_request:
     paths:
       - '**loadbalancer**'
-  schedule:
-    - cron: '0 0 */3 * *'
 jobs:
   functional-loadbalancer:
     strategy:

--- a/.github/workflows/functional-messaging.yaml
+++ b/.github/workflows/functional-messaging.yaml
@@ -3,8 +3,6 @@ on:
   pull_request:
     paths:
       - '**messaging**'
-  schedule:
-    - cron: '0 0 */3 * *'
 jobs:
   functional-messaging:
     strategy:

--- a/.github/workflows/functional-networking.yaml
+++ b/.github/workflows/functional-networking.yaml
@@ -3,8 +3,6 @@ on:
   pull_request:
     paths:
       - '**networking**'
-  schedule:
-    - cron: '0 0 */3 * *'
 jobs:
   functional-networking:
     strategy:

--- a/.github/workflows/functional-objectstorage.yaml
+++ b/.github/workflows/functional-objectstorage.yaml
@@ -3,8 +3,6 @@ on:
   pull_request:
     paths:
       - '**objectstorage**'
-  schedule:
-    - cron: '0 0 */3 * *'
 jobs:
   functional-objectstorage:
     strategy:

--- a/.github/workflows/functional-orchestration.yaml
+++ b/.github/workflows/functional-orchestration.yaml
@@ -3,8 +3,6 @@ on:
   pull_request:
     paths:
       - '**orchestration**'
-  schedule:
-    - cron: '0 0 */3 * *'
 jobs:
   functional-orchestration:
     strategy:

--- a/.github/workflows/functional-placement.yaml
+++ b/.github/workflows/functional-placement.yaml
@@ -3,8 +3,6 @@ on:
   pull_request:
     paths:
       - '**placement**'
-  schedule:
-    - cron: '0 0 */3 * *'
 jobs:
   functional-placement:
     strategy:

--- a/.github/workflows/functional-sharedfilesystems.yaml
+++ b/.github/workflows/functional-sharedfilesystems.yaml
@@ -3,8 +3,6 @@ on:
   pull_request:
     paths:
       - '**sharedfilesystems**'
-  schedule:
-    - cron: '0 0 */3 * *'
 jobs:
   functional-sharedfilesystems:
     strategy:


### PR DESCRIPTION
Periodic jobs can't run against non-default branches with github action. Remove them from our stable branches to avoid confusion.

According to the github documentation [1]:

    Scheduled workflows run on the latest commit on the default or base branch.

[1] https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule