### PR TITLE
v1: backport workflow/label changes for semver+labels

### DIFF
--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -7,9 +7,6 @@
 - color: '6E7624'
   description: No API change
   name: semver:patch
-- color: '30ABB9'
-  description: This PR will be backported to v1
-  name: backport-v1
 - color: 'BCF611'
   description: A good issue for first-time contributors
   name: good first issue


### PR DESCRIPTION
Backport of the following commits from master:

- [CI] Drop branch filters for 'Ensure Labels' and 'CodeQL' jobs

So they can run on stable branches too.

- Instrument backporting to v1

Add the changes to semver & labels, useful for `v1` branch.
The bits around backports are removed in another commit (see below).

- chore: Fix labels

- Remove backport workflow & label

We don't want the backport workflow (and its labels) to exist in v1.

initially created here: https://github.com/gophercloud/gophercloud/pull/2677