### PR TITLE
Restore branch filter for ensure-labels workflow

### DIFF
--- a/.github/workflows/ensure-labels.yaml
+++ b/.github/workflows/ensure-labels.yaml
@@ -1,6 +1,8 @@
 name: Apply labels in .github/labels.yaml
 on:
   push:
+    branches:
+      - master
     paths:
       - .github/labels.yaml
       - .github/workflows/ensure-labels.yaml


### PR DESCRIPTION
This workflow should only run on the main branch. The labels are repo-wide and shouldn't be controlled by multiple branches, as there's a risk it removes non-listed labels if the label declaration files differ between branches.

Partially reverts https://github.com/gophercloud/gophercloud/pull/2674/.