### PR TITLE
Use git-backporting v4.1.0

### DIFF
--- a/.github/workflows/backport_v1.yaml
+++ b/.github/workflows/backport_v1.yaml
@@ -24,8 +24,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Backporting
-        uses: pierreprinetti/backport@v1
+        uses: kiegroup/git-backporting@265955dda77a8191fd1f64517fec20e8d5f8c5b4
         with:
           target-branch: v1
           pull-request: ${{ github.event.pull_request.url }}
           auth: ${{ secrets.GITHUB_TOKEN }}
+          no-squash: true
+          strategy-option: find-renames


### PR DESCRIPTION
Using a fork is no longer necessary, as watermarks have been removed from the code.

This version bump brings merge commits.