### PR TITLE
Add Some Helpful Fields

### DIFF
--- a/openstack/compute/v2/flavors/results.go
+++ b/openstack/compute/v2/flavors/results.go
@@ -80,6 +80,12 @@ type Flavor struct {
 	// 65535 characters in length. Only printable characters are allowed.
 	// New in version 2.55
 	Description string `json:"description"`
+
+	// ExtraSpecs is a dictionary of the flavor's extra_specs, and may be
+	// used to avoid extra calls to Get/ListExtraSpecs.  This is only available
+	// in microversion 2.61 and greater, and only if allowed by the compute
+	// service's policy.
+	ExtraSpecs map[string]string `json:"extra_specs"`
 }
 
 func (r *Flavor) UnmarshalJSON(b []byte) error {

--- a/openstack/compute/v2/flavors/testing/requests_test.go
+++ b/openstack/compute/v2/flavors/testing/requests_test.go
@@ -39,7 +39,10 @@ func TestListFlavors(t *testing.T) {
 								"swap":"",
 								"os-flavor-access:is_public": true,
 								"OS-FLV-EXT-DATA:ephemeral": 10,
-								"description": "foo"
+								"description": "foo",
+								"extra_specs": {
+									"hw:cpu_policy": "CPU-POLICY"
+								}
 							},
 							{
 								"id": "2",
@@ -88,7 +91,7 @@ func TestListFlavors(t *testing.T) {
 		}
 
 		expected := []flavors.Flavor{
-			{ID: "1", Name: "m1.tiny", VCPUs: 1, Disk: 1, RAM: 9216000, Swap: 0, IsPublic: true, Ephemeral: 10, Description: "foo"},
+			{ID: "1", Name: "m1.tiny", VCPUs: 1, Disk: 1, RAM: 9216000, Swap: 0, IsPublic: true, Ephemeral: 10, Description: "foo", ExtraSpecs: map[string]string{"hw:cpu_policy": "CPU-POLICY"}},
 			{ID: "2", Name: "m1.small", VCPUs: 1, Disk: 20, RAM: 2048, Swap: 1000, IsPublic: true, Ephemeral: 0},
 			{ID: "3", Name: "m1.medium", VCPUs: 2, Disk: 40, RAM: 4096, Swap: 1000, IsPublic: false, Ephemeral: 0},
 		}
@@ -126,7 +129,10 @@ func TestGetFlavor(t *testing.T) {
 					"vcpus": 1,
 					"rxtx_factor": 1,
 					"swap": "",
-					"description": "foo"
+					"description": "foo",
+					"extra_specs": {
+						"hw:cpu_policy": "CPU-POLICY"
+					}
 				}
 			}
 		`)
@@ -146,6 +152,9 @@ func TestGetFlavor(t *testing.T) {
 		RxTxFactor:  1,
 		Swap:        0,
 		Description: "foo",
+		ExtraSpecs: map[string]string{
+			"hw:cpu_policy": "CPU-POLICY",
+		},
 	}
 	if !reflect.DeepEqual(expected, actual) {
 		t.Errorf("Expected %#v, but was %#v", expected, actual)


### PR DESCRIPTION
Add the "extra_specs" field in compute flavors, that can avoid another lookup.  As documented it's for microversions 2.61 and greater. Documented here:

* https://docs.openstack.org/api-ref/compute/?expanded=list-server-groups-detail,create-server-group-detail,show-flavor-details-detail,list-flavors-with-details-detail#list-flavors
* https://docs.openstack.org/api-ref/compute/?expanded=list-server-groups-detail,create-server-group-detail,show-flavor-details-detail#list-flavors

Prior to starting a PR, please make sure you have read our
[contributor tutorial](https://github.com/gophercloud/gophercloud/tree/master/docs/contributor-tutorial).

Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

Fixes #2497

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

See commit message... seems I jumped the gun 😸 
