### PR TITLE
Trove: Add ability to create instance replicas via replica_of parameter

### DIFF
--- a/openstack/db/v1/instances/requests.go
+++ b/openstack/db/v1/instances/requests.go
@@ -55,8 +55,8 @@ type CreateOpts struct {
 	Size int
 	// Specifies the volume type.
 	VolumeType string
-  // ID or name of an existing instance to replicate from. Optional.
-  ReplicaOf string
+	// ID or name of an existing instance to replicate from. Optional.
+	ReplicaOf string
 	// Name of the instance to create. The length of the name is limited to
 	// 255 characters and any characters are permitted. Optional.
 	Name string

--- a/openstack/db/v1/instances/requests.go
+++ b/openstack/db/v1/instances/requests.go
@@ -55,6 +55,8 @@ type CreateOpts struct {
 	Size int
 	// Specifies the volume type.
 	VolumeType string
+  // ID or name of an existing instance to replicate from. Optional.
+  ReplicaOf string
 	// Name of the instance to create. The length of the name is limited to
 	// 255 characters and any characters are permitted. Optional.
 	Name string
@@ -122,6 +124,10 @@ func (opts CreateOpts) ToInstanceCreateMap() (map[string]interface{}, error) {
 			}
 		}
 		instance["nics"] = networks
+	}
+
+	if opts.ReplicaOf != "" {
+		instance["replica_of"] = opts.ReplicaOf
 	}
 
 	volume := map[string]interface{}{

--- a/openstack/db/v1/instances/testing/fixtures.go
+++ b/openstack/db/v1/instances/testing/fixtures.go
@@ -116,6 +116,7 @@ var createReq = `
 		],
 		"flavorRef": "1",
 		"name": "json_rack_instance",
+		"replica_of": "1234-sample-source-database-id-1234",
 		"users": [
 			{
 				"databases": [

--- a/openstack/db/v1/instances/testing/requests_test.go
+++ b/openstack/db/v1/instances/testing/requests_test.go
@@ -18,6 +18,7 @@ func TestCreate(t *testing.T) {
 
 	opts := instances.CreateOpts{
 		Name:      "json_rack_instance",
+		ReplicaOf: "1234-sample-source-database-id-1234",
 		FlavorRef: "1",
 		Databases: db.BatchCreateOpts{
 			{CharSet: "utf8", Collate: "utf8_general_ci", Name: "sampledb"},
@@ -49,6 +50,7 @@ func TestCreateWithFault(t *testing.T) {
 
 	opts := instances.CreateOpts{
 		Name:      "json_rack_instance",
+		ReplicaOf: "1234-sample-source-database-id-1234",
 		FlavorRef: "1",
 		Databases: db.BatchCreateOpts{
 			{CharSet: "utf8", Collate: "utf8_general_ci", Name: "sampledb"},


### PR DESCRIPTION
Fixes #2697

Openstack API Ref:
https://docs.openstack.org/api-ref/database/?expanded=create-database-instance-detail#create-database-instance

Merging this PR and #2483 should allow me to create a PR to terraform openstack provider adding availability zone and replication support 
