### PR TITLE
orchestration: Explicit error in optionsmap creation

### DIFF
--- a/openstack/orchestration/v1/stacks/requests.go
+++ b/openstack/orchestration/v1/stacks/requests.go
@@ -1,6 +1,7 @@
 package stacks
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/gophercloud/gophercloud"
@@ -89,7 +90,7 @@ func (opts CreateOpts) ToStackCreateMap() (map[string]interface{}, error) {
 func Create(c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToStackCreateMap()
 	if err != nil {
-		r.Err = err
+		r.Err = fmt.Errorf("error creating the options map: %w", err)
 		return
 	}
 	resp, err := c.Post(createURL(c), b, &r.Body, nil)

--- a/openstack/orchestration/v1/stacks/testing/requests_test.go
+++ b/openstack/orchestration/v1/stacks/testing/requests_test.go
@@ -59,7 +59,7 @@ func TestCreateStackMissingRequiredInOpts(t *testing.T) {
 		DisableRollback: gophercloud.Disabled,
 	}
 	r := stacks.Create(fake.ServiceClient(), createOpts)
-	th.AssertEquals(t, "Missing input for argument [Name]", r.Err.Error())
+	th.AssertEquals(t, "error creating the options map: Missing input for argument [Name]", r.Err.Error())
 }
 
 func TestAdoptStack(t *testing.T) {


### PR DESCRIPTION
Add verbosity to the error signaling a failure in the creation of the optionsmap.