### PR TITLE
baremetal: introduce Node Inventory API

### DIFF
--- a/openstack/baremetal/v1/nodes/requests.go
+++ b/openstack/baremetal/v1/nodes/requests.go
@@ -880,3 +880,12 @@ func UnsetMaintenance(client *gophercloud.ServiceClient, id string) (r SetMainte
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
+
+// GetInventory return stored data from successful inspection.
+func GetInventory(client *gophercloud.ServiceClient, id string) (r InventoryResult) {
+	resp, err := client.Get(inventoryURL(client, id), &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}

--- a/openstack/baremetal/v1/nodes/testing/requests_test.go
+++ b/openstack/baremetal/v1/nodes/testing/requests_test.go
@@ -711,3 +711,22 @@ func TestUnsetMaintenance(t *testing.T) {
 	err := nodes.UnsetMaintenance(c, "1234asdf").ExtractErr()
 	th.AssertNoErr(t, err)
 }
+
+func TestGetInventory(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleGetInventorySuccessfully(t)
+
+	c := client.ServiceClient()
+	actual, err := nodes.GetInventory(c, "1234asdf").Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, NodeInventoryData.Inventory, actual.Inventory)
+
+	pluginData, err := actual.PluginData.AsMap()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, "x86_64", pluginData["cpu_arch"].(string))
+
+	compatData, err := actual.PluginData.AsInspectorData()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, "x86_64", compatData.CPUArch)
+}

--- a/openstack/baremetal/v1/nodes/urls.go
+++ b/openstack/baremetal/v1/nodes/urls.go
@@ -77,3 +77,7 @@ func vendorPassthruCallURL(client *gophercloud.ServiceClient, id string) string 
 func maintenanceURL(client *gophercloud.ServiceClient, id string) string {
 	return client.ServiceURL("nodes", id, "maintenance")
 }
+
+func inventoryURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL("nodes", id, "inventory")
+}


### PR DESCRIPTION
The plugin-specific part of the API gets a more sophisticated handling
than it was the case for Inspector: a new opaque type PluginData is used
for handling different formats.

The Ironic-native plugin data format will be introduced later after
some more preparation work is done.

Part of #2612