### PR TITLE
baremetal: finish moving common inventory bits

### DIFF
--- a/openstack/baremetal/inventory/plugindata.go
+++ b/openstack/baremetal/inventory/plugindata.go
@@ -1,0 +1,73 @@
+package inventory
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type ExtraDataItem map[string]interface{}
+
+type ExtraDataSection map[string]ExtraDataItem
+
+type ExtraDataType struct {
+	CPU      ExtraDataSection `json:"cpu"`
+	Disk     ExtraDataSection `json:"disk"`
+	Firmware ExtraDataSection `json:"firmware"`
+	IPMI     ExtraDataSection `json:"ipmi"`
+	Memory   ExtraDataSection `json:"memory"`
+	Network  ExtraDataSection `json:"network"`
+	System   ExtraDataSection `json:"system"`
+}
+
+type NUMATopology struct {
+	CPUs []NUMACPU `json:"cpus"`
+	NICs []NUMANIC `json:"nics"`
+	RAM  []NUMARAM `json:"ram"`
+}
+
+type NUMACPU struct {
+	CPU            int   `json:"cpu"`
+	NUMANode       int   `json:"numa_node"`
+	ThreadSiblings []int `json:"thread_siblings"`
+}
+
+type NUMANIC struct {
+	Name     string `json:"name"`
+	NUMANode int    `json:"numa_node"`
+}
+
+type NUMARAM struct {
+	NUMANode int `json:"numa_node"`
+	SizeKB   int `json:"size_kb"`
+}
+
+type LLDPTLVType struct {
+	Type  int
+	Value string
+}
+
+// UnmarshalJSON interprets an LLDP TLV [key, value] pair as an LLDPTLVType structure
+func (r *LLDPTLVType) UnmarshalJSON(data []byte) error {
+	var list []interface{}
+	if err := json.Unmarshal(data, &list); err != nil {
+		return err
+	}
+
+	if len(list) != 2 {
+		return fmt.Errorf("Invalid LLDP TLV key-value pair")
+	}
+
+	fieldtype, ok := list[0].(float64)
+	if !ok {
+		return fmt.Errorf("LLDP TLV key is not number")
+	}
+
+	value, ok := list[1].(string)
+	if !ok {
+		return fmt.Errorf("LLDP TLV value is not string")
+	}
+
+	r.Type = int(fieldtype)
+	r.Value = value
+	return nil
+}

--- a/openstack/baremetal/inventory/testing/fixtures.go
+++ b/openstack/baremetal/inventory/testing/fixtures.go
@@ -70,6 +70,126 @@ const InventorySample = `{
     }
 }`
 
+// ExtraDataJSONSample contains extra hardware sample data reported by the inspection process.
+const ExtraDataJSONSample = `
+{
+  "cpu": {
+    "logical": {
+      "number": 16
+    },
+    "physical": {
+      "clock": 2105032704,
+      "cores": 8,
+      "flags": "lm fpu fpu_exception wp vme de"
+    }
+  },
+  "disk": {
+    "sda": {
+      "rotational": 1,
+      "vendor": "TEST"
+    }
+  },
+  "firmware": {
+    "bios": {
+      "date": "01/01/1970",
+      "vendor": "test"
+    }
+  },
+  "ipmi": {
+    "Fan1A RPM": {
+      "unit": "RPM",
+      "value": 3120
+    },
+    "Fan1B RPM": {
+      "unit": "RPM",
+      "value": 2280
+    }
+  },
+  "memory": {
+    "bank0": {
+      "clock": 1600000000.0,
+      "description": "DIMM DDR3 Synchronous Registered (Buffered) 1600 MHz (0.6 ns)"
+    },
+    "bank1": {
+      "clock": 1600000000.0,
+      "description": "DIMM DDR3 Synchronous Registered (Buffered) 1600 MHz (0.6 ns)"
+    }
+  },
+  "network": {
+    "em1": {
+      "Autonegotiate": "on",
+      "loopback": "off [fixed]"
+    },
+    "p2p1": {
+      "Autonegotiate": "on",
+      "loopback": "off [fixed]"
+    }
+  },
+  "system": {
+    "ipmi": {
+      "channel": 1
+    },
+    "kernel": {
+      "arch": "x86_64",
+      "version": "3.10.0"
+    },
+    "motherboard": {
+      "vendor": "Test"
+    },
+    "product": {
+      "name": "test",
+      "vendor": "Test"
+    }
+  }
+}
+`
+
+// NUMADataJSONSample contains NUMA sample data reported by the inspection process.
+const NUMADataJSONSample = `
+{
+  "numa_topology": {
+    "cpus": [
+      {
+        "cpu": 6,
+        "numa_node": 1,
+        "thread_siblings": [
+          3,
+          27
+        ]
+      },
+      {
+        "cpu": 10,
+        "numa_node": 0,
+        "thread_siblings": [
+          20,
+          44
+        ]
+      }
+    ],
+    "nics": [
+      {
+        "name": "p2p1",
+        "numa_node": 0
+      },
+      {
+        "name": "p2p2",
+        "numa_node": 1
+      }
+    ],
+    "ram": [
+      {
+        "numa_node": 0,
+        "size_kb": 99289532
+      },
+      {
+        "numa_node": 1,
+        "size_kb": 100663296
+      }
+    ]
+  }
+}
+`
+
 var Inventory = inventory.InventoryType{
 	SystemVendor: inventory.SystemVendorType{
 		Manufacturer: "Bochs",
@@ -123,4 +243,110 @@ var Inventory = inventory.InventoryType{
 		Total:      2.105864192e+09,
 	},
 	Hostname: "myawesomehost",
+}
+
+var ExtraData = inventory.ExtraDataType{
+	CPU: inventory.ExtraDataSection{
+		"logical": map[string]interface{}{
+			"number": float64(16),
+		},
+		"physical": map[string]interface{}{
+			"clock": float64(2105032704),
+			"cores": float64(8),
+			"flags": "lm fpu fpu_exception wp vme de",
+		},
+	},
+	Disk: inventory.ExtraDataSection{
+		"sda": map[string]interface{}{
+			"rotational": float64(1),
+			"vendor":     "TEST",
+		},
+	},
+	Firmware: inventory.ExtraDataSection{
+		"bios": map[string]interface{}{
+			"date":   "01/01/1970",
+			"vendor": "test",
+		},
+	},
+	IPMI: inventory.ExtraDataSection{
+		"Fan1A RPM": map[string]interface{}{
+			"unit":  "RPM",
+			"value": float64(3120),
+		},
+		"Fan1B RPM": map[string]interface{}{
+			"unit":  "RPM",
+			"value": float64(2280),
+		},
+	},
+	Memory: inventory.ExtraDataSection{
+		"bank0": map[string]interface{}{
+			"clock":       1600000000.0,
+			"description": "DIMM DDR3 Synchronous Registered (Buffered) 1600 MHz (0.6 ns)",
+		},
+		"bank1": map[string]interface{}{
+			"clock":       1600000000.0,
+			"description": "DIMM DDR3 Synchronous Registered (Buffered) 1600 MHz (0.6 ns)",
+		},
+	},
+	Network: inventory.ExtraDataSection{
+		"em1": map[string]interface{}{
+			"Autonegotiate": "on",
+			"loopback":      "off [fixed]",
+		},
+		"p2p1": map[string]interface{}{
+			"Autonegotiate": "on",
+			"loopback":      "off [fixed]",
+		},
+	},
+	System: inventory.ExtraDataSection{
+		"ipmi": map[string]interface{}{
+			"channel": float64(1),
+		},
+		"kernel": map[string]interface{}{
+			"arch":    "x86_64",
+			"version": "3.10.0",
+		},
+		"motherboard": map[string]interface{}{
+			"vendor": "Test",
+		},
+		"product": map[string]interface{}{
+			"name":   "test",
+			"vendor": "Test",
+		},
+	},
+}
+
+var NUMATopology = inventory.NUMATopology{
+	CPUs: []inventory.NUMACPU{
+		{
+			CPU:            6,
+			NUMANode:       1,
+			ThreadSiblings: []int{3, 27},
+		},
+		{
+			CPU:            10,
+			NUMANode:       0,
+			ThreadSiblings: []int{20, 44},
+		},
+	},
+	NICs: []inventory.NUMANIC{
+		{
+			Name:     "p2p1",
+			NUMANode: 0,
+		},
+		{
+			Name:     "p2p2",
+			NUMANode: 1,
+		},
+	},
+	RAM: []inventory.NUMARAM{
+		{
+			NUMANode: 0,
+			SizeKB:   99289532,
+		},
+		{
+			NUMANode: 1,
+			SizeKB:   100663296,
+		},
+	},
 }

--- a/openstack/baremetal/inventory/testing/plugindata_test.go
+++ b/openstack/baremetal/inventory/testing/plugindata_test.go
@@ -1,0 +1,30 @@
+package testing
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/baremetal/inventory"
+	"github.com/gophercloud/gophercloud/openstack/baremetalintrospection/v1/introspection"
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestExtraHardware(t *testing.T) {
+	var output inventory.ExtraDataType
+	err := json.Unmarshal([]byte(ExtraDataJSONSample), &output)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal ExtraHardware data: %s", err)
+	}
+
+	th.CheckDeepEquals(t, ExtraData, output)
+}
+
+func TestIntrospectionNUMA(t *testing.T) {
+	var output introspection.Data
+	err := json.Unmarshal([]byte(NUMADataJSONSample), &output)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal NUMA Data: %s", err)
+	}
+
+	th.CheckDeepEquals(t, NUMATopology, output.NUMATopology)
+}

--- a/openstack/baremetal/inventory/testing/types_test.go
+++ b/openstack/baremetal/inventory/testing/types_test.go
@@ -9,7 +9,7 @@ import (
 	th "github.com/gophercloud/gophercloud/testhelper"
 )
 
-func TestIntrospectionNUMA(t *testing.T) {
+func TestInventory(t *testing.T) {
 	var output inventory.InventoryType
 	err := json.Unmarshal([]byte(InventorySample), &output)
 	if err != nil {

--- a/openstack/baremetal/inventory/types.go
+++ b/openstack/baremetal/inventory/types.go
@@ -1,10 +1,5 @@
 package inventory
 
-import (
-	"encoding/json"
-	"fmt"
-)
-
 type BootInfoType struct {
 	CurrentBootMode string `json:"current_boot_mode"`
 	PXEInterface    string `json:"pxe_interface"`
@@ -29,11 +24,6 @@ type InterfaceType struct {
 	Product     string `json:"product"`
 	SpeedMbps   int    `json:"speed_mbps"`
 	Vendor      string `json:"vendor"`
-}
-
-type LLDPTLVType struct {
-	Type  int
-	Value string
 }
 
 type MemoryType struct {
@@ -77,30 +67,4 @@ type InventoryType struct {
 	Memory       MemoryType       `json:"memory"`
 	SystemVendor SystemVendorType `json:"system_vendor"`
 	Hostname     string           `json:"hostname"`
-}
-
-// UnmarshalJSON interprets an LLDP TLV [key, value] pair as an LLDPTLVType structure
-func (r *LLDPTLVType) UnmarshalJSON(data []byte) error {
-	var list []interface{}
-	if err := json.Unmarshal(data, &list); err != nil {
-		return err
-	}
-
-	if len(list) != 2 {
-		return fmt.Errorf("Invalid LLDP TLV key-value pair")
-	}
-
-	fieldtype, ok := list[0].(float64)
-	if !ok {
-		return fmt.Errorf("LLDP TLV key is not number")
-	}
-
-	value, ok := list[1].(string)
-	if !ok {
-		return fmt.Errorf("LLDP TLV value is not string")
-	}
-
-	r.Type = int(fieldtype)
-	r.Value = value
-	return nil
 }

--- a/openstack/baremetalintrospection/v1/introspection/results.go
+++ b/openstack/baremetalintrospection/v1/introspection/results.go
@@ -174,8 +174,8 @@ type Data struct {
 	MACs          []string                           `json:"macs"`
 	MemoryMB      int                                `json:"memory_mb"`
 	RootDisk      inventory.RootDiskType             `json:"root_disk"`
-	Extra         ExtraHardwareDataType              `json:"extra"`
-	NUMATopology  NUMATopology                       `json:"numa_topology"`
+	Extra         inventory.ExtraDataType            `json:"extra"`
+	NUMATopology  inventory.NUMATopology             `json:"numa_topology"`
 	RawLLDP       map[string][]inventory.LLDPTLVType `json:"lldp_raw"`
 }
 
@@ -187,42 +187,6 @@ type BaseInterfaceType struct {
 	MAC           string                 `json:"mac"`
 	PXE           bool                   `json:"pxe"`
 	LLDPProcessed map[string]interface{} `json:"lldp_processed"`
-}
-
-type ExtraHardwareData map[string]interface{}
-
-type ExtraHardwareDataSection map[string]ExtraHardwareData
-
-type ExtraHardwareDataType struct {
-	CPU      ExtraHardwareDataSection `json:"cpu"`
-	Disk     ExtraHardwareDataSection `json:"disk"`
-	Firmware ExtraHardwareDataSection `json:"firmware"`
-	IPMI     ExtraHardwareDataSection `json:"ipmi"`
-	Memory   ExtraHardwareDataSection `json:"memory"`
-	Network  ExtraHardwareDataSection `json:"network"`
-	System   ExtraHardwareDataSection `json:"system"`
-}
-
-type NUMATopology struct {
-	CPUs []NUMACPU `json:"cpus"`
-	NICs []NUMANIC `json:"nics"`
-	RAM  []NUMARAM `json:"ram"`
-}
-
-type NUMACPU struct {
-	CPU            int   `json:"cpu"`
-	NUMANode       int   `json:"numa_node"`
-	ThreadSiblings []int `json:"thread_siblings"`
-}
-
-type NUMANIC struct {
-	Name     string `json:"name"`
-	NUMANode int    `json:"numa_node"`
-}
-
-type NUMARAM struct {
-	NUMANode int `json:"numa_node"`
-	SizeKB   int `json:"size_kb"`
 }
 
 // Extract interprets any IntrospectionDataResult as IntrospectionData, if possible.

--- a/openstack/baremetalintrospection/v1/introspection/testing/fixtures.go
+++ b/openstack/baremetalintrospection/v1/introspection/testing/fixtures.go
@@ -346,8 +346,8 @@ var (
 		},
 	}
 
-	IntrospectionExtraHardware = introspection.ExtraHardwareDataType{
-		CPU: introspection.ExtraHardwareDataSection{
+	IntrospectionExtraHardware = inventory.ExtraDataType{
+		CPU: inventory.ExtraDataSection{
 			"logical": map[string]interface{}{
 				"number": float64(16),
 			},
@@ -357,19 +357,19 @@ var (
 				"flags": "lm fpu fpu_exception wp vme de",
 			},
 		},
-		Disk: introspection.ExtraHardwareDataSection{
+		Disk: inventory.ExtraDataSection{
 			"sda": map[string]interface{}{
 				"rotational": float64(1),
 				"vendor":     "TEST",
 			},
 		},
-		Firmware: introspection.ExtraHardwareDataSection{
+		Firmware: inventory.ExtraDataSection{
 			"bios": map[string]interface{}{
 				"date":   "01/01/1970",
 				"vendor": "test",
 			},
 		},
-		IPMI: introspection.ExtraHardwareDataSection{
+		IPMI: inventory.ExtraDataSection{
 			"Fan1A RPM": map[string]interface{}{
 				"unit":  "RPM",
 				"value": float64(3120),
@@ -379,7 +379,7 @@ var (
 				"value": float64(2280),
 			},
 		},
-		Memory: introspection.ExtraHardwareDataSection{
+		Memory: inventory.ExtraDataSection{
 			"bank0": map[string]interface{}{
 				"clock":       1600000000.0,
 				"description": "DIMM DDR3 Synchronous Registered (Buffered) 1600 MHz (0.6 ns)",
@@ -389,7 +389,7 @@ var (
 				"description": "DIMM DDR3 Synchronous Registered (Buffered) 1600 MHz (0.6 ns)",
 			},
 		},
-		Network: introspection.ExtraHardwareDataSection{
+		Network: inventory.ExtraDataSection{
 			"em1": map[string]interface{}{
 				"Autonegotiate": "on",
 				"loopback":      "off [fixed]",
@@ -399,7 +399,7 @@ var (
 				"loopback":      "off [fixed]",
 			},
 		},
-		System: introspection.ExtraHardwareDataSection{
+		System: inventory.ExtraDataSection{
 			"ipmi": map[string]interface{}{
 				"channel": float64(1),
 			},
@@ -417,8 +417,8 @@ var (
 		},
 	}
 
-	IntrospectionNUMA = introspection.NUMATopology{
-		CPUs: []introspection.NUMACPU{
+	IntrospectionNUMA = inventory.NUMATopology{
+		CPUs: []inventory.NUMACPU{
 			{
 				CPU:            6,
 				NUMANode:       1,
@@ -430,7 +430,7 @@ var (
 				ThreadSiblings: []int{20, 44},
 			},
 		},
-		NICs: []introspection.NUMANIC{
+		NICs: []inventory.NUMANIC{
 			{
 				Name:     "p2p1",
 				NUMANode: 0,
@@ -440,7 +440,7 @@ var (
 				NUMANode: 1,
 			},
 		},
-		RAM: []introspection.NUMARAM{
+		RAM: []inventory.NUMARAM{
 			{
 				NUMANode: 0,
 				SizeKB:   99289532,

--- a/openstack/baremetalintrospection/v1/introspection/testing/results_test.go
+++ b/openstack/baremetalintrospection/v1/introspection/testing/results_test.go
@@ -8,26 +8,6 @@ import (
 	th "github.com/gophercloud/gophercloud/testhelper"
 )
 
-func TestExtraHardware(t *testing.T) {
-	var output introspection.ExtraHardwareDataType
-	err := json.Unmarshal([]byte(IntrospectionExtraHardwareJSONSample), &output)
-	if err != nil {
-		t.Fatalf("Failed to unmarshal ExtraHardware data: %s", err)
-	}
-
-	th.CheckDeepEquals(t, IntrospectionExtraHardware, output)
-}
-
-func TestIntrospectionNUMA(t *testing.T) {
-	var output introspection.Data
-	err := json.Unmarshal([]byte(IntrospectionNUMADataJSONSample), &output)
-	if err != nil {
-		t.Fatalf("Failed to unmarshal NUMA Data: %s", err)
-	}
-
-	th.CheckDeepEquals(t, IntrospectionNUMA, output.NUMATopology)
-}
-
 func TestHostnameInInventory(t *testing.T) {
 	var output introspection.Data
 	err := json.Unmarshal([]byte(IntrospectionDataJSONSample), &output)


### PR DESCRIPTION
This change concerns plugin-specific structures that are shared between
ironic-inspector and the ironic's native inspection.

Names have been shortened for consistency and clarity.

Part of #2612
