### PR TITLE
networking/v2/ports: allow list filter by security group

### DIFF
--- a/openstack/networking/v2/ports/requests.go
+++ b/openstack/networking/v2/ports/requests.go
@@ -21,26 +21,27 @@ type ListOptsBuilder interface {
 // by a particular port attribute. SortDir sets the direction, and is either
 // `asc' or `desc'. Marker and Limit are used for pagination.
 type ListOpts struct {
-	Status       string `q:"status"`
-	Name         string `q:"name"`
-	Description  string `q:"description"`
-	AdminStateUp *bool  `q:"admin_state_up"`
-	NetworkID    string `q:"network_id"`
-	TenantID     string `q:"tenant_id"`
-	ProjectID    string `q:"project_id"`
-	DeviceOwner  string `q:"device_owner"`
-	MACAddress   string `q:"mac_address"`
-	ID           string `q:"id"`
-	DeviceID     string `q:"device_id"`
-	Limit        int    `q:"limit"`
-	Marker       string `q:"marker"`
-	SortKey      string `q:"sort_key"`
-	SortDir      string `q:"sort_dir"`
-	Tags         string `q:"tags"`
-	TagsAny      string `q:"tags-any"`
-	NotTags      string `q:"not-tags"`
-	NotTagsAny   string `q:"not-tags-any"`
-	FixedIPs     []FixedIPOpts
+	Status         string   `q:"status"`
+	Name           string   `q:"name"`
+	Description    string   `q:"description"`
+	AdminStateUp   *bool    `q:"admin_state_up"`
+	NetworkID      string   `q:"network_id"`
+	TenantID       string   `q:"tenant_id"`
+	ProjectID      string   `q:"project_id"`
+	DeviceOwner    string   `q:"device_owner"`
+	MACAddress     string   `q:"mac_address"`
+	ID             string   `q:"id"`
+	DeviceID       string   `q:"device_id"`
+	Limit          int      `q:"limit"`
+	Marker         string   `q:"marker"`
+	SortKey        string   `q:"sort_key"`
+	SortDir        string   `q:"sort_dir"`
+	Tags           string   `q:"tags"`
+	TagsAny        string   `q:"tags-any"`
+	NotTags        string   `q:"not-tags"`
+	NotTagsAny     string   `q:"not-tags-any"`
+	SecurityGroups []string `q:"security_groups"`
+	FixedIPs       []FixedIPOpts
 }
 
 type FixedIPOpts struct {


### PR DESCRIPTION
neutron v2 ports APIs allow to list ports by security group already:
https://docs.openstack.org/api-ref/network/v2/#show-port-details

This patch adds the `SecurityGroups` field to `ListOpts`.

One way to filter the ports by security group can be done with the
following code:

```
listOpts := ports.ListOpts{
	SecurityGroups: []string{"2183457b-70cc-4fd0-a2dc-95323fa19e45"}
}

allPages, err := ports.List(networkClient, listOpts).AllPages()
if err != nil {
	panic(err)
}

allPorts, err := ports.ExtractPorts(allPages)
if err != nil {
	panic(err)
}

for _, port := range allPorts {
	fmt.Printf("%+v\n", port)
}
```
