### PR TITLE
all: Replace deprecated ioutil

### DIFF
--- a/acceptance/clients/http.go
+++ b/acceptance/clients/http.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"sort"
@@ -75,7 +74,7 @@ func (lrt *LogRoundTripper) logRequest(original io.ReadCloser, contentType strin
 		log.Printf("[DEBUG] OpenStack Request Body: %s", debugInfo)
 	}
 
-	return ioutil.NopCloser(strings.NewReader(bs.String())), nil
+	return io.NopCloser(strings.NewReader(bs.String())), nil
 }
 
 // logResponse will log the HTTP Response details.
@@ -92,7 +91,7 @@ func (lrt *LogRoundTripper) logResponse(original io.ReadCloser, contentType stri
 		if debugInfo != "" {
 			log.Printf("[DEBUG] OpenStack Response Body: %s", debugInfo)
 		}
-		return ioutil.NopCloser(strings.NewReader(bs.String())), nil
+		return io.NopCloser(strings.NewReader(bs.String())), nil
 	}
 
 	log.Printf("[DEBUG] Not logging because OpenStack response body isn't JSON")

--- a/acceptance/openstack/objectstorage/v1/objects_test.go
+++ b/acceptance/openstack/objectstorage/v1/objects_test.go
@@ -5,7 +5,7 @@ package v1
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -106,7 +106,7 @@ func TestObjects(t *testing.T) {
 			th.AssertNoErr(t, fmt.Errorf("unexpected response code: %d", resp.StatusCode))
 		}
 
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		th.AssertNoErr(t, err)
 		th.AssertDeepEquals(t, oContents[i], string(body))
 		resp.Body.Close()
@@ -127,7 +127,7 @@ func TestObjects(t *testing.T) {
 			th.AssertNoErr(t, fmt.Errorf("unexpected response code: %d", resp.StatusCode))
 		}
 
-		body, err = ioutil.ReadAll(resp.Body)
+		body, err = io.ReadAll(resp.Body)
 		th.AssertNoErr(t, err)
 		th.AssertDeepEquals(t, oContents[i], string(body))
 		resp.Body.Close()

--- a/openstack/identity/v3/extensions/oauth1/requests.go
+++ b/openstack/identity/v3/extensions/oauth1/requests.go
@@ -5,7 +5,7 @@ import (
 	"crypto/sha1"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"net/url"
 	"sort"
@@ -319,7 +319,7 @@ func RequestToken(client *gophercloud.ServiceClient, opts RequestTokenOptsBuilde
 		r.Err = fmt.Errorf("unsupported Content-Type: %q", v)
 		return
 	}
-	r.Body, r.Err = ioutil.ReadAll(resp.Body)
+	r.Body, r.Err = io.ReadAll(resp.Body)
 	return
 }
 
@@ -447,7 +447,7 @@ func CreateAccessToken(client *gophercloud.ServiceClient, opts CreateAccessToken
 		r.Err = fmt.Errorf("unsupported Content-Type: %q", v)
 		return
 	}
-	r.Body, r.Err = ioutil.ReadAll(resp.Body)
+	r.Body, r.Err = io.ReadAll(resp.Body)
 	return
 }
 

--- a/openstack/imageservice/v2/imagedata/doc.go
+++ b/openstack/imageservice/v2/imagedata/doc.go
@@ -43,7 +43,7 @@ Example to Download Image Data
 	// close the reader, when reading has finished
 	defer image.Close()
 
-	imageData, err := ioutil.ReadAll(image)
+	imageData, err := io.ReadAll(image)
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/imageservice/v2/imagedata/testing/fixtures.go
+++ b/openstack/imageservice/v2/imagedata/testing/fixtures.go
@@ -1,7 +1,7 @@
 package testing
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -15,7 +15,7 @@ func HandlePutImageDataSuccessfully(t *testing.T) {
 		th.TestMethod(t, r, "PUT")
 		th.TestHeader(t, r, "X-Auth-Token", fakeclient.TokenID)
 
-		b, err := ioutil.ReadAll(r.Body)
+		b, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Errorf("Unable to read request body: %v", err)
 		}
@@ -32,7 +32,7 @@ func HandleStageImageDataSuccessfully(t *testing.T) {
 		th.TestMethod(t, r, "PUT")
 		th.TestHeader(t, r, "X-Auth-Token", fakeclient.TokenID)
 
-		b, err := ioutil.ReadAll(r.Body)
+		b, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Errorf("Unable to read request body: %v", err)
 		}

--- a/openstack/imageservice/v2/imagedata/testing/requests_test.go
+++ b/openstack/imageservice/v2/imagedata/testing/requests_test.go
@@ -3,7 +3,6 @@ package testing
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"testing"
 
 	"github.com/gophercloud/gophercloud/openstack/imageservice/v2/imagedata"
@@ -96,7 +95,7 @@ func TestDownload(t *testing.T) {
 
 	defer rdr.Close()
 
-	bs, err := ioutil.ReadAll(rdr)
+	bs, err := io.ReadAll(rdr)
 	th.AssertNoErr(t, err)
 
 	th.AssertByteArrayEquals(t, []byte{34, 87, 0, 23, 23, 23, 56, 255, 254, 0}, bs)

--- a/openstack/keymanager/v1/secrets/results.go
+++ b/openstack/keymanager/v1/secrets/results.go
@@ -3,7 +3,6 @@ package secrets
 import (
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"time"
 
 	"github.com/gophercloud/gophercloud"
@@ -122,7 +121,7 @@ func (r PayloadResult) Extract() ([]byte, error) {
 		return nil, r.Err
 	}
 	defer r.Body.Close()
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/openstack/objectstorage/v1/objects/requests.go
+++ b/openstack/objectstorage/v1/objects/requests.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"hash"
 	"io"
-	"io/ioutil"
 	"strings"
 	"time"
 
@@ -232,7 +231,7 @@ func (opts CreateOpts) ToObjectCreateParams() (io.Reader, map[string]string, str
 	// file content into memory first.
 	readSeeker, isReadSeeker := opts.Content.(io.ReadSeeker)
 	if !isReadSeeker {
-		data, err := ioutil.ReadAll(opts.Content)
+		data, err := io.ReadAll(opts.Content)
 		if err != nil {
 			return nil, nil, "", err
 		}

--- a/openstack/objectstorage/v1/objects/results.go
+++ b/openstack/objectstorage/v1/objects/results.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"strings"
 	"time"
@@ -212,7 +211,7 @@ func (r *DownloadResult) ExtractContent() ([]byte, error) {
 		return nil, r.Err
 	}
 	defer r.Body.Close()
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/openstack/objectstorage/v1/objects/testing/requests_test.go
+++ b/openstack/objectstorage/v1/objects/testing/requests_test.go
@@ -5,7 +5,6 @@ import (
 	"crypto/md5"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
@@ -464,7 +463,7 @@ func TestObjectCreateParamsWithoutSeek(t *testing.T) {
 	_, ok := reader.(io.ReadSeeker)
 	th.AssertEquals(t, true, ok)
 
-	c, err := ioutil.ReadAll(reader)
+	c, err := io.ReadAll(reader)
 	th.AssertNoErr(t, err)
 
 	th.AssertEquals(t, content, string(c))
@@ -483,7 +482,7 @@ func TestObjectCreateParamsWithSeek(t *testing.T) {
 	_, ok := reader.(io.ReadSeeker)
 	th.AssertEquals(t, ok, true)
 
-	c, err := ioutil.ReadAll(reader)
+	c, err := io.ReadAll(reader)
 	th.AssertNoErr(t, err)
 
 	th.AssertEquals(t, content, string(c))

--- a/openstack/orchestration/v1/stacks/doc.go
+++ b/openstack/orchestration/v1/stacks/doc.go
@@ -42,7 +42,7 @@ Example to Create an Stack
 
 	// Create Template
 	t := make(map[string]interface{})
-	f, err := ioutil.ReadFile("template.yaml")
+	f, err := os.ReadFile("template.yaml")
 	if err != nil {
 	    panic(err)
 	}
@@ -57,7 +57,7 @@ Example to Create an Stack
 	}
 	// Create Environment if needed
 	t_env := make(map[string]interface{})
-	f_env, err := ioutil.ReadFile("env.yaml")
+	f_env, err := os.ReadFile("env.yaml")
 	if err != nil {
 	    panic(err)
 	}
@@ -155,7 +155,7 @@ raw_template value.
 Example to Update a Stack Using the Update (PUT) Method
 
 	t := make(map[string]interface{})
-	f, err := ioutil.ReadFile("template.yaml")
+	f, err := os.ReadFile("template.yaml")
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/orchestration/v1/stacks/utils.go
+++ b/openstack/orchestration/v1/stacks/utils.go
@@ -3,7 +3,7 @@ package stacks
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"path/filepath"
 	"reflect"
@@ -77,7 +77,7 @@ func (t *TE) Fetch() error {
 		return err
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}

--- a/openstack/orchestration/v1/stacktemplates/doc.go
+++ b/openstack/orchestration/v1/stacktemplates/doc.go
@@ -18,7 +18,7 @@ Example to get stack template
 
 Example to validate stack template
 
-	f2, err := ioutil.ReadFile("template.err.yaml")
+	f2, err := os.ReadFile("template.err.yaml")
 	if err != nil {
 	    panic(err)
 	}

--- a/pagination/http.go
+++ b/pagination/http.go
@@ -2,7 +2,7 @@ package pagination
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -22,7 +22,7 @@ func PageResultFrom(resp *http.Response) (PageResult, error) {
 	var parsedBody interface{}
 
 	defer resp.Body.Close()
-	rawBody, err := ioutil.ReadAll(resp.Body)
+	rawBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return PageResult{}, err
 	}

--- a/provider_client.go
+++ b/provider_client.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 	"sync"
@@ -458,7 +457,7 @@ func (client *ProviderClient) doRequest(method, url string, options *RequestOpts
 	}
 
 	if !ok {
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, _ := io.ReadAll(resp.Body)
 		resp.Body.Close()
 		respErr := ErrUnexpectedResponseCode{
 			URL:            url,
@@ -604,7 +603,7 @@ func (client *ProviderClient) doRequest(method, url string, options *RequestOpts
 		// Don't decode JSON when there is no content
 		if resp.StatusCode == http.StatusNoContent {
 			// read till EOF, otherwise the connection will be closed and cannot be reused
-			_, err = io.Copy(ioutil.Discard, resp.Body)
+			_, err = io.Copy(io.Discard, resp.Body)
 			return resp, err
 		}
 		if err := json.NewDecoder(resp.Body).Decode(options.JSONResponse); err != nil {
@@ -626,7 +625,7 @@ func (client *ProviderClient) doRequest(method, url string, options *RequestOpts
 	if !options.KeepResponseBody && options.JSONResponse == nil {
 		defer resp.Body.Close()
 		// read till EOF, otherwise the connection will be closed and cannot be reused
-		if _, err := io.Copy(ioutil.Discard, resp.Body); err != nil {
+		if _, err := io.Copy(io.Discard, resp.Body); err != nil {
 			return nil, err
 		}
 	}

--- a/testhelper/http_responses.go
+++ b/testhelper/http_responses.go
@@ -3,7 +3,7 @@ package testhelper
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -90,7 +90,7 @@ func TestHeaderUnset(t *testing.T, r *http.Request, header string) {
 
 // TestBody verifies that the request body matches an expected body.
 func TestBody(t *testing.T, r *http.Request, expected string) {
-	b, err := ioutil.ReadAll(r.Body)
+	b, err := io.ReadAll(r.Body)
 	if err != nil {
 		t.Errorf("Unable to read body: %v", err)
 	}
@@ -103,7 +103,7 @@ func TestBody(t *testing.T, r *http.Request, expected string) {
 // TestJSONRequest verifies that the JSON payload of a request matches an expected structure, without asserting things about
 // whitespace or ordering.
 func TestJSONRequest(t *testing.T, r *http.Request, expected string) {
-	b, err := ioutil.ReadAll(r.Body)
+	b, err := io.ReadAll(r.Body)
 	if err != nil {
 		t.Errorf("Unable to read request body: %v", err)
 	}

--- a/testing/provider_client_test.go
+++ b/testing/provider_client_test.go
@@ -3,7 +3,7 @@ package testing
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -123,7 +123,7 @@ func TestConcurrentReauth(t *testing.T) {
 				return
 			}
 			defer resp.Body.Close()
-			actual, err := ioutil.ReadAll(resp.Body)
+			actual, err := io.ReadAll(resp.Body)
 			if err != nil {
 				t.Errorf("error reading response body: %s", err)
 				return
@@ -304,7 +304,7 @@ func TestRequestThatCameDuringReauthWaitsUntilItIsCompleted(t *testing.T) {
 				return
 			}
 			defer resp.Body.Close()
-			actual, err := ioutil.ReadAll(resp.Body)
+			actual, err := io.ReadAll(resp.Body)
 			if err != nil {
 				t.Errorf("error reading response body: %s", err)
 				return
@@ -379,7 +379,7 @@ func TestRequestWithContext(t *testing.T) {
 
 	res, err := p.Request("GET", ts.URL, &gophercloud.RequestOpts{KeepResponseBody: true})
 	th.AssertNoErr(t, err)
-	_, err = ioutil.ReadAll(res.Body)
+	_, err = io.ReadAll(res.Body)
 	th.AssertNoErr(t, err)
 	err = res.Body.Close()
 	th.AssertNoErr(t, err)


### PR DESCRIPTION
All functions in `ioutil` have been moved to either `io` or `os`.