### PR TITLE
workflow/semver-auto: rebase PR

### DIFF
--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -19,3 +19,6 @@
 - color: '6E7624'
   description: No API change
   name: semver:patch
+- color: 'EC0101'
+  description: Unable to figure out the semver type
+  name: semver:unknown

--- a/.github/workflows/semver-auto.yaml
+++ b/.github/workflows/semver-auto.yaml
@@ -12,6 +12,17 @@ jobs:
         ref: ${{ github.event.pull_request.head.sha }}
         token: ${{ secrets.GITHUB_TOKEN }}
 
+    - uses: peter-evans/rebase@56c359b35ff7ba8426d0fdb842958b35b1db827
+      with:
+        base: ${{ github.base_ref }}
+
+    - name: Add semver:unknown label
+      if: failure()
+      uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        labels: semver:unknown
+
     - uses: actions/setup-go@v4
       with:
         go-version: '1'
@@ -23,6 +34,7 @@ jobs:
           semver:patch
           semver:minor
           semver:major
+          semver:unknown
         github_token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Checking Go API Compatibility


### PR DESCRIPTION
When testing if a PR is API backward compatible or not, we need to test
against the base branch, not the head against the PR branched is based
on.

Otherwise it can lead to the case where a breaking change was merged
after that a PR was proposed, go-apidiff will fail because it'll test
the repo against base_ref.

The PR needs to be rebased on base_ref so the actual compatibility can be
verified.

If the PR can't be rebase for any reason, we'll return a failure and add
the label `semver:unknown`.
