### PR TITLE
semver-auto: manual rebase instead of external action

### DIFF
--- a/.github/workflows/semver-auto.yaml
+++ b/.github/workflows/semver-auto.yaml
@@ -12,9 +12,11 @@ jobs:
         ref: ${{ github.event.pull_request.head.sha }}
         token: ${{ secrets.GITHUB_TOKEN }}
 
-    - uses: peter-evans/rebase@56c359b35ff7ba8426d0fdb842958b35b1db8277
-      with:
-        base: ${{ github.base_ref }}
+    - name: Rebase the PR against origin/github.base_ref to ensure actual API compatibility
+      run: |
+        git rebase -i origin/${{ github.base_ref }}
+      env:
+        GIT_SEQUENCE_EDITOR: '/usr/bin/true'
 
     - name: Add semver:unknown label
       if: failure()


### PR DESCRIPTION
I haven't found an action that just runs a rebase without pushing it
into the repo.

Let's just run `git rebase -i` for now.
