### PR TITLE
Add networks.ListOptsMulti

### DIFF
--- a/acceptance/openstack/networking/v2/extensions/attributestags_test.go
+++ b/acceptance/openstack/networking/v2/extensions/attributestags_test.go
@@ -105,26 +105,34 @@ func TestQueryByTags(t *testing.T) {
 	defer networking.DeleteNetwork(t, client, network2.ID)
 
 	// Tags - Networks that match all tags will be returned
-	listOpts := networks.ListOptsMulti{}.Tags("a", "b", "c").Tags(testtag)
+	listOpts := networks.NewListOptsBuilder(networks.Tags("a", "b", "c"), networks.Tags(testtag))
 	ids := listNetworkWithTagOpts(t, client, listOpts)
 	th.AssertDeepEquals(t, []string{network1.ID}, ids)
 
 	// TagsAny - Networks that match any tag will be returned
-	listOpts = networks.ListOptsMulti{}.
-		TagsAny("a", "b", "c", testtag).
-		SortKey("id").SortDir("asc")
+	listOpts = networks.NewListOptsBuilder(
+		networks.TagsAny("a", "b", "c", testtag),
+		networks.SortKey("id"),
+		networks.SortDir("asc"),
+	)
 	ids = listNetworkWithTagOpts(t, client, listOpts)
 	expected_ids := []string{network1.ID, network2.ID}
 	sort.Strings(expected_ids)
 	th.AssertDeepEquals(t, expected_ids, ids)
 
 	// NotTags - Networks that match all tags will be excluded
-	listOpts = networks.ListOptsMulti{}.Tags(testtag).NotTags("a", "b", "c")
+	listOpts = networks.NewListOptsBuilder(
+		networks.Tags(testtag),
+		networks.NotTags("a", "b", "c"),
+	)
 	ids = listNetworkWithTagOpts(t, client, listOpts)
 	th.AssertDeepEquals(t, []string{network2.ID}, ids)
 
 	// NotTagsAny - Networks that match any tag will be excluded.
-	listOpts = networks.ListOptsMulti{}.Tags(testtag).NotTagsAny("d")
+	listOpts = networks.NewListOptsBuilder(
+		networks.Tags(testtag),
+		networks.NotTagsAny("d"),
+	)
 	ids = listNetworkWithTagOpts(t, client, listOpts)
 	th.AssertDeepEquals(t, []string{network1.ID}, ids)
 }

--- a/acceptance/openstack/networking/v2/extensions/mtu/mtu_test.go
+++ b/acceptance/openstack/networking/v2/extensions/mtu/mtu_test.go
@@ -46,7 +46,7 @@ func TestMTUNetworkCRUDL(t *testing.T) {
 		// List network successfully
 		var listOpts networks.ListOptsBuilder
 		listOpts = mtu.ListOptsExt{
-			ListOptsBuilder: networks.ListOpts{},
+			ListOptsBuilder: networks.NewListOptsBuilder(),
 			MTU:             networkMTU,
 		}
 		var listedNetworks []NetworkMTU
@@ -71,7 +71,7 @@ func TestMTUNetworkCRUDL(t *testing.T) {
 
 		// List network unsuccessfully
 		listOpts = mtu.ListOptsExt{
-			ListOptsBuilder: networks.ListOpts{},
+			ListOptsBuilder: networks.NewListOptsBuilder(),
 			MTU:             1,
 		}
 		i = 0

--- a/acceptance/openstack/networking/v2/extensions/vlantransparent/vlantransparent.go
+++ b/acceptance/openstack/networking/v2/extensions/vlantransparent/vlantransparent.go
@@ -21,7 +21,7 @@ type VLANTransparentNetwork struct {
 // extension. An error will be returned networks could not be listed.
 func ListVLANTransparentNetworks(t *testing.T, client *gophercloud.ServiceClient) ([]*VLANTransparentNetwork, error) {
 	iTrue := true
-	networkListOpts := networks.ListOpts{}
+	networkListOpts := networks.NewListOptsBuilder()
 	listOpts := vlantransparent.ListOptsExt{
 		ListOptsBuilder: networkListOpts,
 		VLANTransparent: &iTrue,

--- a/acceptance/openstack/networking/v2/networking.go
+++ b/acceptance/openstack/networking/v2/networking.go
@@ -575,9 +575,7 @@ func IDFromName(client *gophercloud.ServiceClient, name string) (string, error) 
 	count := 0
 	id := ""
 
-	listOpts := networks.ListOpts{
-		Name: name,
-	}
+	listOpts := networks.ListOptsMulti{}.Name(name)
 
 	pages, err := networks.List(client, listOpts).AllPages()
 	if err != nil {

--- a/acceptance/openstack/networking/v2/networking.go
+++ b/acceptance/openstack/networking/v2/networking.go
@@ -575,7 +575,7 @@ func IDFromName(client *gophercloud.ServiceClient, name string) (string, error) 
 	count := 0
 	id := ""
 
-	listOpts := networks.ListOptsMulti{}.Name(name)
+	listOpts := networks.NewListOptsBuilder(networks.Name(name))
 
 	pages, err := networks.List(client, listOpts).AllPages()
 	if err != nil {

--- a/acceptance/openstack/networking/v2/networks_test.go
+++ b/acceptance/openstack/networking/v2/networks_test.go
@@ -30,9 +30,7 @@ func TestNetworksExternalList(t *testing.T) {
 	var allNetworks []networkWithExt
 
 	iTrue := true
-	networkListOpts := networks.ListOpts{
-		ID: choices.ExternalNetworkID,
-	}
+	networkListOpts := networks.ListOptsMulti{}.ID(choices.ExternalNetworkID)
 	listOpts := external.ListOptsExt{
 		ListOptsBuilder: networkListOpts,
 		External:        &iTrue,
@@ -54,9 +52,7 @@ func TestNetworksExternalList(t *testing.T) {
 	th.AssertEquals(t, found, true)
 
 	iFalse := false
-	networkListOpts = networks.ListOpts{
-		ID: choices.ExternalNetworkID,
-	}
+	networkListOpts = networks.ListOptsMulti{}.ID(choices.ExternalNetworkID)
 	listOpts = external.ListOptsExt{
 		ListOptsBuilder: networkListOpts,
 		External:        &iFalse,

--- a/acceptance/openstack/networking/v2/networks_test.go
+++ b/acceptance/openstack/networking/v2/networks_test.go
@@ -30,7 +30,7 @@ func TestNetworksExternalList(t *testing.T) {
 	var allNetworks []networkWithExt
 
 	iTrue := true
-	networkListOpts := networks.ListOptsMulti{}.ID(choices.ExternalNetworkID)
+	networkListOpts := networks.NewListOptsBuilder(networks.ID(choices.ExternalNetworkID))
 	listOpts := external.ListOptsExt{
 		ListOptsBuilder: networkListOpts,
 		External:        &iTrue,
@@ -52,7 +52,7 @@ func TestNetworksExternalList(t *testing.T) {
 	th.AssertEquals(t, found, true)
 
 	iFalse := false
-	networkListOpts = networks.ListOptsMulti{}.ID(choices.ExternalNetworkID)
+	networkListOpts = networks.NewListOptsBuilder(networks.ID(choices.ExternalNetworkID))
 	listOpts = external.ListOptsExt{
 		ListOptsBuilder: networkListOpts,
 		External:        &iFalse,

--- a/openstack/networking/v2/common/common.go
+++ b/openstack/networking/v2/common/common.go
@@ -5,6 +5,14 @@ import (
 	"strconv"
 )
 
+type Modifiers interface {
+	MultiOptString(name string, v ...string)
+	MultiOptBool(name string, v ...bool)
+	SingleOptString(name string, v string)
+}
+
+type NeutronListOptsConfig func(Modifiers)
+
 type NeutronListOpts struct {
 	params url.Values
 }
@@ -25,7 +33,57 @@ func (opts NeutronListOpts) SingleOptString(name string, v string) {
 	opts.params.Set(name, v)
 }
 
-func (opts NeutronListOpts) ToQueryString() (string, error) {
+func (opts NeutronListOpts) ToQueryString() string {
 	q := &url.URL{RawQuery: opts.params.Encode()}
-	return q.String(), nil
+	return q.String()
+}
+
+func MultiOptString(name string, v ...string) NeutronListOptsConfig {
+	return func(opts Modifiers) {
+		opts.MultiOptString(name, v...)
+	}
+}
+
+func MultiOptBool(name string, v ...bool) NeutronListOptsConfig {
+	return func(opts Modifiers) {
+		opts.MultiOptBool(name, v...)
+	}
+}
+
+func SingleOptString(name string, v string) NeutronListOptsConfig {
+	return func(opts Modifiers) {
+		opts.SingleOptString(name, v)
+	}
+}
+
+func Tags(v ...string) NeutronListOptsConfig {
+	return MultiOptString("tags", v...)
+}
+
+func TagsAny(v ...string) NeutronListOptsConfig {
+	return MultiOptString("tags-any", v...)
+}
+
+func NotTags(v ...string) NeutronListOptsConfig {
+	return MultiOptString("not-tags", v...)
+}
+
+func NotTagsAny(v ...string) NeutronListOptsConfig {
+	return MultiOptString("not-tags-any", v...)
+}
+
+func SortKey(v string) NeutronListOptsConfig {
+	return SingleOptString("sort_key", v)
+}
+
+func SortDir(v string) NeutronListOptsConfig {
+	return SingleOptString("sort_dir", v)
+}
+
+func Marker(v string) NeutronListOptsConfig {
+	return SingleOptString("marker", v)
+}
+
+func Limit(v int) NeutronListOptsConfig {
+	return SingleOptString("limit", strconv.Itoa(v))
 }

--- a/openstack/networking/v2/common/common.go
+++ b/openstack/networking/v2/common/common.go
@@ -1,0 +1,31 @@
+package common
+
+import (
+	"net/url"
+	"strconv"
+)
+
+type NeutronListOpts struct {
+	params url.Values
+}
+
+func (opts NeutronListOpts) MultiOptString(name string, v ...string) {
+	for _, val := range v {
+		opts.params.Add(name, val)
+	}
+}
+
+func (opts NeutronListOpts) MultiOptBool(name string, v ...bool) {
+	for _, val := range v {
+		opts.params.Add(name, strconv.FormatBool(val))
+	}
+}
+
+func (opts NeutronListOpts) SingleOptString(name string, v string) {
+	opts.params.Set(name, v)
+}
+
+func (opts NeutronListOpts) ToQueryString() (string, error) {
+	q := &url.URL{RawQuery: opts.params.Encode()}
+	return q.String(), nil
+}

--- a/openstack/networking/v2/networks/requests.go
+++ b/openstack/networking/v2/networks/requests.go
@@ -2,7 +2,6 @@ package networks
 
 import (
 	"fmt"
-	"strconv"
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/common"
@@ -45,91 +44,62 @@ func (opts ListOpts) ToNetworkListQuery() (string, error) {
 	return q.String(), err
 }
 
-type ListOptsMulti common.NeutronListOpts
+type commonListOpts struct{ common.NeutronListOpts }
 
-func (opts ListOptsMulti) ToNetworkListQuery() (string, error) {
-	return common.NeutronListOpts(opts).ToQueryString()
+func (opts commonListOpts) ToNetworkListQuery() (string, error) {
+	return opts.ToQueryString(), nil
 }
 
-func (opts ListOptsMulti) Status(v ...string) ListOptsMulti {
-	common.NeutronListOpts(opts).MultiOptString("status", v...)
+func NewListOptsBuilder(config ...common.NeutronListOptsConfig) ListOptsBuilder {
+	opts := commonListOpts{}
+	for _, conf := range config {
+		conf(&opts)
+	}
 	return opts
 }
 
-func (opts ListOptsMulti) Name(v ...string) ListOptsMulti {
-	common.NeutronListOpts(opts).MultiOptString("name", v...)
-	return opts
+func Status(v ...string) common.NeutronListOptsConfig {
+	return common.MultiOptString("status", v...)
 }
 
-func (opts ListOptsMulti) Description(v ...string) ListOptsMulti {
-	common.NeutronListOpts(opts).MultiOptString("description", v...)
-	return opts
+func Name(v ...string) common.NeutronListOptsConfig {
+	return common.MultiOptString("name", v...)
 }
 
-func (opts ListOptsMulti) AdminStateUp(v ...bool) ListOptsMulti {
-	common.NeutronListOpts(opts).MultiOptBool("admin_state_up", v...)
-	return opts
+func Description(v ...string) common.NeutronListOptsConfig {
+	return common.MultiOptString("description", v...)
 }
 
-func (opts ListOptsMulti) TenantID(v ...string) ListOptsMulti {
-	common.NeutronListOpts(opts).MultiOptString("tenant_id", v...)
-	return opts
+func AdminStateUp(v ...bool) common.NeutronListOptsConfig {
+	return common.MultiOptBool("admin_state_up", v...)
 }
 
-func (opts ListOptsMulti) ProjectID(v ...string) ListOptsMulti {
-	common.NeutronListOpts(opts).MultiOptString("project_id", v...)
-	return opts
+func TenantID(v ...string) common.NeutronListOptsConfig {
+	return common.MultiOptString("tenant_id", v...)
 }
 
-func (opts ListOptsMulti) Shared(v ...bool) ListOptsMulti {
-	common.NeutronListOpts(opts).MultiOptBool("shared", v...)
-	return opts
+func ProjectID(v ...string) common.NeutronListOptsConfig {
+	return common.MultiOptString("project_id", v...)
 }
 
-func (opts ListOptsMulti) ID(v ...string) ListOptsMulti {
-	common.NeutronListOpts(opts).MultiOptString("id", v...)
-	return opts
+func Shared(v ...bool) common.NeutronListOptsConfig {
+	return common.MultiOptBool("shared", v...)
 }
 
-func (opts ListOptsMulti) Tags(v ...string) ListOptsMulti {
-	common.NeutronListOpts(opts).MultiOptString("tags", v...)
-	return opts
+func ID(v ...string) common.NeutronListOptsConfig {
+	return common.MultiOptString("id", v...)
 }
 
-func (opts ListOptsMulti) TagsAny(v ...string) ListOptsMulti {
-	common.NeutronListOpts(opts).MultiOptString("tags-any", v...)
-	return opts
-}
-
-func (opts ListOptsMulti) NotTags(v ...string) ListOptsMulti {
-	common.NeutronListOpts(opts).MultiOptString("not-tags", v...)
-	return opts
-}
-
-func (opts ListOptsMulti) NotTagsAny(v ...string) ListOptsMulti {
-	common.NeutronListOpts(opts).MultiOptString("not-tags-any", v...)
-	return opts
-}
-
-func (opts ListOptsMulti) SortKey(v string) ListOptsMulti {
-	common.NeutronListOpts(opts).SingleOptString("sort_key", v)
-	return opts
-}
-
-func (opts ListOptsMulti) SortDir(v string) ListOptsMulti {
-	common.NeutronListOpts(opts).SingleOptString("sort_dir", v)
-	return opts
-}
-
-func (opts ListOptsMulti) Marker(v string) ListOptsMulti {
-	common.NeutronListOpts(opts).SingleOptString("marker", v)
-	return opts
-}
-
-func (opts ListOptsMulti) Limit(v int) ListOptsMulti {
-	common.NeutronListOpts(opts).SingleOptString("limit", strconv.Itoa(v))
-	return opts
-}
+var (
+	Tags       = common.Tags
+	TagsAny    = common.TagsAny
+	NotTags    = common.NotTags
+	NotTagsAny = common.NotTagsAny
+	SortKey    = common.SortKey
+	SortDir    = common.SortDir
+	Marker     = common.Marker
+	Limit      = common.Limit
+)
 
 // List returns a Pager which allows you to iterate over a collection of
 // networks. It accepts a ListOpts struct, which allows you to filter and sort

--- a/openstack/networking/v2/networks/requests.go
+++ b/openstack/networking/v2/networks/requests.go
@@ -2,8 +2,10 @@ package networks
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/common"
 	"github.com/gophercloud/gophercloud/pagination"
 )
 
@@ -41,6 +43,92 @@ type ListOpts struct {
 func (opts ListOpts) ToNetworkListQuery() (string, error) {
 	q, err := gophercloud.BuildQueryString(opts)
 	return q.String(), err
+}
+
+type ListOptsMulti common.NeutronListOpts
+
+func (opts ListOptsMulti) ToNetworkListQuery() (string, error) {
+	return common.NeutronListOpts(opts).ToQueryString()
+}
+
+func (opts ListOptsMulti) Status(v ...string) ListOptsMulti {
+	common.NeutronListOpts(opts).MultiOptString("status", v...)
+	return opts
+}
+
+func (opts ListOptsMulti) Name(v ...string) ListOptsMulti {
+	common.NeutronListOpts(opts).MultiOptString("name", v...)
+	return opts
+}
+
+func (opts ListOptsMulti) Description(v ...string) ListOptsMulti {
+	common.NeutronListOpts(opts).MultiOptString("description", v...)
+	return opts
+}
+
+func (opts ListOptsMulti) AdminStateUp(v ...bool) ListOptsMulti {
+	common.NeutronListOpts(opts).MultiOptBool("admin_state_up", v...)
+	return opts
+}
+
+func (opts ListOptsMulti) TenantID(v ...string) ListOptsMulti {
+	common.NeutronListOpts(opts).MultiOptString("tenant_id", v...)
+	return opts
+}
+
+func (opts ListOptsMulti) ProjectID(v ...string) ListOptsMulti {
+	common.NeutronListOpts(opts).MultiOptString("project_id", v...)
+	return opts
+}
+
+func (opts ListOptsMulti) Shared(v ...bool) ListOptsMulti {
+	common.NeutronListOpts(opts).MultiOptBool("shared", v...)
+	return opts
+}
+
+func (opts ListOptsMulti) ID(v ...string) ListOptsMulti {
+	common.NeutronListOpts(opts).MultiOptString("id", v...)
+	return opts
+}
+
+func (opts ListOptsMulti) Tags(v ...string) ListOptsMulti {
+	common.NeutronListOpts(opts).MultiOptString("tags", v...)
+	return opts
+}
+
+func (opts ListOptsMulti) TagsAny(v ...string) ListOptsMulti {
+	common.NeutronListOpts(opts).MultiOptString("tags-any", v...)
+	return opts
+}
+
+func (opts ListOptsMulti) NotTags(v ...string) ListOptsMulti {
+	common.NeutronListOpts(opts).MultiOptString("not-tags", v...)
+	return opts
+}
+
+func (opts ListOptsMulti) NotTagsAny(v ...string) ListOptsMulti {
+	common.NeutronListOpts(opts).MultiOptString("not-tags-any", v...)
+	return opts
+}
+
+func (opts ListOptsMulti) SortKey(v string) ListOptsMulti {
+	common.NeutronListOpts(opts).SingleOptString("sort_key", v)
+	return opts
+}
+
+func (opts ListOptsMulti) SortDir(v string) ListOptsMulti {
+	common.NeutronListOpts(opts).SingleOptString("sort_dir", v)
+	return opts
+}
+
+func (opts ListOptsMulti) Marker(v string) ListOptsMulti {
+	common.NeutronListOpts(opts).SingleOptString("marker", v)
+	return opts
+}
+
+func (opts ListOptsMulti) Limit(v int) ListOptsMulti {
+	common.NeutronListOpts(opts).SingleOptString("limit", strconv.Itoa(v))
+	return opts
 }
 
 // List returns a Pager which allows you to iterate over a collection of


### PR DESCRIPTION
This is a PoC, and came out of a discussion with @pierreprinetti about https://github.com/gophercloud/utils/pull/190

I've only implemented it for Networks, as that should be sufficient for discussion. I have changed all uses of ListOpts in acceptance tests to use ListOptsMulti instead to kick the tyres.

Something else to make clear: this is 2 PRs in 1! The 2 commits in this PR present 2 alternative APIs. My personal preference is for the first one (the monadic one), as it has the best type safety.

Fixes #[PUT ISSUE NUMBER HERE]

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

Tag filters: https://github.com/openstack/neutron/blob/ed6023c3473585b4af6980404e7fe36ea152f980/neutron/objects/tag.py#L37-L104
Sort fields are singletons: https://github.com/openstack/neutron/blob/ed6023c3473585b4af6980404e7fe36ea152f980/neutron/api/v2/base.py#L291-L293
Most filter values can have multiple values: https://github.com/openstack/neutron/blob/ed6023c3473585b4af6980404e7fe36ea152f980/neutron/api/api_common.py#L70-L115