### PR TITLE
semver-auto: tell who we are during rebase

### DIFF
--- a/.github/workflows/semver-auto.yaml
+++ b/.github/workflows/semver-auto.yaml
@@ -24,6 +24,8 @@ jobs:
 
     - name: Rebase the PR against origin/github.base_ref to ensure actual API compatibility
       run: |
+        git config --global user.email "localrebase@gophercloud.io"
+        git config --global user.name "Local rebase"
         git rebase -i origin/${{ github.base_ref }}
       env:
         GIT_SEQUENCE_EDITOR: '/usr/bin/true'


### PR DESCRIPTION
To avoid the `*** Please tell me who you are` error when a PR is locally
rebased to find out which semver label to apply, let's just set fake
user.email and user.name, which aren't used anyway since the PR isn't
actually rebased, but just for the workflow so we can run `go-apidiff`
which itself requires code to be committed.
