### PR TITLE
ci/functional: switch master jobs to run on ubuntu 22.04

### DIFF
--- a/.github/workflows/functional-baremetal.yaml
+++ b/.github/workflows/functional-baremetal.yaml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         name: ["master"]
         openstack_version: ["master"]
-        ubuntu_version: ["20.04"]
+        ubuntu_version: ["22.04"]
         include:
           - name: "zed"
             openstack_version: "stable/zed"

--- a/.github/workflows/functional-basic.yaml
+++ b/.github/workflows/functional-basic.yaml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         name: ["master"]
         openstack_version: ["master"]
-        ubuntu_version: ["20.04"]
+        ubuntu_version: ["22.04"]
         include:
           - name: "zed"
             openstack_version: "stable/zed"

--- a/.github/workflows/functional-blockstorage.yaml
+++ b/.github/workflows/functional-blockstorage.yaml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         name: ["master"]
         openstack_version: ["master"]
-        ubuntu_version: ["20.04"]
+        ubuntu_version: ["22.04"]
         include:
           - name: "zed"
             openstack_version: "stable/zed"

--- a/.github/workflows/functional-compute.yaml
+++ b/.github/workflows/functional-compute.yaml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         name: ["master"]
         openstack_version: ["master"]
-        ubuntu_version: ["20.04"]
+        ubuntu_version: ["22.04"]
         include:
           - name: "zed"
             openstack_version: "stable/zed"

--- a/.github/workflows/functional-containerinfra.yaml
+++ b/.github/workflows/functional-containerinfra.yaml
@@ -13,7 +13,7 @@ jobs:
         include:
           - name: "master"
             openstack_version: "master"
-            ubuntu_version: "20.04"
+            ubuntu_version: "22.04"
             devstack_conf_overrides: |
               enable_plugin magnum https://github.com/openstack/magnum master
           - name: "zed"

--- a/.github/workflows/functional-dns.yaml
+++ b/.github/workflows/functional-dns.yaml
@@ -14,7 +14,7 @@ jobs:
         include:
           - name: "master"
             openstack_version: "master"
-            ubuntu_version: "20.04"
+            ubuntu_version: "22.04"
             devstack_conf_overrides: |
               enable_plugin designate https://github.com/openstack/designate master
           - name: "zed"

--- a/.github/workflows/functional-identity.yaml
+++ b/.github/workflows/functional-identity.yaml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         name: ["master"]
         openstack_version: ["master"]
-        ubuntu_version: ["20.04"]
+        ubuntu_version: ["22.04"]
         include:
           - name: "zed"
             openstack_version: "stable/zed"

--- a/.github/workflows/functional-imageservice.yaml
+++ b/.github/workflows/functional-imageservice.yaml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         name: ["master"]
         openstack_version: ["master"]
-        ubuntu_version: ["20.04"]
+        ubuntu_version: ["22.04"]
         include:
           - name: "zed"
             openstack_version: "stable/zed"

--- a/.github/workflows/functional-keymanager.yaml
+++ b/.github/workflows/functional-keymanager.yaml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         name: ["master"]
         openstack_version: ["master"]
-        ubuntu_version: ["20.04"]
+        ubuntu_version: ["22.04"]
         include:
           - name: "zed"
             openstack_version: "stable/zed"

--- a/.github/workflows/functional-loadbalancer.yaml
+++ b/.github/workflows/functional-loadbalancer.yaml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         name: ["master"]
         openstack_version: ["master"]
-        ubuntu_version: ["20.04"]
+        ubuntu_version: ["22.04"]
         include:
           - name: "zed"
             openstack_version: "stable/zed"

--- a/.github/workflows/functional-networking.yaml
+++ b/.github/workflows/functional-networking.yaml
@@ -13,7 +13,7 @@ jobs:
         include:
           - name: "master"
             openstack_version: "master"
-            ubuntu_version: "20.04"
+            ubuntu_version: "22.04"
             devstack_conf_overrides: |
               enable_plugin neutron-dynamic-routing https://github.com/openstack/neutron-dynamic-routing master
               enable_plugin neutron-vpnaas https://github.com/openstack/neutron-vpnaas master

--- a/.github/workflows/functional-objectstorage.yaml
+++ b/.github/workflows/functional-objectstorage.yaml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         name: ["master"]
         openstack_version: ["master"]
-        ubuntu_version: ["20.04"]
+        ubuntu_version: ["22.04"]
         include:
           - name: "zed"
             openstack_version: "stable/zed"

--- a/.github/workflows/functional-orchestration.yaml
+++ b/.github/workflows/functional-orchestration.yaml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         name: ["master"]
         openstack_version: ["master"]
-        ubuntu_version: ["20.04"]
+        ubuntu_version: ["22.04"]
         include:
           - name: "zed"
             openstack_version: "stable/zed"

--- a/.github/workflows/functional-placement.yaml
+++ b/.github/workflows/functional-placement.yaml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         name: ["master"]
         openstack_version: ["master"]
-        ubuntu_version: ["20.04"]
+        ubuntu_version: ["22.04"]
         include:
           - name: "zed"
             openstack_version: "stable/zed"

--- a/.github/workflows/functional-sharedfilesystems.yaml
+++ b/.github/workflows/functional-sharedfilesystems.yaml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         name: ["master"]
         openstack_version: ["master"]
-        ubuntu_version: ["20.04"]
+        ubuntu_version: ["22.04"]
         include:
           - name: "zed"
             openstack_version: "stable/zed"


### PR DESCRIPTION
Since https://github.com/openstack/devstack/commit/427a4e1a9b7f20a8be0ad5091f2229945ce711a8
We don't support focal anymore in devstack-master. We need to run 22.04
from now.

Note: some workflows already had it right but it wasn't consistent
across all services.
