### PR TITLE
CI: automatically reject backward incompatible backports

### DIFF
--- a/.github/workflows/backport_v1.yaml
+++ b/.github/workflows/backport_v1.yaml
@@ -31,6 +31,9 @@ jobs:
           private_key: ${{ secrets.BACKPORT_APP_PRIVATE_KEY }}
 
       - name: Backporting
+        if: >
+          contains(github.event.pull_request.labels.*.name, 'semver-patch')
+          || contains(github.event.pull_request.labels.*.name, 'semver-minor')
         uses: kiegroup/git-backporting@4313be48e73b299a20b3c8290fd1ea8704e8dd5e
         with:
           target-branch: v1
@@ -38,3 +41,13 @@ jobs:
           auth: ${{ steps.generate_token.outputs.token }}
           no-squash: true
           strategy-option: find-renames
+
+      - name: Report an error if backport unsupported labels
+        if: >
+          contains(github.event.pull_request.labels.*.name, 'semver-major')
+          || contains(github.event.pull_request.labels.*.name, 'semver-unknown')
+        uses: thollander/actions-comment-pull-request@d61db783da9abefc3437960d0cce08552c7c004f
+        with:
+          message: |
+            Labels `semver-major` or `semver-unknown` can not trigger backports.
+            The PR has to be labeled `semver-patch` or `semver-minor`.


### PR DESCRIPTION
If a backport is labeled as `semver-unknown` or `semver-major`, we
consider it unsafe to backport until someone has verified otherwise and
applied `semver-patch` or `semver-minor`.

We create a commit with an error to make it visible if that happens.

Fixes #2758
