### PR TITLE
ci/functional: fix ubuntu version & add antelope

### DIFF
--- a/.github/workflows/functional-baremetal.yaml
+++ b/.github/workflows/functional-baremetal.yaml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         name: ["master"]
         openstack_version: ["master"]
-        ubuntu_version: ["20.04"]
+        ubuntu_version: ["22.04"]
         include:
           - name: "antelope"
             openstack_version: "stable/2023.1"

--- a/.github/workflows/functional-baremetal.yaml
+++ b/.github/workflows/functional-baremetal.yaml
@@ -14,6 +14,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["20.04"]
         include:
+          - name: "antelope"
+            openstack_version: "stable/2023.1"
+            ubuntu_version: "22.04"
           - name: "zed"
             openstack_version: "stable/zed"
             ubuntu_version: "20.04"

--- a/.github/workflows/functional-basic.yaml
+++ b/.github/workflows/functional-basic.yaml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         name: ["master"]
         openstack_version: ["master"]
-        ubuntu_version: ["20.04"]
+        ubuntu_version: ["22.04"]
         include:
           - name: "antelope"
             openstack_version: "stable/2023.1"

--- a/.github/workflows/functional-basic.yaml
+++ b/.github/workflows/functional-basic.yaml
@@ -17,6 +17,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["20.04"]
         include:
+          - name: "antelope"
+            openstack_version: "stable/2023.1"
+            ubuntu_version: "22.04"
           - name: "zed"
             openstack_version: "stable/zed"
             ubuntu_version: "20.04"

--- a/.github/workflows/functional-blockstorage.yaml
+++ b/.github/workflows/functional-blockstorage.yaml
@@ -42,7 +42,7 @@ jobs:
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |
-            CINDER_ISCSI_HELPER=tgtadm
+            CINDER_ISCSI_HELPER=lioadm
           enabled_services: 's-account,s-container,s-object,s-proxy,c-bak'
       - name: Checkout go
         uses: actions/setup-go@v4

--- a/.github/workflows/functional-blockstorage.yaml
+++ b/.github/workflows/functional-blockstorage.yaml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         name: ["master"]
         openstack_version: ["master"]
-        ubuntu_version: ["20.04"]
+        ubuntu_version: ["22.04"]
         include:
           - name: "antelope"
             openstack_version: "stable/2023.1"

--- a/.github/workflows/functional-blockstorage.yaml
+++ b/.github/workflows/functional-blockstorage.yaml
@@ -14,6 +14,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["20.04"]
         include:
+          - name: "antelope"
+            openstack_version: "stable/2023.1"
+            ubuntu_version: "22.04"
           - name: "zed"
             openstack_version: "stable/zed"
             ubuntu_version: "20.04"

--- a/.github/workflows/functional-clustering.yaml
+++ b/.github/workflows/functional-clustering.yaml
@@ -14,6 +14,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["22.04"]
         include:
+          - name: "antelope"
+            openstack_version: "stable/2023.1"
+            ubuntu_version: "22.04"
           - name: "zed"
             openstack_version: "stable/zed"
             ubuntu_version: "20.04"

--- a/.github/workflows/functional-compute.yaml
+++ b/.github/workflows/functional-compute.yaml
@@ -42,7 +42,7 @@ jobs:
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |
-            CINDER_ISCSI_HELPER=tgtadm
+            CINDER_ISCSI_HELPER=lioadm
       - name: Checkout go
         uses: actions/setup-go@v4
         with:

--- a/.github/workflows/functional-compute.yaml
+++ b/.github/workflows/functional-compute.yaml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         name: ["master"]
         openstack_version: ["master"]
-        ubuntu_version: ["20.04"]
+        ubuntu_version: ["22.04"]
         include:
           - name: "antelope"
             openstack_version: "stable/2023.1"

--- a/.github/workflows/functional-compute.yaml
+++ b/.github/workflows/functional-compute.yaml
@@ -14,6 +14,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["20.04"]
         include:
+          - name: "antelope"
+            openstack_version: "stable/2023.1"
+            ubuntu_version: "22.04"
           - name: "zed"
             openstack_version: "stable/zed"
             ubuntu_version: "20.04"

--- a/.github/workflows/functional-containerinfra.yaml
+++ b/.github/workflows/functional-containerinfra.yaml
@@ -13,7 +13,7 @@ jobs:
         include:
           - name: "master"
             openstack_version: "master"
-            ubuntu_version: "20.04"
+            ubuntu_version: "22.04"
           - name: "antelope"
             openstack_version: "stable/2023.1"
             ubuntu_version: "22.04"

--- a/.github/workflows/functional-containerinfra.yaml
+++ b/.github/workflows/functional-containerinfra.yaml
@@ -16,6 +16,9 @@ jobs:
             ubuntu_version: "20.04"
             devstack_conf_overrides: |
               enable_plugin magnum https://github.com/openstack/magnum master
+          - name: "antelope"
+            openstack_version: "stable/2023.1"
+            ubuntu_version: "22.04"
           - name: "zed"
             openstack_version: "stable/zed"
             ubuntu_version: "20.04"

--- a/.github/workflows/functional-containerinfra.yaml
+++ b/.github/workflows/functional-containerinfra.yaml
@@ -14,36 +14,24 @@ jobs:
           - name: "master"
             openstack_version: "master"
             ubuntu_version: "20.04"
-            devstack_conf_overrides: |
-              enable_plugin magnum https://github.com/openstack/magnum master
           - name: "antelope"
             openstack_version: "stable/2023.1"
             ubuntu_version: "22.04"
           - name: "zed"
             openstack_version: "stable/zed"
             ubuntu_version: "20.04"
-            devstack_conf_overrides: |
-              enable_plugin magnum https://github.com/openstack/magnum stable/zed
           - name: "yoga"
             openstack_version: "stable/yoga"
             ubuntu_version: "20.04"
-            devstack_conf_overrides: |
-              enable_plugin magnum https://github.com/openstack/magnum stable/yoga
           - name: "xena"
             openstack_version: "stable/xena"
             ubuntu_version: "20.04"
-            devstack_conf_overrides: |
-              enable_plugin magnum https://github.com/openstack/magnum stable/xena
           - name: "wallaby"
             openstack_version: "stable/wallaby"
             ubuntu_version: "20.04"
-            devstack_conf_overrides: |
-              enable_plugin magnum https://github.com/openstack/magnum stable/wallaby
           - name: "victoria"
             openstack_version: "stable/victoria"
             ubuntu_version: "20.04"
-            devstack_conf_overrides: |
-              enable_plugin magnum https://github.com/openstack/magnum stable/victoria
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with Magnum and run containerinfra acceptance tests
     steps:
@@ -54,13 +42,13 @@ jobs:
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |
+            enable_plugin magnum https://github.com/openstack/magnum ${{ matrix.openstack_version }}
             enable_plugin barbican https://github.com/openstack/barbican ${{ matrix.openstack_version }}
             enable_plugin heat https://github.com/openstack/heat ${{ matrix.openstack_version }}
             GLANCE_LIMIT_IMAGE_SIZE_TOTAL=5000
             SWIFT_MAX_FILE_SIZE=5368709122
             KEYSTONE_ADMIN_ENDPOINT=true
             MAGNUMCLIENT_BRANCH=${{ matrix.openstack_version }}
-            ${{ matrix.devstack_conf_overrides }}
           enabled_services: 'h-eng,h-api,h-api-cfn,h-api-cw'
       - name: Checkout go
         uses: actions/setup-go@v4

--- a/.github/workflows/functional-dns.yaml
+++ b/.github/workflows/functional-dns.yaml
@@ -14,7 +14,7 @@ jobs:
         include:
           - name: "master"
             openstack_version: "master"
-            ubuntu_version: "20.04"
+            ubuntu_version: "22.04"
           - name: "antelope"
             openstack_version: "stable/2023.1"
             ubuntu_version: "22.04"

--- a/.github/workflows/functional-dns.yaml
+++ b/.github/workflows/functional-dns.yaml
@@ -17,6 +17,9 @@ jobs:
             ubuntu_version: "20.04"
             devstack_conf_overrides: |
               enable_plugin designate https://github.com/openstack/designate master
+          - name: "antelope"
+            openstack_version: "stable/2023.1"
+            ubuntu_version: "22.04"
           - name: "zed"
             openstack_version: "stable/zed"
             ubuntu_version: "20.04"

--- a/.github/workflows/functional-dns.yaml
+++ b/.github/workflows/functional-dns.yaml
@@ -15,36 +15,24 @@ jobs:
           - name: "master"
             openstack_version: "master"
             ubuntu_version: "20.04"
-            devstack_conf_overrides: |
-              enable_plugin designate https://github.com/openstack/designate master
           - name: "antelope"
             openstack_version: "stable/2023.1"
             ubuntu_version: "22.04"
           - name: "zed"
             openstack_version: "stable/zed"
             ubuntu_version: "20.04"
-            devstack_conf_overrides: |
-              enable_plugin designate https://github.com/openstack/designate stable/zed
           - name: "yoga"
             openstack_version: "stable/yoga"
             ubuntu_version: "20.04"
-            devstack_conf_overrides: |
-              enable_plugin designate https://github.com/openstack/designate stable/yoga
           - name: "xena"
             openstack_version: "stable/xena"
             ubuntu_version: "20.04"
-            devstack_conf_overrides: |
-              enable_plugin designate https://github.com/openstack/designate stable/xena
           - name: "wallaby"
             openstack_version: "stable/wallaby"
             ubuntu_version: "20.04"
-            devstack_conf_overrides: |
-              enable_plugin designate https://github.com/openstack/designate stable/wallaby
           - name: "victoria"
             openstack_version: "stable/victoria"
             ubuntu_version: "20.04"
-            devstack_conf_overrides: |
-              enable_plugin designate https://github.com/openstack/designate stable/victoria
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with Designate and run dns acceptance tests
     steps:
@@ -55,7 +43,7 @@ jobs:
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |
-            ${{ matrix.devstack_conf_overrides }}
+            enable_plugin designate https://github.com/openstack/designate ${{ matrix.openstack_version }}
           enabled_services: 'designate,designate-central,designate-api,designate-worker,designate-producer,designate-mdns'
       - name: Checkout go
         uses: actions/setup-go@v4

--- a/.github/workflows/functional-identity.yaml
+++ b/.github/workflows/functional-identity.yaml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         name: ["master"]
         openstack_version: ["master"]
-        ubuntu_version: ["20.04"]
+        ubuntu_version: ["22.04"]
         include:
           - name: "antelope"
             openstack_version: "stable/2023.1"

--- a/.github/workflows/functional-identity.yaml
+++ b/.github/workflows/functional-identity.yaml
@@ -14,6 +14,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["20.04"]
         include:
+          - name: "antelope"
+            openstack_version: "stable/2023.1"
+            ubuntu_version: "22.04"
           - name: "zed"
             openstack_version: "stable/zed"
             ubuntu_version: "20.04"

--- a/.github/workflows/functional-imageservice.yaml
+++ b/.github/workflows/functional-imageservice.yaml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         name: ["master"]
         openstack_version: ["master"]
-        ubuntu_version: ["20.04"]
+        ubuntu_version: ["22.04"]
         include:
           - name: "antelope"
             openstack_version: "stable/2023.1"

--- a/.github/workflows/functional-imageservice.yaml
+++ b/.github/workflows/functional-imageservice.yaml
@@ -14,6 +14,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["20.04"]
         include:
+          - name: "antelope"
+            openstack_version: "stable/2023.1"
+            ubuntu_version: "22.04"
           - name: "zed"
             openstack_version: "stable/zed"
             ubuntu_version: "20.04"

--- a/.github/workflows/functional-keymanager.yaml
+++ b/.github/workflows/functional-keymanager.yaml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         name: ["master"]
         openstack_version: ["master"]
-        ubuntu_version: ["20.04"]
+        ubuntu_version: ["22.04"]
         include:
           - name: "antelope"
             openstack_version: "stable/2023.1"

--- a/.github/workflows/functional-keymanager.yaml
+++ b/.github/workflows/functional-keymanager.yaml
@@ -14,6 +14,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["20.04"]
         include:
+          - name: "antelope"
+            openstack_version: "stable/2023.1"
+            ubuntu_version: "22.04"
           - name: "zed"
             openstack_version: "stable/zed"
             ubuntu_version: "20.04"

--- a/.github/workflows/functional-loadbalancer.yaml
+++ b/.github/workflows/functional-loadbalancer.yaml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         name: ["master"]
         openstack_version: ["master"]
-        ubuntu_version: ["20.04"]
+        ubuntu_version: ["22.04"]
         include:
           - name: "antelope"
             openstack_version: "stable/2023.1"

--- a/.github/workflows/functional-loadbalancer.yaml
+++ b/.github/workflows/functional-loadbalancer.yaml
@@ -14,6 +14,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["20.04"]
         include:
+          - name: "antelope"
+            openstack_version: "stable/2023.1"
+            ubuntu_version: "22.04"
           - name: "zed"
             openstack_version: "stable/zed"
             ubuntu_version: "20.04"

--- a/.github/workflows/functional-messaging.yaml
+++ b/.github/workflows/functional-messaging.yaml
@@ -14,6 +14,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["22.04"]
         include:
+          - name: "antelope"
+            openstack_version: "stable/2023.1"
+            ubuntu_version: "22.04"
           - name: "zed"
             openstack_version: "stable/zed"
             ubuntu_version: "20.04"

--- a/.github/workflows/functional-networking.yaml
+++ b/.github/workflows/functional-networking.yaml
@@ -13,7 +13,7 @@ jobs:
         include:
           - name: "master"
             openstack_version: "master"
-            ubuntu_version: "20.04"
+            ubuntu_version: "22.04"
           - name: "antelope"
             openstack_version: "stable/2023.1"
             ubuntu_version: "22.04"

--- a/.github/workflows/functional-networking.yaml
+++ b/.github/workflows/functional-networking.yaml
@@ -17,6 +17,9 @@ jobs:
             devstack_conf_overrides: |
               enable_plugin neutron-dynamic-routing https://github.com/openstack/neutron-dynamic-routing master
               enable_plugin neutron-vpnaas https://github.com/openstack/neutron-vpnaas master
+          - name: "antelope"
+            openstack_version: "stable/2023.1"
+            ubuntu_version: "22.04"
           - name: "zed"
             openstack_version: "stable/zed"
             ubuntu_version: "20.04"

--- a/.github/workflows/functional-networking.yaml
+++ b/.github/workflows/functional-networking.yaml
@@ -14,42 +14,24 @@ jobs:
           - name: "master"
             openstack_version: "master"
             ubuntu_version: "20.04"
-            devstack_conf_overrides: |
-              enable_plugin neutron-dynamic-routing https://github.com/openstack/neutron-dynamic-routing master
-              enable_plugin neutron-vpnaas https://github.com/openstack/neutron-vpnaas master
           - name: "antelope"
             openstack_version: "stable/2023.1"
             ubuntu_version: "22.04"
           - name: "zed"
             openstack_version: "stable/zed"
             ubuntu_version: "20.04"
-            devstack_conf_overrides: |
-              enable_plugin neutron-dynamic-routing https://github.com/openstack/neutron-dynamic-routing stable/zed
-              enable_plugin neutron-vpnaas https://github.com/openstack/neutron-vpnaas stable/zed
           - name: "yoga"
             openstack_version: "stable/yoga"
             ubuntu_version: "20.04"
-            devstack_conf_overrides: |
-              enable_plugin neutron-dynamic-routing https://github.com/openstack/neutron-dynamic-routing stable/yoga
-              enable_plugin neutron-vpnaas https://github.com/openstack/neutron-vpnaas stable/yoga
           - name: "xena"
             openstack_version: "stable/xena"
             ubuntu_version: "20.04"
-            devstack_conf_overrides: |
-              enable_plugin neutron-dynamic-routing https://github.com/openstack/neutron-dynamic-routing stable/xena
-              enable_plugin neutron-vpnaas https://github.com/openstack/neutron-vpnaas stable/xena
           - name: "wallaby"
             openstack_version: "stable/wallaby"
             ubuntu_version: "20.04"
-            devstack_conf_overrides: |
-              enable_plugin neutron-dynamic-routing https://github.com/openstack/neutron-dynamic-routing stable/wallaby
-              enable_plugin neutron-vpnaas https://github.com/openstack/neutron-vpnaas stable/wallaby
           - name: "victoria"
             openstack_version: "stable/victoria"
             ubuntu_version: "20.04"
-            devstack_conf_overrides: |
-              enable_plugin neutron-dynamic-routing https://github.com/openstack/neutron-dynamic-routing stable/victoria
-              enable_plugin neutron-vpnaas https://github.com/openstack/neutron-vpnaas stable/victoria
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with Neutron and run networking acceptance tests
     steps:
@@ -60,8 +42,9 @@ jobs:
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |
+            enable_plugin neutron-dynamic-routing https://github.com/openstack/neutron-dynamic-routing ${{ matrix.openstack_version }}
+            enable_plugin neutron-vpnaas https://github.com/openstack/neutron-vpnaas ${{ matrix.openstack_version }}
             Q_ML2_PLUGIN_EXT_DRIVERS=qos,port_security,dns_domain_keywords
-            ${{ matrix.devstack_conf_overrides }}
           enabled_services: 'neutron-dns,neutron-qos,neutron-segments,neutron-trunk,neutron-uplink-status-propagation,neutron-network-segment-range,neutron-port-forwarding'
       - name: Checkout go
         uses: actions/setup-go@v4

--- a/.github/workflows/functional-objectstorage.yaml
+++ b/.github/workflows/functional-objectstorage.yaml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         name: ["master"]
         openstack_version: ["master"]
-        ubuntu_version: ["20.04"]
+        ubuntu_version: ["22.04"]
         include:
           - name: "antelope"
             openstack_version: "stable/2023.1"

--- a/.github/workflows/functional-objectstorage.yaml
+++ b/.github/workflows/functional-objectstorage.yaml
@@ -14,6 +14,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["20.04"]
         include:
+          - name: "antelope"
+            openstack_version: "stable/2023.1"
+            ubuntu_version: "22.04"
           - name: "zed"
             openstack_version: "stable/zed"
             ubuntu_version: "20.04"

--- a/.github/workflows/functional-orchestration.yaml
+++ b/.github/workflows/functional-orchestration.yaml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         name: ["master"]
         openstack_version: ["master"]
-        ubuntu_version: ["20.04"]
+        ubuntu_version: ["22.04"]
         include:
           - name: "antelope"
             openstack_version: "stable/2023.1"

--- a/.github/workflows/functional-orchestration.yaml
+++ b/.github/workflows/functional-orchestration.yaml
@@ -14,6 +14,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["20.04"]
         include:
+          - name: "antelope"
+            openstack_version: "stable/2023.1"
+            ubuntu_version: "22.04"
           - name: "zed"
             openstack_version: "stable/zed"
             ubuntu_version: "20.04"

--- a/.github/workflows/functional-placement.yaml
+++ b/.github/workflows/functional-placement.yaml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         name: ["master"]
         openstack_version: ["master"]
-        ubuntu_version: ["20.04"]
+        ubuntu_version: ["22.04"]
         include:
           - name: "antelope"
             openstack_version: "stable/2023.1"

--- a/.github/workflows/functional-placement.yaml
+++ b/.github/workflows/functional-placement.yaml
@@ -14,6 +14,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["20.04"]
         include:
+          - name: "antelope"
+            openstack_version: "stable/2023.1"
+            ubuntu_version: "22.04"
           - name: "zed"
             openstack_version: "stable/zed"
             ubuntu_version: "20.04"

--- a/.github/workflows/functional-sharedfilesystems.yaml
+++ b/.github/workflows/functional-sharedfilesystems.yaml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         name: ["master"]
         openstack_version: ["master"]
-        ubuntu_version: ["20.04"]
+        ubuntu_version: ["22.04"]
         include:
           - name: "antelope"
             openstack_version: "stable/2023.1"

--- a/.github/workflows/functional-sharedfilesystems.yaml
+++ b/.github/workflows/functional-sharedfilesystems.yaml
@@ -14,6 +14,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["20.04"]
         include:
+          - name: "antelope"
+            openstack_version: "stable/2023.1"
+            ubuntu_version: "22.04"
           - name: "zed"
             openstack_version: "stable/zed"
             ubuntu_version: "20.04"

--- a/acceptance/openstack/blockstorage/v3/volumeattachments.go
+++ b/acceptance/openstack/blockstorage/v3/volumeattachments.go
@@ -20,10 +20,6 @@ func CreateVolumeAttachment(t *testing.T, client *gophercloud.ServiceClient, vol
 	attachOpts := &attachments.CreateOpts{
 		VolumeUUID:   volume.ID,
 		InstanceUUID: server.ID,
-		Connector: map[string]interface{}{
-			"mode":      "rw",
-			"initiator": "fake",
-		},
 	}
 
 	t.Logf("Attempting to attach volume %s to server %s", volume.ID, server.ID)
@@ -55,20 +51,6 @@ func CreateVolumeAttachment(t *testing.T, client *gophercloud.ServiceClient, vol
 	if err != nil {
 		return err
 	}
-
-	/*
-		// Not clear how perform a proper update, OpenStack returns "Unable to update the attachment."
-		updateOpts := &attachments.UpdateOpts{
-			Connector: map[string]interface{}{
-				"mode":      "ro",
-				"initiator": "fake",
-			},
-		}
-		attachment, err = attachments.Update(client, attachment.ID, updateOpts).Extract()
-		if err != nil {
-			return err
-		}
-	*/
 
 	listOpts := &attachments.ListOpts{
 		VolumeID:   volume.ID,


### PR DESCRIPTION
- add `antelope` release in the matrix
- switch master jobs to run on ubuntu 22.04
- switch tests to use `lioadm` (supported and stable) and not `tgtd` (broken)

Fixes #2756
