### PR TITLE
Acceptance: Handle numerical version names in version comparison helpers

### DIFF
--- a/acceptance/clients/conditions.go
+++ b/acceptance/clients/conditions.go
@@ -111,7 +111,7 @@ func SkipRelease(t *testing.T, release string) {
 func SkipReleasesBelow(t *testing.T, release string) {
 	current_branch := getReleaseFromEnv(t)
 
-	if IsReleasesBelow(t, release) {
+	if IsCurrentBelow(t, release) {
 		t.Skipf("this is not supported below %s, testing in %s", release, current_branch)
 	}
 }
@@ -123,15 +123,15 @@ func SkipReleasesAbove(t *testing.T, release string) {
 	current_branch := getReleaseFromEnv(t)
 
 	// Assume master is always too new
-	if IsReleasesAbove(t, release) {
+	if IsCurrentAbove(t, release) {
 		t.Skipf("this is not supported above %s, testing in %s", release, current_branch)
 	}
 }
 
-// IsReleasesAbove will return true on releases above a certain
+// IsCurrentAbove will return true on releases above a certain
 // one. The result is always true on master release. Releases are named such
 // as 'stable/mitaka', master, etc.
-func IsReleasesAbove(t *testing.T, release string) bool {
+func IsCurrentAbove(t *testing.T, release string) bool {
 	current_branch := getReleaseFromEnv(t)
 
 	// Assume master is always too new
@@ -142,9 +142,9 @@ func IsReleasesAbove(t *testing.T, release string) bool {
 	return false
 }
 
-// IsReleasesBelow will return true on releases below a certain
+// IsCurrentBelow will return true on releases below a certain
 // one. Releases are named such as 'stable/mitaka', master, etc.
-func IsReleasesBelow(t *testing.T, release string) bool {
+func IsCurrentBelow(t *testing.T, release string) bool {
 	current_branch := getReleaseFromEnv(t)
 
 	if current_branch != "master" || current_branch < release {

--- a/acceptance/clients/conditions.go
+++ b/acceptance/clients/conditions.go
@@ -2,6 +2,8 @@ package clients
 
 import (
 	"os"
+	"strconv"
+	"strings"
 	"testing"
 )
 
@@ -90,18 +92,18 @@ func RequireIronicHTTPBasic(t *testing.T) {
 }
 
 func getReleaseFromEnv(t *testing.T) string {
-	current_branch := os.Getenv("OS_BRANCH")
-	if current_branch == "" {
+	current := strings.TrimPrefix(os.Getenv("OS_BRANCH"), "stable/")
+	if current == "" {
 		t.Fatal("this test requires OS_BRANCH to be set but it wasn't")
 	}
-	return current_branch
+	return current
 }
 
 // SkipRelease will have the test be skipped on a certain
 // release. Releases are named such as 'stable/mitaka', master, etc.
 func SkipRelease(t *testing.T, release string) {
-	current_branch := getReleaseFromEnv(t)
-	if current_branch == release {
+	current := getReleaseFromEnv(t)
+	if current == release {
 		t.Skipf("this is not supported in %s", release)
 	}
 }
@@ -109,10 +111,10 @@ func SkipRelease(t *testing.T, release string) {
 // SkipReleasesBelow will have the test be skipped on releases below a certain
 // one. Releases are named such as 'stable/mitaka', master, etc.
 func SkipReleasesBelow(t *testing.T, release string) {
-	current_branch := getReleaseFromEnv(t)
+	current := getReleaseFromEnv(t)
 
 	if IsCurrentBelow(t, release) {
-		t.Skipf("this is not supported below %s, testing in %s", release, current_branch)
+		t.Skipf("this is not supported below %s, testing in %s", release, current)
 	}
 }
 
@@ -120,36 +122,61 @@ func SkipReleasesBelow(t *testing.T, release string) {
 // one. The test is always skipped on master release. Releases are named such
 // as 'stable/mitaka', master, etc.
 func SkipReleasesAbove(t *testing.T, release string) {
-	current_branch := getReleaseFromEnv(t)
+	current := getReleaseFromEnv(t)
 
-	// Assume master is always too new
 	if IsCurrentAbove(t, release) {
-		t.Skipf("this is not supported above %s, testing in %s", release, current_branch)
+		t.Skipf("this is not supported above %s, testing in %s", release, current)
 	}
+}
+
+func isReleaseNumeral(release string) bool {
+	_, err := strconv.Atoi(release[0:1])
+	return err == nil
 }
 
 // IsCurrentAbove will return true on releases above a certain
 // one. The result is always true on master release. Releases are named such
 // as 'stable/mitaka', master, etc.
 func IsCurrentAbove(t *testing.T, release string) bool {
-	current_branch := getReleaseFromEnv(t)
+	current := getReleaseFromEnv(t)
+	release = strings.TrimPrefix(release, "stable/")
 
-	// Assume master is always too new
-	if current_branch == "master" || current_branch > release {
-		return true
+	if release != "master" {
+		// Assume master is always too new
+		if current == "master" {
+			return true
+		}
+		// Numeral releases are always newer than non-numeral ones
+		if isReleaseNumeral(current) && !isReleaseNumeral(release) {
+			return true
+		}
+		if current > release && !(!isReleaseNumeral(current) && isReleaseNumeral(release)) {
+			return true
+		}
 	}
-	t.Logf("Target release %s is below the current branch %s", release, current_branch)
+	t.Logf("Target release %s is below the current branch %s", release, current)
 	return false
 }
 
 // IsCurrentBelow will return true on releases below a certain
 // one. Releases are named such as 'stable/mitaka', master, etc.
 func IsCurrentBelow(t *testing.T, release string) bool {
-	current_branch := getReleaseFromEnv(t)
+	current := getReleaseFromEnv(t)
+	release = strings.TrimPrefix(release, "stable/")
 
-	if current_branch != "master" || current_branch < release {
-		return true
+	if current != "master" {
+		// Assume master is always too new
+		if release == "master" {
+			return true
+		}
+		// Numeral releases are always newer than non-numeral ones
+		if isReleaseNumeral(release) && !isReleaseNumeral(current) {
+			return true
+		}
+		if release > current && !(!isReleaseNumeral(release) && isReleaseNumeral(current)) {
+			return true
+		}
 	}
-	t.Logf("Target release %s is above the current branch %s", release, current_branch)
+	t.Logf("Target release %s is above the current branch %s", release, current)
 	return false
 }

--- a/acceptance/clients/testing/conditions_test.go
+++ b/acceptance/clients/testing/conditions_test.go
@@ -1,0 +1,65 @@
+package testing
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/acceptance/clients"
+)
+
+func TestIsCurrentAbove(t *testing.T) {
+	cases := []struct {
+		Current string
+		Release string
+		Result  bool
+	}{
+		{Current: "master", Release: "zed", Result: true},
+		{Current: "master", Release: "2023.1", Result: true},
+		{Current: "master", Release: "master", Result: false},
+		{Current: "zed", Release: "master", Result: false},
+		{Current: "zed", Release: "yoga", Result: true},
+		{Current: "zed", Release: "2023.1", Result: false},
+		{Current: "2023.1", Release: "2023.1", Result: false},
+		{Current: "2023.2", Release: "stable/2023.1", Result: true},
+	}
+
+	for _, tt := range cases {
+		t.Run(fmt.Sprintf("%s above %s", tt.Current, tt.Release), func(t *testing.T) {
+			os.Setenv("OS_BRANCH", tt.Current)
+			got := clients.IsCurrentAbove(t, tt.Release)
+			if got != tt.Result {
+				t.Errorf("got %v want %v", got, tt.Result)
+			}
+		})
+
+	}
+}
+
+func TestIsCurrentBelow(t *testing.T) {
+	cases := []struct {
+		Current string
+		Release string
+		Result  bool
+	}{
+		{Current: "master", Release: "zed", Result: false},
+		{Current: "master", Release: "2023.1", Result: false},
+		{Current: "master", Release: "master", Result: false},
+		{Current: "zed", Release: "master", Result: true},
+		{Current: "zed", Release: "yoga", Result: false},
+		{Current: "zed", Release: "2023.1", Result: true},
+		{Current: "2023.1", Release: "2023.1", Result: false},
+		{Current: "2023.2", Release: "stable/2023.1", Result: false},
+	}
+
+	for _, tt := range cases {
+		t.Run(fmt.Sprintf("%s below %s", tt.Current, tt.Release), func(t *testing.T) {
+			os.Setenv("OS_BRANCH", tt.Current)
+			got := clients.IsCurrentBelow(t, tt.Release)
+			if got != tt.Result {
+				t.Errorf("got %v want %v", got, tt.Result)
+			}
+		})
+
+	}
+}

--- a/acceptance/openstack/loadbalancer/v2/loadbalancer.go
+++ b/acceptance/openstack/loadbalancer/v2/loadbalancer.go
@@ -71,7 +71,7 @@ func CreateListenerHTTP(t *testing.T, client *gophercloud.ServiceClient, lb *loa
 	}
 
 	// tls_version is only supported in microversion v2.17 introduced in victoria
-	if clients.IsReleasesAbove(t, "stable/ussuri") {
+	if clients.IsCurrentAbove(t, "stable/ussuri") {
 		tlsVersions = []listeners.TLSVersion{"TLSv1.2", "TLSv1.3"}
 		tlsVersionsExp = []string{"TLSv1.2", "TLSv1.3"}
 	}

--- a/acceptance/openstack/loadbalancer/v2/quotas_test.go
+++ b/acceptance/openstack/loadbalancer/v2/quotas_test.go
@@ -45,7 +45,7 @@ func TestQuotasUpdate(t *testing.T) {
 		Healthmonitor: gophercloud.IntToPointer(5),
 	}
 	// L7 parameters are only supported in microversion v2.19 introduced in victoria
-	if clients.IsReleasesAbove(t, "stable/ussuri") {
+	if clients.IsCurrentAbove(t, "stable/ussuri") {
 		quotaUpdateOpts.L7Policy = gophercloud.IntToPointer(55)
 		quotaUpdateOpts.L7Rule = gophercloud.IntToPointer(105)
 	}
@@ -67,7 +67,7 @@ func TestQuotasUpdate(t *testing.T) {
 		Healthmonitor: &originalQuotas.Healthmonitor,
 	}
 	// L7 parameters are only supported in microversion v2.19 introduced in victoria
-	if clients.IsReleasesAbove(t, "stable/ussuri") {
+	if clients.IsCurrentAbove(t, "stable/ussuri") {
 		restoredQuotaUpdate.L7Policy = &originalQuotas.L7Policy
 		restoredQuotaUpdate.L7Rule = &originalQuotas.L7Rule
 	}


### PR DESCRIPTION
There are two changes here:
- rename the `IsReleasesBelow()` and `IsReleasesAbove()` functions to `IsCurrentBelow()` and `IsCurrentAbove()` respectively.
- fix their behavior to account for numerical release names, after zed, and ensure that
comparing the same version always yields false. Also fixing bugs when comparing to master and add comprehensive tests.