### PR TITLE
script/unittest: run *all* unit tests

### DIFF
--- a/script/unittest
+++ b/script/unittest
@@ -4,4 +4,4 @@
 
 # Do extra rounds of testing to help identify reauth concurrency issues.
 # All other packages are tested in the `coverage` tests.
-go test -v -race -count=5 ./testing
+go test -v -race -count=5 ./...


### PR DESCRIPTION
We have unit tests in multiple sub-directories, let's run them *all*.

Fixes #2766
