### PR TITLE
[v1] (manual clean backport) Add tag field to compute block_device_v2

### DIFF
--- a/acceptance/openstack/compute/v2/bootfromvolume_test.go
+++ b/acceptance/openstack/compute/v2/bootfromvolume_test.go
@@ -51,6 +51,11 @@ func TestBootFromNewVolume(t *testing.T) {
 	choices, err := clients.AcceptanceTestChoicesFromEnv()
 	th.AssertNoErr(t, err)
 
+	// minimum required microversion for getting volume tags is 2.70
+	// https://docs.openstack.org/nova/latest/reference/api-microversion-history.html#id64
+	client.Microversion = "2.70"
+
+	tagName := "tag1"
 	blockDevices := []bootfromvolume.BlockDevice{
 		{
 			DeleteOnTermination: true,
@@ -58,6 +63,7 @@ func TestBootFromNewVolume(t *testing.T) {
 			SourceType:          bootfromvolume.SourceImage,
 			UUID:                choices.ImageID,
 			VolumeSize:          2,
+			Tag:                 tagName,
 		},
 	}
 
@@ -73,6 +79,8 @@ func TestBootFromNewVolume(t *testing.T) {
 
 	tools.PrintResource(t, server)
 	tools.PrintResource(t, attachments)
+	attachmentTag := *attachments[0].Tag
+	th.AssertEquals(t, attachmentTag, tagName)
 
 	if server.Image != nil {
 		t.Fatalf("server image should be nil")

--- a/acceptance/openstack/compute/v2/compute.go
+++ b/acceptance/openstack/compute/v2/compute.go
@@ -178,7 +178,6 @@ func CreateBootableVolumeServer(t *testing.T, client *gophercloud.ServiceClient,
 	}
 
 	th.AssertEquals(t, newServer.Name, name)
-	th.AssertEquals(t, newServer.Flavor["id"], choices.FlavorID)
 
 	return newServer, nil
 }

--- a/openstack/compute/v2/extensions/bootfromvolume/requests.go
+++ b/openstack/compute/v2/extensions/bootfromvolume/requests.go
@@ -79,6 +79,12 @@ type BlockDevice struct {
 	// VolumeType is the volume type of the block device.
 	// This requires Compute API microversion 2.67 or later.
 	VolumeType string `json:"volume_type,omitempty"`
+
+	// Tag is an arbitrary string that can be applied to a block device.
+	// Information about the device tags can be obtained from the metadata API
+	// and the config drive, allowing devices to be easily identified.
+	// This requires Compute API microversion 2.42 or later.
+	Tag string `json:"tag,omitempty"`
 }
 
 // CreateOptsExt is a structure that extends the server `CreateOpts` structure

--- a/openstack/compute/v2/extensions/bootfromvolume/testing/fixtures.go
+++ b/openstack/compute/v2/extensions/bootfromvolume/testing/fixtures.go
@@ -308,3 +308,53 @@ var NewVolumeTypeRequest = bootfromvolume.CreateOptsExt{
 		},
 	},
 }
+
+const ExpectedImageAndExistingVolumeWithTagRequest = `
+{
+	"server": {
+		"name": "createdserver",
+		"imageRef": "asdfasdfasdf",
+		"flavorRef": "performance1-1",
+		"block_device_mapping_v2":[
+			{
+				"boot_index": 0,
+				"delete_on_termination": true,
+				"destination_type":"local",
+				"source_type":"image",
+				"uuid":"asdfasdfasdf"
+			},
+			{
+				"boot_index": -1,
+				"delete_on_termination": true,
+				"destination_type":"volume",
+				"source_type":"volume",
+				"tag": "volume-tag",
+				"uuid":"123456",
+				"volume_size": 1
+			}
+		]
+	}
+}
+`
+
+var ImageAndExistingVolumeWithTagRequest = bootfromvolume.CreateOptsExt{
+	CreateOptsBuilder: BaseCreateOptsWithImageRef,
+	BlockDevice: []bootfromvolume.BlockDevice{
+		{
+			BootIndex:           0,
+			DeleteOnTermination: true,
+			DestinationType:     bootfromvolume.DestinationLocal,
+			SourceType:          bootfromvolume.SourceImage,
+			UUID:                "asdfasdfasdf",
+		},
+		{
+			BootIndex:           -1,
+			DeleteOnTermination: true,
+			DestinationType:     bootfromvolume.DestinationVolume,
+			SourceType:          bootfromvolume.SourceVolume,
+			Tag:                 "volume-tag",
+			UUID:                "123456",
+			VolumeSize:          1,
+		},
+	},
+}

--- a/openstack/compute/v2/extensions/bootfromvolume/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/bootfromvolume/testing/requests_test.go
@@ -47,3 +47,9 @@ func TestBootFromNewVolumeType(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.CheckJSONEquals(t, ExpectedNewVolumeTypeRequest, actual)
 }
+
+func TestAttachExistingVolumeWithTag(t *testing.T) {
+	actual, err := ImageAndExistingVolumeWithTagRequest.ToServerCreateMap()
+	th.AssertNoErr(t, err)
+	th.CheckJSONEquals(t, ExpectedImageAndExistingVolumeWithTagRequest, actual)
+}


### PR DESCRIPTION
- Add tag field to compute block_device_v2
- Add requests test for new field
- acceptance/compute: remove flavor ID check
- Add acceptance tests for tag field to compute block_device_v2

This is a clean backport with no conflict.
I had to do it manually because the workflow has been fixed after these commits so it didn't run.
