### PR TITLE
Add microversion utilities

### DIFF
--- a/openstack/utils/choose_version.go
+++ b/openstack/utils/choose_version.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/gophercloud/gophercloud"
@@ -20,9 +21,12 @@ var goodStatus = map[string]bool{
 	"stable":    true,
 }
 
-// ChooseVersion queries the base endpoint of an API to choose the most recent non-experimental alternative from a service's
-// published versions.
-// It returns the highest-Priority Version among the alternatives that are provided, as well as its corresponding endpoint.
+// ChooseVersion queries the base endpoint of an API to choose the identity service version.
+// It will pick a version among the recognized, taking into account the priority and avoiding
+// experimental alternatives from the published versions. However, if the client specifies a full
+// endpoint that is among the recognized versions, it will be used regardless of priority.
+// It returns the highest-Priority Version, OR exact match with client endpoint,
+// among the alternatives that are provided, as well as its corresponding endpoint.
 func ChooseVersion(client *gophercloud.ProviderClient, recognized []*Version) (*Version, string, error) {
 	type linkResp struct {
 		Href string `json:"href"`
@@ -108,4 +112,124 @@ func ChooseVersion(client *gophercloud.ProviderClient, recognized []*Version) (*
 	}
 
 	return highest, endpoint, nil
+}
+
+type SupportedMicroversions struct {
+	MaxMajor int
+	MaxMinor int
+	MinMajor int
+	MinMinor int
+}
+
+// GetSupportedMicroversions returns the minimum and maximum microversion that is supported by the ServiceClient Endpoint.
+func GetSupportedMicroversions(client *gophercloud.ServiceClient) (SupportedMicroversions, error) {
+	type valueResp struct {
+		ID         string `json:"id"`
+		Status     string `json:"status"`
+		Version    string `json:"version"`
+		MinVersion string `json:"min_version"`
+	}
+
+	type response struct {
+		Version  valueResp   `json:"version"`
+		Versions []valueResp `json:"versions"`
+	}
+	var minVersion, maxVersion string
+	var supportedMicroversions SupportedMicroversions
+	var resp response
+	_, err := client.Get(client.Endpoint, &resp, &gophercloud.RequestOpts{
+		OkCodes: []int{200, 300},
+	})
+
+	if err != nil {
+		return supportedMicroversions, err
+	}
+
+	if len(resp.Versions) > 0 {
+		// We are dealing with an unversioned endpoint
+		// We only handle the case when there is exactly one, and assume it is the correct one
+		if len(resp.Versions) > 1 {
+			return supportedMicroversions, fmt.Errorf("unversioned endpoint with multiple alternatives not supported")
+		}
+		minVersion = resp.Versions[0].MinVersion
+		maxVersion = resp.Versions[0].Version
+	} else {
+		minVersion = resp.Version.MinVersion
+		maxVersion = resp.Version.Version
+	}
+
+	// Return early if the endpoint does not support microversions
+	if minVersion == "" && maxVersion == "" {
+		return supportedMicroversions, fmt.Errorf("microversions not supported by ServiceClient Endpoint")
+	}
+
+	supportedMicroversions.MinMajor, supportedMicroversions.MinMinor, err = ParseMicroversion(minVersion)
+	if err != nil {
+		return supportedMicroversions, err
+	}
+
+	supportedMicroversions.MaxMajor, supportedMicroversions.MaxMinor, err = ParseMicroversion(maxVersion)
+	if err != nil {
+		return supportedMicroversions, err
+	}
+
+	return supportedMicroversions, nil
+}
+
+// RequireMicroversion checks that the required microversion is supported and
+// returns a ServiceClient with the microversion set.
+func RequireMicroversion(client gophercloud.ServiceClient, required string) (gophercloud.ServiceClient, error) {
+	supportedMicroversions, err := GetSupportedMicroversions(&client)
+	if err != nil {
+		return client, fmt.Errorf("unable to determine supported microversions: %w", err)
+	}
+	supported, err := supportedMicroversions.IsSupported(required)
+	if err != nil {
+		return client, err
+	}
+	if !supported {
+		return client, fmt.Errorf("microversion %s not supported. Supported versions: %v", required, supportedMicroversions)
+	}
+	client.Microversion = required
+	return client, nil
+}
+
+// IsSupported checks if a microversion falls in the supported interval.
+// It returns true if the version is within the interval and false otherwise.
+func (supported SupportedMicroversions) IsSupported(version string) (bool, error) {
+	// Parse the version X.Y into X and Y integers that are easier to compare.
+	vMajor, vMinor, err := ParseMicroversion(version)
+	if err != nil {
+		return false, err
+	}
+
+	// Check that the major version number is supported.
+	if (vMajor < supported.MinMajor) || (vMajor > supported.MaxMajor) {
+		return false, nil
+	}
+
+	// Check that the minor version number is supported
+	if (vMinor <= supported.MaxMinor) && (vMinor >= supported.MinMinor) {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// ParseMicroversion parses the version major.minor into separate integers major and minor.
+// For example, "2.53" becomes 2 and 53.
+func ParseMicroversion(version string) (major int, minor int, err error) {
+	parts := strings.Split(version, ".")
+	if len(parts) != 2 {
+		return 0, 0, fmt.Errorf("invalid microversion format: %q", version)
+	}
+	major, err = strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, 0, err
+	}
+	minor, err = strconv.Atoi(parts[1])
+	if err != nil {
+		return 0, 0, err
+	}
+	return major, minor, nil
 }

--- a/openstack/utils/testing/choose_version_test.go
+++ b/openstack/utils/testing/choose_version_test.go
@@ -3,6 +3,7 @@ package testing
 import (
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/gophercloud/gophercloud"
@@ -34,6 +35,150 @@ func setupVersionHandler() {
 				}
 			}
 		`, testhelper.Server.URL, testhelper.Server.URL)
+	})
+	// Compute v2.1 API
+	testhelper.Mux.HandleFunc("/compute/v2.1/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, `
+			{
+				"version": {
+					"id": "v2.1",
+					"status": "CURRENT",
+					"version": "2.90",
+					"min_version": "2.1",
+					"updated": "2013-07-23T11:33:21Z",
+					"links": [
+						{
+							"rel": "self",
+							"href": "%s/compute/v2.1/"
+						},
+						{
+							"rel": "describedby",
+							"type": "text/html",
+							"href": "http://docs.openstack.org/"
+						}
+					],
+					"media-types": [
+						{
+							"base": "application/json",
+							"type": "application/vnd.openstack.compute+json;version=2.1"
+						}
+					]
+				}
+			}
+		`, testhelper.Server.URL)
+	})
+	// Compute v2 API
+	testhelper.Mux.HandleFunc("/compute/v2/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, `
+			{
+				"version": {
+					"id": "v2.0",
+					"status": "SUPPORTED",
+					"version": "",
+					"min_version": "",
+					"updated": "2011-01-21T11:33:21Z",
+					"links": [
+						{
+							"rel": "self",
+							"href": "%s/compute/v2/"
+						},
+						{
+							"rel": "describedby",
+							"type": "text/html",
+							"href": "http://docs.openstack.org/"
+						}
+					],
+					"media-types": [
+						{
+							"base": "application/json",
+							"type": "application/vnd.openstack.compute+json;version=2"
+						}
+					]
+				}
+			}
+		`, testhelper.Server.URL)
+	})
+	// Ironic API
+	testhelper.Mux.HandleFunc("/ironic/v1/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, `
+		{
+			"name": "OpenStack Ironic API",
+			"description": "Ironic is an OpenStack project which enables the provision and management of baremetal machines.",
+			"default_version": {
+				"id": "v1",
+				"links": [
+					{
+						"href": "%s/ironic/v1/",
+						"rel": "self"
+					}
+				],
+				"status": "CURRENT",
+				"min_version": "1.1",
+				"version": "1.87"
+			},
+			"versions": [
+				{
+					"id": "v1",
+					"links": [
+						{
+							"href": "%s/ironic/v1/",
+							"rel": "self"
+						}
+					],
+					"status": "CURRENT",
+					"min_version": "1.1",
+					"version": "1.87"
+				}
+			]
+		}
+		`, testhelper.Server.URL, testhelper.Server.URL)
+	})
+	// Ironic multi-version
+	testhelper.Mux.HandleFunc("/ironic/v1.2/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, `
+		{
+			"name": "OpenStack Ironic API",
+			"description": "Ironic is an OpenStack project which enables the provision and management of baremetal machines.",
+			"default_version": {
+				"id": "v1",
+				"links": [
+					{
+						"href": "%s/ironic/v1/",
+						"rel": "self"
+					}
+				],
+				"status": "CURRENT",
+				"min_version": "1.1",
+				"version": "1.87"
+			},
+			"versions": [
+				{
+					"id": "v1",
+					"links": [
+						{
+							"href": "%s/ironic/v1/",
+							"rel": "self"
+						}
+					],
+					"status": "CURRENT",
+					"min_version": "1.1",
+					"version": "1.87"
+				},
+				{
+					"id": "v1.2",
+					"links": [
+						{
+							"href": "%s/ironic/v1/",
+							"rel": "self"
+						}
+					],
+					"status": "CURRENT",
+					"min_version": "1.2",
+					"version": "1.90"
+				}
+			]
+		}
+		`, testhelper.Server.URL, testhelper.Server.URL, testhelper.Server.URL)
 	})
 }
 
@@ -115,5 +260,165 @@ func TestChooseVersionFromSuffix(t *testing.T) {
 	expected := testhelper.Endpoint() + "v2.0/"
 	if endpoint != expected {
 		t.Errorf("Expected endpoint [%s], but was [%s] instead", expected, endpoint)
+	}
+}
+
+type getSupportedServiceMicroversions struct {
+	Endpoint    string
+	ExpectedMax string
+	ExpectedMin string
+	ExpectedErr bool
+}
+
+func TestGetSupportedVersions(t *testing.T) {
+	testhelper.SetupHTTP()
+	defer testhelper.TeardownHTTP()
+	setupVersionHandler()
+
+	tests := []getSupportedServiceMicroversions{
+		{
+			// v2 does not support microversions and returns error
+			Endpoint:    testhelper.Endpoint() + "compute/v2/",
+			ExpectedMax: "",
+			ExpectedMin: "",
+			ExpectedErr: true,
+		},
+		{
+			Endpoint:    testhelper.Endpoint() + "compute/v2.1/",
+			ExpectedMax: "2.90",
+			ExpectedMin: "2.1",
+			ExpectedErr: false,
+		},
+		{
+			Endpoint:    testhelper.Endpoint() + "ironic/v1/",
+			ExpectedMax: "1.87",
+			ExpectedMin: "1.1",
+			ExpectedErr: false,
+		},
+		{
+			// This endpoint returns multiple versions, which is not supported
+			Endpoint:    testhelper.Endpoint() + "ironic/v1.2/",
+			ExpectedMax: "not-relevant",
+			ExpectedMin: "not-relevant",
+			ExpectedErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		c := &gophercloud.ProviderClient{
+			IdentityBase:     testhelper.Endpoint(),
+			IdentityEndpoint: testhelper.Endpoint() + "v2.0/",
+		}
+
+		client := &gophercloud.ServiceClient{
+			ProviderClient: c,
+			Endpoint:       test.Endpoint,
+		}
+
+		supported, err := utils.GetSupportedMicroversions(client)
+
+		if test.ExpectedErr {
+			if err == nil {
+				t.Error("Expected error but got none!")
+			}
+			// Check for reasonable error message
+			if !strings.Contains(err.Error(), "not supported") {
+				t.Error("Expected error to contain 'not supported' but it did not!")
+			}
+			// No point parsing and comparing versions after error, so continue to next test case
+			continue
+		} else {
+			if err != nil {
+				t.Errorf("Expected no error but got %s", err.Error())
+			}
+		}
+
+		min := fmt.Sprintf("%d.%d", supported.MinMajor, supported.MinMinor)
+		max := fmt.Sprintf("%d.%d", supported.MaxMajor, supported.MaxMinor)
+
+		if (min != test.ExpectedMin) || (max != test.ExpectedMax) {
+			t.Errorf("Expected min=%s and max=%s but got min=%s and max=%s", test.ExpectedMin, test.ExpectedMax, min, max)
+		}
+	}
+}
+
+type microversionSupported struct {
+	Version    string
+	MinVersion string
+	MaxVersion string
+	Supported  bool
+	Error      bool
+}
+
+func TestMicroversionSupported(t *testing.T) {
+	tests := []microversionSupported{
+		{
+			// Checking min version
+			Version:    "2.1",
+			MinVersion: "2.1",
+			MaxVersion: "2.90",
+			Supported:  true,
+			Error:      false,
+		},
+		{
+			// Checking max version
+			Version:    "2.90",
+			MinVersion: "2.1",
+			MaxVersion: "2.90",
+			Supported:  true,
+			Error:      false,
+		},
+		{
+			// Checking too high version
+			Version:    "2.95",
+			MinVersion: "2.1",
+			MaxVersion: "2.90",
+			Supported:  false,
+			Error:      false,
+		},
+		{
+			// Checking too low version
+			Version:    "2.1",
+			MinVersion: "2.53",
+			MaxVersion: "2.90",
+			Supported:  false,
+			Error:      false,
+		},
+		{
+			// Invalid version
+			Version:    "2.1.53",
+			MinVersion: "2.53",
+			MaxVersion: "2.90",
+			Supported:  false,
+			Error:      true,
+		},
+	}
+
+	for _, test := range tests {
+		var err error
+		var supportedVersions utils.SupportedMicroversions
+		supportedVersions.MaxMajor, supportedVersions.MaxMinor, err = utils.ParseMicroversion(test.MaxVersion)
+		if err != nil {
+			t.Error("Error parsing MaxVersion!")
+		}
+		supportedVersions.MinMajor, supportedVersions.MinMinor, err = utils.ParseMicroversion(test.MinVersion)
+		if err != nil {
+			t.Error("Error parsing MinVersion!")
+		}
+
+		supported, err := supportedVersions.IsSupported(test.Version)
+		if test.Error {
+			if err == nil {
+				t.Error("Expected error but got none!")
+			}
+		} else {
+			if err != nil {
+				t.Errorf("Expected no error but got %s", err.Error())
+			}
+		}
+		if test.Supported != supported {
+			t.Errorf("Expected supported=%t to be %t, when version=%s, min=%s and max=%s",
+				supported, test.Supported, test.Version, test.MinVersion, test.MaxVersion)
+		}
 	}
 }


### PR DESCRIPTION
This adds GetSupportedMicroversions and MicroversionSupported utility functions for working with microversions.
The doc string for ChooseVersion is also updated to clarify how it works.

Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

Fixes #2791

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

TODO. I am not sure what is needed here
