### PR TITLE
Support Firmware Interface

### DIFF
--- a/internal/acceptance/openstack/baremetal/httpbasic/nodes_test.go
+++ b/internal/acceptance/openstack/baremetal/httpbasic/nodes_test.go
@@ -97,3 +97,23 @@ func TestNodesRAIDConfig(t *testing.T) {
 	}).ExtractErr()
 	th.AssertNoErr(t, err)
 }
+
+func TestNodesFirmwareInterface(t *testing.T) {
+	clients.SkipReleasesBelow(t, "stable/2023.2")
+	clients.RequireLong(t)
+	clients.RequireIronicHTTPBasic(t)
+
+	client, err := clients.NewBareMetalV1HTTPBasic()
+	th.AssertNoErr(t, err)
+	client.Microversion = "1.86"
+
+	node, err := v1.CreateNode(t, client)
+	th.AssertNoErr(t, err)
+	defer v1.DeleteNode(t, client, node)
+
+	th.AssertEquals(t, node.FirmwareInterface, "no-firmware")
+
+	nodeFirmwareCmps, err := nodes.ListFirmware(client, node.UUID).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, nodeFirmwareCmps, []nodes.FirmwareComponent{})
+}

--- a/internal/acceptance/openstack/baremetal/v1/nodes_test.go
+++ b/internal/acceptance/openstack/baremetal/v1/nodes_test.go
@@ -148,3 +148,22 @@ func TestNodesRAIDConfig(t *testing.T) {
 	}).ExtractErr()
 	th.AssertNoErr(t, err)
 }
+
+func TestNodesFirmwareInterface(t *testing.T) {
+	clients.SkipReleasesBelow(t, "stable/2023.2")
+	clients.RequireLong(t)
+
+	client, err := clients.NewBareMetalV1Client()
+	th.AssertNoErr(t, err)
+	client.Microversion = "1.86"
+
+	node, err := CreateNode(t, client)
+	th.AssertNoErr(t, err)
+	defer DeleteNode(t, client, node)
+
+	th.AssertEquals(t, node.FirmwareInterface, "no-firmware")
+
+	nodeFirmwareCmps, err := nodes.ListFirmware(client, node.UUID).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, nodeFirmwareCmps, []nodes.FirmwareComponent{})
+}

--- a/openstack/baremetal/v1/drivers/results.go
+++ b/openstack/baremetal/v1/drivers/results.go
@@ -51,6 +51,10 @@ type Driver struct {
 	// if no deploy interface is specified for the node.
 	DefaultDeployInterface string `json:"default_deploy_interface"`
 
+	// The default firmware interface used for a node with a dynamic driver,
+	// if no firmware interface is specified for the node.
+	DefaultFirmwareInterface string `json:"default_firmware_interface"`
+
 	// The default inspection interface used for a node with a dynamic driver,
 	// if no inspection interface is specified for the node.
 	DefaultInspectInterface string `json:"default_inspect_interface"`
@@ -94,6 +98,9 @@ type Driver struct {
 
 	// The enabled deploy interfaces for this driver.
 	EnabledDeployInterfaces []string `json:"enabled_deploy_interfaces"`
+
+	// The enabled firmware interfaces for this driver.
+	EnabledFirmwareInterfaces []string `json:"enabled_firmware_interfaces"`
 
 	// The enabled inspection interfaces for this driver.
 	EnabledInspectInterfaces []string `json:"enabled_inspect_interfaces"`

--- a/openstack/baremetal/v1/drivers/testing/fixtures_test.go
+++ b/openstack/baremetal/v1/drivers/testing/fixtures_test.go
@@ -104,6 +104,7 @@ const SingleDriverDetails = `
   "default_boot_interface": "pxe",
   "default_console_interface": "no-console",
   "default_deploy_interface": "iscsi",
+  "default_firmware_interface": "no-firmware",
   "default_inspect_interface": "no-inspect",
   "default_management_interface": "ipmitool",
   "default_network_interface": "flat",
@@ -124,6 +125,9 @@ const SingleDriverDetails = `
   "enabled_deploy_interfaces": [
     "iscsi",
     "direct"
+  ],
+  "enabled_firmware_interfaces": [
+    "no-firmware"
   ],
   "enabled_inspect_interfaces": [
     "no-inspect"
@@ -281,6 +285,7 @@ var (
 		DefaultBootInterface:        "pxe",
 		DefaultConsoleInterface:     "no-console",
 		DefaultDeployInterface:      "iscsi",
+		DefaultFirmwareInterface:    "no-firmware",
 		DefaultInspectInterface:     "no-inspect",
 		DefaultManagementInterface:  "ipmitool",
 		DefaultNetworkInterface:     "flat",
@@ -293,6 +298,7 @@ var (
 		EnabledBootInterfaces:       []string{"pxe"},
 		EnabledConsoleInterface:     []string{"no-console"},
 		EnabledDeployInterfaces:     []string{"iscsi", "direct"},
+		EnabledFirmwareInterfaces:   []string{"no-firmware"},
 		EnabledInspectInterfaces:    []string{"no-inspect"},
 		EnabledManagementInterfaces: []string{"ipmitool"},
 		EnabledNetworkInterfaces:    []string{"flat", "noop"},

--- a/openstack/baremetal/v1/nodes/requests.go
+++ b/openstack/baremetal/v1/nodes/requests.go
@@ -211,6 +211,9 @@ type CreateOpts struct {
 	// A set of one or more arbitrary metadata key and value pairs.
 	Extra map[string]interface{} `json:"extra,omitempty"`
 
+	// The firmware interface for a node, e.g. "redfish"
+	FirmwareInterface string `json:"firmware_interface,omitempty"`
+
 	// The interface used for node inspection, e.g. “no-inspect”.
 	InspectInterface string `json:"inspect_interface,omitempty"`
 
@@ -411,6 +414,7 @@ type StepInterface string
 const (
 	InterfaceBIOS       StepInterface = "bios"
 	InterfaceDeploy     StepInterface = "deploy"
+	InterfaceFirmware   StepInterface = "firmware"
 	InterfaceManagement StepInterface = "management"
 	InterfacePower      StepInterface = "power"
 	InterfaceRAID       StepInterface = "raid"
@@ -884,6 +888,15 @@ func UnsetMaintenance(client *gophercloud.ServiceClient, id string) (r SetMainte
 // GetInventory return stored data from successful inspection.
 func GetInventory(client *gophercloud.ServiceClient, id string) (r InventoryResult) {
 	resp, err := client.Get(inventoryURL(client, id), &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// ListFirmware return the list of Firmware components for the given Node.
+func ListFirmware(client *gophercloud.ServiceClient, id string) (r ListFirmwareResult) {
+	resp, err := client.Get(firmwareListURL(client, id), &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{200},
 	})
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)

--- a/openstack/baremetal/v1/nodes/results.go
+++ b/openstack/baremetal/v1/nodes/results.go
@@ -199,6 +199,9 @@ type Node struct {
 	// Deploy interface for a node, e.g. “iscsi”.
 	DeployInterface string `json:"deploy_interface"`
 
+	// Firmware interface for a node, e.g. “redfish”.
+	FirmwareInterface string `json:"firmware_interface"`
+
 	// Interface used for node inspection, e.g. “no-inspect”.
 	InspectInterface string `json:"inspect_interface"`
 
@@ -405,6 +408,7 @@ type NodeValidation struct {
 	Boot       DriverValidation `json:"boot"`
 	Console    DriverValidation `json:"console"`
 	Deploy     DriverValidation `json:"deploy"`
+	Firmware   DriverValidation `json:"firmware"`
 	Inspect    DriverValidation `json:"inspect"`
 	Management DriverValidation `json:"management"`
 	Network    DriverValidation `json:"network"`
@@ -605,4 +609,36 @@ func (r InventoryResult) Extract() (*InventoryData, error) {
 	var data InventoryData
 	err := r.ExtractInto(&data)
 	return &data, err
+}
+
+// ListFirmwareResult is the response from a ListFirmware operation. Call its Extract method
+// to interpret it as an array of FirmwareComponent structs.
+type ListFirmwareResult struct {
+	gophercloud.Result
+}
+
+// A particular Firmware Component for a node
+type FirmwareComponent struct {
+	// The UTC date and time when the resource was created, ISO 8601 format.
+	CreatedAt time.Time `json:"created_at"`
+	// The UTC date and time when the resource was updated, ISO 8601 format. May be “null”.
+	UpdatedAt *time.Time `json:"updated_at"`
+	// The Component name
+	Component string `json:"component"`
+	// The initial version of the firmware component.
+	InitialVersion string `json:"initial_version"`
+	// The current version of the firmware component.
+	CurrentVersion string `json:"current_version"`
+	// The last firmware version updated for the component.
+	LastVersionFlashed string `json:"last_version_flashed,omitempty"`
+}
+
+// Extract interprets a ListFirmwareResult as an array of FirmwareComponent structs, if possible.
+func (r ListFirmwareResult) Extract() ([]FirmwareComponent, error) {
+	var s struct {
+		Components []FirmwareComponent `json:"firmware"`
+	}
+
+	err := r.ExtractInto(&s)
+	return s.Components, err
 }

--- a/openstack/baremetal/v1/nodes/testing/requests_test.go
+++ b/openstack/baremetal/v1/nodes/testing/requests_test.go
@@ -104,6 +104,7 @@ func TestCreateNode(t *testing.T) {
 			"deploy_ramdisk": "http://172.22.0.1/images/tinyipa-stable-rocky.gz",
 			"ipmi_password":  "admin",
 		},
+		FirmwareInterface: "no-firmware",
 	}).Extract()
 	th.AssertNoErr(t, err)
 
@@ -729,4 +730,15 @@ func TestGetInventory(t *testing.T) {
 	compatData, err := actual.PluginData.AsInspectorData()
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, "x86_64", compatData.CPUArch)
+}
+
+func TestListFirmware(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleListFirmwareSuccessfully(t)
+
+	c := client.ServiceClient()
+	actual, err := nodes.ListFirmware(c, "1234asdf").Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, NodeFirmwareList, actual)
 }

--- a/openstack/baremetal/v1/nodes/urls.go
+++ b/openstack/baremetal/v1/nodes/urls.go
@@ -81,3 +81,7 @@ func maintenanceURL(client *gophercloud.ServiceClient, id string) string {
 func inventoryURL(client *gophercloud.ServiceClient, id string) string {
 	return client.ServiceURL("nodes", id, "inventory")
 }
+
+func firmwareListURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL("nodes", id, "firmware")
+}


### PR DESCRIPTION
* Driver updated to support
- default_firmware_interface and enabled_firmware_interfaces

* Node updated to support
- firmware_interface field can be specified
- List the Firmware Components requires API 1.86

Fixes #2794 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

[https://review.opendev.org/c/openstack/ironic/+/885276]
[https://review.opendev.org/c/openstack/ironic/+/885425]
[https://docs.openstack.org/api-ref/baremetal/#node-firmware-nodes]
