### PR TITLE
Fix baremetal jobs on Ubuntu 20.04

### DIFF
--- a/.github/workflows/functional-baremetal.yaml
+++ b/.github/workflows/functional-baremetal.yaml
@@ -40,6 +40,10 @@ jobs:
     steps:
       - name: Checkout Gophercloud
         uses: actions/checkout@v4
+      - name: Workaround for grub-efi-amd64-signed
+        run: sudo apt update && sudo apt -y upgrade
+        shell: bash
+        if: ${{ matrix.ubuntu_version == "20.04" }}
       - name: Deploy devstack
         uses: EmilienM/devstack-action@v0.11
         with:


### PR DESCRIPTION
    - Workaround to fix the grub-efi-amd64-signed happening in ubuntu 20.04





