### PR TITLE
Add workaround for baremetal jobs on ubuntu 20.04

### DIFF
--- a/.github/workflows/functional-baremetal.yaml
+++ b/.github/workflows/functional-baremetal.yaml
@@ -40,6 +40,14 @@ jobs:
     steps:
       - name: Checkout Gophercloud
         uses: actions/checkout@v4
+      - name: Workaround for grub-efi-amd64-signed
+        run: sudo rm /var/cache/debconf/config.dat
+        shell: bash
+        if: matrix.ubuntu_version == '20.04'
+      - name: Ensure update and upgrade
+        run: sudo apt update && sudo apt -y upgrade
+        shell: bash
+        if: matrix.ubuntu_version == '20.04'
       - name: Deploy devstack
         uses: EmilienM/devstack-action@v0.11
         with:


### PR DESCRIPTION
This commit adds a workaround to baremetal jobs
running on ubuntu 20.04 since they are failling when installing grub-efi-amd64-signed

