### PR TITLE
Fix blind replacement of paths in Heat template referencing other files

### DIFF
--- a/openstack/orchestration/v1/stacks/environment.go
+++ b/openstack/orchestration/v1/stacks/environment.go
@@ -1,6 +1,11 @@
 package stacks
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+
+	yaml "gopkg.in/yaml.v2"
+)
 
 // Environment is a structure that represents stack environments
 type Environment struct {
@@ -108,6 +113,16 @@ func (e *Environment) getRRFileContents(ignoreIf igFunc) error {
 		// if the resource registry contained any URL's, store them. This can
 		// then be passed as parameter to api calls to Heat api.
 		e.Files = tempTemplate.Files
+
+		// In case some element was updated, regenerate the string representation
+		if len(e.Files) > 0 {
+			var err error
+			e.Bin, err = yaml.Marshal(&e.Parsed)
+			if err != nil {
+				return fmt.Errorf("failed to marshal updated environment: %w", err)
+			}
+		}
+
 		return nil
 	default:
 		return nil

--- a/openstack/orchestration/v1/stacks/environment_test.go
+++ b/openstack/orchestration/v1/stacks/environment_test.go
@@ -152,7 +152,6 @@ service_db:
 		"my_env.yaml": fakeEnvURL,
 		"my_db.yaml":  fakeDBURL,
 	}
-	env.fixFileRefs()
 
 	expectedParsed := map[string]interface{}{
 		"resource_registry": map[string]interface{}{
@@ -164,6 +163,6 @@ service_db:
 			},
 		},
 	}
-	env.Parse()
+	th.AssertNoErr(t, env.Parse())
 	th.AssertDeepEquals(t, expectedParsed, env.Parsed)
 }

--- a/openstack/orchestration/v1/stacks/environment_test.go
+++ b/openstack/orchestration/v1/stacks/environment_test.go
@@ -1,10 +1,6 @@
 package stacks
 
 import (
-	"fmt"
-	"net/http"
-	"net/url"
-	"strings"
 	"testing"
 
 	th "github.com/gophercloud/gophercloud/testhelper"
@@ -132,28 +128,9 @@ service_db:
 	baseurl, err := getBasePath()
 	th.AssertNoErr(t, err)
 
-	fakeEnvURL := strings.Join([]string{baseurl, "my_env.yaml"}, "/")
-	urlparsed, err := url.Parse(fakeEnvURL)
-	th.AssertNoErr(t, err)
-	// handler for my_env.yaml
-	th.Mux.HandleFunc(urlparsed.Path, func(w http.ResponseWriter, r *http.Request) {
-		th.TestMethod(t, r, "GET")
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, environmentContent)
-	})
-
-	fakeDBURL := strings.Join([]string{baseurl, "my_db.yaml"}, "/")
-	urlparsed, err = url.Parse(fakeDBURL)
-	th.AssertNoErr(t, err)
-
-	// handler for my_db.yaml
-	th.Mux.HandleFunc(urlparsed.Path, func(w http.ResponseWriter, r *http.Request) {
-		th.TestMethod(t, r, "GET")
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, dbContent)
-	})
+	// Serve "my_env.yaml" and "my_db.yaml"
+	fakeEnvURL := th.ServeFile(t, baseurl, "my_env.yaml", "application/json", environmentContent)
+	fakeDBURL := th.ServeFile(t, baseurl, "my_db.yaml", "application/json", dbContent)
 
 	client := fakeClient{BaseClient: getHTTPClient()}
 	env := new(Environment)

--- a/openstack/orchestration/v1/stacks/requests.go
+++ b/openstack/orchestration/v1/stacks/requests.go
@@ -52,7 +52,6 @@ func (opts CreateOpts) ToStackCreateMap() (map[string]interface{}, error) {
 	if err := opts.TemplateOpts.getFileContents(opts.TemplateOpts.Parsed, ignoreIfTemplate, true); err != nil {
 		return nil, err
 	}
-	opts.TemplateOpts.fixFileRefs()
 	b["template"] = string(opts.TemplateOpts.Bin)
 
 	files := make(map[string]string)
@@ -146,7 +145,6 @@ func (opts AdoptOpts) ToStackAdoptMap() (map[string]interface{}, error) {
 	if err := opts.TemplateOpts.getFileContents(opts.TemplateOpts.Parsed, ignoreIfTemplate, true); err != nil {
 		return nil, err
 	}
-	opts.TemplateOpts.fixFileRefs()
 	b["template"] = string(opts.TemplateOpts.Bin)
 
 	files := make(map[string]string)
@@ -371,7 +369,6 @@ func toStackUpdateMap(opts UpdateOpts) (map[string]interface{}, error) {
 		if err := opts.TemplateOpts.getFileContents(opts.TemplateOpts.Parsed, ignoreIfTemplate, true); err != nil {
 			return nil, err
 		}
-		opts.TemplateOpts.fixFileRefs()
 		b["template"] = string(opts.TemplateOpts.Bin)
 
 		for k, v := range opts.TemplateOpts.Files {
@@ -479,7 +476,6 @@ func (opts PreviewOpts) ToStackPreviewMap() (map[string]interface{}, error) {
 	if err := opts.TemplateOpts.getFileContents(opts.TemplateOpts.Parsed, ignoreIfTemplate, true); err != nil {
 		return nil, err
 	}
-	opts.TemplateOpts.fixFileRefs()
 	b["template"] = string(opts.TemplateOpts.Bin)
 
 	files := make(map[string]string)

--- a/openstack/orchestration/v1/stacks/requests.go
+++ b/openstack/orchestration/v1/stacks/requests.go
@@ -66,7 +66,6 @@ func (opts CreateOpts) ToStackCreateMap() (map[string]interface{}, error) {
 		if err := opts.EnvironmentOpts.getRRFileContents(ignoreIfEnvironment); err != nil {
 			return nil, err
 		}
-		opts.EnvironmentOpts.fixFileRefs()
 		for k, v := range opts.EnvironmentOpts.Files {
 			files[k] = v
 		}
@@ -159,7 +158,6 @@ func (opts AdoptOpts) ToStackAdoptMap() (map[string]interface{}, error) {
 		if err := opts.EnvironmentOpts.getRRFileContents(ignoreIfEnvironment); err != nil {
 			return nil, err
 		}
-		opts.EnvironmentOpts.fixFileRefs()
 		for k, v := range opts.EnvironmentOpts.Files {
 			files[k] = v
 		}
@@ -383,7 +381,6 @@ func toStackUpdateMap(opts UpdateOpts) (map[string]interface{}, error) {
 		if err := opts.EnvironmentOpts.getRRFileContents(ignoreIfEnvironment); err != nil {
 			return nil, err
 		}
-		opts.EnvironmentOpts.fixFileRefs()
 		for k, v := range opts.EnvironmentOpts.Files {
 			files[k] = v
 		}
@@ -490,7 +487,6 @@ func (opts PreviewOpts) ToStackPreviewMap() (map[string]interface{}, error) {
 		if err := opts.EnvironmentOpts.getRRFileContents(ignoreIfEnvironment); err != nil {
 			return nil, err
 		}
-		opts.EnvironmentOpts.fixFileRefs()
 		for k, v := range opts.EnvironmentOpts.Files {
 			files[k] = v
 		}

--- a/openstack/orchestration/v1/stacks/template.go
+++ b/openstack/orchestration/v1/stacks/template.go
@@ -2,6 +2,7 @@ package stacks
 
 import (
 	"fmt"
+	"net/url"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -81,7 +82,13 @@ func (t *Template) getFileContents(te interface{}, ignoreIf igFunc, recurse bool
 				// get the base location of the child template. Child path is relative
 				// to its parent location so that templates can be composed
 				if t.URL != "" {
-					childTemplate.baseURL = filepath.Dir(t.URL)
+					// Preserve all elements of the URL but take the directory part of the path
+					u, err := url.Parse(t.URL)
+					if err != nil {
+						return err
+					}
+					u.Path = filepath.Dir(u.Path)
+					childTemplate.baseURL = u.String()
 				}
 				childTemplate.URL = value
 				childTemplate.client = t.client

--- a/openstack/orchestration/v1/stacks/utils.go
+++ b/openstack/orchestration/v1/stacks/utils.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"path/filepath"
 	"reflect"
-	"strings"
 
 	"github.com/gophercloud/gophercloud"
 	yaml "gopkg.in/yaml.v2"
@@ -142,17 +141,4 @@ func toStringKeys(m interface{}) (map[string]interface{}, error) {
 	default:
 		return nil, gophercloud.ErrUnexpectedType{Expected: "map[string]interface{}/map[interface{}]interface{}", Actual: fmt.Sprintf("%v", reflect.TypeOf(m))}
 	}
-}
-
-// fix the reference to files by replacing relative URL's by absolute
-// URL's
-func (t *TE) fixFileRefs() {
-	tStr := string(t.Bin)
-	if t.fileMaps == nil {
-		return
-	}
-	for k, v := range t.fileMaps {
-		tStr = strings.Replace(tStr, k, v, -1)
-	}
-	t.Bin = []byte(tStr)
 }

--- a/openstack/orchestration/v1/stacks/utils_test.go
+++ b/openstack/orchestration/v1/stacks/utils_test.go
@@ -10,17 +10,6 @@ import (
 	th "github.com/gophercloud/gophercloud/testhelper"
 )
 
-func TestTEFixFileRefs(t *testing.T) {
-	te := TE{
-		Bin: []byte(`string_to_replace: my fair lady`),
-		fileMaps: map[string]string{
-			"string_to_replace": "london bridge is falling down",
-		},
-	}
-	te.fixFileRefs()
-	th.AssertEquals(t, string(te.Bin), `london bridge is falling down: my fair lady`)
-}
-
 func TestToStringKeys(t *testing.T) {
 	var test1 interface{} = map[interface{}]interface{}{
 		"Adam":  "Smith",

--- a/testhelper/http_responses.go
+++ b/testhelper/http_responses.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -46,6 +47,21 @@ func TeardownHTTP() {
 // Endpoint returns a fake endpoint that will actually target the Mux.
 func Endpoint() string {
 	return Server.URL + "/"
+}
+
+// Serves a static content at baseURL/relPath
+func ServeFile(t *testing.T, baseURL, relPath, contentType, content string) string {
+	rawURL := strings.Join([]string{baseURL, relPath}, "/")
+	parsedURL, err := url.Parse(rawURL)
+	AssertNoErr(t, err)
+	Mux.HandleFunc(parsedURL.Path, func(w http.ResponseWriter, r *http.Request) {
+		TestMethod(t, r, "GET")
+		w.Header().Set("Content-Type", contentType)
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, content)
+	})
+
+	return rawURL
 }
 
 // TestFormValues ensures that all the URL parameters given to the http.Request are the same as values.


### PR DESCRIPTION
This change fixes an issue in the handling of Heat templates that reference other files (child templates or files included by means of `get_file:`) and that also contain, in some other context, the same string as the relative path being referenced (that must indeed be substituted for the absolute local path).

The existing fixFileRefs() does a simple blind string replacement inside the referencing template, regardless of the context. This is not appropriate as the same string as the path being replaced could possibly appear outside of the valid template/file reference cases (`type: ...` and `get_file: ...`), as in the below example:

      init-cmd:
        type: OS::Heat::CloudConfig
        properties:
          cloud_config:
            write_files:
              - path: /etc/somefile
                content: { get_file: somefile }

Here "somefile" in "{ get_file: somefile }" should be replaced by the absolute local path to 'somefile', but the "path: /etc/somefile" part should not be modified as that path refers here to the target destination in a completely different context (in this example, a cloud-init target path on a to-be-created VM).

The change also fixes another issue when using go v1.20 where the usage of `filepath.Dir()` on a URL removes any duplicate path separator when they should in fact be preserved (in "file:///some_abs_path/here", the "///" must remain).

Finally, the stack template tests have been slightly cleaned up (removing duplications, more concise code).