### PR TITLE
Allow objects.CreateTempURL with names containing /v1/

### DIFF
--- a/internal/acceptance/openstack/objectstorage/v1/objects_test.go
+++ b/internal/acceptance/openstack/objectstorage/v1/objects_test.go
@@ -22,6 +22,7 @@ import (
 var numObjects = 2
 
 func TestObjects(t *testing.T) {
+	numObjects := numObjects + 1
 	client, err := clients.NewObjectStorageV1Client()
 	if err != nil {
 		t.Fatalf("Unable to create client: %v", err)
@@ -29,9 +30,10 @@ func TestObjects(t *testing.T) {
 
 	// Make a slice of length numObjects to hold the random object names.
 	oNames := make([]string, numObjects)
-	for i := 0; i < len(oNames); i++ {
+	for i := 0; i < len(oNames)-1; i++ {
 		oNames[i] = tools.RandomString("test-object-", 8)
 	}
+	oNames[len(oNames)-1] = "test-object-with-/v1/-in-the-name"
 
 	// Create a container to hold the test objects.
 	cName := tools.RandomString("test-container-", 8)

--- a/openstack/objectstorage/v1/objects/requests.go
+++ b/openstack/objectstorage/v1/objects/requests.go
@@ -612,7 +612,7 @@ func CreateTempURL(c *gophercloud.ServiceClient, containerName, objectName strin
 	}
 
 	secretKey := []byte(tempURLKey)
-	splitPath := strings.Split(url, opts.Split)
+	splitPath := strings.SplitN(url, opts.Split, 2)
 	baseURL, objectPath := splitPath[0], splitPath[1]
 	objectPath = opts.Split + objectPath
 	body := fmt.Sprintf("%s\n%d\n%s", opts.Method, expiry, objectPath)


### PR DESCRIPTION
This PR backports a fix in CreateTempURL that was fixed in the main branch as a byproduct of https://github.com/gophercloud/gophercloud/pull/2821.

Before this patch, if an object's name or container name contained the string `/v1/`, it was not possible to create a TempURL for it. This was due to a bug in how the URL was split between the base part, and the object-path part.

With this patch, container names or object names containing `/v1/` can have a TempURL created successfully.

Fixes #2827 