### PR TITLE
Octavia: Add tags to resources missing them

### DIFF
--- a/openstack/loadbalancer/v2/listeners/requests.go
+++ b/openstack/loadbalancer/v2/listeners/requests.go
@@ -47,23 +47,24 @@ type ListOptsBuilder interface {
 // sort by a particular listener attribute. SortDir sets the direction, and is
 // either `asc' or `desc'. Marker and Limit are used for pagination.
 type ListOpts struct {
-	ID                   string `q:"id"`
-	Name                 string `q:"name"`
-	AdminStateUp         *bool  `q:"admin_state_up"`
-	ProjectID            string `q:"project_id"`
-	LoadbalancerID       string `q:"loadbalancer_id"`
-	DefaultPoolID        string `q:"default_pool_id"`
-	Protocol             string `q:"protocol"`
-	ProtocolPort         int    `q:"protocol_port"`
-	ConnectionLimit      int    `q:"connection_limit"`
-	Limit                int    `q:"limit"`
-	Marker               string `q:"marker"`
-	SortKey              string `q:"sort_key"`
-	SortDir              string `q:"sort_dir"`
-	TimeoutClientData    *int   `q:"timeout_client_data"`
-	TimeoutMemberData    *int   `q:"timeout_member_data"`
-	TimeoutMemberConnect *int   `q:"timeout_member_connect"`
-	TimeoutTCPInspect    *int   `q:"timeout_tcp_inspect"`
+	ID                   string   `q:"id"`
+	Name                 string   `q:"name"`
+	AdminStateUp         *bool    `q:"admin_state_up"`
+	ProjectID            string   `q:"project_id"`
+	LoadbalancerID       string   `q:"loadbalancer_id"`
+	DefaultPoolID        string   `q:"default_pool_id"`
+	Protocol             string   `q:"protocol"`
+	ProtocolPort         int      `q:"protocol_port"`
+	ConnectionLimit      int      `q:"connection_limit"`
+	Limit                int      `q:"limit"`
+	Marker               string   `q:"marker"`
+	SortKey              string   `q:"sort_key"`
+	SortDir              string   `q:"sort_dir"`
+	TimeoutClientData    *int     `q:"timeout_client_data"`
+	TimeoutMemberData    *int     `q:"timeout_member_data"`
+	TimeoutMemberConnect *int     `q:"timeout_member_connect"`
+	TimeoutTCPInspect    *int     `q:"timeout_tcp_inspect"`
+	Tags                 []string `q:"tags"`
 }
 
 // ToListenerListQuery formats a ListOpts into a query string.

--- a/openstack/loadbalancer/v2/monitors/requests.go
+++ b/openstack/loadbalancer/v2/monitors/requests.go
@@ -19,25 +19,26 @@ type ListOptsBuilder interface {
 // sort by a particular Monitor attribute. SortDir sets the direction, and is
 // either `asc' or `desc'. Marker and Limit are used for pagination.
 type ListOpts struct {
-	ID             string `q:"id"`
-	Name           string `q:"name"`
-	TenantID       string `q:"tenant_id"`
-	ProjectID      string `q:"project_id"`
-	PoolID         string `q:"pool_id"`
-	Type           string `q:"type"`
-	Delay          int    `q:"delay"`
-	Timeout        int    `q:"timeout"`
-	MaxRetries     int    `q:"max_retries"`
-	MaxRetriesDown int    `q:"max_retries_down"`
-	HTTPMethod     string `q:"http_method"`
-	URLPath        string `q:"url_path"`
-	ExpectedCodes  string `q:"expected_codes"`
-	AdminStateUp   *bool  `q:"admin_state_up"`
-	Status         string `q:"status"`
-	Limit          int    `q:"limit"`
-	Marker         string `q:"marker"`
-	SortKey        string `q:"sort_key"`
-	SortDir        string `q:"sort_dir"`
+	ID             string   `q:"id"`
+	Name           string   `q:"name"`
+	TenantID       string   `q:"tenant_id"`
+	ProjectID      string   `q:"project_id"`
+	PoolID         string   `q:"pool_id"`
+	Type           string   `q:"type"`
+	Delay          int      `q:"delay"`
+	Timeout        int      `q:"timeout"`
+	MaxRetries     int      `q:"max_retries"`
+	MaxRetriesDown int      `q:"max_retries_down"`
+	HTTPMethod     string   `q:"http_method"`
+	URLPath        string   `q:"url_path"`
+	ExpectedCodes  string   `q:"expected_codes"`
+	AdminStateUp   *bool    `q:"admin_state_up"`
+	Status         string   `q:"status"`
+	Limit          int      `q:"limit"`
+	Marker         string   `q:"marker"`
+	SortKey        string   `q:"sort_key"`
+	SortDir        string   `q:"sort_dir"`
+	Tags           []string `q:"tags"`
 }
 
 // ToMonitorListQuery formats a ListOpts into a query string.
@@ -141,6 +142,9 @@ type CreateOpts struct {
 	// The administrative state of the Monitor. A valid value is true (UP)
 	// or false (DOWN).
 	AdminStateUp *bool `json:"admin_state_up,omitempty"`
+
+	// Tags is a set of resource tags. New in version 2.5
+	Tags []string `json:"tags,omitempty"`
 }
 
 // ToMonitorCreateMap builds a request body from CreateOpts.
@@ -224,6 +228,9 @@ type UpdateOpts struct {
 	// The administrative state of the Monitor. A valid value is true (UP)
 	// or false (DOWN).
 	AdminStateUp *bool `json:"admin_state_up,omitempty"`
+
+	// Tags is a set of resource tags. New in version 2.5
+	Tags []string `json:"tags,omitempty"`
 }
 
 // ToMonitorUpdateMap builds a request body from UpdateOpts.

--- a/openstack/loadbalancer/v2/monitors/results.go
+++ b/openstack/loadbalancer/v2/monitors/results.go
@@ -84,6 +84,10 @@ type Monitor struct {
 
 	// The operating status of the monitor.
 	OperatingStatus string `json:"operating_status"`
+
+	// Tags is a list of resource tags. Tags are arbitrarily defined strings
+	// attached to the resource. New in version 2.5
+	Tags []string `json:"tags"`
 }
 
 // MonitorPage is the page returned by a pager when traversing over a

--- a/openstack/loadbalancer/v2/monitors/testing/fixtures_test.go
+++ b/openstack/loadbalancer/v2/monitors/testing/fixtures_test.go
@@ -24,7 +24,8 @@ const HealthmonitorsListBody = `
 			"timeout":1,
 			"type":"PING",
 			"pools": [{"id": "84f1b61f-58c4-45bf-a8a9-2dafb9e5214d"}],
-			"id":"466c8345-28d8-4f84-a246-e04380b0461d"
+			"id":"466c8345-28d8-4f84-a246-e04380b0461d",
+			"tags":[]
 		},
 		{
 			"admin_state_up":true,
@@ -39,7 +40,8 @@ const HealthmonitorsListBody = `
 			"url_path":"/",
 			"type":"HTTP",
 			"pools": [{"id": "d459f7d8-c6ee-439d-8713-d3fc08aeed8d"}],
-			"id":"5d4b5228-33b0-4e60-b225-9b727c1a20e7"
+			"id":"5d4b5228-33b0-4e60-b225-9b727c1a20e7",
+			"tags":["foobar"]
 		}
 	]
 }
@@ -61,7 +63,8 @@ const SingleHealthmonitorBody = `
 		"url_path":"/",
 		"type":"HTTP",
 		"pools": [{"id": "d459f7d8-c6ee-439d-8713-d3fc08aeed8d"}],
-		"id":"5d4b5228-33b0-4e60-b225-9b727c1a20e7"
+		"id":"5d4b5228-33b0-4e60-b225-9b727c1a20e7",
+		"tags":[]
 	}
 }
 `
@@ -82,7 +85,8 @@ const PostUpdateHealthmonitorBody = `
 		"url_path":"/another_check",
 		"type":"HTTP",
 		"pools": [{"id": "d459f7d8-c6ee-439d-8713-d3fc08aeed8d"}],
-		"id":"5d4b5228-33b0-4e60-b225-9b727c1a20e7"
+		"id":"5d4b5228-33b0-4e60-b225-9b727c1a20e7",
+		"tags":[]
 	}
 }
 `
@@ -99,6 +103,7 @@ var (
 		Type:           "PING",
 		ID:             "466c8345-28d8-4f84-a246-e04380b0461d",
 		Pools:          []monitors.PoolID{{ID: "84f1b61f-58c4-45bf-a8a9-2dafb9e5214d"}},
+		Tags:           []string{},
 	}
 	HealthmonitorDb = monitors.Monitor{
 		AdminStateUp:   true,
@@ -114,6 +119,7 @@ var (
 		HTTPMethod:     "GET",
 		ID:             "5d4b5228-33b0-4e60-b225-9b727c1a20e7",
 		Pools:          []monitors.PoolID{{ID: "d459f7d8-c6ee-439d-8713-d3fc08aeed8d"}},
+		Tags:           []string{},
 	}
 	HealthmonitorUpdated = monitors.Monitor{
 		AdminStateUp:   true,
@@ -129,6 +135,7 @@ var (
 		HTTPMethod:     "GET",
 		ID:             "5d4b5228-33b0-4e60-b225-9b727c1a20e7",
 		Pools:          []monitors.PoolID{{ID: "d459f7d8-c6ee-439d-8713-d3fc08aeed8d"}},
+		Tags:           []string{},
 	}
 )
 

--- a/openstack/loadbalancer/v2/monitors/testing/requests_test.go
+++ b/openstack/loadbalancer/v2/monitors/testing/requests_test.go
@@ -66,6 +66,7 @@ func TestCreateHealthmonitor(t *testing.T) {
 		Timeout:        10,
 		MaxRetries:     5,
 		MaxRetriesDown: 4,
+		Tags:           []string{},
 		URLPath:        "/check",
 		ExpectedCodes:  "200-299",
 	}).Extract()

--- a/openstack/loadbalancer/v2/pools/requests.go
+++ b/openstack/loadbalancer/v2/pools/requests.go
@@ -18,17 +18,18 @@ type ListOptsBuilder interface {
 // sort by a particular Pool attribute. SortDir sets the direction, and is
 // either `asc' or `desc'. Marker and Limit are used for pagination.
 type ListOpts struct {
-	LBMethod       string `q:"lb_algorithm"`
-	Protocol       string `q:"protocol"`
-	ProjectID      string `q:"project_id"`
-	AdminStateUp   *bool  `q:"admin_state_up"`
-	Name           string `q:"name"`
-	ID             string `q:"id"`
-	LoadbalancerID string `q:"loadbalancer_id"`
-	Limit          int    `q:"limit"`
-	Marker         string `q:"marker"`
-	SortKey        string `q:"sort_key"`
-	SortDir        string `q:"sort_dir"`
+	LBMethod       string   `q:"lb_algorithm"`
+	Protocol       string   `q:"protocol"`
+	ProjectID      string   `q:"project_id"`
+	AdminStateUp   *bool    `q:"admin_state_up"`
+	Name           string   `q:"name"`
+	ID             string   `q:"id"`
+	LoadbalancerID string   `q:"loadbalancer_id"`
+	Limit          int      `q:"limit"`
+	Marker         string   `q:"marker"`
+	SortKey        string   `q:"sort_key"`
+	SortDir        string   `q:"sort_dir"`
+	Tags           []string `q:"tags"`
 }
 
 // ToPoolListQuery formats a ListOpts into a query string.


### PR DESCRIPTION
Seems like a bunch of resources are missing the tags fiels that Octavia API reference specified. This commit adds them.

Fixes #2829

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://docs.openstack.org/api-ref/load-balancer/v2/index.html
