### PR TITLE
chore: use String() instead of fmt.Sprintf

### DIFF
--- a/openstack/blockstorage/apiversions/errors.go
+++ b/openstack/blockstorage/apiversions/errors.go
@@ -9,7 +9,7 @@ import (
 type ErrVersionNotFound struct{}
 
 func (e ErrVersionNotFound) Error() string {
-	return fmt.Sprintf("Unable to find requested API version")
+	return "Unable to find requested API version"
 }
 
 // ErrMultipleVersionsFound is the error when a request for an API

--- a/openstack/compute/apiversions/errors.go
+++ b/openstack/compute/apiversions/errors.go
@@ -1,13 +1,9 @@
 package apiversions
 
-import (
-	"fmt"
-)
-
 // ErrVersionNotFound is the error when the requested API version
 // could not be found.
 type ErrVersionNotFound struct{}
 
 func (e ErrVersionNotFound) Error() string {
-	return fmt.Sprintf("Unable to find requested API version")
+	return "Unable to find requested API version"
 }

--- a/openstack/container/v1/capsules/errors.go
+++ b/openstack/container/v1/capsules/errors.go
@@ -1,8 +1,6 @@
 package capsules
 
 import (
-	"fmt"
-
 	"github.com/gophercloud/gophercloud"
 )
 
@@ -11,5 +9,5 @@ type ErrInvalidDataFormat struct {
 }
 
 func (e ErrInvalidDataFormat) Error() string {
-	return fmt.Sprintf("Data in neither json nor yaml format.")
+	return "Data in neither json nor yaml format."
 }

--- a/openstack/containerinfra/apiversions/errors.go
+++ b/openstack/containerinfra/apiversions/errors.go
@@ -9,7 +9,7 @@ import (
 type ErrVersionNotFound struct{}
 
 func (e ErrVersionNotFound) Error() string {
-	return fmt.Sprintf("Unable to find requested API version")
+	return "Unable to find requested API version"
 }
 
 // ErrMultipleVersionsFound is the error when a request for an API

--- a/openstack/orchestration/v1/stacks/errors.go
+++ b/openstack/orchestration/v1/stacks/errors.go
@@ -20,7 +20,7 @@ type ErrInvalidDataFormat struct {
 }
 
 func (e ErrInvalidDataFormat) Error() string {
-	return fmt.Sprintf("Data in neither json nor yaml format.")
+	return "Data in neither json nor yaml format."
 }
 
 type ErrInvalidTemplateFormatVersion struct {
@@ -29,7 +29,7 @@ type ErrInvalidTemplateFormatVersion struct {
 }
 
 func (e ErrInvalidTemplateFormatVersion) Error() string {
-	return fmt.Sprintf("Template format version not found.")
+	return "Template format version not found."
 }
 
 type ErrTemplateRequired struct {
@@ -37,5 +37,5 @@ type ErrTemplateRequired struct {
 }
 
 func (e ErrTemplateRequired) Error() string {
-	return fmt.Sprintf("Template required for this function.")
+	return "Template required for this function."
 }

--- a/openstack/sharedfilesystems/apiversions/errors.go
+++ b/openstack/sharedfilesystems/apiversions/errors.go
@@ -9,7 +9,7 @@ import (
 type ErrVersionNotFound struct{}
 
 func (e ErrVersionNotFound) Error() string {
-	return fmt.Sprintf("Unable to find requested API version")
+	return "Unable to find requested API version"
 }
 
 // ErrMultipleVersionsFound is the error when a request for an API

--- a/testhelper/convenience.go
+++ b/testhelper/convenience.go
@@ -345,7 +345,7 @@ func AssertNoErr(t *testing.T, e error) {
 // nil
 func AssertErr(t *testing.T, e error) {
 	if e == nil {
-		logFatal(t, fmt.Sprintf("expected error, got nil"))
+		logFatal(t, "expected error, got nil")
 	}
 }
 


### PR DESCRIPTION
Prior to starting a PR, please make sure you have read our
[contributor tutorial](https://github.com/gophercloud/gophercloud/tree/master/docs/contributor-tutorial).

Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

Fixes #[PUT ISSUE NUMBER HERE]

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

[PUT URLS HERE]
