### PR TITLE
unit tests: Fix the installation of tools

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -20,22 +20,23 @@ jobs:
       GO111MODULE: "on"
 
     steps:
-      - name: Setup Go ${{ matrix.go-version }}
+      - uses: actions/checkout@v3
+
+      - name: Setup Go v1
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1
+
+      - name: Install tools
+        run: |
+          go install github.com/wadey/gocovmerge@master
+          go install golang.org/x/tools/cmd/goimports@latest
+
+      - if: ${{ matrix.go-version != '1' }}
+        name: Setup Go ${{ matrix.go-version }}
         uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go-version }}
-
-      - uses: actions/checkout@v3
-
-      - name: Setup environment
-        run: |
-          # Changing into a different directory to avoid polluting go.sum with "go get"
-          cd "$(mktemp -d)"
-          go mod init unit_tests
-
-          # we use "go get" for Go v1.14
-          go install github.com/wadey/gocovmerge@master || go get github.com/wadey/gocovmerge
-          go install golang.org/x/tools/cmd/goimports@latest || go get golang.org/x/tools/cmd/goimports@v0.8.0
 
       - name: Run go vet
         run: |
@@ -43,6 +44,7 @@ jobs:
 
       - name: Run unit tests
         run: |
+          go version
           ./script/coverage
           ./script/format
           ./script/unittest -v


### PR DESCRIPTION
Install Go tools with new newest Go version before switching to the target version of Go to run the unit tests.

This commit fixes an issue where the Go tools we use in unit tests can't be compiled with Go v1.14 any more.