### PR TITLE
[db/v1/instance]: adding support for availability_zone for a db instance

### DIFF
--- a/openstack/db/v1/instances/requests.go
+++ b/openstack/db/v1/instances/requests.go
@@ -47,6 +47,8 @@ func (opts NetworkOpts) ToMap() (map[string]interface{}, error) {
 
 // CreateOpts is the struct responsible for configuring a new database instance.
 type CreateOpts struct {
+	// The availability zone of the instance.
+	AvailabilityZone string `json:"availability_zone,omitempty"`
 	// Either the integer UUID (in string form) of the flavor, or its URI
 	// reference as specified in the response from the List() call. Required.
 	FlavorRef string
@@ -85,6 +87,10 @@ func (opts CreateOpts) ToInstanceCreateMap() (map[string]interface{}, error) {
 
 	instance := map[string]interface{}{
 		"flavorRef": opts.FlavorRef,
+	}
+
+	if opts.AvailabilityZone != "" {
+		instance["availability_zone"] = opts.AvailabilityZone
 	}
 
 	if opts.Name != "" {

--- a/openstack/db/v1/instances/testing/fixtures_test.go
+++ b/openstack/db/v1/instances/testing/fixtures_test.go
@@ -104,6 +104,7 @@ var instanceGet = `
 var createReq = `
 {
 	"instance": {
+		"availability_zone": "us-east1",
 		"databases": [
 			{
 				"character_set": "utf8",

--- a/openstack/db/v1/instances/testing/requests_test.go
+++ b/openstack/db/v1/instances/testing/requests_test.go
@@ -17,8 +17,9 @@ func TestCreate(t *testing.T) {
 	HandleCreate(t)
 
 	opts := instances.CreateOpts{
-		Name:      "json_rack_instance",
-		FlavorRef: "1",
+		AvailabilityZone: "us-east1",
+		Name:             "json_rack_instance",
+		FlavorRef:        "1",
 		Databases: db.BatchCreateOpts{
 			{CharSet: "utf8", Collate: "utf8_general_ci", Name: "sampledb"},
 			{Name: "nextround"},
@@ -48,8 +49,9 @@ func TestCreateWithFault(t *testing.T) {
 	HandleCreateWithFault(t)
 
 	opts := instances.CreateOpts{
-		Name:      "json_rack_instance",
-		FlavorRef: "1",
+		AvailabilityZone: "us-east1",
+		Name:             "json_rack_instance",
+		FlavorRef:        "1",
 		Databases: db.BatchCreateOpts{
 			{CharSet: "utf8", Collate: "utf8_general_ci", Name: "sampledb"},
 			{Name: "nextround"},


### PR DESCRIPTION
## Issue

For #2874

## Description

* code: added `AvailabilityZone` struct field
* code: add empty checking for that field
* tests: add `availability_zone` to `testing/fixtures_test.go`
* tests: add `AvailabilityZone` to `testing/requests_test.go`

## Links

* API Docs: https://docs.openstack.org/api-ref/database/#create-database-instance
* Model - Create: https://github.com/openstack/trove/blob/422507ca425f5a1be10cfc979165e7b8d58dfffa/trove/instance/models.py#L1186
* Service - Create: https://github.com/openstack/trove/blob/422507ca425f5a1be10cfc979165e7b8d58dfffa/trove/instance/service.py#L360

Related:
* https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/1644
* https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1643