### PR TITLE
[wip][db/v1/instances] add replica_of field - trove database dbaas

### DIFF
--- a/openstack/db/v1/instances/requests.go
+++ b/openstack/db/v1/instances/requests.go
@@ -52,6 +52,8 @@ type CreateOpts struct {
 	// Either the integer UUID (in string form) of the flavor, or its URI
 	// reference as specified in the response from the List() call. Required.
 	FlavorRef string
+	// ID or name of an existing instance to replicate from.
+	ReplicaOf string `json:"replica_of,omitempty"`
 	// Specifies the volume size in gigabytes (GB). The value must be between 1
 	// and 300. Required.
 	Size int
@@ -87,6 +89,10 @@ func (opts CreateOpts) ToInstanceCreateMap() (map[string]interface{}, error) {
 
 	instance := map[string]interface{}{
 		"flavorRef": opts.FlavorRef,
+	}
+
+	if opts.ReplicaOf != "" {
+		instance["replica_of"] = opts.ReplicaOf
 	}
 
 	if opts.AvailabilityZone != "" {

--- a/openstack/db/v1/instances/requests.go
+++ b/openstack/db/v1/instances/requests.go
@@ -56,9 +56,9 @@ type CreateOpts struct {
 	ReplicaOf string `json:"replica_of,omitempty"`
 	// Specifies the volume size in gigabytes (GB). The value must be between 1
 	// and 300. Required.
-	Size int
+	Size int `json:",omitempty"`
 	// Specifies the volume type.
-	VolumeType string
+	VolumeType string `json:",omitempty"`
 	// Name of the instance to create. The length of the name is limited to
 	// 255 characters and any characters are permitted. Optional.
 	Name string
@@ -75,7 +75,20 @@ type CreateOpts struct {
 
 // ToInstanceCreateMap will render a JSON map.
 func (opts CreateOpts) ToInstanceCreateMap() (map[string]interface{}, error) {
-	if opts.Size > 300 || opts.Size < 1 {
+	instance := map[string]interface{}{}
+
+	if opts.ReplicaOf != "" {
+		instance["replica_of"] = opts.ReplicaOf
+	}
+
+	// Volume Size cannot be specified when creating replicas of another instance.
+	if opts.Size > 0 && opts.ReplicaOf != "" {
+		err := gophercloud.ErrInvalidInput{}
+		err.Argument = "instances.CreateOpts.Size"
+		err.Value = opts.Size
+		err.Info = "Volume Size cannot be specified when ReplicaOf is provided"
+		return nil, err
+	} else if (opts.Size > 300 || opts.Size < 1) && opts.ReplicaOf == "" {
 		err := gophercloud.ErrInvalidInput{}
 		err.Argument = "instances.CreateOpts.Size"
 		err.Value = opts.Size
@@ -83,17 +96,22 @@ func (opts CreateOpts) ToInstanceCreateMap() (map[string]interface{}, error) {
 		return nil, err
 	}
 
-	if opts.FlavorRef == "" {
-		return nil, gophercloud.ErrMissingInput{Argument: "instances.CreateOpts.FlavorRef"}
+	// FlavorRef cannot be specified when creating replicas of another instance.
+	if opts.FlavorRef == "" && opts.ReplicaOf == "" {
+		err := gophercloud.ErrMissingInput{}
+		err.Argument = "instances.CreateOpts.FlavorRef or instances.CreateOpts.ReplicaOf"
+		err.Info = "ReplicaOf or FlavorRef should be provided"
+		return nil, err
+	}
+	if opts.FlavorRef != "" && opts.ReplicaOf != "" {
+		err := gophercloud.ErrInvalidInput{}
+		err.Argument = "instances.CreateOpts.FlavorRef"
+		err.Value = opts.Size
+		err.Info = "FlavorRef cannot be specified when ReplicaOf is provided"
+		return nil, err
 	}
 
-	instance := map[string]interface{}{
-		"flavorRef": opts.FlavorRef,
-	}
-
-	if opts.ReplicaOf != "" {
-		instance["replica_of"] = opts.ReplicaOf
-	}
+	instance["flavorRef"] = opts.FlavorRef
 
 	if opts.AvailabilityZone != "" {
 		instance["availability_zone"] = opts.AvailabilityZone
@@ -116,6 +134,15 @@ func (opts CreateOpts) ToInstanceCreateMap() (map[string]interface{}, error) {
 		}
 		instance["users"] = users["users"]
 	}
+
+	// Datastore cannot be specified when creating replicas of another instance.
+	if opts.Datastore != nil && opts.ReplicaOf != "" {
+		err := gophercloud.ErrInvalidInput{}
+		err.Argument = "instances.CreateOpts.Datastore"
+		err.Value = opts.Size
+		err.Info = "Datastore cannot be specified when ReplicaOf is provided"
+		return nil, err
+	}
 	if opts.Datastore != nil {
 		datastore, err := opts.Datastore.ToMap()
 		if err != nil {
@@ -136,15 +163,26 @@ func (opts CreateOpts) ToInstanceCreateMap() (map[string]interface{}, error) {
 		instance["nics"] = networks
 	}
 
-	volume := map[string]interface{}{
-		"size": opts.Size,
+	volume := map[string]interface{}{}
+
+	if opts.ReplicaOf == "" {
+		volume["size"] = opts.Size
 	}
 
-	if opts.VolumeType != "" {
+	if opts.VolumeType != "" && opts.ReplicaOf != "" {
+		err := gophercloud.ErrInvalidInput{}
+		err.Argument = "instances.CreateOpts.VolumeType"
+		err.Value = opts.Size
+		err.Info = "Volume Type cannot be specified when ReplicaOf is provided"
+		return nil, err
+	}
+	if opts.VolumeType != "" && opts.ReplicaOf == "" {
 		volume["type"] = opts.VolumeType
 	}
 
-	instance["volume"] = volume
+	if opts.ReplicaOf == "" {
+		instance["volume"] = volume
+	}
 
 	return map[string]interface{}{"instance": instance}, nil
 }

--- a/openstack/db/v1/instances/testing/fixtures_test.go
+++ b/openstack/db/v1/instances/testing/fixtures_test.go
@@ -116,6 +116,7 @@ var createReq = `
 			}
 		],
 		"flavorRef": "1",
+		"replica_of": "master-server-to-replicate-of"
 		"name": "json_rack_instance",
 		"users": [
 			{

--- a/openstack/db/v1/instances/testing/fixtures_test.go
+++ b/openstack/db/v1/instances/testing/fixtures_test.go
@@ -53,6 +53,23 @@ var instance = `
 }
 `
 
+var instanceReplicaOf = `
+{
+  "created": "` + timestamp + `",
+  "links": [
+    {
+      "href": "https://openstack.example.com/v1.0/1234/instances/1",
+      "rel": "self"
+    }
+  ],
+  "hostname": "e09ad9a3f73309469cf1f43d11e79549caf9acf2.openstack.example.com",
+  "id": "{instanceID}",
+  "name": "json_rack_instance",
+  "status": "BUILD",
+  "updated": "` + timestamp + `"
+}
+`
+
 var instanceGet = `
 {
   "created": "` + timestamp + `",
@@ -116,7 +133,6 @@ var createReq = `
 			}
 		],
 		"flavorRef": "1",
-		"replica_of": "master-server-to-replicate-of",
 		"name": "json_rack_instance",
 		"users": [
 			{
@@ -133,6 +149,16 @@ var createReq = `
 			"size": 2,
 			"type": "ssd"
 		}
+	}
+}
+`
+
+var createReplicaOfReq = `
+{
+	"instance": {
+		"availability_zone": "us-east1",
+		"replica_of": "master-server-to-replicate-of",
+		"name": "json_rack_instance",
 	}
 }
 `
@@ -198,6 +224,7 @@ var (
 
 var (
 	createResp          = fmt.Sprintf(`{"instance": %s}`, instance)
+	createReplicaOfResp = fmt.Sprintf(`{"instance": %s}`, instanceReplicaOf)
 	createWithFaultResp = fmt.Sprintf(`{"instance": %s}`, instanceWithFault)
 	listInstancesResp   = fmt.Sprintf(`{"instances":[%s]}`, instance)
 	getInstanceResp     = fmt.Sprintf(`{"instance": %s}`, instanceGet)
@@ -227,6 +254,18 @@ var expectedInstance = instances.Instance{
 		Type:    "mysql",
 		Version: "5.6",
 	},
+}
+
+var expectedInstanceReplicaOf = instances.Instance{
+	Created: timeVal,
+	Updated: timeVal,
+	Hostname: "e09ad9a3f73309469cf1f43d11e79549caf9acf2.openstack.example.com",
+	ID:       instanceID,
+	Links: []gophercloud.Link{
+		{Href: "https://openstack.example.com/v1.0/1234/instances/1", Rel: "self"},
+	},
+	Name:   "json_rack_instance",
+	Status: "BUILD",
 }
 
 var expectedGetInstance = instances.Instance{
@@ -287,6 +326,10 @@ var expectedInstanceWithFault = instances.Instance{
 
 func HandleCreate(t *testing.T) {
 	fixture.SetupHandler(t, rootURL, "POST", createReq, createResp, 200)
+}
+
+func HandleCreateWithReplicaOf(t *testing.T) {
+	fixture.SetupHandler(t, rootURL, "POST", createReplicaOfReq, createReplicaOfResp, 200)
 }
 
 func HandleCreateWithFault(t *testing.T) {

--- a/openstack/db/v1/instances/testing/fixtures_test.go
+++ b/openstack/db/v1/instances/testing/fixtures_test.go
@@ -53,6 +53,7 @@ var instance = `
 }
 `
 
+// https://github.com/openstack/trove/blob/40fdb7b44fb33e022b77ba8df63fde2565c70dea/api-ref/source/parameters.yaml#L799
 var instanceReplicaOf = `
 {
   "created": "` + timestamp + `",

--- a/openstack/db/v1/instances/testing/fixtures_test.go
+++ b/openstack/db/v1/instances/testing/fixtures_test.go
@@ -116,7 +116,7 @@ var createReq = `
 			}
 		],
 		"flavorRef": "1",
-		"replica_of": "master-server-to-replicate-of"
+		"replica_of": "master-server-to-replicate-of",
 		"name": "json_rack_instance",
 		"users": [
 			{

--- a/openstack/db/v1/instances/testing/requests_test.go
+++ b/openstack/db/v1/instances/testing/requests_test.go
@@ -20,7 +20,6 @@ func TestCreate(t *testing.T) {
 		AvailabilityZone: "us-east1",
 		Name:             "json_rack_instance",
 		FlavorRef:        "1",
-		ReplicaOf:        "master-server-to-replicate-of",
 		Databases: db.BatchCreateOpts{
 			{CharSet: "utf8", Collate: "utf8_general_ci", Name: "sampledb"},
 			{Name: "nextround"},
@@ -44,6 +43,24 @@ func TestCreate(t *testing.T) {
 	th.AssertDeepEquals(t, &expectedInstance, instance)
 }
 
+func TestCreateWithReplicaOf(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleCreateWithReplicaOf(t)
+
+	// Subtest 1: ReplicaOf Only - No FlavorRef specified
+	t.Run("It creates a replica without specifying FlavorRef", func(t *testing.T) {
+		opts := instances.CreateOpts{
+			AvailabilityZone: "us-east1",
+			Name:             "json_rack_instance",
+			ReplicaOf:        "master-server-to-replicate-of",
+		}
+		instance, err := instances.Create(fake.ServiceClient(), opts).Extract()
+		th.AssertNoErr(t, err)
+		th.AssertDeepEquals(t, &expectedInstance, instance)
+	})
+}
+
 func TestCreateWithFault(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
@@ -53,7 +70,6 @@ func TestCreateWithFault(t *testing.T) {
 		AvailabilityZone: "us-east1",
 		Name:             "json_rack_instance",
 		FlavorRef:        "1",
-		ReplicaOf:        "master-server-to-replicate-of",
 		Databases: db.BatchCreateOpts{
 			{CharSet: "utf8", Collate: "utf8_general_ci", Name: "sampledb"},
 			{Name: "nextround"},

--- a/openstack/db/v1/instances/testing/requests_test.go
+++ b/openstack/db/v1/instances/testing/requests_test.go
@@ -20,6 +20,7 @@ func TestCreate(t *testing.T) {
 		AvailabilityZone: "us-east1",
 		Name:             "json_rack_instance",
 		FlavorRef:        "1",
+		ReplicaOf:        "master-server-to-replicate-of"
 		Databases: db.BatchCreateOpts{
 			{CharSet: "utf8", Collate: "utf8_general_ci", Name: "sampledb"},
 			{Name: "nextround"},
@@ -52,6 +53,7 @@ func TestCreateWithFault(t *testing.T) {
 		AvailabilityZone: "us-east1",
 		Name:             "json_rack_instance",
 		FlavorRef:        "1",
+		ReplicaOf:        "master-server-to-replicate-of"
 		Databases: db.BatchCreateOpts{
 			{CharSet: "utf8", Collate: "utf8_general_ci", Name: "sampledb"},
 			{Name: "nextround"},

--- a/openstack/db/v1/instances/testing/requests_test.go
+++ b/openstack/db/v1/instances/testing/requests_test.go
@@ -20,7 +20,7 @@ func TestCreate(t *testing.T) {
 		AvailabilityZone: "us-east1",
 		Name:             "json_rack_instance",
 		FlavorRef:        "1",
-		ReplicaOf:        "master-server-to-replicate-of"
+		ReplicaOf:        "master-server-to-replicate-of",
 		Databases: db.BatchCreateOpts{
 			{CharSet: "utf8", Collate: "utf8_general_ci", Name: "sampledb"},
 			{Name: "nextround"},
@@ -53,7 +53,7 @@ func TestCreateWithFault(t *testing.T) {
 		AvailabilityZone: "us-east1",
 		Name:             "json_rack_instance",
 		FlavorRef:        "1",
-		ReplicaOf:        "master-server-to-replicate-of"
+		ReplicaOf:        "master-server-to-replicate-of",
 		Databases: db.BatchCreateOpts{
 			{CharSet: "utf8", Collate: "utf8_general_ci", Name: "sampledb"},
 			{Name: "nextround"},


### PR DESCRIPTION
## Issue

Fixes #2697 

## Description

* code: add ReplicaOf field in CreateOpts
* code: mark some values as a omiteptry and optional
* code: add non-empty checking for that field
* code: add checks for replicaOf field - that field cannot be specified with some other fields at the same time - TODO
* code: ...
...
* tests: add fixture for instance that created like a replica of different instance
* tests: ...
...
* tests: add link to api-ref samples - TODO
* tests: add more tests - TODO
* docs: TODO

## Links

* ...

Related:
* https://github.com/gophercloud/gophercloud/pull/2698
* API Docs: https://docs.openstack.org/api-ref/database/?expanded=create-database-instance-detail#create-database-instance
* API Ref Parameters: https://github.com/openstack/trove/blob/40fdb7b44fb33e022b77ba8df63fde2565c70dea/api-ref/source/parameters.yaml#L799https://github.com/openstack/trove/blob/40fdb7b44fb33e022b77ba8df63fde2565c70dea/api-ref/source/parameters.yaml#L799