### PR TITLE
Set the user agent to an unreleased version

### DIFF
--- a/provider_client.go
+++ b/provider_client.go
@@ -13,7 +13,7 @@ import (
 
 // DefaultUserAgent is the default User-Agent string set in the request header.
 const (
-	DefaultUserAgent         = "gophercloud/v1.5.0"
+	DefaultUserAgent         = "gophercloud/v2.0.0-unreleased"
 	DefaultMaxBackoffRetries = 60
 )
 


### PR DESCRIPTION
Building from the development branch should not give a user agent that matches a release.

This PR must not be backported to a release branch.