### PR TITLE
db/v1/instance: Add configuration to createOpts

### DIFF
--- a/openstack/db/v1/instances/requests.go
+++ b/openstack/db/v1/instances/requests.go
@@ -49,6 +49,8 @@ func (opts NetworkOpts) ToMap() (map[string]interface{}, error) {
 type CreateOpts struct {
 	// The availability zone of the instance.
 	AvailabilityZone string `json:"availability_zone,omitempty"`
+	// ID of the configuration group that you want to attach to the instance.
+	Configuration string `json:"configuration,omitempty"`
 	// Either the integer UUID (in string form) of the flavor, or its URI
 	// reference as specified in the response from the List() call. Required.
 	FlavorRef string
@@ -91,6 +93,10 @@ func (opts CreateOpts) ToInstanceCreateMap() (map[string]interface{}, error) {
 
 	if opts.AvailabilityZone != "" {
 		instance["availability_zone"] = opts.AvailabilityZone
+	}
+
+	if opts.Configuration != "" {
+		instance["configuration"] = opts.Configuration
 	}
 
 	if opts.Name != "" {

--- a/openstack/db/v1/instances/testing/fixtures_test.go
+++ b/openstack/db/v1/instances/testing/fixtures_test.go
@@ -105,6 +105,7 @@ var createReq = `
 {
 	"instance": {
 		"availability_zone": "us-east1",
+		"configuration": "4a78b397-c355-4127-be45-56230b2ab74e",
 		"databases": [
 			{
 				"character_set": "utf8",

--- a/openstack/db/v1/instances/testing/requests_test.go
+++ b/openstack/db/v1/instances/testing/requests_test.go
@@ -18,6 +18,7 @@ func TestCreate(t *testing.T) {
 
 	opts := instances.CreateOpts{
 		AvailabilityZone: "us-east1",
+		Configuration:    "4a78b397-c355-4127-be45-56230b2ab74e",
 		Name:             "json_rack_instance",
 		FlavorRef:        "1",
 		Databases: db.BatchCreateOpts{
@@ -50,6 +51,7 @@ func TestCreateWithFault(t *testing.T) {
 
 	opts := instances.CreateOpts{
 		AvailabilityZone: "us-east1",
+		Configuration:    "4a78b397-c355-4127-be45-56230b2ab74e",
 		Name:             "json_rack_instance",
 		FlavorRef:        "1",
 		Databases: db.BatchCreateOpts{


### PR DESCRIPTION
Add configuration group id to createOpts and update unit tests accordingly.

Docs: https://docs.openstack.org/api-ref/database/#create-database-instance