### PR TITLE
Context-aware methods to ProviderClient and ServiceClient

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -17,6 +17,11 @@ jobs:
         language: [ 'go' ]
 
     steps:
+    - name: Setup Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: "1.21"
+
     - name: Checkout repository
       uses: actions/checkout@v4
 

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         go-version:
-          - "1.20"
+          - "1.21"
           - "1"
 
     env:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gophercloud/gophercloud
 
-go 1.20
+go 1.21.6
 
 require (
 	golang.org/x/crypto v0.18.0

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,7 @@ golang.org/x/crypto v0.18.0/go.mod h1:R0j02AL6hcrfOiy9T4ZYp/rcWeMxM3L6QYxlOuEG1m
 golang.org/x/sys v0.16.0 h1:xWw16ngr6ZMtmxDyKyIgsE93KNKz5HKmMa3b8ALHidU=
 golang.org/x/sys v0.16.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.16.0 h1:m+B6fahuftsE9qjo0VWp2FW0mB3MTJvR0BaMQrq0pmE=
+golang.org/x/term v0.16.0/go.mod h1:yn7UURbUtPyrVJPGPq404EukNFxcm/foM+bV/bfcDsY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=

--- a/internal/ctxt/merge.go
+++ b/internal/ctxt/merge.go
@@ -1,0 +1,52 @@
+// package ctxt implements context merging.
+package ctxt
+
+import (
+	"context"
+	"time"
+)
+
+type mergeContext struct {
+	context.Context
+	ctx2 context.Context
+}
+
+// Merge returns a context that is cancelled when at least one of the parents
+// is cancelled. The returned context also returns the values of ctx1, or ctx2
+// if nil.
+func Merge(ctx1, ctx2 context.Context) (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithCancelCause(ctx1)
+	stop := context.AfterFunc(ctx2, func() {
+		cancel(context.Cause(ctx2))
+	})
+
+	return &mergeContext{
+			Context: ctx,
+			ctx2:    ctx2,
+		}, func() {
+			stop()
+			cancel(context.Canceled)
+		}
+}
+
+// Value returns ctx2's value if ctx's is nil.
+func (ctx *mergeContext) Value(key any) any {
+	if v := ctx.Context.Value(key); v != nil {
+		return v
+	}
+	return ctx.ctx2.Value(key)
+}
+
+// Deadline returns the earlier deadline of the two parents of ctx.
+func (ctx *mergeContext) Deadline() (time.Time, bool) {
+	if d1, ok := ctx.Context.Deadline(); ok {
+		if d2, ok := ctx.ctx2.Deadline(); ok {
+			if d1.Before(d2) {
+				return d1, true
+			}
+			return d2, true
+		}
+		return d1, ok
+	}
+	return ctx.ctx2.Deadline()
+}

--- a/internal/ctxt/merge_test.go
+++ b/internal/ctxt/merge_test.go
@@ -1,0 +1,133 @@
+package ctxt_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gophercloud/gophercloud/internal/ctxt"
+)
+
+func TestMerge(t *testing.T) {
+	t.Run("returns values from both parents", func(t *testing.T) {
+		ctx1 := context.WithValue(context.Background(),
+			"key1", "value1")
+
+		ctx2 := context.WithValue(context.WithValue(context.Background(),
+			"key1", "this value should be overridden"),
+			"key2", "value2")
+
+		ctx, cancel := ctxt.Merge(ctx1, ctx2)
+		defer cancel()
+
+		if v1 := ctx.Value("key1"); v1 != nil {
+			if s1, ok := v1.(string); ok {
+				if s1 != "value1" {
+					t.Errorf("found value for key1 %q, expected %q", s1, "value1")
+				}
+			} else {
+				t.Errorf("key1 is not the expected type string")
+			}
+		} else {
+			t.Errorf("key1 returned nil")
+		}
+
+		if v2 := ctx.Value("key2"); v2 != nil {
+			if s2, ok := v2.(string); ok {
+				if s2 != "value2" {
+					t.Errorf("found value for key2 %q, expected %q", s2, "value2")
+				}
+			} else {
+				t.Errorf("key2 is not the expected type string")
+			}
+		} else {
+			t.Errorf("key2 returned nil")
+		}
+	})
+
+	t.Run("first parent cancels", func(t *testing.T) {
+		ctx1, cancel1 := context.WithCancel(context.Background())
+		ctx2, cancel2 := context.WithCancel(context.Background())
+		defer cancel2()
+
+		ctx, cancel := ctxt.Merge(ctx1, ctx2)
+		defer cancel()
+
+		if err := ctx.Err(); err != nil {
+			t.Errorf("context unexpectedly done: %v", err)
+		}
+
+		cancel1()
+		time.Sleep(1 * time.Millisecond)
+		if err := ctx.Err(); err == nil {
+			t.Errorf("context not done despite parent1 cancelled")
+		}
+	})
+
+	t.Run("second parent cancels", func(t *testing.T) {
+		ctx1, cancel1 := context.WithCancel(context.Background())
+		ctx2, cancel2 := context.WithCancel(context.Background())
+		defer cancel1()
+
+		ctx, cancel := ctxt.Merge(ctx1, ctx2)
+		defer cancel()
+
+		if err := ctx.Err(); err != nil {
+			t.Errorf("context unexpectedly done: %v", err)
+		}
+
+		cancel2()
+		time.Sleep(1 * time.Millisecond)
+		if err := ctx.Err(); err == nil {
+			t.Errorf("context not done despite parent2 cancelled")
+		}
+	})
+
+	t.Run("inherits deadline from first parent", func(t *testing.T) {
+		now := time.Now()
+		t1 := now.Add(time.Hour)
+		t2 := t1.Add(time.Second)
+
+		ctx1, cancel1 := context.WithDeadline(context.Background(), t1)
+		ctx2, cancel2 := context.WithDeadline(context.Background(), t2)
+		defer cancel1()
+		defer cancel2()
+
+		ctx, cancel := ctxt.Merge(ctx1, ctx2)
+		defer cancel()
+
+		if err := ctx.Err(); err != nil {
+			t.Errorf("context unexpectedly done: %v", err)
+		}
+
+		if deadline, ok := ctx.Deadline(); ok {
+			if deadline != t1 {
+				t.Errorf("expected deadline to be %v, found %v", t1, deadline)
+			}
+		}
+	})
+
+	t.Run("inherits deadline from second parent", func(t *testing.T) {
+		now := time.Now()
+		t2 := now.Add(time.Hour)
+		t1 := t2.Add(time.Second)
+
+		ctx1, cancel1 := context.WithDeadline(context.Background(), t1)
+		ctx2, cancel2 := context.WithDeadline(context.Background(), t2)
+		defer cancel1()
+		defer cancel2()
+
+		ctx, cancel := ctxt.Merge(ctx1, ctx2)
+		defer cancel()
+
+		if err := ctx.Err(); err != nil {
+			t.Errorf("context unexpectedly done: %v", err)
+		}
+
+		if deadline, ok := ctx.Deadline(); ok {
+			if deadline != t2 {
+				t.Errorf("expected deadline to be %v, found %v", t2, deadline)
+			}
+		}
+	})
+}

--- a/provider_client.go
+++ b/provider_client.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+
+	"github.com/gophercloud/gophercloud/internal/ctxt"
 )
 
 // DefaultUserAgent is the default User-Agent string set in the request header.
@@ -87,7 +89,9 @@ type ProviderClient struct {
 	// with the token and reauth func zeroed. Such client can be used to perform reauthorization.
 	Throwaway bool
 
-	// Context is the context passed to the HTTP request.
+	// Context is the context passed to the HTTP request. Values set on the
+	// per-call context, when available, override values set on this
+	// context.
 	Context context.Context
 
 	// Retry backoff func is called when rate limited.
@@ -351,15 +355,20 @@ type requestState struct {
 
 var applicationJSON = "application/json"
 
-// Request performs an HTTP request using the ProviderClient's current HTTPClient. An authentication
-// header will automatically be provided.
-func (client *ProviderClient) Request(method, url string, options *RequestOpts) (*http.Response, error) {
-	return client.doRequest(method, url, options, &requestState{
+// RequestWithContext performs an HTTP request using the ProviderClient's
+// current HTTPClient. An authentication header will automatically be provided.
+func (client *ProviderClient) RequestWithContext(ctx context.Context, method, url string, options *RequestOpts) (*http.Response, error) {
+	return client.doRequest(ctx, method, url, options, &requestState{
 		hasReauthenticated: false,
 	})
 }
 
-func (client *ProviderClient) doRequest(method, url string, options *RequestOpts, state *requestState) (*http.Response, error) {
+// Request is a compatibility wrapper for Request.
+func (client *ProviderClient) Request(method, url string, options *RequestOpts) (*http.Response, error) {
+	return client.RequestWithContext(context.Background(), method, url, options)
+}
+
+func (client *ProviderClient) doRequest(ctx context.Context, method, url string, options *RequestOpts, state *requestState) (*http.Response, error) {
 	var body io.Reader
 	var contentType *string
 
@@ -388,13 +397,15 @@ func (client *ProviderClient) doRequest(method, url string, options *RequestOpts
 		body = options.RawBody
 	}
 
-	// Construct the http.Request.
-	req, err := http.NewRequest(method, url, body)
+	if client.Context != nil {
+		var cancel context.CancelFunc
+		ctx, cancel = ctxt.Merge(ctx, client.Context)
+		defer cancel()
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, url, body)
 	if err != nil {
 		return nil, err
-	}
-	if client.Context != nil {
-		req = req.WithContext(client.Context)
 	}
 
 	// Populate the request headers.
@@ -431,12 +442,12 @@ func (client *ProviderClient) doRequest(method, url string, options *RequestOpts
 		if client.RetryFunc != nil {
 			var e error
 			state.retries = state.retries + 1
-			e = client.RetryFunc(client.Context, method, url, options, err, state.retries)
+			e = client.RetryFunc(ctx, method, url, options, err, state.retries)
 			if e != nil {
 				return nil, e
 			}
 
-			return client.doRequest(method, url, options, state)
+			return client.doRequest(ctx, method, url, options, state)
 		}
 		return nil, err
 	}
@@ -490,7 +501,7 @@ func (client *ProviderClient) doRequest(method, url string, options *RequestOpts
 					}
 				}
 				state.hasReauthenticated = true
-				resp, err = client.doRequest(method, url, options, state)
+				resp, err = client.doRequest(ctx, method, url, options, state)
 				if err != nil {
 					switch err.(type) {
 					case *ErrUnexpectedResponseCode:
@@ -555,7 +566,7 @@ func (client *ProviderClient) doRequest(method, url string, options *RequestOpts
 					return resp, e
 				}
 
-				return client.doRequest(method, url, options, state)
+				return client.doRequest(ctx, method, url, options, state)
 			}
 		case http.StatusInternalServerError:
 			err = ErrDefault500{respErr}
@@ -591,7 +602,7 @@ func (client *ProviderClient) doRequest(method, url string, options *RequestOpts
 				return resp, e
 			}
 
-			return client.doRequest(method, url, options, state)
+			return client.doRequest(ctx, method, url, options, state)
 		}
 
 		return resp, err
@@ -615,7 +626,7 @@ func (client *ProviderClient) doRequest(method, url string, options *RequestOpts
 					return resp, e
 				}
 
-				return client.doRequest(method, url, options, state)
+				return client.doRequest(ctx, method, url, options, state)
 			}
 			return nil, err
 		}

--- a/service_client.go
+++ b/service_client.go
@@ -1,6 +1,7 @@
 package gophercloud
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"strings"
@@ -59,58 +60,88 @@ func (client *ServiceClient) initReqOpts(JSONBody interface{}, JSONResponse inte
 	}
 }
 
-// Get calls `Request` with the "GET" HTTP verb.
-func (client *ServiceClient) Get(url string, JSONResponse interface{}, opts *RequestOpts) (*http.Response, error) {
+// GetWithContext calls `Request` with the "GET" HTTP verb.
+func (client *ServiceClient) GetWithContext(ctx context.Context, url string, JSONResponse interface{}, opts *RequestOpts) (*http.Response, error) {
 	if opts == nil {
 		opts = new(RequestOpts)
 	}
 	client.initReqOpts(nil, JSONResponse, opts)
-	return client.Request("GET", url, opts)
+	return client.RequestWithContext(ctx, "GET", url, opts)
 }
 
-// Post calls `Request` with the "POST" HTTP verb.
+// Get is a compatibility wrapper for GetWithContext.
+func (client *ServiceClient) Get(url string, JSONResponse interface{}, opts *RequestOpts) (*http.Response, error) {
+	return client.GetWithContext(context.Background(), url, JSONResponse, opts)
+}
+
+// PostWithContext calls `Request` with the "POST" HTTP verb.
+func (client *ServiceClient) PostWithContext(ctx context.Context, url string, JSONBody interface{}, JSONResponse interface{}, opts *RequestOpts) (*http.Response, error) {
+	if opts == nil {
+		opts = new(RequestOpts)
+	}
+	client.initReqOpts(JSONBody, JSONResponse, opts)
+	return client.RequestWithContext(ctx, "POST", url, opts)
+}
+
+// Post is a compatibility wrapper for PostWithContext.
 func (client *ServiceClient) Post(url string, JSONBody interface{}, JSONResponse interface{}, opts *RequestOpts) (*http.Response, error) {
+	return client.PostWithContext(context.Background(), url, JSONBody, JSONResponse, opts)
+}
+
+// PutWithContext calls `Request` with the "PUT" HTTP verb.
+func (client *ServiceClient) PutWithContext(ctx context.Context, url string, JSONBody interface{}, JSONResponse interface{}, opts *RequestOpts) (*http.Response, error) {
 	if opts == nil {
 		opts = new(RequestOpts)
 	}
 	client.initReqOpts(JSONBody, JSONResponse, opts)
-	return client.Request("POST", url, opts)
+	return client.RequestWithContext(ctx, "PUT", url, opts)
 }
 
-// Put calls `Request` with the "PUT" HTTP verb.
+// Put is a compatibility wrapper for PurWithContext.
 func (client *ServiceClient) Put(url string, JSONBody interface{}, JSONResponse interface{}, opts *RequestOpts) (*http.Response, error) {
+	return client.PutWithContext(context.Background(), url, JSONBody, JSONResponse, opts)
+}
+
+// PatchWithContext calls `Request` with the "PATCH" HTTP verb.
+func (client *ServiceClient) PatchWithContext(ctx context.Context, url string, JSONBody interface{}, JSONResponse interface{}, opts *RequestOpts) (*http.Response, error) {
 	if opts == nil {
 		opts = new(RequestOpts)
 	}
 	client.initReqOpts(JSONBody, JSONResponse, opts)
-	return client.Request("PUT", url, opts)
+	return client.RequestWithContext(ctx, "PATCH", url, opts)
 }
 
-// Patch calls `Request` with the "PATCH" HTTP verb.
+// Patch is a compatibility wrapper for PatchWithContext.
 func (client *ServiceClient) Patch(url string, JSONBody interface{}, JSONResponse interface{}, opts *RequestOpts) (*http.Response, error) {
+	return client.PatchWithContext(context.Background(), url, JSONBody, JSONResponse, opts)
+}
+
+// DeleteWithContext calls `Request` with the "DELETE" HTTP verb.
+func (client *ServiceClient) DeleteWithContext(ctx context.Context, url string, opts *RequestOpts) (*http.Response, error) {
 	if opts == nil {
 		opts = new(RequestOpts)
 	}
-	client.initReqOpts(JSONBody, JSONResponse, opts)
-	return client.Request("PATCH", url, opts)
+	client.initReqOpts(nil, nil, opts)
+	return client.RequestWithContext(ctx, "DELETE", url, opts)
 }
 
-// Delete calls `Request` with the "DELETE" HTTP verb.
+// Delete is a compatibility wrapper for DeleteWithContext.
 func (client *ServiceClient) Delete(url string, opts *RequestOpts) (*http.Response, error) {
-	if opts == nil {
-		opts = new(RequestOpts)
-	}
-	client.initReqOpts(nil, nil, opts)
-	return client.Request("DELETE", url, opts)
+	return client.DeleteWithContext(context.Background(), url, opts)
 }
 
-// Head calls `Request` with the "HEAD" HTTP verb.
-func (client *ServiceClient) Head(url string, opts *RequestOpts) (*http.Response, error) {
+// HeadWithContext calls `Request` with the "HEAD" HTTP verb.
+func (client *ServiceClient) HeadWithContext(ctx context.Context, url string, opts *RequestOpts) (*http.Response, error) {
 	if opts == nil {
 		opts = new(RequestOpts)
 	}
 	client.initReqOpts(nil, nil, opts)
-	return client.Request("HEAD", url, opts)
+	return client.RequestWithContext(ctx, "HEAD", url, opts)
+}
+
+// Head is a compatibility wrapper for HeadWithContext.
+func (client *ServiceClient) Head(url string, opts *RequestOpts) (*http.Response, error) {
+	return client.HeadWithContext(context.Background(), url, opts)
 }
 
 func (client *ServiceClient) setMicroversionHeader(opts *RequestOpts) {
@@ -133,7 +164,7 @@ func (client *ServiceClient) setMicroversionHeader(opts *RequestOpts) {
 }
 
 // Request carries out the HTTP operation for the service client
-func (client *ServiceClient) Request(method, url string, options *RequestOpts) (*http.Response, error) {
+func (client *ServiceClient) RequestWithContext(ctx context.Context, method, url string, options *RequestOpts) (*http.Response, error) {
 	if options.MoreHeaders == nil {
 		options.MoreHeaders = make(map[string]string)
 	}
@@ -151,7 +182,12 @@ func (client *ServiceClient) Request(method, url string, options *RequestOpts) (
 			options.MoreHeaders[k] = v
 		}
 	}
-	return client.ProviderClient.Request(method, url, options)
+	return client.ProviderClient.RequestWithContext(ctx, method, url, options)
+}
+
+// Request is a compatibility wrapper for RequestWithContext.
+func (client *ServiceClient) Request(method, url string, options *RequestOpts) (*http.Response, error) {
+	return client.RequestWithContext(context.Background(), method, url, options)
 }
 
 // ParseResponse is a helper function to parse http.Response to constituents.


### PR DESCRIPTION
Provide new methods to leverage per-call `context.Context`.

In the http.Request resulting from using these new context-aware calls, the per-call context values take precendence over the ProviderClient's.

Cancellation obeys both the per-call context and the ProviderClient's.