### PR TITLE
Fix value_specs implementation

### DIFF
--- a/openstack/networking/v2/ports/results.go
+++ b/openstack/networking/v2/ports/results.go
@@ -114,9 +114,6 @@ type Port struct {
 	// PropagateUplinkStatus enables/disables propagate uplink status on the port.
 	PropagateUplinkStatus bool `json:"propagate_uplink_status"`
 
-	// Extra parameters to include in the request.
-	ValueSpecs map[string]string `json:"value_specs"`
-
 	// RevisionNumber optionally set via extensions/standard-attr-revisions
 	RevisionNumber int `json:"revision_number"`
 

--- a/openstack/networking/v2/ports/testing/fixtures.go
+++ b/openstack/networking/v2/ports/testing/fixtures.go
@@ -299,9 +299,7 @@ const CreateValueSpecRequest = `
             "mac_address": "fa:16:3e:c9:cb:f0"
           }
         ],
-        "value_specs": {
-            "key": "value"
-        }
+        "test": "value"
     }
 }
 `
@@ -332,9 +330,6 @@ const CreateValueSpecResponse = `
             "mac_address": "fa:16:3e:c9:cb:f0"
           }
         ],
-        "value_specs": {
-            "key": "value"
-        },
         "device_id": ""
     }
 }
@@ -544,9 +539,7 @@ const UpdatePropagateUplinkStatusResponse = `
 const UpdateValueSpecsRequest = `
 {
     "port": {
-        "value_specs": {
-            "key": "value"
-        }
+        "test": "update"
     }
 }
 `
@@ -577,9 +570,6 @@ const UpdateValueSpecsResponse = `
         "security_groups": [
             "f0ac4394-7e4a-4409-9701-ba8be283dbc3"
         ],
-        "value_specs": {
-            "key": "value"
-        },
         "device_id": ""
     }
 }


### PR DESCRIPTION
The current implementation does not do anything useful. The key-pairs must be extracted and added directly in the body instead of under "value_specs".

This commit fixes the implementation and also adds validation of the value_specs based on what is done in Heat. There are some banned keys that are not allowed in value_specs, and values are not allowed to overwrite existing fields either.

Fixes #2870