### PR TITLE
Authenticate with a clouds.yaml

### DIFF
--- a/openstack/config/clouds/clouds.go
+++ b/openstack/config/clouds/clouds.go
@@ -1,0 +1,271 @@
+// package clouds provides a parser for OpenStack credentials stored in a clouds.yaml file.
+//
+// Example use:
+//
+//	ctx := context.Background()
+//	ao, eo, tlsConfig, err := clouds.Parse()
+//	if err != nil {
+//		panic(err)
+//	}
+//
+//	providerClient, err := config.NewProviderClient(ctx, ao, config.WithTLSConfig(tlsConfig))
+//	if err != nil {
+//		panic(err)
+//	}
+//
+//	networkClient, err := openstack.NewNetworkV2(providerClient, eo)
+//	if err != nil {
+//		panic(err)
+//	}
+package clouds
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path"
+	"reflect"
+
+	"github.com/gophercloud/gophercloud"
+	"gopkg.in/yaml.v2"
+)
+
+// Parse fetches a clouds.yaml file from disk and returns the parsed
+// credentials.
+//
+// By default this function mimics the behaviour of python-openstackclient, which is:
+//
+//   - if the environment variable `OS_CLIENT_CONFIG_FILE` is set and points to a
+//     clouds.yaml, use that location as the only search location for `clouds.yaml` and `secure.yaml`;
+//   - otherwise, the search locations for `clouds.yaml` and `secure.yaml` are:
+//     1. the current working directory (on Linux: `./`)
+//     2. the directory `openstack` under the standatd user config location for
+//     the operating system (on Linux: `${XDG_CONFIG_HOME:-$HOME/.config}/openstack/`)
+//     3. on Linux, `/etc/openstack/`
+//
+// Once `clouds.yaml` is found in a search location, the same location is used to search for `secure.yaml`.
+//
+// Like in python-openstackclient, relative paths in the `clouds.yaml` section
+// `cacert` are interpreted as relative the the current directory, and not to
+// the `clouds.yaml` location.
+//
+// Search locations, as well as individual `clouds.yaml` properties, can be
+// overwritten with functional options.
+func Parse(opts ...func(*cloudOpts)) (gophercloud.AuthOptions, gophercloud.EndpointOpts, *tls.Config, error) {
+	options := cloudOpts{
+		cloudName:    os.Getenv("OS_CLOUD"),
+		region:       os.Getenv("OS_REGION_NAME"),
+		endpointType: os.Getenv("OS_INTERFACE"),
+		locations: func() []string {
+			if path := os.Getenv("OS_CLIENT_CONFIG_FILE"); path != "" {
+				return []string{path}
+			}
+			return nil
+		}(),
+	}
+
+	for _, apply := range opts {
+		apply(&options)
+	}
+
+	if options.cloudName == "" {
+		return gophercloud.AuthOptions{}, gophercloud.EndpointOpts{}, nil, fmt.Errorf("the empty string \"\" is not a valid cloud name")
+	}
+
+	// Set the defaults and open the files for reading. This code only runs
+	// if no override has been set, because it is fallible.
+	if options.cloudsyamlReader == nil {
+		if len(options.locations) < 1 {
+			cwd, err := os.Getwd()
+			if err != nil {
+				return gophercloud.AuthOptions{}, gophercloud.EndpointOpts{}, nil, fmt.Errorf("failed to get the current working directory: %w", err)
+			}
+			userConfig, err := os.UserConfigDir()
+			if err != nil {
+				return gophercloud.AuthOptions{}, gophercloud.EndpointOpts{}, nil, fmt.Errorf("failed to get the user config directory: %w", err)
+			}
+			options.locations = []string{path.Join(cwd, "clouds.yaml"), path.Join(userConfig, "openstack", "clouds.yaml"), path.Join("/etc", "openstack")}
+		}
+
+		for _, cloudsPath := range options.locations {
+			var errNotFound *os.PathError
+			f, err := os.Open(cloudsPath)
+			if err != nil && !errors.As(err, &errNotFound) {
+				return gophercloud.AuthOptions{}, gophercloud.EndpointOpts{}, nil, fmt.Errorf("failed to open %q: %w", cloudsPath, err)
+			}
+			if err == nil {
+				defer f.Close()
+				options.cloudsyamlReader = f
+
+				if options.secureyamlReader == nil {
+					securePath := path.Join(path.Base(cloudsPath), "secure.yaml")
+					secureF, err := os.Open(securePath)
+					if err != nil && !errors.As(err, &errNotFound) {
+						return gophercloud.AuthOptions{}, gophercloud.EndpointOpts{}, nil, fmt.Errorf("failed to open %q: %w", securePath, err)
+					}
+					if err == nil {
+						defer secureF.Close()
+						options.secureyamlReader = secureF
+					}
+				}
+			}
+		}
+		if options.cloudsyamlReader == nil {
+			return gophercloud.AuthOptions{}, gophercloud.EndpointOpts{}, nil, fmt.Errorf("clouds file not found. Search locations were: %v", options.locations)
+		}
+	}
+
+	// Parse the YAML payloads.
+	var clouds Clouds
+	if err := yaml.NewDecoder(options.cloudsyamlReader).Decode(&clouds); err != nil {
+		return gophercloud.AuthOptions{}, gophercloud.EndpointOpts{}, nil, err
+	}
+
+	cloud, ok := clouds.Clouds[options.cloudName]
+	if !ok {
+		return gophercloud.AuthOptions{}, gophercloud.EndpointOpts{}, nil, fmt.Errorf("cloud %q not found in clouds.yaml", options.cloudName)
+	}
+
+	if options.secureyamlReader != nil {
+		var secureClouds Clouds
+		if err := yaml.NewDecoder(options.secureyamlReader).Decode(&secureClouds); err != nil {
+			return gophercloud.AuthOptions{}, gophercloud.EndpointOpts{}, nil, fmt.Errorf("failed to parse secure.yaml: %w", err)
+		}
+
+		if secureCloud, ok := secureClouds.Clouds[options.cloudName]; ok {
+			// If secureCloud has content and it differs from the cloud entry,
+			// merge the two together.
+			if !reflect.DeepEqual((gophercloud.AuthOptions{}), secureClouds) && !reflect.DeepEqual(clouds, secureClouds) {
+				var err error
+				cloud, err = mergeClouds(secureCloud, cloud)
+				if err != nil {
+					return gophercloud.AuthOptions{}, gophercloud.EndpointOpts{}, nil, fmt.Errorf("unable to merge information from clouds.yaml and secure.yaml")
+				}
+			}
+		}
+	}
+
+	tlsConfig, err := computeTLSConfig(cloud, options)
+	if err != nil {
+		return gophercloud.AuthOptions{}, gophercloud.EndpointOpts{}, nil, fmt.Errorf("unable to compute TLS configuration: %w", err)
+	}
+
+	endpointType := coalesce(options.endpointType, cloud.EndpointType, cloud.Interface)
+
+	return gophercloud.AuthOptions{
+			IdentityEndpoint:            coalesce(options.authURL, cloud.AuthInfo.AuthURL),
+			Username:                    coalesce(options.username, cloud.AuthInfo.Username),
+			UserID:                      coalesce(options.userID, cloud.AuthInfo.UserID),
+			Password:                    coalesce(options.password, cloud.AuthInfo.Password),
+			DomainID:                    coalesce(options.domainID, cloud.AuthInfo.UserDomainID, cloud.AuthInfo.ProjectDomainID, cloud.AuthInfo.DomainID),
+			DomainName:                  coalesce(options.domainName, cloud.AuthInfo.UserDomainName, cloud.AuthInfo.ProjectDomainName, cloud.AuthInfo.DomainName),
+			TenantID:                    coalesce(options.projectID, cloud.AuthInfo.ProjectID),
+			TenantName:                  coalesce(options.projectName, cloud.AuthInfo.ProjectName),
+			TokenID:                     coalesce(options.token, cloud.AuthInfo.Token),
+			Scope:                       options.scope,
+			ApplicationCredentialID:     coalesce(options.applicationCredentialID, cloud.AuthInfo.ApplicationCredentialID),
+			ApplicationCredentialName:   coalesce(options.applicationCredentialName, cloud.AuthInfo.ApplicationCredentialName),
+			ApplicationCredentialSecret: coalesce(options.applicationCredentialSecret, cloud.AuthInfo.ApplicationCredentialSecret),
+		}, gophercloud.EndpointOpts{
+			Region:       coalesce(options.region, cloud.RegionName),
+			Availability: computeAvailability(endpointType),
+		},
+		tlsConfig,
+		nil
+}
+
+// computeAvailability is a helper method to determine the endpoint type
+// requested by the user.
+func computeAvailability(endpointType string) gophercloud.Availability {
+	if endpointType == "internal" || endpointType == "internalURL" {
+		return gophercloud.AvailabilityInternal
+	}
+	if endpointType == "admin" || endpointType == "adminURL" {
+		return gophercloud.AvailabilityAdmin
+	}
+	return gophercloud.AvailabilityPublic
+}
+
+// coalesce returns the first argument that is not the empty string, or the
+// empty string.
+func coalesce(items ...string) string {
+	for _, item := range items {
+		if item != "" {
+			return item
+		}
+	}
+	return ""
+}
+
+// mergeClouds merges two Clouds recursively (the AuthInfo also gets merged).
+// In case both Clouds define a value, the value in the 'override' cloud takes precedence
+func mergeClouds(override, cloud Cloud) (Cloud, error) {
+	overrideJson, err := json.Marshal(override)
+	if err != nil {
+		return Cloud{}, err
+	}
+	cloudJson, err := json.Marshal(cloud)
+	if err != nil {
+		return Cloud{}, err
+	}
+	var overrideInterface interface{}
+	err = json.Unmarshal(overrideJson, &overrideInterface)
+	if err != nil {
+		return Cloud{}, err
+	}
+	var cloudInterface interface{}
+	err = json.Unmarshal(cloudJson, &cloudInterface)
+	if err != nil {
+		return Cloud{}, err
+	}
+	var mergedCloud Cloud
+	mergedInterface := mergeInterfaces(overrideInterface, cloudInterface)
+	mergedJson, err := json.Marshal(mergedInterface)
+	err = json.Unmarshal(mergedJson, &mergedCloud)
+	if err != nil {
+		return Cloud{}, err
+	}
+	return mergedCloud, nil
+}
+
+// merges two interfaces. In cases where a value is defined for both 'overridingInterface' and
+// 'inferiorInterface' the value in 'overridingInterface' will take precedence.
+func mergeInterfaces(overridingInterface, inferiorInterface interface{}) interface{} {
+	switch overriding := overridingInterface.(type) {
+	case map[string]interface{}:
+		interfaceMap, ok := inferiorInterface.(map[string]interface{})
+		if !ok {
+			return overriding
+		}
+		for k, v := range interfaceMap {
+			if overridingValue, ok := overriding[k]; ok {
+				overriding[k] = mergeInterfaces(overridingValue, v)
+			} else {
+				overriding[k] = v
+			}
+		}
+	case []interface{}:
+		list, ok := inferiorInterface.([]interface{})
+		if !ok {
+			return overriding
+		}
+		for i := range list {
+			overriding = append(overriding, list[i])
+		}
+		return overriding
+	case nil:
+		// mergeClouds(nil, map[string]interface{...}) -> map[string]interface{...}
+		v, ok := inferiorInterface.(map[string]interface{})
+		if ok {
+			return v
+		}
+	}
+	// We don't want to override with empty values
+	if reflect.DeepEqual(overridingInterface, nil) || reflect.DeepEqual(reflect.Zero(reflect.TypeOf(overridingInterface)).Interface(), overridingInterface) {
+		return inferiorInterface
+	} else {
+		return overridingInterface
+	}
+}

--- a/openstack/config/clouds/clouds_test.go
+++ b/openstack/config/clouds/clouds_test.go
@@ -1,0 +1,64 @@
+package clouds_test
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/gophercloud/gophercloud/openstack/config/clouds"
+)
+
+func ExampleWithCloudName() {
+	const exampleClouds = `clouds:
+  openstack:
+    auth:
+      auth_url: https://example.com:13000`
+
+	ao, _, _, err := clouds.Parse(
+		clouds.WithCloudsYAML(strings.NewReader(exampleClouds)),
+		clouds.WithCloudName("openstack"),
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(ao.IdentityEndpoint)
+	// Output: https://example.com:13000
+}
+
+func ExampleWithUserID() {
+	const exampleClouds = `clouds:
+  openstack:
+    auth:
+      auth_url: https://example.com:13000`
+
+	ao, _, _, err := clouds.Parse(
+		clouds.WithCloudsYAML(strings.NewReader(exampleClouds)),
+		clouds.WithCloudName("openstack"),
+		clouds.WithUsername("Kris"),
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(ao.Username)
+	// Output: Kris
+}
+
+func ExampleWithRegion() {
+	const exampleClouds = `clouds:
+  openstack:
+    auth:
+      auth_url: https://example.com:13000`
+
+	_, eo, _, err := clouds.Parse(
+		clouds.WithCloudsYAML(strings.NewReader(exampleClouds)),
+		clouds.WithCloudName("openstack"),
+		clouds.WithRegion("mars"),
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(eo.Region)
+	// Output: mars
+}

--- a/openstack/config/clouds/options.go
+++ b/openstack/config/clouds/options.go
@@ -1,0 +1,188 @@
+package clouds
+
+import (
+	"io"
+
+	"github.com/gophercloud/gophercloud"
+)
+
+type cloudOpts struct {
+	cloudName        string
+	locations        []string
+	cloudsyamlReader io.Reader
+	secureyamlReader io.Reader
+
+	applicationCredentialID     string
+	applicationCredentialName   string
+	applicationCredentialSecret string
+	authURL                     string
+	domainID                    string
+	domainName                  string
+	endpointType                string
+	password                    string
+	projectID                   string
+	projectName                 string
+	region                      string
+	scope                       *gophercloud.AuthScope
+	token                       string
+	userID                      string
+	username                    string
+
+	caCertPath     string
+	clientCertPath string
+	clientKeyPath  string
+	insecure       *bool
+}
+
+// WithCloudName allows to override the environment variable `OS_CLOUD`.
+func WithCloudName(osCloud string) func(*cloudOpts) {
+	return func(co *cloudOpts) {
+		co.cloudName = osCloud
+	}
+}
+
+// WithLocations is a functional option that sets the search locations for the
+// clouds.yaml file (and its optional companion secure.yaml). Each location is
+// a file path pointing to a possible `clouds.yaml`.
+func WithLocations(locations ...string) func(*cloudOpts) {
+	return func(co *cloudOpts) {
+		co.locations = locations
+	}
+}
+
+// WithCloudsYAML is a functional option that lets you pass a clouds.yaml file
+// as an io.Reader interface. When this option is passed, FromCloudsYaml will
+// not attempt to fetch any file from the file system. To add a secure.yaml,
+// use in conjunction with WithSecureYAML.
+func WithCloudsYAML(clouds io.Reader) func(*cloudOpts) {
+	return func(co *cloudOpts) {
+		co.cloudsyamlReader = clouds
+	}
+}
+
+// WithSecureYAML is a functional option that lets you pass a secure.yaml file
+// as an io.Reader interface, to complement the clouds.yaml that is either
+// fetched from the filesystem, or passed with WithCloudsYAML.
+func WithSecureYAML(secure io.Reader) func(*cloudOpts) {
+	return func(co *cloudOpts) {
+		co.secureyamlReader = secure
+	}
+}
+
+func WithApplicationCredentialID(applicationCredentialID string) func(*cloudOpts) {
+	return func(co *cloudOpts) {
+		co.applicationCredentialID = applicationCredentialID
+	}
+}
+
+func WithApplicationCredentialName(applicationCredentialName string) func(*cloudOpts) {
+	return func(co *cloudOpts) {
+		co.applicationCredentialName = applicationCredentialName
+	}
+}
+
+func WithApplicationCredentialSecret(applicationCredentialSecret string) func(*cloudOpts) {
+	return func(co *cloudOpts) {
+		co.applicationCredentialSecret = applicationCredentialSecret
+	}
+}
+
+func WithIdentityEndpoint(authURL string) func(*cloudOpts) {
+	return func(co *cloudOpts) {
+		co.authURL = authURL
+	}
+}
+
+func WithDomainID(domainID string) func(*cloudOpts) {
+	return func(co *cloudOpts) {
+		co.domainID = domainID
+	}
+}
+
+func WithDomainName(domainName string) func(*cloudOpts) {
+	return func(co *cloudOpts) {
+		co.domainName = domainName
+	}
+}
+
+// WithRegion allows to override the endpoint type set in clouds.yaml or in the
+// environment variable `OS_INTERFACE`.
+func WithEndpointType(endpointType string) func(*cloudOpts) {
+	return func(co *cloudOpts) {
+		co.endpointType = endpointType
+	}
+}
+
+func WithPassword(password string) func(*cloudOpts) {
+	return func(co *cloudOpts) {
+		co.password = password
+	}
+}
+
+func WithProjectID(projectID string) func(*cloudOpts) {
+	return func(co *cloudOpts) {
+		co.projectID = projectID
+	}
+}
+
+func WithProjectName(projectName string) func(*cloudOpts) {
+	return func(co *cloudOpts) {
+		co.projectName = projectName
+	}
+}
+
+// WithRegion allows to override the region set in clouds.yaml or in the
+// environment variable `OS_REGION_NAME`
+func WithRegion(region string) func(*cloudOpts) {
+	return func(co *cloudOpts) {
+		co.region = region
+	}
+}
+
+func WithScope(scope *gophercloud.AuthScope) func(*cloudOpts) {
+	return func(co *cloudOpts) {
+		co.scope = scope
+	}
+}
+
+func WithToken(token string) func(*cloudOpts) {
+	return func(co *cloudOpts) {
+		co.token = token
+	}
+}
+
+func WithUserID(userID string) func(*cloudOpts) {
+	return func(co *cloudOpts) {
+		co.userID = userID
+	}
+}
+
+func WithUsername(username string) func(*cloudOpts) {
+	return func(co *cloudOpts) {
+		co.username = username
+	}
+}
+
+func WithCACertPath(caCertPath string) func(*cloudOpts) {
+	return func(co *cloudOpts) {
+		co.caCertPath = caCertPath
+	}
+}
+
+func WithClientCertPath(clientCertPath string) func(*cloudOpts) {
+	return func(co *cloudOpts) {
+		co.clientCertPath = clientCertPath
+	}
+}
+
+func WithClientKeyPath(clientKeyPath string) func(*cloudOpts) {
+	return func(co *cloudOpts) {
+		co.clientKeyPath = clientKeyPath
+	}
+}
+
+func WithInsecure(insecure bool) func(*cloudOpts) {
+	return func(co *cloudOpts) {
+		co.insecure = &insecure
+	}
+}

--- a/openstack/config/clouds/tls.go
+++ b/openstack/config/clouds/tls.go
@@ -1,0 +1,87 @@
+package clouds
+
+import (
+	"bytes"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"os"
+	"path"
+	"strings"
+)
+
+func computeTLSConfig(cloud Cloud, options cloudOpts) (*tls.Config, error) {
+	tlsConfig := new(tls.Config)
+	if caCertPath := coalesce(options.caCertPath, os.Getenv("OS_CACERT"), cloud.CACertFile); caCertPath != "" {
+		caCertPath, err := resolveTilde(caCertPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve user home directory: %w", err)
+		}
+
+		caCert, err := os.ReadFile(caCertPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to open the CA cert file: %w", err)
+		}
+
+		caCertPool := x509.NewCertPool()
+		if ok := caCertPool.AppendCertsFromPEM(bytes.TrimSpace(caCert)); !ok {
+			return nil, fmt.Errorf("failed to parse the CA Cert from %q", caCertPath)
+		}
+		tlsConfig.RootCAs = caCertPool
+	}
+
+	tlsConfig.InsecureSkipVerify = func() bool {
+		if options.insecure != nil {
+			return *options.insecure
+		}
+		if cloud.Verify != nil {
+			return !*cloud.Verify
+		}
+		return false
+	}()
+
+	if clientCertPath, clientKeyPath := coalesce(options.clientCertPath, os.Getenv("OS_CERT"), cloud.ClientCertFile), coalesce(options.clientKeyPath, os.Getenv("OS_KEY"), cloud.ClientKeyFile); clientCertPath != "" && clientKeyPath != "" {
+		clientCertPath, err := resolveTilde(clientCertPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve user home directory in client cert path: %w", err)
+		}
+		clientKeyPath, err := resolveTilde(clientKeyPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve user home directory in client cert key path: %w", err)
+		}
+
+		clientCert, err := os.ReadFile(clientCertPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read the client cert file: %w", err)
+		}
+
+		clientKey, err := os.ReadFile(clientKeyPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read the client cert key file: %w", err)
+		}
+
+		cert, err := tls.X509KeyPair(clientCert, clientKey)
+		if err != nil {
+			return nil, err
+		}
+
+		tlsConfig.Certificates = []tls.Certificate{cert}
+	} else if clientCertPath != "" && clientKeyPath == "" {
+		return nil, fmt.Errorf("client cert is set, but client cert key is missing")
+	} else if clientCertPath == "" && clientKeyPath != "" {
+		return nil, fmt.Errorf("client cert key is set, but client cert is missing")
+	}
+
+	return tlsConfig, nil
+}
+
+func resolveTilde(p string) (string, error) {
+	if after := strings.TrimPrefix(p, "~/"); after != p {
+		h, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("failed to resolve user home directory: %w", err)
+		}
+		return path.Join(h, after), nil
+	}
+	return p, nil
+}

--- a/openstack/config/clouds/types.go
+++ b/openstack/config/clouds/types.go
@@ -1,0 +1,203 @@
+package clouds
+
+import "encoding/json"
+
+// Clouds represents a collection of Cloud entries in a clouds.yaml file.
+// The format of clouds.yaml is documented at
+// https://docs.openstack.org/os-client-config/latest/user/configuration.html.
+type Clouds struct {
+	Clouds map[string]Cloud `yaml:"clouds" json:"clouds"`
+}
+
+// Cloud represents an entry in a clouds.yaml/public-clouds.yaml/secure.yaml file.
+type Cloud struct {
+	Cloud      string    `yaml:"cloud,omitempty" json:"cloud,omitempty"`
+	Profile    string    `yaml:"profile,omitempty" json:"profile,omitempty"`
+	AuthInfo   *AuthInfo `yaml:"auth,omitempty" json:"auth,omitempty"`
+	AuthType   AuthType  `yaml:"auth_type,omitempty" json:"auth_type,omitempty"`
+	RegionName string    `yaml:"region_name,omitempty" json:"region_name,omitempty"`
+	Regions    []Region  `yaml:"regions,omitempty" json:"regions,omitempty"`
+
+	// EndpointType and Interface both specify whether to use the public, internal,
+	// or admin interface of a service. They should be considered synonymous, but
+	// EndpointType will take precedence when both are specified.
+	EndpointType string `yaml:"endpoint_type,omitempty" json:"endpoint_type,omitempty"`
+	Interface    string `yaml:"interface,omitempty" json:"interface,omitempty"`
+
+	// API Version overrides.
+	IdentityAPIVersion string `yaml:"identity_api_version,omitempty" json:"identity_api_version,omitempty"`
+	VolumeAPIVersion   string `yaml:"volume_api_version,omitempty" json:"volume_api_version,omitempty"`
+
+	// Verify whether or not SSL API requests should be verified.
+	Verify *bool `yaml:"verify,omitempty" json:"verify,omitempty"`
+
+	// CACertFile a path to a CA Cert bundle that can be used as part of
+	// verifying SSL API requests.
+	CACertFile string `yaml:"cacert,omitempty" json:"cacert,omitempty"`
+
+	// ClientCertFile a path to a client certificate to use as part of the SSL
+	// transaction.
+	ClientCertFile string `yaml:"cert,omitempty" json:"cert,omitempty"`
+
+	// ClientKeyFile a path to a client key to use as part of the SSL
+	// transaction.
+	ClientKeyFile string `yaml:"key,omitempty" json:"key,omitempty"`
+}
+
+// AuthInfo represents the auth section of a cloud entry or
+// auth options entered explicitly in ClientOpts.
+type AuthInfo struct {
+	// AuthURL is the keystone/identity endpoint URL.
+	AuthURL string `yaml:"auth_url,omitempty" json:"auth_url,omitempty"`
+
+	// Token is a pre-generated authentication token.
+	Token string `yaml:"token,omitempty" json:"token,omitempty"`
+
+	// Username is the username of the user.
+	Username string `yaml:"username,omitempty" json:"username,omitempty"`
+
+	// UserID is the unique ID of a user.
+	UserID string `yaml:"user_id,omitempty" json:"user_id,omitempty"`
+
+	// Password is the password of the user.
+	Password string `yaml:"password,omitempty" json:"password,omitempty"`
+
+	// Application Credential ID to login with.
+	ApplicationCredentialID string `yaml:"application_credential_id,omitempty" json:"application_credential_id,omitempty"`
+
+	// Application Credential name to login with.
+	ApplicationCredentialName string `yaml:"application_credential_name,omitempty" json:"application_credential_name,omitempty"`
+
+	// Application Credential secret to login with.
+	ApplicationCredentialSecret string `yaml:"application_credential_secret,omitempty" json:"application_credential_secret,omitempty"`
+
+	// SystemScope is a system information to scope to.
+	SystemScope string `yaml:"system_scope,omitempty" json:"system_scope,omitempty"`
+
+	// ProjectName is the common/human-readable name of a project.
+	// Users can be scoped to a project.
+	// ProjectName on its own is not enough to ensure a unique scope. It must
+	// also be combined with either a ProjectDomainName or ProjectDomainID.
+	// ProjectName cannot be combined with ProjectID in a scope.
+	ProjectName string `yaml:"project_name,omitempty" json:"project_name,omitempty"`
+
+	// ProjectID is the unique ID of a project.
+	// It can be used to scope a user to a specific project.
+	ProjectID string `yaml:"project_id,omitempty" json:"project_id,omitempty"`
+
+	// UserDomainName is the name of the domain where a user resides.
+	// It is used to identify the source domain of a user.
+	UserDomainName string `yaml:"user_domain_name,omitempty" json:"user_domain_name,omitempty"`
+
+	// UserDomainID is the unique ID of the domain where a user resides.
+	// It is used to identify the source domain of a user.
+	UserDomainID string `yaml:"user_domain_id,omitempty" json:"user_domain_id,omitempty"`
+
+	// ProjectDomainName is the name of the domain where a project resides.
+	// It is used to identify the source domain of a project.
+	// ProjectDomainName can be used in addition to a ProjectName when scoping
+	// a user to a specific project.
+	ProjectDomainName string `yaml:"project_domain_name,omitempty" json:"project_domain_name,omitempty"`
+
+	// ProjectDomainID is the name of the domain where a project resides.
+	// It is used to identify the source domain of a project.
+	// ProjectDomainID can be used in addition to a ProjectName when scoping
+	// a user to a specific project.
+	ProjectDomainID string `yaml:"project_domain_id,omitempty" json:"project_domain_id,omitempty"`
+
+	// DomainName is the name of a domain which can be used to identify the
+	// source domain of either a user or a project.
+	// If UserDomainName and ProjectDomainName are not specified, then DomainName
+	// is used as a default choice.
+	// It can also be used be used to specify a domain-only scope.
+	DomainName string `yaml:"domain_name,omitempty" json:"domain_name,omitempty"`
+
+	// DomainID is the unique ID of a domain which can be used to identify the
+	// source domain of eitehr a user or a project.
+	// If UserDomainID and ProjectDomainID are not specified, then DomainID is
+	// used as a default choice.
+	// It can also be used be used to specify a domain-only scope.
+	DomainID string `yaml:"domain_id,omitempty" json:"domain_id,omitempty"`
+
+	// DefaultDomain is the domain ID to fall back on if no other domain has
+	// been specified and a domain is required for scope.
+	DefaultDomain string `yaml:"default_domain,omitempty" json:"default_domain,omitempty"`
+
+	// AllowReauth should be set to true if you grant permission for Gophercloud to
+	// cache your credentials in memory, and to allow Gophercloud to attempt to
+	// re-authenticate automatically if/when your token expires.  If you set it to
+	// false, it will not cache these settings, but re-authentication will not be
+	// possible.  This setting defaults to false.
+	AllowReauth bool `yaml:"allow_reauth,omitempty" json:"allow_reauth,omitempty"`
+}
+
+// Region represents a region included as part of cloud in clouds.yaml
+// According to Python-based openstacksdk, this can be either a struct (as defined)
+// or a plain string. Custom unmarshallers handle both cases.
+type Region struct {
+	Name   string `yaml:"name,omitempty" json:"name,omitempty"`
+	Values Cloud  `yaml:"values,omitempty" json:"values,omitempty"`
+}
+
+// UnmarshalJSON handles either a plain string acting as the Name property or
+// a struct, mimicking the Python-based openstacksdk.
+func (r *Region) UnmarshalJSON(data []byte) error {
+	var name string
+	if err := json.Unmarshal(data, &name); err == nil {
+		r.Name = name
+		return nil
+	}
+
+	type region Region
+	var tmp region
+	if err := json.Unmarshal(data, &tmp); err != nil {
+		return err
+	}
+	r.Name = tmp.Name
+	r.Values = tmp.Values
+
+	return nil
+}
+
+// UnmarshalYAML handles either a plain string acting as the Name property or
+// a struct, mimicking the Python-based openstacksdk.
+func (r *Region) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var name string
+	if err := unmarshal(&name); err == nil {
+		r.Name = name
+		return nil
+	}
+
+	type region Region
+	var tmp region
+	if err := unmarshal(&tmp); err != nil {
+		return err
+	}
+	r.Name = tmp.Name
+	r.Values = tmp.Values
+
+	return nil
+}
+
+// AuthType respresents a valid method of authentication.
+type AuthType string
+
+const (
+	// AuthPassword defines an unknown version of the password
+	AuthPassword AuthType = "password"
+	// AuthToken defined an unknown version of the token
+	AuthToken AuthType = "token"
+
+	// AuthV2Password defines version 2 of the password
+	AuthV2Password AuthType = "v2password"
+	// AuthV2Token defines version 2 of the token
+	AuthV2Token AuthType = "v2token"
+
+	// AuthV3Password defines version 3 of the password
+	AuthV3Password AuthType = "v3password"
+	// AuthV3Token defines version 3 of the token
+	AuthV3Token AuthType = "v3token"
+
+	// AuthV3ApplicationCredential defines version 3 of the application credential
+	AuthV3ApplicationCredential AuthType = "v3applicationcredential"
+)

--- a/openstack/config/provider_client.go
+++ b/openstack/config/provider_client.go
@@ -1,0 +1,70 @@
+package config
+
+import (
+	"context"
+	"crypto/tls"
+	"net/http"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack"
+)
+
+type options struct {
+	httpClient http.Client
+	tlsConfig  *tls.Config
+}
+
+// WithHTTPClient enables passing a custom http.Client to be used in the
+// ProviderClient for authentication and for any further call, for example when
+// using a ServiceClient derived from this ProviderClient.
+func WithHTTPClient(httpClient http.Client) func(*options) {
+	return func(o *options) {
+		o.httpClient = httpClient
+	}
+}
+
+// WithTLSConfig replaces the Transport of the default HTTP client (or of the
+// HTTP client passed with WithHTTPClient) with a RoundTripper containing the
+// given TLS config.
+func WithTLSConfig(tlsConfig *tls.Config) func(*options) {
+	return func(o *options) {
+		o.tlsConfig = tlsConfig
+	}
+}
+
+// NewProviderClient logs in to an OpenStack cloud found at the identity
+// endpoint specified by the options, acquires a token, and returns a Provider
+// Client instance that's ready to operate.
+//
+// If the full path to a versioned identity endpoint was specified  (example:
+// http://example.com:5000/v3), that path will be used as the endpoint to
+// query.
+//
+// If a versionless endpoint was specified (example: http://example.com:5000/),
+// the endpoint will be queried to determine which versions of the identity
+// service are available, then chooses the most recent or most supported
+// version.
+func NewProviderClient(ctx context.Context, authOptions gophercloud.AuthOptions, opts ...func(*options)) (*gophercloud.ProviderClient, error) {
+	var options options
+	for _, apply := range opts {
+		apply(&options)
+	}
+
+	client, err := openstack.NewClient(authOptions.IdentityEndpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	if options.tlsConfig != nil {
+		transport := http.DefaultTransport.(*http.Transport).Clone()
+		transport.TLSClientConfig = options.tlsConfig
+		options.httpClient.Transport = transport
+	}
+	client.HTTPClient = options.httpClient
+
+	err = openstack.AuthenticateWithContext(ctx, client, authOptions)
+	if err != nil {
+		return nil, err
+	}
+	return client, nil
+}


### PR DESCRIPTION
This commit imports the clouds.yaml parsing code from the utils module, and exposes it in a way that fits the natural Gophercloud authentication flow.

Unlike the code from utils, this new `clouds.Parse` function keeps the separation between the ProviderClient (holding the cloud coordinates and a Keystone token) and the ServiceClient (holding specific endpoint configuration).

By default, `clouds.Parse` fetches its configuration from the environment, just like the openstack client would do.

Example use:

```Go
func main() {
	ctx := context.Background()
	ao, eo, tlsConfig, err := clouds.Parse()
	if err != nil {
		panic(err)
	}

	providerClient, err := config.NewProviderClient(ctx, ao, config.WithTLSConfig(tlsConfig))
	if err != nil {
		panic(err)
	}

	networkClient, err := openstack.NewNetworkV2(providerClient, eo)
	if err != nil {
		panic(err)
	}
}
```

The `clouds.Parse` function accepts several functional options that can modify its behaviour. For example, to use a `clouds.yaml` that exists in a non-standard path:

```Go
ao, eo, tlsConfig, err := clouds.Parse(clouds.WithLocations("/my/path/clouds2.yaml"))
```

It is also possible to pass a reader directly. Note that any number of options can be passed, with each of them taking precedence of the previous if there is conflict.

```Go
const exampleClouds = `clouds:
  openstack:
    auth:
      auth_url: https://example.com:13000`

ao, eo, tlsConfig, err := clouds.Parse(
	clouds.WithCloudsYAML(strings.NewReader(exampleClouds)),
	clouds.WithIdentityEndpoint("https://example.com:13001"),
	clouds.WithCloudName("osp1"),
	clouds.WithUsername("alice"),
)

```