### PR TITLE
Add AvailabilityFromEndpointType

### DIFF
--- a/endpoint_search.go
+++ b/endpoint_search.go
@@ -22,6 +22,16 @@ const (
 	AvailabilityInternal Availability = "internal"
 )
 
+func AvailabilityFromEndpointType(endpointType string) Availability {
+	if endpointType == "internal" || endpointType == "internalURL" {
+		return AvailabilityInternal
+	}
+	if endpointType == "admin" || endpointType == "adminURL" {
+		return AvailabilityAdmin
+	}
+	return AvailabilityPublic
+}
+
 // EndpointOpts specifies search criteria used by queries against an
 // OpenStack service catalog. The options must contain enough information to
 // unambiguously identify one, and only one, endpoint within the catalog.

--- a/openstack/config/clouds/clouds.go
+++ b/openstack/config/clouds/clouds.go
@@ -170,22 +170,10 @@ func Parse(opts ...func(*cloudOpts)) (gophercloud.AuthOptions, gophercloud.Endpo
 			ApplicationCredentialSecret: coalesce(options.applicationCredentialSecret, cloud.AuthInfo.ApplicationCredentialSecret),
 		}, gophercloud.EndpointOpts{
 			Region:       coalesce(options.region, cloud.RegionName),
-			Availability: computeAvailability(endpointType),
+			Availability: gophercloud.AvailabilityFromEndpointType(endpointType),
 		},
 		tlsConfig,
 		nil
-}
-
-// computeAvailability is a helper method to determine the endpoint type
-// requested by the user.
-func computeAvailability(endpointType string) gophercloud.Availability {
-	if endpointType == "internal" || endpointType == "internalURL" {
-		return gophercloud.AvailabilityInternal
-	}
-	if endpointType == "admin" || endpointType == "adminURL" {
-		return gophercloud.AvailabilityAdmin
-	}
-	return gophercloud.AvailabilityPublic
 }
 
 // coalesce returns the first argument that is not the empty string, or the


### PR DESCRIPTION
We have a function in utils that returns "public" when given "publicURL", "internal" with "internalURL" and "admin" with "adminURL". If it is of any use, I think it has a place in the main Gophercloud repository.