### PR TITLE
v2: Add ParseOption type to made clouds.Parse() more usable for optional With* funcs

### DIFF
--- a/openstack/config/clouds/clouds.go
+++ b/openstack/config/clouds/clouds.go
@@ -86,7 +86,7 @@ func Parse(opts ...func(*cloudOpts)) (gophercloud.AuthOptions, gophercloud.Endpo
 			if err != nil {
 				return gophercloud.AuthOptions{}, gophercloud.EndpointOpts{}, nil, fmt.Errorf("failed to get the user config directory: %w", err)
 			}
-			options.locations = []string{path.Join(cwd, "clouds.yaml"), path.Join(userConfig, "openstack", "clouds.yaml"), path.Join("/etc", "openstack")}
+			options.locations = []string{path.Join(cwd, "clouds.yaml"), path.Join(userConfig, "openstack", "clouds.yaml"), path.Join("/etc", "openstack", "clouds.yaml")}
 		}
 
 		for _, cloudsPath := range options.locations {

--- a/openstack/config/clouds/clouds.go
+++ b/openstack/config/clouds/clouds.go
@@ -53,7 +53,7 @@ import (
 //
 // Search locations, as well as individual `clouds.yaml` properties, can be
 // overwritten with functional options.
-func Parse(opts ...func(*cloudOpts)) (gophercloud.AuthOptions, gophercloud.EndpointOpts, *tls.Config, error) {
+func Parse(opts ...ParseOption) (gophercloud.AuthOptions, gophercloud.EndpointOpts, *tls.Config, error) {
 	options := cloudOpts{
 		cloudName:    os.Getenv("OS_CLOUD"),
 		region:       os.Getenv("OS_REGION_NAME"),

--- a/openstack/config/clouds/options.go
+++ b/openstack/config/clouds/options.go
@@ -34,8 +34,11 @@ type cloudOpts struct {
 	insecure       *bool
 }
 
+// ParseOption one of parse configuration returned by With* modifier
+type ParseOption = func(*cloudOpts)
+
 // WithCloudName allows to override the environment variable `OS_CLOUD`.
-func WithCloudName(osCloud string) func(*cloudOpts) {
+func WithCloudName(osCloud string) ParseOption {
 	return func(co *cloudOpts) {
 		co.cloudName = osCloud
 	}
@@ -44,7 +47,7 @@ func WithCloudName(osCloud string) func(*cloudOpts) {
 // WithLocations is a functional option that sets the search locations for the
 // clouds.yaml file (and its optional companion secure.yaml). Each location is
 // a file path pointing to a possible `clouds.yaml`.
-func WithLocations(locations ...string) func(*cloudOpts) {
+func WithLocations(locations ...string) ParseOption {
 	return func(co *cloudOpts) {
 		co.locations = locations
 	}
@@ -54,7 +57,7 @@ func WithLocations(locations ...string) func(*cloudOpts) {
 // as an io.Reader interface. When this option is passed, FromCloudsYaml will
 // not attempt to fetch any file from the file system. To add a secure.yaml,
 // use in conjunction with WithSecureYAML.
-func WithCloudsYAML(clouds io.Reader) func(*cloudOpts) {
+func WithCloudsYAML(clouds io.Reader) ParseOption {
 	return func(co *cloudOpts) {
 		co.cloudsyamlReader = clouds
 	}
@@ -63,43 +66,43 @@ func WithCloudsYAML(clouds io.Reader) func(*cloudOpts) {
 // WithSecureYAML is a functional option that lets you pass a secure.yaml file
 // as an io.Reader interface, to complement the clouds.yaml that is either
 // fetched from the filesystem, or passed with WithCloudsYAML.
-func WithSecureYAML(secure io.Reader) func(*cloudOpts) {
+func WithSecureYAML(secure io.Reader) ParseOption {
 	return func(co *cloudOpts) {
 		co.secureyamlReader = secure
 	}
 }
 
-func WithApplicationCredentialID(applicationCredentialID string) func(*cloudOpts) {
+func WithApplicationCredentialID(applicationCredentialID string) ParseOption {
 	return func(co *cloudOpts) {
 		co.applicationCredentialID = applicationCredentialID
 	}
 }
 
-func WithApplicationCredentialName(applicationCredentialName string) func(*cloudOpts) {
+func WithApplicationCredentialName(applicationCredentialName string) ParseOption {
 	return func(co *cloudOpts) {
 		co.applicationCredentialName = applicationCredentialName
 	}
 }
 
-func WithApplicationCredentialSecret(applicationCredentialSecret string) func(*cloudOpts) {
+func WithApplicationCredentialSecret(applicationCredentialSecret string) ParseOption {
 	return func(co *cloudOpts) {
 		co.applicationCredentialSecret = applicationCredentialSecret
 	}
 }
 
-func WithIdentityEndpoint(authURL string) func(*cloudOpts) {
+func WithIdentityEndpoint(authURL string) ParseOption {
 	return func(co *cloudOpts) {
 		co.authURL = authURL
 	}
 }
 
-func WithDomainID(domainID string) func(*cloudOpts) {
+func WithDomainID(domainID string) ParseOption {
 	return func(co *cloudOpts) {
 		co.domainID = domainID
 	}
 }
 
-func WithDomainName(domainName string) func(*cloudOpts) {
+func WithDomainName(domainName string) ParseOption {
 	return func(co *cloudOpts) {
 		co.domainName = domainName
 	}
@@ -107,25 +110,25 @@ func WithDomainName(domainName string) func(*cloudOpts) {
 
 // WithRegion allows to override the endpoint type set in clouds.yaml or in the
 // environment variable `OS_INTERFACE`.
-func WithEndpointType(endpointType string) func(*cloudOpts) {
+func WithEndpointType(endpointType string) ParseOption {
 	return func(co *cloudOpts) {
 		co.endpointType = endpointType
 	}
 }
 
-func WithPassword(password string) func(*cloudOpts) {
+func WithPassword(password string) ParseOption {
 	return func(co *cloudOpts) {
 		co.password = password
 	}
 }
 
-func WithProjectID(projectID string) func(*cloudOpts) {
+func WithProjectID(projectID string) ParseOption {
 	return func(co *cloudOpts) {
 		co.projectID = projectID
 	}
 }
 
-func WithProjectName(projectName string) func(*cloudOpts) {
+func WithProjectName(projectName string) ParseOption {
 	return func(co *cloudOpts) {
 		co.projectName = projectName
 	}
@@ -133,55 +136,55 @@ func WithProjectName(projectName string) func(*cloudOpts) {
 
 // WithRegion allows to override the region set in clouds.yaml or in the
 // environment variable `OS_REGION_NAME`
-func WithRegion(region string) func(*cloudOpts) {
+func WithRegion(region string) ParseOption {
 	return func(co *cloudOpts) {
 		co.region = region
 	}
 }
 
-func WithScope(scope *gophercloud.AuthScope) func(*cloudOpts) {
+func WithScope(scope *gophercloud.AuthScope) ParseOption {
 	return func(co *cloudOpts) {
 		co.scope = scope
 	}
 }
 
-func WithToken(token string) func(*cloudOpts) {
+func WithToken(token string) ParseOption {
 	return func(co *cloudOpts) {
 		co.token = token
 	}
 }
 
-func WithUserID(userID string) func(*cloudOpts) {
+func WithUserID(userID string) ParseOption {
 	return func(co *cloudOpts) {
 		co.userID = userID
 	}
 }
 
-func WithUsername(username string) func(*cloudOpts) {
+func WithUsername(username string) ParseOption {
 	return func(co *cloudOpts) {
 		co.username = username
 	}
 }
 
-func WithCACertPath(caCertPath string) func(*cloudOpts) {
+func WithCACertPath(caCertPath string) ParseOption {
 	return func(co *cloudOpts) {
 		co.caCertPath = caCertPath
 	}
 }
 
-func WithClientCertPath(clientCertPath string) func(*cloudOpts) {
+func WithClientCertPath(clientCertPath string) ParseOption {
 	return func(co *cloudOpts) {
 		co.clientCertPath = clientCertPath
 	}
 }
 
-func WithClientKeyPath(clientKeyPath string) func(*cloudOpts) {
+func WithClientKeyPath(clientKeyPath string) ParseOption {
 	return func(co *cloudOpts) {
 		co.clientKeyPath = clientKeyPath
 	}
 }
 
-func WithInsecure(insecure bool) func(*cloudOpts) {
+func WithInsecure(insecure bool) ParseOption {
 	return func(co *cloudOpts) {
 		co.insecure = &insecure
 	}


### PR DESCRIPTION
So that makes easier to have conditional With like that:

https://github.com/sardinasystems/fleeting-plugin-openstack/blob/90c744fc9ee23d8a18dad96f2a677a9d1a54222c/provider.go#L44-L52

Fixes #2913

In addition it fixes search for default `/etc/openstack/clouds.yaml` file.