### PR TITLE
clouds: Fix the system default search location

### DIFF
--- a/openstack/config/clouds/clouds.go
+++ b/openstack/config/clouds/clouds.go
@@ -86,7 +86,7 @@ func Parse(opts ...func(*cloudOpts)) (gophercloud.AuthOptions, gophercloud.Endpo
 			if err != nil {
 				return gophercloud.AuthOptions{}, gophercloud.EndpointOpts{}, nil, fmt.Errorf("failed to get the user config directory: %w", err)
 			}
-			options.locations = []string{path.Join(cwd, "clouds.yaml"), path.Join(userConfig, "openstack", "clouds.yaml"), path.Join("/etc", "openstack")}
+			options.locations = []string{path.Join(cwd, "clouds.yaml"), path.Join(userConfig, "openstack", "clouds.yaml"), path.Join("/etc", "openstack", "clouds.yaml")}
 		}
 
 		for _, cloudsPath := range options.locations {


### PR DESCRIPTION
This patch fixes a bug where a `clouds.yaml` in `/etc/openstack` would be ignored.