### PR TITLE
simplify conditional expressions

### DIFF
--- a/openstack/baremetal/v1/conductors/requests.go
+++ b/openstack/baremetal/v1/conductors/requests.go
@@ -39,7 +39,7 @@ type ListOpts struct {
 
 // ToConductorListQuery formats a ListOpts into a query string.
 func (opts ListOpts) ToConductorListQuery() (string, error) {
-	if opts.Detail == true && len(opts.Fields) > 0 {
+	if opts.Detail && len(opts.Fields) > 0 {
 		return "", fmt.Errorf("cannot have both fields and detail options for conductors")
 	}
 

--- a/openstack/baremetal/v1/nodes/requests.go
+++ b/openstack/baremetal/v1/nodes/requests.go
@@ -662,7 +662,7 @@ type ListBIOSSettingsOpts struct {
 
 // ToListBIOSSettingsOptsQuery formats a ListBIOSSettingsOpts into a query string
 func (opts ListBIOSSettingsOpts) ToListBIOSSettingsOptsQuery() (string, error) {
-	if opts.Detail == true && len(opts.Fields) > 0 {
+	if opts.Detail && len(opts.Fields) > 0 {
 		return "", fmt.Errorf("cannot have both fields and detail options for BIOS settings")
 	}
 

--- a/openstack/compute/v2/extensions/usage/requests.go
+++ b/openstack/compute/v2/extensions/usage/requests.go
@@ -110,7 +110,7 @@ func (opts AllTenantsOpts) ToUsageAllTenantsQuery() (string, error) {
 		params.Add("end", opts.End.Format(gophercloud.RFC3339MilliNoZ))
 	}
 
-	if opts.Detailed == true {
+	if opts.Detailed {
 		params.Add("detailed", "1")
 	}
 


### PR DESCRIPTION
- opts.Detail, a bool type, itself represents a true or false value, so there is no need to compare it again with the comparison operator (==).

Prior to starting a PR, please make sure you have read our
[contributor tutorial](https://github.com/gophercloud/gophercloud/tree/master/docs/contributor-tutorial).

Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

Fixes #[PUT ISSUE NUMBER HERE]

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

[PUT URLS HERE]
