### PR TITLE
Fix AllowReauth reauthentication

### DIFF
--- a/internal/acceptance/openstack/client_test.go
+++ b/internal/acceptance/openstack/client_test.go
@@ -4,6 +4,7 @@
 package openstack
 
 import (
+	"context"
 	"os"
 	"testing"
 	"time"
@@ -140,7 +141,7 @@ func TestReauth(t *testing.T) {
 	time.Sleep(1 * time.Second)
 	t.Logf("Attempting to reauthenticate")
 
-	err = provider.ReauthFunc()
+	err = provider.ReauthFunc(context.TODO())
 	if err != nil {
 		t.Fatalf("Unable to reauthenticate: %v", err)
 	}

--- a/openstack/client.go
+++ b/openstack/client.go
@@ -170,7 +170,7 @@ func v2auth(ctx context.Context, client *gophercloud.ProviderClient, endpoint st
 		tac.SetTokenAndAuthResult(nil)
 		tao := options
 		tao.AllowReauth = false
-		client.ReauthFunc = func() error {
+		client.ReauthFunc = func(ctx context.Context) error {
 			err := v2auth(ctx, &tac, endpoint, tao, eo)
 			if err != nil {
 				return err
@@ -293,7 +293,7 @@ func v3auth(ctx context.Context, client *gophercloud.ProviderClient, endpoint st
 		default:
 			tao = opts
 		}
-		client.ReauthFunc = func() error {
+		client.ReauthFunc = func(ctx context.Context) error {
 			err := v3auth(ctx, &tac, endpoint, tao, eo)
 			if err != nil {
 				return err

--- a/provider_client.go
+++ b/provider_client.go
@@ -83,7 +83,7 @@ type ProviderClient struct {
 	// ReauthFunc is the function used to re-authenticate the user if the request
 	// fails with a 401 HTTP response code. This a needed because there may be multiple
 	// authentication functions for different Identity service versions.
-	ReauthFunc func() error
+	ReauthFunc func(context.Context) error
 
 	// Throwaway determines whether if this client is a throw-away client. It's a copy of user's provider client
 	// with the token and reauth func zeroed. Such client can be used to perform reauthorization.
@@ -273,12 +273,14 @@ func (client *ProviderClient) SetThrowaway(v bool) {
 // reauthenticated in the meantime. If no previous token is known, an empty
 // string should be passed instead to force unconditional reauthentication.
 func (client *ProviderClient) Reauthenticate(previousToken string) error {
+	ctx := context.TODO()
+
 	if client.ReauthFunc == nil {
 		return nil
 	}
 
 	if client.reauthmut == nil {
-		return client.ReauthFunc()
+		return client.ReauthFunc(ctx)
 	}
 
 	future := newReauthFuture()
@@ -299,7 +301,7 @@ func (client *ProviderClient) Reauthenticate(previousToken string) error {
 	// Perform the actual reauthentication.
 	var err error
 	if previousToken == "" || client.TokenID == previousToken {
-		err = client.ReauthFunc()
+		err = client.ReauthFunc(ctx)
 	} else {
 		err = nil
 	}

--- a/testing/provider_client_test.go
+++ b/testing/provider_client_test.go
@@ -66,7 +66,7 @@ func TestConcurrentReauth(t *testing.T) {
 	p := new(gophercloud.ProviderClient)
 	p.UseTokenLock()
 	p.SetToken(prereauthTok)
-	p.ReauthFunc = func() error {
+	p.ReauthFunc = func(_ context.Context) error {
 		p.SetThrowaway(true)
 		time.Sleep(1 * time.Second)
 		p.AuthenticatedHeaders()
@@ -154,7 +154,7 @@ func TestReauthEndLoop(t *testing.T) {
 	p := new(gophercloud.ProviderClient)
 	p.UseTokenLock()
 	p.SetToken(client.TokenID)
-	p.ReauthFunc = func() error {
+	p.ReauthFunc = func(_ context.Context) error {
 		info.mut.Lock()
 		defer info.mut.Unlock()
 
@@ -237,7 +237,7 @@ func TestRequestThatCameDuringReauthWaitsUntilItIsCompleted(t *testing.T) {
 	p := new(gophercloud.ProviderClient)
 	p.UseTokenLock()
 	p.SetToken(prereauthTok)
-	p.ReauthFunc = func() error {
+	p.ReauthFunc = func(_ context.Context) error {
 		info.mut.RLock()
 		if info.numreauths == 0 {
 			info.mut.RUnlock()
@@ -331,7 +331,7 @@ func TestRequestReauthsAtMostOnce(t *testing.T) {
 	p := new(gophercloud.ProviderClient)
 	p.UseTokenLock()
 	p.SetToken(client.TokenID)
-	p.ReauthFunc = func() error {
+	p.ReauthFunc = func(_ context.Context) error {
 		reauthCounterMutex.Lock()
 		reauthCounter++
 		reauthCounterMutex.Unlock()


### PR DESCRIPTION
Due to an error in implementing the addition of `context.Context`, the default reauth function caught the context passed when generating the ProviderClient, which could be long canceled when the reauthentication takes place.

This is a breaking change: this patch changes the signature of the reauthentication function in the ProviderClient to accept a context.

Fixes #2931