### PR TITLE
[v1] compute: Use volumeID, not attachmentID for volume attachments

### DIFF
--- a/openstack/compute/v2/extensions/volumeattach/doc.go
+++ b/openstack/compute/v2/extensions/volumeattach/doc.go
@@ -20,9 +20,9 @@ Example to Attach a Volume
 Example to Detach a Volume
 
 	serverID := "7ac8686c-de71-4acb-9600-ec18b1a1ed6d"
-	attachmentID := "ed081613-1c9b-4231-aa5e-ebfd4d87f983"
+	volumeID := "ed081613-1c9b-4231-aa5e-ebfd4d87f983"
 
-	err := volumeattach.Delete(computeClient, serverID, attachmentID).ExtractErr()
+	err := volumeattach.Delete(computeClient, serverID, volumeID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/compute/v2/extensions/volumeattach/requests.go
+++ b/openstack/compute/v2/extensions/volumeattach/requests.go
@@ -56,16 +56,16 @@ func Create(client *gophercloud.ServiceClient, serverID string, opts CreateOptsB
 }
 
 // Get returns public data about a previously created VolumeAttachment.
-func Get(client *gophercloud.ServiceClient, serverID, attachmentID string) (r GetResult) {
-	resp, err := client.Get(getURL(client, serverID, attachmentID), &r.Body, nil)
+func Get(client *gophercloud.ServiceClient, serverID, volumeID string) (r GetResult) {
+	resp, err := client.Get(getURL(client, serverID, volumeID), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
 // Delete requests the deletion of a previous stored VolumeAttachment from
 // the server.
-func Delete(client *gophercloud.ServiceClient, serverID, attachmentID string) (r DeleteResult) {
-	resp, err := client.Delete(deleteURL(client, serverID, attachmentID), nil)
+func Delete(client *gophercloud.ServiceClient, serverID, volumeID string) (r DeleteResult) {
+	resp, err := client.Delete(deleteURL(client, serverID, volumeID), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }


### PR DESCRIPTION
The volume attachments API operates on volumes, not attachments. Correct the variable name.

Backports: #2939
Closes: #2861