### PR TITLE
Use system scope when running baremetal tests

### DIFF
--- a/.github/workflows/functional-baremetal.yaml
+++ b/.github/workflows/functional-baremetal.yaml
@@ -13,16 +13,20 @@ jobs:
         name: ["master"]
         openstack_version: ["master"]
         ubuntu_version: ["22.04"]
+        os_system_scope: ["all"]
         include:
           - name: "bobcat"
             openstack_version: "stable/2023.2"
             ubuntu_version: "22.04"
+            os_system_scope: ""
           - name: "antelope"
             openstack_version: "stable/2023.1"
             ubuntu_version: "22.04"
+            os_system_scope: ""
           - name: "zed"
             openstack_version: "stable/zed"
             ubuntu_version: "20.04"
+            os_system_scope: ""
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with Ironic and run baremetal acceptance tests
     steps:
@@ -88,6 +92,8 @@ jobs:
           DEVSTACK_PATH: ${{ github.workspace }}/devstack
           ACCEPTANCE_TESTS_FILTER: '^.*baremetal(.(?!noauth).*)?$'
           OS_BRANCH: ${{ matrix.openstack_version }}
+          # TODO(dtantsur): default to "all" when no longer supporting versions before 2024.1
+          OS_SYSTEM_SCOPE: ${{ matrix.os_system_scope }}
       - name: Generate logs on failure
         run: ./script/collectlogs
         if: failure()

--- a/script/stackenv
+++ b/script/stackenv
@@ -30,4 +30,8 @@ echo export OS_DOMAIN_ID=default >> openrc
 echo export OS_MAGNUM_IMAGE_ID="$_MAGNUM_IMAGE_ID" >> openrc
 echo export OS_MAGNUM_KEYPAIR=magnum >> openrc
 source openrc admin admin
+if [[ "${OS_SYSTEM_SCOPE:-}" == "all" ]]; then
+    unset PROJECT_NAME
+    unset TENANT_NAME
+fi
 popd


### PR DESCRIPTION
Starting with 2024.1, some actions no longer work with a project scoped
token.