### PR TITLE
Add bootable filter to v3 cinder list options

### DIFF
--- a/openstack/blockstorage/v3/volumes/requests.go
+++ b/openstack/blockstorage/v3/volumes/requests.go
@@ -149,7 +149,7 @@ type ListOpts struct {
 	Marker string `q:"marker"`
 
 	// Bootable will filter results based on if they are bootable volumes
-	Bootable bool `q:"bootable"`
+	Bootable *bool `q:"bootable,omitempty"`
 }
 
 // ToVolumeListQuery formats a ListOpts into a query string.

--- a/openstack/blockstorage/v3/volumes/requests.go
+++ b/openstack/blockstorage/v3/volumes/requests.go
@@ -147,6 +147,9 @@ type ListOpts struct {
 
 	// The ID of the last-seen item.
 	Marker string `q:"marker"`
+
+	// Bootable will filter results based on if they are bootable volumes
+	Bootable bool `q:"bootable"`
 }
 
 // ToVolumeListQuery formats a ListOpts into a query string.

--- a/openstack/blockstorage/v3/volumes/requests.go
+++ b/openstack/blockstorage/v3/volumes/requests.go
@@ -148,7 +148,7 @@ type ListOpts struct {
 	// The ID of the last-seen item.
 	Marker string `q:"marker"`
 
-	// Bootable will filter results based on if they are bootable volumes
+	// Bootable will filter results based on whether they are bootable volumes
 	Bootable *bool `q:"bootable,omitempty"`
 }
 


### PR DESCRIPTION
Fixes #2977

This PR adds the ability to filter volumes by the "bootable" flag, when using Cinder API V3.