### PR TITLE
[v1] baremetal: fix handling of the "fields" query argument

### DIFF
--- a/openstack/baremetal/v1/allocations/requests.go
+++ b/openstack/baremetal/v1/allocations/requests.go
@@ -80,7 +80,7 @@ type ListOpts struct {
 	State AllocationState `q:"state"`
 
 	// One or more fields to be returned in the response.
-	Fields []string `q:"fields"`
+	Fields []string `q:"fields" format:"comma-separated"`
 
 	// Requests a page size of items.
 	Limit int `q:"limit"`

--- a/openstack/baremetal/v1/conductors/requests.go
+++ b/openstack/baremetal/v1/conductors/requests.go
@@ -19,7 +19,7 @@ type ListOptsBuilder interface {
 // for pagination.
 type ListOpts struct {
 	// One or more fields to be returned in the response.
-	Fields []string `q:"fields"`
+	Fields []string `q:"fields" format:"comma-separated"`
 
 	// Requests a page size of items.
 	Limit int `q:"limit"`

--- a/openstack/baremetal/v1/conductors/testing/requests_test.go
+++ b/openstack/baremetal/v1/conductors/testing/requests_test.go
@@ -87,7 +87,7 @@ func TestListOpts(t *testing.T) {
 
 	// Regular ListOpts can
 	query, err := opts.ToConductorListQuery()
-	th.AssertEquals(t, query, "?fields=hostname&fields=alive")
+	th.AssertEquals(t, "?fields=hostname%2Calive", query)
 	th.AssertNoErr(t, err)
 }
 

--- a/openstack/baremetal/v1/nodes/requests.go
+++ b/openstack/baremetal/v1/nodes/requests.go
@@ -97,7 +97,7 @@ type ListOpts struct {
 	Fault string `q:"fault"`
 
 	// One or more fields to be returned in the response.
-	Fields []string `q:"fields"`
+	Fields []string `q:"fields" format:"comma-separated"`
 
 	// Requests a page size of items.
 	Limit int `q:"limit"`
@@ -653,7 +653,7 @@ type ListBIOSSettingsOpts struct {
 	Detail bool `q:"detail"`
 
 	// One or more fields to be returned in the response.
-	Fields []string `q:"fields"`
+	Fields []string `q:"fields" format:"comma-separated"`
 }
 
 // ToListBIOSSettingsOptsQuery formats a ListBIOSSettingsOpts into a query string

--- a/openstack/baremetal/v1/nodes/testing/requests_test.go
+++ b/openstack/baremetal/v1/nodes/testing/requests_test.go
@@ -83,7 +83,7 @@ func TestListOpts(t *testing.T) {
 
 	// Regular ListOpts can
 	query, err := opts.ToNodeListQuery()
-	th.AssertEquals(t, query, "?fields=name&fields=uuid")
+	th.AssertEquals(t, "?fields=name%2Cuuid", query)
 	th.AssertNoErr(t, err)
 }
 

--- a/openstack/baremetal/v1/ports/requests.go
+++ b/openstack/baremetal/v1/ports/requests.go
@@ -32,7 +32,7 @@ type ListOpts struct {
 	Address string `q:"address"`
 
 	// One or more fields to be returned in the response.
-	Fields []string `q:"fields"`
+	Fields []string `q:"fields" format:"comma-separated"`
 
 	// Requests a page size of items.
 	Limit int `q:"limit"`

--- a/openstack/baremetal/v1/ports/testing/requests_test.go
+++ b/openstack/baremetal/v1/ports/testing/requests_test.go
@@ -80,7 +80,7 @@ func TestListOpts(t *testing.T) {
 
 	// Regular ListOpts can
 	query, err := opts.ToPortListQuery()
-	th.AssertEquals(t, query, "?fields=uuid&fields=address")
+	th.AssertEquals(t, "?fields=uuid%2Caddress", query)
 	th.AssertNoErr(t, err)
 }
 

--- a/params.go
+++ b/params.go
@@ -318,8 +318,15 @@ converted into query parameters based on a "q" tag. For example:
 
 will be converted into "?x_bar=AAA&lorem_ipsum=BBB".
 
-The struct's fields may be strings, integers, or boolean values. Fields left at
-their type's zero value will be omitted from the query.
+The struct's fields may be strings, integers, slices, or boolean values. Fields
+left at their type's zero value will be omitted from the query.
+
+Slice are handled in one of two ways:
+
+	type struct Something {
+	   Bar []string `q:"bar"` // E.g. ?bar=1&bar=2
+	   Baz []int    `q:"baz" format="comma-separated"` // E.g. ?baz=1,2
+	}
 */
 func BuildQueryString(opts interface{}) (*url.URL, error) {
 	optsValue := reflect.ValueOf(opts)
@@ -358,15 +365,21 @@ func BuildQueryString(opts interface{}) (*url.URL, error) {
 					case reflect.Bool:
 						params.Add(tags[0], strconv.FormatBool(v.Bool()))
 					case reflect.Slice:
+						var values []string
 						switch v.Type().Elem() {
 						case reflect.TypeOf(0):
 							for i := 0; i < v.Len(); i++ {
-								params.Add(tags[0], strconv.FormatInt(v.Index(i).Int(), 10))
+								values = append(values, strconv.FormatInt(v.Index(i).Int(), 10))
 							}
 						default:
 							for i := 0; i < v.Len(); i++ {
-								params.Add(tags[0], v.Index(i).String())
+								values = append(values, v.Index(i).String())
 							}
+						}
+						if sliceFormat := f.Tag.Get("format"); sliceFormat == "comma-separated" {
+							params.Add(tags[0], strings.Join(values, ","))
+						} else {
+							params[tags[0]] = append(params[tags[0]], values...)
 						}
 					case reflect.Map:
 						if v.Type().Key().Kind() == reflect.String && v.Type().Elem().Kind() == reflect.String {


### PR DESCRIPTION
Backport: https://github.com/gophercloud/gophercloud/pull/2961
Supersedes https://github.com/gophercloud/gophercloud/pull/2980

Ironic expects a comma-separated string. Add a new feature to BuildQueryString to choose the format of slices.

Closes: #2960 

Manual backport since the original change had a different signature for the EachPage() function, where it expected a context.