### PR TITLE
[CI] Fix trigger for FWaaS v2 presubmit

### DIFF
--- a/.github/workflows/functional-fwaas_v2.yaml
+++ b/.github/workflows/functional-fwaas_v2.yaml
@@ -2,7 +2,7 @@ name: functional-fwaas_v2
 on:
   pull_request:
     paths:
-      - '**networking/extensions/fwaas_v2**'
+      - '**networking/v2/extensions/fwaas_v2**'
   schedule:
     - cron: '0 0 */3 * *'
 jobs:


### PR DESCRIPTION
The path was missing the version which caused changes to FWaaS files to not trigger the FWaaS presubmit jobs. The periodics were unaffected.