### PR TITLE
functional-baremetal: remove dnsmasq-base on all versions

### DIFF
--- a/.github/workflows/functional-baremetal.yaml
+++ b/.github/workflows/functional-baremetal.yaml
@@ -42,7 +42,6 @@ jobs:
         if: matrix.ubuntu_version == '20.04'
       - name: Work around broken dnsmasq
         run: sudo apt-get purge -y dnsmasq-base
-        if: matrix.ubuntu_version == '22.04'
       - name: Deploy devstack
         uses: EmilienM/devstack-action@e82a9cbead099cba72f99537e82a360c3e319c69
         with:


### PR DESCRIPTION
Zed now fails with a similar error. Let's make sure we start without
dnsmasq-base in all baremetal jobs.
