### PR TITLE
tests: Fix lint issues

### DIFF
--- a/internal/acceptance/openstack/container/v1/capsules_test.go
+++ b/internal/acceptance/openstack/container/v1/capsules_test.go
@@ -32,7 +32,7 @@ func TestCapsuleBase(t *testing.T) {
 		TemplateOpts: template,
 	}
 
-	v, err := capsules.Create(client, createOpts).Extract()
+	v, err := capsules.Create(context.TODO(), client, createOpts).Extract()
 	th.AssertNoErr(t, err)
 	capsule := v.(*capsules.Capsule)
 
@@ -50,12 +50,12 @@ func TestCapsuleBase(t *testing.T) {
 			if capsuleUUID != capsule.UUID {
 				continue
 			}
-			capsule, err := capsules.Get(client, capsuleUUID).ExtractBase()
+			capsule, err := capsules.Get(context.TODO(), client, capsuleUUID).ExtractBase()
 
 			th.AssertNoErr(t, err)
 			th.AssertEquals(t, capsule.MetaName, "template")
 
-			err = capsules.Delete(client, capsuleUUID).ExtractErr()
+			err = capsules.Delete(context.TODO(), client, capsuleUUID).ExtractErr()
 			th.AssertNoErr(t, err)
 
 		}
@@ -87,7 +87,7 @@ func TestCapsuleV132(t *testing.T) {
 		TemplateOpts: template,
 	}
 
-	capsule, err := capsules.Create(client, createOpts).ExtractV132()
+	capsule, err := capsules.Create(context.TODO(), client, createOpts).ExtractV132()
 	th.AssertNoErr(t, err)
 
 	err = WaitForCapsuleStatus(client, capsule.UUID, "Running")
@@ -103,12 +103,12 @@ func TestCapsuleV132(t *testing.T) {
 			if capsuleUUID != capsule.UUID {
 				continue
 			}
-			capsule, err := capsules.Get(client, capsuleUUID).ExtractV132()
+			capsule, err := capsules.Get(context.TODO(), client, capsuleUUID).ExtractV132()
 
 			th.AssertNoErr(t, err)
 			th.AssertEquals(t, capsule.MetaName, "template")
 
-			err = capsules.Delete(client, capsuleUUID).ExtractErr()
+			err = capsules.Delete(context.TODO(), client, capsuleUUID).ExtractErr()
 			th.AssertNoErr(t, err)
 
 		}

--- a/internal/acceptance/openstack/db/v1/configurations_test.go
+++ b/internal/acceptance/openstack/db/v1/configurations_test.go
@@ -4,6 +4,7 @@
 package v1
 
 import (
+	"context"
 	"testing"
 
 	"github.com/gophercloud/gophercloud/v2/internal/acceptance/clients"
@@ -38,12 +39,12 @@ func TestConfigurationsCRUD(t *testing.T) {
 	values["collation_server"] = "latin1_swedish_ci"
 	createOpts.Values = values
 
-	cgroup, err := configurations.Create(client, createOpts).Extract()
+	cgroup, err := configurations.Create(context.TODO(), client, createOpts).Extract()
 	if err != nil {
 		t.Fatalf("Unable to create configuration: %v", err)
 	}
 
-	readCgroup, err := configurations.Get(client, cgroup.ID).Extract()
+	readCgroup, err := configurations.Get(context.TODO(), client, cgroup.ID).Extract()
 	if err != nil {
 		t.Fatalf("Unable to read configuration: %v", err)
 	}
@@ -61,10 +62,10 @@ func TestConfigurationsCRUD(t *testing.T) {
 		Name:        newCgroupName,
 		Description: &newCgroupDescription,
 	}
-	err = configurations.Update(client, cgroup.ID, updateOpts).ExtractErr()
+	err = configurations.Update(context.TODO(), client, cgroup.ID, updateOpts).ExtractErr()
 	th.AssertNoErr(t, err)
 
-	newCgroup, err := configurations.Get(client, cgroup.ID).Extract()
+	newCgroup, err := configurations.Get(context.TODO(), client, cgroup.ID).Extract()
 	if err != nil {
 		t.Fatalf("Unable to read updated configuration: %v", err)
 	}
@@ -73,7 +74,7 @@ func TestConfigurationsCRUD(t *testing.T) {
 	th.AssertEquals(t, newCgroup.Name, newCgroupName)
 	th.AssertEquals(t, newCgroup.Description, newCgroupDescription)
 
-	err = configurations.Delete(client, cgroup.ID).ExtractErr()
+	err = configurations.Delete(context.TODO(), client, cgroup.ID).ExtractErr()
 	if err != nil {
 		t.Fatalf("Unable to delete configuration: %v", err)
 	}

--- a/internal/acceptance/openstack/db/v1/flavors_test.go
+++ b/internal/acceptance/openstack/db/v1/flavors_test.go
@@ -50,7 +50,7 @@ func TestFlavorsGet(t *testing.T) {
 	}
 
 	if len(allFlavors) > 0 {
-		flavor, err := flavors.Get(client, allFlavors[0].StrID).Extract()
+		flavor, err := flavors.Get(context.TODO(), client, allFlavors[0].StrID).Extract()
 		if err != nil {
 			t.Fatalf("Unable to get flavor: %v", err)
 		}

--- a/internal/acceptance/openstack/db/v1/instances_test.go
+++ b/internal/acceptance/openstack/db/v1/instances_test.go
@@ -48,12 +48,12 @@ func TestInstances(t *testing.T) {
 	}
 
 	// Enable root user.
-	_, err = instances.EnableRootUser(client, instance.ID).Extract()
+	_, err = instances.EnableRootUser(context.TODO(), client, instance.ID).Extract()
 	if err != nil {
 		t.Fatalf("Unable to enable root user: %v", err)
 	}
 
-	enabled, err := instances.IsRootEnabled(client, instance.ID).Extract()
+	enabled, err := instances.IsRootEnabled(context.TODO(), client, instance.ID).Extract()
 	if err != nil {
 		t.Fatalf("Unable to check if root user is enabled: %v", err)
 	}
@@ -61,7 +61,7 @@ func TestInstances(t *testing.T) {
 	t.Logf("Root user is enabled: %t", enabled)
 
 	// Restart
-	err = instances.Restart(client, instance.ID).ExtractErr()
+	err = instances.Restart(context.TODO(), client, instance.ID).ExtractErr()
 	if err != nil {
 		t.Fatalf("Unable to restart instance: %v", err)
 	}

--- a/internal/acceptance/openstack/dns/v2/recordsets_test.go
+++ b/internal/acceptance/openstack/dns/v2/recordsets_test.go
@@ -43,14 +43,13 @@ func TestRecordSetsListByZone(t *testing.T) {
 		Limit: 1,
 	}
 
-	err = recordsets.ListByZone(client, zone.ID, listOpts).EachPage(
-		func(page pagination.Page) (bool, error) {
-			rr, err := recordsets.ExtractRecordSets(page)
-			th.AssertNoErr(t, err)
-			th.AssertEquals(t, len(rr), 1)
-			return true, nil
-		},
-	)
+	pager := recordsets.ListByZone(client, zone.ID, listOpts)
+	err = pager.EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
+		rr, err := recordsets.ExtractRecordSets(page)
+		th.AssertNoErr(t, err)
+		th.AssertEquals(t, len(rr), 1)
+		return true, nil
+	})
 	th.AssertNoErr(t, err)
 }
 
@@ -75,7 +74,7 @@ func TestRecordSetsCRUD(t *testing.T) {
 		Description: &description,
 	}
 
-	newRS, err := recordsets.Update(client, rs.ZoneID, rs.ID, updateOpts).Extract()
+	newRS, err := recordsets.Update(context.TODO(), client, rs.ZoneID, rs.ID, updateOpts).Extract()
 	th.AssertNoErr(t, err)
 
 	tools.PrintResource(t, &newRS)
@@ -87,7 +86,7 @@ func TestRecordSetsCRUD(t *testing.T) {
 		Records: records,
 	}
 
-	newRS, err = recordsets.Update(client, rs.ZoneID, rs.ID, updateOpts).Extract()
+	newRS, err = recordsets.Update(context.TODO(), client, rs.ZoneID, rs.ID, updateOpts).Extract()
 	th.AssertNoErr(t, err)
 
 	tools.PrintResource(t, &newRS)
@@ -100,7 +99,7 @@ func TestRecordSetsCRUD(t *testing.T) {
 		TTL: &ttl,
 	}
 
-	newRS, err = recordsets.Update(client, rs.ZoneID, rs.ID, updateOpts).Extract()
+	newRS, err = recordsets.Update(context.TODO(), client, rs.ZoneID, rs.ID, updateOpts).Extract()
 	th.AssertNoErr(t, err)
 
 	tools.PrintResource(t, &newRS)

--- a/internal/acceptance/openstack/dns/v2/transfers_test.go
+++ b/internal/acceptance/openstack/dns/v2/transfers_test.go
@@ -49,7 +49,7 @@ func TestTransferRequestCRUD(t *testing.T) {
 		Description: description,
 	}
 
-	newTransferRequest, err := transferRequests.Update(client, transferRequest.ID, updateOpts).Extract()
+	newTransferRequest, err := transferRequests.Update(context.TODO(), client, transferRequest.ID, updateOpts).Extract()
 	th.AssertNoErr(t, err)
 
 	tools.PrintResource(t, &newTransferRequest)

--- a/internal/acceptance/openstack/dns/v2/zones_test.go
+++ b/internal/acceptance/openstack/dns/v2/zones_test.go
@@ -46,7 +46,7 @@ func TestZonesCRUD(t *testing.T) {
 		TTL:         0,
 	}
 
-	newZone, err := zones.Update(client, zone.ID, updateOpts).Extract()
+	newZone, err := zones.Update(context.TODO(), client, zone.ID, updateOpts).Extract()
 	th.AssertNoErr(t, err)
 
 	tools.PrintResource(t, &newZone)

--- a/internal/acceptance/openstack/networking/v2/extensions/fwaas/firewall_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/fwaas/firewall_test.go
@@ -115,8 +115,8 @@ func TestFirewallCRUDRouter(t *testing.T) {
 	}
 
 	updateOpts := routerinsertion.UpdateOptsExt{
-		firewallUpdateOpts,
-		[]string{router2.ID},
+		UpdateOptsBuilder: firewallUpdateOpts,
+		RouterIDs:         []string{router2.ID},
 	}
 
 	_, err = firewalls.Update(context.TODO(), client, firewall.ID, updateOpts).Extract()
@@ -162,8 +162,8 @@ func TestFirewallCRUDRemoveRouter(t *testing.T) {
 	}
 
 	updateOpts := routerinsertion.UpdateOptsExt{
-		firewallUpdateOpts,
-		[]string{},
+		UpdateOptsBuilder: firewallUpdateOpts,
+		RouterIDs:         []string{},
 	}
 
 	_, err = firewalls.Update(context.TODO(), client, firewall.ID, updateOpts).Extract()


### PR DESCRIPTION
We have a number of tests that we do not appear to be running in CI. In addition, we are not running go vet with all suitable build tags resulting in some tests being skipped [[1][1]]. Combined, this has resulted in a number of tests that have not been fully updated to use context. While we will address the root cause elsewhere, we can fix the missed updates here.

You can validate this fix by overriding GOFLAGS, as outlined in [[1][1]]. For example, from the root directory:

```shell
GOFLAGS="-tags=acceptance" go vet ./...
```

[1]: https://github.com/golang/go/issues/29202

Signed-off-by: Stephen Finucane <stephenfin@redhat.com>
