### PR TITLE
tests: Improve our use of 'go:build' directives

### DIFF
--- a/internal/acceptance/clients/testing/conditions_test.go
+++ b/internal/acceptance/clients/testing/conditions_test.go
@@ -1,3 +1,5 @@
+//go:build acceptance
+
 package testing
 
 import (

--- a/internal/acceptance/openstack/baremetal/httpbasic/allocations_test.go
+++ b/internal/acceptance/openstack/baremetal/httpbasic/allocations_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || baremetal || allocations
-// +build acceptance baremetal allocations
 
 package httpbasic
 

--- a/internal/acceptance/openstack/baremetal/httpbasic/nodes_test.go
+++ b/internal/acceptance/openstack/baremetal/httpbasic/nodes_test.go
@@ -1,3 +1,5 @@
+//go:build acceptance || baremetal || httpbasic
+
 package httpbasic
 
 import (

--- a/internal/acceptance/openstack/baremetal/httpbasic/pkg.go
+++ b/internal/acceptance/openstack/baremetal/httpbasic/pkg.go
@@ -1,0 +1,5 @@
+//go:build acceptance || baremetal
+
+// The httpbasic package contains acceptance tests for the OpenStack Bare Metal v1 service with HTTP Basic authentation.
+
+package httpbasic

--- a/internal/acceptance/openstack/baremetal/httpbasic/ports_test.go
+++ b/internal/acceptance/openstack/baremetal/httpbasic/ports_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || baremetal || ports
-// +build acceptance baremetal ports
 
 package httpbasic
 

--- a/internal/acceptance/openstack/baremetal/noauth/allocations_test.go
+++ b/internal/acceptance/openstack/baremetal/noauth/allocations_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || baremetal || allocations
-// +build acceptance baremetal allocations
 
 package noauth
 

--- a/internal/acceptance/openstack/baremetal/noauth/nodes_test.go
+++ b/internal/acceptance/openstack/baremetal/noauth/nodes_test.go
@@ -1,3 +1,5 @@
+//go:build acceptance || baremetal || noauth
+
 package noauth
 
 import (

--- a/internal/acceptance/openstack/baremetal/noauth/pkg.go
+++ b/internal/acceptance/openstack/baremetal/noauth/pkg.go
@@ -1,0 +1,5 @@
+//go:build acceptance || baremetal
+
+// The noauth package contains acceptance tests for the OpenStack Bare Metal v1 service without authentation.
+
+package noauth

--- a/internal/acceptance/openstack/baremetal/noauth/ports_test.go
+++ b/internal/acceptance/openstack/baremetal/noauth/ports_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || baremetal || ports
-// +build acceptance baremetal ports
 
 package noauth
 

--- a/internal/acceptance/openstack/baremetal/v1/allocations_test.go
+++ b/internal/acceptance/openstack/baremetal/v1/allocations_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || baremetal || allocations
-// +build acceptance baremetal allocations
 
 package v1
 

--- a/internal/acceptance/openstack/baremetal/v1/conductors_test.go
+++ b/internal/acceptance/openstack/baremetal/v1/conductors_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || baremetal || conductors
-// +build acceptance baremetal conductors
 
 package v1
 

--- a/internal/acceptance/openstack/baremetal/v1/nodes_test.go
+++ b/internal/acceptance/openstack/baremetal/v1/nodes_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || baremetal || nodes
-// +build acceptance baremetal nodes
 
 package v1
 

--- a/internal/acceptance/openstack/baremetal/v1/pkg.go
+++ b/internal/acceptance/openstack/baremetal/v1/pkg.go
@@ -1,0 +1,5 @@
+//go:build acceptance || baremetal
+
+// The v1 package contains acceptance tests for the OpenStack Bare Metal v1 service.
+
+package v1

--- a/internal/acceptance/openstack/baremetal/v1/ports_test.go
+++ b/internal/acceptance/openstack/baremetal/v1/ports_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || baremetal || ports
-// +build acceptance baremetal ports
 
 package v1
 

--- a/internal/acceptance/openstack/blockstorage/apiversions_test.go
+++ b/internal/acceptance/openstack/blockstorage/apiversions_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || blockstorage
-// +build acceptance blockstorage
 
 package blockstorage
 

--- a/internal/acceptance/openstack/blockstorage/apiversions_test.go
+++ b/internal/acceptance/openstack/blockstorage/apiversions_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance || blockstorage
+//go:build acceptance || blockstorage || apiversions
 
 package blockstorage
 

--- a/internal/acceptance/openstack/blockstorage/noauth/pkg.go
+++ b/internal/acceptance/openstack/blockstorage/noauth/pkg.go
@@ -1,0 +1,5 @@
+//go:build acceptance || blockstorage
+
+// The noauth package contains acceptance tests for the OpenStack Block Storage v3 service with no authentation.
+
+package noauth

--- a/internal/acceptance/openstack/blockstorage/noauth/snapshots_test.go
+++ b/internal/acceptance/openstack/blockstorage/noauth/snapshots_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || blockstorage
-// +build acceptance blockstorage
 
 package noauth
 

--- a/internal/acceptance/openstack/blockstorage/noauth/snapshots_test.go
+++ b/internal/acceptance/openstack/blockstorage/noauth/snapshots_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance || blockstorage
+//go:build acceptance || blockstorage || snapshots
 
 package noauth
 

--- a/internal/acceptance/openstack/blockstorage/noauth/volumes_test.go
+++ b/internal/acceptance/openstack/blockstorage/noauth/volumes_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || blockstorage
-// +build acceptance blockstorage
 
 package noauth
 

--- a/internal/acceptance/openstack/blockstorage/noauth/volumes_test.go
+++ b/internal/acceptance/openstack/blockstorage/noauth/volumes_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance || blockstorage
+//go:build acceptance || blockstorage || volumes
 
 package noauth
 

--- a/internal/acceptance/openstack/blockstorage/v2/backups_test.go
+++ b/internal/acceptance/openstack/blockstorage/v2/backups_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || blockstorage
-// +build acceptance blockstorage
 
 package v2
 

--- a/internal/acceptance/openstack/blockstorage/v2/backups_test.go
+++ b/internal/acceptance/openstack/blockstorage/v2/backups_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance || blockstorage
+//go:build acceptance || blockstorage || backups
 
 package v2
 

--- a/internal/acceptance/openstack/blockstorage/v2/limits_test.go
+++ b/internal/acceptance/openstack/blockstorage/v2/limits_test.go
@@ -1,3 +1,5 @@
+//go:build acceptance || blockstorage || limits
+
 package v2
 
 import (

--- a/internal/acceptance/openstack/blockstorage/v2/pkg.go
+++ b/internal/acceptance/openstack/blockstorage/v2/pkg.go
@@ -1,3 +1,5 @@
-// The v2 package contains acceptance tests for the Openstack Cinder V2 service.
+//go:build acceptance || blockstorage
+
+// The v2 package contains acceptance tests for the Openstack Block Storage v2 service.
 
 package v2

--- a/internal/acceptance/openstack/blockstorage/v2/schedulerhints_test.go
+++ b/internal/acceptance/openstack/blockstorage/v2/schedulerhints_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || blockstorage
-// +build acceptance blockstorage
 
 package v2
 

--- a/internal/acceptance/openstack/blockstorage/v2/schedulerhints_test.go
+++ b/internal/acceptance/openstack/blockstorage/v2/schedulerhints_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance || blockstorage
+//go:build acceptance || blockstorage || schedulerhints
 
 package v2
 

--- a/internal/acceptance/openstack/blockstorage/v2/schedulerstats_test.go
+++ b/internal/acceptance/openstack/blockstorage/v2/schedulerstats_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || blockstorage
-// +build acceptance blockstorage
 
 package v2
 

--- a/internal/acceptance/openstack/blockstorage/v2/schedulerstats_test.go
+++ b/internal/acceptance/openstack/blockstorage/v2/schedulerstats_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance || blockstorage
+//go:build acceptance || blockstorage || schedulerstats
 
 package v2
 

--- a/internal/acceptance/openstack/blockstorage/v2/services_test.go
+++ b/internal/acceptance/openstack/blockstorage/v2/services_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || blockstorage
-// +build acceptance blockstorage
 
 package v2
 

--- a/internal/acceptance/openstack/blockstorage/v2/services_test.go
+++ b/internal/acceptance/openstack/blockstorage/v2/services_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance || blockstorage
+//go:build acceptance || blockstorage || services
 
 package v2
 

--- a/internal/acceptance/openstack/blockstorage/v2/snapshots_test.go
+++ b/internal/acceptance/openstack/blockstorage/v2/snapshots_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || blockstorage
-// +build acceptance blockstorage
 
 package v2
 

--- a/internal/acceptance/openstack/blockstorage/v2/snapshots_test.go
+++ b/internal/acceptance/openstack/blockstorage/v2/snapshots_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance || blockstorage
+//go:build acceptance || blockstorage || snapshots
 
 package v2
 

--- a/internal/acceptance/openstack/blockstorage/v2/volumes_test.go
+++ b/internal/acceptance/openstack/blockstorage/v2/volumes_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || blockstorage
-// +build acceptance blockstorage
 
 package v2
 

--- a/internal/acceptance/openstack/blockstorage/v2/volumes_test.go
+++ b/internal/acceptance/openstack/blockstorage/v2/volumes_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance || blockstorage
+//go:build acceptance || blockstorage || volumes
 
 package v2
 

--- a/internal/acceptance/openstack/blockstorage/v2/volumetenants_test.go
+++ b/internal/acceptance/openstack/blockstorage/v2/volumetenants_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance || blockstorage
+//go:build acceptance || blockstorage || volumetenants
 
 package v2
 

--- a/internal/acceptance/openstack/blockstorage/v2/volumetenants_test.go
+++ b/internal/acceptance/openstack/blockstorage/v2/volumetenants_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || blockstorage
-// +build acceptance blockstorage
 
 package v2
 

--- a/internal/acceptance/openstack/blockstorage/v3/backups_test.go
+++ b/internal/acceptance/openstack/blockstorage/v3/backups_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance || blockstorage
+//go:build acceptance || blockstorage || backups
 
 package v3
 

--- a/internal/acceptance/openstack/blockstorage/v3/backups_test.go
+++ b/internal/acceptance/openstack/blockstorage/v3/backups_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || blockstorage
-// +build acceptance blockstorage
 
 package v3
 

--- a/internal/acceptance/openstack/blockstorage/v3/limits_test.go
+++ b/internal/acceptance/openstack/blockstorage/v3/limits_test.go
@@ -1,3 +1,5 @@
+//go:build acceptance || blockstorage || limits
+
 package v3
 
 import (

--- a/internal/acceptance/openstack/blockstorage/v3/pkg.go
+++ b/internal/acceptance/openstack/blockstorage/v3/pkg.go
@@ -1,3 +1,5 @@
-// The v3 package contains acceptance tests for the OpenStack Cinder V3 service.
+//go:build acceptance || blockstorage
+
+// The v3 package contains acceptance tests for the OpenStack Block Storage v3 service.
 
 package v3

--- a/internal/acceptance/openstack/blockstorage/v3/qos_test.go
+++ b/internal/acceptance/openstack/blockstorage/v3/qos_test.go
@@ -1,3 +1,5 @@
+//go:build acceptance || blockstorage || qos
+
 package v3
 
 import (

--- a/internal/acceptance/openstack/blockstorage/v3/quotaset_test.go
+++ b/internal/acceptance/openstack/blockstorage/v3/quotaset_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || quotasets
-// +build acceptance quotasets
 
 package v3
 

--- a/internal/acceptance/openstack/blockstorage/v3/quotaset_test.go
+++ b/internal/acceptance/openstack/blockstorage/v3/quotaset_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance || quotasets
+//go:build acceptance || blockstorage || quotasets
 
 package v3
 

--- a/internal/acceptance/openstack/blockstorage/v3/schedulerhints_test.go
+++ b/internal/acceptance/openstack/blockstorage/v3/schedulerhints_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || blockstorage
-// +build acceptance blockstorage
 
 package v3
 

--- a/internal/acceptance/openstack/blockstorage/v3/schedulerhints_test.go
+++ b/internal/acceptance/openstack/blockstorage/v3/schedulerhints_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance || blockstorage
+//go:build acceptance || blockstorage || schedulerhints
 
 package v3
 

--- a/internal/acceptance/openstack/blockstorage/v3/schedulerstats_test.go
+++ b/internal/acceptance/openstack/blockstorage/v3/schedulerstats_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || blockstorage
-// +build acceptance blockstorage
 
 package v3
 

--- a/internal/acceptance/openstack/blockstorage/v3/schedulerstats_test.go
+++ b/internal/acceptance/openstack/blockstorage/v3/schedulerstats_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance || blockstorage
+//go:build acceptance || blockstorage || schedulerstats
 
 package v3
 

--- a/internal/acceptance/openstack/blockstorage/v3/services_test.go
+++ b/internal/acceptance/openstack/blockstorage/v3/services_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance || blockstorage
+//go:build acceptance || blockstorage || services
 
 package v3
 

--- a/internal/acceptance/openstack/blockstorage/v3/services_test.go
+++ b/internal/acceptance/openstack/blockstorage/v3/services_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || blockstorage
-// +build acceptance blockstorage
 
 package v3
 

--- a/internal/acceptance/openstack/blockstorage/v3/snapshots_test.go
+++ b/internal/acceptance/openstack/blockstorage/v3/snapshots_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || blockstorage
-// +build acceptance blockstorage
 
 package v3
 

--- a/internal/acceptance/openstack/blockstorage/v3/snapshots_test.go
+++ b/internal/acceptance/openstack/blockstorage/v3/snapshots_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance || blockstorage
+//go:build acceptance || blockstorage || snapshots
 
 package v3
 

--- a/internal/acceptance/openstack/blockstorage/v3/volumeattachments_test.go
+++ b/internal/acceptance/openstack/blockstorage/v3/volumeattachments_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || blockstorage
-// +build acceptance blockstorage
 
 package v3
 

--- a/internal/acceptance/openstack/blockstorage/v3/volumeattachments_test.go
+++ b/internal/acceptance/openstack/blockstorage/v3/volumeattachments_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance || blockstorage
+//go:build acceptance || blockstorage || volumeattachments
 
 package v3
 

--- a/internal/acceptance/openstack/blockstorage/v3/volumes_test.go
+++ b/internal/acceptance/openstack/blockstorage/v3/volumes_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || blockstorage
-// +build acceptance blockstorage
 
 package v3
 

--- a/internal/acceptance/openstack/blockstorage/v3/volumes_test.go
+++ b/internal/acceptance/openstack/blockstorage/v3/volumes_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance || blockstorage
+//go:build acceptance || blockstorage || volumes
 
 package v3
 

--- a/internal/acceptance/openstack/blockstorage/v3/volumetenants_test.go
+++ b/internal/acceptance/openstack/blockstorage/v3/volumetenants_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || blockstorage
-// +build acceptance blockstorage
 
 package v3
 

--- a/internal/acceptance/openstack/blockstorage/v3/volumetenants_test.go
+++ b/internal/acceptance/openstack/blockstorage/v3/volumetenants_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance || blockstorage
+//go:build acceptance || blockstorage || volumetenants
 
 package v3
 

--- a/internal/acceptance/openstack/blockstorage/v3/volumetypes_test.go
+++ b/internal/acceptance/openstack/blockstorage/v3/volumetypes_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance || blockstorage
+//go:build acceptance || blockstorage || volumetypes
 
 package v3
 

--- a/internal/acceptance/openstack/blockstorage/v3/volumetypes_test.go
+++ b/internal/acceptance/openstack/blockstorage/v3/volumetypes_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || blockstorage
-// +build acceptance blockstorage
 
 package v3
 

--- a/internal/acceptance/openstack/client_test.go
+++ b/internal/acceptance/openstack/client_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance
-// +build acceptance
 
 package openstack
 

--- a/internal/acceptance/openstack/clustering/v1/actions_test.go
+++ b/internal/acceptance/openstack/clustering/v1/actions_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || clustering || actions
-// +build acceptance clustering actions
 
 package v1
 

--- a/internal/acceptance/openstack/clustering/v1/clusters_test.go
+++ b/internal/acceptance/openstack/clustering/v1/clusters_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || clustering || policies
-// +build acceptance clustering policies
 
 package v1
 

--- a/internal/acceptance/openstack/clustering/v1/events_test.go
+++ b/internal/acceptance/openstack/clustering/v1/events_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || clustering || events
-// +build acceptance clustering events
 
 package v1
 

--- a/internal/acceptance/openstack/clustering/v1/nodes_test.go
+++ b/internal/acceptance/openstack/clustering/v1/nodes_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || clustering || policies
-// +build acceptance clustering policies
 
 package v1
 

--- a/internal/acceptance/openstack/clustering/v1/pkg.go
+++ b/internal/acceptance/openstack/clustering/v1/pkg.go
@@ -1,2 +1,5 @@
-// Package v1 package contains acceptance tests for the Openstack Clustering V1 service.
+//go:build acceptance || clustering
+
+// The v1 package contains acceptance tests for the Openstack Clustering v1 service.
+
 package v1

--- a/internal/acceptance/openstack/clustering/v1/policies_test.go
+++ b/internal/acceptance/openstack/clustering/v1/policies_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || clustering || policies
-// +build acceptance clustering policies
 
 package v1
 

--- a/internal/acceptance/openstack/clustering/v1/policytypes_test.go
+++ b/internal/acceptance/openstack/clustering/v1/policytypes_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || clustering || policytypes
-// +build acceptance clustering policytypes
 
 package v1
 

--- a/internal/acceptance/openstack/clustering/v1/profiles_test.go
+++ b/internal/acceptance/openstack/clustering/v1/profiles_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || clustering || policies
-// +build acceptance clustering policies
 
 package v1
 

--- a/internal/acceptance/openstack/clustering/v1/profiletypes_test.go
+++ b/internal/acceptance/openstack/clustering/v1/profiletypes_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || clustering || profiletypes
-// +build acceptance clustering profiletypes
 
 package v1
 

--- a/internal/acceptance/openstack/clustering/v1/receivers_test.go
+++ b/internal/acceptance/openstack/clustering/v1/receivers_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || clustering || policies
-// +build acceptance clustering policies
 
 package v1
 

--- a/internal/acceptance/openstack/clustering/v1/webhooktrigger_test.go
+++ b/internal/acceptance/openstack/clustering/v1/webhooktrigger_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || clustering || webhooks
-// +build acceptance clustering webhooks
 
 package v1
 

--- a/internal/acceptance/openstack/compute/v2/aggregates_test.go
+++ b/internal/acceptance/openstack/compute/v2/aggregates_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || compute || aggregates
-// +build acceptance compute aggregates
 
 package v2
 

--- a/internal/acceptance/openstack/compute/v2/attachinterfaces_test.go
+++ b/internal/acceptance/openstack/compute/v2/attachinterfaces_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || compute || servers
-// +build acceptance compute servers
 
 package v2
 

--- a/internal/acceptance/openstack/compute/v2/availabilityzones_test.go
+++ b/internal/acceptance/openstack/compute/v2/availabilityzones_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || compute || availabilityzones
-// +build acceptance compute availabilityzones
 
 package v2
 

--- a/internal/acceptance/openstack/compute/v2/bootfromvolume_test.go
+++ b/internal/acceptance/openstack/compute/v2/bootfromvolume_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || compute || bootfromvolume
-// +build acceptance compute bootfromvolume
 
 package v2
 

--- a/internal/acceptance/openstack/compute/v2/defsecrules_test.go
+++ b/internal/acceptance/openstack/compute/v2/defsecrules_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || compute || defsecrules
-// +build acceptance compute defsecrules
 
 package v2
 

--- a/internal/acceptance/openstack/compute/v2/diagnostics_test.go
+++ b/internal/acceptance/openstack/compute/v2/diagnostics_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || compute || limits
-// +build acceptance compute limits
 
 package v2
 

--- a/internal/acceptance/openstack/compute/v2/extension_test.go
+++ b/internal/acceptance/openstack/compute/v2/extension_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || compute || extensions
-// +build acceptance compute extensions
 
 package v2
 

--- a/internal/acceptance/openstack/compute/v2/flavors_test.go
+++ b/internal/acceptance/openstack/compute/v2/flavors_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || compute || flavors
-// +build acceptance compute flavors
 
 package v2
 

--- a/internal/acceptance/openstack/compute/v2/floatingip_test.go
+++ b/internal/acceptance/openstack/compute/v2/floatingip_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || compute || servers
-// +build acceptance compute servers
 
 package v2
 

--- a/internal/acceptance/openstack/compute/v2/hypervisors_test.go
+++ b/internal/acceptance/openstack/compute/v2/hypervisors_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || compute || hypervisors
-// +build acceptance compute hypervisors
 
 package v2
 

--- a/internal/acceptance/openstack/compute/v2/images_test.go
+++ b/internal/acceptance/openstack/compute/v2/images_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || compute || images
-// +build acceptance compute images
 
 package v2
 

--- a/internal/acceptance/openstack/compute/v2/instance_actions_test.go
+++ b/internal/acceptance/openstack/compute/v2/instance_actions_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || compute || limits
-// +build acceptance compute limits
 
 package v2
 

--- a/internal/acceptance/openstack/compute/v2/keypairs_test.go
+++ b/internal/acceptance/openstack/compute/v2/keypairs_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || compute || keypairs
-// +build acceptance compute keypairs
 
 package v2
 

--- a/internal/acceptance/openstack/compute/v2/limits_test.go
+++ b/internal/acceptance/openstack/compute/v2/limits_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || compute || limits
-// +build acceptance compute limits
 
 package v2
 

--- a/internal/acceptance/openstack/compute/v2/migrate_test.go
+++ b/internal/acceptance/openstack/compute/v2/migrate_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || compute || servers
-// +build acceptance compute servers
 
 package v2
 

--- a/internal/acceptance/openstack/compute/v2/network_test.go
+++ b/internal/acceptance/openstack/compute/v2/network_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || compute || servers
-// +build acceptance compute servers
 
 package v2
 

--- a/internal/acceptance/openstack/compute/v2/pkg.go
+++ b/internal/acceptance/openstack/compute/v2/pkg.go
@@ -1,2 +1,5 @@
-// Package v2 package contains acceptance tests for the Openstack Compute V2 service.
+//go:build acceptance || compute
+
+// Package v2 package contains acceptance tests for the Openstack Compute v2 service.
+
 package v2

--- a/internal/acceptance/openstack/compute/v2/quotaset_test.go
+++ b/internal/acceptance/openstack/compute/v2/quotaset_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || compute || quotasets
-// +build acceptance compute quotasets
 
 package v2
 

--- a/internal/acceptance/openstack/compute/v2/remoteconsoles_test.go
+++ b/internal/acceptance/openstack/compute/v2/remoteconsoles_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || compute || remoteconsoles
-// +build acceptance compute remoteconsoles
 
 package v2
 

--- a/internal/acceptance/openstack/compute/v2/rescueunrescue_test.go
+++ b/internal/acceptance/openstack/compute/v2/rescueunrescue_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || compute || rescueunrescue
-// +build acceptance compute rescueunrescue
 
 package v2
 

--- a/internal/acceptance/openstack/compute/v2/secgroup_test.go
+++ b/internal/acceptance/openstack/compute/v2/secgroup_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || compute || secgroups
-// +build acceptance compute secgroups
 
 package v2
 

--- a/internal/acceptance/openstack/compute/v2/servergroup_test.go
+++ b/internal/acceptance/openstack/compute/v2/servergroup_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || compute || servergroups
-// +build acceptance compute servergroups
 
 package v2
 

--- a/internal/acceptance/openstack/compute/v2/servers_test.go
+++ b/internal/acceptance/openstack/compute/v2/servers_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || compute || servers
-// +build acceptance compute servers
 
 package v2
 

--- a/internal/acceptance/openstack/compute/v2/services_test.go
+++ b/internal/acceptance/openstack/compute/v2/services_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || compute || services
-// +build acceptance compute services
 
 package v2
 

--- a/internal/acceptance/openstack/compute/v2/tenantnetworks_test.go
+++ b/internal/acceptance/openstack/compute/v2/tenantnetworks_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || compute || servers
-// +build acceptance compute servers
 
 package v2
 

--- a/internal/acceptance/openstack/compute/v2/usage_test.go
+++ b/internal/acceptance/openstack/compute/v2/usage_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || compute || usage
-// +build acceptance compute usage
 
 package v2
 

--- a/internal/acceptance/openstack/compute/v2/volumeattach_test.go
+++ b/internal/acceptance/openstack/compute/v2/volumeattach_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || compute || volumeattach
-// +build acceptance compute volumeattach
 
 package v2
 

--- a/internal/acceptance/openstack/container/v1/capsules_test.go
+++ b/internal/acceptance/openstack/container/v1/capsules_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || containers || capsules
-// +build acceptance containers capsules
 
 package v1
 

--- a/internal/acceptance/openstack/container/v1/pkg.go
+++ b/internal/acceptance/openstack/container/v1/pkg.go
@@ -1,0 +1,5 @@
+//go:build acceptance || container
+
+// The v1 package contains acceptance tests for the Openstack Container v1 service.
+
+package v1

--- a/internal/acceptance/openstack/containerinfra/v1/certificates_test.go
+++ b/internal/acceptance/openstack/containerinfra/v1/certificates_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || containerinfra
-// +build acceptance containerinfra
 
 package v1
 

--- a/internal/acceptance/openstack/containerinfra/v1/certificates_test.go
+++ b/internal/acceptance/openstack/containerinfra/v1/certificates_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance || containerinfra
+//go:build acceptance || containerinfra || certificates
 
 package v1
 

--- a/internal/acceptance/openstack/containerinfra/v1/clusters_test.go
+++ b/internal/acceptance/openstack/containerinfra/v1/clusters_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || containerinfra
-// +build acceptance containerinfra
 
 package v1
 

--- a/internal/acceptance/openstack/containerinfra/v1/clusters_test.go
+++ b/internal/acceptance/openstack/containerinfra/v1/clusters_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance || containerinfra
+//go:build acceptance || containerinfra || clusters
 
 package v1
 

--- a/internal/acceptance/openstack/containerinfra/v1/clustertemplates_test.go
+++ b/internal/acceptance/openstack/containerinfra/v1/clustertemplates_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || containerinfra
-// +build acceptance containerinfra
 
 package v1
 

--- a/internal/acceptance/openstack/containerinfra/v1/clustertemplates_test.go
+++ b/internal/acceptance/openstack/containerinfra/v1/clustertemplates_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance || containerinfra
+//go:build acceptance || containerinfra || clustertemplates
 
 package v1
 

--- a/internal/acceptance/openstack/containerinfra/v1/nodegroups_test.go
+++ b/internal/acceptance/openstack/containerinfra/v1/nodegroups_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || containerinfra
-// +build acceptance containerinfra
 
 package v1
 

--- a/internal/acceptance/openstack/containerinfra/v1/nodegroups_test.go
+++ b/internal/acceptance/openstack/containerinfra/v1/nodegroups_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance || containerinfra
+//go:build acceptance || containerinfra || nodegroups
 
 package v1
 

--- a/internal/acceptance/openstack/containerinfra/v1/pkg.go
+++ b/internal/acceptance/openstack/containerinfra/v1/pkg.go
@@ -1,1 +1,5 @@
+//go:build acceptance || containerinfra
+
+// The v1 package contains acceptance tests for the Openstack Container Infra v1 service.
+
 package v1

--- a/internal/acceptance/openstack/containerinfra/v1/quotas_test.go
+++ b/internal/acceptance/openstack/containerinfra/v1/quotas_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || containerinfra
-// +build acceptance containerinfra
 
 package v1
 

--- a/internal/acceptance/openstack/containerinfra/v1/quotas_test.go
+++ b/internal/acceptance/openstack/containerinfra/v1/quotas_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance || containerinfra
+//go:build acceptance || containerinfra || quotas
 
 package v1
 

--- a/internal/acceptance/openstack/db/v1/configurations_test.go
+++ b/internal/acceptance/openstack/db/v1/configurations_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance || db
+//go:build acceptance || db || configurations
 
 package v1
 

--- a/internal/acceptance/openstack/db/v1/configurations_test.go
+++ b/internal/acceptance/openstack/db/v1/configurations_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || db
-// +build acceptance db
 
 package v1
 

--- a/internal/acceptance/openstack/db/v1/databases_test.go
+++ b/internal/acceptance/openstack/db/v1/databases_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance || db
+//go:build acceptance || db || databases
 
 package v1
 

--- a/internal/acceptance/openstack/db/v1/databases_test.go
+++ b/internal/acceptance/openstack/db/v1/databases_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || db
-// +build acceptance db
 
 package v1
 

--- a/internal/acceptance/openstack/db/v1/flavors_test.go
+++ b/internal/acceptance/openstack/db/v1/flavors_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance || db
+//go:build acceptance || db || flavors
 
 package v1
 

--- a/internal/acceptance/openstack/db/v1/flavors_test.go
+++ b/internal/acceptance/openstack/db/v1/flavors_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || db
-// +build acceptance db
 
 package v1
 

--- a/internal/acceptance/openstack/db/v1/instances_test.go
+++ b/internal/acceptance/openstack/db/v1/instances_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance || db
+//go:build acceptance || db || instances
 
 package v1
 

--- a/internal/acceptance/openstack/db/v1/instances_test.go
+++ b/internal/acceptance/openstack/db/v1/instances_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || db
-// +build acceptance db
 
 package v1
 

--- a/internal/acceptance/openstack/db/v1/pkg.go
+++ b/internal/acceptance/openstack/db/v1/pkg.go
@@ -1,1 +1,5 @@
+//go:build acceptance || db
+
+// The v1 package contains acceptance tests for the Openstack DB v1 service.
+
 package v1

--- a/internal/acceptance/openstack/db/v1/users_test.go
+++ b/internal/acceptance/openstack/db/v1/users_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance || db
+//go:build acceptance || db || users
 
 package v1
 

--- a/internal/acceptance/openstack/db/v1/users_test.go
+++ b/internal/acceptance/openstack/db/v1/users_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || db
-// +build acceptance db
 
 package v1
 

--- a/internal/acceptance/openstack/dns/v2/pkg.go
+++ b/internal/acceptance/openstack/dns/v2/pkg.go
@@ -1,0 +1,5 @@
+//go:build acceptance || dns
+
+// The v1 package contains acceptance tests for the Openstack DNS v1 service.
+
+package v2

--- a/internal/acceptance/openstack/dns/v2/recordsets_test.go
+++ b/internal/acceptance/openstack/dns/v2/recordsets_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance
-// +build acceptance
 
 package v2
 

--- a/internal/acceptance/openstack/dns/v2/recordsets_test.go
+++ b/internal/acceptance/openstack/dns/v2/recordsets_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance
+//go:build acceptance || dns || recordsets
 
 package v2
 

--- a/internal/acceptance/openstack/dns/v2/transfers_test.go
+++ b/internal/acceptance/openstack/dns/v2/transfers_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || dns || transfers
-// +build acceptance dns transfers
 
 package v2
 

--- a/internal/acceptance/openstack/dns/v2/zones_test.go
+++ b/internal/acceptance/openstack/dns/v2/zones_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || dns || zones
-// +build acceptance dns zones
 
 package v2
 

--- a/internal/acceptance/openstack/identity/v2/extension_test.go
+++ b/internal/acceptance/openstack/identity/v2/extension_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance || identity
+//go:build acceptance || identity || extensions
 
 package v2
 

--- a/internal/acceptance/openstack/identity/v2/extension_test.go
+++ b/internal/acceptance/openstack/identity/v2/extension_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || identity
-// +build acceptance identity
 
 package v2
 

--- a/internal/acceptance/openstack/identity/v2/pkg.go
+++ b/internal/acceptance/openstack/identity/v2/pkg.go
@@ -1,1 +1,5 @@
+//go:build acceptance || identity
+
+// The v2 package contains acceptance tests for the Openstack Identity v2 service.
+
 package v2

--- a/internal/acceptance/openstack/identity/v2/role_test.go
+++ b/internal/acceptance/openstack/identity/v2/role_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || identity || roles
-// +build acceptance identity roles
 
 package v2
 

--- a/internal/acceptance/openstack/identity/v2/tenant_test.go
+++ b/internal/acceptance/openstack/identity/v2/tenant_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance || identity
+//go:build acceptance || identity || tenants
 
 package v2
 

--- a/internal/acceptance/openstack/identity/v2/tenant_test.go
+++ b/internal/acceptance/openstack/identity/v2/tenant_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || identity
-// +build acceptance identity
 
 package v2
 

--- a/internal/acceptance/openstack/identity/v2/token_test.go
+++ b/internal/acceptance/openstack/identity/v2/token_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance || identity
+//go:build acceptance || identity || tokens
 
 package v2
 

--- a/internal/acceptance/openstack/identity/v2/token_test.go
+++ b/internal/acceptance/openstack/identity/v2/token_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || identity
-// +build acceptance identity
 
 package v2
 

--- a/internal/acceptance/openstack/identity/v2/user_test.go
+++ b/internal/acceptance/openstack/identity/v2/user_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance || identity
+//go:build acceptance || identity || users
 
 package v2
 

--- a/internal/acceptance/openstack/identity/v2/user_test.go
+++ b/internal/acceptance/openstack/identity/v2/user_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || identity
-// +build acceptance identity
 
 package v2
 

--- a/internal/acceptance/openstack/identity/v3/applicationcredentials_test.go
+++ b/internal/acceptance/openstack/identity/v3/applicationcredentials_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance
+//go:build acceptance || identity || applicationcredentials
 
 package v3
 

--- a/internal/acceptance/openstack/identity/v3/applicationcredentials_test.go
+++ b/internal/acceptance/openstack/identity/v3/applicationcredentials_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance
-// +build acceptance
 
 package v3
 

--- a/internal/acceptance/openstack/identity/v3/catalog_test.go
+++ b/internal/acceptance/openstack/identity/v3/catalog_test.go
@@ -1,3 +1,5 @@
+//go:build acceptance || identity || catalog
+
 package v3
 
 import (

--- a/internal/acceptance/openstack/identity/v3/credentials_test.go
+++ b/internal/acceptance/openstack/identity/v3/credentials_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance
+//go:build acceptance || identity || credentials
 
 package v3
 

--- a/internal/acceptance/openstack/identity/v3/credentials_test.go
+++ b/internal/acceptance/openstack/identity/v3/credentials_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance
-// +build acceptance
 
 package v3
 

--- a/internal/acceptance/openstack/identity/v3/domains_test.go
+++ b/internal/acceptance/openstack/identity/v3/domains_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance
+//go:build acceptance || identity || domains
 
 package v3
 

--- a/internal/acceptance/openstack/identity/v3/domains_test.go
+++ b/internal/acceptance/openstack/identity/v3/domains_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance
-// +build acceptance
 
 package v3
 

--- a/internal/acceptance/openstack/identity/v3/ec2credentials_test.go
+++ b/internal/acceptance/openstack/identity/v3/ec2credentials_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance
+//go:build acceptance || identity || ec2credentials
 
 package v3
 

--- a/internal/acceptance/openstack/identity/v3/ec2credentials_test.go
+++ b/internal/acceptance/openstack/identity/v3/ec2credentials_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance
-// +build acceptance
 
 package v3
 

--- a/internal/acceptance/openstack/identity/v3/endpoint_test.go
+++ b/internal/acceptance/openstack/identity/v3/endpoint_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance
+//go:build acceptance || identity || endpoints
 
 package v3
 

--- a/internal/acceptance/openstack/identity/v3/endpoint_test.go
+++ b/internal/acceptance/openstack/identity/v3/endpoint_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance
-// +build acceptance
 
 package v3
 

--- a/internal/acceptance/openstack/identity/v3/federation_test.go
+++ b/internal/acceptance/openstack/identity/v3/federation_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance
+//go:build acceptance || identity || federation
 
 package v3
 

--- a/internal/acceptance/openstack/identity/v3/federation_test.go
+++ b/internal/acceptance/openstack/identity/v3/federation_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance
-// +build acceptance
 
 package v3
 

--- a/internal/acceptance/openstack/identity/v3/groups_test.go
+++ b/internal/acceptance/openstack/identity/v3/groups_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance
+//go:build acceptance || identity || groups
 
 package v3
 

--- a/internal/acceptance/openstack/identity/v3/groups_test.go
+++ b/internal/acceptance/openstack/identity/v3/groups_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance
-// +build acceptance
 
 package v3
 

--- a/internal/acceptance/openstack/identity/v3/limits_test.go
+++ b/internal/acceptance/openstack/identity/v3/limits_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance
+//go:build acceptance || identity || limits
 
 package v3
 

--- a/internal/acceptance/openstack/identity/v3/limits_test.go
+++ b/internal/acceptance/openstack/identity/v3/limits_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance
-// +build acceptance
 
 package v3
 

--- a/internal/acceptance/openstack/identity/v3/oauth1_test.go
+++ b/internal/acceptance/openstack/identity/v3/oauth1_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance
+//go:build acceptance || identity || oauth1
 
 package v3
 

--- a/internal/acceptance/openstack/identity/v3/oauth1_test.go
+++ b/internal/acceptance/openstack/identity/v3/oauth1_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance
-// +build acceptance
 
 package v3
 

--- a/internal/acceptance/openstack/identity/v3/osinherit_test.go
+++ b/internal/acceptance/openstack/identity/v3/osinherit_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance
-// +build acceptance
 
 package v3
 

--- a/internal/acceptance/openstack/identity/v3/osinherit_test.go
+++ b/internal/acceptance/openstack/identity/v3/osinherit_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance
+//go:build acceptance || identity || osinherit
 
 package v3
 

--- a/internal/acceptance/openstack/identity/v3/pkg.go
+++ b/internal/acceptance/openstack/identity/v3/pkg.go
@@ -1,1 +1,5 @@
+//go:build acceptance || identity
+
+// The v3 package contains acceptance tests for the Openstack Identity v3 service.
+
 package v3

--- a/internal/acceptance/openstack/identity/v3/policies_test.go
+++ b/internal/acceptance/openstack/identity/v3/policies_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance
-// +build acceptance
 
 package v3
 

--- a/internal/acceptance/openstack/identity/v3/policies_test.go
+++ b/internal/acceptance/openstack/identity/v3/policies_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance
+//go:build acceptance || identity || policies
 
 package v3
 

--- a/internal/acceptance/openstack/identity/v3/projectendpoint_test.go
+++ b/internal/acceptance/openstack/identity/v3/projectendpoint_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance
+//go:build acceptance || identity || projectendpoints
 
 package v3
 

--- a/internal/acceptance/openstack/identity/v3/projectendpoint_test.go
+++ b/internal/acceptance/openstack/identity/v3/projectendpoint_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance
-// +build acceptance
 
 package v3
 

--- a/internal/acceptance/openstack/identity/v3/projects_test.go
+++ b/internal/acceptance/openstack/identity/v3/projects_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance
-// +build acceptance
 
 package v3
 

--- a/internal/acceptance/openstack/identity/v3/projects_test.go
+++ b/internal/acceptance/openstack/identity/v3/projects_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance
+//go:build acceptance || identity || projects
 
 package v3
 

--- a/internal/acceptance/openstack/identity/v3/reauth_test.go
+++ b/internal/acceptance/openstack/identity/v3/reauth_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance
+//go:build acceptance || identity || reauth
 
 package v3
 

--- a/internal/acceptance/openstack/identity/v3/reauth_test.go
+++ b/internal/acceptance/openstack/identity/v3/reauth_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance
-// +build acceptance
 
 package v3
 

--- a/internal/acceptance/openstack/identity/v3/regions_test.go
+++ b/internal/acceptance/openstack/identity/v3/regions_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance
+//go:build acceptance || identity || regions
 
 package v3
 

--- a/internal/acceptance/openstack/identity/v3/regions_test.go
+++ b/internal/acceptance/openstack/identity/v3/regions_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance
-// +build acceptance
 
 package v3
 

--- a/internal/acceptance/openstack/identity/v3/registeredlimits_test.go
+++ b/internal/acceptance/openstack/identity/v3/registeredlimits_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance
+//go:build acceptance || identity || registeredlimits
 
 package v3
 

--- a/internal/acceptance/openstack/identity/v3/registeredlimits_test.go
+++ b/internal/acceptance/openstack/identity/v3/registeredlimits_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance
-// +build acceptance
 
 package v3
 

--- a/internal/acceptance/openstack/identity/v3/roles_test.go
+++ b/internal/acceptance/openstack/identity/v3/roles_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance
+//go:build acceptance || identity || roles
 
 package v3
 

--- a/internal/acceptance/openstack/identity/v3/roles_test.go
+++ b/internal/acceptance/openstack/identity/v3/roles_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance
-// +build acceptance
 
 package v3
 

--- a/internal/acceptance/openstack/identity/v3/service_test.go
+++ b/internal/acceptance/openstack/identity/v3/service_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance
+//go:build acceptance || identity || services
 
 package v3
 

--- a/internal/acceptance/openstack/identity/v3/service_test.go
+++ b/internal/acceptance/openstack/identity/v3/service_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance
-// +build acceptance
 
 package v3
 

--- a/internal/acceptance/openstack/identity/v3/token_test.go
+++ b/internal/acceptance/openstack/identity/v3/token_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance
-// +build acceptance
 
 package v3
 

--- a/internal/acceptance/openstack/identity/v3/token_test.go
+++ b/internal/acceptance/openstack/identity/v3/token_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance
+//go:build acceptance || identity || tokens
 
 package v3
 

--- a/internal/acceptance/openstack/identity/v3/trusts_test.go
+++ b/internal/acceptance/openstack/identity/v3/trusts_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || identity || trusts
-// +build acceptance identity trusts
 
 package v3
 

--- a/internal/acceptance/openstack/identity/v3/users_test.go
+++ b/internal/acceptance/openstack/identity/v3/users_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance
+//go:build acceptance || identity || users
 
 package v3
 

--- a/internal/acceptance/openstack/identity/v3/users_test.go
+++ b/internal/acceptance/openstack/identity/v3/users_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance
-// +build acceptance
 
 package v3
 

--- a/internal/acceptance/openstack/image/v2/imagedata_test.go
+++ b/internal/acceptance/openstack/image/v2/imagedata_test.go
@@ -1,3 +1,5 @@
+//go:build acceptance || image || imagedata
+
 package v2
 
 import (

--- a/internal/acceptance/openstack/image/v2/imageimport_test.go
+++ b/internal/acceptance/openstack/image/v2/imageimport_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || image || imageimport
-// +build acceptance image imageimport
 
 package v2
 

--- a/internal/acceptance/openstack/image/v2/images_test.go
+++ b/internal/acceptance/openstack/image/v2/images_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || image || images
-// +build acceptance image images
 
 package v2
 

--- a/internal/acceptance/openstack/image/v2/pkg.go
+++ b/internal/acceptance/openstack/image/v2/pkg.go
@@ -1,0 +1,5 @@
+//go:build acceptance || image
+
+// The v2 package contains acceptance tests for the Openstack Image v2 service.
+
+package v2

--- a/internal/acceptance/openstack/image/v2/tasks_test.go
+++ b/internal/acceptance/openstack/image/v2/tasks_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || image || tasks
-// +build acceptance image tasks
 
 package v2
 

--- a/internal/acceptance/openstack/keymanager/v1/acls_test.go
+++ b/internal/acceptance/openstack/keymanager/v1/acls_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || keymanager || acls
-// +build acceptance keymanager acls
 
 package v1
 

--- a/internal/acceptance/openstack/keymanager/v1/containers_test.go
+++ b/internal/acceptance/openstack/keymanager/v1/containers_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || keymanager || containers
-// +build acceptance keymanager containers
 
 package v1
 

--- a/internal/acceptance/openstack/keymanager/v1/orders_test.go
+++ b/internal/acceptance/openstack/keymanager/v1/orders_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || keymanager || orders
-// +build acceptance keymanager orders
 
 package v1
 

--- a/internal/acceptance/openstack/keymanager/v1/pkg.go
+++ b/internal/acceptance/openstack/keymanager/v1/pkg.go
@@ -1,0 +1,5 @@
+//go:build acceptance || keymanager
+
+// The v1 package contains acceptance tests for the Openstack Keymanager v1 service.
+
+package v1

--- a/internal/acceptance/openstack/keymanager/v1/secrets_test.go
+++ b/internal/acceptance/openstack/keymanager/v1/secrets_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || keymanager || secrets
-// +build acceptance keymanager secrets
 
 package v1
 

--- a/internal/acceptance/openstack/loadbalancer/v2/amphorae_test.go
+++ b/internal/acceptance/openstack/loadbalancer/v2/amphorae_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || containers || capsules
-// +build acceptance containers capsules
 
 package v2
 

--- a/internal/acceptance/openstack/loadbalancer/v2/flavorprofiles_test.go
+++ b/internal/acceptance/openstack/loadbalancer/v2/flavorprofiles_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || networking || loadbalancer || flavorprofiles
-// +build acceptance networking loadbalancer flavorprofiles
 
 package v2
 

--- a/internal/acceptance/openstack/loadbalancer/v2/flavors_test.go
+++ b/internal/acceptance/openstack/loadbalancer/v2/flavors_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || networking || loadbalancer || flavors
-// +build acceptance networking loadbalancer flavors
 
 package v2
 

--- a/internal/acceptance/openstack/loadbalancer/v2/l7policies_test.go
+++ b/internal/acceptance/openstack/loadbalancer/v2/l7policies_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || networking || loadbalancer || l7policies
-// +build acceptance networking loadbalancer l7policies
 
 package v2
 

--- a/internal/acceptance/openstack/loadbalancer/v2/listeners_test.go
+++ b/internal/acceptance/openstack/loadbalancer/v2/listeners_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || networking || loadbalancer || listeners
-// +build acceptance networking loadbalancer listeners
 
 package v2
 

--- a/internal/acceptance/openstack/loadbalancer/v2/loadbalancers_test.go
+++ b/internal/acceptance/openstack/loadbalancer/v2/loadbalancers_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || networking || loadbalancer || loadbalancers
-// +build acceptance networking loadbalancer loadbalancers
 
 package v2
 

--- a/internal/acceptance/openstack/loadbalancer/v2/monitors_test.go
+++ b/internal/acceptance/openstack/loadbalancer/v2/monitors_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || networking || loadbalancer || monitors
-// +build acceptance networking loadbalancer monitors
 
 package v2
 

--- a/internal/acceptance/openstack/loadbalancer/v2/pkg.go
+++ b/internal/acceptance/openstack/loadbalancer/v2/pkg.go
@@ -1,1 +1,5 @@
+//go:build acceptance || loadbalancer
+
+// The v2 package contains acceptance tests for the Openstack Loadbalancer v2 service.
+
 package v2

--- a/internal/acceptance/openstack/loadbalancer/v2/pools_test.go
+++ b/internal/acceptance/openstack/loadbalancer/v2/pools_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || networking || loadbalancer || pools
-// +build acceptance networking loadbalancer pools
 
 package v2
 

--- a/internal/acceptance/openstack/loadbalancer/v2/providers_test.go
+++ b/internal/acceptance/openstack/loadbalancer/v2/providers_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || networking || loadbalancer || providers
-// +build acceptance networking loadbalancer providers
 
 package v2
 

--- a/internal/acceptance/openstack/loadbalancer/v2/quotas_test.go
+++ b/internal/acceptance/openstack/loadbalancer/v2/quotas_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || networking || loadbalancer || quotas
-// +build acceptance networking loadbalancer quotas
 
 package v2
 

--- a/internal/acceptance/openstack/messaging/v2/claims_test.go
+++ b/internal/acceptance/openstack/messaging/v2/claims_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || messaging || claims
-// +build acceptance messaging claims
 
 package v2
 

--- a/internal/acceptance/openstack/messaging/v2/message_test.go
+++ b/internal/acceptance/openstack/messaging/v2/message_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || messaging || messages
-// +build acceptance messaging messages
 
 package v2
 

--- a/internal/acceptance/openstack/messaging/v2/pkg.go
+++ b/internal/acceptance/openstack/messaging/v2/pkg.go
@@ -1,0 +1,5 @@
+//go:build acceptance || messaging
+
+// The v2 package contains acceptance tests for the Openstack Messaging v2 service.
+
+package v2

--- a/internal/acceptance/openstack/messaging/v2/queue_test.go
+++ b/internal/acceptance/openstack/messaging/v2/queue_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || messaging || queues
-// +build acceptance messaging queues
 
 package v2
 

--- a/internal/acceptance/openstack/networking/v2/apiversion_test.go
+++ b/internal/acceptance/openstack/networking/v2/apiversion_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance || networking
+//go:build acceptance || networking || apiversion
 
 package v2
 

--- a/internal/acceptance/openstack/networking/v2/apiversion_test.go
+++ b/internal/acceptance/openstack/networking/v2/apiversion_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || networking
-// +build acceptance networking
 
 package v2
 

--- a/internal/acceptance/openstack/networking/v2/extension_test.go
+++ b/internal/acceptance/openstack/networking/v2/extension_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || networking || extensions
-// +build acceptance networking extensions
 
 package v2
 

--- a/internal/acceptance/openstack/networking/v2/extensions/agents/agents_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/agents/agents_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || networking || agents
-// +build acceptance networking agents
 
 package agents
 

--- a/internal/acceptance/openstack/networking/v2/extensions/attributestags_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/attributestags_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || networking || tags
-// +build acceptance networking tags
 
 package extensions
 

--- a/internal/acceptance/openstack/networking/v2/extensions/bgp/peers/bgppeers_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/bgp/peers/bgppeers_test.go
@@ -1,3 +1,5 @@
+//go:build acceptance || networking || bgp || peers
+
 package peers
 
 import (

--- a/internal/acceptance/openstack/networking/v2/extensions/bgp/speakers/bgpspeakers_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/bgp/speakers/bgpspeakers_test.go
@@ -1,3 +1,5 @@
+//go:build acceptance || networking || bgp || speakers
+
 package speakers
 
 import (

--- a/internal/acceptance/openstack/networking/v2/extensions/dns/dns_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/dns/dns_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance || networking
+//go:build acceptance || networking || dns
 
 package dns
 

--- a/internal/acceptance/openstack/networking/v2/extensions/dns/dns_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/dns/dns_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || networking
-// +build acceptance networking
 
 package dns
 

--- a/internal/acceptance/openstack/networking/v2/extensions/fwaas_v2/groups_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/fwaas_v2/groups_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || networking || fwaas_v2
-// +build acceptance networking fwaas_v2
 
 package fwaas_v2
 

--- a/internal/acceptance/openstack/networking/v2/extensions/fwaas_v2/policy_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/fwaas_v2/policy_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || networking || fwaas_v2
-// +build acceptance networking fwaas_v2
 
 package fwaas_v2
 

--- a/internal/acceptance/openstack/networking/v2/extensions/fwaas_v2/rule_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/fwaas_v2/rule_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || networking || fwaas_v2
-// +build acceptance networking fwaas_v2
 
 package fwaas_v2
 

--- a/internal/acceptance/openstack/networking/v2/extensions/layer3/addressscopes_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/layer3/addressscopes_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || networking || layer3 || addressscopes
-// +build acceptance networking layer3 addressscopes
 
 package layer3
 

--- a/internal/acceptance/openstack/networking/v2/extensions/layer3/extraroutes_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/layer3/extraroutes_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || networking || layer3 || router
-// +build acceptance networking layer3 router
 
 package layer3
 

--- a/internal/acceptance/openstack/networking/v2/extensions/layer3/floatingips_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/layer3/floatingips_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || networking || layer3 || floatingips
-// +build acceptance networking layer3 floatingips
 
 package layer3
 

--- a/internal/acceptance/openstack/networking/v2/extensions/layer3/l3_scheduling_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/layer3/l3_scheduling_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || networking || layer3 || router
-// +build acceptance networking layer3 router
 
 package layer3
 

--- a/internal/acceptance/openstack/networking/v2/extensions/layer3/portforwardings_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/layer3/portforwardings_test.go
@@ -1,3 +1,5 @@
+//go:build acceptance || networking || layer3 || portforwardings
+
 package layer3
 
 import (

--- a/internal/acceptance/openstack/networking/v2/extensions/layer3/routers_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/layer3/routers_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || networking || layer3 || router
-// +build acceptance networking layer3 router
 
 package layer3
 

--- a/internal/acceptance/openstack/networking/v2/extensions/mtu/mtu_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/mtu/mtu_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance || networking
+//go:build acceptance || networking || mtu
 
 package mtu
 

--- a/internal/acceptance/openstack/networking/v2/extensions/mtu/mtu_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/mtu/mtu_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || networking
-// +build acceptance networking
 
 package mtu
 

--- a/internal/acceptance/openstack/networking/v2/extensions/networkipavailabilities/networkipavailabilities_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/networkipavailabilities/networkipavailabilities_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || networking || networkipavailabilities
-// +build acceptance networking networkipavailabilities
 
 package networkipavailabilities
 

--- a/internal/acceptance/openstack/networking/v2/extensions/portsbinding/portsbinding_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/portsbinding/portsbinding_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance || networking
+//go:build acceptance || networking || portbinding
 
 package portsbinding
 

--- a/internal/acceptance/openstack/networking/v2/extensions/portsbinding/portsbinding_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/portsbinding/portsbinding_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || networking
-// +build acceptance networking
 
 package portsbinding
 

--- a/internal/acceptance/openstack/networking/v2/extensions/provider_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/provider_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || networking || provider
-// +build acceptance networking provider
 
 package extensions
 

--- a/internal/acceptance/openstack/networking/v2/extensions/qos/policies/policies_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/qos/policies/policies_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || networking || qos || policies
-// +build acceptance networking qos policies
 
 package policies
 

--- a/internal/acceptance/openstack/networking/v2/extensions/qos/rules/rules_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/qos/rules/rules_test.go
@@ -1,3 +1,5 @@
+//go:build acceptance || networking || qos || rules
+
 package rules
 
 import (

--- a/internal/acceptance/openstack/networking/v2/extensions/qos/ruletypes/ruletypes_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/qos/ruletypes/ruletypes_test.go
@@ -1,3 +1,5 @@
+//go:build acceptance || networking || qos || ruletypes
+
 package ruletypes
 
 import (

--- a/internal/acceptance/openstack/networking/v2/extensions/quotas/quotas_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/quotas/quotas_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || networking || quotas
-// +build acceptance networking quotas
 
 package quotas
 

--- a/internal/acceptance/openstack/networking/v2/extensions/rbacpolicies/rbacpolicies_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/rbacpolicies/rbacpolicies_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance
+//go:build acceptance || networking || rbacpolicies
 
 package rbacpolicies
 

--- a/internal/acceptance/openstack/networking/v2/extensions/rbacpolicies/rbacpolicies_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/rbacpolicies/rbacpolicies_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance
-// +build acceptance
 
 package rbacpolicies
 

--- a/internal/acceptance/openstack/networking/v2/extensions/security_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/security_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || networking || security
-// +build acceptance networking security
 
 package extensions
 

--- a/internal/acceptance/openstack/networking/v2/extensions/subnetpools/subnetpools_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/subnetpools/subnetpools_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || networking || subnetpools
-// +build acceptance networking subnetpools
 
 package v2
 

--- a/internal/acceptance/openstack/networking/v2/extensions/trunk_details/trunks_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/trunk_details/trunks_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || trunks
-// +build acceptance trunks
 
 package trunk_details
 

--- a/internal/acceptance/openstack/networking/v2/extensions/trunk_details/trunks_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/trunk_details/trunks_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance || trunks
+//go:build acceptance || networking || trunks
 
 package trunk_details
 

--- a/internal/acceptance/openstack/networking/v2/extensions/trunks/trunks_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/trunks/trunks_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance || trunks
+//go:build acceptance || networking || trunks
 
 package trunks
 

--- a/internal/acceptance/openstack/networking/v2/extensions/trunks/trunks_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/trunks/trunks_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || trunks
-// +build acceptance trunks
 
 package trunks
 

--- a/internal/acceptance/openstack/networking/v2/extensions/vlantransparent/vlantransparent_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/vlantransparent/vlantransparent_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || networking || vlantransparent
-// +build acceptance networking vlantransparent
 
 package v2
 

--- a/internal/acceptance/openstack/networking/v2/extensions/vpnaas/group_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/vpnaas/group_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || networking || vpnaas
-// +build acceptance networking vpnaas
 
 package vpnaas
 

--- a/internal/acceptance/openstack/networking/v2/extensions/vpnaas/ikepolicy_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/vpnaas/ikepolicy_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || networking || vpnaas
-// +build acceptance networking vpnaas
 
 package vpnaas
 

--- a/internal/acceptance/openstack/networking/v2/extensions/vpnaas/ipsecpolicy_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/vpnaas/ipsecpolicy_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || networking || vpnaas
-// +build acceptance networking vpnaas
 
 package vpnaas
 

--- a/internal/acceptance/openstack/networking/v2/extensions/vpnaas/service_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/vpnaas/service_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || networking || vpnaas
-// +build acceptance networking vpnaas
 
 package vpnaas
 

--- a/internal/acceptance/openstack/networking/v2/extensions/vpnaas/siteconnection_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/vpnaas/siteconnection_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || networking || vpnaas
-// +build acceptance networking vpnaas
 
 package vpnaas
 

--- a/internal/acceptance/openstack/networking/v2/networks_test.go
+++ b/internal/acceptance/openstack/networking/v2/networks_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance || networking
+//go:build acceptance || networking || networks
 
 package v2
 

--- a/internal/acceptance/openstack/networking/v2/networks_test.go
+++ b/internal/acceptance/openstack/networking/v2/networks_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || networking
-// +build acceptance networking
 
 package v2
 

--- a/internal/acceptance/openstack/networking/v2/pkg.go
+++ b/internal/acceptance/openstack/networking/v2/pkg.go
@@ -1,0 +1,5 @@
+//go:build acceptance || networking
+
+// The v2 package contains acceptance tests for the Openstack Networking v2 service.
+
+package v2

--- a/internal/acceptance/openstack/networking/v2/ports_test.go
+++ b/internal/acceptance/openstack/networking/v2/ports_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance || networking
+//go:build acceptance || networking || ports
 
 package v2
 

--- a/internal/acceptance/openstack/networking/v2/ports_test.go
+++ b/internal/acceptance/openstack/networking/v2/ports_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || networking
-// +build acceptance networking
 
 package v2
 

--- a/internal/acceptance/openstack/networking/v2/subnets_test.go
+++ b/internal/acceptance/openstack/networking/v2/subnets_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance || networking
+//go:build acceptance || networking || subnets
 
 package v2
 

--- a/internal/acceptance/openstack/networking/v2/subnets_test.go
+++ b/internal/acceptance/openstack/networking/v2/subnets_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || networking
-// +build acceptance networking
 
 package v2
 

--- a/internal/acceptance/openstack/objectstorage/v1/accounts_test.go
+++ b/internal/acceptance/openstack/objectstorage/v1/accounts_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance
-// +build acceptance
 
 package v1
 

--- a/internal/acceptance/openstack/objectstorage/v1/accounts_test.go
+++ b/internal/acceptance/openstack/objectstorage/v1/accounts_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance
+//go:build acceptance || objectstorage || accounts
 
 package v1
 

--- a/internal/acceptance/openstack/objectstorage/v1/containers_test.go
+++ b/internal/acceptance/openstack/objectstorage/v1/containers_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance
-// +build acceptance
 
 package v1
 

--- a/internal/acceptance/openstack/objectstorage/v1/containers_test.go
+++ b/internal/acceptance/openstack/objectstorage/v1/containers_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance
+//go:build acceptance || objectstorage || containers
 
 package v1
 

--- a/internal/acceptance/openstack/objectstorage/v1/objects_test.go
+++ b/internal/acceptance/openstack/objectstorage/v1/objects_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance
+//go:build acceptance || objectstorage || objects
 
 package v1
 

--- a/internal/acceptance/openstack/objectstorage/v1/objects_test.go
+++ b/internal/acceptance/openstack/objectstorage/v1/objects_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance
-// +build acceptance
 
 package v1
 

--- a/internal/acceptance/openstack/objectstorage/v1/pkg.go
+++ b/internal/acceptance/openstack/objectstorage/v1/pkg.go
@@ -1,1 +1,5 @@
+//go:build acceptance || objectstorage
+
+// The v1 package contains acceptance tests for the Openstack Object Storage v1 service.
+
 package v1

--- a/internal/acceptance/openstack/objectstorage/v1/versioning_test.go
+++ b/internal/acceptance/openstack/objectstorage/v1/versioning_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance
-// +build acceptance
 
 package v1
 

--- a/internal/acceptance/openstack/objectstorage/v1/versioning_test.go
+++ b/internal/acceptance/openstack/objectstorage/v1/versioning_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance
+//go:build acceptance || objectstorage || versioning
 
 package v1
 

--- a/internal/acceptance/openstack/orchestration/v1/buildinfo_test.go
+++ b/internal/acceptance/openstack/orchestration/v1/buildinfo_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance
-// +build acceptance
 
 package v1
 

--- a/internal/acceptance/openstack/orchestration/v1/buildinfo_test.go
+++ b/internal/acceptance/openstack/orchestration/v1/buildinfo_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance
+//go:build acceptance || orchestration || buildinfo
 
 package v1
 

--- a/internal/acceptance/openstack/orchestration/v1/pkg.go
+++ b/internal/acceptance/openstack/orchestration/v1/pkg.go
@@ -1,0 +1,5 @@
+//go:build acceptance || orchestration
+
+// The v1 package contains acceptance tests for the Openstack Orchestration v1 service.
+
+package v1

--- a/internal/acceptance/openstack/orchestration/v1/stackevents_test.go
+++ b/internal/acceptance/openstack/orchestration/v1/stackevents_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance
+//go:build acceptance || orchestration || stackevents
 
 package v1
 

--- a/internal/acceptance/openstack/orchestration/v1/stackevents_test.go
+++ b/internal/acceptance/openstack/orchestration/v1/stackevents_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance
-// +build acceptance
 
 package v1
 

--- a/internal/acceptance/openstack/orchestration/v1/stackresources_test.go
+++ b/internal/acceptance/openstack/orchestration/v1/stackresources_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance
+//go:build acceptance || orchestration || stackresources
 
 package v1
 

--- a/internal/acceptance/openstack/orchestration/v1/stackresources_test.go
+++ b/internal/acceptance/openstack/orchestration/v1/stackresources_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance
-// +build acceptance
 
 package v1
 

--- a/internal/acceptance/openstack/orchestration/v1/stacks_test.go
+++ b/internal/acceptance/openstack/orchestration/v1/stacks_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance
+//go:build acceptance || orchestration || stacks
 
 package v1
 

--- a/internal/acceptance/openstack/orchestration/v1/stacks_test.go
+++ b/internal/acceptance/openstack/orchestration/v1/stacks_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance
-// +build acceptance
 
 package v1
 

--- a/internal/acceptance/openstack/orchestration/v1/stacktemplates_test.go
+++ b/internal/acceptance/openstack/orchestration/v1/stacktemplates_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance
-// +build acceptance
 
 package v1
 

--- a/internal/acceptance/openstack/orchestration/v1/stacktemplates_test.go
+++ b/internal/acceptance/openstack/orchestration/v1/stacktemplates_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance
+//go:build acceptance || orchestration || stacktemplates
 
 package v1
 

--- a/internal/acceptance/openstack/pkg.go
+++ b/internal/acceptance/openstack/pkg.go
@@ -1,4 +1,3 @@
 //go:build acceptance
-// +build acceptance
 
 package openstack

--- a/internal/acceptance/openstack/placement/v1/pkg.go
+++ b/internal/acceptance/openstack/placement/v1/pkg.go
@@ -1,2 +1,5 @@
-// Package placement contains acceptance tests for the Openstack Placement service.
+//go:build acceptance || placement
+
+// The v1 package contains acceptance tests for the Openstack Placment v1 service.
+
 package v1

--- a/internal/acceptance/openstack/placement/v1/resourceproviders_test.go
+++ b/internal/acceptance/openstack/placement/v1/resourceproviders_test.go
@@ -1,3 +1,5 @@
+//go:build acceptance || placement || resourceproviders
+
 package v1
 
 import (

--- a/internal/acceptance/openstack/sharedfilesystems/v2/availabilityzones_test.go
+++ b/internal/acceptance/openstack/sharedfilesystems/v2/availabilityzones_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance
-// +build acceptance
 
 package v2
 

--- a/internal/acceptance/openstack/sharedfilesystems/v2/availabilityzones_test.go
+++ b/internal/acceptance/openstack/sharedfilesystems/v2/availabilityzones_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance
+//go:build acceptance || sharedfilesystems || availabilityzones
 
 package v2
 

--- a/internal/acceptance/openstack/sharedfilesystems/v2/messages.go
+++ b/internal/acceptance/openstack/sharedfilesystems/v2/messages.go
@@ -1,4 +1,4 @@
-package messages
+package v2
 
 import (
 	"context"

--- a/internal/acceptance/openstack/sharedfilesystems/v2/messages/messages_test.go
+++ b/internal/acceptance/openstack/sharedfilesystems/v2/messages/messages_test.go
@@ -1,3 +1,5 @@
+//go:build acceptance || sharedfilesystems || messages
+
 package messages
 
 import (

--- a/internal/acceptance/openstack/sharedfilesystems/v2/messages/pkg.go
+++ b/internal/acceptance/openstack/sharedfilesystems/v2/messages/pkg.go
@@ -1,3 +1,0 @@
-// The v2 package contains acceptance tests for the Openstack Manila V2 messages package
-
-package messages

--- a/internal/acceptance/openstack/sharedfilesystems/v2/messages_test.go
+++ b/internal/acceptance/openstack/sharedfilesystems/v2/messages_test.go
@@ -1,6 +1,6 @@
 //go:build acceptance || sharedfilesystems || messages
 
-package messages
+package v2
 
 import (
 	"context"

--- a/internal/acceptance/openstack/sharedfilesystems/v2/pkg.go
+++ b/internal/acceptance/openstack/sharedfilesystems/v2/pkg.go
@@ -1,3 +1,5 @@
-// The v2 package contains acceptance tests for the Openstack Manila V2 service.
+//go:build acceptance || sharedfilesystems
+
+// The v2 package contains acceptance tests for the Openstack Shared File Systems v2 service.
 
 package v2

--- a/internal/acceptance/openstack/sharedfilesystems/v2/replicas_test.go
+++ b/internal/acceptance/openstack/sharedfilesystems/v2/replicas_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance
-// +build acceptance
 
 package v2
 

--- a/internal/acceptance/openstack/sharedfilesystems/v2/replicas_test.go
+++ b/internal/acceptance/openstack/sharedfilesystems/v2/replicas_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance
+//go:build acceptance || sharedfilesystems || replicas
 
 package v2
 

--- a/internal/acceptance/openstack/sharedfilesystems/v2/schedulerstats_test.go
+++ b/internal/acceptance/openstack/sharedfilesystems/v2/schedulerstats_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance
-// +build acceptance
 
 package v2
 

--- a/internal/acceptance/openstack/sharedfilesystems/v2/schedulerstats_test.go
+++ b/internal/acceptance/openstack/sharedfilesystems/v2/schedulerstats_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance
+//go:build acceptance || sharedfilesystems || schedulerstats
 
 package v2
 

--- a/internal/acceptance/openstack/sharedfilesystems/v2/securityservices_test.go
+++ b/internal/acceptance/openstack/sharedfilesystems/v2/securityservices_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance
-// +build acceptance
 
 package v2
 

--- a/internal/acceptance/openstack/sharedfilesystems/v2/securityservices_test.go
+++ b/internal/acceptance/openstack/sharedfilesystems/v2/securityservices_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance
+//go:build acceptance || sharedfilesystems || securityservices
 
 package v2
 

--- a/internal/acceptance/openstack/sharedfilesystems/v2/services_test.go
+++ b/internal/acceptance/openstack/sharedfilesystems/v2/services_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance
-// +build acceptance
 
 package v2
 

--- a/internal/acceptance/openstack/sharedfilesystems/v2/services_test.go
+++ b/internal/acceptance/openstack/sharedfilesystems/v2/services_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance
+//go:build acceptance || sharedfilesystems || services
 
 package v2
 

--- a/internal/acceptance/openstack/sharedfilesystems/v2/shareaccessrules_test.go
+++ b/internal/acceptance/openstack/sharedfilesystems/v2/shareaccessrules_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance
-// +build acceptance
 
 package v2
 

--- a/internal/acceptance/openstack/sharedfilesystems/v2/shareaccessrules_test.go
+++ b/internal/acceptance/openstack/sharedfilesystems/v2/shareaccessrules_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance
+//go:build acceptance || sharedfilesystems || shareaccessrules
 
 package v2
 

--- a/internal/acceptance/openstack/sharedfilesystems/v2/sharenetworks_test.go
+++ b/internal/acceptance/openstack/sharedfilesystems/v2/sharenetworks_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance
-// +build acceptance
 
 package v2
 

--- a/internal/acceptance/openstack/sharedfilesystems/v2/sharenetworks_test.go
+++ b/internal/acceptance/openstack/sharedfilesystems/v2/sharenetworks_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance
+//go:build acceptance || sharedfilesystems || sharenetworks
 
 package v2
 

--- a/internal/acceptance/openstack/sharedfilesystems/v2/shares_test.go
+++ b/internal/acceptance/openstack/sharedfilesystems/v2/shares_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance
-// +build acceptance
 
 package v2
 

--- a/internal/acceptance/openstack/sharedfilesystems/v2/shares_test.go
+++ b/internal/acceptance/openstack/sharedfilesystems/v2/shares_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance
+//go:build acceptance || sharedfilesystems || shares
 
 package v2
 

--- a/internal/acceptance/openstack/sharedfilesystems/v2/sharetransfers_test.go
+++ b/internal/acceptance/openstack/sharedfilesystems/v2/sharetransfers_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance || share || transfers
+//go:build acceptance || sharedfilesystems || sharetransfers
 
 package v2
 

--- a/internal/acceptance/openstack/sharedfilesystems/v2/sharetransfers_test.go
+++ b/internal/acceptance/openstack/sharedfilesystems/v2/sharetransfers_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance || share || transfers
-// +build acceptance share transfers
 
 package v2
 

--- a/internal/acceptance/openstack/sharedfilesystems/v2/sharetypes_test.go
+++ b/internal/acceptance/openstack/sharedfilesystems/v2/sharetypes_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance
-// +build acceptance
 
 package v2
 

--- a/internal/acceptance/openstack/sharedfilesystems/v2/sharetypes_test.go
+++ b/internal/acceptance/openstack/sharedfilesystems/v2/sharetypes_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance
+//go:build acceptance || sharedfilesystems || sharetypes
 
 package v2
 

--- a/internal/acceptance/openstack/sharedfilesystems/v2/snapshots_test.go
+++ b/internal/acceptance/openstack/sharedfilesystems/v2/snapshots_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance
-// +build acceptance
 
 package v2
 

--- a/internal/acceptance/openstack/sharedfilesystems/v2/snapshots_test.go
+++ b/internal/acceptance/openstack/sharedfilesystems/v2/snapshots_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance
+//go:build acceptance || sharedfilesystems || snapshots
 
 package v2
 

--- a/internal/acceptance/openstack/workflow/v2/crontriggers_test.go
+++ b/internal/acceptance/openstack/workflow/v2/crontriggers_test.go
@@ -1,3 +1,5 @@
+//go:build acceptance || workflow || crontriggers
+
 package v2
 
 import (

--- a/internal/acceptance/openstack/workflow/v2/executions_test.go
+++ b/internal/acceptance/openstack/workflow/v2/executions_test.go
@@ -1,3 +1,5 @@
+//go:build acceptance || workflow || executions
+
 package v2
 
 import (

--- a/internal/acceptance/openstack/workflow/v2/pkg.go
+++ b/internal/acceptance/openstack/workflow/v2/pkg.go
@@ -1,0 +1,5 @@
+//go:build acceptance || workflow
+
+// The v2 package contains acceptance tests for the Openstack Workflow v2 service.
+
+package v2

--- a/internal/acceptance/openstack/workflow/v2/workflows_test.go
+++ b/internal/acceptance/openstack/workflow/v2/workflows_test.go
@@ -1,3 +1,5 @@
+//go:build acceptance || workflow || workflows
+
 package v2
 
 import (


### PR DESCRIPTION
These should be set on *all* functional tests so that we can run e.g. `go test ./...` and only have unit tests run.

This is broken out from https://github.com/gophercloud/gophercloud/pull/3001 to help minimize the diff from that (rather beefy) PR
