### PR TITLE
Add missing contexts to go docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ specification) and image ID (operating system) we're interested in:
 ```go
 import "github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
 
-server, err := servers.Create(client, servers.CreateOpts{
+server, err := servers.Create(context.TODO(), client, servers.CreateOpts{
 	Name:      "My new server!",
 	FlavorRef: "flavor_id",
 	ImageRef:  "image_id",

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ import (
 opts := new(clientconfig.ClientOpts)
 opts.Cloud = "devstack-admin"
 
-provider, err := clientconfig.AuthenticatedClient(opts)
+provider, err := clientconfig.AuthenticatedClient(context.TODO(), opts)
 ```
 
 A provider client is a top-level client that all of your OpenStack service
@@ -118,7 +118,7 @@ Once you have the `opts` variable, you can pass it in and get back a
 `ProviderClient` struct:
 
 ```go
-provider, err := openstack.AuthenticatedClient(opts)
+provider, err := openstack.AuthenticatedClient(context.TODO(), opts)
 ```
 
 As above, you can then use this provider client to generate a service client

--- a/auth_options.go
+++ b/auth_options.go
@@ -19,13 +19,13 @@ An example of manually providing authentication information:
 	  TenantID: "{tenant_id}",
 	}
 
-	provider, err := openstack.AuthenticatedClient(opts)
+	provider, err := openstack.AuthenticatedClient(context.TODO(), opts)
 
 An example of using AuthOptionsFromEnv(), where the environment variables can
 be read from a file, such as a standard openrc file:
 
 	opts, err := openstack.AuthOptionsFromEnv()
-	provider, err := openstack.AuthenticatedClient(opts)
+	provider, err := openstack.AuthenticatedClient(context.TODO(), opts)
 */
 type AuthOptions struct {
 	// IdentityEndpoint specifies the HTTP endpoint that is required to work with

--- a/doc.go
+++ b/doc.go
@@ -100,7 +100,7 @@ of results:
 If you want to obtain the entire collection of pages without doing any
 intermediary processing on each page, you can use the AllPages method:
 
-	allPages, err := servers.List(client, nil).AllPages()
+	allPages, err := servers.List(client, nil).AllPages(context.TODO())
 	allServers, err := servers.ExtractServers(allPages)
 
 This top-level package contains utility functions and data types that are used

--- a/doc.go
+++ b/doc.go
@@ -29,7 +29,7 @@ specified like so:
 		TenantID: "{tenant_id}",
 	}
 
-	provider, err := openstack.AuthenticatedClient(opts)
+	provider, err := openstack.AuthenticatedClient(context.TODO(), opts)
 
 You can authenticate with a token by doing:
 
@@ -39,7 +39,7 @@ You can authenticate with a token by doing:
 		TenantID: "{tenant_id}",
 	}
 
-	provider, err := openstack.AuthenticatedClient(opts)
+	provider, err := openstack.AuthenticatedClient(context.TODO(), opts)
 
 You may also use the openstack.AuthOptionsFromEnv() helper function. This
 function reads in standard environment variables frequently found in an
@@ -47,7 +47,7 @@ OpenStack `openrc` file. Again note that Gophercloud currently uses "tenant"
 instead of "project".
 
 	opts, err := openstack.AuthOptionsFromEnv()
-	provider, err := openstack.AuthenticatedClient(opts)
+	provider, err := openstack.AuthenticatedClient(context.TODO(), opts)
 
 # Service Clients
 

--- a/doc.go
+++ b/doc.go
@@ -65,7 +65,7 @@ pass in the parent provider, like so:
 Resource structs are the domain models that services make use of in order
 to work with and represent the state of API resources:
 
-	server, err := servers.Get(client, "{serverId}").Extract()
+	server, err := servers.Get(context.TODO(), client, "{serverId}").Extract()
 
 Intermediate Result structs are returned for API operations, which allow
 generic access to the HTTP headers, response body, and any errors associated
@@ -73,7 +73,7 @@ with the network transaction. To turn a result into a usable resource struct,
 you must call the Extract method which is chained to the response, or an
 Extract function from an applicable extension:
 
-	result := servers.Get(client, "{serverId}")
+	result := servers.Get(context.TODO(), client, "{serverId}")
 
 	// Attempt to extract the disk configuration from the OS-DCF disk config
 	// extension:
@@ -85,7 +85,7 @@ Pager to handle each successive Page in a closure, then use the appropriate
 extraction method from that request's package to interpret that Page as a slice
 of results:
 
-	err := servers.List(client, nil).EachPage(func (page pagination.Page) (bool, error) {
+	err := servers.List(client, nil).EachPage(context.TODO(), func (_ context.Context, page pagination.Page) (bool, error) {
 		s, err := servers.ExtractServers(page)
 		if err != nil {
 			return false, err

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -94,7 +94,7 @@ myOpts := MyCreateServerOpts{
 	Name: "s1",
 	Size: "100",
 }
-server, err := servers.Create(computeClient, myOpts).Extract()
+server, err := servers.Create(context.TODO(), computeClient, myOpts).Extract()
 // ...
 ```
 
@@ -114,7 +114,7 @@ var v struct {
   MyVolume `json:"volume"`
 }
 
-err := volumes.Get(client, volID).ExtractInto(&v)
+err := volumes.Get(context.TODO(), client, volID).ExtractInto(&v)
 // ...
 ```
 

--- a/docs/contributor-tutorial/.template/requests.go
+++ b/docs/contributor-tutorial/.template/requests.go
@@ -1,6 +1,8 @@
 package RESOURCE
 
 import (
+	"context"
+
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/pagination"
 )
@@ -37,8 +39,8 @@ func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pa
 }
 
 // Get retrieves details of a RESOURCE.
-func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {
-	resp, err := client.Get(getURL(client, id), &r.Body, nil)
+func Get(ctx context.Context, client *gophercloud.ServiceClient, id string) (r GetResult) {
+	resp, err := client.Get(ctx, getURL(client, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
@@ -59,13 +61,13 @@ func (opts CreateOpts) ToResourceCreateMap() (map[string]interface{}, error) {
 }
 
 // Create creates a new RESOURCE.
-func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToResourceCreateMap()
 	if err != nil {
 		r.Err = err
 		return
 	}
-	resp, err := client.Post(createURL(client), &b, &r.Body, &gophercloud.RequestOpts{
+	resp, err := client.Post(ctx, createURL(client), &b, &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{201},
 	})
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
@@ -73,8 +75,8 @@ func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r Create
 }
 
 // Delete deletes a RESOURCE.
-func Delete(client *gophercloud.ServiceClient, id string) (r DeleteResult) {
-	resp, err := client.Delete(deleteURL(client, id), nil)
+func Delete(ctx context.Context, client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+	resp, err := client.Delete(ctx, deleteURL(client, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
@@ -95,13 +97,13 @@ func (opts UpdateOpts) ToResourceUpdateMap() (map[string]interface{}, error) {
 }
 
 // Update modifies the attributes of a RESOURCE.
-func Update(client *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, client *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToResourceUpdateMap()
 	if err != nil {
 		r.Err = err
 		return
 	}
-	resp, err := client.Patch(updateURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
+	resp, err := client.Patch(ctx, updateURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{200},
 	})
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)

--- a/docs/contributor-tutorial/.template/testing/requests_test.go
+++ b/docs/contributor-tutorial/.template/testing/requests_test.go
@@ -1,6 +1,7 @@
 package testing
 
 import (
+	"context"
 	"testing"
 
 	"github.com/gophercloud/gophercloud/v2/openstack/service/vN/resources"
@@ -46,7 +47,7 @@ func TestGetResource(t *testing.T) {
 	defer th.TeardownHTTP()
 	HandleGetResourceSuccessfully(t)
 
-	actual, err := resources.Get(client.ServiceClient(), "9fe1d3").Extract()
+	actual, err := resources.Get(context.TODO(), client.ServiceClient(), "9fe1d3").Extract()
 	th.AssertNoErr(t, err)
 	th.AssertDeepEquals(t, SecondResource, *actual)
 }
@@ -60,7 +61,7 @@ func TestCreateResource(t *testing.T) {
 		Name: "resource two",
 	}
 
-	actual, err := resources.Create(client.ServiceClient(), createOpts).Extract()
+	actual, err := resources.Create(context.TODO(), client.ServiceClient(), createOpts).Extract()
 	th.AssertNoErr(t, err)
 	th.AssertDeepEquals(t, SecondResource, *actual)
 }
@@ -70,7 +71,7 @@ func TestDeleteResource(t *testing.T) {
 	defer th.TeardownHTTP()
 	HandleDeleteResourceSuccessfully(t)
 
-	res := resources.Delete(client.ServiceClient(), "9fe1d3")
+	res := resources.Delete(context.TODO(), client.ServiceClient(), "9fe1d3")
 	th.AssertNoErr(t, res.Err)
 }
 
@@ -83,7 +84,7 @@ func TestUpdateResource(t *testing.T) {
 		Description: "Staging Resource",
 	}
 
-	actual, err := resources.Update(client.ServiceClient(), "9fe1d3", updateOpts).Extract()
+	actual, err := resources.Update(context.TODO(), client.ServiceClient(), "9fe1d3", updateOpts).Extract()
 	th.AssertNoErr(t, err)
 	th.AssertDeepEquals(t, SecondResourceUpdated, *actual)
 }

--- a/docs/contributor-tutorial/.template/testing/requests_test.go
+++ b/docs/contributor-tutorial/.template/testing/requests_test.go
@@ -34,7 +34,7 @@ func TestListResourcesAllPages(t *testing.T) {
 	defer th.TeardownHTTP()
 	HandleListResourcesSuccessfully(t)
 
-	allPages, err := resources.List(client.ServiceClient(), nil).AllPages()
+	allPages, err := resources.List(client.ServiceClient(), nil).AllPages(context.TODO())
 	th.AssertNoErr(t, err)
 	actual, err := resources.ExtractResources(allPages)
 	th.AssertNoErr(t, err)

--- a/docs/contributor-tutorial/.template/testing/requests_test.go
+++ b/docs/contributor-tutorial/.template/testing/requests_test.go
@@ -15,7 +15,7 @@ func TestListResources(t *testing.T) {
 	HandleListResourcesSuccessfully(t)
 
 	count := 0
-	err := resources.List(client.ServiceClient(), nil).EachPage(func(page pagination.Page) (bool, error) {
+	err := resources.List(client.ServiceClient(), nil).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
 		count++
 
 		actual, err := resources.ExtractResources(page)

--- a/openstack/auth_env.go
+++ b/openstack/auth_env.go
@@ -31,7 +31,7 @@ To use this function, first set the OS_* environment variables (for example,
 by sourcing an `openrc` file), then:
 
 	opts, err := openstack.AuthOptionsFromEnv()
-	provider, err := openstack.AuthenticatedClient(opts)
+	provider, err := openstack.AuthenticatedClient(context.TODO(), opts)
 */
 func AuthOptionsFromEnv() (gophercloud.AuthOptions, error) {
 	authURL := os.Getenv("OS_AUTH_URL")

--- a/openstack/baremetal/apiversions/doc.go
+++ b/openstack/baremetal/apiversions/doc.go
@@ -3,7 +3,7 @@ Package apiversions provides information about the versions supported by a speci
 
 	Example to list versions
 
-		allVersions, err := apiversions.List(baremetalClient).Extract()
+		allVersions, err := apiversions.List(context.TODO(), baremetalClient).Extract()
 		if err != nil {
 			panic("unable to get API versions: " + err.Error())
 		}
@@ -14,7 +14,7 @@ Package apiversions provides information about the versions supported by a speci
 
 	Example to get a specific version
 
-		actual, err := apiversions.Get(baremetalClient).Extract()
+		actual, err := apiversions.Get(context.TODO(), baremetalClient).Extract()
 		if err != nil {
 			panic("unable to get API version: " + err.Error())
 		}

--- a/openstack/baremetal/v1/conductors/doc.go
+++ b/openstack/baremetal/v1/conductors/doc.go
@@ -4,7 +4,7 @@ resource in the OpenStack Bare Metal service.
 
 Example to List Conductors with Detail
 
-	conductors.List(client, conductors.ListOpts{Detail: true}).EachPage(func(page pagination.Page) (bool, error) {
+	conductors.List(client, conductors.ListOpts{Detail: true}).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
 		conductorList, err := conductors.ExtractConductors(page)
 		if err != nil {
 			return false, err
@@ -23,7 +23,7 @@ Example to List Conductors
 		Fields:         []string{"hostname"},
 	}
 
-	conductors.List(client, listOpts).EachPage(func(page pagination.Page) (bool, error) {
+	conductors.List(client, listOpts).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
 		conductorList, err := conductors.ExtractConductors(page)
 		if err != nil {
 			return false, err

--- a/openstack/baremetal/v1/conductors/doc.go
+++ b/openstack/baremetal/v1/conductors/doc.go
@@ -38,7 +38,7 @@ Example to List Conductors
 
 Example to Get Conductor
 
-	showConductor, err := conductors.Get(client, "compute2.localdomain").Extract()
+	showConductor, err := conductors.Get(context.TODO(), client, "compute2.localdomain").Extract()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/baremetal/v1/drivers/doc.go
+++ b/openstack/baremetal/v1/drivers/doc.go
@@ -6,7 +6,7 @@ API reference: https://developer.openstack.org/api-ref/baremetal/#drivers-driver
 
 Example to List Drivers
 
-	drivers.ListDrivers(client.ServiceClient(), drivers.ListDriversOpts{}).EachPage(func(page pagination.Page) (bool, error) {
+	drivers.ListDrivers(client.ServiceClient(), drivers.ListDriversOpts{}).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
 		driversList, err := drivers.ExtractDrivers(page)
 		if err != nil {
 			return false, err

--- a/openstack/baremetal/v1/drivers/doc.go
+++ b/openstack/baremetal/v1/drivers/doc.go
@@ -21,21 +21,21 @@ Example to List Drivers
 
 Example to Get single Driver Details
 
-	showDriverDetails, err := drivers.GetDriverDetails(client, "ipmi").Extract()
+	showDriverDetails, err := drivers.GetDriverDetails(context.TODO(), client, "ipmi").Extract()
 	if err != nil {
 		panic(err)
 	}
 
 Example to Get single Driver Properties
 
-	showDriverProperties, err := drivers.GetDriverProperties(client, "ipmi").Extract()
+	showDriverProperties, err := drivers.GetDriverProperties(context.TODO(), client, "ipmi").Extract()
 	if err != nil {
 		panic(err)
 	}
 
 Example to Get single Driver Logical Disk Properties
 
-	showDriverDiskProperties, err := drivers.GetDriverDiskProperties(client, "ipmi").Extract()
+	showDriverDiskProperties, err := drivers.GetDriverDiskProperties(context.TODO(), client, "ipmi").Extract()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/baremetal/v1/nodes/doc.go
+++ b/openstack/baremetal/v1/nodes/doc.go
@@ -4,7 +4,7 @@ resource in the OpenStack Bare Metal service.
 
 Example to List Nodes with Detail
 
-	nodes.ListDetail(client, nodes.ListOpts{}).EachPage(func(page pagination.Page) (bool, error) {
+	nodes.ListDetail(client, nodes.ListOpts{}).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
 		nodeList, err := nodes.ExtractNodes(page)
 		if err != nil {
 			return false, err
@@ -24,7 +24,7 @@ Example to List Nodes
 		Fields:         []string{"name"},
 	}
 
-	nodes.List(client, listOpts).EachPage(func(page pagination.Page) (bool, error) {
+	nodes.List(client, listOpts).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
 		nodeList, err := nodes.ExtractNodes(page)
 		if err != nil {
 			return false, err

--- a/openstack/baremetal/v1/nodes/doc.go
+++ b/openstack/baremetal/v1/nodes/doc.go
@@ -53,14 +53,14 @@ Example to Create Node
 		},
 	}
 
-	createNode, err := nodes.Create(client, createOpts).Extract()
+	createNode, err := nodes.Create(context.TODO(), client, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
 
 Example to Get Node
 
-	showNode, err := nodes.Get(client, "c9afd385-5d89-4ecb-9e1c-68194da6b474").Extract()
+	showNode, err := nodes.Get(context.TODO(), client, "c9afd385-5d89-4ecb-9e1c-68194da6b474").Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -75,35 +75,35 @@ Example to Update Node
 		},
 	}
 
-	updateNode, err := nodes.Update(client, "c9afd385-5d89-4ecb-9e1c-68194da6b474", updateOpts).Extract()
+	updateNode, err := nodes.Update(context.TODO(), client, "c9afd385-5d89-4ecb-9e1c-68194da6b474", updateOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
 
 Example to Delete Node
 
-	err = nodes.Delete(client, "c9afd385-5d89-4ecb-9e1c-68194da6b474").ExtractErr()
+	err = nodes.Delete(context.TODO(), client, "c9afd385-5d89-4ecb-9e1c-68194da6b474").ExtractErr()
 	if err != nil {
 		panic(err)
 	}
 
 Example to Validate Node
 
-	validation, err := nodes.Validate(client, "a62b8495-52e2-407b-b3cb-62775d04c2b8").Extract()
+	validation, err := nodes.Validate(context.TODO(), client, "a62b8495-52e2-407b-b3cb-62775d04c2b8").Extract()
 	if err != nil {
 		panic(err)
 	}
 
 Example to inject non-masking interrupts
 
-	err := nodes.InjectNMI(client, "a62b8495-52e2-407b-b3cb-62775d04c2b8").ExtractErr()
+	err := nodes.InjectNMI(context.TODO(), client, "a62b8495-52e2-407b-b3cb-62775d04c2b8").ExtractErr()
 	if err != nil {
 		panic(err)
 	}
 
 Example to get array of supported boot devices for a node
 
-	bootDevices, err := nodes.GetSupportedBootDevices(client, "a62b8495-52e2-407b-b3cb-62775d04c2b8").Extract()
+	bootDevices, err := nodes.GetSupportedBootDevices(context.TODO(), client, "a62b8495-52e2-407b-b3cb-62775d04c2b8").Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -115,21 +115,21 @@ Example to set boot device for a node
 		Persistent: false,
 	}
 
-	err := nodes.SetBootDevice(client, "a62b8495-52e2-407b-b3cb-62775d04c2b8", bootOpts).ExtractErr()
+	err := nodes.SetBootDevice(context.TODO(), client, "a62b8495-52e2-407b-b3cb-62775d04c2b8", bootOpts).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
 
 Example to get boot device for a node
 
-	bootDevice, err := nodes.GetBootDevice(client, "a62b8495-52e2-407b-b3cb-62775d04c2b8").Extract()
+	bootDevice, err := nodes.GetBootDevice(context.TODO(), client, "a62b8495-52e2-407b-b3cb-62775d04c2b8").Extract()
 	if err != nil {
 		panic(err)
 	}
 
 Example to list all vendor passthru methods
 
-	methods, err := nodes.GetVendorPassthruMethods(client, "a62b8495-52e2-407b-b3cb-62775d04c2b8").Extract()
+	methods, err := nodes.GetVendorPassthruMethods(context.TODO(), client, "a62b8495-52e2-407b-b3cb-62775d04c2b8").Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -139,7 +139,7 @@ Example to list all subscriptions
 	method := nodes.CallVendorPassthruOpts{
 		Method: "get_all_subscriptions",
 	}
-	allSubscriptions, err := nodes.GetAllSubscriptions(client, "a62b8495-52e2-407b-b3cb-62775d04c2b8", method).Extract()
+	allSubscriptions, err := nodes.GetAllSubscriptions(context.TODO(), client, "a62b8495-52e2-407b-b3cb-62775d04c2b8", method).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -153,7 +153,7 @@ Example to get a subscription
 		Id:     "subscription id",
 	}
 
-	subscription, err := nodes.GetSubscription(client, "a62b8495-52e2-407b-b3cb-62775d04c2b8", method, subscriptionOpt).Extract()
+	subscription, err := nodes.GetSubscription(context.TODO(), client, "a62b8495-52e2-407b-b3cb-62775d04c2b8", method, subscriptionOpt).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -167,7 +167,7 @@ Example to delete a subscription
 		Id: "subscription id",
 	}
 
-	err := nodes.DeleteSubscription(client, "a62b8495-52e2-407b-b3cb-62775d04c2b8", method, subscriptionDeleteOpt).ExtractErr()
+	err := nodes.DeleteSubscription(context.TODO(), client, "a62b8495-52e2-407b-b3cb-62775d04c2b8", method, subscriptionDeleteOpt).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
@@ -185,7 +185,7 @@ Example to create a subscription
 		HttpHeaders: [{"Key1":"Value1"}, {"Key2":"Value2"}],
 	}
 
-	newSubscription, err := nodes.CreateSubscription(client, "a62b8495-52e2-407b-b3cb-62775d04c2b8", method, subscriptionCreateOpt).Extract()
+	newSubscription, err := nodes.CreateSubscription(context.TODO(), client, "a62b8495-52e2-407b-b3cb-62775d04c2b8", method, subscriptionCreateOpt).Extract()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/baremetal/v1/ports/doc.go
+++ b/openstack/baremetal/v1/ports/doc.go
@@ -6,7 +6,7 @@
 
 Example to List Ports with Detail
 
-	ports.ListDetail(client, nil).EachPage(func(page pagination.Page) (bool, error) {
+	ports.ListDetail(client, nil).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
 		portList, err := ports.ExtractPorts(page)
 		if err != nil {
 			return false, err
@@ -25,7 +25,7 @@ Example to List Ports
 	 		Limit: 10,
 		}
 
-	 	ports.List(client, listOpts).EachPage(func(page pagination.Page) (bool, error) {
+	 	ports.List(client, listOpts).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
 	 		portList, err := ports.ExtractPorts(page)
 	 		if err != nil {
 	 			return false, err

--- a/openstack/baremetal/v1/ports/doc.go
+++ b/openstack/baremetal/v1/ports/doc.go
@@ -46,14 +46,14 @@ Example to Create a Port
 	    PhysicalNetwork: "my-network",
 		}
 
-	 	createPort, err := ports.Create(client, createOpts).Extract()
+	 	createPort, err := ports.Create(context.TODO(), client, createOpts).Extract()
 	 	if err != nil {
 	 		panic(err)
 	 	}
 
 Example to Get a Port
 
-	showPort, err := ports.Get(client, "c9afd385-5d89-4ecb-9e1c-68194da6b474").Extract()
+	showPort, err := ports.Get(context.TODO(), client, "c9afd385-5d89-4ecb-9e1c-68194da6b474").Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -68,14 +68,14 @@ Example to Update a Port
 	 		},
 		}
 
-	 	updatePort, err := ports.Update(client, "c9afd385-5d89-4ecb-9e1c-68194da6b474", updateOpts).Extract()
+	 	updatePort, err := ports.Update(context.TODO(), client, "c9afd385-5d89-4ecb-9e1c-68194da6b474", updateOpts).Extract()
 	 	if err != nil {
 	 		panic(err)
 	 	}
 
 Example to Delete a Port
 
-	 	err = ports.Delete(client, "c9afd385-5d89-4ecb-9e1c-68194da6b474").ExtractErr()
+	 	err = ports.Delete(context.TODO(), client, "c9afd385-5d89-4ecb-9e1c-68194da6b474").ExtractErr()
 	 	if err != nil {
 	 		panic(err)
 		}

--- a/openstack/baremetalintrospection/httpbasic/doc.go
+++ b/openstack/baremetalintrospection/httpbasic/doc.go
@@ -12,6 +12,6 @@ Example of obtaining and using a client:
 		panic(err)
 	}
 
-	introspection.GetIntrospectionStatus(client, "a62b8495-52e2-407b-b3cb-62775d04c2b8")
+	introspection.GetIntrospectionStatus(context.TODO(), client, "a62b8495-52e2-407b-b3cb-62775d04c2b8")
 */
 package httpbasic

--- a/openstack/baremetalintrospection/noauth/doc.go
+++ b/openstack/baremetalintrospection/noauth/doc.go
@@ -10,6 +10,6 @@ Example of obtaining and using a client:
 		panic(err)
 	}
 
-	introspection.GetIntrospectionStatus(client, "a62b8495-52e2-407b-b3cb-62775d04c2b8")
+	introspection.GetIntrospectionStatus(context.TODO(), client, "a62b8495-52e2-407b-b3cb-62775d04c2b8")
 */
 package noauth

--- a/openstack/baremetalintrospection/v1/introspection/doc.go
+++ b/openstack/baremetalintrospection/v1/introspection/doc.go
@@ -8,14 +8,14 @@ API reference https://developer.openstack.org/api-ref/baremetal-introspection/#n
 
 Example to Start Introspection
 
-	err := introspection.StartIntrospection(client, NodeUUID, introspection.StartOpts{}).ExtractErr()
+	err := introspection.StartIntrospection(context.TODO(), client, NodeUUID, introspection.StartOpts{}).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
 
 Example to Get an Introspection status
 
-	_, err := introspection.GetIntrospectionStatus(client, NodeUUID).Extract()
+	_, err := introspection.GetIntrospectionStatus(context.TODO(), client, NodeUUID).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -37,7 +37,7 @@ Example to List all introspection statuses
 
 Example to Abort an Introspection
 
-	err := introspection.AbortIntrospection(client, NodeUUID).ExtractErr()
+	err := introspection.AbortIntrospection(context.TODO(), client, NodeUUID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/baremetalintrospection/v1/introspection/doc.go
+++ b/openstack/baremetalintrospection/v1/introspection/doc.go
@@ -22,7 +22,7 @@ Example to Get an Introspection status
 
 Example to List all introspection statuses
 
-	introspection.ListIntrospections(client.ServiceClient(), nil).EachPage(func(page pagination.Page) (bool, error) {
+	introspection.ListIntrospections(client.ServiceClient(), nil).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
 		introspectionsList, err := introspection.ExtractIntrospections(page)
 		if err != nil {
 			return false, err

--- a/openstack/blockstorage/apiversions/doc.go
+++ b/openstack/blockstorage/apiversions/doc.go
@@ -20,7 +20,7 @@ Example of Retrieving all API Versions
 
 Example of Retrieving an API Version
 
-	version, err := apiversions.Get(client, "v3").Extract()
+	version, err := apiversions.Get(context.TODO(), client, "v3").Extract()
 	if err != nil {
 		panic("unable to get API version: " + err.Error())
 	}

--- a/openstack/blockstorage/apiversions/doc.go
+++ b/openstack/blockstorage/apiversions/doc.go
@@ -4,7 +4,7 @@ API versions for the OpenStack Block Storage service, code-named Cinder.
 
 Example of Retrieving all API Versions
 
-	allPages, err := apiversions.List(client).AllPages()
+	allPages, err := apiversions.List(client).AllPages(context.TODO())
 	if err != nil {
 		panic("unable to get API versions: " + err.Error())
 	}

--- a/openstack/blockstorage/extensions/availabilityzones/doc.go
+++ b/openstack/blockstorage/extensions/availabilityzones/doc.go
@@ -4,7 +4,7 @@ available volume availability zones.
 
 Example of Get Availability Zone Information
 
-		allPages, err := availabilityzones.List(volumeClient).AllPages()
+		allPages, err := availabilityzones.List(volumeClient).AllPages(context.TODO())
 		if err != nil {
 			panic(err)
 		}

--- a/openstack/blockstorage/extensions/backups/doc.go
+++ b/openstack/blockstorage/extensions/backups/doc.go
@@ -10,7 +10,7 @@ Example to List Backups
 		VolumeID: "uuid",
 	}
 
-	allPages, err := backups.List(client, listOpts).AllPages()
+	allPages, err := backups.List(client, listOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/blockstorage/extensions/backups/doc.go
+++ b/openstack/blockstorage/extensions/backups/doc.go
@@ -31,7 +31,7 @@ Example to Create a Backup
 		Name:     "my-backup",
 	}
 
-	backup, err := backups.Create(client, createOpts).Extract()
+	backup, err := backups.Create(context.TODO(), client, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -44,7 +44,7 @@ Example to Update a Backup
 		Name: "new-name",
 	}
 
-	backup, err := backups.Update(client, "uuid", updateOpts).Extract()
+	backup, err := backups.Update(context.TODO(), client, "uuid", updateOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -58,7 +58,7 @@ Example to Restore a Backup to a Volume
 		Name:     "vol-001",
 	}
 
-	restore, err := backups.RestoreFromBackup(client, "uuid", options).Extract()
+	restore, err := backups.RestoreFromBackup(context.TODO(), client, "uuid", options).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -67,14 +67,14 @@ Example to Restore a Backup to a Volume
 
 Example to Delete a Backup
 
-	err := backups.Delete(client, "uuid").ExtractErr()
+	err := backups.Delete(context.TODO(), client, "uuid").ExtractErr()
 	if err != nil {
 		panic(err)
 	}
 
 Example to Export a Backup
 
-	export, err := backups.Export(client, "uuid").Extract()
+	export, err := backups.Export(context.TODO(), client, "uuid").Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -114,7 +114,7 @@ Example to Import a Backup
 		BackupURL:     backupURL,
 	}
 
-	backup, err := backups.Import(client, options).Extract()
+	backup, err := backups.Import(context.TODO(), client, options).Extract()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/blockstorage/extensions/limits/doc.go
+++ b/openstack/blockstorage/extensions/limits/doc.go
@@ -3,7 +3,7 @@ Package limits shows rate and limit information for a project you authorized for
 
 Example to Retrieve Limits
 
-	limits, err := limits.Get(blockStorageClient).Extract()
+	limits, err := limits.Get(context.TODO(), blockStorageClient).Extract()
 	if err != nil {
 	    panic(err)
 	}

--- a/openstack/blockstorage/extensions/quotasets/doc.go
+++ b/openstack/blockstorage/extensions/quotasets/doc.go
@@ -3,7 +3,7 @@ Package quotasets enables retrieving and managing Block Storage quotas.
 
 Example to Get a Quota Set
 
-	quotaset, err := quotasets.Get(blockStorageClient, "project-id").Extract()
+	quotaset, err := quotasets.Get(context.TODO(), blockStorageClient, "project-id").Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -12,7 +12,7 @@ Example to Get a Quota Set
 
 Example to Get Quota Set Usage
 
-	quotaset, err := quotasets.GetUsage(blockStorageClient, "project-id").Extract()
+	quotaset, err := quotasets.GetUsage(context.TODO(), blockStorageClient, "project-id").Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -25,7 +25,7 @@ Example to Update a Quota Set
 		Volumes: gophercloud.IntToPointer(100),
 	}
 
-	quotaset, err := quotasets.Update(blockStorageClient, "project-id", updateOpts).Extract()
+	quotaset, err := quotasets.Update(context.TODO(), blockStorageClient, "project-id", updateOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -43,7 +43,7 @@ Example to Update a Quota set with volume_type quotas
 		},
 	}
 
-	quotaset, err := quotasets.Update(blockStorageClient, "project-id", updateOpts).Extract()
+	quotaset, err := quotasets.Update(context.TODO(), blockStorageClient, "project-id", updateOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -52,7 +52,7 @@ Example to Update a Quota set with volume_type quotas
 
 Example to Delete a Quota Set
 
-	err := quotasets.Delete(blockStorageClient, "project-id").ExtractErr()
+	err := quotasets.Delete(context.TODO(), blockStorageClient, "project-id").ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/blockstorage/extensions/schedulerhints/doc.go
+++ b/openstack/blockstorage/extensions/schedulerhints/doc.go
@@ -21,7 +21,7 @@ Example to Place Volume B on a Different Host than Volume A
 		SchedulerHints:    schedulerHints,
 	}
 
-	volume, err := volumes.Create(computeClient, createOpts).Extract()
+	volume, err := volumes.Create(context.TODO(), computeClient, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -44,7 +44,7 @@ Example to Place Volume B on the Same Host as Volume A
 		SchedulerHints:    schedulerHints,
 	}
 
-	volume, err := volumes.Create(computeClient, createOpts).Extract()
+	volume, err := volumes.Create(context.TODO(), computeClient, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/blockstorage/extensions/schedulerstats/doc.go
+++ b/openstack/blockstorage/extensions/schedulerstats/doc.go
@@ -6,7 +6,7 @@ and utilisation. Example:
 		Detail: true,
 	}
 
-	allPages, err := schedulerstats.List(client, listOpts).AllPages()
+	allPages, err := schedulerstats.List(client, listOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/blockstorage/extensions/services/doc.go
+++ b/openstack/blockstorage/extensions/services/doc.go
@@ -4,7 +4,7 @@ OpenStack cloud.
 
 Example of Retrieving list of all services
 
-	allPages, err := services.List(blockstorageClient, services.ListOpts{}).AllPages()
+	allPages, err := services.List(blockstorageClient, services.ListOpts{}).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/blockstorage/extensions/volumeactions/doc.go
+++ b/openstack/blockstorage/extensions/volumeactions/doc.go
@@ -11,7 +11,7 @@ Example of Attaching a Volume to an Instance
 		InstanceUUID: server.ID,
 	}
 
-	err := volumeactions.Attach(client, volume.ID, attachOpts).ExtractErr()
+	err := volumeactions.Attach(context.TODO(), client, volume.ID, attachOpts).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
@@ -20,7 +20,7 @@ Example of Attaching a Volume to an Instance
 		AttachmentID: volume.Attachments[0].AttachmentID,
 	}
 
-	err = volumeactions.Detach(client, volume.ID, detachOpts).ExtractErr()
+	err = volumeactions.Detach(context.TODO(), client, volume.ID, detachOpts).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
@@ -32,7 +32,7 @@ Example of Creating an Image from a Volume
 		Force:     true,
 	}
 
-	volumeImage, err := volumeactions.UploadImage(client, volume.ID, uploadImageOpts).Extract()
+	volumeImage, err := volumeactions.UploadImage(context.TODO(), client, volume.ID, uploadImageOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -45,7 +45,7 @@ Example of Extending a Volume's Size
 		NewSize: 100,
 	}
 
-	err := volumeactions.ExtendSize(client, volume.ID, extendOpts).ExtractErr()
+	err := volumeactions.ExtendSize(context.TODO(), client, volume.ID, extendOpts).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
@@ -61,7 +61,7 @@ Example of Initializing a Volume Connection
 		OSType:    "linux2",
 	}
 
-	connectionInfo, err := volumeactions.InitializeConnection(client, volume.ID, connectOpts).Extract()
+	connectionInfo, err := volumeactions.InitializeConnection(context.TODO(), client, volume.ID, connectOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -77,7 +77,7 @@ Example of Initializing a Volume Connection
 		OSType:    "linux2",
 	}
 
-	err = volumeactions.TerminateConnection(client, volume.ID, terminateOpts).ExtractErr()
+	err = volumeactions.TerminateConnection(context.TODO(), client, volume.ID, terminateOpts).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
@@ -88,7 +88,7 @@ Example of Setting a Volume's Bootable status
 		Bootable: true,
 	}
 
-	err := volumeactions.SetBootable(client, volume.ID, options).ExtractErr()
+	err := volumeactions.SetBootable(context.TODO(), client, volume.ID, options).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
@@ -100,7 +100,7 @@ Example of Changing Type of a Volume
 		MigrationPolicy: volumeactions.MigrationPolicyOnDemand,
 	}
 
-	err = volumeactions.ChangeType(client, volumeID, changeTypeOpts).ExtractErr()
+	err = volumeactions.ChangeType(context.TODO(), client, volumeID, changeTypeOpts).ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/blockstorage/extensions/volumehost/doc.go
+++ b/openstack/blockstorage/extensions/volumehost/doc.go
@@ -9,7 +9,7 @@ information about the Openstack host holding the volume. Example:
 
 	var allVolumes []VolumeWithHost
 
-	allPages, err := volumes.List(client, nil).AllPages()
+	allPages, err := volumes.List(client, nil).AllPages(context.TODO())
 	if err != nil {
 		panic("Unable to retrieve volumes: %s", err)
 	}

--- a/openstack/blockstorage/extensions/volumetenants/doc.go
+++ b/openstack/blockstorage/extensions/volumetenants/doc.go
@@ -9,7 +9,7 @@ tenant/project information. Example:
 
 	var allVolumes []VolumeWithTenant
 
-	allPages, err := volumes.List(client, nil).AllPages()
+	allPages, err := volumes.List(client, nil).AllPages(context.TODO())
 	if err != nil {
 		panic("Unable to retrieve volumes: %s", err)
 	}

--- a/openstack/blockstorage/extensions/volumetransfers/doc.go
+++ b/openstack/blockstorage/extensions/volumetransfers/doc.go
@@ -31,7 +31,7 @@ Example to Create a Volume Transfer request
 		Name:	  "my-volume-transfer",
 	}
 
-	transfer, err := volumetransfers.Create(client, createOpts).Extract()
+	transfer, err := volumetransfers.Create(context.TODO(), client, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -48,7 +48,7 @@ Example to Accept a Volume Transfer request from the target project
 	}
 
 	// see the transfer ID from the create response above
-	transfer, err := volumetransfers.Accept(client, "transfer-uuid", acceptOpts).Extract()
+	transfer, err := volumetransfers.Accept(context.TODO(), client, "transfer-uuid", acceptOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -57,7 +57,7 @@ Example to Accept a Volume Transfer request from the target project
 
 Example to Delete a Volume Transfer request from the source project
 
-	err := volumetransfers.Delete(client, "transfer-uuid").ExtractErr()
+	err := volumetransfers.Delete(context.TODO(), client, "transfer-uuid").ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/blockstorage/extensions/volumetransfers/doc.go
+++ b/openstack/blockstorage/extensions/volumetransfers/doc.go
@@ -10,7 +10,7 @@ Example to List all Volume Transfer requests being an OpenStack admin
 		AllTenants: true,
 	}
 
-	allPages, err := volumetransfers.List(client, listOpts).AllPages()
+	allPages, err := volumetransfers.List(client, listOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/blockstorage/v3/attachments/doc.go
+++ b/openstack/blockstorage/v3/attachments/doc.go
@@ -34,7 +34,7 @@ Example to Create Attachment
 	}
 
 	client.Microversion = "3.27"
-	attachment, err := attachments.Create(client, createOpts).Extract()
+	attachment, err := attachments.Create(context.TODO(), client, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -44,7 +44,7 @@ Example to Create Attachment
 Example to Get Attachment
 
 	client.Microversion = "3.27"
-	attachment, err := attachments.Get(client, "uuid").Extract()
+	attachment, err := attachments.Get(context.TODO(), client, "uuid").Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -60,7 +60,7 @@ Example to Update Attachment
 	}
 
 	client.Microversion = "3.27"
-	attachment, err := attachments.Update(client, "uuid", opts).Extract()
+	attachment, err := attachments.Update(context.TODO(), client, "uuid", opts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -70,7 +70,7 @@ Example to Update Attachment
 Example to Complete Attachment
 
 	client.Microversion = "3.44"
-	err := attachments.Complete(client, "uuid").ExtractErr()
+	err := attachments.Complete(context.TODO(), client, "uuid").ExtractErr()
 	if err != nil {
 		panic(err)
 	}
@@ -78,7 +78,7 @@ Example to Complete Attachment
 Example to Delete Attachment
 
 	client.Microversion = "3.27"
-	err := attachments.Delete(client, "uuid").ExtractErr()
+	err := attachments.Delete(context.TODO(), client, "uuid").ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/blockstorage/v3/attachments/doc.go
+++ b/openstack/blockstorage/v3/attachments/doc.go
@@ -12,7 +12,7 @@ Example to List Attachments
 	}
 
 	client.Microversion = "3.27"
-	allPages, err := attachments.List(client, listOpts).AllPages()
+	allPages, err := attachments.List(client, listOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/blockstorage/v3/qos/doc.go
+++ b/openstack/blockstorage/v3/qos/doc.go
@@ -36,7 +36,7 @@ Example to list QoS specifications
 
 	listOpts := qos.ListOpts{}
 
-	allPages, err := qos.List(client, listOpts).AllPages()
+	allPages, err := qos.List(client, listOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}
@@ -129,7 +129,7 @@ Example of listing all associations of a QoS
 
 	qosID := "de075d5e-8afc-4e23-9388-b84a5183d1c0"
 
-	allQosAssociations, err := qos.ListAssociations(client, qosID).AllPages()
+	allQosAssociations, err := qos.ListAssociations(client, qosID).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/blockstorage/v3/qos/doc.go
+++ b/openstack/blockstorage/v3/qos/doc.go
@@ -12,7 +12,7 @@ Example to create a QoS specification
 		},
 	}
 
-	test, err := qos.Create(client, createOpts).Extract()
+	test, err := qos.Create(context.TODO(), client, createOpts).Extract()
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -27,7 +27,7 @@ Example to delete a QoS specification
 		Force: false,
 	}
 
-	err = qos.Delete(client, qosID, deleteOpts).ExtractErr()
+	err = qos.Delete(context.TODO(), client, qosID, deleteOpts).ExtractErr()
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -54,7 +54,7 @@ Example to get a single QoS specification
 
 	qosID := "de075d5e-8afc-4e23-9388-b84a5183d1c0"
 
-	singleQos, err := qos.Get(client, test.ID).Extract()
+	singleQos, err := qos.Get(context.TODO(), client, test.ID).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -72,7 +72,7 @@ Example of updating QoSSpec
 		},
 	}
 
-	specs, err := qos.Update(client, qosID, updateOpts).Extract()
+	specs, err := qos.Update(context.TODO(), client, qosID, updateOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -83,7 +83,7 @@ Example of deleting specific keys/specs from a QoS
 	qosID := "de075d5e-8afc-4e23-9388-b84a5183d1c0"
 
 	keysToDelete := qos.DeleteKeysOpts{"read_iops_sec"}
-	err = qos.DeleteKeys(client, qosID, keysToDelete).ExtractErr()
+	err = qos.DeleteKeys(context.TODO(), client, qosID, keysToDelete).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
@@ -97,7 +97,7 @@ Example of associating a QoS with a volume type
 		VolumeTypeID: volID,
 	}
 
-	err = qos.Associate(client, qosID, associateOpts).ExtractErr()
+	err = qos.Associate(context.TODO(), client, qosID, associateOpts).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
@@ -111,7 +111,7 @@ Example of disassociating a QoS from a volume type
 		VolumeTypeID: volID,
 	}
 
-	err = qos.Disassociate(client, qosID, disassociateOpts).ExtractErr()
+	err = qos.Disassociate(context.TODO(), client, qosID, disassociateOpts).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
@@ -120,7 +120,7 @@ Example of disaassociating a Qos from all volume types
 
 	qosID := "de075d5e-8afc-4e23-9388-b84a5183d1c0"
 
-	err = qos.DisassociateAll(client, qosID).ExtractErr()
+	err = qos.DisassociateAll(context.TODO(), client, qosID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/blockstorage/v3/snapshots/doc.go
+++ b/openstack/blockstorage/v3/snapshots/doc.go
@@ -6,7 +6,7 @@ programmatically.
 
 Example to list Snapshots
 
-	allPages, err := snapshots.List(client, snapshots.ListOpts{}).AllPages()
+	allPages, err := snapshots.List(client, snapshots.ListOpts{}).AllPages(context.TODO())
 	if err != nil{
 		panic(err)
 	}

--- a/openstack/blockstorage/v3/snapshots/doc.go
+++ b/openstack/blockstorage/v3/snapshots/doc.go
@@ -21,7 +21,7 @@ Example to list Snapshots
 Example to get a Snapshot
 
 	snapshotID := "4a584cae-e4ce-429b-9154-d4c9eb8fda4c"
-	snapshot, err := snapshots.Get(client, snapshotID).Extract()
+	snapshot, err := snapshots.Get(context.TODO(), client, snapshotID).Extract()
 	if err != nil{
 		panic(err)
 	}
@@ -29,7 +29,7 @@ Example to get a Snapshot
 
 Example to create a Snapshot
 
-	snapshot, err := snapshots.Create(client, snapshots.CreateOpts{
+	snapshot, err := snapshots.Create(context.TODO(), client, snapshots.CreateOpts{
 		Name:"snapshot_001",
 		VolumeID:"5aa119a8-d25b-45a7-8d1b-88e127885635",
 	}).Extract()
@@ -41,7 +41,7 @@ Example to create a Snapshot
 Example to delete a Snapshot
 
 	snapshotID := "4a584cae-e4ce-429b-9154-d4c9eb8fda4c"
-	err := snapshots.Delete(client, snapshotID).ExtractErr()
+	err := snapshots.Delete(context.TODO(), client, snapshotID).ExtractErr()
 	if err != nil{
 		panic(err)
 	}
@@ -49,7 +49,7 @@ Example to delete a Snapshot
 Example to update a Snapshot
 
 	snapshotID := "4a584cae-e4ce-429b-9154-d4c9eb8fda4c"
-	snapshot, err = snapshots.Update(client, snapshotID, snapshots.UpdateOpts{
+	snapshot, err = snapshots.Update(context.TODO(), client, snapshotID, snapshots.UpdateOpts{
 		Name: "snapshot_002",
 		Description:"description_002",
 	}).Extract()

--- a/openstack/blockstorage/v3/volumes/doc.go
+++ b/openstack/blockstorage/v3/volumes/doc.go
@@ -13,7 +13,7 @@ Example to create a Volume from a Backup
 	}
 
 	client.Microversion = "3.47"
-	volume, err := volumes.Create(client, options).Extract()
+	volume, err := volumes.Create(context.TODO(), client, options).Extract()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/blockstorage/v3/volumetypes/doc.go
+++ b/openstack/blockstorage/v3/volumetypes/doc.go
@@ -20,7 +20,7 @@ Example to list Volume Types
 Example to show a Volume Type
 
 	typeID := "7ffaca22-f646-41d4-b79d-d7e4452ef8cc"
-	volumeType, err := volumetypes.Get(client, typeID).Extract()
+	volumeType, err := volumetypes.Get(context.TODO(), client, typeID).Extract()
 	if err != nil{
 		panic(err)
 	}
@@ -28,7 +28,7 @@ Example to show a Volume Type
 
 Example to create a Volume Type
 
-	volumeType, err := volumetypes.Create(client, volumetypes.CreateOpts{
+	volumeType, err := volumetypes.Create(context.TODO(), client, volumetypes.CreateOpts{
 		Name:"volume_type_001",
 		IsPublic:true,
 		Description:"description_001",
@@ -41,7 +41,7 @@ Example to create a Volume Type
 Example to delete a Volume Type
 
 	typeID := "7ffaca22-f646-41d4-b79d-d7e4452ef8cc"
-	err := volumetypes.Delete(client, typeID).ExtractErr()
+	err := volumetypes.Delete(context.TODO(), client, typeID).ExtractErr()
 	if err != nil{
 		panic(err)
 	}
@@ -49,7 +49,7 @@ Example to delete a Volume Type
 Example to update a Volume Type
 
 	typeID := "7ffaca22-f646-41d4-b79d-d7e4452ef8cc"
-	volumetype, err = volumetypes.Update(client, typeID, volumetypes.UpdateOpts{
+	volumetype, err = volumetypes.Update(context.TODO(), client, typeID, volumetypes.UpdateOpts{
 		Name: "volume_type_002",
 		Description:"description_002",
 		IsPublic:false,
@@ -66,7 +66,7 @@ Example to Create Extra Specs for a Volume Type
 	createOpts := volumetypes.ExtraSpecsOpts{
 		"capabilities": "gpu",
 	}
-	createdExtraSpecs, err := volumetypes.CreateExtraSpecs(client, typeID, createOpts).Extract()
+	createdExtraSpecs, err := volumetypes.CreateExtraSpecs(context.TODO(), client, typeID, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -77,7 +77,7 @@ Example to Get Extra Specs for a Volume Type
 
 	typeID := "7ffaca22-f646-41d4-b79d-d7e4452ef8cc"
 
-	extraSpecs, err := volumetypes.ListExtraSpecs(client, typeID).Extract()
+	extraSpecs, err := volumetypes.ListExtraSpecs(context.TODO(), client, typeID).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -88,7 +88,7 @@ Example to Get specific Extra Spec for a Volume Type
 
 	typeID := "7ffaca22-f646-41d4-b79d-d7e4452ef8cc"
 
-	extraSpec, err := volumetypes.GetExtraSpec(client, typeID, "capabilities").Extract()
+	extraSpec, err := volumetypes.GetExtraSpec(context.TODO(), client, typeID, "capabilities").Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -102,7 +102,7 @@ Example to Update Extra Specs for a Volume Type
 	updateOpts := volumetypes.ExtraSpecsOpts{
 		"capabilities": "capabilities-updated",
 	}
-	updatedExtraSpec, err := volumetypes.UpdateExtraSpec(client, typeID, updateOpts).Extract()
+	updatedExtraSpec, err := volumetypes.UpdateExtraSpec(context.TODO(), client, typeID, updateOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -112,7 +112,7 @@ Example to Update Extra Specs for a Volume Type
 Example to Delete an Extra Spec for a Volume Type
 
 	typeID := "7ffaca22-f646-41d4-b79d-d7e4452ef8cc"
-	err := volumetypes.DeleteExtraSpec(client, typeID, "capabilities").ExtractErr()
+	err := volumetypes.DeleteExtraSpec(context.TODO(), client, typeID, "capabilities").ExtractErr()
 	if err != nil {
 		panic(err)
 	}
@@ -143,7 +143,7 @@ Example to Grant Access to a Volume Type
 		Project: "15153a0979884b59b0592248ef947921",
 	}
 
-	err := volumetypes.AddAccess(client, typeID, accessOpts).ExtractErr()
+	err := volumetypes.AddAccess(context.TODO(), client, typeID, accessOpts).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
@@ -156,7 +156,7 @@ Example to Remove/Revoke Access to a Volume Type
 		Project: "15153a0979884b59b0592248ef947921",
 	}
 
-	err := volumetypes.RemoveAccess(client, typeID, accessOpts).ExtractErr()
+	err := volumetypes.RemoveAccess(context.TODO(), client, typeID, accessOpts).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
@@ -164,7 +164,7 @@ Example to Remove/Revoke Access to a Volume Type
 Example to Create the Encryption of a Volume Type
 
 	  typeID := "7ffaca22-f646-41d4-b79d-d7e4452ef8cc"
-		volumeType, err := volumetypes.CreateEncryption(client, typeID, .CreateEncryptionOpts{
+		volumeType, err := volumetypes.CreateEncryption(context.TODO(), client, typeID, .CreateEncryptionOpts{
 			KeySize:      256,
 			Provider:    "luks",
 			ControlLocation: "front-end",
@@ -179,7 +179,7 @@ Example to Delete the Encryption of a Volume Type
 
 		typeID := "7ffaca22-f646-41d4-b79d-d7e4452ef8cc"
 	  encryptionID := ""81e069c6-7394-4856-8df7-3b237ca61f74
-		err := volumetypes.DeleteEncryption(client, typeID, encryptionID).ExtractErr()
+		err := volumetypes.DeleteEncryption(context.TODO(), client, typeID, encryptionID).ExtractErr()
 		if err != nil{
 			panic(err)
 		}
@@ -187,7 +187,7 @@ Example to Delete the Encryption of a Volume Type
 Example to Update the Encryption of a Volume Type
 
 	typeID := "7ffaca22-f646-41d4-b79d-d7e4452ef8cc"
-	volumetype, err = volumetypes.UpdateEncryption(client, typeID, volumetypes.UpdateEncryptionOpts{
+	volumetype, err = volumetypes.UpdateEncryption(context.TODO(), client, typeID, volumetypes.UpdateEncryptionOpts{
 		KeySize:      256,
 		Provider:    "luks",
 		ControlLocation: "front-end",

--- a/openstack/blockstorage/v3/volumetypes/doc.go
+++ b/openstack/blockstorage/v3/volumetypes/doc.go
@@ -5,7 +5,7 @@ define the volume capabilities.
 
 Example to list Volume Types
 
-	allPages, err := volumetypes.List(client, volumetypes.ListOpts{}).AllPages()
+	allPages, err := volumetypes.List(client, volumetypes.ListOpts{}).AllPages(context.TODO())
 	if err != nil{
 		panic(err)
 	}
@@ -121,7 +121,7 @@ Example to List Volume Type Access
 
 	typeID := "e91758d6-a54a-4778-ad72-0c73a1cb695b"
 
-	allPages, err := volumetypes.ListAccesses(client, typeID).AllPages()
+	allPages, err := volumetypes.ListAccesses(client, typeID).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/clustering/v1/actions/doc.go
+++ b/openstack/clustering/v1/actions/doc.go
@@ -8,7 +8,7 @@ Example to List Actions
 		Limit: 5,
 	}
 
-	err = actions.List(serviceClient, opts).EachPage(func(page pagination.Page) (bool, error) {
+	err = actions.List(serviceClient, opts).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
 		actionInfos, err := actions.ExtractActions(page)
 		if err != nil {
 			return false, err

--- a/openstack/clustering/v1/actions/doc.go
+++ b/openstack/clustering/v1/actions/doc.go
@@ -23,7 +23,7 @@ Example to List Actions
 Example to Get an Action
 
 	actionID := "edce3528-864f-41fb-8759-f4707925cc09"
-	action, err := actions.Get(serviceClient, actionID).Extract()
+	action, err := actions.Get(context.TODO(), serviceClient, actionID).Extract()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/clustering/v1/clusters/doc.go
+++ b/openstack/clustering/v1/clusters/doc.go
@@ -30,7 +30,7 @@ Example to List Clusters
 		Name: "testcluster",
 	}
 
-	allPages, err := clusters.List(serviceClient, listOpts).AllPages()
+	allPages, err := clusters.List(serviceClient, listOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}
@@ -117,7 +117,7 @@ Example to ScaleOut a cluster
 Example to List Policies for a Cluster
 
 	clusterID := "7d85f602-a948-4a30-afd4-e84f47471c15"
-	allPages, err := clusters.ListPolicies(serviceClient, clusterID, nil).AllPages()
+	allPages, err := clusters.ListPolicies(serviceClient, clusterID, nil).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/clustering/v1/clusters/doc.go
+++ b/openstack/clustering/v1/clusters/doc.go
@@ -10,7 +10,7 @@ Example to Create a Cluster
 		ProfileID:       "b7b870ee-d3c5-4a93-b9d7-846c53b2c2da",
 	}
 
-	cluster, err := clusters.Create(serviceClient, createOpts).Extract()
+	cluster, err := clusters.Create(context.TODO(), serviceClient, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -18,7 +18,7 @@ Example to Create a Cluster
 Example to Get a Cluster
 
 	clusterName := "cluster123"
-	cluster, err := clusters.Get(serviceClient, clusterName).Extract()
+	cluster, err := clusters.Get(context.TODO(), serviceClient, clusterName).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -52,7 +52,7 @@ Example to Update a Cluster
 	}
 
 	clusterID := "7d85f602-a948-4a30-afd4-e84f47471c15"
-	cluster, err := clusters.Update(serviceClient, clusterName, opts).Extract()
+	cluster, err := clusters.Update(context.TODO(), serviceClient, clusterName, opts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -61,7 +61,7 @@ Example to Update a Cluster
 Example to Delete a Cluster
 
 	clusterID := "dc6d336e3fc4c0a951b5698cd1236ee"
-	err := clusters.Delete(serviceClient, clusterID).ExtractErr()
+	err := clusters.Delete(context.TODO(), serviceClient, clusterID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
@@ -83,7 +83,7 @@ Example to Resize a Cluster
 		Strict:         &strict,
 	}
 
-	actionID, err := clusters.Resize(client, clusterName, resizeOpts).Extract()
+	actionID, err := clusters.Resize(context.TODO(), client, clusterName, resizeOpts).Extract()
 	if err != nil {
 		t.Fatalf("Unable to resize cluster: %v", err)
 	}
@@ -97,7 +97,7 @@ Example to ScaleIn a Cluster
 	}
 	clusterID:  "b7b870e3-d3c5-4a93-b9d7-846c53b2c2da"
 
-	action, err := clusters.ScaleIn(computeClient, clusterID, scaleInOpts).Extract()
+	action, err := clusters.ScaleIn(context.TODO(), computeClient, clusterID, scaleInOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -109,7 +109,7 @@ Example to ScaleOut a cluster
 	}
 	clusterID := "b7b870e3-d3c5-4a93-b9d7-846c53b2c2da"
 
-	actionID, err := clusters.ScaleOut(computeClient, clusterID, scaleOutOpts).Extract()
+	actionID, err := clusters.ScaleOut(context.TODO(), computeClient, clusterID, scaleOutOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -151,7 +151,7 @@ Example to Attach a Policy to a Cluster
 	}
 
 	clusterID := "b7b870e3-d3c5-4a93-b9d7-846c53b2c2da"
-	actionID, err := clusters.AttachPolicy(serviceClient, clusterID, attachPolicyOpts).Extract()
+	actionID, err := clusters.AttachPolicy(context.TODO(), serviceClient, clusterID, attachPolicyOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -165,7 +165,7 @@ Example to Detach a Policy to Cluster
 	}
 
 	clusterID :=  "b7b870e3-d3c5-4a93-b9d7-846c53b2c2da"
-	actionID, err := clusters.DetachPolicy(serviceClient, clusterID, detachpolicyOpts).Extract()
+	actionID, err := clusters.DetachPolicy(context.TODO(), serviceClient, clusterID, detachpolicyOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -181,7 +181,7 @@ Example to Update a Policy to a Cluster
 	}
 
 	clusterID := "b7b870e3-d3c5-4a93-b9d7-846c53b2c2da"
-	actionID, err := clusters.UpdatePolicy(serviceClient, clusterID, updatePolicyOpts).Extract()
+	actionID, err := clusters.UpdatePolicy(context.TODO(), serviceClient, clusterID, updatePolicyOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -199,7 +199,7 @@ Example to Recover a Cluster
 	}
 
 	clusterID := "b7b870e3-d3c5-4a93-b9d7-846c53b2c2da"
-	actionID, err := clusters.Recover(computeClient, clusterID, recoverOpts).Extract()
+	actionID, err := clusters.Recover(context.TODO(), computeClient, clusterID, recoverOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -208,7 +208,7 @@ Example to Recover a Cluster
 Example to Check a Cluster
 
 	clusterID :=  "b7b870e3-d3c5-4a93-b9d7-846c53b2c2da"
-	action, err := clusters.Check(computeClient, clusterID).Extract()
+	action, err := clusters.Check(context.TODO(), computeClient, clusterID).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -218,7 +218,7 @@ Example to Complete Life Cycle
 	clusterID :=  "b7b870e3-d3c5-4a93-b9d7-846c53b2c2da"
 	lifecycleOpts := clusters.CompleteLifecycleOpts{LifecycleActionTokenID: "2b827124-69e1-496e-9484-33ca769fe4df"}
 
-	action, err := clusters.CompleteLifecycle(computeClient, clusterID, lifecycleOpts).Extract()
+	action, err := clusters.CompleteLifecycle(context.TODO(), computeClient, clusterID, lifecycleOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -229,7 +229,7 @@ Example to add nodes to a cluster
 			Nodes: []string{"node-123"},
 		}
 		clusterID := "b7b870e3-d3c5-4a93-b9d7-846c53b2c2da"
-		actionID, err := clusters.AddNodes(serviceClient, clusterID, addNodesOpts).Extract()
+		actionID, err := clusters.AddNodes(context.TODO(), serviceClient, clusterID, addNodesOpts).Extract()
 		if err != nil {
 			panic(err)
 		}
@@ -241,7 +241,7 @@ Example to remove nodes from a cluster
 		Nodes: []string{"node-123"},
 	}
 	clusterID := "b7b870e3-d3c5-4a93-b9d7-846c53b2c2da"
-	err := clusters.RemoveNodes(serviceClient, clusterID, removeNodesOpts).ExtractErr()
+	err := clusters.RemoveNodes(context.TODO(), serviceClient, clusterID, removeNodesOpts).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
@@ -252,7 +252,7 @@ Example to replace nodes for a cluster
 		Nodes: map[string]string{"node-1234": "node-5678"},
 	}
 	clusterID := "b7b870e3-d3c5-4a93-b9d7-846c53b2c2da"
-	actionID, err := clusters.ReplaceNodes(serviceClient, clusterID, replaceNodesOpts).Extract()
+	actionID, err := clusters.ReplaceNodes(context.TODO(), serviceClient, clusterID, replaceNodesOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -264,7 +264,7 @@ Example to collect node attributes across a cluster
 	opts := clusters.CollectOpts{
 		Path: "status",
 	}
-	attrs, err := clusters.Collect(serviceClient, clusterID, opts).Extract()
+	attrs, err := clusters.Collect(context.TODO(), serviceClient, clusterID, opts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -278,7 +278,7 @@ Example to perform an operation on a cluster
 		Filters:   clusters.OperationFilters{"role": "slave"},
 		Params:    clusters.OperationParams{"type": "SOFT"},
 	}
-	actionID, err := clusters.Ops(serviceClient, clusterID, operationOpts).Extract()
+	actionID, err := clusters.Ops(context.TODO(), serviceClient, clusterID, operationOpts).Extract()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/clustering/v1/events/doc.go
+++ b/openstack/clustering/v1/events/doc.go
@@ -8,7 +8,7 @@ Example to List Events
 		Limit: 5,
 	}
 
-	err = events.List(serviceClient, opts).EachPage(func(page pagination.Page) (bool, error) {
+	err = events.List(serviceClient, opts).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
 		eventInfos, err := events.ExtractEvents(page)
 		if err != nil {
 			return false, err

--- a/openstack/clustering/v1/events/doc.go
+++ b/openstack/clustering/v1/events/doc.go
@@ -23,7 +23,7 @@ Example to List Events
 Example to Get an Event
 
 	eventID := "edce3528-864f-41fb-8759-f4707925cc09"
-	event, err := events.Get(serviceClient, eventID).Extract()
+	event, err := events.Get(context.TODO(), serviceClient, eventID).Extract()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/clustering/v1/nodes/doc.go
+++ b/openstack/clustering/v1/nodes/doc.go
@@ -12,7 +12,7 @@ Example to Create a Node
 		Role:      "",
 	}
 
-	node, err := nodes.Create(serviceClient, createOpts).Extract()
+	node, err := nodes.Create(context.TODO(), serviceClient, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -46,7 +46,7 @@ Example to Update a Node
 	}
 
 	nodeID := "82fe28e0-9fcb-42ca-a2fa-6eb7dddd75a1"
-	node, err := nodes.Update(serviceClient, nodeID, opts).Extract()
+	node, err := nodes.Update(context.TODO(), serviceClient, nodeID, opts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -56,7 +56,7 @@ Example to Update a Node
 Example to Delete a Node
 
 	nodeID := "6dc6d336e3fc4c0a951b5698cd1236ee"
-	err := nodes.Delete(serviceClient, nodeID).ExtractErr()
+	err := nodes.Delete(context.TODO(), serviceClient, nodeID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
@@ -64,7 +64,7 @@ Example to Delete a Node
 Example to Get a Node
 
 	nodeID := "node123"
-	node, err := nodes.Get(serviceClient, nodeID).Extract()
+	node, err := nodes.Get(context.TODO(), serviceClient, nodeID).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -79,7 +79,7 @@ Example to Perform an Operation on a Node
 		Operation: nodes.RebootOperation,
 		Params:    nodes.OperationParams{"type": "SOFT"},
 	}
-	actionID, err := nodes.Ops(serviceClient, nodeID, operationOpts).Extract()
+	actionID, err := nodes.Ops(context.TODO(), serviceClient, nodeID, operationOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -92,7 +92,7 @@ Example to Recover a Node
 		Operation:     nodes.RebuildRecovery,
 		Check:         &check,
 	}
-	actionID, err := nodes.Recover(computeClient, nodeID, recoverOpts).Extract()
+	actionID, err := nodes.Recover(context.TODO(), computeClient, nodeID, recoverOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -101,7 +101,7 @@ Example to Recover a Node
 Example to Check a Node
 
 	nodeID := "b7b870e3-d3c5-4a93-b9d7-846c53b2c2da"
-	actionID, err := nodes.Check(serviceClient, nodeID).Extract()
+	actionID, err := nodes.Check(context.TODO(), serviceClient, nodeID).Extract()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/clustering/v1/nodes/doc.go
+++ b/openstack/clustering/v1/nodes/doc.go
@@ -25,7 +25,7 @@ Example to List Nodes
 		Name: "testnode",
 	}
 
-	allPages, err := nodes.List(serviceClient, listOpts).AllPages()
+	allPages, err := nodes.List(serviceClient, listOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/clustering/v1/policies/doc.go
+++ b/openstack/clustering/v1/policies/doc.go
@@ -42,7 +42,7 @@ Example to Create a Policy
 		},
 	}
 
-	createdPolicy, err := policies.Create(client, createOpts).Extract()
+	createdPolicy, err := policies.Create(context.TODO(), client, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -50,7 +50,7 @@ Example to Create a Policy
 Example to Get a Policy
 
 	policyName := "get_policy"
-	policyDetail, err := policies.Get(clusteringClient, policyName).Extract()
+	policyDetail, err := policies.Get(context.TODO(), clusteringClient, policyName).Extract()
 	if err != nil {
 	    panic(err)
 	}
@@ -63,7 +63,7 @@ Example to Update a Policy
 		Name: "update_policy",
 	}
 
-	updatePolicy, err := policies.Update(client, opts).Extract()
+	updatePolicy, err := policies.Update(context.TODO(), client, opts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -87,7 +87,7 @@ Example to Validate a Policy
 		},
 	}
 
-	validatePolicy, err := policies.Validate(client, opts).Extract()
+	validatePolicy, err := policies.Validate(context.TODO(), client, opts).Extract()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/clustering/v1/policies/doc.go
+++ b/openstack/clustering/v1/policies/doc.go
@@ -8,7 +8,7 @@ Example to List Policies
 		Limit: 2,
 	}
 
-	allPages, err := policies.List(clusteringClient, listOpts).AllPages()
+	allPages, err := policies.List(clusteringClient, listOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/clustering/v1/policytypes/doc.go
+++ b/openstack/clustering/v1/policytypes/doc.go
@@ -21,7 +21,7 @@ Example to List Policy Types
 Example to Get a Policy Type
 
 	policyTypeName := "senlin.policy.affinity-1.0"
-	policyTypeDetail, err := policyTypes.Get(clusteringClient, policyTypeName).Extract()
+	policyTypeDetail, err := policyTypes.Get(context.TODO(), clusteringClient, policyTypeName).Extract()
 	if err != nil {
 	    panic(err)
 	}

--- a/openstack/clustering/v1/policytypes/doc.go
+++ b/openstack/clustering/v1/policytypes/doc.go
@@ -4,7 +4,7 @@ from the OpenStack Clustering Service.
 
 Example to List Policy Types
 
-	allPages, err := policytypes.List(clusteringClient).AllPages()
+	allPages, err := policytypes.List(clusteringClient).AllPages(context.TODO())
 	if err != nil {
 	    panic(err)
 	}

--- a/openstack/clustering/v1/profiles/doc.go
+++ b/openstack/clustering/v1/profiles/doc.go
@@ -25,7 +25,7 @@ Example to Create a Profile
 		},
 	}
 
-	profile, err := profiles.Create(serviceClient, createOpts).Extract()
+	profile, err := profiles.Create(context.TODO(), serviceClient, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -34,7 +34,7 @@ Example to Create a Profile
 
 Example to Get a Profile
 
-	profile, err := profiles.Get(serviceClient, "profile-name").Extract()
+	profile, err := profiles.Get(context.TODO(), serviceClient, "profile-name").Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -65,7 +65,7 @@ Example to Update a Profile
 		Name: "new-name",
 	}
 
-	profile, err := profiles.Update(serviceClient, profileName, updateOpts).Extract()
+	profile, err := profiles.Update(context.TODO(), serviceClient, profileName, updateOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -75,7 +75,7 @@ Example to Update a Profile
 Example to Delete a Profile
 
 	profileID := "6dc6d336e3fc4c0a951b5698cd1236ee"
-	err := profiles.Delete(serviceClient, profileID).ExtractErr()
+	err := profiles.Delete(context.TODO(), serviceClient, profileID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
@@ -100,7 +100,7 @@ Example to Validate a profile
 		},
 	}
 
-	profile, err := profiles.Validate(serviceClient, validateOpts).Extract()
+	profile, err := profiles.Validate(context.TODO(), serviceClient, validateOpts).Extract()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/clustering/v1/profiles/doc.go
+++ b/openstack/clustering/v1/profiles/doc.go
@@ -47,7 +47,7 @@ Example to List Profiles
 		Limit: 2,
 	}
 
-	profiles.List(serviceClient, listOpts).EachPage(func(page pagination.Page) (bool, error) {
+	profiles.List(serviceClient, listOpts).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
 		allProfiles, err := profiles.ExtractProfiles(page)
 		if err != nil {
 			panic(err)

--- a/openstack/clustering/v1/profiletypes/doc.go
+++ b/openstack/clustering/v1/profiletypes/doc.go
@@ -19,7 +19,7 @@ Example to List ProfileType
 Example to Get a ProfileType
 
 	profileTypeName := "os.nova.server"
-	profileType, err := profiletypes.Get(clusteringClient, profileTypeName).Extract()
+	profileType, err := profiletypes.Get(context.TODO(), clusteringClient, profileTypeName).Extract()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/clustering/v1/profiletypes/doc.go
+++ b/openstack/clustering/v1/profiletypes/doc.go
@@ -4,7 +4,7 @@ Clustering Service.
 
 Example to List ProfileType
 
-	err = profiletypes.List(serviceClient).EachPage(func(page pagination.Page) (bool, error) {
+	err = profiletypes.List(serviceClient).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
 		profileTypes, err := profiletypes.ExtractProfileTypes(page)
 		if err != nil {
 			return false, err

--- a/openstack/clustering/v1/profiletypes/doc.go
+++ b/openstack/clustering/v1/profiletypes/doc.go
@@ -30,7 +30,7 @@ Example of list operations supported by a profile type
 	serviceClient.Microversion = "1.5"
 
 	profileTypeName := "os.nova.server-1.0"
-	allPages, err := profiletypes.ListOps(serviceClient, profileTypeName).AllPages()
+	allPages, err := profiletypes.ListOps(serviceClient, profileTypeName).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/clustering/v1/receivers/doc.go
+++ b/openstack/clustering/v1/receivers/doc.go
@@ -57,7 +57,7 @@ Example to List Receivers
 		Limit: 2,
 	}
 
-	receivers.List(serviceClient, listOpts).EachPage(func(page pagination.Page) (bool, error) {
+	receivers.List(serviceClient, listOpts).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
 		allReceivers, err := receivers.ExtractReceivers(page)
 		if err != nil {
 			panic(err)

--- a/openstack/clustering/v1/receivers/doc.go
+++ b/openstack/clustering/v1/receivers/doc.go
@@ -11,7 +11,7 @@ Example to Create a Receiver
 		Type:       receivers.WebhookReceiver,
 	}
 
-	receiver, err := receivers.Create(serviceClient, createOpts).Extract()
+	receiver, err := receivers.Create(context.TODO(), serviceClient, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -20,7 +20,7 @@ Example to Create a Receiver
 
 Example to Get a Receiver
 
-	receiver, err := receivers.Get(serviceClient, "receiver-name").Extract()
+	receiver, err := receivers.Get(context.TODO(), serviceClient, "receiver-name").Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -30,7 +30,7 @@ Example to Get a Receiver
 Example to Delete receiver
 
 	receiverID := "6dc6d336e3fc4c0a951b5698cd1236ee"
-	err := receivers.Delete(serviceClient, receiverID).ExtractErr()
+	err := receivers.Delete(context.TODO(), serviceClient, receiverID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
@@ -44,7 +44,7 @@ Example to Update Receiver
 	}
 
 	receiverID := "6dc6d336e3fc4c0a951b5698cd1236ee"
-	receiver, err := receivers.Update(serviceClient, receiverID, updateOpts).Extract()
+	receiver, err := receivers.Update(context.TODO(), serviceClient, receiverID, updateOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -72,7 +72,7 @@ Example to List Receivers
 Example to Notify a Receiver
 
 	receiverID := "6dc6d336e3fc4c0a951b5698cd1236ee"
-	requestID, err := receivers.Notify(serviceClient, receiverID).Extract()
+	requestID, err := receivers.Notify(context.TODO(), serviceClient, receiverID).Extract()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/clustering/v1/webhooks/doc.go
+++ b/openstack/clustering/v1/webhooks/doc.go
@@ -4,7 +4,7 @@ Service.
 
 Example to Trigger webhook action
 
-	result, err := webhooks.Trigger(serviceClient(), "f93f83f6-762b-41b6-b757-80507834d394", webhooks.TriggerOpts{V: "1"}).Extract()
+	result, err := webhooks.Trigger(context.TODO(), serviceClient(), "f93f83f6-762b-41b6-b757-80507834d394", webhooks.TriggerOpts{V: "1"}).Extract()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/common/extensions/doc.go
+++ b/openstack/common/extensions/doc.go
@@ -21,7 +21,7 @@ Service Client.
 Example of Retrieving Compute Extensions
 
 	ao, err := openstack.AuthOptionsFromEnv()
-	provider, err := openstack.AuthenticatedClient(ao)
+	provider, err := openstack.AuthenticatedClient(context.TODO(), ao)
 	computeClient, err := openstack.NewComputeV2(provider, gophercloud.EndpointOpts{
 		Region: os.Getenv("OS_REGION_NAME"),
 	})
@@ -36,7 +36,7 @@ Example of Retrieving Compute Extensions
 Example of Retrieving Network Extensions
 
 	ao, err := openstack.AuthOptionsFromEnv()
-	provider, err := openstack.AuthenticatedClient(ao)
+	provider, err := openstack.AuthenticatedClient(context.TODO(), ao)
 	networkClient, err := openstack.NewNetworkV2(provider, gophercloud.EndpointOpts{
 		Region: os.Getenv("OS_REGION_NAME"),
 	})

--- a/openstack/common/extensions/doc.go
+++ b/openstack/common/extensions/doc.go
@@ -26,7 +26,7 @@ Example of Retrieving Compute Extensions
 		Region: os.Getenv("OS_REGION_NAME"),
 	})
 
-	allPages, err := extensions.List(computeClient).AllPages()
+	allPages, err := extensions.List(computeClient).AllPages(context.TODO())
 	allExtensions, err := extensions.ExtractExtensions(allPages)
 
 	for _, extension := range allExtensions{
@@ -41,7 +41,7 @@ Example of Retrieving Network Extensions
 		Region: os.Getenv("OS_REGION_NAME"),
 	})
 
-	allPages, err := extensions.List(networkClient).AllPages()
+	allPages, err := extensions.List(networkClient).AllPages(context.TODO())
 	allExtensions, err := extensions.ExtractExtensions(allPages)
 
 	for _, extension := range allExtensions{

--- a/openstack/compute/apiversions/doc.go
+++ b/openstack/compute/apiversions/doc.go
@@ -20,7 +20,7 @@ Example to List API Versions
 
 Example to Get an API Version
 
-	version, err := apiVersions.Get(computeClient, "v2.1").Extract()
+	version, err := apiVersions.Get(context.TODO(), computeClient, "v2.1").Extract()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/compute/apiversions/doc.go
+++ b/openstack/compute/apiversions/doc.go
@@ -4,7 +4,7 @@ API versions for the Compute service, code-named Nova.
 
 Example to List API Versions
 
-	allPages, err := apiversions.List(computeClient).AllPages()
+	allPages, err := apiversions.List(computeClient).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/compute/v2/extensions/aggregates/doc.go
+++ b/openstack/compute/v2/extensions/aggregates/doc.go
@@ -9,7 +9,7 @@ Example of Create Aggregate
 		AvailabilityZone: "london",
 	}
 
-	aggregate, err := aggregates.Create(computeClient, createOpts).Extract()
+	aggregate, err := aggregates.Create(context.TODO(), computeClient, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -18,7 +18,7 @@ Example of Create Aggregate
 Example of Show Aggregate Details
 
 	aggregateID := 42
-	aggregate, err := aggregates.Get(computeClient, aggregateID).Extract()
+	aggregate, err := aggregates.Get(context.TODO(), computeClient, aggregateID).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -27,7 +27,7 @@ Example of Show Aggregate Details
 Example of Delete Aggregate
 
 	aggregateID := 32
-	err := aggregates.Delete(computeClient, aggregateID).ExtractErr()
+	err := aggregates.Delete(context.TODO(), computeClient, aggregateID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
@@ -40,7 +40,7 @@ Example of Update Aggregate
 		AvailabilityZone: "nova2",
 	}
 
-	aggregate, err := aggregates.Update(computeClient, aggregateID, opts).Extract()
+	aggregate, err := aggregates.Update(context.TODO(), computeClient, aggregateID, opts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -69,7 +69,7 @@ Example of Add Host
 		Host: "newhost-cmp1",
 	}
 
-	aggregate, err := aggregates.AddHost(computeClient, aggregateID, opts).Extract()
+	aggregate, err := aggregates.AddHost(context.TODO(), computeClient, aggregateID, opts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -82,7 +82,7 @@ Example of Remove Host
 		Host: "newhost-cmp1",
 	}
 
-	aggregate, err := aggregates.RemoveHost(computeClient, aggregateID, opts).Extract()
+	aggregate, err := aggregates.RemoveHost(context.TODO(), computeClient, aggregateID, opts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -95,7 +95,7 @@ Example of Create or Update Metadata
 		Metadata: map[string]string{"key": "value"},
 	}
 
-	aggregate, err := aggregates.SetMetadata(computeClient, aggregateID, opts).Extract()
+	aggregate, err := aggregates.SetMetadata(context.TODO(), computeClient, aggregateID, opts).Extract()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/compute/v2/extensions/aggregates/doc.go
+++ b/openstack/compute/v2/extensions/aggregates/doc.go
@@ -48,7 +48,7 @@ Example of Update Aggregate
 
 Example of Retrieving list of all aggregates
 
-	allPages, err := aggregates.List(computeClient).AllPages()
+	allPages, err := aggregates.List(computeClient).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/compute/v2/extensions/attachinterfaces/doc.go
+++ b/openstack/compute/v2/extensions/attachinterfaces/doc.go
@@ -5,7 +5,7 @@ interfaces through Nova.
 Example of Listing a Server's Interfaces
 
 	serverID := "b07e7a3b-d951-4efc-a4f9-ac9f001afb7f"
-	allPages, err := attachinterfaces.List(computeClient, serverID).AllPages()
+	allPages, err := attachinterfaces.List(computeClient, serverID).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/compute/v2/extensions/attachinterfaces/doc.go
+++ b/openstack/compute/v2/extensions/attachinterfaces/doc.go
@@ -23,7 +23,7 @@ Example to Get a Server's Interface
 
 	portID = "0dde1598-b374-474e-986f-5b8dd1df1d4e"
 	serverID := "b07e7a3b-d951-4efc-a4f9-ac9f001afb7f"
-	interface, err := attachinterfaces.Get(computeClient, serverID, portID).Extract()
+	interface, err := attachinterfaces.Get(context.TODO(), computeClient, serverID, portID).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -35,7 +35,7 @@ Example to Create a new Interface attachment on the Server
 	attachOpts := attachinterfaces.CreateOpts{
 		NetworkID: networkID,
 	}
-	interface, err := attachinterfaces.Create(computeClient, serverID, attachOpts).Extract()
+	interface, err := attachinterfaces.Create(context.TODO(), computeClient, serverID, attachOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -44,7 +44,7 @@ Example to Delete an Interface attachment from the Server
 
 	portID = "0dde1598-b374-474e-986f-5b8dd1df1d4e"
 	serverID := "b07e7a3b-d951-4efc-a4f9-ac9f001afb7f"
-	err := attachinterfaces.Delete(computeClient, serverID, portID).ExtractErr()
+	err := attachinterfaces.Delete(context.TODO(), computeClient, serverID, portID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/compute/v2/extensions/availabilityzones/doc.go
+++ b/openstack/compute/v2/extensions/availabilityzones/doc.go
@@ -12,7 +12,7 @@ Example of Extend server result with Availability Zone Information:
 
 	var allServers []ServerWithAZ
 
-	allPages, err := servers.List(client, nil).AllPages()
+	allPages, err := servers.List(client, nil).AllPages(context.TODO())
 	if err != nil {
 		panic("Unable to retrieve servers: %s", err)
 	}
@@ -28,7 +28,7 @@ Example of Extend server result with Availability Zone Information:
 
 Example of Get Availability Zone Information
 
-		allPages, err := availabilityzones.List(computeClient).AllPages()
+		allPages, err := availabilityzones.List(computeClient).AllPages(context.TODO())
 		if err != nil {
 			panic(err)
 		}
@@ -44,7 +44,7 @@ Example of Get Availability Zone Information
 
 Example of Get Detailed Availability Zone Information
 
-		allPages, err := availabilityzones.ListDetail(computeClient).AllPages()
+		allPages, err := availabilityzones.ListDetail(computeClient).AllPages(context.TODO())
 		if err != nil {
 			panic(err)
 		}

--- a/openstack/compute/v2/extensions/bootfromvolume/doc.go
+++ b/openstack/compute/v2/extensions/bootfromvolume/doc.go
@@ -37,7 +37,7 @@ a server without using block device mappings.
 		BlockDevice:       blockDevices,
 	}
 
-	server, err := bootfromvolume.Create(client, createOpts).Extract()
+	server, err := bootfromvolume.Create(context.TODO(), client, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -67,7 +67,7 @@ server will use this volume as its root disk.
 		BlockDevice:       blockDevices,
 	}
 
-	server, err := bootfromvolume.Create(client, createOpts).Extract()
+	server, err := bootfromvolume.Create(context.TODO(), client, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -95,7 +95,7 @@ This example will create a server with an existing volume as its root disk.
 		BlockDevice:       blockDevices,
 	}
 
-	server, err := bootfromvolume.Create(client, createOpts).Extract()
+	server, err := bootfromvolume.Create(context.TODO(), client, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -144,7 +144,7 @@ ephemeral disks must have an index of -1.
 		BlockDevice:       blockDevices,
 	}
 
-	server, err := bootfromvolume.Create(client, createOpts).Extract()
+	server, err := bootfromvolume.Create(context.TODO(), client, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/compute/v2/extensions/defsecrules/doc.go
+++ b/openstack/compute/v2/extensions/defsecrules/doc.go
@@ -10,7 +10,7 @@ not work if the OpenStack environment is running the OpenStack Networking
 
 Example of Listing Default Security Group Rules
 
-	allPages, err := defsecrules.List(computeClient).AllPages()
+	allPages, err := defsecrules.List(computeClient).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/compute/v2/extensions/defsecrules/doc.go
+++ b/openstack/compute/v2/extensions/defsecrules/doc.go
@@ -26,7 +26,7 @@ Example of Listing Default Security Group Rules
 
 Example of Retrieving a Default Security Group Rule
 
-	rule, err := defsecrules.Get(computeClient, "rule-id").Extract()
+	rule, err := defsecrules.Get(context.TODO(), computeClient, "rule-id").Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -40,14 +40,14 @@ Example of Creating a Default Security Group Rule
 		CIDR:       "10.10.12.0/24",
 	}
 
-	rule, err := defsecrules.Create(computeClient, createOpts).Extract()
+	rule, err := defsecrules.Create(context.TODO(), computeClient, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
 
 Example of Deleting a Default Security Group Rule
 
-	err := defsecrules.Delete(computeClient, "rule-id").ExtractErr()
+	err := defsecrules.Delete(context.TODO(), computeClient, "rule-id").ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/compute/v2/extensions/diagnostics/doc.go
+++ b/openstack/compute/v2/extensions/diagnostics/doc.go
@@ -3,7 +3,7 @@ Package diagnostics returns details about a nova instance diagnostics
 
 Example of Show Diagnostics
 
-	diags, err := diagnostics.Get(computeClient, serverId).Extract()
+	diags, err := diagnostics.Get(context.TODO(), computeClient, serverId).Extract()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/compute/v2/extensions/diskconfig/doc.go
+++ b/openstack/compute/v2/extensions/diskconfig/doc.go
@@ -38,7 +38,7 @@ Example of Creating a Server with Disk Config
 		DiskConfig:        diskconfig.Manual,
 	}
 
-	server, err := servers.Create(computeClient, createOpts).Extract()
+	server, err := servers.Create(context.TODO(), computeClient, createOpts).Extract()
 	if err != nil {
 		panic("Unable to create server: %s", err)
 	}

--- a/openstack/compute/v2/extensions/diskconfig/doc.go
+++ b/openstack/compute/v2/extensions/diskconfig/doc.go
@@ -11,7 +11,7 @@ Example of Obtaining the Disk Config of a Server
 
 	var allServers []ServerWithDiskConfig
 
-	allPages, err := servers.List(client, nil).AllPages()
+	allPages, err := servers.List(client, nil).AllPages(context.TODO())
 	if err != nil {
 		panic("Unable to retrieve servers: %s", err)
 	}

--- a/openstack/compute/v2/extensions/evacuate/doc.go
+++ b/openstack/compute/v2/extensions/evacuate/doc.go
@@ -5,7 +5,7 @@ provisioned by the OpenStack Compute service from a failed host to a new host.
 Example to Evacuate a Server from a Host
 
 	serverID := "b16ba811-199d-4ffd-8839-ba96c1185a67"
-	err := evacuate.Evacuate(computeClient, serverID, evacuate.EvacuateOpts{}).ExtractErr()
+	err := evacuate.Evacuate(context.TODO(), computeClient, serverID, evacuate.EvacuateOpts{}).ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/compute/v2/extensions/extendedserverattributes/doc.go
+++ b/openstack/compute/v2/extensions/extendedserverattributes/doc.go
@@ -10,7 +10,7 @@ Example to Get basic extended information:
 	}
 	var serverWithAttributesExt serverAttributesExt
 
-	err := servers.Get(computeClient, "d650a0ce-17c3-497d-961a-43c4af80998a").ExtractInto(&serverWithAttributesExt)
+	err := servers.Get(context.TODO(), computeClient, "d650a0ce-17c3-497d-961a-43c4af80998a").ExtractInto(&serverWithAttributesExt)
 	if err != nil {
 	  panic(err)
 	}
@@ -20,7 +20,7 @@ Example to Get basic extended information:
 Example to get additional fields with microversion 2.3 or later
 
 	computeClient.Microversion = "2.3"
-	result := servers.Get(computeClient, "d650a0ce-17c3-497d-961a-43c4af80998a")
+	result := servers.Get(context.TODO(), computeClient, "d650a0ce-17c3-497d-961a-43c4af80998a")
 
 	reservationID, err := extendedserverattributes.ExtractReservationID(result.Result)
 	if err != nil {

--- a/openstack/compute/v2/extensions/extendedstatus/doc.go
+++ b/openstack/compute/v2/extensions/extendedstatus/doc.go
@@ -9,7 +9,7 @@ the extended status information. Example:
 
 	var allServers []ServerWithExt
 
-	allPages, err := servers.List(client, nil).AllPages()
+	allPages, err := servers.List(client, nil).AllPages(context.TODO())
 	if err != nil {
 		panic("Unable to retrieve servers: %s", err)
 	}

--- a/openstack/compute/v2/extensions/floatingips/doc.go
+++ b/openstack/compute/v2/extensions/floatingips/doc.go
@@ -11,7 +11,7 @@ service.
 
 Example to List Floating IPs
 
-	allPages, err := floatingips.List(computeClient).AllPages()
+	allPages, err := floatingips.List(computeClient).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/compute/v2/extensions/floatingips/doc.go
+++ b/openstack/compute/v2/extensions/floatingips/doc.go
@@ -31,14 +31,14 @@ Example to Create a Floating IP
 		Pool: "nova",
 	}
 
-	fip, err := floatingips.Create(computeClient, createOpts).Extract()
+	fip, err := floatingips.Create(context.TODO(), computeClient, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
 
 Example to Delete a Floating IP
 
-	err := floatingips.Delete(computeClient, "floatingip-id").ExtractErr()
+	err := floatingips.Delete(context.TODO(), computeClient, "floatingip-id").ExtractErr()
 	if err != nil {
 		panic(err)
 	}
@@ -49,7 +49,7 @@ Example to Associate a Floating IP With a Server
 		FloatingIP: "10.10.10.2",
 	}
 
-	err := floatingips.AssociateInstance(computeClient, "server-id", associateOpts).ExtractErr()
+	err := floatingips.AssociateInstance(context.TODO(), computeClient, "server-id", associateOpts).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
@@ -60,7 +60,7 @@ Example to Disassociate a Floating IP From a Server
 		FloatingIP: "10.10.10.2",
 	}
 
-	err := floatingips.DisassociateInstance(computeClient, "server-id", disassociateOpts).ExtractErr()
+	err := floatingips.DisassociateInstance(context.TODO(), computeClient, "server-id", disassociateOpts).ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/compute/v2/extensions/hypervisors/doc.go
+++ b/openstack/compute/v2/extensions/hypervisors/doc.go
@@ -26,7 +26,7 @@ Example of Show Hypervisor Details when using Compute API microversion greater t
 
 Example of Retrieving Details of All Hypervisors
 
-	allPages, err := hypervisors.List(computeClient, nil).AllPages()
+	allPages, err := hypervisors.List(computeClient, nil).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}
@@ -49,7 +49,7 @@ Example of Retrieving Details of All Hypervisors when using Compute API microver
 		WithServers: &true,
 	}
 
-	allPages, err := hypervisors.List(computeClient, listOpts).AllPages()
+	allPages, err := hypervisors.List(computeClient, listOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/compute/v2/extensions/hypervisors/doc.go
+++ b/openstack/compute/v2/extensions/hypervisors/doc.go
@@ -5,7 +5,7 @@ and shows summary statistics for all hypervisors over all compute nodes in the O
 Example of Show Hypervisor Details
 
 	hypervisorID := "42"
-	hypervisor, err := hypervisors.Get(computeClient, hypervisorID).Extract()
+	hypervisor, err := hypervisors.Get(context.TODO(), computeClient, hypervisorID).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -17,7 +17,7 @@ Example of Show Hypervisor Details when using Compute API microversion greater t
 	computeClient.Microversion = "2.53"
 
 	hypervisorID := "c48f6247-abe4-4a24-824e-ea39e108874f"
-	hypervisor, err := hypervisors.Get(computeClient, hypervisorID).Extract()
+	hypervisor, err := hypervisors.Get(context.TODO(), computeClient, hypervisorID).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -65,7 +65,7 @@ Example of Retrieving Details of All Hypervisors when using Compute API microver
 
 Example of Show Hypervisors Statistics
 
-	hypervisorsStatistics, err := hypervisors.GetStatistics(computeClient).Extract()
+	hypervisorsStatistics, err := hypervisors.GetStatistics(context.TODO(), computeClient).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -75,7 +75,7 @@ Example of Show Hypervisors Statistics
 Example of Show Hypervisor Uptime
 
 	hypervisorID := "42"
-	hypervisorUptime, err := hypervisors.GetUptime(computeClient, hypervisorID).Extract()
+	hypervisorUptime, err := hypervisors.GetUptime(context.TODO(), computeClient, hypervisorID).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -87,7 +87,7 @@ Example of Show Hypervisor Uptime with Compute API microversion greater than 2.5
 	computeClient.Microversion = "2.53"
 
 	hypervisorID := "c48f6247-abe4-4a24-824e-ea39e108874f"
-	hypervisorUptime, err := hypervisors.GetUptime(computeClient, hypervisorID).Extract()
+	hypervisorUptime, err := hypervisors.GetUptime(context.TODO(), computeClient, hypervisorID).Extract()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/compute/v2/extensions/injectnetworkinfo/doc.go
+++ b/openstack/compute/v2/extensions/injectnetworkinfo/doc.go
@@ -6,7 +6,7 @@ requires admin privileges and Nova configured with a Xen hypervisor driver.
 Example to Inject a Network Info into a Server
 
 	serverID := "47b6b7b7-568d-40e4-868c-d5c41735532e"
-	err := injectnetworkinfo.InjectNetworkInfo(client, id).ExtractErr()
+	err := injectnetworkinfo.InjectNetworkInfo(context.TODO(), client, id).ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/compute/v2/extensions/instanceactions/doc.go
+++ b/openstack/compute/v2/extensions/instanceactions/doc.go
@@ -5,7 +5,7 @@ Package instanceactions provides the ability to list or get a server instance-ac
 
 Example to List and Get actions:
 
-	pages, err := instanceactions.List(client, "server-id", nil).AllPages()
+	pages, err := instanceactions.List(client, "server-id", nil).AllPages(context.TODO())
 	if err != nil {
 		panic("fail to get actions pages")
 	}

--- a/openstack/compute/v2/extensions/instanceactions/doc.go
+++ b/openstack/compute/v2/extensions/instanceactions/doc.go
@@ -16,7 +16,7 @@ Example to List and Get actions:
 	}
 
 	for _, action := range actions {
-		action, err = instanceactions.Get(client, "server-id", action.RequestID).Extract()
+		action, err = instanceactions.Get(context.TODO(), client, "server-id", action.RequestID).Extract()
 		if err != nil {
 			panic("fail to get instance action")
 		}

--- a/openstack/compute/v2/extensions/keypairs/doc.go
+++ b/openstack/compute/v2/extensions/keypairs/doc.go
@@ -46,7 +46,7 @@ Example to Create a Key Pair
 		Name: "keypair-name",
 	}
 
-	keypair, err := keypairs.Create(computeClient, createOpts).Extract()
+	keypair, err := keypairs.Create(context.TODO(), computeClient, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -60,14 +60,14 @@ Example to Import a Key Pair
 		PublicKey: "public-key",
 	}
 
-	keypair, err := keypairs.Create(computeClient, createOpts).Extract()
+	keypair, err := keypairs.Create(context.TODO(), computeClient, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
 
 Example to Delete a Key Pair
 
-	err := keypairs.Delete(computeClient, "keypair-name", nil).ExtractErr()
+	err := keypairs.Delete(context.TODO(), computeClient, "keypair-name", nil).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
@@ -80,7 +80,7 @@ Example to Delete a Key Pair owned by a certain user using microversion 2.10 or 
 		UserID: "user-id",
 	}
 
-	err := keypairs.Delete(client, "keypair-name", deleteOpts).ExtractErr()
+	err := keypairs.Delete(context.TODO(), client, "keypair-name", deleteOpts).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
@@ -98,7 +98,7 @@ Example to Create a Server With a Key Pair
 		KeyName:           "keypair-name",
 	}
 
-	server, err := servers.Create(computeClient, createOpts).Extract()
+	server, err := servers.Create(context.TODO(), computeClient, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -111,7 +111,7 @@ Example to Get a Key Pair owned by a certain user using microversion 2.10 or gre
 		UserID: "user-id",
 	}
 
-	keypair, err := keypairs.Get(computeClient, "keypair-name", getOpts).Extract()
+	keypair, err := keypairs.Get(context.TODO(), computeClient, "keypair-name", getOpts).Extract()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/compute/v2/extensions/keypairs/doc.go
+++ b/openstack/compute/v2/extensions/keypairs/doc.go
@@ -4,7 +4,7 @@ servers with a specified key pair.
 
 Example to List Key Pairs
 
-	allPages, err := keypairs.List(computeClient, nil).AllPages()
+	allPages, err := keypairs.List(computeClient, nil).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}
@@ -26,7 +26,7 @@ Example to List Key Pairs using microversion 2.10 or greater
 		UserID: "user-id",
 	}
 
-	allPages, err := keypairs.List(computeClient, listOpts).AllPages()
+	allPages, err := keypairs.List(computeClient, listOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/compute/v2/extensions/limits/doc.go
+++ b/openstack/compute/v2/extensions/limits/doc.go
@@ -7,7 +7,7 @@ Example to Retrieve Limits for a Tenant
 		TenantID: "tenant-id",
 	}
 
-	limits, err := limits.Get(computeClient, getOpts).Extract()
+	limits, err := limits.Get(context.TODO(), computeClient, getOpts).Extract()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/compute/v2/extensions/lockunlock/doc.go
+++ b/openstack/compute/v2/extensions/lockunlock/doc.go
@@ -6,12 +6,12 @@ Example to Lock and Unlock a Server
 
 	serverID := "47b6b7b7-568d-40e4-868c-d5c41735532e"
 
-	err := lockunlock.Lock(computeClient, serverID).ExtractErr()
+	err := lockunlock.Lock(context.TODO(), computeClient, serverID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
 
-	err = lockunlock.Unlock(computeClient, serverID).ExtractErr()
+	err = lockunlock.Unlock(context.TODO(), computeClient, serverID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/compute/v2/extensions/migrate/doc.go
+++ b/openstack/compute/v2/extensions/migrate/doc.go
@@ -5,7 +5,7 @@ provisioned by the OpenStack Compute service.
 Example of Migrate Server (migrate Action)
 
 	serverID := "b16ba811-199d-4ffd-8839-ba96c1185a67"
-	err := migrate.Migrate(computeClient, serverID).ExtractErr()
+	err := migrate.Migrate(context.TODO(), computeClient, serverID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
@@ -21,7 +21,7 @@ Example of Live-Migrate Server (os-migrateLive Action)
 		BlockMigration: &blockMigration,
 	}
 
-	err := migrate.LiveMigrate(computeClient, serverID, migrationOpts).ExtractErr()
+	err := migrate.LiveMigrate(context.TODO(), computeClient, serverID, migrationOpts).ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/compute/v2/extensions/networks/doc.go
+++ b/openstack/compute/v2/extensions/networks/doc.go
@@ -7,7 +7,7 @@ networks.
 
 Example to List Networks
 
-	allPages, err := networks.List(computeClient).AllPages()
+	allPages, err := networks.List(computeClient).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/compute/v2/extensions/pauseunpause/doc.go
+++ b/openstack/compute/v2/extensions/pauseunpause/doc.go
@@ -5,12 +5,12 @@ have been provisioned by the OpenStack Compute service.
 Example to Pause and Unpause a Server
 
 	serverID := "32c8baf7-1cdb-4cc2-bc31-c3a55b89f56b"
-	err := pauseunpause.Pause(computeClient, serverID).ExtractErr()
+	err := pauseunpause.Pause(context.TODO(), computeClient, serverID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
 
-	err = pauseunpause.Unpause(computeClient, serverID).ExtractErr()
+	err = pauseunpause.Unpause(context.TODO(), computeClient, serverID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/compute/v2/extensions/quotasets/doc.go
+++ b/openstack/compute/v2/extensions/quotasets/doc.go
@@ -3,7 +3,7 @@ Package quotasets enables retrieving and managing Compute quotas.
 
 Example to Get a Quota Set
 
-	quotaset, err := quotasets.Get(computeClient, "tenant-id").Extract()
+	quotaset, err := quotasets.Get(context.TODO(), computeClient, "tenant-id").Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -12,7 +12,7 @@ Example to Get a Quota Set
 
 Example to Get a Detailed Quota Set
 
-	quotaset, err := quotasets.GetDetail(computeClient, "tenant-id").Extract()
+	quotaset, err := quotasets.GetDetail(context.TODO(), computeClient, "tenant-id").Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -26,7 +26,7 @@ Example to Update a Quota Set
 		Cores:    gophercloud.IntToPointer(64),
 	}
 
-	quotaset, err := quotasets.Update(computeClient, "tenant-id", updateOpts).Extract()
+	quotaset, err := quotasets.Update(context.TODO(), computeClient, "tenant-id", updateOpts).Extract()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/compute/v2/extensions/remoteconsoles/doc.go
+++ b/openstack/compute/v2/extensions/remoteconsoles/doc.go
@@ -15,7 +15,7 @@ Example of Creating a new RemoteConsole
 	}
 	serverID := "b16ba811-199d-4ffd-8839-ba96c1185a67"
 
-	remtoteConsole, err := remoteconsoles.Create(computeClient, serverID, createOpts).Extract()
+	remtoteConsole, err := remoteconsoles.Create(context.TODO(), computeClient, serverID, createOpts).Extract()
 	if err != nil {
 	  panic(err)
 	}

--- a/openstack/compute/v2/extensions/rescueunrescue/doc.go
+++ b/openstack/compute/v2/extensions/rescueunrescue/doc.go
@@ -10,7 +10,7 @@ Example to Rescue a server
 	}
 	serverID := "3f54d05f-3430-4d80-aa07-63e6af9e2488"
 
-	adminPass, err := rescueunrescue.Rescue(computeClient, serverID, rescueOpts).Extract()
+	adminPass, err := rescueunrescue.Rescue(context.TODO(), computeClient, serverID, rescueOpts).Extract()
 	if err != nil {
 	  panic(err)
 	}
@@ -21,7 +21,7 @@ Example to Unrescue a server
 
 	serverID := "3f54d05f-3430-4d80-aa07-63e6af9e2488"
 
-	if err := rescueunrescue.Unrescue(computeClient, serverID).ExtractErr(); err != nil {
+	if err := rescueunrescue.Unrescue(context.TODO(), computeClient, serverID).ExtractErr(); err != nil {
 	  panic(err)
 	}
 */

--- a/openstack/compute/v2/extensions/resetnetwork/doc.go
+++ b/openstack/compute/v2/extensions/resetnetwork/doc.go
@@ -6,7 +6,7 @@ requires admin privileges and Nova configured with a Xen hypervisor driver.
 Example to Reset a Network of a Server
 
 	serverID := "47b6b7b7-568d-40e4-868c-d5c41735532e"
-	err := resetnetwork.ResetNetwork(client, id).ExtractErr()
+	err := resetnetwork.ResetNetwork(context.TODO(), client, id).ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/compute/v2/extensions/resetstate/doc.go
+++ b/openstack/compute/v2/extensions/resetstate/doc.go
@@ -5,7 +5,7 @@ been provisioned by the OpenStack Compute service.
 Example to Reset a Server
 
 	serverID := "47b6b7b7-568d-40e4-868c-d5c41735532e"
-	err := resetstate.ResetState(client, id, resetstate.StateActive).ExtractErr()
+	err := resetstate.ResetState(context.TODO(), client, id, resetstate.StateActive).ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/compute/v2/extensions/schedulerhints/doc.go
+++ b/openstack/compute/v2/extensions/schedulerhints/doc.go
@@ -20,7 +20,7 @@ Example to Add a Server to a Server Group
 		SchedulerHints:    schedulerHints,
 	}
 
-	server, err := servers.Create(computeClient, createOpts).Extract()
+	server, err := servers.Create(context.TODO(), computeClient, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -44,7 +44,7 @@ Example to Place Server B on a Different Host than Server A
 		SchedulerHints:    schedulerHints,
 	}
 
-	server, err := servers.Create(computeClient, createOpts).Extract()
+	server, err := servers.Create(context.TODO(), computeClient, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -68,7 +68,7 @@ Example to Place Server B on the Same Host as Server A
 		SchedulerHints:    schedulerHints,
 	}
 
-	server, err := servers.Create(computeClient, createOpts).Extract()
+	server, err := servers.Create(context.TODO(), computeClient, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/compute/v2/extensions/secgroups/doc.go
+++ b/openstack/compute/v2/extensions/secgroups/doc.go
@@ -50,7 +50,7 @@ Example to Create a Security Group
 		Description: "A Security Group",
 	}
 
-	sg, err := secgroups.Create(computeClient, createOpts).Extract()
+	sg, err := secgroups.Create(context.TODO(), computeClient, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -67,7 +67,7 @@ Example to Create a Security Group Rule
 		CIDR:          "0.0.0.0/0",
 	}
 
-	rule, err := secgroups.CreateRule(computeClient, createOpts).Extract()
+	rule, err := secgroups.CreateRule(context.TODO(), computeClient, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -77,7 +77,7 @@ Example to Add a Security Group to a Server
 	serverID := "aab3ad01-9956-4623-a29b-24afc89a7d36"
 	sgID := "37d94f8a-d136-465c-ae46-144f0d8ef141"
 
-	err := secgroups.AddServer(computeClient, serverID, sgID).ExtractErr()
+	err := secgroups.AddServer(context.TODO(), computeClient, serverID, sgID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
@@ -87,7 +87,7 @@ Example to Remove a Security Group from a Server
 	serverID := "aab3ad01-9956-4623-a29b-24afc89a7d36"
 	sgID := "37d94f8a-d136-465c-ae46-144f0d8ef141"
 
-	err := secgroups.RemoveServer(computeClient, serverID, sgID).ExtractErr()
+	err := secgroups.RemoveServer(context.TODO(), computeClient, serverID, sgID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
@@ -95,7 +95,7 @@ Example to Remove a Security Group from a Server
 # Example to Delete a Security Group
 
 	sgID := "37d94f8a-d136-465c-ae46-144f0d8ef141"
-	err := secgroups.Delete(computeClient, sgID).ExtractErr()
+	err := secgroups.Delete(context.TODO(), computeClient, sgID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
@@ -103,7 +103,7 @@ Example to Remove a Security Group from a Server
 Example to Delete a Security Group Rule
 
 	ruleID := "6221fe3e-383d-46c9-a3a6-845e66c1e8b4"
-	err := secgroups.DeleteRule(computeClient, ruleID).ExtractErr()
+	err := secgroups.DeleteRule(context.TODO(), computeClient, ruleID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/compute/v2/extensions/secgroups/doc.go
+++ b/openstack/compute/v2/extensions/secgroups/doc.go
@@ -11,7 +11,7 @@ service.
 
 Example to List Security Groups
 
-	allPages, err := secroups.List(computeClient).AllPages()
+	allPages, err := secroups.List(computeClient).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}
@@ -29,7 +29,7 @@ Example to List Security Groups by Server
 
 	serverID := "aab3ad01-9956-4623-a29b-24afc89a7d36"
 
-	allPages, err := secroups.ListByServer(computeClient, serverID).AllPages()
+	allPages, err := secroups.ListByServer(computeClient, serverID).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/compute/v2/extensions/servergroups/doc.go
+++ b/openstack/compute/v2/extensions/servergroups/doc.go
@@ -24,7 +24,7 @@ Example to Create a Server Group
 		Policies: []string{"anti-affinity"},
 	}
 
-	sg, err := servergroups.Create(computeClient, createOpts).Extract()
+	sg, err := servergroups.Create(context.TODO(), computeClient, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -40,7 +40,7 @@ Example to Create a Server Group with additional microversion 2.64 fields
 		}
 
 		computeClient.Microversion = "2.64"
-		result := servergroups.Create(computeClient, createOpts)
+		result := servergroups.Create(context.TODO(), computeClient, createOpts)
 
 		serverGroup, err := result.Extract()
 		if err != nil {
@@ -50,7 +50,7 @@ Example to Create a Server Group with additional microversion 2.64 fields
 Example to Delete a Server Group
 
 	sgID := "7a6f29ad-e34d-4368-951a-58a08f11cfb7"
-	err := servergroups.Delete(computeClient, sgID).ExtractErr()
+	err := servergroups.Delete(context.TODO(), computeClient, sgID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/compute/v2/extensions/servergroups/doc.go
+++ b/openstack/compute/v2/extensions/servergroups/doc.go
@@ -3,7 +3,7 @@ Package servergroups provides the ability to manage server groups.
 
 Example to List Server Groups
 
-	allpages, err := servergroups.List(computeClient).AllPages()
+	allpages, err := servergroups.List(computeClient).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/compute/v2/extensions/serverusage/doc.go
+++ b/openstack/compute/v2/extensions/serverusage/doc.go
@@ -10,7 +10,7 @@ Example to Get an extended information:
 	}
 	var serverWithUsageExt serverUsageExt
 
-	err := servers.Get(computeClient, "d650a0ce-17c3-497d-961a-43c4af80998a").ExtractInto(&serverWithUsageExt)
+	err := servers.Get(context.TODO(), computeClient, "d650a0ce-17c3-497d-961a-43c4af80998a").ExtractInto(&serverWithUsageExt)
 	if err != nil {
 	  panic(err)
 	}

--- a/openstack/compute/v2/extensions/services/doc.go
+++ b/openstack/compute/v2/extensions/services/doc.go
@@ -8,7 +8,7 @@ Example of Retrieving list of all services
 		Binary: "nova-scheduler",
 	}
 
-	allPages, err := services.List(computeClient, opts).AllPages()
+	allPages, err := services.List(computeClient, opts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/compute/v2/extensions/services/doc.go
+++ b/openstack/compute/v2/extensions/services/doc.go
@@ -28,14 +28,14 @@ Example of updating a service
 		Status: services.ServiceDisabled,
 	}
 
-	updated, err := services.Update(client, serviceID, opts).Extract()
+	updated, err := services.Update(context.TODO(), client, serviceID, opts).Extract()
 	if err != nil {
 		panic(err)
 	}
 
 Example of delete a service
 
-	updated, err := services.Delete(client, serviceID).Extract()
+	updated, err := services.Delete(context.TODO(), client, serviceID).Extract()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/compute/v2/extensions/shelveunshelve/doc.go
+++ b/openstack/compute/v2/extensions/shelveunshelve/doc.go
@@ -6,17 +6,17 @@ Example to Shelve, Shelve-offload and Unshelve a Server
 
 	serverID := "47b6b7b7-568d-40e4-868c-d5c41735532e"
 
-	err := shelveunshelve.Shelve(computeClient, serverID).ExtractErr()
+	err := shelveunshelve.Shelve(context.TODO(), computeClient, serverID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
 
-	err := shelveunshelve.ShelveOffload(computeClient, serverID).ExtractErr()
+	err := shelveunshelve.ShelveOffload(context.TODO(), computeClient, serverID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
 
-	err := shelveunshelve.Unshelve(computeClient, serverID, nil).ExtractErr()
+	err := shelveunshelve.Unshelve(context.TODO(), computeClient, serverID, nil).ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/compute/v2/extensions/startstop/doc.go
+++ b/openstack/compute/v2/extensions/startstop/doc.go
@@ -6,12 +6,12 @@ Example to Stop and Start a Server
 
 	serverID := "47b6b7b7-568d-40e4-868c-d5c41735532e"
 
-	err := startstop.Stop(computeClient, serverID).ExtractErr()
+	err := startstop.Stop(context.TODO(), computeClient, serverID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
 
-	err := startstop.Start(computeClient, serverID).ExtractErr()
+	err := startstop.Start(context.TODO(), computeClient, serverID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/compute/v2/extensions/suspendresume/doc.go
+++ b/openstack/compute/v2/extensions/suspendresume/doc.go
@@ -6,12 +6,12 @@ Example to Suspend and Resume a Server
 
 	serverID := "47b6b7b7-568d-40e4-868c-d5c41735532e"
 
-	err := suspendresume.Suspend(computeClient, serverID).ExtractErr()
+	err := suspendresume.Suspend(context.TODO(), computeClient, serverID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
 
-	err := suspendresume.Resume(computeClient, serverID).ExtractErr()
+	err := suspendresume.Resume(context.TODO(), computeClient, serverID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/compute/v2/extensions/tags/doc.go
+++ b/openstack/compute/v2/extensions/tags/doc.go
@@ -7,7 +7,7 @@ Example to List all server Tags
 
 		client.Microversion = "2.26"
 
-	    serverTags, err := tags.List(client, serverID).Extract()
+	    serverTags, err := tags.List(context.TODO(), client, serverID).Extract()
 	    if err != nil {
 	        log.Fatal(err)
 	    }
@@ -18,7 +18,7 @@ Example to Check if the specific Tag exists on a server
 
 	client.Microversion = "2.26"
 
-	exists, err := tags.Check(client, serverID, tag).Extract()
+	exists, err := tags.Check(context.TODO(), client, serverID, tag).Extract()
 	if err != nil {
 	    log.Fatal(err)
 	}
@@ -33,7 +33,7 @@ Example to Replace all Tags on a server
 
 	client.Microversion = "2.26"
 
-	newTags, err := tags.ReplaceAll(client, serverID, tags.ReplaceAllOpts{Tags: []string{"foo", "bar"}}).Extract()
+	newTags, err := tags.ReplaceAll(context.TODO(), client, serverID, tags.ReplaceAllOpts{Tags: []string{"foo", "bar"}}).Extract()
 	if err != nil {
 	    log.Fatal(err)
 	}
@@ -44,7 +44,7 @@ Example to Add a new Tag on a server
 
 	client.Microversion = "2.26"
 
-	err := tags.Add(client, serverID, "foo").ExtractErr()
+	err := tags.Add(context.TODO(), client, serverID, "foo").ExtractErr()
 	if err != nil {
 	    log.Fatal(err)
 	}
@@ -53,7 +53,7 @@ Example to Delete a Tag on a server
 
 	client.Microversion = "2.26"
 
-	err := tags.Delete(client, serverID, "foo").ExtractErr()
+	err := tags.Delete(context.TODO(), client, serverID, "foo").ExtractErr()
 	if err != nil {
 	    log.Fatal(err)
 	}
@@ -62,7 +62,7 @@ Example to Delete all Tags on a server
 
 	client.Microversion = "2.26"
 
-	err := tags.DeleteAll(client, serverID).ExtractErr()
+	err := tags.DeleteAll(context.TODO(), client, serverID).ExtractErr()
 	if err != nil {
 	    log.Fatal(err)
 	}

--- a/openstack/compute/v2/extensions/tenantnetworks/doc.go
+++ b/openstack/compute/v2/extensions/tenantnetworks/doc.go
@@ -9,7 +9,7 @@ This API works in both Neutron and nova-network based OpenStack clouds.
 
 Example to List Networks Available to a Tenant
 
-	allPages, err := tenantnetworks.List(computeClient).AllPages()
+	allPages, err := tenantnetworks.List(computeClient).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/compute/v2/extensions/usage/doc.go
+++ b/openstack/compute/v2/extensions/usage/doc.go
@@ -19,7 +19,7 @@ Example to Retrieve Usage for a Single Tenant:
 		End: &end,
 	}
 
-	err := usage.SingleTenant(computeClient, tenantID, singleTenantOpts).EachPage(func(page pagination.Page) (bool, error) {
+	err := usage.SingleTenant(computeClient, tenantID, singleTenantOpts).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
 		tenantUsage, err := usage.ExtractSingleTenant(page)
 		if err != nil {
 			return false, err
@@ -40,7 +40,7 @@ Example to Retrieve Usage for All Tenants:
 		Detailed: true,
 	}
 
-	err := usage.AllTenants(computeClient, allTenantsOpts).EachPage(func(page pagination.Page) (bool, error) {
+	err := usage.AllTenants(computeClient, allTenantsOpts).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
 		allTenantsUsage, err := usage.ExtractAllTenants(page)
 		if err != nil {
 			return false, err

--- a/openstack/compute/v2/extensions/volumeattach/doc.go
+++ b/openstack/compute/v2/extensions/volumeattach/doc.go
@@ -12,7 +12,7 @@ Example to Attach a Volume
 		VolumeID: volumeID,
 	}
 
-	result, err := volumeattach.Create(computeClient, serverID, createOpts).Extract()
+	result, err := volumeattach.Create(context.TODO(), computeClient, serverID, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -22,7 +22,7 @@ Example to Detach a Volume
 	serverID := "7ac8686c-de71-4acb-9600-ec18b1a1ed6d"
 	volumeID := "ed081613-1c9b-4231-aa5e-ebfd4d87f983"
 
-	err := volumeattach.Delete(computeClient, serverID, volumeID).ExtractErr()
+	err := volumeattach.Delete(context.TODO(), computeClient, serverID, volumeID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/compute/v2/flavors/doc.go
+++ b/openstack/compute/v2/flavors/doc.go
@@ -12,7 +12,7 @@ Example to List Flavors
 		AccessType: flavors.PublicAccess,
 	}
 
-	allPages, err := flavors.ListDetail(computeClient, listOpts).AllPages()
+	allPages, err := flavors.ListDetail(computeClient, listOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}
@@ -59,7 +59,7 @@ Example to List Flavor Access
 
 	flavorID := "e91758d6-a54a-4778-ad72-0c73a1cb695b"
 
-	allPages, err := flavors.ListAccesses(computeClient, flavorID).AllPages()
+	allPages, err := flavors.ListAccesses(computeClient, flavorID).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/compute/v2/flavors/doc.go
+++ b/openstack/compute/v2/flavors/doc.go
@@ -37,7 +37,7 @@ Example to Create a Flavor
 		RxTxFactor: 1.0,
 	}
 
-	flavor, err := flavors.Create(computeClient, createOpts).Extract()
+	flavor, err := flavors.Create(context.TODO(), computeClient, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -50,7 +50,7 @@ Example to Update a Flavor
 		Description: "This is a good description"
 	}
 
-	flavor, err := flavors.Update(computeClient, flavorID, updateOpts).Extract()
+	flavor, err := flavors.Update(context.TODO(), computeClient, flavorID, updateOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -81,7 +81,7 @@ Example to Grant Access to a Flavor
 		Tenant: "15153a0979884b59b0592248ef947921",
 	}
 
-	accessList, err := flavors.AddAccess(computeClient, flavor.ID, accessOpts).Extract()
+	accessList, err := flavors.AddAccess(context.TODO(), computeClient, flavor.ID, accessOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -94,7 +94,7 @@ Example to Remove/Revoke Access to a Flavor
 		Tenant: "15153a0979884b59b0592248ef947921",
 	}
 
-	accessList, err := flavors.RemoveAccess(computeClient, flavor.ID, accessOpts).Extract()
+	accessList, err := flavors.RemoveAccess(context.TODO(), computeClient, flavor.ID, accessOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -107,7 +107,7 @@ Example to Create Extra Specs for a Flavor
 		"hw:cpu_policy":        "CPU-POLICY",
 		"hw:cpu_thread_policy": "CPU-THREAD-POLICY",
 	}
-	createdExtraSpecs, err := flavors.CreateExtraSpecs(computeClient, flavorID, createOpts).Extract()
+	createdExtraSpecs, err := flavors.CreateExtraSpecs(context.TODO(), computeClient, flavorID, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -118,7 +118,7 @@ Example to Get Extra Specs for a Flavor
 
 	flavorID := "e91758d6-a54a-4778-ad72-0c73a1cb695b"
 
-	extraSpecs, err := flavors.ListExtraSpecs(computeClient, flavorID).Extract()
+	extraSpecs, err := flavors.ListExtraSpecs(context.TODO(), computeClient, flavorID).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -132,7 +132,7 @@ Example to Update Extra Specs for a Flavor
 	updateOpts := flavors.ExtraSpecsOpts{
 		"hw:cpu_thread_policy": "CPU-THREAD-POLICY-UPDATED",
 	}
-	updatedExtraSpec, err := flavors.UpdateExtraSpec(computeClient, flavorID, updateOpts).Extract()
+	updatedExtraSpec, err := flavors.UpdateExtraSpec(context.TODO(), computeClient, flavorID, updateOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -142,7 +142,7 @@ Example to Update Extra Specs for a Flavor
 Example to Delete an Extra Spec for a Flavor
 
 	flavorID := "e91758d6-a54a-4778-ad72-0c73a1cb695b"
-	err := flavors.DeleteExtraSpec(computeClient, flavorID, "hw:cpu_thread_policy").ExtractErr()
+	err := flavors.DeleteExtraSpec(context.TODO(), computeClient, flavorID, "hw:cpu_thread_policy").ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/compute/v2/images/doc.go
+++ b/openstack/compute/v2/images/doc.go
@@ -15,7 +15,7 @@ Example to List Images
 		Limit: 2,
 	}
 
-	allPages, err := images.ListDetail(computeClient, listOpts).AllPages()
+	allPages, err := images.ListDetail(computeClient, listOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/compute/v2/servers/doc.go
+++ b/openstack/compute/v2/servers/doc.go
@@ -11,7 +11,7 @@ Example to List Servers
 		AllTenants: true,
 	}
 
-	allPages, err := servers.ListSimple(computeClient, listOpts).AllPages()
+	allPages, err := servers.ListSimple(computeClient, listOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}
@@ -31,7 +31,7 @@ Example to List Detail Servers
 		AllTenants: true,
 	}
 
-	allPages, err := servers.List(computeClient, listOpts).AllPages()
+	allPages, err := servers.List(computeClient, listOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/compute/v2/servers/doc.go
+++ b/openstack/compute/v2/servers/doc.go
@@ -53,7 +53,7 @@ Example to Create a Server
 		FlavorRef: "flavor-uuid",
 	}
 
-	server, err := servers.Create(computeClient, createOpts).Extract()
+	server, err := servers.Create(context.TODO(), computeClient, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -61,7 +61,7 @@ Example to Create a Server
 Example to Delete a Server
 
 	serverID := "d9072956-1560-487c-97f2-18bdf65ec749"
-	err := servers.Delete(computeClient, serverID).ExtractErr()
+	err := servers.Delete(context.TODO(), computeClient, serverID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
@@ -69,7 +69,7 @@ Example to Delete a Server
 Example to Force Delete a Server
 
 	serverID := "d9072956-1560-487c-97f2-18bdf65ec749"
-	err := servers.ForceDelete(computeClient, serverID).ExtractErr()
+	err := servers.ForceDelete(context.TODO(), computeClient, serverID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
@@ -82,7 +82,7 @@ Example to Reboot a Server
 
 	serverID := "d9072956-1560-487c-97f2-18bdf65ec749"
 
-	err := servers.Reboot(computeClient, serverID, rebootOpts).ExtractErr()
+	err := servers.Reboot(context.TODO(), computeClient, serverID, rebootOpts).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
@@ -109,12 +109,12 @@ Example to Resize a Server
 
 	serverID := "d9072956-1560-487c-97f2-18bdf65ec749"
 
-	err := servers.Resize(computeClient, serverID, resizeOpts).ExtractErr()
+	err := servers.Resize(context.TODO(), computeClient, serverID, resizeOpts).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
 
-	err = servers.ConfirmResize(computeClient, serverID).ExtractErr()
+	err = servers.ConfirmResize(context.TODO(), computeClient, serverID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
@@ -127,7 +127,7 @@ Example to Snapshot a Server
 
 	serverID := "d9072956-1560-487c-97f2-18bdf65ec749"
 
-	image, err := servers.CreateImage(computeClient, serverID, snapshotOpts).ExtractImageID()
+	image, err := servers.CreateImage(context.TODO(), computeClient, serverID, snapshotOpts).ExtractImageID()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/containerinfra/v1/certificates/doc.go
+++ b/openstack/containerinfra/v1/certificates/doc.go
@@ -6,7 +6,7 @@ the OpenStack Container Infra service.
 
 Example to get certificates
 
-	certificate, err := certificates.Get(serviceClient, "d564b18a-2890-4152-be3d-e05d784ff72").Extract()
+	certificate, err := certificates.Get(context.TODO(), serviceClient, "d564b18a-2890-4152-be3d-e05d784ff72").Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -18,14 +18,14 @@ Example to create certificates
 		CSR:		"-----BEGIN CERTIFICATE REQUEST-----\nMIIEfzCCAmcCAQAwFDESMBAGA1UEAxMJWW91ciBOYW1lMIICIjANBgkqhkiG9w0B\n-----END CERTIFICATE REQUEST-----\n",
 	}
 
-	response, err := certificates.Create(sc, createOpts).Extract()
+	response, err := certificates.Create(context.TODO(), client, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
 
 Example to update certificates
 
-	err := certificates.Update(client, clusterUUID).ExtractErr()
+	err := certificates.Update(context.TODO(), client, clusterUUID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/containerinfra/v1/clusters/doc.go
+++ b/openstack/containerinfra/v1/clusters/doc.go
@@ -21,7 +21,7 @@ Example to Create a Cluster
 		MasterLBEnabled:   &masterLBEnabled,
 	}
 
-	cluster, err := clusters.Create(serviceClient, createOpts).Extract()
+	cluster, err := clusters.Create(context.TODO(), serviceClient, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -29,7 +29,7 @@ Example to Create a Cluster
 Example to Get a Cluster
 
 	clusterName := "cluster123"
-	cluster, err := clusters.Get(serviceClient, clusterName).Extract()
+	cluster, err := clusters.Get(context.TODO(), serviceClient, clusterName).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -85,7 +85,7 @@ Example to Update a Cluster
 			Value: "True",
 		},
 	}
-	clusterUUID, err := clusters.Update(serviceClient, clusterUUID, updateOpts).Extract()
+	clusterUUID, err := clusters.Update(context.TODO(), serviceClient, clusterUUID, updateOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -96,7 +96,7 @@ Example to Upgrade a Cluster
 	upgradeOpts := clusters.UpgradeOpts{
 		ClusterTemplate: "0562d357-8641-4759-8fed-8173f02c9633",
 	}
-	clusterUUID, err := clusters.Upgrade(serviceClient, clusterUUID, upgradeOpts).Extract()
+	clusterUUID, err := clusters.Upgrade(context.TODO(), serviceClient, clusterUUID, upgradeOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -105,7 +105,7 @@ Example to Upgrade a Cluster
 Example to Delete a Cluster
 
 	clusterUUID := "dc6d336e3fc4c0a951b5698cd1236ee"
-	err := clusters.Delete(serviceClient, clusterUUID).ExtractErr()
+	err := clusters.Delete(context.TODO(), serviceClient, clusterUUID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/containerinfra/v1/clusters/doc.go
+++ b/openstack/containerinfra/v1/clusters/doc.go
@@ -41,7 +41,7 @@ Example to List Clusters
 		Limit: 20,
 	}
 
-	allPages, err := clusters.List(serviceClient, listOpts).AllPages()
+	allPages, err := clusters.List(serviceClient, listOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}
@@ -57,7 +57,7 @@ Example to List Clusters
 
 Example to List Clusters with detailed information
 
-	allPagesDetail, err := clusters.ListDetail(serviceClient, clusters.ListOpts{}).AllPages()
+	allPagesDetail, err := clusters.ListDetail(serviceClient, clusters.ListOpts{}).AllPages(context.TODO())
 	if err != nil {
 	    panic(err)
 	}

--- a/openstack/containerinfra/v1/clustertemplates/doc.go
+++ b/openstack/containerinfra/v1/clustertemplates/doc.go
@@ -33,7 +33,7 @@ Example to Create Cluster Template
 		DNSNameServer:       "8.8.8.8",
 	}
 
-	clustertemplate, err := clustertemplates.Create(serviceClient, createOpts).Extract()
+	clustertemplate, err := clustertemplates.Create(context.TODO(), serviceClient, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -41,7 +41,7 @@ Example to Create Cluster Template
 Example to Delete Cluster Template
 
 	clusterTemplateID := "dc6d336e3fc4c0a951b5698cd1236ee"
-	err := clustertemplates.Delete(serviceClient, clusterTemplateID).ExtractErr()
+	err := clustertemplates.Delete(context.TODO(), serviceClient, clusterTemplateID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
@@ -81,7 +81,7 @@ Example to Update Cluster Template
 		},
 	}
 
-	clustertemplate, err := clustertemplates.Update(serviceClient, updateOpts).Extract()
+	clustertemplate, err := clustertemplates.Update(context.TODO(), serviceClient, updateOpts).Extract()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/containerinfra/v1/clustertemplates/doc.go
+++ b/openstack/containerinfra/v1/clustertemplates/doc.go
@@ -52,7 +52,7 @@ Example to List Clusters Templates
 		Limit: 20,
 	}
 
-	allPages, err := clustertemplates.List(serviceClient, listOpts).AllPages()
+	allPages, err := clustertemplates.List(serviceClient, listOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/containerinfra/v1/nodegroups/doc.go
+++ b/openstack/containerinfra/v1/nodegroups/doc.go
@@ -25,7 +25,7 @@ Create a client to use:
 
 Example of Getting a node group:
 
-	ng, err := nodegroups.Get(client, clusterUUID, nodeGroupUUID).Extract()
+	ng, err := nodegroups.Get(context.TODO(), client, clusterUUID, nodeGroupUUID).Extract()
 	if err != nil {
 	    panic(err)
 	}
@@ -57,7 +57,7 @@ Example of Creating a node group:
 	// Role will default to "worker" if not set.
 
 	// To add a label to the new node group, need to know the cluster labels
-	cluster, err := clusters.Get(client, clusterUUID).Extract()
+	cluster, err := clusters.Get(context.TODO(), client, clusterUUID).Extract()
 	if err != nil {
 	    panic(err)
 	}
@@ -74,7 +74,7 @@ Example of Creating a node group:
 	    Labels: labels,
 	}
 
-	ng, err := nodegroups.Create(client, clusterUUID, createOpts).Extract()
+	ng, err := nodegroups.Create(context.TODO(), client, clusterUUID, createOpts).Extract()
 	if err != nil {
 	    panic(err)
 	}
@@ -95,7 +95,7 @@ Example of Updating a node group:
 	    },
 	}
 
-	ng, err = nodegroups.Update(client, clusterUUID, nodeGroupUUID, updateOpts).Extract()
+	ng, err = nodegroups.Update(context.TODO(), client, clusterUUID, nodeGroupUUID, updateOpts).Extract()
 	if err != nil {
 	    panic(err)
 	}
@@ -104,7 +104,7 @@ Example of Updating a node group:
 
 Example of Deleting a node group:
 
-	err = nodegroups.Delete(client, clusterUUID, nodeGroupUUID).ExtractErr()
+	err = nodegroups.Delete(context.TODO(), client, clusterUUID, nodeGroupUUID).ExtractErr()
 	if err != nil {
 	    panic(err)
 	}

--- a/openstack/containerinfra/v1/nodegroups/doc.go
+++ b/openstack/containerinfra/v1/nodegroups/doc.go
@@ -11,7 +11,7 @@ Create a client to use:
 	    panic(err)
 	}
 
-	provider, err := openstack.AuthenticatedClient(opts)
+	provider, err := openstack.AuthenticatedClient(context.TODO(), opts)
 	if err != nil {
 	    panic(err)
 	}

--- a/openstack/containerinfra/v1/nodegroups/doc.go
+++ b/openstack/containerinfra/v1/nodegroups/doc.go
@@ -37,7 +37,7 @@ Example of Listing node groups:
 	    Role: "worker",
 	}
 
-	allPages, err := nodegroups.List(client, clusterUUID, listOpts).AllPages()
+	allPages, err := nodegroups.List(client, clusterUUID, listOpts).AllPages(context.TODO())
 	if err != nil {
 	    panic(err)
 	}

--- a/openstack/containerinfra/v1/quotas/doc.go
+++ b/openstack/containerinfra/v1/quotas/doc.go
@@ -9,7 +9,7 @@ Example to Create a Quota
 		HardLimit: 10,
 	}
 
-	quota, err := quotas.Create(serviceClient, createOpts).Extract()
+	quota, err := quotas.Create(context.TODO(), serviceClient, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/dns/v2/recordsets/doc.go
+++ b/openstack/dns/v2/recordsets/doc.go
@@ -36,7 +36,7 @@ Example to Create a RecordSet
 
 	zoneID := "fff121f5-c506-410a-a69e-2d73ef9cbdbd"
 
-	rr, err := recordsets.Create(dnsClient, zoneID, createOpts).Extract()
+	rr, err := recordsets.Create(context.TODO(), dnsClient, zoneID, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -46,7 +46,7 @@ Example to Delete a RecordSet
 	zoneID := "fff121f5-c506-410a-a69e-2d73ef9cbdbd"
 	recordsetID := "d96ed01a-b439-4eb8-9b90-7a9f71017f7b"
 
-	err := recordsets.Delete(dnsClient, zoneID, recordsetID).ExtractErr()
+	err := recordsets.Delete(context.TODO(), dnsClient, zoneID, recordsetID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/dns/v2/recordsets/doc.go
+++ b/openstack/dns/v2/recordsets/doc.go
@@ -10,7 +10,7 @@ Example to List RecordSets by Zone
 
 	zoneID := "fff121f5-c506-410a-a69e-2d73ef9cbdbd"
 
-	allPages, err := recordsets.ListByZone(dnsClient, zoneID, listOpts).AllPages()
+	allPages, err := recordsets.ListByZone(dnsClient, zoneID, listOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/dns/v2/transfer/accept/doc.go
+++ b/openstack/dns/v2/transfer/accept/doc.go
@@ -27,7 +27,7 @@ Example to Create a Zone Transfer Accept
 		ZoneTransferRequestID: zoneTransferRequestID,
 		Key: key,
 	}
-	transferAccept, err := transferAccepts.Create(dnsClient, createOpts).Extract()
+	transferAccept, err := transferAccepts.Create(context.TODO(), dnsClient, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -35,7 +35,7 @@ Example to Create a Zone Transfer Accept
 Example to Get a Zone Transfer Accept
 
 	transferAcceptID := "99d10f68-5623-4491-91a0-6daafa32b60e"
-	transferAccept, err := transferAccepts.Get(dnsClient, transferAcceptID).Extract()
+	transferAccept, err := transferAccepts.Get(context.TODO(), dnsClient, transferAcceptID).Extract()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/dns/v2/transfer/accept/doc.go
+++ b/openstack/dns/v2/transfer/accept/doc.go
@@ -5,7 +5,7 @@ resource for the OpenStack DNS service.
 Example to List Zone Transfer Accepts
 
 	// Optionaly you can provide Status as query parameter for filtering the result.
-	allPages, err := transferAccepts.List(dnsClient, nil).AllPages()
+	allPages, err := transferAccepts.List(dnsClient, nil).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/dns/v2/transfer/request/doc.go
+++ b/openstack/dns/v2/transfer/request/doc.go
@@ -4,7 +4,7 @@ resource for the OpenStack DNS service.
 
 Example to List Zone Transfer Requests
 
-	allPages, err := transferRequests.List(dnsClient, nil).AllPages()
+	allPages, err := transferRequests.List(dnsClient, nil).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/dns/v2/transfer/request/doc.go
+++ b/openstack/dns/v2/transfer/request/doc.go
@@ -26,7 +26,7 @@ Example to Create a Zone Transfer Request
 	        TargetProjectID: targetProjectID,
 		Description: "This is a zone transfer request.",
 	}
-	transferRequest, err := transferRequests.Create(dnsClient, zoneID, createOpts).Extract()
+	transferRequest, err := transferRequests.Create(context.TODO(), dnsClient, zoneID, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -34,7 +34,7 @@ Example to Create a Zone Transfer Request
 Example to Delete a Zone Transfer Request
 
 	transferID := "99d10f68-5623-4491-91a0-6daafa32b60e"
-	err := transferRequests.Delete(dnsClient, transferID).ExtractErr()
+	err := transferRequests.Delete(context.TODO(), dnsClient, transferID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/dns/v2/zones/doc.go
+++ b/openstack/dns/v2/zones/doc.go
@@ -8,7 +8,7 @@ Example to List Zones
 		Email: "jdoe@example.com",
 	}
 
-	allPages, err := zones.List(dnsClient, listOpts).AllPages()
+	allPages, err := zones.List(dnsClient, listOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/dns/v2/zones/doc.go
+++ b/openstack/dns/v2/zones/doc.go
@@ -32,7 +32,7 @@ Example to Create a Zone
 		Description: "This is a zone.",
 	}
 
-	zone, err := zones.Create(dnsClient, createOpts).Extract()
+	zone, err := zones.Create(context.TODO(), dnsClient, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -40,7 +40,7 @@ Example to Create a Zone
 Example to Delete a Zone
 
 	zoneID := "99d10f68-5623-4491-91a0-6daafa32b60e"
-	err := zones.Delete(dnsClient, zoneID).ExtractErr()
+	err := zones.Delete(context.TODO(), dnsClient, zoneID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/doc.go
+++ b/openstack/doc.go
@@ -6,7 +6,7 @@ OpenStack cloud and for provisioning various service-level clients.
 Example of Creating a Service Client
 
 	ao, err := openstack.AuthOptionsFromEnv()
-	provider, err := openstack.AuthenticatedClient(ao)
+	provider, err := openstack.AuthenticatedClient(context.TODO(), ao)
 	client, err := openstack.NewNetworkV2(provider, gophercloud.EndpointOpts{
 		Region: os.Getenv("OS_REGION_NAME"),
 	})

--- a/openstack/identity/v2/extensions/admin/roles/doc.go
+++ b/openstack/identity/v2/extensions/admin/roles/doc.go
@@ -17,7 +17,7 @@ arbitrary name assigned by the user.
 
 Example to List Roles
 
-	allPages, err := roles.List(identityClient).AllPages()
+	allPages, err := roles.List(identityClient).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/identity/v2/extensions/admin/roles/doc.go
+++ b/openstack/identity/v2/extensions/admin/roles/doc.go
@@ -37,7 +37,7 @@ Example to Grant a Role to a User
 	userID := "9df1a02f5eb2416a9781e8b0c022d3ae"
 	roleID := "9fe2ff9ee4384b1894a90878d3e92bab"
 
-	err := roles.AddUser(identityClient, tenantID, userID, roleID).ExtractErr()
+	err := roles.AddUser(context.TODO(), identityClient, tenantID, userID, roleID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
@@ -48,7 +48,7 @@ Example to Remove a Role from a User
 	userID := "9df1a02f5eb2416a9781e8b0c022d3ae"
 	roleID := "9fe2ff9ee4384b1894a90878d3e92bab"
 
-	err := roles.DeleteUser(identityClient, tenantID, userID, roleID).ExtractErr()
+	err := roles.DeleteUser(context.TODO(), identityClient, tenantID, userID, roleID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/identity/v2/tenants/doc.go
+++ b/openstack/identity/v2/tenants/doc.go
@@ -34,7 +34,7 @@ Example to Create a Tenant
 		Enabled:     gophercloud.Enabled,
 	}
 
-	tenant, err := tenants.Create(identityClient, createOpts).Extract()
+	tenant, err := tenants.Create(context.TODO(), identityClient, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -48,7 +48,7 @@ Example to Update a Tenant
 		Enabled:     gophercloud.Disabled,
 	}
 
-	tenant, err := tenants.Update(identityClient, tenantID, updateOpts).Extract()
+	tenant, err := tenants.Update(context.TODO(), identityClient, tenantID, updateOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -57,7 +57,7 @@ Example to Delete a Tenant
 
 	tenantID := "e6db6ed6277c461a853458589063b295"
 
-	err := tenants.Delete(identitYClient, tenantID).ExtractErr()
+	err := tenants.Delete(context.TODO(), identitYClient, tenantID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/identity/v2/tenants/doc.go
+++ b/openstack/identity/v2/tenants/doc.go
@@ -12,7 +12,7 @@ Example to List Tenants
 		Limit: 2,
 	}
 
-	allPages, err := tenants.List(identityClient, listOpts).AllPages()
+	allPages, err := tenants.List(identityClient, listOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/identity/v2/tokens/doc.go
+++ b/openstack/identity/v2/tokens/doc.go
@@ -12,7 +12,7 @@ Example to Create an Unscoped Token from a Password
 		Password: "pass"
 	}
 
-	token, err := tokens.Create(identityClient, authOpts).ExtractToken()
+	token, err := tokens.Create(context.TODO(), identityClient, authOpts).ExtractToken()
 	if err != nil {
 		panic(err)
 	}
@@ -25,7 +25,7 @@ Example to Create a Token from a Tenant ID and Password
 		TenantID: "fc394f2ab2df4114bde39905f800dc57"
 	}
 
-	token, err := tokens.Create(identityClient, authOpts).ExtractToken()
+	token, err := tokens.Create(context.TODO(), identityClient, authOpts).ExtractToken()
 	if err != nil {
 		panic(err)
 	}
@@ -38,7 +38,7 @@ Example to Create a Token from a Tenant Name and Password
 		TenantName: "tenantname"
 	}
 
-	token, err := tokens.Create(identityClient, authOpts).ExtractToken()
+	token, err := tokens.Create(context.TODO(), identityClient, authOpts).ExtractToken()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/identity/v2/users/doc.go
+++ b/openstack/identity/v2/users/doc.go
@@ -4,7 +4,7 @@ resource for the OpenStack Identity Service.
 
 Example to List Users
 
-	allPages, err := users.List(identityClient).AllPages()
+	allPages, err := users.List(identityClient).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}
@@ -58,7 +58,7 @@ Example to List a User's Roles
 	tenantID := "1d8b6120dcc640fda4fc9194ffc80273"
 	userID := "c39e3de9be2d4c779f1dfd6abacc176d"
 
-	allPages, err := users.ListRoles(identityClient, tenantID, userID).AllPages()
+	allPages, err := users.ListRoles(identityClient, tenantID, userID).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/identity/v2/users/doc.go
+++ b/openstack/identity/v2/users/doc.go
@@ -26,7 +26,7 @@ Example to Create a User
 		Enabled:  gophercloud.Enabled,
 	}
 
-	user, err := users.Create(identityClient, createOpts).Extract()
+	user, err := users.Create(context.TODO(), identityClient, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -40,7 +40,7 @@ Example to Update a User
 		Enabled: gophercloud.Disabled,
 	}
 
-	user, err := users.Update(identityClient, userID, updateOpts).Extract()
+	user, err := users.Update(context.TODO(), identityClient, userID, updateOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -48,7 +48,7 @@ Example to Update a User
 Example to Delete a User
 
 	userID := "9fe2ff9ee4384b1894a90878d3e92bab"
-	err := users.Delete(identityClient, userID).ExtractErr()
+	err := users.Delete(context.TODO(), identityClient, userID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/identity/v3/domains/doc.go
+++ b/openstack/identity/v3/domains/doc.go
@@ -8,7 +8,7 @@ Example to List Domains
 		Enabled: &iTrue,
 	}
 
-	allPages, err := domains.List(identityClient, listOpts).AllPages()
+	allPages, err := domains.List(identityClient, listOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/identity/v3/domains/doc.go
+++ b/openstack/identity/v3/domains/doc.go
@@ -29,7 +29,7 @@ Example to Create a Domain
 		Description:      "Test domain",
 	}
 
-	domain, err := domains.Create(identityClient, createOpts).Extract()
+	domain, err := domains.Create(context.TODO(), identityClient, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -43,7 +43,7 @@ Example to Update a Domain
 		Enabled: &iFalse,
 	}
 
-	domain, err := domains.Update(identityClient, domainID, updateOpts).Extract()
+	domain, err := domains.Update(context.TODO(), identityClient, domainID, updateOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -51,7 +51,7 @@ Example to Update a Domain
 Example to Delete a Domain
 
 	domainID := "0fe36e73809d46aeae6705c39077b1b3"
-	err := domains.Delete(identityClient, domainID).ExtractErr()
+	err := domains.Delete(context.TODO(), identityClient, domainID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/identity/v3/endpoints/doc.go
+++ b/openstack/identity/v3/endpoints/doc.go
@@ -39,7 +39,7 @@ Example to Create an Endpoint
 		ServiceID:    serviceID,
 	}
 
-	endpoint, err := endpoints.Create(identityClient, createOpts).Extract()
+	endpoint, err := endpoints.Create(context.TODO(), identityClient, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -52,7 +52,7 @@ Example to Update an Endpoint
 		Region: "RegionTwo",
 	}
 
-	endpoint, err := endpoints.Update(identityClient, endpointID, updateOpts).Extract()
+	endpoint, err := endpoints.Update(context.TODO(), identityClient, endpointID, updateOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -60,7 +60,7 @@ Example to Update an Endpoint
 Example to Delete an Endpoint
 
 	endpointID := "ad59deeec5154d1fa0dcff518596f499"
-	err := endpoints.Delete(identityClient, endpointID).ExtractErr()
+	err := endpoints.Delete(context.TODO(), identityClient, endpointID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/identity/v3/endpoints/doc.go
+++ b/openstack/identity/v3/endpoints/doc.go
@@ -13,7 +13,7 @@ Example to List Endpoints
 		ServiceID: serviceID,
 	}
 
-	allPages, err := endpoints.List(identityClient, listOpts).AllPages()
+	allPages, err := endpoints.List(identityClient, listOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/identity/v3/extensions/ec2credentials/doc.go
+++ b/openstack/identity/v3/extensions/ec2credentials/doc.go
@@ -12,7 +12,7 @@ Example to Create an EC2 credential
 		TenantID: projectID,
 	}
 
-	credential, err := ec2credentials.Create(identityClient, userID, createOpts).Extract()
+	credential, err := ec2credentials.Create(context.TODO(), identityClient, userID, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/identity/v3/extensions/ec2tokens/doc.go
+++ b/openstack/identity/v3/extensions/ec2tokens/doc.go
@@ -13,7 +13,7 @@ Example to Create a Token From an EC2 access and secret keys
 		Secret: "18f4f6761ada4e3795fa5273c30349b9",
 	}
 
-	token, err := ec2tokens.Create(identityClient, authOptions).ExtractToken()
+	token, err := ec2tokens.Create(context.TODO(), identityClient, authOptions).ExtractToken()
 	if err != nil {
 		panic(err)
 	}
@@ -32,7 +32,7 @@ Example to auth a client using EC2 access and secret keys
 		AllowReauth: true,
 	}
 
-	err = openstack.AuthenticateV3(client, authOptions, gophercloud.EndpointOpts{})
+	err = openstack.AuthenticateV3(context.TODO(), client, authOptions, gophercloud.EndpointOpts{})
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/identity/v3/extensions/federation/doc.go
+++ b/openstack/identity/v3/extensions/federation/doc.go
@@ -46,14 +46,14 @@ Example to Create Mappings
 		},
 	}
 
-	createdMapping, err := federation.CreateMapping(identityClient, "ACME", createOpts).Extract()
+	createdMapping, err := federation.CreateMapping(context.TODO(), identityClient, "ACME", createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
 
 Example to Get a Mapping
 
-	mapping, err := federation.GetMapping(identityClient, "ACME").Extract()
+	mapping, err := federation.GetMapping(context.TODO(), identityClient, "ACME").Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -90,14 +90,14 @@ Example to Update a Mapping
 			},
 		},
 	}
-	updatedMapping, err := federation.UpdateMapping(identityClient, "ACME", updateOpts).Extract()
+	updatedMapping, err := federation.UpdateMapping(context.TODO(), identityClient, "ACME", updateOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
 
 Example to Delete a Mapping
 
-	err := federation.DeleteMapping(identityClient, "ACME").ExtractErr()
+	err := federation.DeleteMapping(context.TODO(), identityClient, "ACME").ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/identity/v3/extensions/federation/doc.go
+++ b/openstack/identity/v3/extensions/federation/doc.go
@@ -4,7 +4,7 @@ Openstack Identity service.
 
 Example to List Mappings
 
-	allPages, err := federation.ListMappings(identityClient).AllPages()
+	allPages, err := federation.ListMappings(identityClient).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/identity/v3/extensions/oauth1/doc.go
+++ b/openstack/identity/v3/extensions/oauth1/doc.go
@@ -64,7 +64,7 @@ Example to Create an OAuth1 Access Token
 
 Example to List User's OAuth1 Access Tokens
 
-	allPages, err := oauth1.ListAccessTokens(identityClient, userID).AllPages()
+	allPages, err := oauth1.ListAccessTokens(identityClient, userID).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/identity/v3/extensions/oauth1/doc.go
+++ b/openstack/identity/v3/extensions/oauth1/doc.go
@@ -6,7 +6,7 @@ Example to Create an OAuth1 Consumer
 	createConsumerOpts := oauth1.CreateConsumerOpts{
 		Description: "My consumer",
 	}
-	consumer, err := oauth1.CreateConsumer(identityClient, createConsumerOpts).Extract()
+	consumer, err := oauth1.CreateConsumer(context.TODO(), identityClient, createConsumerOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -22,7 +22,7 @@ Example to Request an unauthorized OAuth1 token
 		OAuthSignatureMethod: oauth1.HMACSHA1,
 		RequestedProjectID:   projectID,
 	}
-	requestToken, err := oauth1.RequestToken(identityClient, requestTokenOpts).Extract()
+	requestToken, err := oauth1.RequestToken(context.TODO(), identityClient, requestTokenOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -37,7 +37,7 @@ Example to Authorize an unauthorized OAuth1 token
 			{Name: "member"},
 		},
 	}
-	authToken, err := oauth1.AuthorizeToken(identityClient, requestToken.OAuthToken, authorizeTokenOpts).Extract()
+	authToken, err := oauth1.AuthorizeToken(context.TODO(), identityClient, requestToken.OAuthToken, authorizeTokenOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -54,7 +54,7 @@ Example to Create an OAuth1 Access Token
 		OAuthVerifier:        authToken.OAuthVerifier,
 		OAuthSignatureMethod: oauth1.HMACSHA1,
 	}
-	accessToken, err := oauth1.CreateAccessToken(identityClient, accessTokenOpts).Extract()
+	accessToken, err := oauth1.CreateAccessToken(context.TODO(), identityClient, accessTokenOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -93,7 +93,7 @@ Example to Authenticate a client using OAuth1 method
 		OAuthTokenSecret:     accessToken.OAuthTokenSecret,
 		OAuthSignatureMethod: oauth1.HMACSHA1,
 	}
-	err = openstack.AuthenticateV3(client, authOptions, gophercloud.EndpointOpts{})
+	err = openstack.AuthenticateV3(context.TODO(), client, authOptions, gophercloud.EndpointOpts{})
 	if err != nil {
 		panic(err)
 	}
@@ -114,7 +114,7 @@ Example to Create a Token using OAuth1 method
 		OAuthTokenSecret:     accessToken.OAuthTokenSecret,
 		OAuthSignatureMethod: oauth1.HMACSHA1,
 	}
-	err := tokens.Create(identityClient, createOpts).ExtractInto(&oauth1Token)
+	err := tokens.Create(context.TODO(), identityClient, createOpts).ExtractInto(&oauth1Token)
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/identity/v3/extensions/projectendpoints/doc.go
+++ b/openstack/identity/v3/extensions/projectendpoints/doc.go
@@ -9,7 +9,7 @@ Example to List Project Endpoints
 
 	projectD := "e629d6e599d9489fb3ae5d9cc12eaea3"
 
-	allPages, err := projectendpoints.List(identityClient, projectID).AllPages()
+	allPages, err := projectendpoints.List(identityClient, projectID).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/identity/v3/extensions/trusts/doc.go
+++ b/openstack/identity/v3/extensions/trusts/doc.go
@@ -69,7 +69,7 @@ Example to List a Trust
 		TrustorUserId: "3422b7c113894f5d90665e1a79655e23",
 	}
 
-	allPages, err := trusts.List(identityClient, listOpts).AllPages()
+	allPages, err := trusts.List(identityClient, listOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/identity/v3/extensions/trusts/doc.go
+++ b/openstack/identity/v3/extensions/trusts/doc.go
@@ -18,7 +18,7 @@ Example to Create a Token with Username, Password, and Trust ID
 		TrustID:            "de0945a",
 	}
 
-	err := tokens.Create(identityClient, createOpts).ExtractInto(&trustToken)
+	err := tokens.Create(context.TODO(), identityClient, createOpts).ExtractInto(&trustToken)
 	if err != nil {
 		panic(err)
 	}
@@ -40,7 +40,7 @@ Example to Create a Trust
 	    TrustorUserID: "959ed913a32c4ec88c041c98e61cbbc3",
 	}
 
-	trust, err := trusts.Create(identityClient, createOpts).Extract()
+	trust, err := trusts.Create(context.TODO(), identityClient, createOpts).Extract()
 	if err != nil {
 	    panic(err)
 	}
@@ -50,7 +50,7 @@ Example to Create a Trust
 Example to Delete a Trust
 
 	trustID := "3422b7c113894f5d90665e1a79655e23"
-	err := trusts.Delete(identityClient, trustID).ExtractErr()
+	err := trusts.Delete(context.TODO(), identityClient, trustID).ExtractErr()
 	if err != nil {
 	    panic(err)
 	}
@@ -58,7 +58,7 @@ Example to Delete a Trust
 Example to Get a Trust
 
 	trustID := "3422b7c113894f5d90665e1a79655e23"
-	err := trusts.Get(identityClient, trustID).ExtractErr()
+	err := trusts.Get(context.TODO(), identityClient, trustID).ExtractErr()
 	if err != nil {
 	    panic(err)
 	}

--- a/openstack/identity/v3/groups/doc.go
+++ b/openstack/identity/v3/groups/doc.go
@@ -7,7 +7,7 @@ Example to List Groups
 		DomainID: "default",
 	}
 
-	allPages, err := groups.List(identityClient, listOpts).AllPages()
+	allPages, err := groups.List(identityClient, listOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/identity/v3/groups/doc.go
+++ b/openstack/identity/v3/groups/doc.go
@@ -31,7 +31,7 @@ Example to Create a Group
 		}
 	}
 
-	group, err := groups.Create(identityClient, createOpts).Extract()
+	group, err := groups.Create(context.TODO(), identityClient, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -44,7 +44,7 @@ Example to Update a Group
 		Description: "Updated Description for group",
 	}
 
-	group, err := groups.Update(identityClient, groupID, updateOpts).Extract()
+	group, err := groups.Update(context.TODO(), identityClient, groupID, updateOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -52,7 +52,7 @@ Example to Update a Group
 Example to Delete a Group
 
 	groupID := "0fe36e73809d46aeae6705c39077b1b3"
-	err := groups.Delete(identityClient, groupID).ExtractErr()
+	err := groups.Delete(context.TODO(), identityClient, groupID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/identity/v3/limits/doc.go
+++ b/openstack/identity/v3/limits/doc.go
@@ -4,7 +4,7 @@ Openstack Identity service.
 
 Example to Get EnforcementModel
 
-	model, err := limits.GetEnforcementModel(identityClient).Extract()
+	model, err := limits.GetEnforcementModel(context.TODO(), identityClient).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -44,14 +44,14 @@ Example to Create Limits
 		},
 	}
 
-	createdLimits, err := limits.Create(identityClient, batchCreateOpts).Extract()
+	createdLimits, err := limits.Create(context.TODO(), identityClient, batchCreateOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
 
 Example to Get a Limit
 
-	limit, err := limits.Get(identityClient, "25a04c7a065c430590881c646cdcdd58").Extract()
+	limit, err := limits.Get(context.TODO(), identityClient, "25a04c7a065c430590881c646cdcdd58").Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -67,7 +67,7 @@ Example to Update a Limit
 	  ResourceLimit: &resourceLimit,
 	}
 
-	limit, err := limits.Update(identityClient, limitID, updateOpts).Extract()
+	limit, err := limits.Update(context.TODO(), identityClient, limitID, updateOpts).Extract()
 	if err != nil {
 	  panic(err)
 	}
@@ -75,7 +75,7 @@ Example to Update a Limit
 Example to Delete a Limit
 
 	limitID := "0fe36e73809d46aeae6705c39077b1b3"
-	err := limits.Delete(identityClient, limitID).ExtractErr()
+	err := limits.Delete(context.TODO(), identityClient, limitID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/identity/v3/limits/doc.go
+++ b/openstack/identity/v3/limits/doc.go
@@ -15,7 +15,7 @@ Example to List Limits
 		ProjectID: "3d596369fd2043bf8aca3c8decb0189e",
 	}
 
-	allPages, err := limits.List(identityClient, listOpts).AllPages()
+	allPages, err := limits.List(identityClient, listOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/identity/v3/osinherit/doc.go
+++ b/openstack/identity/v3/osinherit/doc.go
@@ -8,7 +8,7 @@ Example to Assign a Inherited Role to a User to a Domain
 	userID := "9df1a02f5eb2416a9781e8b0c022d3ae"
 	roleID := "9fe2ff9ee4384b1894a90878d3e92bab"
 
-	err := osinherit.Assign(identityClient, roleID, osinherit.AssignOpts{
+	err := osinherit.Assign(context.TODO(), identityClient, roleID, osinherit.AssignOpts{
 		UserID:   userID,
 		domainID: domainID,
 	}).ExtractErr()
@@ -23,7 +23,7 @@ Example to Assign a Inherited Role to a User to a Project's subtree
 	userID := "9df1a02f5eb2416a9781e8b0c022d3ae"
 	roleID := "9fe2ff9ee4384b1894a90878d3e92bab"
 
-	err := osinherit.Assign(identityClient, roleID, osinherit.AssignOpts{
+	err := osinherit.Assign(context.TODO(), identityClient, roleID, osinherit.AssignOpts{
 		UserID:    userID,
 		ProjectID: projectID,
 	}).ExtractErr()
@@ -38,7 +38,7 @@ Example to validate a Inherited Role to a User to a Project's subtree
 	userID := "9df1a02f5eb2416a9781e8b0c022d3ae"
 	roleID := "9fe2ff9ee4384b1894a90878d3e92bab"
 
-	err := osinherit.Validate(identityClient, roleID, osinherit.validateOpts{
+	err := osinherit.Validate(context.TODO(), identityClient, roleID, osinherit.validateOpts{
 		UserID:    userID,
 		ProjectID: projectID,
 	}).ExtractErr()
@@ -53,7 +53,7 @@ Example to unassign a Inherited Role to a User to a Project's subtree
 	userID := "9df1a02f5eb2416a9781e8b0c022d3ae"
 	roleID := "9fe2ff9ee4384b1894a90878d3e92bab"
 
-	err := osinherit.Unassign(identityClient, roleID, osinherit.UnassignOpts{
+	err := osinherit.Unassign(context.TODO(), identityClient, roleID, osinherit.UnassignOpts{
 		UserID:    userID,
 		ProjectID: projectID,
 	}).ExtractErr()

--- a/openstack/identity/v3/policies/doc.go
+++ b/openstack/identity/v3/policies/doc.go
@@ -8,7 +8,7 @@ Example to List Policies
 		Type: "application/json",
 	}
 
-	allPages, err := policies.List(identityClient, listOpts).AllPages()
+	allPages, err := policies.List(identityClient, listOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/identity/v3/policies/doc.go
+++ b/openstack/identity/v3/policies/doc.go
@@ -32,7 +32,7 @@ Example to Create a Policy
 		},
 	}
 
-	policy, err := policies.Create(identityClient, createOpts).Extract()
+	policy, err := policies.Create(context.TODO(), identityClient, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -40,7 +40,7 @@ Example to Create a Policy
 Example to Get a Policy
 
 	policyID := "0fe36e73809d46aeae6705c39077b1b3"
-	policy, err := policies.Get(identityClient, policyID).Extract()
+	policy, err := policies.Get(context.TODO(), identityClient, policyID).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -59,7 +59,7 @@ Example to Update a Policy
 		},
 	}
 
-	policy, err := policies.Update(identityClient, policyID, updateOpts).Extract()
+	policy, err := policies.Update(context.TODO(), identityClient, policyID, updateOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -69,7 +69,7 @@ Example to Update a Policy
 Example to Delete a Policy
 
 	policyID := "0fe36e73809d46aeae6705c39077b1b3"
-	err := policies.Delete(identityClient, policyID).ExtractErr()
+	err := policies.Delete(context.TODO(), identityClient, policyID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/identity/v3/projects/doc.go
+++ b/openstack/identity/v3/projects/doc.go
@@ -8,7 +8,7 @@ Example to List Projects
 		Enabled: gophercloud.Enabled,
 	}
 
-	allPages, err := projects.List(identityClient, listOpts).AllPages()
+	allPages, err := projects.List(identityClient, listOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/identity/v3/projects/doc.go
+++ b/openstack/identity/v3/projects/doc.go
@@ -30,7 +30,7 @@ Example to Create a Project
 		Tags:        []string{"FirstTag", "SecondTag"},
 	}
 
-	project, err := projects.Create(identityClient, createOpts).Extract()
+	project, err := projects.Create(context.TODO(), identityClient, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -43,7 +43,7 @@ Example to Update a Project
 		Enabled: gophercloud.Disabled,
 	}
 
-	project, err := projects.Update(identityClient, projectID, updateOpts).Extract()
+	project, err := projects.Update(context.TODO(), identityClient, projectID, updateOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -52,7 +52,7 @@ Example to Update a Project
 		Tags: &[]string{"FirstTag"},
 	}
 
-	project, err = projects.Update(identityClient, projectID, updateOpts).Extract()
+	project, err = projects.Update(context.TODO(), identityClient, projectID, updateOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -60,7 +60,7 @@ Example to Update a Project
 Example to Delete a Project
 
 	projectID := "966b3c7d36a24facaf20b7e458bf2192"
-	err := projects.Delete(identityClient, projectID).ExtractErr()
+	err := projects.Delete(context.TODO(), identityClient, projectID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/identity/v3/regions/doc.go
+++ b/openstack/identity/v3/regions/doc.go
@@ -31,7 +31,7 @@ Example to Create a Region
 		}
 	}
 
-	region, err := regions.Create(identityClient, createOpts).Extract()
+	region, err := regions.Create(context.TODO(), identityClient, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -47,7 +47,7 @@ Example to Update a Region
 		Description: "Updated Description for region",
 	}
 
-	region, err := regions.Update(identityClient, regionID, updateOpts).Extract()
+	region, err := regions.Update(context.TODO(), identityClient, regionID, updateOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -55,7 +55,7 @@ Example to Update a Region
 Example to Delete a Region
 
 	regionID := "TestRegion"
-	err := regions.Delete(identityClient, regionID).ExtractErr()
+	err := regions.Delete(context.TODO(), identityClient, regionID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/identity/v3/regions/doc.go
+++ b/openstack/identity/v3/regions/doc.go
@@ -7,7 +7,7 @@ Example to List Regions
 		ParentRegionID: "RegionOne",
 	}
 
-	allPages, err := regions.List(identityClient, listOpts).AllPages()
+	allPages, err := regions.List(identityClient, listOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/identity/v3/registeredlimits/doc.go
+++ b/openstack/identity/v3/registeredlimits/doc.go
@@ -8,7 +8,7 @@ Example to List RegisteredLimits
 		ResourceName: "image_size_total",
 	}
 
-	allPages, err := registeredlimits.List(identityClient, listOpts).AllPages()
+	allPages, err := registeredlimits.List(identityClient, listOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/identity/v3/registeredlimits/doc.go
+++ b/openstack/identity/v3/registeredlimits/doc.go
@@ -36,7 +36,7 @@ Example to Create a RegisteredLimit
 		},
 	}
 
-	createdRegisteredLimits, err := limits.Create(identityClient, batchCreateOpts).Extract()
+	createdRegisteredLimits, err := limits.Create(context.TODO(), identityClient, batchCreateOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -44,7 +44,7 @@ Example to Create a RegisteredLimit
 Example to Get a RegisteredLimit
 
 	    registeredLimitID := "966b3c7d36a24facaf20b7e458bf2192"
-	    registered_limit, err := registeredlimits.Get(client, registeredLimitID).Extract()
+	    registered_limit, err := registeredlimits.Get(context.TODO(), client, registeredLimitID).Extract()
 		if err != nil {
 			panic(err)
 		}
@@ -65,7 +65,7 @@ Example to Update a RegisteredLimit
 			ServiceID:    "9408080f1970482aa0e38bc2d4ea34b7",
 		}
 
-		registered_limit, err := registeredlimits.Update(client, registeredLimitID, updateOpts).Extract()
+		registered_limit, err := registeredlimits.Update(context.TODO(), client, registeredLimitID, updateOpts).Extract()
 		if err != nil {
 			panic(err)
 		}
@@ -73,7 +73,7 @@ Example to Update a RegisteredLimit
 Example to Delete a RegisteredLimit
 
 	registeredLimitID := "966b3c7d36a24facaf20b7e458bf2192"
-	err := registeredlimits.Delete(identityClient, registeredLimitID).ExtractErr()
+	err := registeredlimits.Delete(context.TODO(), identityClient, registeredLimitID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/identity/v3/roles/doc.go
+++ b/openstack/identity/v3/roles/doc.go
@@ -32,7 +32,7 @@ Example to Create a Role
 		}
 	}
 
-	role, err := roles.Create(identityClient, createOpts).Extract()
+	role, err := roles.Create(context.TODO(), identityClient, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -45,7 +45,7 @@ Example to Update a Role
 		Name: "read only admin",
 	}
 
-	role, err := roles.Update(identityClient, roleID, updateOpts).Extract()
+	role, err := roles.Update(context.TODO(), identityClient, roleID, updateOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -53,7 +53,7 @@ Example to Update a Role
 Example to Delete a Role
 
 	roleID := "0fe36e73809d46aeae6705c39077b1b3"
-	err := roles.Delete(identityClient, roleID).ExtractErr()
+	err := roles.Delete(context.TODO(), identityClient, roleID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
@@ -108,7 +108,7 @@ Example to Assign a Role to a User in a Project
 	userID := "9df1a02f5eb2416a9781e8b0c022d3ae"
 	roleID := "9fe2ff9ee4384b1894a90878d3e92bab"
 
-	err := roles.Assign(identityClient, roleID, roles.AssignOpts{
+	err := roles.Assign(context.TODO(), identityClient, roleID, roles.AssignOpts{
 		UserID:    userID,
 		ProjectID: projectID,
 	}).ExtractErr()
@@ -123,7 +123,7 @@ Example to Unassign a Role From a User in a Project
 	userID := "9df1a02f5eb2416a9781e8b0c022d3ae"
 	roleID := "9fe2ff9ee4384b1894a90878d3e92bab"
 
-	err := roles.Unassign(identityClient, roleID, roles.UnassignOpts{
+	err := roles.Unassign(context.TODO(), identityClient, roleID, roles.UnassignOpts{
 		UserID:    userID,
 		ProjectID: projectID,
 	}).ExtractErr()

--- a/openstack/identity/v3/roles/doc.go
+++ b/openstack/identity/v3/roles/doc.go
@@ -8,7 +8,7 @@ Example to List Roles
 		DomainID: "default",
 	}
 
-	allPages, err := roles.List(identityClient, listOpts).AllPages()
+	allPages, err := roles.List(identityClient, listOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}
@@ -65,7 +65,7 @@ Example to List Role Assignments
 		ScopeProjectID: "9df1a02f5eb2416a9781e8b0c022d3ae",
 	}
 
-	allPages, err := roles.ListAssignments(identityClient, listOpts).AllPages()
+	allPages, err := roles.ListAssignments(identityClient, listOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}
@@ -88,7 +88,7 @@ Example to List Role Assignments for a User on a Project
 		ProjectID: projectID,
 	}
 
-	allPages, err := roles.ListAssignmentsOnResource(identityClient, listAssignmentsOnResourceOpts).AllPages()
+	allPages, err := roles.ListAssignmentsOnResource(identityClient, listAssignmentsOnResourceOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/identity/v3/services/doc.go
+++ b/openstack/identity/v3/services/doc.go
@@ -32,7 +32,7 @@ Example to Create a Service
 		},
 	}
 
-	service, err := services.Create(identityClient, createOpts).Extract()
+	service, err := services.Create(context.TODO(), identityClient, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -49,7 +49,7 @@ Example to Update a Service
 		},
 	}
 
-	service, err := services.Update(identityClient, serviceID, updateOpts).Extract()
+	service, err := services.Update(context.TODO(), identityClient, serviceID, updateOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -57,7 +57,7 @@ Example to Update a Service
 Example to Delete a Service
 
 	serviceID := "3c7bbe9a6ecb453ca1789586291380ed"
-	err := services.Delete(identityClient, serviceID).ExtractErr()
+	err := services.Delete(context.TODO(), identityClient, serviceID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/identity/v3/services/doc.go
+++ b/openstack/identity/v3/services/doc.go
@@ -8,7 +8,7 @@ Example to List Services
 		ServiceType: "compute",
 	}
 
-	allPages, err := services.List(identityClient, listOpts).AllPages()
+	allPages, err := services.List(identityClient, listOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/identity/v3/tokens/doc.go
+++ b/openstack/identity/v3/tokens/doc.go
@@ -12,7 +12,7 @@ Example to Create a Token From a Username and Password
 		Password: "password",
 	}
 
-	token, err := tokens.Create(identityClient, authOptions).ExtractToken()
+	token, err := tokens.Create(context.TODO(), identityClient, authOptions).ExtractToken()
 	if err != nil {
 		panic(err)
 	}
@@ -25,7 +25,7 @@ Example to Create a Token From a Username, Password, and Domain
 		DomainID: "default",
 	}
 
-	token, err := tokens.Create(identityClient, authOptions).ExtractToken()
+	token, err := tokens.Create(context.TODO(), identityClient, authOptions).ExtractToken()
 	if err != nil {
 		panic(err)
 	}
@@ -36,7 +36,7 @@ Example to Create a Token From a Username, Password, and Domain
 		DomainName: "default",
 	}
 
-	token, err = tokens.Create(identityClient, authOptions).ExtractToken()
+	token, err = tokens.Create(context.TODO(), identityClient, authOptions).ExtractToken()
 	if err != nil {
 		panic(err)
 	}
@@ -47,7 +47,7 @@ Example to Create a Token From a Token
 		TokenID: "token_id",
 	}
 
-	token, err := tokens.Create(identityClient, authOptions).ExtractToken()
+	token, err := tokens.Create(context.TODO(), identityClient, authOptions).ExtractToken()
 	if err != nil {
 		panic(err)
 	}
@@ -64,7 +64,7 @@ Example to Create a Token from a Username and Password with Project ID Scope
 		Password: "password",
 	}
 
-	token, err = tokens.Create(identityClient, authOptions).ExtractToken()
+	token, err = tokens.Create(context.TODO(), identityClient, authOptions).ExtractToken()
 	if err != nil {
 		panic(err)
 	}
@@ -81,7 +81,7 @@ Example to Create a Token from a Username and Password with Domain ID Scope
 		Password: "password",
 	}
 
-	token, err = tokens.Create(identityClient, authOptions).ExtractToken()
+	token, err = tokens.Create(context.TODO(), identityClient, authOptions).ExtractToken()
 	if err != nil {
 		panic(err)
 	}
@@ -99,7 +99,7 @@ Example to Create a Token from a Username and Password with Project Name Scope
 		Password: "password",
 	}
 
-	token, err = tokens.Create(identityClient, authOptions).ExtractToken()
+	token, err = tokens.Create(context.TODO(), identityClient, authOptions).ExtractToken()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/identity/v3/users/doc.go
+++ b/openstack/identity/v3/users/doc.go
@@ -36,7 +36,7 @@ Example to Create a User
 		}
 	}
 
-	user, err := users.Create(identityClient, createOpts).Extract()
+	user, err := users.Create(context.TODO(), identityClient, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -49,7 +49,7 @@ Example to Update a User
 		Enabled: gophercloud.Disabled,
 	}
 
-	user, err := users.Update(identityClient, userID, updateOpts).Extract()
+	user, err := users.Update(context.TODO(), identityClient, userID, updateOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -65,7 +65,7 @@ Example to Change Password of a User
 		Password:         password,
 	}
 
-	err := users.ChangePassword(identityClient, userID, changePasswordOpts).ExtractErr()
+	err := users.ChangePassword(context.TODO(), identityClient, userID, changePasswordOpts).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
@@ -73,7 +73,7 @@ Example to Change Password of a User
 Example to Delete a User
 
 	userID := "0fe36e73809d46aeae6705c39077b1b3"
-	err := users.Delete(identityClient, userID).ExtractErr()
+	err := users.Delete(context.TODO(), identityClient, userID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
@@ -100,7 +100,7 @@ Example to Add a User to a Group
 
 	groupID := "bede500ee1124ae9b0006ff859758b3a"
 	userID := "0fe36e73809d46aeae6705c39077b1b3"
-	err := users.AddToGroup(identityClient, groupID, userID).ExtractErr()
+	err := users.AddToGroup(context.TODO(), identityClient, groupID, userID).ExtractErr()
 
 	if err != nil {
 		panic(err)
@@ -110,7 +110,7 @@ Example to Check Whether a User Belongs to a Group
 
 	groupID := "bede500ee1124ae9b0006ff859758b3a"
 	userID := "0fe36e73809d46aeae6705c39077b1b3"
-	ok, err := users.IsMemberOfGroup(identityClient, groupID, userID).Extract()
+	ok, err := users.IsMemberOfGroup(context.TODO(), identityClient, groupID, userID).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -123,7 +123,7 @@ Example to Remove a User from a Group
 
 	groupID := "bede500ee1124ae9b0006ff859758b3a"
 	userID := "0fe36e73809d46aeae6705c39077b1b3"
-	err := users.RemoveFromGroup(identityClient, groupID, userID).ExtractErr()
+	err := users.RemoveFromGroup(context.TODO(), identityClient, groupID, userID).ExtractErr()
 
 	if err != nil {
 		panic(err)

--- a/openstack/identity/v3/users/doc.go
+++ b/openstack/identity/v3/users/doc.go
@@ -7,7 +7,7 @@ Example to List Users
 		DomainID: "default",
 	}
 
-	allPages, err := users.List(identityClient, listOpts).AllPages()
+	allPages, err := users.List(identityClient, listOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}
@@ -82,7 +82,7 @@ Example to List Groups a User Belongs To
 
 	userID := "0fe36e73809d46aeae6705c39077b1b3"
 
-	allPages, err := users.ListGroups(identityClient, userID).AllPages()
+	allPages, err := users.ListGroups(identityClient, userID).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}
@@ -133,7 +133,7 @@ Example to List Projects a User Belongs To
 
 	userID := "0fe36e73809d46aeae6705c39077b1b3"
 
-	allPages, err := users.ListProjects(identityClient, userID).AllPages()
+	allPages, err := users.ListProjects(identityClient, userID).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}
@@ -154,7 +154,7 @@ Example to List Users in a Group
 		DomainID: "default",
 	}
 
-	allPages, err := users.ListInGroup(identityClient, groupID, listOpts).AllPages()
+	allPages, err := users.ListInGroup(identityClient, groupID, listOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/image/v2/imagedata/doc.go
+++ b/openstack/image/v2/imagedata/doc.go
@@ -11,7 +11,7 @@ Example to Upload Image Data
 	}
 	defer imageData.Close()
 
-	err = imagedata.Upload(imageClient, imageID, imageData).ExtractErr()
+	err = imagedata.Upload(context.TODO(), imageClient, imageID, imageData).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
@@ -26,7 +26,7 @@ Example to Stage Image Data
 	}
 	defer imageData.Close()
 
-	err = imagedata.Stage(imageClient, imageID, imageData).ExtractErr()
+	err = imagedata.Stage(context.TODO(), imageClient, imageID, imageData).ExtractErr()
 	if err != nil {
 	  panic(err)
 	}
@@ -35,7 +35,7 @@ Example to Download Image Data
 
 	imageID := "da3b75d9-3f4a-40e7-8a2c-bfab23927dea"
 
-	image, err := imagedata.Download(imageClient, imageID).Extract()
+	image, err := imagedata.Download(context.TODO(), imageClient, imageID).Extract()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/image/v2/imageimport/doc.go
+++ b/openstack/image/v2/imageimport/doc.go
@@ -4,7 +4,7 @@ Image service Import API information.
 
 Example to Get an information about the Import API
 
-	importInfo, err := imageimport.Get(imagesClient).Extract()
+	importInfo, err := imageimport.Get(context.TODO(), imagesClient).Extract()
 	if err != nil {
 	  panic(err)
 	}
@@ -19,7 +19,7 @@ Example to Create a new image import
 	}
 	imageID := "da3b75d9-3f4a-40e7-8a2c-bfab23927dea"
 
-	err := imageimport.Create(imagesClient, imageID, createOpts).ExtractErr()
+	err := imageimport.Create(context.TODO(), imagesClient, imageID, createOpts).ExtractErr()
 	if err != nil {
 	  panic(err)
 	}

--- a/openstack/image/v2/images/doc.go
+++ b/openstack/image/v2/images/doc.go
@@ -8,7 +8,7 @@ Example to List Images
 		Owner: "a7509e1ae65945fda83f3e52c6296017",
 	}
 
-	allPages, err := images.List(imagesClient, listOpts).AllPages()
+	allPages, err := images.List(imagesClient, listOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/image/v2/images/doc.go
+++ b/openstack/image/v2/images/doc.go
@@ -29,7 +29,7 @@ Example to Create an Image
 		Visibility: images.ImageVisibilityPrivate,
 	}
 
-	image, err := images.Create(imageClient, createOpts)
+	image, err := images.Create(context.TODO(), imageClient, createOpts)
 	if err != nil {
 		panic(err)
 	}
@@ -44,7 +44,7 @@ Example to Update an Image
 		},
 	}
 
-	image, err := images.Update(imageClient, imageID, updateOpts).Extract()
+	image, err := images.Update(context.TODO(), imageClient, imageID, updateOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -52,7 +52,7 @@ Example to Update an Image
 Example to Delete an Image
 
 	imageID := "1bea47ed-f6a9-463b-b423-14b9cca9ad27"
-	err := images.Delete(imageClient, imageID).ExtractErr()
+	err := images.Delete(context.TODO(), imageClient, imageID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/image/v2/members/doc.go
+++ b/openstack/image/v2/members/doc.go
@@ -26,7 +26,7 @@ Example to Add a Member to an Image
 	imageID := "2b6cacd4-cfd6-4b95-8302-4c04ccf0be3f"
 	projectID := "fc404778935a4cebaddcb4788fb3ff2c"
 
-	member, err := members.Create(imageClient, imageID, projectID).Extract()
+	member, err := members.Create(context.TODO(), imageClient, imageID, projectID).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -40,7 +40,7 @@ Example to Update the Status of a Member
 		Status: "accepted",
 	}
 
-	member, err := members.Update(imageClient, imageID, projectID, updateOpts).Extract()
+	member, err := members.Update(context.TODO(), imageClient, imageID, projectID, updateOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -50,7 +50,7 @@ Example to Delete a Member from an Image
 	imageID := "2b6cacd4-cfd6-4b95-8302-4c04ccf0be3f"
 	projectID := "fc404778935a4cebaddcb4788fb3ff2c"
 
-	err := members.Delete(imageClient, imageID, projectID).ExtractErr()
+	err := members.Delete(context.TODO(), imageClient, imageID, projectID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/image/v2/members/doc.go
+++ b/openstack/image/v2/members/doc.go
@@ -7,7 +7,7 @@ Example to List Members of an Image
 
 	imageID := "2b6cacd4-cfd6-4b95-8302-4c04ccf0be3f"
 
-	allPages, err := members.List(imageID).AllPages()
+	allPages, err := members.List(imageID).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/image/v2/tasks/doc.go
+++ b/openstack/image/v2/tasks/doc.go
@@ -8,7 +8,7 @@ Example to List Tasks
 	  Owner: "424e7cf0243c468ca61732ba45973b3e",
 	}
 
-	allPages, err := tasks.List(imagesClient, listOpts).AllPages()
+	allPages, err := tasks.List(imagesClient, listOpts).AllPages(context.TODO())
 	if err != nil {
 	  panic(err)
 	}

--- a/openstack/image/v2/tasks/doc.go
+++ b/openstack/image/v2/tasks/doc.go
@@ -24,7 +24,7 @@ Example to List Tasks
 
 Example to Get a Task
 
-	task, err := tasks.Get(imagesClient, "1252f636-1246-4319-bfba-c47cde0efbe0").Extract()
+	task, err := tasks.Get(context.TODO(), imagesClient, "1252f636-1246-4319-bfba-c47cde0efbe0").Extract()
 	if err != nil {
 	  panic(err)
 	}
@@ -45,7 +45,7 @@ Example to Create a Task
 	  },
 	}
 
-	task, err := tasks.Create(imagesClient, createOpts).Extract()
+	task, err := tasks.Create(context.TODO(), imagesClient, createOpts).Extract()
 	if err != nil {
 	  panic(err)
 	}

--- a/openstack/keymanager/v1/acls/doc.go
+++ b/openstack/keymanager/v1/acls/doc.go
@@ -5,7 +5,7 @@ All functions have a Secret and Container equivalent.
 
 Example to Get a Secret's ACL
 
-	acl, err := acls.GetSecretACL(client, secretID).Extract()
+	acl, err := acls.GetSecretACL(context.TODO(), client, secretID).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -22,7 +22,7 @@ Example to Set a Secret's ACL
 		ProjectAccess: &iFalse,
 	}
 
-	aclRef, err := acls.SetSecretACL(client, secretID, setOpts).Extract()
+	aclRef, err := acls.SetSecretACL(context.TODO(), client, secretID, setOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -37,7 +37,7 @@ Example to Update a Secret's ACL
 		users: &users,
 	}
 
-	aclRef, err := acls.UpdateSecretACL(client, secretID, setOpts).Extract()
+	aclRef, err := acls.UpdateSecretACL(context.TODO(), client, secretID, setOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -46,7 +46,7 @@ Example to Update a Secret's ACL
 
 Example to Delete a Secret's ACL
 
-	err := acls.DeleteSecretACL(client, secretID).ExtractErr()
+	err := acls.DeleteSecretACL(context.TODO(), client, secretID).ExtractErr()
 	if err != nil {
 		panci(err)
 	}

--- a/openstack/keymanager/v1/containers/doc.go
+++ b/openstack/keymanager/v1/containers/doc.go
@@ -31,7 +31,7 @@ Example to Create a Container
 		},
 	}
 
-	container, err := containers.Create(client, createOpts).Extract()
+	container, err := containers.Create(context.TODO(), client, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -40,7 +40,7 @@ Example to Create a Container
 
 Example to Delete a Container
 
-	err := containers.Delete(client, containerID).ExtractErr()
+	err := containers.Delete(context.TODO(), client, containerID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
@@ -66,7 +66,7 @@ Example to Create a Consumer of a Container
 		URL:  "http://example.com",
 	}
 
-	container, err := containers.CreateConsumer(client, containerID, createOpts).Extract()
+	container, err := containers.CreateConsumer(context.TODO(), client, containerID, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -78,7 +78,7 @@ Example to Delete a Consumer of a Container
 		URL:  "http://example.com",
 	}
 
-	container, err := containers.DeleteConsumer(client, containerID, deleteOpts).Extract()
+	container, err := containers.DeleteConsumer(context.TODO(), client, containerID, deleteOpts).Extract()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/keymanager/v1/containers/doc.go
+++ b/openstack/keymanager/v1/containers/doc.go
@@ -4,7 +4,7 @@ Service.
 
 Example to List Containers
 
-	allPages, err := containers.List(client, nil).AllPages()
+	allPages, err := containers.List(client, nil).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}
@@ -47,7 +47,7 @@ Example to Delete a Container
 
 Example to List Consumers of a Container
 
-	allPages, err := containers.ListConsumers(client, containerID, nil).AllPages()
+	allPages, err := containers.ListConsumers(client, containerID, nil).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/keymanager/v1/orders/doc.go
+++ b/openstack/keymanager/v1/orders/doc.go
@@ -28,7 +28,7 @@ Example to Create a Order
 		},
 	}
 
-	order, err := orders.Create(client, createOpts).Extract()
+	order, err := orders.Create(context.TODO(), client, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -37,7 +37,7 @@ Example to Create a Order
 
 Example to Delete a Order
 
-	err := orders.Delete(client, orderID).ExtractErr()
+	err := orders.Delete(context.TODO(), client, orderID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/keymanager/v1/orders/doc.go
+++ b/openstack/keymanager/v1/orders/doc.go
@@ -4,7 +4,7 @@ Service.
 
 Example to List Orders
 
-	allPages, err := orders.List(client, nil).AllPages()
+	allPages, err := orders.List(client, nil).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/keymanager/v1/secrets/doc.go
+++ b/openstack/keymanager/v1/secrets/doc.go
@@ -29,7 +29,7 @@ Example to List Secrets
 
 Example to Get a Secret
 
-	secret, err := secrets.Get(client, secretID).Extract()
+	secret, err := secrets.Get(context.TODO(), client, secretID).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -39,7 +39,7 @@ Example to Get a Secret
 Example to Get a Payload
 
 	// if "Extract" method is not called, the HTTP connection will remain consumed
-	payload, err := secrets.GetPayload(client, secretID).Extract()
+	payload, err := secrets.GetPayload(context.TODO(), client, secretID).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -58,7 +58,7 @@ Example to Create a Secrets
 		SecretType:         secrets.OpaqueSecret,
 	}
 
-	secret, err := secrets.Create(client, createOpts).Extract()
+	secret, err := secrets.Create(context.TODO(), client, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -72,14 +72,14 @@ Example to Add a Payload
 		Payload:     "super-secret",
 	}
 
-	err := secrets.Update(client, secretID, updateOpts).ExtractErr()
+	err := secrets.Update(context.TODO(), client, secretID, updateOpts).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
 
 Example to Delete a Secrets
 
-	err := secrets.Delete(client, secretID).ExtractErr()
+	err := secrets.Delete(context.TODO(), client, secretID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
@@ -91,7 +91,7 @@ Example to Create Metadata for a Secret
 		"something": "something else",
 	}
 
-	ref, err := secrets.CreateMetadata(client, secretID, createOpts).Extract()
+	ref, err := secrets.CreateMetadata(context.TODO(), client, secretID, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -100,7 +100,7 @@ Example to Create Metadata for a Secret
 
 Example to Get Metadata for a Secret
 
-	metadata, err := secrets.GetMetadata(client, secretID).Extract()
+	metadata, err := secrets.GetMetadata(context.TODO(), client, secretID).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -114,7 +114,7 @@ Example to Add Metadata to a Secret
 		Value: "bar",
 	}
 
-	err := secrets.CreateMetadatum(client, secretID, metadatumOpts).ExtractErr()
+	err := secrets.CreateMetadatum(context.TODO(), client, secretID, metadatumOpts).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
@@ -126,7 +126,7 @@ Example to Update Metadata of a Secret
 		Value: "bar",
 	}
 
-	metadatum, err := secrets.UpdateMetadatum(client, secretID, metadatumOpts).Extract()
+	metadatum, err := secrets.UpdateMetadatum(context.TODO(), client, secretID, metadatumOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -135,7 +135,7 @@ Example to Update Metadata of a Secret
 
 Example to Delete Metadata of a Secret
 
-	err := secrets.DeleteMetadatum(client, secretID, "foo").ExtractErr()
+	err := secrets.DeleteMetadatum(context.TODO(), client, secretID, "foo").ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/keymanager/v1/secrets/doc.go
+++ b/openstack/keymanager/v1/secrets/doc.go
@@ -13,7 +13,7 @@ Example to List Secrets
 		CreatedQuery: createdQuery,
 	}
 
-	allPages, err := secrets.List(client, listOpts).AllPages()
+	allPages, err := secrets.List(client, listOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/loadbalancer/v2/amphorae/doc.go
+++ b/openstack/loadbalancer/v2/amphorae/doc.go
@@ -26,7 +26,7 @@ Example to Failover an amphora
 
 	ampID := "d67d56a6-4a86-4688-a282-f46444705c64"
 
-	err := amphorae.Failover(octaviaClient, ampID).ExtractErr()
+	err := amphorae.Failover(context.TODO(), octaviaClient, ampID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/loadbalancer/v2/amphorae/doc.go
+++ b/openstack/loadbalancer/v2/amphorae/doc.go
@@ -8,7 +8,7 @@ Example to List Amphorae
 		LoadbalancerID: "6bd55cd3-802e-447e-a518-1e74e23bb106",
 	}
 
-	allPages, err := amphorae.List(octaviaClient, listOpts).AllPages()
+	allPages, err := amphorae.List(octaviaClient, listOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/loadbalancer/v2/apiversions/doc.go
+++ b/openstack/loadbalancer/v2/apiversions/doc.go
@@ -5,7 +5,7 @@ restricted to this particular version.
 
 Example to List API Versions
 
-	allPages, err := apiversions.List(loadbalancerClient).AllPages()
+	allPages, err := apiversions.List(loadbalancerClient).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/loadbalancer/v2/flavorprofiles/doc.go
+++ b/openstack/loadbalancer/v2/flavorprofiles/doc.go
@@ -6,7 +6,7 @@ Example to List FlavorProfiles
 
 	listOpts := flavorprofiles.ListOpts{}
 
-	allPages, err := flavorprofiles.List(octaviaClient, listOpts).AllPages()
+	allPages, err := flavorprofiles.List(octaviaClient, listOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/loadbalancer/v2/flavorprofiles/doc.go
+++ b/openstack/loadbalancer/v2/flavorprofiles/doc.go
@@ -28,7 +28,7 @@ Example to Create a FlavorProfile
 		FlavorData:   "{\"loadbalancer_topology\": \"SINGLE\"}",
 	}
 
-	flavorProfile, err := flavorprofiles.Create(octaviaClient, createOpts).Extract()
+	flavorProfile, err := flavorprofiles.Create(context.TODO(), octaviaClient, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -41,7 +41,7 @@ Example to Update a FlavorProfile
 		Name: "amphora-single-updated",
 	}
 
-	flavorProfile, err := flavorprofiles.Update(octaviaClient, flavorProfileID, updateOpts).Extract()
+	flavorProfile, err := flavorprofiles.Update(context.TODO(), octaviaClient, flavorProfileID, updateOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -49,7 +49,7 @@ Example to Update a FlavorProfile
 Example to Delete a FlavorProfile
 
 	flavorProfileID := "dd6a26af-8085-4047-a62b-3080f4c76521"
-	err := flavorprofiles.Delete(octaviaClient, flavorProfileID).ExtractErr()
+	err := flavorprofiles.Delete(context.TODO(), octaviaClient, flavorProfileID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/loadbalancer/v2/flavors/doc.go
+++ b/openstack/loadbalancer/v2/flavors/doc.go
@@ -6,7 +6,7 @@ Example to List Flavors
 
 	listOpts := flavors.ListOpts{}
 
-	allPages, err := flavors.List(octaviaClient, listOpts).AllPages()
+	allPages, err := flavors.List(octaviaClient, listOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/loadbalancer/v2/flavors/doc.go
+++ b/openstack/loadbalancer/v2/flavors/doc.go
@@ -29,7 +29,7 @@ Example to Create a Flavor
 		FlavorProfileId: "9daa2768-74e7-4d13-bf5d-1b8e0dc239e1",
 	}
 
-	flavor, err := flavors.Create(octaviaClient, createOpts).Extract()
+	flavor, err := flavors.Create(context.TODO(), octaviaClient, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -42,7 +42,7 @@ Example to Update a Flavor
 		Name: "New name",
 	}
 
-	flavor, err := flavors.Update(octaviaClient, flavorID, updateOpts).Extract()
+	flavor, err := flavors.Update(context.TODO(), octaviaClient, flavorID, updateOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -50,7 +50,7 @@ Example to Update a Flavor
 Example to Delete a Flavor
 
 	flavorID := "d67d56a6-4a86-4688-a282-f46444705c64"
-	err := flavors.Delete(octaviaClient, flavorID).ExtractErr()
+	err := flavors.Delete(context.TODO(), octaviaClient, flavorID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/loadbalancer/v2/l7policies/doc.go
+++ b/openstack/loadbalancer/v2/l7policies/doc.go
@@ -10,7 +10,7 @@ Example to Create a L7Policy
 		Action:      l7policies.ActionRedirectToURL,
 		RedirectURL: "http://www.example.com",
 	}
-	l7policy, err := l7policies.Create(lbClient, createOpts).Extract()
+	l7policy, err := l7policies.Create(context.TODO(), lbClient, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -34,7 +34,7 @@ Example to List L7Policies
 
 Example to Get a L7Policy
 
-	l7policy, err := l7policies.Get(lbClient, "023f2e34-7806-443b-bfae-16c324569a3d").Extract()
+	l7policy, err := l7policies.Get(context.TODO(), lbClient, "023f2e34-7806-443b-bfae-16c324569a3d").Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -42,7 +42,7 @@ Example to Get a L7Policy
 Example to Delete a L7Policy
 
 	l7policyID := "d67d56a6-4a86-4688-a282-f46444705c64"
-	err := l7policies.Delete(lbClient, l7policyID).ExtractErr()
+	err := l7policies.Delete(context.TODO(), lbClient, l7policyID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
@@ -54,7 +54,7 @@ Example to Update a L7Policy
 	updateOpts := l7policies.UpdateOpts{
 		Name: &name,
 	}
-	l7policy, err := l7policies.Update(lbClient, l7policyID, updateOpts).Extract()
+	l7policy, err := l7policies.Update(context.TODO(), lbClient, l7policyID, updateOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -67,7 +67,7 @@ Example to Create a Rule
 		CompareType: l7policies.CompareTypeRegex,
 		Value:       "/images*",
 	}
-	rule, err := l7policies.CreateRule(lbClient, l7policyID, createOpts).Extract()
+	rule, err := l7policies.CreateRule(context.TODO(), lbClient, l7policyID, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -92,7 +92,7 @@ Example to List L7 Rules
 
 Example to Get a l7 rule
 
-	l7rule, err := l7policies.GetRule(lbClient, "023f2e34-7806-443b-bfae-16c324569a3d", "53ad8ab8-40fa-11e8-a508-00224d6b7bc1").Extract()
+	l7rule, err := l7policies.GetRule(context.TODO(), lbClient, "023f2e34-7806-443b-bfae-16c324569a3d", "53ad8ab8-40fa-11e8-a508-00224d6b7bc1").Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -101,7 +101,7 @@ Example to Delete a l7 rule
 
 	l7policyID := "d67d56a6-4a86-4688-a282-f46444705c64"
 	ruleID := "64dba99f-8af8-4200-8882-e32a0660f23e"
-	err := l7policies.DeleteRule(lbClient, l7policyID, ruleID).ExtractErr()
+	err := l7policies.DeleteRule(context.TODO(), lbClient, l7policyID, ruleID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
@@ -115,7 +115,7 @@ Example to Update a Rule
 		CompareType: l7policies.CompareTypeRegex,
 		Value:       "/images/special*",
 	}
-	rule, err := l7policies.UpdateRule(lbClient, l7policyID, ruleID, updateOpts).Extract()
+	rule, err := l7policies.UpdateRule(context.TODO(), lbClient, l7policyID, ruleID, updateOpts).Extract()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/loadbalancer/v2/l7policies/doc.go
+++ b/openstack/loadbalancer/v2/l7policies/doc.go
@@ -20,7 +20,7 @@ Example to List L7Policies
 	listOpts := l7policies.ListOpts{
 		ListenerID: "c79a4468-d788-410c-bf79-9a8ef6354852",
 	}
-	allPages, err := l7policies.List(lbClient, listOpts).AllPages()
+	allPages, err := l7policies.List(lbClient, listOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}
@@ -78,7 +78,7 @@ Example to List L7 Rules
 	listOpts := l7policies.ListRulesOpts{
 		RuleType: l7policies.TypePath,
 	}
-	allPages, err := l7policies.ListRules(lbClient, l7policyID, listOpts).AllPages()
+	allPages, err := l7policies.ListRules(lbClient, l7policyID, listOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/loadbalancer/v2/listeners/doc.go
+++ b/openstack/loadbalancer/v2/listeners/doc.go
@@ -34,7 +34,7 @@ Example to Create a Listener
 		Tags:                   []string{"test", "stage"},
 	}
 
-	listener, err := listeners.Create(networkClient, createOpts).Extract()
+	listener, err := listeners.Create(context.TODO(), networkClient, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -53,7 +53,7 @@ Example to Update a Listener
 		Tags: &newTags,
 	}
 
-	listener, err := listeners.Update(networkClient, listenerID, updateOpts).Extract()
+	listener, err := listeners.Update(context.TODO(), networkClient, listenerID, updateOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -61,7 +61,7 @@ Example to Update a Listener
 Example to Delete a Listener
 
 	listenerID := "d67d56a6-4a86-4688-a282-f46444705c64"
-	err := listeners.Delete(networkClient, listenerID).ExtractErr()
+	err := listeners.Delete(context.TODO(), networkClient, listenerID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
@@ -69,7 +69,7 @@ Example to Delete a Listener
 Example to Get the Statistics of a Listener
 
 	listenerID := "d67d56a6-4a86-4688-a282-f46444705c64"
-	stats, err := listeners.GetStats(networkClient, listenerID).Extract()
+	stats, err := listeners.GetStats(context.TODO(), networkClient, listenerID).Extract()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/loadbalancer/v2/listeners/doc.go
+++ b/openstack/loadbalancer/v2/listeners/doc.go
@@ -8,7 +8,7 @@ Example to List Listeners
 		LoadbalancerID : "ca430f80-1737-4712-8dc6-3f640d55594b",
 	}
 
-	allPages, err := listeners.List(networkClient, listOpts).AllPages()
+	allPages, err := listeners.List(networkClient, listOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/loadbalancer/v2/loadbalancers/doc.go
+++ b/openstack/loadbalancer/v2/loadbalancers/doc.go
@@ -8,7 +8,7 @@ Example to List Load Balancers
 		Provider: "haproxy",
 	}
 
-	allPages, err := loadbalancers.List(networkClient, listOpts).AllPages()
+	allPages, err := loadbalancers.List(networkClient, listOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/loadbalancer/v2/loadbalancers/doc.go
+++ b/openstack/loadbalancer/v2/loadbalancers/doc.go
@@ -34,7 +34,7 @@ Example to Create a Load Balancer
 		Tags:         []string{"test", "stage"},
 	}
 
-	lb, err := loadbalancers.Create(networkClient, createOpts).Extract()
+	lb, err := loadbalancers.Create(context.TODO(), networkClient, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -82,7 +82,7 @@ Example to Create a fully populated Load Balancer
 		}},
 	}
 
-	lb, err := loadbalancers.Create(networkClient, createOpts).Extract()
+	lb, err := loadbalancers.Create(context.TODO(), networkClient, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -94,7 +94,7 @@ Example to Update a Load Balancer
 	updateOpts := loadbalancers.UpdateOpts{
 		Name: &name,
 	}
-	lb, err := loadbalancers.Update(networkClient, lbID, updateOpts).Extract()
+	lb, err := loadbalancers.Update(context.TODO(), networkClient, lbID, updateOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -107,7 +107,7 @@ Example to Delete a Load Balancers
 
 	lbID := "d67d56a6-4a86-4688-a282-f46444705c64"
 
-	err := loadbalancers.Delete(networkClient, lbID, deleteOpts).ExtractErr()
+	err := loadbalancers.Delete(context.TODO(), networkClient, lbID, deleteOpts).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
@@ -115,7 +115,7 @@ Example to Delete a Load Balancers
 Example to Get the Status of a Load Balancer
 
 	lbID := "d67d56a6-4a86-4688-a282-f46444705c64"
-	status, err := loadbalancers.GetStatuses(networkClient, LBID).Extract()
+	status, err := loadbalancers.GetStatuses(context.TODO(), networkClient, LBID).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -123,7 +123,7 @@ Example to Get the Status of a Load Balancer
 Example to Get the Statistics of a Load Balancer
 
 	lbID := "d67d56a6-4a86-4688-a282-f46444705c64"
-	stats, err := loadbalancers.GetStats(networkClient, LBID).Extract()
+	stats, err := loadbalancers.GetStats(context.TODO(), networkClient, LBID).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -132,7 +132,7 @@ Example to Failover a Load Balancers
 
 	lbID := "d67d56a6-4a86-4688-a282-f46444705c64"
 
-	err := loadbalancers.Failover(networkClient, lbID).ExtractErr()
+	err := loadbalancers.Failover(context.TODO(), networkClient, lbID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/loadbalancer/v2/monitors/doc.go
+++ b/openstack/loadbalancer/v2/monitors/doc.go
@@ -36,7 +36,7 @@ Example to Create a Monitor
 		ExpectedCodes:  "200-299",
 	}
 
-	monitor, err := monitors.Create(networkClient, createOpts).Extract()
+	monitor, err := monitors.Create(context.TODO(), networkClient, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -55,7 +55,7 @@ Example to Update a Monitor
 		ExpectedCodes:  "301",
 	}
 
-	monitor, err := monitors.Update(networkClient, monitorID, updateOpts).Extract()
+	monitor, err := monitors.Update(context.TODO(), networkClient, monitorID, updateOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -63,7 +63,7 @@ Example to Update a Monitor
 Example to Delete a Monitor
 
 	monitorID := "d67d56a6-4a86-4688-a282-f46444705c64"
-	err := monitors.Delete(networkClient, monitorID).ExtractErr()
+	err := monitors.Delete(context.TODO(), networkClient, monitorID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/loadbalancer/v2/monitors/doc.go
+++ b/openstack/loadbalancer/v2/monitors/doc.go
@@ -8,7 +8,7 @@ Example to List Monitors
 		PoolID: "c79a4468-d788-410c-bf79-9a8ef6354852",
 	}
 
-	allPages, err := monitors.List(networkClient, listOpts).AllPages()
+	allPages, err := monitors.List(networkClient, listOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/loadbalancer/v2/pools/doc.go
+++ b/openstack/loadbalancer/v2/pools/doc.go
@@ -8,7 +8,7 @@ Example to List Pools
 		LoadbalancerID: "c79a4468-d788-410c-bf79-9a8ef6354852",
 	}
 
-	allPages, err := pools.List(networkClient, listOpts).AllPages()
+	allPages, err := pools.List(networkClient, listOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}
@@ -68,7 +68,7 @@ Example to List Pool Members
 		ProtocolPort: 80,
 	}
 
-	allPages, err := pools.ListMembers(networkClient, poolID, listOpts).AllPages()
+	allPages, err := pools.ListMembers(networkClient, poolID, listOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/loadbalancer/v2/pools/doc.go
+++ b/openstack/loadbalancer/v2/pools/doc.go
@@ -32,7 +32,7 @@ Example to Create a Pool
 		LoadbalancerID: "79e05663-7f03-45d2-a092-8b94062f22ab",
 	}
 
-	pool, err := pools.Create(networkClient, createOpts).Extract()
+	pool, err := pools.Create(context.TODO(), networkClient, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -47,7 +47,7 @@ Example to Update a Pool
 		Tags: &newTags,
 	}
 
-	pool, err := pools.Update(networkClient, poolID, updateOpts).Extract()
+	pool, err := pools.Update(context.TODO(), networkClient, poolID, updateOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -55,7 +55,7 @@ Example to Update a Pool
 Example to Delete a Pool
 
 	poolID := "d67d56a6-4a86-4688-a282-f46444705c64"
-	err := pools.Delete(networkClient, poolID).ExtractErr()
+	err := pools.Delete(context.TODO(), networkClient, poolID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
@@ -95,7 +95,7 @@ Example to Create a Member
 		Weight:       &weight,
 	}
 
-	member, err := pools.CreateMember(networkClient, poolID, createOpts).Extract()
+	member, err := pools.CreateMember(context.TODO(), networkClient, poolID, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -111,7 +111,7 @@ Example to Update a Member
 		Weight: &weight,
 	}
 
-	member, err := pools.UpdateMember(networkClient, poolID, memberID, updateOpts).Extract()
+	member, err := pools.UpdateMember(context.TODO(), networkClient, poolID, memberID, updateOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -121,7 +121,7 @@ Example to Delete a Member
 	poolID := "d67d56a6-4a86-4688-a282-f46444705c64"
 	memberID := "64dba99f-8af8-4200-8882-e32a0660f23e"
 
-	err := pools.DeleteMember(networkClient, poolID, memberID).ExtractErr()
+	err := pools.DeleteMember(context.TODO(), networkClient, poolID, memberID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
@@ -149,7 +149,7 @@ Example to Update Members:
 	}
 	members := []pools.BatchUpdateMemberOpts{member1, member2}
 
-	err := pools.BatchUpdateMembers(networkClient, poolID, members).ExtractErr()
+	err := pools.BatchUpdateMembers(context.TODO(), networkClient, poolID, members).ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/loadbalancer/v2/providers/doc.go
+++ b/openstack/loadbalancer/v2/providers/doc.go
@@ -4,7 +4,7 @@ at OpenStack Octavia Load Balancing service.
 
 Example to List Providers
 
-	allPages, err := providers.List(lbClient).AllPages()
+	allPages, err := providers.List(lbClient).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/loadbalancer/v2/quotas/doc.go
+++ b/openstack/loadbalancer/v2/quotas/doc.go
@@ -4,7 +4,7 @@ Package quotas provides the ability to retrieve and manage Load Balancer quotas
 Example to Get project quotas
 
 	projectID = "23d5d3f79dfa4f73b72b8b0b0063ec55"
-	quotasInfo, err := quotas.Get(networkClient, projectID).Extract()
+	quotasInfo, err := quotas.Get(context.TODO(), networkClient, projectID).Extract()
 	if err != nil {
 	    log.Fatal(err)
 	}
@@ -24,7 +24,7 @@ Example to Update project quotas
 			L7Policy:      gophercloud.IntToPointer(50),
 			L7Rule:        gophercloud.IntToPointer(100),
 	    }
-	    quotasInfo, err := quotas.Update(networkClient, projectID)
+	    quotasInfo, err := quotas.Update(context.TODO(), networkClient, projectID)
 	    if err != nil {
 	        log.Fatal(err)
 	    }

--- a/openstack/messaging/v2/claims/doc.go
+++ b/openstack/messaging/v2/claims/doc.go
@@ -12,7 +12,7 @@ Example to Create a Claim on a specified Zaqar queue
 
 	queueName := "my_queue"
 
-	messages, err := claims.Create(messagingClient, queueName, createOpts).Extract()
+	messages, err := claims.Create(context.TODO(), messagingClient, queueName, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -22,7 +22,7 @@ Example to get a claim for a specified Zaqar queue
 	queueName := "my_queue"
 	claimID := "123456789012345678"
 
-	claim, err := claims.Get(messagingClient, queueName, claimID).Extract()
+	claim, err := claims.Get(context.TODO(), messagingClient, queueName, claimID).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -36,7 +36,7 @@ Example to update a claim for a specified Zaqar queue
 
 	queueName := "my_queue"
 
-	err := claims.Update(messagingClient, queueName, claimID, updateOpts).ExtractErr()
+	err := claims.Update(context.TODO(), messagingClient, queueName, claimID, updateOpts).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
@@ -45,7 +45,7 @@ Example to delete a claim for a specified Zaqar queue
 
 	queueName := "my_queue"
 
-	err := claims.Delete(messagingClient, queueName, claimID).ExtractErr()
+	err := claims.Delete(context.TODO(), messagingClient, queueName, claimID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/messaging/v2/messages/doc.go
+++ b/openstack/messaging/v2/messages/doc.go
@@ -12,7 +12,7 @@ Example to List Messages
 
 	pager := messages.List(client, queueName, listOpts)
 
-	err = pager.EachPage(func(page pagination.Page) (bool, error) {
+	err = pager.EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
 		allMessages, err := queues.ExtractQueues(page)
 		if err != nil {
 			panic(err)

--- a/openstack/messaging/v2/messages/doc.go
+++ b/openstack/messaging/v2/messages/doc.go
@@ -49,7 +49,7 @@ Example to Create Messages
 		},
 	}
 
-	resources, err := messages.Create(client, queueName, createOpts).Extract()
+	resources, err := messages.Create(context.TODO(), client, queueName, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -62,7 +62,7 @@ Example to Get a set of Messages
 		IDs: "123456",
 	}
 
-	messagesList, err := messages.GetMessages(client, createdQueueName, getMessageOpts).Extract()
+	messagesList, err := messages.GetMessages(context.TODO(), client, createdQueueName, getMessageOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -72,7 +72,7 @@ Example to get a singular Message
 	queueName := "my_queue"
 	messageID := "123456"
 
-	message, err := messages.Get(client, queueName, messageID).Extract()
+	message, err := messages.Get(context.TODO(), client, queueName, messageID).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -85,7 +85,7 @@ Example to Delete a set of Messages
 		IDs: []string{"9988776655"},
 	}
 
-	err := messages.DeleteMessages(client, queueName, deleteMessagesOpts).ExtractErr()
+	err := messages.DeleteMessages(context.TODO(), client, queueName, deleteMessagesOpts).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
@@ -98,7 +98,7 @@ Example to Pop a set of Messages
 		Pop: 5,
 	}
 
-	resources, err := messages.PopMessages(client, queueName, popMessagesOpts).Extract()
+	resources, err := messages.PopMessages(context.TODO(), client, queueName, popMessagesOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -113,7 +113,7 @@ Example to Delete a singular Message
 		ClaimID: "12345",
 	}
 
-	err := messages.Delete(client), queueName, messageID, deleteOpts).ExtractErr()
+	err := messages.Delete(context.TODO(), client), queueName, messageID, deleteOpts).ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/messaging/v2/queues/doc.go
+++ b/openstack/messaging/v2/queues/doc.go
@@ -6,24 +6,24 @@ Lists all queues and creates, shows information for updates, deletes, and action
 
 Example to List Queues
 
-		listOpts := queues.ListOpts{
-			Limit: 10,
+	listOpts := queues.ListOpts{
+		Limit: 10,
+	}
+
+	pager := queues.List(cclient, listOpts)
+
+	err = pager.EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
+		queues, err := queues.ExtractQueues(page)
+		if err != nil {
+			panic(err)
 		}
 
-		pager := queues.List(client, listOpts)
+		for _, queue := range queues {
+			fmt.Printf("%+v\n", queue)
+		}
 
-	    err = pager.EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
-			queues, err := queues.ExtractQueues(page)
-			if err != nil {
-				panic(err)
-			}
-
-			for _, queue := range queues {
-				fmt.Printf("%+v\n", queue)
-			}
-
-			return true, nil
-		})
+		return true, nil
+	})
 
 Example to Create a Queue
 
@@ -37,7 +37,7 @@ Example to Create a Queue
 		Extra:                      map[string]interface{}{"description": "Test queue."},
 	}
 
-	err := queues.Create(client, createOpts).ExtractErr()
+	err := queues.Create(context.TODO(), client, createOpts).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
@@ -57,28 +57,28 @@ Example to Update a Queue
 		},
 	}
 
-	updateResult, err := queues.Update(client, queueName, updateOpts).Extract()
+	updateResult, err := queues.Update(context.TODO(), client, queueName, updateOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
 
 Example to Get a Queue
 
-	queue, err := queues.Get(client, queueName).Extract()
+	queue, err := queues.Get(context.TODO(), client, queueName).Extract()
 	if err != nil {
 		panic(err)
 	}
 
 Example to Delete a Queue
 
-	err := queues.Delete(client, queueName).ExtractErr()
+	err := queues.Delete(context.TODO(), client, queueName).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
 
 Example to Get Message Stats of a Queue
 
-	queueStats, err := queues.GetStats(client, queueName).Extract()
+	queueStats, err := queues.GetStats(context.TODO(), client, queueName).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -90,7 +90,7 @@ Example to Share a queue
 		Methods: []queues.ShareMethod{queues.MethodGet},
 	}
 
-	queueShare, err := queues.Share(client, queueName, shareOpts).Extract()
+	queueShare, err := queues.Share(context.TODO(), client, queueName, shareOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -103,7 +103,7 @@ Example to Purge a queue
 		},
 	}
 
-	err := queues.Purge(client, queueName, purgeOpts).ExtractErr()
+	err := queues.Purge(context.TODO(), client, queueName, purgeOpts).ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/messaging/v2/queues/doc.go
+++ b/openstack/messaging/v2/queues/doc.go
@@ -12,7 +12,7 @@ Example to List Queues
 
 		pager := queues.List(client, listOpts)
 
-	    err = pager.EachPage(func(page pagination.Page) (bool, error) {
+	    err = pager.EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
 			queues, err := queues.ExtractQueues(page)
 			if err != nil {
 				panic(err)

--- a/openstack/networking/v2/apiversions/doc.go
+++ b/openstack/networking/v2/apiversions/doc.go
@@ -5,7 +5,7 @@ restricted to this particular version.
 
 Example to List API Versions
 
-	allPages, err := apiversions.ListVersions(networkingClient).AllPages()
+	allPages, err := apiversions.ListVersions(networkingClient).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/networking/v2/extensions/agents/doc.go
+++ b/openstack/networking/v2/extensions/agents/doc.go
@@ -24,7 +24,7 @@ Example of Listing Agents
 Example to Get an Agent
 
 	agentID := "76af7b1f-d61b-4526-94f7-d2e14e2698df"
-	agent, err := agents.Get(networkClient, agentID).Extract()
+	agent, err := agents.Get(context.TODO(), networkClient, agentID).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -38,7 +38,7 @@ Example to Update an Agent
 		AdminStateUp: &adminStateUp,
 	}
 	agentID := "76af7b1f-d61b-4526-94f7-d2e14e2698df"
-	agent, err := agents.Update(networkClient, agentID, updateOpts).Extract()
+	agent, err := agents.Update(context.TODO(), networkClient, agentID, updateOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -46,7 +46,7 @@ Example to Update an Agent
 Example to Delete an Agent
 
 	agentID := "76af7b1f-d61b-4526-94f7-d2e14e2698df"
-	err := agents.Delete(networkClient, agentID).ExtractErr()
+	err := agents.Delete(context.TODO(), networkClient, agentID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
@@ -54,7 +54,7 @@ Example to Delete an Agent
 Example to List Networks hosted by a DHCP Agent
 
 	agentID := "76af7b1f-d61b-4526-94f7-d2e14e2698df"
-	networks, err := agents.ListDHCPNetworks(networkClient, agentID).Extract()
+	networks, err := agents.ListDHCPNetworks(context.TODO(), networkClient, agentID).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -69,7 +69,7 @@ Example to Schedule a network to a DHCP Agent
 	opts := &agents.ScheduleDHCPNetworkOpts{
 		NetworkID: "1ae075ca-708b-4e66-b4a7-b7698632f05f",
 	}
-	err := agents.ScheduleDHCPNetwork(networkClient, agentID, opts).ExtractErr()
+	err := agents.ScheduleDHCPNetwork(context.TODO(), networkClient, agentID, opts).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
@@ -78,7 +78,7 @@ Example to Remove a network from a DHCP Agent
 
 	agentID := "76af7b1f-d61b-4526-94f7-d2e14e2698df"
 	networkID := "1ae075ca-708b-4e66-b4a7-b7698632f05f"
-	err := agents.RemoveDHCPNetwork(networkClient, agentID, networkID).ExtractErr()
+	err := agents.RemoveDHCPNetwork(context.TODO(), networkClient, agentID, networkID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/networking/v2/extensions/agents/doc.go
+++ b/openstack/networking/v2/extensions/agents/doc.go
@@ -7,7 +7,7 @@ Example of Listing Agents
 		AgentType: "Open vSwitch agent",
 	}
 
-	allPages, err := agents.List(networkClient, listOpts).AllPages()
+	allPages, err := agents.List(networkClient, listOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}
@@ -85,7 +85,7 @@ Example to Remove a network from a DHCP Agent
 
 Example to List BGP speakers by dragent
 
-	pages, err := agents.ListBGPSpeakers(c, agentID).AllPages()
+	pages, err := agents.ListBGPSpeakers(c, agentID).AllPages(context.TODO())
 	if err != nil {
 		log.Panicf("%v", err)
 	}
@@ -115,7 +115,7 @@ Example to Remove bgp speaker from dragent
 
 Example to list dragents hosting specific bgp speaker
 
-	pages, err := agents.ListDRAgentHostingBGPSpeakers(client, speakerID).AllPages()
+	pages, err := agents.ListDRAgentHostingBGPSpeakers(client, speakerID).AllPages(context.TODO())
 	if err != nil {
 		log.Panic(err)
 	}

--- a/openstack/networking/v2/extensions/attributestags/doc.go
+++ b/openstack/networking/v2/extensions/attributestags/doc.go
@@ -7,31 +7,31 @@ See https://developer.openstack.org/api-ref/network/v2/#standard-attributes-tag-
 
 Example to ReplaceAll Resource Tags
 
-	network, err := networks.Create(conn, createOpts).Extract()
+	network, err := networks.Create(context.TODO(), client, createOpts).Extract()
 
 	tagReplaceAllOpts := attributestags.ReplaceAllOpts{
 	    Tags:         []string{"abc", "123"},
 	}
-	attributestags.ReplaceAll(conn, "networks", network.ID, tagReplaceAllOpts)
+	attributestags.ReplaceAll(context.TODO(), client, "networks", network.ID, tagReplaceAllOpts)
 
 Example to List all Resource Tags
 
-	tags, err = attributestags.List(conn, "networks", network.ID).Extract()
+	tags, err = attributestags.List(context.TODO(), client, "networks", network.ID).Extract()
 
 Example to Delete all Resource Tags
 
-	err = attributestags.DeleteAll(conn, "networks", network.ID).ExtractErr()
+	err = attributestags.DeleteAll(context.TODO(), client, "networks", network.ID).ExtractErr()
 
 Example to Add a tag to a Resource
 
-	err = attributestags.Add(client, "networks", network.ID, "atag").ExtractErr()
+	err = attributestags.Add(context.TODO(), client, "networks", network.ID, "atag").ExtractErr()
 
 Example to Delete a tag from a Resource
 
-	err = attributestags.Delete(client, "networks", network.ID, "atag").ExtractErr()
+	err = attributestags.Delete(context.TODO(), client, "networks", network.ID, "atag").ExtractErr()
 
 Example to confirm if a tag exists on a resource
 
-	exists, _ := attributestags.Confirm(client, "networks", network.ID, "atag").Extract()
+	exists, _ := attributestags.Confirm(context.TODO(), client, "networks", network.ID, "atag").Extract()
 */
 package attributestags

--- a/openstack/networking/v2/extensions/bgp/peers/doc.go
+++ b/openstack/networking/v2/extensions/bgp/peers/doc.go
@@ -7,7 +7,7 @@ Package peers contains the functionality for working with Neutron bgp peers.
 
 Example:
 
-        pages, err := peers.List(c).AllPages()
+        pages, err := peers.List(c).AllPages(context.TODO())
         if err != nil {
                 log.Panic(err)
         }

--- a/openstack/networking/v2/extensions/bgp/peers/doc.go
+++ b/openstack/networking/v2/extensions/bgp/peers/doc.go
@@ -7,7 +7,7 @@ Package peers contains the functionality for working with Neutron bgp peers.
 
 Example:
 
-        pages, err := peers.List(c).AllPages(context.TODO())
+        pages, err := peers.List(client).AllPages(context.TODO())
         if err != nil {
                 log.Panic(err)
         }
@@ -23,7 +23,7 @@ Example:
 2. Get BGP Peer, a.k.a. GET /bgp-peers/{id}
 
 Example:
-        p, err := peers.Get(c, id).Extract()
+        p, err := peers.Get(context.TODO(), client, id).Extract()
 
         if err != nil {
                 log.Panic(err)
@@ -39,7 +39,7 @@ Example:
         opts.RemoteAS = 20000
         opts.Name = "gophercloud-testing-bgp-peer"
         opts.PeerIP = "192.168.0.1"
-        r, err := peers.Create(c, opts).Extract()
+        r, err := peers.Create(context.TODO(), client, opts).Extract()
         if err != nil {
                 log.Panic(err)
         }
@@ -49,7 +49,7 @@ Example:
 
 Example:
 
-        err := peers.Delete(c, bgpPeerID).ExtractErr()
+        err := peers.Delete(context.TODO(), client, bgpPeerID).ExtractErr()
         if err != nil {
                 log.Panic(err)
         }
@@ -63,7 +63,7 @@ Example:
         var opt peers.UpdateOpts
         opt.Name = "peer-name-updated"
         opt.Password = "superStrong"
-        p, err := peers.Update(c, id, opts).Extract()
+        p, err := peers.Update(context.TODO(), client, id, opts).Extract()
         if err != nil {
                 log.Panic(err)
         }

--- a/openstack/networking/v2/extensions/bgp/speakers/doc.go
+++ b/openstack/networking/v2/extensions/bgp/speakers/doc.go
@@ -8,7 +8,7 @@ Package speakers contains the functionality for working with Neutron bgp speaker
 
 Example:
 
-        pages, err := speakers.List(c).AllPages(context.TODO())
+        pages, err := speakers.List(client).AllPages(context.TODO())
         if err != nil {
                 log.Panic(err)
         }
@@ -26,7 +26,7 @@ Example:
 
 Example:
 
-        speaker, err := speakers.Get(c, id).Extract()
+        speaker, err := speakers.Get(context.TODO(), client, id).Extract()
         if err != nil {
                 log.Panic(nil)
         }
@@ -45,7 +45,7 @@ Example:
                 LocalAS:                       "2000",
                 Networks:                      []string{},
         }
-        r, err := speakers.Create(c, opts).Extract()
+        r, err := speakers.Create(context.TODO(), client, opts).Extract()
         if err != nil {
                 log.Panic(err)
         }
@@ -72,7 +72,7 @@ Example:
                 AdvertiseTenantNetworks:       false,
                 AdvertiseFloatingIPHostRoutes: true,
         }
-        spk, err := speakers.Update(c, bgpSpeakerID, opts).Extract()
+        spk, err := speakers.Update(context.TODO(), client, bgpSpeakerID, opts).Extract()
         if err != nil {
                 log.Panic(err)
         }
@@ -84,7 +84,7 @@ Example:
 Example:
 
         opts := speakers.AddBGPPeerOpts{BGPPeerID: bgpPeerID}
-        r, err := speakers.AddBGPPeer(c, bgpSpeakerID, opts).Extract()
+        r, err := speakers.AddBGPPeer(context.TODO(), client, bgpSpeakerID, opts).Extract()
         if err != nil {
                 log.Panic(err)
         }
@@ -96,7 +96,7 @@ Example:
 Example:
 
         opts := speakers.RemoveBGPPeerOpts{BGPPeerID: bgpPeerID}
-        err := speakers.RemoveBGPPeer(c, bgpSpeakerID, opts).ExtractErr()
+        err := speakers.RemoveBGPPeer(context.TODO(), client, bgpSpeakerID, opts).ExtractErr()
         if err != nil {
                 log.Panic(err)
         }
@@ -107,7 +107,7 @@ Example:
 
 Example:
 
-        pages, err := speakers.GetAdvertisedRoutes(c, speakerID).AllPages(context.TODO())
+        pages, err := speakers.GetAdvertisedRoutes(client, speakerID).AllPages(context.TODO())
         if err != nil {
                 log.Panic(err)
         }
@@ -126,7 +126,7 @@ Example:
 
 
         opts := speakers.AddGatewayNetworkOpts{NetworkID: networkID}
-        r, err := speakers.AddGatewayNetwork(c, speakerID, opts).Extract()
+        r, err := speakers.AddGatewayNetwork(context.TODO(), client, speakerID, opts).Extract()
         if err != nil {
                 log.Panic(err)
         }
@@ -138,7 +138,7 @@ Example:
 Example:
 
         opts := speakers.RemoveGatewayNetworkOpts{NetworkID: networkID}
-        err := speakers.RemoveGatewayNetwork(c, speakerID, opts).ExtractErr()
+        err := speakers.RemoveGatewayNetwork(context.TODO(), client, speakerID, opts).ExtractErr()
         if err != nil {
                 log.Panic(err)
         }

--- a/openstack/networking/v2/extensions/bgp/speakers/doc.go
+++ b/openstack/networking/v2/extensions/bgp/speakers/doc.go
@@ -8,7 +8,7 @@ Package speakers contains the functionality for working with Neutron bgp speaker
 
 Example:
 
-        pages, err := speakers.List(c).AllPages()
+        pages, err := speakers.List(c).AllPages(context.TODO())
         if err != nil {
                 log.Panic(err)
         }
@@ -107,7 +107,7 @@ Example:
 
 Example:
 
-        pages, err := speakers.GetAdvertisedRoutes(c, speakerID).AllPages()
+        pages, err := speakers.GetAdvertisedRoutes(c, speakerID).AllPages(context.TODO())
         if err != nil {
                 log.Panic(err)
         }

--- a/openstack/networking/v2/extensions/external/doc.go
+++ b/openstack/networking/v2/extensions/external/doc.go
@@ -45,7 +45,7 @@ Example to Create a Network with External Information
 		&iTrue,
 	}
 
-	network, err := networks.Create(networkClient, createOpts).Extract()
+	network, err := networks.Create(context.TODO(), networkClient, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/networking/v2/extensions/external/doc.go
+++ b/openstack/networking/v2/extensions/external/doc.go
@@ -18,7 +18,7 @@ Example to List Networks with External Information
 
 	var allNetworks []NetworkWithExternalExt
 
-	allPages, err := networks.List(networkClient, listOpts).AllPages()
+	allPages, err := networks.List(networkClient, listOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/networking/v2/extensions/extradhcpopts/doc.go
+++ b/openstack/networking/v2/extensions/extradhcpopts/doc.go
@@ -9,7 +9,7 @@ Example to Get a Port with Extra DHCP Options
 		extradhcpopts.ExtraDHCPOptsExt
 	}
 
-	err := ports.Get(networkClient, portID).ExtractInto(&s)
+	err := ports.Get(context.TODO(), networkClient, portID).ExtractInto(&s)
 	if err != nil {
 		panic(err)
 	}
@@ -41,7 +41,7 @@ Example to Create a Port with Extra DHCP Options
 		},
 	}
 
-	err := ports.Create(networkClient, createOpts).ExtractInto(&s)
+	err := ports.Create(context.TODO(), networkClient, createOpts).ExtractInto(&s)
 	if err != nil {
 		panic(err)
 	}
@@ -72,7 +72,7 @@ Example to Update a Port with Extra DHCP Options
 	}
 
 	portID := "46d4bfb9-b26e-41f3-bd2e-e6dcc1ccedb2"
-	err := ports.Update(networkClient, portID, updateOpts).ExtractInto(&s)
+	err := ports.Update(context.TODO(), networkClient, portID, updateOpts).ExtractInto(&s)
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/networking/v2/extensions/layer3/addressscopes/doc.go
+++ b/openstack/networking/v2/extensions/layer3/addressscopes/doc.go
@@ -24,7 +24,7 @@ Example of Listing Address scopes
 Example to Get an Address scope
 
 	addressScopeID = "9cc35860-522a-4d35-974d-51d4b011801e"
-	addressScope, err := addressscopes.Get(networkClient, addressScopeID).Extract()
+	addressScope, err := addressscopes.Get(context.TODO(), networkClient, addressScopeID).Extract()
 	if err != nil {
 	    panic(err)
 	}
@@ -35,7 +35,7 @@ Example to Create a new Address scope
 	    Name: "my_address_scope",
 	    IPVersion: 6,
 	}
-	addressScope, err := addressscopes.Create(networkClient, addressScopeOpts).Extract()
+	addressScope, err := addressscopes.Create(context.TODO(), networkClient, addressScopeOpts).Extract()
 	if err != nil {
 	    panic(err)
 	}
@@ -48,7 +48,7 @@ Example to Update an Address scope
 	    Name: &newName,
 	}
 
-	addressScope, err := addressscopes.Update(networkClient, addressScopeID, updateOpts).Extract()
+	addressScope, err := addressscopes.Update(context.TODO(), networkClient, addressScopeID, updateOpts).Extract()
 	if err != nil {
 	    panic(err)
 	}
@@ -56,7 +56,7 @@ Example to Update an Address scope
 Example to Delete an Address scope
 
 	addressScopeID = "9cc35860-522a-4d35-974d-51d4b011801e"
-	err := addressscopes.Delete(networkClient, addressScopeID).ExtractErr()
+	err := addressscopes.Delete(context.TODO(), networkClient, addressScopeID).ExtractErr()
 	if err != nil {
 	    panic(err)
 	}

--- a/openstack/networking/v2/extensions/layer3/addressscopes/doc.go
+++ b/openstack/networking/v2/extensions/layer3/addressscopes/doc.go
@@ -7,7 +7,7 @@ Example of Listing Address scopes
 	    IPVersion: 6,
 	}
 
-	allPages, err := addressscopes.List(networkClient, listOpts).AllPages()
+	allPages, err := addressscopes.List(networkClient, listOpts).AllPages(context.TODO())
 	if err != nil {
 	    panic(err)
 	}

--- a/openstack/networking/v2/extensions/layer3/floatingips/doc.go
+++ b/openstack/networking/v2/extensions/layer3/floatingips/doc.go
@@ -8,7 +8,7 @@ Example to List Floating IPs
 		FloatingNetworkID: "a6917946-38ab-4ffd-a55a-26c0980ce5ee",
 	}
 
-	allPages, err := floatingips.List(networkClient, listOpts).AllPages()
+	allPages, err := floatingips.List(networkClient, listOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/networking/v2/extensions/layer3/floatingips/doc.go
+++ b/openstack/networking/v2/extensions/layer3/floatingips/doc.go
@@ -28,7 +28,7 @@ Example to Create a Floating IP
 		FloatingNetworkID: "a6917946-38ab-4ffd-a55a-26c0980ce5ee",
 	}
 
-	fip, err := floatingips.Create(networkingClient, createOpts).Extract()
+	fip, err := floatingips.Create(context.TODO(), networkingClient, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -42,7 +42,7 @@ Example to Update a Floating IP
 		PortID: &portID,
 	}
 
-	fip, err := floatingips.Update(networkingClient, fipID, updateOpts).Extract()
+	fip, err := floatingips.Update(context.TODO(), networkingClient, fipID, updateOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -55,7 +55,7 @@ Example to Disassociate a Floating IP with a Port
 		PortID: new(string),
 	}
 
-	fip, err := floatingips.Update(networkingClient, fipID, updateOpts).Extract()
+	fip, err := floatingips.Update(context.TODO(), networkingClient, fipID, updateOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -63,7 +63,7 @@ Example to Disassociate a Floating IP with a Port
 Example to Delete a Floating IP
 
 	fipID := "2f245a7b-796b-4f26-9cf9-9e82d248fda7"
-	err := floatingips.Delete(networkClient, fipID).ExtractErr()
+	err := floatingips.Delete(context.TODO(), networkClient, fipID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/networking/v2/extensions/layer3/portforwarding/doc.go
+++ b/openstack/networking/v2/extensions/layer3/portforwarding/doc.go
@@ -5,7 +5,7 @@ OpenStack Networking service.
 Example to list all Port Forwardings for a floating IP
 
 	fipID := "2f245a7b-796b-4f26-9cf9-9e82d248fda7"
-	allPages, err := portforwarding.List(client, portforwarding.ListOpts{}, fipID).AllPages()
+	allPages, err := portforwarding.List(client, portforwarding.ListOpts{}, fipID).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/networking/v2/extensions/layer3/portforwarding/doc.go
+++ b/openstack/networking/v2/extensions/layer3/portforwarding/doc.go
@@ -23,7 +23,7 @@ Example to Get a Port Forwarding with a certain ID
 
 	fipID := "2f245a7b-796b-4f26-9cf9-9e82d248fda7"
 	pfID := "725ade3c-9760-4880-8080-8fc2dbab9acc"
-	pf, err := portforwarding.Get(client, fipID, pfID).Extract()
+	pf, err := portforwarding.Get(context.TODO(), client, fipID, pfID).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -38,7 +38,7 @@ Example to Create a Port Forwarding for a floating IP
 		InternalPortID:    portID,
 	}
 
-	pf, err := portforwarding.Create(networkingClient, floatingIPID, createOpts).Extract()
+	pf, err := portforwarding.Create(context.TODO(), networkingClient, floatingIPID, createOpts).Extract()
 
 	if err != nil {
 		panic(err)
@@ -54,7 +54,7 @@ Example to Update a Port Forwarding
 	fipID := "2f245a7b-796b-4f26-9cf9-9e82d248fda7"
 	pfID := "725ade3c-9760-4880-8080-8fc2dbab9acc"
 
-	pf, err := portforwarding.Update(client, fipID, pfID, updateOpts).Extract()
+	pf, err := portforwarding.Update(context.TODO(), client, fipID, pfID, updateOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -63,7 +63,7 @@ Example to Delete a Port forwarding
 
 	fipID := "2f245a7b-796b-4f26-9cf9-9e82d248fda7"
 	pfID := "725ade3c-9760-4880-8080-8fc2dbab9acc"
-	err := portforwarding.Delete(networkClient, fipID, pfID).ExtractErr()
+	err := portforwarding.Delete(context.TODO(), networkClient, fipID, pfID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/networking/v2/extensions/layer3/routers/doc.go
+++ b/openstack/networking/v2/extensions/layer3/routers/doc.go
@@ -5,7 +5,7 @@ Networking service.
 Example to List Routers
 
 	listOpts := routers.ListOpts{}
-	allPages, err := routers.List(networkClient, listOpts).AllPages()
+	allPages, err := routers.List(networkClient, listOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}
@@ -122,7 +122,7 @@ Example to List an L3 agents for a Router
 
 	routerID := "4e8e5957-649f-477b-9e5b-f1f75b21c03c"
 
-	allPages, err := routers.ListL3Agents(networkClient, routerID).AllPages()
+	allPages, err := routers.ListL3Agents(networkClient, routerID).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/networking/v2/extensions/layer3/routers/doc.go
+++ b/openstack/networking/v2/extensions/layer3/routers/doc.go
@@ -32,7 +32,7 @@ Example to Create a Router
 		GatewayInfo:  &gwi,
 	}
 
-	router, err := routers.Create(networkClient, createOpts).Extract()
+	router, err := routers.Create(context.TODO(), networkClient, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -51,7 +51,7 @@ Example to Update a Router
 		Routes: &routes,
 	}
 
-	router, err := routers.Update(networkClient, routerID, updateOpts).Extract()
+	router, err := routers.Update(context.TODO(), networkClient, routerID, updateOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -64,7 +64,7 @@ Example to Update just the Router name, keeping everything else as-is
 		Name:   "new_name",
 	}
 
-	router, err := routers.Update(networkClient, routerID, updateOpts).Extract()
+	router, err := routers.Update(context.TODO(), networkClient, routerID, updateOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -79,7 +79,7 @@ Example to Remove all Routes from a Router
 		Routes: &routes,
 	}
 
-	router, err := routers.Update(networkClient, routerID, updateOpts).Extract()
+	router, err := routers.Update(context.TODO(), networkClient, routerID, updateOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -87,7 +87,7 @@ Example to Remove all Routes from a Router
 Example to Delete a Router
 
 	routerID := "4e8e5957-649f-477b-9e5b-f1f75b21c03c"
-	err := routers.Delete(networkClient, routerID).ExtractErr()
+	err := routers.Delete(context.TODO(), networkClient, routerID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
@@ -100,7 +100,7 @@ Example to Add an Interface to a Router
 		SubnetID: "a2f1f29d-571b-4533-907f-5803ab96ead1",
 	}
 
-	interface, err := routers.AddInterface(networkClient, routerID, intOpts).Extract()
+	interface, err := routers.AddInterface(context.TODO(), networkClient, routerID, intOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -113,7 +113,7 @@ Example to Remove an Interface from a Router
 		SubnetID: "a2f1f29d-571b-4533-907f-5803ab96ead1",
 	}
 
-	interface, err := routers.RemoveInterface(networkClient, routerID, intOpts).Extract()
+	interface, err := routers.RemoveInterface(context.TODO(), networkClient, routerID, intOpts).Extract()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/networking/v2/extensions/networkipavailabilities/doc.go
+++ b/openstack/networking/v2/extensions/networkipavailabilities/doc.go
@@ -20,7 +20,7 @@ Example of Listing NetworkIPAvailabilities
 
 Example of Getting a single NetworkIPAvailability
 
-	availability, err := networkipavailabilities.Get(networkClient, "cf11ab78-2302-49fa-870f-851a08c7afb8").Extract()
+	availability, err := networkipavailabilities.Get(context.TODO(), networkClient, "cf11ab78-2302-49fa-870f-851a08c7afb8").Extract()
 	if err != nil {
 	  panic(err)
 	}

--- a/openstack/networking/v2/extensions/networkipavailabilities/doc.go
+++ b/openstack/networking/v2/extensions/networkipavailabilities/doc.go
@@ -4,7 +4,7 @@ networkipavailabilities through the Neutron API.
 
 Example of Listing NetworkIPAvailabilities
 
-	allPages, err := networkipavailabilities.List(networkClient, networkipavailabilities.ListOpts{}).AllPages()
+	allPages, err := networkipavailabilities.List(networkClient, networkipavailabilities.ListOpts{}).AllPages(context.TODO())
 	if err != nil {
 	  panic(err)
 	}

--- a/openstack/networking/v2/extensions/portsecurity/doc.go
+++ b/openstack/networking/v2/extensions/portsecurity/doc.go
@@ -15,7 +15,7 @@ Example to List Networks with Port Security Information
 		Name: "network_1",
 	}
 
-	allPages, err := networks.List(networkClient, listOpts).AllPages()
+	allPages, err := networks.List(networkClient, listOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/networking/v2/extensions/portsecurity/doc.go
+++ b/openstack/networking/v2/extensions/portsecurity/doc.go
@@ -46,7 +46,7 @@ Example to Create a Network without Port Security
 		PortSecurityEnabled: &iFalse,
 	}
 
-	err := networks.Create(networkClient, createOpts).ExtractInto(&networkWithPortSecurityExt)
+	err := networks.Create(context.TODO(), networkClient, createOpts).ExtractInto(&networkWithPortSecurityExt)
 	if err != nil {
 		panic(err)
 	}
@@ -68,7 +68,7 @@ Example to Disable Port Security on an Existing Network
 		PortSecurityEnabled: &iFalse,
 	}
 
-	err := networks.Update(networkClient, networkID, updateOpts).ExtractInto(&networkWithPortSecurityExt)
+	err := networks.Update(context.TODO(), networkClient, networkID, updateOpts).ExtractInto(&networkWithPortSecurityExt)
 	if err != nil {
 		panic(err)
 	}
@@ -84,7 +84,7 @@ Example to Get a Port with Port Security Information
 
 	portID := "46d4bfb9-b26e-41f3-bd2e-e6dcc1ccedb2"
 
-	err := ports.Get(networkingClient, portID).ExtractInto(&portWithPortSecurityExtensions)
+	err := ports.Get(context.TODO(), networkingClient, portID).ExtractInto(&portWithPortSecurityExtensions)
 	if err != nil {
 		panic(err)
 	}
@@ -112,7 +112,7 @@ Example to Create a Port Without Port Security
 		PortSecurityEnabled: &iFalse,
 	}
 
-	err := ports.Create(networkingClient, createOpts).ExtractInto(&portWithPortSecurityExtensions)
+	err := ports.Create(context.TODO(), networkingClient, createOpts).ExtractInto(&portWithPortSecurityExtensions)
 	if err != nil {
 		panic(err)
 	}
@@ -135,7 +135,7 @@ Example to Disable Port Security on an Existing Port
 		PortSecurityEnabled: &iFalse,
 	}
 
-	err := ports.Update(networkingClient, portID, updateOpts).ExtractInto(&portWithPortSecurityExtensions)
+	err := ports.Update(context.TODO(), networkingClient, portID, updateOpts).ExtractInto(&portWithPortSecurityExtensions)
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/networking/v2/extensions/provider/doc.go
+++ b/openstack/networking/v2/extensions/provider/doc.go
@@ -65,7 +65,7 @@ Example to Create a Provider Network
 		Segments:          segments,
 	}
 
-	network, err := networks.Create(networkClient, createOpts).Extract()
+	network, err := networks.Create(context.TODO(), networkClient, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/networking/v2/extensions/provider/doc.go
+++ b/openstack/networking/v2/extensions/provider/doc.go
@@ -29,7 +29,7 @@ Example to List Networks with Provider Information
 
 	var allNetworks []NetworkWithProvider
 
-	allPages, err := networks.List(networkClient, nil).AllPages()
+	allPages, err := networks.List(networkClient, nil).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/networking/v2/extensions/qos/policies/doc.go
+++ b/openstack/networking/v2/extensions/qos/policies/doc.go
@@ -186,7 +186,7 @@ Example to List QoS policies
 	        Shared: &shared,
 	    }
 
-	    allPages, err := policies.List(networkClient, listOpts).AllPages()
+	    allPages, err := policies.List(networkClient, listOpts).AllPages(context.TODO())
 	    if err != nil {
 	        panic(err)
 	    }

--- a/openstack/networking/v2/extensions/qos/policies/doc.go
+++ b/openstack/networking/v2/extensions/qos/policies/doc.go
@@ -11,7 +11,7 @@ Example to Get a Port with a QoS policy
 
 	portID := "46d4bfb9-b26e-41f3-bd2e-e6dcc1ccedb2"
 
-	err = ports.Get(client, portID).ExtractInto(&portWithQoS)
+	err = ports.Get(context.TODO(), client, portID).ExtractInto(&portWithQoS)
 	if err != nil {
 	    log.Fatal(err)
 	}
@@ -37,7 +37,7 @@ Example to Create a Port with a QoS policy
 	    QoSPolicyID:       policyID,
 	}
 
-	err = ports.Create(client, createOpts).ExtractInto(&portWithQoS)
+	err = ports.Create(context.TODO(), client, createOpts).ExtractInto(&portWithQoS)
 	if err != nil {
 	    panic(err)
 	}
@@ -60,7 +60,7 @@ Example to Add a QoS policy to an existing Port
 	    QoSPolicyID:       &policyID,
 	}
 
-	err := ports.Update(client, "65c0ee9f-d634-4522-8954-51021b570b0d", updateOpts).ExtractInto(&portWithQoS)
+	err := ports.Update(context.TODO(), client, "65c0ee9f-d634-4522-8954-51021b570b0d", updateOpts).ExtractInto(&portWithQoS)
 	if err != nil {
 	    panic(err)
 	}
@@ -83,7 +83,7 @@ Example to Delete a QoS policy from the existing Port
 	    QoSPolicyID:       &policyID,
 	}
 
-	err := ports.Update(client, "65c0ee9f-d634-4522-8954-51021b570b0d", updateOpts).ExtractInto(&portWithQoS)
+	err := ports.Update(context.TODO(), client, "65c0ee9f-d634-4522-8954-51021b570b0d", updateOpts).ExtractInto(&portWithQoS)
 	if err != nil {
 	    panic(err)
 	}
@@ -99,7 +99,7 @@ Example to Get a Network with a QoS policy
 
 	networkID := "46d4bfb9-b26e-41f3-bd2e-e6dcc1ccedb2"
 
-	err = networks.Get(client, networkID).ExtractInto(&networkWithQoS)
+	err = networks.Get(context.TODO(), client, networkID).ExtractInto(&networkWithQoS)
 	if err != nil {
 	    log.Fatal(err)
 	}
@@ -125,7 +125,7 @@ Example to Create a Network with a QoS policy
 	    QoSPolicyID:       policyID,
 	}
 
-	err = networks.Create(client, createOpts).ExtractInto(&networkWithQoS)
+	err = networks.Create(context.TODO(), client, createOpts).ExtractInto(&networkWithQoS)
 	if err != nil {
 	    panic(err)
 	}
@@ -148,7 +148,7 @@ Example to add a QoS policy to an existing Network
 	    QoSPolicyID:       &policyID,
 	}
 
-	err := networks.Update(client, "65c0ee9f-d634-4522-8954-51021b570b0d", updateOpts).ExtractInto(&networkWithQoS)
+	err := networks.Update(context.TODO(), client, "65c0ee9f-d634-4522-8954-51021b570b0d", updateOpts).ExtractInto(&networkWithQoS)
 	if err != nil {
 	    panic(err)
 	}
@@ -171,7 +171,7 @@ Example to delete a QoS policy from the existing Network
 	    QoSPolicyID:       &policyID,
 	}
 
-	err := networks.Update(client, "65c0ee9f-d634-4522-8954-51021b570b0d", updateOpts).ExtractInto(&networkWithQoS)
+	err := networks.Update(context.TODO(), client, "65c0ee9f-d634-4522-8954-51021b570b0d", updateOpts).ExtractInto(&networkWithQoS)
 	if err != nil {
 	    panic(err)
 	}
@@ -204,7 +204,7 @@ Example to Get a specific QoS policy
 
 	policyID := "30a57f4a-336b-4382-8275-d708babd2241"
 
-	policy, err := policies.Get(networkClient, policyID).Extract()
+	policy, err := policies.Get(context.TODO(), networkClient, policyID).Extract()
 	if err != nil {
 	    panic(err)
 	}
@@ -219,7 +219,7 @@ Example to Create a QoS policy
 	    IsDefault: true,
 	}
 
-	policy, err := policies.Create(networkClient, createOpts).Extract()
+	policy, err := policies.Create(context.TODO(), networkClient, createOpts).Extract()
 	if err != nil {
 	    panic(err)
 	}
@@ -238,7 +238,7 @@ Example to Update a QoS policy
 
 	policyID := "30a57f4a-336b-4382-8275-d708babd2241"
 
-	policy, err := policies.Update(networkClient, policyID, opts).Extract()
+	policy, err := policies.Update(context.TODO(), networkClient, policyID, opts).Extract()
 	if err != nil {
 	    panic(err)
 	}
@@ -249,7 +249,7 @@ Example to Delete a QoS policy
 
 	policyID := "30a57f4a-336b-4382-8275-d708babd2241"
 
-	err := policies.Delete(networkClient, policyID).ExtractErr()
+	err := policies.Delete(context.TODO(), networkClient, policyID).ExtractErr()
 	if err != nil {
 	    panic(err)
 	}

--- a/openstack/networking/v2/extensions/qos/rules/doc.go
+++ b/openstack/networking/v2/extensions/qos/rules/doc.go
@@ -9,7 +9,7 @@ Example of Listing BandwidthLimitRules
 
 	policyID := "501005fa-3b56-4061-aaca-3f24995112e1"
 
-	allPages, err := rules.ListBandwidthLimitRules(networkClient, policyID, listOpts).AllPages()
+	allPages, err := rules.ListBandwidthLimitRules(networkClient, policyID, listOpts).AllPages(context.TODO())
 	if err != nil {
 	    panic(err)
 	}
@@ -87,7 +87,7 @@ Example of Listing DSCP marking rules
 
 	policyID := "501005fa-3b56-4061-aaca-3f24995112e1"
 
-	allPages, err := rules.ListDSCPMarkingRules(networkClient, policyID, listOpts).AllPages()
+	allPages, err := rules.ListDSCPMarkingRules(networkClient, policyID, listOpts).AllPages(context.TODO())
 	if err != nil {
 	    panic(err)
 	}
@@ -164,7 +164,7 @@ Example of Listing MinimumBandwidthRules
 
 	policyID := "501005fa-3b56-4061-aaca-3f24995112e1"
 
-	allPages, err := rules.ListMinimumBandwidthRules(networkClient, policyID, listOpts).AllPages()
+	allPages, err := rules.ListMinimumBandwidthRules(networkClient, policyID, listOpts).AllPages(context.TODO())
 	if err != nil {
 	    panic(err)
 	}

--- a/openstack/networking/v2/extensions/qos/rules/doc.go
+++ b/openstack/networking/v2/extensions/qos/rules/doc.go
@@ -28,7 +28,7 @@ Example of Getting a single BandwidthLimitRule
 	policyID := "501005fa-3b56-4061-aaca-3f24995112e1"
 	ruleID   := "30a57f4a-336b-4382-8275-d708babd2241"
 
-	rule, err := rules.GetBandwidthLimitRule(networkClient, policyID, ruleID).ExtractBandwidthLimitRule()
+	rule, err := rules.GetBandwidthLimitRule(context.TODO(), networkClient, policyID, ruleID).ExtractBandwidthLimitRule()
 	if err != nil {
 	    panic(err)
 	}
@@ -44,7 +44,7 @@ Example of Creating a single BandwidthLimitRule
 
 	policyID := "501005fa-3b56-4061-aaca-3f24995112e1"
 
-	rule, err := rules.CreateBandwidthLimitRule(networkClient, policyID, opts).ExtractBandwidthLimitRule()
+	rule, err := rules.CreateBandwidthLimitRule(context.TODO(), networkClient, policyID, opts).ExtractBandwidthLimitRule()
 	if err != nil {
 	    panic(err)
 	}
@@ -64,7 +64,7 @@ Example of Updating a single BandwidthLimitRule
 	policyID := "501005fa-3b56-4061-aaca-3f24995112e1"
 	ruleID   := "30a57f4a-336b-4382-8275-d708babd2241"
 
-	rule, err := rules.UpdateBandwidthLimitRule(networkClient, policyID, ruleID, opts).ExtractBandwidthLimitRule()
+	rule, err := rules.UpdateBandwidthLimitRule(context.TODO(), networkClient, policyID, ruleID, opts).ExtractBandwidthLimitRule()
 	if err != nil {
 	    panic(err)
 	}
@@ -106,7 +106,7 @@ Example of Getting a single DSCPMarkingRule
 	policyID := "501005fa-3b56-4061-aaca-3f24995112e1"
 	ruleID   := "30a57f4a-336b-4382-8275-d708babd2241"
 
-	rule, err := rules.GetDSCPMarkingRule(networkClient, policyID, ruleID).ExtractDSCPMarkingRule()
+	rule, err := rules.GetDSCPMarkingRule(context.TODO(), networkClient, policyID, ruleID).ExtractDSCPMarkingRule()
 	if err != nil {
 	    panic(err)
 	}
@@ -121,7 +121,7 @@ Example of Creating a single DSCPMarkingRule
 
 	policyID := "501005fa-3b56-4061-aaca-3f24995112e1"
 
-	rule, err := rules.CreateDSCPMarkingRule(networkClient, policyID, opts).ExtractDSCPMarkingRule()
+	rule, err := rules.CreateDSCPMarkingRule(context.TODO(), networkClient, policyID, opts).ExtractDSCPMarkingRule()
 	if err != nil {
 	    panic(err)
 	}
@@ -139,7 +139,7 @@ Example of Updating a single DSCPMarkingRule
 	policyID := "501005fa-3b56-4061-aaca-3f24995112e1"
 	ruleID   := "30a57f4a-336b-4382-8275-d708babd2241"
 
-	rule, err := rules.UpdateDSCPMarkingRule(networkClient, policyID, ruleID, opts).ExtractDSCPMarkingRule()
+	rule, err := rules.UpdateDSCPMarkingRule(context.TODO(), networkClient, policyID, ruleID, opts).ExtractDSCPMarkingRule()
 	if err != nil {
 	    panic(err)
 	}
@@ -183,7 +183,7 @@ Example of Getting a single MinimumBandwidthRule
 	policyID := "501005fa-3b56-4061-aaca-3f24995112e1"
 	ruleID   := "30a57f4a-336b-4382-8275-d708babd2241"
 
-	rule, err := rules.GetMinimumBandwidthRule(networkClient, policyID, ruleID).ExtractMinimumBandwidthRule()
+	rule, err := rules.GetMinimumBandwidthRule(context.TODO(), networkClient, policyID, ruleID).ExtractMinimumBandwidthRule()
 	if err != nil {
 	    panic(err)
 	}
@@ -198,7 +198,7 @@ Example of Creating a single MinimumBandwidthRule
 
 	policyID := "501005fa-3b56-4061-aaca-3f24995112e1"
 
-	rule, err := rules.CreateMinimumBandwidthRule(networkClient, policyID, opts).ExtractMinimumBandwidthRule()
+	rule, err := rules.CreateMinimumBandwidthRule(context.TODO(), networkClient, policyID, opts).ExtractMinimumBandwidthRule()
 	if err != nil {
 	    panic(err)
 	}
@@ -216,7 +216,7 @@ Example of Updating a single MinimumBandwidthRule
 	policyID := "501005fa-3b56-4061-aaca-3f24995112e1"
 	ruleID   := "30a57f4a-336b-4382-8275-d708babd2241"
 
-	rule, err := rules.UpdateMinimumBandwidthRule(networkClient, policyID, ruleID, opts).ExtractMinimumBandwidthRule()
+	rule, err := rules.UpdateMinimumBandwidthRule(context.TODO(), networkClient, policyID, ruleID, opts).ExtractMinimumBandwidthRule()
 	if err != nil {
 	    panic(err)
 	}

--- a/openstack/networking/v2/extensions/qos/ruletypes/doc.go
+++ b/openstack/networking/v2/extensions/qos/ruletypes/doc.go
@@ -19,7 +19,7 @@ Example of Getting a single QoS rule type by name
 
 	ruleTypeName := "bandwidth_limit"
 
-	ruleType, err := ruletypes.Get(networkClient, ruleTypeName).Extract()
+	ruleType, err := ruletypes.Get(context.TODO(), networkClient, ruleTypeName).Extract()
 	if err != nil {
 	    panic(err)
 	}

--- a/openstack/networking/v2/extensions/qos/ruletypes/doc.go
+++ b/openstack/networking/v2/extensions/qos/ruletypes/doc.go
@@ -3,7 +3,7 @@ Package ruletypes contains functionality for working with Neutron 'quality of se
 
 Example of Listing QoS rule types
 
-	page, err := ruletypes.ListRuleTypes(client).AllPages()
+	page, err := ruletypes.ListRuleTypes(client).AllPages(context.TODO())
 	if err != nil {
 		return
 	}

--- a/openstack/networking/v2/extensions/quotas/doc.go
+++ b/openstack/networking/v2/extensions/quotas/doc.go
@@ -4,7 +4,7 @@ Package quotas provides the ability to retrieve and manage Networking quotas thr
 Example to Get project quotas
 
 	projectID = "23d5d3f79dfa4f73b72b8b0b0063ec55"
-	quotasInfo, err := quotas.Get(networkClient, projectID).Extract()
+	quotasInfo, err := quotas.Get(context.TODO(), networkClient, projectID).Extract()
 	if err != nil {
 	    log.Fatal(err)
 	}
@@ -14,7 +14,7 @@ Example to Get project quotas
 Example to Get a Detailed Quota Set
 
 	projectID = "23d5d3f79dfa4f73b72b8b0b0063ec55"
-	quotasInfo, err := quotas.GetDetail(networkClient, projectID).Extract()
+	quotasInfo, err := quotas.GetDetail(context.TODO(), networkClient, projectID).Extract()
 	if err != nil {
 	    log.Fatal(err)
 	}
@@ -37,7 +37,7 @@ Example to Update project quotas
 	    SubnetPool:        gophercloud.IntToPointer(0),
 	    Trunk:             gophercloud.IntToPointer(0),
 	}
-	quotasInfo, err := quotas.Update(networkClient, projectID)
+	quotasInfo, err := quotas.Update(context.TODO(), networkClient, projectID)
 	if err != nil {
 	    log.Fatal(err)
 	}

--- a/openstack/networking/v2/extensions/rbacpolicies/doc.go
+++ b/openstack/networking/v2/extensions/rbacpolicies/doc.go
@@ -22,7 +22,7 @@ Example to Create a RBAC Policy
 	                ObjectID:     "240d22bf-bd17-4238-9758-25f72610ecdc"
 		}
 
-		rbacPolicy, err := rbacpolicies.Create(rbacClient, createOpts).Extract()
+		rbacPolicy, err := rbacpolicies.Create(context.TODO(), rbacClient, createOpts).Extract()
 		if err != nil {
 			panic(err)
 		}
@@ -50,7 +50,7 @@ Example to List RBAC Policies
 Example to Delete a RBAC Policy
 
 	rbacPolicyID := "94fe107f-da78-4d92-a9d7-5611b06dad8d"
-	err := rbacpolicies.Delete(rbacClient, rbacPolicyID).ExtractErr()
+	err := rbacpolicies.Delete(context.TODO(), rbacClient, rbacPolicyID).ExtractErr()
 	if err != nil {
 	  panic(err)
 	}
@@ -58,7 +58,7 @@ Example to Delete a RBAC Policy
 Example to Get RBAC Policy by ID
 
 	rbacPolicyID := "94fe107f-da78-4d92-a9d7-5611b06dad8d"
-	rbacpolicy, err := rbacpolicies.Get(rbacClient, rbacPolicyID).Extract()
+	rbacpolicy, err := rbacpolicies.Get(context.TODO(), rbacClient, rbacPolicyID).Extract()
 	if err != nil {
 	  panic(err)
 	}
@@ -70,7 +70,7 @@ Example to Update a RBAC Policy
 	updateOpts := rbacpolicies.UpdateOpts{
 		TargetTenant: "9d766060b6354c9e8e2da44cab0e8f38",
 	}
-	rbacPolicy, err := rbacpolicies.Update(rbacClient, rbacPolicyID, updateOpts).Extract()
+	rbacPolicy, err := rbacpolicies.Update(context.TODO(), rbacClient, rbacPolicyID, updateOpts).Extract()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/networking/v2/extensions/rbacpolicies/doc.go
+++ b/openstack/networking/v2/extensions/rbacpolicies/doc.go
@@ -33,7 +33,7 @@ Example to List RBAC Policies
 		TenantID: "a99e9b4e620e4db09a2dfb6e42a01e66",
 	}
 
-	allPages, err := rbacpolicies.List(rbacClient, listOpts).AllPages()
+	allPages, err := rbacpolicies.List(rbacClient, listOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/networking/v2/extensions/security/groups/doc.go
+++ b/openstack/networking/v2/extensions/security/groups/doc.go
@@ -8,7 +8,7 @@ Example to List Security Groups
 		TenantID: "966b3c7d36a24facaf20b7e458bf2192",
 	}
 
-	allPages, err := groups.List(networkClient, listOpts).AllPages()
+	allPages, err := groups.List(networkClient, listOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/networking/v2/extensions/security/groups/doc.go
+++ b/openstack/networking/v2/extensions/security/groups/doc.go
@@ -29,7 +29,7 @@ Example to Create a Security Group
 		Description: "A Security Group",
 	}
 
-	group, err := groups.Create(networkClient, createOpts).Extract()
+	group, err := groups.Create(context.TODO(), networkClient, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -42,7 +42,7 @@ Example to Update a Security Group
 		Name: "new_name",
 	}
 
-	group, err := groups.Update(networkClient, groupID, updateOpts).Extract()
+	group, err := groups.Update(context.TODO(), networkClient, groupID, updateOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -50,7 +50,7 @@ Example to Update a Security Group
 Example to Delete a Security Group
 
 	groupID := "37d94f8a-d136-465c-ae46-144f0d8ef141"
-	err := groups.Delete(networkClient, groupID).ExtractErr()
+	err := groups.Delete(context.TODO(), networkClient, groupID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/networking/v2/extensions/security/rules/doc.go
+++ b/openstack/networking/v2/extensions/security/rules/doc.go
@@ -34,7 +34,7 @@ Example to Create a Security Group Rule
 		SecGroupID:    "a7734e61-b545-452d-a3cd-0189cbd9747a",
 	}
 
-	rule, err := rules.Create(networkClient, createOpts).Extract()
+	rule, err := rules.Create(context.TODO(), networkClient, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -42,7 +42,7 @@ Example to Create a Security Group Rule
 Example to Delete a Security Group Rule
 
 	ruleID := "37d94f8a-d136-465c-ae46-144f0d8ef141"
-	err := rules.Delete(networkClient, ruleID).ExtractErr()
+	err := rules.Delete(context.TODO(), networkClient, ruleID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/networking/v2/extensions/security/rules/doc.go
+++ b/openstack/networking/v2/extensions/security/rules/doc.go
@@ -8,7 +8,7 @@ Example to List Security Groups Rules
 		Protocol: "tcp",
 	}
 
-	allPages, err := rules.List(networkClient, listOpts).AllPages()
+	allPages, err := rules.List(networkClient, listOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/networking/v2/extensions/subnetpools/doc.go
+++ b/openstack/networking/v2/extensions/subnetpools/doc.go
@@ -24,7 +24,7 @@ Example of Listing Subnetpools
 Example to Get a Subnetpool
 
 	subnetPoolID = "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55"
-	subnetPool, err := subnetpools.Get(networkClient, subnetPoolID).Extract()
+	subnetPool, err := subnetpools.Get(context.TODO(), networkClient, subnetPoolID).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -41,7 +41,7 @@ Example to Create a new Subnetpool
 		Name: subnetPoolName,
 		Prefixes: subnetPoolPrefixes,
 	}
-	subnetPool, err := subnetpools.Create(networkClient, subnetPoolOpts).Extract()
+	subnetPool, err := subnetpools.Create(context.TODO(), networkClient, subnetPoolOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -56,7 +56,7 @@ Example to Update a Subnetpool
 		MaxPrefixLen: 72,
 	}
 
-	subnetPool, err := subnetpools.Update(networkClient, subnetPoolID, updateOpts).Extract()
+	subnetPool, err := subnetpools.Update(context.TODO(), networkClient, subnetPoolID, updateOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -64,7 +64,7 @@ Example to Update a Subnetpool
 Example to Delete a Subnetpool
 
 	subnetPoolID := "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55"
-	err := subnetpools.Delete(networkClient, subnetPoolID).ExtractErr()
+	err := subnetpools.Delete(context.TODO(), networkClient, subnetPoolID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/networking/v2/extensions/subnetpools/doc.go
+++ b/openstack/networking/v2/extensions/subnetpools/doc.go
@@ -7,7 +7,7 @@ Example of Listing Subnetpools
 		IPVersion: 6,
 	}
 
-	allPages, err := subnetpools.List(networkClient, listOpts).AllPages()
+	allPages, err := subnetpools.List(networkClient, listOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/networking/v2/extensions/trunk_details/doc.go
+++ b/openstack/networking/v2/extensions/trunk_details/doc.go
@@ -10,7 +10,7 @@ Example:
 	}
 	var portExt portExt
 
-	err := ports.Get(networkClient, "2ba3a709-e40e-462c-a541-85e99de589bf").ExtractInto(&portExt)
+	err := ports.Get(context.TODO(), networkClient, "2ba3a709-e40e-462c-a541-85e99de589bf").ExtractInto(&portExt)
 	if err != nil {
 	  panic(err)
 	}

--- a/openstack/networking/v2/extensions/trunks/doc.go
+++ b/openstack/networking/v2/extensions/trunks/doc.go
@@ -59,7 +59,7 @@ Example of deleting a Trunk
 Example of listing Trunks
 
 	listOpts := trunks.ListOpts{}
-	allPages, err := trunks.List(networkClient, listOpts).AllPages()
+	allPages, err := trunks.List(networkClient, listOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/networking/v2/extensions/trunks/doc.go
+++ b/openstack/networking/v2/extensions/trunks/doc.go
@@ -14,7 +14,7 @@ Example of a new empty Trunk creation
 		PortID:       "a6f0560c-b7a8-401f-bf6e-d0a5c851ae10",
 	}
 
-	trunk, err := trunks.Create(networkClient, createOpts).Extract()
+	trunk, err := trunks.Create(context.TODO(), networkClient, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -42,7 +42,7 @@ Example of a new Trunk creation with 2 subports
 		},
 	}
 
-	trunk, err := trunks.Create(client, createOpts).Extract()
+	trunk, err := trunks.Create(context.TODO(), client, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -51,7 +51,7 @@ Example of a new Trunk creation with 2 subports
 Example of deleting a Trunk
 
 	trunkID := "c36e7f2e-0c53-4742-8696-aee77c9df159"
-	err := trunks.Delete(networkClient, trunkID).ExtractErr()
+	err := trunks.Delete(context.TODO(), networkClient, trunkID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
@@ -74,7 +74,7 @@ Example of listing Trunks
 Example of getting a Trunk
 
 	trunkID = "52d8d124-3dc9-4563-9fef-bad3187ecf2d"
-	trunk, err := trunks.Get(networkClient, trunkID).Extract()
+	trunk, err := trunks.Get(context.TODO(), networkClient, trunkID).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -83,14 +83,14 @@ Example of getting a Trunk
 Example of updating a Trunk
 
 	trunkID := "c36e7f2e-0c53-4742-8696-aee77c9df159"
-	subports, err := trunks.GetSubports(client, trunkID).Extract()
+	subports, err := trunks.GetSubports(context.TODO(), client, trunkID).Extract()
 	iFalse := false
 	updateOpts := trunks.UpdateOpts{
 		AdminStateUp: &iFalse,
 		Name:         "updated_gophertrunk",
 		Description:  "trunk updated by gophercloud",
 	}
-	trunk, err = trunks.Update(networkClient, trunkID, updateOpts).Extract()
+	trunk, err = trunks.Update(context.TODO(), networkClient, trunkID, updateOpts).Extract()
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -99,7 +99,7 @@ Example of updating a Trunk
 Example of showing subports of a Trunk
 
 	trunkID := "c36e7f2e-0c53-4742-8696-aee77c9df159"
-	subports, err := trunks.GetSubports(client, trunkID).Extract()
+	subports, err := trunks.GetSubports(context.TODO(), client, trunkID).Extract()
 	fmt.Printf("%+v\n", subports)
 
 Example of adding two subports to a Trunk
@@ -119,7 +119,7 @@ Example of adding two subports to a Trunk
 			},
 		},
 	}
-	trunk, err := trunks.AddSubports(client, trunkID, addSubportsOpts).Extract()
+	trunk, err := trunks.AddSubports(context.TODO(), client, trunkID, addSubportsOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -134,7 +134,7 @@ Example of deleting two subports from a Trunk
 			{PortID: "2cf671b9-02b3-4121-9e85-e0af3548d112"},
 		},
 	}
-	trunk, err := trunks.RemoveSubports(networkClient, trunkID, removeSubportsOpts).Extract()
+	trunk, err := trunks.RemoveSubports(context.TODO(), networkClient, trunkID, removeSubportsOpts).Extract()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/networking/v2/extensions/vlantransparent/doc.go
+++ b/openstack/networking/v2/extensions/vlantransparent/doc.go
@@ -39,7 +39,7 @@ Example of Getting a Network with the vlan-transparent extension
 		vlantransparent.TransparentExt
 	}
 
-	err := networks.Get(networkClient, "db193ab3-96e3-4cb3-8fc5-05f4296d0324").ExtractInto(&network)
+	err := networks.Get(context.TODO(), networkClient, "db193ab3-96e3-4cb3-8fc5-05f4296d0324").ExtractInto(&network)
 	if err != nil {
 		panic(err)
 	}
@@ -63,7 +63,7 @@ Example of Creating Network with the vlan-transparent extension
 		vlantransparent.TransparentExt
 	}
 
-	err := networks.Create(networkClient, createOpts).ExtractInto(&network)
+	err := networks.Create(context.TODO(), networkClient, createOpts).ExtractInto(&network)
 	if err != nil {
 		panic(err)
 	}
@@ -87,7 +87,7 @@ Example of Updating Network with the vlan-transparent extension
 		vlantransparent.TransparentExt
 	}
 
-	err := networks.Update(networkClient, updateOpts).ExtractInto(&network)
+	err := networks.Update(context.TODO(), networkClient, updateOpts).ExtractInto(&network)
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/networking/v2/extensions/vlantransparent/doc.go
+++ b/openstack/networking/v2/extensions/vlantransparent/doc.go
@@ -18,7 +18,7 @@ Example of Listing Networks with the vlan-transparent extension
 
 	    var allNetworks []NetworkWithVLANTransparentExt
 
-	    allPages, err := networks.List(networkClient, listOpts).AllPages()
+	    allPages, err := networks.List(networkClient, listOpts).AllPages(context.TODO())
 	    if err != nil {
 	        panic(err)
 	    }

--- a/openstack/networking/v2/extensions/vpnaas/endpointgroups/doc.go
+++ b/openstack/networking/v2/extensions/vpnaas/endpointgroups/doc.go
@@ -32,7 +32,7 @@ Example to Delete an Endpoint Group
 
 Example to List Endpoint groups
 
-	allPages, err := endpointgroups.List(client, nil).AllPages()
+	allPages, err := endpointgroups.List(client, nil).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/networking/v2/extensions/vpnaas/endpointgroups/doc.go
+++ b/openstack/networking/v2/extensions/vpnaas/endpointgroups/doc.go
@@ -11,21 +11,21 @@ Example to create an Endpoint Group
 			"10.3.0.0/24",
 		},
 	}
-	group, err := endpointgroups.Create(client, createOpts).Extract()
+	group, err := endpointgroups.Create(context.TODO(), client, createOpts).Extract()
 	if err != nil {
 		return group, err
 	}
 
 Example to retrieve an Endpoint Group
 
-	group, err := endpointgroups.Get(client, "6ecd9cf3-ca64-46c7-863f-f2eb1b9e838a").Extract()
+	group, err := endpointgroups.Get(context.TODO(), client, "6ecd9cf3-ca64-46c7-863f-f2eb1b9e838a").Extract()
 	if err != nil {
 		panic(err)
 	}
 
 Example to Delete an Endpoint Group
 
-	err := endpointgroups.Delete(client, "5291b189-fd84-46e5-84bd-78f40c05d69c").ExtractErr()
+	err := endpointgroups.Delete(context.TODO(), client, "5291b189-fd84-46e5-84bd-78f40c05d69c").ExtractErr()
 	if err != nil {
 		panic(err)
 	}
@@ -50,7 +50,7 @@ Example to Update an endpoint group
 		Name:        &name,
 		Description: &description,
 	}
-	updatedPolicy, err := endpointgroups.Update(client, "5c561d9d-eaea-45f6-ae3e-08d1a7080828", updateOpts).Extract()
+	updatedPolicy, err := endpointgroups.Update(context.TODO(), client, "5c561d9d-eaea-45f6-ae3e-08d1a7080828", updateOpts).Extract()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/networking/v2/extensions/vpnaas/ikepolicies/doc.go
+++ b/openstack/networking/v2/extensions/vpnaas/ikepolicies/doc.go
@@ -47,7 +47,7 @@ Example to Update an IKE policy
 
 Example to List IKE policies
 
-	allPages, err := ikepolicies.List(client, nil).AllPages()
+	allPages, err := ikepolicies.List(client, nil).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/networking/v2/extensions/vpnaas/ikepolicies/doc.go
+++ b/openstack/networking/v2/extensions/vpnaas/ikepolicies/doc.go
@@ -11,21 +11,21 @@ Example to Create an IKE policy
 		PFS:                 ikepolicies.PFSGroup5,
 	}
 
-	policy, err := ikepolicies.Create(networkClient, createOpts).Extract()
+	policy, err := ikepolicies.Create(context.TODO(), networkClient, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
 
 Example to Show the details of a specific IKE policy by ID
 
-	policy, err := ikepolicies.Get(client, "f2b08c1e-aa81-4668-8ae1-1401bcb0576c").Extract()
+	policy, err := ikepolicies.Get(context.TODO(), client, "f2b08c1e-aa81-4668-8ae1-1401bcb0576c").Extract()
 	if err != nil {
 		panic(err)
 	}
 
 Example to Delete a Policy
 
-	err := ikepolicies.Delete(client, "5291b189-fd84-46e5-84bd-78f40c05d69c").ExtractErr()
+	err := ikepolicies.Delete(context.TODO(), client, "5291b189-fd84-46e5-84bd-78f40c05d69c").ExtractErr()
 	if err != nil {
 		panic(err)
 
@@ -40,7 +40,7 @@ Example to Update an IKE policy
 			Value: 7000,
 		},
 	}
-	updatedPolicy, err := ikepolicies.Update(client, "5c561d9d-eaea-45f6-ae3e-08d1a7080828", updateOpts).Extract()
+	updatedPolicy, err := ikepolicies.Update(context.TODO(), client, "5c561d9d-eaea-45f6-ae3e-08d1a7080828", updateOpts).Extract()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/networking/v2/extensions/vpnaas/ipsecpolicies/doc.go
+++ b/openstack/networking/v2/extensions/vpnaas/ipsecpolicies/doc.go
@@ -8,21 +8,21 @@ Example to Create a Policy
 		Name:        "IPSecPolicy_1",
 	}
 
-	policy, err := policies.Create(networkClient, createOpts).Extract()
+	policy, err := policies.Create(context.TODO(), networkClient, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
 
 Example to Delete a Policy
 
-	err := ipsecpolicies.Delete(client, "5291b189-fd84-46e5-84bd-78f40c05d69c").ExtractErr()
+	err := ipsecpolicies.Delete(context.TODO(), client, "5291b189-fd84-46e5-84bd-78f40c05d69c").ExtractErr()
 	if err != nil {
 		panic(err)
 	}
 
 Example to Show the details of a specific IPSec policy by ID
 
-	policy, err := ipsecpolicies.Get(client, "f2b08c1e-aa81-4668-8ae1-1401bcb0576c").Extract()
+	policy, err := ipsecpolicies.Get(context.TODO(), client, "f2b08c1e-aa81-4668-8ae1-1401bcb0576c").Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -35,7 +35,7 @@ Example to Update an IPSec policy
 		Name:        &name,
 		Description: &description,
 	}
-	updatedPolicy, err := ipsecpolicies.Update(client, "5c561d9d-eaea-45f6-ae3e-08d1a7080828", updateOpts).Extract()
+	updatedPolicy, err := ipsecpolicies.Update(context.TODO(), client, "5c561d9d-eaea-45f6-ae3e-08d1a7080828", updateOpts).Extract()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/networking/v2/extensions/vpnaas/ipsecpolicies/doc.go
+++ b/openstack/networking/v2/extensions/vpnaas/ipsecpolicies/doc.go
@@ -42,7 +42,7 @@ Example to Update an IPSec policy
 
 Example to List IPSec policies
 
-	allPages, err := ipsecpolicies.List(client, nil).AllPages()
+	allPages, err := ipsecpolicies.List(client, nil).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/networking/v2/extensions/vpnaas/services/doc.go
+++ b/openstack/networking/v2/extensions/vpnaas/services/doc.go
@@ -31,7 +31,7 @@ Example to Create a Service
 		AdminStateUp: gophercloud.Enabled,
 	}
 
-	service, err := services.Create(networkClient, createOpts).Extract()
+	service, err := services.Create(context.TODO(), networkClient, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -44,7 +44,7 @@ Example to Update a Service
 		Description: "New Description",
 	}
 
-	service, err := services.Update(networkClient, serviceID, updateOpts).Extract()
+	service, err := services.Update(context.TODO(), networkClient, serviceID, updateOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -52,14 +52,14 @@ Example to Update a Service
 Example to Delete a Service
 
 	serviceID := "38aee955-6283-4279-b091-8b9c828000ec"
-	err := services.Delete(networkClient, serviceID).ExtractErr()
+	err := services.Delete(context.TODO(), networkClient, serviceID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
 
 Example to Show the details of a specific Service by ID
 
-	service, err := services.Get(client, "f2b08c1e-aa81-4668-8ae1-1401bcb0576c").Extract()
+	service, err := services.Get(context.TODO(), client, "f2b08c1e-aa81-4668-8ae1-1401bcb0576c").Extract()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/networking/v2/extensions/vpnaas/services/doc.go
+++ b/openstack/networking/v2/extensions/vpnaas/services/doc.go
@@ -8,7 +8,7 @@ Example to List Services
 		TenantID: "966b3c7d36a24facaf20b7e458bf2192",
 	}
 
-	allPages, err := services.List(networkClient, listOpts).AllPages()
+	allPages, err := services.List(networkClient, listOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/networking/v2/extensions/vpnaas/siteconnections/doc.go
+++ b/openstack/networking/v2/extensions/vpnaas/siteconnections/doc.go
@@ -40,7 +40,7 @@ Example to Delete a site connection
 
 Example to List site connections
 
-	allPages, err := siteconnections.List(client, nil).AllPages()
+	allPages, err := siteconnections.List(client, nil).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/networking/v2/extensions/vpnaas/siteconnections/doc.go
+++ b/openstack/networking/v2/extensions/vpnaas/siteconnections/doc.go
@@ -18,14 +18,14 @@ OpenStack Networking Service.
 			PeerID:         "172.24.4.233",
 			MTU:            1500,
 		}
-		connection, err := siteconnections.Create(client, createOpts).Extract()
+		connection, err := siteconnections.Create(context.TODO(), client, createOpts).Extract()
 		if err != nil {
 			panic(err)
 		}
 
 Example to Show the details of a specific IPSec site connection by ID
 
-	conn, err := siteconnections.Get(client, "f2b08c1e-aa81-4668-8ae1-1401bcb0576c").Extract()
+	conn, err := siteconnections.Get(context.TODO(), client, "f2b08c1e-aa81-4668-8ae1-1401bcb0576c").Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -33,7 +33,7 @@ Example to Show the details of a specific IPSec site connection by ID
 Example to Delete a site connection
 
 	connID := "38aee955-6283-4279-b091-8b9c828000ec"
-	err := siteconnections.Delete(networkClient, connID).ExtractErr()
+	err := siteconnections.Delete(context.TODO(), networkClient, connID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
@@ -58,7 +58,7 @@ Example to Update an IPSec site connection
 		Name:        &name,
 		Description: &description,
 	}
-	updatedConnection, err := siteconnections.Update(client, "5c561d9d-eaea-45f6-ae3e-08d1a7080828", updateOpts).Extract()
+	updatedConnection, err := siteconnections.Update(context.TODO(), client, "5c561d9d-eaea-45f6-ae3e-08d1a7080828", updateOpts).Extract()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/networking/v2/networks/doc.go
+++ b/openstack/networking/v2/networks/doc.go
@@ -14,7 +14,7 @@ Example to List Networks
 		TenantID: "a99e9b4e620e4db09a2dfb6e42a01e66",
 	}
 
-	allPages, err := networks.List(networkClient, listOpts).AllPages()
+	allPages, err := networks.List(networkClient, listOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/networking/v2/networks/doc.go
+++ b/openstack/networking/v2/networks/doc.go
@@ -36,7 +36,7 @@ Example to Create a Network
 		AdminStateUp: &iTrue,
 	}
 
-	network, err := networks.Create(networkClient, createOpts).Extract()
+	network, err := networks.Create(context.TODO(), networkClient, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -50,7 +50,7 @@ Example to Update a Network
 		Name: &name,
 	}
 
-	network, err := networks.Update(networkClient, networkID, updateOpts).Extract()
+	network, err := networks.Update(context.TODO(), networkClient, networkID, updateOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -58,7 +58,7 @@ Example to Update a Network
 Example to Delete a Network
 
 	networkID := "484cda0e-106f-4f4b-bb3f-d413710bbe78"
-	err := networks.Delete(networkClient, networkID).ExtractErr()
+	err := networks.Delete(context.TODO(), networkClient, networkID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/networking/v2/ports/doc.go
+++ b/openstack/networking/v2/ports/doc.go
@@ -14,7 +14,7 @@ Example to List Ports
 		DeviceID: "b0b89efe-82f8-461d-958b-adbf80f50c7d",
 	}
 
-	allPages, err := ports.List(networkClient, listOpts).AllPages()
+	allPages, err := ports.List(networkClient, listOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/networking/v2/ports/doc.go
+++ b/openstack/networking/v2/ports/doc.go
@@ -43,7 +43,7 @@ Example to Create a Port
 		},
 	}
 
-	port, err := ports.Create(networkClient, createOpts).Extract()
+	port, err := ports.Create(context.TODO(), networkClient, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -57,7 +57,7 @@ Example to Update a Port
 		SecurityGroups: &[]string{},
 	}
 
-	port, err := ports.Update(networkClient, portID, updateOpts).Extract()
+	port, err := ports.Update(context.TODO(), networkClient, portID, updateOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -65,7 +65,7 @@ Example to Update a Port
 Example to Delete a Port
 
 	portID := "c34bae2b-7641-49b6-bf6d-d8e473620ed8"
-	err := ports.Delete(networkClient, portID).ExtractErr()
+	err := ports.Delete(context.TODO(), networkClient, portID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/networking/v2/subnets/doc.go
+++ b/openstack/networking/v2/subnets/doc.go
@@ -15,7 +15,7 @@ Example to List Subnets
 		IPVersion: 4,
 	}
 
-	allPages, err := subnets.List(networkClient, listOpts).AllPages()
+	allPages, err := subnets.List(networkClient, listOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/networking/v2/subnets/doc.go
+++ b/openstack/networking/v2/subnets/doc.go
@@ -47,7 +47,7 @@ Example to Create a Subnet With Specified Gateway
 		ServiceTypes: []string{"network:floatingip"},
 	}
 
-	subnet, err := subnets.Create(networkClient, createOpts).Extract()
+	subnet, err := subnets.Create(context.TODO(), networkClient, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -70,7 +70,7 @@ Example to Create a Subnet With No Gateway
 		DNSNameservers: []string{},
 	}
 
-	subnet, err := subnets.Create(networkClient, createOpts).Extract()
+	subnet, err := subnets.Create(context.TODO(), networkClient, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -90,7 +90,7 @@ Example to Create a Subnet With a Default Gateway
 		DNSNameservers: []string{},
 	}
 
-	subnet, err := subnets.Create(networkClient, createOpts).Extract()
+	subnet, err := subnets.Create(context.TODO(), networkClient, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -108,7 +108,7 @@ Example to Update a Subnet
 		ServiceTypes:   &serviceTypes,
 	}
 
-	subnet, err := subnets.Update(networkClient, subnetID, updateOpts).Extract()
+	subnet, err := subnets.Update(context.TODO(), networkClient, subnetID, updateOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -122,7 +122,7 @@ Example to Remove a Gateway From a Subnet
 		GatewayIP: &noGateway,
 	}
 
-	subnet, err := subnets.Update(networkClient, subnetID, updateOpts).Extract()
+	subnet, err := subnets.Update(context.TODO(), networkClient, subnetID, updateOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -130,7 +130,7 @@ Example to Remove a Gateway From a Subnet
 Example to Delete a Subnet
 
 	subnetID := "db77d064-e34f-4d06-b060-f21e28a61c23"
-	err := subnets.Delete(networkClient, subnetID).ExtractErr()
+	err := subnets.Delete(context.TODO(), networkClient, subnetID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/objectstorage/v1/accounts/doc.go
+++ b/openstack/objectstorage/v1/accounts/doc.go
@@ -9,7 +9,7 @@ services.
 
 Example to Get an Account
 
-	account, err := accounts.Get(objectStorageClient, nil).Extract()
+	account, err := accounts.Get(context.TODO(), objectStorageClient, nil).Extract()
 	fmt.Printf("%+v\n", account)
 
 Example to Update an Account
@@ -22,7 +22,7 @@ Example to Update an Account
 		Metadata: metadata,
 	}
 
-	updateResult, err := accounts.Update(objectStorageClient, updateOpts).Extract()
+	updateResult, err := accounts.Update(context.TODO(), objectStorageClient, updateOpts).Extract()
 	fmt.Printf("%+v\n", updateResult)
 */
 package accounts

--- a/openstack/objectstorage/v1/containers/doc.go
+++ b/openstack/objectstorage/v1/containers/doc.go
@@ -17,7 +17,7 @@ Example to List Containers
 		Full: true,
 	}
 
-	allPages, err := containers.List(objectStorageClient, listOpts).AllPages()
+	allPages, err := containers.List(objectStorageClient, listOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}
@@ -37,7 +37,7 @@ Example to List Only Container Names
 		Full: false,
 	}
 
-	allPages, err := containers.List(objectStorageClient, listOpts).AllPages()
+	allPages, err := containers.List(objectStorageClient, listOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/objectstorage/v1/containers/doc.go
+++ b/openstack/objectstorage/v1/containers/doc.go
@@ -60,7 +60,7 @@ Example to Create a Container
 		},
 	}
 
-	container, err := containers.Create(objectStorageClient, createOpts).Extract()
+	container, err := containers.Create(context.TODO(), objectStorageClient, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -78,7 +78,7 @@ Example to Update a Container
 		},
 	}
 
-	container, err := containers.Update(objectStorageClient, containerName, updateOpts).Extract()
+	container, err := containers.Update(context.TODO(), objectStorageClient, containerName, updateOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -87,7 +87,7 @@ Example to Delete a Container
 
 	containerName := "my_container"
 
-	container, err := containers.Delete(objectStorageClient, containerName).Extract()
+	container, err := containers.Delete(context.TODO(), objectStorageClient, containerName).Extract()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/objectstorage/v1/objects/doc.go
+++ b/openstack/objectstorage/v1/objects/doc.go
@@ -63,7 +63,7 @@ Example to Create an Object
 		Content:     strings.NewReader(content),
 	}
 
-	object, err := objects.Create(objectStorageClient, containerName, objectName, createOpts).Extract()
+	object, err := objects.Create(context.TODO(), objectStorageClient, containerName, objectName, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -77,7 +77,7 @@ Example to Copy an Object
 		Destination: "/newContainer/newObject",
 	}
 
-	object, err := objects.Copy(objectStorageClient, containerName, objectName, copyOpts).Extract()
+	object, err := objects.Copy(context.TODO(), objectStorageClient, containerName, objectName, copyOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -87,7 +87,7 @@ Example to Delete an Object
 	objectName := "my_object"
 	containerName := "my_container"
 
-	object, err := objects.Delete(objectStorageClient, containerName, objectName).Extract()
+	object, err := objects.Delete(context.TODO(), objectStorageClient, containerName, objectName).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -97,7 +97,7 @@ Example to Download an Object's Data
 	objectName := "my_object"
 	containerName := "my_container"
 
-	object := objects.Download(objectStorageClient, containerName, objectName, nil)
+	object := objects.Download(context.TODO(), objectStorageClient, containerName, objectName, nil)
 	if object.Err != nil {
 		panic(object.Err)
 	}

--- a/openstack/objectstorage/v1/objects/doc.go
+++ b/openstack/objectstorage/v1/objects/doc.go
@@ -16,7 +16,7 @@ Example to List Objects
 		Full: true,
 	}
 
-	allPages, err := objects.List(objectStorageClient, containerName, listOpts).AllPages()
+	allPages, err := objects.List(objectStorageClient, containerName, listOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}
@@ -38,7 +38,7 @@ Example to List Object Names
 		Full: false,
 	}
 
-	allPages, err := objects.List(objectStorageClient, containerName, listOpts).AllPages()
+	allPages, err := objects.List(objectStorageClient, containerName, listOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/objectstorage/v1/swauth/doc.go
+++ b/openstack/objectstorage/v1/swauth/doc.go
@@ -8,7 +8,7 @@ Example to Authenticate with swauth
 		Key:  "password",
 	}
 
-	swiftClient, err := swauth.NewObjectStorageV1(providerClient, authOpts)
+	swiftClient, err := swauth.NewObjectStorageV1(context.TODO(), providerClient, authOpts)
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/orchestration/v1/resourcetypes/doc.go
+++ b/openstack/orchestration/v1/resourcetypes/doc.go
@@ -9,7 +9,7 @@ Example of listing available resource types:
 	    SupportStatus: resourcetypes.SupportStatusSupported,
 	}
 
-	resourceTypes, err := resourcetypes.List(client, listOpts).Extract()
+	resourceTypes, err := resourcetypes.List(context.TODO(), client, listOpts).Extract()
 	if err != nil {
 	    panic(err)
 	}

--- a/openstack/orchestration/v1/stackevents/doc.go
+++ b/openstack/orchestration/v1/stackevents/doc.go
@@ -5,7 +5,7 @@ updating and abandoning.
 
 Example for list events for a stack
 
-	pages, err := stackevents.List(client, stack.Name, stack.ID, nil).AllPages()
+	pages, err := stackevents.List(client, stack.Name, stack.ID, nil).AllPages(context.TODO())
 	if err != nil {
 	    panic(err)
 	}

--- a/openstack/orchestration/v1/stackresources/doc.go
+++ b/openstack/orchestration/v1/stackresources/doc.go
@@ -17,7 +17,7 @@ Example of get resource information in stack
 
 Example for list stack resources
 
-	all_stack_rsrc_pages, err := stackresources.List(client, stack.Name, stack.ID, nil).AllPages()
+	all_stack_rsrc_pages, err := stackresources.List(client, stack.Name, stack.ID, nil).AllPages(context.TODO())
 	if err != nil {
 	    panic(err)
 	}

--- a/openstack/orchestration/v1/stackresources/doc.go
+++ b/openstack/orchestration/v1/stackresources/doc.go
@@ -6,7 +6,7 @@ balancer, some configuration management system, and so forth).
 
 Example of get resource information in stack
 
-	rsrc_result := stackresources.Get(client, stack.Name, stack.ID, rsrc.Name)
+	rsrc_result := stackresources.Get(context.TODO(), client, stack.Name, stack.ID, rsrc.Name)
 	if rsrc_result.Err != nil {
 	    panic(rsrc_result.Err)
 	}
@@ -30,7 +30,7 @@ Example for list stack resources
 	fmt.Println("Resource List:")
 	for _, rsrc := range all_stack_rsrcs {
 	    // Get information of a resource in stack
-	    rsrc_result := stackresources.Get(client, stack.Name, stack.ID, rsrc.Name)
+	    rsrc_result := stackresources.Get(context.TODO(), client, stack.Name, stack.ID, rsrc.Name)
 	    if rsrc_result.Err != nil {
 	        panic(rsrc_result.Err)
 	    }
@@ -43,7 +43,7 @@ Example for list stack resources
 
 Example for get resource type schema
 
-	schema_result := stackresources.Schema(client, "OS::Heat::Stack")
+	schema_result := stackresources.Schema(context.TODO(), client, "OS::Heat::Stack")
 	if schema_result.Err != nil {
 	    panic(schema_result.Err)
 	}
@@ -56,7 +56,7 @@ Example for get resource type schema
 
 Example for get resource type Template
 
-	tmp_result := stackresources.Template(client, "OS::Heat::Stack")
+	tmp_result := stackresources.Template(context.TODO(), client, "OS::Heat::Stack")
 	if tmp_result.Err != nil {
 	    panic(tmp_result.Err)
 	}

--- a/openstack/orchestration/v1/stacks/doc.go
+++ b/openstack/orchestration/v1/stacks/doc.go
@@ -24,7 +24,7 @@ Example of Preparing Orchestration client:
 
 Example of List Stack:
 
-	all_stack_pages, err := stacks.List(client, nil).AllPages()
+	all_stack_pages, err := stacks.List(client, nil).AllPages(context.TODO())
 	if err != nil {
 	    panic(err)
 	}

--- a/openstack/orchestration/v1/stacks/doc.go
+++ b/openstack/orchestration/v1/stacks/doc.go
@@ -90,7 +90,7 @@ Example to Create an Stack
 	    Tags: tags,
 	}
 
-	r := stacks.Create(client, createOpts)
+	r := stacks.Create(context.TODO(), client, createOpts)
 	//dcreated_stack := stacks.CreatedStack()
 	if r.Err != nil {
 	    panic(r.Err)
@@ -103,7 +103,7 @@ Example to Create an Stack
 
 Example for Get Stack
 
-	get_result := stacks.Get(client, stackName, created_stack.ID)
+	get_result := stacks.Get(context.TODO(), client, stackName, created_stack.ID)
 	if get_result.Err != nil {
 	    panic(get_result.Err)
 	}
@@ -115,7 +115,7 @@ Example for Get Stack
 
 Example for Find Stack
 
-	find_result  := stacks.Find(client, stackIdentity)
+	find_result  := stacks.Find(context.TODO(), client, stackIdentity)
 	if find_result.Err != nil {
 		panic(find_result.Err)
 	}
@@ -127,7 +127,7 @@ Example for Find Stack
 
 Example for Delete Stack
 
-	del_r := stacks.Delete(client, stackName, created_stack.ID)
+	del_r := stacks.Delete(context.TODO(), client, stackName, created_stack.ID)
 	if del_r.Err != nil {
 	    panic(del_r.Err)
 	}
@@ -180,7 +180,7 @@ Example to Update a Stack Using the Update (PUT) Method
 		TemplateOpts: &template,
 	}
 
-	res := stacks.Update(orchestrationClient, stackName, stackId, stackOpts)
+	res := stacks.Update(context.TODO(), orchestrationClient, stackName, stackId, stackOpts)
 	if res.Err != nil {
 		panic(res.Err)
 	}
@@ -197,7 +197,7 @@ Example to Update a Stack Using the UpdatePatch (PATCH) Method
 		Parameters: params,
 	}
 
-	res := stacks.UpdatePatch(orchestrationClient, stackName, stackId, stackOpts)
+	res := stacks.UpdatePatch(context.TODO(), orchestrationClient, stackName, stackId, stackOpts)
 	if res.Err != nil {
 		panic(res.Err)
 	}

--- a/openstack/orchestration/v1/stacktemplates/doc.go
+++ b/openstack/orchestration/v1/stacktemplates/doc.go
@@ -9,7 +9,7 @@ specific application stack.
 
 Example to get stack template
 
-	temp, err := stacktemplates.Get(client, stack.Name, stack.ID).Extract()
+	temp, err := stacktemplates.Get(context.TODO(), client, stack.Name, stack.ID).Extract()
 	if err != nil {
 	    panic(err)
 	}
@@ -26,7 +26,7 @@ Example to validate stack template
 	validateOpts := &stacktemplates.ValidateOpts{
 	    Template: string(f2),
 	}
-	validate_result, err := stacktemplates.Validate(client, validateOpts).Extract()
+	validate_result, err := stacktemplates.Validate(context.TODO(), client, validateOpts).Extract()
 	if err != nil {
 	    // If validate failed, you will get error message here
 	    fmt.Println("Validate failed: ", err.Error())

--- a/openstack/placement/v1/resourceproviders/doc.go
+++ b/openstack/placement/v1/resourceproviders/doc.go
@@ -25,7 +25,7 @@ Example to create resource providers
 		ParentProvider: "c7f50b40-6f32-4d7a-9f32-9384057be83b"
 	}
 
-	rp, err := resourceproviders.Create(placementClient, createOpts).Extract()
+	rp, err := resourceproviders.Create(context.TODO(), placementClient, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -33,7 +33,7 @@ Example to create resource providers
 Example to Delete a resource provider
 
 	resourceProviderID := "b99b3ab4-3aa6-4fba-b827-69b88b9c544a"
-	err := resourceproviders.Delete(placementClient, resourceProviderID).ExtractErr()
+	err := resourceproviders.Delete(context.TODO(), placementClient, resourceProviderID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
@@ -41,7 +41,7 @@ Example to Delete a resource provider
 Example to Get a resource provider
 
 	resourceProviderID := "b99b3ab4-3aa6-4fba-b827-69b88b9c544a"
-	resourceProvider, err := resourceproviders.Get(placementClient, resourceProviderID).Extract()
+	resourceProvider, err := resourceproviders.Get(context.TODO(), placementClient, resourceProviderID).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -56,35 +56,35 @@ Example to Update a resource provider
 	}
 
 	placementClient.Microversion = "1.37"
-	resourceProvider, err := resourceproviders.Update(placementClient, resourceProviderID).Extract()
+	resourceProvider, err := resourceproviders.Update(context.TODO(), placementClient, resourceProviderID).Extract()
 	if err != nil {
 		panic(err)
 	}
 
 Example to get resource providers usages
 
-	rp, err := resourceproviders.GetUsages(placementClient, resourceProviderID).Extract()
+	rp, err := resourceproviders.GetUsages(context.TODO(), placementClient, resourceProviderID).Extract()
 	if err != nil {
 		panic(err)
 	}
 
 Example to get resource providers inventories
 
-	rp, err := resourceproviders.GetInventories(placementClient, resourceProviderID).Extract()
+	rp, err := resourceproviders.GetInventories(context.TODO(), placementClient, resourceProviderID).Extract()
 	if err != nil {
 		panic(err)
 	}
 
 Example to get resource providers traits
 
-	rp, err := resourceproviders.GetTraits(placementClient, resourceProviderID).Extract()
+	rp, err := resourceproviders.GetTraits(context.TODO(), placementClient, resourceProviderID).Extract()
 	if err != nil {
 		panic(err)
 	}
 
 Example to get resource providers allocations
 
-	rp, err := resourceproviders.GetAllocations(placementClient, resourceProviderID).Extract()
+	rp, err := resourceproviders.GetAllocations(context.TODO(), placementClient, resourceProviderID).Extract()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/placement/v1/resourceproviders/doc.go
+++ b/openstack/placement/v1/resourceproviders/doc.go
@@ -3,7 +3,7 @@ Package resourceproviders creates and lists all resource providers from the Open
 
 Example to list resource providers
 
-	allPages, err := resourceproviders.List(placementClient, resourceproviders.ListOpts{}).AllPages()
+	allPages, err := resourceproviders.List(placementClient, resourceproviders.ListOpts{}).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/sharedfilesystems/apiversions/doc.go
+++ b/openstack/sharedfilesystems/apiversions/doc.go
@@ -4,7 +4,7 @@ API versions for the Shared File System service, code-named Manila.
 
 Example to List API Versions
 
-	allPages, err := apiversions.List(client).AllPages()
+	allPages, err := apiversions.List(client).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/sharedfilesystems/apiversions/doc.go
+++ b/openstack/sharedfilesystems/apiversions/doc.go
@@ -20,7 +20,7 @@ Example to List API Versions
 
 Example to Get an API Version
 
-	version, err := apiVersions.Get(client, "v2.1").Extract()
+	version, err := apiVersions.Get(context.TODO(), client, "v2.1").Extract()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/sharedfilesystems/v2/schedulerstats/doc.go
+++ b/openstack/sharedfilesystems/v2/schedulerstats/doc.go
@@ -5,7 +5,7 @@ and utilisation. Example:
 	listOpts := schedulerstats.ListOpts{
 	}
 
-	allPages, err := schedulerstats.List(client, listOpts).AllPages()
+	allPages, err := schedulerstats.List(client, listOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/sharedfilesystems/v2/services/doc.go
+++ b/openstack/sharedfilesystems/v2/services/doc.go
@@ -4,7 +4,7 @@ OpenStack cloud.
 
 Example of Retrieving list of all services
 
-	allPages, err := services.List(sharedFileSystemV2, services.ListOpts{}).AllPages()
+	allPages, err := services.List(sharedFileSystemV2, services.ListOpts{}).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/sharedfilesystems/v2/shares/doc.go
+++ b/openstack/sharedfilesystems/v2/shares/doc.go
@@ -12,7 +12,7 @@ Example to Revert a Share to a Snapshot ID
 		SnapshotID: "ddeac769-9742-497f-b985-5bcfa94a3fd6",
 	}
 	manilaClient.Microversion = "2.27"
-	err := shares.Revert(manilaClient, shareID, opts).ExtractErr()
+	err := shares.Revert(context.TODO(), manilaClient, shareID, opts).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
@@ -24,7 +24,7 @@ Example to Reset a Share Status
 		Status: "available",
 	}
 	manilaClient.Microversion = "2.7"
-	err := shares.ResetStatus(manilaClient, shareID, opts).ExtractErr()
+	err := shares.ResetStatus(context.TODO(), manilaClient, shareID, opts).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
@@ -32,7 +32,7 @@ Example to Reset a Share Status
 Example to Force Delete a Share
 
 	manilaClient.Microversion = "2.7"
-	err := shares.ForceDelete(manilaClient, shareID).ExtractErr()
+	err := shares.ForceDelete(context.TODO(), manilaClient, shareID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}
@@ -40,7 +40,7 @@ Example to Force Delete a Share
 Example to Unmanage a Share
 
 	manilaClient.Microversion = "2.7"
-	err := shares.Unmanage(manilaClient, shareID).ExtractErr()
+	err := shares.Unmanage(context.TODO(), manilaClient, shareID).ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/workflow/v2/crontriggers/doc.go
+++ b/openstack/workflow/v2/crontriggers/doc.go
@@ -48,14 +48,14 @@ Create a cron trigger. This example will start the workflow "echo" each day at 8
 			"msg": "world",
 		},
 	}
-	crontrigger, err := crontriggers.Create(mistralClient, createOpts).Extract()
+	crontrigger, err := crontriggers.Create(context.TODO(), mistralClient, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
 
 Get a cron trigger
 
-	crontrigger, err := crontriggers.Get(mistralClient, "0520ffd8-f7f1-4f2e-845b-55d953a1cf46").Extract()
+	crontrigger, err := crontriggers.Get(context.TODO(), mistralClient, "0520ffd8-f7f1-4f2e-845b-55d953a1cf46").Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -64,7 +64,7 @@ Get a cron trigger
 
 Delete a cron trigger
 
-	res := crontriggers.Delete(mistralClient, "0520ffd8-f7f1-4f2e-845b-55d953a1cf46")
+	res := crontriggers.Delete(context.TODO(), mistralClient, "0520ffd8-f7f1-4f2e-845b-55d953a1cf46")
 	if res.Err != nil {
 		panic(res.Err)
 	}

--- a/openstack/workflow/v2/crontriggers/doc.go
+++ b/openstack/workflow/v2/crontriggers/doc.go
@@ -20,7 +20,7 @@ Default Filter checks equality, but you can override it with provided filter typ
 		},
 	}
 
-	allPages, err := crontriggers.List(mistralClient, listOpts).AllPages()
+	allPages, err := crontriggers.List(mistralClient, listOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/workflow/v2/executions/doc.go
+++ b/openstack/workflow/v2/executions/doc.go
@@ -46,14 +46,14 @@ Create an execution
 		Description: "this is a description",
 	}
 
-	execution, err := executions.Create(mistralClient, createOpts).Extract()
+	execution, err := executions.Create(context.TODO(), mistralClient, createOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
 
 Get an execution
 
-	execution, err := executions.Get(mistralClient, "50bb59f1-eb77-4017-a77f-6d575b002667").Extract()
+	execution, err := executions.Get(context.TODO(), mistralClient, "50bb59f1-eb77-4017-a77f-6d575b002667").Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -61,7 +61,7 @@ Get an execution
 
 Delete an execution
 
-	res := executions.Delete(mistralClient, "50bb59f1-eb77-4017-a77f-6d575b002667")
+	res := executions.Delete(context.TODO(), mistralClient, "50bb59f1-eb77-4017-a77f-6d575b002667")
 	if res.Err != nil {
 		panic(res.Err)
 	}

--- a/openstack/workflow/v2/executions/doc.go
+++ b/openstack/workflow/v2/executions/doc.go
@@ -22,7 +22,7 @@ Default Filter checks equality, but you can override it with provided filter typ
 		},
 	}
 
-	allPages, err := executions.List(mistralClient, listOpts).AllPages()
+	allPages, err := executions.List(mistralClient, listOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/workflow/v2/workflows/doc.go
+++ b/openstack/workflow/v2/workflows/doc.go
@@ -12,7 +12,7 @@ List workflows
 		Namespace: "some-namespace",
 	}
 
-	allPages, err := workflows.List(mistralClient, listOpts).AllPages()
+	allPages, err := workflows.List(mistralClient, listOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/workflow/v2/workflows/doc.go
+++ b/openstack/workflow/v2/workflows/doc.go
@@ -28,7 +28,7 @@ List workflows
 
 Get a workflow
 
-	workflow, err := workflows.Get(mistralClient, "604a3a1e-94e3-4066-a34a-aa56873ef236").Extract()
+	workflow, err := workflows.Get(context.TODO(), mistralClient, "604a3a1e-94e3-4066-a34a-aa56873ef236").Extract()
 	if err != nil {
 		t.Fatalf("Unable to get workflow %s: %v", id, err)
 	}
@@ -56,7 +56,7 @@ Create a workflow
 			Namespace: "some-namespace",
 		}
 
-		workflow, err := workflows.Create(mistralClient, createOpts).Extract()
+		workflow, err := workflows.Create(context.TODO(), mistralClient, createOpts).Extract()
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
Gophercloud was made context aware in https://github.com/gophercloud/gophercloud/pull/2936, however we forgot to update the go doc comments to match the new function signatures.

This patch was mostly generated with the following command:
```
for f in $(git show 1b7c1ceb72b30b5dada9993e8113a67fa95ab419 | grep "+func" | cut -d "(" -f 1 | cut -d " " -f 2 | sort | uniq | tail -n +2); do
        find . -name doc.go -exec sed -i "s/$f(\(\w\?\+[Cc]lient\)/$f(context.TODO(), \1/g" {} \;;
done
```

Then manual edits for List functions that shouldn't have been modified.
