### PR TITLE
Remove `name` opt from create/update opts

### DIFF
--- a/openstack/identity/v3/endpoints/doc.go
+++ b/openstack/identity/v3/endpoints/doc.go
@@ -33,7 +33,6 @@ Example to Create an Endpoint
 
 	createOpts := endpoints.CreateOpts{
 		Availability: gophercloud.AvailabilityPublic,
-		Name:         "neutron",
 		Region:       "RegionOne",
 		URL:          "https://localhost:9696",
 		ServiceID:    serviceID,

--- a/openstack/identity/v3/endpoints/requests.go
+++ b/openstack/identity/v3/endpoints/requests.go
@@ -18,9 +18,6 @@ type CreateOpts struct {
 	// or public), referenced by the gophercloud.Availability type.
 	Availability gophercloud.Availability `json:"interface" required:"true"`
 
-	// Name is the name of the Endpoint.
-	Name string `json:"name" required:"true"`
-
 	// Region is the region the Endpoint is located in.
 	// This field can be omitted or left as a blank string.
 	Region string `json:"region,omitempty"`
@@ -101,9 +98,6 @@ type UpdateOpts struct {
 	// Availability is the interface type of the Endpoint (admin, internal,
 	// or public), referenced by the gophercloud.Availability type.
 	Availability gophercloud.Availability `json:"interface,omitempty"`
-
-	// Name is the name of the Endpoint.
-	Name string `json:"name,omitempty"`
 
 	// Region is the region the Endpoint is located in.
 	// This field can be omitted or left as a blank string.

--- a/openstack/identity/v3/endpoints/results.go
+++ b/openstack/identity/v3/endpoints/results.go
@@ -46,9 +46,6 @@ type Endpoint struct {
 	// or public), referenced by the gophercloud.Availability type.
 	Availability gophercloud.Availability `json:"interface"`
 
-	// Name is the name of the Endpoint.
-	Name string `json:"name"`
-
 	// Region is the region the Endpoint is located in.
 	Region string `json:"region"`
 

--- a/openstack/identity/v3/endpoints/testing/requests_test.go
+++ b/openstack/identity/v3/endpoints/testing/requests_test.go
@@ -24,7 +24,6 @@ func TestCreateSuccessful(t *testing.T) {
       {
         "endpoint": {
           "interface": "public",
-          "name": "the-endiest-of-points",
           "region": "underground",
           "url": "https://1.2.3.4:9000/",
           "service_id": "asdfasdfasdfasdf"
@@ -42,7 +41,6 @@ func TestCreateSuccessful(t *testing.T) {
 		  "links": {
             "self": "https://localhost:5000/v3/endpoints/12"
           },
-          "name": "the-endiest-of-points",
           "region": "underground",
           "service_id": "asdfasdfasdfasdf",
           "url": "https://1.2.3.4:9000/"
@@ -53,7 +51,6 @@ func TestCreateSuccessful(t *testing.T) {
 
 	actual, err := endpoints.Create(context.TODO(), client.ServiceClient(), endpoints.CreateOpts{
 		Availability: gophercloud.AvailabilityPublic,
-		Name:         "the-endiest-of-points",
 		Region:       "underground",
 		URL:          "https://1.2.3.4:9000/",
 		ServiceID:    "asdfasdfasdfasdf",
@@ -64,7 +61,6 @@ func TestCreateSuccessful(t *testing.T) {
 		ID:           "12",
 		Availability: gophercloud.AvailabilityPublic,
 		Enabled:      true,
-		Name:         "the-endiest-of-points",
 		Region:       "underground",
 		ServiceID:    "asdfasdfasdfasdf",
 		URL:          "https://1.2.3.4:9000/",
@@ -92,7 +88,6 @@ func TestListEndpoints(t *testing.T) {
 						"links": {
 							"self": "https://localhost:5000/v3/endpoints/12"
 						},
-						"name": "the-endiest-of-points",
 						"region": "underground",
 						"service_id": "asdfasdfasdfasdf",
 						"url": "https://1.2.3.4:9000/"
@@ -104,7 +99,6 @@ func TestListEndpoints(t *testing.T) {
 						"links": {
 							"self": "https://localhost:5000/v3/endpoints/13"
 						},
-						"name": "shhhh",
 						"region": "underground",
 						"service_id": "asdfasdfasdfasdf",
 						"url": "https://1.2.3.4:9001/"
@@ -132,7 +126,6 @@ func TestListEndpoints(t *testing.T) {
 				ID:           "12",
 				Availability: gophercloud.AvailabilityPublic,
 				Enabled:      true,
-				Name:         "the-endiest-of-points",
 				Region:       "underground",
 				ServiceID:    "asdfasdfasdfasdf",
 				URL:          "https://1.2.3.4:9000/",
@@ -141,7 +134,6 @@ func TestListEndpoints(t *testing.T) {
 				ID:           "13",
 				Availability: gophercloud.AvailabilityInternal,
 				Enabled:      false,
-				Name:         "shhhh",
 				Region:       "underground",
 				ServiceID:    "asdfasdfasdfasdf",
 				URL:          "https://1.2.3.4:9001/",
@@ -163,7 +155,6 @@ func TestUpdateEndpoint(t *testing.T) {
 		th.TestJSONRequest(t, r, `
 		{
 	    "endpoint": {
-	      "name": "renamed",
 				"region": "somewhere-else"
 	    }
 		}
@@ -178,7 +169,6 @@ func TestUpdateEndpoint(t *testing.T) {
 				"links": {
 					"self": "https://localhost:5000/v3/endpoints/12"
 				},
-				"name": "renamed",
 				"region": "somewhere-else",
 				"service_id": "asdfasdfasdfasdf",
 				"url": "https://1.2.3.4:9000/"
@@ -188,7 +178,6 @@ func TestUpdateEndpoint(t *testing.T) {
 	})
 
 	actual, err := endpoints.Update(context.TODO(), client.ServiceClient(), "12", endpoints.UpdateOpts{
-		Name:   "renamed",
 		Region: "somewhere-else",
 	}).Extract()
 	if err != nil {
@@ -199,7 +188,6 @@ func TestUpdateEndpoint(t *testing.T) {
 		ID:           "12",
 		Availability: gophercloud.AvailabilityPublic,
 		Enabled:      true,
-		Name:         "renamed",
 		Region:       "somewhere-else",
 		ServiceID:    "asdfasdfasdfasdf",
 		URL:          "https://1.2.3.4:9000/",


### PR DESCRIPTION
Fixes #3016

Remove `name` opt from create/update opts because the property is not in endpoint schema (1).

Also, `name` is not in keystone api v3 document (2).

Links to the line numbers/files in the OpenStack source code that support the code in this PR:

* 1) https://github.com/openstack/keystone/blob/stable/zed/keystone/catalog/schema.py#L70
* 2) https://docs.openstack.org/api-ref/identity/v3/#create-endpoint
