### PR TITLE
compute, block storage: Rework scheduler hints

### DIFF
--- a/internal/acceptance/openstack/blockstorage/noauth/blockstorage.go
+++ b/internal/acceptance/openstack/blockstorage/noauth/blockstorage.go
@@ -30,7 +30,7 @@ func CreateVolume(t *testing.T, client *gophercloud.ServiceClient) (*volumes.Vol
 		Name: volumeName,
 	}
 
-	volume, err := volumes.Create(context.TODO(), client, createOpts).Extract()
+	volume, err := volumes.Create(context.TODO(), client, createOpts, nil).Extract()
 	if err != nil {
 		return volume, err
 	}
@@ -67,7 +67,7 @@ func CreateVolumeFromImage(t *testing.T, client *gophercloud.ServiceClient) (*vo
 		ImageID: choices.ImageID,
 	}
 
-	volume, err := volumes.Create(context.TODO(), client, createOpts).Extract()
+	volume, err := volumes.Create(context.TODO(), client, createOpts, nil).Extract()
 	if err != nil {
 		return volume, err
 	}

--- a/internal/acceptance/openstack/blockstorage/v2/blockstorage.go
+++ b/internal/acceptance/openstack/blockstorage/v2/blockstorage.go
@@ -66,7 +66,7 @@ func CreateVolume(t *testing.T, client *gophercloud.ServiceClient) (*volumes.Vol
 		Description: volumeDescription,
 	}
 
-	volume, err := volumes.Create(context.TODO(), client, createOpts).Extract()
+	volume, err := volumes.Create(context.TODO(), client, createOpts, nil).Extract()
 	if err != nil {
 		return volume, err
 	}
@@ -106,7 +106,7 @@ func CreateVolumeFromImage(t *testing.T, client *gophercloud.ServiceClient) (*vo
 		ImageID: choices.ImageID,
 	}
 
-	volume, err := volumes.Create(context.TODO(), client, createOpts).Extract()
+	volume, err := volumes.Create(context.TODO(), client, createOpts, nil).Extract()
 	if err != nil {
 		return volume, err
 	}

--- a/internal/acceptance/openstack/blockstorage/v2/schedulerhints_test.go
+++ b/internal/acceptance/openstack/blockstorage/v2/schedulerhints_test.go
@@ -26,7 +26,7 @@ func TestSchedulerHints(t *testing.T) {
 		Name: volumeName,
 	}
 
-	volume1, err := volumes.Create(context.TODO(), client, createOpts).Extract()
+	volume1, err := volumes.Create(context.TODO(), client, createOpts, nil).Extract()
 	th.AssertNoErr(t, err)
 
 	ctx, cancel := context.WithTimeout(context.TODO(), 60*time.Second)
@@ -37,18 +37,17 @@ func TestSchedulerHints(t *testing.T) {
 	defer volumes.Delete(context.TODO(), client, volume1.ID, volumes.DeleteOpts{})
 
 	volumeName = tools.RandomString("ACPTTEST", 16)
-	schedulerHints := volumes.SchedulerHints{
+	createOpts = volumes.CreateOpts{
+		Size: 1,
+		Name: volumeName,
+	}
+	schedulerHintOpts := volumes.SchedulerHintOpts{
 		SameHost: []string{
 			volume1.ID,
 		},
 	}
-	createOpts = volumes.CreateOpts{
-		Size:           1,
-		Name:           volumeName,
-		SchedulerHints: schedulerHints,
-	}
 
-	volume2, err := volumes.Create(context.TODO(), client, createOpts).Extract()
+	volume2, err := volumes.Create(context.TODO(), client, createOpts, schedulerHintOpts).Extract()
 	th.AssertNoErr(t, err)
 
 	ctx2, cancel := context.WithTimeout(context.TODO(), 60*time.Second)

--- a/internal/acceptance/openstack/blockstorage/v2/volumes_test.go
+++ b/internal/acceptance/openstack/blockstorage/v2/volumes_test.go
@@ -277,7 +277,7 @@ func TestVolumeConns(t *testing.T) {
     cv, err := volumes.Create(client, &volumes.CreateOpts{
         Size: 1,
         Name: "blockv2-volume",
-    }).Extract()
+    }, nil).Extract()
     th.AssertNoErr(t, err)
 
     defer func() {

--- a/internal/acceptance/openstack/blockstorage/v3/blockstorage.go
+++ b/internal/acceptance/openstack/blockstorage/v3/blockstorage.go
@@ -76,7 +76,7 @@ func CreateVolume(t *testing.T, client *gophercloud.ServiceClient) (*volumes.Vol
 		Description: volumeDescription,
 	}
 
-	volume, err := volumes.Create(context.TODO(), client, createOpts).Extract()
+	volume, err := volumes.Create(context.TODO(), client, createOpts, nil).Extract()
 	if err != nil {
 		return volume, err
 	}
@@ -119,7 +119,7 @@ func CreateVolumeWithType(t *testing.T, client *gophercloud.ServiceClient, vt *v
 		VolumeType:  vt.Name,
 	}
 
-	volume, err := volumes.Create(context.TODO(), client, createOpts).Extract()
+	volume, err := volumes.Create(context.TODO(), client, createOpts, nil).Extract()
 	if err != nil {
 		return volume, err
 	}

--- a/internal/acceptance/openstack/blockstorage/v3/schedulerhints_test.go
+++ b/internal/acceptance/openstack/blockstorage/v3/schedulerhints_test.go
@@ -25,7 +25,7 @@ func TestSchedulerHints(t *testing.T) {
 		Name: volumeName,
 	}
 
-	volume1, err := volumes.Create(context.TODO(), client, createOpts).Extract()
+	volume1, err := volumes.Create(context.TODO(), client, createOpts, nil).Extract()
 	th.AssertNoErr(t, err)
 
 	ctx, cancel := context.WithTimeout(context.TODO(), 60*time.Second)
@@ -36,18 +36,17 @@ func TestSchedulerHints(t *testing.T) {
 	defer volumes.Delete(context.TODO(), client, volume1.ID, volumes.DeleteOpts{})
 
 	volumeName = tools.RandomString("ACPTTEST", 16)
-	schedulerHints := volumes.SchedulerHints{
+	createOpts = volumes.CreateOpts{
+		Size: 1,
+		Name: volumeName,
+	}
+	schedulerHintOpts := volumes.SchedulerHintOpts{
 		SameHost: []string{
 			volume1.ID,
 		},
 	}
-	createOpts = volumes.CreateOpts{
-		Size:           1,
-		Name:           volumeName,
-		SchedulerHints: schedulerHints,
-	}
 
-	volume2, err := volumes.Create(context.TODO(), client, createOpts).Extract()
+	volume2, err := volumes.Create(context.TODO(), client, createOpts, schedulerHintOpts).Extract()
 	th.AssertNoErr(t, err)
 
 	ctx2, cancel2 := context.WithTimeout(context.TODO(), 60*time.Second)

--- a/internal/acceptance/openstack/blockstorage/v3/volumes_test.go
+++ b/internal/acceptance/openstack/blockstorage/v3/volumes_test.go
@@ -88,7 +88,7 @@ func TestVolumesMultiAttach(t *testing.T) {
 		VolumeType:  vt.ID,
 	}
 
-	vol, err := volumes.Create(context.TODO(), client, volOpts).Extract()
+	vol, err := volumes.Create(context.TODO(), client, volOpts, nil).Extract()
 	th.AssertNoErr(t, err)
 	defer DeleteVolume(t, client, vol)
 
@@ -332,7 +332,7 @@ func TestVolumeConns(t *testing.T) {
     cv, err := volumes.Create(context.TODO(), client, &volumes.CreateOpts{
         Size: 1,
         Name: "blockv2-volume",
-    }).Extract()
+    }, nil).Extract()
     th.AssertNoErr(t, err)
 
     defer func() {

--- a/internal/acceptance/openstack/compute/v2/compute.go
+++ b/internal/acceptance/openstack/compute/v2/compute.go
@@ -122,7 +122,7 @@ func CreateBootableVolumeServer(t *testing.T, client *gophercloud.ServiceClient,
 		createOpts.ImageRef = blockDevices[0].UUID
 	}
 
-	server, err = servers.Create(context.TODO(), client, createOpts).Extract()
+	server, err = servers.Create(context.TODO(), client, createOpts, nil).Extract()
 
 	if err != nil {
 		return server, err
@@ -249,7 +249,7 @@ func CreateMultiEphemeralServer(t *testing.T, client *gophercloud.ServiceClient,
 		BlockDevice: blockDevices,
 	}
 
-	server, err = servers.Create(context.TODO(), client, createOpts).Extract()
+	server, err = servers.Create(context.TODO(), client, createOpts, nil).Extract()
 
 	if err != nil {
 		return server, err
@@ -389,7 +389,7 @@ func CreateServer(t *testing.T, client *gophercloud.ServiceClient) (*servers.Ser
 				Contents: []byte("hello world"),
 			},
 		},
-	}).Extract()
+	}, nil).Extract()
 	if err != nil {
 		return server, err
 	}
@@ -443,7 +443,7 @@ func CreateMicroversionServer(t *testing.T, client *gophercloud.ServiceClient) (
 		Metadata: map[string]string{
 			"abc": "def",
 		},
-	}).Extract()
+	}, nil).Extract()
 	if err != nil {
 		return server, err
 	}
@@ -497,7 +497,7 @@ func CreateServerWithoutImageRef(t *testing.T, client *gophercloud.ServiceClient
 				Contents: []byte("hello world"),
 			},
 		},
-	}).Extract()
+	}, nil).Extract()
 	if err != nil {
 		return nil, err
 	}
@@ -544,7 +544,7 @@ func CreateServerWithTags(t *testing.T, client *gophercloud.ServiceClient, netwo
 			},
 		},
 		Tags: []string{"tag1", "tag2"},
-	}).Extract()
+	}, nil).Extract()
 	if err != nil {
 		return server, err
 	}
@@ -643,12 +643,12 @@ func CreateServerInServerGroup(t *testing.T, client *gophercloud.ServiceClient, 
 		Networks: []servers.Network{
 			{UUID: networkID},
 		},
-		SchedulerHints: servers.SchedulerHints{
-			Group: serverGroup.ID,
-		},
+	}
+	schedulerHintOpts := servers.SchedulerHintOpts{
+		Group: serverGroup.ID,
 	}
 
-	server, err := servers.Create(context.TODO(), client, serverCreateOpts).Extract()
+	server, err := servers.Create(context.TODO(), client, serverCreateOpts, schedulerHintOpts).Extract()
 	if err != nil {
 		return nil, err
 	}
@@ -697,7 +697,7 @@ func CreateServerWithPublicKey(t *testing.T, client *gophercloud.ServiceClient, 
 	server, err := servers.Create(context.TODO(), client, keypairs.CreateOptsExt{
 		CreateOptsBuilder: serverCreateOpts,
 		KeyName:           keyPairName,
-	}).Extract()
+	}, nil).Extract()
 	if err != nil {
 		return nil, err
 	}
@@ -1056,7 +1056,7 @@ func CreateServerNoNetwork(t *testing.T, client *gophercloud.ServiceClient) (*se
 				Contents: []byte("hello world"),
 			},
 		},
-	}).Extract()
+	}, nil).Extract()
 	if err != nil {
 		return server, err
 	}

--- a/openstack/blockstorage/v2/volumes/doc.go
+++ b/openstack/blockstorage/v2/volumes/doc.go
@@ -6,7 +6,7 @@ a time.
 
 Example of creating Volume B on a Different Host than Volume A
 
-	schedulerHints := volumes.SchedulerHints{
+	schedulerHintOpts := volumes.SchedulerHintCreateOpts{
 		DifferentHost: []string{
 			"volume-a-uuid",
 		}
@@ -15,17 +15,16 @@ Example of creating Volume B on a Different Host than Volume A
 	createOpts := volumes.CreateOpts{
 		Name:           "volume_b",
 		Size:           10,
-		SchedulerHints: schedulerHints,
 	}
 
-	volume, err := volumes.Create(context.TODO(), computeClient, createOpts).Extract()
+	volume, err := volumes.Create(context.TODO(), computeClient, createOpts, schedulerHintOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
 
 Example of creating Volume B on the Same Host as Volume A
 
-	schedulerHints := volumes.SchedulerHints{
+	schedulerHintOpts := volumes.SchedulerHintCreateOpts{
 		SameHost: []string{
 			"volume-a-uuid",
 		}
@@ -34,10 +33,9 @@ Example of creating Volume B on the Same Host as Volume A
 	createOpts := volumes.CreateOpts{
 		Name:              "volume_b",
 		Size:              10
-		SchedulerHints:    schedulerHints,
 	}
 
-	volume, err := volumes.Create(context.TODO(), computeClient, createOpts).Extract()
+	volume, err := volumes.Create(context.TODO(), computeClient, createOpts, schedulerHintOpts).Extract()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/blockstorage/v2/volumes/testing/requests_test.go
+++ b/openstack/blockstorage/v2/volumes/testing/requests_test.go
@@ -203,16 +203,15 @@ func TestCreate(t *testing.T) {
 	MockCreateResponse(t)
 
 	options := &volumes.CreateOpts{Size: 75, Name: "vol-001"}
-	n, err := volumes.Create(context.TODO(), client.ServiceClient(), options).Extract()
+	n, err := volumes.Create(context.TODO(), client.ServiceClient(), options, nil).Extract()
 	th.AssertNoErr(t, err)
 
 	th.AssertEquals(t, n.Size, 75)
 	th.AssertEquals(t, n.ID, "d32019d3-bc6e-4319-9c1d-6722fc136a22")
 }
 
-func TestCreateWithSchedulerHints(t *testing.T) {
-
-	schedulerHints := volumes.SchedulerHints{
+func TestCreateSchedulerHints(t *testing.T) {
+	base := volumes.SchedulerHintOpts{
 		DifferentHost: []string{
 			"a0cf03a5-d921-4877-bb5c-86d26cf818e1",
 			"8c19174f-4220-44f0-824a-cd1eeef10287",
@@ -224,18 +223,8 @@ func TestCreateWithSchedulerHints(t *testing.T) {
 		LocalToInstance:      "0ffb2c1b-d621-4fc1-9ae4-88d99c088ff6",
 		AdditionalProperties: map[string]interface{}{"mark": "a0cf03a5-d921-4877-bb5c-86d26cf818e1"},
 	}
-	base := volumes.CreateOpts{
-		Size:           10,
-		Name:           "testvolume",
-		SchedulerHints: schedulerHints,
-	}
-
 	expected := `
 		{
-			"volume": {
-				"size": 10,
-				"name": "testvolume"
-			},
 			"OS-SCH-HNT:scheduler_hints": {
 				"different_host": [
 					"a0cf03a5-d921-4877-bb5c-86d26cf818e1",
@@ -250,7 +239,7 @@ func TestCreateWithSchedulerHints(t *testing.T) {
 			}
 		}
 	`
-	actual, err := base.ToVolumeCreateMap()
+	actual, err := base.ToSchedulerHintsMap()
 	th.AssertNoErr(t, err)
 	th.CheckJSONEquals(t, expected, actual)
 }

--- a/openstack/blockstorage/v3/volumes/doc.go
+++ b/openstack/blockstorage/v3/volumes/doc.go
@@ -6,7 +6,7 @@ a time.
 
 Example of creating Volume B on a Different Host than Volume A
 
-	schedulerHints := volumes.SchedulerHints{
+	schedulerHintOpts := volumes.SchedulerHintCreateOpts{
 		DifferentHost: []string{
 			"volume-a-uuid",
 		}
@@ -15,17 +15,16 @@ Example of creating Volume B on a Different Host than Volume A
 	createOpts := volumes.CreateOpts{
 		Name:           "volume_b",
 		Size:           10,
-		SchedulerHints: schedulerHints,
 	}
 
-	volume, err := volumes.Create(context.TODO(), computeClient, createOpts).Extract()
+	volume, err := volumes.Create(context.TODO(), computeClient, createOpts, schedulerHintOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
 
 Example of creating Volume B on the Same Host as Volume A
 
-	schedulerHints := volumes.SchedulerHints{
+	schedulerHintOpts := volumes.SchedulerHintCreateOpts{
 		SameHost: []string{
 			"volume-a-uuid",
 		}
@@ -34,10 +33,9 @@ Example of creating Volume B on the Same Host as Volume A
 	createOpts := volumes.CreateOpts{
 		Name:              "volume_b",
 		Size:              10
-		SchedulerHints:    schedulerHints,
 	}
 
-	volume, err := volumes.Create(context.TODO(), computeClient, createOpts).Extract()
+	volume, err := volumes.Create(context.TODO(), computeClient, createOpts, schedulerHintOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -51,7 +49,7 @@ Example of creating a Volume from a Backup
 	}
 
 	client.Microversion = "3.47"
-	volume, err := volumes.Create(context.TODO(), client, options).Extract()
+	volume, err := volumes.Create(context.TODO(), client, options, nil).Extract()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/blockstorage/v3/volumes/requests.go
+++ b/openstack/blockstorage/v3/volumes/requests.go
@@ -2,20 +2,22 @@ package volumes
 
 import (
 	"context"
+	"maps"
 	"regexp"
 
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/pagination"
 )
 
-// CreateOptsBuilder builds the scheduler hints into a serializable format.
-type SchedulerHintsCreateOptsBuilder interface {
-	ToVolumeSchedulerHintsCreateMap() (map[string]interface{}, error)
+// SchedulerHintOptsBuilder builds the scheduler hints into a serializable format.
+type SchedulerHintOptsBuilder interface {
+	ToSchedulerHintsMap() (map[string]interface{}, error)
 }
 
-// SchedulerHints represents a set of scheduling hints that are passed to the
-// OpenStack scheduler.
-type SchedulerHints struct {
+// SchedulerHintOpts contains options for providing scheduler hints
+// when creating a Volume. This object is passed to the volumes.Create function.
+// For more information about these parameters, see the Volume object.
+type SchedulerHintOpts struct {
 	// DifferentHost will place the volume on a different back-end that does not
 	// host the given volumes.
 	DifferentHost []string
@@ -34,8 +36,8 @@ type SchedulerHints struct {
 	AdditionalProperties map[string]interface{}
 }
 
-// ToVolumeSchedulerHintsCreateMap assembles a request body for the scheduler
-func (opts SchedulerHints) ToVolumeSchedulerHintsCreateMap() (map[string]interface{}, error) {
+// ToSchedulerHintsMap assembles a request body for scheduler hints
+func (opts SchedulerHintOpts) ToSchedulerHintsMap() (map[string]interface{}, error) {
 	sh := make(map[string]interface{})
 
 	uuidRegex, _ := regexp.Compile("^[a-z0-9]{8}-[a-z0-9]{4}-[1-5][a-z0-9]{3}-[a-z0-9]{4}-[a-z0-9]{12}$")
@@ -44,7 +46,7 @@ func (opts SchedulerHints) ToVolumeSchedulerHintsCreateMap() (map[string]interfa
 		for _, diffHost := range opts.DifferentHost {
 			if !uuidRegex.MatchString(diffHost) {
 				err := gophercloud.ErrInvalidInput{}
-				err.Argument = "schedulerhints.SchedulerHints.DifferentHost"
+				err.Argument = "volumes.SchedulerHintOpts.DifferentHost"
 				err.Value = opts.DifferentHost
 				err.Info = "The hosts must be in UUID format."
 				return nil, err
@@ -57,7 +59,7 @@ func (opts SchedulerHints) ToVolumeSchedulerHintsCreateMap() (map[string]interfa
 		for _, sameHost := range opts.SameHost {
 			if !uuidRegex.MatchString(sameHost) {
 				err := gophercloud.ErrInvalidInput{}
-				err.Argument = "schedulerhints.SchedulerHints.SameHost"
+				err.Argument = "volumes.SchedulerHintOpts.SameHost"
 				err.Value = opts.SameHost
 				err.Info = "The hosts must be in UUID format."
 				return nil, err
@@ -69,7 +71,7 @@ func (opts SchedulerHints) ToVolumeSchedulerHintsCreateMap() (map[string]interfa
 	if opts.LocalToInstance != "" {
 		if !uuidRegex.MatchString(opts.LocalToInstance) {
 			err := gophercloud.ErrInvalidInput{}
-			err.Argument = "schedulerhints.SchedulerHints.LocalToInstance"
+			err.Argument = "volumes.SchedulerHintOpts.LocalToInstance"
 			err.Value = opts.LocalToInstance
 			err.Info = "The instance must be in UUID format."
 			return nil, err
@@ -87,7 +89,11 @@ func (opts SchedulerHints) ToVolumeSchedulerHintsCreateMap() (map[string]interfa
 		}
 	}
 
-	return sh, nil
+	if len(sh) == 0 {
+		return sh, nil
+	}
+
+	return map[string]interface{}{"OS-SCH-HNT:scheduler_hints": sh}, nil
 }
 
 // CreateOptsBuilder allows extensions to add additional parameters to the
@@ -126,52 +132,33 @@ type CreateOpts struct {
 	BackupID string `json:"backup_id,omitempty"`
 	// The associated volume type
 	VolumeType string `json:"volume_type,omitempty"`
-	// SchedulerHints provides a set of hints to the scheduler.
-	SchedulerHints SchedulerHintsCreateOptsBuilder
 }
 
 // ToVolumeCreateMap assembles a request body based on the contents of a
 // CreateOpts.
 func (opts CreateOpts) ToVolumeCreateMap() (map[string]interface{}, error) {
-	// We intentionally don't envelope the body here since we want to strip
-	// some fields out
-	base, err := gophercloud.BuildRequestBody(opts, "")
-	if err != nil {
-		return nil, err
-	}
-
-	delete(base, "SchedulerHints")
-
-	// Now we do our enveloping
-	base = map[string]interface{}{"volume": base}
-
-	if opts.SchedulerHints == nil {
-		return base, nil
-	}
-
-	schedulerHints, err := opts.SchedulerHints.ToVolumeSchedulerHintsCreateMap()
-	if err != nil {
-		return nil, err
-	}
-
-	if len(schedulerHints) == 0 {
-		return base, nil
-	}
-
-	base["OS-SCH-HNT:scheduler_hints"] = schedulerHints
-
-	return base, err
+	return gophercloud.BuildRequestBody(opts, "volume")
 }
 
 // Create will create a new Volume based on the values in CreateOpts. To extract
 // the Volume object from the response, call the Extract method on the
 // CreateResult.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder, hintOpts SchedulerHintOptsBuilder) (r CreateResult) {
 	b, err := opts.ToVolumeCreateMap()
 	if err != nil {
 		r.Err = err
 		return
 	}
+
+	if hintOpts != nil {
+		sh, err := hintOpts.ToSchedulerHintsMap()
+		if err != nil {
+			r.Err = err
+			return
+		}
+		maps.Copy(b, sh)
+	}
+
 	resp, err := client.Post(ctx, createURL(client), b, &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{202},
 	})

--- a/openstack/blockstorage/v3/volumes/testing/requests_test.go
+++ b/openstack/blockstorage/v3/volumes/testing/requests_test.go
@@ -207,16 +207,15 @@ func TestCreate(t *testing.T) {
 	MockCreateResponse(t)
 
 	options := &volumes.CreateOpts{Size: 75, Name: "vol-001"}
-	n, err := volumes.Create(context.TODO(), client.ServiceClient(), options).Extract()
+	n, err := volumes.Create(context.TODO(), client.ServiceClient(), options, nil).Extract()
 	th.AssertNoErr(t, err)
 
 	th.AssertEquals(t, n.Size, 75)
 	th.AssertEquals(t, n.ID, "d32019d3-bc6e-4319-9c1d-6722fc136a22")
 }
 
-func TestCreateWithSchedulerHints(t *testing.T) {
-
-	schedulerHints := volumes.SchedulerHints{
+func TestCreateSchedulerHints(t *testing.T) {
+	base := volumes.SchedulerHintOpts{
 		DifferentHost: []string{
 			"a0cf03a5-d921-4877-bb5c-86d26cf818e1",
 			"8c19174f-4220-44f0-824a-cd1eeef10287",
@@ -228,18 +227,8 @@ func TestCreateWithSchedulerHints(t *testing.T) {
 		LocalToInstance:      "0ffb2c1b-d621-4fc1-9ae4-88d99c088ff6",
 		AdditionalProperties: map[string]interface{}{"mark": "a0cf03a5-d921-4877-bb5c-86d26cf818e1"},
 	}
-	base := volumes.CreateOpts{
-		Size:           10,
-		Name:           "testvolume",
-		SchedulerHints: schedulerHints,
-	}
-
 	expected := `
 		{
-			"volume": {
-				"size": 10,
-				"name": "testvolume"
-			},
 			"OS-SCH-HNT:scheduler_hints": {
 				"different_host": [
 					"a0cf03a5-d921-4877-bb5c-86d26cf818e1",
@@ -254,7 +243,7 @@ func TestCreateWithSchedulerHints(t *testing.T) {
 			}
 		}
 	`
-	actual, err := base.ToVolumeCreateMap()
+	actual, err := base.ToSchedulerHintsMap()
 	th.AssertNoErr(t, err)
 	th.CheckJSONEquals(t, expected, actual)
 }
@@ -310,8 +299,7 @@ func TestCreateFromBackup(t *testing.T) {
 		Name:     "vol-001",
 		BackupID: "20c792f0-bb03-434f-b653-06ef238e337e",
 	}
-
-	v, err := volumes.Create(context.TODO(), client.ServiceClient(), options).Extract()
+	v, err := volumes.Create(context.TODO(), client.ServiceClient(), options, nil).Extract()
 
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, v.Size, 30)

--- a/openstack/compute/v2/servers/doc.go
+++ b/openstack/compute/v2/servers/doc.go
@@ -53,59 +53,62 @@ Example to Create a Server
 		FlavorRef: "flavor-uuid",
 	}
 
-	server, err := servers.Create(context.TODO(), computeClient, createOpts).Extract()
+	server, err := servers.Create(context.TODO(), computeClient, createOpts, nil).Extract()
 	if err != nil {
 		panic(err)
 	}
 
 Example to Add a Server to a Server Group
 
-	createOpts := servers.CreateOpts{
-		Name:           "server_name",
-		ImageRef:       "image-uuid",
-		FlavorRef:      "flavor-uuid",
-		SchedulerHints: servers.SchedulerHints{
-			Group: "servergroup-uuid",
-		},
+	schedulerHintOpts := servers.SchedulerHintOpts{
+		Group: "servergroup-uuid",
 	}
 
-	server, err := servers.Create(context.TODO(), computeClient, createOpts).Extract()
+	createOpts := servers.CreateOpts{
+		Name:      "server_name",
+		ImageRef:  "image-uuid",
+		FlavorRef: "flavor-uuid",
+	}
+
+	server, err := servers.Create(context.TODO(), computeClient, createOpts, schedulerHintOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
 
 Example to Place Server B on a Different Host than Server A
 
-	createOpts := servers.CreateOpts{
-		Name:           "server_name",
-		ImageRef:       "image-uuid",
-		FlavorRef:      "flavor-uuid",
-		SchedulerHints: servers.SchedulerHints{
-			DifferentHost: []string{
-				"server-a-uuid",
-			}
-		},
+	schedulerHintOpts := servers.SchedulerHintOpts{
+		DifferentHost: []string{
+			"server-a-uuid",
+		}
 	}
 
-	server, err := servers.Create(context.TODO(), computeClient, createOpts).Extract()
+	createOpts := servers.CreateOpts{
+		Name:      "server_b",
+		ImageRef:  "image-uuid",
+		FlavorRef: "flavor-uuid",
+	}
+
+	server, err := servers.Create(context.TODO(), computeClient, createOpts, schedulerHintOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
 
 Example to Place Server B on the Same Host as Server A
 
-	createOpts := servers.CreateOpts{
-		Name:           "server_name",
-		ImageRef:       "image-uuid",
-		FlavorRef:      "flavor-uuid",
-		SchedulerHints: servers.SchedulerHints{
-			SameHost: []string{
-				"server-a-uuid",
-			}
-		},
+	schedulerHintOpts := servers.SchedulerHintOpts{
+		SameHost: []string{
+			"server-a-uuid",
+		}
 	}
 
-	server, err := servers.Create(context.TODO(), computeClient, createOpts).Extract()
+	createOpts := servers.CreateOpts{
+		Name:      "server_b",
+		ImageRef:  "image-uuid",
+		FlavorRef: "flavor-uuid",
+	}
+
+	server, err := servers.Create(context.TODO(), computeClient, createOpts, schedulerHintOpts).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -133,7 +136,7 @@ a server without using block device mappings.
 		BlockDevice: blockDevices,
 	}
 
-	server, err := servers.Create(context.TODO(), client, createOpts).Extract()
+	server, err := servers.Create(context.TODO(), client, createOpts, nil).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -159,7 +162,7 @@ server will use this volume as its root disk.
 		BlockDevice: blockDevices,
 	}
 
-	server, err := servers.Create(context.TODO(), client, createOpts).Extract()
+	server, err := servers.Create(context.TODO(), client, createOpts, nil).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -183,7 +186,7 @@ This example will create a server with an existing volume as its root disk.
 		BlockDevice: blockDevices,
 	}
 
-	server, err := servers.Create(context.TODO(), client, createOpts).Extract()
+	server, err := servers.Create(context.TODO(), client, createOpts, nil).Extract()
 	if err != nil {
 		panic(err)
 	}
@@ -228,7 +231,7 @@ ephemeral disks must have an index of -1.
 		BlockDevice: blockDevices,
 	}
 
-	server, err := servers.Create(context.TODO(), client, createOpts).Extract()
+	server, err := servers.Create(context.TODO(), client, createOpts, nil).Extract()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/compute/v2/servers/testing/fixtures_test.go
+++ b/openstack/compute/v2/servers/testing/fixtures_test.go
@@ -721,8 +721,6 @@ func (opts CreateOptsWithCustomField) ToServerCreateMap() (map[string]interface{
 		return nil, err
 	}
 
-	delete(b, "SchedulerHints")
-
 	return map[string]interface{}{"server": b}, nil
 }
 

--- a/openstack/compute/v2/servers/testing/requests_test.go
+++ b/openstack/compute/v2/servers/testing/requests_test.go
@@ -85,7 +85,7 @@ func TestCreateServer(t *testing.T) {
 		Name:      "derp",
 		ImageRef:  "f90f6034-2570-4974-8351-6b49732ef2eb",
 		FlavorRef: "1",
-	}).Extract()
+	}, nil).Extract()
 	th.AssertNoErr(t, err)
 
 	th.CheckDeepEquals(t, ServerDerp, *actual)
@@ -101,7 +101,7 @@ func TestCreateServerNoNetwork(t *testing.T) {
 		ImageRef:  "f90f6034-2570-4974-8351-6b49732ef2eb",
 		FlavorRef: "1",
 		Networks:  "none",
-	}).Extract()
+	}, nil).Extract()
 	th.AssertNoErr(t, err)
 
 	th.CheckDeepEquals(t, ServerDerp, *actual)
@@ -118,7 +118,7 @@ func TestCreateServers(t *testing.T) {
 		FlavorRef: "1",
 		Min:       3,
 		Max:       3,
-	}).Extract()
+	}, nil).Extract()
 	th.AssertNoErr(t, err)
 
 	th.CheckDeepEquals(t, ServerDerp, *actual)
@@ -136,7 +136,7 @@ func TestCreateServerWithCustomField(t *testing.T) {
 			FlavorRef: "1",
 		},
 		Foo: "bar",
-	}).Extract()
+	}, nil).Extract()
 	th.AssertNoErr(t, err)
 
 	th.CheckDeepEquals(t, ServerDerp, *actual)
@@ -154,7 +154,7 @@ func TestCreateServerWithMetadata(t *testing.T) {
 		Metadata: map[string]string{
 			"abc": "def",
 		},
-	}).Extract()
+	}, nil).Extract()
 	th.AssertNoErr(t, err)
 
 	th.CheckDeepEquals(t, ServerDerp, *actual)
@@ -170,7 +170,7 @@ func TestCreateServerWithUserdataString(t *testing.T) {
 		ImageRef:  "f90f6034-2570-4974-8351-6b49732ef2eb",
 		FlavorRef: "1",
 		UserData:  []byte("userdata string"),
-	}).Extract()
+	}, nil).Extract()
 	th.AssertNoErr(t, err)
 
 	th.CheckDeepEquals(t, ServerDerp, *actual)
@@ -188,7 +188,7 @@ func TestCreateServerWithUserdataEncoded(t *testing.T) {
 		ImageRef:  "f90f6034-2570-4974-8351-6b49732ef2eb",
 		FlavorRef: "1",
 		UserData:  []byte(encoded),
-	}).Extract()
+	}, nil).Extract()
 	th.AssertNoErr(t, err)
 
 	th.CheckDeepEquals(t, ServerDerp, *actual)
@@ -204,7 +204,7 @@ func TestCreateServerWithHostname(t *testing.T) {
 		ImageRef:  "f90f6034-2570-4974-8351-6b49732ef2eb",
 		FlavorRef: "1",
 		Hostname:  "derp.local",
-	}).Extract()
+	}, nil).Extract()
 	th.AssertNoErr(t, err)
 
 	th.CheckDeepEquals(t, ServerDerp, *actual)
@@ -629,8 +629,8 @@ func TestCreateServerWithBFVAttachExistingVolumeWithTag(t *testing.T) {
 	th.CheckJSONEquals(t, ExpectedImageAndExistingVolumeWithTagRequest, actual)
 }
 
-func TestCreateServerWithSchedulerHints(t *testing.T) {
-	schedulerHints := servers.SchedulerHints{
+func TestCreateSchedulerHints(t *testing.T) {
+	opts := servers.SchedulerHintOpts{
 		Group: "101aed42-22d9-4a3e-9ba1-21103b0d1aba",
 		DifferentHost: []string{
 			"a0cf03a5-d921-4877-bb5c-86d26cf818e1",
@@ -650,20 +650,8 @@ func TestCreateServerWithSchedulerHints(t *testing.T) {
 		AdditionalProperties: map[string]interface{}{"reservation": "a0cf03a5-d921-4877-bb5c-86d26cf818e1"},
 	}
 
-	opts := servers.CreateOpts{
-		Name:           "createdserver",
-		ImageRef:       "asdfasdfasdf",
-		FlavorRef:      "performance1-1",
-		SchedulerHints: schedulerHints,
-	}
-
 	expected := `
 		{
-			"server": {
-				"name": "createdserver",
-				"imageRef": "asdfasdfasdf",
-				"flavorRef": "performance1-1"
-			},
 			"os:scheduler_hints": {
 				"group": "101aed42-22d9-4a3e-9ba1-21103b0d1aba",
 				"different_host": [
@@ -686,13 +674,13 @@ func TestCreateServerWithSchedulerHints(t *testing.T) {
 			}
 		}
 	`
-	actual, err := opts.ToServerCreateMap()
+	actual, err := opts.ToSchedulerHintsMap()
 	th.AssertNoErr(t, err)
 	th.CheckJSONEquals(t, expected, actual)
 }
 
-func TestCreateServerWithComplexSchedulerHints(t *testing.T) {
-	schedulerHints := servers.SchedulerHints{
+func TestCreateComplexSchedulerHints(t *testing.T) {
+	opts := servers.SchedulerHintOpts{
 		Group: "101aed42-22d9-4a3e-9ba1-21103b0d1aba",
 		DifferentHost: []string{
 			"a0cf03a5-d921-4877-bb5c-86d26cf818e1",
@@ -712,20 +700,8 @@ func TestCreateServerWithComplexSchedulerHints(t *testing.T) {
 		AdditionalProperties: map[string]interface{}{"reservation": "a0cf03a5-d921-4877-bb5c-86d26cf818e1"},
 	}
 
-	opts := servers.CreateOpts{
-		Name:           "createdserver",
-		ImageRef:       "asdfasdfasdf",
-		FlavorRef:      "performance1-1",
-		SchedulerHints: schedulerHints,
-	}
-
 	expected := `
 		{
-			"server": {
-				"name": "createdserver",
-				"imageRef": "asdfasdfasdf",
-				"flavorRef": "performance1-1"
-			},
 			"os:scheduler_hints": {
 				"group": "101aed42-22d9-4a3e-9ba1-21103b0d1aba",
 				"different_host": [
@@ -748,7 +724,7 @@ func TestCreateServerWithComplexSchedulerHints(t *testing.T) {
 			}
 		}
 	`
-	actual, err := opts.ToServerCreateMap()
+	actual, err := opts.ToSchedulerHintsMap()
 	th.AssertNoErr(t, err)
 	th.CheckJSONEquals(t, expected, actual)
 }
@@ -1176,7 +1152,7 @@ func TestCreateServerWithTags(t *testing.T) {
 		FlavorRef: "1",
 		Tags:      tags,
 	}
-	res := servers.Create(context.TODO(), c, createOpts)
+	res := servers.Create(context.TODO(), c, createOpts, nil)
 	th.AssertNoErr(t, res.Err)
 	actualServer, err := res.Extract()
 	th.AssertNoErr(t, err)


### PR DESCRIPTION
As noted in #2945 and #2938, scheduler hints in the Compute and Block Storage service are slightly weird in that they are passed as separate top-level keys in the request body, rather than nested in the `server` or `volume` bodies, respectively.

Reflect this API nuance in our own API by exposing these hints as a top-level argument to the `Create` functions for servers and volumes. This should ease the path to auto-generation down the line and keeps us a little "truer" to the APIs themselves.
