### PR TITLE
Enable golangci-lint and fix issues

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,4 +1,15 @@
 ---
+linters:
+  disable-all: true
+  enable:
+    - errcheck
+    - gofmt
+    - goimports
+    - govet
+    - staticcheck
+    - unparam
+    - unused
+
 issues:
   exclude:
     - SA1006  # printf-style function with dynamic format string and no further arguments should use print-style function instead (staticcheck)

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,20 @@
+---
+linters:
+  disable:
+    - errcheck  # Error return value is not checked (errcheck)
+    - ineffassign  # ineffectual assignment to tags (ineffassign)
+    - unused
+issues:
+  exclude:
+    - SA1006  # printf-style function with dynamic format string and no further arguments should use print-style function instead (staticcheck)
+    - SA1019  # (deprecated standard library function) (staticcheck)
+    - SA4006  # this value of `***` is never used (staticcheck)
+    - SA5011  # possible nil pointer dereference (staticcheck)
+    - SA6005  # should use strings.EqualFold instead (staticcheck)
+    - S1005  # unnecessary assignment to the blank identifier (gosimple)
+    - S1020  # when ok is true, err can't be nil (gosimple)
+    - S1021  # should merge variable declaration with assignment on next line (gosimple)
+    - S1023  # redundant `return` statement (gosimple)
+    - S1030  # should use buf.String() instead of string(buf.Bytes()) (gosimple)
+    - S1033  # unnecessary guard around call to delete (gosimple)
+    - S1034  # assigning the result of this type assertion to a variable (***) could eliminate type assertions in switch cases (gosimple)

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -3,5 +3,4 @@ issues:
   exclude:
     - SA1006  # printf-style function with dynamic format string and no further arguments should use print-style function instead (staticcheck)
     - SA1019  # (deprecated standard library function) (staticcheck)
-    - SA5011  # possible nil pointer dereference (staticcheck)
     - SA6005  # should use strings.EqualFold instead (staticcheck)

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,7 +1,4 @@
 ---
-linters:
-  disable:
-    - ineffassign  # ineffectual assignment to tags (ineffassign)
 issues:
   exclude:
     - SA1006  # printf-style function with dynamic format string and no further arguments should use print-style function instead (staticcheck)

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -2,4 +2,7 @@
 issues:
   exclude:
     - SA1006  # printf-style function with dynamic format string and no further arguments should use print-style function instead (staticcheck)
-    - SA1019  # (deprecated standard library function) (staticcheck)
+  exclude-rules:
+    - linters:
+        - staticcheck
+      text: 'SA1019: (x509.EncryptPEMBlock|strings.Title)'

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -14,7 +14,6 @@ issues:
     - S1005  # unnecessary assignment to the blank identifier (gosimple)
     - S1020  # when ok is true, err can't be nil (gosimple)
     - S1021  # should merge variable declaration with assignment on next line (gosimple)
-    - S1023  # redundant `return` statement (gosimple)
     - S1030  # should use buf.String() instead of string(buf.Bytes()) (gosimple)
     - S1033  # unnecessary guard around call to delete (gosimple)
     - S1034  # assigning the result of this type assertion to a variable (***) could eliminate type assertions in switch cases (gosimple)

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -6,7 +6,3 @@ issues:
     - SA4006  # this value of `***` is never used (staticcheck)
     - SA5011  # possible nil pointer dereference (staticcheck)
     - SA6005  # should use strings.EqualFold instead (staticcheck)
-    - S1020  # when ok is true, err can't be nil (gosimple)
-    - S1021  # should merge variable declaration with assignment on next line (gosimple)
-    - S1030  # should use buf.String() instead of string(buf.Bytes()) (gosimple)
-    - S1034  # assigning the result of this type assertion to a variable (***) could eliminate type assertions in switch cases (gosimple)

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -3,7 +3,6 @@ linters:
   disable:
     - errcheck  # Error return value is not checked (errcheck)
     - ineffassign  # ineffectual assignment to tags (ineffassign)
-    - unused
 issues:
   exclude:
     - SA1006  # printf-style function with dynamic format string and no further arguments should use print-style function instead (staticcheck)

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -15,5 +15,4 @@ issues:
     - S1020  # when ok is true, err can't be nil (gosimple)
     - S1021  # should merge variable declaration with assignment on next line (gosimple)
     - S1030  # should use buf.String() instead of string(buf.Bytes()) (gosimple)
-    - S1033  # unnecessary guard around call to delete (gosimple)
     - S1034  # assigning the result of this type assertion to a variable (***) could eliminate type assertions in switch cases (gosimple)

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,7 +1,6 @@
 ---
 linters:
   disable:
-    - errcheck  # Error return value is not checked (errcheck)
     - ineffassign  # ineffectual assignment to tags (ineffassign)
 issues:
   exclude:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -11,7 +11,6 @@ issues:
     - SA4006  # this value of `***` is never used (staticcheck)
     - SA5011  # possible nil pointer dereference (staticcheck)
     - SA6005  # should use strings.EqualFold instead (staticcheck)
-    - S1005  # unnecessary assignment to the blank identifier (gosimple)
     - S1020  # when ok is true, err can't be nil (gosimple)
     - S1021  # should merge variable declaration with assignment on next line (gosimple)
     - S1030  # should use buf.String() instead of string(buf.Bytes()) (gosimple)

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -3,6 +3,5 @@ issues:
   exclude:
     - SA1006  # printf-style function with dynamic format string and no further arguments should use print-style function instead (staticcheck)
     - SA1019  # (deprecated standard library function) (staticcheck)
-    - SA4006  # this value of `***` is never used (staticcheck)
     - SA5011  # possible nil pointer dereference (staticcheck)
     - SA6005  # should use strings.EqualFold instead (staticcheck)

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -3,4 +3,3 @@ issues:
   exclude:
     - SA1006  # printf-style function with dynamic format string and no further arguments should use print-style function instead (staticcheck)
     - SA1019  # (deprecated standard library function) (staticcheck)
-    - SA6005  # should use strings.EqualFold instead (staticcheck)

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,6 @@ endif
 #   chcon -Rt svirt_sandbox_file_t .
 #   chcon -Rt svirt_sandbox_file_t ~/.cache/golangci-lint
 lint:
-	go fmt ./...
-	go vet -tags "fixtures acceptance" ./...
 	$(RUNNER) run -t --rm \
 		-v $(shell pwd):/app \
 		-v ~/.cache/golangci-lint/$(GOLANGCI_LINT_VERSION):/root/.cache \

--- a/auth_options.go
+++ b/auth_options.go
@@ -146,12 +146,6 @@ func (opts *AuthOptions) ToTokenV3CreateMap(scope map[string]interface{}) (map[s
 		Name *string `json:"name,omitempty"`
 	}
 
-	type projectReq struct {
-		Domain *domainReq `json:"domain,omitempty"`
-		Name   *string    `json:"name,omitempty"`
-		ID     *string    `json:"id,omitempty"`
-	}
-
 	type userReq struct {
 		ID       *string    `json:"id,omitempty"`
 		Name     *string    `json:"name,omitempty"`

--- a/internal/acceptance/clients/http.go
+++ b/internal/acceptance/clients/http.go
@@ -159,7 +159,7 @@ func redactHeaders(headers http.Header) (processedHeaders []string) {
 		var sensitive bool
 
 		for _, redact_header := range REDACT_HEADERS {
-			if strings.ToLower(name) == strings.ToLower(redact_header) {
+			if strings.EqualFold(name, redact_header) {
 				sensitive = true
 			}
 		}

--- a/internal/acceptance/openstack/baremetal/httpbasic/ports_test.go
+++ b/internal/acceptance/openstack/baremetal/httpbasic/ports_test.go
@@ -23,6 +23,7 @@ func TestPortsCreateDestroy(t *testing.T) {
 	client.Microversion = "1.53"
 
 	node, err := v1.CreateFakeNode(t, client)
+	th.AssertNoErr(t, err)
 	port, err := v1.CreatePort(t, client, node)
 	th.AssertNoErr(t, err)
 	defer v1.DeleteNode(t, client, node)
@@ -58,6 +59,7 @@ func TestPortsUpdate(t *testing.T) {
 	client.Microversion = "1.53"
 
 	node, err := v1.CreateFakeNode(t, client)
+	th.AssertNoErr(t, err)
 	port, err := v1.CreatePort(t, client, node)
 	th.AssertNoErr(t, err)
 	defer v1.DeleteNode(t, client, node)

--- a/internal/acceptance/openstack/baremetal/noauth/ports_test.go
+++ b/internal/acceptance/openstack/baremetal/noauth/ports_test.go
@@ -23,6 +23,7 @@ func TestPortsCreateDestroy(t *testing.T) {
 	client.Microversion = "1.53"
 
 	node, err := v1.CreateFakeNode(t, client)
+	th.AssertNoErr(t, err)
 	port, err := v1.CreatePort(t, client, node)
 	th.AssertNoErr(t, err)
 	defer v1.DeleteNode(t, client, node)
@@ -58,6 +59,7 @@ func TestPortsUpdate(t *testing.T) {
 	client.Microversion = "1.53"
 
 	node, err := v1.CreateFakeNode(t, client)
+	th.AssertNoErr(t, err)
 	port, err := v1.CreatePort(t, client, node)
 	th.AssertNoErr(t, err)
 	defer v1.DeleteNode(t, client, node)

--- a/internal/acceptance/openstack/client_test.go
+++ b/internal/acceptance/openstack/client_test.go
@@ -97,8 +97,7 @@ func TestEC2AuthMethod(t *testing.T) {
 	newClient, err := clients.NewIdentityV3UnauthenticatedClient()
 	th.AssertNoErr(t, err)
 
-	var ec2AuthOptions tokens.AuthOptionsBuilder
-	ec2AuthOptions = &ec2tokens.AuthOptions{
+	ec2AuthOptions := &ec2tokens.AuthOptions{
 		Access: "181920",
 		Secret: "secretKey",
 	}

--- a/internal/acceptance/openstack/compute/v2/instance_actions_test.go
+++ b/internal/acceptance/openstack/compute/v2/instance_actions_test.go
@@ -60,6 +60,7 @@ func TestInstanceActionsMicroversions(t *testing.T) {
 	}
 
 	err = servers.Reboot(context.TODO(), client, server.ID, rebootOpts).ExtractErr()
+	th.AssertNoErr(t, err)
 	if err = WaitForComputeStatus(client, server, "ACTIVE"); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/acceptance/openstack/compute/v2/keypairs_test.go
+++ b/internal/acceptance/openstack/compute/v2/keypairs_test.go
@@ -15,8 +15,6 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
-const keyName = "gophercloud_test_key_pair"
-
 func TestKeyPairsParse(t *testing.T) {
 	client, err := clients.NewComputeV2Client()
 	th.AssertNoErr(t, err)

--- a/internal/acceptance/openstack/compute/v2/servers_test.go
+++ b/internal/acceptance/openstack/compute/v2/servers_test.go
@@ -331,7 +331,8 @@ func TestServersActionResizeConfirm(t *testing.T) {
 	defer DeleteServer(t, client, server)
 
 	t.Logf("Attempting to resize server %s", server.ID)
-	ResizeServer(t, client, server)
+	err = ResizeServer(t, client, server)
+	th.AssertNoErr(t, err)
 
 	t.Logf("Attempting to confirm resize for server %s", server.ID)
 	if res := servers.ConfirmResize(context.TODO(), client, server.ID); res.Err != nil {
@@ -362,7 +363,8 @@ func TestServersActionResizeRevert(t *testing.T) {
 	defer DeleteServer(t, client, server)
 
 	t.Logf("Attempting to resize server %s", server.ID)
-	ResizeServer(t, client, server)
+	err = ResizeServer(t, client, server)
+	th.AssertNoErr(t, err)
 
 	t.Logf("Attempting to revert resize for server %s", server.ID)
 	if res := servers.RevertResize(context.TODO(), client, server.ID); res.Err != nil {

--- a/internal/acceptance/openstack/compute/v2/servers_test.go
+++ b/internal/acceptance/openstack/compute/v2/servers_test.go
@@ -149,6 +149,7 @@ func TestServersUpdate(t *testing.T) {
 
 		return latest.Name == alternateName, nil
 	})
+	th.AssertNoErr(t, err)
 }
 
 func TestServersMetadata(t *testing.T) {

--- a/internal/acceptance/openstack/containerinfra/v1/containerinfra.go
+++ b/internal/acceptance/openstack/containerinfra/v1/containerinfra.go
@@ -97,8 +97,6 @@ func DeleteClusterTemplate(t *testing.T, client *gophercloud.ServiceClient, id s
 	}
 
 	t.Logf("Successfully deleted cluster-template: %s", id)
-
-	return
 }
 
 // CreateClusterTimeout will create a random cluster and wait for it to reach CREATE_COMPLETE status
@@ -181,8 +179,6 @@ func DeleteCluster(t *testing.T, client *gophercloud.ServiceClient, id string) {
 	}
 
 	t.Logf("Successfully deleted cluster: %s", id)
-
-	return
 }
 
 func WaitForCluster(client *gophercloud.ServiceClient, clusterID string, status string, timeout time.Duration) error {

--- a/internal/acceptance/openstack/dns/v2/transfers_test.go
+++ b/internal/acceptance/openstack/dns/v2/transfers_test.go
@@ -74,9 +74,11 @@ func TestTransferRequestAccept(t *testing.T) {
 
 	// Create transfers request to new tenant
 	transferRequest, err := CreateTransferRequest(t, client, zone, project.ID)
+	th.AssertNoErr(t, err)
 
 	// Accept Zone Transfer Request
 	transferAccept, err := CreateTransferAccept(t, client, transferRequest.ID, transferRequest.Key)
+	th.AssertNoErr(t, err)
 
 	allTransferAcceptsPages, err := transferAccepts.List(client, nil).AllPages(context.TODO())
 	th.AssertNoErr(t, err)

--- a/internal/acceptance/openstack/identity/v3/limits_test.go
+++ b/internal/acceptance/openstack/identity/v3/limits_test.go
@@ -60,6 +60,7 @@ func TestLimitsCRUD(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	svList, err := services.ExtractServices(allPages)
+	th.AssertNoErr(t, err)
 	serviceID := ""
 	for _, service := range svList {
 		serviceID = service.ID

--- a/internal/acceptance/openstack/identity/v3/oauth1_test.go
+++ b/internal/acceptance/openstack/identity/v3/oauth1_test.go
@@ -93,11 +93,11 @@ func TestOAuth1CRUD(t *testing.T) {
 
 	// test HMACSHA1 and PLAINTEXT signature methods
 	for _, method := range []oauth1.SignatureMethod{oauth1.HMACSHA1, oauth1.PLAINTEXT} {
-		oauth1MethodTest(t, client, consumer, method, user, project, roles, ao.IdentityEndpoint)
+		oauth1MethodTest(t, client, consumer, method, user, project, roles)
 	}
 }
 
-func oauth1MethodTest(t *testing.T, client *gophercloud.ServiceClient, consumer *oauth1.Consumer, method oauth1.SignatureMethod, user *tokens.User, project *tokens.Project, roles []tokens.Role, identityEndpoint string) {
+func oauth1MethodTest(t *testing.T, client *gophercloud.ServiceClient, consumer *oauth1.Consumer, method oauth1.SignatureMethod, user *tokens.User, project *tokens.Project, roles []tokens.Role) {
 	// Request a token
 	requestTokenOpts := oauth1.RequestTokenOpts{
 		OAuthConsumerKey:     consumer.ID,

--- a/internal/acceptance/openstack/identity/v3/reauth_test.go
+++ b/internal/acceptance/openstack/identity/v3/reauth_test.go
@@ -28,6 +28,7 @@ func TestReauthAuthResultDeadlock(t *testing.T) {
 	provider.SetToken("this is not a valid token")
 
 	client, err := openstack.NewIdentityV3(provider, gophercloud.EndpointOpts{})
+	th.AssertNoErr(t, err)
 	pages, err := projects.List(client, nil).AllPages(context.TODO())
 	th.AssertNoErr(t, err)
 	_, err = projects.ExtractProjects(pages)

--- a/internal/acceptance/openstack/identity/v3/registeredlimits_test.go
+++ b/internal/acceptance/openstack/identity/v3/registeredlimits_test.go
@@ -29,6 +29,7 @@ func TestRegisteredLimitsCRUD(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	svList, err := services.ExtractServices(allServicePages)
+	th.AssertNoErr(t, err)
 	serviceID := ""
 	for _, service := range svList {
 		serviceID = service.ID

--- a/internal/acceptance/openstack/image/v2/images_test.go
+++ b/internal/acceptance/openstack/image/v2/images_test.go
@@ -37,6 +37,7 @@ func TestImagesListEachPage(t *testing.T) {
 
 		return true, nil
 	})
+	th.AssertNoErr(t, err)
 }
 
 func TestImagesListAllPages(t *testing.T) {

--- a/internal/acceptance/openstack/image/v2/tasks_test.go
+++ b/internal/acceptance/openstack/image/v2/tasks_test.go
@@ -32,6 +32,7 @@ func TestTasksListEachPage(t *testing.T) {
 
 		return true, nil
 	})
+	th.AssertNoErr(t, err)
 }
 
 func TestTasksListAllPages(t *testing.T) {

--- a/internal/acceptance/openstack/keymanager/v1/containers_test.go
+++ b/internal/acceptance/openstack/keymanager/v1/containers_test.go
@@ -97,6 +97,7 @@ func TestCertificateContainer(t *testing.T) {
 	container, err := CreateCertificateContainer(t, client, passphrase, private, certificate)
 	th.AssertNoErr(t, err)
 	containerID, err := ParseID(container.ContainerRef)
+	th.AssertNoErr(t, err)
 	defer DeleteContainer(t, client, containerID)
 }
 
@@ -141,6 +142,7 @@ func TestRSAContainer(t *testing.T) {
 	container, err := CreateRSAContainer(t, client, passphrase, private, public)
 	th.AssertNoErr(t, err)
 	containerID, err := ParseID(container.ContainerRef)
+	th.AssertNoErr(t, err)
 	defer DeleteContainer(t, client, containerID)
 }
 

--- a/internal/acceptance/openstack/messaging/v2/claims_test.go
+++ b/internal/acceptance/openstack/messaging/v2/claims_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gophercloud/gophercloud/v2/internal/acceptance/clients"
 	"github.com/gophercloud/gophercloud/v2/internal/acceptance/tools"
 	"github.com/gophercloud/gophercloud/v2/openstack/messaging/v2/claims"
+	th "github.com/gophercloud/gophercloud/v2/testhelper"
 )
 
 func TestCRUDClaim(t *testing.T) {
@@ -29,7 +30,8 @@ func TestCRUDClaim(t *testing.T) {
 		t.Fatalf("Unable to create a messaging service client: %v", err)
 	}
 	for i := 0; i < 3; i++ {
-		CreateMessage(t, client, createdQueueName)
+		_, err := CreateMessage(t, client, createdQueueName)
+		th.AssertNoErr(t, err)
 	}
 
 	clientID = "3381af92-2b9e-11e3-b191-7186130073dd"
@@ -59,6 +61,7 @@ func TestCRUDClaim(t *testing.T) {
 		}
 
 		tools.PrintResource(t, updatedClaim)
-		DeleteClaim(t, client, createdQueueName, claimID)
+		err := DeleteClaim(t, client, createdQueueName, claimID)
+		th.AssertNoErr(t, err)
 	}
 }

--- a/internal/acceptance/openstack/messaging/v2/claims_test.go
+++ b/internal/acceptance/openstack/messaging/v2/claims_test.go
@@ -21,6 +21,7 @@ func TestCRUDClaim(t *testing.T) {
 	}
 
 	createdQueueName, err := CreateQueue(t, client)
+	th.AssertNoErr(t, err)
 	defer DeleteQueue(t, client, createdQueueName)
 
 	clientID = "3381af92-2b9e-11e3-b191-71861300734d"
@@ -34,8 +35,8 @@ func TestCRUDClaim(t *testing.T) {
 		th.AssertNoErr(t, err)
 	}
 
-	clientID = "3381af92-2b9e-11e3-b191-7186130073dd"
 	claimedMessages, err := CreateClaim(t, client, createdQueueName)
+	th.AssertNoErr(t, err)
 	claimIDs, _ := ExtractIDs(claimedMessages)
 
 	tools.PrintResource(t, claimedMessages)
@@ -47,21 +48,20 @@ func TestCRUDClaim(t *testing.T) {
 
 	for _, claimID := range claimIDs {
 		t.Logf("Attempting to update claim: %s", claimID)
-		updateErr := claims.Update(context.TODO(), client, createdQueueName, claimID, updateOpts).ExtractErr()
-
-		if updateErr != nil {
+		err := claims.Update(context.TODO(), client, createdQueueName, claimID, updateOpts).ExtractErr()
+		if err != nil {
 			t.Fatalf("Unable to update claim %s: %v", claimID, err)
 		} else {
 			t.Logf("Successfully updated claim: %s", claimID)
 		}
 
-		updatedClaim, getErr := GetClaim(t, client, createdQueueName, claimID)
-		if getErr != nil {
-			t.Fatalf("Unable to retrieve claim %s: %v", claimID, getErr)
+		updatedClaim, err := GetClaim(t, client, createdQueueName, claimID)
+		if err != nil {
+			t.Fatalf("Unable to retrieve claim %s: %v", claimID, err)
 		}
 
 		tools.PrintResource(t, updatedClaim)
-		err := DeleteClaim(t, client, createdQueueName, claimID)
+		err = DeleteClaim(t, client, createdQueueName, claimID)
 		th.AssertNoErr(t, err)
 	}
 }

--- a/internal/acceptance/openstack/messaging/v2/message_test.go
+++ b/internal/acceptance/openstack/messaging/v2/message_test.go
@@ -22,6 +22,7 @@ func TestListMessages(t *testing.T) {
 	}
 
 	createdQueueName, err := CreateQueue(t, client)
+	th.AssertNoErr(t, err)
 	defer DeleteQueue(t, client, createdQueueName)
 
 	totalNumberOfMessages := 3
@@ -35,6 +36,7 @@ func TestListMessages(t *testing.T) {
 	// Use a different client/clientID in order to see messages on the Queue
 	clientID = "3381af92-2b9e-11e3-b191-71861300734d"
 	client, err = clients.NewMessagingV2Client(clientID)
+	th.AssertNoErr(t, err)
 
 	listOpts := messages.ListOpts{}
 
@@ -52,6 +54,7 @@ func TestListMessages(t *testing.T) {
 
 		return true, nil
 	})
+	th.AssertNoErr(t, err)
 	th.AssertEquals(t, totalNumberOfMessages, currentNumberOfMessages)
 }
 
@@ -64,6 +67,7 @@ func TestCreateMessages(t *testing.T) {
 	}
 
 	createdQueueName, err := CreateQueue(t, client)
+	th.AssertNoErr(t, err)
 	defer DeleteQueue(t, client, createdQueueName)
 
 	_, err = CreateMessage(t, client, createdQueueName)
@@ -79,6 +83,7 @@ func TestGetMessages(t *testing.T) {
 	}
 
 	createdQueueName, err := CreateQueue(t, client)
+	th.AssertNoErr(t, err)
 	defer DeleteQueue(t, client, createdQueueName)
 
 	_, err = CreateMessage(t, client, createdQueueName)
@@ -89,6 +94,7 @@ func TestGetMessages(t *testing.T) {
 	// Use a different client/clientID in order to see messages on the Queue
 	clientID = "3381af92-2b9e-11e3-b191-71861300734d"
 	client, err = clients.NewMessagingV2Client(clientID)
+	th.AssertNoErr(t, err)
 
 	listOpts := messages.ListOpts{}
 
@@ -107,6 +113,7 @@ func TestGetMessages(t *testing.T) {
 
 		return true, nil
 	})
+	th.AssertNoErr(t, err)
 
 	getMessageOpts := messages.GetMessagesOpts{
 		IDs: messageIDs,
@@ -129,6 +136,7 @@ func TestGetMessage(t *testing.T) {
 	}
 
 	createdQueueName, err := CreateQueue(t, client)
+	th.AssertNoErr(t, err)
 	defer DeleteQueue(t, client, createdQueueName)
 
 	_, err = CreateMessage(t, client, createdQueueName)
@@ -137,6 +145,7 @@ func TestGetMessage(t *testing.T) {
 	// Use a different client/clientID in order to see messages on the Queue
 	clientID = "3381af92-2b9e-11e3-b191-71861300734d"
 	client, err = clients.NewMessagingV2Client(clientID)
+	th.AssertNoErr(t, err)
 
 	listOpts := messages.ListOpts{}
 
@@ -155,6 +164,7 @@ func TestGetMessage(t *testing.T) {
 
 		return true, nil
 	})
+	th.AssertNoErr(t, err)
 
 	for _, messageID := range messageIDs {
 		t.Logf("Attempting to get message from queue %s: %s", createdQueueName, messageID)
@@ -175,6 +185,7 @@ func TestDeleteMessagesIDs(t *testing.T) {
 	}
 
 	createdQueueName, err := CreateQueue(t, client)
+	th.AssertNoErr(t, err)
 	defer DeleteQueue(t, client, createdQueueName)
 
 	_, err = CreateMessage(t, client, createdQueueName)
@@ -186,6 +197,7 @@ func TestDeleteMessagesIDs(t *testing.T) {
 	clientID = "3381af92-2b9e-11e3-b191-71861300734d"
 
 	client, err = clients.NewMessagingV2Client(clientID)
+	th.AssertNoErr(t, err)
 
 	listOpts := messages.ListOpts{}
 
@@ -205,6 +217,7 @@ func TestDeleteMessagesIDs(t *testing.T) {
 
 		return true, nil
 	})
+	th.AssertNoErr(t, err)
 
 	deleteOpts := messages.DeleteMessagesOpts{
 		IDs: messageIDs,
@@ -218,6 +231,7 @@ func TestDeleteMessagesIDs(t *testing.T) {
 
 	t.Logf("Attempting to list messages.")
 	messageList, err := ListMessages(t, client, createdQueueName)
+	th.AssertNoErr(t, err)
 
 	if len(messageList) > 0 {
 		t.Fatalf("Did not delete all specified messages in the queue.")
@@ -233,6 +247,7 @@ func TestDeleteMessagesPop(t *testing.T) {
 	}
 
 	createdQueueName, err := CreateQueue(t, client)
+	th.AssertNoErr(t, err)
 	defer DeleteQueue(t, client, createdQueueName)
 
 	for i := 0; i < 5; i++ {
@@ -244,8 +259,10 @@ func TestDeleteMessagesPop(t *testing.T) {
 	clientID = "3381af92-2b9e-11e3-b191-71861300734d"
 
 	client, err = clients.NewMessagingV2Client(clientID)
+	th.AssertNoErr(t, err)
 
 	messageList, err := ListMessages(t, client, createdQueueName)
+	th.AssertNoErr(t, err)
 
 	messagesNumber := len(messageList)
 	popNumber := 3
@@ -263,6 +280,7 @@ func TestDeleteMessagesPop(t *testing.T) {
 	tools.PrintResource(t, popMessages)
 
 	messageList, err = ListMessages(t, client, createdQueueName)
+	th.AssertNoErr(t, err)
 	if len(messageList) != messagesNumber-popNumber {
 		t.Fatalf("Unable to Pop specified number of messages.")
 	}
@@ -277,6 +295,7 @@ func TestDeleteMessage(t *testing.T) {
 	}
 
 	createdQueueName, err := CreateQueue(t, client)
+	th.AssertNoErr(t, err)
 	defer DeleteQueue(t, client, createdQueueName)
 
 	_, err = CreateMessage(t, client, createdQueueName)
@@ -285,6 +304,7 @@ func TestDeleteMessage(t *testing.T) {
 	// Use a different client/clientID in order to see messages on the Queue
 	clientID = "3381af92-2b9e-11e3-b191-71861300734d"
 	client, err = clients.NewMessagingV2Client(clientID)
+	th.AssertNoErr(t, err)
 
 	listOpts := messages.ListOpts{}
 
@@ -303,6 +323,7 @@ func TestDeleteMessage(t *testing.T) {
 
 		return true, nil
 	})
+	th.AssertNoErr(t, err)
 
 	for _, messageID := range messageIDs {
 		t.Logf("Attempting to delete message from queue %s: %s", createdQueueName, messageID)

--- a/internal/acceptance/openstack/messaging/v2/message_test.go
+++ b/internal/acceptance/openstack/messaging/v2/message_test.go
@@ -28,7 +28,8 @@ func TestListMessages(t *testing.T) {
 	currentNumberOfMessages := 0
 
 	for i := 0; i < totalNumberOfMessages; i++ {
-		CreateMessage(t, client, createdQueueName)
+		_, err = CreateMessage(t, client, createdQueueName)
+		th.AssertNoErr(t, err)
 	}
 
 	// Use a different client/clientID in order to see messages on the Queue
@@ -65,7 +66,8 @@ func TestCreateMessages(t *testing.T) {
 	createdQueueName, err := CreateQueue(t, client)
 	defer DeleteQueue(t, client, createdQueueName)
 
-	CreateMessage(t, client, createdQueueName)
+	_, err = CreateMessage(t, client, createdQueueName)
+	th.AssertNoErr(t, err)
 }
 
 func TestGetMessages(t *testing.T) {
@@ -79,8 +81,10 @@ func TestGetMessages(t *testing.T) {
 	createdQueueName, err := CreateQueue(t, client)
 	defer DeleteQueue(t, client, createdQueueName)
 
-	CreateMessage(t, client, createdQueueName)
-	CreateMessage(t, client, createdQueueName)
+	_, err = CreateMessage(t, client, createdQueueName)
+	th.AssertNoErr(t, err)
+	_, err = CreateMessage(t, client, createdQueueName)
+	th.AssertNoErr(t, err)
 
 	// Use a different client/clientID in order to see messages on the Queue
 	clientID = "3381af92-2b9e-11e3-b191-71861300734d"
@@ -127,7 +131,8 @@ func TestGetMessage(t *testing.T) {
 	createdQueueName, err := CreateQueue(t, client)
 	defer DeleteQueue(t, client, createdQueueName)
 
-	CreateMessage(t, client, createdQueueName)
+	_, err = CreateMessage(t, client, createdQueueName)
+	th.AssertNoErr(t, err)
 
 	// Use a different client/clientID in order to see messages on the Queue
 	clientID = "3381af92-2b9e-11e3-b191-71861300734d"
@@ -172,8 +177,10 @@ func TestDeleteMessagesIDs(t *testing.T) {
 	createdQueueName, err := CreateQueue(t, client)
 	defer DeleteQueue(t, client, createdQueueName)
 
-	CreateMessage(t, client, createdQueueName)
-	CreateMessage(t, client, createdQueueName)
+	_, err = CreateMessage(t, client, createdQueueName)
+	th.AssertNoErr(t, err)
+	_, err = CreateMessage(t, client, createdQueueName)
+	th.AssertNoErr(t, err)
 
 	// Use a different client/clientID in order to see messages on the Queue
 	clientID = "3381af92-2b9e-11e3-b191-71861300734d"
@@ -229,7 +236,8 @@ func TestDeleteMessagesPop(t *testing.T) {
 	defer DeleteQueue(t, client, createdQueueName)
 
 	for i := 0; i < 5; i++ {
-		CreateMessage(t, client, createdQueueName)
+		_, err = CreateMessage(t, client, createdQueueName)
+		th.AssertNoErr(t, err)
 	}
 
 	// Use a different client/clientID in order to see messages on the Queue
@@ -271,7 +279,8 @@ func TestDeleteMessage(t *testing.T) {
 	createdQueueName, err := CreateQueue(t, client)
 	defer DeleteQueue(t, client, createdQueueName)
 
-	CreateMessage(t, client, createdQueueName)
+	_, err = CreateMessage(t, client, createdQueueName)
+	th.AssertNoErr(t, err)
 
 	// Use a different client/clientID in order to see messages on the Queue
 	clientID = "3381af92-2b9e-11e3-b191-71861300734d"

--- a/internal/acceptance/openstack/messaging/v2/messaging.go
+++ b/internal/acceptance/openstack/messaging/v2/messaging.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gophercloud/gophercloud/v2/openstack/messaging/v2/messages"
 	"github.com/gophercloud/gophercloud/v2/openstack/messaging/v2/queues"
 	"github.com/gophercloud/gophercloud/v2/pagination"
+	th "github.com/gophercloud/gophercloud/v2/testhelper"
 )
 
 func CreateQueue(t *testing.T, client *gophercloud.ServiceClient) (string, error) {
@@ -32,7 +33,8 @@ func CreateQueue(t *testing.T, client *gophercloud.ServiceClient) (string, error
 		t.Fatalf("Unable to create Queue: %v", createErr)
 	}
 
-	GetQueue(t, client, queueName)
+	_, err := GetQueue(t, client, queueName)
+	th.AssertNoErr(t, err)
 
 	t.Logf("Created Queue: %s", queueName)
 	return queueName, nil

--- a/internal/acceptance/openstack/messaging/v2/queue_test.go
+++ b/internal/acceptance/openstack/messaging/v2/queue_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gophercloud/gophercloud/v2/internal/acceptance/tools"
 	"github.com/gophercloud/gophercloud/v2/openstack/messaging/v2/queues"
 	"github.com/gophercloud/gophercloud/v2/pagination"
+	th "github.com/gophercloud/gophercloud/v2/testhelper"
 )
 
 func TestCRUDQueues(t *testing.T) {
@@ -21,9 +22,11 @@ func TestCRUDQueues(t *testing.T) {
 	}
 
 	createdQueueName, err := CreateQueue(t, client)
+	th.AssertNoErr(t, err)
 	defer DeleteQueue(t, client, createdQueueName)
 
 	createdQueue, err := queues.Get(context.TODO(), client, createdQueueName).Extract()
+	th.AssertNoErr(t, err)
 
 	tools.PrintResource(t, createdQueue)
 	tools.PrintResource(t, createdQueue.Extra)
@@ -48,6 +51,7 @@ func TestCRUDQueues(t *testing.T) {
 	}
 
 	updatedQueue, err := GetQueue(t, client, createdQueueName)
+	th.AssertNoErr(t, err)
 
 	tools.PrintResource(t, updateResult)
 	tools.PrintResource(t, updatedQueue)
@@ -63,9 +67,11 @@ func TestListQueues(t *testing.T) {
 	}
 
 	firstQueueName, err := CreateQueue(t, client)
+	th.AssertNoErr(t, err)
 	defer DeleteQueue(t, client, firstQueueName)
 
 	secondQueueName, err := CreateQueue(t, client)
+	th.AssertNoErr(t, err)
 	defer DeleteQueue(t, client, secondQueueName)
 
 	listOpts := queues.ListOpts{
@@ -86,6 +92,7 @@ func TestListQueues(t *testing.T) {
 
 		return true, nil
 	})
+	th.AssertNoErr(t, err)
 }
 
 func TestStatQueue(t *testing.T) {
@@ -97,6 +104,7 @@ func TestStatQueue(t *testing.T) {
 	}
 
 	createdQueueName, err := CreateQueue(t, client)
+	th.AssertNoErr(t, err)
 	defer DeleteQueue(t, client, createdQueueName)
 
 	queueStats, err := queues.GetStats(context.TODO(), client, createdQueueName).Extract()
@@ -139,6 +147,7 @@ func TestPurge(t *testing.T) {
 	}
 
 	queueName, err := CreateQueue(t, client)
+	th.AssertNoErr(t, err)
 	defer DeleteQueue(t, client, queueName)
 
 	purgeOpts := queues.PurgeOpts{

--- a/internal/acceptance/openstack/networking/v2/extensions/agents/agents_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/agents/agents_test.go
@@ -184,7 +184,7 @@ func TestBGPAgentRUD(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	// Delete the BGP Speaker
-	speakers.Delete(context.TODO(), client, bgpSpeaker.ID).ExtractErr()
+	err = speakers.Delete(context.TODO(), client, bgpSpeaker.ID).ExtractErr()
 	th.AssertNoErr(t, err)
 	t.Logf("Successfully deleted the BGP Speaker, %s", bgpSpeaker.ID)
 	err = tools.WaitForTimeout(

--- a/internal/acceptance/openstack/networking/v2/extensions/attributestags_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/attributestags_test.go
@@ -67,6 +67,7 @@ func TestTags(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, true, exists)
 	noexists, err := attributestags.Confirm(context.TODO(), client, "networks", network.ID, "a").Extract()
+	th.AssertNoErr(t, err)
 	th.AssertEquals(t, false, noexists)
 
 	// Delete all tags

--- a/internal/acceptance/openstack/networking/v2/extensions/bgp/peers/bgppeers_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/bgp/peers/bgppeers_test.go
@@ -54,7 +54,7 @@ func TestBGPPeerCRUD(t *testing.T) {
 	err = peers.Delete(context.TODO(), client, bgpPeerGot.ID).ExtractErr()
 	th.AssertNoErr(t, err)
 
-	bgpPeerGot, err = peers.Get(context.TODO(), client, bgpPeerGot.ID).Extract()
+	_, err = peers.Get(context.TODO(), client, bgpPeerGot.ID).Extract()
 	th.AssertErr(t, err)
 	t.Logf("BGP Peer %s deleted", bgpPeerUpdated.Name)
 }

--- a/internal/acceptance/openstack/networking/v2/extensions/dns/dns_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/dns/dns_test.go
@@ -115,8 +115,7 @@ func TestDNSPortCRUDL(t *testing.T) {
 		Name:        &newPortName,
 		Description: &newPortDescription,
 	}
-	var updateOpts ports.UpdateOptsBuilder
-	updateOpts = dns.PortUpdateOptsExt{
+	updateOpts := dns.PortUpdateOptsExt{
 		UpdateOptsBuilder: portUpdateOpts,
 		DNSName:           &newDNSName,
 	}
@@ -233,8 +232,7 @@ func TestDNSNetwork(t *testing.T) {
 		Name:        &newNetworkName,
 		Description: &newNetworkDescription,
 	}
-	var updateOpts networks.UpdateOptsBuilder
-	updateOpts = dns.NetworkUpdateOptsExt{
+	updateOpts := dns.NetworkUpdateOptsExt{
 		UpdateOptsBuilder: networkUpdateOpts,
 		DNSDomain:         &newNetworkDNSDomain,
 	}

--- a/internal/acceptance/openstack/networking/v2/extensions/layer3/l3_scheduling_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/layer3/l3_scheduling_test.go
@@ -54,7 +54,7 @@ func TestLayer3RouterScheduling(t *testing.T) {
 
 	containsRouterFunc := func(rs []routers.Router, routerID string) bool {
 		for _, r := range rs {
-			if r.ID == router.ID {
+			if r.ID == routerID {
 				return true
 			}
 		}

--- a/internal/acceptance/openstack/networking/v2/extensions/mtu/mtu_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/mtu/mtu_test.go
@@ -106,8 +106,7 @@ func TestMTUNetworkCRUDL(t *testing.T) {
 		networkUpdateOpts := networks.UpdateOpts{
 			Description: &newNetworkDescription,
 		}
-		var updateOpts networks.UpdateOptsBuilder
-		updateOpts = mtu.UpdateOptsExt{
+		updateOpts := mtu.UpdateOptsExt{
 			UpdateOptsBuilder: networkUpdateOpts,
 			MTU:               newNetworkMTU,
 		}

--- a/internal/acceptance/openstack/networking/v2/extensions/portsbinding/portsbinding_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/portsbinding/portsbinding_test.go
@@ -54,9 +54,7 @@ func TestPortsbindingCRUD(t *testing.T) {
 		Description: &newPortDescription,
 	}
 
-	var finalUpdateOpts ports.UpdateOptsBuilder
-
-	finalUpdateOpts = portsbinding.UpdateOptsExt{
+	finalUpdateOpts := portsbinding.UpdateOptsExt{
 		UpdateOptsBuilder: updateOpts,
 		HostID:            &newHostID,
 		Profile:           newProfile,

--- a/internal/acceptance/openstack/networking/v2/extensions/trunk_details/trunks_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/trunk_details/trunks_test.go
@@ -101,6 +101,7 @@ func TestListPortWithSubports(t *testing.T) {
 
 	// Test GET port with trunk details
 	err = ports.Get(context.TODO(), client, parentPort.ID).ExtractInto(&port)
+	th.AssertNoErr(t, err)
 	th.AssertEquals(t, trunk.ID, port.TrunkDetails.TrunkID)
 	th.AssertEquals(t, 2, len(port.TrunkDetails.SubPorts))
 	th.AssertDeepEquals(t, trunk_details.Subport{

--- a/internal/acceptance/openstack/networking/v2/extensions/trunks/trunks_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/trunks/trunks_test.go
@@ -263,7 +263,7 @@ func TestTrunkTags(t *testing.T) {
 		// docs say list of tags, but it's a set e.g no duplicates
 		Tags: []string{"a", "b", "c"},
 	}
-	tags, err := attributestags.ReplaceAll(context.TODO(), client, "trunks", trunk.ID, tagReplaceAllOpts).Extract()
+	_, err = attributestags.ReplaceAll(context.TODO(), client, "trunks", trunk.ID, tagReplaceAllOpts).Extract()
 	if err != nil {
 		t.Fatalf("Unable to set trunk tags: %v", err)
 	}
@@ -272,7 +272,7 @@ func TestTrunkTags(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to get trunk: %v", err)
 	}
-	tags = gtrunk.Tags
+	tags := gtrunk.Tags
 	sort.Strings(tags) // Ensure ordering, older OpenStack versions aren't sorted...
 	th.AssertDeepEquals(t, []string{"a", "b", "c"}, tags)
 

--- a/internal/acceptance/openstack/networking/v2/networks_test.go
+++ b/internal/acceptance/openstack/networking/v2/networks_test.go
@@ -66,6 +66,7 @@ func TestNetworksExternalList(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	v, err := networks.ExtractNetworks(allPages)
+	th.AssertNoErr(t, err)
 	th.AssertEquals(t, len(v), 0)
 }
 

--- a/internal/acceptance/openstack/networking/v2/ports_test.go
+++ b/internal/acceptance/openstack/networking/v2/ports_test.go
@@ -189,14 +189,14 @@ func TestPortsRemoveSecurityGroups(t *testing.T) {
 	updateOpts := ports.UpdateOpts{
 		SecurityGroups: &[]string{group.ID},
 	}
-	newPort, err := ports.Update(context.TODO(), client, port.ID, updateOpts).Extract()
+	_, err = ports.Update(context.TODO(), client, port.ID, updateOpts).Extract()
 	th.AssertNoErr(t, err)
 
 	// Remove the group
 	updateOpts = ports.UpdateOpts{
 		SecurityGroups: &[]string{},
 	}
-	newPort, err = ports.Update(context.TODO(), client, port.ID, updateOpts).Extract()
+	newPort, err := ports.Update(context.TODO(), client, port.ID, updateOpts).Extract()
 	th.AssertNoErr(t, err)
 
 	tools.PrintResource(t, newPort)
@@ -236,7 +236,7 @@ func TestPortsDontAlterSecurityGroups(t *testing.T) {
 	updateOpts := ports.UpdateOpts{
 		SecurityGroups: &[]string{group.ID},
 	}
-	newPort, err := ports.Update(context.TODO(), client, port.ID, updateOpts).Extract()
+	_, err = ports.Update(context.TODO(), client, port.ID, updateOpts).Extract()
 	th.AssertNoErr(t, err)
 
 	// Update the port again
@@ -244,7 +244,7 @@ func TestPortsDontAlterSecurityGroups(t *testing.T) {
 	updateOpts = ports.UpdateOpts{
 		Name: &name,
 	}
-	newPort, err = ports.Update(context.TODO(), client, port.ID, updateOpts).Extract()
+	newPort, err := ports.Update(context.TODO(), client, port.ID, updateOpts).Extract()
 	th.AssertNoErr(t, err)
 
 	tools.PrintResource(t, newPort)
@@ -307,14 +307,14 @@ func TestPortsRemoveAddressPair(t *testing.T) {
 			{IPAddress: "192.168.255.10", MACAddress: "aa:bb:cc:dd:ee:ff"},
 		},
 	}
-	newPort, err := ports.Update(context.TODO(), client, port.ID, updateOpts).Extract()
+	_, err = ports.Update(context.TODO(), client, port.ID, updateOpts).Extract()
 	th.AssertNoErr(t, err)
 
 	// Remove the address pair
 	updateOpts = ports.UpdateOpts{
 		AllowedAddressPairs: &[]ports.AddressPair{},
 	}
-	newPort, err = ports.Update(context.TODO(), client, port.ID, updateOpts).Extract()
+	newPort, err := ports.Update(context.TODO(), client, port.ID, updateOpts).Extract()
 	th.AssertNoErr(t, err)
 
 	tools.PrintResource(t, newPort)

--- a/internal/acceptance/openstack/networking/v2/ports_test.go
+++ b/internal/acceptance/openstack/networking/v2/ports_test.go
@@ -503,7 +503,7 @@ func TestPortsRevision(t *testing.T) {
 		AllowedAddressPairs: &[]ports.AddressPair{},
 		RevisionNumber:      &port.RevisionNumber,
 	}
-	newPort, err = ports.Update(context.TODO(), client, port.ID, updateOpts).Extract()
+	_, err = ports.Update(context.TODO(), client, port.ID, updateOpts).Extract()
 	th.AssertErr(t, err)
 	if !strings.Contains(err.Error(), "RevisionNumberConstraintFailed") {
 		t.Fatalf("expected to see an error of type RevisionNumberConstraintFailed, but got the following error instead: %v", err)

--- a/internal/acceptance/openstack/sharedfilesystems/v2/replicas.go
+++ b/internal/acceptance/openstack/sharedfilesystems/v2/replicas.go
@@ -28,7 +28,7 @@ func CreateReplica(t *testing.T, client *gophercloud.ServiceClient, share *share
 		return nil, err
 	}
 
-	_, err = waitForReplicaStatus(t, client, replica.ID, "available")
+	err = waitForReplicaStatus(t, client, replica.ID, "available")
 	if err != nil {
 		t.Logf("Failed to get %s replica status", replica.ID)
 		DeleteReplica(t, client, replica)
@@ -49,7 +49,7 @@ func DeleteReplica(t *testing.T, client *gophercloud.ServiceClient, replica *rep
 		t.Errorf("Unable to delete replica %s: %v", replica.ID, err)
 	}
 
-	_, err = waitForReplicaStatus(t, client, replica.ID, "deleted")
+	err = waitForReplicaStatus(t, client, replica.ID, "deleted")
 	if err != nil {
 		t.Errorf("Failed to wait for 'deleted' status for %s replica: %v", replica.ID, err)
 	} else {
@@ -71,7 +71,7 @@ func ListShareReplicas(t *testing.T, client *gophercloud.ServiceClient, shareID 
 	return replicas.ExtractReplicas(pages)
 }
 
-func waitForReplicaStatus(t *testing.T, c *gophercloud.ServiceClient, id, status string) (*replicas.Replica, error) {
+func waitForReplicaStatus(t *testing.T, c *gophercloud.ServiceClient, id, status string) error {
 	var current *replicas.Replica
 
 	err := tools.WaitFor(func(ctx context.Context) (bool, error) {
@@ -104,14 +104,14 @@ func waitForReplicaStatus(t *testing.T, c *gophercloud.ServiceClient, id, status
 	if err != nil {
 		mErr := PrintMessages(t, c, id)
 		if mErr != nil {
-			return current, fmt.Errorf("Replica status is '%s' and unable to get manila messages: %s", err, mErr)
+			return fmt.Errorf("Replica status is '%s' and unable to get manila messages: %s", err, mErr)
 		}
 	}
 
-	return current, err
+	return err
 }
 
-func waitForReplicaState(t *testing.T, c *gophercloud.ServiceClient, id, state string) (*replicas.Replica, error) {
+func waitForReplicaState(t *testing.T, c *gophercloud.ServiceClient, id, state string) error {
 	var current *replicas.Replica
 
 	err := tools.WaitFor(func(ctx context.Context) (bool, error) {
@@ -136,9 +136,9 @@ func waitForReplicaState(t *testing.T, c *gophercloud.ServiceClient, id, state s
 	if err != nil {
 		mErr := PrintMessages(t, c, id)
 		if mErr != nil {
-			return current, fmt.Errorf("Replica state is '%s' and unable to get manila messages: %s", err, mErr)
+			return fmt.Errorf("Replica state is '%s' and unable to get manila messages: %s", err, mErr)
 		}
 	}
 
-	return current, err
+	return err
 }

--- a/internal/acceptance/openstack/sharedfilesystems/v2/replicas_test.go
+++ b/internal/acceptance/openstack/sharedfilesystems/v2/replicas_test.go
@@ -86,7 +86,7 @@ func TestReplicaPromote(t *testing.T) {
 	// sync new replica
 	err = replicas.Resync(context.TODO(), client, created.ID).ExtractErr()
 	th.AssertNoErr(t, err)
-	_, err = waitForReplicaState(t, client, created.ID, "in_sync")
+	err = waitForReplicaState(t, client, created.ID, "in_sync")
 	if err != nil {
 		t.Fatalf("Replica status error: %v", err)
 	}
@@ -95,7 +95,7 @@ func TestReplicaPromote(t *testing.T) {
 	err = replicas.Promote(context.TODO(), client, created.ID, &replicas.PromoteOpts{}).ExtractErr()
 	th.AssertNoErr(t, err)
 
-	_, err = waitForReplicaState(t, client, created.ID, "active")
+	err = waitForReplicaState(t, client, created.ID, "active")
 	if err != nil {
 		t.Fatalf("Replica status error: %v", err)
 	}
@@ -117,14 +117,14 @@ func TestReplicaPromote(t *testing.T) {
 	// sync old replica
 	err = replicas.Resync(context.TODO(), client, oldReplicaID).ExtractErr()
 	th.AssertNoErr(t, err)
-	_, err = waitForReplicaState(t, client, oldReplicaID, "in_sync")
+	err = waitForReplicaState(t, client, oldReplicaID, "in_sync")
 	if err != nil {
 		t.Fatalf("Replica status error: %v", err)
 	}
 	err = replicas.Promote(context.TODO(), client, oldReplicaID, &replicas.PromoteOpts{}).ExtractErr()
 	th.AssertNoErr(t, err)
 
-	_, err = waitForReplicaState(t, client, oldReplicaID, "active")
+	err = waitForReplicaState(t, client, oldReplicaID, "active")
 	if err != nil {
 		t.Fatalf("Replica status error: %v", err)
 	}
@@ -262,7 +262,7 @@ func TestReplicaResetStatus(t *testing.T) {
 	}
 
 	// We need to wait till the Extend operation is done
-	_, err = waitForReplicaStatus(t, client, replica.ID, "error")
+	err = waitForReplicaStatus(t, client, replica.ID, "error")
 	if err != nil {
 		t.Fatalf("Replica status error: %v", err)
 	}
@@ -300,7 +300,7 @@ func TestReplicaForceDelete(t *testing.T) {
 		t.Fatalf("Unable to force delete a replica: %v", err)
 	}
 
-	_, err = waitForReplicaStatus(t, client, replica.ID, "deleted")
+	err = waitForReplicaStatus(t, client, replica.ID, "deleted")
 	if err != nil {
 		t.Fatalf("Replica status error: %v", err)
 	}

--- a/openstack/baremetal/v1/allocations/testing/fixtures_test.go
+++ b/openstack/baremetal/v1/allocations/testing/fixtures_test.go
@@ -113,7 +113,9 @@ func HandleAllocationListSuccessfully(t *testing.T) {
 		th.TestMethod(t, r, "GET")
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		w.Header().Add("Content-Type", "application/json")
-		r.ParseForm()
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("Failed to parse request form %v", err)
+		}
 
 		marker := r.Form.Get("marker")
 		switch marker {

--- a/openstack/baremetal/v1/conductors/testing/fixtures_test.go
+++ b/openstack/baremetal/v1/conductors/testing/fixtures_test.go
@@ -143,7 +143,9 @@ func HandleConductorListSuccessfully(t *testing.T) {
 		th.TestMethod(t, r, "GET")
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		w.Header().Add("Content-Type", "application/json")
-		r.ParseForm()
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("Failed to parse request form %v", err)
+		}
 
 		marker := r.Form.Get("marker")
 		switch marker {
@@ -164,7 +166,9 @@ func HandleConductorListDetailSuccessfully(t *testing.T) {
 		th.TestMethod(t, r, "GET")
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		w.Header().Add("Content-Type", "application/json")
-		r.ParseForm()
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("Failed to parse request form %v", err)
+		}
 
 		fmt.Fprintf(w, ConductorListDetailBody)
 	})

--- a/openstack/baremetal/v1/drivers/testing/fixtures_test.go
+++ b/openstack/baremetal/v1/drivers/testing/fixtures_test.go
@@ -373,7 +373,9 @@ func HandleListDriversSuccessfully(t *testing.T) {
 		th.TestMethod(t, r, "GET")
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		w.Header().Add("Content-Type", "application/json")
-		r.ParseForm()
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("Failed to parse request form %v", err)
+		}
 
 		fmt.Fprintf(w, ListDriversBody)
 	})

--- a/openstack/baremetal/v1/nodes/testing/fixtures_test.go
+++ b/openstack/baremetal/v1/nodes/testing/fixtures_test.go
@@ -1290,7 +1290,9 @@ func HandleNodeListSuccessfully(t *testing.T) {
 		th.TestMethod(t, r, "GET")
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		w.Header().Add("Content-Type", "application/json")
-		r.ParseForm()
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("Failed to parse request form %v", err)
+		}
 
 		marker := r.Form.Get("marker")
 		switch marker {
@@ -1311,7 +1313,9 @@ func HandleNodeListDetailSuccessfully(t *testing.T) {
 		th.TestMethod(t, r, "GET")
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		w.Header().Add("Content-Type", "application/json")
-		r.ParseForm()
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("Failed to parse request form %v", err)
+		}
 
 		fmt.Fprintf(w, NodeListDetailBody)
 	})

--- a/openstack/baremetal/v1/ports/testing/fixtures_test.go
+++ b/openstack/baremetal/v1/ports/testing/fixtures_test.go
@@ -174,7 +174,9 @@ func HandlePortListSuccessfully(t *testing.T) {
 		th.TestMethod(t, r, "GET")
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		w.Header().Add("Content-Type", "application/json")
-		r.ParseForm()
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("Failed to parse request form %v", err)
+		}
 
 		marker := r.Form.Get("marker")
 		switch marker {
@@ -195,7 +197,9 @@ func HandlePortListDetailSuccessfully(t *testing.T) {
 		th.TestMethod(t, r, "GET")
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		w.Header().Add("Content-Type", "application/json")
-		r.ParseForm()
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("Failed to parse request form %v", err)
+		}
 
 		fmt.Fprintf(w, PortListDetailBody)
 	})

--- a/openstack/baremetalintrospection/v1/introspection/testing/fixtures.go
+++ b/openstack/baremetalintrospection/v1/introspection/testing/fixtures.go
@@ -459,7 +459,9 @@ func HandleListIntrospectionsSuccessfully(t *testing.T) {
 		th.TestMethod(t, r, "GET")
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		w.Header().Add("Content-Type", "application/json")
-		r.ParseForm()
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("Failed to parse request form %v", err)
+		}
 
 		marker := r.Form.Get("marker")
 

--- a/openstack/blockstorage/v2/backups/testing/fixtures_test.go
+++ b/openstack/blockstorage/v2/backups/testing/fixtures_test.go
@@ -202,7 +202,9 @@ func MockListResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		r.ParseForm()
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("Failed to parse request form %v", err)
+		}
 		marker := r.Form.Get("marker")
 		switch marker {
 		case "":
@@ -223,7 +225,9 @@ func MockListDetailResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		r.ParseForm()
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("Failed to parse request form %v", err)
+		}
 		marker := r.Form.Get("marker")
 		switch marker {
 		case "":

--- a/openstack/blockstorage/v2/quotasets/requests.go
+++ b/openstack/blockstorage/v2/quotasets/requests.go
@@ -109,7 +109,7 @@ type UpdateOpts struct {
 
 // Resets the quotas for the given tenant to their default values.
 func Delete(ctx context.Context, client *gophercloud.ServiceClient, projectID string) (r DeleteResult) {
-	resp, err := client.Delete(ctx, updateURL(client, projectID), &gophercloud.RequestOpts{
+	resp, err := client.Delete(ctx, deleteURL(client, projectID), &gophercloud.RequestOpts{
 		OkCodes: []int{200},
 	})
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)

--- a/openstack/blockstorage/v2/schedulerstats/results.go
+++ b/openstack/blockstorage/v2/schedulerstats/results.go
@@ -61,11 +61,11 @@ func (r *Capabilities) UnmarshalJSON(b []byte) error {
 	// value, "unknown", or "infinite"
 	parseCapacity := func(capacity interface{}) float64 {
 		if capacity != nil {
-			switch capacity.(type) {
+			switch c := capacity.(type) {
 			case float64:
-				return capacity.(float64)
+				return c
 			case string:
-				if capacity.(string) == "infinite" {
+				if c == "infinite" {
 					return math.Inf(1)
 				}
 			}

--- a/openstack/blockstorage/v2/schedulerstats/testing/fixtures_test.go
+++ b/openstack/blockstorage/v2/schedulerstats/testing/fixtures_test.go
@@ -100,7 +100,9 @@ func HandleStoragePoolsListSuccessfully(t *testing.T) {
 
 		w.Header().Add("Content-Type", "application/json")
 
-		r.ParseForm()
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("Failed to parse request form %v", err)
+		}
 		if r.FormValue("detail") == "true" {
 			fmt.Fprintf(w, StoragePoolsListBodyDetail)
 		} else {

--- a/openstack/blockstorage/v2/snapshots/testing/requests_test.go
+++ b/openstack/blockstorage/v2/snapshots/testing/requests_test.go
@@ -19,7 +19,7 @@ func TestList(t *testing.T) {
 
 	count := 0
 
-	snapshots.List(client.ServiceClient(), &snapshots.ListOpts{}).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
+	err := snapshots.List(client.ServiceClient(), &snapshots.ListOpts{}).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
 		count++
 		actual, err := snapshots.ExtractSnapshots(page)
 		if err != nil {
@@ -52,6 +52,7 @@ func TestList(t *testing.T) {
 
 		return true, nil
 	})
+	th.AssertNoErr(t, err)
 
 	if count != 1 {
 		t.Errorf("Expected 1 page, got %d", count)

--- a/openstack/blockstorage/v2/volumes/testing/requests_test.go
+++ b/openstack/blockstorage/v2/volumes/testing/requests_test.go
@@ -20,7 +20,7 @@ func TestListWithExtensions(t *testing.T) {
 
 	count := 0
 
-	volumes.List(client.ServiceClient(), &volumes.ListOpts{}).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
+	err := volumes.List(client.ServiceClient(), &volumes.ListOpts{}).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
 		count++
 		actual, err := volumes.ExtractVolumes(page)
 		if err != nil {
@@ -89,6 +89,7 @@ func TestListWithExtensions(t *testing.T) {
 
 		return true, nil
 	})
+	th.AssertNoErr(t, err)
 
 	if count != 1 {
 		t.Errorf("Expected 1 page, got %d", count)

--- a/openstack/blockstorage/v3/attachments/testing/fixtures_test.go
+++ b/openstack/blockstorage/v3/attachments/testing/fixtures_test.go
@@ -35,7 +35,9 @@ func MockListResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		r.ParseForm()
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("Failed to parse request form %v", err)
+		}
 		marker := r.Form.Get("marker")
 		switch marker {
 		case "":

--- a/openstack/blockstorage/v3/backups/testing/fixtures_test.go
+++ b/openstack/blockstorage/v3/backups/testing/fixtures_test.go
@@ -202,7 +202,9 @@ func MockListResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		r.ParseForm()
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("Failed to parse request form %v", err)
+		}
 		marker := r.Form.Get("marker")
 		switch marker {
 		case "":
@@ -223,7 +225,9 @@ func MockListDetailResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		r.ParseForm()
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("Failed to parse request form %v", err)
+		}
 		marker := r.Form.Get("marker")
 		switch marker {
 		case "":

--- a/openstack/blockstorage/v3/qos/testing/fixtures_test.go
+++ b/openstack/blockstorage/v3/qos/testing/fixtures_test.go
@@ -76,7 +76,9 @@ func MockListResponse(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
-		r.ParseForm()
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("Failed to parse request form %v", err)
+		}
 		marker := r.Form.Get("marker")
 		switch marker {
 		case "":

--- a/openstack/blockstorage/v3/quotasets/requests.go
+++ b/openstack/blockstorage/v3/quotasets/requests.go
@@ -109,7 +109,7 @@ type UpdateOpts struct {
 
 // Resets the quotas for the given tenant to their default values.
 func Delete(ctx context.Context, client *gophercloud.ServiceClient, projectID string) (r DeleteResult) {
-	resp, err := client.Delete(ctx, updateURL(client, projectID), &gophercloud.RequestOpts{
+	resp, err := client.Delete(ctx, deleteURL(client, projectID), &gophercloud.RequestOpts{
 		OkCodes: []int{200},
 	})
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)

--- a/openstack/blockstorage/v3/schedulerstats/results.go
+++ b/openstack/blockstorage/v3/schedulerstats/results.go
@@ -61,11 +61,11 @@ func (r *Capabilities) UnmarshalJSON(b []byte) error {
 	// value, "unknown", or "infinite"
 	parseCapacity := func(capacity interface{}) float64 {
 		if capacity != nil {
-			switch capacity.(type) {
+			switch c := capacity.(type) {
 			case float64:
-				return capacity.(float64)
+				return c
 			case string:
-				if capacity.(string) == "infinite" {
+				if c == "infinite" {
 					return math.Inf(1)
 				}
 			}

--- a/openstack/blockstorage/v3/schedulerstats/testing/fixtures_test.go
+++ b/openstack/blockstorage/v3/schedulerstats/testing/fixtures_test.go
@@ -100,7 +100,9 @@ func HandleStoragePoolsListSuccessfully(t *testing.T) {
 
 		w.Header().Add("Content-Type", "application/json")
 
-		r.ParseForm()
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("Failed to parse request form %v", err)
+		}
 		if r.FormValue("detail") == "true" {
 			fmt.Fprintf(w, StoragePoolsListBodyDetail)
 		} else {

--- a/openstack/blockstorage/v3/snapshots/requests.go
+++ b/openstack/blockstorage/v3/snapshots/requests.go
@@ -259,7 +259,7 @@ func UpdateStatus(ctx context.Context, client *gophercloud.ServiceClient, id str
 		return
 	}
 
-	resp, err := client.Post(ctx, resetStatusURL(client, id), b, nil, &gophercloud.RequestOpts{
+	resp, err := client.Post(ctx, updateStatusURL(client, id), b, nil, &gophercloud.RequestOpts{
 		OkCodes: []int{202},
 	})
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)

--- a/openstack/blockstorage/v3/snapshots/testing/fixtures_test.go
+++ b/openstack/blockstorage/v3/snapshots/testing/fixtures_test.go
@@ -18,7 +18,9 @@ func MockListResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		r.ParseForm()
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("Failed to parse request form %v", err)
+		}
 		marker := r.Form.Get("marker")
 		switch marker {
 		case "":

--- a/openstack/blockstorage/v3/snapshots/testing/requests_test.go
+++ b/openstack/blockstorage/v3/snapshots/testing/requests_test.go
@@ -19,7 +19,7 @@ func TestList(t *testing.T) {
 
 	count := 0
 
-	snapshots.List(client.ServiceClient(), &snapshots.ListOpts{}).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
+	err := snapshots.List(client.ServiceClient(), &snapshots.ListOpts{}).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
 		count++
 		actual, err := snapshots.ExtractSnapshots(page)
 		if err != nil {
@@ -52,6 +52,7 @@ func TestList(t *testing.T) {
 
 		return true, nil
 	})
+	th.AssertNoErr(t, err)
 
 	if count != 1 {
 		t.Errorf("Expected 1 page, got %d", count)

--- a/openstack/blockstorage/v3/volumes/testing/fixtures_test.go
+++ b/openstack/blockstorage/v3/volumes/testing/fixtures_test.go
@@ -17,7 +17,9 @@ func MockListResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		r.ParseForm()
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("Failed to parse request form %v", err)
+		}
 		marker := r.Form.Get("marker")
 		switch marker {
 		case "":

--- a/openstack/blockstorage/v3/volumes/testing/requests_test.go
+++ b/openstack/blockstorage/v3/volumes/testing/requests_test.go
@@ -20,7 +20,7 @@ func TestListWithExtensions(t *testing.T) {
 
 	count := 0
 
-	volumes.List(client.ServiceClient(), &volumes.ListOpts{}).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
+	err := volumes.List(client.ServiceClient(), &volumes.ListOpts{}).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
 		count++
 		actual, err := volumes.ExtractVolumes(page)
 		if err != nil {
@@ -90,6 +90,7 @@ func TestListWithExtensions(t *testing.T) {
 
 		return true, nil
 	})
+	th.AssertNoErr(t, err)
 
 	if count != 1 {
 		t.Errorf("Expected 1 page, got %d", count)

--- a/openstack/blockstorage/v3/volumetypes/testing/fixtures_test.go
+++ b/openstack/blockstorage/v3/volumetypes/testing/fixtures_test.go
@@ -17,7 +17,9 @@ func MockListResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		r.ParseForm()
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("Failed to parse request form %v", err)
+		}
 		marker := r.Form.Get("marker")
 		switch marker {
 		case "":

--- a/openstack/client.go
+++ b/openstack/client.go
@@ -152,7 +152,10 @@ func v2auth(ctx context.Context, client *gophercloud.ProviderClient, endpoint st
 		tac := *client
 		tac.SetThrowaway(true)
 		tac.ReauthFunc = nil
-		tac.SetTokenAndAuthResult(nil)
+		err := tac.SetTokenAndAuthResult(nil)
+		if err != nil {
+			return err
+		}
 		tao := options
 		tao.AllowReauth = false
 		client.ReauthFunc = func(ctx context.Context) error {
@@ -251,7 +254,10 @@ func v3auth(ctx context.Context, client *gophercloud.ProviderClient, endpoint st
 		tac := *client
 		tac.SetThrowaway(true)
 		tac.ReauthFunc = nil
-		tac.SetTokenAndAuthResult(nil)
+		err = tac.SetTokenAndAuthResult(nil)
+		if err != nil {
+			return err
+		}
 		var tao tokens3.AuthOptionsBuilder
 		switch ot := opts.(type) {
 		case *gophercloud.AuthOptions:

--- a/openstack/common/extensions/testing/requests_test.go
+++ b/openstack/common/extensions/testing/requests_test.go
@@ -17,7 +17,7 @@ func TestList(t *testing.T) {
 
 	count := 0
 
-	extensions.List(client.ServiceClient()).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
+	err := extensions.List(client.ServiceClient()).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
 		count++
 		actual, err := extensions.ExtractExtensions(page)
 		th.AssertNoErr(t, err)
@@ -25,6 +25,7 @@ func TestList(t *testing.T) {
 
 		return true, nil
 	})
+	th.AssertNoErr(t, err)
 
 	th.CheckEquals(t, 1, count)
 }

--- a/openstack/compute/v2/diagnostics/testing/fixtures_test.go
+++ b/openstack/compute/v2/diagnostics/testing/fixtures_test.go
@@ -16,6 +16,7 @@ func HandleDiagnosticGetSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "Accept", "application/json")
 
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"cpu0_time":173,"memory":524288}`))
+		_, err := w.Write([]byte(`{"cpu0_time":173,"memory":524288}`))
+		th.AssertNoErr(t, err)
 	})
 }

--- a/openstack/compute/v2/extensions/testing/delegate_test.go
+++ b/openstack/compute/v2/extensions/testing/delegate_test.go
@@ -18,7 +18,7 @@ func TestList(t *testing.T) {
 	HandleListExtensionsSuccessfully(t)
 
 	count := 0
-	extensions.List(client.ServiceClient()).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
+	err := extensions.List(client.ServiceClient()).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
 		count++
 		actual, err := extensions.ExtractExtensions(page)
 		th.AssertNoErr(t, err)
@@ -37,6 +37,7 @@ func TestList(t *testing.T) {
 
 		return true, nil
 	})
+	th.AssertNoErr(t, err)
 	th.CheckEquals(t, 1, count)
 }
 

--- a/openstack/compute/v2/flavors/testing/requests_test.go
+++ b/openstack/compute/v2/flavors/testing/requests_test.go
@@ -13,8 +13,6 @@ import (
 	fake "github.com/gophercloud/gophercloud/v2/testhelper/client"
 )
 
-const tokenID = "blerb"
-
 func TestListFlavors(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()

--- a/openstack/compute/v2/flavors/testing/requests_test.go
+++ b/openstack/compute/v2/flavors/testing/requests_test.go
@@ -22,7 +22,9 @@ func TestListFlavors(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
-		r.ParseForm()
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("Failed to parse request form %v", err)
+		}
 		marker := r.Form.Get("marker")
 		switch marker {
 		case "":

--- a/openstack/compute/v2/quotasets/urls.go
+++ b/openstack/compute/v2/quotasets/urls.go
@@ -4,10 +4,6 @@ import "github.com/gophercloud/gophercloud/v2"
 
 const resourcePath = "os-quota-sets"
 
-func resourceURL(c *gophercloud.ServiceClient) string {
-	return c.ServiceURL(resourcePath)
-}
-
 func getURL(c *gophercloud.ServiceClient, tenantID string) string {
 	return c.ServiceURL(resourcePath, tenantID)
 }

--- a/openstack/compute/v2/servers/testing/fixtures_test.go
+++ b/openstack/compute/v2/servers/testing/fixtures_test.go
@@ -769,7 +769,9 @@ func HandleServerCreationSuccessfully(t *testing.T, response string) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
-		r.ParseForm()
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("Failed to parse request form %v", err)
+		}
 		marker := r.Form.Get("marker")
 		switch marker {
 		case "":
@@ -813,7 +815,9 @@ func HandleServerCreationSuccessfully(t *testing.T, response string) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
-		r.ParseForm()
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("Failed to parse request form %v", err)
+		}
 		marker := r.Form.Get("marker")
 		switch marker {
 		case "":
@@ -966,7 +970,9 @@ func HandleServerListSimpleSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
-		r.ParseForm()
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("Failed to parse request form %v", err)
+		}
 		marker := r.Form.Get("marker")
 		switch marker {
 		case "":
@@ -986,7 +992,9 @@ func HandleServerListSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
-		r.ParseForm()
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("Failed to parse request form %v", err)
+		}
 		marker := r.Form.Get("marker")
 		switch marker {
 		case "":
@@ -1124,7 +1132,8 @@ func HandleMetadatumGetSuccessfully(t *testing.T) {
 
 		w.WriteHeader(http.StatusOK)
 		w.Header().Add("Content-Type", "application/json")
-		w.Write([]byte(`{ "meta": {"foo":"bar"}}`))
+		_, err := w.Write([]byte(`{ "meta": {"foo":"bar"}}`))
+		th.AssertNoErr(t, err)
 	})
 }
 
@@ -1141,7 +1150,8 @@ func HandleMetadatumCreateSuccessfully(t *testing.T) {
 
 		w.WriteHeader(http.StatusOK)
 		w.Header().Add("Content-Type", "application/json")
-		w.Write([]byte(`{ "meta": {"foo":"bar"}}`))
+		_, err := w.Write([]byte(`{ "meta": {"foo":"bar"}}`))
+		th.AssertNoErr(t, err)
 	})
 }
 
@@ -1163,7 +1173,8 @@ func HandleMetadataGetSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "Accept", "application/json")
 
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{ "metadata": {"foo":"bar", "this":"that"}}`))
+		_, err := w.Write([]byte(`{ "metadata": {"foo":"bar", "this":"that"}}`))
+		th.AssertNoErr(t, err)
 	})
 }
 
@@ -1181,7 +1192,8 @@ func HandleMetadataResetSuccessfully(t *testing.T) {
 
 		w.WriteHeader(http.StatusOK)
 		w.Header().Add("Content-Type", "application/json")
-		w.Write([]byte(`{ "metadata": {"foo":"bar", "this":"that"}}`))
+		_, err := w.Write([]byte(`{ "metadata": {"foo":"bar", "this":"that"}}`))
+		th.AssertNoErr(t, err)
 	})
 }
 
@@ -1199,7 +1211,8 @@ func HandleMetadataUpdateSuccessfully(t *testing.T) {
 
 		w.WriteHeader(http.StatusOK)
 		w.Header().Add("Content-Type", "application/json")
-		w.Write([]byte(`{ "metadata": {"foo":"baz", "this":"those"}}`))
+		_, err := w.Write([]byte(`{ "metadata": {"foo":"baz", "this":"those"}}`))
+		th.AssertNoErr(t, err)
 	})
 }
 

--- a/openstack/config/clouds/clouds.go
+++ b/openstack/config/clouds/clouds.go
@@ -217,6 +217,9 @@ func mergeClouds(override, cloud Cloud) (Cloud, error) {
 	var mergedCloud Cloud
 	mergedInterface := mergeInterfaces(overrideInterface, cloudInterface)
 	mergedJson, err := json.Marshal(mergedInterface)
+	if err != nil {
+		return Cloud{}, err
+	}
 	err = json.Unmarshal(mergedJson, &mergedCloud)
 	if err != nil {
 		return Cloud{}, err

--- a/openstack/containerinfra/v1/clusters/testing/requests_test.go
+++ b/openstack/containerinfra/v1/clusters/testing/requests_test.go
@@ -77,7 +77,7 @@ func TestListClusters(t *testing.T) {
 	count := 0
 	sc := fake.ServiceClient()
 	sc.Endpoint = sc.Endpoint + "v1/"
-	clusters.List(sc, clusters.ListOpts{Limit: 2}).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
+	err := clusters.List(sc, clusters.ListOpts{Limit: 2}).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
 		count++
 		actual, err := clusters.ExtractClusters(page)
 		th.AssertNoErr(t, err)
@@ -89,6 +89,7 @@ func TestListClusters(t *testing.T) {
 
 		return true, nil
 	})
+	th.AssertNoErr(t, err)
 
 	if count != 1 {
 		t.Errorf("Expected 1 page, got %d", count)
@@ -104,7 +105,7 @@ func TestListDetailClusters(t *testing.T) {
 	count := 0
 	sc := fake.ServiceClient()
 	sc.Endpoint = sc.Endpoint + "v1/"
-	clusters.ListDetail(sc, clusters.ListOpts{Limit: 2}).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
+	err := clusters.ListDetail(sc, clusters.ListOpts{Limit: 2}).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
 		count++
 		actual, err := clusters.ExtractClusters(page)
 		th.AssertNoErr(t, err)
@@ -116,6 +117,7 @@ func TestListDetailClusters(t *testing.T) {
 
 		return true, nil
 	})
+	th.AssertNoErr(t, err)
 
 	if count != 1 {
 		t.Errorf("Expected 1 page, got %d", count)

--- a/openstack/containerinfra/v1/clusters/testing/requests_test.go
+++ b/openstack/containerinfra/v1/clusters/testing/requests_test.go
@@ -163,8 +163,7 @@ func TestUpgradeCluster(t *testing.T) {
 
 	HandleUpgradeClusterSuccessfully(t)
 
-	var opts clusters.UpgradeOptsBuilder
-	opts = clusters.UpgradeOpts{
+	opts := clusters.UpgradeOpts{
 		ClusterTemplate: "0562d357-8641-4759-8fed-8173f02c9633",
 	}
 
@@ -216,8 +215,7 @@ func TestResizeCluster(t *testing.T) {
 
 	nodeCount := 2
 
-	var opts clusters.ResizeOptsBuilder
-	opts = clusters.ResizeOpts{
+	opts := clusters.ResizeOpts{
 		NodeCount: &nodeCount,
 	}
 

--- a/openstack/containerinfra/v1/clustertemplates/testing/requests_test.go
+++ b/openstack/containerinfra/v1/clustertemplates/testing/requests_test.go
@@ -85,7 +85,7 @@ func TestListClusterTemplates(t *testing.T) {
 
 	sc := fake.ServiceClient()
 	sc.Endpoint = sc.Endpoint + "v1/"
-	clustertemplates.List(sc, clustertemplates.ListOpts{Limit: 2}).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
+	err := clustertemplates.List(sc, clustertemplates.ListOpts{Limit: 2}).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
 		count++
 		actual, err := clustertemplates.ExtractClusterTemplates(page)
 		th.AssertNoErr(t, err)
@@ -96,6 +96,7 @@ func TestListClusterTemplates(t *testing.T) {
 
 		return true, nil
 	})
+	th.AssertNoErr(t, err)
 
 	if count != 1 {
 		t.Errorf("Expected 1 page, got %d", count)

--- a/openstack/containerinfra/v1/nodegroups/testing/fixtures_test.go
+++ b/openstack/containerinfra/v1/nodegroups/testing/fixtures_test.go
@@ -181,7 +181,9 @@ func handleListNodeGroupsLimitSuccess(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		r.ParseForm()
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("Failed to parse request form %v", err)
+		}
 		if marker, ok := r.Form["marker"]; !ok {
 			// No marker, this is the first request.
 			th.TestFormValues(t, r, map[string]string{"limit": "1"})

--- a/openstack/dns/v2/recordsets/testing/fixtures_test.go
+++ b/openstack/dns/v2/recordsets/testing/fixtures_test.go
@@ -201,21 +201,22 @@ var ExpectedRecordSetSliceLimited = []recordsets.RecordSet{SecondRecordSet}
 
 // HandleListByZoneSuccessfully configures the test server to respond to a ListByZone request.
 func HandleListByZoneSuccessfully(t *testing.T) {
-	th.Mux.HandleFunc("/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets",
-		func(w http.ResponseWriter, r *http.Request) {
-			th.TestMethod(t, r, "GET")
-			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+	th.Mux.HandleFunc("/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
-			w.Header().Add("Content-Type", "application/json")
-			r.ParseForm()
-			marker := r.Form.Get("marker")
-			switch marker {
-			case "f7b10e9b-0cae-4a91-b162-562bc6096648":
-				fmt.Fprintf(w, ListByZoneOutputLimited)
-			case "":
-				fmt.Fprintf(w, ListByZoneOutput)
-			}
-		})
+		w.Header().Add("Content-Type", "application/json")
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("Failed to parse request form %v", err)
+		}
+		marker := r.Form.Get("marker")
+		switch marker {
+		case "f7b10e9b-0cae-4a91-b162-562bc6096648":
+			fmt.Fprintf(w, ListByZoneOutputLimited)
+		case "":
+			fmt.Fprintf(w, ListByZoneOutput)
+		}
+	})
 }
 
 // HandleGetSuccessfully configures the test server to respond to a Get request.

--- a/openstack/identity/v2/roles/urls.go
+++ b/openstack/identity/v2/roles/urls.go
@@ -8,10 +8,6 @@ const (
 	UserPath = "users"
 )
 
-func resourceURL(c *gophercloud.ServiceClient, id string) string {
-	return c.ServiceURL(ExtPath, RolePath, id)
-}
-
 func rootURL(c *gophercloud.ServiceClient) string {
 	return c.ServiceURL(ExtPath, RolePath)
 }

--- a/openstack/identity/v3/ec2tokens/requests.go
+++ b/openstack/identity/v3/ec2tokens/requests.go
@@ -238,12 +238,8 @@ func (opts *AuthOptions) ToTokenV3CreateMap(map[string]interface{}) (map[string]
 
 	// detect and process a signature v2
 	if v, ok := p["SignatureVersion"]; ok && v == "2" {
-		if _, ok := c["body_hash"]; ok {
-			delete(c, "body_hash")
-		}
-		if _, ok := c["headers"]; ok {
-			delete(c, "headers")
-		}
+		delete(c, "body_hash")
+		delete(c, "headers")
 		if v, ok := p["SignatureMethod"]; ok {
 			// params is a map of strings
 			strToSign := EC2CredentialsBuildStringToSignV2(*opts)
@@ -370,9 +366,7 @@ func interfaceToMap(c map[string]interface{}, key string) map[string]string {
 func deleteBodyElements(b map[string]interface{}, elements ...string) {
 	if c, ok := b["credentials"].(map[string]interface{}); ok {
 		for _, k := range elements {
-			if _, ok := c[k]; ok {
-				delete(c, k)
-			}
+			delete(c, k)
 		}
 	}
 }

--- a/openstack/identity/v3/ec2tokens/requests.go
+++ b/openstack/identity/v3/ec2tokens/requests.go
@@ -265,12 +265,12 @@ func (opts *AuthOptions) ToTokenV3CreateMap(map[string]interface{}) (map[string]
 	if opts.Timestamp != nil {
 		date = *opts.Timestamp
 	}
-	if v, _ := c["body_hash"]; v == nil {
+	if v := c["body_hash"]; v == nil {
 		// when body_hash is not set, generate a random one
 		c["body_hash"] = randomBodyHash()
 	}
 
-	signedHeaders, _ := h["X-Amz-SignedHeaders"]
+	signedHeaders := h["X-Amz-SignedHeaders"]
 
 	stringToSign := EC2CredentialsBuildStringToSignV4(*opts, signedHeaders, c["body_hash"].(string), date)
 	key := EC2CredentialsBuildSignatureKeyV4(opts.Secret, opts.Region, opts.Service, date)

--- a/openstack/identity/v3/ec2tokens/requests.go
+++ b/openstack/identity/v3/ec2tokens/requests.go
@@ -267,7 +267,11 @@ func (opts *AuthOptions) ToTokenV3CreateMap(map[string]interface{}) (map[string]
 	}
 	if v := c["body_hash"]; v == nil {
 		// when body_hash is not set, generate a random one
-		c["body_hash"] = randomBodyHash()
+		bodyHash, err := randomBodyHash()
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate random hash")
+		}
+		c["body_hash"] = bodyHash
 	}
 
 	signedHeaders := h["X-Amz-SignedHeaders"]
@@ -340,10 +344,12 @@ func sumHMAC256(key []byte, data []byte) []byte {
 }
 
 // randomBodyHash is a func to generate a random sha256 hexdigest.
-func randomBodyHash() string {
+func randomBodyHash() (string, error) {
 	h := make([]byte, 64)
-	rand.Read(h)
-	return hex.EncodeToString(h)
+	if _, err := rand.Read(h); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h), nil
 }
 
 // interfaceToMap is a func used to represent a "credentials" map element as a

--- a/openstack/identity/v3/endpoints/testing/requests_test.go
+++ b/openstack/identity/v3/endpoints/testing/requests_test.go
@@ -119,7 +119,7 @@ func TestListEndpoints(t *testing.T) {
 	})
 
 	count := 0
-	endpoints.List(client.ServiceClient(), endpoints.ListOpts{}).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
+	err := endpoints.List(client.ServiceClient(), endpoints.ListOpts{}).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
 		count++
 		actual, err := endpoints.ExtractEndpoints(page)
 		if err != nil {
@@ -150,6 +150,7 @@ func TestListEndpoints(t *testing.T) {
 		th.AssertDeepEquals(t, expected, actual)
 		return true, nil
 	})
+	th.AssertNoErr(t, err)
 	th.AssertEquals(t, 1, count)
 }
 

--- a/openstack/identity/v3/projectendpoints/testing/requests_test.go
+++ b/openstack/identity/v3/projectendpoints/testing/requests_test.go
@@ -71,7 +71,7 @@ func TestListEndpoints(t *testing.T) {
 	})
 
 	count := 0
-	projectendpoints.List(client.ServiceClient(), "project-id").EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
+	err := projectendpoints.List(client.ServiceClient(), "project-id").EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
 		count++
 		actual, err := projectendpoints.ExtractEndpoints(page)
 		if err != nil {
@@ -98,6 +98,7 @@ func TestListEndpoints(t *testing.T) {
 		th.AssertDeepEquals(t, expected, actual)
 		return true, nil
 	})
+	th.AssertNoErr(t, err)
 	th.AssertEquals(t, 1, count)
 }
 

--- a/openstack/identity/v3/registeredlimits/urls.go
+++ b/openstack/identity/v3/registeredlimits/urls.go
@@ -7,10 +7,6 @@ const (
 	enforcementModelPath = "model"
 )
 
-func enforcementModelURL(client *gophercloud.ServiceClient) string {
-	return client.ServiceURL(rootPath, enforcementModelPath)
-}
-
 func rootURL(client *gophercloud.ServiceClient) string {
 	return client.ServiceURL(rootPath)
 }

--- a/openstack/image/v2/members/testing/requests_test.go
+++ b/openstack/image/v2/members/testing/requests_test.go
@@ -111,7 +111,7 @@ func TestShowMemberDetails(t *testing.T) {
 
 	th.AssertNoErr(t, err)
 	if md == nil {
-		t.Errorf("Expected non-nil value for md")
+		t.Fatalf("Expected non-nil value for md")
 	}
 
 	createdAt, err := time.Parse(time.RFC3339, "2013-11-26T07:21:21Z")

--- a/openstack/image/v2/tasks/testing/requests_test.go
+++ b/openstack/image/v2/tasks/testing/requests_test.go
@@ -29,7 +29,7 @@ func TestList(t *testing.T) {
 
 	count := 0
 
-	tasks.List(fakeclient.ServiceClient(), tasks.ListOpts{}).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
+	err := tasks.List(fakeclient.ServiceClient(), tasks.ListOpts{}).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
 		count++
 		actual, err := tasks.ExtractTasks(page)
 		if err != nil {
@@ -46,6 +46,7 @@ func TestList(t *testing.T) {
 
 		return true, nil
 	})
+	th.AssertNoErr(t, err)
 
 	if count != 1 {
 		t.Errorf("Expected 1 page, got %d", count)

--- a/openstack/keymanager/v1/containers/results.go
+++ b/openstack/keymanager/v1/containers/results.go
@@ -176,28 +176,17 @@ func (r *Consumer) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-type consumerResult struct {
-	gophercloud.Result
-}
-
-// Extract interprets any consumerResult as a Consumer.
-func (r consumerResult) Extract() (*Consumer, error) {
-	var s *Consumer
-	err := r.ExtractInto(&s)
-	return s, err
-}
-
 // CreateConsumerResult is the response from a CreateConsumer operation.
 // Call its Extract method to interpret it as a container.
 type CreateConsumerResult struct {
-	// This is not a typo.
+	// This is not a typo: the API returns a Container, not a Consumer
 	commonResult
 }
 
 // DeleteConsumerResult is the response from a DeleteConsumer operation.
 // Call its Extract to interpret it as a container.
 type DeleteConsumerResult struct {
-	// This is not a typo.
+	// This is not a typo: the API returns a Container, not a Consumer
 	commonResult
 }
 

--- a/openstack/loadbalancer/v2/amphorae/testing/fixtures_test.go
+++ b/openstack/loadbalancer/v2/amphorae/testing/fixtures_test.go
@@ -144,7 +144,9 @@ func HandleAmphoraListSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
-		r.ParseForm()
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("Failed to parse request form %v", err)
+		}
 		marker := r.Form.Get("marker")
 		switch marker {
 		case "":

--- a/openstack/loadbalancer/v2/flavorprofiles/testing/fixtures.go
+++ b/openstack/loadbalancer/v2/flavorprofiles/testing/fixtures.go
@@ -88,7 +88,9 @@ func HandleFlavorProfileListSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
-		r.ParseForm()
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("Failed to parse request form %v", err)
+		}
 		marker := r.Form.Get("marker")
 		switch marker {
 		case "":

--- a/openstack/loadbalancer/v2/flavors/testing/fixtures.go
+++ b/openstack/loadbalancer/v2/flavors/testing/fixtures.go
@@ -96,7 +96,9 @@ func HandleFlavorListSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
-		r.ParseForm()
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("Failed to parse request form %v", err)
+		}
 		marker := r.Form.Get("marker")
 		switch marker {
 		case "":

--- a/openstack/loadbalancer/v2/l7policies/testing/fixtures_test.go
+++ b/openstack/loadbalancer/v2/l7policies/testing/fixtures_test.go
@@ -212,7 +212,9 @@ func HandleL7PolicyListSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
-		r.ParseForm()
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("Failed to parse request form %v", err)
+		}
 		marker := r.Form.Get("marker")
 		switch marker {
 		case "":
@@ -354,7 +356,9 @@ func HandleRuleListSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
-		r.ParseForm()
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("Failed to parse request form %v", err)
+		}
 		marker := r.Form.Get("marker")
 		switch marker {
 		case "":

--- a/openstack/loadbalancer/v2/listeners/testing/fixtures_test.go
+++ b/openstack/loadbalancer/v2/listeners/testing/fixtures_test.go
@@ -212,7 +212,9 @@ func HandleListenerListSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
-		r.ParseForm()
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("Failed to parse request form %v", err)
+		}
 		marker := r.Form.Get("marker")
 		switch marker {
 		case "":

--- a/openstack/loadbalancer/v2/loadbalancers/testing/fixtures_test.go
+++ b/openstack/loadbalancer/v2/loadbalancers/testing/fixtures_test.go
@@ -447,7 +447,9 @@ func HandleLoadbalancerListSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
-		r.ParseForm()
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("Failed to parse request form %v", err)
+		}
 		marker := r.Form.Get("marker")
 		switch marker {
 		case "":

--- a/openstack/loadbalancer/v2/monitors/requests.go
+++ b/openstack/loadbalancer/v2/monitors/requests.go
@@ -2,7 +2,6 @@ package monitors
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/pagination"
@@ -80,10 +79,6 @@ const (
 	TypeTLSHELLO   = "TLS-HELLO"
 	TypeUDPConnect = "UDP-CONNECT"
 	TypeSCTP       = "SCTP"
-)
-
-var (
-	errDelayMustGETimeout = fmt.Errorf("Delay must be greater than or equal to timeout")
 )
 
 // CreateOptsBuilder allows extensions to add additional parameters to the

--- a/openstack/loadbalancer/v2/monitors/testing/fixtures_test.go
+++ b/openstack/loadbalancer/v2/monitors/testing/fixtures_test.go
@@ -146,7 +146,9 @@ func HandleHealthmonitorListSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
-		r.ParseForm()
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("Failed to parse request form %v", err)
+		}
 		marker := r.Form.Get("marker")
 		switch marker {
 		case "":

--- a/openstack/loadbalancer/v2/pools/testing/fixtures_test.go
+++ b/openstack/loadbalancer/v2/pools/testing/fixtures_test.go
@@ -139,7 +139,9 @@ func HandlePoolListSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
-		r.ParseForm()
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("Failed to parse request form %v", err)
+		}
 		marker := r.Form.Get("marker")
 		switch marker {
 		case "":
@@ -334,7 +336,9 @@ func HandleMemberListSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
-		r.ParseForm()
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("Failed to parse request form %v", err)
+		}
 		marker := r.Form.Get("marker")
 		switch marker {
 		case "":

--- a/openstack/loadbalancer/v2/providers/testing/fixtures_test.go
+++ b/openstack/loadbalancer/v2/providers/testing/fixtures_test.go
@@ -44,7 +44,9 @@ func HandleProviderListSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
-		r.ParseForm()
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("Failed to parse request form %v", err)
+		}
 		marker := r.Form.Get("marker")
 		switch marker {
 		case "":

--- a/openstack/messaging/v2/messages/results.go
+++ b/openstack/messaging/v2/messages/results.go
@@ -5,11 +5,6 @@ import (
 	"github.com/gophercloud/gophercloud/v2/pagination"
 )
 
-// commonResult is the response of a base result.
-type commonResult struct {
-	gophercloud.Result
-}
-
 // CreateResult is the response of a Create operations.
 type CreateResult struct {
 	gophercloud.Result

--- a/openstack/networking/v2/apiversions/testing/requests_test.go
+++ b/openstack/networking/v2/apiversions/testing/requests_test.go
@@ -42,7 +42,7 @@ func TestListVersions(t *testing.T) {
 
 	count := 0
 
-	apiversions.ListVersions(fake.ServiceClient()).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
+	err := apiversions.ListVersions(fake.ServiceClient()).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
 		count++
 		actual, err := apiversions.ExtractAPIVersions(page)
 		if err != nil {
@@ -61,6 +61,7 @@ func TestListVersions(t *testing.T) {
 
 		return true, nil
 	})
+	th.AssertNoErr(t, err)
 
 	if count != 1 {
 		t.Errorf("Expected 1 page, got %d", count)
@@ -75,12 +76,13 @@ func TestNonJSONCannotBeExtractedIntoAPIVersions(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	apiversions.ListVersions(fake.ServiceClient()).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
+	err := apiversions.ListVersions(fake.ServiceClient()).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
 		if _, err := apiversions.ExtractAPIVersions(page); err == nil {
 			t.Fatalf("Expected error, got nil")
 		}
 		return true, nil
 	})
+	th.AssertErr(t, err)
 }
 
 func TestAPIInfo(t *testing.T) {
@@ -134,7 +136,7 @@ func TestAPIInfo(t *testing.T) {
 
 	count := 0
 
-	apiversions.ListVersionResources(fake.ServiceClient(), "v2.0").EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
+	err := apiversions.ListVersionResources(fake.ServiceClient(), "v2.0").EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
 		count++
 		actual, err := apiversions.ExtractVersionResources(page)
 		if err != nil {
@@ -161,6 +163,7 @@ func TestAPIInfo(t *testing.T) {
 
 		return true, nil
 	})
+	th.AssertNoErr(t, err)
 
 	if count != 1 {
 		t.Errorf("Expected 1 page, got %d", count)
@@ -175,10 +178,11 @@ func TestNonJSONCannotBeExtractedIntoAPIVersionResources(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	apiversions.ListVersionResources(fake.ServiceClient(), "v2.0").EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
+	err := apiversions.ListVersionResources(fake.ServiceClient(), "v2.0").EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
 		if _, err := apiversions.ExtractVersionResources(page); err == nil {
 			t.Fatalf("Expected error, got nil")
 		}
 		return true, nil
 	})
+	th.AssertErr(t, err)
 }

--- a/openstack/networking/v2/extensions/agents/requests.go
+++ b/openstack/networking/v2/extensions/agents/requests.go
@@ -101,7 +101,7 @@ func Update(ctx context.Context, c *gophercloud.ServiceClient, id string, opts U
 
 // Delete deletes a specific agent based on its ID.
 func Delete(ctx context.Context, c *gophercloud.ServiceClient, id string) (r DeleteResult) {
-	resp, err := c.Delete(ctx, getURL(c, id), nil)
+	resp, err := c.Delete(ctx, deleteURL(c, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }

--- a/openstack/networking/v2/extensions/agents/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/agents/testing/requests_test.go
@@ -30,7 +30,7 @@ func TestList(t *testing.T) {
 
 	count := 0
 
-	agents.List(fake.ServiceClient(), agents.ListOpts{}).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
+	err := agents.List(fake.ServiceClient(), agents.ListOpts{}).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
 		count++
 		actual, err := agents.ExtractAgents(page)
 
@@ -48,6 +48,7 @@ func TestList(t *testing.T) {
 
 		return true, nil
 	})
+	th.AssertNoErr(t, err)
 
 	if count != 1 {
 		t.Errorf("Expected 1 page, got %d", count)
@@ -226,7 +227,7 @@ func TestListBGPSpeakers(t *testing.T) {
 		})
 
 	count := 0
-	agents.ListBGPSpeakers(fake.ServiceClient(), agentID).EachPage(
+	err := agents.ListBGPSpeakers(fake.ServiceClient(), agentID).EachPage(
 		context.TODO(),
 		func(_ context.Context, page pagination.Page) (bool, error) {
 			count++
@@ -240,6 +241,7 @@ func TestListBGPSpeakers(t *testing.T) {
 			th.AssertEquals(t, actual[0].IPVersion, 4)
 			return true, nil
 		})
+	th.AssertNoErr(t, err)
 	if count != 1 {
 		t.Errorf("Expected 1 page, got %d", count)
 	}
@@ -307,7 +309,7 @@ func TestListDRAgentHostingBGPSpeakers(t *testing.T) {
 		})
 
 	count := 0
-	agents.ListDRAgentHostingBGPSpeakers(fake.ServiceClient(), speakerID).EachPage(
+	err := agents.ListDRAgentHostingBGPSpeakers(fake.ServiceClient(), speakerID).EachPage(
 		context.TODO(),
 		func(_ context.Context, page pagination.Page) (bool, error) {
 			count++
@@ -322,6 +324,7 @@ func TestListDRAgentHostingBGPSpeakers(t *testing.T) {
 			th.CheckDeepEquals(t, expected, actual)
 			return true, nil
 		})
+	th.AssertNoErr(t, err)
 
 	if count != 1 {
 		t.Errorf("Expected 1 page, got %d", count)

--- a/openstack/networking/v2/extensions/bgp/peers/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/bgp/peers/testing/requests_test.go
@@ -27,7 +27,7 @@ func TestList(t *testing.T) {
 		})
 	count := 0
 
-	peers.List(fake.ServiceClient()).EachPage(
+	err := peers.List(fake.ServiceClient()).EachPage(
 		context.TODO(),
 		func(_ context.Context, page pagination.Page) (bool, error) {
 			count++
@@ -41,6 +41,7 @@ func TestList(t *testing.T) {
 			th.CheckDeepEquals(t, expected, actual)
 			return true, nil
 		})
+	th.AssertNoErr(t, err)
 }
 
 func TestGet(t *testing.T) {

--- a/openstack/networking/v2/extensions/bgp/speakers/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/bgp/speakers/testing/requests_test.go
@@ -224,9 +224,9 @@ func TestGetAdvertisedRoutes(t *testing.T) {
 			}
 
 			expected := []speakers.AdvertisedRoute{
-				speakers.AdvertisedRoute{NextHop: "172.17.128.212", Destination: "172.17.129.192/27"},
-				speakers.AdvertisedRoute{NextHop: "172.17.128.218", Destination: "172.17.129.0/27"},
-				speakers.AdvertisedRoute{NextHop: "172.17.128.231", Destination: "172.17.129.160/27"},
+				{NextHop: "172.17.128.212", Destination: "172.17.129.192/27"},
+				{NextHop: "172.17.128.218", Destination: "172.17.129.0/27"},
+				{NextHop: "172.17.128.231", Destination: "172.17.129.160/27"},
 			}
 			th.CheckDeepEquals(t, count, 1)
 			th.CheckDeepEquals(t, expected, actual)

--- a/openstack/networking/v2/extensions/bgp/speakers/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/bgp/speakers/testing/requests_test.go
@@ -28,7 +28,7 @@ func TestList(t *testing.T) {
 		})
 	count := 0
 
-	speakers.List(fake.ServiceClient()).EachPage(
+	err := speakers.List(fake.ServiceClient()).EachPage(
 		context.TODO(),
 		func(_ context.Context, page pagination.Page) (bool, error) {
 			count++
@@ -42,6 +42,7 @@ func TestList(t *testing.T) {
 			th.CheckDeepEquals(t, expected, actual)
 			return true, nil
 		})
+	th.AssertNoErr(t, err)
 }
 
 func TestGet(t *testing.T) {
@@ -211,7 +212,7 @@ func TestGetAdvertisedRoutes(t *testing.T) {
 	})
 
 	count := 0
-	speakers.GetAdvertisedRoutes(fake.ServiceClient(), bgpSpeakerID).EachPage(
+	err := speakers.GetAdvertisedRoutes(fake.ServiceClient(), bgpSpeakerID).EachPage(
 		context.TODO(),
 		func(_ context.Context, page pagination.Page) (bool, error) {
 			count++
@@ -231,6 +232,7 @@ func TestGetAdvertisedRoutes(t *testing.T) {
 			th.CheckDeepEquals(t, expected, actual)
 			return true, nil
 		})
+	th.AssertNoErr(t, err)
 }
 
 func TestAddGatewayNetwork(t *testing.T) {

--- a/openstack/networking/v2/extensions/dns/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/dns/testing/requests_test.go
@@ -74,8 +74,7 @@ func TestPortList(t *testing.T) {
 		},
 	}
 
-	var listOptsBuilder ports.ListOptsBuilder
-	listOptsBuilder = dns.PortListOptsExt{
+	listOptsBuilder := dns.PortListOptsExt{
 		ListOptsBuilder: ports.ListOpts{},
 		DNSName:         "test-port",
 	}

--- a/openstack/networking/v2/extensions/fwaas_v2/groups/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/fwaas_v2/groups/testing/requests_test.go
@@ -68,7 +68,7 @@ func TestList(t *testing.T) {
 
 	count := 0
 
-	groups.List(fake.ServiceClient(), groups.ListOpts{}).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
+	err := groups.List(fake.ServiceClient(), groups.ListOpts{}).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
 		count++
 		actual, err := groups.ExtractGroups(page)
 		if err != nil {
@@ -118,6 +118,7 @@ func TestList(t *testing.T) {
 
 		return true, nil
 	})
+	th.AssertNoErr(t, err)
 
 	if count != 1 {
 		t.Errorf("Expected 1 page, got %d", count)

--- a/openstack/networking/v2/extensions/fwaas_v2/policies/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/fwaas_v2/policies/testing/requests_test.go
@@ -59,7 +59,7 @@ func TestList(t *testing.T) {
 
 	count := 0
 
-	policies.List(fake.ServiceClient(), policies.ListOpts{}).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
+	err := policies.List(fake.ServiceClient(), policies.ListOpts{}).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
 		count++
 		actual, err := policies.ExtractPolicies(page)
 		if err != nil {
@@ -99,6 +99,7 @@ func TestList(t *testing.T) {
 
 		return true, nil
 	})
+	th.AssertNoErr(t, err)
 
 	if count != 1 {
 		t.Errorf("Expected 1 page, got %d", count)

--- a/openstack/networking/v2/extensions/fwaas_v2/rules/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/fwaas_v2/rules/testing/requests_test.go
@@ -68,7 +68,7 @@ func TestList(t *testing.T) {
 
 	count := 0
 
-	rules.List(fake.ServiceClient(), rules.ListOpts{}).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
+	err := rules.List(fake.ServiceClient(), rules.ListOpts{}).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
 		count++
 		actual, err := rules.ExtractRules(page)
 		if err != nil {
@@ -117,6 +117,7 @@ func TestList(t *testing.T) {
 
 		return true, nil
 	})
+	th.AssertNoErr(t, err)
 
 	if count != 1 {
 		t.Errorf("Expected 1 page, got %d", count)

--- a/openstack/networking/v2/extensions/layer3/addressscopes/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/layer3/addressscopes/testing/requests_test.go
@@ -28,7 +28,7 @@ func TestList(t *testing.T) {
 
 	count := 0
 
-	addressscopes.List(fake.ServiceClient(), addressscopes.ListOpts{}).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
+	err := addressscopes.List(fake.ServiceClient(), addressscopes.ListOpts{}).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
 		count++
 		actual, err := addressscopes.ExtractAddressScopes(page)
 		if err != nil {
@@ -45,6 +45,7 @@ func TestList(t *testing.T) {
 
 		return true, nil
 	})
+	th.AssertNoErr(t, err)
 
 	if count != 1 {
 		t.Errorf("Expected 1 page, got %d", count)

--- a/openstack/networking/v2/extensions/layer3/floatingips/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/layer3/floatingips/testing/requests_test.go
@@ -91,10 +91,14 @@ func TestInvalidNextPageURLs(t *testing.T) {
 		fmt.Fprintf(w, `{"floatingips": [{}], "floatingips_links": {}}`)
 	})
 
-	floatingips.List(fake.ServiceClient(), floatingips.ListOpts{}).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
-		floatingips.ExtractFloatingIPs(page)
+	err := floatingips.List(fake.ServiceClient(), floatingips.ListOpts{}).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
+		_, err := floatingips.ExtractFloatingIPs(page)
+		if err != nil {
+			return false, err
+		}
 		return true, nil
 	})
+	th.AssertErr(t, err)
 }
 
 func TestRequiredFieldsForCreate(t *testing.T) {

--- a/openstack/networking/v2/extensions/layer3/portforwarding/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/layer3/portforwarding/testing/requests_test.go
@@ -28,7 +28,7 @@ func TestPortForwardingList(t *testing.T) {
 
 	count := 0
 
-	portforwarding.List(fake.ServiceClient(), portforwarding.ListOpts{}, "2f95fd2b-9f6a-4e8e-9e9a-2cbe286cbf9e").EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
+	err := portforwarding.List(fake.ServiceClient(), portforwarding.ListOpts{}, "2f95fd2b-9f6a-4e8e-9e9a-2cbe286cbf9e").EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
 		count++
 		actual, err := portforwarding.ExtractPortForwardings(page)
 		if err != nil {
@@ -59,6 +59,7 @@ func TestPortForwardingList(t *testing.T) {
 
 		return true, nil
 	})
+	th.AssertNoErr(t, err)
 
 	if count != 1 {
 		t.Errorf("Expected 1 page, got %d", count)

--- a/openstack/networking/v2/extensions/layer3/routers/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/layer3/routers/testing/requests_test.go
@@ -70,7 +70,7 @@ func TestList(t *testing.T) {
 
 	count := 0
 
-	routers.List(fake.ServiceClient(), routers.ListOpts{}).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
+	err := routers.List(fake.ServiceClient(), routers.ListOpts{}).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
 		count++
 		actual, err := routers.ExtractRouters(page)
 		if err != nil {
@@ -119,6 +119,7 @@ func TestList(t *testing.T) {
 
 		return true, nil
 	})
+	th.AssertNoErr(t, err)
 
 	if count != 1 {
 		t.Errorf("Expected 1 page, got %d", count)

--- a/openstack/networking/v2/extensions/rbacpolicies/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/rbacpolicies/testing/requests_test.go
@@ -76,7 +76,7 @@ func TestList(t *testing.T) {
 	client := fake.ServiceClient()
 	count := 0
 
-	rbacpolicies.List(client, rbacpolicies.ListOpts{}).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
+	err := rbacpolicies.List(client, rbacpolicies.ListOpts{}).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
 		count++
 		actual, err := rbacpolicies.ExtractRBACPolicies(page)
 		if err != nil {
@@ -88,6 +88,7 @@ func TestList(t *testing.T) {
 
 		return true, nil
 	})
+	th.AssertNoErr(t, err)
 
 	if count != 1 {
 		t.Errorf("Expected 1 page, got %d", count)

--- a/openstack/networking/v2/extensions/security/rules/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/security/rules/testing/requests_test.go
@@ -57,7 +57,7 @@ func TestList(t *testing.T) {
 
 	count := 0
 
-	rules.List(fake.ServiceClient(), rules.ListOpts{}).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
+	err := rules.List(fake.ServiceClient(), rules.ListOpts{}).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
 		count++
 		actual, err := rules.ExtractRules(page)
 		if err != nil {
@@ -97,6 +97,7 @@ func TestList(t *testing.T) {
 
 		return true, nil
 	})
+	th.AssertNoErr(t, err)
 
 	if count != 1 {
 		t.Errorf("Expected 1 page, got %d", count)

--- a/openstack/networking/v2/extensions/testing/delegate_test.go
+++ b/openstack/networking/v2/extensions/testing/delegate_test.go
@@ -41,7 +41,7 @@ func TestList(t *testing.T) {
 
 	count := 0
 
-	extensions.List(fake.ServiceClient()).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
+	err := extensions.List(fake.ServiceClient()).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
 		count++
 		actual, err := extensions.ExtractExtensions(page)
 		if err != nil {
@@ -65,6 +65,7 @@ func TestList(t *testing.T) {
 
 		return true, nil
 	})
+	th.AssertNoErr(t, err)
 
 	if count != 1 {
 		t.Errorf("Expected 1 page, got %d", count)

--- a/openstack/networking/v2/extensions/trunks/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/trunks/testing/requests_test.go
@@ -121,7 +121,7 @@ func TestList(t *testing.T) {
 	client := fake.ServiceClient()
 	count := 0
 
-	trunks.List(client, trunks.ListOpts{}).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
+	err := trunks.List(client, trunks.ListOpts{}).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
 		count++
 		actual, err := trunks.ExtractTrunks(page)
 		if err != nil {
@@ -135,6 +135,7 @@ func TestList(t *testing.T) {
 
 		return true, nil
 	})
+	th.AssertNoErr(t, err)
 
 	if count != 1 {
 		t.Errorf("Expected 1 page, got %d", count)

--- a/openstack/networking/v2/extensions/vpnaas/endpointgroups/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/vpnaas/endpointgroups/testing/requests_test.go
@@ -157,7 +157,7 @@ func TestList(t *testing.T) {
 
 	count := 0
 
-	endpointgroups.List(fake.ServiceClient(), endpointgroups.ListOpts{}).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
+	err := endpointgroups.List(fake.ServiceClient(), endpointgroups.ListOpts{}).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
 		count++
 		actual, err := endpointgroups.ExtractEndpointGroups(page)
 		if err != nil {
@@ -182,6 +182,7 @@ func TestList(t *testing.T) {
 
 		return true, nil
 	})
+	th.AssertNoErr(t, err)
 
 	if count != 1 {
 		t.Errorf("Expected 1 page, got %d", count)

--- a/openstack/networking/v2/extensions/vpnaas/ikepolicies/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/vpnaas/ikepolicies/testing/requests_test.go
@@ -191,7 +191,7 @@ func TestList(t *testing.T) {
 
 	count := 0
 
-	ikepolicies.List(fake.ServiceClient(), ikepolicies.ListOpts{}).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
+	err := ikepolicies.List(fake.ServiceClient(), ikepolicies.ListOpts{}).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
 		count++
 		actual, err := ikepolicies.ExtractPolicies(page)
 		if err != nil {
@@ -222,6 +222,7 @@ func TestList(t *testing.T) {
 
 		return true, nil
 	})
+	th.AssertNoErr(t, err)
 
 	if count != 1 {
 		t.Errorf("Expected 1 page, got %d", count)

--- a/openstack/networking/v2/extensions/vpnaas/ipsecpolicies/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/vpnaas/ipsecpolicies/testing/requests_test.go
@@ -206,7 +206,7 @@ func TestList(t *testing.T) {
 
 	count := 0
 
-	ipsecpolicies.List(fake.ServiceClient(), ipsecpolicies.ListOpts{}).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
+	err := ipsecpolicies.List(fake.ServiceClient(), ipsecpolicies.ListOpts{}).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
 		count++
 		actual, err := ipsecpolicies.ExtractPolicies(page)
 		if err != nil {
@@ -237,6 +237,7 @@ func TestList(t *testing.T) {
 
 		return true, nil
 	})
+	th.AssertNoErr(t, err)
 
 	if count != 1 {
 		t.Errorf("Expected 1 page, got %d", count)

--- a/openstack/networking/v2/extensions/vpnaas/services/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/vpnaas/services/testing/requests_test.go
@@ -111,7 +111,7 @@ func TestList(t *testing.T) {
 
 	count := 0
 
-	services.List(fake.ServiceClient(), services.ListOpts{}).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
+	err := services.List(fake.ServiceClient(), services.ListOpts{}).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
 		count++
 		actual, err := services.ExtractServices(page)
 		if err != nil {
@@ -136,6 +136,7 @@ func TestList(t *testing.T) {
 
 		return true, nil
 	})
+	th.AssertNoErr(t, err)
 
 	if count != 1 {
 		t.Errorf("Expected 1 page, got %d", count)

--- a/openstack/networking/v2/extensions/vpnaas/siteconnections/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/vpnaas/siteconnections/testing/requests_test.go
@@ -263,7 +263,7 @@ func TestList(t *testing.T) {
 
 	count := 0
 
-	siteconnections.List(fake.ServiceClient(), siteconnections.ListOpts{}).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
+	err := siteconnections.List(fake.ServiceClient(), siteconnections.ListOpts{}).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
 		count++
 		actual, err := siteconnections.ExtractConnections(page)
 		if err != nil {
@@ -306,6 +306,7 @@ func TestList(t *testing.T) {
 
 		return true, nil
 	})
+	th.AssertNoErr(t, err)
 
 	if count != 1 {
 		t.Errorf("Expected 1 page, got %d", count)

--- a/openstack/networking/v2/subnets/testing/requests_test.go
+++ b/openstack/networking/v2/subnets/testing/requests_test.go
@@ -28,7 +28,7 @@ func TestList(t *testing.T) {
 
 	count := 0
 
-	subnets.List(fake.ServiceClient(), subnets.ListOpts{}).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
+	err := subnets.List(fake.ServiceClient(), subnets.ListOpts{}).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
 		count++
 		actual, err := subnets.ExtractSubnets(page)
 		if err != nil {
@@ -47,6 +47,7 @@ func TestList(t *testing.T) {
 
 		return true, nil
 	})
+	th.AssertNoErr(t, err)
 
 	if count != 1 {
 		t.Errorf("Expected 1 page, got %d", count)

--- a/openstack/objectstorage/v1/containers/testing/fixtures.go
+++ b/openstack/objectstorage/v1/containers/testing/fixtures.go
@@ -50,7 +50,9 @@ func HandleListContainerInfoSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "Accept", "application/json")
 
 		w.Header().Set("Content-Type", "application/json")
-		r.ParseForm()
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("Failed to parse request form %v", err)
+		}
 		marker := r.Form.Get("marker")
 		switch marker {
 		case "":

--- a/openstack/objectstorage/v1/containers/testing/requests_test.go
+++ b/openstack/objectstorage/v1/containers/testing/requests_test.go
@@ -12,10 +12,6 @@ import (
 	fake "github.com/gophercloud/gophercloud/v2/testhelper/client"
 )
 
-var (
-	metadata = map[string]string{"gophercloud-test": "containers"}
-)
-
 func TestContainerNames(t *testing.T) {
 	for _, tc := range [...]struct {
 		name          string

--- a/openstack/objectstorage/v1/objects/requests.go
+++ b/openstack/objectstorage/v1/objects/requests.go
@@ -241,7 +241,10 @@ func (opts CreateOpts) ToObjectCreateParams() (io.Reader, map[string]string, str
 	if _, err := io.Copy(hash, readSeeker); err != nil {
 		return nil, nil, "", err
 	}
-	readSeeker.Seek(0, io.SeekStart)
+	_, err = readSeeker.Seek(0, io.SeekStart)
+	if err != nil {
+		return nil, nil, "", err
+	}
 
 	h["ETag"] = fmt.Sprintf("%x", hash.Sum(nil))
 

--- a/openstack/objectstorage/v1/objects/requests.go
+++ b/openstack/objectstorage/v1/objects/requests.go
@@ -596,10 +596,7 @@ func CreateTempURL(ctx context.Context, c *gophercloud.ServiceClient, containerN
 	if err != nil {
 		return "", err
 	}
-	urlToBeSigned, err := tempURL(c, containerName, objectName)
-	if err != nil {
-		return "", err
-	}
+	urlToBeSigned := tempURL(c, containerName, objectName)
 
 	if opts.Split == "" {
 		opts.Split = "/v1/"

--- a/openstack/objectstorage/v1/objects/testing/fixtures_test.go
+++ b/openstack/objectstorage/v1/objects/testing/fixtures_test.go
@@ -112,7 +112,9 @@ func HandleListObjectsInfoSuccessfully(t *testing.T, options ...option) {
 		th.TestHeader(t, r, "Accept", "application/json")
 
 		w.Header().Set("Content-Type", "application/json")
-		r.ParseForm()
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("Failed to parse request form %v", err)
+		}
 		marker := r.Form.Get("marker")
 		switch marker {
 		case "":
@@ -149,7 +151,9 @@ func HandleListSubdirSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "Accept", "application/json")
 
 		w.Header().Set("Content-Type", "application/json")
-		r.ParseForm()
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("Failed to parse request form %v", err)
+		}
 		marker := r.Form.Get("marker")
 		switch marker {
 		case "":
@@ -197,7 +201,8 @@ func HandleCreateTextObjectSuccessfully(t *testing.T, content string, options ..
 		th.TestBody(t, r, `Did gyre and gimble in the wabe`)
 
 		hash := md5.New()
-		io.WriteString(hash, content)
+		_, err := io.WriteString(hash, content)
+		th.AssertNoErr(t, err)
 		localChecksum := hash.Sum(nil)
 
 		w.Header().Set("ETag", fmt.Sprintf("%x", localChecksum))
@@ -216,7 +221,8 @@ func HandleCreateTextWithCacheControlSuccessfully(t *testing.T, content string) 
 		th.TestBody(t, r, `All mimsy were the borogoves`)
 
 		hash := md5.New()
-		io.WriteString(hash, content)
+		_, err := io.WriteString(hash, content)
+		th.AssertNoErr(t, err)
 		localChecksum := hash.Sum(nil)
 
 		w.Header().Set("ETag", fmt.Sprintf("%x", localChecksum))
@@ -239,7 +245,8 @@ func HandleCreateTypelessObjectSuccessfully(t *testing.T, content string) {
 		}
 
 		hash := md5.New()
-		io.WriteString(hash, content)
+		_, err := io.WriteString(hash, content)
+		th.AssertNoErr(t, err)
 		localChecksum := hash.Sum(nil)
 
 		w.Header().Set("ETag", fmt.Sprintf("%x", localChecksum))

--- a/openstack/objectstorage/v1/objects/testing/requests_test.go
+++ b/openstack/objectstorage/v1/objects/testing/requests_test.go
@@ -135,7 +135,8 @@ func TestDownloadReader(t *testing.T) {
 
 	// Check reader
 	buf := bytes.NewBuffer(make([]byte, 0))
-	io.CopyN(buf, response.Body, 10)
+	_, err := io.CopyN(buf, response.Body, 10)
+	th.AssertNoErr(t, err)
 	th.CheckEquals(t, "Successful", string(buf.Bytes()))
 }
 
@@ -448,7 +449,8 @@ func TestETag(t *testing.T) {
 	th.AssertEquals(t, false, ok)
 
 	hash := md5.New()
-	io.WriteString(hash, content)
+	_, err = io.WriteString(hash, content)
+	th.AssertNoErr(t, err)
 	localChecksum := fmt.Sprintf("%x", hash.Sum(nil))
 
 	createOpts = objects.CreateOpts{

--- a/openstack/objectstorage/v1/objects/testing/requests_test.go
+++ b/openstack/objectstorage/v1/objects/testing/requests_test.go
@@ -137,7 +137,7 @@ func TestDownloadReader(t *testing.T) {
 	buf := bytes.NewBuffer(make([]byte, 0))
 	_, err := io.CopyN(buf, response.Body, 10)
 	th.AssertNoErr(t, err)
-	th.CheckEquals(t, "Successful", string(buf.Bytes()))
+	th.CheckEquals(t, "Successful", buf.String())
 }
 
 func TestDownloadExtraction(t *testing.T) {

--- a/openstack/objectstorage/v1/objects/urls.go
+++ b/openstack/objectstorage/v1/objects/urls.go
@@ -11,8 +11,8 @@ import (
 // Names must not be URL-encoded in this case.
 //
 // See: https://docs.openstack.org/swift/latest/api/temporary_url_middleware.html#hmac-signature-for-temporary-urls
-func tempURL(c *gophercloud.ServiceClient, container, object string) (string, error) {
-	return c.ServiceURL(container, object), nil
+func tempURL(c *gophercloud.ServiceClient, container, object string) string {
+	return c.ServiceURL(container, object)
 }
 
 func listURL(c *gophercloud.ServiceClient, container string) (string, error) {

--- a/openstack/orchestration/v1/apiversions/testing/requests_test.go
+++ b/openstack/orchestration/v1/apiversions/testing/requests_test.go
@@ -43,7 +43,7 @@ func TestListVersions(t *testing.T) {
 
 	count := 0
 
-	apiversions.ListVersions(fake.ServiceClient()).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
+	err := apiversions.ListVersions(fake.ServiceClient()).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
 		count++
 		actual, err := apiversions.ExtractAPIVersions(page)
 		if err != nil {
@@ -68,6 +68,7 @@ func TestListVersions(t *testing.T) {
 
 		return true, nil
 	})
+	th.AssertNoErr(t, err)
 
 	if count != 1 {
 		t.Errorf("Expected 1 page, got %d", count)
@@ -82,10 +83,11 @@ func TestNonJSONCannotBeExtractedIntoAPIVersions(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	apiversions.ListVersions(fake.ServiceClient()).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
+	err := apiversions.ListVersions(fake.ServiceClient()).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
 		if _, err := apiversions.ExtractAPIVersions(page); err == nil {
 			t.Fatalf("Expected error, got nil")
 		}
 		return true, nil
 	})
+	th.AssertErr(t, err)
 }

--- a/openstack/orchestration/v1/resourcetypes/testing/fixtures_test.go
+++ b/openstack/orchestration/v1/resourcetypes/testing/fixtures_test.go
@@ -84,7 +84,9 @@ func HandleListSuccessfully(t *testing.T) {
 
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			r.ParseForm()
+			if err := r.ParseForm(); err != nil {
+				t.Errorf("Failed to parse request form %v", err)
+			}
 			var output string
 			if r.Form.Get("with_description") == "true" {
 				if r.Form.Get("name") == listFilterRegex {
@@ -376,7 +378,9 @@ func HandleGenerateTemplateSuccessfully(t *testing.T) {
 			th.TestHeader(t, r, "Accept", "application/json")
 
 			w.Header().Set("Content-Type", "application/json")
-			r.ParseForm()
+			if err := r.ParseForm(); err != nil {
+				t.Errorf("Failed to parse request form %v", err)
+			}
 			if r.Form.Get("template_type") == "hot" {
 				w.WriteHeader(http.StatusOK)
 				fmt.Fprint(w, GenerateTemplateOutput)

--- a/openstack/orchestration/v1/stackevents/testing/fixtures_test.go
+++ b/openstack/orchestration/v1/stackevents/testing/fixtures_test.go
@@ -244,7 +244,9 @@ func HandleListSuccessfully(t *testing.T, output string) {
 		th.TestHeader(t, r, "Accept", "application/json")
 
 		w.Header().Set("Content-Type", "application/json")
-		r.ParseForm()
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("Failed to parse request form %v", err)
+		}
 		marker := r.Form.Get("marker")
 		switch marker {
 		case "":
@@ -369,7 +371,9 @@ func HandleListResourceEventsSuccessfully(t *testing.T, output string) {
 		th.TestHeader(t, r, "Accept", "application/json")
 
 		w.Header().Set("Content-Type", "application/json")
-		r.ParseForm()
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("Failed to parse request form %v", err)
+		}
 		marker := r.Form.Get("marker")
 		switch marker {
 		case "":

--- a/openstack/orchestration/v1/stackresources/testing/fixtures_test.go
+++ b/openstack/orchestration/v1/stackresources/testing/fixtures_test.go
@@ -151,7 +151,9 @@ func HandleListSuccessfully(t *testing.T, output string) {
 		th.TestHeader(t, r, "Accept", "application/json")
 
 		w.Header().Set("Content-Type", "application/json")
-		r.ParseForm()
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("Failed to parse request form %v", err)
+		}
 		marker := r.Form.Get("marker")
 		switch marker {
 		case "":

--- a/openstack/orchestration/v1/stacks/testing/fixtures_test.go
+++ b/openstack/orchestration/v1/stacks/testing/fixtures_test.go
@@ -136,7 +136,9 @@ func HandleListSuccessfully(t *testing.T, output string) {
 		th.TestHeader(t, r, "Accept", "application/json")
 
 		w.Header().Set("Content-Type", "application/json")
-		r.ParseForm()
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("Failed to parse request form %v", err)
+		}
 		marker := r.Form.Get("marker")
 		switch marker {
 		case "":

--- a/openstack/sharedfilesystems/v2/replicas/testing/fixtures_test.go
+++ b/openstack/sharedfilesystems/v2/replicas/testing/fixtures_test.go
@@ -215,7 +215,9 @@ func MockListResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		r.ParseForm()
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("Failed to parse request form %v", err)
+		}
 		marker := r.Form.Get("offset")
 		shareID := r.Form.Get("share_id")
 		if shareID != "65a34695-f9e5-4eea-b48d-a0b261d82943" {
@@ -282,7 +284,9 @@ func MockListDetailResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		r.ParseForm()
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("Failed to parse request form %v", err)
+		}
 		marker := r.Form.Get("offset")
 		shareID := r.Form.Get("share_id")
 		if shareID != "65a34695-f9e5-4eea-b48d-a0b261d82943" {

--- a/openstack/sharedfilesystems/v2/schedulerstats/results.go
+++ b/openstack/sharedfilesystems/v2/schedulerstats/results.go
@@ -74,11 +74,11 @@ func (r *Capabilities) UnmarshalJSON(b []byte) error {
 	// value, "unknown", or "infinite"
 	parseCapacity := func(capacity interface{}) float64 {
 		if capacity != nil {
-			switch capacity.(type) {
+			switch c := capacity.(type) {
 			case float64:
-				return capacity.(float64)
+				return c
 			case string:
-				if capacity.(string) == "infinite" {
+				if c == "infinite" {
 					return math.Inf(1)
 				}
 			}

--- a/openstack/sharedfilesystems/v2/schedulerstats/testing/fixtures_test.go
+++ b/openstack/sharedfilesystems/v2/schedulerstats/testing/fixtures_test.go
@@ -271,7 +271,9 @@ func HandlePoolsListSuccessfully(t *testing.T) {
 
 		w.Header().Add("Content-Type", "application/json")
 
-		r.ParseForm()
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("Failed to parse request form %v", err)
+		}
 		fmt.Fprintf(w, PoolsListBody)
 
 	})
@@ -281,7 +283,9 @@ func HandlePoolsListSuccessfully(t *testing.T) {
 
 		w.Header().Add("Content-Type", "application/json")
 
-		r.ParseForm()
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("Failed to parse request form %v", err)
+		}
 		fmt.Fprintf(w, PoolsListBodyDetail)
 	})
 }

--- a/openstack/sharedfilesystems/v2/sharenetworks/testing/fixtures_test.go
+++ b/openstack/sharedfilesystems/v2/sharenetworks/testing/fixtures_test.go
@@ -78,7 +78,9 @@ func MockListResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		r.ParseForm()
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("Failed to parse request form %v", err)
+		}
 		marker := r.Form.Get("offset")
 
 		switch marker {
@@ -149,7 +151,9 @@ func MockFilteredListResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		r.ParseForm()
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("Failed to parse request form %v", err)
+		}
 		marker := r.Form.Get("offset")
 		switch marker {
 		case "":

--- a/openstack/sharedfilesystems/v2/shares/testing/fixtures_test.go
+++ b/openstack/sharedfilesystems/v2/shares/testing/fixtures_test.go
@@ -265,7 +265,9 @@ func MockListDetailResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		r.ParseForm()
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("Failed to parse request form %v", err)
+		}
 		marker := r.Form.Get("offset")
 
 		switch marker {

--- a/openstack/sharedfilesystems/v2/snapshots/testing/fixtures_test.go
+++ b/openstack/sharedfilesystems/v2/snapshots/testing/fixtures_test.go
@@ -193,7 +193,9 @@ func MockListDetailResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		r.ParseForm()
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("Failed to parse request form %v", err)
+		}
 		marker := r.Form.Get("offset")
 
 		switch marker {

--- a/openstack/workflow/v2/crontriggers/testing/requests_test.go
+++ b/openstack/workflow/v2/crontriggers/testing/requests_test.go
@@ -167,7 +167,9 @@ func TestListCronTriggers(t *testing.T) {
 		th.TestMethod(t, r, "GET")
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 		w.Header().Add("Content-Type", "application/json")
-		r.ParseForm()
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("Failed to parse request form %v", err)
+		}
 		marker := r.Form.Get("marker")
 		switch marker {
 		case "":

--- a/openstack/workflow/v2/executions/testing/requests_test.go
+++ b/openstack/workflow/v2/executions/testing/requests_test.go
@@ -161,7 +161,9 @@ func TestListExecutions(t *testing.T) {
 		th.TestMethod(t, r, "GET")
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 		w.Header().Add("Content-Type", "application/json")
-		r.ParseForm()
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("Failed to parse request form %v", err)
+		}
 		marker := r.Form.Get("marker")
 		switch marker {
 		case "":

--- a/openstack/workflow/v2/workflows/testing/requests_test.go
+++ b/openstack/workflow/v2/workflows/testing/requests_test.go
@@ -163,7 +163,9 @@ func TestListWorkflows(t *testing.T) {
 		th.TestMethod(t, r, "GET")
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 		w.Header().Add("Content-Type", "application/json")
-		r.ParseForm()
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("Failed to parse request form %v", err)
+		}
 		marker := r.Form.Get("marker")
 		switch marker {
 		case "":

--- a/pagination/testing/linked_test.go
+++ b/pagination/testing/linked_test.go
@@ -30,7 +30,7 @@ func ExtractLinkedInts(r pagination.Page) ([]int, error) {
 	return s.Ints, err
 }
 
-func createLinked(t *testing.T) pagination.Pager {
+func createLinked() pagination.Pager {
 	testhelper.SetupHTTP()
 
 	testhelper.Mux.HandleFunc("/page1", func(w http.ResponseWriter, r *http.Request) {
@@ -58,7 +58,7 @@ func createLinked(t *testing.T) pagination.Pager {
 }
 
 func TestEnumerateLinked(t *testing.T) {
-	pager := createLinked(t)
+	pager := createLinked()
 	defer testhelper.TeardownHTTP()
 
 	callCount := 0
@@ -100,7 +100,7 @@ func TestEnumerateLinked(t *testing.T) {
 }
 
 func TestAllPagesLinked(t *testing.T) {
-	pager := createLinked(t)
+	pager := createLinked()
 	defer testhelper.TeardownHTTP()
 
 	page, err := pager.AllPages(context.TODO())

--- a/pagination/testing/marker_test.go
+++ b/pagination/testing/marker_test.go
@@ -40,7 +40,9 @@ func createMarkerPaged(t *testing.T) pagination.Pager {
 	testhelper.SetupHTTP()
 
 	testhelper.Mux.HandleFunc("/page", func(w http.ResponseWriter, r *http.Request) {
-		r.ParseForm()
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("Failed to parse request form %v", err)
+		}
 		ms := r.Form["marker"]
 		switch {
 		case len(ms) == 0:

--- a/provider_client.go
+++ b/provider_client.go
@@ -470,7 +470,9 @@ func (client *ProviderClient) doRequest(ctx context.Context, method, url string,
 				}
 				if options.RawBody != nil {
 					if seeker, ok := options.RawBody.(io.Seeker); ok {
-						seeker.Seek(0, 0)
+						if _, err := seeker.Seek(0, 0); err != nil {
+							return nil, err
+						}
 					}
 				}
 				state.hasReauthenticated = true

--- a/provider_client.go
+++ b/provider_client.go
@@ -478,15 +478,15 @@ func (client *ProviderClient) doRequest(ctx context.Context, method, url string,
 				state.hasReauthenticated = true
 				resp, err = client.doRequest(ctx, method, url, options, state)
 				if err != nil {
-					switch err.(type) {
+					switch e := err.(type) {
 					case *ErrUnexpectedResponseCode:
-						e := &ErrErrorAfterReauthentication{}
-						e.ErrOriginal = err.(*ErrUnexpectedResponseCode)
-						return nil, e
+						err := &ErrErrorAfterReauthentication{}
+						err.ErrOriginal = e
+						return nil, err
 					default:
-						e := &ErrErrorAfterReauthentication{}
-						e.ErrOriginal = err
-						return nil, e
+						err := &ErrErrorAfterReauthentication{}
+						err.ErrOriginal = e
+						return nil, err
 					}
 				}
 				return resp, nil

--- a/testhelper/convenience.go
+++ b/testhelper/convenience.go
@@ -268,7 +268,7 @@ func CheckDeepEquals(t *testing.T, expected, actual interface{}) {
 	})
 }
 
-func isByteArrayEquals(t *testing.T, expectedBytes []byte, actualBytes []byte) bool {
+func isByteArrayEquals(expectedBytes []byte, actualBytes []byte) bool {
 	return bytes.Equal(expectedBytes, actualBytes)
 }
 
@@ -276,7 +276,7 @@ func isByteArrayEquals(t *testing.T, expectedBytes []byte, actualBytes []byte) b
 func AssertByteArrayEquals(t *testing.T, expectedBytes []byte, actualBytes []byte) {
 	t.Helper()
 
-	if !isByteArrayEquals(t, expectedBytes, actualBytes) {
+	if !isByteArrayEquals(expectedBytes, actualBytes) {
 		logFatal(t, "The bytes differed.")
 	}
 }
@@ -285,7 +285,7 @@ func AssertByteArrayEquals(t *testing.T, expectedBytes []byte, actualBytes []byt
 func CheckByteArrayEquals(t *testing.T, expectedBytes []byte, actualBytes []byte) {
 	t.Helper()
 
-	if !isByteArrayEquals(t, expectedBytes, actualBytes) {
+	if !isByteArrayEquals(expectedBytes, actualBytes) {
 		logError(t, "The bytes differed.")
 	}
 }

--- a/testhelper/http_responses.go
+++ b/testhelper/http_responses.go
@@ -71,7 +71,9 @@ func TestFormValues(t *testing.T, r *http.Request, values map[string]string) {
 		want.Add(k, v)
 	}
 
-	r.ParseForm()
+	if err := r.ParseForm(); err != nil {
+		t.Errorf("Failed to parse request form %v", r)
+	}
 	if !reflect.DeepEqual(want, r.Form) {
 		t.Errorf("Request parameters = %v, want %v", r.Form, want)
 	}

--- a/testing/errors_test.go
+++ b/testing/errors_test.go
@@ -9,17 +9,6 @@ import (
 	th "github.com/gophercloud/gophercloud/v2/testhelper"
 )
 
-func returnsUnexpectedResp(code int) gophercloud.ErrUnexpectedResponseCode {
-	return gophercloud.ErrUnexpectedResponseCode{
-		URL:            "http://example.com",
-		Method:         "GET",
-		Expected:       []int{200},
-		Actual:         code,
-		Body:           []byte("the response body"),
-		ResponseHeader: nil,
-	}
-}
-
 func TestErrUnexpectedResponseCode(t *testing.T) {
 	err := gophercloud.ErrUnexpectedResponseCode{
 		URL:            "http://example.com",

--- a/testing/provider_client_test.go
+++ b/testing/provider_client_test.go
@@ -177,7 +177,6 @@ func TestReauthEndLoop(t *testing.T) {
 	th.Mux.HandleFunc("/route", func(w http.ResponseWriter, r *http.Request) {
 		// route always return 401
 		w.WriteHeader(http.StatusUnauthorized)
-		return
 	})
 
 	reqopts := new(gophercloud.RequestOpts)

--- a/testing/provider_client_test.go
+++ b/testing/provider_client_test.go
@@ -387,7 +387,7 @@ func TestRequestWithContext(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	cancel()
-	res, err = p.Request(ctx, "GET", ts.URL, &gophercloud.RequestOpts{})
+	_, err = p.Request(ctx, "GET", ts.URL, &gophercloud.RequestOpts{})
 	if err == nil {
 		t.Fatal("expecting error, got nil")
 	}


### PR DESCRIPTION
This PR comes out of comments from @EmilienM in #2940 and depends on same. Add `golangci-lint` to the `lint` target added by that PR. Most of the changes are noddy and don't really benefit us massively, but fixing them is easier than ignoring them on a file-by-file basis :smile:.

<details>
<summary>Commits</summary>

- ``Add minimal Makefile``
- ``make: Add golangci-lint to lint target``
- ``lint: Remove redundant returns (gosimple)``
- ``lint: Remove unnecessary guards around calls to delete (gosimple)``
- ``lint: Remove unnecessary assignments to the blank identifier (gosimple)``
- ``lint: Remove unused variables (unused)``
- ``lint: Check all return codes (errcheck)``
- ``lint: Resolve ineffectual assignments to err (ineffassign)``
- ``lint: Simplify various bits of code (gosimple)``
- ``lint: Remove unused variables (staticcheck)``
- ``lint: Resolve nil pointer dereference (staticcheck)``
- ``lint: Use strings.Equalfold (staticcheck)``
- ``lint: Replace use of deprecated stdlib functions (staticcheck)``
- ``lint: Enable additional linters``
</details>

Depends-On: #2940
