### PR TITLE
remove golang patch version from main go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gophercloud/gophercloud/v2
 
-go 1.21.6
+go 1.21
 
 require (
 	golang.org/x/crypto v0.22.0


### PR DESCRIPTION
Since golang 1.21, the patch version in go.mod is trickled to downstream consumers as minimum go version, and to their consumers etc. Remove the patch version, and use only minor version to allow consumers some flexibility.

Fixes: #3031
