### PR TITLE
Add support for implied roles

### DIFF
--- a/openstack/identity/v3/roles/doc.go
+++ b/openstack/identity/v3/roles/doc.go
@@ -131,5 +131,46 @@ Example to Unassign a Role From a User in a Project
 	if err != nil {
 		panic(err)
 	}
+
+Example to Create a Role Inference Rule
+
+	priorRoleID := "7ceab6192ea34a548cc71b24f72e762c"
+	impliedRoleID := "97e2f5d38bc94842bc3da818c16762ed"
+
+	actual, err := roles.CreateRoleInferenceRule(context.TODO(), identityClient, priorRoleID, impliedRoleID).Extract()
+
+	if err != nil {
+		panic(err)
+	}
+
+Example to Get a Role Inference Rule
+
+	priorRoleID := "7ceab6192ea34a548cc71b24f72e762c"
+	impliedRoleID := "97e2f5d38bc94842bc3da818c16762ed"
+
+	actual, err := roles.GetRoleInferenceRule(context.TODO(), identityClient, priorRoleID, impliedRoleID).Extract()
+
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete a Role Inference Rule
+
+	priorRoleID := "7ceab6192ea34a548cc71b24f72e762c"
+	impliedRoleID := "97e2f5d38bc94842bc3da818c16762ed"
+
+	actual, err := roles.DeleteRoleInferenceRule(context.TODO(), identityClient, priorRoleID, impliedRoleID).ExtractErr()
+
+	if err != nil {
+		panic(err)
+	}
+
+Example to List Role Inference Rules
+
+	actual, err := roles.ListRoleInferenceRules(context.TODO(), identityClient).Extract()
+
+	if err != nil {
+		panic(err)
+	}
 */
 package roles

--- a/openstack/identity/v3/roles/requests.go
+++ b/openstack/identity/v3/roles/requests.go
@@ -406,3 +406,35 @@ func Unassign(ctx context.Context, client *gophercloud.ServiceClient, roleID str
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
+
+func CreateRoleInferenceRule(ctx context.Context, client *gophercloud.ServiceClient, priorRoleID, impliedRoleID string) (r CreateImpliedRoleResult) {
+	resp, err := client.Put(ctx, createRoleInferenceRuleURL(client, priorRoleID, impliedRoleID), nil, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{201},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+func GetRoleInferenceRule(ctx context.Context, client *gophercloud.ServiceClient, priorRoleID, impliedRoleID string) (r CreateImpliedRoleResult) {
+	resp, err := client.Get(ctx, getRoleInferenceRuleURL(client, priorRoleID, impliedRoleID), &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+func DeleteRoleInferenceRule(ctx context.Context, client *gophercloud.ServiceClient, priorRoleID, impliedRoleID string) (r DeleteImpliedRoleResult) {
+	resp, err := client.Delete(ctx, deleteRoleInferenceRuleURL(client, priorRoleID, impliedRoleID), &gophercloud.RequestOpts{
+		OkCodes: []int{204},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+func ListRoleInferenceRules(ctx context.Context, client *gophercloud.ServiceClient) (r ListImpliedRolesResult) {
+	resp, err := client.Get(ctx, listRoleInferenceRulesURL(client), &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}

--- a/openstack/identity/v3/roles/results.go
+++ b/openstack/identity/v3/roles/results.go
@@ -227,3 +227,99 @@ type AssignmentResult struct {
 type UnassignmentResult struct {
 	gophercloud.ErrResult
 }
+
+type impliedRoleResult struct {
+	gophercloud.Result
+}
+
+// ImpliedRoleResult is the result of an PUT request. Call its Extract method to
+// interpret it as a roleInference.
+type CreateImpliedRoleResult struct {
+	impliedRoleResult
+}
+
+type GetImpliedRoleResult struct {
+	impliedRoleResult
+}
+type PriorRole struct {
+	// ID contains the ID of the role in a prior_role object.
+	ID string `json:"id,omitempty"`
+	// Name contains the name of a role in a prior_role object.
+	Name string `json:"name,omitempty"`
+	// Links contains referencing links to the  prior_role.
+	Links map[string]interface{} `json:"links"`
+}
+
+type ImpliedRole struct {
+	// ID contains the ID of the role in an implied_role object.
+	ID string `json:"id,omitempty"`
+	// Name contains the name of role  in an implied_role.
+	Name string `json:"name,omitempty"`
+	// Links contains referencing links to the implied_role.
+	Links map[string]interface{} `json:"links"`
+}
+
+type RoleInference struct {
+	// PriorRole is the role object that implies a list of implied_role objects.
+	PriorRole PriorRole `json:"prior_role"`
+	// Implies is an array of implied_role objects implied by a prior_role object.
+	ImpliedRole ImpliedRole `json:"implies"`
+}
+
+type RoleInferenceRule struct {
+	RoleInference RoleInference          `json:"role_inference"`
+	Links         map[string]interface{} `json:"links"`
+}
+
+func (r impliedRoleResult) Extract() (*RoleInferenceRule, error) {
+	var s = &RoleInferenceRule{}
+	err := r.ExtractInto(s)
+	return s, err
+}
+
+type ListImpliedRolesResult struct {
+	gophercloud.Result
+}
+
+type ImpliedRoleObject struct {
+	// ID contains the ID of the role in an implied_role object.
+	ID string `json:"id,omitempty"`
+	// Name contains the name of role  in an implied_role.
+	Name string `json:"name,omitempty"`
+	// Name contains the name of role  in an implied_role.
+	Description string `json:"description,omitempty"`
+	// Links contains referencing links to the implied_role.
+	Links map[string]interface{} `json:"links"`
+}
+
+type PriorRoleObject struct {
+	// ID contains the ID of the role in an implied_role object.
+	ID string `json:"id,omitempty"`
+	// Name contains the name of role  in an implied_role.
+	Name string `json:"name,omitempty"`
+	// Name contains the name of role  in an implied_role.
+	Description string `json:"description,omitempty"`
+	// Links contains referencing links to the implied_role.
+	Links map[string]interface{} `json:"links"`
+}
+type RoleInferenceRules struct {
+	// PriorRole is the role object that implies a list of implied_role objects.
+	PriorRole PriorRoleObject `json:"prior_role"`
+	// Implies is an array of implied_role objects implied by a prior_role object.
+	ImpliedRoles []ImpliedRoleObject `json:"implies"`
+}
+
+type RoleInferenceRuleList struct {
+	RoleInferenceRuleList []RoleInferenceRules   `json:"role_inferences"`
+	Links                 map[string]interface{} `json:"links"`
+}
+
+func (r ListImpliedRolesResult) Extract() (*RoleInferenceRuleList, error) {
+	var s = &RoleInferenceRuleList{}
+	err := r.ExtractInto(s)
+	return s, err
+}
+
+type DeleteImpliedRoleResult struct {
+	gophercloud.ErrResult
+}

--- a/openstack/identity/v3/roles/testing/fixtures_test.go
+++ b/openstack/identity/v3/roles/testing/fixtures_test.go
@@ -210,6 +210,96 @@ const ListAssignmentsOnResourceOutput = `
 }
 `
 
+const CreateRoleInferenceRuleOutput = `
+{
+    "role_inference": {
+        "prior_role": {
+            "id": "7ceab6192ea34a548cc71b24f72e762c",
+            "links": {
+                "self": "http://example.com/identity/v3/roles/7ceab6192ea34a548cc71b24f72e762c"
+            },
+            "name": "prior role name"
+        },
+        "implies": {
+            "id": "97e2f5d38bc94842bc3da818c16762ed",
+            "links": {
+                "self": "http://example.com/identity/v3/roles/97e2f5d38bc94842bc3da818c16762ed"
+            },
+            "name": "implied role name"
+        }
+    },
+    "links": {
+        "self": "http://example.com/identity/v3/roles/7ceab6192ea34a548cc71b24f72e762c/implies/97e2f5d38bc94842bc3da818c16762ed"
+    }
+}
+`
+
+const ListRoleInferenceRulesOutput = `
+{
+    "role_inferences": [
+        {
+            "prior_role": {
+                "id": "1acd3c5aa0e246b9a7427d252160dcd1",
+                "links": {
+                    "self": "http://example.com/identity/v3/roles/1acd3c5aa0e246b9a7427d252160dcd1"
+                },
+                "description": "My new role",
+                "name": "prior role name"
+            },
+            "implies": [
+                {
+                    "id": "3602510e2e1f499589f78a0724dcf614",
+                    "links": {
+                        "self": "http://example.com/identity/v3/roles/3602510e2e1f499589f78a0724dcf614"
+                    },
+                    "description": "My new role",
+                    "name": "implied role1 name"
+                },
+                {
+                    "id": "738289aeef684e73a987f7cf2ec6d925",
+                    "links": {
+                        "self": "http://example.com/identity/v3/roles/738289aeef684e73a987f7cf2ec6d925"
+                    },
+                    "description": "My new role",
+                    "name": "implied role2 name"
+                }
+            ]
+        },
+        {
+            "prior_role": {
+                "id": "bbf7a5098bb34407b7164eb6ff9f144e",
+                "links": {
+                    "self" : "http://example.com/identity/v3/roles/bbf7a5098bb34407b7164eb6ff9f144e"
+                },
+                "description": "My new role",
+                "name": "prior role name"
+            },
+            "implies": [
+                {
+                    "id": "872b20ad124c4c1bafaef2b1aae316ab",
+                    "links": {
+                        "self": "http://example.com/identity/v3/roles/872b20ad124c4c1bafaef2b1aae316ab"
+                    },
+                    "description": null,
+                    "name": "implied role1 name"
+                },
+                {
+                    "id": "1d865b1b2da14cb7b05254677e5f36a2",
+                    "links": {
+                        "self": "http://example.com/identity/v3/roles/1d865b1b2da14cb7b05254677e5f36a2"
+                    },
+                    "description": null,
+                    "name": "implied role2 name"
+                }
+            ]
+        }
+    ],
+    "links": {
+        "self": "http://example.com/identity/v3/role_inferences"
+    }
+}
+`
+
 // FirstRole is the first role in the List request.
 var FirstRole = roles.Role{
 	DomainID: "default",
@@ -513,4 +603,142 @@ func HandleListAssignmentsOnResourceSuccessfully_DomainsGroups(t *testing.T) {
 	}
 
 	th.Mux.HandleFunc("/domains/{domain_id}/groups/{group_id}/roles", fn)
+}
+
+var expectedRoleInferenceRule = roles.RoleInferenceRule{
+	RoleInference: roles.RoleInference{
+		PriorRole: roles.PriorRole{
+			ID: "7ceab6192ea34a548cc71b24f72e762c",
+			Links: map[string]interface{}{
+				"self": "http://example.com/identity/v3/roles/7ceab6192ea34a548cc71b24f72e762c",
+			},
+			Name: "prior role name",
+		},
+		ImpliedRole: roles.ImpliedRole{
+			ID: "97e2f5d38bc94842bc3da818c16762ed",
+			Links: map[string]interface{}{
+				"self": "http://example.com/identity/v3/roles/97e2f5d38bc94842bc3da818c16762ed",
+			},
+			Name: "implied role name",
+		},
+	},
+	Links: map[string]interface{}{
+		"self": "http://example.com/identity/v3/roles/7ceab6192ea34a548cc71b24f72e762c/implies/97e2f5d38bc94842bc3da818c16762ed",
+	},
+}
+
+func HandleCreateRoleInferenceRule(t *testing.T) {
+	fn := func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprintf(w, CreateRoleInferenceRuleOutput)
+	}
+
+	th.Mux.HandleFunc("/roles/7ceab6192ea34a548cc71b24f72e762c/implies/97e2f5d38bc94842bc3da818c16762ed", fn)
+}
+
+var expectedRoleInferenceRuleList = roles.RoleInferenceRuleList{
+	RoleInferenceRuleList: []roles.RoleInferenceRules{
+		{
+			PriorRole: roles.PriorRoleObject{
+				ID: "1acd3c5aa0e246b9a7427d252160dcd1",
+				Links: map[string]interface{}{
+					"self": "http://example.com/identity/v3/roles/1acd3c5aa0e246b9a7427d252160dcd1",
+				},
+				Name:        "prior role name",
+				Description: "My new role",
+			},
+			ImpliedRoles: []roles.ImpliedRoleObject{
+				{
+					ID: "3602510e2e1f499589f78a0724dcf614",
+					Links: map[string]interface{}{
+						"self": "http://example.com/identity/v3/roles/3602510e2e1f499589f78a0724dcf614",
+					},
+					Name:        "implied role1 name",
+					Description: "My new role",
+				},
+				{
+					ID: "738289aeef684e73a987f7cf2ec6d925",
+					Links: map[string]interface{}{
+						"self": "http://example.com/identity/v3/roles/738289aeef684e73a987f7cf2ec6d925",
+					},
+					Name:        "implied role2 name",
+					Description: "My new role",
+				},
+			},
+		},
+		{
+			PriorRole: roles.PriorRoleObject{
+				ID: "bbf7a5098bb34407b7164eb6ff9f144e",
+				Links: map[string]interface{}{
+					"self": "http://example.com/identity/v3/roles/bbf7a5098bb34407b7164eb6ff9f144e",
+				},
+				Name:        "prior role name",
+				Description: "My new role",
+			},
+			ImpliedRoles: []roles.ImpliedRoleObject{
+				{
+					ID: "872b20ad124c4c1bafaef2b1aae316ab",
+					Links: map[string]interface{}{
+						"self": "http://example.com/identity/v3/roles/872b20ad124c4c1bafaef2b1aae316ab",
+					},
+					Name:        "implied role1 name",
+					Description: "",
+				},
+				{
+					ID: "1d865b1b2da14cb7b05254677e5f36a2",
+					Links: map[string]interface{}{
+						"self": "http://example.com/identity/v3/roles/1d865b1b2da14cb7b05254677e5f36a2",
+					},
+					Name:        "implied role2 name",
+					Description: "",
+				},
+			},
+		},
+	},
+	Links: map[string]interface{}{
+		"self": "http://example.com/identity/v3/role_inferences",
+	},
+}
+
+func HandleListRoleInferenceRules(t *testing.T) {
+	fn := func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, ListRoleInferenceRulesOutput)
+	}
+
+	th.Mux.HandleFunc("/role_inferences", fn)
+}
+
+func HandleDeleteRoleInferenceRule(t *testing.T) {
+	fn := func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.WriteHeader(http.StatusNoContent)
+	}
+	th.Mux.HandleFunc("/roles/7ceab6192ea34a548cc71b24f72e762c/implies/97e2f5d38bc94842bc3da818c16762ed", fn)
+}
+
+func HandleGetRoleInferenceRule(t *testing.T) {
+	fn := func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, CreateRoleInferenceRuleOutput)
+	}
+
+	th.Mux.HandleFunc("/roles/7ceab6192ea34a548cc71b24f72e762c/implies/97e2f5d38bc94842bc3da818c16762ed", fn)
 }

--- a/openstack/identity/v3/roles/testing/requests_test.go
+++ b/openstack/identity/v3/roles/testing/requests_test.go
@@ -343,3 +343,42 @@ func TestUnassign(t *testing.T) {
 	}).ExtractErr()
 	th.AssertNoErr(t, err)
 }
+
+func TestCreateRoleInferenceRule(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleCreateRoleInferenceRule(t)
+
+	actual, err := roles.CreateRoleInferenceRule(context.TODO(), client.ServiceClient(), "7ceab6192ea34a548cc71b24f72e762c", "97e2f5d38bc94842bc3da818c16762ed").Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, expectedRoleInferenceRule, *actual)
+}
+
+func TestListRoleInferenceRules(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleListRoleInferenceRules(t)
+
+	actual, err := roles.ListRoleInferenceRules(context.TODO(), client.ServiceClient()).Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, expectedRoleInferenceRuleList, *actual)
+}
+
+func TestDeleteRoleInferenceRule(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleDeleteRoleInferenceRule(t)
+
+	err := roles.DeleteRoleInferenceRule(context.TODO(), client.ServiceClient(), "7ceab6192ea34a548cc71b24f72e762c", "97e2f5d38bc94842bc3da818c16762ed").ExtractErr()
+	th.AssertNoErr(t, err)
+}
+
+func TestGetInferenceRule(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleGetRoleInferenceRule(t)
+
+	actual, err := roles.GetRoleInferenceRule(context.TODO(), client.ServiceClient(), "7ceab6192ea34a548cc71b24f72e762c", "97e2f5d38bc94842bc3da818c16762ed").Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, expectedRoleInferenceRule, *actual)
+}

--- a/openstack/identity/v3/roles/urls.go
+++ b/openstack/identity/v3/roles/urls.go
@@ -37,3 +37,19 @@ func listAssignmentsOnResourceURL(client *gophercloud.ServiceClient, targetType,
 func assignURL(client *gophercloud.ServiceClient, targetType, targetID, actorType, actorID, roleID string) string {
 	return client.ServiceURL(targetType, targetID, actorType, actorID, rolePath, roleID)
 }
+
+func createRoleInferenceRuleURL(client *gophercloud.ServiceClient, priorRoleID, impliedRoleID string) string {
+	return client.ServiceURL(rolePath, priorRoleID, "implies", impliedRoleID)
+}
+
+func getRoleInferenceRuleURL(client *gophercloud.ServiceClient, priorRoleID, impliedRoleID string) string {
+	return client.ServiceURL(rolePath, priorRoleID, "implies", impliedRoleID)
+}
+
+func listRoleInferenceRulesURL(client *gophercloud.ServiceClient) string {
+	return client.ServiceURL("role_inferences")
+}
+
+func deleteRoleInferenceRuleURL(client *gophercloud.ServiceClient, priorRoleID, impliedRoleID string) string {
+	return client.ServiceURL(rolePath, priorRoleID, "implies", impliedRoleID)
+}


### PR DESCRIPTION
With this PR, we add API support for:
* Create role inference rule.
* List all role inference rules.
* Delete role inference rule.
* Get a role inference rules.

Implements: #2225 

Create role inference rule:
[API Docs ](https://docs.openstack.org/api-ref/identity/v3/index.html#create-role-inference-rule)
[Py code](https://github.com/openstack/keystone/blob/master/keystone/api/roles.py#L252)

Get role inference rule:
[API Docs ](https://docs.openstack.org/api-ref/identity/v3/index.html#get-role-inference-rule)
[Py code](https://github.com/openstack/keystone/blob/master/keystone/api/roles.py#L227)

Delete a role inference rule:
[API Docs ](https://docs.openstack.org/api-ref/identity/v3/index.html#delete-role-inference-rule)
[Py code](https://github.com/openstack/keystone/blob/master/keystone/api/roles.py#L263)

List all role inference rules:
[API Docs ](https://docs.openstack.org/api-ref/identity/v3/index.html#list-all-role-inference-rules)
[Py code](https://github.com/openstack/keystone/blob/master/keystone/api/roles.py#L188)
