### PR TITLE
clouds: Fix secure.yaml parsing

### DIFF
--- a/openstack/config/clouds/clouds.go
+++ b/openstack/config/clouds/clouds.go
@@ -100,7 +100,7 @@ func Parse(opts ...ParseOption) (gophercloud.AuthOptions, gophercloud.EndpointOp
 				options.cloudsyamlReader = f
 
 				if options.secureyamlReader == nil {
-					securePath := path.Join(path.Base(cloudsPath), "secure.yaml")
+					securePath := path.Join(path.Dir(cloudsPath), "secure.yaml")
 					secureF, err := os.Open(securePath)
 					if err != nil && !errors.As(err, &errNotFound) {
 						return gophercloud.AuthOptions{}, gophercloud.EndpointOpts{}, nil, fmt.Errorf("failed to open %q: %w", securePath, err)

--- a/openstack/config/clouds/clouds_test.go
+++ b/openstack/config/clouds/clouds_test.go
@@ -2,7 +2,9 @@ package clouds_test
 
 import (
 	"fmt"
+	"os"
 	"strings"
+	"testing"
 
 	"github.com/gophercloud/gophercloud/v2/openstack/config/clouds"
 )
@@ -61,4 +63,64 @@ func ExampleWithRegion() {
 
 	fmt.Println(eo.Region)
 	// Output: mars
+}
+
+func TestParse(t *testing.T) {
+	t.Run("parses the local clouds.yaml and secure.yaml if present", func(t *testing.T) {
+		const cloudsYAML = `clouds:
+  gophercloud-test:
+    auth:
+      auth_url: https://example.com/gophercloud-test-12345:13000`
+		const secureYAML = `clouds:
+  gophercloud-test:
+    auth:
+      password: secret
+      username: gophercloud-test-username`
+
+		tmpDir, err := os.MkdirTemp(os.TempDir(), "gophercloud-test")
+		if err != nil {
+			t.Fatalf("unable to create a temporary directory: %v", err)
+		}
+		defer func(tmpDir string) {
+			if err := os.RemoveAll(tmpDir); err != nil {
+				panic("unable to remove the temporary files: " + err.Error())
+			}
+		}(tmpDir)
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatalf("unable to determine the current working directory: %v", err)
+		}
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatalf("unable to move to a temporary directory: %v", err)
+		}
+		defer func() {
+			if err := os.Chdir(cwd); err != nil {
+				panic("unable to reset the current working directory: " + err.Error())
+			}
+		}()
+
+		if err := os.WriteFile("clouds.yaml", []byte(cloudsYAML), 0644); err != nil {
+			t.Fatalf("unable to create a mock clouds.yaml file: %v", err)
+		}
+
+		if err := os.WriteFile("secure.yaml", []byte(secureYAML), 0644); err != nil {
+			t.Fatalf("unable to create a mock secure.yaml file: %v", err)
+		}
+
+		ao, _, _, err := clouds.Parse(
+			clouds.WithCloudName("gophercloud-test"),
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if got := ao.IdentityEndpoint; got != "https://example.com/gophercloud-test-12345:13000" {
+			t.Errorf("unexpected identity endpoint: %q", got)
+		}
+
+		if got := ao.Username; got != "gophercloud-test-username" {
+			t.Errorf("unexpected username: %q", got)
+		}
+	})
 }


### PR DESCRIPTION
Before this patch, no `secure.yaml` could ever be found by the Parse function, because a programming error caused Gophercloud to always look at a path that doesn't exist.

Fixes #3039