### PR TITLE
CI: baremetal: also use system scope in 2024.1

### DIFF
--- a/.github/workflows/functional-baremetal.yaml
+++ b/.github/workflows/functional-baremetal.yaml
@@ -14,12 +14,15 @@ jobs:
           - name: "master"
             openstack_version: "master"
             ubuntu_version: "22.04"
+            # NOTE(dtantsur): this forces running tests with a system scope
+            # token, which is required for certain actions. Use "all" on
+            # versions starting with 2024.1.
             os_system_scope: "all"
             additional_services: "openstack-cli-server"
           - name: "caracal"
             openstack_version: "stable/2024.1"
             ubuntu_version: "22.04"
-            os_system_scope: ""
+            os_system_scope: "all"
             additional_services: ""
           - name: "bobcat"
             openstack_version: "stable/2023.2"


### PR DESCRIPTION
The RBAC changes were already there but the correct scope was not set
when adding the caracal branch.
