### PR TITLE
Enable openstack-client-server service in functional jobs

### DIFF
--- a/.github/workflows/functional-baremetal.yaml
+++ b/.github/workflows/functional-baremetal.yaml
@@ -10,11 +10,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        name: ["master"]
-        openstack_version: ["master"]
-        ubuntu_version: ["22.04"]
-        os_system_scope: ["all"]
         include:
+          - name: "master"
+            openstack_version: "master"
+            ubuntu_version: "22.04"
+            os_system_scope: "all"
           - name: "caracal"
             openstack_version: "stable/2024.1"
             ubuntu_version: "22.04"

--- a/.github/workflows/functional-baremetal.yaml
+++ b/.github/workflows/functional-baremetal.yaml
@@ -15,18 +15,22 @@ jobs:
             openstack_version: "master"
             ubuntu_version: "22.04"
             os_system_scope: "all"
+            additional_services: "openstack-cli-server"
           - name: "caracal"
             openstack_version: "stable/2024.1"
             ubuntu_version: "22.04"
             os_system_scope: ""
+            additional_services: ""
           - name: "bobcat"
             openstack_version: "stable/2023.2"
             ubuntu_version: "22.04"
             os_system_scope: ""
+            additional_services: ""
           - name: "antelope"
             openstack_version: "stable/2023.1"
             ubuntu_version: "22.04"
             os_system_scope: ""
+            additional_services: ""
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with Ironic and run baremetal acceptance tests
     steps:
@@ -80,7 +84,7 @@ jobs:
             IRONIC_ENABLED_DEPLOY_INTERFACES=direct,fake
             SWIFT_ENABLE_TEMPURLS=True
             SWIFT_TEMPURL_KEY=secretkey
-          enabled_services: 'ir-api,ir-cond,s-account,s-container,s-object,s-proxy,q-svc,q-agt,q-dhcp,q-l3,q-meta,-cinder,-c-sch,-c-api,-c-vol,-c-bak,-ovn,-ovn-controller,-ovn-northd,-q-ovn-metadata-agent'
+          enabled_services: "ir-api,ir-cond,s-account,s-container,s-object,s-proxy,q-svc,q-agt,q-dhcp,q-l3,q-meta,-cinder,-c-sch,-c-api,-c-vol,-c-bak,-ovn,-ovn-controller,-ovn-northd,-q-ovn-metadata-agent,${{ matrix.additional_services }}"
       - name: Checkout go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/functional-basic.yaml
+++ b/.github/workflows/functional-basic.yaml
@@ -17,15 +17,19 @@ jobs:
           - name: "master"
             openstack_version: "master"
             ubuntu_version: "22.04"
+            additional_services: "openstack-cli-server"
           - name: "caracal"
             openstack_version: "stable/2024.1"
             ubuntu_version: "22.04"
+            additional_services: ""
           - name: "bobcat"
             openstack_version: "stable/2023.2"
             ubuntu_version: "22.04"
+            additional_services: ""
           - name: "antelope"
             openstack_version: "stable/2023.1"
             ubuntu_version: "22.04"
+            additional_services: ""
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with defaults and run basic acceptance tests
     steps:
@@ -35,7 +39,7 @@ jobs:
         uses: EmilienM/devstack-action@e82a9cbead099cba72f99537e82a360c3e319c69
         with:
           branch: ${{ matrix.openstack_version }}
-          enabled_services: 's-account,s-container,s-object,s-proxy'
+          enabled_services: 's-account,s-container,s-object,s-proxy,${{ matrix.additional_services }}'
       - name: Checkout go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/functional-basic.yaml
+++ b/.github/workflows/functional-basic.yaml
@@ -13,10 +13,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        name: ["master"]
-        openstack_version: ["master"]
-        ubuntu_version: ["22.04"]
         include:
+          - name: "master"
+            openstack_version: "master"
+            ubuntu_version: "22.04"
           - name: "caracal"
             openstack_version: "stable/2024.1"
             ubuntu_version: "22.04"

--- a/.github/workflows/functional-blockstorage.yaml
+++ b/.github/workflows/functional-blockstorage.yaml
@@ -14,15 +14,19 @@ jobs:
           - name: "master"
             openstack_version: "master"
             ubuntu_version: "22.04"
+            additional_services: "openstack-cli-server"
           - name: "caracal"
             openstack_version: "stable/2024.1"
             ubuntu_version: "22.04"
+            additional_services: ""
           - name: "bobcat"
             openstack_version: "stable/2023.2"
             ubuntu_version: "22.04"
+            additional_services: ""
           - name: "antelope"
             openstack_version: "stable/2023.1"
             ubuntu_version: "22.04"
+            additional_services: ""
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with Cinder and run blockstorage acceptance tests
     steps:
@@ -34,7 +38,7 @@ jobs:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |
             CINDER_ISCSI_HELPER=lioadm
-          enabled_services: 's-account,s-container,s-object,s-proxy,c-bak'
+          enabled_services: "s-account,s-container,s-object,s-proxy,c-bak,${{ matrix.additional_services }}"
       - name: Checkout go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/functional-blockstorage.yaml
+++ b/.github/workflows/functional-blockstorage.yaml
@@ -10,10 +10,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        name: ["master"]
-        openstack_version: ["master"]
-        ubuntu_version: ["22.04"]
         include:
+          - name: "master"
+            openstack_version: "master"
+            ubuntu_version: "22.04"
           - name: "caracal"
             openstack_version: "stable/2024.1"
             ubuntu_version: "22.04"

--- a/.github/workflows/functional-compute.yaml
+++ b/.github/workflows/functional-compute.yaml
@@ -14,15 +14,19 @@ jobs:
           - name: "master"
             openstack_version: "master"
             ubuntu_version: "22.04"
+            additional_services: "openstack-cli-server"
           - name: "caracal"
             openstack_version: "stable/2024.1"
             ubuntu_version: "22.04"
+            additional_services: ""
           - name: "bobcat"
             openstack_version: "stable/2023.2"
             ubuntu_version: "22.04"
+            additional_services: ""
           - name: "antelope"
             openstack_version: "stable/2023.1"
             ubuntu_version: "22.04"
+            additional_services: ""
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with Nova and run compute acceptance tests
     steps:
@@ -34,6 +38,7 @@ jobs:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |
             CINDER_ISCSI_HELPER=lioadm
+          enabled_services: "${{ matrix.additional_services }}"
       - name: Checkout go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/functional-compute.yaml
+++ b/.github/workflows/functional-compute.yaml
@@ -10,10 +10,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        name: ["master"]
-        openstack_version: ["master"]
-        ubuntu_version: ["22.04"]
         include:
+          - name: "master"
+            openstack_version: "master"
+            ubuntu_version: "22.04"
           - name: "caracal"
             openstack_version: "stable/2024.1"
             ubuntu_version: "22.04"

--- a/.github/workflows/functional-containerinfra.yaml
+++ b/.github/workflows/functional-containerinfra.yaml
@@ -17,24 +17,28 @@ jobs:
             devstack_conf_overrides: |
               enable_plugin magnum https://github.com/openstack/magnum master
               MAGNUMCLIENT_BRANCH=master
+            additional_services: "openstack-cli-server"
           - name: "caracal"
             openstack_version: "stable/2024.1"
             ubuntu_version: "22.04"
             devstack_conf_overrides: |
               enable_plugin magnum https://github.com/openstack/magnum stable/2024.1
               MAGNUMCLIENT_BRANCH=stable/2024.1
+            additional_services: ""
           - name: "bobcat"
             openstack_version: "stable/2023.2"
             ubuntu_version: "22.04"
             devstack_conf_overrides: |
               enable_plugin magnum https://github.com/openstack/magnum stable/2023.2
               MAGNUMCLIENT_BRANCH=stable/2023.2
+            additional_services: ""
           - name: "antelope"
             openstack_version: "stable/2023.1"
             ubuntu_version: "22.04"
             devstack_conf_overrides: |
               enable_plugin magnum https://github.com/openstack/magnum stable/2023.1
               MAGNUMCLIENT_BRANCH=stable/2023.1
+            additional_services: ""
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with Magnum and run containerinfra acceptance tests
     steps:
@@ -51,7 +55,7 @@ jobs:
             SWIFT_MAX_FILE_SIZE=5368709122
             KEYSTONE_ADMIN_ENDPOINT=true
             ${{ matrix.devstack_conf_overrides }}
-          enabled_services: 'h-eng,h-api,h-api-cfn,h-api-cw'
+          enabled_services: "h-eng,h-api,h-api-cfn,h-api-cw,${{ matrix.additional_services }}"
       - name: Checkout go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/functional-dns.yaml
+++ b/.github/workflows/functional-dns.yaml
@@ -15,15 +15,19 @@ jobs:
           - name: "master"
             openstack_version: "master"
             ubuntu_version: "22.04"
+            additional_services: "openstack-cli-server"
           - name: "caracal"
             openstack_version: "stable/2024.1"
             ubuntu_version: "22.04"
+            additional_services: ""
           - name: "bobcat"
             openstack_version: "stable/2023.2"
             ubuntu_version: "22.04"
+            additional_services: ""
           - name: "antelope"
             openstack_version: "stable/2023.1"
             ubuntu_version: "22.04"
+            additional_services: ""
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with Designate and run dns acceptance tests
     steps:
@@ -35,7 +39,7 @@ jobs:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |
             enable_plugin designate https://github.com/openstack/designate ${{ matrix.openstack_version }}
-          enabled_services: 'designate,designate-central,designate-api,designate-worker,designate-producer,designate-mdns'
+          enabled_services: "designate,designate-central,designate-api,designate-worker,designate-producer,designate-mdns,${{ matrix.additional_services }}"
       - name: Checkout go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/functional-fwaas_v2.yaml
+++ b/.github/workflows/functional-fwaas_v2.yaml
@@ -14,15 +14,19 @@ jobs:
           - name: "master"
             openstack_version: "master"
             ubuntu_version: "22.04"
+            additional_services: "openstack-cli-server"
           - name: "caracal"
             openstack_version: "stable/2024.1"
             ubuntu_version: "22.04"
+            additional_services: ""
           - name: "bobcat"
             openstack_version: "stable/2023.2"
             ubuntu_version: "22.04"
+            additional_services: ""
           - name: "antelope"
             openstack_version: "stable/2023.1"
             ubuntu_version: "22.04"
+            additional_services: ""
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with enabled FWaaS_v2 and run networking acceptance tests
     steps:
@@ -39,7 +43,7 @@ jobs:
             Q_ML2_PLUGIN_TYPE_DRIVERS=flat,gre,vlan,vxlan
             Q_ML2_TENANT_NETWORK_TYPE=vxlan
             Q_TUNNEL_TYPES=vxlan,gre
-          enabled_services: 'q-svc,q-agt,q-dhcp,q-l3,q-meta,q-fwaas-v2,-cinder,-horizon,-tempest,-swift,-c-sch,-c-api,-c-vol,-c-bak,-ovn,-ovn-controller,-ovn-northd,-q-ovn-metadata-agent'
+          enabled_services: 'q-svc,q-agt,q-dhcp,q-l3,q-meta,q-fwaas-v2,-cinder,-horizon,-tempest,-swift,-c-sch,-c-api,-c-vol,-c-bak,-ovn,-ovn-controller,-ovn-northd,-q-ovn-metadata-agent,${{ matrix.additional_services }}'
       - name: Checkout go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/functional-fwaas_v2.yaml
+++ b/.github/workflows/functional-fwaas_v2.yaml
@@ -10,10 +10,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        name: ["master"]
-        openstack_version: ["master"]
-        ubuntu_version: ["22.04"]
         include:
+          - name: "master"
+            openstack_version: "master"
+            ubuntu_version: "22.04"
           - name: "caracal"
             openstack_version: "stable/2024.1"
             ubuntu_version: "22.04"

--- a/.github/workflows/functional-identity.yaml
+++ b/.github/workflows/functional-identity.yaml
@@ -14,15 +14,19 @@ jobs:
           - name: "master"
             openstack_version: "master"
             ubuntu_version: "22.04"
+            additional_services: "openstack-cli-server"
           - name: "caracal"
             openstack_version: "stable/2024.1"
             ubuntu_version: "22.04"
+            additional_services: ""
           - name: "bobcat"
             openstack_version: "stable/2023.2"
             ubuntu_version: "22.04"
+            additional_services: ""
           - name: "antelope"
             openstack_version: "stable/2023.1"
             ubuntu_version: "22.04"
+            additional_services: ""
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with Keystone and run identity acceptance tests
     steps:
@@ -32,6 +36,7 @@ jobs:
         uses: EmilienM/devstack-action@e82a9cbead099cba72f99537e82a360c3e319c69
         with:
           branch: ${{ matrix.openstack_version }}
+          enabled_services: "${{ matrix.additional_services }}"
       - name: Checkout go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/functional-identity.yaml
+++ b/.github/workflows/functional-identity.yaml
@@ -10,10 +10,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        name: ["master"]
-        openstack_version: ["master"]
-        ubuntu_version: ["22.04"]
         include:
+          - name: "master"
+            openstack_version: "master"
+            ubuntu_version: "22.04"
           - name: "caracal"
             openstack_version: "stable/2024.1"
             ubuntu_version: "22.04"

--- a/.github/workflows/functional-image.yaml
+++ b/.github/workflows/functional-image.yaml
@@ -14,15 +14,19 @@ jobs:
           - name: "master"
             openstack_version: "master"
             ubuntu_version: "22.04"
+            additional_services: "openstack-cli-server"
           - name: "caracal"
             openstack_version: "stable/2024.1"
             ubuntu_version: "22.04"
+            additional_services: ""
           - name: "bobcat"
             openstack_version: "stable/2023.2"
             ubuntu_version: "22.04"
+            additional_services: ""
           - name: "antelope"
             openstack_version: "stable/2023.1"
             ubuntu_version: "22.04"
+            additional_services: ""
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with Glance and run image acceptance tests
     steps:
@@ -32,6 +36,7 @@ jobs:
         uses: EmilienM/devstack-action@e82a9cbead099cba72f99537e82a360c3e319c69
         with:
           branch: ${{ matrix.openstack_version }}
+          enabled_services: "${{ matrix.additional_services }}"
       - name: Checkout go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/functional-image.yaml
+++ b/.github/workflows/functional-image.yaml
@@ -10,10 +10,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        name: ["master"]
-        openstack_version: ["master"]
-        ubuntu_version: ["22.04"]
         include:
+          - name: "master"
+            openstack_version: "master"
+            ubuntu_version: "22.04"
           - name: "caracal"
             openstack_version: "stable/2024.1"
             ubuntu_version: "22.04"

--- a/.github/workflows/functional-keymanager.yaml
+++ b/.github/workflows/functional-keymanager.yaml
@@ -14,15 +14,19 @@ jobs:
           - name: "master"
             openstack_version: "master"
             ubuntu_version: "22.04"
+            additional_services: "openstack-cli-server"
           - name: "caracal"
             openstack_version: "stable/2024.1"
             ubuntu_version: "22.04"
+            additional_services: ""
           - name: "bobcat"
             openstack_version: "stable/2023.2"
             ubuntu_version: "22.04"
+            additional_services: ""
           - name: "antelope"
             openstack_version: "stable/2023.1"
             ubuntu_version: "22.04"
+            additional_services: ""
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with Barbican and run keymanager acceptance tests
     steps:
@@ -34,7 +38,7 @@ jobs:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |
             enable_plugin barbican https://github.com/openstack/barbican ${{ matrix.openstack_version }}
-          enabled_services: 'barbican-svc,barbican-retry,barbican-keystone-listener'
+          enabled_services: "barbican-svc,barbican-retry,barbican-keystone-listener,${{ matrix.additional_services }}"
       - name: Checkout go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/functional-keymanager.yaml
+++ b/.github/workflows/functional-keymanager.yaml
@@ -10,10 +10,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        name: ["master"]
-        openstack_version: ["master"]
-        ubuntu_version: ["22.04"]
         include:
+          - name: "master"
+            openstack_version: "master"
+            ubuntu_version: "22.04"
           - name: "caracal"
             openstack_version: "stable/2024.1"
             ubuntu_version: "22.04"

--- a/.github/workflows/functional-loadbalancer.yaml
+++ b/.github/workflows/functional-loadbalancer.yaml
@@ -14,15 +14,19 @@ jobs:
           - name: "master"
             openstack_version: "master"
             ubuntu_version: "22.04"
+            additional_services: "openstack-cli-server"
           - name: "caracal"
             openstack_version: "stable/2024.1"
             ubuntu_version: "22.04"
+            additional_services: ""
           - name: "bobcat"
             openstack_version: "stable/2023.2"
             ubuntu_version: "22.04"
+            additional_services: ""
           - name: "antelope"
             openstack_version: "stable/2023.1"
             ubuntu_version: "22.04"
+            additional_services: ""
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with Octavia and run loadbalancer acceptance tests
     steps:
@@ -35,7 +39,7 @@ jobs:
           conf_overrides: |
             enable_plugin octavia https://github.com/openstack/octavia ${{ matrix.openstack_version }}
             enable_plugin neutron https://github.com/openstack/neutron ${{ matrix.openstack_version }}
-          enabled_services: 'octavia,o-api,o-cw,o-hk,o-hm,o-da,neutron-qos'
+          enabled_services: "octavia,o-api,o-cw,o-hk,o-hm,o-da,neutron-qos,${{ matrix.additional_services }}"
       - name: Checkout go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/functional-loadbalancer.yaml
+++ b/.github/workflows/functional-loadbalancer.yaml
@@ -10,10 +10,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        name: ["master"]
-        openstack_version: ["master"]
-        ubuntu_version: ["22.04"]
         include:
+          - name: "master"
+            openstack_version: "master"
+            ubuntu_version: "22.04"
           - name: "caracal"
             openstack_version: "stable/2024.1"
             ubuntu_version: "22.04"

--- a/.github/workflows/functional-messaging.yaml
+++ b/.github/workflows/functional-messaging.yaml
@@ -14,15 +14,19 @@ jobs:
           - name: "master"
             openstack_version: "master"
             ubuntu_version: "22.04"
+            additional_services: "openstack-cli-server"
           - name: "caracal"
             openstack_version: "stable/2024.1"
             ubuntu_version: "22.04"
+            additional_services: ""
           - name: "bobcat"
             openstack_version: "stable/2023.2"
             ubuntu_version: "22.04"
+            additional_services: ""
           - name: "antelope"
             openstack_version: "stable/2023.1"
             ubuntu_version: "22.04"
+            additional_services: ""
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with Zaqar and run messaging acceptance tests
     steps:
@@ -35,6 +39,7 @@ jobs:
           conf_overrides: |
             enable_plugin zaqar https://github.com/openstack/zaqar ${{ matrix.openstack_version }}
             ZAQARCLIENT_BRANCH=${{ matrix.openstack_version }}
+          enabled_services: "${{ matrix.additional_services }}"
       - name: Checkout go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/functional-messaging.yaml
+++ b/.github/workflows/functional-messaging.yaml
@@ -10,10 +10,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        name: ["master"]
-        openstack_version: ["master"]
-        ubuntu_version: ["22.04"]
         include:
+          - name: "master"
+            openstack_version: "master"
+            ubuntu_version: "22.04"
           - name: "caracal"
             openstack_version: "stable/2024.1"
             ubuntu_version: "22.04"

--- a/.github/workflows/functional-networking.yaml
+++ b/.github/workflows/functional-networking.yaml
@@ -14,15 +14,19 @@ jobs:
           - name: "master"
             openstack_version: "master"
             ubuntu_version: "22.04"
+            additional_services: "openstack-cli-server"
           - name: "caracal"
             openstack_version: "stable/2024.1"
             ubuntu_version: "22.04"
+            additional_services: ""
           - name: "bobcat"
             openstack_version: "stable/2023.2"
             ubuntu_version: "22.04"
+            additional_services: ""
           - name: "antelope"
             openstack_version: "stable/2023.1"
             ubuntu_version: "22.04"
+            additional_services: ""
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with Neutron and run networking acceptance tests
     steps:
@@ -48,7 +52,7 @@ jobs:
             [[post-config|\$NEUTRON_CONF]]
             [oslo_policy]
             policy_dirs = /tmp/neutron-policies
-          enabled_services: 'neutron-dns,neutron-qos,neutron-segments,neutron-trunk,neutron-uplink-status-propagation,neutron-network-segment-range,neutron-port-forwarding'
+          enabled_services: "neutron-dns,neutron-qos,neutron-segments,neutron-trunk,neutron-uplink-status-propagation,neutron-network-segment-range,neutron-port-forwarding,${{ matrix.additional_services }}"
       - name: Checkout go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/functional-objectstorage.yaml
+++ b/.github/workflows/functional-objectstorage.yaml
@@ -14,15 +14,19 @@ jobs:
           - name: "master"
             openstack_version: "master"
             ubuntu_version: "22.04"
+            additional_services: "openstack-cli-server"
           - name: "caracal"
             openstack_version: "stable/2024.1"
             ubuntu_version: "22.04"
+            additional_services: ""
           - name: "bobcat"
             openstack_version: "stable/2023.2"
             ubuntu_version: "22.04"
+            additional_services: ""
           - name: "antelope"
             openstack_version: "stable/2023.1"
             ubuntu_version: "22.04"
+            additional_services: ""
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with Swift and run objectstorage acceptance tests
     steps:
@@ -38,7 +42,7 @@ jobs:
             [[post-config|\$SWIFT_CONFIG_PROXY_SERVER]]
             [filter:versioned_writes]
             allow_object_versioning = true
-          enabled_services: 's-account,s-container,s-object,s-proxy'
+          enabled_services: 's-account,s-container,s-object,s-proxy,${{ matrix.additional_services }}'
       - name: Checkout go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/functional-objectstorage.yaml
+++ b/.github/workflows/functional-objectstorage.yaml
@@ -10,10 +10,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        name: ["master"]
-        openstack_version: ["master"]
-        ubuntu_version: ["22.04"]
         include:
+          - name: "master"
+            openstack_version: "master"
+            ubuntu_version: "22.04"
           - name: "caracal"
             openstack_version: "stable/2024.1"
             ubuntu_version: "22.04"

--- a/.github/workflows/functional-orchestration.yaml
+++ b/.github/workflows/functional-orchestration.yaml
@@ -14,15 +14,19 @@ jobs:
           - name: "master"
             openstack_version: "master"
             ubuntu_version: "22.04"
+            additional_services: "openstack-cli-server"
           - name: "caracal"
             openstack_version: "stable/2024.1"
             ubuntu_version: "22.04"
+            additional_services: ""
           - name: "bobcat"
             openstack_version: "stable/2023.2"
             ubuntu_version: "22.04"
+            additional_services: ""
           - name: "antelope"
             openstack_version: "stable/2023.1"
             ubuntu_version: "22.04"
+            additional_services: ""
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with Heat and run orchestration acceptance tests
     steps:
@@ -34,7 +38,7 @@ jobs:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |
             enable_plugin heat https://github.com/openstack/heat ${{ matrix.openstack_version }}
-          enabled_services: 'h-eng,h-api,h-api-cfn,h-api-cw'
+          enabled_services: 'h-eng,h-api,h-api-cfn,h-api-cw,${{ matrix.additional_services }}'
       - name: Checkout go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/functional-orchestration.yaml
+++ b/.github/workflows/functional-orchestration.yaml
@@ -10,10 +10,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        name: ["master"]
-        openstack_version: ["master"]
-        ubuntu_version: ["22.04"]
         include:
+          - name: "master"
+            openstack_version: "master"
+            ubuntu_version: "22.04"
           - name: "caracal"
             openstack_version: "stable/2024.1"
             ubuntu_version: "22.04"

--- a/.github/workflows/functional-placement.yaml
+++ b/.github/workflows/functional-placement.yaml
@@ -14,15 +14,19 @@ jobs:
           - name: "master"
             openstack_version: "master"
             ubuntu_version: "22.04"
+            additional_services: "openstack-cli-server"
           - name: "caracal"
             openstack_version: "stable/2024.1"
             ubuntu_version: "22.04"
+            additional_services: ""
           - name: "bobcat"
             openstack_version: "stable/2023.2"
             ubuntu_version: "22.04"
+            additional_services: ""
           - name: "antelope"
             openstack_version: "stable/2023.1"
             ubuntu_version: "22.04"
+            additional_services: ""
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with Placement and run placement acceptance tests
     steps:
@@ -32,6 +36,7 @@ jobs:
         uses: EmilienM/devstack-action@e82a9cbead099cba72f99537e82a360c3e319c69
         with:
           branch: ${{ matrix.openstack_version }}
+          enabled_services: "${{ matrix.additional_services }}"
       - name: Checkout go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/functional-placement.yaml
+++ b/.github/workflows/functional-placement.yaml
@@ -10,10 +10,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        name: ["master"]
-        openstack_version: ["master"]
-        ubuntu_version: ["22.04"]
         include:
+          - name: "master"
+            openstack_version: "master"
+            ubuntu_version: "22.04"
           - name: "caracal"
             openstack_version: "stable/2024.1"
             ubuntu_version: "22.04"

--- a/.github/workflows/functional-sharedfilesystems.yaml
+++ b/.github/workflows/functional-sharedfilesystems.yaml
@@ -14,15 +14,19 @@ jobs:
           - name: "master"
             openstack_version: "master"
             ubuntu_version: "22.04"
+            additional_services: "openstack-cli-server"
           - name: "caracal"
             openstack_version: "stable/2024.1"
             ubuntu_version: "22.04"
+            additional_services: ""
           - name: "bobcat"
             openstack_version: "stable/2023.2"
             ubuntu_version: "22.04"
+            additional_services: ""
           - name: "antelope"
             openstack_version: "stable/2023.1"
             ubuntu_version: "22.04"
+            additional_services: ""
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with Manila and run sharedfilesystems acceptance tests
     steps:
@@ -48,6 +52,7 @@ jobs:
             MANILA_DEFAULT_SHARE_TYPE_EXTRA_SPECS='snapshot_support=True create_share_from_snapshot_support=True revert_to_snapshot_support=True mount_snapshot_support=True'
             MANILA_CONFIGURE_DEFAULT_TYPES=True
             MANILA_INSTALL_TEMPEST_PLUGIN_SYSTEMWIDE=false
+          enabled_services: "${{ matrix.additional_services }}"
       - name: Checkout go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/functional-sharedfilesystems.yaml
+++ b/.github/workflows/functional-sharedfilesystems.yaml
@@ -10,10 +10,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        name: ["master"]
-        openstack_version: ["master"]
-        ubuntu_version: ["22.04"]
         include:
+          - name: "master"
+            openstack_version: "master"
+            ubuntu_version: "22.04"
           - name: "caracal"
             openstack_version: "stable/2024.1"
             ubuntu_version: "22.04"


### PR DESCRIPTION
This has the ability to shave a few minutes off our deployment time for DevStack and is already being used [upstream in Nova](https://review.opendev.org/c/openstack/nova/+/919738). Use it here also.
