### PR TITLE
loadbalancer pools: Simplify types and allow extension

### DIFF
--- a/docs/MIGRATING.md
+++ b/docs/MIGRATING.md
@@ -132,6 +132,21 @@ The `objectstorage/v1/objects.Copy#Destination` field must be in the form
 `/container/object`. The function will reject a destination path if it doesn't
 start with a slash (`/`).
 
+### Load balancer pools
+
+`(pools.CreateOpts).Members` and `(pools.CreateOpts).Monitor` are now
+interfaces (`pools.CreateMemberOptsBuilder` and `monitors.CreateOptsBuilder`)
+rather than concrete types. When including `Members`, the `CreateOpts` literal
+must now include explicit types:
+
+```go
+opts := pools.CreateOpts{
+    Members: []pools.CreateMemberOptsBuilder{
+        pools.MemberOpts{Name: "lb-member-1"},
+    }
+}
+```
+
 ### Removed services and extensions
 
 Support for services that are no longer supported upstream has been removed.

--- a/internal/acceptance/openstack/loadbalancer/v2/loadbalancer.go
+++ b/internal/acceptance/openstack/loadbalancer/v2/loadbalancer.go
@@ -200,13 +200,15 @@ func CreateLoadBalancerFullyPopulated(t *testing.T, client *gophercloud.ServiceC
 				Description: poolDescription,
 				Protocol:    pools.ProtocolHTTP,
 				LBMethod:    pools.LBMethodLeastConnections,
-				Members: []pools.CreateMemberOpts{{
-					Name:         memberName,
-					ProtocolPort: memberPort,
-					Weight:       &memberWeight,
-					Address:      "1.2.3.4",
-					SubnetID:     subnetID,
-				}},
+				Members: []pools.CreateMemberOptsBuilder{
+					pools.CreateMemberOpts{
+						Name:         memberName,
+						ProtocolPort: memberPort,
+						Weight:       &memberWeight,
+						Address:      "1.2.3.4",
+						SubnetID:     subnetID,
+					},
+				},
 				Monitor: &monitors.CreateOpts{
 					Delay:          10,
 					Timeout:        5,

--- a/openstack/containerinfra/v1/clusters/requests.go
+++ b/openstack/containerinfra/v1/clusters/requests.go
@@ -150,7 +150,7 @@ func (opts UpdateOpts) ToClustersUpdateMap() (map[string]any, error) {
 }
 
 // Update implements cluster updated request.
-func Update(ctx context.Context, client *gophercloud.ServiceClient, id string, opts []UpdateOptsBuilder) (r UpdateResult) {
+func Update[T UpdateOptsBuilder](ctx context.Context, client *gophercloud.ServiceClient, id string, opts []T) (r UpdateResult) {
 	var o []map[string]any
 	for _, opt := range opts {
 		b, err := opt.ToClustersUpdateMap()

--- a/openstack/containerinfra/v1/clustertemplates/requests.go
+++ b/openstack/containerinfra/v1/clustertemplates/requests.go
@@ -148,7 +148,7 @@ func (opts UpdateOpts) ToClusterTemplateUpdateMap() (map[string]any, error) {
 }
 
 // Update implements cluster updated request.
-func Update(ctx context.Context, client *gophercloud.ServiceClient, id string, opts []UpdateOptsBuilder) (r UpdateResult) {
+func Update[T UpdateOptsBuilder](ctx context.Context, client *gophercloud.ServiceClient, id string, opts []T) (r UpdateResult) {
 	var o []map[string]any
 	for _, opt := range opts {
 		b, err := opt.ToClusterTemplateUpdateMap()

--- a/openstack/containerinfra/v1/nodegroups/requests.go
+++ b/openstack/containerinfra/v1/nodegroups/requests.go
@@ -143,7 +143,7 @@ func (opts UpdateOpts) ToResourceUpdateMap() (map[string]any, error) {
 // one UpdateOpts can be passed at a time.
 // Use the Extract method of the returned UpdateResult to extract the
 // updated node group from the result.
-func Update(ctx context.Context, client *gophercloud.ServiceClient, clusterID string, nodeGroupID string, opts []UpdateOptsBuilder) (r UpdateResult) {
+func Update[T UpdateOptsBuilder](ctx context.Context, client *gophercloud.ServiceClient, clusterID string, nodeGroupID string, opts []T) (r UpdateResult) {
 	var o []map[string]any
 	for _, opt := range opts {
 		b, err := opt.ToResourceUpdateMap()

--- a/openstack/containerinfra/v1/nodegroups/testing/requests_test.go
+++ b/openstack/containerinfra/v1/nodegroups/testing/requests_test.go
@@ -197,25 +197,47 @@ func TestCreateNodeGroupBadSizes(t *testing.T) {
 
 // TestUpdateNodeGroupSuccess updates a node group successfully.
 func TestUpdateNodeGroupSuccess(t *testing.T) {
-	th.SetupHTTP()
-	defer th.TeardownHTTP()
+	t.Run("with opts struct", func(t *testing.T) {
+		th.SetupHTTP()
+		defer th.TeardownHTTP()
 
-	handleUpdateNodeGroupSuccess(t)
+		handleUpdateNodeGroupSuccess(t)
 
-	sc := fake.ServiceClient()
-	sc.Endpoint = sc.Endpoint + "v1/"
+		sc := fake.ServiceClient()
+		sc.Endpoint = sc.Endpoint + "v1/"
 
-	updateOpts := []nodegroups.UpdateOptsBuilder{
-		nodegroups.UpdateOpts{
+		updateOpts := []nodegroups.UpdateOpts{{
 			Op:    nodegroups.ReplaceOp,
 			Path:  "/max_node_count",
 			Value: 3,
-		},
-	}
+		}}
 
-	ng, err := nodegroups.Update(context.TODO(), sc, clusterUUID, nodeGroup2UUID, updateOpts).Extract()
-	th.AssertNoErr(t, err)
-	th.AssertDeepEquals(t, expectedUpdatedNodeGroup, *ng)
+		ng, err := nodegroups.Update(context.TODO(), sc, clusterUUID, nodeGroup2UUID, updateOpts).Extract()
+		th.AssertNoErr(t, err)
+		th.AssertDeepEquals(t, expectedUpdatedNodeGroup, *ng)
+	})
+
+	t.Run("with opts interface", func(t *testing.T) {
+		th.SetupHTTP()
+		defer th.TeardownHTTP()
+
+		handleUpdateNodeGroupSuccess(t)
+
+		sc := fake.ServiceClient()
+		sc.Endpoint = sc.Endpoint + "v1/"
+
+		updateOpts := []nodegroups.UpdateOptsBuilder{
+			nodegroups.UpdateOpts{
+				Op:    nodegroups.ReplaceOp,
+				Path:  "/max_node_count",
+				Value: 3,
+			},
+		}
+
+		ng, err := nodegroups.Update(context.TODO(), sc, clusterUUID, nodeGroup2UUID, updateOpts).Extract()
+		th.AssertNoErr(t, err)
+		th.AssertDeepEquals(t, expectedUpdatedNodeGroup, *ng)
+	})
 }
 
 // TestUpdateNodeGroupInternal tries to update an internal

--- a/openstack/loadbalancer/v2/loadbalancers/testing/requests_test.go
+++ b/openstack/loadbalancer/v2/loadbalancers/testing/requests_test.go
@@ -117,13 +117,15 @@ func TestCreateFullyPopulatedLoadbalancer(t *testing.T) {
 				LBMethod: pools.LBMethodRoundRobin,
 				Protocol: "HTTP",
 				Name:     "Example pool",
-				Members: []pools.CreateMemberOpts{{
-					Address:      "192.0.2.51",
-					ProtocolPort: 80,
-				}, {
-					Address:      "192.0.2.52",
-					ProtocolPort: 80,
-				}},
+				Members: []pools.CreateMemberOptsBuilder{
+					pools.CreateMemberOpts{
+						Address:      "192.0.2.51",
+						ProtocolPort: 80,
+					},
+					pools.CreateMemberOpts{
+						Address:      "192.0.2.52",
+						ProtocolPort: 80,
+					}},
 				Monitor: &monitors.CreateOpts{
 					Name:           "db",
 					Type:           "HTTP",

--- a/openstack/loadbalancer/v2/pools/requests.go
+++ b/openstack/loadbalancer/v2/pools/requests.go
@@ -131,14 +131,14 @@ type CreateOpts struct {
 	//
 	// This is only possible to use when creating a fully populated
 	// Loadbalancer.
-	Members []CreateMemberOpts `json:"members,omitempty"`
+	Members []CreateMemberOptsBuilder `json:"members,omitempty"`
 
 	// Monitor is an instance of monitors.CreateOpts which allows a monitor
 	// to be created at the same time the pool is created.
 	//
 	// This is only possible to use when creating a fully populated
 	// Loadbalancer.
-	Monitor *monitors.CreateOpts `json:"healthmonitor,omitempty"`
+	Monitor monitors.CreateOptsBuilder `json:"healthmonitor,omitempty"`
 
 	// Tags is a set of resource tags. New in version 2.5
 	Tags []string `json:"tags,omitempty"`
@@ -476,7 +476,7 @@ func (opts BatchUpdateMemberOpts) ToBatchMemberUpdateMap() (map[string]any, erro
 }
 
 // BatchUpdateMembers updates the pool members in batch
-func BatchUpdateMembers(ctx context.Context, c *gophercloud.ServiceClient, poolID string, opts []BatchUpdateMemberOpts) (r UpdateMembersResult) {
+func BatchUpdateMembers[T BatchUpdateMemberOptsBuilder](ctx context.Context, c *gophercloud.ServiceClient, poolID string, opts []T) (r UpdateMembersResult) {
 	members := []map[string]any{}
 	for _, opt := range opts {
 		b, err := opt.ToBatchMemberUpdateMap()


### PR DESCRIPTION
With this change, `pools.CreateMemberOpts` and
`pools.BatchUpdateMemberOpts` have been merged into a single struct called `MemberOpts` that implements both interfaces. Alias types have been set up to facilitate migration. As a consequence, those can be used interchangeably.

`(pools.CreateOpts).Members` and `(pools.CreateOpts).Monitor` are now interfaces (`pools.CreateMemberOptsBuilder` and
`monitors.CreateOptsBuilder`) rather than concrete types. This means that when using `pools.CreateMemberOpts`, its type must be explicitly set in the literal:

```go
opts := pools.CreateOpts{
    Members: pools.CreateMemberOptsBuilder{
        []pools.CreateMemberOpts{
            pools.MemberOpts{
                Name: "lb-member-1",
            },
        },
    }
}
```