### PR TITLE
Accept interfaces wherever possible

### DIFF
--- a/openstack/containerinfra/v1/clusters/requests.go
+++ b/openstack/containerinfra/v1/clusters/requests.go
@@ -150,7 +150,7 @@ func (opts UpdateOpts) ToClustersUpdateMap() (map[string]any, error) {
 }
 
 // Update implements cluster updated request.
-func Update(ctx context.Context, client *gophercloud.ServiceClient, id string, opts []UpdateOptsBuilder) (r UpdateResult) {
+func Update[T UpdateOptsBuilder](ctx context.Context, client *gophercloud.ServiceClient, id string, opts []T) (r UpdateResult) {
 	var o []map[string]any
 	for _, opt := range opts {
 		b, err := opt.ToClustersUpdateMap()

--- a/openstack/containerinfra/v1/clustertemplates/requests.go
+++ b/openstack/containerinfra/v1/clustertemplates/requests.go
@@ -148,7 +148,7 @@ func (opts UpdateOpts) ToClusterTemplateUpdateMap() (map[string]any, error) {
 }
 
 // Update implements cluster updated request.
-func Update(ctx context.Context, client *gophercloud.ServiceClient, id string, opts []UpdateOptsBuilder) (r UpdateResult) {
+func Update[T UpdateOptsBuilder](ctx context.Context, client *gophercloud.ServiceClient, id string, opts []T) (r UpdateResult) {
 	var o []map[string]any
 	for _, opt := range opts {
 		b, err := opt.ToClusterTemplateUpdateMap()

--- a/openstack/containerinfra/v1/nodegroups/requests.go
+++ b/openstack/containerinfra/v1/nodegroups/requests.go
@@ -143,7 +143,7 @@ func (opts UpdateOpts) ToResourceUpdateMap() (map[string]any, error) {
 // one UpdateOpts can be passed at a time.
 // Use the Extract method of the returned UpdateResult to extract the
 // updated node group from the result.
-func Update(ctx context.Context, client *gophercloud.ServiceClient, clusterID string, nodeGroupID string, opts []UpdateOptsBuilder) (r UpdateResult) {
+func Update[T UpdateOptsBuilder](ctx context.Context, client *gophercloud.ServiceClient, clusterID string, nodeGroupID string, opts []T) (r UpdateResult) {
 	var o []map[string]any
 	for _, opt := range opts {
 		b, err := opt.ToResourceUpdateMap()

--- a/openstack/loadbalancer/v2/pools/requests.go
+++ b/openstack/loadbalancer/v2/pools/requests.go
@@ -138,7 +138,7 @@ type CreateOpts struct {
 	//
 	// This is only possible to use when creating a fully populated
 	// Loadbalancer.
-	Monitor *monitors.CreateOpts `json:"healthmonitor,omitempty"`
+	Monitor monitors.CreateOptsBuilder `json:"healthmonitor,omitempty"`
 
 	// Tags is a set of resource tags. New in version 2.5
 	Tags []string `json:"tags,omitempty"`
@@ -476,7 +476,7 @@ func (opts BatchUpdateMemberOpts) ToBatchMemberUpdateMap() (map[string]any, erro
 }
 
 // BatchUpdateMembers updates the pool members in batch
-func BatchUpdateMembers(ctx context.Context, c *gophercloud.ServiceClient, poolID string, opts []BatchUpdateMemberOpts) (r UpdateMembersResult) {
+func BatchUpdateMembers[T BatchUpdateMemberOptsBuilder](ctx context.Context, c *gophercloud.ServiceClient, poolID string, opts []T) (r UpdateMembersResult) {
 	members := []map[string]any{}
 	for _, opt := range opts {
 		b, err := opt.ToBatchMemberUpdateMap()


### PR DESCRIPTION
Use generics to allow passing slices of both bare structs and interfaces.