### PR TITLE
networks: Security groups and sg rules List to accept a Builder

### DIFF
--- a/openstack/networking/v2/extensions/security/groups/requests.go
+++ b/openstack/networking/v2/extensions/security/groups/requests.go
@@ -7,6 +7,12 @@ import (
 	"github.com/gophercloud/gophercloud/v2/pagination"
 )
 
+// ListOptsBuilder allows extensions to add additional parameters to the
+// List request.
+type ListOptsBuilder interface {
+	ToSecGroupListQuery() (string, error)
+}
+
 // ListOpts allows the filtering and sorting of paginated collections through
 // the API. Filtering is achieved by passing in struct field values that map to
 // the group attributes you want to see returned. SortKey allows you to
@@ -28,15 +34,27 @@ type ListOpts struct {
 	NotTagsAny  string `q:"not-tags-any"`
 }
 
+// ToSecGroupListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToSecGroupListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	if err != nil {
+		return "", err
+	}
+	return q.String(), nil
+}
+
 // List returns a Pager which allows you to iterate over a collection of
 // security groups. It accepts a ListOpts struct, which allows you to filter
 // and sort the returned collection for greater efficiency.
-func List(c *gophercloud.ServiceClient, opts ListOpts) pagination.Pager {
-	q, err := gophercloud.BuildQueryString(&opts)
-	if err != nil {
-		return pagination.Pager{Err: err}
+func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	u := rootURL(c)
+	if opts != nil {
+		q, err := opts.ToSecGroupListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		u += q
 	}
-	u := rootURL(c) + q.String()
 	return pagination.NewPager(c, u, func(r pagination.PageResult) pagination.Page {
 		return SecGroupPage{pagination.LinkedPageBase{PageResult: r}}
 	})


### PR DESCRIPTION
Allow clients to pass a custom ListOptsBuilder to the List functions for both Security groups and Security group rules.