### PR TITLE
[tests]: increase timeout for the TestBGPAgentRUD test

### DIFF
--- a/internal/acceptance/openstack/networking/v2/extensions/agents/agents_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/agents/agents_test.go
@@ -97,7 +97,7 @@ func TestAgentsRUD(t *testing.T) {
 }
 
 func TestBGPAgentRUD(t *testing.T) {
-	timeout := 120 * time.Second
+	timeout := 15 * time.Minute
 	clients.RequireAdmin(t)
 
 	client, err := clients.NewNetworkV2Client()


### PR DESCRIPTION
An attempt to fix failing `TestBGPAgentRUD` tests