### PR TITLE
[neutron]: introduce Description argument for the portforwarding

### DIFF
--- a/internal/acceptance/openstack/networking/v2/extensions/layer3/layer3.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/layer3/layer3.go
@@ -75,7 +75,9 @@ func CreatePortForwarding(t *testing.T, client *gophercloud.ServiceClient, fipID
 
 	fixedIP := portFixedIPs[0]
 	internalIP := fixedIP.IPAddress
+	pfDescription := "Test description"
 	createOpts := &portforwarding.CreateOpts{
+		Description:       pfDescription,
 		Protocol:          "tcp",
 		InternalPort:      25,
 		ExternalPort:      2230,

--- a/internal/acceptance/openstack/networking/v2/extensions/layer3/portforwardings_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/layer3/portforwardings_test.go
@@ -56,6 +56,7 @@ func TestLayer3PortForwardingsCreateDelete(t *testing.T) {
 
 	pf, err := CreatePortForwarding(t, client, fip.ID, port.ID, port.FixedIPs)
 	th.AssertNoErr(t, err)
+	th.AssertEquals(t, pf.Description, "Test description")
 	defer DeletePortForwarding(t, client, fip.ID, pf.ID)
 	tools.PrintResource(t, pf)
 
@@ -63,6 +64,7 @@ func TestLayer3PortForwardingsCreateDelete(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	updateOpts := portforwarding.UpdateOpts{
+		Description:  new(string),
 		Protocol:     "udp",
 		InternalPort: 30,
 		ExternalPort: 678,
@@ -73,6 +75,7 @@ func TestLayer3PortForwardingsCreateDelete(t *testing.T) {
 
 	newPf, err = portforwarding.Get(context.TODO(), client, fip.ID, pf.ID).Extract()
 	th.AssertNoErr(t, err)
+	th.AssertEquals(t, newPf.Description, "")
 
 	allPages, err := portforwarding.List(client, portforwarding.ListOpts{}, fip.ID).AllPages(context.TODO())
 	th.AssertNoErr(t, err)

--- a/openstack/networking/v2/extensions/layer3/portforwarding/requests.go
+++ b/openstack/networking/v2/extensions/layer3/portforwarding/requests.go
@@ -18,6 +18,7 @@ type ListOptsBuilder interface {
 // either `asc' or `desc'. Marker and Limit are used for pagination.
 type ListOpts struct {
 	ID                string `q:"id"`
+	Description       string `q:"description"`
 	InternalPortID    string `q:"internal_port_id"`
 	ExternalPort      string `q:"external_port"`
 	InternalIPAddress string `q:"internal_ip_address"`
@@ -63,6 +64,7 @@ func Get(ctx context.Context, c *gophercloud.ServiceClient, floatingIpId string,
 // CreateOpts contains all the values needed to create a new port forwarding
 // resource. All attributes are required.
 type CreateOpts struct {
+	Description       string `json:"description,omitempty"`
 	InternalPortID    string `json:"internal_port_id"`
 	InternalIPAddress string `json:"internal_ip_address"`
 	InternalPort      int    `json:"internal_port"`
@@ -97,22 +99,18 @@ func Create(ctx context.Context, c *gophercloud.ServiceClient, floatingIpId stri
 
 // UpdateOpts contains the values used when updating a port forwarding resource.
 type UpdateOpts struct {
-	InternalPortID    string `json:"internal_port_id,omitempty"`
-	InternalIPAddress string `json:"internal_ip_address,omitempty"`
-	InternalPort      int    `json:"internal_port,omitempty"`
-	ExternalPort      int    `json:"external_port,omitempty"`
-	Protocol          string `json:"protocol,omitempty"`
+	Description       *string `json:"description,omitempty"`
+	InternalPortID    string  `json:"internal_port_id,omitempty"`
+	InternalIPAddress string  `json:"internal_ip_address,omitempty"`
+	InternalPort      int     `json:"internal_port,omitempty"`
+	ExternalPort      int     `json:"external_port,omitempty"`
+	Protocol          string  `json:"protocol,omitempty"`
 }
 
 // ToPortForwardingUpdateMap allows UpdateOpts to satisfy the UpdateOptsBuilder
 // interface
 func (opts UpdateOpts) ToPortForwardingUpdateMap() (map[string]any, error) {
-	b, err := gophercloud.BuildRequestBody(opts, "port_forwarding")
-	if err != nil {
-		return nil, err
-	}
-
-	return b, nil
+	return gophercloud.BuildRequestBody(opts, "port_forwarding")
 }
 
 // UpdateOptsBuilder allows extensions to add additional parameters to the

--- a/openstack/networking/v2/extensions/layer3/portforwarding/results.go
+++ b/openstack/networking/v2/extensions/layer3/portforwarding/results.go
@@ -9,6 +9,10 @@ type PortForwarding struct {
 	// The ID of the floating IP port forwarding
 	ID string `json:"id"`
 
+	// A text describing the rule, which helps users to manage/find easily
+	// theirs rules.
+	Description string `json:"description"`
+
 	// The ID of the Neutron port associated to the floating IP port forwarding.
 	InternalPortID string `json:"internal_port_id"`
 


### PR DESCRIPTION
Prior to starting a PR, please make sure you have read our
[contributor tutorial](https://github.com/gophercloud/gophercloud/tree/master/docs/contributor-tutorial).

Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

Fixes #3093 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/neutron-lib/blob/47e1736c10ffd6f1850eba9970acdc00373f9de7/neutron_lib/api/definitions/fip_pf_description.py