### PR TITLE
CI: Append job ID to artifact name

### DIFF
--- a/.github/workflows/functional-baremetal.yaml
+++ b/.github/workflows/functional-baremetal.yaml
@@ -107,5 +107,5 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: functional-baremetal-${{ matrix.name }}
+          name: functional-baremetal-${{ matrix.name }}-${{ github.run_id }}
           path: /tmp/devstack-logs/*

--- a/.github/workflows/functional-basic.yaml
+++ b/.github/workflows/functional-basic.yaml
@@ -57,5 +57,5 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: functional-basic-${{ matrix.name }}
+          name: functional-basic-${{ matrix.name }}-${{ github.run_id }}
           path: /tmp/devstack-logs/*

--- a/.github/workflows/functional-blockstorage.yaml
+++ b/.github/workflows/functional-blockstorage.yaml
@@ -56,5 +56,5 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: functional-blockstorage-${{ matrix.name }}
+          name: functional-blockstorage-${{ matrix.name }}-${{ github.run_id }}
           path: /tmp/devstack-logs/*

--- a/.github/workflows/functional-compute.yaml
+++ b/.github/workflows/functional-compute.yaml
@@ -56,5 +56,5 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: functional-compute-${{ matrix.name }}
+          name: functional-compute-${{ matrix.name }}-${{ github.run_id }}
           path: /tmp/devstack-logs/*

--- a/.github/workflows/functional-containerinfra.yaml
+++ b/.github/workflows/functional-containerinfra.yaml
@@ -73,5 +73,5 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: functional-containerinfra-${{ matrix.name }}
+          name: functional-containerinfra-${{ matrix.name }}-${{ github.run_id }}
           path: /tmp/devstack-logs/*

--- a/.github/workflows/functional-dns.yaml
+++ b/.github/workflows/functional-dns.yaml
@@ -57,5 +57,5 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: functional-dns-${{ matrix.name }}
+          name: functional-dns-${{ matrix.name }}-${{ github.run_id }}
           path: /tmp/devstack-logs/*

--- a/.github/workflows/functional-fwaas_v2.yaml
+++ b/.github/workflows/functional-fwaas_v2.yaml
@@ -61,5 +61,5 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: functional-fwaas_v2-${{ matrix.name }}
+          name: functional-fwaas_v2-${{ matrix.name }}-${{ github.run_id }}
           path: /tmp/devstack-logs/*

--- a/.github/workflows/functional-identity.yaml
+++ b/.github/workflows/functional-identity.yaml
@@ -54,5 +54,5 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: functional-identity-${{ matrix.name }}
+          name: functional-identity-${{ matrix.name }}-${{ github.run_id }}
           path: /tmp/devstack-logs/*

--- a/.github/workflows/functional-image.yaml
+++ b/.github/workflows/functional-image.yaml
@@ -54,5 +54,5 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: functional-image-${{ matrix.name }}
+          name: functional-image-${{ matrix.name }}-${{ github.run_id }}
           path: /tmp/devstack-logs/*

--- a/.github/workflows/functional-keymanager.yaml
+++ b/.github/workflows/functional-keymanager.yaml
@@ -56,5 +56,5 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: functional-keymanager-${{ matrix.name }}
+          name: functional-keymanager-${{ matrix.name }}-${{ github.run_id }}
           path: /tmp/devstack-logs/*

--- a/.github/workflows/functional-loadbalancer.yaml
+++ b/.github/workflows/functional-loadbalancer.yaml
@@ -57,5 +57,5 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: functional-loadbalancer-${{ matrix.name }}
+          name: functional-loadbalancer-${{ matrix.name }}-${{ github.run_id }}
           path: /tmp/devstack-logs/*

--- a/.github/workflows/functional-messaging.yaml
+++ b/.github/workflows/functional-messaging.yaml
@@ -57,5 +57,5 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: functional-messaging-${{ matrix.name }}
+          name: functional-messaging-${{ matrix.name }}-${{ github.run_id }}
           path: /tmp/devstack-logs/*

--- a/.github/workflows/functional-networking.yaml
+++ b/.github/workflows/functional-networking.yaml
@@ -71,5 +71,5 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: functional-networking-${{ matrix.name }}
+          name: functional-networking-${{ matrix.name }}-${{ github.run_id }}
           path: /tmp/devstack-logs/*

--- a/.github/workflows/functional-objectstorage.yaml
+++ b/.github/workflows/functional-objectstorage.yaml
@@ -60,5 +60,5 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: functional-objectstorage-${{ matrix.name }}
+          name: functional-objectstorage-${{ matrix.name }}-${{ github.run_id }}
           path: /tmp/devstack-logs/*

--- a/.github/workflows/functional-orchestration.yaml
+++ b/.github/workflows/functional-orchestration.yaml
@@ -56,5 +56,5 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: functional-orchestration-${{ matrix.name }}
+          name: functional-orchestration-${{ matrix.name }}-${{ github.run_id }}
           path: /tmp/devstack-logs/*

--- a/.github/workflows/functional-placement.yaml
+++ b/.github/workflows/functional-placement.yaml
@@ -54,5 +54,5 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: functional-placement-${{ matrix.name }}
+          name: functional-placement-${{ matrix.name }}-${{ github.run_id }}
           path: /tmp/devstack-logs/*

--- a/.github/workflows/functional-sharedfilesystems.yaml
+++ b/.github/workflows/functional-sharedfilesystems.yaml
@@ -70,5 +70,5 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: functional-sharedfilesystems-${{ matrix.name }}
+          name: functional-sharedfilesystems-${{ matrix.name }}-${{ github.run_id }}
           path: /tmp/devstack-logs/*


### PR DESCRIPTION
Otherwise you end up with lots of duplicate `functional-{service}-{branch}` tarballs when debugging.

Signed-off-by: Stephen Finucane <stephenfin@redhat.com>
