### PR TITLE
[v2] [neutron]: introduce Stateful argument for the security groups

### DIFF
--- a/internal/acceptance/openstack/networking/v2/extensions/security_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/security_test.go
@@ -20,6 +20,7 @@ func TestSecurityGroupsCreateUpdateDelete(t *testing.T) {
 	group, err := CreateSecurityGroup(t, client)
 	th.AssertNoErr(t, err)
 	defer DeleteSecurityGroup(t, client, group.ID)
+	th.AssertEquals(t, group.Stateful, true)
 
 	rule, err := CreateSecurityGroupRule(t, client, group.ID)
 	th.AssertNoErr(t, err)
@@ -32,6 +33,7 @@ func TestSecurityGroupsCreateUpdateDelete(t *testing.T) {
 	updateOpts := groups.UpdateOpts{
 		Name:        name,
 		Description: &description,
+		Stateful:    new(bool),
 	}
 
 	newGroup, err := groups.Update(context.TODO(), client, group.ID, updateOpts).Extract()
@@ -40,6 +42,7 @@ func TestSecurityGroupsCreateUpdateDelete(t *testing.T) {
 	tools.PrintResource(t, newGroup)
 	th.AssertEquals(t, newGroup.Name, name)
 	th.AssertEquals(t, newGroup.Description, description)
+	th.AssertEquals(t, newGroup.Stateful, false)
 
 	listOpts := groups.ListOpts{}
 	allPages, err := groups.List(client, listOpts).AllPages(context.TODO())

--- a/openstack/networking/v2/extensions/security/groups/requests.go
+++ b/openstack/networking/v2/extensions/security/groups/requests.go
@@ -16,6 +16,7 @@ type ListOpts struct {
 	ID          string `q:"id"`
 	Name        string `q:"name"`
 	Description string `q:"description"`
+	Stateful    *bool  `q:"stateful"`
 	TenantID    string `q:"tenant_id"`
 	ProjectID   string `q:"project_id"`
 	Limit       int    `q:"limit"`
@@ -63,6 +64,9 @@ type CreateOpts struct {
 
 	// Describes the security group.
 	Description string `json:"description,omitempty"`
+
+	// Stateful indicates if the security group is stateful or stateless.
+	Stateful *bool `json:"stateful,omitempty"`
 }
 
 // ToSecGroupCreateMap builds a request body from CreateOpts.
@@ -97,6 +101,9 @@ type UpdateOpts struct {
 
 	// Describes the security group.
 	Description *string `json:"description,omitempty"`
+
+	// Stateful indicates if the security group is stateful or stateless.
+	Stateful *bool `json:"stateful,omitempty"`
 }
 
 // ToSecGroupUpdateMap builds a request body from UpdateOpts.

--- a/openstack/networking/v2/extensions/security/groups/results.go
+++ b/openstack/networking/v2/extensions/security/groups/results.go
@@ -25,6 +25,9 @@ type SecGroup struct {
 	// traffic entering and leaving the group.
 	Rules []rules.SecGroupRule `json:"security_group_rules"`
 
+	// Indicates if the security group is stateful or stateless.
+	Stateful bool `json:"stateful"`
+
 	// TenantID is the project owner of the security group.
 	TenantID string `json:"tenant_id"`
 


### PR DESCRIPTION
Prior to starting a PR, please make sure you have read our
[contributor tutorial](https://github.com/gophercloud/gophercloud/tree/master/docs/contributor-tutorial).

Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

Fixes #3091
Backport of the #3092 without changing the List function signature

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

[PUT URLS HERE]