### PR TITLE
tests: Remove AZ add/remove host integration test

### DIFF
--- a/internal/acceptance/openstack/compute/v2/aggregates_test.go
+++ b/internal/acceptance/openstack/compute/v2/aggregates_test.go
@@ -60,42 +60,6 @@ func TestAggregatesCRUD(t *testing.T) {
 	th.AssertEquals(t, updatedAggregate.AvailabilityZone, "new_azone")
 }
 
-func TestAggregatesAddRemoveHost(t *testing.T) {
-	clients.RequireAdmin(t)
-
-	client, err := clients.NewComputeV2Client()
-	th.AssertNoErr(t, err)
-
-	hostToAdd, err := getHypervisor(t, client)
-	th.AssertNoErr(t, err)
-
-	aggregate, err := CreateAggregate(t, client)
-	th.AssertNoErr(t, err)
-	defer DeleteAggregate(t, client, aggregate)
-
-	addHostOpts := aggregates.AddHostOpts{
-		Host: hostToAdd,
-	}
-
-	aggregateWithNewHost, err := aggregates.AddHost(context.TODO(), client, aggregate.ID, addHostOpts).Extract()
-	th.AssertNoErr(t, err)
-
-	tools.PrintResource(t, aggregateWithNewHost)
-
-	th.AssertEquals(t, aggregateWithNewHost.Hosts[0], hostToAdd)
-
-	removeHostOpts := aggregates.RemoveHostOpts{
-		Host: hostToAdd,
-	}
-
-	aggregateWithRemovedHost, err := aggregates.RemoveHost(context.TODO(), client, aggregate.ID, removeHostOpts).Extract()
-	th.AssertNoErr(t, err)
-
-	tools.PrintResource(t, aggregateWithRemovedHost)
-
-	th.AssertEquals(t, len(aggregateWithRemovedHost.Hosts), 0)
-}
-
 func TestAggregatesSetRemoveMetadata(t *testing.T) {
 	clients.RequireAdmin(t)
 


### PR DESCRIPTION
Go runs tests in parallel for different packages in parallel. The AZ add/remove host test was adding and removing hosts from an AZ and if this ran at the same time as another test that created a server then the host addition or removal would fail since Nova forbids it. There does not appear to be any way to resolve this. We could run all integration tests serially instead, but this would be a backwards step that will massively increase test run time. We could also rewrite the test to only add/remove an unused host, but that would require us to fence off this compute node in all other tests using non-default parameters to server create. Given the lack of better options, we simply remove the test and assume our testing to date on this method has been good enough and unit tests will be enough to carry us forward.

Signed-off-by: Stephen Finucane <stephenfin@redhat.com>
