### PR TITLE
[v1] actions: Add a label to hold merging

### DIFF
--- a/.github/workflows/check-pr-labels.yaml
+++ b/.github/workflows/check-pr-labels.yaml
@@ -1,0 +1,18 @@
+name: Ready
+on:
+  pull_request_target:
+    types:
+      - opened
+      - labeled
+
+jobs:
+  hold:
+    if: github.event.pull_request.merged == false
+    runs-on: ubuntu-latest
+    steps:
+      - if: >
+          contains(github.event.pull_request.labels.*.name, 'hold')
+        run: 'false'
+      - if: >
+          !contains(github.event.pull_request.labels.*.name, 'hold')
+        run: 'true'


### PR DESCRIPTION
Add a check that fails when the PR has the 'hold' label.