### PR TITLE
actions: Correctly refresh hold state

### DIFF
--- a/.github/workflows/check-pr-labels.yaml
+++ b/.github/workflows/check-pr-labels.yaml
@@ -2,8 +2,11 @@ name: Ready
 on:
   pull_request_target:
     types:
-      - opened
       - labeled
+      - opened
+      - reopened
+      - synchronize
+      - unlabeled
 
 jobs:
   hold:


### PR DESCRIPTION
Before adding these trigger types, the `hold` job was often skipped, unnecessarily blocking the Pull request.