### PR TITLE
actions: Refactor the semver assessment

### DIFF
--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -22,9 +22,6 @@
 - color: '6E7624'
   description: No API change
   name: semver:patch
-- color: 'EC0101'
-  description: Unable to figure out the semver type
-  name: semver:unknown
 - color: 'D73A4A'
   description: Do not merge
   name: hold

--- a/.github/workflows/semver-auto.yaml
+++ b/.github/workflows/semver-auto.yaml
@@ -1,21 +1,15 @@
-name: Add PR semver labels
+name: Add semver labels
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened]
+    types:
+      - opened
+      - synchronize
+      - reopened
+
 jobs:
   go-apidiff:
     runs-on: ubuntu-latest
     steps:
-    - name: Remove the semver labels
-      uses: actions-ecosystem/action-remove-labels@2ce5d41b4b6aa8503e285553f75ed56e0a40bae0
-      with:
-        labels: |
-          semver:patch
-          semver:minor
-          semver:major
-          semver:unknown
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
@@ -29,13 +23,6 @@ jobs:
         git rebase -i origin/${{ github.base_ref }}
       env:
         GIT_SEQUENCE_EDITOR: '/usr/bin/true'
-
-    - name: Add semver:unknown label
-      if: failure()
-      uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        labels: semver:unknown
 
     - uses: actions/setup-go@v5
       with:
@@ -54,23 +41,39 @@ jobs:
       if: steps.go-apidiff.outcome != 'success' && steps.go-apidiff.outputs.semver-type != 'major'
       run: exit 1
 
-    - name: Add semver:patch label
+    - name: Add label semver:patch
       if: steps.go-apidiff.outputs.semver-type == 'patch'
-      uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        labels: semver:patch
+      run: gh pr edit "$NUMBER" --add-label "semver:patch" --remove-label "semver:major,semver:minor"
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_REPO: ${{ github.repository }}
+        NUMBER: ${{ github.event.pull_request.number }}
 
-    - name: Add semver:minor label
+    - name: Add label semver:minor
       if: steps.go-apidiff.outputs.semver-type == 'minor'
-      uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        labels: semver:minor
+      run: gh pr edit "$NUMBER" --add-label "semver:minor" --remove-label "semver:major,semver:patch"
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_REPO: ${{ github.repository }}
+        NUMBER: ${{ github.event.pull_request.number }}
 
-    - name: Add semver:major label
+    - name: Add label semver:major
       if: steps.go-apidiff.outputs.semver-type == 'major'
-      uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        labels: semver:major
+      run: gh pr edit "$NUMBER" --add-label "semver:major" --remove-label "semver:minor,semver:patch"
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_REPO: ${{ github.repository }}
+        NUMBER: ${{ github.event.pull_request.number }}
+
+    - name: Report failure
+      if: failure()
+      run: |
+        gh pr edit "$NUMBER" --remove-label "semver:major,semver:minor,semver:patch"
+        gh issue comment "$NUMBER" --body "$BODY"
+        exit 1
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_REPO: ${{ github.repository }}
+        NUMBER: ${{ github.event.pull_request.number }}
+        BODY: >
+          Failed to assess the semver bump. See [logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.


### PR DESCRIPTION
Using `gh` lets us drop two external dependencies, and condensate the steps a bit.

After this change:
* new pushes in the PR won't trigger relabeling if the assessment is unchanged
* failures in the workflow will be notified as comments in the PR rather than via the `semver:unknown` label

The next natural step is to set this job as mandatory, to that a failure to assess semver will block merging.