### PR TITLE
Align ServiceFail provisioning state value with Ironic

### DIFF
--- a/openstack/baremetal/v1/nodes/requests.go
+++ b/openstack/baremetal/v1/nodes/requests.go
@@ -50,7 +50,7 @@ const (
 	Unrescuing   ProvisionState = "unrescuing"
 	Servicing    ProvisionState = "servicing"
 	ServiceWait  ProvisionState = "service wait"
-	ServiceFail  ProvisionState = "service fail"
+	ServiceFail  ProvisionState = "service failed"
 	ServiceHold  ProvisionState = "service hold"
 )
 


### PR DESCRIPTION
There is a mismatch between ServiceFail values used by Gophercloud and Ironic. Ironic uses "service failed" value [1], rather than "service fail". This commit addresses this discrepancy.

Fixes #3130 

[1] https://github.com/openstack/ironic/blob/stable/2024.1/ironic/common/states.py#L248