### PR TITLE
Added Node.Retired in v1 branch

### DIFF
--- a/openstack/baremetal/v1/nodes/results.go
+++ b/openstack/baremetal/v1/nodes/results.go
@@ -251,6 +251,13 @@ type Node struct {
 
 	// The UTC date and time when the last inspection was finished, ISO 8601 format. May be “null” if inspection hasn't been finished yet.
 	InspectionFinishedAt *time.Time `json:"inspection_finished_at"`
+
+	// Whether the node is retired. A Node tagged as retired will prevent any further
+	// scheduling of instances, but will still allow for other operations, such as cleaning, to happen
+	Retired bool `json:"retired"`
+
+	// Reason the node is marked as retired.
+	RetiredReason string `json:"retired_reason"`
 }
 
 // NodePage abstracts the raw results of making a List() request against


### PR DESCRIPTION
This is a `v1` branch version of https://github.com/gophercloud/gophercloud/pull/3136

Our end use-case is in https://github.com/openstack-exporter/openstack-exporter/issues/377, so this is something we will need, unless I update os-exporter to use v2 across the board.

Let me know if this is acceptable 