### PR TITLE
Add needinfo label

### DIFF
--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -25,3 +25,6 @@
 - color: 'D73A4A'
   description: Do not merge
   name: hold
+- color: 'F9D0C4'
+  description: Additional information requested
+  name: needinfo

--- a/.github/workflows/label-issue.yaml
+++ b/.github/workflows/label-issue.yaml
@@ -1,0 +1,17 @@
+name: Label issue
+on:
+  issue_comment:
+    types:
+    - created
+
+jobs:
+  clear_needinfo:
+    name: Clear needinfo
+    if: ${{ github.event.issue.user.login }} == ${{ github.event.comment.user.login }}
+    runs-on: ubuntu-latest
+    steps:
+    - run: gh pr edit "$NUMBER" --remove-label "needinfo"
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_REPO: ${{ github.repository }}
+        NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
Includes a Github action that automatically removes the `needinfo` label when the original author adds a comment.