### PR TITLE
Github templates: Hide suggestions

### DIFF
--- a/.github/ISSUE_TEMPLATE
+++ b/.github/ISSUE_TEMPLATE
@@ -1,1 +1,3 @@
+<!--
 Before starting a PR, please read our [contributor tutorial](https://github.com/gophercloud/gophercloud/tree/master/docs/contributor-tutorial).
+-->

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,9 +1,11 @@
+<!--
 Prior to starting a PR, please make sure you have read our
 [contributor tutorial](https://github.com/gophercloud/gophercloud/tree/master/docs/contributor-tutorial).
 
 Prior to a PR being reviewed, there needs to be a Github issue that the PR
 addresses. Replace the brackets and text below with that issue number.
 
+-->
 Fixes #[PUT ISSUE NUMBER HERE]
 
 Links to the line numbers/files in the OpenStack source code that support the


### PR DESCRIPTION
Use HTML comments to hide the suggestions from the final issue or Pull request text.