### PR TITLE
Fix security group rule "any protocol"

### DIFF
--- a/openstack/networking/v2/extensions/security/rules/requests.go
+++ b/openstack/networking/v2/extensions/security/rules/requests.go
@@ -75,7 +75,7 @@ const (
 	ProtocolUDP       RuleProtocol  = "udp"
 	ProtocolUDPLite   RuleProtocol  = "udplite"
 	ProtocolVRRP      RuleProtocol  = "vrrp"
-	ProtocolAny       RuleProtocol  = "any"
+	ProtocolAny       RuleProtocol  = ""
 )
 
 // CreateOptsBuilder allows extensions to add additional parameters to the


### PR DESCRIPTION
Backport of https://github.com/gophercloud/gophercloud/pull/3157

Before this patch, Gophercloud attempted to create a security group rule that would be applied regardless of the protocol by passing the literal `"any"` as the rule protocol.

Despite being correct according to [the documentation][1], Neutron rejects the value `"any"` with an HTTP status code of  `400 Bad Request`.

This change replaces the value of `ProtocolAny` to be the empty string `""`, which has the effect of creating a rule that applies to any protocol.

cf: [Neutron bug 2074056][2]

[1]: https://docs.openstack.org/api-ref/network/v2/#create-security-group-rule
[2]: https://bugs.launchpad.net/neutron/+bug/2074056


Fixes #2442
