### PR TITLE
[core]: handle empty response body

### DIFF
--- a/openstack/networking/v2/extensions/bgp/speakers/requests.go
+++ b/openstack/networking/v2/extensions/bgp/speakers/requests.go
@@ -142,7 +142,7 @@ func RemoveBGPPeer(ctx context.Context, c *gophercloud.ServiceClient, bgpSpeaker
 		r.Err = err
 		return
 	}
-	resp, err := c.Put(ctx, removeBGPPeerURL(c, bgpSpeakerID), b, &r.Body, &gophercloud.RequestOpts{
+	resp, err := c.Put(ctx, removeBGPPeerURL(c, bgpSpeakerID), b, nil, &gophercloud.RequestOpts{
 		OkCodes: []int{200},
 	})
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
@@ -207,7 +207,7 @@ func RemoveGatewayNetwork(ctx context.Context, c *gophercloud.ServiceClient, bgp
 		r.Err = err
 		return
 	}
-	resp, err := c.Put(ctx, removeGatewayNetworkURL(c, bgpSpeakerID), b, &r.Body, &gophercloud.RequestOpts{
+	resp, err := c.Put(ctx, removeGatewayNetworkURL(c, bgpSpeakerID), b, nil, &gophercloud.RequestOpts{
 		OkCodes: []int{200},
 	})
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)

--- a/openstack/networking/v2/extensions/bgp/speakers/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/bgp/speakers/testing/requests_test.go
@@ -3,7 +3,6 @@ package testing
 import (
 	"context"
 	"fmt"
-	"io"
 	"net/http"
 	"testing"
 
@@ -195,7 +194,7 @@ func TestRemoveBGPPeer(t *testing.T) {
 
 	opts := speakers.RemoveBGPPeerOpts{BGPPeerID: bgpPeerID}
 	err := speakers.RemoveBGPPeer(context.TODO(), fake.ServiceClient(), bgpSpeakerID, opts).ExtractErr()
-	th.AssertEquals(t, err, io.EOF)
+	th.AssertNoErr(t, err)
 }
 
 func TestGetAdvertisedRoutes(t *testing.T) {
@@ -279,5 +278,5 @@ func TestRemoveGatewayNetwork(t *testing.T) {
 
 	opts := speakers.RemoveGatewayNetworkOpts{NetworkID: networkID}
 	err := speakers.RemoveGatewayNetwork(context.TODO(), fake.ServiceClient(), bgpSpeakerID, opts).ExtractErr()
-	th.AssertEquals(t, err, io.EOF)
+	th.AssertNoErr(t, err)
 }


### PR DESCRIPTION
Fixes https://github.com/gophercloud/utils/issues/198

Not sure whether we need to adjust the `utils` itself like https://github.com/gophercloud/utils/pull/230

I'm not sure whether we need to check for `err != io.EOF` in the `doRequest`'s `json.NewDecoder(resp.Body).Decode(options.JSONResponse)`. It's not clear whether API should return body or not, e.g.  `[]` or `{}` or an empty response.