### PR TITLE
compute: Fix expected and actual test results

### DIFF
--- a/internal/acceptance/openstack/compute/v2/attachinterfaces_test.go
+++ b/internal/acceptance/openstack/compute/v2/attachinterfaces_test.go
@@ -48,5 +48,5 @@ func TestAttachDetachInterface(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 }

--- a/internal/acceptance/openstack/compute/v2/availabilityzones_test.go
+++ b/internal/acceptance/openstack/compute/v2/availabilityzones_test.go
@@ -31,7 +31,7 @@ func TestAvailabilityZonesList(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 }
 
 func TestAvailabilityZonesListDetail(t *testing.T) {
@@ -55,5 +55,5 @@ func TestAvailabilityZonesListDetail(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 }

--- a/internal/acceptance/openstack/compute/v2/bootfromvolume_test.go
+++ b/internal/acceptance/openstack/compute/v2/bootfromvolume_test.go
@@ -39,7 +39,7 @@ func TestBootFromImage(t *testing.T) {
 
 	tools.PrintResource(t, server)
 
-	th.AssertEquals(t, server.Image["id"], choices.ImageID)
+	th.AssertEquals(t, choices.ImageID, server.Image["id"])
 }
 
 func TestBootFromNewVolume(t *testing.T) {
@@ -80,13 +80,13 @@ func TestBootFromNewVolume(t *testing.T) {
 	tools.PrintResource(t, server)
 	tools.PrintResource(t, attachments)
 	attachmentTag := *attachments[0].Tag
-	th.AssertEquals(t, attachmentTag, tagName)
+	th.AssertEquals(t, tagName, attachmentTag)
 
 	if server.Image != nil {
 		t.Fatalf("server image should be nil")
 	}
 
-	th.AssertEquals(t, len(attachments), 1)
+	th.AssertEquals(t, 1, len(attachments))
 
 	// TODO: volumes_attached extension
 }
@@ -131,8 +131,8 @@ func TestBootFromExistingVolume(t *testing.T) {
 		t.Fatalf("server image should be nil")
 	}
 
-	th.AssertEquals(t, len(attachments), 1)
-	th.AssertEquals(t, attachments[0].VolumeID, volume.ID)
+	th.AssertEquals(t, 1, len(attachments))
+	th.AssertEquals(t, volume.ID, attachments[0].VolumeID)
 	// TODO: volumes_attached extension
 }
 
@@ -218,8 +218,8 @@ func TestAttachNewVolume(t *testing.T) {
 	tools.PrintResource(t, server)
 	tools.PrintResource(t, attachments)
 
-	th.AssertEquals(t, server.Image["id"], choices.ImageID)
-	th.AssertEquals(t, len(attachments), 1)
+	th.AssertEquals(t, choices.ImageID, server.Image["id"])
+	th.AssertEquals(t, 1, len(attachments))
 
 	// TODO: volumes_attached extension
 }
@@ -269,9 +269,9 @@ func TestAttachExistingVolume(t *testing.T) {
 	tools.PrintResource(t, server)
 	tools.PrintResource(t, attachments)
 
-	th.AssertEquals(t, server.Image["id"], choices.ImageID)
-	th.AssertEquals(t, len(attachments), 1)
-	th.AssertEquals(t, attachments[0].VolumeID, volume.ID)
+	th.AssertEquals(t, choices.ImageID, server.Image["id"])
+	th.AssertEquals(t, 1, len(attachments))
+	th.AssertEquals(t, volume.ID, attachments[0].VolumeID)
 
 	// TODO: volumes_attached extension
 }

--- a/internal/acceptance/openstack/compute/v2/compute.go
+++ b/internal/acceptance/openstack/compute/v2/compute.go
@@ -84,8 +84,8 @@ func CreateAggregate(t *testing.T, client *gophercloud.ServiceClient) (*aggregat
 		return nil, err
 	}
 
-	th.AssertEquals(t, aggregate.Name, aggregateName)
-	th.AssertEquals(t, aggregate.AvailabilityZone, availabilityZone)
+	th.AssertEquals(t, aggregateName, aggregate.Name)
+	th.AssertEquals(t, availabilityZone, aggregate.AvailabilityZone)
 
 	return aggregate, nil
 }
@@ -137,7 +137,7 @@ func CreateBootableVolumeServer(t *testing.T, client *gophercloud.ServiceClient,
 		return nil, err
 	}
 
-	th.AssertEquals(t, newServer.Name, name)
+	th.AssertEquals(t, name, newServer.Name)
 
 	return newServer, nil
 }
@@ -169,12 +169,12 @@ func CreateFlavor(t *testing.T, client *gophercloud.ServiceClient) (*flavors.Fla
 
 	t.Logf("Successfully created flavor %s", flavor.ID)
 
-	th.AssertEquals(t, flavor.Name, flavorName)
-	th.AssertEquals(t, flavor.RAM, 1)
-	th.AssertEquals(t, flavor.Disk, 1)
-	th.AssertEquals(t, flavor.VCPUs, 1)
-	th.AssertEquals(t, flavor.IsPublic, true)
-	th.AssertEquals(t, flavor.Description, flavorDescription)
+	th.AssertEquals(t, flavorName, flavor.Name)
+	th.AssertEquals(t, 1, flavor.RAM)
+	th.AssertEquals(t, 1, flavor.Disk)
+	th.AssertEquals(t, 1, flavor.VCPUs)
+	th.AssertEquals(t, true, flavor.IsPublic)
+	th.AssertEquals(t, flavorDescription, flavor.Description)
 
 	return flavor, nil
 }
@@ -213,7 +213,7 @@ func CreateKeyPair(t *testing.T, client *gophercloud.ServiceClient) (*keypairs.K
 
 	t.Logf("Created keypair: %s", keyPairName)
 
-	th.AssertEquals(t, keyPair.Name, keyPairName)
+	th.AssertEquals(t, keyPairName, keyPair.Name)
 
 	return keyPair, nil
 }
@@ -263,9 +263,9 @@ func CreateMultiEphemeralServer(t *testing.T, client *gophercloud.ServiceClient,
 	if err != nil {
 		return server, err
 	}
-	th.AssertEquals(t, newServer.Name, name)
-	th.AssertEquals(t, newServer.Flavor["id"], choices.FlavorID)
-	th.AssertEquals(t, newServer.Image["id"], choices.ImageID)
+	th.AssertEquals(t, name, newServer.Name)
+	th.AssertEquals(t, choices.FlavorID, newServer.Flavor["id"])
+	th.AssertEquals(t, choices.ImageID, newServer.Image["id"])
 
 	return newServer, nil
 }
@@ -292,11 +292,11 @@ func CreatePrivateFlavor(t *testing.T, client *gophercloud.ServiceClient) (*flav
 
 	t.Logf("Successfully created flavor %s", flavor.ID)
 
-	th.AssertEquals(t, flavor.Name, flavorName)
-	th.AssertEquals(t, flavor.RAM, 1)
-	th.AssertEquals(t, flavor.Disk, 1)
-	th.AssertEquals(t, flavor.VCPUs, 1)
-	th.AssertEquals(t, flavor.IsPublic, false)
+	th.AssertEquals(t, flavorName, flavor.Name)
+	th.AssertEquals(t, 1, flavor.RAM)
+	th.AssertEquals(t, 1, flavor.Disk)
+	th.AssertEquals(t, 1, flavor.VCPUs)
+	th.AssertEquals(t, false, flavor.IsPublic)
 
 	return flavor, nil
 }
@@ -318,7 +318,7 @@ func CreateSecurityGroup(t *testing.T, client *gophercloud.ServiceClient) (*secg
 
 	t.Logf("Created security group: %s", securityGroup.ID)
 
-	th.AssertEquals(t, securityGroup.Name, name)
+	th.AssertEquals(t, name, securityGroup.Name)
 
 	return securityGroup, nil
 }
@@ -344,9 +344,9 @@ func CreateSecurityGroupRule(t *testing.T, client *gophercloud.ServiceClient, se
 
 	t.Logf("Created security group rule: %s", rule.ID)
 
-	th.AssertEquals(t, rule.FromPort, fromPort)
-	th.AssertEquals(t, rule.ToPort, toPort)
-	th.AssertEquals(t, rule.ParentGroupID, securityGroupID)
+	th.AssertEquals(t, fromPort, rule.FromPort)
+	th.AssertEquals(t, toPort, rule.ToPort)
+	th.AssertEquals(t, securityGroupID, rule.ParentGroupID)
 
 	return rule, nil
 }
@@ -403,9 +403,9 @@ func CreateServer(t *testing.T, client *gophercloud.ServiceClient) (*servers.Ser
 		return nil, err
 	}
 
-	th.AssertEquals(t, newServer.Name, name)
-	th.AssertEquals(t, newServer.Flavor["id"], choices.FlavorID)
-	th.AssertEquals(t, newServer.Image["id"], choices.ImageID)
+	th.AssertEquals(t, name, newServer.Name)
+	th.AssertEquals(t, choices.FlavorID, newServer.Flavor["id"])
+	th.AssertEquals(t, choices.ImageID, newServer.Image["id"])
 
 	return newServer, nil
 }
@@ -457,8 +457,8 @@ func CreateMicroversionServer(t *testing.T, client *gophercloud.ServiceClient) (
 		return nil, err
 	}
 
-	th.AssertEquals(t, newServer.Name, name)
-	th.AssertEquals(t, newServer.Image["id"], choices.ImageID)
+	th.AssertEquals(t, name, newServer.Name)
+	th.AssertEquals(t, choices.ImageID, newServer.Image["id"])
 
 	return newServer, nil
 }
@@ -560,8 +560,8 @@ func CreateServerWithTags(t *testing.T, client *gophercloud.ServiceClient, netwo
 
 	newServer, err := res.Extract()
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, newServer.Name, name)
-	th.AssertDeepEquals(t, *newServer.Tags, []string{"tag1", "tag2"})
+	th.AssertEquals(t, name, newServer.Name)
+	th.AssertDeepEquals(t, []string{"tag1", "tag2"}, *newServer.Tags)
 
 	return newServer, nil
 }
@@ -584,7 +584,7 @@ func CreateServerGroup(t *testing.T, client *gophercloud.ServiceClient, policy s
 
 	t.Logf("Successfully created server group %s", name)
 
-	th.AssertEquals(t, sg.Name, name)
+	th.AssertEquals(t, name, sg.Name)
 
 	return sg, nil
 }
@@ -612,7 +612,7 @@ func CreateServerGroupMicroversion(t *testing.T, client *gophercloud.ServiceClie
 
 	t.Logf("Successfully created server group %s", name)
 
-	th.AssertEquals(t, sg.Name, name)
+	th.AssertEquals(t, name, sg.Name)
 
 	return sg, nil
 }
@@ -662,9 +662,9 @@ func CreateServerInServerGroup(t *testing.T, client *gophercloud.ServiceClient, 
 		return nil, err
 	}
 
-	th.AssertEquals(t, newServer.Name, name)
-	th.AssertEquals(t, newServer.Flavor["id"], choices.FlavorID)
-	th.AssertEquals(t, newServer.Image["id"], choices.ImageID)
+	th.AssertEquals(t, name, newServer.Name)
+	th.AssertEquals(t, choices.FlavorID, newServer.Flavor["id"])
+	th.AssertEquals(t, choices.ImageID, newServer.Image["id"])
 
 	return newServer, nil
 }
@@ -711,9 +711,9 @@ func CreateServerWithPublicKey(t *testing.T, client *gophercloud.ServiceClient, 
 		return nil, err
 	}
 
-	th.AssertEquals(t, newServer.Name, name)
-	th.AssertEquals(t, newServer.Flavor["id"], choices.FlavorID)
-	th.AssertEquals(t, newServer.Image["id"], choices.ImageID)
+	th.AssertEquals(t, name, newServer.Name)
+	th.AssertEquals(t, choices.FlavorID, newServer.Flavor["id"])
+	th.AssertEquals(t, choices.ImageID, newServer.Image["id"])
 
 	return newServer, nil
 }
@@ -910,8 +910,8 @@ func ImportPublicKey(t *testing.T, client *gophercloud.ServiceClient, publicKey 
 
 	t.Logf("Created keypair: %s", keyPairName)
 
-	th.AssertEquals(t, keyPair.Name, keyPairName)
-	th.AssertEquals(t, keyPair.PublicKey, publicKey)
+	th.AssertEquals(t, keyPairName, keyPair.Name)
+	th.AssertEquals(t, publicKey, keyPair.PublicKey)
 
 	return keyPair, nil
 }
@@ -1070,9 +1070,9 @@ func CreateServerNoNetwork(t *testing.T, client *gophercloud.ServiceClient) (*se
 		return nil, err
 	}
 
-	th.AssertEquals(t, newServer.Name, name)
-	th.AssertEquals(t, newServer.Flavor["id"], choices.FlavorID)
-	th.AssertEquals(t, newServer.Image["id"], choices.ImageID)
+	th.AssertEquals(t, name, newServer.Name)
+	th.AssertEquals(t, choices.FlavorID, newServer.Flavor["id"])
+	th.AssertEquals(t, choices.ImageID, newServer.Image["id"])
 
 	return newServer, nil
 }

--- a/internal/acceptance/openstack/compute/v2/extension_test.go
+++ b/internal/acceptance/openstack/compute/v2/extension_test.go
@@ -31,7 +31,7 @@ func TestExtensionsList(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 }
 
 func TestExtensionsGet(t *testing.T) {
@@ -43,5 +43,5 @@ func TestExtensionsGet(t *testing.T) {
 
 	tools.PrintResource(t, extension)
 
-	th.AssertEquals(t, extension.Name, "AdminActions")
+	th.AssertEquals(t, "AdminActions", extension.Name)
 }

--- a/internal/acceptance/openstack/compute/v2/flavors_test.go
+++ b/internal/acceptance/openstack/compute/v2/flavors_test.go
@@ -35,7 +35,7 @@ func TestFlavorsList(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 }
 
 func TestFlavorsAccessTypeList(t *testing.T) {
@@ -74,7 +74,7 @@ func TestFlavorsGet(t *testing.T) {
 
 	tools.PrintResource(t, flavor)
 
-	th.AssertEquals(t, flavor.ID, choices.FlavorID)
+	th.AssertEquals(t, choices.FlavorID, flavor.ID)
 }
 
 func TestFlavorExtraSpecsGet(t *testing.T) {
@@ -103,9 +103,9 @@ func TestFlavorExtraSpecsGet(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	tools.PrintResource(t, flavor)
-	th.AssertEquals(t, len(flavor.ExtraSpecs), 2)
-	th.AssertEquals(t, flavor.ExtraSpecs["hw:cpu_policy"], "CPU-POLICY")
-	th.AssertEquals(t, flavor.ExtraSpecs["hw:cpu_thread_policy"], "CPU-THREAD-POLICY")
+	th.AssertEquals(t, 2, len(flavor.ExtraSpecs))
+	th.AssertEquals(t, "CPU-POLICY", flavor.ExtraSpecs["hw:cpu_policy"])
+	th.AssertEquals(t, "CPU-THREAD-POLICY", flavor.ExtraSpecs["hw:cpu_thread_policy"])
 }
 
 func TestFlavorsCreateDelete(t *testing.T) {
@@ -140,7 +140,7 @@ func TestFlavorsCreateUpdateDelete(t *testing.T) {
 
 	flavor, err = flavors.Update(context.TODO(), client, flavor.ID, updateOpts).Extract()
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, flavor.Description, newFlavorDescription)
+	th.AssertEquals(t, newFlavorDescription, flavor.Description)
 
 	tools.PrintResource(t, flavor)
 }
@@ -161,7 +161,7 @@ func TestFlavorsAccessesList(t *testing.T) {
 	allAccesses, err := flavors.ExtractAccesses(allPages)
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, len(allAccesses), 0)
+	th.AssertEquals(t, 0, len(allAccesses))
 }
 
 func TestFlavorsAccessCRUD(t *testing.T) {
@@ -188,9 +188,9 @@ func TestFlavorsAccessCRUD(t *testing.T) {
 	accessList, err := flavors.AddAccess(context.TODO(), client, flavor.ID, addAccessOpts).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, len(accessList), 1)
-	th.AssertEquals(t, accessList[0].TenantID, project.ID)
-	th.AssertEquals(t, accessList[0].FlavorID, flavor.ID)
+	th.AssertEquals(t, 1, len(accessList))
+	th.AssertEquals(t, project.ID, accessList[0].TenantID)
+	th.AssertEquals(t, flavor.ID, accessList[0].FlavorID)
 
 	for _, access := range accessList {
 		tools.PrintResource(t, access)
@@ -203,7 +203,7 @@ func TestFlavorsAccessCRUD(t *testing.T) {
 	accessList, err = flavors.RemoveAccess(context.TODO(), client, flavor.ID, removeAccessOpts).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, len(accessList), 0)
+	th.AssertEquals(t, 0, len(accessList))
 }
 
 func TestFlavorsExtraSpecsCRUD(t *testing.T) {
@@ -225,9 +225,9 @@ func TestFlavorsExtraSpecsCRUD(t *testing.T) {
 
 	tools.PrintResource(t, createdExtraSpecs)
 
-	th.AssertEquals(t, len(createdExtraSpecs), 2)
-	th.AssertEquals(t, createdExtraSpecs["hw:cpu_policy"], "CPU-POLICY")
-	th.AssertEquals(t, createdExtraSpecs["hw:cpu_thread_policy"], "CPU-THREAD-POLICY")
+	th.AssertEquals(t, 2, len(createdExtraSpecs))
+	th.AssertEquals(t, "CPU-POLICY", createdExtraSpecs["hw:cpu_policy"])
+	th.AssertEquals(t, "CPU-THREAD-POLICY", createdExtraSpecs["hw:cpu_thread_policy"])
 
 	err = flavors.DeleteExtraSpec(context.TODO(), client, flavor.ID, "hw:cpu_policy").ExtractErr()
 	th.AssertNoErr(t, err)
@@ -245,13 +245,13 @@ func TestFlavorsExtraSpecsCRUD(t *testing.T) {
 
 	tools.PrintResource(t, allExtraSpecs)
 
-	th.AssertEquals(t, len(allExtraSpecs), 1)
-	th.AssertEquals(t, allExtraSpecs["hw:cpu_thread_policy"], "CPU-THREAD-POLICY-BETTER")
+	th.AssertEquals(t, 1, len(allExtraSpecs))
+	th.AssertEquals(t, "CPU-THREAD-POLICY-BETTER", allExtraSpecs["hw:cpu_thread_policy"])
 
 	spec, err := flavors.GetExtraSpec(context.TODO(), client, flavor.ID, "hw:cpu_thread_policy").Extract()
 	th.AssertNoErr(t, err)
 
 	tools.PrintResource(t, spec)
 
-	th.AssertEquals(t, spec["hw:cpu_thread_policy"], "CPU-THREAD-POLICY-BETTER")
+	th.AssertEquals(t, "CPU-THREAD-POLICY-BETTER", spec["hw:cpu_thread_policy"])
 }

--- a/internal/acceptance/openstack/compute/v2/instance_actions_test.go
+++ b/internal/acceptance/openstack/compute/v2/instance_actions_test.go
@@ -39,7 +39,7 @@ func TestInstanceActions(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 }
 
 func TestInstanceActionsMicroversions(t *testing.T) {
@@ -88,7 +88,7 @@ func TestInstanceActionsMicroversions(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 
 	listOpts = instanceactions.ListOpts{
 		Limit:         1,
@@ -101,5 +101,5 @@ func TestInstanceActionsMicroversions(t *testing.T) {
 	allActions, err = instanceactions.ExtractInstanceActions(allPages)
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, len(allActions), 0)
+	th.AssertEquals(t, 0, len(allActions))
 }

--- a/internal/acceptance/openstack/compute/v2/keypairs_test.go
+++ b/internal/acceptance/openstack/compute/v2/keypairs_test.go
@@ -57,7 +57,7 @@ func TestKeyPairsCreateDelete(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 }
 
 func TestKeyPairsImportPublicKey(t *testing.T) {
@@ -94,7 +94,7 @@ func TestKeyPairsServerCreateWithKey(t *testing.T) {
 	server, err = servers.Get(context.TODO(), client, server.ID).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, server.KeyName, keyPair.Name)
+	th.AssertEquals(t, keyPair.Name, server.KeyName)
 }
 
 func TestKeyPairsCreateDeleteByID(t *testing.T) {
@@ -146,7 +146,7 @@ func TestKeyPairsCreateDeleteByID(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 
 	deleteOpts := keypairs.DeleteOpts{
 		UserID: user.ID,

--- a/internal/acceptance/openstack/compute/v2/limits_test.go
+++ b/internal/acceptance/openstack/compute/v2/limits_test.go
@@ -22,7 +22,7 @@ func TestLimits(t *testing.T) {
 
 	tools.PrintResource(t, limits)
 
-	th.AssertEquals(t, limits.Absolute.MaxPersonalitySize, 10240)
+	th.AssertEquals(t, 10240, limits.Absolute.MaxPersonalitySize)
 }
 
 func TestLimitsForTenant(t *testing.T) {
@@ -47,5 +47,5 @@ func TestLimitsForTenant(t *testing.T) {
 
 	tools.PrintResource(t, limits)
 
-	th.AssertEquals(t, limits.Absolute.MaxPersonalitySize, 10240)
+	th.AssertEquals(t, 10240, limits.Absolute.MaxPersonalitySize)
 }

--- a/internal/acceptance/openstack/compute/v2/quotaset_test.go
+++ b/internal/acceptance/openstack/compute/v2/quotaset_test.go
@@ -31,7 +31,7 @@ func TestQuotasetGet(t *testing.T) {
 
 	tools.PrintResource(t, quotaSet)
 
-	th.AssertEquals(t, quotaSet.FixedIPs, -1)
+	th.AssertEquals(t, -1, quotaSet.FixedIPs)
 }
 
 func getProjectID(t *testing.T, client *gophercloud.ServiceClient) (string, error) {

--- a/internal/acceptance/openstack/compute/v2/secgroup_test.go
+++ b/internal/acceptance/openstack/compute/v2/secgroup_test.go
@@ -32,7 +32,7 @@ func TestSecGroupsList(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 }
 
 func TestSecGroupsCRUD(t *testing.T) {
@@ -58,8 +58,8 @@ func TestSecGroupsCRUD(t *testing.T) {
 
 	t.Logf("Updated %s's name to %s", updatedSecurityGroup.ID, updatedSecurityGroup.Name)
 
-	th.AssertEquals(t, updatedSecurityGroup.Name, newName)
-	th.AssertEquals(t, updatedSecurityGroup.Description, description)
+	th.AssertEquals(t, newName, updatedSecurityGroup.Name)
+	th.AssertEquals(t, description, updatedSecurityGroup.Description)
 }
 
 func TestSecGroupsRuleCreate(t *testing.T) {
@@ -83,7 +83,7 @@ func TestSecGroupsRuleCreate(t *testing.T) {
 
 	tools.PrintResource(t, newSecurityGroup)
 
-	th.AssertEquals(t, len(newSecurityGroup.Rules), 1)
+	th.AssertEquals(t, 1, len(newSecurityGroup.Rules))
 }
 
 func TestSecGroupsAddGroupToServer(t *testing.T) {
@@ -120,7 +120,7 @@ func TestSecGroupsAddGroupToServer(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 
 	t.Logf("Removing group %s from server %s", securityGroup.ID, server.ID)
 	err = secgroups.RemoveServer(context.TODO(), client, server.ID, securityGroup.Name).ExtractErr()
@@ -139,5 +139,5 @@ func TestSecGroupsAddGroupToServer(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, false)
+	th.AssertEquals(t, false, found)
 }

--- a/internal/acceptance/openstack/compute/v2/servergroup_test.go
+++ b/internal/acceptance/openstack/compute/v2/servergroup_test.go
@@ -41,7 +41,7 @@ func TestServergroupsCreateDelete(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 }
 
 func TestServergroupsAffinityPolicy(t *testing.T) {
@@ -100,5 +100,5 @@ func TestServergroupsMicroversionCreateDelete(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 }

--- a/internal/acceptance/openstack/compute/v2/servers_test.go
+++ b/internal/acceptance/openstack/compute/v2/servers_test.go
@@ -45,7 +45,7 @@ func TestServersCreateDestroy(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 
 	allAddressPages, err := servers.ListAddresses(client, server.ID).AllPages(context.TODO())
 	th.AssertNoErr(t, err)
@@ -93,12 +93,12 @@ func TestServersWithExtensionsCreateDestroy(t *testing.T) {
 	th.AssertNoErr(t, err)
 	tools.PrintResource(t, created)
 
-	th.AssertEquals(t, created.AvailabilityZone, "nova")
-	th.AssertEquals(t, int(created.PowerState), servers.RUNNING)
-	th.AssertEquals(t, created.TaskState, "")
-	th.AssertEquals(t, created.VmState, "active")
-	th.AssertEquals(t, created.LaunchedAt.IsZero(), false)
-	th.AssertEquals(t, created.TerminatedAt.IsZero(), true)
+	th.AssertEquals(t, "nova", created.AvailabilityZone)
+	th.AssertEquals(t, servers.RUNNING, int(created.PowerState))
+	th.AssertEquals(t, "", created.TaskState)
+	th.AssertEquals(t, "active", created.VmState)
+	th.AssertEquals(t, false, created.LaunchedAt.IsZero())
+	th.AssertEquals(t, true, created.TerminatedAt.IsZero())
 }
 
 func TestServersWithoutImageRef(t *testing.T) {
@@ -139,7 +139,7 @@ func TestServersUpdate(t *testing.T) {
 	updated, err := servers.Update(context.TODO(), client, server.ID, updateOpts).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, updated.ID, server.ID)
+	th.AssertEquals(t, server.ID, updated.ID)
 
 	err = tools.WaitFor(func(ctx context.Context) (bool, error) {
 		latest, err := servers.Get(ctx, client, updated.ID).Extract()
@@ -307,7 +307,7 @@ func TestServersActionRebuild(t *testing.T) {
 	rebuilt, err := servers.Rebuild(context.TODO(), client, server.ID, rebuildOpts).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, rebuilt.ID, server.ID)
+	th.AssertEquals(t, server.ID, rebuilt.ID)
 
 	if err = WaitForComputeStatus(client, rebuilt, "REBUILD"); err != nil {
 		t.Fatal(err)
@@ -347,7 +347,7 @@ func TestServersActionResizeConfirm(t *testing.T) {
 	server, err = servers.Get(context.TODO(), client, server.ID).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, server.Flavor["id"], choices.FlavorIDResize)
+	th.AssertEquals(t, choices.FlavorIDResize, server.Flavor["id"])
 }
 
 func TestServersActionResizeRevert(t *testing.T) {
@@ -379,7 +379,7 @@ func TestServersActionResizeRevert(t *testing.T) {
 	server, err = servers.Get(context.TODO(), client, server.ID).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, server.Flavor["id"], choices.FlavorID)
+	th.AssertEquals(t, choices.FlavorID, server.Flavor["id"])
 }
 
 func TestServersActionPause(t *testing.T) {
@@ -447,7 +447,7 @@ func TestServersActionLock(t *testing.T) {
 
 	t.Logf("Attempting to delete locked server %s", server.ID)
 	err = servers.Delete(context.TODO(), client, server.ID).ExtractErr()
-	th.AssertEquals(t, err != nil, true)
+	th.AssertEquals(t, true, err != nil)
 
 	t.Logf("Attempting to unlock server %s", server.ID)
 	err = servers.Unlock(context.TODO(), client, server.ID).ExtractErr()
@@ -565,13 +565,13 @@ func TestServersWithExtendedAttributesCreateDestroy(t *testing.T) {
 
 	t.Logf("Server With Extended Attributes: %#v", created)
 
-	th.AssertEquals(t, *created.ReservationID != "", true)
-	th.AssertEquals(t, *created.LaunchIndex, 0)
-	th.AssertEquals(t, *created.RAMDiskID == "", true)
-	th.AssertEquals(t, *created.KernelID == "", true)
-	th.AssertEquals(t, *created.Hostname != "", true)
-	th.AssertEquals(t, *created.RootDeviceName != "", true)
-	th.AssertEquals(t, created.Userdata == nil, true)
+	th.AssertEquals(t, true, *created.ReservationID != "")
+	th.AssertEquals(t, 0, *created.LaunchIndex)
+	th.AssertEquals(t, true, *created.RAMDiskID == "")
+	th.AssertEquals(t, true, *created.KernelID == "")
+	th.AssertEquals(t, true, *created.Hostname != "")
+	th.AssertEquals(t, true, *created.RootDeviceName != "")
+	th.AssertEquals(t, true, created.Userdata == nil)
 }
 
 func TestServerNoNetworkCreateDestroy(t *testing.T) {
@@ -604,7 +604,7 @@ func TestServerNoNetworkCreateDestroy(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 
 	allAddressPages, err := servers.ListAddresses(client, server.ID).AllPages(context.TODO())
 	th.AssertNoErr(t, err)

--- a/internal/acceptance/openstack/compute/v2/services_test.go
+++ b/internal/acceptance/openstack/compute/v2/services_test.go
@@ -33,7 +33,7 @@ func TestServicesList(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 }
 
 func TestServicesListWithOpts(t *testing.T) {
@@ -55,12 +55,12 @@ func TestServicesListWithOpts(t *testing.T) {
 	var found bool
 	for _, service := range allServices {
 		tools.PrintResource(t, service)
-		th.AssertEquals(t, service.Binary, "nova-scheduler")
+		th.AssertEquals(t, "nova-scheduler", service.Binary)
 
 		if service.Binary == "nova-scheduler" {
 			found = true
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 }

--- a/internal/acceptance/openstack/compute/v2/volumeattach_test.go
+++ b/internal/acceptance/openstack/compute/v2/volumeattach_test.go
@@ -35,5 +35,5 @@ func TestVolumeAttachAttachment(t *testing.T) {
 
 	tools.PrintResource(t, volumeAttachment)
 
-	th.AssertEquals(t, volumeAttachment.ServerID, server.ID)
+	th.AssertEquals(t, server.ID, volumeAttachment.ServerID)
 }


### PR DESCRIPTION
Our test convenience function `AssertEquals` accept the expected value first, then the actual value. Many tests in Compute were using it the other way around, thus potentially returning confusing error messages.

https://github.com/gophercloud/gophercloud/blob/abca462164fb9fe6ab103b61fafb1399547f4438/testhelper/convenience.go#L218