### PR TITLE
all: Accept ServiceClient as an interface

### DIFF
--- a/openstack/baremetal/apiversions/requests.go
+++ b/openstack/baremetal/apiversions/requests.go
@@ -7,14 +7,14 @@ import (
 )
 
 // List lists all the API versions available to end users.
-func List(ctx context.Context, client *gophercloud.ServiceClient) (r ListResult) {
+func List(ctx context.Context, client gophercloud.Client) (r ListResult) {
 	resp, err := client.Get(ctx, listURL(client), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
 // Get will get a specific API version, specified by major ID.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, v string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, v string) (r GetResult) {
 	resp, err := client.Get(ctx, getURL(client, v), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/baremetal/apiversions/urls.go
+++ b/openstack/baremetal/apiversions/urls.go
@@ -4,10 +4,10 @@ import (
 	"github.com/gophercloud/gophercloud/v2"
 )
 
-func getURL(c *gophercloud.ServiceClient, version string) string {
+func getURL(c gophercloud.Client, version string) string {
 	return c.ServiceURL(version)
 }
 
-func listURL(c *gophercloud.ServiceClient) string {
+func listURL(c gophercloud.Client) string {
 	return c.ServiceURL()
 }

--- a/openstack/baremetal/v1/allocations/requests.go
+++ b/openstack/baremetal/v1/allocations/requests.go
@@ -45,7 +45,7 @@ func (opts CreateOpts) ToAllocationCreateMap() (map[string]any, error) {
 }
 
 // Create requests a node to be created
-func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	reqBody, err := opts.ToAllocationCreateMap()
 	if err != nil {
 		r.Err = err
@@ -105,7 +105,7 @@ func (opts ListOpts) ToAllocationListQuery() (string, error) {
 }
 
 // List makes a request against the API to list allocations accessible to you.
-func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(client gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(client)
 	if opts != nil {
 		query, err := opts.ToAllocationListQuery()
@@ -120,7 +120,7 @@ func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pa
 }
 
 // Get requests the details of an allocation by ID.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, id string) (r GetResult) {
 	resp, err := client.Get(ctx, getURL(client, id), &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{200},
 	})
@@ -129,7 +129,7 @@ func Get(ctx context.Context, client *gophercloud.ServiceClient, id string) (r G
 }
 
 // Delete requests the deletion of an allocation
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, id string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, deleteURL(client, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/baremetal/v1/allocations/urls.go
+++ b/openstack/baremetal/v1/allocations/urls.go
@@ -2,22 +2,22 @@ package allocations
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func createURL(client *gophercloud.ServiceClient) string {
+func createURL(client gophercloud.Client) string {
 	return client.ServiceURL("allocations")
 }
 
-func listURL(client *gophercloud.ServiceClient) string {
+func listURL(client gophercloud.Client) string {
 	return createURL(client)
 }
 
-func resourceURL(client *gophercloud.ServiceClient, id string) string {
+func resourceURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL("allocations", id)
 }
 
-func deleteURL(client *gophercloud.ServiceClient, id string) string {
+func deleteURL(client gophercloud.Client, id string) string {
 	return resourceURL(client, id)
 }
 
-func getURL(client *gophercloud.ServiceClient, id string) string {
+func getURL(client gophercloud.Client, id string) string {
 	return resourceURL(client, id)
 }

--- a/openstack/baremetal/v1/conductors/requests.go
+++ b/openstack/baremetal/v1/conductors/requests.go
@@ -49,7 +49,7 @@ func (opts ListOpts) ToConductorListQuery() (string, error) {
 }
 
 // List makes a request against the API to list conductors accessible to you.
-func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(client gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(client)
 	if opts != nil {
 		query, err := opts.ToConductorListQuery()
@@ -64,7 +64,7 @@ func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pa
 }
 
 // Get requests details on a single conductor by hostname
-func Get(ctx context.Context, client *gophercloud.ServiceClient, name string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, name string) (r GetResult) {
 	resp, err := client.Get(ctx, getURL(client, name), &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{200},
 	})

--- a/openstack/baremetal/v1/conductors/urls.go
+++ b/openstack/baremetal/v1/conductors/urls.go
@@ -2,10 +2,10 @@ package conductors
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func listURL(client *gophercloud.ServiceClient) string {
+func listURL(client gophercloud.Client) string {
 	return client.ServiceURL("conductors")
 }
 
-func getURL(client *gophercloud.ServiceClient, id string) string {
+func getURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL("conductors", id)
 }

--- a/openstack/baremetal/v1/drivers/requests.go
+++ b/openstack/baremetal/v1/drivers/requests.go
@@ -29,7 +29,7 @@ func (opts ListDriversOpts) ToListDriversOptsQuery() (string, error) {
 }
 
 // ListDrivers makes a request against the API to list all drivers
-func ListDrivers(client *gophercloud.ServiceClient, opts ListDriversOptsBuilder) pagination.Pager {
+func ListDrivers(client gophercloud.Client, opts ListDriversOptsBuilder) pagination.Pager {
 	url := driversURL(client)
 	if opts != nil {
 		query, err := opts.ToListDriversOptsQuery()
@@ -44,7 +44,7 @@ func ListDrivers(client *gophercloud.ServiceClient, opts ListDriversOptsBuilder)
 }
 
 // GetDriverDetails Shows details for a driver
-func GetDriverDetails(ctx context.Context, client *gophercloud.ServiceClient, driverName string) (r GetDriverResult) {
+func GetDriverDetails(ctx context.Context, client gophercloud.Client, driverName string) (r GetDriverResult) {
 	resp, err := client.Get(ctx, driverDetailsURL(client, driverName), &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{200},
 	})
@@ -55,7 +55,7 @@ func GetDriverDetails(ctx context.Context, client *gophercloud.ServiceClient, dr
 // GetDriverProperties Shows the required and optional parameters that
 // driverName expects to be supplied in the driver_info field for every
 // Node it manages
-func GetDriverProperties(ctx context.Context, client *gophercloud.ServiceClient, driverName string) (r GetPropertiesResult) {
+func GetDriverProperties(ctx context.Context, client gophercloud.Client, driverName string) (r GetPropertiesResult) {
 	resp, err := client.Get(ctx, driverPropertiesURL(client, driverName), &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{200},
 	})
@@ -66,7 +66,7 @@ func GetDriverProperties(ctx context.Context, client *gophercloud.ServiceClient,
 // GetDriverDiskProperties Show the required and optional parameters that
 // driverName expects to be supplied in the node’s raid_config field, if a
 // RAID configuration change is requested.
-func GetDriverDiskProperties(ctx context.Context, client *gophercloud.ServiceClient, driverName string) (r GetDiskPropertiesResult) {
+func GetDriverDiskProperties(ctx context.Context, client gophercloud.Client, driverName string) (r GetDiskPropertiesResult) {
 	resp, err := client.Get(ctx, driverDiskPropertiesURL(client, driverName), &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{200},
 	})

--- a/openstack/baremetal/v1/drivers/urls.go
+++ b/openstack/baremetal/v1/drivers/urls.go
@@ -2,18 +2,18 @@ package drivers
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func driversURL(client *gophercloud.ServiceClient) string {
+func driversURL(client gophercloud.Client) string {
 	return client.ServiceURL("drivers")
 }
 
-func driverDetailsURL(client *gophercloud.ServiceClient, driverName string) string {
+func driverDetailsURL(client gophercloud.Client, driverName string) string {
 	return client.ServiceURL("drivers", driverName)
 }
 
-func driverPropertiesURL(client *gophercloud.ServiceClient, driverName string) string {
+func driverPropertiesURL(client gophercloud.Client, driverName string) string {
 	return client.ServiceURL("drivers", driverName, "properties")
 }
 
-func driverDiskPropertiesURL(client *gophercloud.ServiceClient, driverName string) string {
+func driverDiskPropertiesURL(client gophercloud.Client, driverName string) string {
 	return client.ServiceURL("drivers", driverName, "raid", "logical_disk_properties")
 }

--- a/openstack/baremetal/v1/nodes/requests.go
+++ b/openstack/baremetal/v1/nodes/requests.go
@@ -139,7 +139,7 @@ func (opts ListOpts) ToNodeListQuery() (string, error) {
 }
 
 // List makes a request against the API to list nodes accessible to you.
-func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(client gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(client)
 	if opts != nil {
 		query, err := opts.ToNodeListQuery()
@@ -166,7 +166,7 @@ func (opts ListOpts) ToNodeListDetailQuery() (string, error) {
 
 // Return a list of bare metal Nodes with complete details. Some filtering is possible by passing in flags in ListOpts,
 // but you cannot limit by the fields returned.
-func ListDetail(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func ListDetail(client gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	// This URL is deprecated. In the future, we should compare the microversion and if >= 1.43, hit the listURL
 	// with ListOpts{Detail: true,}
 	url := listDetailURL(client)
@@ -183,7 +183,7 @@ func ListDetail(client *gophercloud.ServiceClient, opts ListOptsBuilder) paginat
 }
 
 // Get requests details on a single node, by ID.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, id string) (r GetResult) {
 	resp, err := client.Get(ctx, getURL(client, id), &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{200},
 	})
@@ -291,7 +291,7 @@ func (opts CreateOpts) ToNodeCreateMap() (map[string]any, error) {
 }
 
 // Create requests a node to be created
-func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	reqBody, err := opts.ToNodeCreateMap()
 	if err != nil {
 		r.Err = err
@@ -329,7 +329,7 @@ func (opts UpdateOperation) ToNodeUpdateMap() (map[string]any, error) {
 }
 
 // Update requests that a node be updated
-func Update(ctx context.Context, client *gophercloud.ServiceClient, id string, opts UpdateOpts) (r UpdateResult) {
+func Update(ctx context.Context, client gophercloud.Client, id string, opts UpdateOpts) (r UpdateResult) {
 	body := make([]map[string]any, len(opts))
 	for i, patch := range opts {
 		result, err := patch.ToNodeUpdateMap()
@@ -348,7 +348,7 @@ func Update(ctx context.Context, client *gophercloud.ServiceClient, id string, o
 }
 
 // Delete requests that a node be removed
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, id string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, deleteURL(client, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -356,7 +356,7 @@ func Delete(ctx context.Context, client *gophercloud.ServiceClient, id string) (
 
 // Request that Ironic validate whether the Node’s driver has enough information to manage the Node. This polls each
 // interface on the driver, and returns the status of that interface.
-func Validate(ctx context.Context, client *gophercloud.ServiceClient, id string) (r ValidateResult) {
+func Validate(ctx context.Context, client gophercloud.Client, id string) (r ValidateResult) {
 	resp, err := client.Get(ctx, validateURL(client, id), &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{200},
 	})
@@ -366,7 +366,7 @@ func Validate(ctx context.Context, client *gophercloud.ServiceClient, id string)
 
 // Inject NMI (Non-Masking Interrupts) for the given Node. This feature can be used for hardware diagnostics, and
 // actual support depends on a driver.
-func InjectNMI(ctx context.Context, client *gophercloud.ServiceClient, id string) (r InjectNMIResult) {
+func InjectNMI(ctx context.Context, client gophercloud.Client, id string) (r InjectNMIResult) {
 	resp, err := client.Put(ctx, injectNMIURL(client, id), map[string]string{}, nil, &gophercloud.RequestOpts{
 		OkCodes: []int{204},
 	})
@@ -397,7 +397,7 @@ func (opts BootDeviceOpts) ToBootDeviceMap() (map[string]any, error) {
 
 // Set the boot device for the given Node, and set it persistently or for one-time boot. The exact behaviour
 // of this depends on the hardware driver.
-func SetBootDevice(ctx context.Context, client *gophercloud.ServiceClient, id string, bootDevice BootDeviceOptsBuilder) (r SetBootDeviceResult) {
+func SetBootDevice(ctx context.Context, client gophercloud.Client, id string, bootDevice BootDeviceOptsBuilder) (r SetBootDeviceResult) {
 	reqBody, err := bootDevice.ToBootDeviceMap()
 	if err != nil {
 		r.Err = err
@@ -412,7 +412,7 @@ func SetBootDevice(ctx context.Context, client *gophercloud.ServiceClient, id st
 }
 
 // Get the current boot device for the given Node.
-func GetBootDevice(ctx context.Context, client *gophercloud.ServiceClient, id string) (r BootDeviceResult) {
+func GetBootDevice(ctx context.Context, client gophercloud.Client, id string) (r BootDeviceResult) {
 	resp, err := client.Get(ctx, bootDeviceURL(client, id), &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{200},
 	})
@@ -421,7 +421,7 @@ func GetBootDevice(ctx context.Context, client *gophercloud.ServiceClient, id st
 }
 
 // Retrieve the acceptable set of supported boot devices for a specific Node.
-func GetSupportedBootDevices(ctx context.Context, client *gophercloud.ServiceClient, id string) (r SupportedBootDeviceResult) {
+func GetSupportedBootDevices(ctx context.Context, client gophercloud.Client, id string) (r SupportedBootDeviceResult) {
 	resp, err := client.Get(ctx, supportedBootDeviceURL(client, id), &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{200},
 	})
@@ -500,7 +500,7 @@ func (opts ProvisionStateOpts) ToProvisionStateMap() (map[string]any, error) {
 
 // Request a change to the Node’s provision state. Acceptable target states depend on the Node’s current provision
 // state. More detailed documentation of the Ironic State Machine is available in the developer docs.
-func ChangeProvisionState(ctx context.Context, client *gophercloud.ServiceClient, id string, opts ProvisionStateOptsBuilder) (r ChangeStateResult) {
+func ChangeProvisionState(ctx context.Context, client gophercloud.Client, id string, opts ProvisionStateOptsBuilder) (r ChangeStateResult) {
 	reqBody, err := opts.ToProvisionStateMap()
 	if err != nil {
 		r.Err = err
@@ -547,7 +547,7 @@ func (opts PowerStateOpts) ToPowerStateMap() (map[string]any, error) {
 }
 
 // Request to change a Node's power state.
-func ChangePowerState(ctx context.Context, client *gophercloud.ServiceClient, id string, opts PowerStateOptsBuilder) (r ChangePowerStateResult) {
+func ChangePowerState(ctx context.Context, client gophercloud.Client, id string, opts PowerStateOptsBuilder) (r ChangePowerStateResult) {
 	reqBody, err := opts.ToPowerStateMap()
 	if err != nil {
 		r.Err = err
@@ -656,7 +656,7 @@ func (opts RAIDConfigOpts) ToRAIDConfigMap() (map[string]any, error) {
 }
 
 // Request to change a Node's RAID config.
-func SetRAIDConfig(ctx context.Context, client *gophercloud.ServiceClient, id string, raidConfigOptsBuilder RAIDConfigOptsBuilder) (r ChangeStateResult) {
+func SetRAIDConfig(ctx context.Context, client gophercloud.Client, id string, raidConfigOptsBuilder RAIDConfigOptsBuilder) (r ChangeStateResult) {
 	reqBody, err := raidConfigOptsBuilder.ToRAIDConfigMap()
 	if err != nil {
 		r.Err = err
@@ -697,7 +697,7 @@ func (opts ListBIOSSettingsOpts) ToListBIOSSettingsOptsQuery() (string, error) {
 
 // Get the current BIOS Settings for the given Node.
 // To use the opts requires microversion 1.74.
-func ListBIOSSettings(ctx context.Context, client *gophercloud.ServiceClient, id string, opts ListBIOSSettingsOptsBuilder) (r ListBIOSSettingsResult) {
+func ListBIOSSettings(ctx context.Context, client gophercloud.Client, id string, opts ListBIOSSettingsOptsBuilder) (r ListBIOSSettingsResult) {
 	url := biosListSettingsURL(client, id)
 	if opts != nil {
 
@@ -717,7 +717,7 @@ func ListBIOSSettings(ctx context.Context, client *gophercloud.ServiceClient, id
 }
 
 // Get one BIOS Setting for the given Node.
-func GetBIOSSetting(ctx context.Context, client *gophercloud.ServiceClient, id string, setting string) (r GetBIOSSettingResult) {
+func GetBIOSSetting(ctx context.Context, client gophercloud.Client, id string, setting string) (r GetBIOSSettingResult) {
 	resp, err := client.Get(ctx, biosGetSettingURL(client, id, setting), &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{200},
 	})
@@ -737,7 +737,7 @@ func ToGetAllSubscriptionMap(opts CallVendorPassthruOpts) (string, error) {
 }
 
 // Get all vendor_passthru methods available for the given Node.
-func GetVendorPassthruMethods(ctx context.Context, client *gophercloud.ServiceClient, id string) (r VendorPassthruMethodsResult) {
+func GetVendorPassthruMethods(ctx context.Context, client gophercloud.Client, id string) (r VendorPassthruMethodsResult) {
 	resp, err := client.Get(ctx, vendorPassthruMethodsURL(client, id), &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{200},
 	})
@@ -746,7 +746,7 @@ func GetVendorPassthruMethods(ctx context.Context, client *gophercloud.ServiceCl
 }
 
 // Get all subscriptions available for the given Node.
-func GetAllSubscriptions(ctx context.Context, client *gophercloud.ServiceClient, id string, method CallVendorPassthruOpts) (r GetAllSubscriptionsVendorPassthruResult) {
+func GetAllSubscriptions(ctx context.Context, client gophercloud.Client, id string, method CallVendorPassthruOpts) (r GetAllSubscriptionsVendorPassthruResult) {
 	query, err := ToGetAllSubscriptionMap(method)
 	if err != nil {
 		r.Err = err
@@ -780,7 +780,7 @@ func ToGetSubscriptionMap(method CallVendorPassthruOpts, opts GetSubscriptionOpt
 }
 
 // Get a subscription on the given Node.
-func GetSubscription(ctx context.Context, client *gophercloud.ServiceClient, id string, method CallVendorPassthruOpts, subscriptionOpts GetSubscriptionOpts) (r SubscriptionVendorPassthruResult) {
+func GetSubscription(ctx context.Context, client gophercloud.Client, id string, method CallVendorPassthruOpts, subscriptionOpts GetSubscriptionOpts) (r SubscriptionVendorPassthruResult) {
 	query, reqBody, err := ToGetSubscriptionMap(method, subscriptionOpts)
 	if err != nil {
 		r.Err = err
@@ -814,7 +814,7 @@ func ToDeleteSubscriptionMap(method CallVendorPassthruOpts, opts DeleteSubscript
 }
 
 // Delete a subscription on the given node.
-func DeleteSubscription(ctx context.Context, client *gophercloud.ServiceClient, id string, method CallVendorPassthruOpts, subscriptionOpts DeleteSubscriptionOpts) (r DeleteSubscriptionVendorPassthruResult) {
+func DeleteSubscription(ctx context.Context, client gophercloud.Client, id string, method CallVendorPassthruOpts, subscriptionOpts DeleteSubscriptionOpts) (r DeleteSubscriptionVendorPassthruResult) {
 	query, reqBody, err := ToDeleteSubscriptionMap(method, subscriptionOpts)
 	if err != nil {
 		r.Err = err
@@ -852,7 +852,7 @@ func ToCreateSubscriptionMap(method CallVendorPassthruOpts, opts CreateSubscript
 }
 
 // Creates a subscription on the given node.
-func CreateSubscription(ctx context.Context, client *gophercloud.ServiceClient, id string, method CallVendorPassthruOpts, subscriptionOpts CreateSubscriptionOpts) (r SubscriptionVendorPassthruResult) {
+func CreateSubscription(ctx context.Context, client gophercloud.Client, id string, method CallVendorPassthruOpts, subscriptionOpts CreateSubscriptionOpts) (r SubscriptionVendorPassthruResult) {
 	query, reqBody, err := ToCreateSubscriptionMap(method, subscriptionOpts)
 	if err != nil {
 		r.Err = err
@@ -887,7 +887,7 @@ func (opts MaintenanceOpts) ToMaintenanceMap() (map[string]any, error) {
 }
 
 // Request to set the Node's maintenance mode.
-func SetMaintenance(ctx context.Context, client *gophercloud.ServiceClient, id string, opts MaintenanceOptsBuilder) (r SetMaintenanceResult) {
+func SetMaintenance(ctx context.Context, client gophercloud.Client, id string, opts MaintenanceOptsBuilder) (r SetMaintenanceResult) {
 	reqBody, err := opts.ToMaintenanceMap()
 	if err != nil {
 		r.Err = err
@@ -902,7 +902,7 @@ func SetMaintenance(ctx context.Context, client *gophercloud.ServiceClient, id s
 }
 
 // Request to unset the Node's maintenance mode.
-func UnsetMaintenance(ctx context.Context, client *gophercloud.ServiceClient, id string) (r SetMaintenanceResult) {
+func UnsetMaintenance(ctx context.Context, client gophercloud.Client, id string) (r SetMaintenanceResult) {
 	resp, err := client.Delete(ctx, maintenanceURL(client, id), &gophercloud.RequestOpts{
 		OkCodes: []int{202},
 	})
@@ -911,7 +911,7 @@ func UnsetMaintenance(ctx context.Context, client *gophercloud.ServiceClient, id
 }
 
 // GetInventory return stored data from successful inspection.
-func GetInventory(ctx context.Context, client *gophercloud.ServiceClient, id string) (r InventoryResult) {
+func GetInventory(ctx context.Context, client gophercloud.Client, id string) (r InventoryResult) {
 	resp, err := client.Get(ctx, inventoryURL(client, id), &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{200},
 	})
@@ -920,7 +920,7 @@ func GetInventory(ctx context.Context, client *gophercloud.ServiceClient, id str
 }
 
 // ListFirmware return the list of Firmware components for the given Node.
-func ListFirmware(ctx context.Context, client *gophercloud.ServiceClient, id string) (r ListFirmwareResult) {
+func ListFirmware(ctx context.Context, client gophercloud.Client, id string) (r ListFirmwareResult) {
 	resp, err := client.Get(ctx, firmwareListURL(client, id), &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{200},
 	})
@@ -960,7 +960,7 @@ func (opts AttachVirtualMediaOpts) ToAttachVirtualMediaMap() (map[string]any, er
 }
 
 // Request to attach a virtual media device to the Node.
-func AttachVirtualMedia(ctx context.Context, client *gophercloud.ServiceClient, id string, opts AttachVirtualMediaOptsBuilder) (r VirtualMediaAttachResult) {
+func AttachVirtualMedia(ctx context.Context, client gophercloud.Client, id string, opts AttachVirtualMediaOptsBuilder) (r VirtualMediaAttachResult) {
 	reqBody, err := opts.ToAttachVirtualMediaMap()
 	if err != nil {
 		r.Err = err
@@ -989,7 +989,7 @@ func (opts DetachVirtualMediaOpts) ToDetachVirtualMediaOptsQuery() (string, erro
 }
 
 // Request to detach a virtual media device from the Node.
-func DetachVirtualMedia(ctx context.Context, client *gophercloud.ServiceClient, id string, opts DetachVirtualMediaOptsBuilder) (r VirtualMediaDetachResult) {
+func DetachVirtualMedia(ctx context.Context, client gophercloud.Client, id string, opts DetachVirtualMediaOptsBuilder) (r VirtualMediaDetachResult) {
 	query, err := opts.ToDetachVirtualMediaOptsQuery()
 	if err != nil {
 		r.Err = err

--- a/openstack/baremetal/v1/nodes/urls.go
+++ b/openstack/baremetal/v1/nodes/urls.go
@@ -2,90 +2,90 @@ package nodes
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func createURL(client *gophercloud.ServiceClient) string {
+func createURL(client gophercloud.Client) string {
 	return client.ServiceURL("nodes")
 }
 
-func listURL(client *gophercloud.ServiceClient) string {
+func listURL(client gophercloud.Client) string {
 	return createURL(client)
 }
 
-func listDetailURL(client *gophercloud.ServiceClient) string {
+func listDetailURL(client gophercloud.Client) string {
 	return client.ServiceURL("nodes", "detail")
 }
 
-func deleteURL(client *gophercloud.ServiceClient, id string) string {
+func deleteURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL("nodes", id)
 }
 
-func getURL(client *gophercloud.ServiceClient, id string) string {
+func getURL(client gophercloud.Client, id string) string {
 	return deleteURL(client, id)
 }
 
-func updateURL(client *gophercloud.ServiceClient, id string) string {
+func updateURL(client gophercloud.Client, id string) string {
 	return deleteURL(client, id)
 }
 
-func validateURL(client *gophercloud.ServiceClient, id string) string {
+func validateURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL("nodes", id, "validate")
 }
 
-func injectNMIURL(client *gophercloud.ServiceClient, id string) string {
+func injectNMIURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL("nodes", id, "management", "inject_nmi")
 }
 
-func bootDeviceURL(client *gophercloud.ServiceClient, id string) string {
+func bootDeviceURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL("nodes", id, "management", "boot_device")
 }
 
-func supportedBootDeviceURL(client *gophercloud.ServiceClient, id string) string {
+func supportedBootDeviceURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL("nodes", id, "management", "boot_device", "supported")
 }
 
-func statesResourceURL(client *gophercloud.ServiceClient, id string, state string) string {
+func statesResourceURL(client gophercloud.Client, id string, state string) string {
 	return client.ServiceURL("nodes", id, "states", state)
 }
 
-func powerStateURL(client *gophercloud.ServiceClient, id string) string {
+func powerStateURL(client gophercloud.Client, id string) string {
 	return statesResourceURL(client, id, "power")
 }
 
-func provisionStateURL(client *gophercloud.ServiceClient, id string) string {
+func provisionStateURL(client gophercloud.Client, id string) string {
 	return statesResourceURL(client, id, "provision")
 }
 
-func raidConfigURL(client *gophercloud.ServiceClient, id string) string {
+func raidConfigURL(client gophercloud.Client, id string) string {
 	return statesResourceURL(client, id, "raid")
 }
 
-func biosListSettingsURL(client *gophercloud.ServiceClient, id string) string {
+func biosListSettingsURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL("nodes", id, "bios")
 }
 
-func biosGetSettingURL(client *gophercloud.ServiceClient, id string, setting string) string {
+func biosGetSettingURL(client gophercloud.Client, id string, setting string) string {
 	return client.ServiceURL("nodes", id, "bios", setting)
 }
 
-func vendorPassthruMethodsURL(client *gophercloud.ServiceClient, id string) string {
+func vendorPassthruMethodsURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL("nodes", id, "vendor_passthru", "methods")
 }
 
-func vendorPassthruCallURL(client *gophercloud.ServiceClient, id string) string {
+func vendorPassthruCallURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL("nodes", id, "vendor_passthru")
 }
 
-func maintenanceURL(client *gophercloud.ServiceClient, id string) string {
+func maintenanceURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL("nodes", id, "maintenance")
 }
 
-func inventoryURL(client *gophercloud.ServiceClient, id string) string {
+func inventoryURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL("nodes", id, "inventory")
 }
 
-func firmwareListURL(client *gophercloud.ServiceClient, id string) string {
+func firmwareListURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL("nodes", id, "firmware")
 }
 
-func virtualMediaURL(client *gophercloud.ServiceClient, id string) string {
+func virtualMediaURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL("nodes", id, "vmedia")
 }

--- a/openstack/baremetal/v1/nodes/util.go
+++ b/openstack/baremetal/v1/nodes/util.go
@@ -9,7 +9,7 @@ import (
 // WaitForProvisionState will continually poll a node until it successfully
 // transitions to a specified state. It will do this for at most the number
 // of seconds specified.
-func WaitForProvisionState(ctx context.Context, c *gophercloud.ServiceClient, id string, state ProvisionState) error {
+func WaitForProvisionState(ctx context.Context, c gophercloud.Client, id string, state ProvisionState) error {
 	return gophercloud.WaitFor(ctx, func(ctx context.Context) (bool, error) {
 		current, err := Get(ctx, c, id).Extract()
 		if err != nil {

--- a/openstack/baremetal/v1/ports/requests.go
+++ b/openstack/baremetal/v1/ports/requests.go
@@ -56,7 +56,7 @@ func (opts ListOpts) ToPortListQuery() (string, error) {
 }
 
 // List makes a request against the API to list ports accessible to you.
-func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(client gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(client)
 	if opts != nil {
 		query, err := opts.ToPortListQuery()
@@ -84,7 +84,7 @@ func (opts ListOpts) ToPortListDetailQuery() (string, error) {
 // ListDetail - Return a list ports with complete details.
 // Some filtering is possible by passing in flags in "ListOpts",
 // but you cannot limit by the fields returned.
-func ListDetail(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func ListDetail(client gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := listDetailURL(client)
 	if opts != nil {
 		query, err := opts.ToPortListDetailQuery()
@@ -99,7 +99,7 @@ func ListDetail(client *gophercloud.ServiceClient, opts ListOptsBuilder) paginat
 }
 
 // Get - requests the details off a port, by ID.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, id string) (r GetResult) {
 	resp, err := client.Get(ctx, getURL(client, id), &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{200},
 	})
@@ -156,7 +156,7 @@ func (opts CreateOpts) ToPortCreateMap() (map[string]any, error) {
 }
 
 // Create - requests the creation of a port
-func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	reqBody, err := opts.ToPortCreateMap()
 	if err != nil {
 		r.Err = err
@@ -199,7 +199,7 @@ func (opts UpdateOperation) ToPortUpdateMap() map[string]any {
 }
 
 // Update - requests the update of a port
-func Update(ctx context.Context, client *gophercloud.ServiceClient, id string, opts UpdateOpts) (r UpdateResult) {
+func Update(ctx context.Context, client gophercloud.Client, id string, opts UpdateOpts) (r UpdateResult) {
 	body := make([]map[string]any, len(opts))
 	for i, patch := range opts {
 		body[i] = patch.ToPortUpdateMap()
@@ -213,7 +213,7 @@ func Update(ctx context.Context, client *gophercloud.ServiceClient, id string, o
 }
 
 // Delete - requests the deletion of a port
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, id string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, deleteURL(client, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/baremetal/v1/ports/urls.go
+++ b/openstack/baremetal/v1/ports/urls.go
@@ -2,30 +2,30 @@ package ports
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func createURL(client *gophercloud.ServiceClient) string {
+func createURL(client gophercloud.Client) string {
 	return client.ServiceURL("ports")
 }
 
-func listURL(client *gophercloud.ServiceClient) string {
+func listURL(client gophercloud.Client) string {
 	return createURL(client)
 }
 
-func listDetailURL(client *gophercloud.ServiceClient) string {
+func listDetailURL(client gophercloud.Client) string {
 	return client.ServiceURL("ports", "detail")
 }
 
-func resourceURL(client *gophercloud.ServiceClient, id string) string {
+func resourceURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL("ports", id)
 }
 
-func deleteURL(client *gophercloud.ServiceClient, id string) string {
+func deleteURL(client gophercloud.Client, id string) string {
 	return resourceURL(client, id)
 }
 
-func getURL(client *gophercloud.ServiceClient, id string) string {
+func getURL(client gophercloud.Client, id string) string {
 	return resourceURL(client, id)
 }
 
-func updateURL(client *gophercloud.ServiceClient, id string) string {
+func updateURL(client gophercloud.Client, id string) string {
 	return resourceURL(client, id)
 }

--- a/openstack/baremetalintrospection/v1/introspection/requests.go
+++ b/openstack/baremetalintrospection/v1/introspection/requests.go
@@ -32,7 +32,7 @@ func (opts ListIntrospectionsOpts) ToIntrospectionsListQuery() (string, error) {
 }
 
 // ListIntrospections makes a request against the Inspector API to list the current introspections.
-func ListIntrospections(client *gophercloud.ServiceClient, opts ListIntrospectionsOptsBuilder) pagination.Pager {
+func ListIntrospections(client gophercloud.Client, opts ListIntrospectionsOptsBuilder) pagination.Pager {
 	url := listIntrospectionsURL(client)
 	if opts != nil {
 		query, err := opts.ToIntrospectionsListQuery()
@@ -49,7 +49,7 @@ func ListIntrospections(client *gophercloud.ServiceClient, opts ListIntrospectio
 
 // GetIntrospectionStatus makes a request against the Inspector API to get the
 // status of a single introspection.
-func GetIntrospectionStatus(ctx context.Context, client *gophercloud.ServiceClient, nodeID string) (r GetIntrospectionStatusResult) {
+func GetIntrospectionStatus(ctx context.Context, client gophercloud.Client, nodeID string) (r GetIntrospectionStatusResult) {
 	resp, err := client.Get(ctx, introspectionURL(client, nodeID), &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{200},
 	})
@@ -77,7 +77,7 @@ func (opts StartOpts) ToStartIntrospectionQuery() (string, error) {
 
 // StartIntrospection initiate hardware introspection for node NodeID .
 // All power management configuration for this node needs to be done prior to calling the endpoint.
-func StartIntrospection(ctx context.Context, client *gophercloud.ServiceClient, nodeID string, opts StartOptsBuilder) (r StartResult) {
+func StartIntrospection(ctx context.Context, client gophercloud.Client, nodeID string, opts StartOptsBuilder) (r StartResult) {
 	_, err := opts.ToStartIntrospectionQuery()
 	if err != nil {
 		r.Err = err
@@ -92,7 +92,7 @@ func StartIntrospection(ctx context.Context, client *gophercloud.ServiceClient, 
 }
 
 // AbortIntrospection abort running introspection.
-func AbortIntrospection(ctx context.Context, client *gophercloud.ServiceClient, nodeID string) (r AbortResult) {
+func AbortIntrospection(ctx context.Context, client gophercloud.Client, nodeID string) (r AbortResult) {
 	resp, err := client.Post(ctx, abortIntrospectionURL(client, nodeID), nil, nil, &gophercloud.RequestOpts{
 		OkCodes: []int{202},
 	})
@@ -101,7 +101,7 @@ func AbortIntrospection(ctx context.Context, client *gophercloud.ServiceClient, 
 }
 
 // GetIntrospectionData return stored data from successful introspection.
-func GetIntrospectionData(ctx context.Context, client *gophercloud.ServiceClient, nodeID string) (r DataResult) {
+func GetIntrospectionData(ctx context.Context, client gophercloud.Client, nodeID string) (r DataResult) {
 	resp, err := client.Get(ctx, introspectionDataURL(client, nodeID), &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{200},
 	})
@@ -111,7 +111,7 @@ func GetIntrospectionData(ctx context.Context, client *gophercloud.ServiceClient
 
 // ReApplyIntrospection triggers introspection on stored unprocessed data.
 // No data is allowed to be sent along with the request.
-func ReApplyIntrospection(ctx context.Context, client *gophercloud.ServiceClient, nodeID string) (r ApplyDataResult) {
+func ReApplyIntrospection(ctx context.Context, client gophercloud.Client, nodeID string) (r ApplyDataResult) {
 	resp, err := client.Post(ctx, introspectionUnprocessedDataURL(client, nodeID), nil, nil, &gophercloud.RequestOpts{
 		OkCodes: []int{202},
 	})

--- a/openstack/baremetalintrospection/v1/introspection/urls.go
+++ b/openstack/baremetalintrospection/v1/introspection/urls.go
@@ -2,22 +2,22 @@ package introspection
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func listIntrospectionsURL(client *gophercloud.ServiceClient) string {
+func listIntrospectionsURL(client gophercloud.Client) string {
 	return client.ServiceURL("introspection")
 }
 
-func introspectionURL(client *gophercloud.ServiceClient, nodeID string) string {
+func introspectionURL(client gophercloud.Client, nodeID string) string {
 	return client.ServiceURL("introspection", nodeID)
 }
 
-func abortIntrospectionURL(client *gophercloud.ServiceClient, nodeID string) string {
+func abortIntrospectionURL(client gophercloud.Client, nodeID string) string {
 	return client.ServiceURL("introspection", nodeID, "abort")
 }
 
-func introspectionDataURL(client *gophercloud.ServiceClient, nodeID string) string {
+func introspectionDataURL(client gophercloud.Client, nodeID string) string {
 	return client.ServiceURL("introspection", nodeID, "data")
 }
 
-func introspectionUnprocessedDataURL(client *gophercloud.ServiceClient, nodeID string) string {
+func introspectionUnprocessedDataURL(client gophercloud.Client, nodeID string) string {
 	return client.ServiceURL("introspection", nodeID, "data", "unprocessed")
 }

--- a/openstack/blockstorage/apiversions/requests.go
+++ b/openstack/blockstorage/apiversions/requests.go
@@ -6,7 +6,7 @@ import (
 )
 
 // List lists all the Cinder API versions available to end-users.
-func List(c *gophercloud.ServiceClient) pagination.Pager {
+func List(c gophercloud.Client) pagination.Pager {
 	return pagination.NewPager(c, listURL(c), func(r pagination.PageResult) pagination.Page {
 		return APIVersionPage{pagination.SinglePageBase(r)}
 	})

--- a/openstack/blockstorage/apiversions/urls.go
+++ b/openstack/blockstorage/apiversions/urls.go
@@ -7,8 +7,8 @@ import (
 	"github.com/gophercloud/gophercloud/v2/openstack/utils"
 )
 
-func listURL(c *gophercloud.ServiceClient) string {
-	baseEndpoint, _ := utils.BaseEndpoint(c.Endpoint)
+func listURL(c gophercloud.Client) string {
+	baseEndpoint, _ := utils.BaseEndpoint(c.EndpointURL())
 	endpoint := strings.TrimRight(baseEndpoint, "/") + "/"
 	return endpoint
 }

--- a/openstack/blockstorage/noauth/doc.go
+++ b/openstack/blockstorage/noauth/doc.go
@@ -1,5 +1,5 @@
 /*
-Package noauth creates a "noauth" *gophercloud.ServiceClient for use in Cinder
+Package noauth creates a "noauth" gophercloud.Client for use in Cinder
 environments configured with the noauth authentication middleware.
 
 Example of Creating a noauth Service Client

--- a/openstack/blockstorage/v2/availabilityzones/requests.go
+++ b/openstack/blockstorage/v2/availabilityzones/requests.go
@@ -6,7 +6,7 @@ import (
 )
 
 // List will return the existing availability zones.
-func List(client *gophercloud.ServiceClient) pagination.Pager {
+func List(client gophercloud.Client) pagination.Pager {
 	return pagination.NewPager(client, listURL(client), func(r pagination.PageResult) pagination.Page {
 		return AvailabilityZonePage{pagination.SinglePageBase(r)}
 	})

--- a/openstack/blockstorage/v2/availabilityzones/urls.go
+++ b/openstack/blockstorage/v2/availabilityzones/urls.go
@@ -2,6 +2,6 @@ package availabilityzones
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func listURL(c *gophercloud.ServiceClient) string {
+func listURL(c gophercloud.Client) string {
 	return c.ServiceURL("os-availability-zone")
 }

--- a/openstack/blockstorage/v2/backups/requests.go
+++ b/openstack/blockstorage/v2/backups/requests.go
@@ -57,7 +57,7 @@ func (opts CreateOpts) ToBackupCreateMap() (map[string]any, error) {
 // Create will create a new Backup based on the values in CreateOpts. To
 // extract the Backup object from the response, call the Extract method on the
 // CreateResult.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToBackupCreateMap()
 	if err != nil {
 		r.Err = err
@@ -71,7 +71,7 @@ func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateO
 }
 
 // Delete will delete the existing Backup with the provided ID.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, id string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, deleteURL(client, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -79,7 +79,7 @@ func Delete(ctx context.Context, client *gophercloud.ServiceClient, id string) (
 
 // Get retrieves the Backup with the provided ID. To extract the Backup
 // object from the response, call the Extract method on the GetResult.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, id string) (r GetResult) {
 	resp, err := client.Get(ctx, getURL(client, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -133,7 +133,7 @@ func (opts ListOpts) ToBackupListQuery() (string, error) {
 
 // List returns Backups optionally limited by the conditions provided in
 // ListOpts.
-func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(client gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(client)
 	if opts != nil {
 		query, err := opts.ToBackupListQuery()
@@ -182,7 +182,7 @@ func (opts ListDetailOpts) ToBackupListDetailQuery() (string, error) {
 
 // ListDetail returns more detailed information about Backups optionally
 // limited by the conditions provided in ListDetailOpts.
-func ListDetail(client *gophercloud.ServiceClient, opts ListDetailOptsBuilder) pagination.Pager {
+func ListDetail(client gophercloud.Client, opts ListDetailOptsBuilder) pagination.Pager {
 	url := listDetailURL(client)
 	if opts != nil {
 		query, err := opts.ToBackupListDetailQuery()
@@ -225,7 +225,7 @@ func (opts UpdateOpts) ToBackupUpdateMap() (map[string]any, error) {
 // the updated Backup from the response, call the Extract method on the
 // UpdateResult.
 // Requires microversion 3.9 or later.
-func Update(ctx context.Context, client *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, client gophercloud.Client, id string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToBackupUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -257,7 +257,7 @@ func (opts RestoreOpts) ToRestoreMap() (map[string]any, error) {
 // RestoreFromBackup will restore a Backup to a volume based on the values in
 // RestoreOpts. To extract the Restore object from the response, call the
 // Extract method on the RestoreResult.
-func RestoreFromBackup(ctx context.Context, client *gophercloud.ServiceClient, id string, opts RestoreOpts) (r RestoreResult) {
+func RestoreFromBackup(ctx context.Context, client gophercloud.Client, id string, opts RestoreOpts) (r RestoreResult) {
 	b, err := opts.ToRestoreMap()
 	if err != nil {
 		r.Err = err
@@ -272,7 +272,7 @@ func RestoreFromBackup(ctx context.Context, client *gophercloud.ServiceClient, i
 
 // Export will export a Backup information. To extract the Backup export record
 // object from the response, call the Extract method on the ExportResult.
-func Export(ctx context.Context, client *gophercloud.ServiceClient, id string) (r ExportResult) {
+func Export(ctx context.Context, client gophercloud.Client, id string) (r ExportResult) {
 	resp, err := client.Get(ctx, exportURL(client, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -291,7 +291,7 @@ func (opts ImportOpts) ToBackupImportMap() (map[string]any, error) {
 // Import will import a Backup data to a backup based on the values in
 // ImportOpts. To extract the Backup object from the response, call the
 // Extract method on the ImportResult.
-func Import(ctx context.Context, client *gophercloud.ServiceClient, opts ImportOpts) (r ImportResult) {
+func Import(ctx context.Context, client gophercloud.Client, opts ImportOpts) (r ImportResult) {
 	b, err := opts.ToBackupImportMap()
 	if err != nil {
 		r.Err = err
@@ -326,7 +326,7 @@ func (opts ResetStatusOpts) ToBackupResetStatusMap() (map[string]any, error) {
 
 // ResetStatus will reset the existing backup status. ResetStatusResult contains only the error.
 // To extract it, call the ExtractErr method on the ResetStatusResult.
-func ResetStatus(ctx context.Context, client *gophercloud.ServiceClient, id string, opts ResetStatusOptsBuilder) (r ResetStatusResult) {
+func ResetStatus(ctx context.Context, client gophercloud.Client, id string, opts ResetStatusOptsBuilder) (r ResetStatusResult) {
 	b, err := opts.ToBackupResetStatusMap()
 	if err != nil {
 		r.Err = err
@@ -342,7 +342,7 @@ func ResetStatus(ctx context.Context, client *gophercloud.ServiceClient, id stri
 
 // ForceDelete will delete the existing backup in any state. ForceDeleteResult contains only the error.
 // To extract it, call the ExtractErr method on the ForceDeleteResult.
-func ForceDelete(ctx context.Context, client *gophercloud.ServiceClient, id string) (r ForceDeleteResult) {
+func ForceDelete(ctx context.Context, client gophercloud.Client, id string) (r ForceDeleteResult) {
 	b := map[string]any{
 		"os-force_delete": struct{}{},
 	}

--- a/openstack/blockstorage/v2/backups/urls.go
+++ b/openstack/blockstorage/v2/backups/urls.go
@@ -2,46 +2,46 @@ package backups
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func createURL(c *gophercloud.ServiceClient) string {
+func createURL(c gophercloud.Client) string {
 	return c.ServiceURL("backups")
 }
 
-func deleteURL(c *gophercloud.ServiceClient, id string) string {
+func deleteURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("backups", id)
 }
 
-func getURL(c *gophercloud.ServiceClient, id string) string {
+func getURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("backups", id)
 }
 
-func listURL(c *gophercloud.ServiceClient) string {
+func listURL(c gophercloud.Client) string {
 	return c.ServiceURL("backups")
 }
 
-func listDetailURL(c *gophercloud.ServiceClient) string {
+func listDetailURL(c gophercloud.Client) string {
 	return c.ServiceURL("backups", "detail")
 }
 
-func updateURL(c *gophercloud.ServiceClient, id string) string {
+func updateURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("backups", id)
 }
 
-func restoreURL(c *gophercloud.ServiceClient, id string) string {
+func restoreURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("backups", id, "restore")
 }
 
-func exportURL(c *gophercloud.ServiceClient, id string) string {
+func exportURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("backups", id, "export_record")
 }
 
-func importURL(c *gophercloud.ServiceClient) string {
+func importURL(c gophercloud.Client) string {
 	return c.ServiceURL("backups", "import_record")
 }
 
-func resetStatusURL(c *gophercloud.ServiceClient, id string) string {
+func resetStatusURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("backups", id, "action")
 }
 
-func forceDeleteURL(c *gophercloud.ServiceClient, id string) string {
+func forceDeleteURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("backups", id, "action")
 }

--- a/openstack/blockstorage/v2/limits/requests.go
+++ b/openstack/blockstorage/v2/limits/requests.go
@@ -7,7 +7,7 @@ import (
 )
 
 // Get returns the limits about the currently scoped tenant.
-func Get(ctx context.Context, client *gophercloud.ServiceClient) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client) (r GetResult) {
 	url := getURL(client)
 	resp, err := client.Get(ctx, url, &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)

--- a/openstack/blockstorage/v2/limits/urls.go
+++ b/openstack/blockstorage/v2/limits/urls.go
@@ -6,6 +6,6 @@ import (
 
 const resourcePath = "limits"
 
-func getURL(c *gophercloud.ServiceClient) string {
+func getURL(c gophercloud.Client) string {
 	return c.ServiceURL(resourcePath)
 }

--- a/openstack/blockstorage/v2/quotasets/requests.go
+++ b/openstack/blockstorage/v2/quotasets/requests.go
@@ -8,21 +8,21 @@ import (
 )
 
 // Get returns public data about a previously created QuotaSet.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, projectID string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, projectID string) (r GetResult) {
 	resp, err := client.Get(ctx, getURL(client, projectID), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
 // GetDefaults returns public data about the project's default block storage quotas.
-func GetDefaults(ctx context.Context, client *gophercloud.ServiceClient, projectID string) (r GetResult) {
+func GetDefaults(ctx context.Context, client gophercloud.Client, projectID string) (r GetResult) {
 	resp, err := client.Get(ctx, getDefaultsURL(client, projectID), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
 // GetUsage returns detailed public data about a previously created QuotaSet.
-func GetUsage(ctx context.Context, client *gophercloud.ServiceClient, projectID string) (r GetUsageResult) {
+func GetUsage(ctx context.Context, client gophercloud.Client, projectID string) (r GetUsageResult) {
 	u := fmt.Sprintf("%s?usage=true", getURL(client, projectID))
 	resp, err := client.Get(ctx, u, &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
@@ -30,7 +30,7 @@ func GetUsage(ctx context.Context, client *gophercloud.ServiceClient, projectID 
 }
 
 // Updates the quotas for the given projectID and returns the new QuotaSet.
-func Update(ctx context.Context, client *gophercloud.ServiceClient, projectID string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, client gophercloud.Client, projectID string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToBlockStorageQuotaUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -108,7 +108,7 @@ type UpdateOpts struct {
 }
 
 // Resets the quotas for the given tenant to their default values.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, projectID string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, projectID string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, deleteURL(client, projectID), &gophercloud.RequestOpts{
 		OkCodes: []int{200},
 	})

--- a/openstack/blockstorage/v2/quotasets/urls.go
+++ b/openstack/blockstorage/v2/quotasets/urls.go
@@ -4,18 +4,18 @@ import "github.com/gophercloud/gophercloud/v2"
 
 const resourcePath = "os-quota-sets"
 
-func getURL(c *gophercloud.ServiceClient, projectID string) string {
+func getURL(c gophercloud.Client, projectID string) string {
 	return c.ServiceURL(resourcePath, projectID)
 }
 
-func getDefaultsURL(c *gophercloud.ServiceClient, projectID string) string {
+func getDefaultsURL(c gophercloud.Client, projectID string) string {
 	return c.ServiceURL(resourcePath, projectID, "defaults")
 }
 
-func updateURL(c *gophercloud.ServiceClient, projectID string) string {
+func updateURL(c gophercloud.Client, projectID string) string {
 	return getURL(c, projectID)
 }
 
-func deleteURL(c *gophercloud.ServiceClient, projectID string) string {
+func deleteURL(c gophercloud.Client, projectID string) string {
 	return getURL(c, projectID)
 }

--- a/openstack/blockstorage/v2/schedulerstats/requests.go
+++ b/openstack/blockstorage/v2/schedulerstats/requests.go
@@ -28,7 +28,7 @@ func (opts ListOpts) ToStoragePoolsListQuery() (string, error) {
 }
 
 // List makes a request against the API to list storage pool information.
-func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(client gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := storagePoolsListURL(client)
 	if opts != nil {
 		query, err := opts.ToStoragePoolsListQuery()

--- a/openstack/blockstorage/v2/schedulerstats/urls.go
+++ b/openstack/blockstorage/v2/schedulerstats/urls.go
@@ -2,6 +2,6 @@ package schedulerstats
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func storagePoolsListURL(c *gophercloud.ServiceClient) string {
+func storagePoolsListURL(c gophercloud.Client) string {
 	return c.ServiceURL("scheduler-stats", "get_pools")
 }

--- a/openstack/blockstorage/v2/services/requests.go
+++ b/openstack/blockstorage/v2/services/requests.go
@@ -27,7 +27,7 @@ func (opts ListOpts) ToServiceListQuery() (string, error) {
 }
 
 // List makes a request against the API to list services.
-func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(client gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(client)
 	if opts != nil {
 		query, err := opts.ToServiceListQuery()

--- a/openstack/blockstorage/v2/services/urls.go
+++ b/openstack/blockstorage/v2/services/urls.go
@@ -2,6 +2,6 @@ package services
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func listURL(c *gophercloud.ServiceClient) string {
+func listURL(c gophercloud.Client) string {
 	return c.ServiceURL("os-services")
 }

--- a/openstack/blockstorage/v2/snapshots/requests.go
+++ b/openstack/blockstorage/v2/snapshots/requests.go
@@ -33,7 +33,7 @@ func (opts CreateOpts) ToSnapshotCreateMap() (map[string]any, error) {
 // Create will create a new Snapshot based on the values in CreateOpts. To
 // extract the Snapshot object from the response, call the Extract method on the
 // CreateResult.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToSnapshotCreateMap()
 	if err != nil {
 		r.Err = err
@@ -47,7 +47,7 @@ func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateO
 }
 
 // Delete will delete the existing Snapshot with the provided ID.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, id string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, deleteURL(client, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -55,7 +55,7 @@ func Delete(ctx context.Context, client *gophercloud.ServiceClient, id string) (
 
 // Get retrieves the Snapshot with the provided ID. To extract the Snapshot
 // object from the response, call the Extract method on the GetResult.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, id string) (r GetResult) {
 	resp, err := client.Get(ctx, getURL(client, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -95,7 +95,7 @@ func (opts ListOpts) ToSnapshotListQuery() (string, error) {
 
 // List returns Snapshots optionally limited by the conditions provided in
 // ListOpts.
-func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(client gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(client)
 	if opts != nil {
 		query, err := opts.ToSnapshotListQuery()
@@ -131,7 +131,7 @@ func (opts UpdateMetadataOpts) ToSnapshotUpdateMetadataMap() (map[string]any, er
 // UpdateMetadata will update the Snapshot with provided information. To
 // extract the updated Snapshot from the response, call the ExtractMetadata
 // method on the UpdateMetadataResult.
-func UpdateMetadata(ctx context.Context, client *gophercloud.ServiceClient, id string, opts UpdateMetadataOptsBuilder) (r UpdateMetadataResult) {
+func UpdateMetadata(ctx context.Context, client gophercloud.Client, id string, opts UpdateMetadataOptsBuilder) (r UpdateMetadataResult) {
 	b, err := opts.ToSnapshotUpdateMetadataMap()
 	if err != nil {
 		r.Err = err

--- a/openstack/blockstorage/v2/snapshots/urls.go
+++ b/openstack/blockstorage/v2/snapshots/urls.go
@@ -2,26 +2,26 @@ package snapshots
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func createURL(c *gophercloud.ServiceClient) string {
+func createURL(c gophercloud.Client) string {
 	return c.ServiceURL("snapshots")
 }
 
-func deleteURL(c *gophercloud.ServiceClient, id string) string {
+func deleteURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("snapshots", id)
 }
 
-func getURL(c *gophercloud.ServiceClient, id string) string {
+func getURL(c gophercloud.Client, id string) string {
 	return deleteURL(c, id)
 }
 
-func listURL(c *gophercloud.ServiceClient) string {
+func listURL(c gophercloud.Client) string {
 	return createURL(c)
 }
 
-func metadataURL(c *gophercloud.ServiceClient, id string) string {
+func metadataURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("snapshots", id, "metadata")
 }
 
-func updateMetadataURL(c *gophercloud.ServiceClient, id string) string {
+func updateMetadataURL(c gophercloud.Client, id string) string {
 	return metadataURL(c, id)
 }

--- a/openstack/blockstorage/v2/snapshots/util.go
+++ b/openstack/blockstorage/v2/snapshots/util.go
@@ -7,7 +7,7 @@ import (
 )
 
 // WaitForStatus will continually poll the resource, checking for a particular status.
-func WaitForStatus(ctx context.Context, c *gophercloud.ServiceClient, id, status string) error {
+func WaitForStatus(ctx context.Context, c gophercloud.Client, id, status string) error {
 	return gophercloud.WaitFor(ctx, func(ctx context.Context) (bool, error) {
 		current, err := Get(ctx, c, id).Extract()
 		if err != nil {

--- a/openstack/blockstorage/v2/transfers/requests.go
+++ b/openstack/blockstorage/v2/transfers/requests.go
@@ -23,7 +23,7 @@ func (opts CreateOpts) ToCreateMap() (map[string]any, error) {
 }
 
 // Create will create a volume tranfer request based on the values in CreateOpts.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOpts) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, opts CreateOpts) (r CreateResult) {
 	b, err := opts.ToCreateMap()
 	if err != nil {
 		r.Err = err
@@ -49,7 +49,7 @@ func (opts AcceptOpts) ToAcceptMap() (map[string]any, error) {
 }
 
 // Accept will accept a volume tranfer request based on the values in AcceptOpts.
-func Accept(ctx context.Context, client *gophercloud.ServiceClient, id string, opts AcceptOpts) (r CreateResult) {
+func Accept(ctx context.Context, client gophercloud.Client, id string, opts AcceptOpts) (r CreateResult) {
 	b, err := opts.ToAcceptMap()
 	if err != nil {
 		r.Err = err
@@ -63,7 +63,7 @@ func Accept(ctx context.Context, client *gophercloud.ServiceClient, id string, o
 }
 
 // Delete deletes a volume transfer.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, id string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, deleteURL(client, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -102,7 +102,7 @@ func (opts ListOpts) ToTransferListQuery() (string, error) {
 }
 
 // List returns Transfers optionally limited by the conditions provided in ListOpts.
-func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(client gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(client)
 	if opts != nil {
 		query, err := opts.ToTransferListQuery()
@@ -119,7 +119,7 @@ func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pa
 
 // Get retrieves the Transfer with the provided ID. To extract the Transfer object
 // from the response, call the Extract method on the GetResult.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, id string) (r GetResult) {
 	resp, err := client.Get(ctx, getURL(client, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/blockstorage/v2/transfers/urls.go
+++ b/openstack/blockstorage/v2/transfers/urls.go
@@ -2,22 +2,22 @@ package transfers
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func transferURL(c *gophercloud.ServiceClient) string {
+func transferURL(c gophercloud.Client) string {
 	return c.ServiceURL("os-volume-transfer")
 }
 
-func acceptURL(c *gophercloud.ServiceClient, id string) string {
+func acceptURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("os-volume-transfer", id, "accept")
 }
 
-func deleteURL(c *gophercloud.ServiceClient, id string) string {
+func deleteURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("os-volume-transfer", id)
 }
 
-func listURL(c *gophercloud.ServiceClient) string {
+func listURL(c gophercloud.Client) string {
 	return c.ServiceURL("os-volume-transfer", "detail")
 }
 
-func getURL(c *gophercloud.ServiceClient, id string) string {
+func getURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("os-volume-transfer", id)
 }

--- a/openstack/blockstorage/v2/volumes/requests.go
+++ b/openstack/blockstorage/v2/volumes/requests.go
@@ -140,7 +140,7 @@ func (opts CreateOpts) ToVolumeCreateMap() (map[string]any, error) {
 // Create will create a new Volume based on the values in CreateOpts. To extract
 // the Volume object from the response, call the Extract method on the
 // CreateResult.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder, hintOpts SchedulerHintOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, opts CreateOptsBuilder, hintOpts SchedulerHintOptsBuilder) (r CreateResult) {
 	b, err := opts.ToVolumeCreateMap()
 	if err != nil {
 		r.Err = err
@@ -183,7 +183,7 @@ func (opts DeleteOpts) ToVolumeDeleteQuery() (string, error) {
 }
 
 // Delete will delete the existing Volume with the provided ID.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, id string, opts DeleteOptsBuilder) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, id string, opts DeleteOptsBuilder) (r DeleteResult) {
 	url := deleteURL(client, id)
 	if opts != nil {
 		query, err := opts.ToVolumeDeleteQuery()
@@ -200,7 +200,7 @@ func Delete(ctx context.Context, client *gophercloud.ServiceClient, id string, o
 
 // Get retrieves the Volume with the provided ID. To extract the Volume object
 // from the response, call the Extract method on the GetResult.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, id string) (r GetResult) {
 	resp, err := client.Get(ctx, getURL(client, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -252,7 +252,7 @@ func (opts ListOpts) ToVolumeListQuery() (string, error) {
 }
 
 // List returns Volumes optionally limited by the conditions provided in ListOpts.
-func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(client gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(client)
 	if opts != nil {
 		query, err := opts.ToVolumeListQuery()
@@ -290,7 +290,7 @@ func (opts UpdateOpts) ToVolumeUpdateMap() (map[string]any, error) {
 
 // Update will update the Volume with provided information. To extract the updated
 // Volume from the response, call the Extract method on the UpdateResult.
-func Update(ctx context.Context, client *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, client gophercloud.Client, id string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToVolumeUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -340,7 +340,7 @@ func (opts AttachOpts) ToVolumeAttachMap() (map[string]any, error) {
 }
 
 // Attach will attach a volume based on the values in AttachOpts.
-func Attach(ctx context.Context, client *gophercloud.ServiceClient, id string, opts AttachOptsBuilder) (r AttachResult) {
+func Attach(ctx context.Context, client gophercloud.Client, id string, opts AttachOptsBuilder) (r AttachResult) {
 	b, err := opts.ToVolumeAttachMap()
 	if err != nil {
 		r.Err = err
@@ -354,7 +354,7 @@ func Attach(ctx context.Context, client *gophercloud.ServiceClient, id string, o
 }
 
 // BeginDetaching will mark the volume as detaching.
-func BeginDetaching(ctx context.Context, client *gophercloud.ServiceClient, id string) (r BeginDetachingResult) {
+func BeginDetaching(ctx context.Context, client gophercloud.Client, id string) (r BeginDetachingResult) {
 	b := map[string]any{"os-begin_detaching": make(map[string]any)}
 	resp, err := client.Post(ctx, actionURL(client, id), b, nil, &gophercloud.RequestOpts{
 		OkCodes: []int{202},
@@ -382,7 +382,7 @@ func (opts DetachOpts) ToVolumeDetachMap() (map[string]any, error) {
 }
 
 // Detach will detach a volume based on volume ID.
-func Detach(ctx context.Context, client *gophercloud.ServiceClient, id string, opts DetachOptsBuilder) (r DetachResult) {
+func Detach(ctx context.Context, client gophercloud.Client, id string, opts DetachOptsBuilder) (r DetachResult) {
 	b, err := opts.ToVolumeDetachMap()
 	if err != nil {
 		r.Err = err
@@ -396,7 +396,7 @@ func Detach(ctx context.Context, client *gophercloud.ServiceClient, id string, o
 }
 
 // Reserve will reserve a volume based on volume ID.
-func Reserve(ctx context.Context, client *gophercloud.ServiceClient, id string) (r ReserveResult) {
+func Reserve(ctx context.Context, client gophercloud.Client, id string) (r ReserveResult) {
 	b := map[string]any{"os-reserve": make(map[string]any)}
 	resp, err := client.Post(ctx, actionURL(client, id), b, nil, &gophercloud.RequestOpts{
 		OkCodes: []int{200, 201, 202},
@@ -406,7 +406,7 @@ func Reserve(ctx context.Context, client *gophercloud.ServiceClient, id string) 
 }
 
 // Unreserve will unreserve a volume based on volume ID.
-func Unreserve(ctx context.Context, client *gophercloud.ServiceClient, id string) (r UnreserveResult) {
+func Unreserve(ctx context.Context, client gophercloud.Client, id string) (r UnreserveResult) {
 	b := map[string]any{"os-unreserve": make(map[string]any)}
 	resp, err := client.Post(ctx, actionURL(client, id), b, nil, &gophercloud.RequestOpts{
 		OkCodes: []int{200, 201, 202},
@@ -443,7 +443,7 @@ func (opts InitializeConnectionOpts) ToVolumeInitializeConnectionMap() (map[stri
 }
 
 // InitializeConnection initializes an iSCSI connection by volume ID.
-func InitializeConnection(ctx context.Context, client *gophercloud.ServiceClient, id string, opts InitializeConnectionOptsBuilder) (r InitializeConnectionResult) {
+func InitializeConnection(ctx context.Context, client gophercloud.Client, id string, opts InitializeConnectionOptsBuilder) (r InitializeConnectionResult) {
 	b, err := opts.ToVolumeInitializeConnectionMap()
 	if err != nil {
 		r.Err = err
@@ -482,7 +482,7 @@ func (opts TerminateConnectionOpts) ToVolumeTerminateConnectionMap() (map[string
 }
 
 // TerminateConnection terminates an iSCSI connection by volume ID.
-func TerminateConnection(ctx context.Context, client *gophercloud.ServiceClient, id string, opts TerminateConnectionOptsBuilder) (r TerminateConnectionResult) {
+func TerminateConnection(ctx context.Context, client gophercloud.Client, id string, opts TerminateConnectionOptsBuilder) (r TerminateConnectionResult) {
 	b, err := opts.ToVolumeTerminateConnectionMap()
 	if err != nil {
 		r.Err = err
@@ -516,7 +516,7 @@ func (opts ExtendSizeOpts) ToVolumeExtendSizeMap() (map[string]any, error) {
 
 // ExtendSize will extend the size of the volume based on the provided information.
 // This operation does not return a response body.
-func ExtendSize(ctx context.Context, client *gophercloud.ServiceClient, id string, opts ExtendSizeOptsBuilder) (r ExtendSizeResult) {
+func ExtendSize(ctx context.Context, client gophercloud.Client, id string, opts ExtendSizeOptsBuilder) (r ExtendSizeResult) {
 	b, err := opts.ToVolumeExtendSizeMap()
 	if err != nil {
 		r.Err = err
@@ -565,7 +565,7 @@ func (opts UploadImageOpts) ToVolumeUploadImageMap() (map[string]any, error) {
 }
 
 // UploadImage will upload an image based on the values in UploadImageOptsBuilder.
-func UploadImage(ctx context.Context, client *gophercloud.ServiceClient, id string, opts UploadImageOptsBuilder) (r UploadImageResult) {
+func UploadImage(ctx context.Context, client gophercloud.Client, id string, opts UploadImageOptsBuilder) (r UploadImageResult) {
 	b, err := opts.ToVolumeUploadImageMap()
 	if err != nil {
 		r.Err = err
@@ -579,7 +579,7 @@ func UploadImage(ctx context.Context, client *gophercloud.ServiceClient, id stri
 }
 
 // ForceDelete will delete the volume regardless of state.
-func ForceDelete(ctx context.Context, client *gophercloud.ServiceClient, id string) (r ForceDeleteResult) {
+func ForceDelete(ctx context.Context, client gophercloud.Client, id string) (r ForceDeleteResult) {
 	resp, err := client.Post(ctx, actionURL(client, id), map[string]any{"os-force_delete": ""}, nil, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -604,7 +604,7 @@ func (opts ImageMetadataOpts) ToImageMetadataMap() (map[string]any, error) {
 }
 
 // SetImageMetadata will set image metadata on a volume based on the values in ImageMetadataOptsBuilder.
-func SetImageMetadata(ctx context.Context, client *gophercloud.ServiceClient, id string, opts ImageMetadataOptsBuilder) (r SetImageMetadataResult) {
+func SetImageMetadata(ctx context.Context, client gophercloud.Client, id string, opts ImageMetadataOptsBuilder) (r SetImageMetadataResult) {
 	b, err := opts.ToImageMetadataMap()
 	if err != nil {
 		r.Err = err
@@ -630,7 +630,7 @@ func (opts BootableOpts) ToBootableMap() (map[string]any, error) {
 }
 
 // SetBootable will set bootable status on a volume based on the values in BootableOpts
-func SetBootable(ctx context.Context, client *gophercloud.ServiceClient, id string, opts BootableOpts) (r SetBootableResult) {
+func SetBootable(ctx context.Context, client gophercloud.Client, id string, opts BootableOpts) (r SetBootableResult) {
 	b, err := opts.ToBootableMap()
 	if err != nil {
 		r.Err = err
@@ -678,7 +678,7 @@ func (opts ChangeTypeOpts) ToVolumeChangeTypeMap() (map[string]any, error) {
 
 // ChangeType will change the volume type of the volume based on the provided information.
 // This operation does not return a response body.
-func ChangeType(ctx context.Context, client *gophercloud.ServiceClient, id string, opts ChangeTypeOptsBuilder) (r ChangeTypeResult) {
+func ChangeType(ctx context.Context, client gophercloud.Client, id string, opts ChangeTypeOptsBuilder) (r ChangeTypeResult) {
 	b, err := opts.ToVolumeChangeTypeMap()
 	if err != nil {
 		r.Err = err
@@ -705,7 +705,7 @@ func (opts ReImageOpts) ToReImageMap() (map[string]any, error) {
 }
 
 // ReImage will re-image a volume based on the values in ReImageOpts
-func ReImage(ctx context.Context, client *gophercloud.ServiceClient, id string, opts ReImageOpts) (r ReImageResult) {
+func ReImage(ctx context.Context, client gophercloud.Client, id string, opts ReImageOpts) (r ReImageResult) {
 	b, err := opts.ToReImageMap()
 	if err != nil {
 		r.Err = err
@@ -744,7 +744,7 @@ func (opts ResetStatusOpts) ToResetStatusMap() (map[string]any, error) {
 
 // ResetStatus will reset the existing volume status. ResetStatusResult contains only the error.
 // To extract it, call the ExtractErr method on the ResetStatusResult.
-func ResetStatus(ctx context.Context, client *gophercloud.ServiceClient, id string, opts ResetStatusOptsBuilder) (r ResetStatusResult) {
+func ResetStatus(ctx context.Context, client gophercloud.Client, id string, opts ResetStatusOptsBuilder) (r ResetStatusResult) {
 	b, err := opts.ToResetStatusMap()
 	if err != nil {
 		r.Err = err

--- a/openstack/blockstorage/v2/volumes/urls.go
+++ b/openstack/blockstorage/v2/volumes/urls.go
@@ -2,26 +2,26 @@ package volumes
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func createURL(c *gophercloud.ServiceClient) string {
+func createURL(c gophercloud.Client) string {
 	return c.ServiceURL("volumes")
 }
 
-func listURL(c *gophercloud.ServiceClient) string {
+func listURL(c gophercloud.Client) string {
 	return c.ServiceURL("volumes", "detail")
 }
 
-func deleteURL(c *gophercloud.ServiceClient, id string) string {
+func deleteURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("volumes", id)
 }
 
-func getURL(c *gophercloud.ServiceClient, id string) string {
+func getURL(c gophercloud.Client, id string) string {
 	return deleteURL(c, id)
 }
 
-func updateURL(c *gophercloud.ServiceClient, id string) string {
+func updateURL(c gophercloud.Client, id string) string {
 	return deleteURL(c, id)
 }
 
-func actionURL(c *gophercloud.ServiceClient, id string) string {
+func actionURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("volumes", id, "action")
 }

--- a/openstack/blockstorage/v2/volumes/util.go
+++ b/openstack/blockstorage/v2/volumes/util.go
@@ -7,7 +7,7 @@ import (
 )
 
 // WaitForStatus will continually poll the resource, checking for a particular status.
-func WaitForStatus(ctx context.Context, c *gophercloud.ServiceClient, id, status string) error {
+func WaitForStatus(ctx context.Context, c gophercloud.Client, id, status string) error {
 	return gophercloud.WaitFor(ctx, func(ctx context.Context) (bool, error) {
 		current, err := Get(ctx, c, id).Extract()
 		if err != nil {

--- a/openstack/blockstorage/v3/attachments/requests.go
+++ b/openstack/blockstorage/v3/attachments/requests.go
@@ -42,7 +42,7 @@ func (opts CreateOpts) ToAttachmentCreateMap() (map[string]any, error) {
 // Create will create a new Attachment based on the values in CreateOpts. To
 // extract the Attachment object from the response, call the Extract method on
 // the CreateResult.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToAttachmentCreateMap()
 	if err != nil {
 		r.Err = err
@@ -56,7 +56,7 @@ func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateO
 }
 
 // Delete will delete the existing Attachment with the provided ID.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, id string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, deleteURL(client, id), &gophercloud.RequestOpts{
 		OkCodes: []int{200},
 	})
@@ -66,7 +66,7 @@ func Delete(ctx context.Context, client *gophercloud.ServiceClient, id string) (
 
 // Get retrieves the Attachment with the provided ID. To extract the Attachment
 // object from the response, call the Extract method on the GetResult.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, id string) (r GetResult) {
 	resp, err := client.Get(ctx, getURL(client, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -118,7 +118,7 @@ func (opts ListOpts) ToAttachmentListQuery() (string, error) {
 
 // List returns Attachments optionally limited by the conditions provided in
 // ListOpts.
-func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(client gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(client)
 	if opts != nil {
 		query, err := opts.ToAttachmentListQuery()
@@ -155,7 +155,7 @@ func (opts UpdateOpts) ToAttachmentUpdateMap() (map[string]any, error) {
 // Update will update the Attachment with provided information. To extract the
 // updated Attachment from the response, call the Extract method on the
 // UpdateResult.
-func Update(ctx context.Context, client *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, client gophercloud.Client, id string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToAttachmentUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -170,7 +170,7 @@ func Update(ctx context.Context, client *gophercloud.ServiceClient, id string, o
 
 // Complete will complete an attachment for a cinder volume.
 // Available starting in the 3.44 microversion.
-func Complete(ctx context.Context, client *gophercloud.ServiceClient, id string) (r CompleteResult) {
+func Complete(ctx context.Context, client gophercloud.Client, id string) (r CompleteResult) {
 	b := map[string]any{
 		"os-complete": nil,
 	}

--- a/openstack/blockstorage/v3/attachments/urls.go
+++ b/openstack/blockstorage/v3/attachments/urls.go
@@ -2,26 +2,26 @@ package attachments
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func createURL(c *gophercloud.ServiceClient) string {
+func createURL(c gophercloud.Client) string {
 	return c.ServiceURL("attachments")
 }
 
-func listURL(c *gophercloud.ServiceClient) string {
+func listURL(c gophercloud.Client) string {
 	return c.ServiceURL("attachments", "detail")
 }
 
-func getURL(c *gophercloud.ServiceClient, id string) string {
+func getURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("attachments", id)
 }
 
-func updateURL(c *gophercloud.ServiceClient, id string) string {
+func updateURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("attachments", id)
 }
 
-func deleteURL(c *gophercloud.ServiceClient, id string) string {
+func deleteURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("attachments", id)
 }
 
-func completeURL(c *gophercloud.ServiceClient, id string) string {
+func completeURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("attachments", id, "action")
 }

--- a/openstack/blockstorage/v3/attachments/util.go
+++ b/openstack/blockstorage/v3/attachments/util.go
@@ -7,7 +7,7 @@ import (
 )
 
 // WaitForStatus will continually poll the resource, checking for a particular status.
-func WaitForStatus(ctx context.Context, c *gophercloud.ServiceClient, id, status string) error {
+func WaitForStatus(ctx context.Context, c gophercloud.Client, id, status string) error {
 	return gophercloud.WaitFor(ctx, func(ctx context.Context) (bool, error) {
 		current, err := Get(ctx, c, id).Extract()
 		if err != nil {

--- a/openstack/blockstorage/v3/availabilityzones/requests.go
+++ b/openstack/blockstorage/v3/availabilityzones/requests.go
@@ -6,7 +6,7 @@ import (
 )
 
 // List will return the existing availability zones.
-func List(client *gophercloud.ServiceClient) pagination.Pager {
+func List(client gophercloud.Client) pagination.Pager {
 	return pagination.NewPager(client, listURL(client), func(r pagination.PageResult) pagination.Page {
 		return AvailabilityZonePage{pagination.SinglePageBase(r)}
 	})

--- a/openstack/blockstorage/v3/availabilityzones/urls.go
+++ b/openstack/blockstorage/v3/availabilityzones/urls.go
@@ -2,6 +2,6 @@ package availabilityzones
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func listURL(c *gophercloud.ServiceClient) string {
+func listURL(c gophercloud.Client) string {
 	return c.ServiceURL("os-availability-zone")
 }

--- a/openstack/blockstorage/v3/backups/requests.go
+++ b/openstack/blockstorage/v3/backups/requests.go
@@ -57,7 +57,7 @@ func (opts CreateOpts) ToBackupCreateMap() (map[string]any, error) {
 // Create will create a new Backup based on the values in CreateOpts. To
 // extract the Backup object from the response, call the Extract method on the
 // CreateResult.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToBackupCreateMap()
 	if err != nil {
 		r.Err = err
@@ -71,7 +71,7 @@ func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateO
 }
 
 // Delete will delete the existing Backup with the provided ID.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, id string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, deleteURL(client, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -79,7 +79,7 @@ func Delete(ctx context.Context, client *gophercloud.ServiceClient, id string) (
 
 // Get retrieves the Backup with the provided ID. To extract the Backup
 // object from the response, call the Extract method on the GetResult.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, id string) (r GetResult) {
 	resp, err := client.Get(ctx, getURL(client, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -133,7 +133,7 @@ func (opts ListOpts) ToBackupListQuery() (string, error) {
 
 // List returns Backups optionally limited by the conditions provided in
 // ListOpts.
-func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(client gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(client)
 	if opts != nil {
 		query, err := opts.ToBackupListQuery()
@@ -182,7 +182,7 @@ func (opts ListDetailOpts) ToBackupListDetailQuery() (string, error) {
 
 // ListDetail returns more detailed information about Backups optionally
 // limited by the conditions provided in ListDetailOpts.
-func ListDetail(client *gophercloud.ServiceClient, opts ListDetailOptsBuilder) pagination.Pager {
+func ListDetail(client gophercloud.Client, opts ListDetailOptsBuilder) pagination.Pager {
 	url := listDetailURL(client)
 	if opts != nil {
 		query, err := opts.ToBackupListDetailQuery()
@@ -225,7 +225,7 @@ func (opts UpdateOpts) ToBackupUpdateMap() (map[string]any, error) {
 // the updated Backup from the response, call the Extract method on the
 // UpdateResult.
 // Requires microversion 3.9 or later.
-func Update(ctx context.Context, client *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, client gophercloud.Client, id string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToBackupUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -257,7 +257,7 @@ func (opts RestoreOpts) ToRestoreMap() (map[string]any, error) {
 // RestoreFromBackup will restore a Backup to a volume based on the values in
 // RestoreOpts. To extract the Restore object from the response, call the
 // Extract method on the RestoreResult.
-func RestoreFromBackup(ctx context.Context, client *gophercloud.ServiceClient, id string, opts RestoreOpts) (r RestoreResult) {
+func RestoreFromBackup(ctx context.Context, client gophercloud.Client, id string, opts RestoreOpts) (r RestoreResult) {
 	b, err := opts.ToRestoreMap()
 	if err != nil {
 		r.Err = err
@@ -272,7 +272,7 @@ func RestoreFromBackup(ctx context.Context, client *gophercloud.ServiceClient, i
 
 // Export will export a Backup information. To extract the Backup export record
 // object from the response, call the Extract method on the ExportResult.
-func Export(ctx context.Context, client *gophercloud.ServiceClient, id string) (r ExportResult) {
+func Export(ctx context.Context, client gophercloud.Client, id string) (r ExportResult) {
 	resp, err := client.Get(ctx, exportURL(client, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -291,7 +291,7 @@ func (opts ImportOpts) ToBackupImportMap() (map[string]any, error) {
 // Import will import a Backup data to a backup based on the values in
 // ImportOpts. To extract the Backup object from the response, call the
 // Extract method on the ImportResult.
-func Import(ctx context.Context, client *gophercloud.ServiceClient, opts ImportOpts) (r ImportResult) {
+func Import(ctx context.Context, client gophercloud.Client, opts ImportOpts) (r ImportResult) {
 	b, err := opts.ToBackupImportMap()
 	if err != nil {
 		r.Err = err
@@ -326,7 +326,7 @@ func (opts ResetStatusOpts) ToBackupResetStatusMap() (map[string]any, error) {
 
 // ResetStatus will reset the existing backup status. ResetStatusResult contains only the error.
 // To extract it, call the ExtractErr method on the ResetStatusResult.
-func ResetStatus(ctx context.Context, client *gophercloud.ServiceClient, id string, opts ResetStatusOptsBuilder) (r ResetStatusResult) {
+func ResetStatus(ctx context.Context, client gophercloud.Client, id string, opts ResetStatusOptsBuilder) (r ResetStatusResult) {
 	b, err := opts.ToBackupResetStatusMap()
 	if err != nil {
 		r.Err = err
@@ -342,7 +342,7 @@ func ResetStatus(ctx context.Context, client *gophercloud.ServiceClient, id stri
 
 // ForceDelete will delete the existing backup in any state. ForceDeleteResult contains only the error.
 // To extract it, call the ExtractErr method on the ForceDeleteResult.
-func ForceDelete(ctx context.Context, client *gophercloud.ServiceClient, id string) (r ForceDeleteResult) {
+func ForceDelete(ctx context.Context, client gophercloud.Client, id string) (r ForceDeleteResult) {
 	b := map[string]any{
 		"os-force_delete": struct{}{},
 	}

--- a/openstack/blockstorage/v3/backups/urls.go
+++ b/openstack/blockstorage/v3/backups/urls.go
@@ -2,46 +2,46 @@ package backups
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func createURL(c *gophercloud.ServiceClient) string {
+func createURL(c gophercloud.Client) string {
 	return c.ServiceURL("backups")
 }
 
-func deleteURL(c *gophercloud.ServiceClient, id string) string {
+func deleteURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("backups", id)
 }
 
-func getURL(c *gophercloud.ServiceClient, id string) string {
+func getURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("backups", id)
 }
 
-func listURL(c *gophercloud.ServiceClient) string {
+func listURL(c gophercloud.Client) string {
 	return c.ServiceURL("backups")
 }
 
-func listDetailURL(c *gophercloud.ServiceClient) string {
+func listDetailURL(c gophercloud.Client) string {
 	return c.ServiceURL("backups", "detail")
 }
 
-func updateURL(c *gophercloud.ServiceClient, id string) string {
+func updateURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("backups", id)
 }
 
-func restoreURL(c *gophercloud.ServiceClient, id string) string {
+func restoreURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("backups", id, "restore")
 }
 
-func exportURL(c *gophercloud.ServiceClient, id string) string {
+func exportURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("backups", id, "export_record")
 }
 
-func importURL(c *gophercloud.ServiceClient) string {
+func importURL(c gophercloud.Client) string {
 	return c.ServiceURL("backups", "import_record")
 }
 
-func resetStatusURL(c *gophercloud.ServiceClient, id string) string {
+func resetStatusURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("backups", id, "action")
 }
 
-func forceDeleteURL(c *gophercloud.ServiceClient, id string) string {
+func forceDeleteURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("backups", id, "action")
 }

--- a/openstack/blockstorage/v3/limits/requests.go
+++ b/openstack/blockstorage/v3/limits/requests.go
@@ -7,7 +7,7 @@ import (
 )
 
 // Get returns the limits about the currently scoped tenant.
-func Get(ctx context.Context, client *gophercloud.ServiceClient) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client) (r GetResult) {
 	url := getURL(client)
 	resp, err := client.Get(ctx, url, &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)

--- a/openstack/blockstorage/v3/limits/urls.go
+++ b/openstack/blockstorage/v3/limits/urls.go
@@ -6,6 +6,6 @@ import (
 
 const resourcePath = "limits"
 
-func getURL(c *gophercloud.ServiceClient) string {
+func getURL(c gophercloud.Client) string {
 	return c.ServiceURL(resourcePath)
 }

--- a/openstack/blockstorage/v3/qos/requests.go
+++ b/openstack/blockstorage/v3/qos/requests.go
@@ -60,7 +60,7 @@ func (opts CreateOpts) ToQoSCreateMap() (map[string]any, error) {
 // Create will create a new QoS based on the values in CreateOpts. To extract
 // the QoS object from the response, call the Extract method on the
 // CreateResult.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToQoSCreateMap()
 	if err != nil {
 		r.Err = err
@@ -93,7 +93,7 @@ func (opts DeleteOpts) ToQoSDeleteQuery() (string, error) {
 }
 
 // Delete will delete the existing QoS with the provided ID.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, id string, opts DeleteOptsBuilder) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, id string, opts DeleteOptsBuilder) (r DeleteResult) {
 	url := deleteURL(client, id)
 	if opts != nil {
 		query, err := opts.ToQoSDeleteQuery()
@@ -132,7 +132,7 @@ func (opts ListOpts) ToQoSListQuery() (string, error) {
 // List instructs OpenStack to provide a list of QoS.
 // You may provide criteria by which List curtails its results for easier
 // processing.
-func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(client gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(client)
 	if opts != nil {
 		query, err := opts.ToQoSListQuery()
@@ -148,7 +148,7 @@ func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pa
 
 // Get retrieves details of a single qos. Use Extract to convert its
 // result into a QoS.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, id string) (r GetResult) {
 	resp, err := client.Get(ctx, getURL(client, id), &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{200},
 	})
@@ -199,7 +199,7 @@ func (opts UpdateOpts) ToQoSUpdateMap() (map[string]any, error) {
 // Update will update an existing QoS based on the values in UpdateOpts.
 // To extract the QoS object from the response, call the Extract method
 // on the UpdateResult.
-func Update(ctx context.Context, client *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r updateResult) {
+func Update(ctx context.Context, client gophercloud.Client, id string, opts UpdateOptsBuilder) (r updateResult) {
 	b, err := opts.ToQoSUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -228,7 +228,7 @@ func (opts DeleteKeysOpts) ToDeleteKeysCreateMap() (map[string]any, error) {
 }
 
 // DeleteKeys will delete the keys/specs from the specified QoS
-func DeleteKeys(ctx context.Context, client *gophercloud.ServiceClient, qosID string, opts DeleteKeysOptsBuilder) (r DeleteResult) {
+func DeleteKeys(ctx context.Context, client gophercloud.Client, qosID string, opts DeleteKeysOptsBuilder) (r DeleteResult) {
 	b, err := opts.ToDeleteKeysCreateMap()
 	if err != nil {
 		r.Err = err
@@ -260,7 +260,7 @@ func (opts AssociateOpts) ToQosAssociateQuery() (string, error) {
 }
 
 // Associate will associate a qos with a volute type
-func Associate(ctx context.Context, client *gophercloud.ServiceClient, qosID string, opts AssociateOptsBuilder) (r AssociateResult) {
+func Associate(ctx context.Context, client gophercloud.Client, qosID string, opts AssociateOptsBuilder) (r AssociateResult) {
 	url := associateURL(client, qosID)
 	query, err := opts.ToQosAssociateQuery()
 	if err != nil {
@@ -295,7 +295,7 @@ func (opts DisassociateOpts) ToQosDisassociateQuery() (string, error) {
 }
 
 // Disassociate will disassociate a qos from a volute type
-func Disassociate(ctx context.Context, client *gophercloud.ServiceClient, qosID string, opts DisassociateOptsBuilder) (r DisassociateResult) {
+func Disassociate(ctx context.Context, client gophercloud.Client, qosID string, opts DisassociateOptsBuilder) (r DisassociateResult) {
 	url := disassociateURL(client, qosID)
 	query, err := opts.ToQosDisassociateQuery()
 	if err != nil {
@@ -312,7 +312,7 @@ func Disassociate(ctx context.Context, client *gophercloud.ServiceClient, qosID 
 }
 
 // DisassociateAll will disassociate a qos from all volute types
-func DisassociateAll(ctx context.Context, client *gophercloud.ServiceClient, qosID string) (r DisassociateAllResult) {
+func DisassociateAll(ctx context.Context, client gophercloud.Client, qosID string) (r DisassociateAllResult) {
 	resp, err := client.Get(ctx, disassociateAllURL(client, qosID), nil, &gophercloud.RequestOpts{
 		OkCodes: []int{202},
 	})
@@ -321,7 +321,7 @@ func DisassociateAll(ctx context.Context, client *gophercloud.ServiceClient, qos
 }
 
 // ListAssociations retrieves the associations of a QoS.
-func ListAssociations(client *gophercloud.ServiceClient, qosID string) pagination.Pager {
+func ListAssociations(client gophercloud.Client, qosID string) pagination.Pager {
 	url := listAssociationsURL(client, qosID)
 
 	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {

--- a/openstack/blockstorage/v3/qos/urls.go
+++ b/openstack/blockstorage/v3/qos/urls.go
@@ -2,42 +2,42 @@ package qos
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func getURL(client *gophercloud.ServiceClient, id string) string {
+func getURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL("qos-specs", id)
 }
 
-func createURL(c *gophercloud.ServiceClient) string {
+func createURL(c gophercloud.Client) string {
 	return c.ServiceURL("qos-specs")
 }
 
-func listURL(c *gophercloud.ServiceClient) string {
+func listURL(c gophercloud.Client) string {
 	return c.ServiceURL("qos-specs")
 }
 
-func deleteURL(c *gophercloud.ServiceClient, id string) string {
+func deleteURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("qos-specs", id)
 }
 
-func updateURL(client *gophercloud.ServiceClient, id string) string {
+func updateURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL("qos-specs", id)
 }
 
-func deleteKeysURL(client *gophercloud.ServiceClient, id string) string {
+func deleteKeysURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL("qos-specs", id, "delete_keys")
 }
 
-func associateURL(client *gophercloud.ServiceClient, id string) string {
+func associateURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL("qos-specs", id, "associate")
 }
 
-func disassociateURL(client *gophercloud.ServiceClient, id string) string {
+func disassociateURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL("qos-specs", id, "disassociate")
 }
 
-func disassociateAllURL(client *gophercloud.ServiceClient, id string) string {
+func disassociateAllURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL("qos-specs", id, "disassociate_all")
 }
 
-func listAssociationsURL(client *gophercloud.ServiceClient, id string) string {
+func listAssociationsURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL("qos-specs", id, "associations")
 }

--- a/openstack/blockstorage/v3/quotasets/requests.go
+++ b/openstack/blockstorage/v3/quotasets/requests.go
@@ -8,21 +8,21 @@ import (
 )
 
 // Get returns public data about a previously created QuotaSet.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, projectID string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, projectID string) (r GetResult) {
 	resp, err := client.Get(ctx, getURL(client, projectID), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
 // GetDefaults returns public data about the project's default block storage quotas.
-func GetDefaults(ctx context.Context, client *gophercloud.ServiceClient, projectID string) (r GetResult) {
+func GetDefaults(ctx context.Context, client gophercloud.Client, projectID string) (r GetResult) {
 	resp, err := client.Get(ctx, getDefaultsURL(client, projectID), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
 // GetUsage returns detailed public data about a previously created QuotaSet.
-func GetUsage(ctx context.Context, client *gophercloud.ServiceClient, projectID string) (r GetUsageResult) {
+func GetUsage(ctx context.Context, client gophercloud.Client, projectID string) (r GetUsageResult) {
 	u := fmt.Sprintf("%s?usage=true", getURL(client, projectID))
 	resp, err := client.Get(ctx, u, &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
@@ -30,7 +30,7 @@ func GetUsage(ctx context.Context, client *gophercloud.ServiceClient, projectID 
 }
 
 // Updates the quotas for the given projectID and returns the new QuotaSet.
-func Update(ctx context.Context, client *gophercloud.ServiceClient, projectID string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, client gophercloud.Client, projectID string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToBlockStorageQuotaUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -108,7 +108,7 @@ type UpdateOpts struct {
 }
 
 // Resets the quotas for the given tenant to their default values.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, projectID string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, projectID string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, deleteURL(client, projectID), &gophercloud.RequestOpts{
 		OkCodes: []int{200},
 	})

--- a/openstack/blockstorage/v3/quotasets/urls.go
+++ b/openstack/blockstorage/v3/quotasets/urls.go
@@ -4,18 +4,18 @@ import "github.com/gophercloud/gophercloud/v2"
 
 const resourcePath = "os-quota-sets"
 
-func getURL(c *gophercloud.ServiceClient, projectID string) string {
+func getURL(c gophercloud.Client, projectID string) string {
 	return c.ServiceURL(resourcePath, projectID)
 }
 
-func getDefaultsURL(c *gophercloud.ServiceClient, projectID string) string {
+func getDefaultsURL(c gophercloud.Client, projectID string) string {
 	return c.ServiceURL(resourcePath, projectID, "defaults")
 }
 
-func updateURL(c *gophercloud.ServiceClient, projectID string) string {
+func updateURL(c gophercloud.Client, projectID string) string {
 	return getURL(c, projectID)
 }
 
-func deleteURL(c *gophercloud.ServiceClient, projectID string) string {
+func deleteURL(c gophercloud.Client, projectID string) string {
 	return getURL(c, projectID)
 }

--- a/openstack/blockstorage/v3/schedulerstats/requests.go
+++ b/openstack/blockstorage/v3/schedulerstats/requests.go
@@ -28,7 +28,7 @@ func (opts ListOpts) ToStoragePoolsListQuery() (string, error) {
 }
 
 // List makes a request against the API to list storage pool information.
-func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(client gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := storagePoolsListURL(client)
 	if opts != nil {
 		query, err := opts.ToStoragePoolsListQuery()

--- a/openstack/blockstorage/v3/schedulerstats/urls.go
+++ b/openstack/blockstorage/v3/schedulerstats/urls.go
@@ -2,6 +2,6 @@ package schedulerstats
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func storagePoolsListURL(c *gophercloud.ServiceClient) string {
+func storagePoolsListURL(c gophercloud.Client) string {
 	return c.ServiceURL("scheduler-stats", "get_pools")
 }

--- a/openstack/blockstorage/v3/services/requests.go
+++ b/openstack/blockstorage/v3/services/requests.go
@@ -27,7 +27,7 @@ func (opts ListOpts) ToServiceListQuery() (string, error) {
 }
 
 // List makes a request against the API to list services.
-func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(client gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(client)
 	if opts != nil {
 		query, err := opts.ToServiceListQuery()

--- a/openstack/blockstorage/v3/services/urls.go
+++ b/openstack/blockstorage/v3/services/urls.go
@@ -2,6 +2,6 @@ package services
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func listURL(c *gophercloud.ServiceClient) string {
+func listURL(c gophercloud.Client) string {
 	return c.ServiceURL("os-services")
 }

--- a/openstack/blockstorage/v3/snapshots/requests.go
+++ b/openstack/blockstorage/v3/snapshots/requests.go
@@ -33,7 +33,7 @@ func (opts CreateOpts) ToSnapshotCreateMap() (map[string]any, error) {
 // Create will create a new Snapshot based on the values in CreateOpts. To
 // extract the Snapshot object from the response, call the Extract method on the
 // CreateResult.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToSnapshotCreateMap()
 	if err != nil {
 		r.Err = err
@@ -47,7 +47,7 @@ func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateO
 }
 
 // Delete will delete the existing Snapshot with the provided ID.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, id string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, deleteURL(client, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -55,7 +55,7 @@ func Delete(ctx context.Context, client *gophercloud.ServiceClient, id string) (
 
 // Get retrieves the Snapshot with the provided ID. To extract the Snapshot
 // object from the response, call the Extract method on the GetResult.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, id string) (r GetResult) {
 	resp, err := client.Get(ctx, getURL(client, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -108,7 +108,7 @@ func (opts ListOpts) ToSnapshotListQuery() (string, error) {
 
 // List returns Snapshots optionally limited by the conditions provided in
 // ListOpts.
-func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(client gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(client)
 	if opts != nil {
 		query, err := opts.ToSnapshotListQuery()
@@ -144,7 +144,7 @@ func (opts UpdateOpts) ToSnapshotUpdateMap() (map[string]any, error) {
 
 // Update will update the Snapshot with provided information. To extract the updated
 // Snapshot from the response, call the Extract method on the UpdateResult.
-func Update(ctx context.Context, client *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, client gophercloud.Client, id string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToSnapshotUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -179,7 +179,7 @@ func (opts UpdateMetadataOpts) ToSnapshotUpdateMetadataMap() (map[string]any, er
 // UpdateMetadata will update the Snapshot with provided information. To
 // extract the updated Snapshot from the response, call the ExtractMetadata
 // method on the UpdateMetadataResult.
-func UpdateMetadata(ctx context.Context, client *gophercloud.ServiceClient, id string, opts UpdateMetadataOptsBuilder) (r UpdateMetadataResult) {
+func UpdateMetadata(ctx context.Context, client gophercloud.Client, id string, opts UpdateMetadataOptsBuilder) (r UpdateMetadataResult) {
 	b, err := opts.ToSnapshotUpdateMetadataMap()
 	if err != nil {
 		r.Err = err
@@ -214,7 +214,7 @@ func (opts ResetStatusOpts) ToSnapshotResetStatusMap() (map[string]any, error) {
 
 // ResetStatus will reset the existing snapshot status. ResetStatusResult contains only the error.
 // To extract it, call the ExtractErr method on the ResetStatusResult.
-func ResetStatus(ctx context.Context, client *gophercloud.ServiceClient, id string, opts ResetStatusOptsBuilder) (r ResetStatusResult) {
+func ResetStatus(ctx context.Context, client gophercloud.Client, id string, opts ResetStatusOptsBuilder) (r ResetStatusResult) {
 	b, err := opts.ToSnapshotResetStatusMap()
 	if err != nil {
 		r.Err = err
@@ -252,7 +252,7 @@ func (opts UpdateStatusOpts) ToSnapshotUpdateStatusMap() (map[string]any, error)
 
 // UpdateStatus will update the existing snapshot status. UpdateStatusResult contains only the error.
 // To extract it, call the ExtractErr method on the UpdateStatusResult.
-func UpdateStatus(ctx context.Context, client *gophercloud.ServiceClient, id string, opts UpdateStatusOptsBuilder) (r UpdateStatusResult) {
+func UpdateStatus(ctx context.Context, client gophercloud.Client, id string, opts UpdateStatusOptsBuilder) (r UpdateStatusResult) {
 	b, err := opts.ToSnapshotUpdateStatusMap()
 	if err != nil {
 		r.Err = err
@@ -268,7 +268,7 @@ func UpdateStatus(ctx context.Context, client *gophercloud.ServiceClient, id str
 
 // ForceDelete will delete the existing snapshot in any state. ForceDeleteResult contains only the error.
 // To extract it, call the ExtractErr method on the ForceDeleteResult.
-func ForceDelete(ctx context.Context, client *gophercloud.ServiceClient, id string) (r ForceDeleteResult) {
+func ForceDelete(ctx context.Context, client gophercloud.Client, id string) (r ForceDeleteResult) {
 	b := map[string]any{
 		"os-force_delete": struct{}{},
 	}

--- a/openstack/blockstorage/v3/snapshots/urls.go
+++ b/openstack/blockstorage/v3/snapshots/urls.go
@@ -2,42 +2,42 @@ package snapshots
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func createURL(c *gophercloud.ServiceClient) string {
+func createURL(c gophercloud.Client) string {
 	return c.ServiceURL("snapshots")
 }
 
-func deleteURL(c *gophercloud.ServiceClient, id string) string {
+func deleteURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("snapshots", id)
 }
 
-func getURL(c *gophercloud.ServiceClient, id string) string {
+func getURL(c gophercloud.Client, id string) string {
 	return deleteURL(c, id)
 }
 
-func listURL(c *gophercloud.ServiceClient) string {
+func listURL(c gophercloud.Client) string {
 	return createURL(c)
 }
 
-func updateURL(c *gophercloud.ServiceClient, id string) string {
+func updateURL(c gophercloud.Client, id string) string {
 	return deleteURL(c, id)
 }
 
-func metadataURL(c *gophercloud.ServiceClient, id string) string {
+func metadataURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("snapshots", id, "metadata")
 }
 
-func updateMetadataURL(c *gophercloud.ServiceClient, id string) string {
+func updateMetadataURL(c gophercloud.Client, id string) string {
 	return metadataURL(c, id)
 }
 
-func resetStatusURL(c *gophercloud.ServiceClient, id string) string {
+func resetStatusURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("snapshots", id, "action")
 }
 
-func updateStatusURL(c *gophercloud.ServiceClient, id string) string {
+func updateStatusURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("snapshots", id, "action")
 }
 
-func forceDeleteURL(c *gophercloud.ServiceClient, id string) string {
+func forceDeleteURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("snapshots", id, "action")
 }

--- a/openstack/blockstorage/v3/snapshots/util.go
+++ b/openstack/blockstorage/v3/snapshots/util.go
@@ -7,7 +7,7 @@ import (
 )
 
 // WaitForStatus will continually poll the resource, checking for a particular status.
-func WaitForStatus(ctx context.Context, c *gophercloud.ServiceClient, id, status string) error {
+func WaitForStatus(ctx context.Context, c gophercloud.Client, id, status string) error {
 	return gophercloud.WaitFor(ctx, func(ctx context.Context) (bool, error) {
 		current, err := Get(ctx, c, id).Extract()
 		if err != nil {

--- a/openstack/blockstorage/v3/transfers/requests.go
+++ b/openstack/blockstorage/v3/transfers/requests.go
@@ -23,7 +23,7 @@ func (opts CreateOpts) ToCreateMap() (map[string]any, error) {
 }
 
 // Create will create a volume tranfer request based on the values in CreateOpts.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOpts) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, opts CreateOpts) (r CreateResult) {
 	b, err := opts.ToCreateMap()
 	if err != nil {
 		r.Err = err
@@ -49,7 +49,7 @@ func (opts AcceptOpts) ToAcceptMap() (map[string]any, error) {
 }
 
 // Accept will accept a volume tranfer request based on the values in AcceptOpts.
-func Accept(ctx context.Context, client *gophercloud.ServiceClient, id string, opts AcceptOpts) (r CreateResult) {
+func Accept(ctx context.Context, client gophercloud.Client, id string, opts AcceptOpts) (r CreateResult) {
 	b, err := opts.ToAcceptMap()
 	if err != nil {
 		r.Err = err
@@ -63,7 +63,7 @@ func Accept(ctx context.Context, client *gophercloud.ServiceClient, id string, o
 }
 
 // Delete deletes a volume transfer.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, id string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, deleteURL(client, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -102,7 +102,7 @@ func (opts ListOpts) ToTransferListQuery() (string, error) {
 }
 
 // List returns Transfers optionally limited by the conditions provided in ListOpts.
-func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(client gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(client)
 	if opts != nil {
 		query, err := opts.ToTransferListQuery()
@@ -119,7 +119,7 @@ func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pa
 
 // Get retrieves the Transfer with the provided ID. To extract the Transfer object
 // from the response, call the Extract method on the GetResult.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, id string) (r GetResult) {
 	resp, err := client.Get(ctx, getURL(client, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/blockstorage/v3/transfers/urls.go
+++ b/openstack/blockstorage/v3/transfers/urls.go
@@ -2,22 +2,22 @@ package transfers
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func transferURL(c *gophercloud.ServiceClient) string {
+func transferURL(c gophercloud.Client) string {
 	return c.ServiceURL("os-volume-transfer")
 }
 
-func acceptURL(c *gophercloud.ServiceClient, id string) string {
+func acceptURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("os-volume-transfer", id, "accept")
 }
 
-func deleteURL(c *gophercloud.ServiceClient, id string) string {
+func deleteURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("os-volume-transfer", id)
 }
 
-func listURL(c *gophercloud.ServiceClient) string {
+func listURL(c gophercloud.Client) string {
 	return c.ServiceURL("os-volume-transfer", "detail")
 }
 
-func getURL(c *gophercloud.ServiceClient, id string) string {
+func getURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("os-volume-transfer", id)
 }

--- a/openstack/blockstorage/v3/volumes/requests.go
+++ b/openstack/blockstorage/v3/volumes/requests.go
@@ -143,7 +143,7 @@ func (opts CreateOpts) ToVolumeCreateMap() (map[string]any, error) {
 // Create will create a new Volume based on the values in CreateOpts. To extract
 // the Volume object from the response, call the Extract method on the
 // CreateResult.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder, hintOpts SchedulerHintOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, opts CreateOptsBuilder, hintOpts SchedulerHintOptsBuilder) (r CreateResult) {
 	b, err := opts.ToVolumeCreateMap()
 	if err != nil {
 		r.Err = err
@@ -186,7 +186,7 @@ func (opts DeleteOpts) ToVolumeDeleteQuery() (string, error) {
 }
 
 // Delete will delete the existing Volume with the provided ID.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, id string, opts DeleteOptsBuilder) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, id string, opts DeleteOptsBuilder) (r DeleteResult) {
 	url := deleteURL(client, id)
 	if opts != nil {
 		query, err := opts.ToVolumeDeleteQuery()
@@ -203,7 +203,7 @@ func Delete(ctx context.Context, client *gophercloud.ServiceClient, id string, o
 
 // Get retrieves the Volume with the provided ID. To extract the Volume object
 // from the response, call the Extract method on the GetResult.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, id string) (r GetResult) {
 	resp, err := client.Get(ctx, getURL(client, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -258,7 +258,7 @@ func (opts ListOpts) ToVolumeListQuery() (string, error) {
 }
 
 // List returns Volumes optionally limited by the conditions provided in ListOpts.
-func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(client gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(client)
 	if opts != nil {
 		query, err := opts.ToVolumeListQuery()
@@ -296,7 +296,7 @@ func (opts UpdateOpts) ToVolumeUpdateMap() (map[string]any, error) {
 
 // Update will update the Volume with provided information. To extract the updated
 // Volume from the response, call the Extract method on the UpdateResult.
-func Update(ctx context.Context, client *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, client gophercloud.Client, id string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToVolumeUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -346,7 +346,7 @@ func (opts AttachOpts) ToVolumeAttachMap() (map[string]any, error) {
 }
 
 // Attach will attach a volume based on the values in AttachOpts.
-func Attach(ctx context.Context, client *gophercloud.ServiceClient, id string, opts AttachOptsBuilder) (r AttachResult) {
+func Attach(ctx context.Context, client gophercloud.Client, id string, opts AttachOptsBuilder) (r AttachResult) {
 	b, err := opts.ToVolumeAttachMap()
 	if err != nil {
 		r.Err = err
@@ -360,7 +360,7 @@ func Attach(ctx context.Context, client *gophercloud.ServiceClient, id string, o
 }
 
 // BeginDetaching will mark the volume as detaching.
-func BeginDetaching(ctx context.Context, client *gophercloud.ServiceClient, id string) (r BeginDetachingResult) {
+func BeginDetaching(ctx context.Context, client gophercloud.Client, id string) (r BeginDetachingResult) {
 	b := map[string]any{"os-begin_detaching": make(map[string]any)}
 	resp, err := client.Post(ctx, actionURL(client, id), b, nil, &gophercloud.RequestOpts{
 		OkCodes: []int{202},
@@ -388,7 +388,7 @@ func (opts DetachOpts) ToVolumeDetachMap() (map[string]any, error) {
 }
 
 // Detach will detach a volume based on volume ID.
-func Detach(ctx context.Context, client *gophercloud.ServiceClient, id string, opts DetachOptsBuilder) (r DetachResult) {
+func Detach(ctx context.Context, client gophercloud.Client, id string, opts DetachOptsBuilder) (r DetachResult) {
 	b, err := opts.ToVolumeDetachMap()
 	if err != nil {
 		r.Err = err
@@ -402,7 +402,7 @@ func Detach(ctx context.Context, client *gophercloud.ServiceClient, id string, o
 }
 
 // Reserve will reserve a volume based on volume ID.
-func Reserve(ctx context.Context, client *gophercloud.ServiceClient, id string) (r ReserveResult) {
+func Reserve(ctx context.Context, client gophercloud.Client, id string) (r ReserveResult) {
 	b := map[string]any{"os-reserve": make(map[string]any)}
 	resp, err := client.Post(ctx, actionURL(client, id), b, nil, &gophercloud.RequestOpts{
 		OkCodes: []int{200, 201, 202},
@@ -412,7 +412,7 @@ func Reserve(ctx context.Context, client *gophercloud.ServiceClient, id string) 
 }
 
 // Unreserve will unreserve a volume based on volume ID.
-func Unreserve(ctx context.Context, client *gophercloud.ServiceClient, id string) (r UnreserveResult) {
+func Unreserve(ctx context.Context, client gophercloud.Client, id string) (r UnreserveResult) {
 	b := map[string]any{"os-unreserve": make(map[string]any)}
 	resp, err := client.Post(ctx, actionURL(client, id), b, nil, &gophercloud.RequestOpts{
 		OkCodes: []int{200, 201, 202},
@@ -449,7 +449,7 @@ func (opts InitializeConnectionOpts) ToVolumeInitializeConnectionMap() (map[stri
 }
 
 // InitializeConnection initializes an iSCSI connection by volume ID.
-func InitializeConnection(ctx context.Context, client *gophercloud.ServiceClient, id string, opts InitializeConnectionOptsBuilder) (r InitializeConnectionResult) {
+func InitializeConnection(ctx context.Context, client gophercloud.Client, id string, opts InitializeConnectionOptsBuilder) (r InitializeConnectionResult) {
 	b, err := opts.ToVolumeInitializeConnectionMap()
 	if err != nil {
 		r.Err = err
@@ -488,7 +488,7 @@ func (opts TerminateConnectionOpts) ToVolumeTerminateConnectionMap() (map[string
 }
 
 // TerminateConnection terminates an iSCSI connection by volume ID.
-func TerminateConnection(ctx context.Context, client *gophercloud.ServiceClient, id string, opts TerminateConnectionOptsBuilder) (r TerminateConnectionResult) {
+func TerminateConnection(ctx context.Context, client gophercloud.Client, id string, opts TerminateConnectionOptsBuilder) (r TerminateConnectionResult) {
 	b, err := opts.ToVolumeTerminateConnectionMap()
 	if err != nil {
 		r.Err = err
@@ -522,7 +522,7 @@ func (opts ExtendSizeOpts) ToVolumeExtendSizeMap() (map[string]any, error) {
 
 // ExtendSize will extend the size of the volume based on the provided information.
 // This operation does not return a response body.
-func ExtendSize(ctx context.Context, client *gophercloud.ServiceClient, id string, opts ExtendSizeOptsBuilder) (r ExtendSizeResult) {
+func ExtendSize(ctx context.Context, client gophercloud.Client, id string, opts ExtendSizeOptsBuilder) (r ExtendSizeResult) {
 	b, err := opts.ToVolumeExtendSizeMap()
 	if err != nil {
 		r.Err = err
@@ -571,7 +571,7 @@ func (opts UploadImageOpts) ToVolumeUploadImageMap() (map[string]any, error) {
 }
 
 // UploadImage will upload an image based on the values in UploadImageOptsBuilder.
-func UploadImage(ctx context.Context, client *gophercloud.ServiceClient, id string, opts UploadImageOptsBuilder) (r UploadImageResult) {
+func UploadImage(ctx context.Context, client gophercloud.Client, id string, opts UploadImageOptsBuilder) (r UploadImageResult) {
 	b, err := opts.ToVolumeUploadImageMap()
 	if err != nil {
 		r.Err = err
@@ -585,7 +585,7 @@ func UploadImage(ctx context.Context, client *gophercloud.ServiceClient, id stri
 }
 
 // ForceDelete will delete the volume regardless of state.
-func ForceDelete(ctx context.Context, client *gophercloud.ServiceClient, id string) (r ForceDeleteResult) {
+func ForceDelete(ctx context.Context, client gophercloud.Client, id string) (r ForceDeleteResult) {
 	resp, err := client.Post(ctx, actionURL(client, id), map[string]any{"os-force_delete": ""}, nil, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -610,7 +610,7 @@ func (opts ImageMetadataOpts) ToImageMetadataMap() (map[string]any, error) {
 }
 
 // SetImageMetadata will set image metadata on a volume based on the values in ImageMetadataOptsBuilder.
-func SetImageMetadata(ctx context.Context, client *gophercloud.ServiceClient, id string, opts ImageMetadataOptsBuilder) (r SetImageMetadataResult) {
+func SetImageMetadata(ctx context.Context, client gophercloud.Client, id string, opts ImageMetadataOptsBuilder) (r SetImageMetadataResult) {
 	b, err := opts.ToImageMetadataMap()
 	if err != nil {
 		r.Err = err
@@ -636,7 +636,7 @@ func (opts BootableOpts) ToBootableMap() (map[string]any, error) {
 }
 
 // SetBootable will set bootable status on a volume based on the values in BootableOpts
-func SetBootable(ctx context.Context, client *gophercloud.ServiceClient, id string, opts BootableOpts) (r SetBootableResult) {
+func SetBootable(ctx context.Context, client gophercloud.Client, id string, opts BootableOpts) (r SetBootableResult) {
 	b, err := opts.ToBootableMap()
 	if err != nil {
 		r.Err = err
@@ -684,7 +684,7 @@ func (opts ChangeTypeOpts) ToVolumeChangeTypeMap() (map[string]any, error) {
 
 // ChangeType will change the volume type of the volume based on the provided information.
 // This operation does not return a response body.
-func ChangeType(ctx context.Context, client *gophercloud.ServiceClient, id string, opts ChangeTypeOptsBuilder) (r ChangeTypeResult) {
+func ChangeType(ctx context.Context, client gophercloud.Client, id string, opts ChangeTypeOptsBuilder) (r ChangeTypeResult) {
 	b, err := opts.ToVolumeChangeTypeMap()
 	if err != nil {
 		r.Err = err
@@ -711,7 +711,7 @@ func (opts ReImageOpts) ToReImageMap() (map[string]any, error) {
 }
 
 // ReImage will re-image a volume based on the values in ReImageOpts
-func ReImage(ctx context.Context, client *gophercloud.ServiceClient, id string, opts ReImageOpts) (r ReImageResult) {
+func ReImage(ctx context.Context, client gophercloud.Client, id string, opts ReImageOpts) (r ReImageResult) {
 	b, err := opts.ToReImageMap()
 	if err != nil {
 		r.Err = err
@@ -750,7 +750,7 @@ func (opts ResetStatusOpts) ToResetStatusMap() (map[string]any, error) {
 
 // ResetStatus will reset the existing volume status. ResetStatusResult contains only the error.
 // To extract it, call the ExtractErr method on the ResetStatusResult.
-func ResetStatus(ctx context.Context, client *gophercloud.ServiceClient, id string, opts ResetStatusOptsBuilder) (r ResetStatusResult) {
+func ResetStatus(ctx context.Context, client gophercloud.Client, id string, opts ResetStatusOptsBuilder) (r ResetStatusResult) {
 	b, err := opts.ToResetStatusMap()
 	if err != nil {
 		r.Err = err

--- a/openstack/blockstorage/v3/volumes/urls.go
+++ b/openstack/blockstorage/v3/volumes/urls.go
@@ -2,26 +2,26 @@ package volumes
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func createURL(c *gophercloud.ServiceClient) string {
+func createURL(c gophercloud.Client) string {
 	return c.ServiceURL("volumes")
 }
 
-func listURL(c *gophercloud.ServiceClient) string {
+func listURL(c gophercloud.Client) string {
 	return c.ServiceURL("volumes", "detail")
 }
 
-func deleteURL(c *gophercloud.ServiceClient, id string) string {
+func deleteURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("volumes", id)
 }
 
-func getURL(c *gophercloud.ServiceClient, id string) string {
+func getURL(c gophercloud.Client, id string) string {
 	return deleteURL(c, id)
 }
 
-func updateURL(c *gophercloud.ServiceClient, id string) string {
+func updateURL(c gophercloud.Client, id string) string {
 	return deleteURL(c, id)
 }
 
-func actionURL(c *gophercloud.ServiceClient, id string) string {
+func actionURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("volumes", id, "action")
 }

--- a/openstack/blockstorage/v3/volumes/util.go
+++ b/openstack/blockstorage/v3/volumes/util.go
@@ -7,7 +7,7 @@ import (
 )
 
 // WaitForStatus will continually poll the resource, checking for a particular status.
-func WaitForStatus(ctx context.Context, c *gophercloud.ServiceClient, id, status string) error {
+func WaitForStatus(ctx context.Context, c gophercloud.Client, id, status string) error {
 	return gophercloud.WaitFor(ctx, func(ctx context.Context) (bool, error) {
 		current, err := Get(ctx, c, id).Extract()
 		if err != nil {

--- a/openstack/blockstorage/v3/volumetypes/requests.go
+++ b/openstack/blockstorage/v3/volumetypes/requests.go
@@ -36,7 +36,7 @@ func (opts CreateOpts) ToVolumeTypeCreateMap() (map[string]any, error) {
 // Create will create a new Volume Type based on the values in CreateOpts. To extract
 // the Volume Type object from the response, call the Extract method on the
 // CreateResult.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToVolumeTypeCreateMap()
 	if err != nil {
 		r.Err = err
@@ -50,7 +50,7 @@ func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateO
 }
 
 // Delete will delete the existing Volume Type with the provided ID.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, id string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, deleteURL(client, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -58,7 +58,7 @@ func Delete(ctx context.Context, client *gophercloud.ServiceClient, id string) (
 
 // Get retrieves the Volume Type with the provided ID. To extract the Volume Type object
 // from the response, call the Extract method on the GetResult.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, id string) (r GetResult) {
 	resp, err := client.Get(ctx, getURL(client, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -91,7 +91,7 @@ func (opts ListOpts) ToVolumeTypeListQuery() (string, error) {
 }
 
 // List returns Volume types.
-func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(client gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(client)
 
 	if opts != nil {
@@ -130,7 +130,7 @@ func (opts UpdateOpts) ToVolumeTypeUpdateMap() (map[string]any, error) {
 
 // Update will update the Volume Type with provided information. To extract the updated
 // Volume Type from the response, call the Extract method on the UpdateResult.
-func Update(ctx context.Context, client *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, client gophercloud.Client, id string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToVolumeTypeUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -144,14 +144,14 @@ func Update(ctx context.Context, client *gophercloud.ServiceClient, id string, o
 }
 
 // ListExtraSpecs requests all the extra-specs for the given volume type ID.
-func ListExtraSpecs(ctx context.Context, client *gophercloud.ServiceClient, volumeTypeID string) (r ListExtraSpecsResult) {
+func ListExtraSpecs(ctx context.Context, client gophercloud.Client, volumeTypeID string) (r ListExtraSpecsResult) {
 	resp, err := client.Get(ctx, extraSpecsListURL(client, volumeTypeID), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
 // GetExtraSpec requests an extra-spec specified by key for the given volume type ID
-func GetExtraSpec(ctx context.Context, client *gophercloud.ServiceClient, volumeTypeID string, key string) (r GetExtraSpecResult) {
+func GetExtraSpec(ctx context.Context, client gophercloud.Client, volumeTypeID string, key string) (r GetExtraSpecResult) {
 	resp, err := client.Get(ctx, extraSpecsGetURL(client, volumeTypeID, key), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -174,7 +174,7 @@ func (opts ExtraSpecsOpts) ToVolumeTypeExtraSpecsCreateMap() (map[string]any, er
 
 // CreateExtraSpecs will create or update the extra-specs key-value pairs for
 // the specified volume type.
-func CreateExtraSpecs(ctx context.Context, client *gophercloud.ServiceClient, volumeTypeID string, opts CreateExtraSpecsOptsBuilder) (r CreateExtraSpecsResult) {
+func CreateExtraSpecs(ctx context.Context, client gophercloud.Client, volumeTypeID string, opts CreateExtraSpecsOptsBuilder) (r CreateExtraSpecsResult) {
 	b, err := opts.ToVolumeTypeExtraSpecsCreateMap()
 	if err != nil {
 		r.Err = err
@@ -213,7 +213,7 @@ func (opts ExtraSpecsOpts) ToVolumeTypeExtraSpecUpdateMap() (map[string]string, 
 
 // UpdateExtraSpec will updates the value of the specified volume type's extra spec
 // for the key in opts.
-func UpdateExtraSpec(ctx context.Context, client *gophercloud.ServiceClient, volumeTypeID string, opts UpdateExtraSpecOptsBuilder) (r UpdateExtraSpecResult) {
+func UpdateExtraSpec(ctx context.Context, client gophercloud.Client, volumeTypeID string, opts UpdateExtraSpecOptsBuilder) (r UpdateExtraSpecResult) {
 	b, key, err := opts.ToVolumeTypeExtraSpecUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -228,7 +228,7 @@ func UpdateExtraSpec(ctx context.Context, client *gophercloud.ServiceClient, vol
 
 // DeleteExtraSpec will delete the key-value pair with the given key for the given
 // volume type ID.
-func DeleteExtraSpec(ctx context.Context, client *gophercloud.ServiceClient, volumeTypeID, key string) (r DeleteExtraSpecResult) {
+func DeleteExtraSpec(ctx context.Context, client gophercloud.Client, volumeTypeID, key string) (r DeleteExtraSpecResult) {
 	resp, err := client.Delete(ctx, extraSpecDeleteURL(client, volumeTypeID, key), &gophercloud.RequestOpts{
 		OkCodes: []int{202},
 	})
@@ -237,7 +237,7 @@ func DeleteExtraSpec(ctx context.Context, client *gophercloud.ServiceClient, vol
 }
 
 // ListAccesses retrieves the tenants which have access to a volume type.
-func ListAccesses(client *gophercloud.ServiceClient, id string) pagination.Pager {
+func ListAccesses(client gophercloud.Client, id string) pagination.Pager {
 	url := accessURL(client, id)
 
 	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
@@ -263,7 +263,7 @@ func (opts AddAccessOpts) ToVolumeTypeAddAccessMap() (map[string]any, error) {
 }
 
 // AddAccess grants a tenant/project access to a volume type.
-func AddAccess(ctx context.Context, client *gophercloud.ServiceClient, id string, opts AddAccessOptsBuilder) (r AddAccessResult) {
+func AddAccess(ctx context.Context, client gophercloud.Client, id string, opts AddAccessOptsBuilder) (r AddAccessResult) {
 	b, err := opts.ToVolumeTypeAddAccessMap()
 	if err != nil {
 		r.Err = err
@@ -294,7 +294,7 @@ func (opts RemoveAccessOpts) ToVolumeTypeRemoveAccessMap() (map[string]any, erro
 }
 
 // RemoveAccess removes/revokes a tenant/project access to a volume type.
-func RemoveAccess(ctx context.Context, client *gophercloud.ServiceClient, id string, opts RemoveAccessOptsBuilder) (r RemoveAccessResult) {
+func RemoveAccess(ctx context.Context, client gophercloud.Client, id string, opts RemoveAccessOptsBuilder) (r RemoveAccessResult) {
 	b, err := opts.ToVolumeTypeRemoveAccessMap()
 	if err != nil {
 		r.Err = err
@@ -336,7 +336,7 @@ func (opts CreateEncryptionOpts) ToEncryptionCreateMap() (map[string]any, error)
 // CreateEncryption will creates an Encryption Type object based on the CreateEncryptionOpts.
 // To extract the Encryption Type object from the response, call the Extract method on the
 // EncryptionCreateResult.
-func CreateEncryption(ctx context.Context, client *gophercloud.ServiceClient, id string, opts CreateEncryptionOptsBuilder) (r CreateEncryptionResult) {
+func CreateEncryption(ctx context.Context, client gophercloud.Client, id string, opts CreateEncryptionOptsBuilder) (r CreateEncryptionResult) {
 	b, err := opts.ToEncryptionCreateMap()
 	if err != nil {
 		r.Err = err
@@ -350,21 +350,21 @@ func CreateEncryption(ctx context.Context, client *gophercloud.ServiceClient, id
 }
 
 // Delete will delete an encryption type for an existing Volume Type with the provided ID.
-func DeleteEncryption(ctx context.Context, client *gophercloud.ServiceClient, id, encryptionID string) (r DeleteEncryptionResult) {
+func DeleteEncryption(ctx context.Context, client gophercloud.Client, id, encryptionID string) (r DeleteEncryptionResult) {
 	resp, err := client.Delete(ctx, deleteEncryptionURL(client, id, encryptionID), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
 // GetEncryption retrieves the encryption type for an existing VolumeType with the provided ID.
-func GetEncryption(ctx context.Context, client *gophercloud.ServiceClient, id string) (r GetEncryptionResult) {
+func GetEncryption(ctx context.Context, client gophercloud.Client, id string) (r GetEncryptionResult) {
 	resp, err := client.Get(ctx, getEncryptionURL(client, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
 // GetEncryptionSpecs retrieves the encryption type specs for an existing VolumeType with the provided ID.
-func GetEncryptionSpec(ctx context.Context, client *gophercloud.ServiceClient, id, key string) (r GetEncryptionSpecResult) {
+func GetEncryptionSpec(ctx context.Context, client gophercloud.Client, id, key string) (r GetEncryptionSpecResult) {
 	resp, err := client.Get(ctx, getEncryptionSpecURL(client, id, key), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -399,7 +399,7 @@ func (opts UpdateEncryptionOpts) ToUpdateEncryptionMap() (map[string]any, error)
 // Update will update an existing encryption for a Volume Type based on the values in UpdateEncryptionOpts.
 // To extract the UpdateEncryption Type object from the response, call the Extract method on the
 // UpdateEncryptionResult.
-func UpdateEncryption(ctx context.Context, client *gophercloud.ServiceClient, id, encryptionID string, opts UpdateEncryptionOptsBuilder) (r UpdateEncryptionResult) {
+func UpdateEncryption(ctx context.Context, client gophercloud.Client, id, encryptionID string, opts UpdateEncryptionOptsBuilder) (r UpdateEncryptionResult) {
 	b, err := opts.ToUpdateEncryptionMap()
 	if err != nil {
 		r.Err = err

--- a/openstack/blockstorage/v3/volumetypes/urls.go
+++ b/openstack/blockstorage/v3/volumetypes/urls.go
@@ -2,70 +2,70 @@ package volumetypes
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func listURL(c *gophercloud.ServiceClient) string {
+func listURL(c gophercloud.Client) string {
 	return c.ServiceURL("types")
 }
 
-func getURL(c *gophercloud.ServiceClient, id string) string {
+func getURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("types", id)
 }
 
-func createURL(c *gophercloud.ServiceClient) string {
+func createURL(c gophercloud.Client) string {
 	return c.ServiceURL("types")
 }
 
-func deleteURL(c *gophercloud.ServiceClient, id string) string {
+func deleteURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("types", id)
 }
 
-func updateURL(c *gophercloud.ServiceClient, id string) string {
+func updateURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("types", id)
 }
 
-func extraSpecsListURL(client *gophercloud.ServiceClient, id string) string {
+func extraSpecsListURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL("types", id, "extra_specs")
 }
 
-func extraSpecsGetURL(client *gophercloud.ServiceClient, id, key string) string {
+func extraSpecsGetURL(client gophercloud.Client, id, key string) string {
 	return client.ServiceURL("types", id, "extra_specs", key)
 }
 
-func extraSpecsCreateURL(client *gophercloud.ServiceClient, id string) string {
+func extraSpecsCreateURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL("types", id, "extra_specs")
 }
 
-func extraSpecUpdateURL(client *gophercloud.ServiceClient, id, key string) string {
+func extraSpecUpdateURL(client gophercloud.Client, id, key string) string {
 	return client.ServiceURL("types", id, "extra_specs", key)
 }
 
-func extraSpecDeleteURL(client *gophercloud.ServiceClient, id, key string) string {
+func extraSpecDeleteURL(client gophercloud.Client, id, key string) string {
 	return client.ServiceURL("types", id, "extra_specs", key)
 }
 
-func accessURL(client *gophercloud.ServiceClient, id string) string {
+func accessURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL("types", id, "os-volume-type-access")
 }
 
-func accessActionURL(client *gophercloud.ServiceClient, id string) string {
+func accessActionURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL("types", id, "action")
 }
 
-func createEncryptionURL(client *gophercloud.ServiceClient, id string) string {
+func createEncryptionURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL("types", id, "encryption")
 }
 
-func deleteEncryptionURL(client *gophercloud.ServiceClient, id, encryptionID string) string {
+func deleteEncryptionURL(client gophercloud.Client, id, encryptionID string) string {
 	return client.ServiceURL("types", id, "encryption", encryptionID)
 }
 
-func getEncryptionURL(client *gophercloud.ServiceClient, id string) string {
+func getEncryptionURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL("types", id, "encryption")
 }
 
-func getEncryptionSpecURL(client *gophercloud.ServiceClient, id, key string) string {
+func getEncryptionSpecURL(client gophercloud.Client, id, key string) string {
 	return client.ServiceURL("types", id, "encryption", key)
 }
 
-func updateEncryptionURL(client *gophercloud.ServiceClient, id, encryptionID string) string {
+func updateEncryptionURL(client gophercloud.Client, id, encryptionID string) string {
 	return client.ServiceURL("types", id, "encryption", encryptionID)
 }

--- a/openstack/common/extensions/requests.go
+++ b/openstack/common/extensions/requests.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Get retrieves information for a specific extension using its alias.
-func Get(ctx context.Context, c *gophercloud.ServiceClient, alias string) (r GetResult) {
+func Get(ctx context.Context, c gophercloud.Client, alias string) (r GetResult) {
 	resp, err := c.Get(ctx, ExtensionURL(c, alias), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -16,7 +16,7 @@ func Get(ctx context.Context, c *gophercloud.ServiceClient, alias string) (r Get
 
 // List returns a Pager which allows you to iterate over the full collection of extensions.
 // It does not accept query parameters.
-func List(c *gophercloud.ServiceClient) pagination.Pager {
+func List(c gophercloud.Client) pagination.Pager {
 	return pagination.NewPager(c, ListExtensionURL(c), func(r pagination.PageResult) pagination.Page {
 		return ExtensionPage{pagination.SinglePageBase(r)}
 	})

--- a/openstack/common/extensions/urls.go
+++ b/openstack/common/extensions/urls.go
@@ -3,11 +3,11 @@ package extensions
 import "github.com/gophercloud/gophercloud/v2"
 
 // ExtensionURL generates the URL for an extension resource by name.
-func ExtensionURL(c *gophercloud.ServiceClient, name string) string {
+func ExtensionURL(c gophercloud.Client, name string) string {
 	return c.ServiceURL("extensions", name)
 }
 
 // ListExtensionURL generates the URL for the extensions resource collection.
-func ListExtensionURL(c *gophercloud.ServiceClient) string {
+func ListExtensionURL(c gophercloud.Client) string {
 	return c.ServiceURL("extensions")
 }

--- a/openstack/compute/apiversions/requests.go
+++ b/openstack/compute/apiversions/requests.go
@@ -8,14 +8,14 @@ import (
 )
 
 // List lists all the API versions available to end-users.
-func List(c *gophercloud.ServiceClient) pagination.Pager {
+func List(c gophercloud.Client) pagination.Pager {
 	return pagination.NewPager(c, listURL(c), func(r pagination.PageResult) pagination.Page {
 		return APIVersionPage{pagination.SinglePageBase(r)}
 	})
 }
 
 // Get will get a specific API version, specified by major ID.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, v string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, v string) (r GetResult) {
 	resp, err := client.Get(ctx, getURL(client, v), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/compute/apiversions/urls.go
+++ b/openstack/compute/apiversions/urls.go
@@ -7,14 +7,14 @@ import (
 	"github.com/gophercloud/gophercloud/v2/openstack/utils"
 )
 
-func getURL(c *gophercloud.ServiceClient, version string) string {
-	baseEndpoint, _ := utils.BaseEndpoint(c.Endpoint)
+func getURL(c gophercloud.Client, version string) string {
+	baseEndpoint, _ := utils.BaseEndpoint(c.EndpointURL())
 	endpoint := strings.TrimRight(baseEndpoint, "/") + "/" + strings.TrimRight(version, "/") + "/"
 	return endpoint
 }
 
-func listURL(c *gophercloud.ServiceClient) string {
-	baseEndpoint, _ := utils.BaseEndpoint(c.Endpoint)
+func listURL(c gophercloud.Client) string {
+	baseEndpoint, _ := utils.BaseEndpoint(c.EndpointURL())
 	endpoint := strings.TrimRight(baseEndpoint, "/") + "/"
 	return endpoint
 }

--- a/openstack/compute/v2/aggregates/requests.go
+++ b/openstack/compute/v2/aggregates/requests.go
@@ -9,7 +9,7 @@ import (
 )
 
 // List makes a request against the API to list aggregates.
-func List(client *gophercloud.ServiceClient) pagination.Pager {
+func List(client gophercloud.Client) pagination.Pager {
 	return pagination.NewPager(client, aggregatesListURL(client), func(r pagination.PageResult) pagination.Page {
 		return AggregatesPage{pagination.SinglePageBase(r)}
 	})
@@ -31,7 +31,7 @@ func (opts CreateOpts) ToAggregatesCreateMap() (map[string]any, error) {
 }
 
 // Create makes a request against the API to create an aggregate.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOpts) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, opts CreateOpts) (r CreateResult) {
 	b, err := opts.ToAggregatesCreateMap()
 	if err != nil {
 		r.Err = err
@@ -45,7 +45,7 @@ func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateO
 }
 
 // Delete makes a request against the API to delete an aggregate.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, aggregateID int) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, aggregateID int) (r DeleteResult) {
 	v := strconv.Itoa(aggregateID)
 	resp, err := client.Delete(ctx, aggregatesDeleteURL(client, v), &gophercloud.RequestOpts{
 		OkCodes: []int{200},
@@ -55,7 +55,7 @@ func Delete(ctx context.Context, client *gophercloud.ServiceClient, aggregateID 
 }
 
 // Get makes a request against the API to get details for a specific aggregate.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, aggregateID int) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, aggregateID int) (r GetResult) {
 	v := strconv.Itoa(aggregateID)
 	resp, err := client.Get(ctx, aggregatesGetURL(client, v), &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{200},
@@ -80,7 +80,7 @@ func (opts UpdateOpts) ToAggregatesUpdateMap() (map[string]any, error) {
 }
 
 // Update makes a request against the API to update a specific aggregate.
-func Update(ctx context.Context, client *gophercloud.ServiceClient, aggregateID int, opts UpdateOpts) (r UpdateResult) {
+func Update(ctx context.Context, client gophercloud.Client, aggregateID int, opts UpdateOpts) (r UpdateResult) {
 	v := strconv.Itoa(aggregateID)
 
 	b, err := opts.ToAggregatesUpdateMap()
@@ -105,7 +105,7 @@ func (opts AddHostOpts) ToAggregatesAddHostMap() (map[string]any, error) {
 }
 
 // AddHost makes a request against the API to add host to a specific aggregate.
-func AddHost(ctx context.Context, client *gophercloud.ServiceClient, aggregateID int, opts AddHostOpts) (r ActionResult) {
+func AddHost(ctx context.Context, client gophercloud.Client, aggregateID int, opts AddHostOpts) (r ActionResult) {
 	v := strconv.Itoa(aggregateID)
 
 	b, err := opts.ToAggregatesAddHostMap()
@@ -130,7 +130,7 @@ func (opts RemoveHostOpts) ToAggregatesRemoveHostMap() (map[string]any, error) {
 }
 
 // RemoveHost makes a request against the API to remove host from a specific aggregate.
-func RemoveHost(ctx context.Context, client *gophercloud.ServiceClient, aggregateID int, opts RemoveHostOpts) (r ActionResult) {
+func RemoveHost(ctx context.Context, client gophercloud.Client, aggregateID int, opts RemoveHostOpts) (r ActionResult) {
 	v := strconv.Itoa(aggregateID)
 
 	b, err := opts.ToAggregatesRemoveHostMap()
@@ -154,7 +154,7 @@ func (opts SetMetadataOpts) ToSetMetadataMap() (map[string]any, error) {
 }
 
 // SetMetadata makes a request against the API to set metadata to a specific aggregate.
-func SetMetadata(ctx context.Context, client *gophercloud.ServiceClient, aggregateID int, opts SetMetadataOpts) (r ActionResult) {
+func SetMetadata(ctx context.Context, client gophercloud.Client, aggregateID int, opts SetMetadataOpts) (r ActionResult) {
 	v := strconv.Itoa(aggregateID)
 
 	b, err := opts.ToSetMetadataMap()

--- a/openstack/compute/v2/aggregates/urls.go
+++ b/openstack/compute/v2/aggregates/urls.go
@@ -2,34 +2,34 @@ package aggregates
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func aggregatesListURL(c *gophercloud.ServiceClient) string {
+func aggregatesListURL(c gophercloud.Client) string {
 	return c.ServiceURL("os-aggregates")
 }
 
-func aggregatesCreateURL(c *gophercloud.ServiceClient) string {
+func aggregatesCreateURL(c gophercloud.Client) string {
 	return c.ServiceURL("os-aggregates")
 }
 
-func aggregatesDeleteURL(c *gophercloud.ServiceClient, aggregateID string) string {
+func aggregatesDeleteURL(c gophercloud.Client, aggregateID string) string {
 	return c.ServiceURL("os-aggregates", aggregateID)
 }
 
-func aggregatesGetURL(c *gophercloud.ServiceClient, aggregateID string) string {
+func aggregatesGetURL(c gophercloud.Client, aggregateID string) string {
 	return c.ServiceURL("os-aggregates", aggregateID)
 }
 
-func aggregatesUpdateURL(c *gophercloud.ServiceClient, aggregateID string) string {
+func aggregatesUpdateURL(c gophercloud.Client, aggregateID string) string {
 	return c.ServiceURL("os-aggregates", aggregateID)
 }
 
-func aggregatesAddHostURL(c *gophercloud.ServiceClient, aggregateID string) string {
+func aggregatesAddHostURL(c gophercloud.Client, aggregateID string) string {
 	return c.ServiceURL("os-aggregates", aggregateID, "action")
 }
 
-func aggregatesRemoveHostURL(c *gophercloud.ServiceClient, aggregateID string) string {
+func aggregatesRemoveHostURL(c gophercloud.Client, aggregateID string) string {
 	return c.ServiceURL("os-aggregates", aggregateID, "action")
 }
 
-func aggregatesSetMetadataURL(c *gophercloud.ServiceClient, aggregateID string) string {
+func aggregatesSetMetadataURL(c gophercloud.Client, aggregateID string) string {
 	return c.ServiceURL("os-aggregates", aggregateID, "action")
 }

--- a/openstack/compute/v2/attachinterfaces/requests.go
+++ b/openstack/compute/v2/attachinterfaces/requests.go
@@ -8,14 +8,14 @@ import (
 )
 
 // List makes a request against the nova API to list the server's interfaces.
-func List(client *gophercloud.ServiceClient, serverID string) pagination.Pager {
+func List(client gophercloud.Client, serverID string) pagination.Pager {
 	return pagination.NewPager(client, listInterfaceURL(client, serverID), func(r pagination.PageResult) pagination.Page {
 		return InterfacePage{pagination.SinglePageBase(r)}
 	})
 }
 
 // Get requests details on a single interface attachment by the server and port IDs.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, serverID, portID string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, serverID, portID string) (r GetResult) {
 	resp, err := client.Get(ctx, getInterfaceURL(client, serverID, portID), &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{200},
 	})
@@ -55,7 +55,7 @@ func (opts CreateOpts) ToAttachInterfacesCreateMap() (map[string]any, error) {
 }
 
 // Create requests the creation of a new interface attachment on the server.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, serverID string, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, serverID string, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToAttachInterfacesCreateMap()
 	if err != nil {
 		r.Err = err
@@ -70,7 +70,7 @@ func Create(ctx context.Context, client *gophercloud.ServiceClient, serverID str
 
 // Delete makes a request against the nova API to detach a single interface from the server.
 // It needs server and port IDs to make a such request.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, serverID, portID string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, serverID, portID string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, deleteInterfaceURL(client, serverID, portID), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/compute/v2/attachinterfaces/urls.go
+++ b/openstack/compute/v2/attachinterfaces/urls.go
@@ -2,17 +2,17 @@ package attachinterfaces
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func listInterfaceURL(client *gophercloud.ServiceClient, serverID string) string {
+func listInterfaceURL(client gophercloud.Client, serverID string) string {
 	return client.ServiceURL("servers", serverID, "os-interface")
 }
 
-func getInterfaceURL(client *gophercloud.ServiceClient, serverID, portID string) string {
+func getInterfaceURL(client gophercloud.Client, serverID, portID string) string {
 	return client.ServiceURL("servers", serverID, "os-interface", portID)
 }
 
-func createInterfaceURL(client *gophercloud.ServiceClient, serverID string) string {
+func createInterfaceURL(client gophercloud.Client, serverID string) string {
 	return client.ServiceURL("servers", serverID, "os-interface")
 }
-func deleteInterfaceURL(client *gophercloud.ServiceClient, serverID, portID string) string {
+func deleteInterfaceURL(client gophercloud.Client, serverID, portID string) string {
 	return client.ServiceURL("servers", serverID, "os-interface", portID)
 }

--- a/openstack/compute/v2/availabilityzones/requests.go
+++ b/openstack/compute/v2/availabilityzones/requests.go
@@ -6,14 +6,14 @@ import (
 )
 
 // List will return the existing availability zones.
-func List(client *gophercloud.ServiceClient) pagination.Pager {
+func List(client gophercloud.Client) pagination.Pager {
 	return pagination.NewPager(client, listURL(client), func(r pagination.PageResult) pagination.Page {
 		return AvailabilityZonePage{pagination.SinglePageBase(r)}
 	})
 }
 
 // ListDetail will return the existing availability zones with detailed information.
-func ListDetail(client *gophercloud.ServiceClient) pagination.Pager {
+func ListDetail(client gophercloud.Client) pagination.Pager {
 	return pagination.NewPager(client, listDetailURL(client), func(r pagination.PageResult) pagination.Page {
 		return AvailabilityZonePage{pagination.SinglePageBase(r)}
 	})

--- a/openstack/compute/v2/availabilityzones/urls.go
+++ b/openstack/compute/v2/availabilityzones/urls.go
@@ -2,10 +2,10 @@ package availabilityzones
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func listURL(c *gophercloud.ServiceClient) string {
+func listURL(c gophercloud.Client) string {
 	return c.ServiceURL("os-availability-zone")
 }
 
-func listDetailURL(c *gophercloud.ServiceClient) string {
+func listDetailURL(c gophercloud.Client) string {
 	return c.ServiceURL("os-availability-zone", "detail")
 }

--- a/openstack/compute/v2/diagnostics/requests.go
+++ b/openstack/compute/v2/diagnostics/requests.go
@@ -7,7 +7,7 @@ import (
 )
 
 // Diagnostics
-func Get(ctx context.Context, client *gophercloud.ServiceClient, serverId string) (r serverDiagnosticsResult) {
+func Get(ctx context.Context, client gophercloud.Client, serverId string) (r serverDiagnosticsResult) {
 	resp, err := client.Get(ctx, serverDiagnosticsURL(client, serverId), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/compute/v2/diagnostics/urls.go
+++ b/openstack/compute/v2/diagnostics/urls.go
@@ -3,6 +3,6 @@ package diagnostics
 import "github.com/gophercloud/gophercloud/v2"
 
 // serverDiagnosticsURL returns the diagnostics url for a nova instance/server
-func serverDiagnosticsURL(client *gophercloud.ServiceClient, id string) string {
+func serverDiagnosticsURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL("servers", id, "diagnostics")
 }

--- a/openstack/compute/v2/extensions/delegate.go
+++ b/openstack/compute/v2/extensions/delegate.go
@@ -14,12 +14,12 @@ func ExtractExtensions(page pagination.Page) ([]common.Extension, error) {
 }
 
 // Get retrieves information for a specific extension using its alias.
-func Get(ctx context.Context, c *gophercloud.ServiceClient, alias string) common.GetResult {
+func Get(ctx context.Context, c gophercloud.Client, alias string) common.GetResult {
 	return common.Get(ctx, c, alias)
 }
 
 // List returns a Pager which allows you to iterate over the full collection of extensions.
 // It does not accept query parameters.
-func List(c *gophercloud.ServiceClient) pagination.Pager {
+func List(c gophercloud.Client) pagination.Pager {
 	return common.List(c)
 }

--- a/openstack/compute/v2/extensions/urls.go
+++ b/openstack/compute/v2/extensions/urls.go
@@ -2,6 +2,6 @@ package extensions
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func ActionURL(client *gophercloud.ServiceClient, id string) string {
+func ActionURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL("servers", id, "action")
 }

--- a/openstack/compute/v2/flavors/requests.go
+++ b/openstack/compute/v2/flavors/requests.go
@@ -84,7 +84,7 @@ func (opts ListOpts) ToFlavorListQuery() (string, error) {
 // ListDetail instructs OpenStack to provide a list of flavors.
 // You may provide criteria by which List curtails its results for easier
 // processing.
-func ListDetail(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func ListDetail(client gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(client)
 	if opts != nil {
 		query, err := opts.ToFlavorListQuery()
@@ -143,7 +143,7 @@ func (opts CreateOpts) ToFlavorCreateMap() (map[string]any, error) {
 }
 
 // Create requests the creation of a new flavor.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToFlavorCreateMap()
 	if err != nil {
 		r.Err = err
@@ -174,7 +174,7 @@ func (opts UpdateOpts) ToFlavorUpdateMap() (map[string]any, error) {
 }
 
 // Update requests the update of a new flavor.
-func Update(ctx context.Context, client *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, client gophercloud.Client, id string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToFlavorUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -189,21 +189,21 @@ func Update(ctx context.Context, client *gophercloud.ServiceClient, id string, o
 
 // Get retrieves details of a single flavor. Use Extract to convert its
 // result into a Flavor.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, id string) (r GetResult) {
 	resp, err := client.Get(ctx, getURL(client, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
 // Delete deletes the specified flavor ID.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, id string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, deleteURL(client, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
 // ListAccesses retrieves the tenants which have access to a flavor.
-func ListAccesses(client *gophercloud.ServiceClient, id string) pagination.Pager {
+func ListAccesses(client gophercloud.Client, id string) pagination.Pager {
 	url := accessURL(client, id)
 
 	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
@@ -229,7 +229,7 @@ func (opts AddAccessOpts) ToFlavorAddAccessMap() (map[string]any, error) {
 }
 
 // AddAccess grants a tenant/project access to a flavor.
-func AddAccess(ctx context.Context, client *gophercloud.ServiceClient, id string, opts AddAccessOptsBuilder) (r AddAccessResult) {
+func AddAccess(ctx context.Context, client gophercloud.Client, id string, opts AddAccessOptsBuilder) (r AddAccessResult) {
 	b, err := opts.ToFlavorAddAccessMap()
 	if err != nil {
 		r.Err = err
@@ -260,7 +260,7 @@ func (opts RemoveAccessOpts) ToFlavorRemoveAccessMap() (map[string]any, error) {
 }
 
 // RemoveAccess removes/revokes a tenant/project access to a flavor.
-func RemoveAccess(ctx context.Context, client *gophercloud.ServiceClient, id string, opts RemoveAccessOptsBuilder) (r RemoveAccessResult) {
+func RemoveAccess(ctx context.Context, client gophercloud.Client, id string, opts RemoveAccessOptsBuilder) (r RemoveAccessResult) {
 	b, err := opts.ToFlavorRemoveAccessMap()
 	if err != nil {
 		r.Err = err
@@ -274,13 +274,13 @@ func RemoveAccess(ctx context.Context, client *gophercloud.ServiceClient, id str
 }
 
 // ExtraSpecs requests all the extra-specs for the given flavor ID.
-func ListExtraSpecs(ctx context.Context, client *gophercloud.ServiceClient, flavorID string) (r ListExtraSpecsResult) {
+func ListExtraSpecs(ctx context.Context, client gophercloud.Client, flavorID string) (r ListExtraSpecsResult) {
 	resp, err := client.Get(ctx, extraSpecsListURL(client, flavorID), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
-func GetExtraSpec(ctx context.Context, client *gophercloud.ServiceClient, flavorID string, key string) (r GetExtraSpecResult) {
+func GetExtraSpec(ctx context.Context, client gophercloud.Client, flavorID string, key string) (r GetExtraSpecResult) {
 	resp, err := client.Get(ctx, extraSpecsGetURL(client, flavorID, key), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -303,7 +303,7 @@ func (opts ExtraSpecsOpts) ToFlavorExtraSpecsCreateMap() (map[string]any, error)
 
 // CreateExtraSpecs will create or update the extra-specs key-value pairs for
 // the specified Flavor.
-func CreateExtraSpecs(ctx context.Context, client *gophercloud.ServiceClient, flavorID string, opts CreateExtraSpecsOptsBuilder) (r CreateExtraSpecsResult) {
+func CreateExtraSpecs(ctx context.Context, client gophercloud.Client, flavorID string, opts CreateExtraSpecsOptsBuilder) (r CreateExtraSpecsResult) {
 	b, err := opts.ToFlavorExtraSpecsCreateMap()
 	if err != nil {
 		r.Err = err
@@ -342,7 +342,7 @@ func (opts ExtraSpecsOpts) ToFlavorExtraSpecUpdateMap() (map[string]string, stri
 
 // UpdateExtraSpec will updates the value of the specified flavor's extra spec
 // for the key in opts.
-func UpdateExtraSpec(ctx context.Context, client *gophercloud.ServiceClient, flavorID string, opts UpdateExtraSpecOptsBuilder) (r UpdateExtraSpecResult) {
+func UpdateExtraSpec(ctx context.Context, client gophercloud.Client, flavorID string, opts UpdateExtraSpecOptsBuilder) (r UpdateExtraSpecResult) {
 	b, key, err := opts.ToFlavorExtraSpecUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -357,7 +357,7 @@ func UpdateExtraSpec(ctx context.Context, client *gophercloud.ServiceClient, fla
 
 // DeleteExtraSpec will delete the key-value pair with the given key for the given
 // flavor ID.
-func DeleteExtraSpec(ctx context.Context, client *gophercloud.ServiceClient, flavorID, key string) (r DeleteExtraSpecResult) {
+func DeleteExtraSpec(ctx context.Context, client gophercloud.Client, flavorID, key string) (r DeleteExtraSpecResult) {
 	resp, err := client.Delete(ctx, extraSpecDeleteURL(client, flavorID, key), &gophercloud.RequestOpts{
 		OkCodes: []int{200},
 	})

--- a/openstack/compute/v2/flavors/urls.go
+++ b/openstack/compute/v2/flavors/urls.go
@@ -4,50 +4,50 @@ import (
 	"github.com/gophercloud/gophercloud/v2"
 )
 
-func getURL(client *gophercloud.ServiceClient, id string) string {
+func getURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL("flavors", id)
 }
 
-func listURL(client *gophercloud.ServiceClient) string {
+func listURL(client gophercloud.Client) string {
 	return client.ServiceURL("flavors", "detail")
 }
 
-func createURL(client *gophercloud.ServiceClient) string {
+func createURL(client gophercloud.Client) string {
 	return client.ServiceURL("flavors")
 }
 
-func updateURL(client *gophercloud.ServiceClient, id string) string {
+func updateURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL("flavors", id)
 }
 
-func deleteURL(client *gophercloud.ServiceClient, id string) string {
+func deleteURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL("flavors", id)
 }
 
-func accessURL(client *gophercloud.ServiceClient, id string) string {
+func accessURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL("flavors", id, "os-flavor-access")
 }
 
-func accessActionURL(client *gophercloud.ServiceClient, id string) string {
+func accessActionURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL("flavors", id, "action")
 }
 
-func extraSpecsListURL(client *gophercloud.ServiceClient, id string) string {
+func extraSpecsListURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL("flavors", id, "os-extra_specs")
 }
 
-func extraSpecsGetURL(client *gophercloud.ServiceClient, id, key string) string {
+func extraSpecsGetURL(client gophercloud.Client, id, key string) string {
 	return client.ServiceURL("flavors", id, "os-extra_specs", key)
 }
 
-func extraSpecsCreateURL(client *gophercloud.ServiceClient, id string) string {
+func extraSpecsCreateURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL("flavors", id, "os-extra_specs")
 }
 
-func extraSpecUpdateURL(client *gophercloud.ServiceClient, id, key string) string {
+func extraSpecUpdateURL(client gophercloud.Client, id, key string) string {
 	return client.ServiceURL("flavors", id, "os-extra_specs", key)
 }
 
-func extraSpecDeleteURL(client *gophercloud.ServiceClient, id, key string) string {
+func extraSpecDeleteURL(client gophercloud.Client, id, key string) string {
 	return client.ServiceURL("flavors", id, "os-extra_specs", key)
 }

--- a/openstack/compute/v2/hypervisors/requests.go
+++ b/openstack/compute/v2/hypervisors/requests.go
@@ -42,7 +42,7 @@ func (opts ListOpts) ToHypervisorListQuery() (string, error) {
 }
 
 // List makes a request against the API to list hypervisors.
-func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(client gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := hypervisorsListDetailURL(client)
 	if opts != nil {
 		query, err := opts.ToHypervisorListQuery()
@@ -58,7 +58,7 @@ func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pa
 }
 
 // Statistics makes a request against the API to get hypervisors statistics.
-func GetStatistics(ctx context.Context, client *gophercloud.ServiceClient) (r StatisticsResult) {
+func GetStatistics(ctx context.Context, client gophercloud.Client) (r StatisticsResult) {
 	resp, err := client.Get(ctx, hypervisorsStatisticsURL(client), &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{200},
 	})
@@ -67,7 +67,7 @@ func GetStatistics(ctx context.Context, client *gophercloud.ServiceClient) (r St
 }
 
 // Get makes a request against the API to get details for specific hypervisor.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, hypervisorID string) (r HypervisorResult) {
+func Get(ctx context.Context, client gophercloud.Client, hypervisorID string) (r HypervisorResult) {
 	resp, err := client.Get(ctx, hypervisorsGetURL(client, hypervisorID), &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{200},
 	})
@@ -76,7 +76,7 @@ func Get(ctx context.Context, client *gophercloud.ServiceClient, hypervisorID st
 }
 
 // GetUptime makes a request against the API to get uptime for specific hypervisor.
-func GetUptime(ctx context.Context, client *gophercloud.ServiceClient, hypervisorID string) (r UptimeResult) {
+func GetUptime(ctx context.Context, client gophercloud.Client, hypervisorID string) (r UptimeResult) {
 	resp, err := client.Get(ctx, hypervisorsUptimeURL(client, hypervisorID), &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{200},
 	})

--- a/openstack/compute/v2/hypervisors/urls.go
+++ b/openstack/compute/v2/hypervisors/urls.go
@@ -2,18 +2,18 @@ package hypervisors
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func hypervisorsListDetailURL(c *gophercloud.ServiceClient) string {
+func hypervisorsListDetailURL(c gophercloud.Client) string {
 	return c.ServiceURL("os-hypervisors", "detail")
 }
 
-func hypervisorsStatisticsURL(c *gophercloud.ServiceClient) string {
+func hypervisorsStatisticsURL(c gophercloud.Client) string {
 	return c.ServiceURL("os-hypervisors", "statistics")
 }
 
-func hypervisorsGetURL(c *gophercloud.ServiceClient, hypervisorID string) string {
+func hypervisorsGetURL(c gophercloud.Client, hypervisorID string) string {
 	return c.ServiceURL("os-hypervisors", hypervisorID)
 }
 
-func hypervisorsUptimeURL(c *gophercloud.ServiceClient, hypervisorID string) string {
+func hypervisorsUptimeURL(c gophercloud.Client, hypervisorID string) string {
 	return c.ServiceURL("os-hypervisors", hypervisorID, "uptime")
 }

--- a/openstack/compute/v2/instanceactions/request.go
+++ b/openstack/compute/v2/instanceactions/request.go
@@ -57,7 +57,7 @@ func (opts ListOpts) ToInstanceActionsListQuery() (string, error) {
 }
 
 // List makes a request against the API to list the servers actions.
-func List(client *gophercloud.ServiceClient, id string, opts ListOptsBuilder) pagination.Pager {
+func List(client gophercloud.Client, id string, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(client, id)
 	if opts != nil {
 		query, err := opts.ToInstanceActionsListQuery()
@@ -72,7 +72,7 @@ func List(client *gophercloud.ServiceClient, id string, opts ListOptsBuilder) pa
 }
 
 // Get makes a request against the API to get a server action.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, serverID, requestID string) (r InstanceActionResult) {
+func Get(ctx context.Context, client gophercloud.Client, serverID, requestID string) (r InstanceActionResult) {
 	resp, err := client.Get(ctx, instanceActionsURL(client, serverID, requestID), &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{200},
 	})

--- a/openstack/compute/v2/instanceactions/urls.go
+++ b/openstack/compute/v2/instanceactions/urls.go
@@ -2,10 +2,10 @@ package instanceactions
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func listURL(client *gophercloud.ServiceClient, id string) string {
+func listURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL("servers", id, "os-instance-actions")
 }
 
-func instanceActionsURL(client *gophercloud.ServiceClient, serverID, requestID string) string {
+func instanceActionsURL(client gophercloud.Client, serverID, requestID string) string {
 	return client.ServiceURL("servers", serverID, "os-instance-actions", requestID)
 }

--- a/openstack/compute/v2/keypairs/requests.go
+++ b/openstack/compute/v2/keypairs/requests.go
@@ -53,7 +53,7 @@ func (opts ListOpts) ToKeyPairListQuery() (string, error) {
 }
 
 // List returns a Pager that allows you to iterate over a collection of KeyPairs.
-func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(client gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(client)
 	if opts != nil {
 		query, err := opts.ToKeyPairListQuery()
@@ -99,7 +99,7 @@ func (opts CreateOpts) ToKeyPairCreateMap() (map[string]any, error) {
 
 // Create requests the creation of a new KeyPair on the server, or to import a
 // pre-existing keypair.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToKeyPairCreateMap()
 	if err != nil {
 		r.Err = err
@@ -132,7 +132,7 @@ func (opts GetOpts) ToKeyPairGetQuery() (string, error) {
 }
 
 // Get returns public data about a previously uploaded KeyPair.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, name string, opts GetOptsBuilder) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, name string, opts GetOptsBuilder) (r GetResult) {
 	url := getURL(client, name)
 	if opts != nil {
 		query, err := opts.ToKeyPairGetQuery()
@@ -168,7 +168,7 @@ func (opts DeleteOpts) ToKeyPairDeleteQuery() (string, error) {
 }
 
 // Delete requests the deletion of a previous stored KeyPair from the server.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, name string, opts DeleteOptsBuilder) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, name string, opts DeleteOptsBuilder) (r DeleteResult) {
 	url := deleteURL(client, name)
 	if opts != nil {
 		query, err := opts.ToKeyPairDeleteQuery()

--- a/openstack/compute/v2/keypairs/urls.go
+++ b/openstack/compute/v2/keypairs/urls.go
@@ -4,22 +4,22 @@ import "github.com/gophercloud/gophercloud/v2"
 
 const resourcePath = "os-keypairs"
 
-func resourceURL(c *gophercloud.ServiceClient) string {
+func resourceURL(c gophercloud.Client) string {
 	return c.ServiceURL(resourcePath)
 }
 
-func listURL(c *gophercloud.ServiceClient) string {
+func listURL(c gophercloud.Client) string {
 	return resourceURL(c)
 }
 
-func createURL(c *gophercloud.ServiceClient) string {
+func createURL(c gophercloud.Client) string {
 	return resourceURL(c)
 }
 
-func getURL(c *gophercloud.ServiceClient, name string) string {
+func getURL(c gophercloud.Client, name string) string {
 	return c.ServiceURL(resourcePath, name)
 }
 
-func deleteURL(c *gophercloud.ServiceClient, name string) string {
+func deleteURL(c gophercloud.Client, name string) string {
 	return getURL(c, name)
 }

--- a/openstack/compute/v2/limits/requests.go
+++ b/openstack/compute/v2/limits/requests.go
@@ -25,7 +25,7 @@ func (opts GetOpts) ToLimitsQuery() (string, error) {
 }
 
 // Get returns the limits about the currently scoped tenant.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, opts GetOptsBuilder) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, opts GetOptsBuilder) (r GetResult) {
 	url := getURL(client)
 	if opts != nil {
 		query, err := opts.ToLimitsQuery()

--- a/openstack/compute/v2/limits/urls.go
+++ b/openstack/compute/v2/limits/urls.go
@@ -6,6 +6,6 @@ import (
 
 const resourcePath = "limits"
 
-func getURL(c *gophercloud.ServiceClient) string {
+func getURL(c gophercloud.Client) string {
 	return c.ServiceURL(resourcePath)
 }

--- a/openstack/compute/v2/quotasets/requests.go
+++ b/openstack/compute/v2/quotasets/requests.go
@@ -7,21 +7,21 @@ import (
 )
 
 // Get returns public data about a previously created QuotaSet.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, tenantID string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, tenantID string) (r GetResult) {
 	resp, err := client.Get(ctx, getURL(client, tenantID), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
 // GetDetail returns detailed public data about a previously created QuotaSet.
-func GetDetail(ctx context.Context, client *gophercloud.ServiceClient, tenantID string) (r GetDetailResult) {
+func GetDetail(ctx context.Context, client gophercloud.Client, tenantID string) (r GetDetailResult) {
 	resp, err := client.Get(ctx, getDetailURL(client, tenantID), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
 // Updates the quotas for the given tenantID and returns the new QuotaSet.
-func Update(ctx context.Context, client *gophercloud.ServiceClient, tenantID string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, client gophercloud.Client, tenantID string, opts UpdateOptsBuilder) (r UpdateResult) {
 	reqBody, err := opts.ToComputeQuotaUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -34,7 +34,7 @@ func Update(ctx context.Context, client *gophercloud.ServiceClient, tenantID str
 }
 
 // Resets the quotas for the given tenant to their default values.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, tenantID string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, tenantID string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, deleteURL(client, tenantID), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/compute/v2/quotasets/urls.go
+++ b/openstack/compute/v2/quotasets/urls.go
@@ -4,18 +4,18 @@ import "github.com/gophercloud/gophercloud/v2"
 
 const resourcePath = "os-quota-sets"
 
-func getURL(c *gophercloud.ServiceClient, tenantID string) string {
+func getURL(c gophercloud.Client, tenantID string) string {
 	return c.ServiceURL(resourcePath, tenantID)
 }
 
-func getDetailURL(c *gophercloud.ServiceClient, tenantID string) string {
+func getDetailURL(c gophercloud.Client, tenantID string) string {
 	return c.ServiceURL(resourcePath, tenantID, "detail")
 }
 
-func updateURL(c *gophercloud.ServiceClient, tenantID string) string {
+func updateURL(c gophercloud.Client, tenantID string) string {
 	return getURL(c, tenantID)
 }
 
-func deleteURL(c *gophercloud.ServiceClient, tenantID string) string {
+func deleteURL(c gophercloud.Client, tenantID string) string {
 	return getURL(c, tenantID)
 }

--- a/openstack/compute/v2/remoteconsoles/requests.go
+++ b/openstack/compute/v2/remoteconsoles/requests.go
@@ -71,7 +71,7 @@ func (opts CreateOpts) ToRemoteConsoleCreateMap() (map[string]any, error) {
 }
 
 // Create requests the creation of a new remote console on the specified server.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, serverID string, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, serverID string, opts CreateOptsBuilder) (r CreateResult) {
 	reqBody, err := opts.ToRemoteConsoleCreateMap()
 	if err != nil {
 		r.Err = err

--- a/openstack/compute/v2/remoteconsoles/urls.go
+++ b/openstack/compute/v2/remoteconsoles/urls.go
@@ -8,10 +8,10 @@ const (
 	resourcePath = "remote-consoles"
 )
 
-func rootURL(c *gophercloud.ServiceClient, serverID string) string {
+func rootURL(c gophercloud.Client, serverID string) string {
 	return c.ServiceURL(rootPath, serverID, resourcePath)
 }
 
-func createURL(c *gophercloud.ServiceClient, serverID string) string {
+func createURL(c gophercloud.Client, serverID string) string {
 	return rootURL(c, serverID)
 }

--- a/openstack/compute/v2/secgroups/requests.go
+++ b/openstack/compute/v2/secgroups/requests.go
@@ -7,7 +7,7 @@ import (
 	"github.com/gophercloud/gophercloud/v2/pagination"
 )
 
-func commonList(client *gophercloud.ServiceClient, url string) pagination.Pager {
+func commonList(client gophercloud.Client, url string) pagination.Pager {
 	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
 		return SecurityGroupPage{pagination.SinglePageBase(r)}
 	})
@@ -15,13 +15,13 @@ func commonList(client *gophercloud.ServiceClient, url string) pagination.Pager 
 
 // List will return a collection of all the security groups for a particular
 // tenant.
-func List(client *gophercloud.ServiceClient) pagination.Pager {
+func List(client gophercloud.Client) pagination.Pager {
 	return commonList(client, rootURL(client))
 }
 
 // ListByServer will return a collection of all the security groups which are
 // associated with a particular server.
-func ListByServer(client *gophercloud.ServiceClient, serverID string) pagination.Pager {
+func ListByServer(client gophercloud.Client, serverID string) pagination.Pager {
 	return commonList(client, listByServerURL(client, serverID))
 }
 
@@ -45,7 +45,7 @@ func (opts CreateOpts) ToSecGroupCreateMap() (map[string]any, error) {
 }
 
 // Create will create a new security group.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToSecGroupCreateMap()
 	if err != nil {
 		r.Err = err
@@ -79,7 +79,7 @@ func (opts UpdateOpts) ToSecGroupUpdateMap() (map[string]any, error) {
 
 // Update will modify the mutable properties of a security group, notably its
 // name and description.
-func Update(ctx context.Context, client *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, client gophercloud.Client, id string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToSecGroupUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -93,14 +93,14 @@ func Update(ctx context.Context, client *gophercloud.ServiceClient, id string, o
 }
 
 // Get will return details for a particular security group.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, id string) (r GetResult) {
 	resp, err := client.Get(ctx, resourceURL(client, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
 // Delete will permanently delete a security group from the project.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, id string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, resourceURL(client, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -151,7 +151,7 @@ func (opts CreateRuleOpts) ToRuleCreateMap() (map[string]any, error) {
 // CreateRule will add a new rule to an existing security group (whose ID is
 // specified in CreateRuleOpts). You have the option of controlling inbound
 // traffic from either an IP range (CIDR) or from another security group.
-func CreateRule(ctx context.Context, client *gophercloud.ServiceClient, opts CreateRuleOptsBuilder) (r CreateRuleResult) {
+func CreateRule(ctx context.Context, client gophercloud.Client, opts CreateRuleOptsBuilder) (r CreateRuleResult) {
 	b, err := opts.ToRuleCreateMap()
 	if err != nil {
 		r.Err = err
@@ -165,7 +165,7 @@ func CreateRule(ctx context.Context, client *gophercloud.ServiceClient, opts Cre
 }
 
 // DeleteRule will permanently delete a rule from a security group.
-func DeleteRule(ctx context.Context, client *gophercloud.ServiceClient, id string) (r DeleteRuleResult) {
+func DeleteRule(ctx context.Context, client gophercloud.Client, id string) (r DeleteRuleResult) {
 	resp, err := client.Delete(ctx, resourceRuleURL(client, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -179,14 +179,14 @@ func actionMap(prefix, groupName string) map[string]map[string]string {
 
 // AddServer will associate a server and a security group, enforcing the
 // rules of the group on the server.
-func AddServer(ctx context.Context, client *gophercloud.ServiceClient, serverID, groupName string) (r AddServerResult) {
+func AddServer(ctx context.Context, client gophercloud.Client, serverID, groupName string) (r AddServerResult) {
 	resp, err := client.Post(ctx, serverActionURL(client, serverID), actionMap("add", groupName), nil, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
 // RemoveServer will disassociate a server from a security group.
-func RemoveServer(ctx context.Context, client *gophercloud.ServiceClient, serverID, groupName string) (r RemoveServerResult) {
+func RemoveServer(ctx context.Context, client gophercloud.Client, serverID, groupName string) (r RemoveServerResult) {
 	resp, err := client.Post(ctx, serverActionURL(client, serverID), actionMap("remove", groupName), nil, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/compute/v2/secgroups/urls.go
+++ b/openstack/compute/v2/secgroups/urls.go
@@ -7,26 +7,26 @@ const (
 	rulepath     = "os-security-group-rules"
 )
 
-func resourceURL(c *gophercloud.ServiceClient, id string) string {
+func resourceURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL(secgrouppath, id)
 }
 
-func rootURL(c *gophercloud.ServiceClient) string {
+func rootURL(c gophercloud.Client) string {
 	return c.ServiceURL(secgrouppath)
 }
 
-func listByServerURL(c *gophercloud.ServiceClient, serverID string) string {
+func listByServerURL(c gophercloud.Client, serverID string) string {
 	return c.ServiceURL("servers", serverID, secgrouppath)
 }
 
-func rootRuleURL(c *gophercloud.ServiceClient) string {
+func rootRuleURL(c gophercloud.Client) string {
 	return c.ServiceURL(rulepath)
 }
 
-func resourceRuleURL(c *gophercloud.ServiceClient, id string) string {
+func resourceRuleURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL(rulepath, id)
 }
 
-func serverActionURL(c *gophercloud.ServiceClient, id string) string {
+func serverActionURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("servers", id, "action")
 }

--- a/openstack/compute/v2/servergroups/requests.go
+++ b/openstack/compute/v2/servergroups/requests.go
@@ -30,7 +30,7 @@ func (opts ListOpts) ToServerListQuery() (string, error) {
 
 // List returns a Pager that allows you to iterate over a collection of
 // ServerGroups.
-func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(client gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(client)
 	if opts != nil {
 		query, err := opts.ToServerListQuery()
@@ -74,7 +74,7 @@ func (opts CreateOpts) ToServerGroupCreateMap() (map[string]any, error) {
 }
 
 // Create requests the creation of a new Server Group.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToServerGroupCreateMap()
 	if err != nil {
 		r.Err = err
@@ -88,14 +88,14 @@ func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateO
 }
 
 // Get returns data about a previously created ServerGroup.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, id string) (r GetResult) {
 	resp, err := client.Get(ctx, getURL(client, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
 // Delete requests the deletion of a previously allocated ServerGroup.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, id string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, deleteURL(client, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/compute/v2/servergroups/urls.go
+++ b/openstack/compute/v2/servergroups/urls.go
@@ -4,22 +4,22 @@ import "github.com/gophercloud/gophercloud/v2"
 
 const resourcePath = "os-server-groups"
 
-func resourceURL(c *gophercloud.ServiceClient) string {
+func resourceURL(c gophercloud.Client) string {
 	return c.ServiceURL(resourcePath)
 }
 
-func listURL(c *gophercloud.ServiceClient) string {
+func listURL(c gophercloud.Client) string {
 	return resourceURL(c)
 }
 
-func createURL(c *gophercloud.ServiceClient) string {
+func createURL(c gophercloud.Client) string {
 	return resourceURL(c)
 }
 
-func getURL(c *gophercloud.ServiceClient, id string) string {
+func getURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL(resourcePath, id)
 }
 
-func deleteURL(c *gophercloud.ServiceClient, id string) string {
+func deleteURL(c gophercloud.Client, id string) string {
 	return getURL(c, id)
 }

--- a/openstack/compute/v2/servers/requests.go
+++ b/openstack/compute/v2/servers/requests.go
@@ -100,7 +100,7 @@ func (opts ListOpts) ToServerListQuery() (string, error) {
 }
 
 // ListSimple makes a request against the API to list servers accessible to you.
-func ListSimple(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func ListSimple(client gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(client)
 	if opts != nil {
 		query, err := opts.ToServerListQuery()
@@ -115,7 +115,7 @@ func ListSimple(client *gophercloud.ServiceClient, opts ListOptsBuilder) paginat
 }
 
 // List makes a request against the API to list servers details accessible to you.
-func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(client gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := listDetailURL(client)
 	if opts != nil {
 		query, err := opts.ToServerListQuery()
@@ -582,7 +582,7 @@ func (opts CreateOpts) ToServerCreateMap() (map[string]any, error) {
 }
 
 // Create requests a server to be provisioned to the user in the current tenant.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder, hintOpts SchedulerHintOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, opts CreateOptsBuilder, hintOpts SchedulerHintOptsBuilder) (r CreateResult) {
 	b, err := opts.ToServerCreateMap()
 	if err != nil {
 		r.Err = err
@@ -607,21 +607,21 @@ func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateO
 
 // Delete requests that a server previously provisioned be removed from your
 // account.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, id string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, deleteURL(client, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
 // ForceDelete forces the deletion of a server.
-func ForceDelete(ctx context.Context, client *gophercloud.ServiceClient, id string) (r ActionResult) {
+func ForceDelete(ctx context.Context, client gophercloud.Client, id string) (r ActionResult) {
 	resp, err := client.Post(ctx, actionURL(client, id), map[string]any{"forceDelete": ""}, nil, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
 // Get requests details on a single server, by ID.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, id string) (r GetResult) {
 	resp, err := client.Get(ctx, getURL(client, id), &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{200, 203},
 	})
@@ -656,7 +656,7 @@ func (opts UpdateOpts) ToServerUpdateMap() (map[string]any, error) {
 }
 
 // Update requests that various attributes of the indicated server be changed.
-func Update(ctx context.Context, client *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, client gophercloud.Client, id string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToServerUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -671,7 +671,7 @@ func Update(ctx context.Context, client *gophercloud.ServiceClient, id string, o
 
 // ChangeAdminPassword alters the administrator or root password for a specified
 // server.
-func ChangeAdminPassword(ctx context.Context, client *gophercloud.ServiceClient, id, newPassword string) (r ActionResult) {
+func ChangeAdminPassword(ctx context.Context, client gophercloud.Client, id, newPassword string) (r ActionResult) {
 	b := map[string]any{
 		"changePassword": map[string]string{
 			"adminPass": newPassword,
@@ -726,7 +726,7 @@ procedure.
 E.g., in Linux, asking it to enter runlevel 6, or executing
 "sudo shutdown -r now", or by asking Windows to rtart the machine.
 */
-func Reboot(ctx context.Context, client *gophercloud.ServiceClient, id string, opts RebootOptsBuilder) (r ActionResult) {
+func Reboot(ctx context.Context, client gophercloud.Client, id string, opts RebootOptsBuilder) (r ActionResult) {
 	b, err := opts.ToServerRebootMap()
 	if err != nil {
 		r.Err = err
@@ -792,7 +792,7 @@ func (opts RebuildOpts) ToServerRebuildMap() (map[string]any, error) {
 
 // Rebuild will reprovision the server according to the configuration options
 // provided in the RebuildOpts struct.
-func Rebuild(ctx context.Context, client *gophercloud.ServiceClient, id string, opts RebuildOptsBuilder) (r RebuildResult) {
+func Rebuild(ctx context.Context, client gophercloud.Client, id string, opts RebuildOptsBuilder) (r RebuildResult) {
 	b, err := opts.ToServerRebuildMap()
 	if err != nil {
 		r.Err = err
@@ -841,7 +841,7 @@ func (opts ResizeOpts) ToServerResizeMap() (map[string]any, error) {
 // While in this state, you can explore the use of the new server's
 // configuration. If you like it, call ConfirmResize() to commit the resize
 // permanently. Otherwise, call RevertResize() to restore the old configuration.
-func Resize(ctx context.Context, client *gophercloud.ServiceClient, id string, opts ResizeOptsBuilder) (r ActionResult) {
+func Resize(ctx context.Context, client gophercloud.Client, id string, opts ResizeOptsBuilder) (r ActionResult) {
 	b, err := opts.ToServerResizeMap()
 	if err != nil {
 		r.Err = err
@@ -854,7 +854,7 @@ func Resize(ctx context.Context, client *gophercloud.ServiceClient, id string, o
 
 // ConfirmResize confirms a previous resize operation on a server.
 // See Resize() for more details.
-func ConfirmResize(ctx context.Context, client *gophercloud.ServiceClient, id string) (r ActionResult) {
+func ConfirmResize(ctx context.Context, client gophercloud.Client, id string) (r ActionResult) {
 	resp, err := client.Post(ctx, actionURL(client, id), map[string]any{"confirmResize": nil}, nil, &gophercloud.RequestOpts{
 		OkCodes: []int{201, 202, 204},
 	})
@@ -864,7 +864,7 @@ func ConfirmResize(ctx context.Context, client *gophercloud.ServiceClient, id st
 
 // RevertResize cancels a previous resize operation on a server.
 // See Resize() for more details.
-func RevertResize(ctx context.Context, client *gophercloud.ServiceClient, id string) (r ActionResult) {
+func RevertResize(ctx context.Context, client gophercloud.Client, id string) (r ActionResult) {
 	resp, err := client.Post(ctx, actionURL(client, id), map[string]any{"revertResize": nil}, nil, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -896,7 +896,7 @@ func (opts MetadataOpts) ToMetadataUpdateMap() (map[string]any, error) {
 // Note: Using this operation will erase any already-existing metadata and
 // create the new metadata provided. To keep any already-existing metadata,
 // use the UpdateMetadatas or UpdateMetadata function.
-func ResetMetadata(ctx context.Context, client *gophercloud.ServiceClient, id string, opts ResetMetadataOptsBuilder) (r ResetMetadataResult) {
+func ResetMetadata(ctx context.Context, client gophercloud.Client, id string, opts ResetMetadataOptsBuilder) (r ResetMetadataResult) {
 	b, err := opts.ToMetadataResetMap()
 	if err != nil {
 		r.Err = err
@@ -910,7 +910,7 @@ func ResetMetadata(ctx context.Context, client *gophercloud.ServiceClient, id st
 }
 
 // Metadata requests all the metadata for the given server ID.
-func Metadata(ctx context.Context, client *gophercloud.ServiceClient, id string) (r GetMetadataResult) {
+func Metadata(ctx context.Context, client gophercloud.Client, id string) (r GetMetadataResult) {
 	resp, err := client.Get(ctx, metadataURL(client, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -925,7 +925,7 @@ type UpdateMetadataOptsBuilder interface {
 // UpdateMetadata updates (or creates) all the metadata specified by opts for
 // the given server ID. This operation does not affect already-existing metadata
 // that is not specified by opts.
-func UpdateMetadata(ctx context.Context, client *gophercloud.ServiceClient, id string, opts UpdateMetadataOptsBuilder) (r UpdateMetadataResult) {
+func UpdateMetadata(ctx context.Context, client gophercloud.Client, id string, opts UpdateMetadataOptsBuilder) (r UpdateMetadataResult) {
 	b, err := opts.ToMetadataUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -966,7 +966,7 @@ func (opts MetadatumOpts) ToMetadatumCreateMap() (map[string]any, string, error)
 
 // CreateMetadatum will create or update the key-value pair with the given key
 // for the given server ID.
-func CreateMetadatum(ctx context.Context, client *gophercloud.ServiceClient, id string, opts MetadatumOptsBuilder) (r CreateMetadatumResult) {
+func CreateMetadatum(ctx context.Context, client gophercloud.Client, id string, opts MetadatumOptsBuilder) (r CreateMetadatumResult) {
 	b, key, err := opts.ToMetadatumCreateMap()
 	if err != nil {
 		r.Err = err
@@ -981,7 +981,7 @@ func CreateMetadatum(ctx context.Context, client *gophercloud.ServiceClient, id 
 
 // Metadatum requests the key-value pair with the given key for the given
 // server ID.
-func Metadatum(ctx context.Context, client *gophercloud.ServiceClient, id, key string) (r GetMetadatumResult) {
+func Metadatum(ctx context.Context, client gophercloud.Client, id, key string) (r GetMetadatumResult) {
 	resp, err := client.Get(ctx, metadatumURL(client, id, key), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -989,7 +989,7 @@ func Metadatum(ctx context.Context, client *gophercloud.ServiceClient, id, key s
 
 // DeleteMetadatum will delete the key-value pair with the given key for the
 // given server ID.
-func DeleteMetadatum(ctx context.Context, client *gophercloud.ServiceClient, id, key string) (r DeleteMetadatumResult) {
+func DeleteMetadatum(ctx context.Context, client gophercloud.Client, id, key string) (r DeleteMetadatumResult) {
 	resp, err := client.Delete(ctx, metadatumURL(client, id, key), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -997,7 +997,7 @@ func DeleteMetadatum(ctx context.Context, client *gophercloud.ServiceClient, id,
 
 // ListAddresses makes a request against the API to list the servers IP
 // addresses.
-func ListAddresses(client *gophercloud.ServiceClient, id string) pagination.Pager {
+func ListAddresses(client gophercloud.Client, id string) pagination.Pager {
 	return pagination.NewPager(client, listAddressesURL(client, id), func(r pagination.PageResult) pagination.Page {
 		return AddressPage{pagination.SinglePageBase(r)}
 	})
@@ -1005,7 +1005,7 @@ func ListAddresses(client *gophercloud.ServiceClient, id string) pagination.Page
 
 // ListAddressesByNetwork makes a request against the API to list the servers IP
 // addresses for the given network.
-func ListAddressesByNetwork(client *gophercloud.ServiceClient, id, network string) pagination.Pager {
+func ListAddressesByNetwork(client gophercloud.Client, id, network string) pagination.Pager {
 	return pagination.NewPager(client, listAddressesByNetworkURL(client, id, network), func(r pagination.PageResult) pagination.Page {
 		return NetworkAddressPage{pagination.SinglePageBase(r)}
 	})
@@ -1035,7 +1035,7 @@ func (opts CreateImageOpts) ToServerCreateImageMap() (map[string]any, error) {
 
 // CreateImage makes a request against the nova API to schedule an image to be
 // created of the server
-func CreateImage(ctx context.Context, client *gophercloud.ServiceClient, id string, opts CreateImageOptsBuilder) (r CreateImageResult) {
+func CreateImage(ctx context.Context, client gophercloud.Client, id string, opts CreateImageOptsBuilder) (r CreateImageResult) {
 	b, err := opts.ToServerCreateImageMap()
 	if err != nil {
 		r.Err = err
@@ -1050,7 +1050,7 @@ func CreateImage(ctx context.Context, client *gophercloud.ServiceClient, id stri
 
 // GetPassword makes a request against the nova API to get the encrypted
 // administrative password.
-func GetPassword(ctx context.Context, client *gophercloud.ServiceClient, serverId string) (r GetPasswordResult) {
+func GetPassword(ctx context.Context, client gophercloud.Client, serverId string) (r GetPasswordResult) {
 	resp, err := client.Get(ctx, passwordURL(client, serverId), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -1075,7 +1075,7 @@ func (opts ShowConsoleOutputOpts) ToServerShowConsoleOutputMap() (map[string]any
 }
 
 // ShowConsoleOutput makes a request against the nova API to get console log from the server
-func ShowConsoleOutput(ctx context.Context, client *gophercloud.ServiceClient, id string, opts ShowConsoleOutputOptsBuilder) (r ShowConsoleOutputResult) {
+func ShowConsoleOutput(ctx context.Context, client gophercloud.Client, id string, opts ShowConsoleOutputOptsBuilder) (r ShowConsoleOutputResult) {
 	b, err := opts.ToServerShowConsoleOutputMap()
 	if err != nil {
 		r.Err = err
@@ -1112,7 +1112,7 @@ func (opts EvacuateOpts) ToEvacuateMap() (map[string]any, error) {
 }
 
 // Evacuate will Evacuate a failed instance to another host.
-func Evacuate(ctx context.Context, client *gophercloud.ServiceClient, id string, opts EvacuateOptsBuilder) (r EvacuateResult) {
+func Evacuate(ctx context.Context, client gophercloud.Client, id string, opts EvacuateOptsBuilder) (r EvacuateResult) {
 	b, err := opts.ToEvacuateMap()
 	if err != nil {
 		r.Err = err
@@ -1126,7 +1126,7 @@ func Evacuate(ctx context.Context, client *gophercloud.ServiceClient, id string,
 }
 
 // InjectNetworkInfo will inject the network info into a server
-func InjectNetworkInfo(ctx context.Context, client *gophercloud.ServiceClient, id string) (r InjectNetworkResult) {
+func InjectNetworkInfo(ctx context.Context, client gophercloud.Client, id string) (r InjectNetworkResult) {
 	b := map[string]any{
 		"injectNetworkInfo": nil,
 	}
@@ -1136,21 +1136,21 @@ func InjectNetworkInfo(ctx context.Context, client *gophercloud.ServiceClient, i
 }
 
 // Lock is the operation responsible for locking a Compute server.
-func Lock(ctx context.Context, client *gophercloud.ServiceClient, id string) (r LockResult) {
+func Lock(ctx context.Context, client gophercloud.Client, id string) (r LockResult) {
 	resp, err := client.Post(ctx, actionURL(client, id), map[string]any{"lock": nil}, nil, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
 // Unlock is the operation responsible for unlocking a Compute server.
-func Unlock(ctx context.Context, client *gophercloud.ServiceClient, id string) (r UnlockResult) {
+func Unlock(ctx context.Context, client gophercloud.Client, id string) (r UnlockResult) {
 	resp, err := client.Post(ctx, actionURL(client, id), map[string]any{"unlock": nil}, nil, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
 // Migrate will initiate a migration of the instance to another host.
-func Migrate(ctx context.Context, client *gophercloud.ServiceClient, id string) (r MigrateResult) {
+func Migrate(ctx context.Context, client gophercloud.Client, id string) (r MigrateResult) {
 	resp, err := client.Post(ctx, actionURL(client, id), map[string]any{"migrate": nil}, nil, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -1185,7 +1185,7 @@ func (opts LiveMigrateOpts) ToLiveMigrateMap() (map[string]any, error) {
 }
 
 // LiveMigrate will initiate a live-migration (without rebooting) of the instance to another host.
-func LiveMigrate(ctx context.Context, client *gophercloud.ServiceClient, id string, opts LiveMigrateOptsBuilder) (r MigrateResult) {
+func LiveMigrate(ctx context.Context, client gophercloud.Client, id string, opts LiveMigrateOptsBuilder) (r MigrateResult) {
 	b, err := opts.ToLiveMigrateMap()
 	if err != nil {
 		r.Err = err
@@ -1197,14 +1197,14 @@ func LiveMigrate(ctx context.Context, client *gophercloud.ServiceClient, id stri
 }
 
 // Pause is the operation responsible for pausing a Compute server.
-func Pause(ctx context.Context, client *gophercloud.ServiceClient, id string) (r PauseResult) {
+func Pause(ctx context.Context, client gophercloud.Client, id string) (r PauseResult) {
 	resp, err := client.Post(ctx, actionURL(client, id), map[string]any{"pause": nil}, nil, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
 // Unpause is the operation responsible for unpausing a Compute server.
-func Unpause(ctx context.Context, client *gophercloud.ServiceClient, id string) (r UnpauseResult) {
+func Unpause(ctx context.Context, client gophercloud.Client, id string) (r UnpauseResult) {
 	resp, err := client.Post(ctx, actionURL(client, id), map[string]any{"unpause": nil}, nil, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -1237,7 +1237,7 @@ func (opts RescueOpts) ToServerRescueMap() (map[string]any, error) {
 }
 
 // Rescue instructs the provider to place the server into RESCUE mode.
-func Rescue(ctx context.Context, client *gophercloud.ServiceClient, id string, opts RescueOptsBuilder) (r RescueResult) {
+func Rescue(ctx context.Context, client gophercloud.Client, id string, opts RescueOptsBuilder) (r RescueResult) {
 	b, err := opts.ToServerRescueMap()
 	if err != nil {
 		r.Err = err
@@ -1251,14 +1251,14 @@ func Rescue(ctx context.Context, client *gophercloud.ServiceClient, id string, o
 }
 
 // Unrescue instructs the provider to return the server from RESCUE mode.
-func Unrescue(ctx context.Context, client *gophercloud.ServiceClient, id string) (r UnrescueResult) {
+func Unrescue(ctx context.Context, client gophercloud.Client, id string) (r UnrescueResult) {
 	resp, err := client.Post(ctx, actionURL(client, id), map[string]any{"unrescue": nil}, nil, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
 // ResetNetwork will reset the network of a server
-func ResetNetwork(ctx context.Context, client *gophercloud.ServiceClient, id string) (r ResetNetworkResult) {
+func ResetNetwork(ctx context.Context, client gophercloud.Client, id string) (r ResetNetworkResult) {
 	b := map[string]any{
 		"resetNetwork": nil,
 	}
@@ -1279,7 +1279,7 @@ const (
 )
 
 // ResetState will reset the state of a server
-func ResetState(ctx context.Context, client *gophercloud.ServiceClient, id string, state ServerState) (r ResetStateResult) {
+func ResetState(ctx context.Context, client gophercloud.Client, id string, state ServerState) (r ResetStateResult) {
 	stateMap := map[string]any{"state": state}
 	resp, err := client.Post(ctx, actionURL(client, id), map[string]any{"os-resetState": stateMap}, nil, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
@@ -1287,14 +1287,14 @@ func ResetState(ctx context.Context, client *gophercloud.ServiceClient, id strin
 }
 
 // Shelve is the operation responsible for shelving a Compute server.
-func Shelve(ctx context.Context, client *gophercloud.ServiceClient, id string) (r ShelveResult) {
+func Shelve(ctx context.Context, client gophercloud.Client, id string) (r ShelveResult) {
 	resp, err := client.Post(ctx, actionURL(client, id), map[string]any{"shelve": nil}, nil, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
 // ShelveOffload is the operation responsible for Shelve-Offload a Compute server.
-func ShelveOffload(ctx context.Context, client *gophercloud.ServiceClient, id string) (r ShelveOffloadResult) {
+func ShelveOffload(ctx context.Context, client gophercloud.Client, id string) (r ShelveOffloadResult) {
 	resp, err := client.Post(ctx, actionURL(client, id), map[string]any{"shelveOffload": nil}, nil, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -1329,7 +1329,7 @@ func (opts UnshelveOpts) ToUnshelveMap() (map[string]any, error) {
 }
 
 // Unshelve is the operation responsible for unshelve a Compute server.
-func Unshelve(ctx context.Context, client *gophercloud.ServiceClient, id string, opts UnshelveOptsBuilder) (r UnshelveResult) {
+func Unshelve(ctx context.Context, client gophercloud.Client, id string, opts UnshelveOptsBuilder) (r UnshelveResult) {
 	b, err := opts.ToUnshelveMap()
 	if err != nil {
 		r.Err = err
@@ -1341,28 +1341,28 @@ func Unshelve(ctx context.Context, client *gophercloud.ServiceClient, id string,
 }
 
 // Start is the operation responsible for starting a Compute server.
-func Start(ctx context.Context, client *gophercloud.ServiceClient, id string) (r StartResult) {
+func Start(ctx context.Context, client gophercloud.Client, id string) (r StartResult) {
 	resp, err := client.Post(ctx, actionURL(client, id), map[string]any{"os-start": nil}, nil, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
 // Stop is the operation responsible for stopping a Compute server.
-func Stop(ctx context.Context, client *gophercloud.ServiceClient, id string) (r StopResult) {
+func Stop(ctx context.Context, client gophercloud.Client, id string) (r StopResult) {
 	resp, err := client.Post(ctx, actionURL(client, id), map[string]any{"os-stop": nil}, nil, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
 // Suspend is the operation responsible for suspending a Compute server.
-func Suspend(ctx context.Context, client *gophercloud.ServiceClient, id string) (r SuspendResult) {
+func Suspend(ctx context.Context, client gophercloud.Client, id string) (r SuspendResult) {
 	resp, err := client.Post(ctx, actionURL(client, id), map[string]any{"suspend": nil}, nil, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
 // Resume is the operation responsible for resuming a Compute server.
-func Resume(ctx context.Context, client *gophercloud.ServiceClient, id string) (r ResumeResult) {
+func Resume(ctx context.Context, client gophercloud.Client, id string) (r ResumeResult) {
 	resp, err := client.Post(ctx, actionURL(client, id), map[string]any{"resume": nil}, nil, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/compute/v2/servers/urls.go
+++ b/openstack/compute/v2/servers/urls.go
@@ -2,50 +2,50 @@ package servers
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func createURL(client *gophercloud.ServiceClient) string {
+func createURL(client gophercloud.Client) string {
 	return client.ServiceURL("servers")
 }
 
-func listURL(client *gophercloud.ServiceClient) string {
+func listURL(client gophercloud.Client) string {
 	return createURL(client)
 }
 
-func listDetailURL(client *gophercloud.ServiceClient) string {
+func listDetailURL(client gophercloud.Client) string {
 	return client.ServiceURL("servers", "detail")
 }
 
-func deleteURL(client *gophercloud.ServiceClient, id string) string {
+func deleteURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL("servers", id)
 }
 
-func getURL(client *gophercloud.ServiceClient, id string) string {
+func getURL(client gophercloud.Client, id string) string {
 	return deleteURL(client, id)
 }
 
-func updateURL(client *gophercloud.ServiceClient, id string) string {
+func updateURL(client gophercloud.Client, id string) string {
 	return deleteURL(client, id)
 }
 
-func actionURL(client *gophercloud.ServiceClient, id string) string {
+func actionURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL("servers", id, "action")
 }
 
-func metadatumURL(client *gophercloud.ServiceClient, id, key string) string {
+func metadatumURL(client gophercloud.Client, id, key string) string {
 	return client.ServiceURL("servers", id, "metadata", key)
 }
 
-func metadataURL(client *gophercloud.ServiceClient, id string) string {
+func metadataURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL("servers", id, "metadata")
 }
 
-func listAddressesURL(client *gophercloud.ServiceClient, id string) string {
+func listAddressesURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL("servers", id, "ips")
 }
 
-func listAddressesByNetworkURL(client *gophercloud.ServiceClient, id, network string) string {
+func listAddressesByNetworkURL(client gophercloud.Client, id, network string) string {
 	return client.ServiceURL("servers", id, "ips", network)
 }
 
-func passwordURL(client *gophercloud.ServiceClient, id string) string {
+func passwordURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL("servers", id, "os-server-password")
 }

--- a/openstack/compute/v2/servers/util.go
+++ b/openstack/compute/v2/servers/util.go
@@ -8,7 +8,7 @@ import (
 
 // WaitForStatus will continually poll a server until it successfully
 // transitions to a specified status.
-func WaitForStatus(ctx context.Context, c *gophercloud.ServiceClient, id, status string) error {
+func WaitForStatus(ctx context.Context, c gophercloud.Client, id, status string) error {
 	return gophercloud.WaitFor(ctx, func(ctx context.Context) (bool, error) {
 		current, err := Get(ctx, c, id).Extract()
 		if err != nil {

--- a/openstack/compute/v2/services/requests.go
+++ b/openstack/compute/v2/services/requests.go
@@ -26,7 +26,7 @@ func (opts ListOpts) ToServicesListQuery() (string, error) {
 }
 
 // List makes a request against the API to list services.
-func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(client gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(client)
 	if opts != nil {
 		query, err := opts.ToServicesListQuery()
@@ -70,7 +70,7 @@ func (opts UpdateOpts) ToServiceUpdateMap() (map[string]any, error) {
 }
 
 // Update requests that various attributes of the indicated service be changed.
-func Update(ctx context.Context, client *gophercloud.ServiceClient, id string, opts UpdateOpts) (r UpdateResult) {
+func Update(ctx context.Context, client gophercloud.Client, id string, opts UpdateOpts) (r UpdateResult) {
 	b, err := opts.ToServiceUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -84,7 +84,7 @@ func Update(ctx context.Context, client *gophercloud.ServiceClient, id string, o
 }
 
 // Delete will delete the existing service with the provided ID.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, id string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, updateURL(client, id), &gophercloud.RequestOpts{
 		OkCodes: []int{204},
 	})

--- a/openstack/compute/v2/services/urls.go
+++ b/openstack/compute/v2/services/urls.go
@@ -2,10 +2,10 @@ package services
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func listURL(c *gophercloud.ServiceClient) string {
+func listURL(c gophercloud.Client) string {
 	return c.ServiceURL("os-services")
 }
 
-func updateURL(c *gophercloud.ServiceClient, id string) string {
+func updateURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("os-services", id)
 }

--- a/openstack/compute/v2/tags/requests.go
+++ b/openstack/compute/v2/tags/requests.go
@@ -7,7 +7,7 @@ import (
 )
 
 // List all tags on a server.
-func List(ctx context.Context, client *gophercloud.ServiceClient, serverID string) (r ListResult) {
+func List(ctx context.Context, client gophercloud.Client, serverID string) (r ListResult) {
 	url := listURL(client, serverID)
 	resp, err := client.Get(ctx, url, &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{200},
@@ -17,7 +17,7 @@ func List(ctx context.Context, client *gophercloud.ServiceClient, serverID strin
 }
 
 // Check if a tag exists on a server.
-func Check(ctx context.Context, client *gophercloud.ServiceClient, serverID, tag string) (r CheckResult) {
+func Check(ctx context.Context, client gophercloud.Client, serverID, tag string) (r CheckResult) {
 	url := checkURL(client, serverID, tag)
 	resp, err := client.Get(ctx, url, nil, &gophercloud.RequestOpts{
 		OkCodes: []int{204},
@@ -42,7 +42,7 @@ func (opts ReplaceAllOpts) ToTagsReplaceAllMap() (map[string]any, error) {
 }
 
 // ReplaceAll replaces all Tags on a server.
-func ReplaceAll(ctx context.Context, client *gophercloud.ServiceClient, serverID string, opts ReplaceAllOptsBuilder) (r ReplaceAllResult) {
+func ReplaceAll(ctx context.Context, client gophercloud.Client, serverID string, opts ReplaceAllOptsBuilder) (r ReplaceAllResult) {
 	b, err := opts.ToTagsReplaceAllMap()
 	url := replaceAllURL(client, serverID)
 	if err != nil {
@@ -57,7 +57,7 @@ func ReplaceAll(ctx context.Context, client *gophercloud.ServiceClient, serverID
 }
 
 // Add adds a new Tag on a server.
-func Add(ctx context.Context, client *gophercloud.ServiceClient, serverID, tag string) (r AddResult) {
+func Add(ctx context.Context, client gophercloud.Client, serverID, tag string) (r AddResult) {
 	url := addURL(client, serverID, tag)
 	resp, err := client.Put(ctx, url, nil, nil, &gophercloud.RequestOpts{
 		OkCodes: []int{201, 204},
@@ -67,7 +67,7 @@ func Add(ctx context.Context, client *gophercloud.ServiceClient, serverID, tag s
 }
 
 // Delete removes a tag from a server.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, serverID, tag string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, serverID, tag string) (r DeleteResult) {
 	url := deleteURL(client, serverID, tag)
 	resp, err := client.Delete(ctx, url, &gophercloud.RequestOpts{
 		OkCodes: []int{204},
@@ -77,7 +77,7 @@ func Delete(ctx context.Context, client *gophercloud.ServiceClient, serverID, ta
 }
 
 // DeleteAll removes all tag from a server.
-func DeleteAll(ctx context.Context, client *gophercloud.ServiceClient, serverID string) (r DeleteResult) {
+func DeleteAll(ctx context.Context, client gophercloud.Client, serverID string) (r DeleteResult) {
 	url := deleteAllURL(client, serverID)
 	resp, err := client.Delete(ctx, url, &gophercloud.RequestOpts{
 		OkCodes: []int{204},

--- a/openstack/compute/v2/tags/urls.go
+++ b/openstack/compute/v2/tags/urls.go
@@ -7,34 +7,34 @@ const (
 	resourcePath     = "tags"
 )
 
-func rootURL(c *gophercloud.ServiceClient, serverID string) string {
+func rootURL(c gophercloud.Client, serverID string) string {
 	return c.ServiceURL(rootResourcePath, serverID, resourcePath)
 }
 
-func resourceURL(c *gophercloud.ServiceClient, serverID, tag string) string {
+func resourceURL(c gophercloud.Client, serverID, tag string) string {
 	return c.ServiceURL(rootResourcePath, serverID, resourcePath, tag)
 }
 
-func listURL(c *gophercloud.ServiceClient, serverID string) string {
+func listURL(c gophercloud.Client, serverID string) string {
 	return rootURL(c, serverID)
 }
 
-func checkURL(c *gophercloud.ServiceClient, serverID, tag string) string {
+func checkURL(c gophercloud.Client, serverID, tag string) string {
 	return resourceURL(c, serverID, tag)
 }
 
-func replaceAllURL(c *gophercloud.ServiceClient, serverID string) string {
+func replaceAllURL(c gophercloud.Client, serverID string) string {
 	return rootURL(c, serverID)
 }
 
-func addURL(c *gophercloud.ServiceClient, serverID, tag string) string {
+func addURL(c gophercloud.Client, serverID, tag string) string {
 	return resourceURL(c, serverID, tag)
 }
 
-func deleteURL(c *gophercloud.ServiceClient, serverID, tag string) string {
+func deleteURL(c gophercloud.Client, serverID, tag string) string {
 	return resourceURL(c, serverID, tag)
 }
 
-func deleteAllURL(c *gophercloud.ServiceClient, serverID string) string {
+func deleteAllURL(c gophercloud.Client, serverID string) string {
 	return rootURL(c, serverID)
 }

--- a/openstack/compute/v2/usage/requests.go
+++ b/openstack/compute/v2/usage/requests.go
@@ -53,7 +53,7 @@ func (opts SingleTenantOpts) ToUsageSingleTenantQuery() (string, error) {
 }
 
 // SingleTenant returns usage data about a single tenant.
-func SingleTenant(client *gophercloud.ServiceClient, tenantID string, opts SingleTenantOptsBuilder) pagination.Pager {
+func SingleTenant(client gophercloud.Client, tenantID string, opts SingleTenantOptsBuilder) pagination.Pager {
 	url := getTenantURL(client, tenantID)
 	if opts != nil {
 		query, err := opts.ToUsageSingleTenantQuery()
@@ -119,7 +119,7 @@ func (opts AllTenantsOpts) ToUsageAllTenantsQuery() (string, error) {
 }
 
 // AllTenants returns usage data about all tenants.
-func AllTenants(client *gophercloud.ServiceClient, opts AllTenantsOptsBuilder) pagination.Pager {
+func AllTenants(client gophercloud.Client, opts AllTenantsOptsBuilder) pagination.Pager {
 	url := allTenantsURL(client)
 	if opts != nil {
 		query, err := opts.ToUsageAllTenantsQuery()

--- a/openstack/compute/v2/usage/urls.go
+++ b/openstack/compute/v2/usage/urls.go
@@ -4,10 +4,10 @@ import "github.com/gophercloud/gophercloud/v2"
 
 const resourcePath = "os-simple-tenant-usage"
 
-func allTenantsURL(client *gophercloud.ServiceClient) string {
+func allTenantsURL(client gophercloud.Client) string {
 	return client.ServiceURL(resourcePath)
 }
 
-func getTenantURL(client *gophercloud.ServiceClient, tenantID string) string {
+func getTenantURL(client gophercloud.Client, tenantID string) string {
 	return client.ServiceURL(resourcePath, tenantID)
 }

--- a/openstack/compute/v2/volumeattach/requests.go
+++ b/openstack/compute/v2/volumeattach/requests.go
@@ -9,7 +9,7 @@ import (
 
 // List returns a Pager that allows you to iterate over a collection of
 // VolumeAttachments.
-func List(client *gophercloud.ServiceClient, serverID string) pagination.Pager {
+func List(client gophercloud.Client, serverID string) pagination.Pager {
 	return pagination.NewPager(client, listURL(client, serverID), func(r pagination.PageResult) pagination.Page {
 		return VolumeAttachmentPage{pagination.SinglePageBase(r)}
 	})
@@ -44,7 +44,7 @@ func (opts CreateOpts) ToVolumeAttachmentCreateMap() (map[string]any, error) {
 }
 
 // Create requests the creation of a new volume attachment on the server.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, serverID string, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, serverID string, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToVolumeAttachmentCreateMap()
 	if err != nil {
 		r.Err = err
@@ -58,7 +58,7 @@ func Create(ctx context.Context, client *gophercloud.ServiceClient, serverID str
 }
 
 // Get returns public data about a previously created VolumeAttachment.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, serverID, volumeID string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, serverID, volumeID string) (r GetResult) {
 	resp, err := client.Get(ctx, getURL(client, serverID, volumeID), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -66,7 +66,7 @@ func Get(ctx context.Context, client *gophercloud.ServiceClient, serverID, volum
 
 // Delete requests the deletion of a previous stored VolumeAttachment from
 // the server.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, serverID, volumeID string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, serverID, volumeID string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, deleteURL(client, serverID, volumeID), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/compute/v2/volumeattach/urls.go
+++ b/openstack/compute/v2/volumeattach/urls.go
@@ -4,22 +4,22 @@ import "github.com/gophercloud/gophercloud/v2"
 
 const resourcePath = "os-volume_attachments"
 
-func resourceURL(c *gophercloud.ServiceClient, serverID string) string {
+func resourceURL(c gophercloud.Client, serverID string) string {
 	return c.ServiceURL("servers", serverID, resourcePath)
 }
 
-func listURL(c *gophercloud.ServiceClient, serverID string) string {
+func listURL(c gophercloud.Client, serverID string) string {
 	return resourceURL(c, serverID)
 }
 
-func createURL(c *gophercloud.ServiceClient, serverID string) string {
+func createURL(c gophercloud.Client, serverID string) string {
 	return resourceURL(c, serverID)
 }
 
-func getURL(c *gophercloud.ServiceClient, serverID, aID string) string {
+func getURL(c gophercloud.Client, serverID, aID string) string {
 	return c.ServiceURL("servers", serverID, resourcePath, aID)
 }
 
-func deleteURL(c *gophercloud.ServiceClient, serverID, aID string) string {
+func deleteURL(c gophercloud.Client, serverID, aID string) string {
 	return getURL(c, serverID, aID)
 }

--- a/openstack/container/v1/capsules/requests.go
+++ b/openstack/container/v1/capsules/requests.go
@@ -22,7 +22,7 @@ type ListOptsBuilder interface {
 }
 
 // Get requests details on a single capsule, by ID.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, id string) (r GetResult) {
 	resp, err := client.Get(ctx, getURL(client, id), &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{200, 203},
 	})
@@ -55,7 +55,7 @@ func (opts CreateOpts) ToCapsuleCreateMap() (map[string]any, error) {
 }
 
 // Create implements create capsule request.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToCapsuleCreateMap()
 	if err != nil {
 		r.Err = err
@@ -85,7 +85,7 @@ func (opts ListOpts) ToCapsuleListQuery() (string, error) {
 }
 
 // List makes a request against the API to list capsules accessible to you.
-func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(client gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(client)
 	if opts != nil {
 		query, err := opts.ToCapsuleListQuery()
@@ -100,7 +100,7 @@ func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pa
 }
 
 // Delete implements Capsule delete request.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, id string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, deleteURL(client, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/container/v1/capsules/urls.go
+++ b/openstack/container/v1/capsules/urls.go
@@ -2,20 +2,20 @@ package capsules
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func getURL(client *gophercloud.ServiceClient, id string) string {
+func getURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL("capsules", id)
 }
 
-func createURL(client *gophercloud.ServiceClient) string {
+func createURL(client gophercloud.Client) string {
 	return client.ServiceURL("capsules")
 }
 
 // `listURL` is a pure function. `listURL(c)` is a URL for which a GET
 // request will respond with a list of capsules in the service `c`.
-func listURL(c *gophercloud.ServiceClient) string {
+func listURL(c gophercloud.Client) string {
 	return c.ServiceURL("capsules")
 }
 
-func deleteURL(c *gophercloud.ServiceClient, id string) string {
+func deleteURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("capsules", id)
 }

--- a/openstack/containerinfra/apiversions/requests.go
+++ b/openstack/containerinfra/apiversions/requests.go
@@ -8,14 +8,14 @@ import (
 )
 
 // List lists all the API versions available to end-users.
-func List(c *gophercloud.ServiceClient) pagination.Pager {
+func List(c gophercloud.Client) pagination.Pager {
 	return pagination.NewPager(c, listURL(c), func(r pagination.PageResult) pagination.Page {
 		return APIVersionPage{pagination.SinglePageBase(r)}
 	})
 }
 
 // Get will get a specific API version, specified by major ID.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, v string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, v string) (r GetResult) {
 	resp, err := client.Get(ctx, getURL(client, v), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/containerinfra/apiversions/urls.go
+++ b/openstack/containerinfra/apiversions/urls.go
@@ -7,14 +7,14 @@ import (
 	"github.com/gophercloud/gophercloud/v2/openstack/utils"
 )
 
-func getURL(c *gophercloud.ServiceClient, version string) string {
-	baseEndpoint, _ := utils.BaseEndpoint(c.Endpoint)
+func getURL(c gophercloud.Client, version string) string {
+	baseEndpoint, _ := utils.BaseEndpoint(c.EndpointURL())
 	endpoint := strings.TrimRight(baseEndpoint, "/") + "/" + strings.TrimRight(version, "/") + "/"
 	return endpoint
 }
 
-func listURL(c *gophercloud.ServiceClient) string {
-	baseEndpoint, _ := utils.BaseEndpoint(c.Endpoint)
+func listURL(c gophercloud.Client) string {
+	baseEndpoint, _ := utils.BaseEndpoint(c.EndpointURL())
 	endpoint := strings.TrimRight(baseEndpoint, "/") + "/"
 	return endpoint
 }

--- a/openstack/containerinfra/v1/certificates/requests.go
+++ b/openstack/containerinfra/v1/certificates/requests.go
@@ -25,7 +25,7 @@ func (opts CreateOpts) ToCertificateCreateMap() (map[string]any, error) {
 }
 
 // Get makes a request against the API to get details for a certificate.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, clusterID string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, clusterID string) (r GetResult) {
 	url := getURL(client, clusterID)
 	resp, err := client.Get(ctx, url, &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{200},
@@ -35,7 +35,7 @@ func Get(ctx context.Context, client *gophercloud.ServiceClient, clusterID strin
 }
 
 // Create requests the creation of a new certificate.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToCertificateCreateMap()
 	if err != nil {
 		r.Err = err
@@ -49,7 +49,7 @@ func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateO
 }
 
 // Update will rotate the CA certificate for a cluster
-func Update(ctx context.Context, client *gophercloud.ServiceClient, clusterID string) (r UpdateResult) {
+func Update(ctx context.Context, client gophercloud.Client, clusterID string) (r UpdateResult) {
 	resp, err := client.Patch(ctx, updateURL(client, clusterID), nil, &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{202},
 	})

--- a/openstack/containerinfra/v1/certificates/urls.go
+++ b/openstack/containerinfra/v1/certificates/urls.go
@@ -6,18 +6,18 @@ import (
 
 var apiName = "certificates"
 
-func commonURL(client *gophercloud.ServiceClient) string {
+func commonURL(client gophercloud.Client) string {
 	return client.ServiceURL(apiName)
 }
 
-func getURL(client *gophercloud.ServiceClient, id string) string {
+func getURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL(apiName, id)
 }
 
-func createURL(client *gophercloud.ServiceClient) string {
+func createURL(client gophercloud.Client) string {
 	return commonURL(client)
 }
 
-func updateURL(client *gophercloud.ServiceClient, id string) string {
+func updateURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL(apiName, id)
 }

--- a/openstack/containerinfra/v1/clusters/requests.go
+++ b/openstack/containerinfra/v1/clusters/requests.go
@@ -38,7 +38,7 @@ func (opts CreateOpts) ToClusterCreateMap() (map[string]any, error) {
 }
 
 // Create requests the creation of a new cluster.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToClusterCreateMap()
 	if err != nil {
 		r.Err = err
@@ -52,14 +52,14 @@ func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateO
 }
 
 // Get retrieves a specific clusters based on its unique ID.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, id string) (r GetResult) {
 	resp, err := client.Get(ctx, getURL(client, id), &r.Body, &gophercloud.RequestOpts{OkCodes: []int{200}})
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
 // Delete deletes the specified cluster ID.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, id string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, deleteURL(client, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -91,7 +91,7 @@ func (opts ListOpts) ToClustersListQuery() (string, error) {
 // List returns a Pager which allows you to iterate over a collection of
 // clusters. It accepts a ListOptsBuilder, which allows you to sort
 // the returned collection for greater efficiency.
-func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(c gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(c)
 	if opts != nil {
 		query, err := opts.ToClustersListQuery()
@@ -109,7 +109,7 @@ func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 // clusters with detailed information.
 // It accepts a ListOptsBuilder, which allows you to sort the returned
 // collection for greater efficiency.
-func ListDetail(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func ListDetail(c gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := listDetailURL(c)
 	if opts != nil {
 		query, err := opts.ToClustersListQuery()
@@ -150,7 +150,7 @@ func (opts UpdateOpts) ToClustersUpdateMap() (map[string]any, error) {
 }
 
 // Update implements cluster updated request.
-func Update[T UpdateOptsBuilder](ctx context.Context, client *gophercloud.ServiceClient, id string, opts []T) (r UpdateResult) {
+func Update[T UpdateOptsBuilder](ctx context.Context, client gophercloud.Client, id string, opts []T) (r UpdateResult) {
 	var o []map[string]any
 	for _, opt := range opts {
 		b, err := opt.ToClustersUpdateMap()
@@ -189,7 +189,7 @@ func (opts UpgradeOpts) ToClustersUpgradeMap() (map[string]any, error) {
 }
 
 // Upgrade implements cluster upgrade request.
-func Upgrade(ctx context.Context, client *gophercloud.ServiceClient, id string, opts UpgradeOptsBuilder) (r UpgradeResult) {
+func Upgrade(ctx context.Context, client gophercloud.Client, id string, opts UpgradeOptsBuilder) (r UpgradeResult) {
 	b, err := opts.ToClustersUpgradeMap()
 	if err != nil {
 		r.Err = err
@@ -222,7 +222,7 @@ func (opts ResizeOpts) ToClusterResizeMap() (map[string]any, error) {
 }
 
 // Resize an existing cluster node count.
-func Resize(ctx context.Context, client *gophercloud.ServiceClient, id string, opts ResizeOptsBuilder) (r ResizeResult) {
+func Resize(ctx context.Context, client gophercloud.Client, id string, opts ResizeOptsBuilder) (r ResizeResult) {
 	b, err := opts.ToClusterResizeMap()
 	if err != nil {
 		r.Err = err

--- a/openstack/containerinfra/v1/clusters/urls.go
+++ b/openstack/containerinfra/v1/clusters/urls.go
@@ -6,42 +6,42 @@ import (
 
 var apiName = "clusters"
 
-func commonURL(client *gophercloud.ServiceClient) string {
+func commonURL(client gophercloud.Client) string {
 	return client.ServiceURL(apiName)
 }
 
-func idURL(client *gophercloud.ServiceClient, id string) string {
+func idURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL(apiName, id)
 }
 
-func createURL(client *gophercloud.ServiceClient) string {
+func createURL(client gophercloud.Client) string {
 	return commonURL(client)
 }
 
-func deleteURL(client *gophercloud.ServiceClient, id string) string {
+func deleteURL(client gophercloud.Client, id string) string {
 	return idURL(client, id)
 }
 
-func getURL(c *gophercloud.ServiceClient, id string) string {
+func getURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("clusters", id)
 }
 
-func listURL(client *gophercloud.ServiceClient) string {
+func listURL(client gophercloud.Client) string {
 	return client.ServiceURL("clusters")
 }
 
-func listDetailURL(client *gophercloud.ServiceClient) string {
+func listDetailURL(client gophercloud.Client) string {
 	return client.ServiceURL("clusters", "detail")
 }
 
-func updateURL(client *gophercloud.ServiceClient, id string) string {
+func updateURL(client gophercloud.Client, id string) string {
 	return idURL(client, id)
 }
 
-func upgradeURL(client *gophercloud.ServiceClient, id string) string {
+func upgradeURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL("clusters", id, "actions/upgrade")
 }
 
-func resizeURL(client *gophercloud.ServiceClient, id string) string {
+func resizeURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL("clusters", id, "actions/resize")
 }

--- a/openstack/containerinfra/v1/clustertemplates/requests.go
+++ b/openstack/containerinfra/v1/clustertemplates/requests.go
@@ -49,7 +49,7 @@ func (opts CreateOpts) ToClusterCreateMap() (map[string]any, error) {
 }
 
 // Create requests the creation of a new cluster.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToClusterCreateMap()
 	if err != nil {
 		r.Err = err
@@ -63,7 +63,7 @@ func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateO
 }
 
 // Delete deletes the specified cluster ID.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, id string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, deleteURL(client, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -95,7 +95,7 @@ func (opts ListOpts) ToClusterTemplateListQuery() (string, error) {
 // List returns a Pager which allows you to iterate over a collection of
 // cluster-templates. It accepts a ListOptsBuilder, which allows you to sort
 // the returned collection for greater efficiency.
-func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(client gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(client)
 	if opts != nil {
 		query, err := opts.ToClusterTemplateListQuery()
@@ -110,7 +110,7 @@ func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pa
 }
 
 // Get retrieves a specific cluster-template based on its unique ID.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, id string) (r GetResult) {
 	resp, err := client.Get(ctx, getURL(client, id), &r.Body, &gophercloud.RequestOpts{OkCodes: []int{200}})
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -148,7 +148,7 @@ func (opts UpdateOpts) ToClusterTemplateUpdateMap() (map[string]any, error) {
 }
 
 // Update implements cluster updated request.
-func Update[T UpdateOptsBuilder](ctx context.Context, client *gophercloud.ServiceClient, id string, opts []T) (r UpdateResult) {
+func Update[T UpdateOptsBuilder](ctx context.Context, client gophercloud.Client, id string, opts []T) (r UpdateResult) {
 	var o []map[string]any
 	for _, opt := range opts {
 		b, err := opt.ToClusterTemplateUpdateMap()

--- a/openstack/containerinfra/v1/clustertemplates/urls.go
+++ b/openstack/containerinfra/v1/clustertemplates/urls.go
@@ -6,30 +6,30 @@ import (
 
 var apiName = "clustertemplates"
 
-func commonURL(client *gophercloud.ServiceClient) string {
+func commonURL(client gophercloud.Client) string {
 	return client.ServiceURL(apiName)
 }
 
-func idURL(client *gophercloud.ServiceClient, id string) string {
+func idURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL(apiName, id)
 }
 
-func createURL(client *gophercloud.ServiceClient) string {
+func createURL(client gophercloud.Client) string {
 	return commonURL(client)
 }
 
-func deleteURL(client *gophercloud.ServiceClient, id string) string {
+func deleteURL(client gophercloud.Client, id string) string {
 	return idURL(client, id)
 }
 
-func listURL(client *gophercloud.ServiceClient) string {
+func listURL(client gophercloud.Client) string {
 	return commonURL(client)
 }
 
-func getURL(client *gophercloud.ServiceClient, id string) string {
+func getURL(client gophercloud.Client, id string) string {
 	return idURL(client, id)
 }
 
-func updateURL(client *gophercloud.ServiceClient, id string) string {
+func updateURL(client gophercloud.Client, id string) string {
 	return idURL(client, id)
 }

--- a/openstack/containerinfra/v1/nodegroups/requests.go
+++ b/openstack/containerinfra/v1/nodegroups/requests.go
@@ -11,7 +11,7 @@ import (
 // with the given ID/name belonging to the given cluster.
 // Use the Extract method of the returned GetResult to extract the
 // node group from the result.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, clusterID, nodeGroupID string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, clusterID, nodeGroupID string) (r GetResult) {
 	resp, err := client.Get(ctx, getURL(client, clusterID, nodeGroupID), &r.Body, &gophercloud.RequestOpts{OkCodes: []int{200}})
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -54,7 +54,7 @@ func (opts ListOpts) ToNodeGroupsListQuery() (string, error) {
 // NodeCount, Role, IsDefault, Status and StackID
 // are returned, all other fields are omitted
 // and will have their zero value when extracted.
-func List(client *gophercloud.ServiceClient, clusterID string, opts ListOptsBuilder) pagination.Pager {
+func List(client gophercloud.Client, clusterID string, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(client, clusterID)
 	if opts != nil {
 		query, err := opts.ToNodeGroupsListQuery()
@@ -101,7 +101,7 @@ func (opts CreateOpts) ToNodeGroupCreateMap() (map[string]any, error) {
 // for the the given cluster.
 // Use the Extract method of the returned CreateResult to extract the
 // returned node group.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, clusterID string, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, clusterID string, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToNodeGroupCreateMap()
 	if err != nil {
 		r.Err = err
@@ -143,7 +143,7 @@ func (opts UpdateOpts) ToResourceUpdateMap() (map[string]any, error) {
 // one UpdateOpts can be passed at a time.
 // Use the Extract method of the returned UpdateResult to extract the
 // updated node group from the result.
-func Update[T UpdateOptsBuilder](ctx context.Context, client *gophercloud.ServiceClient, clusterID string, nodeGroupID string, opts []T) (r UpdateResult) {
+func Update[T UpdateOptsBuilder](ctx context.Context, client gophercloud.Client, clusterID string, nodeGroupID string, opts []T) (r UpdateResult) {
 	var o []map[string]any
 	for _, opt := range opts {
 		b, err := opt.ToResourceUpdateMap()
@@ -159,7 +159,7 @@ func Update[T UpdateOptsBuilder](ctx context.Context, client *gophercloud.Servic
 }
 
 // Delete makes a request to the Magnum API to delete a node group.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, clusterID, nodeGroupID string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, clusterID, nodeGroupID string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, deleteURL(client, clusterID, nodeGroupID), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/containerinfra/v1/nodegroups/urls.go
+++ b/openstack/containerinfra/v1/nodegroups/urls.go
@@ -4,22 +4,22 @@ import (
 	"github.com/gophercloud/gophercloud/v2"
 )
 
-func getURL(c *gophercloud.ServiceClient, clusterID, nodeGroupID string) string {
+func getURL(c gophercloud.Client, clusterID, nodeGroupID string) string {
 	return c.ServiceURL("clusters", clusterID, "nodegroups", nodeGroupID)
 }
 
-func listURL(c *gophercloud.ServiceClient, clusterID string) string {
+func listURL(c gophercloud.Client, clusterID string) string {
 	return c.ServiceURL("clusters", clusterID, "nodegroups")
 }
 
-func createURL(c *gophercloud.ServiceClient, clusterID string) string {
+func createURL(c gophercloud.Client, clusterID string) string {
 	return c.ServiceURL("clusters", clusterID, "nodegroups")
 }
 
-func updateURL(c *gophercloud.ServiceClient, clusterID, nodeGroupID string) string {
+func updateURL(c gophercloud.Client, clusterID, nodeGroupID string) string {
 	return c.ServiceURL("clusters", clusterID, "nodegroups", nodeGroupID)
 }
 
-func deleteURL(c *gophercloud.ServiceClient, clusterID, nodeGroupID string) string {
+func deleteURL(c gophercloud.Client, clusterID, nodeGroupID string) string {
 	return c.ServiceURL("clusters", clusterID, "nodegroups", nodeGroupID)
 }

--- a/openstack/containerinfra/v1/quotas/requests.go
+++ b/openstack/containerinfra/v1/quotas/requests.go
@@ -24,7 +24,7 @@ func (opts CreateOpts) ToQuotaCreateMap() (map[string]any, error) {
 }
 
 // Create requests the creation of a new quota.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToQuotaCreateMap()
 	if err != nil {
 		r.Err = err

--- a/openstack/containerinfra/v1/quotas/urls.go
+++ b/openstack/containerinfra/v1/quotas/urls.go
@@ -6,10 +6,10 @@ import (
 
 var apiName = "quotas"
 
-func commonURL(client *gophercloud.ServiceClient) string {
+func commonURL(client gophercloud.Client) string {
 	return client.ServiceURL(apiName)
 }
 
-func createURL(client *gophercloud.ServiceClient) string {
+func createURL(client gophercloud.Client) string {
 	return commonURL(client)
 }

--- a/openstack/db/v1/configurations/requests.go
+++ b/openstack/db/v1/configurations/requests.go
@@ -9,7 +9,7 @@ import (
 )
 
 // List will list all of the available configurations.
-func List(client *gophercloud.ServiceClient) pagination.Pager {
+func List(client gophercloud.Client) pagination.Pager {
 	return pagination.NewPager(client, baseURL(client), func(r pagination.PageResult) pagination.Page {
 		return ConfigPage{pagination.SinglePageBase(r)}
 	})
@@ -49,7 +49,7 @@ func (opts CreateOpts) ToConfigCreateMap() (map[string]any, error) {
 }
 
 // Create will create a new configuration group.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToConfigCreateMap()
 	if err != nil {
 		r.Err = err
@@ -61,7 +61,7 @@ func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateO
 }
 
 // Get will retrieve the details for a specified configuration group.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, configID string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, configID string) (r GetResult) {
 	resp, err := client.Get(ctx, resourceURL(client, configID), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -95,7 +95,7 @@ func (opts UpdateOpts) ToConfigUpdateMap() (map[string]any, error) {
 // Update will modify an existing configuration group by performing a merge
 // between new and existing values. If the key already exists, the new value
 // will overwrite. All other keys will remain unaffected.
-func Update(ctx context.Context, client *gophercloud.ServiceClient, configID string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, client gophercloud.Client, configID string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToConfigUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -109,7 +109,7 @@ func Update(ctx context.Context, client *gophercloud.ServiceClient, configID str
 // Replace will modify an existing configuration group by overwriting the
 // entire parameter group with the new values provided. Any existing keys not
 // included in UpdateOptsBuilder will be deleted.
-func Replace(ctx context.Context, client *gophercloud.ServiceClient, configID string, opts UpdateOptsBuilder) (r ReplaceResult) {
+func Replace(ctx context.Context, client gophercloud.Client, configID string, opts UpdateOptsBuilder) (r ReplaceResult) {
 	b, err := opts.ToConfigUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -123,7 +123,7 @@ func Replace(ctx context.Context, client *gophercloud.ServiceClient, configID st
 // Delete will permanently delete a configuration group. Please note that
 // config groups cannot be deleted whilst still attached to running instances -
 // you must detach and then delete them.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, configID string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, configID string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, resourceURL(client, configID), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -131,7 +131,7 @@ func Delete(ctx context.Context, client *gophercloud.ServiceClient, configID str
 
 // ListInstances will list all the instances associated with a particular
 // configuration group.
-func ListInstances(client *gophercloud.ServiceClient, configID string) pagination.Pager {
+func ListInstances(client gophercloud.Client, configID string) pagination.Pager {
 	return pagination.NewPager(client, instancesURL(client, configID), func(r pagination.PageResult) pagination.Page {
 		return instances.InstancePage{LinkedPageBase: pagination.LinkedPageBase{PageResult: r}}
 	})
@@ -142,7 +142,7 @@ func ListInstances(client *gophercloud.ServiceClient, configID string) paginatio
 // For example, if you are wondering how you can configure a MySQL 5.6 instance,
 // you can use this operation (you will need to retrieve the MySQL datastore ID
 // by using the datastores API).
-func ListDatastoreParams(client *gophercloud.ServiceClient, datastoreID, versionID string) pagination.Pager {
+func ListDatastoreParams(client gophercloud.Client, datastoreID, versionID string) pagination.Pager {
 	return pagination.NewPager(client, listDSParamsURL(client, datastoreID, versionID), func(r pagination.PageResult) pagination.Page {
 		return ParamPage{pagination.SinglePageBase(r)}
 	})
@@ -153,7 +153,7 @@ func ListDatastoreParams(client *gophercloud.ServiceClient, datastoreID, version
 // "innodb_file_per_table" configuration param for MySQL datastores. You will
 // need the param's ID first, which can be attained by using the ListDatastoreParams
 // operation.
-func GetDatastoreParam(ctx context.Context, client *gophercloud.ServiceClient, datastoreID, versionID, paramID string) (r ParamResult) {
+func GetDatastoreParam(ctx context.Context, client gophercloud.Client, datastoreID, versionID, paramID string) (r ParamResult) {
 	resp, err := client.Get(ctx, getDSParamURL(client, datastoreID, versionID, paramID), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -161,7 +161,7 @@ func GetDatastoreParam(ctx context.Context, client *gophercloud.ServiceClient, d
 
 // ListGlobalParams is similar to ListDatastoreParams but does not require a
 // DatastoreID.
-func ListGlobalParams(client *gophercloud.ServiceClient, versionID string) pagination.Pager {
+func ListGlobalParams(client gophercloud.Client, versionID string) pagination.Pager {
 	return pagination.NewPager(client, listGlobalParamsURL(client, versionID), func(r pagination.PageResult) pagination.Page {
 		return ParamPage{pagination.SinglePageBase(r)}
 	})
@@ -169,7 +169,7 @@ func ListGlobalParams(client *gophercloud.ServiceClient, versionID string) pagin
 
 // GetGlobalParam is similar to GetDatastoreParam but does not require a
 // DatastoreID.
-func GetGlobalParam(ctx context.Context, client *gophercloud.ServiceClient, versionID, paramID string) (r ParamResult) {
+func GetGlobalParam(ctx context.Context, client gophercloud.Client, versionID, paramID string) (r ParamResult) {
 	resp, err := client.Get(ctx, getGlobalParamURL(client, versionID, paramID), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/db/v1/configurations/urls.go
+++ b/openstack/db/v1/configurations/urls.go
@@ -2,30 +2,30 @@ package configurations
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func baseURL(c *gophercloud.ServiceClient) string {
+func baseURL(c gophercloud.Client) string {
 	return c.ServiceURL("configurations")
 }
 
-func resourceURL(c *gophercloud.ServiceClient, configID string) string {
+func resourceURL(c gophercloud.Client, configID string) string {
 	return c.ServiceURL("configurations", configID)
 }
 
-func instancesURL(c *gophercloud.ServiceClient, configID string) string {
+func instancesURL(c gophercloud.Client, configID string) string {
 	return c.ServiceURL("configurations", configID, "instances")
 }
 
-func listDSParamsURL(c *gophercloud.ServiceClient, datastoreID, versionID string) string {
+func listDSParamsURL(c gophercloud.Client, datastoreID, versionID string) string {
 	return c.ServiceURL("datastores", datastoreID, "versions", versionID, "parameters")
 }
 
-func getDSParamURL(c *gophercloud.ServiceClient, datastoreID, versionID, paramID string) string {
+func getDSParamURL(c gophercloud.Client, datastoreID, versionID, paramID string) string {
 	return c.ServiceURL("datastores", datastoreID, "versions", versionID, "parameters", paramID)
 }
 
-func listGlobalParamsURL(c *gophercloud.ServiceClient, versionID string) string {
+func listGlobalParamsURL(c gophercloud.Client, versionID string) string {
 	return c.ServiceURL("datastores", "versions", versionID, "parameters")
 }
 
-func getGlobalParamURL(c *gophercloud.ServiceClient, versionID, paramID string) string {
+func getGlobalParamURL(c gophercloud.Client, versionID, paramID string) string {
 	return c.ServiceURL("datastores", "versions", versionID, "parameters", paramID)
 }

--- a/openstack/db/v1/databases/requests.go
+++ b/openstack/db/v1/databases/requests.go
@@ -64,7 +64,7 @@ func (opts BatchCreateOpts) ToDBCreateMap() (map[string]any, error) {
 
 // Create will create a new database within the specified instance. If the
 // specified instance does not exist, a 404 error will be returned.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, instanceID string, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, instanceID string, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToDBCreateMap()
 	if err != nil {
 		r.Err = err
@@ -78,7 +78,7 @@ func Create(ctx context.Context, client *gophercloud.ServiceClient, instanceID s
 // List will list all of the databases for a specified instance. Note: this
 // operation will only return user-defined databases; it will exclude system
 // databases like "mysql", "information_schema", "lost+found" etc.
-func List(client *gophercloud.ServiceClient, instanceID string) pagination.Pager {
+func List(client gophercloud.Client, instanceID string) pagination.Pager {
 	return pagination.NewPager(client, baseURL(client, instanceID), func(r pagination.PageResult) pagination.Page {
 		return DBPage{pagination.LinkedPageBase{PageResult: r}}
 	})
@@ -86,7 +86,7 @@ func List(client *gophercloud.ServiceClient, instanceID string) pagination.Pager
 
 // Delete will permanently delete the database within a specified instance.
 // All contained data inside the database will also be permanently deleted.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, instanceID, dbName string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, instanceID, dbName string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, dbURL(client, instanceID, dbName), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/db/v1/databases/urls.go
+++ b/openstack/db/v1/databases/urls.go
@@ -2,10 +2,10 @@ package databases
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func baseURL(c *gophercloud.ServiceClient, instanceID string) string {
+func baseURL(c gophercloud.Client, instanceID string) string {
 	return c.ServiceURL("instances", instanceID, "databases")
 }
 
-func dbURL(c *gophercloud.ServiceClient, instanceID, dbName string) string {
+func dbURL(c gophercloud.Client, instanceID, dbName string) string {
 	return c.ServiceURL("instances", instanceID, "databases", dbName)
 }

--- a/openstack/db/v1/datastores/requests.go
+++ b/openstack/db/v1/datastores/requests.go
@@ -8,14 +8,14 @@ import (
 )
 
 // List will list all available datastore types that instances can use.
-func List(client *gophercloud.ServiceClient) pagination.Pager {
+func List(client gophercloud.Client) pagination.Pager {
 	return pagination.NewPager(client, baseURL(client), func(r pagination.PageResult) pagination.Page {
 		return DatastorePage{pagination.SinglePageBase(r)}
 	})
 }
 
 // Get will retrieve the details of a specified datastore type.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, datastoreID string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, datastoreID string) (r GetResult) {
 	resp, err := client.Get(ctx, resourceURL(client, datastoreID), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -23,14 +23,14 @@ func Get(ctx context.Context, client *gophercloud.ServiceClient, datastoreID str
 
 // ListVersions will list all of the available versions for a specified
 // datastore type.
-func ListVersions(client *gophercloud.ServiceClient, datastoreID string) pagination.Pager {
+func ListVersions(client gophercloud.Client, datastoreID string) pagination.Pager {
 	return pagination.NewPager(client, versionsURL(client, datastoreID), func(r pagination.PageResult) pagination.Page {
 		return VersionPage{pagination.SinglePageBase(r)}
 	})
 }
 
 // GetVersion will retrieve the details of a specified datastore version.
-func GetVersion(ctx context.Context, client *gophercloud.ServiceClient, datastoreID, versionID string) (r GetVersionResult) {
+func GetVersion(ctx context.Context, client gophercloud.Client, datastoreID, versionID string) (r GetVersionResult) {
 	resp, err := client.Get(ctx, versionURL(client, datastoreID, versionID), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/db/v1/datastores/urls.go
+++ b/openstack/db/v1/datastores/urls.go
@@ -2,18 +2,18 @@ package datastores
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func baseURL(c *gophercloud.ServiceClient) string {
+func baseURL(c gophercloud.Client) string {
 	return c.ServiceURL("datastores")
 }
 
-func resourceURL(c *gophercloud.ServiceClient, dsID string) string {
+func resourceURL(c gophercloud.Client, dsID string) string {
 	return c.ServiceURL("datastores", dsID)
 }
 
-func versionsURL(c *gophercloud.ServiceClient, dsID string) string {
+func versionsURL(c gophercloud.Client, dsID string) string {
 	return c.ServiceURL("datastores", dsID, "versions")
 }
 
-func versionURL(c *gophercloud.ServiceClient, dsID, versionID string) string {
+func versionURL(c gophercloud.Client, dsID, versionID string) string {
 	return c.ServiceURL("datastores", dsID, "versions", versionID)
 }

--- a/openstack/db/v1/flavors/requests.go
+++ b/openstack/db/v1/flavors/requests.go
@@ -10,14 +10,14 @@ import (
 // List will list all available hardware flavors that an instance can use. The
 // operation is identical to the one supported by the Nova API, but without the
 // "disk" property.
-func List(client *gophercloud.ServiceClient) pagination.Pager {
+func List(client gophercloud.Client) pagination.Pager {
 	return pagination.NewPager(client, listURL(client), func(r pagination.PageResult) pagination.Page {
 		return FlavorPage{pagination.LinkedPageBase{PageResult: r}}
 	})
 }
 
 // Get will retrieve information for a specified hardware flavor.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, id string) (r GetResult) {
 	resp, err := client.Get(ctx, getURL(client, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/db/v1/flavors/urls.go
+++ b/openstack/db/v1/flavors/urls.go
@@ -2,10 +2,10 @@ package flavors
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func getURL(client *gophercloud.ServiceClient, id string) string {
+func getURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL("flavors", id)
 }
 
-func listURL(client *gophercloud.ServiceClient) string {
+func listURL(client gophercloud.Client) string {
 	return client.ServiceURL("flavors")
 }

--- a/openstack/db/v1/instances/requests.go
+++ b/openstack/db/v1/instances/requests.go
@@ -159,7 +159,7 @@ func (opts CreateOpts) ToInstanceCreateMap() (map[string]any, error) {
 // Although this call only allows the creation of 1 instance per request, you
 // can create an instance with multiple databases and users. The default
 // binding for a MySQL instance is port 3306.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToInstanceCreateMap()
 	if err != nil {
 		r.Err = err
@@ -171,21 +171,21 @@ func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateO
 }
 
 // List retrieves the status and information for all database instances.
-func List(client *gophercloud.ServiceClient) pagination.Pager {
+func List(client gophercloud.Client) pagination.Pager {
 	return pagination.NewPager(client, baseURL(client), func(r pagination.PageResult) pagination.Page {
 		return InstancePage{pagination.LinkedPageBase{PageResult: r}}
 	})
 }
 
 // Get retrieves the status and information for a specified database instance.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, id string) (r GetResult) {
 	resp, err := client.Get(ctx, resourceURL(client, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
 // Delete permanently destroys the database instance.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, id string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, resourceURL(client, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -193,7 +193,7 @@ func Delete(ctx context.Context, client *gophercloud.ServiceClient, id string) (
 
 // EnableRootUser enables the login from any host for the root user and
 // provides the user with a generated root password.
-func EnableRootUser(ctx context.Context, client *gophercloud.ServiceClient, id string) (r EnableRootUserResult) {
+func EnableRootUser(ctx context.Context, client gophercloud.Client, id string) (r EnableRootUserResult) {
 	resp, err := client.Post(ctx, userRootURL(client, id), nil, &r.Body, &gophercloud.RequestOpts{OkCodes: []int{200}})
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -202,7 +202,7 @@ func EnableRootUser(ctx context.Context, client *gophercloud.ServiceClient, id s
 // IsRootEnabled checks an instance to see if root access is enabled. It returns
 // True if root user is enabled for the specified database instance or False
 // otherwise.
-func IsRootEnabled(ctx context.Context, client *gophercloud.ServiceClient, id string) (r IsRootEnabledResult) {
+func IsRootEnabled(ctx context.Context, client gophercloud.Client, id string) (r IsRootEnabledResult) {
 	resp, err := client.Get(ctx, userRootURL(client, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -211,7 +211,7 @@ func IsRootEnabled(ctx context.Context, client *gophercloud.ServiceClient, id st
 // Restart will restart only the MySQL Instance. Restarting MySQL will
 // erase any dynamic configuration settings that you have made within MySQL.
 // The MySQL service will be unavailable until the instance restarts.
-func Restart(ctx context.Context, client *gophercloud.ServiceClient, id string) (r ActionResult) {
+func Restart(ctx context.Context, client gophercloud.Client, id string) (r ActionResult) {
 	b := map[string]any{"restart": struct{}{}}
 	resp, err := client.Post(ctx, actionURL(client, id), &b, nil, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
@@ -220,7 +220,7 @@ func Restart(ctx context.Context, client *gophercloud.ServiceClient, id string) 
 
 // Resize changes the memory size of the instance, assuming a valid
 // flavorRef is provided. It will also restart the MySQL service.
-func Resize(ctx context.Context, client *gophercloud.ServiceClient, id, flavorRef string) (r ActionResult) {
+func Resize(ctx context.Context, client gophercloud.Client, id, flavorRef string) (r ActionResult) {
 	b := map[string]any{"resize": map[string]string{"flavorRef": flavorRef}}
 	resp, err := client.Post(ctx, actionURL(client, id), &b, nil, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
@@ -230,7 +230,7 @@ func Resize(ctx context.Context, client *gophercloud.ServiceClient, id, flavorRe
 // ResizeVolume will resize the attached volume for an instance. It supports
 // only increasing the volume size and does not support decreasing the size.
 // The volume size is in gigabytes (GB) and must be an integer.
-func ResizeVolume(ctx context.Context, client *gophercloud.ServiceClient, id string, size int) (r ActionResult) {
+func ResizeVolume(ctx context.Context, client gophercloud.Client, id string, size int) (r ActionResult) {
 	b := map[string]any{"resize": map[string]any{"volume": map[string]int{"size": size}}}
 	resp, err := client.Post(ctx, actionURL(client, id), &b, nil, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
@@ -238,7 +238,7 @@ func ResizeVolume(ctx context.Context, client *gophercloud.ServiceClient, id str
 }
 
 // AttachConfigurationGroup will attach configuration group to the instance
-func AttachConfigurationGroup(ctx context.Context, client *gophercloud.ServiceClient, instanceID string, configID string) (r ConfigurationResult) {
+func AttachConfigurationGroup(ctx context.Context, client gophercloud.Client, instanceID string, configID string) (r ConfigurationResult) {
 	b := map[string]any{"instance": map[string]any{"configuration": configID}}
 	resp, err := client.Put(ctx, resourceURL(client, instanceID), &b, nil, &gophercloud.RequestOpts{OkCodes: []int{202}})
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
@@ -246,7 +246,7 @@ func AttachConfigurationGroup(ctx context.Context, client *gophercloud.ServiceCl
 }
 
 // DetachConfigurationGroup will dettach configuration group from the instance
-func DetachConfigurationGroup(ctx context.Context, client *gophercloud.ServiceClient, instanceID string) (r ConfigurationResult) {
+func DetachConfigurationGroup(ctx context.Context, client gophercloud.Client, instanceID string) (r ConfigurationResult) {
 	b := map[string]any{"instance": map[string]any{}}
 	resp, err := client.Put(ctx, resourceURL(client, instanceID), &b, nil, &gophercloud.RequestOpts{OkCodes: []int{202}})
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)

--- a/openstack/db/v1/instances/urls.go
+++ b/openstack/db/v1/instances/urls.go
@@ -2,18 +2,18 @@ package instances
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func baseURL(c *gophercloud.ServiceClient) string {
+func baseURL(c gophercloud.Client) string {
 	return c.ServiceURL("instances")
 }
 
-func resourceURL(c *gophercloud.ServiceClient, id string) string {
+func resourceURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("instances", id)
 }
 
-func userRootURL(c *gophercloud.ServiceClient, id string) string {
+func userRootURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("instances", id, "root")
 }
 
-func actionURL(c *gophercloud.ServiceClient, id string) string {
+func actionURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("instances", id, "action")
 }

--- a/openstack/db/v1/users/requests.go
+++ b/openstack/db/v1/users/requests.go
@@ -67,7 +67,7 @@ func (opts BatchCreateOpts) ToUserCreateMap() (map[string]any, error) {
 // instance based on the configuration defined in CreateOpts. If databases are
 // assigned for a particular user, the user will be granted all privileges
 // for those specified databases. "root" is a reserved name and cannot be used.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, instanceID string, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, instanceID string, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToUserCreateMap()
 	if err != nil {
 		r.Err = err
@@ -81,14 +81,14 @@ func Create(ctx context.Context, client *gophercloud.ServiceClient, instanceID s
 // List will list all the users associated with a specified database instance,
 // along with their associated databases. This operation will not return any
 // system users or administrators for a database.
-func List(client *gophercloud.ServiceClient, instanceID string) pagination.Pager {
+func List(client gophercloud.Client, instanceID string) pagination.Pager {
 	return pagination.NewPager(client, baseURL(client, instanceID), func(r pagination.PageResult) pagination.Page {
 		return UserPage{pagination.LinkedPageBase{PageResult: r}}
 	})
 }
 
 // Delete will permanently delete a user from a specified database instance.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, instanceID, userName string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, instanceID, userName string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, userURL(client, instanceID, userName), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/db/v1/users/urls.go
+++ b/openstack/db/v1/users/urls.go
@@ -2,10 +2,10 @@ package users
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func baseURL(c *gophercloud.ServiceClient, instanceID string) string {
+func baseURL(c gophercloud.Client, instanceID string) string {
 	return c.ServiceURL("instances", instanceID, "users")
 }
 
-func userURL(c *gophercloud.ServiceClient, instanceID, userName string) string {
+func userURL(c gophercloud.Client, instanceID, userName string) string {
 	return c.ServiceURL("instances", instanceID, "users", userName)
 }

--- a/openstack/dns/v2/recordsets/requests.go
+++ b/openstack/dns/v2/recordsets/requests.go
@@ -43,7 +43,7 @@ func (opts ListOpts) ToRecordSetListQuery() (string, error) {
 }
 
 // ListByZone implements the recordset list request.
-func ListByZone(client *gophercloud.ServiceClient, zoneID string, opts ListOptsBuilder) pagination.Pager {
+func ListByZone(client gophercloud.Client, zoneID string, opts ListOptsBuilder) pagination.Pager {
 	url := baseURL(client, zoneID)
 	if opts != nil {
 		query, err := opts.ToRecordSetListQuery()
@@ -58,7 +58,7 @@ func ListByZone(client *gophercloud.ServiceClient, zoneID string, opts ListOptsB
 }
 
 // Get implements the recordset Get request.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, zoneID string, rrsetID string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, zoneID string, rrsetID string) (r GetResult) {
 	resp, err := client.Get(ctx, rrsetURL(client, zoneID, rrsetID), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -100,7 +100,7 @@ func (opts CreateOpts) ToRecordSetCreateMap() (map[string]any, error) {
 }
 
 // Create creates a recordset in a given zone.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, zoneID string, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, zoneID string, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToRecordSetCreateMap()
 	if err != nil {
 		r.Err = err
@@ -156,7 +156,7 @@ func (opts UpdateOpts) ToRecordSetUpdateMap() (map[string]any, error) {
 }
 
 // Update updates a recordset in a given zone
-func Update(ctx context.Context, client *gophercloud.ServiceClient, zoneID string, rrsetID string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, client gophercloud.Client, zoneID string, rrsetID string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToRecordSetUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -170,7 +170,7 @@ func Update(ctx context.Context, client *gophercloud.ServiceClient, zoneID strin
 }
 
 // Delete removes an existing RecordSet.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, zoneID string, rrsetID string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, zoneID string, rrsetID string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, rrsetURL(client, zoneID, rrsetID), &gophercloud.RequestOpts{
 		OkCodes: []int{202},
 	})

--- a/openstack/dns/v2/recordsets/urls.go
+++ b/openstack/dns/v2/recordsets/urls.go
@@ -2,10 +2,10 @@ package recordsets
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func baseURL(c *gophercloud.ServiceClient, zoneID string) string {
+func baseURL(c gophercloud.Client, zoneID string) string {
 	return c.ServiceURL("zones", zoneID, "recordsets")
 }
 
-func rrsetURL(c *gophercloud.ServiceClient, zoneID string, rrsetID string) string {
+func rrsetURL(c gophercloud.Client, zoneID string, rrsetID string) string {
 	return c.ServiceURL("zones", zoneID, "recordsets", rrsetID)
 }

--- a/openstack/dns/v2/transfer/accept/requests.go
+++ b/openstack/dns/v2/transfer/accept/requests.go
@@ -28,7 +28,7 @@ func (opts ListOpts) ToTransferAcceptListQuery() (string, error) {
 }
 
 // List implements a transfer accept List request.
-func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(client gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := baseURL(client)
 	if opts != nil {
 		query, err := opts.ToTransferAcceptListQuery()
@@ -43,7 +43,7 @@ func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pa
 }
 
 // Get returns information about a transfer accept, given its ID.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, transferAcceptID string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, transferAcceptID string) (r GetResult) {
 	resp, err := client.Get(ctx, resourceURL(client, transferAcceptID), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -75,7 +75,7 @@ func (opts CreateOpts) ToTransferAcceptCreateMap() (map[string]any, error) {
 }
 
 // Create implements a transfer accept create request.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToTransferAcceptCreateMap()
 	if err != nil {
 		r.Err = err

--- a/openstack/dns/v2/transfer/accept/urls.go
+++ b/openstack/dns/v2/transfer/accept/urls.go
@@ -8,10 +8,10 @@ const (
 	resourcePath = "transfer_accepts"
 )
 
-func baseURL(c *gophercloud.ServiceClient) string {
+func baseURL(c gophercloud.Client) string {
 	return c.ServiceURL(rootPath, tasksPath, resourcePath)
 }
 
-func resourceURL(c *gophercloud.ServiceClient, transferAcceptID string) string {
+func resourceURL(c gophercloud.Client, transferAcceptID string) string {
 	return c.ServiceURL(rootPath, tasksPath, resourcePath, transferAcceptID)
 }

--- a/openstack/dns/v2/transfer/request/requests.go
+++ b/openstack/dns/v2/transfer/request/requests.go
@@ -28,7 +28,7 @@ func (opts ListOpts) ToTransferRequestListQuery() (string, error) {
 }
 
 // List implements a transfer request List request.
-func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(client gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := baseURL(client)
 	if opts != nil {
 		query, err := opts.ToTransferRequestListQuery()
@@ -43,7 +43,7 @@ func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pa
 }
 
 // Get returns information about a transfer request, given its ID.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, transferRequestID string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, transferRequestID string) (r GetResult) {
 	resp, err := client.Get(ctx, resourceURL(client, transferRequestID), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -75,7 +75,7 @@ func (opts CreateOpts) ToTransferRequestCreateMap() (map[string]any, error) {
 }
 
 // Create implements a transfer request create request.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, zoneID string, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, zoneID string, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToTransferRequestCreateMap()
 	if err != nil {
 		r.Err = err
@@ -114,7 +114,7 @@ func (opts UpdateOpts) ToTransferRequestUpdateMap() (map[string]any, error) {
 }
 
 // Update implements a transfer request update request.
-func Update(ctx context.Context, client *gophercloud.ServiceClient, transferID string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, client gophercloud.Client, transferID string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToTransferRequestUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -128,7 +128,7 @@ func Update(ctx context.Context, client *gophercloud.ServiceClient, transferID s
 }
 
 // Delete implements a transfer request delete request.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, transferID string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, transferID string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, resourceURL(client, transferID), &gophercloud.RequestOpts{
 		OkCodes: []int{http.StatusNoContent},
 	})

--- a/openstack/dns/v2/transfer/request/urls.go
+++ b/openstack/dns/v2/transfer/request/urls.go
@@ -8,14 +8,14 @@ const (
 	resourcePath = "transfer_requests"
 )
 
-func baseURL(c *gophercloud.ServiceClient) string {
+func baseURL(c gophercloud.Client) string {
 	return c.ServiceURL(rootPath, tasksPath, resourcePath)
 }
 
-func createURL(c *gophercloud.ServiceClient, zoneID string) string {
+func createURL(c gophercloud.Client, zoneID string) string {
 	return c.ServiceURL(rootPath, zoneID, tasksPath, resourcePath)
 }
 
-func resourceURL(c *gophercloud.ServiceClient, transferID string) string {
+func resourceURL(c gophercloud.Client, transferID string) string {
 	return c.ServiceURL(rootPath, tasksPath, resourcePath, transferID)
 }

--- a/openstack/dns/v2/zones/requests.go
+++ b/openstack/dns/v2/zones/requests.go
@@ -41,7 +41,7 @@ func (opts ListOpts) ToZoneListQuery() (string, error) {
 }
 
 // List implements a zone List request.
-func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(client gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := baseURL(client)
 	if opts != nil {
 		query, err := opts.ToZoneListQuery()
@@ -56,7 +56,7 @@ func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pa
 }
 
 // Get returns information about a zone, given its ID.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, zoneID string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, zoneID string) (r GetResult) {
 	resp, err := client.Get(ctx, zoneURL(client, zoneID), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -107,7 +107,7 @@ func (opts CreateOpts) ToZoneCreateMap() (map[string]any, error) {
 }
 
 // Create implements a zone create request.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToZoneCreateMap()
 	if err != nil {
 		r.Err = err
@@ -156,7 +156,7 @@ func (opts UpdateOpts) ToZoneUpdateMap() (map[string]any, error) {
 }
 
 // Update implements a zone update request.
-func Update(ctx context.Context, client *gophercloud.ServiceClient, zoneID string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, client gophercloud.Client, zoneID string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToZoneUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -170,7 +170,7 @@ func Update(ctx context.Context, client *gophercloud.ServiceClient, zoneID strin
 }
 
 // Delete implements a zone delete request.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, zoneID string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, zoneID string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, zoneURL(client, zoneID), &gophercloud.RequestOpts{
 		OkCodes:      []int{202},
 		JSONResponse: &r.Body,

--- a/openstack/dns/v2/zones/urls.go
+++ b/openstack/dns/v2/zones/urls.go
@@ -2,10 +2,10 @@ package zones
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func baseURL(c *gophercloud.ServiceClient) string {
+func baseURL(c gophercloud.Client) string {
 	return c.ServiceURL("zones")
 }
 
-func zoneURL(c *gophercloud.ServiceClient, zoneID string) string {
+func zoneURL(c gophercloud.Client, zoneID string) string {
 	return c.ServiceURL("zones", zoneID)
 }

--- a/openstack/identity/v2/extensions/requests.go
+++ b/openstack/identity/v2/extensions/requests.go
@@ -9,13 +9,13 @@ import (
 )
 
 // Get retrieves information for a specific extension using its alias.
-func Get(ctx context.Context, c *gophercloud.ServiceClient, alias string) common.GetResult {
+func Get(ctx context.Context, c gophercloud.Client, alias string) common.GetResult {
 	return common.Get(ctx, c, alias)
 }
 
 // List returns a Pager which allows you to iterate over the full collection of extensions.
 // It does not accept query parameters.
-func List(c *gophercloud.ServiceClient) pagination.Pager {
+func List(c gophercloud.Client) pagination.Pager {
 	return common.List(c).WithPageCreator(func(r pagination.PageResult) pagination.Page {
 		return ExtensionPage{
 			ExtensionPage: common.ExtensionPage{SinglePageBase: pagination.SinglePageBase(r)},

--- a/openstack/identity/v2/roles/requests.go
+++ b/openstack/identity/v2/roles/requests.go
@@ -9,7 +9,7 @@ import (
 
 // List is the operation responsible for listing all available global roles
 // that a user can adopt.
-func List(client *gophercloud.ServiceClient) pagination.Pager {
+func List(client gophercloud.Client) pagination.Pager {
 	return pagination.NewPager(client, rootURL(client), func(r pagination.PageResult) pagination.Page {
 		return RolePage{pagination.SinglePageBase(r)}
 	})
@@ -18,7 +18,7 @@ func List(client *gophercloud.ServiceClient) pagination.Pager {
 // AddUser is the operation responsible for assigning a particular role to
 // a user. This is confined to the scope of the user's tenant - so the tenant
 // ID is a required argument.
-func AddUser(ctx context.Context, client *gophercloud.ServiceClient, tenantID, userID, roleID string) (r UserRoleResult) {
+func AddUser(ctx context.Context, client gophercloud.Client, tenantID, userID, roleID string) (r UserRoleResult) {
 	resp, err := client.Put(ctx, userTenantRoleURL(client, tenantID, userID, roleID), nil, nil, &gophercloud.RequestOpts{
 		OkCodes: []int{200, 201},
 	})
@@ -29,7 +29,7 @@ func AddUser(ctx context.Context, client *gophercloud.ServiceClient, tenantID, u
 // DeleteUser is the operation responsible for deleting a particular role
 // from a user. This is confined to the scope of the user's tenant - so the
 // tenant ID is a required argument.
-func DeleteUser(ctx context.Context, client *gophercloud.ServiceClient, tenantID, userID, roleID string) (r UserRoleResult) {
+func DeleteUser(ctx context.Context, client gophercloud.Client, tenantID, userID, roleID string) (r UserRoleResult) {
 	resp, err := client.Delete(ctx, userTenantRoleURL(client, tenantID, userID, roleID), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/identity/v2/roles/urls.go
+++ b/openstack/identity/v2/roles/urls.go
@@ -8,10 +8,10 @@ const (
 	UserPath = "users"
 )
 
-func rootURL(c *gophercloud.ServiceClient) string {
+func rootURL(c gophercloud.Client) string {
 	return c.ServiceURL(ExtPath, RolePath)
 }
 
-func userTenantRoleURL(c *gophercloud.ServiceClient, tenantID, userID, roleID string) string {
+func userTenantRoleURL(c gophercloud.Client, tenantID, userID, roleID string) string {
 	return c.ServiceURL("tenants", tenantID, UserPath, userID, RolePath, ExtPath, roleID)
 }

--- a/openstack/identity/v2/tenants/requests.go
+++ b/openstack/identity/v2/tenants/requests.go
@@ -17,7 +17,7 @@ type ListOpts struct {
 }
 
 // List enumerates the Tenants to which the current token has access.
-func List(client *gophercloud.ServiceClient, opts *ListOpts) pagination.Pager {
+func List(client gophercloud.Client, opts *ListOpts) pagination.Pager {
 	url := listURL(client)
 	if opts != nil {
 		q, err := gophercloud.BuildQueryString(opts)
@@ -56,7 +56,7 @@ func (opts CreateOpts) ToTenantCreateMap() (map[string]any, error) {
 }
 
 // Create is the operation responsible for creating new tenant.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToTenantCreateMap()
 	if err != nil {
 		r.Err = err
@@ -70,7 +70,7 @@ func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateO
 }
 
 // Get requests details on a single tenant by ID.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, id string) (r GetResult) {
 	resp, err := client.Get(ctx, getURL(client, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -101,7 +101,7 @@ func (opts UpdateOpts) ToTenantUpdateMap() (map[string]any, error) {
 }
 
 // Update is the operation responsible for updating exist tenants by their TenantID.
-func Update(ctx context.Context, client *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, client gophercloud.Client, id string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToTenantUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -115,7 +115,7 @@ func Update(ctx context.Context, client *gophercloud.ServiceClient, id string, o
 }
 
 // Delete is the operation responsible for permanently deleting a tenant.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, id string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, deleteURL(client, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/identity/v2/tenants/urls.go
+++ b/openstack/identity/v2/tenants/urls.go
@@ -2,22 +2,22 @@ package tenants
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func listURL(client *gophercloud.ServiceClient) string {
+func listURL(client gophercloud.Client) string {
 	return client.ServiceURL("tenants")
 }
 
-func getURL(client *gophercloud.ServiceClient, tenantID string) string {
+func getURL(client gophercloud.Client, tenantID string) string {
 	return client.ServiceURL("tenants", tenantID)
 }
 
-func createURL(client *gophercloud.ServiceClient) string {
+func createURL(client gophercloud.Client) string {
 	return client.ServiceURL("tenants")
 }
 
-func deleteURL(client *gophercloud.ServiceClient, tenantID string) string {
+func deleteURL(client gophercloud.Client, tenantID string) string {
 	return client.ServiceURL("tenants", tenantID)
 }
 
-func updateURL(client *gophercloud.ServiceClient, tenantID string) string {
+func updateURL(client gophercloud.Client, tenantID string) string {
 	return client.ServiceURL("tenants", tenantID)
 }

--- a/openstack/identity/v2/tokens/requests.go
+++ b/openstack/identity/v2/tokens/requests.go
@@ -90,7 +90,7 @@ func (opts AuthOptions) CanReauth() bool {
 // Generally, rather than interact with this call directly, end users should
 // call openstack.AuthenticatedClient(), which abstracts all of the gory details
 // about navigating service catalogs and such.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, auth AuthOptionsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, auth AuthOptionsBuilder) (r CreateResult) {
 	b, err := auth.ToTokenV2CreateMap()
 	if err != nil {
 		r.Err = err
@@ -105,7 +105,7 @@ func Create(ctx context.Context, client *gophercloud.ServiceClient, auth AuthOpt
 }
 
 // Get validates and retrieves information for user's token.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, token string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, token string) (r GetResult) {
 	resp, err := client.Get(ctx, GetURL(client, token), &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{200, 203},
 	})

--- a/openstack/identity/v2/tokens/urls.go
+++ b/openstack/identity/v2/tokens/urls.go
@@ -3,11 +3,11 @@ package tokens
 import "github.com/gophercloud/gophercloud/v2"
 
 // CreateURL generates the URL used to create new Tokens.
-func CreateURL(client *gophercloud.ServiceClient) string {
+func CreateURL(client gophercloud.Client) string {
 	return client.ServiceURL("tokens")
 }
 
 // GetURL generates the URL used to Validate Tokens.
-func GetURL(client *gophercloud.ServiceClient, token string) string {
+func GetURL(client gophercloud.Client, token string) string {
 	return client.ServiceURL("tokens", token)
 }

--- a/openstack/identity/v2/users/requests.go
+++ b/openstack/identity/v2/users/requests.go
@@ -8,7 +8,7 @@ import (
 )
 
 // List lists the existing users.
-func List(client *gophercloud.ServiceClient) pagination.Pager {
+func List(client gophercloud.Client) pagination.Pager {
 	return pagination.NewPager(client, rootURL(client), func(r pagination.PageResult) pagination.Page {
 		return UserPage{pagination.SinglePageBase(r)}
 	})
@@ -55,7 +55,7 @@ func (opts CreateOpts) ToUserCreateMap() (map[string]any, error) {
 }
 
 // Create is the operation responsible for creating new users.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToUserCreateMap()
 	if err != nil {
 		r.Err = err
@@ -69,7 +69,7 @@ func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateO
 }
 
 // Get requests details on a single user, either by ID or Name.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, id string) (r GetResult) {
 	resp, err := client.Get(ctx, ResourceURL(client, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -91,7 +91,7 @@ func (opts UpdateOpts) ToUserUpdateMap() (map[string]any, error) {
 }
 
 // Update is the operation responsible for updating exist users by their ID.
-func Update(ctx context.Context, client *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, client gophercloud.Client, id string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToUserUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -105,14 +105,14 @@ func Update(ctx context.Context, client *gophercloud.ServiceClient, id string, o
 }
 
 // Delete is the operation responsible for permanently deleting a User.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, id string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, ResourceURL(client, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
 // ListRoles lists the existing roles that can be assigned to users.
-func ListRoles(client *gophercloud.ServiceClient, tenantID, userID string) pagination.Pager {
+func ListRoles(client gophercloud.Client, tenantID, userID string) pagination.Pager {
 	return pagination.NewPager(client, listRolesURL(client, tenantID, userID), func(r pagination.PageResult) pagination.Page {
 		return RolePage{pagination.SinglePageBase(r)}
 	})

--- a/openstack/identity/v2/users/urls.go
+++ b/openstack/identity/v2/users/urls.go
@@ -8,14 +8,14 @@ const (
 	rolePath   = "roles"
 )
 
-func ResourceURL(c *gophercloud.ServiceClient, id string) string {
+func ResourceURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL(userPath, id)
 }
 
-func rootURL(c *gophercloud.ServiceClient) string {
+func rootURL(c gophercloud.Client) string {
 	return c.ServiceURL(userPath)
 }
 
-func listRolesURL(c *gophercloud.ServiceClient, tenantID, userID string) string {
+func listRolesURL(c gophercloud.Client, tenantID, userID string) string {
 	return c.ServiceURL(tenantPath, tenantID, userPath, userID, rolePath)
 }

--- a/openstack/identity/v3/applicationcredentials/requests.go
+++ b/openstack/identity/v3/applicationcredentials/requests.go
@@ -27,7 +27,7 @@ func (opts ListOpts) ToApplicationCredentialListQuery() (string, error) {
 }
 
 // List enumerates the ApplicationCredentials to which the current token has access.
-func List(client *gophercloud.ServiceClient, userID string, opts ListOptsBuilder) pagination.Pager {
+func List(client gophercloud.Client, userID string, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(client, userID)
 	if opts != nil {
 		query, err := opts.ToApplicationCredentialListQuery()
@@ -42,7 +42,7 @@ func List(client *gophercloud.ServiceClient, userID string, opts ListOptsBuilder
 }
 
 // Get retrieves details on a single user, by ID.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, userID string, id string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, userID string, id string) (r GetResult) {
 	resp, err := client.Get(ctx, getURL(client, userID, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -94,7 +94,7 @@ func (opts CreateOpts) ToApplicationCredentialCreateMap() (map[string]any, error
 }
 
 // Create creates a new ApplicationCredential.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, userID string, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, userID string, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToApplicationCredentialCreateMap()
 	if err != nil {
 		r.Err = err
@@ -108,14 +108,14 @@ func Create(ctx context.Context, client *gophercloud.ServiceClient, userID strin
 }
 
 // Delete deletes an application credential.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, userID string, id string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, userID string, id string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, deleteURL(client, userID, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
 // ListAccessRules enumerates the AccessRules to which the current user has access.
-func ListAccessRules(client *gophercloud.ServiceClient, userID string) pagination.Pager {
+func ListAccessRules(client gophercloud.Client, userID string) pagination.Pager {
 	url := listAccessRulesURL(client, userID)
 	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
 		return AccessRulePage{pagination.LinkedPageBase{PageResult: r}}
@@ -123,14 +123,14 @@ func ListAccessRules(client *gophercloud.ServiceClient, userID string) paginatio
 }
 
 // GetAccessRule retrieves details on a single access rule by ID.
-func GetAccessRule(ctx context.Context, client *gophercloud.ServiceClient, userID string, id string) (r GetAccessRuleResult) {
+func GetAccessRule(ctx context.Context, client gophercloud.Client, userID string, id string) (r GetAccessRuleResult) {
 	resp, err := client.Get(ctx, getAccessRuleURL(client, userID, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
 // DeleteAccessRule deletes an access rule.
-func DeleteAccessRule(ctx context.Context, client *gophercloud.ServiceClient, userID string, id string) (r DeleteResult) {
+func DeleteAccessRule(ctx context.Context, client gophercloud.Client, userID string, id string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, deleteAccessRuleURL(client, userID, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/identity/v3/applicationcredentials/urls.go
+++ b/openstack/identity/v3/applicationcredentials/urls.go
@@ -2,30 +2,30 @@ package applicationcredentials
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func listURL(client *gophercloud.ServiceClient, userID string) string {
+func listURL(client gophercloud.Client, userID string) string {
 	return client.ServiceURL("users", userID, "application_credentials")
 }
 
-func getURL(client *gophercloud.ServiceClient, userID string, id string) string {
+func getURL(client gophercloud.Client, userID string, id string) string {
 	return client.ServiceURL("users", userID, "application_credentials", id)
 }
 
-func createURL(client *gophercloud.ServiceClient, userID string) string {
+func createURL(client gophercloud.Client, userID string) string {
 	return client.ServiceURL("users", userID, "application_credentials")
 }
 
-func deleteURL(client *gophercloud.ServiceClient, userID string, id string) string {
+func deleteURL(client gophercloud.Client, userID string, id string) string {
 	return client.ServiceURL("users", userID, "application_credentials", id)
 }
 
-func listAccessRulesURL(client *gophercloud.ServiceClient, userID string) string {
+func listAccessRulesURL(client gophercloud.Client, userID string) string {
 	return client.ServiceURL("users", userID, "access_rules")
 }
 
-func getAccessRuleURL(client *gophercloud.ServiceClient, userID string, id string) string {
+func getAccessRuleURL(client gophercloud.Client, userID string, id string) string {
 	return client.ServiceURL("users", userID, "access_rules", id)
 }
 
-func deleteAccessRuleURL(client *gophercloud.ServiceClient, userID string, id string) string {
+func deleteAccessRuleURL(client gophercloud.Client, userID string, id string) string {
 	return client.ServiceURL("users", userID, "access_rules", id)
 }

--- a/openstack/identity/v3/catalog/requests.go
+++ b/openstack/identity/v3/catalog/requests.go
@@ -6,7 +6,7 @@ import (
 )
 
 // List enumerates the services available to a specific user.
-func List(client *gophercloud.ServiceClient) pagination.Pager {
+func List(client gophercloud.Client) pagination.Pager {
 	url := listURL(client)
 	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
 		return ServiceCatalogPage{pagination.LinkedPageBase{PageResult: r}}

--- a/openstack/identity/v3/catalog/urls.go
+++ b/openstack/identity/v3/catalog/urls.go
@@ -2,6 +2,6 @@ package catalog
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func listURL(client *gophercloud.ServiceClient) string {
+func listURL(client gophercloud.Client) string {
 	return client.ServiceURL("auth", "catalog")
 }

--- a/openstack/identity/v3/credentials/requests.go
+++ b/openstack/identity/v3/credentials/requests.go
@@ -28,7 +28,7 @@ func (opts ListOpts) ToCredentialListQuery() (string, error) {
 }
 
 // List enumerates the Credentials to which the current token has access.
-func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(client gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(client)
 	if opts != nil {
 		query, err := opts.ToCredentialListQuery()
@@ -43,7 +43,7 @@ func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pa
 }
 
 // Get retrieves details on a single user, by ID.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, id string) (r GetResult) {
 	resp, err := client.Get(ctx, getURL(client, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -73,7 +73,7 @@ func (opts CreateOpts) ToCredentialCreateMap() (map[string]any, error) {
 }
 
 // Create creates a new Credential.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToCredentialCreateMap()
 	if err != nil {
 		r.Err = err
@@ -87,7 +87,7 @@ func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateO
 }
 
 // Delete deletes a credential.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, id string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, deleteURL(client, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -117,7 +117,7 @@ func (opts UpdateOpts) ToCredentialsUpdateMap() (map[string]any, error) {
 }
 
 // Update modifies the attributes of a Credential.
-func Update(ctx context.Context, client *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, client gophercloud.Client, id string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToCredentialsUpdateMap()
 	if err != nil {
 		r.Err = err

--- a/openstack/identity/v3/credentials/urls.go
+++ b/openstack/identity/v3/credentials/urls.go
@@ -2,22 +2,22 @@ package credentials
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func listURL(client *gophercloud.ServiceClient) string {
+func listURL(client gophercloud.Client) string {
 	return client.ServiceURL("credentials")
 }
 
-func getURL(client *gophercloud.ServiceClient, credentialID string) string {
+func getURL(client gophercloud.Client, credentialID string) string {
 	return client.ServiceURL("credentials", credentialID)
 }
 
-func createURL(client *gophercloud.ServiceClient) string {
+func createURL(client gophercloud.Client) string {
 	return client.ServiceURL("credentials")
 }
 
-func deleteURL(client *gophercloud.ServiceClient, credentialID string) string {
+func deleteURL(client gophercloud.Client, credentialID string) string {
 	return client.ServiceURL("credentials", credentialID)
 }
 
-func updateURL(client *gophercloud.ServiceClient, credentialID string) string {
+func updateURL(client gophercloud.Client, credentialID string) string {
 	return client.ServiceURL("credentials", credentialID)
 }

--- a/openstack/identity/v3/domains/requests.go
+++ b/openstack/identity/v3/domains/requests.go
@@ -29,7 +29,7 @@ func (opts ListOpts) ToDomainListQuery() (string, error) {
 }
 
 // List enumerates the domains to which the current token has access.
-func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(client gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(client)
 	if opts != nil {
 		query, err := opts.ToDomainListQuery()
@@ -44,7 +44,7 @@ func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pa
 }
 
 // ListAvailable enumerates the domains which are available to a specific user.
-func ListAvailable(client *gophercloud.ServiceClient) pagination.Pager {
+func ListAvailable(client gophercloud.Client) pagination.Pager {
 	url := listAvailableURL(client)
 	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
 		return DomainPage{pagination.LinkedPageBase{PageResult: r}}
@@ -52,7 +52,7 @@ func ListAvailable(client *gophercloud.ServiceClient) pagination.Pager {
 }
 
 // Get retrieves details on a single domain, by ID.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, id string) (r GetResult) {
 	resp, err := client.Get(ctx, getURL(client, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -82,7 +82,7 @@ func (opts CreateOpts) ToDomainCreateMap() (map[string]any, error) {
 }
 
 // Create creates a new Domain.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToDomainCreateMap()
 	if err != nil {
 		r.Err = err
@@ -96,7 +96,7 @@ func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateO
 }
 
 // Delete deletes a domain.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, domainID string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, domainID string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, deleteURL(client, domainID), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -126,7 +126,7 @@ func (opts UpdateOpts) ToDomainUpdateMap() (map[string]any, error) {
 }
 
 // Update modifies the attributes of a domain.
-func Update(ctx context.Context, client *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, client gophercloud.Client, id string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToDomainUpdateMap()
 	if err != nil {
 		r.Err = err

--- a/openstack/identity/v3/domains/urls.go
+++ b/openstack/identity/v3/domains/urls.go
@@ -2,26 +2,26 @@ package domains
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func listAvailableURL(client *gophercloud.ServiceClient) string {
+func listAvailableURL(client gophercloud.Client) string {
 	return client.ServiceURL("auth", "domains")
 }
 
-func listURL(client *gophercloud.ServiceClient) string {
+func listURL(client gophercloud.Client) string {
 	return client.ServiceURL("domains")
 }
 
-func getURL(client *gophercloud.ServiceClient, domainID string) string {
+func getURL(client gophercloud.Client, domainID string) string {
 	return client.ServiceURL("domains", domainID)
 }
 
-func createURL(client *gophercloud.ServiceClient) string {
+func createURL(client gophercloud.Client) string {
 	return client.ServiceURL("domains")
 }
 
-func deleteURL(client *gophercloud.ServiceClient, domainID string) string {
+func deleteURL(client gophercloud.Client, domainID string) string {
 	return client.ServiceURL("domains", domainID)
 }
 
-func updateURL(client *gophercloud.ServiceClient, domainID string) string {
+func updateURL(client gophercloud.Client, domainID string) string {
 	return client.ServiceURL("domains", domainID)
 }

--- a/openstack/identity/v3/ec2credentials/requests.go
+++ b/openstack/identity/v3/ec2credentials/requests.go
@@ -8,7 +8,7 @@ import (
 )
 
 // List enumerates the Credentials to which the current token has access.
-func List(client *gophercloud.ServiceClient, userID string) pagination.Pager {
+func List(client gophercloud.Client, userID string) pagination.Pager {
 	url := listURL(client, userID)
 	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
 		return CredentialPage{pagination.LinkedPageBase{PageResult: r}}
@@ -16,7 +16,7 @@ func List(client *gophercloud.ServiceClient, userID string) pagination.Pager {
 }
 
 // Get retrieves details on a single EC2 credential by ID.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, userID string, id string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, userID string, id string) (r GetResult) {
 	resp, err := client.Get(ctx, getURL(client, userID, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -34,7 +34,7 @@ func (opts CreateOpts) ToCredentialCreateMap() (map[string]any, error) {
 }
 
 // Create creates a new EC2 Credential.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, userID string, opts CreateOpts) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, userID string, opts CreateOpts) (r CreateResult) {
 	b, err := opts.ToCredentialCreateMap()
 	if err != nil {
 		r.Err = err
@@ -48,7 +48,7 @@ func Create(ctx context.Context, client *gophercloud.ServiceClient, userID strin
 }
 
 // Delete deletes an EC2 credential.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, userID string, id string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, userID string, id string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, deleteURL(client, userID, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/identity/v3/ec2credentials/urls.go
+++ b/openstack/identity/v3/ec2credentials/urls.go
@@ -2,18 +2,18 @@ package ec2credentials
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func listURL(client *gophercloud.ServiceClient, userID string) string {
+func listURL(client gophercloud.Client, userID string) string {
 	return client.ServiceURL("users", userID, "credentials", "OS-EC2")
 }
 
-func getURL(client *gophercloud.ServiceClient, userID string, id string) string {
+func getURL(client gophercloud.Client, userID string, id string) string {
 	return client.ServiceURL("users", userID, "credentials", "OS-EC2", id)
 }
 
-func createURL(client *gophercloud.ServiceClient, userID string) string {
+func createURL(client gophercloud.Client, userID string) string {
 	return client.ServiceURL("users", userID, "credentials", "OS-EC2")
 }
 
-func deleteURL(client *gophercloud.ServiceClient, userID string, id string) string {
+func deleteURL(client gophercloud.Client, userID string, id string) string {
 	return client.ServiceURL("users", userID, "credentials", "OS-EC2", id)
 }

--- a/openstack/identity/v3/ec2tokens/requests.go
+++ b/openstack/identity/v3/ec2tokens/requests.go
@@ -289,7 +289,7 @@ func (opts *AuthOptions) ToTokenV3CreateMap(map[string]any) (map[string]any, err
 }
 
 // Create authenticates and either generates a new token from EC2 credentials
-func Create(ctx context.Context, c *gophercloud.ServiceClient, opts tokens.AuthOptionsBuilder) (r tokens.CreateResult) {
+func Create(ctx context.Context, c gophercloud.Client, opts tokens.AuthOptionsBuilder) (r tokens.CreateResult) {
 	b, err := opts.ToTokenV3CreateMap(nil)
 	if err != nil {
 		r.Err = err
@@ -309,7 +309,7 @@ func Create(ctx context.Context, c *gophercloud.ServiceClient, opts tokens.AuthO
 
 // ValidateS3Token authenticates an S3 request using EC2 credentials. Doesn't
 // generate a new token ID, but returns a tokens.CreateResult.
-func ValidateS3Token(ctx context.Context, c *gophercloud.ServiceClient, opts tokens.AuthOptionsBuilder) (r tokens.CreateResult) {
+func ValidateS3Token(ctx context.Context, c gophercloud.Client, opts tokens.AuthOptionsBuilder) (r tokens.CreateResult) {
 	b, err := opts.ToTokenV3CreateMap(nil)
 	if err != nil {
 		r.Err = err

--- a/openstack/identity/v3/ec2tokens/urls.go
+++ b/openstack/identity/v3/ec2tokens/urls.go
@@ -2,10 +2,10 @@ package ec2tokens
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func ec2tokensURL(c *gophercloud.ServiceClient) string {
+func ec2tokensURL(c gophercloud.Client) string {
 	return c.ServiceURL("ec2tokens")
 }
 
-func s3tokensURL(c *gophercloud.ServiceClient) string {
+func s3tokensURL(c gophercloud.Client) string {
 	return c.ServiceURL("s3tokens")
 }

--- a/openstack/identity/v3/endpoints/requests.go
+++ b/openstack/identity/v3/endpoints/requests.go
@@ -38,7 +38,7 @@ func (opts CreateOpts) ToEndpointCreateMap() (map[string]any, error) {
 }
 
 // Create inserts a new Endpoint into the service catalog.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToEndpointCreateMap()
 	if err != nil {
 		r.Err = err
@@ -76,7 +76,7 @@ func (opts ListOpts) ToEndpointListParams() (string, error) {
 
 // List enumerates endpoints in a paginated collection, optionally filtered
 // by ListOpts criteria.
-func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(client gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	u := listURL(client)
 	if opts != nil {
 		q, err := gophercloud.BuildQueryString(opts)
@@ -122,7 +122,7 @@ func (opts UpdateOpts) ToEndpointUpdateMap() (map[string]any, error) {
 }
 
 // Update changes an existing endpoint with new data.
-func Update(ctx context.Context, client *gophercloud.ServiceClient, endpointID string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, client gophercloud.Client, endpointID string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToEndpointUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -134,7 +134,7 @@ func Update(ctx context.Context, client *gophercloud.ServiceClient, endpointID s
 }
 
 // Delete removes an endpoint from the service catalog.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, endpointID string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, endpointID string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, endpointURL(client, endpointID), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/identity/v3/endpoints/urls.go
+++ b/openstack/identity/v3/endpoints/urls.go
@@ -2,10 +2,10 @@ package endpoints
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func listURL(client *gophercloud.ServiceClient) string {
+func listURL(client gophercloud.Client) string {
 	return client.ServiceURL("endpoints")
 }
 
-func endpointURL(client *gophercloud.ServiceClient, endpointID string) string {
+func endpointURL(client gophercloud.Client, endpointID string) string {
 	return client.ServiceURL("endpoints", endpointID)
 }

--- a/openstack/identity/v3/federation/requests.go
+++ b/openstack/identity/v3/federation/requests.go
@@ -8,7 +8,7 @@ import (
 )
 
 // ListMappings enumerates the mappings.
-func ListMappings(client *gophercloud.ServiceClient) pagination.Pager {
+func ListMappings(client gophercloud.Client) pagination.Pager {
 	return pagination.NewPager(client, mappingsRootURL(client), func(r pagination.PageResult) pagination.Page {
 		return MappingsPage{pagination.LinkedPageBase{PageResult: r}}
 	})
@@ -32,7 +32,7 @@ func (opts CreateMappingOpts) ToMappingCreateMap() (map[string]any, error) {
 }
 
 // CreateMapping creates a new Mapping.
-func CreateMapping(ctx context.Context, client *gophercloud.ServiceClient, mappingID string, opts CreateMappingOptsBuilder) (r CreateMappingResult) {
+func CreateMapping(ctx context.Context, client gophercloud.Client, mappingID string, opts CreateMappingOptsBuilder) (r CreateMappingResult) {
 	b, err := opts.ToMappingCreateMap()
 	if err != nil {
 		r.Err = err
@@ -46,7 +46,7 @@ func CreateMapping(ctx context.Context, client *gophercloud.ServiceClient, mappi
 }
 
 // GetMapping retrieves details on a single mapping, by ID.
-func GetMapping(ctx context.Context, client *gophercloud.ServiceClient, mappingID string) (r GetMappingResult) {
+func GetMapping(ctx context.Context, client gophercloud.Client, mappingID string) (r GetMappingResult) {
 	resp, err := client.Get(ctx, mappingsResourceURL(client, mappingID), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -70,7 +70,7 @@ func (opts UpdateMappingOpts) ToMappingUpdateMap() (map[string]any, error) {
 }
 
 // UpdateMapping updates an existing mapping.
-func UpdateMapping(ctx context.Context, client *gophercloud.ServiceClient, mappingID string, opts UpdateMappingOptsBuilder) (r UpdateMappingResult) {
+func UpdateMapping(ctx context.Context, client gophercloud.Client, mappingID string, opts UpdateMappingOptsBuilder) (r UpdateMappingResult) {
 	b, err := opts.ToMappingUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -84,7 +84,7 @@ func UpdateMapping(ctx context.Context, client *gophercloud.ServiceClient, mappi
 }
 
 // DeleteMapping deletes a mapping.
-func DeleteMapping(ctx context.Context, client *gophercloud.ServiceClient, mappingID string) (r DeleteMappingResult) {
+func DeleteMapping(ctx context.Context, client gophercloud.Client, mappingID string) (r DeleteMappingResult) {
 	resp, err := client.Delete(ctx, mappingsResourceURL(client, mappingID), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/identity/v3/federation/urls.go
+++ b/openstack/identity/v3/federation/urls.go
@@ -7,10 +7,10 @@ const (
 	mappingsPath = "mappings"
 )
 
-func mappingsRootURL(c *gophercloud.ServiceClient) string {
+func mappingsRootURL(c gophercloud.Client) string {
 	return c.ServiceURL(rootPath, mappingsPath)
 }
 
-func mappingsResourceURL(c *gophercloud.ServiceClient, mappingID string) string {
+func mappingsResourceURL(c gophercloud.Client, mappingID string) string {
 	return c.ServiceURL(rootPath, mappingsPath, mappingID)
 }

--- a/openstack/identity/v3/groups/requests.go
+++ b/openstack/identity/v3/groups/requests.go
@@ -50,7 +50,7 @@ func (opts ListOpts) ToGroupListQuery() (string, error) {
 }
 
 // List enumerates the Groups to which the current token has access.
-func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(client gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(client)
 	if opts != nil {
 		query, err := opts.ToGroupListQuery()
@@ -65,7 +65,7 @@ func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pa
 }
 
 // Get retrieves details on a single group, by ID.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, id string) (r GetResult) {
 	resp, err := client.Get(ctx, getURL(client, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -111,7 +111,7 @@ func (opts CreateOpts) ToGroupCreateMap() (map[string]any, error) {
 }
 
 // Create creates a new Group.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToGroupCreateMap()
 	if err != nil {
 		r.Err = err
@@ -164,7 +164,7 @@ func (opts UpdateOpts) ToGroupUpdateMap() (map[string]any, error) {
 }
 
 // Update updates an existing Group.
-func Update(ctx context.Context, client *gophercloud.ServiceClient, groupID string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, client gophercloud.Client, groupID string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToGroupUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -178,7 +178,7 @@ func Update(ctx context.Context, client *gophercloud.ServiceClient, groupID stri
 }
 
 // Delete deletes a group.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, groupID string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, groupID string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, deleteURL(client, groupID), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/identity/v3/groups/urls.go
+++ b/openstack/identity/v3/groups/urls.go
@@ -2,22 +2,22 @@ package groups
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func listURL(client *gophercloud.ServiceClient) string {
+func listURL(client gophercloud.Client) string {
 	return client.ServiceURL("groups")
 }
 
-func getURL(client *gophercloud.ServiceClient, groupID string) string {
+func getURL(client gophercloud.Client, groupID string) string {
 	return client.ServiceURL("groups", groupID)
 }
 
-func createURL(client *gophercloud.ServiceClient) string {
+func createURL(client gophercloud.Client) string {
 	return client.ServiceURL("groups")
 }
 
-func updateURL(client *gophercloud.ServiceClient, groupID string) string {
+func updateURL(client gophercloud.Client, groupID string) string {
 	return client.ServiceURL("groups", groupID)
 }
 
-func deleteURL(client *gophercloud.ServiceClient, groupID string) string {
+func deleteURL(client gophercloud.Client, groupID string) string {
 	return client.ServiceURL("groups", groupID)
 }

--- a/openstack/identity/v3/limits/requests.go
+++ b/openstack/identity/v3/limits/requests.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Get retrieves details on a single limit, by ID.
-func GetEnforcementModel(ctx context.Context, client *gophercloud.ServiceClient) (r EnforcementModelResult) {
+func GetEnforcementModel(ctx context.Context, client gophercloud.Client) (r EnforcementModelResult) {
 	resp, err := client.Get(ctx, enforcementModelURL(client), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -45,7 +45,7 @@ func (opts ListOpts) ToLimitListQuery() (string, error) {
 }
 
 // List enumerates the limits.
-func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(client gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := rootURL(client)
 	if opts != nil {
 		query, err := opts.ToLimitListQuery()
@@ -109,7 +109,7 @@ func (opts CreateOpts) ToMap() (map[string]any, error) {
 }
 
 // BatchCreate creates new Limits.
-func BatchCreate(ctx context.Context, client *gophercloud.ServiceClient, opts BatchCreateOptsBuilder) (r CreateResult) {
+func BatchCreate(ctx context.Context, client gophercloud.Client, opts BatchCreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToLimitsCreateMap()
 	if err != nil {
 		r.Err = err
@@ -123,7 +123,7 @@ func BatchCreate(ctx context.Context, client *gophercloud.ServiceClient, opts Ba
 }
 
 // Get retrieves details on a single limit, by ID.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, limitID string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, limitID string) (r GetResult) {
 	resp, err := client.Get(ctx, resourceURL(client, limitID), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -150,7 +150,7 @@ func (opts UpdateOpts) ToLimitUpdateMap() (map[string]any, error) {
 }
 
 // Update modifies the attributes of a limit.
-func Update(ctx context.Context, client *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, client gophercloud.Client, id string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToLimitUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -164,7 +164,7 @@ func Update(ctx context.Context, client *gophercloud.ServiceClient, id string, o
 }
 
 // Delete deletes a limit.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, limitID string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, limitID string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, resourceURL(client, limitID), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/identity/v3/limits/urls.go
+++ b/openstack/identity/v3/limits/urls.go
@@ -7,14 +7,14 @@ const (
 	enforcementModelPath = "model"
 )
 
-func enforcementModelURL(client *gophercloud.ServiceClient) string {
+func enforcementModelURL(client gophercloud.Client) string {
 	return client.ServiceURL(rootPath, enforcementModelPath)
 }
 
-func rootURL(client *gophercloud.ServiceClient) string {
+func rootURL(client gophercloud.Client) string {
 	return client.ServiceURL(rootPath)
 }
 
-func resourceURL(client *gophercloud.ServiceClient, id string) string {
+func resourceURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL(rootPath, id)
 }

--- a/openstack/identity/v3/oauth1/requests.go
+++ b/openstack/identity/v3/oauth1/requests.go
@@ -136,7 +136,7 @@ func (opts AuthOptions) ToTokenV3CreateMap(map[string]any) (map[string]any, erro
 
 // Create authenticates and either generates a new OpenStack token
 // from an OAuth1 token.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, opts tokens.AuthOptionsBuilder) (r tokens.CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, opts tokens.AuthOptionsBuilder) (r tokens.CreateResult) {
 	b, err := opts.ToTokenV3CreateMap(nil)
 	if err != nil {
 		r.Err = err
@@ -180,7 +180,7 @@ func (opts CreateConsumerOpts) ToOAuth1CreateConsumerMap() (map[string]any, erro
 }
 
 // CreateConsumer creates a new Consumer.
-func CreateConsumer(ctx context.Context, client *gophercloud.ServiceClient, opts CreateConsumerOptsBuilder) (r CreateConsumerResult) {
+func CreateConsumer(ctx context.Context, client gophercloud.Client, opts CreateConsumerOptsBuilder) (r CreateConsumerResult) {
 	b, err := opts.ToOAuth1CreateConsumerMap()
 	if err != nil {
 		r.Err = err
@@ -194,21 +194,21 @@ func CreateConsumer(ctx context.Context, client *gophercloud.ServiceClient, opts
 }
 
 // DeleteConsumer deletes a Consumer.
-func DeleteConsumer(ctx context.Context, client *gophercloud.ServiceClient, id string) (r DeleteConsumerResult) {
+func DeleteConsumer(ctx context.Context, client gophercloud.Client, id string) (r DeleteConsumerResult) {
 	resp, err := client.Delete(ctx, consumerURL(client, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
 // List enumerates Consumers.
-func ListConsumers(client *gophercloud.ServiceClient) pagination.Pager {
+func ListConsumers(client gophercloud.Client) pagination.Pager {
 	return pagination.NewPager(client, consumersURL(client), func(r pagination.PageResult) pagination.Page {
 		return ConsumersPage{pagination.LinkedPageBase{PageResult: r}}
 	})
 }
 
 // GetConsumer retrieves details on a single Consumer by ID.
-func GetConsumer(ctx context.Context, client *gophercloud.ServiceClient, id string) (r GetConsumerResult) {
+func GetConsumer(ctx context.Context, client gophercloud.Client, id string) (r GetConsumerResult) {
 	resp, err := client.Get(ctx, consumerURL(client, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -227,7 +227,7 @@ func (opts UpdateConsumerOpts) ToOAuth1UpdateConsumerMap() (map[string]any, erro
 }
 
 // UpdateConsumer updates an existing Consumer.
-func UpdateConsumer(ctx context.Context, client *gophercloud.ServiceClient, id string, opts UpdateConsumerOpts) (r UpdateConsumerResult) {
+func UpdateConsumer(ctx context.Context, client gophercloud.Client, id string, opts UpdateConsumerOpts) (r UpdateConsumerResult) {
 	b, err := opts.ToOAuth1UpdateConsumerMap()
 	if err != nil {
 		r.Err = err
@@ -299,7 +299,7 @@ func (opts RequestTokenOpts) ToOAuth1RequestTokenHeaders(method, u string) (map[
 }
 
 // RequestToken requests an unauthorized OAuth1 Token.
-func RequestToken(ctx context.Context, client *gophercloud.ServiceClient, opts RequestTokenOptsBuilder) (r TokenResult) {
+func RequestToken(ctx context.Context, client gophercloud.Client, opts RequestTokenOptsBuilder) (r TokenResult) {
 	h, err := opts.ToOAuth1RequestTokenHeaders("POST", requestTokenURL(client))
 	if err != nil {
 		r.Err = err
@@ -353,7 +353,7 @@ func (opts AuthorizeTokenOpts) ToOAuth1AuthorizeTokenMap() (map[string]any, erro
 }
 
 // AuthorizeToken authorizes an unauthorized consumer token.
-func AuthorizeToken(ctx context.Context, client *gophercloud.ServiceClient, id string, opts AuthorizeTokenOptsBuilder) (r AuthorizeTokenResult) {
+func AuthorizeToken(ctx context.Context, client gophercloud.Client, id string, opts AuthorizeTokenOptsBuilder) (r AuthorizeTokenResult) {
 	b, err := opts.ToOAuth1AuthorizeTokenMap()
 	if err != nil {
 		r.Err = err
@@ -427,7 +427,7 @@ func (opts CreateAccessTokenOpts) ToOAuth1CreateAccessTokenHeaders(method, u str
 }
 
 // CreateAccessToken creates a new OAuth1 Access Token
-func CreateAccessToken(ctx context.Context, client *gophercloud.ServiceClient, opts CreateAccessTokenOptsBuilder) (r TokenResult) {
+func CreateAccessToken(ctx context.Context, client gophercloud.Client, opts CreateAccessTokenOptsBuilder) (r TokenResult) {
 	h, err := opts.ToOAuth1CreateAccessTokenHeaders("POST", createAccessTokenURL(client))
 	if err != nil {
 		r.Err = err
@@ -453,21 +453,21 @@ func CreateAccessToken(ctx context.Context, client *gophercloud.ServiceClient, o
 }
 
 // GetAccessToken retrieves details on a single OAuth1 access token by an ID.
-func GetAccessToken(ctx context.Context, client *gophercloud.ServiceClient, userID string, id string) (r GetAccessTokenResult) {
+func GetAccessToken(ctx context.Context, client gophercloud.Client, userID string, id string) (r GetAccessTokenResult) {
 	resp, err := client.Get(ctx, userAccessTokenURL(client, userID, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
 // RevokeAccessToken revokes an OAuth1 access token.
-func RevokeAccessToken(ctx context.Context, client *gophercloud.ServiceClient, userID string, id string) (r RevokeAccessTokenResult) {
+func RevokeAccessToken(ctx context.Context, client gophercloud.Client, userID string, id string) (r RevokeAccessTokenResult) {
 	resp, err := client.Delete(ctx, userAccessTokenURL(client, userID, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
 // ListAccessTokens enumerates authorized access tokens.
-func ListAccessTokens(client *gophercloud.ServiceClient, userID string) pagination.Pager {
+func ListAccessTokens(client gophercloud.Client, userID string) pagination.Pager {
 	url := userAccessTokensURL(client, userID)
 	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
 		return AccessTokensPage{pagination.LinkedPageBase{PageResult: r}}
@@ -475,7 +475,7 @@ func ListAccessTokens(client *gophercloud.ServiceClient, userID string) paginati
 }
 
 // ListAccessTokenRoles enumerates authorized access token roles.
-func ListAccessTokenRoles(client *gophercloud.ServiceClient, userID string, id string) pagination.Pager {
+func ListAccessTokenRoles(client gophercloud.Client, userID string, id string) pagination.Pager {
 	url := userAccessTokenRolesURL(client, userID, id)
 	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
 		return AccessTokenRolesPage{pagination.LinkedPageBase{PageResult: r}}
@@ -484,7 +484,7 @@ func ListAccessTokenRoles(client *gophercloud.ServiceClient, userID string, id s
 
 // GetAccessTokenRole retrieves details on a single OAuth1 access token role by
 // an ID.
-func GetAccessTokenRole(ctx context.Context, client *gophercloud.ServiceClient, userID string, id string, roleID string) (r GetAccessTokenRoleResult) {
+func GetAccessTokenRole(ctx context.Context, client gophercloud.Client, userID string, id string, roleID string) (r GetAccessTokenRoleResult) {
 	resp, err := client.Get(ctx, userAccessTokenRoleURL(client, userID, id, roleID), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/identity/v3/oauth1/urls.go
+++ b/openstack/identity/v3/oauth1/urls.go
@@ -2,42 +2,42 @@ package oauth1
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func consumersURL(c *gophercloud.ServiceClient) string {
+func consumersURL(c gophercloud.Client) string {
 	return c.ServiceURL("OS-OAUTH1", "consumers")
 }
 
-func consumerURL(c *gophercloud.ServiceClient, id string) string {
+func consumerURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("OS-OAUTH1", "consumers", id)
 }
 
-func requestTokenURL(c *gophercloud.ServiceClient) string {
+func requestTokenURL(c gophercloud.Client) string {
 	return c.ServiceURL("OS-OAUTH1", "request_token")
 }
 
-func authorizeTokenURL(c *gophercloud.ServiceClient, id string) string {
+func authorizeTokenURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("OS-OAUTH1", "authorize", id)
 }
 
-func createAccessTokenURL(c *gophercloud.ServiceClient) string {
+func createAccessTokenURL(c gophercloud.Client) string {
 	return c.ServiceURL("OS-OAUTH1", "access_token")
 }
 
-func userAccessTokensURL(c *gophercloud.ServiceClient, userID string) string {
+func userAccessTokensURL(c gophercloud.Client, userID string) string {
 	return c.ServiceURL("users", userID, "OS-OAUTH1", "access_tokens")
 }
 
-func userAccessTokenURL(c *gophercloud.ServiceClient, userID string, id string) string {
+func userAccessTokenURL(c gophercloud.Client, userID string, id string) string {
 	return c.ServiceURL("users", userID, "OS-OAUTH1", "access_tokens", id)
 }
 
-func userAccessTokenRolesURL(c *gophercloud.ServiceClient, userID string, id string) string {
+func userAccessTokenRolesURL(c gophercloud.Client, userID string, id string) string {
 	return c.ServiceURL("users", userID, "OS-OAUTH1", "access_tokens", id, "roles")
 }
 
-func userAccessTokenRoleURL(c *gophercloud.ServiceClient, userID string, id string, roleID string) string {
+func userAccessTokenRoleURL(c gophercloud.Client, userID string, id string, roleID string) string {
 	return c.ServiceURL("users", userID, "OS-OAUTH1", "access_tokens", id, "roles", roleID)
 }
 
-func authURL(c *gophercloud.ServiceClient) string {
+func authURL(c gophercloud.Client) string {
 	return c.ServiceURL("auth", "tokens")
 }

--- a/openstack/identity/v3/osinherit/requests.go
+++ b/openstack/identity/v3/osinherit/requests.go
@@ -65,7 +65,7 @@ type UnassignOpts struct {
 
 // Assign is the operation responsible for assigning an inherited role
 // to a user/group on a project/domain.
-func Assign(ctx context.Context, client *gophercloud.ServiceClient, roleID string, opts AssignOpts) (r AssignmentResult) {
+func Assign(ctx context.Context, client gophercloud.Client, roleID string, opts AssignOpts) (r AssignmentResult) {
 	// Check xor conditions
 	_, err := gophercloud.BuildRequestBody(opts, "")
 	if err != nil {
@@ -103,7 +103,7 @@ func Assign(ctx context.Context, client *gophercloud.ServiceClient, roleID strin
 
 // Validate is the operation responsible for validating an inherited role
 // of a user/group on a project/domain.
-func Validate(ctx context.Context, client *gophercloud.ServiceClient, roleID string, opts ValidateOpts) (r ValidateResult) {
+func Validate(ctx context.Context, client gophercloud.Client, roleID string, opts ValidateOpts) (r ValidateResult) {
 	// Check xor conditions
 	_, err := gophercloud.BuildRequestBody(opts, "")
 	if err != nil {
@@ -141,7 +141,7 @@ func Validate(ctx context.Context, client *gophercloud.ServiceClient, roleID str
 
 // Unassign is the operation responsible for unassigning an inherited
 // role to a user/group on a project/domain.
-func Unassign(ctx context.Context, client *gophercloud.ServiceClient, roleID string, opts UnassignOpts) (r UnassignmentResult) {
+func Unassign(ctx context.Context, client gophercloud.Client, roleID string, opts UnassignOpts) (r UnassignmentResult) {
 	// Check xor conditions
 	_, err := gophercloud.BuildRequestBody(opts, "")
 	if err != nil {

--- a/openstack/identity/v3/osinherit/urls.go
+++ b/openstack/identity/v3/osinherit/urls.go
@@ -6,6 +6,6 @@ const (
 	inheritPath = "OS-INHERIT"
 )
 
-func assignURL(client *gophercloud.ServiceClient, targetType, targetID, actorType, actorID, roleID string) string {
+func assignURL(client gophercloud.Client, targetType, targetID, actorType, actorID, roleID string) string {
 	return client.ServiceURL(inheritPath, targetType, targetID, actorType, actorID, "roles", roleID, "inherited_to_projects")
 }

--- a/openstack/identity/v3/policies/requests.go
+++ b/openstack/identity/v3/policies/requests.go
@@ -50,7 +50,7 @@ func (opts ListOpts) ToPolicyListQuery() (string, error) {
 }
 
 // List enumerates the policies to which the current token has access.
-func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(client gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(client)
 	if opts != nil {
 		query, err := opts.ToPolicyListQuery()
@@ -111,7 +111,7 @@ func (opts CreateOpts) ToPolicyCreateMap() (map[string]any, error) {
 }
 
 // Create creates a new Policy.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToPolicyCreateMap()
 	if err != nil {
 		r.Err = err
@@ -125,7 +125,7 @@ func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateO
 }
 
 // Get retrieves details on a single policy, by ID.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, policyID string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, policyID string) (r GetResult) {
 	resp, err := client.Get(ctx, getURL(client, policyID), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -179,7 +179,7 @@ func (opts UpdateOpts) ToPolicyUpdateMap() (map[string]any, error) {
 }
 
 // Update updates an existing Role.
-func Update(ctx context.Context, client *gophercloud.ServiceClient, policyID string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, client gophercloud.Client, policyID string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToPolicyUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -193,7 +193,7 @@ func Update(ctx context.Context, client *gophercloud.ServiceClient, policyID str
 }
 
 // Delete deletes a policy.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, policyID string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, policyID string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, deleteURL(client, policyID), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/identity/v3/policies/urls.go
+++ b/openstack/identity/v3/policies/urls.go
@@ -4,22 +4,22 @@ import "github.com/gophercloud/gophercloud/v2"
 
 const policyPath = "policies"
 
-func listURL(client *gophercloud.ServiceClient) string {
+func listURL(client gophercloud.Client) string {
 	return client.ServiceURL(policyPath)
 }
 
-func createURL(client *gophercloud.ServiceClient) string {
+func createURL(client gophercloud.Client) string {
 	return client.ServiceURL(policyPath)
 }
 
-func getURL(client *gophercloud.ServiceClient, policyID string) string {
+func getURL(client gophercloud.Client, policyID string) string {
 	return client.ServiceURL(policyPath, policyID)
 }
 
-func updateURL(client *gophercloud.ServiceClient, policyID string) string {
+func updateURL(client gophercloud.Client, policyID string) string {
 	return client.ServiceURL(policyPath, policyID)
 }
 
-func deleteURL(client *gophercloud.ServiceClient, policyID string) string {
+func deleteURL(client gophercloud.Client, policyID string) string {
 	return client.ServiceURL(policyPath, policyID)
 }

--- a/openstack/identity/v3/projectendpoints/requests.go
+++ b/openstack/identity/v3/projectendpoints/requests.go
@@ -12,7 +12,7 @@ type CreateOptsBuilder interface {
 }
 
 // Create inserts a new Endpoint association to a project.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, projectID, endpointID string) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, projectID, endpointID string) (r CreateResult) {
 	resp, err := client.Put(ctx, createURL(client, projectID, endpointID), nil, nil, &gophercloud.RequestOpts{OkCodes: []int{204}})
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -20,7 +20,7 @@ func Create(ctx context.Context, client *gophercloud.ServiceClient, projectID, e
 
 // List enumerates endpoints in a paginated collection, optionally filtered
 // by ListOpts criteria.
-func List(client *gophercloud.ServiceClient, projectID string) pagination.Pager {
+func List(client gophercloud.Client, projectID string) pagination.Pager {
 	u := listURL(client, projectID)
 	return pagination.NewPager(client, u, func(r pagination.PageResult) pagination.Page {
 		return EndpointPage{pagination.LinkedPageBase{PageResult: r}}
@@ -28,7 +28,7 @@ func List(client *gophercloud.ServiceClient, projectID string) pagination.Pager 
 }
 
 // Delete removes an endpoint from the service catalog.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, projectID string, endpointID string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, projectID string, endpointID string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, deleteURL(client, projectID, endpointID), &gophercloud.RequestOpts{OkCodes: []int{204}})
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/identity/v3/projectendpoints/urls.go
+++ b/openstack/identity/v3/projectendpoints/urls.go
@@ -2,14 +2,14 @@ package projectendpoints
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func listURL(client *gophercloud.ServiceClient, projectID string) string {
+func listURL(client gophercloud.Client, projectID string) string {
 	return client.ServiceURL("OS-EP-FILTER", "projects", projectID, "endpoints")
 }
 
-func createURL(client *gophercloud.ServiceClient, projectID, endpointID string) string {
+func createURL(client gophercloud.Client, projectID, endpointID string) string {
 	return client.ServiceURL("OS-EP-FILTER", "projects", projectID, "endpoints", endpointID)
 }
 
-func deleteURL(client *gophercloud.ServiceClient, projectID, endpointID string) string {
+func deleteURL(client gophercloud.Client, projectID, endpointID string) string {
 	return client.ServiceURL("OS-EP-FILTER", "projects", projectID, "endpoints", endpointID)
 }

--- a/openstack/identity/v3/projects/requests.go
+++ b/openstack/identity/v3/projects/requests.go
@@ -72,7 +72,7 @@ func (opts ListOpts) ToProjectListQuery() (string, error) {
 }
 
 // List enumerates the Projects to which the current token has access.
-func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(client gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(client)
 	if opts != nil {
 		query, err := opts.ToProjectListQuery()
@@ -87,7 +87,7 @@ func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pa
 }
 
 // ListAvailable enumerates the Projects which are available to a specific user.
-func ListAvailable(client *gophercloud.ServiceClient) pagination.Pager {
+func ListAvailable(client gophercloud.Client) pagination.Pager {
 	url := listAvailableURL(client)
 	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
 		return ProjectPage{pagination.LinkedPageBase{PageResult: r}}
@@ -95,7 +95,7 @@ func ListAvailable(client *gophercloud.ServiceClient) pagination.Pager {
 }
 
 // Get retrieves details on a single project, by ID.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, id string) (r GetResult) {
 	resp, err := client.Get(ctx, getURL(client, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -157,7 +157,7 @@ func (opts CreateOpts) ToProjectCreateMap() (map[string]any, error) {
 }
 
 // Create creates a new Project.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToProjectCreateMap()
 	if err != nil {
 		r.Err = err
@@ -169,7 +169,7 @@ func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateO
 }
 
 // Delete deletes a project.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, projectID string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, projectID string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, deleteURL(client, projectID), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -231,7 +231,7 @@ func (opts UpdateOpts) ToProjectUpdateMap() (map[string]any, error) {
 }
 
 // Update modifies the attributes of a project.
-func Update(ctx context.Context, client *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, client gophercloud.Client, id string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToProjectUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -245,7 +245,7 @@ func Update(ctx context.Context, client *gophercloud.ServiceClient, id string, o
 }
 
 // CheckTags lists tags for a project.
-func ListTags(ctx context.Context, client *gophercloud.ServiceClient, projectID string) (r ListTagsResult) {
+func ListTags(ctx context.Context, client gophercloud.Client, projectID string) (r ListTagsResult) {
 	resp, err := client.Get(ctx, listTagsURL(client, projectID), &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{200},
 	})
@@ -276,7 +276,7 @@ func (opts ModifyTagsOpts) ToModifyTagsCreateMap() (map[string]any, error) {
 }
 
 // ModifyTags deletes all tags of a project and adds new ones.
-func ModifyTags(ctx context.Context, client *gophercloud.ServiceClient, projectID string, opts ModifyTagsOpts) (r ModifyTagsResult) {
+func ModifyTags(ctx context.Context, client gophercloud.Client, projectID string, opts ModifyTagsOpts) (r ModifyTagsResult) {
 
 	b, err := opts.ToModifyTagsCreateMap()
 	if err != nil {
@@ -291,7 +291,7 @@ func ModifyTags(ctx context.Context, client *gophercloud.ServiceClient, projectI
 }
 
 // DeleteTag deletes a tag from a project.
-func DeleteTags(ctx context.Context, client *gophercloud.ServiceClient, projectID string) (r DeleteTagsResult) {
+func DeleteTags(ctx context.Context, client gophercloud.Client, projectID string) (r DeleteTagsResult) {
 	resp, err := client.Delete(ctx, deleteTagsURL(client, projectID), &gophercloud.RequestOpts{
 		OkCodes: []int{204},
 	})

--- a/openstack/identity/v3/projects/urls.go
+++ b/openstack/identity/v3/projects/urls.go
@@ -2,38 +2,38 @@ package projects
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func listAvailableURL(client *gophercloud.ServiceClient) string {
+func listAvailableURL(client gophercloud.Client) string {
 	return client.ServiceURL("auth", "projects")
 }
 
-func listURL(client *gophercloud.ServiceClient) string {
+func listURL(client gophercloud.Client) string {
 	return client.ServiceURL("projects")
 }
 
-func getURL(client *gophercloud.ServiceClient, projectID string) string {
+func getURL(client gophercloud.Client, projectID string) string {
 	return client.ServiceURL("projects", projectID)
 }
 
-func createURL(client *gophercloud.ServiceClient) string {
+func createURL(client gophercloud.Client) string {
 	return client.ServiceURL("projects")
 }
 
-func deleteURL(client *gophercloud.ServiceClient, projectID string) string {
+func deleteURL(client gophercloud.Client, projectID string) string {
 	return client.ServiceURL("projects", projectID)
 }
 
-func updateURL(client *gophercloud.ServiceClient, projectID string) string {
+func updateURL(client gophercloud.Client, projectID string) string {
 	return client.ServiceURL("projects", projectID)
 }
 
-func listTagsURL(client *gophercloud.ServiceClient, projectID string) string {
+func listTagsURL(client gophercloud.Client, projectID string) string {
 	return client.ServiceURL("projects", projectID, "tags")
 }
 
-func modifyTagsURL(client *gophercloud.ServiceClient, projectID string) string {
+func modifyTagsURL(client gophercloud.Client, projectID string) string {
 	return client.ServiceURL("projects", projectID, "tags")
 }
 
-func deleteTagsURL(client *gophercloud.ServiceClient, projectID string) string {
+func deleteTagsURL(client gophercloud.Client, projectID string) string {
 	return client.ServiceURL("projects", projectID, "tags")
 }

--- a/openstack/identity/v3/regions/requests.go
+++ b/openstack/identity/v3/regions/requests.go
@@ -26,7 +26,7 @@ func (opts ListOpts) ToRegionListQuery() (string, error) {
 }
 
 // List enumerates the Regions to which the current token has access.
-func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(client gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(client)
 	if opts != nil {
 		query, err := opts.ToRegionListQuery()
@@ -41,7 +41,7 @@ func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pa
 }
 
 // Get retrieves details on a single region, by ID.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, id string) (r GetResult) {
 	resp, err := client.Get(ctx, getURL(client, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -87,7 +87,7 @@ func (opts CreateOpts) ToRegionCreateMap() (map[string]any, error) {
 }
 
 // Create creates a new Region.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToRegionCreateMap()
 	if err != nil {
 		r.Err = err
@@ -149,7 +149,7 @@ func (opts UpdateOpts) ToRegionUpdateMap() (map[string]any, error) {
 }
 
 // Update updates an existing Region.
-func Update(ctx context.Context, client *gophercloud.ServiceClient, regionID string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, client gophercloud.Client, regionID string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToRegionUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -163,7 +163,7 @@ func Update(ctx context.Context, client *gophercloud.ServiceClient, regionID str
 }
 
 // Delete deletes a region.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, regionID string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, regionID string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, deleteURL(client, regionID), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/identity/v3/regions/urls.go
+++ b/openstack/identity/v3/regions/urls.go
@@ -2,22 +2,22 @@ package regions
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func listURL(client *gophercloud.ServiceClient) string {
+func listURL(client gophercloud.Client) string {
 	return client.ServiceURL("regions")
 }
 
-func getURL(client *gophercloud.ServiceClient, regionID string) string {
+func getURL(client gophercloud.Client, regionID string) string {
 	return client.ServiceURL("regions", regionID)
 }
 
-func createURL(client *gophercloud.ServiceClient) string {
+func createURL(client gophercloud.Client) string {
 	return client.ServiceURL("regions")
 }
 
-func updateURL(client *gophercloud.ServiceClient, regionID string) string {
+func updateURL(client gophercloud.Client, regionID string) string {
 	return client.ServiceURL("regions", regionID)
 }
 
-func deleteURL(client *gophercloud.ServiceClient, regionID string) string {
+func deleteURL(client gophercloud.Client, regionID string) string {
 	return client.ServiceURL("regions", regionID)
 }

--- a/openstack/identity/v3/registeredlimits/requests.go
+++ b/openstack/identity/v3/registeredlimits/requests.go
@@ -32,7 +32,7 @@ func (opts ListOpts) ToRegisteredLimitListQuery() (string, error) {
 }
 
 // List enumerates the registered limits.
-func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(client gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := rootURL(client)
 	if opts != nil {
 		query, err := opts.ToRegisteredLimitListQuery()
@@ -90,7 +90,7 @@ func (opts CreateOpts) ToMap() (map[string]any, error) {
 }
 
 // BatchCreate creates new Limits.
-func BatchCreate(ctx context.Context, client *gophercloud.ServiceClient, opts BatchCreateOptsBuilder) (r CreateResult) {
+func BatchCreate(ctx context.Context, client gophercloud.Client, opts BatchCreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToRegisteredLimitsCreateMap()
 	if err != nil {
 		r.Err = err
@@ -104,7 +104,7 @@ func BatchCreate(ctx context.Context, client *gophercloud.ServiceClient, opts Ba
 }
 
 // Get retrieves details on a single registered_limit, by ID.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, registeredLimitID string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, registeredLimitID string) (r GetResult) {
 	resp, err := client.Get(ctx, resourceURL(client, registeredLimitID), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -141,7 +141,7 @@ func (opts UpdateOpts) ToRegisteredLimitUpdateMap() (map[string]any, error) {
 }
 
 // Update modifies the attributes of a registered limit.
-func Update(ctx context.Context, client *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, client gophercloud.Client, id string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToRegisteredLimitUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -155,7 +155,7 @@ func Update(ctx context.Context, client *gophercloud.ServiceClient, id string, o
 }
 
 // Delete deletes a registered_limit.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, registeredLimitID string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, registeredLimitID string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, resourceURL(client, registeredLimitID), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/identity/v3/registeredlimits/urls.go
+++ b/openstack/identity/v3/registeredlimits/urls.go
@@ -7,10 +7,10 @@ const (
 	enforcementModelPath = "model"
 )
 
-func rootURL(client *gophercloud.ServiceClient) string {
+func rootURL(client gophercloud.Client) string {
 	return client.ServiceURL(rootPath)
 }
 
-func resourceURL(client *gophercloud.ServiceClient, id string) string {
+func resourceURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL(rootPath, id)
 }

--- a/openstack/identity/v3/roles/requests.go
+++ b/openstack/identity/v3/roles/requests.go
@@ -50,7 +50,7 @@ func (opts ListOpts) ToRoleListQuery() (string, error) {
 }
 
 // List enumerates the roles to which the current token has access.
-func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(client gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(client)
 	if opts != nil {
 		query, err := opts.ToRoleListQuery()
@@ -66,7 +66,7 @@ func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pa
 }
 
 // Get retrieves details on a single role, by ID.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, id string) (r GetResult) {
 	resp, err := client.Get(ctx, getURL(client, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -109,7 +109,7 @@ func (opts CreateOpts) ToRoleCreateMap() (map[string]any, error) {
 }
 
 // Create creates a new Role.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToRoleCreateMap()
 	if err != nil {
 		r.Err = err
@@ -156,7 +156,7 @@ func (opts UpdateOpts) ToRoleUpdateMap() (map[string]any, error) {
 }
 
 // Update updates an existing Role.
-func Update(ctx context.Context, client *gophercloud.ServiceClient, roleID string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, client gophercloud.Client, roleID string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToRoleUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -170,7 +170,7 @@ func Update(ctx context.Context, client *gophercloud.ServiceClient, roleID strin
 }
 
 // Delete deletes a role.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, roleID string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, roleID string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, deleteURL(client, roleID), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -223,7 +223,7 @@ func (opts ListAssignmentsOpts) ToRolesListAssignmentsQuery() (string, error) {
 }
 
 // ListAssignments enumerates the roles assigned to a specified resource.
-func ListAssignments(client *gophercloud.ServiceClient, opts ListAssignmentsOptsBuilder) pagination.Pager {
+func ListAssignments(client gophercloud.Client, opts ListAssignmentsOptsBuilder) pagination.Pager {
 	url := listAssignmentsURL(client)
 	if opts != nil {
 		query, err := opts.ToRolesListAssignmentsQuery()
@@ -297,7 +297,7 @@ type UnassignOpts struct {
 
 // ListAssignmentsOnResource is the operation responsible for listing role
 // assignments for a user/group on a project/domain.
-func ListAssignmentsOnResource(client *gophercloud.ServiceClient, opts ListAssignmentsOnResourceOpts) pagination.Pager {
+func ListAssignmentsOnResource(client gophercloud.Client, opts ListAssignmentsOnResourceOpts) pagination.Pager {
 	// Check xor conditions
 	_, err := gophercloud.BuildRequestBody(opts, "")
 	if err != nil {
@@ -333,7 +333,7 @@ func ListAssignmentsOnResource(client *gophercloud.ServiceClient, opts ListAssig
 
 // Assign is the operation responsible for assigning a role
 // to a user/group on a project/domain.
-func Assign(ctx context.Context, client *gophercloud.ServiceClient, roleID string, opts AssignOpts) (r AssignmentResult) {
+func Assign(ctx context.Context, client gophercloud.Client, roleID string, opts AssignOpts) (r AssignmentResult) {
 	// Check xor conditions
 	_, err := gophercloud.BuildRequestBody(opts, "")
 	if err != nil {
@@ -371,7 +371,7 @@ func Assign(ctx context.Context, client *gophercloud.ServiceClient, roleID strin
 
 // Unassign is the operation responsible for unassigning a role
 // from a user/group on a project/domain.
-func Unassign(ctx context.Context, client *gophercloud.ServiceClient, roleID string, opts UnassignOpts) (r UnassignmentResult) {
+func Unassign(ctx context.Context, client gophercloud.Client, roleID string, opts UnassignOpts) (r UnassignmentResult) {
 	// Check xor conditions
 	_, err := gophercloud.BuildRequestBody(opts, "")
 	if err != nil {
@@ -407,7 +407,7 @@ func Unassign(ctx context.Context, client *gophercloud.ServiceClient, roleID str
 	return
 }
 
-func CreateRoleInferenceRule(ctx context.Context, client *gophercloud.ServiceClient, priorRoleID, impliedRoleID string) (r CreateImpliedRoleResult) {
+func CreateRoleInferenceRule(ctx context.Context, client gophercloud.Client, priorRoleID, impliedRoleID string) (r CreateImpliedRoleResult) {
 	resp, err := client.Put(ctx, createRoleInferenceRuleURL(client, priorRoleID, impliedRoleID), nil, &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{201},
 	})
@@ -415,7 +415,7 @@ func CreateRoleInferenceRule(ctx context.Context, client *gophercloud.ServiceCli
 	return
 }
 
-func GetRoleInferenceRule(ctx context.Context, client *gophercloud.ServiceClient, priorRoleID, impliedRoleID string) (r CreateImpliedRoleResult) {
+func GetRoleInferenceRule(ctx context.Context, client gophercloud.Client, priorRoleID, impliedRoleID string) (r CreateImpliedRoleResult) {
 	resp, err := client.Get(ctx, getRoleInferenceRuleURL(client, priorRoleID, impliedRoleID), &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{200},
 	})
@@ -423,7 +423,7 @@ func GetRoleInferenceRule(ctx context.Context, client *gophercloud.ServiceClient
 	return
 }
 
-func DeleteRoleInferenceRule(ctx context.Context, client *gophercloud.ServiceClient, priorRoleID, impliedRoleID string) (r DeleteImpliedRoleResult) {
+func DeleteRoleInferenceRule(ctx context.Context, client gophercloud.Client, priorRoleID, impliedRoleID string) (r DeleteImpliedRoleResult) {
 	resp, err := client.Delete(ctx, deleteRoleInferenceRuleURL(client, priorRoleID, impliedRoleID), &gophercloud.RequestOpts{
 		OkCodes: []int{204},
 	})
@@ -431,7 +431,7 @@ func DeleteRoleInferenceRule(ctx context.Context, client *gophercloud.ServiceCli
 	return
 }
 
-func ListRoleInferenceRules(ctx context.Context, client *gophercloud.ServiceClient) (r ListImpliedRolesResult) {
+func ListRoleInferenceRules(ctx context.Context, client gophercloud.Client) (r ListImpliedRolesResult) {
 	resp, err := client.Get(ctx, listRoleInferenceRulesURL(client), &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{200},
 	})

--- a/openstack/identity/v3/roles/urls.go
+++ b/openstack/identity/v3/roles/urls.go
@@ -6,50 +6,50 @@ const (
 	rolePath = "roles"
 )
 
-func listURL(client *gophercloud.ServiceClient) string {
+func listURL(client gophercloud.Client) string {
 	return client.ServiceURL(rolePath)
 }
 
-func getURL(client *gophercloud.ServiceClient, roleID string) string {
+func getURL(client gophercloud.Client, roleID string) string {
 	return client.ServiceURL(rolePath, roleID)
 }
 
-func createURL(client *gophercloud.ServiceClient) string {
+func createURL(client gophercloud.Client) string {
 	return client.ServiceURL(rolePath)
 }
 
-func updateURL(client *gophercloud.ServiceClient, roleID string) string {
+func updateURL(client gophercloud.Client, roleID string) string {
 	return client.ServiceURL(rolePath, roleID)
 }
 
-func deleteURL(client *gophercloud.ServiceClient, roleID string) string {
+func deleteURL(client gophercloud.Client, roleID string) string {
 	return client.ServiceURL(rolePath, roleID)
 }
 
-func listAssignmentsURL(client *gophercloud.ServiceClient) string {
+func listAssignmentsURL(client gophercloud.Client) string {
 	return client.ServiceURL("role_assignments")
 }
 
-func listAssignmentsOnResourceURL(client *gophercloud.ServiceClient, targetType, targetID, actorType, actorID string) string {
+func listAssignmentsOnResourceURL(client gophercloud.Client, targetType, targetID, actorType, actorID string) string {
 	return client.ServiceURL(targetType, targetID, actorType, actorID, rolePath)
 }
 
-func assignURL(client *gophercloud.ServiceClient, targetType, targetID, actorType, actorID, roleID string) string {
+func assignURL(client gophercloud.Client, targetType, targetID, actorType, actorID, roleID string) string {
 	return client.ServiceURL(targetType, targetID, actorType, actorID, rolePath, roleID)
 }
 
-func createRoleInferenceRuleURL(client *gophercloud.ServiceClient, priorRoleID, impliedRoleID string) string {
+func createRoleInferenceRuleURL(client gophercloud.Client, priorRoleID, impliedRoleID string) string {
 	return client.ServiceURL(rolePath, priorRoleID, "implies", impliedRoleID)
 }
 
-func getRoleInferenceRuleURL(client *gophercloud.ServiceClient, priorRoleID, impliedRoleID string) string {
+func getRoleInferenceRuleURL(client gophercloud.Client, priorRoleID, impliedRoleID string) string {
 	return client.ServiceURL(rolePath, priorRoleID, "implies", impliedRoleID)
 }
 
-func listRoleInferenceRulesURL(client *gophercloud.ServiceClient) string {
+func listRoleInferenceRulesURL(client gophercloud.Client) string {
 	return client.ServiceURL("role_inferences")
 }
 
-func deleteRoleInferenceRuleURL(client *gophercloud.ServiceClient, priorRoleID, impliedRoleID string) string {
+func deleteRoleInferenceRuleURL(client gophercloud.Client, priorRoleID, impliedRoleID string) string {
 	return client.ServiceURL(rolePath, priorRoleID, "implies", impliedRoleID)
 }

--- a/openstack/identity/v3/services/requests.go
+++ b/openstack/identity/v3/services/requests.go
@@ -44,7 +44,7 @@ func (opts CreateOpts) ToServiceCreateMap() (map[string]any, error) {
 }
 
 // Create adds a new service of the requested type to the catalog.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToServiceCreateMap()
 	if err != nil {
 		r.Err = err
@@ -79,7 +79,7 @@ func (opts ListOpts) ToServiceListMap() (string, error) {
 }
 
 // List enumerates the services available to a specific user.
-func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(client gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(client)
 	if opts != nil {
 		query, err := opts.ToServiceListMap()
@@ -94,7 +94,7 @@ func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pa
 }
 
 // Get returns additional information about a service, given its ID.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, serviceID string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, serviceID string) (r GetResult) {
 	resp, err := client.Get(ctx, serviceURL(client, serviceID), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -137,7 +137,7 @@ func (opts UpdateOpts) ToServiceUpdateMap() (map[string]any, error) {
 }
 
 // Update updates an existing Service.
-func Update(ctx context.Context, client *gophercloud.ServiceClient, serviceID string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, client gophercloud.Client, serviceID string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToServiceUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -153,7 +153,7 @@ func Update(ctx context.Context, client *gophercloud.ServiceClient, serviceID st
 // Delete removes an existing service.
 // It either deletes all associated endpoints, or fails until all endpoints
 // are deleted.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, serviceID string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, serviceID string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, serviceURL(client, serviceID), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/identity/v3/services/urls.go
+++ b/openstack/identity/v3/services/urls.go
@@ -2,18 +2,18 @@ package services
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func listURL(client *gophercloud.ServiceClient) string {
+func listURL(client gophercloud.Client) string {
 	return client.ServiceURL("services")
 }
 
-func createURL(client *gophercloud.ServiceClient) string {
+func createURL(client gophercloud.Client) string {
 	return client.ServiceURL("services")
 }
 
-func serviceURL(client *gophercloud.ServiceClient, serviceID string) string {
+func serviceURL(client gophercloud.Client, serviceID string) string {
 	return client.ServiceURL("services", serviceID)
 }
 
-func updateURL(client *gophercloud.ServiceClient, serviceID string) string {
+func updateURL(client gophercloud.Client, serviceID string) string {
 	return client.ServiceURL("services", serviceID)
 }

--- a/openstack/identity/v3/tokens/requests.go
+++ b/openstack/identity/v3/tokens/requests.go
@@ -126,7 +126,7 @@ func subjectTokenHeaders(subjectToken string) map[string]string {
 
 // Create authenticates and either generates a new token, or changes the Scope
 // of an existing token.
-func Create(ctx context.Context, c *gophercloud.ServiceClient, opts AuthOptionsBuilder) (r CreateResult) {
+func Create(ctx context.Context, c gophercloud.Client, opts AuthOptionsBuilder) (r CreateResult) {
 	scope, err := opts.ToTokenV3ScopeMap()
 	if err != nil {
 		r.Err = err
@@ -147,7 +147,7 @@ func Create(ctx context.Context, c *gophercloud.ServiceClient, opts AuthOptionsB
 }
 
 // Get validates and retrieves information about another token.
-func Get(ctx context.Context, c *gophercloud.ServiceClient, token string) (r GetResult) {
+func Get(ctx context.Context, c gophercloud.Client, token string) (r GetResult) {
 	resp, err := c.Get(ctx, tokenURL(c), &r.Body, &gophercloud.RequestOpts{
 		MoreHeaders: subjectTokenHeaders(token),
 		OkCodes:     []int{200, 203},
@@ -157,7 +157,7 @@ func Get(ctx context.Context, c *gophercloud.ServiceClient, token string) (r Get
 }
 
 // Validate determines if a specified token is valid or not.
-func Validate(ctx context.Context, c *gophercloud.ServiceClient, token string) (bool, error) {
+func Validate(ctx context.Context, c gophercloud.Client, token string) (bool, error) {
 	resp, err := c.Head(ctx, tokenURL(c), &gophercloud.RequestOpts{
 		MoreHeaders: subjectTokenHeaders(token),
 		OkCodes:     []int{200, 204, 404},
@@ -170,7 +170,7 @@ func Validate(ctx context.Context, c *gophercloud.ServiceClient, token string) (
 }
 
 // Revoke immediately makes specified token invalid.
-func Revoke(ctx context.Context, c *gophercloud.ServiceClient, token string) (r RevokeResult) {
+func Revoke(ctx context.Context, c gophercloud.Client, token string) (r RevokeResult) {
 	resp, err := c.Delete(ctx, tokenURL(c), &gophercloud.RequestOpts{
 		MoreHeaders: subjectTokenHeaders(token),
 	})

--- a/openstack/identity/v3/tokens/urls.go
+++ b/openstack/identity/v3/tokens/urls.go
@@ -2,6 +2,6 @@ package tokens
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func tokenURL(c *gophercloud.ServiceClient) string {
+func tokenURL(c gophercloud.Client) string {
 	return c.ServiceURL("auth", "tokens")
 }

--- a/openstack/identity/v3/trusts/requests.go
+++ b/openstack/identity/v3/trusts/requests.go
@@ -81,7 +81,7 @@ func (opts ListOpts) ToTrustListQuery() (string, error) {
 }
 
 // Create creates a new Trust.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToTrustCreateMap()
 	if err != nil {
 		r.Err = err
@@ -95,14 +95,14 @@ func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateO
 }
 
 // Delete deletes a Trust.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, trustID string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, trustID string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, deleteURL(client, trustID), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
 // List enumerates the Trust to which the current token has access.
-func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(client gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(client)
 	if opts != nil {
 		query, err := opts.ToTrustListQuery()
@@ -117,14 +117,14 @@ func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pa
 }
 
 // Get retrieves details on a single Trust, by ID.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, id string) (r GetResult) {
 	resp, err := client.Get(ctx, resourceURL(client, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
 // ListRoles lists roles delegated by a Trust.
-func ListRoles(client *gophercloud.ServiceClient, id string) pagination.Pager {
+func ListRoles(client gophercloud.Client, id string) pagination.Pager {
 	url := listRolesURL(client, id)
 	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
 		return RolesPage{pagination.LinkedPageBase{PageResult: r}}
@@ -132,14 +132,14 @@ func ListRoles(client *gophercloud.ServiceClient, id string) pagination.Pager {
 }
 
 // GetRole retrieves details on a single role delegated by a Trust.
-func GetRole(ctx context.Context, client *gophercloud.ServiceClient, id string, roleID string) (r GetRoleResult) {
+func GetRole(ctx context.Context, client gophercloud.Client, id string, roleID string) (r GetRoleResult) {
 	resp, err := client.Get(ctx, getRoleURL(client, id, roleID), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
 // CheckRole checks whether a role ID is delegated by a Trust.
-func CheckRole(ctx context.Context, client *gophercloud.ServiceClient, id string, roleID string) (r CheckRoleResult) {
+func CheckRole(ctx context.Context, client gophercloud.Client, id string, roleID string) (r CheckRoleResult) {
 	resp, err := client.Head(ctx, getRoleURL(client, id, roleID), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/identity/v3/trusts/urls.go
+++ b/openstack/identity/v3/trusts/urls.go
@@ -4,30 +4,30 @@ import "github.com/gophercloud/gophercloud/v2"
 
 const resourcePath = "OS-TRUST/trusts"
 
-func rootURL(c *gophercloud.ServiceClient) string {
+func rootURL(c gophercloud.Client) string {
 	return c.ServiceURL(resourcePath)
 }
 
-func resourceURL(c *gophercloud.ServiceClient, id string) string {
+func resourceURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL(resourcePath, id)
 }
 
-func createURL(c *gophercloud.ServiceClient) string {
+func createURL(c gophercloud.Client) string {
 	return rootURL(c)
 }
 
-func deleteURL(c *gophercloud.ServiceClient, id string) string {
+func deleteURL(c gophercloud.Client, id string) string {
 	return resourceURL(c, id)
 }
 
-func listURL(c *gophercloud.ServiceClient) string {
+func listURL(c gophercloud.Client) string {
 	return c.ServiceURL(resourcePath)
 }
 
-func listRolesURL(c *gophercloud.ServiceClient, id string) string {
+func listRolesURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL(resourcePath, id, "roles")
 }
 
-func getRoleURL(c *gophercloud.ServiceClient, id, roleID string) string {
+func getRoleURL(c gophercloud.Client, id, roleID string) string {
 	return c.ServiceURL(resourcePath, id, "roles", roleID)
 }

--- a/openstack/identity/v3/users/requests.go
+++ b/openstack/identity/v3/users/requests.go
@@ -79,7 +79,7 @@ func (opts ListOpts) ToUserListQuery() (string, error) {
 }
 
 // List enumerates the Users to which the current token has access.
-func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(client gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(client)
 	if opts != nil {
 		query, err := opts.ToUserListQuery()
@@ -94,7 +94,7 @@ func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pa
 }
 
 // Get retrieves details on a single user, by ID.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, id string) (r GetResult) {
 	resp, err := client.Get(ctx, getURL(client, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -152,7 +152,7 @@ func (opts CreateOpts) ToUserCreateMap() (map[string]any, error) {
 }
 
 // Create creates a new User.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToUserCreateMap()
 	if err != nil {
 		r.Err = err
@@ -217,7 +217,7 @@ func (opts UpdateOpts) ToUserUpdateMap() (map[string]any, error) {
 }
 
 // Update updates an existing User.
-func Update(ctx context.Context, client *gophercloud.ServiceClient, userID string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, client gophercloud.Client, userID string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToUserUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -256,7 +256,7 @@ func (opts ChangePasswordOpts) ToUserChangePasswordMap() (map[string]any, error)
 }
 
 // ChangePassword changes password for a user.
-func ChangePassword(ctx context.Context, client *gophercloud.ServiceClient, userID string, opts ChangePasswordOptsBuilder) (r ChangePasswordResult) {
+func ChangePassword(ctx context.Context, client gophercloud.Client, userID string, opts ChangePasswordOptsBuilder) (r ChangePasswordResult) {
 	b, err := opts.ToUserChangePasswordMap()
 	if err != nil {
 		r.Err = err
@@ -271,14 +271,14 @@ func ChangePassword(ctx context.Context, client *gophercloud.ServiceClient, user
 }
 
 // Delete deletes a user.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, userID string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, userID string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, deleteURL(client, userID), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
 // ListGroups enumerates groups user belongs to.
-func ListGroups(client *gophercloud.ServiceClient, userID string) pagination.Pager {
+func ListGroups(client gophercloud.Client, userID string) pagination.Pager {
 	url := listGroupsURL(client, userID)
 	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
 		return groups.GroupPage{LinkedPageBase: pagination.LinkedPageBase{PageResult: r}}
@@ -286,7 +286,7 @@ func ListGroups(client *gophercloud.ServiceClient, userID string) pagination.Pag
 }
 
 // AddToGroup adds a user to a group.
-func AddToGroup(ctx context.Context, client *gophercloud.ServiceClient, groupID, userID string) (r AddToGroupResult) {
+func AddToGroup(ctx context.Context, client gophercloud.Client, groupID, userID string) (r AddToGroupResult) {
 	url := addToGroupURL(client, groupID, userID)
 	resp, err := client.Put(ctx, url, nil, nil, &gophercloud.RequestOpts{
 		OkCodes: []int{204},
@@ -296,7 +296,7 @@ func AddToGroup(ctx context.Context, client *gophercloud.ServiceClient, groupID,
 }
 
 // IsMemberOfGroup checks whether a user belongs to a group.
-func IsMemberOfGroup(ctx context.Context, client *gophercloud.ServiceClient, groupID, userID string) (r IsMemberOfGroupResult) {
+func IsMemberOfGroup(ctx context.Context, client gophercloud.Client, groupID, userID string) (r IsMemberOfGroupResult) {
 	url := isMemberOfGroupURL(client, groupID, userID)
 	resp, err := client.Head(ctx, url, &gophercloud.RequestOpts{
 		OkCodes: []int{204, 404},
@@ -311,7 +311,7 @@ func IsMemberOfGroup(ctx context.Context, client *gophercloud.ServiceClient, gro
 }
 
 // RemoveFromGroup removes a user from a group.
-func RemoveFromGroup(ctx context.Context, client *gophercloud.ServiceClient, groupID, userID string) (r RemoveFromGroupResult) {
+func RemoveFromGroup(ctx context.Context, client gophercloud.Client, groupID, userID string) (r RemoveFromGroupResult) {
 	url := removeFromGroupURL(client, groupID, userID)
 	resp, err := client.Delete(ctx, url, &gophercloud.RequestOpts{
 		OkCodes: []int{204},
@@ -321,7 +321,7 @@ func RemoveFromGroup(ctx context.Context, client *gophercloud.ServiceClient, gro
 }
 
 // ListProjects enumerates groups user belongs to.
-func ListProjects(client *gophercloud.ServiceClient, userID string) pagination.Pager {
+func ListProjects(client gophercloud.Client, userID string) pagination.Pager {
 	url := listProjectsURL(client, userID)
 	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
 		return projects.ProjectPage{LinkedPageBase: pagination.LinkedPageBase{PageResult: r}}
@@ -329,7 +329,7 @@ func ListProjects(client *gophercloud.ServiceClient, userID string) pagination.P
 }
 
 // ListInGroup enumerates users that belong to a group.
-func ListInGroup(client *gophercloud.ServiceClient, groupID string, opts ListOptsBuilder) pagination.Pager {
+func ListInGroup(client gophercloud.Client, groupID string, opts ListOptsBuilder) pagination.Pager {
 	url := listInGroupURL(client, groupID)
 	if opts != nil {
 		query, err := opts.ToUserListQuery()

--- a/openstack/identity/v3/users/urls.go
+++ b/openstack/identity/v3/users/urls.go
@@ -2,50 +2,50 @@ package users
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func listURL(client *gophercloud.ServiceClient) string {
+func listURL(client gophercloud.Client) string {
 	return client.ServiceURL("users")
 }
 
-func getURL(client *gophercloud.ServiceClient, userID string) string {
+func getURL(client gophercloud.Client, userID string) string {
 	return client.ServiceURL("users", userID)
 }
 
-func createURL(client *gophercloud.ServiceClient) string {
+func createURL(client gophercloud.Client) string {
 	return client.ServiceURL("users")
 }
 
-func updateURL(client *gophercloud.ServiceClient, userID string) string {
+func updateURL(client gophercloud.Client, userID string) string {
 	return client.ServiceURL("users", userID)
 }
 
-func changePasswordURL(client *gophercloud.ServiceClient, userID string) string {
+func changePasswordURL(client gophercloud.Client, userID string) string {
 	return client.ServiceURL("users", userID, "password")
 }
 
-func deleteURL(client *gophercloud.ServiceClient, userID string) string {
+func deleteURL(client gophercloud.Client, userID string) string {
 	return client.ServiceURL("users", userID)
 }
 
-func listGroupsURL(client *gophercloud.ServiceClient, userID string) string {
+func listGroupsURL(client gophercloud.Client, userID string) string {
 	return client.ServiceURL("users", userID, "groups")
 }
 
-func addToGroupURL(client *gophercloud.ServiceClient, groupID, userID string) string {
+func addToGroupURL(client gophercloud.Client, groupID, userID string) string {
 	return client.ServiceURL("groups", groupID, "users", userID)
 }
 
-func isMemberOfGroupURL(client *gophercloud.ServiceClient, groupID, userID string) string {
+func isMemberOfGroupURL(client gophercloud.Client, groupID, userID string) string {
 	return client.ServiceURL("groups", groupID, "users", userID)
 }
 
-func removeFromGroupURL(client *gophercloud.ServiceClient, groupID, userID string) string {
+func removeFromGroupURL(client gophercloud.Client, groupID, userID string) string {
 	return client.ServiceURL("groups", groupID, "users", userID)
 }
 
-func listProjectsURL(client *gophercloud.ServiceClient, userID string) string {
+func listProjectsURL(client gophercloud.Client, userID string) string {
 	return client.ServiceURL("users", userID, "projects")
 }
 
-func listInGroupURL(client *gophercloud.ServiceClient, groupID string) string {
+func listInGroupURL(client gophercloud.Client, groupID string) string {
 	return client.ServiceURL("groups", groupID, "users")
 }

--- a/openstack/image/v2/imagedata/requests.go
+++ b/openstack/image/v2/imagedata/requests.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Upload uploads an image file.
-func Upload(ctx context.Context, client *gophercloud.ServiceClient, id string, data io.Reader) (r UploadResult) {
+func Upload(ctx context.Context, client gophercloud.Client, id string, data io.Reader) (r UploadResult) {
 	resp, err := client.Put(ctx, uploadURL(client, id), data, nil, &gophercloud.RequestOpts{
 		MoreHeaders: map[string]string{"Content-Type": "application/octet-stream"},
 		OkCodes:     []int{204},
@@ -20,7 +20,7 @@ func Upload(ctx context.Context, client *gophercloud.ServiceClient, id string, d
 // Stage performs PUT call on the existing image object in the Image service with
 // the provided file.
 // Existing image object must be in the "queued" status.
-func Stage(ctx context.Context, client *gophercloud.ServiceClient, id string, data io.Reader) (r StageResult) {
+func Stage(ctx context.Context, client gophercloud.Client, id string, data io.Reader) (r StageResult) {
 	resp, err := client.Put(ctx, stageURL(client, id), data, nil, &gophercloud.RequestOpts{
 		MoreHeaders: map[string]string{"Content-Type": "application/octet-stream"},
 		OkCodes:     []int{204},
@@ -30,7 +30,7 @@ func Stage(ctx context.Context, client *gophercloud.ServiceClient, id string, da
 }
 
 // Download retrieves an image.
-func Download(ctx context.Context, client *gophercloud.ServiceClient, id string) (r DownloadResult) {
+func Download(ctx context.Context, client gophercloud.Client, id string) (r DownloadResult) {
 	resp, err := client.Get(ctx, downloadURL(client, id), nil, &gophercloud.RequestOpts{
 		KeepResponseBody: true,
 	})

--- a/openstack/image/v2/imagedata/urls.go
+++ b/openstack/image/v2/imagedata/urls.go
@@ -10,14 +10,14 @@ const (
 
 // `imageDataURL(c,i)` is the URL for the binary image data for the
 // image identified by ID `i` in the service `c`.
-func uploadURL(c *gophercloud.ServiceClient, imageID string) string {
+func uploadURL(c gophercloud.Client, imageID string) string {
 	return c.ServiceURL(rootPath, imageID, uploadPath)
 }
 
-func stageURL(c *gophercloud.ServiceClient, imageID string) string {
+func stageURL(c gophercloud.Client, imageID string) string {
 	return c.ServiceURL(rootPath, imageID, stagePath)
 }
 
-func downloadURL(c *gophercloud.ServiceClient, imageID string) string {
+func downloadURL(c gophercloud.Client, imageID string) string {
 	return uploadURL(c, imageID)
 }

--- a/openstack/image/v2/imageimport/requests.go
+++ b/openstack/image/v2/imageimport/requests.go
@@ -18,7 +18,7 @@ const (
 )
 
 // Get retrieves Import API information data.
-func Get(ctx context.Context, c *gophercloud.ServiceClient) (r GetResult) {
+func Get(ctx context.Context, c gophercloud.Client) (r GetResult) {
 	resp, err := c.Get(ctx, infoURL(c), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -45,7 +45,7 @@ func (opts CreateOpts) ToImportCreateMap() (map[string]any, error) {
 }
 
 // Create requests the creation of a new image import on the server.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, imageID string, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, imageID string, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToImportCreateMap()
 	if err != nil {
 		r.Err = err

--- a/openstack/image/v2/imageimport/urls.go
+++ b/openstack/image/v2/imageimport/urls.go
@@ -8,10 +8,10 @@ const (
 	resourcePath = "import"
 )
 
-func infoURL(c *gophercloud.ServiceClient) string {
+func infoURL(c gophercloud.Client) string {
 	return c.ServiceURL(infoPath, resourcePath)
 }
 
-func importURL(c *gophercloud.ServiceClient, imageID string) string {
+func importURL(c gophercloud.Client, imageID string) string {
 	return c.ServiceURL(rootPath, imageID, resourcePath)
 }

--- a/openstack/image/v2/images/requests.go
+++ b/openstack/image/v2/images/requests.go
@@ -123,7 +123,7 @@ func (opts ListOpts) ToImageListQuery() (string, error) {
 }
 
 // List implements image list request.
-func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(c gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(c)
 	if opts != nil {
 		query, err := opts.ToImageListQuery()
@@ -207,7 +207,7 @@ func (opts CreateOpts) ToImageCreateMap() (map[string]any, error) {
 }
 
 // Create implements create image request.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToImageCreateMap()
 	if err != nil {
 		r.Err = err
@@ -219,21 +219,21 @@ func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateO
 }
 
 // Delete implements image delete request.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, id string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, deleteURL(client, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
 // Get implements image get request.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, id string) (r GetResult) {
 	resp, err := client.Get(ctx, getURL(client, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
 // Update implements image updated request.
-func Update(ctx context.Context, client *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, client gophercloud.Client, id string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToImageUpdateMap()
 	if err != nil {
 		r.Err = err

--- a/openstack/image/v2/images/urls.go
+++ b/openstack/image/v2/images/urls.go
@@ -10,32 +10,32 @@ import (
 
 // `listURL` is a pure function. `listURL(c)` is a URL for which a GET
 // request will respond with a list of images in the service `c`.
-func listURL(c *gophercloud.ServiceClient) string {
+func listURL(c gophercloud.Client) string {
 	return c.ServiceURL("images")
 }
 
-func createURL(c *gophercloud.ServiceClient) string {
+func createURL(c gophercloud.Client) string {
 	return c.ServiceURL("images")
 }
 
 // `imageURL(c,i)` is the URL for the image identified by ID `i` in
 // the service `c`.
-func imageURL(c *gophercloud.ServiceClient, imageID string) string {
+func imageURL(c gophercloud.Client, imageID string) string {
 	return c.ServiceURL("images", imageID)
 }
 
 // `getURL(c,i)` is a URL for which a GET request will respond with
 // information about the image identified by ID `i` in the service
 // `c`.
-func getURL(c *gophercloud.ServiceClient, imageID string) string {
+func getURL(c gophercloud.Client, imageID string) string {
 	return imageURL(c, imageID)
 }
 
-func updateURL(c *gophercloud.ServiceClient, imageID string) string {
+func updateURL(c gophercloud.Client, imageID string) string {
 	return imageURL(c, imageID)
 }
 
-func deleteURL(c *gophercloud.ServiceClient, imageID string) string {
+func deleteURL(c gophercloud.Client, imageID string) string {
 	return imageURL(c, imageID)
 }
 

--- a/openstack/image/v2/members/requests.go
+++ b/openstack/image/v2/members/requests.go
@@ -25,7 +25,7 @@ pending through API calls.
 More details here:
 http://developer.openstack.org/api-ref-image-v2.html#createImageMember-v2
 */
-func Create(ctx context.Context, client *gophercloud.ServiceClient, id string, member string) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, id string, member string) (r CreateResult) {
 	b := map[string]any{"member": member}
 	resp, err := client.Post(ctx, createMemberURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{200},
@@ -35,21 +35,21 @@ func Create(ctx context.Context, client *gophercloud.ServiceClient, id string, m
 }
 
 // List members returns list of members for specifed image id.
-func List(client *gophercloud.ServiceClient, id string) pagination.Pager {
+func List(client gophercloud.Client, id string) pagination.Pager {
 	return pagination.NewPager(client, listMembersURL(client, id), func(r pagination.PageResult) pagination.Page {
 		return MemberPage{pagination.SinglePageBase(r)}
 	})
 }
 
 // Get image member details.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, imageID string, memberID string) (r DetailsResult) {
+func Get(ctx context.Context, client gophercloud.Client, imageID string, memberID string) (r DetailsResult) {
 	resp, err := client.Get(ctx, getMemberURL(client, imageID, memberID), &r.Body, &gophercloud.RequestOpts{OkCodes: []int{200}})
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
 // Delete membership for given image. Callee should be image owner.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, imageID string, memberID string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, imageID string, memberID string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, deleteMemberURL(client, imageID, memberID), &gophercloud.RequestOpts{OkCodes: []int{204}})
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -74,7 +74,7 @@ func (opts UpdateOpts) ToImageMemberUpdateMap() (map[string]any, error) {
 }
 
 // Update function updates member.
-func Update(ctx context.Context, client *gophercloud.ServiceClient, imageID string, memberID string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, client gophercloud.Client, imageID string, memberID string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToImageMemberUpdateMap()
 	if err != nil {
 		r.Err = err

--- a/openstack/image/v2/members/urls.go
+++ b/openstack/image/v2/members/urls.go
@@ -2,30 +2,30 @@ package members
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func imageMembersURL(c *gophercloud.ServiceClient, imageID string) string {
+func imageMembersURL(c gophercloud.Client, imageID string) string {
 	return c.ServiceURL("images", imageID, "members")
 }
 
-func listMembersURL(c *gophercloud.ServiceClient, imageID string) string {
+func listMembersURL(c gophercloud.Client, imageID string) string {
 	return imageMembersURL(c, imageID)
 }
 
-func createMemberURL(c *gophercloud.ServiceClient, imageID string) string {
+func createMemberURL(c gophercloud.Client, imageID string) string {
 	return imageMembersURL(c, imageID)
 }
 
-func imageMemberURL(c *gophercloud.ServiceClient, imageID string, memberID string) string {
+func imageMemberURL(c gophercloud.Client, imageID string, memberID string) string {
 	return c.ServiceURL("images", imageID, "members", memberID)
 }
 
-func getMemberURL(c *gophercloud.ServiceClient, imageID string, memberID string) string {
+func getMemberURL(c gophercloud.Client, imageID string, memberID string) string {
 	return imageMemberURL(c, imageID, memberID)
 }
 
-func updateMemberURL(c *gophercloud.ServiceClient, imageID string, memberID string) string {
+func updateMemberURL(c gophercloud.Client, imageID string, memberID string) string {
 	return imageMemberURL(c, imageID, memberID)
 }
 
-func deleteMemberURL(c *gophercloud.ServiceClient, imageID string, memberID string) string {
+func deleteMemberURL(c gophercloud.Client, imageID string, memberID string) string {
 	return imageMemberURL(c, imageID, memberID)
 }

--- a/openstack/image/v2/tasks/requests.go
+++ b/openstack/image/v2/tasks/requests.go
@@ -71,7 +71,7 @@ func (opts ListOpts) ToTaskListQuery() (string, error) {
 }
 
 // List returns a Pager which allows you to iterate over a collection of the tasks.
-func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(c gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(c)
 	if opts != nil {
 		query, err := opts.ToTaskListQuery()
@@ -91,7 +91,7 @@ func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 }
 
 // Get retrieves a specific Image service task based on its ID.
-func Get(ctx context.Context, c *gophercloud.ServiceClient, taskID string) (r GetResult) {
+func Get(ctx context.Context, c gophercloud.Client, taskID string) (r GetResult) {
 	resp, err := c.Get(ctx, getURL(c, taskID), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -118,7 +118,7 @@ func (opts CreateOpts) ToTaskCreateMap() (map[string]any, error) {
 }
 
 // Create requests the creation of a new Image service task on the server.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToTaskCreateMap()
 	if err != nil {
 		r.Err = err

--- a/openstack/image/v2/tasks/urls.go
+++ b/openstack/image/v2/tasks/urls.go
@@ -10,23 +10,23 @@ import (
 
 const resourcePath = "tasks"
 
-func rootURL(c *gophercloud.ServiceClient) string {
+func rootURL(c gophercloud.Client) string {
 	return c.ServiceURL(resourcePath)
 }
 
-func resourceURL(c *gophercloud.ServiceClient, taskID string) string {
+func resourceURL(c gophercloud.Client, taskID string) string {
 	return c.ServiceURL(resourcePath, taskID)
 }
 
-func listURL(c *gophercloud.ServiceClient) string {
+func listURL(c gophercloud.Client) string {
 	return rootURL(c)
 }
 
-func getURL(c *gophercloud.ServiceClient, taskID string) string {
+func getURL(c gophercloud.Client, taskID string) string {
 	return resourceURL(c, taskID)
 }
 
-func createURL(c *gophercloud.ServiceClient) string {
+func createURL(c gophercloud.Client) string {
 	return rootURL(c)
 }
 

--- a/openstack/keymanager/v1/acls/requests.go
+++ b/openstack/keymanager/v1/acls/requests.go
@@ -7,14 +7,14 @@ import (
 )
 
 // GetContainerACL retrieves the ACL of a container.
-func GetContainerACL(ctx context.Context, client *gophercloud.ServiceClient, containerID string) (r ACLResult) {
+func GetContainerACL(ctx context.Context, client gophercloud.Client, containerID string) (r ACLResult) {
 	resp, err := client.Get(ctx, containerURL(client, containerID), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
 // GetSecretACL retrieves the ACL of a secret.
-func GetSecretACL(ctx context.Context, client *gophercloud.ServiceClient, secretID string) (r ACLResult) {
+func GetSecretACL(ctx context.Context, client gophercloud.Client, secretID string) (r ACLResult) {
 	resp, err := client.Get(ctx, secretURL(client, secretID), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -55,7 +55,7 @@ func (opts SetOpts) ToACLSetMap() (map[string]any, error) {
 }
 
 // SetContainerACL will set an ACL on a container.
-func SetContainerACL(ctx context.Context, client *gophercloud.ServiceClient, containerID string, opts SetOptsBuilder) (r ACLRefResult) {
+func SetContainerACL(ctx context.Context, client gophercloud.Client, containerID string, opts SetOptsBuilder) (r ACLRefResult) {
 	b, err := opts.ToACLSetMap()
 	if err != nil {
 		r.Err = err
@@ -70,7 +70,7 @@ func SetContainerACL(ctx context.Context, client *gophercloud.ServiceClient, con
 }
 
 // SetSecretACL will set an ACL on a secret.
-func SetSecretACL(ctx context.Context, client *gophercloud.ServiceClient, secretID string, opts SetOptsBuilder) (r ACLRefResult) {
+func SetSecretACL(ctx context.Context, client gophercloud.Client, secretID string, opts SetOptsBuilder) (r ACLRefResult) {
 	b, err := opts.ToACLSetMap()
 	if err != nil {
 		r.Err = err
@@ -85,7 +85,7 @@ func SetSecretACL(ctx context.Context, client *gophercloud.ServiceClient, secret
 }
 
 // UpdateContainerACL will update an ACL on a container.
-func UpdateContainerACL(ctx context.Context, client *gophercloud.ServiceClient, containerID string, opts SetOptsBuilder) (r ACLRefResult) {
+func UpdateContainerACL(ctx context.Context, client gophercloud.Client, containerID string, opts SetOptsBuilder) (r ACLRefResult) {
 	b, err := opts.ToACLSetMap()
 	if err != nil {
 		r.Err = err
@@ -100,7 +100,7 @@ func UpdateContainerACL(ctx context.Context, client *gophercloud.ServiceClient, 
 }
 
 // UpdateSecretACL will update an ACL on a secret.
-func UpdateSecretACL(ctx context.Context, client *gophercloud.ServiceClient, secretID string, opts SetOptsBuilder) (r ACLRefResult) {
+func UpdateSecretACL(ctx context.Context, client gophercloud.Client, secretID string, opts SetOptsBuilder) (r ACLRefResult) {
 	b, err := opts.ToACLSetMap()
 	if err != nil {
 		r.Err = err
@@ -115,7 +115,7 @@ func UpdateSecretACL(ctx context.Context, client *gophercloud.ServiceClient, sec
 }
 
 // DeleteContainerACL will delete an ACL from a conatiner.
-func DeleteContainerACL(ctx context.Context, client *gophercloud.ServiceClient, containerID string) (r DeleteResult) {
+func DeleteContainerACL(ctx context.Context, client gophercloud.Client, containerID string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, containerURL(client, containerID), &gophercloud.RequestOpts{
 		OkCodes: []int{200},
 	})
@@ -124,7 +124,7 @@ func DeleteContainerACL(ctx context.Context, client *gophercloud.ServiceClient, 
 }
 
 // DeleteSecretACL will delete an ACL from a secret.
-func DeleteSecretACL(ctx context.Context, client *gophercloud.ServiceClient, secretID string) (r DeleteResult) {
+func DeleteSecretACL(ctx context.Context, client gophercloud.Client, secretID string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, secretURL(client, secretID), &gophercloud.RequestOpts{
 		OkCodes: []int{200},
 	})

--- a/openstack/keymanager/v1/acls/urls.go
+++ b/openstack/keymanager/v1/acls/urls.go
@@ -2,10 +2,10 @@ package acls
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func containerURL(client *gophercloud.ServiceClient, containerID string) string {
+func containerURL(client gophercloud.Client, containerID string) string {
 	return client.ServiceURL("containers", containerID, "acl")
 }
 
-func secretURL(client *gophercloud.ServiceClient, secretID string) string {
+func secretURL(client gophercloud.Client, secretID string) string {
 	return client.ServiceURL("secrets", secretID, "acl")
 }

--- a/openstack/keymanager/v1/containers/requests.go
+++ b/openstack/keymanager/v1/containers/requests.go
@@ -41,7 +41,7 @@ func (opts ListOpts) ToContainerListQuery() (string, error) {
 }
 
 // List retrieves a list of containers.
-func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(client gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(client)
 	if opts != nil {
 		query, err := opts.ToContainerListQuery()
@@ -56,7 +56,7 @@ func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pa
 }
 
 // Get retrieves details of a container.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, id string) (r GetResult) {
 	resp, err := client.Get(ctx, getURL(client, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -86,7 +86,7 @@ func (opts CreateOpts) ToContainerCreateMap() (map[string]any, error) {
 }
 
 // Create creates a new container.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToContainerCreateMap()
 	if err != nil {
 		r.Err = err
@@ -100,7 +100,7 @@ func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateO
 }
 
 // Delete deletes a container.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, id string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, deleteURL(client, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -129,7 +129,7 @@ func (opts ListOpts) ToContainerListConsumersQuery() (string, error) {
 }
 
 // ListConsumers retrieves a list of consumers from a container.
-func ListConsumers(client *gophercloud.ServiceClient, containerID string, opts ListConsumersOptsBuilder) pagination.Pager {
+func ListConsumers(client gophercloud.Client, containerID string, opts ListConsumersOptsBuilder) pagination.Pager {
 	url := listConsumersURL(client, containerID)
 	if opts != nil {
 		query, err := opts.ToContainerListConsumersQuery()
@@ -165,7 +165,7 @@ func (opts CreateConsumerOpts) ToContainerConsumerCreateMap() (map[string]any, e
 }
 
 // CreateConsumer creates a new consumer.
-func CreateConsumer(ctx context.Context, client *gophercloud.ServiceClient, containerID string, opts CreateConsumerOptsBuilder) (r CreateConsumerResult) {
+func CreateConsumer(ctx context.Context, client gophercloud.Client, containerID string, opts CreateConsumerOptsBuilder) (r CreateConsumerResult) {
 	b, err := opts.ToContainerConsumerCreateMap()
 	if err != nil {
 		r.Err = err
@@ -200,7 +200,7 @@ func (opts DeleteConsumerOpts) ToContainerConsumerDeleteMap() (map[string]any, e
 }
 
 // DeleteConsumer deletes a consumer.
-func DeleteConsumer(ctx context.Context, client *gophercloud.ServiceClient, containerID string, opts DeleteConsumerOptsBuilder) (r DeleteConsumerResult) {
+func DeleteConsumer(ctx context.Context, client gophercloud.Client, containerID string, opts DeleteConsumerOptsBuilder) (r DeleteConsumerResult) {
 	url := deleteConsumerURL(client, containerID)
 
 	b, err := opts.ToContainerConsumerDeleteMap()
@@ -231,7 +231,7 @@ func (opts SecretRef) ToContainerSecretRefMap() (map[string]any, error) {
 }
 
 // CreateSecret creates a new consumer.
-func CreateSecretRef(ctx context.Context, client *gophercloud.ServiceClient, containerID string, opts SecretRefBuilder) (r CreateSecretRefResult) {
+func CreateSecretRef(ctx context.Context, client gophercloud.Client, containerID string, opts SecretRefBuilder) (r CreateSecretRefResult) {
 	b, err := opts.ToContainerSecretRefMap()
 	if err != nil {
 		r.Err = err
@@ -245,7 +245,7 @@ func CreateSecretRef(ctx context.Context, client *gophercloud.ServiceClient, con
 }
 
 // DeleteSecret deletes a consumer.
-func DeleteSecretRef(ctx context.Context, client *gophercloud.ServiceClient, containerID string, opts SecretRefBuilder) (r DeleteSecretRefResult) {
+func DeleteSecretRef(ctx context.Context, client gophercloud.Client, containerID string, opts SecretRefBuilder) (r DeleteSecretRefResult) {
 	url := deleteSecretRefURL(client, containerID)
 
 	b, err := opts.ToContainerSecretRefMap()

--- a/openstack/keymanager/v1/containers/urls.go
+++ b/openstack/keymanager/v1/containers/urls.go
@@ -2,38 +2,38 @@ package containers
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func listURL(client *gophercloud.ServiceClient) string {
+func listURL(client gophercloud.Client) string {
 	return client.ServiceURL("containers")
 }
 
-func getURL(client *gophercloud.ServiceClient, id string) string {
+func getURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL("containers", id)
 }
 
-func createURL(client *gophercloud.ServiceClient) string {
+func createURL(client gophercloud.Client) string {
 	return client.ServiceURL("containers")
 }
 
-func deleteURL(client *gophercloud.ServiceClient, id string) string {
+func deleteURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL("containers", id)
 }
 
-func listConsumersURL(client *gophercloud.ServiceClient, id string) string {
+func listConsumersURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL("containers", id, "consumers")
 }
 
-func createConsumerURL(client *gophercloud.ServiceClient, id string) string {
+func createConsumerURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL("containers", id, "consumers")
 }
 
-func deleteConsumerURL(client *gophercloud.ServiceClient, id string) string {
+func deleteConsumerURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL("containers", id, "consumers")
 }
 
-func createSecretRefURL(client *gophercloud.ServiceClient, id string) string {
+func createSecretRefURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL("containers", id, "secrets")
 }
 
-func deleteSecretRefURL(client *gophercloud.ServiceClient, id string) string {
+func deleteSecretRefURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL("containers", id, "secrets")
 }

--- a/openstack/keymanager/v1/orders/requests.go
+++ b/openstack/keymanager/v1/orders/requests.go
@@ -38,7 +38,7 @@ func (opts ListOpts) ToOrderListQuery() (string, error) {
 }
 
 // List retrieves a list of orders.
-func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(client gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(client)
 	if opts != nil {
 		query, err := opts.ToOrderListQuery()
@@ -53,7 +53,7 @@ func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pa
 }
 
 // Get retrieves details of a orders.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, id string) (r GetResult) {
 	resp, err := client.Get(ctx, getURL(client, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -112,7 +112,7 @@ func (opts CreateOpts) ToOrderCreateMap() (map[string]any, error) {
 }
 
 // Create creates a new orders.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToOrderCreateMap()
 	if err != nil {
 		r.Err = err
@@ -126,7 +126,7 @@ func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateO
 }
 
 // Delete deletes a orders.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, id string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, deleteURL(client, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/keymanager/v1/orders/urls.go
+++ b/openstack/keymanager/v1/orders/urls.go
@@ -2,18 +2,18 @@ package orders
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func listURL(client *gophercloud.ServiceClient) string {
+func listURL(client gophercloud.Client) string {
 	return client.ServiceURL("orders")
 }
 
-func getURL(client *gophercloud.ServiceClient, id string) string {
+func getURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL("orders", id)
 }
 
-func createURL(client *gophercloud.ServiceClient) string {
+func createURL(client gophercloud.Client) string {
 	return client.ServiceURL("orders")
 }
 
-func deleteURL(client *gophercloud.ServiceClient, id string) string {
+func deleteURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL("orders", id)
 }

--- a/openstack/keymanager/v1/secrets/requests.go
+++ b/openstack/keymanager/v1/secrets/requests.go
@@ -128,7 +128,7 @@ func (opts ListOpts) ToSecretListQuery() (string, error) {
 }
 
 // List retrieves a list of Secrets.
-func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(client gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(client)
 	if opts != nil {
 		query, err := opts.ToSecretListQuery()
@@ -143,7 +143,7 @@ func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pa
 }
 
 // Get retrieves details of a secrets.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, id string) (r GetResult) {
 	resp, err := client.Get(ctx, getURL(client, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -166,7 +166,7 @@ func (opts GetPayloadOpts) ToSecretPayloadGetParams() (map[string]string, error)
 }
 
 // GetPayload retrieves the payload of a secret.
-func GetPayload(ctx context.Context, client *gophercloud.ServiceClient, id string, opts GetPayloadOptsBuilder) (r PayloadResult) {
+func GetPayload(ctx context.Context, client gophercloud.Client, id string, opts GetPayloadOptsBuilder) (r PayloadResult) {
 	h := map[string]string{"Accept": "text/plain"}
 
 	if opts != nil {
@@ -241,7 +241,7 @@ func (opts CreateOpts) ToSecretCreateMap() (map[string]any, error) {
 }
 
 // Create creates a new secrets.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToSecretCreateMap()
 	if err != nil {
 		r.Err = err
@@ -255,7 +255,7 @@ func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateO
 }
 
 // Delete deletes a secrets.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, id string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, deleteURL(client, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -291,7 +291,7 @@ func (opts UpdateOpts) ToSecretUpdateRequest() (string, map[string]string, error
 }
 
 // Update modifies the attributes of a secrets.
-func Update(ctx context.Context, client *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, client gophercloud.Client, id string, opts UpdateOptsBuilder) (r UpdateResult) {
 	url := updateURL(client, id)
 	h := make(map[string]string)
 	var b string
@@ -319,7 +319,7 @@ func Update(ctx context.Context, client *gophercloud.ServiceClient, id string, o
 }
 
 // GetMetadata will list metadata for a given secret.
-func GetMetadata(ctx context.Context, client *gophercloud.ServiceClient, secretID string) (r MetadataResult) {
+func GetMetadata(ctx context.Context, client gophercloud.Client, secretID string) (r MetadataResult) {
 	resp, err := client.Get(ctx, metadataURL(client, secretID), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -340,7 +340,7 @@ func (opts MetadataOpts) ToMetadataCreateMap() (map[string]any, error) {
 }
 
 // CreateMetadata will set metadata for a given secret.
-func CreateMetadata(ctx context.Context, client *gophercloud.ServiceClient, secretID string, opts CreateMetadataOptsBuilder) (r MetadataCreateResult) {
+func CreateMetadata(ctx context.Context, client gophercloud.Client, secretID string, opts CreateMetadataOptsBuilder) (r MetadataCreateResult) {
 	b, err := opts.ToMetadataCreateMap()
 	if err != nil {
 		r.Err = err
@@ -354,7 +354,7 @@ func CreateMetadata(ctx context.Context, client *gophercloud.ServiceClient, secr
 }
 
 // GetMetadatum will get a single key/value metadata from a secret.
-func GetMetadatum(ctx context.Context, client *gophercloud.ServiceClient, secretID string, key string) (r MetadatumResult) {
+func GetMetadatum(ctx context.Context, client gophercloud.Client, secretID string, key string) (r MetadatumResult) {
 	resp, err := client.Get(ctx, metadatumURL(client, secretID, key), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -378,7 +378,7 @@ func (opts MetadatumOpts) ToMetadatumCreateMap() (map[string]any, error) {
 }
 
 // CreateMetadatum will add a single key/value metadata to a secret.
-func CreateMetadatum(ctx context.Context, client *gophercloud.ServiceClient, secretID string, opts CreateMetadatumOptsBuilder) (r MetadatumCreateResult) {
+func CreateMetadatum(ctx context.Context, client gophercloud.Client, secretID string, opts CreateMetadatumOptsBuilder) (r MetadatumCreateResult) {
 	b, err := opts.ToMetadatumCreateMap()
 	if err != nil {
 		r.Err = err
@@ -404,7 +404,7 @@ func (opts MetadatumOpts) ToMetadatumUpdateMap() (map[string]any, string, error)
 }
 
 // UpdateMetadatum will update a single key/value metadata to a secret.
-func UpdateMetadatum(ctx context.Context, client *gophercloud.ServiceClient, secretID string, opts UpdateMetadatumOptsBuilder) (r MetadatumResult) {
+func UpdateMetadatum(ctx context.Context, client gophercloud.Client, secretID string, opts UpdateMetadatumOptsBuilder) (r MetadatumResult) {
 	b, key, err := opts.ToMetadatumUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -418,7 +418,7 @@ func UpdateMetadatum(ctx context.Context, client *gophercloud.ServiceClient, sec
 }
 
 // DeleteMetadatum will delete an individual metadatum from a secret.
-func DeleteMetadatum(ctx context.Context, client *gophercloud.ServiceClient, secretID string, key string) (r MetadatumDeleteResult) {
+func DeleteMetadatum(ctx context.Context, client gophercloud.Client, secretID string, key string) (r MetadatumDeleteResult) {
 	resp, err := client.Delete(ctx, metadatumURL(client, secretID, key), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/keymanager/v1/secrets/urls.go
+++ b/openstack/keymanager/v1/secrets/urls.go
@@ -2,34 +2,34 @@ package secrets
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func listURL(client *gophercloud.ServiceClient) string {
+func listURL(client gophercloud.Client) string {
 	return client.ServiceURL("secrets")
 }
 
-func getURL(client *gophercloud.ServiceClient, id string) string {
+func getURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL("secrets", id)
 }
 
-func createURL(client *gophercloud.ServiceClient) string {
+func createURL(client gophercloud.Client) string {
 	return client.ServiceURL("secrets")
 }
 
-func deleteURL(client *gophercloud.ServiceClient, id string) string {
+func deleteURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL("secrets", id)
 }
 
-func updateURL(client *gophercloud.ServiceClient, id string) string {
+func updateURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL("secrets", id)
 }
 
-func payloadURL(client *gophercloud.ServiceClient, id string) string {
+func payloadURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL("secrets", id, "payload")
 }
 
-func metadataURL(client *gophercloud.ServiceClient, id string) string {
+func metadataURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL("secrets", id, "metadata")
 }
 
-func metadatumURL(client *gophercloud.ServiceClient, id, key string) string {
+func metadatumURL(client gophercloud.Client, id, key string) string {
 	return client.ServiceURL("secrets", id, "metadata", key)
 }

--- a/openstack/loadbalancer/v2/amphorae/requests.go
+++ b/openstack/loadbalancer/v2/amphorae/requests.go
@@ -40,7 +40,7 @@ func (opts ListOpts) ToAmphoraListQuery() (string, error) {
 // List returns a Pager which allows you to iterate over a collection of
 // amphorae. It accepts a ListOpts struct, which allows you to filter
 // and sort the returned collection for greater efficiency.
-func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(c gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := rootURL(c)
 	if opts != nil {
 		query, err := opts.ToAmphoraListQuery()
@@ -55,14 +55,14 @@ func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 }
 
 // Get retrieves a particular amphora based on its unique ID.
-func Get(ctx context.Context, c *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, c gophercloud.Client, id string) (r GetResult) {
 	resp, err := c.Get(ctx, resourceURL(c, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
 // Failover performs a failover of an amphora.
-func Failover(ctx context.Context, c *gophercloud.ServiceClient, id string) (r FailoverResult) {
+func Failover(ctx context.Context, c gophercloud.Client, id string) (r FailoverResult) {
 	resp, err := c.Put(ctx, failoverRootURL(c, id), nil, nil, &gophercloud.RequestOpts{
 		OkCodes: []int{202},
 	})

--- a/openstack/loadbalancer/v2/amphorae/urls.go
+++ b/openstack/loadbalancer/v2/amphorae/urls.go
@@ -8,14 +8,14 @@ const (
 	failoverPath = "failover"
 )
 
-func rootURL(c *gophercloud.ServiceClient) string {
+func rootURL(c gophercloud.Client) string {
 	return c.ServiceURL(rootPath, resourcePath)
 }
 
-func resourceURL(c *gophercloud.ServiceClient, id string) string {
+func resourceURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL(rootPath, resourcePath, id)
 }
 
-func failoverRootURL(c *gophercloud.ServiceClient, id string) string {
+func failoverRootURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL(rootPath, resourcePath, id, failoverPath)
 }

--- a/openstack/loadbalancer/v2/apiversions/requests.go
+++ b/openstack/loadbalancer/v2/apiversions/requests.go
@@ -6,7 +6,7 @@ import (
 )
 
 // List lists all the load balancer API versions available to end-users.
-func List(c *gophercloud.ServiceClient) pagination.Pager {
+func List(c gophercloud.Client) pagination.Pager {
 	return pagination.NewPager(c, listURL(c), func(r pagination.PageResult) pagination.Page {
 		return APIVersionPage{pagination.SinglePageBase(r)}
 	})

--- a/openstack/loadbalancer/v2/apiversions/urls.go
+++ b/openstack/loadbalancer/v2/apiversions/urls.go
@@ -7,8 +7,8 @@ import (
 	"github.com/gophercloud/gophercloud/v2/openstack/utils"
 )
 
-func listURL(c *gophercloud.ServiceClient) string {
-	baseEndpoint, _ := utils.BaseEndpoint(c.Endpoint)
+func listURL(c gophercloud.Client) string {
+	baseEndpoint, _ := utils.BaseEndpoint(c.EndpointURL())
 	endpoint := strings.TrimRight(baseEndpoint, "/") + "/"
 	return endpoint
 }

--- a/openstack/loadbalancer/v2/flavorprofiles/requests.go
+++ b/openstack/loadbalancer/v2/flavorprofiles/requests.go
@@ -32,7 +32,7 @@ func (opts ListOpts) ToFlavorProfileListQuery() (string, error) {
 // List returns a Pager which allows you to iterate over a collection of
 // FlavorProfiles. It accepts a ListOpts struct, which allows you to filter
 // and sort the returned collection for greater efficiency.
-func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(c gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := rootURL(c)
 	if opts != nil {
 		query, err := opts.ToFlavorProfileListQuery()
@@ -72,7 +72,7 @@ func (opts CreateOpts) ToFlavorProfileCreateMap() (map[string]any, error) {
 
 // Create is and operation which add a new FlavorProfile into the database.
 // CreateResult will be returned.
-func Create(ctx context.Context, c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, c gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToFlavorProfileCreateMap()
 	if err != nil {
 		r.Err = err
@@ -84,7 +84,7 @@ func Create(ctx context.Context, c *gophercloud.ServiceClient, opts CreateOptsBu
 }
 
 // Get retrieves a particular FlavorProfile based on its unique ID.
-func Get(ctx context.Context, c *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, c gophercloud.Client, id string) (r GetResult) {
 	resp, err := c.Get(ctx, resourceURL(c, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -121,7 +121,7 @@ func (opts UpdateOpts) ToFlavorProfileUpdateMap() (map[string]any, error) {
 
 // Update is an operation which modifies the attributes of the specified
 // FlavorProfile.
-func Update(ctx context.Context, c *gophercloud.ServiceClient, id string, opts UpdateOpts) (r UpdateResult) {
+func Update(ctx context.Context, c gophercloud.Client, id string, opts UpdateOpts) (r UpdateResult) {
 	b, err := opts.ToFlavorProfileUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -136,7 +136,7 @@ func Update(ctx context.Context, c *gophercloud.ServiceClient, id string, opts U
 
 // Delete will permanently delete a particular FlavorProfile based on its
 // unique ID.
-func Delete(ctx context.Context, c *gophercloud.ServiceClient, id string) (r DeleteResult) {
+func Delete(ctx context.Context, c gophercloud.Client, id string) (r DeleteResult) {
 	resp, err := c.Delete(ctx, resourceURL(c, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/loadbalancer/v2/flavorprofiles/urls.go
+++ b/openstack/loadbalancer/v2/flavorprofiles/urls.go
@@ -7,10 +7,10 @@ const (
 	resourcePath = "flavorprofiles"
 )
 
-func rootURL(c *gophercloud.ServiceClient) string {
+func rootURL(c gophercloud.Client) string {
 	return c.ServiceURL(rootPath, resourcePath)
 }
 
-func resourceURL(c *gophercloud.ServiceClient, id string) string {
+func resourceURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL(rootPath, resourcePath, id)
 }

--- a/openstack/loadbalancer/v2/flavors/requests.go
+++ b/openstack/loadbalancer/v2/flavors/requests.go
@@ -34,7 +34,7 @@ func (opts ListOpts) ToFlavorListQuery() (string, error) {
 // List returns a Pager which allows you to iterate over a collection of
 // Flavor. It accepts a ListOpts struct, which allows you to filter
 // and sort the returned collection for greater efficiency.
-func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(c gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := rootURL(c)
 	if opts != nil {
 		query, err := opts.ToFlavorListQuery()
@@ -78,7 +78,7 @@ func (opts CreateOpts) ToFlavorCreateMap() (map[string]any, error) {
 
 // Create is and operation which add a new Flavor into the database.
 // CreateResult will be returned.
-func Create(ctx context.Context, c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, c gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToFlavorCreateMap()
 	if err != nil {
 		r.Err = err
@@ -90,7 +90,7 @@ func Create(ctx context.Context, c *gophercloud.ServiceClient, opts CreateOptsBu
 }
 
 // Get retrieves a particular Flavor based on its unique ID.
-func Get(ctx context.Context, c *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, c gophercloud.Client, id string) (r GetResult) {
 	resp, err := c.Get(ctx, resourceURL(c, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -127,7 +127,7 @@ func (opts UpdateOpts) ToFlavorUpdateMap() (map[string]any, error) {
 
 // Update is an operation which modifies the attributes of the specified
 // Flavor.
-func Update(ctx context.Context, c *gophercloud.ServiceClient, id string, opts UpdateOpts) (r UpdateResult) {
+func Update(ctx context.Context, c gophercloud.Client, id string, opts UpdateOpts) (r UpdateResult) {
 	b, err := opts.ToFlavorUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -142,7 +142,7 @@ func Update(ctx context.Context, c *gophercloud.ServiceClient, id string, opts U
 
 // Delete will permanently delete a particular Flavor based on its
 // unique ID.
-func Delete(ctx context.Context, c *gophercloud.ServiceClient, id string) (r DeleteResult) {
+func Delete(ctx context.Context, c gophercloud.Client, id string) (r DeleteResult) {
 	resp, err := c.Delete(ctx, resourceURL(c, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/loadbalancer/v2/flavors/urls.go
+++ b/openstack/loadbalancer/v2/flavors/urls.go
@@ -7,10 +7,10 @@ const (
 	resourcePath = "flavors"
 )
 
-func rootURL(c *gophercloud.ServiceClient) string {
+func rootURL(c gophercloud.Client) string {
 	return c.ServiceURL(rootPath, resourcePath)
 }
 
-func resourceURL(c *gophercloud.ServiceClient, id string) string {
+func resourceURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL(rootPath, resourcePath, id)
 }

--- a/openstack/loadbalancer/v2/l7policies/requests.go
+++ b/openstack/loadbalancer/v2/l7policies/requests.go
@@ -99,7 +99,7 @@ func (opts CreateOpts) ToL7PolicyCreateMap() (map[string]any, error) {
 }
 
 // Create accepts a CreateOpts struct and uses the values to create a new l7policy.
-func Create(ctx context.Context, c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, c gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToL7PolicyCreateMap()
 	if err != nil {
 		r.Err = err
@@ -147,7 +147,7 @@ func (opts ListOpts) ToL7PolicyListQuery() (string, error) {
 //
 // Default policy settings return only those l7policies that are owned by the
 // project who submits the request, unless an admin user submits the request.
-func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(c gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := rootURL(c)
 	if opts != nil {
 		query, err := opts.ToL7PolicyListQuery()
@@ -162,14 +162,14 @@ func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 }
 
 // Get retrieves a particular l7policy based on its unique ID.
-func Get(ctx context.Context, c *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, c gophercloud.Client, id string) (r GetResult) {
 	resp, err := c.Get(ctx, resourceURL(c, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
 // Delete will permanently delete a particular l7policy based on its unique ID.
-func Delete(ctx context.Context, c *gophercloud.ServiceClient, id string) (r DeleteResult) {
+func Delete(ctx context.Context, c gophercloud.Client, id string) (r DeleteResult) {
 	resp, err := c.Delete(ctx, resourceURL(c, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -250,7 +250,7 @@ func (opts UpdateOpts) ToL7PolicyUpdateMap() (map[string]any, error) {
 }
 
 // Update allows l7policy to be updated.
-func Update(ctx context.Context, c *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, c gophercloud.Client, id string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToL7PolicyUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -300,7 +300,7 @@ func (opts CreateRuleOpts) ToRuleCreateMap() (map[string]any, error) {
 }
 
 // CreateRule will create and associate a Rule with a particular L7Policy.
-func CreateRule(ctx context.Context, c *gophercloud.ServiceClient, policyID string, opts CreateRuleOpts) (r CreateRuleResult) {
+func CreateRule(ctx context.Context, c gophercloud.Client, policyID string, opts CreateRuleOpts) (r CreateRuleResult) {
 	b, err := opts.ToRuleCreateMap()
 	if err != nil {
 		r.Err = err
@@ -346,7 +346,7 @@ func (opts ListRulesOpts) ToRulesListQuery() (string, error) {
 //
 // Default policy settings return only those rules that are owned by the
 // project who submits the request, unless an admin user submits the request.
-func ListRules(c *gophercloud.ServiceClient, policyID string, opts ListRulesOptsBuilder) pagination.Pager {
+func ListRules(c gophercloud.Client, policyID string, opts ListRulesOptsBuilder) pagination.Pager {
 	url := ruleRootURL(c, policyID)
 	if opts != nil {
 		query, err := opts.ToRulesListQuery()
@@ -361,14 +361,14 @@ func ListRules(c *gophercloud.ServiceClient, policyID string, opts ListRulesOpts
 }
 
 // GetRule retrieves a particular L7Policy Rule based on its unique ID.
-func GetRule(ctx context.Context, c *gophercloud.ServiceClient, policyID string, ruleID string) (r GetRuleResult) {
+func GetRule(ctx context.Context, c gophercloud.Client, policyID string, ruleID string) (r GetRuleResult) {
 	resp, err := c.Get(ctx, ruleResourceURL(c, policyID, ruleID), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
 // DeleteRule will remove a Rule from a particular L7Policy.
-func DeleteRule(ctx context.Context, c *gophercloud.ServiceClient, policyID string, ruleID string) (r DeleteRuleResult) {
+func DeleteRule(ctx context.Context, c gophercloud.Client, policyID string, ruleID string) (r DeleteRuleResult) {
 	resp, err := c.Delete(ctx, ruleResourceURL(c, policyID, ruleID), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -421,7 +421,7 @@ func (opts UpdateRuleOpts) ToRuleUpdateMap() (map[string]any, error) {
 }
 
 // UpdateRule allows Rule to be updated.
-func UpdateRule(ctx context.Context, c *gophercloud.ServiceClient, policyID string, ruleID string, opts UpdateRuleOptsBuilder) (r UpdateRuleResult) {
+func UpdateRule(ctx context.Context, c gophercloud.Client, policyID string, ruleID string, opts UpdateRuleOptsBuilder) (r UpdateRuleResult) {
 	b, err := opts.ToRuleUpdateMap()
 	if err != nil {
 		r.Err = err

--- a/openstack/loadbalancer/v2/l7policies/urls.go
+++ b/openstack/loadbalancer/v2/l7policies/urls.go
@@ -8,18 +8,18 @@ const (
 	rulePath     = "rules"
 )
 
-func rootURL(c *gophercloud.ServiceClient) string {
+func rootURL(c gophercloud.Client) string {
 	return c.ServiceURL(rootPath, resourcePath)
 }
 
-func resourceURL(c *gophercloud.ServiceClient, id string) string {
+func resourceURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL(rootPath, resourcePath, id)
 }
 
-func ruleRootURL(c *gophercloud.ServiceClient, policyID string) string {
+func ruleRootURL(c gophercloud.Client, policyID string) string {
 	return c.ServiceURL(rootPath, resourcePath, policyID, rulePath)
 }
 
-func ruleResourceURL(c *gophercloud.ServiceClient, policyID string, ruleID string) string {
+func ruleResourceURL(c gophercloud.Client, policyID string, ruleID string) string {
 	return c.ServiceURL(rootPath, resourcePath, policyID, rulePath, ruleID)
 }

--- a/openstack/loadbalancer/v2/listeners/requests.go
+++ b/openstack/loadbalancer/v2/listeners/requests.go
@@ -90,7 +90,7 @@ func (opts ListOpts) ToListenerListQuery() (string, error) {
 //
 // Default policy settings return only those listeners that are owned by the
 // project who submits the request, unless an admin user submits the request.
-func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(c gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := rootURL(c)
 	if opts != nil {
 		query, err := opts.ToListenerListQuery()
@@ -238,7 +238,7 @@ func (opts CreateOpts) ToListenerCreateMap() (map[string]any, error) {
 //
 // Users with an admin role can create Listeners on behalf of other projects by
 // specifying a ProjectID attribute different than their own.
-func Create(ctx context.Context, c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, c gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToListenerCreateMap()
 	if err != nil {
 		r.Err = err
@@ -250,7 +250,7 @@ func Create(ctx context.Context, c *gophercloud.ServiceClient, opts CreateOptsBu
 }
 
 // Get retrieves a particular Listeners based on its unique ID.
-func Get(ctx context.Context, c *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, c gophercloud.Client, id string) (r GetResult) {
 	resp, err := c.Get(ctx, resourceURL(c, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -380,7 +380,7 @@ func (opts UpdateOpts) ToListenerUpdateMap() (map[string]any, error) {
 
 // Update is an operation which modifies the attributes of the specified
 // Listener.
-func Update(ctx context.Context, c *gophercloud.ServiceClient, id string, opts UpdateOpts) (r UpdateResult) {
+func Update(ctx context.Context, c gophercloud.Client, id string, opts UpdateOpts) (r UpdateResult) {
 	b, err := opts.ToListenerUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -394,14 +394,14 @@ func Update(ctx context.Context, c *gophercloud.ServiceClient, id string, opts U
 }
 
 // Delete will permanently delete a particular Listeners based on its unique ID.
-func Delete(ctx context.Context, c *gophercloud.ServiceClient, id string) (r DeleteResult) {
+func Delete(ctx context.Context, c gophercloud.Client, id string) (r DeleteResult) {
 	resp, err := c.Delete(ctx, resourceURL(c, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
 // GetStats will return the shows the current statistics of a particular Listeners.
-func GetStats(ctx context.Context, c *gophercloud.ServiceClient, id string) (r StatsResult) {
+func GetStats(ctx context.Context, c gophercloud.Client, id string) (r StatsResult) {
 	resp, err := c.Get(ctx, statisticsRootURL(c, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/loadbalancer/v2/listeners/urls.go
+++ b/openstack/loadbalancer/v2/listeners/urls.go
@@ -8,14 +8,14 @@ const (
 	statisticsPath = "stats"
 )
 
-func rootURL(c *gophercloud.ServiceClient) string {
+func rootURL(c gophercloud.Client) string {
 	return c.ServiceURL(rootPath, resourcePath)
 }
 
-func resourceURL(c *gophercloud.ServiceClient, id string) string {
+func resourceURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL(rootPath, resourcePath, id)
 }
 
-func statisticsRootURL(c *gophercloud.ServiceClient, id string) string {
+func statisticsRootURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL(rootPath, resourcePath, id, statisticsPath)
 }

--- a/openstack/loadbalancer/v2/loadbalancers/requests.go
+++ b/openstack/loadbalancer/v2/loadbalancers/requests.go
@@ -57,7 +57,7 @@ func (opts ListOpts) ToLoadBalancerListQuery() (string, error) {
 //
 // Default policy settings return only those load balancers that are owned by
 // the project who submits the request, unless an admin user submits the request.
-func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(c gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := rootURL(c)
 	if opts != nil {
 		query, err := opts.ToLoadBalancerListQuery()
@@ -157,7 +157,7 @@ func (opts CreateOpts) ToLoadBalancerCreateMap() (map[string]any, error) {
 // configuration defined in the CreateOpts struct. Once the request is
 // validated and progress has started on the provisioning process, a
 // CreateResult will be returned.
-func Create(ctx context.Context, c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, c gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToLoadBalancerCreateMap()
 	if err != nil {
 		r.Err = err
@@ -169,7 +169,7 @@ func Create(ctx context.Context, c *gophercloud.ServiceClient, opts CreateOptsBu
 }
 
 // Get retrieves a particular Loadbalancer based on its unique ID.
-func Get(ctx context.Context, c *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, c gophercloud.Client, id string) (r GetResult) {
 	resp, err := c.Get(ctx, resourceURL(c, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -208,7 +208,7 @@ func (opts UpdateOpts) ToLoadBalancerUpdateMap() (map[string]any, error) {
 
 // Update is an operation which modifies the attributes of the specified
 // LoadBalancer.
-func Update(ctx context.Context, c *gophercloud.ServiceClient, id string, opts UpdateOpts) (r UpdateResult) {
+func Update(ctx context.Context, c gophercloud.Client, id string, opts UpdateOpts) (r UpdateResult) {
 	b, err := opts.ToLoadBalancerUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -242,7 +242,7 @@ func (opts DeleteOpts) ToLoadBalancerDeleteQuery() (string, error) {
 
 // Delete will permanently delete a particular LoadBalancer based on its
 // unique ID.
-func Delete(ctx context.Context, c *gophercloud.ServiceClient, id string, opts DeleteOptsBuilder) (r DeleteResult) {
+func Delete(ctx context.Context, c gophercloud.Client, id string, opts DeleteOptsBuilder) (r DeleteResult) {
 	url := resourceURL(c, id)
 	if opts != nil {
 		query, err := opts.ToLoadBalancerDeleteQuery()
@@ -258,21 +258,21 @@ func Delete(ctx context.Context, c *gophercloud.ServiceClient, id string, opts D
 }
 
 // GetStatuses will return the status of a particular LoadBalancer.
-func GetStatuses(ctx context.Context, c *gophercloud.ServiceClient, id string) (r GetStatusesResult) {
+func GetStatuses(ctx context.Context, c gophercloud.Client, id string) (r GetStatusesResult) {
 	resp, err := c.Get(ctx, statusRootURL(c, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
 // GetStats will return the shows the current statistics of a particular LoadBalancer.
-func GetStats(ctx context.Context, c *gophercloud.ServiceClient, id string) (r StatsResult) {
+func GetStats(ctx context.Context, c gophercloud.Client, id string) (r StatsResult) {
 	resp, err := c.Get(ctx, statisticsRootURL(c, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
 // Failover performs a failover of a load balancer.
-func Failover(ctx context.Context, c *gophercloud.ServiceClient, id string) (r FailoverResult) {
+func Failover(ctx context.Context, c gophercloud.Client, id string) (r FailoverResult) {
 	resp, err := c.Put(ctx, failoverRootURL(c, id), nil, nil, &gophercloud.RequestOpts{
 		OkCodes: []int{202},
 	})

--- a/openstack/loadbalancer/v2/loadbalancers/urls.go
+++ b/openstack/loadbalancer/v2/loadbalancers/urls.go
@@ -10,22 +10,22 @@ const (
 	failoverPath   = "failover"
 )
 
-func rootURL(c *gophercloud.ServiceClient) string {
+func rootURL(c gophercloud.Client) string {
 	return c.ServiceURL(rootPath, resourcePath)
 }
 
-func resourceURL(c *gophercloud.ServiceClient, id string) string {
+func resourceURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL(rootPath, resourcePath, id)
 }
 
-func statusRootURL(c *gophercloud.ServiceClient, id string) string {
+func statusRootURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL(rootPath, resourcePath, id, statusPath)
 }
 
-func statisticsRootURL(c *gophercloud.ServiceClient, id string) string {
+func statisticsRootURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL(rootPath, resourcePath, id, statisticsPath)
 }
 
-func failoverRootURL(c *gophercloud.ServiceClient, id string) string {
+func failoverRootURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL(rootPath, resourcePath, id, failoverPath)
 }

--- a/openstack/loadbalancer/v2/monitors/requests.go
+++ b/openstack/loadbalancer/v2/monitors/requests.go
@@ -56,7 +56,7 @@ func (opts ListOpts) ToMonitorListQuery() (string, error) {
 //
 // Default policy settings return only those health monitors that are owned by the
 // tenant who submits the request, unless an admin user submits the request.
-func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(c gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := rootURL(c)
 	if opts != nil {
 		query, err := opts.ToMonitorListQuery()
@@ -171,7 +171,7 @@ Here is an example config struct to use when creating a HTTP(S) Monitor:
 CreateOpts{Type: TypeHTTP, Delay: 20, Timeout: 10, MaxRetries: 3,
 HttpMethod: "HEAD", ExpectedCodes: "200", PoolID: "2c946bfc-1804-43ab-a2ff-58f6a762b505"}
 */
-func Create(ctx context.Context, c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, c gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToMonitorCreateMap()
 	if err != nil {
 		r.Err = err
@@ -183,7 +183,7 @@ func Create(ctx context.Context, c *gophercloud.ServiceClient, opts CreateOptsBu
 }
 
 // Get retrieves a particular Health Monitor based on its unique ID.
-func Get(ctx context.Context, c *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, c gophercloud.Client, id string) (r GetResult) {
 	resp, err := c.Get(ctx, resourceURL(c, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -252,7 +252,7 @@ func (opts UpdateOpts) ToMonitorUpdateMap() (map[string]any, error) {
 
 // Update is an operation which modifies the attributes of the specified
 // Monitor.
-func Update(ctx context.Context, c *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, c gophercloud.Client, id string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToMonitorUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -267,7 +267,7 @@ func Update(ctx context.Context, c *gophercloud.ServiceClient, id string, opts U
 }
 
 // Delete will permanently delete a particular Monitor based on its unique ID.
-func Delete(ctx context.Context, c *gophercloud.ServiceClient, id string) (r DeleteResult) {
+func Delete(ctx context.Context, c gophercloud.Client, id string) (r DeleteResult) {
 	resp, err := c.Delete(ctx, resourceURL(c, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/loadbalancer/v2/monitors/urls.go
+++ b/openstack/loadbalancer/v2/monitors/urls.go
@@ -7,10 +7,10 @@ const (
 	resourcePath = "healthmonitors"
 )
 
-func rootURL(c *gophercloud.ServiceClient) string {
+func rootURL(c gophercloud.Client) string {
 	return c.ServiceURL(rootPath, resourcePath)
 }
 
-func resourceURL(c *gophercloud.ServiceClient, id string) string {
+func resourceURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL(rootPath, resourcePath, id)
 }

--- a/openstack/loadbalancer/v2/pools/requests.go
+++ b/openstack/loadbalancer/v2/pools/requests.go
@@ -57,7 +57,7 @@ func (opts ListOpts) ToPoolListQuery() (string, error) {
 //
 // Default policy settings return only those pools that are owned by the
 // project who submits the request, unless an admin user submits the request.
-func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(c gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := rootURL(c)
 	if opts != nil {
 		query, err := opts.ToPoolListQuery()
@@ -193,7 +193,7 @@ func (opts CreateOpts) ToPoolCreateMap() (map[string]any, error) {
 
 // Create accepts a CreateOpts struct and uses the values to create a new
 // load balancer pool.
-func Create(ctx context.Context, c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, c gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToPoolCreateMap()
 	if err != nil {
 		r.Err = err
@@ -205,7 +205,7 @@ func Create(ctx context.Context, c *gophercloud.ServiceClient, opts CreateOptsBu
 }
 
 // Get retrieves a particular pool based on its unique ID.
-func Get(ctx context.Context, c *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, c gophercloud.Client, id string) (r GetResult) {
 	resp, err := c.Get(ctx, resourceURL(c, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -301,7 +301,7 @@ func (opts UpdateOpts) ToPoolUpdateMap() (map[string]any, error) {
 }
 
 // Update allows pools to be updated.
-func Update(ctx context.Context, c *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, c gophercloud.Client, id string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToPoolUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -315,7 +315,7 @@ func Update(ctx context.Context, c *gophercloud.ServiceClient, id string, opts U
 }
 
 // Delete will permanently delete a particular pool based on its unique ID.
-func Delete(ctx context.Context, c *gophercloud.ServiceClient, id string) (r DeleteResult) {
+func Delete(ctx context.Context, c gophercloud.Client, id string) (r DeleteResult) {
 	resp, err := c.Delete(ctx, resourceURL(c, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -358,7 +358,7 @@ func (opts ListMembersOpts) ToMembersListQuery() (string, error) {
 //
 // Default policy settings return only those members that are owned by the
 // project who submits the request, unless an admin user submits the request.
-func ListMembers(c *gophercloud.ServiceClient, poolID string, opts ListMembersOptsBuilder) pagination.Pager {
+func ListMembers(c gophercloud.Client, poolID string, opts ListMembersOptsBuilder) pagination.Pager {
 	url := memberRootURL(c, poolID)
 	if opts != nil {
 		query, err := opts.ToMembersListQuery()
@@ -430,7 +430,7 @@ func (opts CreateMemberOpts) ToMemberCreateMap() (map[string]any, error) {
 }
 
 // CreateMember will create and associate a Member with a particular Pool.
-func CreateMember(ctx context.Context, c *gophercloud.ServiceClient, poolID string, opts CreateMemberOptsBuilder) (r CreateMemberResult) {
+func CreateMember(ctx context.Context, c gophercloud.Client, poolID string, opts CreateMemberOptsBuilder) (r CreateMemberResult) {
 	b, err := opts.ToMemberCreateMap()
 	if err != nil {
 		r.Err = err
@@ -442,7 +442,7 @@ func CreateMember(ctx context.Context, c *gophercloud.ServiceClient, poolID stri
 }
 
 // GetMember retrieves a particular Pool Member based on its unique ID.
-func GetMember(ctx context.Context, c *gophercloud.ServiceClient, poolID string, memberID string) (r GetMemberResult) {
+func GetMember(ctx context.Context, c gophercloud.Client, poolID string, memberID string) (r GetMemberResult) {
 	resp, err := c.Get(ctx, memberResourceURL(c, poolID, memberID), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -492,7 +492,7 @@ func (opts UpdateMemberOpts) ToMemberUpdateMap() (map[string]any, error) {
 }
 
 // Update allows Member to be updated.
-func UpdateMember(ctx context.Context, c *gophercloud.ServiceClient, poolID string, memberID string, opts UpdateMemberOptsBuilder) (r UpdateMemberResult) {
+func UpdateMember(ctx context.Context, c gophercloud.Client, poolID string, memberID string, opts UpdateMemberOptsBuilder) (r UpdateMemberResult) {
 	b, err := opts.ToMemberUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -571,7 +571,7 @@ func (opts BatchUpdateMemberOpts) ToBatchMemberUpdateMap() (map[string]any, erro
 }
 
 // BatchUpdateMembers updates the pool members in batch
-func BatchUpdateMembers[T BatchUpdateMemberOptsBuilder](ctx context.Context, c *gophercloud.ServiceClient, poolID string, opts []T) (r UpdateMembersResult) {
+func BatchUpdateMembers[T BatchUpdateMemberOptsBuilder](ctx context.Context, c gophercloud.Client, poolID string, opts []T) (r UpdateMembersResult) {
 	members := []map[string]any{}
 	for _, opt := range opts {
 		b, err := opt.ToBatchMemberUpdateMap()
@@ -590,7 +590,7 @@ func BatchUpdateMembers[T BatchUpdateMemberOptsBuilder](ctx context.Context, c *
 }
 
 // DeleteMember will remove and disassociate a Member from a particular Pool.
-func DeleteMember(ctx context.Context, c *gophercloud.ServiceClient, poolID string, memberID string) (r DeleteMemberResult) {
+func DeleteMember(ctx context.Context, c gophercloud.Client, poolID string, memberID string) (r DeleteMemberResult) {
 	resp, err := c.Delete(ctx, memberResourceURL(c, poolID, memberID), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/loadbalancer/v2/pools/urls.go
+++ b/openstack/loadbalancer/v2/pools/urls.go
@@ -8,18 +8,18 @@ const (
 	memberPath   = "members"
 )
 
-func rootURL(c *gophercloud.ServiceClient) string {
+func rootURL(c gophercloud.Client) string {
 	return c.ServiceURL(rootPath, resourcePath)
 }
 
-func resourceURL(c *gophercloud.ServiceClient, id string) string {
+func resourceURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL(rootPath, resourcePath, id)
 }
 
-func memberRootURL(c *gophercloud.ServiceClient, poolId string) string {
+func memberRootURL(c gophercloud.Client, poolId string) string {
 	return c.ServiceURL(rootPath, resourcePath, poolId, memberPath)
 }
 
-func memberResourceURL(c *gophercloud.ServiceClient, poolID string, memberID string) string {
+func memberResourceURL(c gophercloud.Client, poolID string, memberID string) string {
 	return c.ServiceURL(rootPath, resourcePath, poolID, memberPath, memberID)
 }

--- a/openstack/loadbalancer/v2/providers/requests.go
+++ b/openstack/loadbalancer/v2/providers/requests.go
@@ -29,7 +29,7 @@ func (opts ListOpts) ToProviderListQuery() (string, error) {
 //
 // Default policy settings return only those providers that are owned by
 // the project who submits the request, unless an admin user submits the request.
-func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(c gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := rootURL(c)
 	if opts != nil {
 		query, err := opts.ToProviderListQuery()

--- a/openstack/loadbalancer/v2/providers/urls.go
+++ b/openstack/loadbalancer/v2/providers/urls.go
@@ -7,6 +7,6 @@ const (
 	resourcePath = "providers"
 )
 
-func rootURL(c *gophercloud.ServiceClient) string {
+func rootURL(c gophercloud.Client) string {
 	return c.ServiceURL(rootPath, resourcePath)
 }

--- a/openstack/loadbalancer/v2/quotas/requests.go
+++ b/openstack/loadbalancer/v2/quotas/requests.go
@@ -7,7 +7,7 @@ import (
 )
 
 // Get returns load balancer Quotas for a project.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, projectID string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, projectID string) (r GetResult) {
 	resp, err := client.Get(ctx, getURL(client, projectID), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -50,7 +50,7 @@ func (opts UpdateOpts) ToQuotaUpdateMap() (map[string]any, error) {
 
 // Update accepts a UpdateOpts struct and updates an existing load balancer Quotas using the
 // values provided.
-func Update(ctx context.Context, c *gophercloud.ServiceClient, projectID string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, c gophercloud.Client, projectID string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToQuotaUpdateMap()
 	if err != nil {
 		r.Err = err

--- a/openstack/loadbalancer/v2/quotas/urls.go
+++ b/openstack/loadbalancer/v2/quotas/urls.go
@@ -4,14 +4,14 @@ import "github.com/gophercloud/gophercloud/v2"
 
 const resourcePath = "quotas"
 
-func resourceURL(c *gophercloud.ServiceClient, projectID string) string {
+func resourceURL(c gophercloud.Client, projectID string) string {
 	return c.ServiceURL(resourcePath, projectID)
 }
 
-func getURL(c *gophercloud.ServiceClient, projectID string) string {
+func getURL(c gophercloud.Client, projectID string) string {
 	return resourceURL(c, projectID)
 }
 
-func updateURL(c *gophercloud.ServiceClient, projectID string) string {
+func updateURL(c gophercloud.Client, projectID string) string {
 	return resourceURL(c, projectID)
 }

--- a/openstack/loadbalancer/v2/testhelper/client.go
+++ b/openstack/loadbalancer/v2/testhelper/client.go
@@ -7,7 +7,7 @@ import (
 
 const TokenID = client.TokenID
 
-func ServiceClient() *gophercloud.ServiceClient {
+func ServiceClient() gophercloud.Client {
 	sc := client.ServiceClient()
 	sc.ResourceBase = sc.Endpoint + "v2.0/"
 	return sc

--- a/openstack/messaging/v2/claims/requests.go
+++ b/openstack/messaging/v2/claims/requests.go
@@ -40,7 +40,7 @@ func (opts CreateOpts) ToClaimCreateRequest() (map[string]any, string, error) {
 }
 
 // Create creates a Claim that claims messages on a specified queue.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, queueName string, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, queueName string, opts CreateOptsBuilder) (r CreateResult) {
 	b, q, err := opts.ToClaimCreateRequest()
 	if err != nil {
 		r.Err = err
@@ -60,7 +60,7 @@ func Create(ctx context.Context, client *gophercloud.ServiceClient, queueName st
 }
 
 // Get queries the specified claim for the specified queue.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, queueName string, claimID string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, queueName string, claimID string) (r GetResult) {
 	resp, err := client.Get(ctx, getURL(client, queueName, claimID), &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{200},
 	})
@@ -94,7 +94,7 @@ func (opts UpdateOpts) ToClaimUpdateMap() (map[string]any, error) {
 }
 
 // Update will update the options for a specified claim.
-func Update(ctx context.Context, client *gophercloud.ServiceClient, queueName string, claimID string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, client gophercloud.Client, queueName string, claimID string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToClaimUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -108,7 +108,7 @@ func Update(ctx context.Context, client *gophercloud.ServiceClient, queueName st
 }
 
 // Delete will delete a Claim for a specified Queue.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, queueName string, claimID string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, queueName string, claimID string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, deleteURL(client, queueName, claimID), &gophercloud.RequestOpts{
 		OkCodes: []int{204},
 	})

--- a/openstack/messaging/v2/claims/urls.go
+++ b/openstack/messaging/v2/claims/urls.go
@@ -7,18 +7,18 @@ const (
 	apiName    = "queues"
 )
 
-func createURL(client *gophercloud.ServiceClient, queueName string) string {
+func createURL(client gophercloud.Client, queueName string) string {
 	return client.ServiceURL(apiVersion, apiName, queueName, "claims")
 }
 
-func getURL(client *gophercloud.ServiceClient, queueName string, claimID string) string {
+func getURL(client gophercloud.Client, queueName string, claimID string) string {
 	return client.ServiceURL(apiVersion, apiName, queueName, "claims", claimID)
 }
 
-func updateURL(client *gophercloud.ServiceClient, queueName string, claimID string) string {
+func updateURL(client gophercloud.Client, queueName string, claimID string) string {
 	return client.ServiceURL(apiVersion, apiName, queueName, "claims", claimID)
 }
 
-func deleteURL(client *gophercloud.ServiceClient, queueName string, claimID string) string {
+func deleteURL(client gophercloud.Client, queueName string, claimID string) string {
 	return client.ServiceURL(apiVersion, apiName, queueName, "claims", claimID)
 }

--- a/openstack/messaging/v2/messages/requests.go
+++ b/openstack/messaging/v2/messages/requests.go
@@ -37,7 +37,7 @@ func (opts ListOpts) ToMessageListQuery() (string, error) {
 }
 
 // ListMessages lists messages on a specific queue based off queue name.
-func List(client *gophercloud.ServiceClient, queueName string, opts ListOptsBuilder) pagination.Pager {
+func List(client gophercloud.Client, queueName string, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(client, queueName)
 	if opts != nil {
 		query, err := opts.ToMessageListQuery()
@@ -93,7 +93,7 @@ func (opts CreateOpts) ToMap() (map[string]any, error) {
 }
 
 // Create creates a message on a specific queue based of off queue name.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, queueName string, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, queueName string, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToMessageCreateMap()
 	if err != nil {
 		r.Err = err
@@ -125,7 +125,7 @@ func (opts DeleteMessagesOpts) ToMessagesDeleteQuery() (string, error) {
 }
 
 // DeleteMessages deletes multiple messages based off of ID.
-func DeleteMessages(ctx context.Context, client *gophercloud.ServiceClient, queueName string, opts DeleteMessagesOptsBuilder) (r DeleteResult) {
+func DeleteMessages(ctx context.Context, client gophercloud.Client, queueName string, opts DeleteMessagesOptsBuilder) (r DeleteResult) {
 	url := deleteURL(client, queueName)
 	if opts != nil {
 		query, err := opts.ToMessagesDeleteQuery()
@@ -160,7 +160,7 @@ func (opts PopMessagesOpts) ToMessagesPopQuery() (string, error) {
 }
 
 // PopMessages deletes and returns multiple messages based off of number of messages.
-func PopMessages(ctx context.Context, client *gophercloud.ServiceClient, queueName string, opts PopMessagesOptsBuilder) (r PopResult) {
+func PopMessages(ctx context.Context, client gophercloud.Client, queueName string, opts PopMessagesOptsBuilder) (r PopResult) {
 	url := deleteURL(client, queueName)
 	if opts != nil {
 		query, err := opts.ToMessagesPopQuery()
@@ -196,7 +196,7 @@ func (opts GetMessagesOpts) ToGetMessagesListQuery() (string, error) {
 }
 
 // GetMessages requests details on a multiple messages, by IDs.
-func GetMessages(ctx context.Context, client *gophercloud.ServiceClient, queueName string, opts GetMessagesOptsBuilder) (r GetMessagesResult) {
+func GetMessages(ctx context.Context, client gophercloud.Client, queueName string, opts GetMessagesOptsBuilder) (r GetMessagesResult) {
 	url := getURL(client, queueName)
 	if opts != nil {
 		query, err := opts.ToGetMessagesListQuery()
@@ -214,7 +214,7 @@ func GetMessages(ctx context.Context, client *gophercloud.ServiceClient, queueNa
 }
 
 // Get requests details on a single message, by ID.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, queueName string, messageID string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, queueName string, messageID string) (r GetResult) {
 	resp, err := client.Get(ctx, messageURL(client, queueName, messageID), &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{200},
 	})
@@ -241,7 +241,7 @@ func (opts DeleteOpts) ToMessageDeleteQuery() (string, error) {
 }
 
 // Delete deletes a specific message from the queue.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, queueName string, messageID string, opts DeleteOptsBuilder) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, queueName string, messageID string, opts DeleteOptsBuilder) (r DeleteResult) {
 	url := DeleteMessageURL(client, queueName, messageID)
 	if opts != nil {
 		query, err := opts.ToMessageDeleteQuery()

--- a/openstack/messaging/v2/messages/urls.go
+++ b/openstack/messaging/v2/messages/urls.go
@@ -11,27 +11,27 @@ const (
 	apiName    = "queues"
 )
 
-func createURL(client *gophercloud.ServiceClient, queueName string) string {
+func createURL(client gophercloud.Client, queueName string) string {
 	return client.ServiceURL(apiVersion, apiName, queueName, "messages")
 }
 
-func listURL(client *gophercloud.ServiceClient, queueName string) string {
+func listURL(client gophercloud.Client, queueName string) string {
 	return client.ServiceURL(apiVersion, apiName, queueName, "messages")
 }
 
-func getURL(client *gophercloud.ServiceClient, queueName string) string {
+func getURL(client gophercloud.Client, queueName string) string {
 	return client.ServiceURL(apiVersion, apiName, queueName, "messages")
 }
 
-func deleteURL(client *gophercloud.ServiceClient, queueName string) string {
+func deleteURL(client gophercloud.Client, queueName string) string {
 	return client.ServiceURL(apiVersion, apiName, queueName, "messages")
 }
 
-func DeleteMessageURL(client *gophercloud.ServiceClient, queueName string, messageID string) string {
+func DeleteMessageURL(client gophercloud.Client, queueName string, messageID string) string {
 	return client.ServiceURL(apiVersion, apiName, queueName, "messages", messageID)
 }
 
-func messageURL(client *gophercloud.ServiceClient, queueName string, messageID string) string {
+func messageURL(client gophercloud.Client, queueName string, messageID string) string {
 	return client.ServiceURL(apiVersion, apiName, queueName, "messages", messageID)
 }
 

--- a/openstack/messaging/v2/queues/requests.go
+++ b/openstack/messaging/v2/queues/requests.go
@@ -38,7 +38,7 @@ func (opts ListOpts) ToQueueListQuery() (string, error) {
 }
 
 // List instructs OpenStack to provide a list of queues.
-func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(client gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(client)
 	if opts != nil {
 		query, err := opts.ToQueueListQuery()
@@ -117,7 +117,7 @@ func (opts CreateOpts) ToQueueCreateMap() (map[string]any, error) {
 }
 
 // Create requests the creation of a new queue.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToQueueCreateMap()
 	if err != nil {
 		r.Err = err
@@ -177,7 +177,7 @@ func (opts UpdateOpts) ToMap() (map[string]any, error) {
 }
 
 // Update Updates the specified queue.
-func Update(ctx context.Context, client *gophercloud.ServiceClient, queueName string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, client gophercloud.Client, queueName string, opts UpdateOptsBuilder) (r UpdateResult) {
 	resp, err := client.Patch(ctx, updateURL(client, queueName), opts, &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{200, 201, 204},
 		MoreHeaders: map[string]string{
@@ -188,7 +188,7 @@ func Update(ctx context.Context, client *gophercloud.ServiceClient, queueName st
 }
 
 // Get requests details on a single queue, by name.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, queueName string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, queueName string) (r GetResult) {
 	resp, err := client.Get(ctx, getURL(client, queueName), &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{200},
 	})
@@ -197,7 +197,7 @@ func Get(ctx context.Context, client *gophercloud.ServiceClient, queueName strin
 }
 
 // Delete deletes the specified queue.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, queueName string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, queueName string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, deleteURL(client, queueName), &gophercloud.RequestOpts{
 		OkCodes: []int{204},
 	})
@@ -206,7 +206,7 @@ func Delete(ctx context.Context, client *gophercloud.ServiceClient, queueName st
 }
 
 // GetStats returns statistics for the specified queue.
-func GetStats(ctx context.Context, client *gophercloud.ServiceClient, queueName string) (r StatResult) {
+func GetStats(ctx context.Context, client gophercloud.Client, queueName string) (r StatResult) {
 	resp, err := client.Get(ctx, statURL(client, queueName), &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{200},
 	})
@@ -254,7 +254,7 @@ func (opts ShareOpts) ToQueueShareMap() (map[string]any, error) {
 }
 
 // Share creates a pre-signed URL for a given queue.
-func Share(ctx context.Context, client *gophercloud.ServiceClient, queueName string, opts ShareOptsBuilder) (r ShareResult) {
+func Share(ctx context.Context, client gophercloud.Client, queueName string, opts ShareOptsBuilder) (r ShareResult) {
 	b, err := opts.ToQueueShareMap()
 	if err != nil {
 		r.Err = err
@@ -296,7 +296,7 @@ func (opts PurgeOpts) ToQueuePurgeMap() (map[string]any, error) {
 }
 
 // Purge purges particular resource of the queue.
-func Purge(ctx context.Context, client *gophercloud.ServiceClient, queueName string, opts PurgeOptsBuilder) (r PurgeResult) {
+func Purge(ctx context.Context, client gophercloud.Client, queueName string, opts PurgeOptsBuilder) (r PurgeResult) {
 	b, err := opts.ToQueuePurgeMap()
 	if err != nil {
 		r.Err = err

--- a/openstack/messaging/v2/queues/urls.go
+++ b/openstack/messaging/v2/queues/urls.go
@@ -11,39 +11,39 @@ const (
 	apiName    = "queues"
 )
 
-func commonURL(client *gophercloud.ServiceClient) string {
+func commonURL(client gophercloud.Client) string {
 	return client.ServiceURL(apiVersion, apiName)
 }
 
-func createURL(client *gophercloud.ServiceClient, queueName string) string {
+func createURL(client gophercloud.Client, queueName string) string {
 	return client.ServiceURL(apiVersion, apiName, queueName)
 }
 
-func listURL(client *gophercloud.ServiceClient) string {
+func listURL(client gophercloud.Client) string {
 	return commonURL(client)
 }
 
-func updateURL(client *gophercloud.ServiceClient, queueName string) string {
+func updateURL(client gophercloud.Client, queueName string) string {
 	return client.ServiceURL(apiVersion, apiName, queueName)
 }
 
-func getURL(client *gophercloud.ServiceClient, queueName string) string {
+func getURL(client gophercloud.Client, queueName string) string {
 	return client.ServiceURL(apiVersion, apiName, queueName)
 }
 
-func deleteURL(client *gophercloud.ServiceClient, queueName string) string {
+func deleteURL(client gophercloud.Client, queueName string) string {
 	return client.ServiceURL(apiVersion, apiName, queueName)
 }
 
-func statURL(client *gophercloud.ServiceClient, queueName string) string {
+func statURL(client gophercloud.Client, queueName string) string {
 	return client.ServiceURL(apiVersion, apiName, queueName, "stats")
 }
 
-func shareURL(client *gophercloud.ServiceClient, queueName string) string {
+func shareURL(client gophercloud.Client, queueName string) string {
 	return client.ServiceURL(apiVersion, apiName, queueName, "share")
 }
 
-func purgeURL(client *gophercloud.ServiceClient, queueName string) string {
+func purgeURL(client gophercloud.Client, queueName string) string {
 	return client.ServiceURL(apiVersion, apiName, queueName, "purge")
 }
 

--- a/openstack/networking/v2/apiversions/requests.go
+++ b/openstack/networking/v2/apiversions/requests.go
@@ -6,7 +6,7 @@ import (
 )
 
 // ListVersions lists all the Neutron API versions available to end-users.
-func ListVersions(c *gophercloud.ServiceClient) pagination.Pager {
+func ListVersions(c gophercloud.Client) pagination.Pager {
 	return pagination.NewPager(c, listURL(c), func(r pagination.PageResult) pagination.Page {
 		return APIVersionPage{pagination.SinglePageBase(r)}
 	})
@@ -15,7 +15,7 @@ func ListVersions(c *gophercloud.ServiceClient) pagination.Pager {
 // ListVersionResources lists all of the different API resources for a
 // particular API versions. Typical resources for Neutron might be: networks,
 // subnets, etc.
-func ListVersionResources(c *gophercloud.ServiceClient, v string) pagination.Pager {
+func ListVersionResources(c gophercloud.Client, v string) pagination.Pager {
 	return pagination.NewPager(c, getURL(c, v), func(r pagination.PageResult) pagination.Page {
 		return APIVersionResourcePage{pagination.SinglePageBase(r)}
 	})

--- a/openstack/networking/v2/apiversions/urls.go
+++ b/openstack/networking/v2/apiversions/urls.go
@@ -7,14 +7,14 @@ import (
 	"github.com/gophercloud/gophercloud/v2/openstack/utils"
 )
 
-func getURL(c *gophercloud.ServiceClient, version string) string {
-	baseEndpoint, _ := utils.BaseEndpoint(c.Endpoint)
+func getURL(c gophercloud.Client, version string) string {
+	baseEndpoint, _ := utils.BaseEndpoint(c.EndpointURL())
 	endpoint := strings.TrimRight(baseEndpoint, "/") + "/" + strings.TrimRight(version, "/") + "/"
 	return endpoint
 }
 
-func listURL(c *gophercloud.ServiceClient) string {
-	baseEndpoint, _ := utils.BaseEndpoint(c.Endpoint)
+func listURL(c gophercloud.Client) string {
+	baseEndpoint, _ := utils.BaseEndpoint(c.EndpointURL())
 	endpoint := strings.TrimRight(baseEndpoint, "/") + "/"
 	return endpoint
 }

--- a/openstack/networking/v2/common/common_tests.go
+++ b/openstack/networking/v2/common/common_tests.go
@@ -7,7 +7,7 @@ import (
 
 const TokenID = client.TokenID
 
-func ServiceClient() *gophercloud.ServiceClient {
+func ServiceClient() gophercloud.Client {
 	sc := client.ServiceClient()
 	sc.ResourceBase = sc.Endpoint + "v2.0/"
 	return sc

--- a/openstack/networking/v2/extensions/agents/requests.go
+++ b/openstack/networking/v2/extensions/agents/requests.go
@@ -47,7 +47,7 @@ func (opts ListOpts) ToAgentListQuery() (string, error) {
 // Default policy settings return only the agents owned by the project
 // of the user submitting the request, unless the user has the administrative
 // role.
-func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(c gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(c)
 	if opts != nil {
 		query, err := opts.ToAgentListQuery()
@@ -62,7 +62,7 @@ func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 }
 
 // Get retrieves a specific agent based on its ID.
-func Get(ctx context.Context, c *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, c gophercloud.Client, id string) (r GetResult) {
 	resp, err := c.Get(ctx, getURL(c, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -86,7 +86,7 @@ func (opts UpdateOpts) ToAgentUpdateMap() (map[string]any, error) {
 }
 
 // Update updates a specific agent based on its ID.
-func Update(ctx context.Context, c *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, c gophercloud.Client, id string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToAgentUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -100,7 +100,7 @@ func Update(ctx context.Context, c *gophercloud.ServiceClient, id string, opts U
 }
 
 // Delete deletes a specific agent based on its ID.
-func Delete(ctx context.Context, c *gophercloud.ServiceClient, id string) (r DeleteResult) {
+func Delete(ctx context.Context, c gophercloud.Client, id string) (r DeleteResult) {
 	resp, err := c.Delete(ctx, deleteURL(c, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -108,7 +108,7 @@ func Delete(ctx context.Context, c *gophercloud.ServiceClient, id string) (r Del
 
 // ListDHCPNetworks returns a list of networks scheduled to a specific
 // dhcp agent.
-func ListDHCPNetworks(ctx context.Context, c *gophercloud.ServiceClient, id string) (r ListDHCPNetworksResult) {
+func ListDHCPNetworks(ctx context.Context, c gophercloud.Client, id string) (r ListDHCPNetworksResult) {
 	resp, err := c.Get(ctx, listDHCPNetworksURL(c, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -132,7 +132,7 @@ func (opts ScheduleDHCPNetworkOpts) ToAgentScheduleDHCPNetworkMap() (map[string]
 }
 
 // ScheduleDHCPNetwork schedule a network to a DHCP agent.
-func ScheduleDHCPNetwork(ctx context.Context, c *gophercloud.ServiceClient, id string, opts ScheduleDHCPNetworkOptsBuilder) (r ScheduleDHCPNetworkResult) {
+func ScheduleDHCPNetwork(ctx context.Context, c gophercloud.Client, id string, opts ScheduleDHCPNetworkOptsBuilder) (r ScheduleDHCPNetworkResult) {
 	b, err := opts.ToAgentScheduleDHCPNetworkMap()
 	if err != nil {
 		r.Err = err
@@ -146,7 +146,7 @@ func ScheduleDHCPNetwork(ctx context.Context, c *gophercloud.ServiceClient, id s
 }
 
 // RemoveDHCPNetwork removes a network from a DHCP agent.
-func RemoveDHCPNetwork(ctx context.Context, c *gophercloud.ServiceClient, id string, networkID string) (r RemoveDHCPNetworkResult) {
+func RemoveDHCPNetwork(ctx context.Context, c gophercloud.Client, id string, networkID string) (r RemoveDHCPNetworkResult) {
 	resp, err := c.Delete(ctx, removeDHCPNetworkURL(c, id, networkID), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -154,7 +154,7 @@ func RemoveDHCPNetwork(ctx context.Context, c *gophercloud.ServiceClient, id str
 
 // ListBGPSpeakers list the BGP Speakers hosted by a specific dragent
 // GET /v2.0/agents/{agent-id}/bgp-drinstances
-func ListBGPSpeakers(c *gophercloud.ServiceClient, agentID string) pagination.Pager {
+func ListBGPSpeakers(c gophercloud.Client, agentID string) pagination.Pager {
 	url := listBGPSpeakersURL(c, agentID)
 	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
 		return ListBGPSpeakersResult{pagination.SinglePageBase(r)}
@@ -178,7 +178,7 @@ func (opts ScheduleBGPSpeakerOpts) ToAgentScheduleBGPSpeakerMap() (map[string]an
 
 // ScheduleBGPSpeaker schedule a BGP speaker to a BGP agent
 // POST /v2.0/agents/{agent-id}/bgp-drinstances
-func ScheduleBGPSpeaker(ctx context.Context, c *gophercloud.ServiceClient, agentID string, opts ScheduleBGPSpeakerOptsBuilder) (r ScheduleBGPSpeakerResult) {
+func ScheduleBGPSpeaker(ctx context.Context, c gophercloud.Client, agentID string, opts ScheduleBGPSpeakerOptsBuilder) (r ScheduleBGPSpeakerResult) {
 	b, err := opts.ToAgentScheduleBGPSpeakerMap()
 	if err != nil {
 		r.Err = err
@@ -193,7 +193,7 @@ func ScheduleBGPSpeaker(ctx context.Context, c *gophercloud.ServiceClient, agent
 
 // RemoveBGPSpeaker removes a BGP speaker from a BGP agent
 // DELETE /v2.0/agents/{agent-id}/bgp-drinstances
-func RemoveBGPSpeaker(ctx context.Context, c *gophercloud.ServiceClient, agentID string, speakerID string) (r RemoveBGPSpeakerResult) {
+func RemoveBGPSpeaker(ctx context.Context, c gophercloud.Client, agentID string, speakerID string) (r RemoveBGPSpeakerResult) {
 	resp, err := c.Delete(ctx, removeBGPSpeakersURL(c, agentID, speakerID), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -201,7 +201,7 @@ func RemoveBGPSpeaker(ctx context.Context, c *gophercloud.ServiceClient, agentID
 
 // ListDRAgentHostingBGPSpeakers the dragents that are hosting a specific bgp speaker
 // GET /v2.0/bgp-speakers/{bgp-speaker-id}/bgp-dragents
-func ListDRAgentHostingBGPSpeakers(c *gophercloud.ServiceClient, bgpSpeakerID string) pagination.Pager {
+func ListDRAgentHostingBGPSpeakers(c gophercloud.Client, bgpSpeakerID string) pagination.Pager {
 	url := listDRAgentHostingBGPSpeakersURL(c, bgpSpeakerID)
 	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
 		return AgentPage{pagination.LinkedPageBase{PageResult: r}}
@@ -210,7 +210,7 @@ func ListDRAgentHostingBGPSpeakers(c *gophercloud.ServiceClient, bgpSpeakerID st
 
 // ListL3Routers returns a list of routers scheduled to a specific
 // L3 agent.
-func ListL3Routers(ctx context.Context, c *gophercloud.ServiceClient, id string) (r ListL3RoutersResult) {
+func ListL3Routers(ctx context.Context, c gophercloud.Client, id string) (r ListL3RoutersResult) {
 	resp, err := c.Get(ctx, listL3RoutersURL(c, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -234,7 +234,7 @@ func (opts ScheduleL3RouterOpts) ToAgentScheduleL3RouterMap() (map[string]any, e
 }
 
 // ScheduleL3Router schedule a router to a L3 agent.
-func ScheduleL3Router(ctx context.Context, c *gophercloud.ServiceClient, id string, opts ScheduleL3RouterOptsBuilder) (r ScheduleL3RouterResult) {
+func ScheduleL3Router(ctx context.Context, c gophercloud.Client, id string, opts ScheduleL3RouterOptsBuilder) (r ScheduleL3RouterResult) {
 	b, err := opts.ToAgentScheduleL3RouterMap()
 	if err != nil {
 		r.Err = err
@@ -248,7 +248,7 @@ func ScheduleL3Router(ctx context.Context, c *gophercloud.ServiceClient, id stri
 }
 
 // RemoveL3Router removes a router from a L3 agent.
-func RemoveL3Router(ctx context.Context, c *gophercloud.ServiceClient, id string, routerID string) (r RemoveL3RouterResult) {
+func RemoveL3Router(ctx context.Context, c gophercloud.Client, id string, routerID string) (r RemoveL3RouterResult) {
 	resp, err := c.Delete(ctx, removeL3RouterURL(c, id, routerID), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/networking/v2/extensions/agents/urls.go
+++ b/openstack/networking/v2/extensions/agents/urls.go
@@ -9,78 +9,78 @@ const bgpSpeakersResourcePath = "bgp-drinstances"
 const bgpDRAgentSpeakersResourcePath = "bgp-speakers"
 const bgpDRAgentAgentResourcePath = "bgp-dragents"
 
-func resourceURL(c *gophercloud.ServiceClient, id string) string {
+func resourceURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL(resourcePath, id)
 }
 
-func rootURL(c *gophercloud.ServiceClient) string {
+func rootURL(c gophercloud.Client) string {
 	return c.ServiceURL(resourcePath)
 }
 
-func listURL(c *gophercloud.ServiceClient) string {
+func listURL(c gophercloud.Client) string {
 	return rootURL(c)
 }
 
-func getURL(c *gophercloud.ServiceClient, id string) string {
+func getURL(c gophercloud.Client, id string) string {
 	return resourceURL(c, id)
 }
 
-func updateURL(c *gophercloud.ServiceClient, id string) string {
+func updateURL(c gophercloud.Client, id string) string {
 	return resourceURL(c, id)
 }
 
-func deleteURL(c *gophercloud.ServiceClient, id string) string {
+func deleteURL(c gophercloud.Client, id string) string {
 	return resourceURL(c, id)
 }
 
-func dhcpNetworksURL(c *gophercloud.ServiceClient, id string) string {
+func dhcpNetworksURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL(resourcePath, id, dhcpNetworksResourcePath)
 }
 
-func l3RoutersURL(c *gophercloud.ServiceClient, id string) string {
+func l3RoutersURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL(resourcePath, id, l3RoutersResourcePath)
 }
 
-func listDHCPNetworksURL(c *gophercloud.ServiceClient, id string) string {
+func listDHCPNetworksURL(c gophercloud.Client, id string) string {
 	return dhcpNetworksURL(c, id)
 }
 
-func listL3RoutersURL(c *gophercloud.ServiceClient, id string) string {
+func listL3RoutersURL(c gophercloud.Client, id string) string {
 	return l3RoutersURL(c, id)
 }
 
-func scheduleDHCPNetworkURL(c *gophercloud.ServiceClient, id string) string {
+func scheduleDHCPNetworkURL(c gophercloud.Client, id string) string {
 	return dhcpNetworksURL(c, id)
 }
 
-func scheduleL3RouterURL(c *gophercloud.ServiceClient, id string) string {
+func scheduleL3RouterURL(c gophercloud.Client, id string) string {
 	return l3RoutersURL(c, id)
 }
 
-func removeDHCPNetworkURL(c *gophercloud.ServiceClient, id string, networkID string) string {
+func removeDHCPNetworkURL(c gophercloud.Client, id string, networkID string) string {
 	return c.ServiceURL(resourcePath, id, dhcpNetworksResourcePath, networkID)
 }
 
-func removeL3RouterURL(c *gophercloud.ServiceClient, id string, routerID string) string {
+func removeL3RouterURL(c gophercloud.Client, id string, routerID string) string {
 	return c.ServiceURL(resourcePath, id, l3RoutersResourcePath, routerID)
 }
 
 // return /v2.0/agents/{agent-id}/bgp-drinstances
-func listBGPSpeakersURL(c *gophercloud.ServiceClient, agentID string) string {
+func listBGPSpeakersURL(c gophercloud.Client, agentID string) string {
 	return c.ServiceURL(resourcePath, agentID, bgpSpeakersResourcePath)
 }
 
 // return /v2.0/agents/{agent-id}/bgp-drinstances
-func scheduleBGPSpeakersURL(c *gophercloud.ServiceClient, id string) string {
+func scheduleBGPSpeakersURL(c gophercloud.Client, id string) string {
 	return listBGPSpeakersURL(c, id)
 }
 
 // return /v2.0/agents/{agent-id}/bgp-drinstances/{bgp-speaker-id}
-func removeBGPSpeakersURL(c *gophercloud.ServiceClient, agentID string, speakerID string) string {
+func removeBGPSpeakersURL(c gophercloud.Client, agentID string, speakerID string) string {
 	return c.ServiceURL(resourcePath, agentID, bgpSpeakersResourcePath, speakerID)
 }
 
 // return /v2.0/bgp-speakers/{bgp-speaker-id}/bgp-dragents
-func listDRAgentHostingBGPSpeakersURL(c *gophercloud.ServiceClient, speakerID string) string {
+func listDRAgentHostingBGPSpeakersURL(c gophercloud.Client, speakerID string) string {
 	return c.ServiceURL(bgpDRAgentSpeakersResourcePath, speakerID, bgpDRAgentAgentResourcePath)
 }

--- a/openstack/networking/v2/extensions/attributestags/requests.go
+++ b/openstack/networking/v2/extensions/attributestags/requests.go
@@ -24,7 +24,7 @@ func (opts ReplaceAllOpts) ToAttributeTagsReplaceAllMap() (map[string]any, error
 }
 
 // ReplaceAll updates all tags on a resource, replacing any existing tags
-func ReplaceAll(ctx context.Context, client *gophercloud.ServiceClient, resourceType string, resourceID string, opts ReplaceAllOptsBuilder) (r ReplaceAllResult) {
+func ReplaceAll(ctx context.Context, client gophercloud.Client, resourceType string, resourceID string, opts ReplaceAllOptsBuilder) (r ReplaceAllResult) {
 	b, err := opts.ToAttributeTagsReplaceAllMap()
 	url := replaceURL(client, resourceType, resourceID)
 	if err != nil {
@@ -39,7 +39,7 @@ func ReplaceAll(ctx context.Context, client *gophercloud.ServiceClient, resource
 }
 
 // List all tags on a resource
-func List(ctx context.Context, client *gophercloud.ServiceClient, resourceType string, resourceID string) (r ListResult) {
+func List(ctx context.Context, client gophercloud.Client, resourceType string, resourceID string) (r ListResult) {
 	url := listURL(client, resourceType, resourceID)
 	resp, err := client.Get(ctx, url, &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{200},
@@ -49,7 +49,7 @@ func List(ctx context.Context, client *gophercloud.ServiceClient, resourceType s
 }
 
 // DeleteAll deletes all tags on a resource
-func DeleteAll(ctx context.Context, client *gophercloud.ServiceClient, resourceType string, resourceID string) (r DeleteResult) {
+func DeleteAll(ctx context.Context, client gophercloud.Client, resourceType string, resourceID string) (r DeleteResult) {
 	url := deleteAllURL(client, resourceType, resourceID)
 	resp, err := client.Delete(ctx, url, &gophercloud.RequestOpts{
 		OkCodes: []int{204},
@@ -59,7 +59,7 @@ func DeleteAll(ctx context.Context, client *gophercloud.ServiceClient, resourceT
 }
 
 // Add a tag on a resource
-func Add(ctx context.Context, client *gophercloud.ServiceClient, resourceType string, resourceID string, tag string) (r AddResult) {
+func Add(ctx context.Context, client gophercloud.Client, resourceType string, resourceID string, tag string) (r AddResult) {
 	url := addURL(client, resourceType, resourceID, tag)
 	resp, err := client.Put(ctx, url, nil, nil, &gophercloud.RequestOpts{
 		OkCodes: []int{201},
@@ -69,7 +69,7 @@ func Add(ctx context.Context, client *gophercloud.ServiceClient, resourceType st
 }
 
 // Delete a tag on a resource
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, resourceType string, resourceID string, tag string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, resourceType string, resourceID string, tag string) (r DeleteResult) {
 	url := deleteURL(client, resourceType, resourceID, tag)
 	resp, err := client.Delete(ctx, url, &gophercloud.RequestOpts{
 		OkCodes: []int{204},
@@ -79,7 +79,7 @@ func Delete(ctx context.Context, client *gophercloud.ServiceClient, resourceType
 }
 
 // Confirm if a tag exists on a resource
-func Confirm(ctx context.Context, client *gophercloud.ServiceClient, resourceType string, resourceID string, tag string) (r ConfirmResult) {
+func Confirm(ctx context.Context, client gophercloud.Client, resourceType string, resourceID string, tag string) (r ConfirmResult) {
 	url := confirmURL(client, resourceType, resourceID, tag)
 	resp, err := client.Get(ctx, url, nil, &gophercloud.RequestOpts{
 		OkCodes: []int{204},

--- a/openstack/networking/v2/extensions/attributestags/urls.go
+++ b/openstack/networking/v2/extensions/attributestags/urls.go
@@ -6,26 +6,26 @@ const (
 	tagsPath = "tags"
 )
 
-func replaceURL(c *gophercloud.ServiceClient, r_type string, id string) string {
+func replaceURL(c gophercloud.Client, r_type string, id string) string {
 	return c.ServiceURL(r_type, id, tagsPath)
 }
 
-func listURL(c *gophercloud.ServiceClient, r_type string, id string) string {
+func listURL(c gophercloud.Client, r_type string, id string) string {
 	return c.ServiceURL(r_type, id, tagsPath)
 }
 
-func deleteAllURL(c *gophercloud.ServiceClient, r_type string, id string) string {
+func deleteAllURL(c gophercloud.Client, r_type string, id string) string {
 	return c.ServiceURL(r_type, id, tagsPath)
 }
 
-func addURL(c *gophercloud.ServiceClient, r_type string, id string, tag string) string {
+func addURL(c gophercloud.Client, r_type string, id string, tag string) string {
 	return c.ServiceURL(r_type, id, tagsPath, tag)
 }
 
-func deleteURL(c *gophercloud.ServiceClient, r_type string, id string, tag string) string {
+func deleteURL(c gophercloud.Client, r_type string, id string, tag string) string {
 	return c.ServiceURL(r_type, id, tagsPath, tag)
 }
 
-func confirmURL(c *gophercloud.ServiceClient, r_type string, id string, tag string) string {
+func confirmURL(c gophercloud.Client, r_type string, id string, tag string) string {
 	return c.ServiceURL(r_type, id, tagsPath, tag)
 }

--- a/openstack/networking/v2/extensions/bgp/peers/requests.go
+++ b/openstack/networking/v2/extensions/bgp/peers/requests.go
@@ -8,7 +8,7 @@ import (
 )
 
 // List the bgp peers
-func List(c *gophercloud.ServiceClient) pagination.Pager {
+func List(c gophercloud.Client) pagination.Pager {
 	url := listURL(c)
 	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
 		return BGPPeerPage{pagination.SinglePageBase(r)}
@@ -16,7 +16,7 @@ func List(c *gophercloud.ServiceClient) pagination.Pager {
 }
 
 // Get retrieve the specific bgp peer by its uuid
-func Get(ctx context.Context, c *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, c gophercloud.Client, id string) (r GetResult) {
 	resp, err := c.Get(ctx, getURL(c, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -43,7 +43,7 @@ func (opts CreateOpts) ToPeerCreateMap() (map[string]any, error) {
 }
 
 // Create a BGP Peer
-func Create(ctx context.Context, c *gophercloud.ServiceClient, opts CreateOpts) (r CreateResult) {
+func Create(ctx context.Context, c gophercloud.Client, opts CreateOpts) (r CreateResult) {
 	b, err := opts.ToPeerCreateMap()
 	if err != nil {
 		r.Err = err
@@ -55,7 +55,7 @@ func Create(ctx context.Context, c *gophercloud.ServiceClient, opts CreateOpts) 
 }
 
 // Delete accepts a unique ID and deletes the bgp Peer associated with it.
-func Delete(ctx context.Context, c *gophercloud.ServiceClient, bgpPeerID string) (r DeleteResult) {
+func Delete(ctx context.Context, c gophercloud.Client, bgpPeerID string) (r DeleteResult) {
 	resp, err := c.Delete(ctx, deleteURL(c, bgpPeerID), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -79,7 +79,7 @@ func (opts UpdateOpts) ToPeerUpdateMap() (map[string]any, error) {
 }
 
 // Update accept a BGP Peer ID and an UpdateOpts and update the BGP Peer
-func Update(ctx context.Context, c *gophercloud.ServiceClient, bgpPeerID string, opts UpdateOpts) (r UpdateResult) {
+func Update(ctx context.Context, c gophercloud.Client, bgpPeerID string, opts UpdateOpts) (r UpdateResult) {
 	b, err := opts.ToPeerUpdateMap()
 	if err != nil {
 		r.Err = err

--- a/openstack/networking/v2/extensions/bgp/peers/urls.go
+++ b/openstack/networking/v2/extensions/bgp/peers/urls.go
@@ -5,36 +5,36 @@ import "github.com/gophercloud/gophercloud/v2"
 const urlBase = "bgp-peers"
 
 // return /v2.0/bgp-peers/{bgp-peer-id}
-func resourceURL(c *gophercloud.ServiceClient, id string) string {
+func resourceURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL(urlBase, id)
 }
 
 // return /v2.0/bgp-peers
-func rootURL(c *gophercloud.ServiceClient) string {
+func rootURL(c gophercloud.Client) string {
 	return c.ServiceURL(urlBase)
 }
 
 // return /v2.0/bgp-peers/{bgp-peer-id}
-func getURL(c *gophercloud.ServiceClient, id string) string {
+func getURL(c gophercloud.Client, id string) string {
 	return resourceURL(c, id)
 }
 
 // return /v2.0/bgp-peers
-func listURL(c *gophercloud.ServiceClient) string {
+func listURL(c gophercloud.Client) string {
 	return rootURL(c)
 }
 
 // return /v2.0/bgp-peers
-func createURL(c *gophercloud.ServiceClient) string {
+func createURL(c gophercloud.Client) string {
 	return rootURL(c)
 }
 
 // return /v2.0/bgp-peers/{bgp-peer-id}
-func deleteURL(c *gophercloud.ServiceClient, id string) string {
+func deleteURL(c gophercloud.Client, id string) string {
 	return resourceURL(c, id)
 }
 
 // return /v2.0/bgp-peers/{bgp-peer-id}
-func updateURL(c *gophercloud.ServiceClient, id string) string {
+func updateURL(c gophercloud.Client, id string) string {
 	return resourceURL(c, id)
 }

--- a/openstack/networking/v2/extensions/bgp/speakers/requests.go
+++ b/openstack/networking/v2/extensions/bgp/speakers/requests.go
@@ -8,7 +8,7 @@ import (
 )
 
 // List the bgp speakers
-func List(c *gophercloud.ServiceClient) pagination.Pager {
+func List(c gophercloud.Client) pagination.Pager {
 	url := listURL(c)
 	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
 		return BGPSpeakerPage{pagination.SinglePageBase(r)}
@@ -16,7 +16,7 @@ func List(c *gophercloud.ServiceClient) pagination.Pager {
 }
 
 // Get retrieve the specific bgp speaker by its uuid
-func Get(ctx context.Context, c *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, c gophercloud.Client, id string) (r GetResult) {
 	resp, err := c.Get(ctx, getURL(c, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -43,7 +43,7 @@ func (opts CreateOpts) ToSpeakerCreateMap() (map[string]any, error) {
 }
 
 // Create accepts a CreateOpts and create a BGP Speaker.
-func Create(ctx context.Context, c *gophercloud.ServiceClient, opts CreateOpts) (r CreateResult) {
+func Create(ctx context.Context, c gophercloud.Client, opts CreateOpts) (r CreateResult) {
 	b, err := opts.ToSpeakerCreateMap()
 	if err != nil {
 		r.Err = err
@@ -55,7 +55,7 @@ func Create(ctx context.Context, c *gophercloud.ServiceClient, opts CreateOpts) 
 }
 
 // Delete accepts a unique ID and deletes the bgp speaker associated with it.
-func Delete(ctx context.Context, c *gophercloud.ServiceClient, speakerID string) (r DeleteResult) {
+func Delete(ctx context.Context, c gophercloud.Client, speakerID string) (r DeleteResult) {
 	resp, err := c.Delete(ctx, deleteURL(c, speakerID), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -80,7 +80,7 @@ type UpdateOptsBuilder interface {
 }
 
 // Update accepts a UpdateOpts and update the BGP Speaker.
-func Update(ctx context.Context, c *gophercloud.ServiceClient, speakerID string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, c gophercloud.Client, speakerID string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToSpeakerUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -109,7 +109,7 @@ func (opts AddBGPPeerOpts) ToBGPSpeakerAddBGPPeerMap() (map[string]any, error) {
 }
 
 // AddBGPPeer add the BGP peer to the speaker a.k.a. PUT /v2.0/bgp-speakers/{bgp-speaker-id}/add_bgp_peer
-func AddBGPPeer(ctx context.Context, c *gophercloud.ServiceClient, bgpSpeakerID string, opts AddBGPPeerOptsBuilder) (r AddBGPPeerResult) {
+func AddBGPPeer(ctx context.Context, c gophercloud.Client, bgpSpeakerID string, opts AddBGPPeerOptsBuilder) (r AddBGPPeerResult) {
 	b, err := opts.ToBGPSpeakerAddBGPPeerMap()
 	if err != nil {
 		r.Err = err
@@ -136,7 +136,7 @@ func (opts RemoveBGPPeerOpts) ToBGPSpeakerRemoveBGPPeerMap() (map[string]any, er
 }
 
 // RemoveBGPPeer remove the BGP peer from the speaker, a.k.a. PUT /v2.0/bgp-speakers/{bgp-speaker-id}/add_bgp_peer
-func RemoveBGPPeer(ctx context.Context, c *gophercloud.ServiceClient, bgpSpeakerID string, opts RemoveBGPPeerOptsBuilder) (r RemoveBGPPeerResult) {
+func RemoveBGPPeer(ctx context.Context, c gophercloud.Client, bgpSpeakerID string, opts RemoveBGPPeerOptsBuilder) (r RemoveBGPPeerResult) {
 	b, err := opts.ToBGPSpeakerRemoveBGPPeerMap()
 	if err != nil {
 		r.Err = err
@@ -150,7 +150,7 @@ func RemoveBGPPeer(ctx context.Context, c *gophercloud.ServiceClient, bgpSpeaker
 }
 
 // GetAdvertisedRoutes a.k.a. GET /v2.0/bgp-speakers/{bgp-speaker-id}/get_advertised_routes
-func GetAdvertisedRoutes(c *gophercloud.ServiceClient, bgpSpeakerID string) pagination.Pager {
+func GetAdvertisedRoutes(c gophercloud.Client, bgpSpeakerID string) pagination.Pager {
 	url := getAdvertisedRoutesURL(c, bgpSpeakerID)
 	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
 		return AdvertisedRoutePage{pagination.SinglePageBase(r)}
@@ -174,7 +174,7 @@ func (opts AddGatewayNetworkOpts) ToBGPSpeakerAddGatewayNetworkMap() (map[string
 }
 
 // AddGatewayNetwork a.k.a. PUT /v2.0/bgp-speakers/{bgp-speaker-id}/add_gateway_network
-func AddGatewayNetwork(ctx context.Context, c *gophercloud.ServiceClient, bgpSpeakerID string, opts AddGatewayNetworkOptsBuilder) (r AddGatewayNetworkResult) {
+func AddGatewayNetwork(ctx context.Context, c gophercloud.Client, bgpSpeakerID string, opts AddGatewayNetworkOptsBuilder) (r AddGatewayNetworkResult) {
 	b, err := opts.ToBGPSpeakerAddGatewayNetworkMap()
 	if err != nil {
 		r.Err = err
@@ -201,7 +201,7 @@ func (opts RemoveGatewayNetworkOpts) ToBGPSpeakerRemoveGatewayNetworkMap() (map[
 }
 
 // RemoveGatewayNetwork a.k.a. PUT /v2.0/bgp-speakers/{bgp-speaker-id}/remove_gateway_network
-func RemoveGatewayNetwork(ctx context.Context, c *gophercloud.ServiceClient, bgpSpeakerID string, opts RemoveGatewayNetworkOptsBuilder) (r RemoveGatewayNetworkResult) {
+func RemoveGatewayNetwork(ctx context.Context, c gophercloud.Client, bgpSpeakerID string, opts RemoveGatewayNetworkOptsBuilder) (r RemoveGatewayNetworkResult) {
 	b, err := opts.ToBGPSpeakerRemoveGatewayNetworkMap()
 	if err != nil {
 		r.Err = err

--- a/openstack/networking/v2/extensions/bgp/speakers/urls.go
+++ b/openstack/networking/v2/extensions/bgp/speakers/urls.go
@@ -5,61 +5,61 @@ import "github.com/gophercloud/gophercloud/v2"
 const urlBase = "bgp-speakers"
 
 // return /v2.0/bgp-speakers/{bgp-speaker-id}
-func resourceURL(c *gophercloud.ServiceClient, id string) string {
+func resourceURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL(urlBase, id)
 }
 
 // return /v2.0/bgp-speakers
-func rootURL(c *gophercloud.ServiceClient) string {
+func rootURL(c gophercloud.Client) string {
 	return c.ServiceURL(urlBase)
 }
 
 // return /v2.0/bgp-speakers/{bgp-speaker-id}
-func getURL(c *gophercloud.ServiceClient, id string) string {
+func getURL(c gophercloud.Client, id string) string {
 	return resourceURL(c, id)
 }
 
 // return /v2.0/bgp-speakers
-func listURL(c *gophercloud.ServiceClient) string {
+func listURL(c gophercloud.Client) string {
 	return rootURL(c)
 }
 
 // return /v2.0/bgp-speakers
-func createURL(c *gophercloud.ServiceClient) string {
+func createURL(c gophercloud.Client) string {
 	return rootURL(c)
 }
 
 // return /v2.0/bgp-speakers/{bgp-peer-id}
-func deleteURL(c *gophercloud.ServiceClient, id string) string {
+func deleteURL(c gophercloud.Client, id string) string {
 	return resourceURL(c, id)
 }
 
 // return /v2.0/bgp-speakers/{bgp-peer-id}
-func updateURL(c *gophercloud.ServiceClient, id string) string {
+func updateURL(c gophercloud.Client, id string) string {
 	return resourceURL(c, id)
 }
 
 // return /v2.0/bgp-speakers/{bgp-speaker-id}/add_bgp_peer
-func addBGPPeerURL(c *gophercloud.ServiceClient, speakerID string) string {
+func addBGPPeerURL(c gophercloud.Client, speakerID string) string {
 	return c.ServiceURL(urlBase, speakerID, "add_bgp_peer")
 }
 
 // return /v2.0/bgp-speakers/{bgp-speaker-id}/remove_bgp_peer
-func removeBGPPeerURL(c *gophercloud.ServiceClient, speakerID string) string {
+func removeBGPPeerURL(c gophercloud.Client, speakerID string) string {
 	return c.ServiceURL(urlBase, speakerID, "remove_bgp_peer")
 }
 
 // return /v2.0/bgp-speakers/{bgp-speaker-id}/get_advertised_routes
-func getAdvertisedRoutesURL(c *gophercloud.ServiceClient, speakerID string) string {
+func getAdvertisedRoutesURL(c gophercloud.Client, speakerID string) string {
 	return c.ServiceURL(urlBase, speakerID, "get_advertised_routes")
 }
 
 // return /v2.0/bgp-speakers/{bgp-speaker-id}/add_gateway_network
-func addGatewayNetworkURL(c *gophercloud.ServiceClient, speakerID string) string {
+func addGatewayNetworkURL(c gophercloud.Client, speakerID string) string {
 	return c.ServiceURL(urlBase, speakerID, "add_gateway_network")
 }
 
 // return /v2.0/bgp-speakers/{bgp-speaker-id}/remove_gateway_network
-func removeGatewayNetworkURL(c *gophercloud.ServiceClient, speakerID string) string {
+func removeGatewayNetworkURL(c gophercloud.Client, speakerID string) string {
 	return c.ServiceURL(urlBase, speakerID, "remove_gateway_network")
 }

--- a/openstack/networking/v2/extensions/bgpvpns/requests.go
+++ b/openstack/networking/v2/extensions/bgpvpns/requests.go
@@ -34,7 +34,7 @@ func (opts ListOpts) ToBGPVPNListQuery() (string, error) {
 }
 
 // List the BGP VPNs
-func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(c gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(c)
 	query, err := opts.ToBGPVPNListQuery()
 	if err != nil {
@@ -49,7 +49,7 @@ func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 }
 
 // Get retrieve the specific BGP VPN by its uuid
-func Get(ctx context.Context, c *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, c gophercloud.Client, id string) (r GetResult) {
 	resp, err := c.Get(ctx, getURL(c, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -81,7 +81,7 @@ func (opts CreateOpts) ToBGPVPNCreateMap() (map[string]any, error) {
 }
 
 // Create a BGP VPN
-func Create(ctx context.Context, c *gophercloud.ServiceClient, opts CreateOpts) (r CreateResult) {
+func Create(ctx context.Context, c gophercloud.Client, opts CreateOpts) (r CreateResult) {
 	b, err := opts.ToBGPVPNCreateMap()
 	if err != nil {
 		r.Err = err
@@ -93,7 +93,7 @@ func Create(ctx context.Context, c *gophercloud.ServiceClient, opts CreateOpts) 
 }
 
 // Delete accepts a unique ID and deletes the BGP VPN associated with it.
-func Delete(ctx context.Context, c *gophercloud.ServiceClient, id string) (r DeleteResult) {
+func Delete(ctx context.Context, c gophercloud.Client, id string) (r DeleteResult) {
 	resp, err := c.Delete(ctx, deleteURL(c, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -121,7 +121,7 @@ func (opts UpdateOpts) ToBGPVPNUpdateMap() (map[string]any, error) {
 }
 
 // Update accept a BGP VPN ID and an UpdateOpts and update the BGP VPN
-func Update(ctx context.Context, c *gophercloud.ServiceClient, id string, opts UpdateOpts) (r UpdateResult) {
+func Update(ctx context.Context, c gophercloud.Client, id string, opts UpdateOpts) (r UpdateResult) {
 	b, err := opts.ToBGPVPNUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -160,7 +160,7 @@ func (opts ListNetworkAssociationsOpts) ToNetworkAssociationsListQuery() (string
 
 // ListNetworkAssociations pages over the network associations of a specified
 // BGP VPN.
-func ListNetworkAssociations(c *gophercloud.ServiceClient, id string, opts ListNetworkAssociationsOptsBuilder) pagination.Pager {
+func ListNetworkAssociations(c gophercloud.Client, id string, opts ListNetworkAssociationsOptsBuilder) pagination.Pager {
 	url := listNetworkAssociationsURL(c, id)
 	query, err := opts.ToNetworkAssociationsListQuery()
 	if err != nil {
@@ -196,7 +196,7 @@ func (opts CreateNetworkAssociationOpts) ToNetworkAssociationCreateMap() (map[st
 
 // CreateNetworkAssociation creates a new network association for a specified
 // BGP VPN.
-func CreateNetworkAssociation(ctx context.Context, client *gophercloud.ServiceClient, id string, opts CreateNetworkAssociationOptsBuilder) (r CreateNetworkAssociationResult) {
+func CreateNetworkAssociation(ctx context.Context, client gophercloud.Client, id string, opts CreateNetworkAssociationOptsBuilder) (r CreateNetworkAssociationResult) {
 	b, err := opts.ToNetworkAssociationCreateMap()
 	if err != nil {
 		r.Err = err
@@ -209,7 +209,7 @@ func CreateNetworkAssociation(ctx context.Context, client *gophercloud.ServiceCl
 
 // GetNetworkAssociation retrieves a specific network association by BGP VPN id
 // and network association id.
-func GetNetworkAssociation(ctx context.Context, c *gophercloud.ServiceClient, bgpVpnID string, id string) (r GetNetworkAssociationResult) {
+func GetNetworkAssociation(ctx context.Context, c gophercloud.Client, bgpVpnID string, id string) (r GetNetworkAssociationResult) {
 	resp, err := c.Get(ctx, getNetworkAssociationURL(c, bgpVpnID, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -217,7 +217,7 @@ func GetNetworkAssociation(ctx context.Context, c *gophercloud.ServiceClient, bg
 
 // DeleteNetworkAssociation deletes a specific network association by BGP VPN id
 // and network association id.
-func DeleteNetworkAssociation(ctx context.Context, c *gophercloud.ServiceClient, bgpVpnID string, id string) (r DeleteNetworkAssociationResult) {
+func DeleteNetworkAssociation(ctx context.Context, c gophercloud.Client, bgpVpnID string, id string) (r DeleteNetworkAssociationResult) {
 	resp, err := c.Delete(ctx, deleteNetworkAssociationURL(c, bgpVpnID, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -249,7 +249,7 @@ func (opts ListRouterAssociationsOpts) ToRouterAssociationsListQuery() (string, 
 
 // ListRouterAssociations pages over the router associations of a specified
 // BGP VPN.
-func ListRouterAssociations(c *gophercloud.ServiceClient, id string, opts ListRouterAssociationsOptsBuilder) pagination.Pager {
+func ListRouterAssociations(c gophercloud.Client, id string, opts ListRouterAssociationsOptsBuilder) pagination.Pager {
 	url := listRouterAssociationsURL(c, id)
 	query, err := opts.ToRouterAssociationsListQuery()
 	if err != nil {
@@ -286,7 +286,7 @@ func (opts CreateRouterAssociationOpts) ToRouterAssociationCreateMap() (map[stri
 
 // CreateRouterAssociation creates a new router association for a specified
 // BGP VPN.
-func CreateRouterAssociation(ctx context.Context, client *gophercloud.ServiceClient, id string, opts CreateRouterAssociationOptsBuilder) (r CreateRouterAssociationResult) {
+func CreateRouterAssociation(ctx context.Context, client gophercloud.Client, id string, opts CreateRouterAssociationOptsBuilder) (r CreateRouterAssociationResult) {
 	b, err := opts.ToRouterAssociationCreateMap()
 	if err != nil {
 		r.Err = err
@@ -299,7 +299,7 @@ func CreateRouterAssociation(ctx context.Context, client *gophercloud.ServiceCli
 
 // GetRouterAssociation retrieves a specific router association by BGP VPN id
 // and router association id.
-func GetRouterAssociation(ctx context.Context, c *gophercloud.ServiceClient, bgpVpnID string, id string) (r GetRouterAssociationResult) {
+func GetRouterAssociation(ctx context.Context, c gophercloud.Client, bgpVpnID string, id string) (r GetRouterAssociationResult) {
 	resp, err := c.Get(ctx, getRouterAssociationURL(c, bgpVpnID, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -307,7 +307,7 @@ func GetRouterAssociation(ctx context.Context, c *gophercloud.ServiceClient, bgp
 
 // DeleteRouterAssociation deletes a specific router association by BGP VPN id
 // and router association id.
-func DeleteRouterAssociation(ctx context.Context, c *gophercloud.ServiceClient, bgpVpnID string, id string) (r DeleteRouterAssociationResult) {
+func DeleteRouterAssociation(ctx context.Context, c gophercloud.Client, bgpVpnID string, id string) (r DeleteRouterAssociationResult) {
 	resp, err := c.Delete(ctx, deleteRouterAssociationURL(c, bgpVpnID, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -332,7 +332,7 @@ func (opts UpdateRouterAssociationOpts) ToRouterAssociationUpdateMap() (map[stri
 }
 
 // UpdateRouterAssociation updates a router association for a specified BGP VPN.
-func UpdateRouterAssociation(ctx context.Context, client *gophercloud.ServiceClient, bgpVpnID string, id string, opts UpdateRouterAssociationOptsBuilder) (r UpdateRouterAssociationResult) {
+func UpdateRouterAssociation(ctx context.Context, client gophercloud.Client, bgpVpnID string, id string, opts UpdateRouterAssociationOptsBuilder) (r UpdateRouterAssociationResult) {
 	b, err := opts.ToRouterAssociationUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -371,7 +371,7 @@ func (opts ListPortAssociationsOpts) ToPortAssociationsListQuery() (string, erro
 
 // ListPortAssociations pages over the port associations of a specified
 // BGP VPN.
-func ListPortAssociations(c *gophercloud.ServiceClient, id string, opts ListPortAssociationsOptsBuilder) pagination.Pager {
+func ListPortAssociations(c gophercloud.Client, id string, opts ListPortAssociationsOptsBuilder) pagination.Pager {
 	url := listPortAssociationsURL(c, id)
 	query, err := opts.ToPortAssociationsListQuery()
 	if err != nil {
@@ -417,7 +417,7 @@ func (opts CreatePortAssociationOpts) ToPortAssociationCreateMap() (map[string]i
 
 // CreatePortAssociation creates a new port association for a specified
 // BGP VPN.
-func CreatePortAssociation(ctx context.Context, client *gophercloud.ServiceClient, id string, opts CreatePortAssociationOptsBuilder) (r CreatePortAssociationResult) {
+func CreatePortAssociation(ctx context.Context, client gophercloud.Client, id string, opts CreatePortAssociationOptsBuilder) (r CreatePortAssociationResult) {
 	b, err := opts.ToPortAssociationCreateMap()
 	if err != nil {
 		r.Err = err
@@ -430,7 +430,7 @@ func CreatePortAssociation(ctx context.Context, client *gophercloud.ServiceClien
 
 // GetPortAssociation retrieves a specific port association by BGP VPN id
 // and port association id.
-func GetPortAssociation(ctx context.Context, c *gophercloud.ServiceClient, bgpVpnID string, id string) (r GetPortAssociationResult) {
+func GetPortAssociation(ctx context.Context, c gophercloud.Client, bgpVpnID string, id string) (r GetPortAssociationResult) {
 	resp, err := c.Get(ctx, getPortAssociationURL(c, bgpVpnID, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -438,7 +438,7 @@ func GetPortAssociation(ctx context.Context, c *gophercloud.ServiceClient, bgpVp
 
 // DeletePortAssociation deletes a specific port association by BGP VPN id
 // and port association id.
-func DeletePortAssociation(ctx context.Context, c *gophercloud.ServiceClient, bgpVpnID string, id string) (r DeletePortAssociationResult) {
+func DeletePortAssociation(ctx context.Context, c gophercloud.Client, bgpVpnID string, id string) (r DeletePortAssociationResult) {
 	resp, err := c.Delete(ctx, deletePortAssociationURL(c, bgpVpnID, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -464,7 +464,7 @@ func (opts UpdatePortAssociationOpts) ToPortAssociationUpdateMap() (map[string]i
 }
 
 // UpdatePortAssociation updates a port association for a specified BGP VPN.
-func UpdatePortAssociation(ctx context.Context, client *gophercloud.ServiceClient, bgpVpnID string, id string, opts UpdatePortAssociationOptsBuilder) (r UpdatePortAssociationResult) {
+func UpdatePortAssociation(ctx context.Context, client gophercloud.Client, bgpVpnID string, id string, opts UpdatePortAssociationOptsBuilder) (r UpdatePortAssociationResult) {
 	b, err := opts.ToPortAssociationUpdateMap()
 	if err != nil {
 		r.Err = err

--- a/openstack/networking/v2/extensions/bgpvpns/urls.go
+++ b/openstack/networking/v2/extensions/bgpvpns/urls.go
@@ -5,136 +5,136 @@ import "github.com/gophercloud/gophercloud/v2"
 const urlBase = "bgpvpn/bgpvpns"
 
 // return /v2.0/bgpvpn/bgpvpns/{bgpvpn-id}
-func resourceURL(c *gophercloud.ServiceClient, id string) string {
+func resourceURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL(urlBase, id)
 }
 
 // return /v2.0/bgpvpn/bgpvpns
-func rootURL(c *gophercloud.ServiceClient) string {
+func rootURL(c gophercloud.Client) string {
 	return c.ServiceURL(urlBase)
 }
 
 // return /v2.0/bgpvpn/bgpvpns/{bgpvpn-id}
-func getURL(c *gophercloud.ServiceClient, id string) string {
+func getURL(c gophercloud.Client, id string) string {
 	return resourceURL(c, id)
 }
 
 // return /v2.0/bgpvpn/bgpvpns
-func listURL(c *gophercloud.ServiceClient) string {
+func listURL(c gophercloud.Client) string {
 	return rootURL(c)
 }
 
 // return /v2.0/bgpvpn/bgpvpns
-func createURL(c *gophercloud.ServiceClient) string {
+func createURL(c gophercloud.Client) string {
 	return rootURL(c)
 }
 
 // return /v2.0/bgpvpn/bgpvpns/{bgpvpn-id}
-func deleteURL(c *gophercloud.ServiceClient, id string) string {
+func deleteURL(c gophercloud.Client, id string) string {
 	return resourceURL(c, id)
 }
 
 // return /v2.0/bgpvpn/bgpvpns/{bgpvpn-id}
-func updateURL(c *gophercloud.ServiceClient, id string) string {
+func updateURL(c gophercloud.Client, id string) string {
 	return resourceURL(c, id)
 }
 
 // return /v2.0/bgpvpn/bgpvpns/{bgpvpn-id}/network_associations
-func networkAssociationsURL(c *gophercloud.ServiceClient, bgpVpnID string) string {
+func networkAssociationsURL(c gophercloud.Client, bgpVpnID string) string {
 	return c.ServiceURL(urlBase, bgpVpnID, "network_associations")
 }
 
 // return /v2.0/bgpvpn/bgpvpns/{bgpvpn-id}/network_associations/{network-association-id}
-func networkAssociationResourceURL(c *gophercloud.ServiceClient, bgpVpnID string, id string) string {
+func networkAssociationResourceURL(c gophercloud.Client, bgpVpnID string, id string) string {
 	return c.ServiceURL(urlBase, bgpVpnID, "network_associations", id)
 }
 
 // return /v2.0/bgpvpn/bgpvpns/{bgpvpn-id}/network_associations
-func listNetworkAssociationsURL(c *gophercloud.ServiceClient, bgpVpnID string) string {
+func listNetworkAssociationsURL(c gophercloud.Client, bgpVpnID string) string {
 	return networkAssociationsURL(c, bgpVpnID)
 }
 
 // return /v2.0/bgpvpn/bgpvpns/{bgpvpn-id}/network_associations
-func createNetworkAssociationURL(c *gophercloud.ServiceClient, bgpVpnID string) string {
+func createNetworkAssociationURL(c gophercloud.Client, bgpVpnID string) string {
 	return networkAssociationsURL(c, bgpVpnID)
 }
 
 // return /v2.0/bgpvpn/bgpvpns/{bgpvpn-id}/network_associations/{network-association-id}
-func getNetworkAssociationURL(c *gophercloud.ServiceClient, bgpVpnID string, id string) string {
+func getNetworkAssociationURL(c gophercloud.Client, bgpVpnID string, id string) string {
 	return networkAssociationResourceURL(c, bgpVpnID, id)
 }
 
 // return /v2.0/bgpvpn/bgpvpns/{bgpvpn-id}/network_associations/{network-association-id}
-func deleteNetworkAssociationURL(c *gophercloud.ServiceClient, bgpVpnID string, id string) string {
+func deleteNetworkAssociationURL(c gophercloud.Client, bgpVpnID string, id string) string {
 	return networkAssociationResourceURL(c, bgpVpnID, id)
 }
 
 // return /v2.0/bgpvpn/bgpvpns/{bgpvpn-id}/router_associations
-func routerAssociationsURL(c *gophercloud.ServiceClient, bgpVpnID string) string {
+func routerAssociationsURL(c gophercloud.Client, bgpVpnID string) string {
 	return c.ServiceURL(urlBase, bgpVpnID, "router_associations")
 }
 
 // return /v2.0/bgpvpn/bgpvpns/{bgpvpn-id}/router_associations/{router-association-id}
-func routerAssociationResourceURL(c *gophercloud.ServiceClient, bgpVpnID string, id string) string {
+func routerAssociationResourceURL(c gophercloud.Client, bgpVpnID string, id string) string {
 	return c.ServiceURL(urlBase, bgpVpnID, "router_associations", id)
 }
 
 // return /v2.0/bgpvpn/bgpvpns/{bgpvpn-id}/router_associations
-func listRouterAssociationsURL(c *gophercloud.ServiceClient, bgpVpnID string) string {
+func listRouterAssociationsURL(c gophercloud.Client, bgpVpnID string) string {
 	return routerAssociationsURL(c, bgpVpnID)
 }
 
 // return /v2.0/bgpvpn/bgpvpns/{bgpvpn-id}/router_associations
-func createRouterAssociationURL(c *gophercloud.ServiceClient, bgpVpnID string) string {
+func createRouterAssociationURL(c gophercloud.Client, bgpVpnID string) string {
 	return routerAssociationsURL(c, bgpVpnID)
 }
 
 // return /v2.0/bgpvpn/bgpvpns/{bgpvpn-id}/router_associations/{router-association-id}
-func getRouterAssociationURL(c *gophercloud.ServiceClient, bgpVpnID string, id string) string {
+func getRouterAssociationURL(c gophercloud.Client, bgpVpnID string, id string) string {
 	return routerAssociationResourceURL(c, bgpVpnID, id)
 }
 
 // return /v2.0/bgpvpn/bgpvpns/{bgpvpn-id}/router_associations/{router-association-id}
-func updateRouterAssociationURL(c *gophercloud.ServiceClient, bgpVpnID string, id string) string {
+func updateRouterAssociationURL(c gophercloud.Client, bgpVpnID string, id string) string {
 	return routerAssociationResourceURL(c, bgpVpnID, id)
 }
 
 // return /v2.0/bgpvpn/bgpvpns/{bgpvpn-id}/router_associations/{router-association-id}
-func deleteRouterAssociationURL(c *gophercloud.ServiceClient, bgpVpnID string, id string) string {
+func deleteRouterAssociationURL(c gophercloud.Client, bgpVpnID string, id string) string {
 	return routerAssociationResourceURL(c, bgpVpnID, id)
 }
 
 // return /v2.0/bgpvpn/bgpvpns/{bgpvpn-id}/port_associations
-func portAssociationsURL(c *gophercloud.ServiceClient, bgpVpnID string) string {
+func portAssociationsURL(c gophercloud.Client, bgpVpnID string) string {
 	return c.ServiceURL(urlBase, bgpVpnID, "port_associations")
 }
 
 // return /v2.0/bgpvpn/bgpvpns/{bgpvpn-id}/port_associations/{port-association-id}
-func portAssociationResourceURL(c *gophercloud.ServiceClient, bgpVpnID string, id string) string {
+func portAssociationResourceURL(c gophercloud.Client, bgpVpnID string, id string) string {
 	return c.ServiceURL(urlBase, bgpVpnID, "port_associations", id)
 }
 
 // return /v2.0/bgpvpn/bgpvpns/{bgpvpn-id}/port_associations
-func listPortAssociationsURL(c *gophercloud.ServiceClient, bgpVpnID string) string {
+func listPortAssociationsURL(c gophercloud.Client, bgpVpnID string) string {
 	return portAssociationsURL(c, bgpVpnID)
 }
 
 // return /v2.0/bgpvpn/bgpvpns/{bgpvpn-id}/port_associations
-func createPortAssociationURL(c *gophercloud.ServiceClient, bgpVpnID string) string {
+func createPortAssociationURL(c gophercloud.Client, bgpVpnID string) string {
 	return portAssociationsURL(c, bgpVpnID)
 }
 
 // return /v2.0/bgpvpn/bgpvpns/{bgpvpn-id}/port_associations/{port-association-id}
-func getPortAssociationURL(c *gophercloud.ServiceClient, bgpVpnID string, id string) string {
+func getPortAssociationURL(c gophercloud.Client, bgpVpnID string, id string) string {
 	return portAssociationResourceURL(c, bgpVpnID, id)
 }
 
 // return /v2.0/bgpvpn/bgpvpns/{bgpvpn-id}/port_associations/{port-association-id}
-func updatePortAssociationURL(c *gophercloud.ServiceClient, bgpVpnID string, id string) string {
+func updatePortAssociationURL(c gophercloud.Client, bgpVpnID string, id string) string {
 	return portAssociationResourceURL(c, bgpVpnID, id)
 }
 
 // return /v2.0/bgpvpn/bgpvpns/{bgpvpn-id}/port_associations/{port-association-id}
-func deletePortAssociationURL(c *gophercloud.ServiceClient, bgpVpnID string, id string) string {
+func deletePortAssociationURL(c gophercloud.Client, bgpVpnID string, id string) string {
 	return portAssociationResourceURL(c, bgpVpnID, id)
 }

--- a/openstack/networking/v2/extensions/delegate.go
+++ b/openstack/networking/v2/extensions/delegate.go
@@ -32,12 +32,12 @@ func ExtractExtensions(page pagination.Page) ([]Extension, error) {
 }
 
 // Get retrieves information for a specific extension using its alias.
-func Get(ctx context.Context, c *gophercloud.ServiceClient, alias string) GetResult {
+func Get(ctx context.Context, c gophercloud.Client, alias string) GetResult {
 	return GetResult{common.Get(ctx, c, alias)}
 }
 
 // List returns a Pager which allows you to iterate over the full collection of extensions.
 // It does not accept query parameters.
-func List(c *gophercloud.ServiceClient) pagination.Pager {
+func List(c gophercloud.Client) pagination.Pager {
 	return common.List(c)
 }

--- a/openstack/networking/v2/extensions/fwaas_v2/groups/requests.go
+++ b/openstack/networking/v2/extensions/fwaas_v2/groups/requests.go
@@ -51,7 +51,7 @@ func (opts ListOpts) ToGroupListQuery() (string, error) {
 //
 // Default group settings return only those firewall groups that are owned by the
 // tenant who submits the request, unless an admin user submits the request.
-func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(c gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := rootURL(c)
 
 	if opts != nil {
@@ -68,7 +68,7 @@ func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 }
 
 // Get retrieves a particular firewall group based on its unique ID.
-func Get(ctx context.Context, c *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, c gophercloud.Client, id string) (r GetResult) {
 	resp, err := c.Get(ctx, resourceURL(c, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -102,7 +102,7 @@ func (opts CreateOpts) ToFirewallGroupCreateMap() (map[string]any, error) {
 }
 
 // Create accepts a CreateOpts struct and uses the values to create a new firewall group
-func Create(ctx context.Context, c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, c gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToFirewallGroupCreateMap()
 	if err != nil {
 		r.Err = err
@@ -138,7 +138,7 @@ func (opts UpdateOpts) ToFirewallGroupUpdateMap() (map[string]any, error) {
 }
 
 // Update allows firewall groups to be updated.
-func Update(ctx context.Context, c *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, c gophercloud.Client, id string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToFirewallGroupUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -162,7 +162,7 @@ type RemoveIngressPolicyOpts struct {
 	IngressFirewallPolicyID *string `json:"ingress_firewall_policy_id"`
 }
 
-func RemoveIngressPolicy(ctx context.Context, c *gophercloud.ServiceClient, id string) (r UpdateResult) {
+func RemoveIngressPolicy(ctx context.Context, c gophercloud.Client, id string) (r UpdateResult) {
 	b, err := gophercloud.BuildRequestBody(RemoveIngressPolicyOpts{IngressFirewallPolicyID: nil}, "firewall_group")
 	if err != nil {
 		r.Err = err
@@ -179,7 +179,7 @@ type RemoveEgressPolicyOpts struct {
 	EgressFirewallPolicyID *string `json:"egress_firewall_policy_id"`
 }
 
-func RemoveEgressPolicy(ctx context.Context, c *gophercloud.ServiceClient, id string) (r UpdateResult) {
+func RemoveEgressPolicy(ctx context.Context, c gophercloud.Client, id string) (r UpdateResult) {
 	b, err := gophercloud.BuildRequestBody(RemoveEgressPolicyOpts{EgressFirewallPolicyID: nil}, "firewall_group")
 	if err != nil {
 		r.Err = err
@@ -193,7 +193,7 @@ func RemoveEgressPolicy(ctx context.Context, c *gophercloud.ServiceClient, id st
 }
 
 // Delete will permanently delete a particular firewall group based on its unique ID.
-func Delete(ctx context.Context, c *gophercloud.ServiceClient, id string) (r DeleteResult) {
+func Delete(ctx context.Context, c gophercloud.Client, id string) (r DeleteResult) {
 	resp, err := c.Delete(ctx, resourceURL(c, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/networking/v2/extensions/fwaas_v2/groups/urls.go
+++ b/openstack/networking/v2/extensions/fwaas_v2/groups/urls.go
@@ -7,10 +7,10 @@ const (
 	resourcePath = "firewall_groups"
 )
 
-func rootURL(c *gophercloud.ServiceClient) string {
+func rootURL(c gophercloud.Client) string {
 	return c.ServiceURL(rootPath, resourcePath)
 }
 
-func resourceURL(c *gophercloud.ServiceClient, id string) string {
+func resourceURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL(rootPath, resourcePath, id)
 }

--- a/openstack/networking/v2/extensions/fwaas_v2/policies/requests.go
+++ b/openstack/networking/v2/extensions/fwaas_v2/policies/requests.go
@@ -44,7 +44,7 @@ func (opts ListOpts) ToPolicyListQuery() (string, error) {
 //
 // Default policy settings return only those firewall policies that are owned by the
 // tenant who submits the request, unless an admin user submits the request.
-func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(c gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := rootURL(c)
 	if opts != nil {
 		query, err := opts.ToPolicyListQuery()
@@ -85,7 +85,7 @@ func (opts CreateOpts) ToFirewallPolicyCreateMap() (map[string]any, error) {
 }
 
 // Create accepts a CreateOpts struct and uses the values to create a new firewall policy
-func Create(ctx context.Context, c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, c gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToFirewallPolicyCreateMap()
 	if err != nil {
 		r.Err = err
@@ -97,7 +97,7 @@ func Create(ctx context.Context, c *gophercloud.ServiceClient, opts CreateOptsBu
 }
 
 // Get retrieves a particular firewall policy based on its unique ID.
-func Get(ctx context.Context, c *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, c gophercloud.Client, id string) (r GetResult) {
 	resp, err := c.Get(ctx, resourceURL(c, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -126,7 +126,7 @@ func (opts UpdateOpts) ToFirewallPolicyUpdateMap() (map[string]any, error) {
 }
 
 // Update allows firewall policies to be updated.
-func Update(ctx context.Context, c *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, c gophercloud.Client, id string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToFirewallPolicyUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -140,7 +140,7 @@ func Update(ctx context.Context, c *gophercloud.ServiceClient, id string, opts U
 }
 
 // Delete will permanently delete a particular firewall policy based on its unique ID.
-func Delete(ctx context.Context, c *gophercloud.ServiceClient, id string) (r DeleteResult) {
+func Delete(ctx context.Context, c gophercloud.Client, id string) (r DeleteResult) {
 	resp, err := c.Delete(ctx, resourceURL(c, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -160,7 +160,7 @@ func (opts InsertRuleOpts) ToFirewallPolicyInsertRuleMap() (map[string]any, erro
 	return gophercloud.BuildRequestBody(opts, "")
 }
 
-func InsertRule(ctx context.Context, c *gophercloud.ServiceClient, id string, opts InsertRuleOptsBuilder) (r InsertRuleResult) {
+func InsertRule(ctx context.Context, c gophercloud.Client, id string, opts InsertRuleOptsBuilder) (r InsertRuleResult) {
 	b, err := opts.ToFirewallPolicyInsertRuleMap()
 	if err != nil {
 		r.Err = err
@@ -173,7 +173,7 @@ func InsertRule(ctx context.Context, c *gophercloud.ServiceClient, id string, op
 	return
 }
 
-func RemoveRule(ctx context.Context, c *gophercloud.ServiceClient, id, ruleID string) (r RemoveRuleResult) {
+func RemoveRule(ctx context.Context, c gophercloud.Client, id, ruleID string) (r RemoveRuleResult) {
 	b := map[string]any{"firewall_rule_id": ruleID}
 	resp, err := c.Put(ctx, removeURL(c, id), b, &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{200},

--- a/openstack/networking/v2/extensions/fwaas_v2/policies/urls.go
+++ b/openstack/networking/v2/extensions/fwaas_v2/policies/urls.go
@@ -9,18 +9,18 @@ const (
 	removePath   = "remove_rule"
 )
 
-func rootURL(c *gophercloud.ServiceClient) string {
+func rootURL(c gophercloud.Client) string {
 	return c.ServiceURL(rootPath, resourcePath)
 }
 
-func resourceURL(c *gophercloud.ServiceClient, id string) string {
+func resourceURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL(rootPath, resourcePath, id)
 }
 
-func insertURL(c *gophercloud.ServiceClient, id string) string {
+func insertURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL(rootPath, resourcePath, id, insertPath)
 }
 
-func removeURL(c *gophercloud.ServiceClient, id string) string {
+func removeURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL(rootPath, resourcePath, id, removePath)
 }

--- a/openstack/networking/v2/extensions/fwaas_v2/rules/requests.go
+++ b/openstack/networking/v2/extensions/fwaas_v2/rules/requests.go
@@ -90,7 +90,7 @@ func (opts ListOpts) ToRuleListQuery() (string, error) {
 //
 // Default policy settings return only those firewall rules that are owned by the
 // tenant who submits the request, unless an admin user submits the request.
-func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(c gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := rootURL(c)
 
 	if opts != nil {
@@ -146,7 +146,7 @@ func (opts CreateOpts) ToRuleCreateMap() (map[string]any, error) {
 }
 
 // Create accepts a CreateOpts struct and uses the values to create a new firewall rule
-func Create(ctx context.Context, c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, c gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToRuleCreateMap()
 	if err != nil {
 		r.Err = err
@@ -158,7 +158,7 @@ func Create(ctx context.Context, c *gophercloud.ServiceClient, opts CreateOptsBu
 }
 
 // Get retrieves a particular firewall rule based on its unique ID.
-func Get(ctx context.Context, c *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, c gophercloud.Client, id string) (r GetResult) {
 	resp, err := c.Get(ctx, resourceURL(c, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -193,7 +193,7 @@ func (opts UpdateOpts) ToRuleUpdateMap() (map[string]any, error) {
 }
 
 // Update allows firewall policies to be updated.
-func Update(ctx context.Context, c *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, c gophercloud.Client, id string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToRuleUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -207,7 +207,7 @@ func Update(ctx context.Context, c *gophercloud.ServiceClient, id string, opts U
 }
 
 // Delete will permanently delete a particular firewall rule based on its unique ID.
-func Delete(ctx context.Context, c *gophercloud.ServiceClient, id string) (r DeleteResult) {
+func Delete(ctx context.Context, c gophercloud.Client, id string) (r DeleteResult) {
 	resp, err := c.Delete(ctx, resourceURL(c, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/networking/v2/extensions/fwaas_v2/rules/urls.go
+++ b/openstack/networking/v2/extensions/fwaas_v2/rules/urls.go
@@ -7,10 +7,10 @@ const (
 	resourcePath = "firewall_rules"
 )
 
-func rootURL(c *gophercloud.ServiceClient) string {
+func rootURL(c gophercloud.Client) string {
 	return c.ServiceURL(rootPath, resourcePath)
 }
 
-func resourceURL(c *gophercloud.ServiceClient, id string) string {
+func resourceURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL(rootPath, resourcePath, id)
 }

--- a/openstack/networking/v2/extensions/layer3/addressscopes/requests.go
+++ b/openstack/networking/v2/extensions/layer3/addressscopes/requests.go
@@ -46,7 +46,7 @@ func (opts ListOpts) ToAddressScopeListQuery() (string, error) {
 // Default policy settings return only the address-scopes owned by the project
 // of the user submitting the request, unless the user has the administrative
 // role.
-func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(c gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(c)
 	if opts != nil {
 		query, err := opts.ToAddressScopeListQuery()
@@ -61,7 +61,7 @@ func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 }
 
 // Get retrieves a specific address-scope based on its ID.
-func Get(ctx context.Context, c *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, c gophercloud.Client, id string) (r GetResult) {
 	resp, err := c.Get(ctx, getURL(c, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -97,7 +97,7 @@ func (opts CreateOpts) ToAddressScopeCreateMap() (map[string]any, error) {
 }
 
 // Create requests the creation of a new address-scope on the server.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToAddressScopeCreateMap()
 	if err != nil {
 		r.Err = err
@@ -132,7 +132,7 @@ func (opts UpdateOpts) ToAddressScopeUpdateMap() (map[string]any, error) {
 
 // Update accepts a UpdateOpts struct and updates an existing address-scope
 // using the values provided.
-func Update(ctx context.Context, c *gophercloud.ServiceClient, addressScopeID string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, c gophercloud.Client, addressScopeID string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToAddressScopeUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -146,7 +146,7 @@ func Update(ctx context.Context, c *gophercloud.ServiceClient, addressScopeID st
 }
 
 // Delete accepts a unique ID and deletes the address-scope associated with it.
-func Delete(ctx context.Context, c *gophercloud.ServiceClient, id string) (r DeleteResult) {
+func Delete(ctx context.Context, c gophercloud.Client, id string) (r DeleteResult) {
 	resp, err := c.Delete(ctx, deleteURL(c, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/networking/v2/extensions/layer3/addressscopes/urls.go
+++ b/openstack/networking/v2/extensions/layer3/addressscopes/urls.go
@@ -4,30 +4,30 @@ import "github.com/gophercloud/gophercloud/v2"
 
 const resourcePath = "address-scopes"
 
-func resourceURL(c *gophercloud.ServiceClient, id string) string {
+func resourceURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL(resourcePath, id)
 }
 
-func rootURL(c *gophercloud.ServiceClient) string {
+func rootURL(c gophercloud.Client) string {
 	return c.ServiceURL(resourcePath)
 }
 
-func listURL(c *gophercloud.ServiceClient) string {
+func listURL(c gophercloud.Client) string {
 	return rootURL(c)
 }
 
-func getURL(c *gophercloud.ServiceClient, id string) string {
+func getURL(c gophercloud.Client, id string) string {
 	return resourceURL(c, id)
 }
 
-func createURL(c *gophercloud.ServiceClient) string {
+func createURL(c gophercloud.Client) string {
 	return rootURL(c)
 }
 
-func updateURL(c *gophercloud.ServiceClient, id string) string {
+func updateURL(c gophercloud.Client, id string) string {
 	return resourceURL(c, id)
 }
 
-func deleteURL(c *gophercloud.ServiceClient, id string) string {
+func deleteURL(c gophercloud.Client, id string) string {
 	return resourceURL(c, id)
 }

--- a/openstack/networking/v2/extensions/layer3/extraroutes/requests.go
+++ b/openstack/networking/v2/extensions/layer3/extraroutes/requests.go
@@ -25,7 +25,7 @@ func (opts Opts) ToExtraRoutesUpdateMap() (map[string]any, error) {
 }
 
 // Add allows routers to be updated with a list of routes to be added.
-func Add(ctx context.Context, c *gophercloud.ServiceClient, id string, opts OptsBuilder) (r AddResult) {
+func Add(ctx context.Context, c gophercloud.Client, id string, opts OptsBuilder) (r AddResult) {
 	b, err := opts.ToExtraRoutesUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -39,7 +39,7 @@ func Add(ctx context.Context, c *gophercloud.ServiceClient, id string, opts Opts
 }
 
 // Remove allows routers to be updated with a list of routes to be removed.
-func Remove(ctx context.Context, c *gophercloud.ServiceClient, id string, opts OptsBuilder) (r RemoveResult) {
+func Remove(ctx context.Context, c gophercloud.Client, id string, opts OptsBuilder) (r RemoveResult) {
 	b, err := opts.ToExtraRoutesUpdateMap()
 	if err != nil {
 		r.Err = err

--- a/openstack/networking/v2/extensions/layer3/extraroutes/urls.go
+++ b/openstack/networking/v2/extensions/layer3/extraroutes/urls.go
@@ -4,10 +4,10 @@ import "github.com/gophercloud/gophercloud/v2"
 
 const resourcePath = "routers"
 
-func addExtraRoutesURL(c *gophercloud.ServiceClient, id string) string {
+func addExtraRoutesURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL(resourcePath, id, "add_extraroutes")
 }
 
-func removeExtraRoutesURL(c *gophercloud.ServiceClient, id string) string {
+func removeExtraRoutesURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL(resourcePath, id, "remove_extraroutes")
 }

--- a/openstack/networking/v2/extensions/layer3/floatingips/requests.go
+++ b/openstack/networking/v2/extensions/layer3/floatingips/requests.go
@@ -48,7 +48,7 @@ func (opts ListOpts) ToFloatingIPListQuery() (string, error) {
 // List returns a Pager which allows you to iterate over a collection of
 // floating IP resources. It accepts a ListOpts struct, which allows you to
 // filter and sort the returned collection for greater efficiency.
-func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(c gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := rootURL(c)
 	if opts != nil {
 		query, err := opts.ToFloatingIPListQuery()
@@ -112,7 +112,7 @@ func (opts CreateOpts) ToFloatingIPCreateMap() (map[string]any, error) {
 // operation will fail and return a 400 error code. If the PortID and FixedIP
 // are already associated with another resource, the operation will fail and
 // returns a 409 error code.
-func Create(ctx context.Context, c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, c gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToFloatingIPCreateMap()
 	if err != nil {
 		r.Err = err
@@ -124,7 +124,7 @@ func Create(ctx context.Context, c *gophercloud.ServiceClient, opts CreateOptsBu
 }
 
 // Get retrieves a particular floating IP resource based on its unique ID.
-func Get(ctx context.Context, c *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, c gophercloud.Client, id string) (r GetResult) {
 	resp, err := c.Get(ctx, resourceURL(c, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -165,7 +165,7 @@ func (opts UpdateOpts) ToFloatingIPUpdateMap() (map[string]any, error) {
 // "update" a floating IP is to associate it with a new internal port, or
 // disassociated it from all ports. See UpdateOpts for instructions of how to
 // do this.
-func Update(ctx context.Context, c *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, c gophercloud.Client, id string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToFloatingIPUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -181,7 +181,7 @@ func Update(ctx context.Context, c *gophercloud.ServiceClient, id string, opts U
 // Delete will permanently delete a particular floating IP resource. Please
 // ensure this is what you want - you can also disassociate the IP from existing
 // internal ports.
-func Delete(ctx context.Context, c *gophercloud.ServiceClient, id string) (r DeleteResult) {
+func Delete(ctx context.Context, c gophercloud.Client, id string) (r DeleteResult) {
 	resp, err := c.Delete(ctx, resourceURL(c, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/networking/v2/extensions/layer3/floatingips/urls.go
+++ b/openstack/networking/v2/extensions/layer3/floatingips/urls.go
@@ -4,10 +4,10 @@ import "github.com/gophercloud/gophercloud/v2"
 
 const resourcePath = "floatingips"
 
-func rootURL(c *gophercloud.ServiceClient) string {
+func rootURL(c gophercloud.Client) string {
 	return c.ServiceURL(resourcePath)
 }
 
-func resourceURL(c *gophercloud.ServiceClient, id string) string {
+func resourceURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL(resourcePath, id)
 }

--- a/openstack/networking/v2/extensions/layer3/portforwarding/requests.go
+++ b/openstack/networking/v2/extensions/layer3/portforwarding/requests.go
@@ -40,7 +40,7 @@ func (opts ListOpts) ToPortForwardingListQuery() (string, error) {
 // List returns a Pager which allows you to iterate over a collection of
 // Port Forwarding resources. It accepts a ListOpts struct, which allows you to
 // filter and sort the returned collection for greater efficiency.
-func List(c *gophercloud.ServiceClient, opts ListOptsBuilder, id string) pagination.Pager {
+func List(c gophercloud.Client, opts ListOptsBuilder, id string) pagination.Pager {
 	url := portForwardingUrl(c, id)
 	if opts != nil {
 		query, err := opts.ToPortForwardingListQuery()
@@ -55,7 +55,7 @@ func List(c *gophercloud.ServiceClient, opts ListOptsBuilder, id string) paginat
 }
 
 // Get retrieves a particular port forwarding resource based on its unique ID.
-func Get(ctx context.Context, c *gophercloud.ServiceClient, floatingIpId string, pfId string) (r GetResult) {
+func Get(ctx context.Context, c gophercloud.Client, floatingIpId string, pfId string) (r GetResult) {
 	resp, err := c.Get(ctx, singlePortForwardingUrl(c, floatingIpId, pfId), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -86,7 +86,7 @@ func (opts CreateOpts) ToPortForwardingCreateMap() (map[string]any, error) {
 
 // Create accepts a CreateOpts struct and uses the values provided to create a
 // new port forwarding for an existing floating IP.
-func Create(ctx context.Context, c *gophercloud.ServiceClient, floatingIpId string, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, c gophercloud.Client, floatingIpId string, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToPortForwardingCreateMap()
 	if err != nil {
 		r.Err = err
@@ -120,7 +120,7 @@ type UpdateOptsBuilder interface {
 }
 
 // Update allows port forwarding resources to be updated.
-func Update(ctx context.Context, c *gophercloud.ServiceClient, fipID string, pfID string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, c gophercloud.Client, fipID string, pfID string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToPortForwardingUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -134,7 +134,7 @@ func Update(ctx context.Context, c *gophercloud.ServiceClient, fipID string, pfI
 }
 
 // Delete will permanently delete a particular port forwarding for a given floating ID.
-func Delete(ctx context.Context, c *gophercloud.ServiceClient, floatingIpId string, pfId string) (r DeleteResult) {
+func Delete(ctx context.Context, c gophercloud.Client, floatingIpId string, pfId string) (r DeleteResult) {
 	resp, err := c.Delete(ctx, singlePortForwardingUrl(c, floatingIpId, pfId), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/networking/v2/extensions/layer3/portforwarding/urls.go
+++ b/openstack/networking/v2/extensions/layer3/portforwarding/urls.go
@@ -5,10 +5,10 @@ import "github.com/gophercloud/gophercloud/v2"
 const resourcePath = "floatingips"
 const portForwardingPath = "port_forwardings"
 
-func portForwardingUrl(c *gophercloud.ServiceClient, id string) string {
+func portForwardingUrl(c gophercloud.Client, id string) string {
 	return c.ServiceURL(resourcePath, id, portForwardingPath)
 }
 
-func singlePortForwardingUrl(c *gophercloud.ServiceClient, id string, portForwardingID string) string {
+func singlePortForwardingUrl(c gophercloud.Client, id string, portForwardingID string) string {
 	return c.ServiceURL(resourcePath, id, portForwardingPath, portForwardingID)
 }

--- a/openstack/networking/v2/extensions/layer3/routers/requests.go
+++ b/openstack/networking/v2/extensions/layer3/routers/requests.go
@@ -37,7 +37,7 @@ type ListOpts struct {
 //
 // Default policy settings return only those routers that are owned by the
 // tenant who submits the request, unless an admin user submits the request.
-func List(c *gophercloud.ServiceClient, opts ListOpts) pagination.Pager {
+func List(c gophercloud.Client, opts ListOpts) pagination.Pager {
 	q, err := gophercloud.BuildQueryString(&opts)
 	if err != nil {
 		return pagination.Pager{Err: err}
@@ -80,7 +80,7 @@ func (opts CreateOpts) ToRouterCreateMap() (map[string]any, error) {
 // GatewayInfo struct. The external gateway for the router must be plugged into
 // an external network (it is external if its `router:external' field is set to
 // true).
-func Create(ctx context.Context, c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, c gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToRouterCreateMap()
 	if err != nil {
 		r.Err = err
@@ -92,7 +92,7 @@ func Create(ctx context.Context, c *gophercloud.ServiceClient, opts CreateOptsBu
 }
 
 // Get retrieves a particular router based on its unique ID.
-func Get(ctx context.Context, c *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, c gophercloud.Client, id string) (r GetResult) {
 	resp, err := c.Get(ctx, resourceURL(c, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -124,7 +124,7 @@ func (opts UpdateOpts) ToRouterUpdateMap() (map[string]any, error) {
 // external gateway for a router, see Create. This operation does not enable
 // the update of router interfaces. To do this, use the AddInterface and
 // RemoveInterface functions.
-func Update(ctx context.Context, c *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, c gophercloud.Client, id string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToRouterUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -138,7 +138,7 @@ func Update(ctx context.Context, c *gophercloud.ServiceClient, id string, opts U
 }
 
 // Delete will permanently delete a particular router based on its unique ID.
-func Delete(ctx context.Context, c *gophercloud.ServiceClient, id string) (r DeleteResult) {
+func Delete(ctx context.Context, c gophercloud.Client, id string) (r DeleteResult) {
 	resp, err := c.Delete(ctx, resourceURL(c, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -182,7 +182,7 @@ func (opts AddInterfaceOpts) ToRouterAddInterfaceMap() (map[string]any, error) {
 // identifier of a new port created by this operation. After the operation
 // completes, the device ID of the port is set to the router ID, and the
 // device owner attribute is set to `network:router_interface'.
-func AddInterface(ctx context.Context, c *gophercloud.ServiceClient, id string, opts AddInterfaceOptsBuilder) (r InterfaceResult) {
+func AddInterface(ctx context.Context, c gophercloud.Client, id string, opts AddInterfaceOptsBuilder) (r InterfaceResult) {
 	b, err := opts.ToRouterAddInterfaceMap()
 	if err != nil {
 		r.Err = err
@@ -227,7 +227,7 @@ func (opts RemoveInterfaceOpts) ToRouterRemoveInterfaceMap() (map[string]any, er
 // visible to you, the operation will fail and a 404 Not Found error will be
 // returned. After this operation completes, the port connecting the router
 // with the subnet is removed from the subnet for the network.
-func RemoveInterface(ctx context.Context, c *gophercloud.ServiceClient, id string, opts RemoveInterfaceOptsBuilder) (r InterfaceResult) {
+func RemoveInterface(ctx context.Context, c gophercloud.Client, id string, opts RemoveInterfaceOptsBuilder) (r InterfaceResult) {
 	b, err := opts.ToRouterRemoveInterfaceMap()
 	if err != nil {
 		r.Err = err
@@ -241,7 +241,7 @@ func RemoveInterface(ctx context.Context, c *gophercloud.ServiceClient, id strin
 }
 
 // ListL3Agents returns a list of l3-agents scheduled for a specific router.
-func ListL3Agents(c *gophercloud.ServiceClient, id string) (result pagination.Pager) {
+func ListL3Agents(c gophercloud.Client, id string) (result pagination.Pager) {
 	return pagination.NewPager(c, listl3AgentsURL(c, id), func(r pagination.PageResult) pagination.Page {
 		return ListL3AgentsPage{pagination.SinglePageBase(r)}
 	})

--- a/openstack/networking/v2/extensions/layer3/routers/urls.go
+++ b/openstack/networking/v2/extensions/layer3/routers/urls.go
@@ -4,22 +4,22 @@ import "github.com/gophercloud/gophercloud/v2"
 
 const resourcePath = "routers"
 
-func rootURL(c *gophercloud.ServiceClient) string {
+func rootURL(c gophercloud.Client) string {
 	return c.ServiceURL(resourcePath)
 }
 
-func resourceURL(c *gophercloud.ServiceClient, id string) string {
+func resourceURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL(resourcePath, id)
 }
 
-func addInterfaceURL(c *gophercloud.ServiceClient, id string) string {
+func addInterfaceURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL(resourcePath, id, "add_router_interface")
 }
 
-func removeInterfaceURL(c *gophercloud.ServiceClient, id string) string {
+func removeInterfaceURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL(resourcePath, id, "remove_router_interface")
 }
 
-func listl3AgentsURL(c *gophercloud.ServiceClient, id string) string {
+func listl3AgentsURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL(resourcePath, id, "l3-agents")
 }

--- a/openstack/networking/v2/extensions/networkipavailabilities/requests.go
+++ b/openstack/networking/v2/extensions/networkipavailabilities/requests.go
@@ -42,7 +42,7 @@ func (opts ListOpts) ToNetworkIPAvailabilityListQuery() (string, error) {
 // List returns a Pager which allows you to iterate over a collection of
 // networkipavailabilities. It accepts a ListOpts struct, which allows you to
 // filter the returned collection for greater efficiency.
-func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(c gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(c)
 	if opts != nil {
 		query, err := opts.ToNetworkIPAvailabilityListQuery()
@@ -57,7 +57,7 @@ func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 }
 
 // Get retrieves a specific NetworkIPAvailability based on its ID.
-func Get(ctx context.Context, c *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, c gophercloud.Client, id string) (r GetResult) {
 	resp, err := c.Get(ctx, getURL(c, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/networking/v2/extensions/networkipavailabilities/urls.go
+++ b/openstack/networking/v2/extensions/networkipavailabilities/urls.go
@@ -4,18 +4,18 @@ import "github.com/gophercloud/gophercloud/v2"
 
 const resourcePath = "network-ip-availabilities"
 
-func rootURL(c *gophercloud.ServiceClient) string {
+func rootURL(c gophercloud.Client) string {
 	return c.ServiceURL(resourcePath)
 }
 
-func resourceURL(c *gophercloud.ServiceClient, networkIPAvailabilityID string) string {
+func resourceURL(c gophercloud.Client, networkIPAvailabilityID string) string {
 	return c.ServiceURL(resourcePath, networkIPAvailabilityID)
 }
 
-func listURL(c *gophercloud.ServiceClient) string {
+func listURL(c gophercloud.Client) string {
 	return rootURL(c)
 }
 
-func getURL(c *gophercloud.ServiceClient, networkIPAvailabilityID string) string {
+func getURL(c gophercloud.Client, networkIPAvailabilityID string) string {
 	return resourceURL(c, networkIPAvailabilityID)
 }

--- a/openstack/networking/v2/extensions/qos/policies/requests.go
+++ b/openstack/networking/v2/extensions/qos/policies/requests.go
@@ -156,7 +156,7 @@ func (opts ListOpts) ToPolicyListQuery() (string, error) {
 // List returns a Pager which allows you to iterate over a collection of
 // Policy. It accepts a ListOpts struct, which allows you to filter and sort
 // the returned collection for greater efficiency.
-func List(c *gophercloud.ServiceClient, opts PolicyListOptsBuilder) pagination.Pager {
+func List(c gophercloud.Client, opts PolicyListOptsBuilder) pagination.Pager {
 	url := listURL(c)
 	if opts != nil {
 		query, err := opts.ToPolicyListQuery()
@@ -172,7 +172,7 @@ func List(c *gophercloud.ServiceClient, opts PolicyListOptsBuilder) pagination.P
 }
 
 // Get retrieves a specific QoS policy based on its ID.
-func Get(ctx context.Context, c *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, c gophercloud.Client, id string) (r GetResult) {
 	resp, err := c.Get(ctx, getURL(c, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -211,7 +211,7 @@ func (opts CreateOpts) ToPolicyCreateMap() (map[string]any, error) {
 }
 
 // Create requests the creation of a new QoS policy on the server.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToPolicyCreateMap()
 	if err != nil {
 		r.Err = err
@@ -252,7 +252,7 @@ func (opts UpdateOpts) ToPolicyUpdateMap() (map[string]any, error) {
 
 // Update accepts a UpdateOpts struct and updates an existing policy using the
 // values provided.
-func Update(ctx context.Context, c *gophercloud.ServiceClient, policyID string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, c gophercloud.Client, policyID string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToPolicyUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -266,7 +266,7 @@ func Update(ctx context.Context, c *gophercloud.ServiceClient, policyID string, 
 }
 
 // Delete accepts a unique ID and deletes the QoS policy associated with it.
-func Delete(ctx context.Context, c *gophercloud.ServiceClient, id string) (r DeleteResult) {
+func Delete(ctx context.Context, c gophercloud.Client, id string) (r DeleteResult) {
 	resp, err := c.Delete(ctx, deleteURL(c, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/networking/v2/extensions/qos/policies/urls.go
+++ b/openstack/networking/v2/extensions/qos/policies/urls.go
@@ -4,30 +4,30 @@ import "github.com/gophercloud/gophercloud/v2"
 
 const resourcePath = "qos/policies"
 
-func rootURL(c *gophercloud.ServiceClient) string {
+func rootURL(c gophercloud.Client) string {
 	return c.ServiceURL(resourcePath)
 }
 
-func resourceURL(c *gophercloud.ServiceClient, id string) string {
+func resourceURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL(resourcePath, id)
 }
 
-func listURL(c *gophercloud.ServiceClient) string {
+func listURL(c gophercloud.Client) string {
 	return rootURL(c)
 }
 
-func getURL(c *gophercloud.ServiceClient, id string) string {
+func getURL(c gophercloud.Client, id string) string {
 	return resourceURL(c, id)
 }
 
-func createURL(c *gophercloud.ServiceClient) string {
+func createURL(c gophercloud.Client) string {
 	return rootURL(c)
 }
 
-func updateURL(c *gophercloud.ServiceClient, id string) string {
+func updateURL(c gophercloud.Client, id string) string {
 	return resourceURL(c, id)
 }
 
-func deleteURL(c *gophercloud.ServiceClient, id string) string {
+func deleteURL(c gophercloud.Client, id string) string {
 	return resourceURL(c, id)
 }

--- a/openstack/networking/v2/extensions/qos/rules/requests.go
+++ b/openstack/networking/v2/extensions/qos/rules/requests.go
@@ -44,7 +44,7 @@ func (opts BandwidthLimitRulesListOpts) ToBandwidthLimitRulesListQuery() (string
 // ListBandwidthLimitRules returns a Pager which allows you to iterate over a collection of
 // BandwidthLimitRules. It accepts a ListOpts struct, which allows you to filter and sort
 // the returned collection for greater efficiency.
-func ListBandwidthLimitRules(c *gophercloud.ServiceClient, policyID string, opts BandwidthLimitRulesListOptsBuilder) pagination.Pager {
+func ListBandwidthLimitRules(c gophercloud.Client, policyID string, opts BandwidthLimitRulesListOptsBuilder) pagination.Pager {
 	url := listBandwidthLimitRulesURL(c, policyID)
 	if opts != nil {
 		query, err := opts.ToBandwidthLimitRulesListQuery()
@@ -60,7 +60,7 @@ func ListBandwidthLimitRules(c *gophercloud.ServiceClient, policyID string, opts
 }
 
 // GetBandwidthLimitRule retrieves a specific BandwidthLimitRule based on its ID.
-func GetBandwidthLimitRule(ctx context.Context, c *gophercloud.ServiceClient, policyID, ruleID string) (r GetBandwidthLimitRuleResult) {
+func GetBandwidthLimitRule(ctx context.Context, c gophercloud.Client, policyID, ruleID string) (r GetBandwidthLimitRuleResult) {
 	resp, err := c.Get(ctx, getBandwidthLimitRuleURL(c, policyID, ruleID), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -90,7 +90,7 @@ func (opts CreateBandwidthLimitRuleOpts) ToBandwidthLimitRuleCreateMap() (map[st
 }
 
 // CreateBandwidthLimitRule requests the creation of a new BandwidthLimitRule on the server.
-func CreateBandwidthLimitRule(ctx context.Context, client *gophercloud.ServiceClient, policyID string, opts CreateBandwidthLimitRuleOptsBuilder) (r CreateBandwidthLimitRuleResult) {
+func CreateBandwidthLimitRule(ctx context.Context, client gophercloud.Client, policyID string, opts CreateBandwidthLimitRuleOptsBuilder) (r CreateBandwidthLimitRuleResult) {
 	b, err := opts.ToBandwidthLimitRuleCreateMap()
 	if err != nil {
 		r.Err = err
@@ -127,7 +127,7 @@ func (opts UpdateBandwidthLimitRuleOpts) ToBandwidthLimitRuleUpdateMap() (map[st
 }
 
 // UpdateBandwidthLimitRule requests the creation of a new BandwidthLimitRule on the server.
-func UpdateBandwidthLimitRule(ctx context.Context, client *gophercloud.ServiceClient, policyID, ruleID string, opts UpdateBandwidthLimitRuleOptsBuilder) (r UpdateBandwidthLimitRuleResult) {
+func UpdateBandwidthLimitRule(ctx context.Context, client gophercloud.Client, policyID, ruleID string, opts UpdateBandwidthLimitRuleOptsBuilder) (r UpdateBandwidthLimitRuleResult) {
 	b, err := opts.ToBandwidthLimitRuleUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -141,7 +141,7 @@ func UpdateBandwidthLimitRule(ctx context.Context, client *gophercloud.ServiceCl
 }
 
 // Delete accepts policy and rule ID and deletes the BandwidthLimitRule associated with them.
-func DeleteBandwidthLimitRule(ctx context.Context, c *gophercloud.ServiceClient, policyID, ruleID string) (r DeleteBandwidthLimitRuleResult) {
+func DeleteBandwidthLimitRule(ctx context.Context, c gophercloud.Client, policyID, ruleID string) (r DeleteBandwidthLimitRuleResult) {
 	resp, err := c.Delete(ctx, deleteBandwidthLimitRuleURL(c, policyID, ruleID), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -182,7 +182,7 @@ func (opts DSCPMarkingRulesListOpts) ToDSCPMarkingRulesListQuery() (string, erro
 // ListDSCPMarkingRules returns a Pager which allows you to iterate over a collection of
 // DSCPMarkingRules. It accepts a ListOpts struct, which allows you to filter and sort
 // the returned collection for greater efficiency.
-func ListDSCPMarkingRules(c *gophercloud.ServiceClient, policyID string, opts DSCPMarkingRulesListOptsBuilder) pagination.Pager {
+func ListDSCPMarkingRules(c gophercloud.Client, policyID string, opts DSCPMarkingRulesListOptsBuilder) pagination.Pager {
 	url := listDSCPMarkingRulesURL(c, policyID)
 	if opts != nil {
 		query, err := opts.ToDSCPMarkingRulesListQuery()
@@ -198,7 +198,7 @@ func ListDSCPMarkingRules(c *gophercloud.ServiceClient, policyID string, opts DS
 }
 
 // GetDSCPMarkingRule retrieves a specific DSCPMarkingRule based on its ID.
-func GetDSCPMarkingRule(ctx context.Context, c *gophercloud.ServiceClient, policyID, ruleID string) (r GetDSCPMarkingRuleResult) {
+func GetDSCPMarkingRule(ctx context.Context, c gophercloud.Client, policyID, ruleID string) (r GetDSCPMarkingRuleResult) {
 	resp, err := c.Get(ctx, getDSCPMarkingRuleURL(c, policyID, ruleID), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -222,7 +222,7 @@ func (opts CreateDSCPMarkingRuleOpts) ToDSCPMarkingRuleCreateMap() (map[string]a
 }
 
 // CreateDSCPMarkingRule requests the creation of a new DSCPMarkingRule on the server.
-func CreateDSCPMarkingRule(ctx context.Context, client *gophercloud.ServiceClient, policyID string, opts CreateDSCPMarkingRuleOptsBuilder) (r CreateDSCPMarkingRuleResult) {
+func CreateDSCPMarkingRule(ctx context.Context, client gophercloud.Client, policyID string, opts CreateDSCPMarkingRuleOptsBuilder) (r CreateDSCPMarkingRuleResult) {
 	b, err := opts.ToDSCPMarkingRuleCreateMap()
 	if err != nil {
 		r.Err = err
@@ -253,7 +253,7 @@ func (opts UpdateDSCPMarkingRuleOpts) ToDSCPMarkingRuleUpdateMap() (map[string]a
 }
 
 // UpdateDSCPMarkingRule requests the creation of a new DSCPMarkingRule on the server.
-func UpdateDSCPMarkingRule(ctx context.Context, client *gophercloud.ServiceClient, policyID, ruleID string, opts UpdateDSCPMarkingRuleOptsBuilder) (r UpdateDSCPMarkingRuleResult) {
+func UpdateDSCPMarkingRule(ctx context.Context, client gophercloud.Client, policyID, ruleID string, opts UpdateDSCPMarkingRuleOptsBuilder) (r UpdateDSCPMarkingRuleResult) {
 	b, err := opts.ToDSCPMarkingRuleUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -267,7 +267,7 @@ func UpdateDSCPMarkingRule(ctx context.Context, client *gophercloud.ServiceClien
 }
 
 // DeleteDSCPMarkingRule accepts policy and rule ID and deletes the DSCPMarkingRule associated with them.
-func DeleteDSCPMarkingRule(ctx context.Context, c *gophercloud.ServiceClient, policyID, ruleID string) (r DeleteDSCPMarkingRuleResult) {
+func DeleteDSCPMarkingRule(ctx context.Context, c gophercloud.Client, policyID, ruleID string) (r DeleteDSCPMarkingRuleResult) {
 	resp, err := c.Delete(ctx, deleteDSCPMarkingRuleURL(c, policyID, ruleID), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -309,7 +309,7 @@ func (opts MinimumBandwidthRulesListOpts) ToMinimumBandwidthRulesListQuery() (st
 // ListMinimumBandwidthRules returns a Pager which allows you to iterate over a collection of
 // MinimumBandwidthRules. It accepts a ListOpts struct, which allows you to filter and sort
 // the returned collection for greater efficiency.
-func ListMinimumBandwidthRules(c *gophercloud.ServiceClient, policyID string, opts MinimumBandwidthRulesListOptsBuilder) pagination.Pager {
+func ListMinimumBandwidthRules(c gophercloud.Client, policyID string, opts MinimumBandwidthRulesListOptsBuilder) pagination.Pager {
 	url := listMinimumBandwidthRulesURL(c, policyID)
 	if opts != nil {
 		query, err := opts.ToMinimumBandwidthRulesListQuery()
@@ -325,7 +325,7 @@ func ListMinimumBandwidthRules(c *gophercloud.ServiceClient, policyID string, op
 }
 
 // GetMinimumBandwidthRule retrieves a specific MinimumBandwidthRule based on its ID.
-func GetMinimumBandwidthRule(ctx context.Context, c *gophercloud.ServiceClient, policyID, ruleID string) (r GetMinimumBandwidthRuleResult) {
+func GetMinimumBandwidthRule(ctx context.Context, c gophercloud.Client, policyID, ruleID string) (r GetMinimumBandwidthRuleResult) {
 	resp, err := c.Get(ctx, getMinimumBandwidthRuleURL(c, policyID, ruleID), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -352,7 +352,7 @@ func (opts CreateMinimumBandwidthRuleOpts) ToMinimumBandwidthRuleCreateMap() (ma
 }
 
 // CreateMinimumBandwidthRule requests the creation of a new MinimumBandwidthRule on the server.
-func CreateMinimumBandwidthRule(ctx context.Context, client *gophercloud.ServiceClient, policyID string, opts CreateMinimumBandwidthRuleOptsBuilder) (r CreateMinimumBandwidthRuleResult) {
+func CreateMinimumBandwidthRule(ctx context.Context, client gophercloud.Client, policyID string, opts CreateMinimumBandwidthRuleOptsBuilder) (r CreateMinimumBandwidthRuleResult) {
 	b, err := opts.ToMinimumBandwidthRuleCreateMap()
 	if err != nil {
 		r.Err = err
@@ -386,7 +386,7 @@ func (opts UpdateMinimumBandwidthRuleOpts) ToMinimumBandwidthRuleUpdateMap() (ma
 }
 
 // UpdateMinimumBandwidthRule requests the creation of a new MinimumBandwidthRule on the server.
-func UpdateMinimumBandwidthRule(ctx context.Context, client *gophercloud.ServiceClient, policyID, ruleID string, opts UpdateMinimumBandwidthRuleOptsBuilder) (r UpdateMinimumBandwidthRuleResult) {
+func UpdateMinimumBandwidthRule(ctx context.Context, client gophercloud.Client, policyID, ruleID string, opts UpdateMinimumBandwidthRuleOptsBuilder) (r UpdateMinimumBandwidthRuleResult) {
 	b, err := opts.ToMinimumBandwidthRuleUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -400,7 +400,7 @@ func UpdateMinimumBandwidthRule(ctx context.Context, client *gophercloud.Service
 }
 
 // DeleteMinimumBandwidthRule accepts policy and rule ID and deletes the MinimumBandwidthRule associated with them.
-func DeleteMinimumBandwidthRule(ctx context.Context, c *gophercloud.ServiceClient, policyID, ruleID string) (r DeleteMinimumBandwidthRuleResult) {
+func DeleteMinimumBandwidthRule(ctx context.Context, c gophercloud.Client, policyID, ruleID string) (r DeleteMinimumBandwidthRuleResult) {
 	resp, err := c.Delete(ctx, deleteMinimumBandwidthRuleURL(c, policyID, ruleID), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/networking/v2/extensions/qos/rules/urls.go
+++ b/openstack/networking/v2/extensions/qos/rules/urls.go
@@ -10,86 +10,86 @@ const (
 	minimumBandwidthRulesResourcePath = "minimum_bandwidth_rules"
 )
 
-func bandwidthLimitRulesRootURL(c *gophercloud.ServiceClient, policyID string) string {
+func bandwidthLimitRulesRootURL(c gophercloud.Client, policyID string) string {
 	return c.ServiceURL(rootPath, policyID, bandwidthLimitRulesResourcePath)
 }
 
-func bandwidthLimitRulesResourceURL(c *gophercloud.ServiceClient, policyID, ruleID string) string {
+func bandwidthLimitRulesResourceURL(c gophercloud.Client, policyID, ruleID string) string {
 	return c.ServiceURL(rootPath, policyID, bandwidthLimitRulesResourcePath, ruleID)
 }
 
-func listBandwidthLimitRulesURL(c *gophercloud.ServiceClient, policyID string) string {
+func listBandwidthLimitRulesURL(c gophercloud.Client, policyID string) string {
 	return bandwidthLimitRulesRootURL(c, policyID)
 }
 
-func getBandwidthLimitRuleURL(c *gophercloud.ServiceClient, policyID, ruleID string) string {
+func getBandwidthLimitRuleURL(c gophercloud.Client, policyID, ruleID string) string {
 	return bandwidthLimitRulesResourceURL(c, policyID, ruleID)
 }
 
-func createBandwidthLimitRuleURL(c *gophercloud.ServiceClient, policyID string) string {
+func createBandwidthLimitRuleURL(c gophercloud.Client, policyID string) string {
 	return bandwidthLimitRulesRootURL(c, policyID)
 }
 
-func updateBandwidthLimitRuleURL(c *gophercloud.ServiceClient, policyID, ruleID string) string {
+func updateBandwidthLimitRuleURL(c gophercloud.Client, policyID, ruleID string) string {
 	return bandwidthLimitRulesResourceURL(c, policyID, ruleID)
 }
 
-func deleteBandwidthLimitRuleURL(c *gophercloud.ServiceClient, policyID, ruleID string) string {
+func deleteBandwidthLimitRuleURL(c gophercloud.Client, policyID, ruleID string) string {
 	return bandwidthLimitRulesResourceURL(c, policyID, ruleID)
 }
 
-func dscpMarkingRulesRootURL(c *gophercloud.ServiceClient, policyID string) string {
+func dscpMarkingRulesRootURL(c gophercloud.Client, policyID string) string {
 	return c.ServiceURL(rootPath, policyID, dscpMarkingRulesResourcePath)
 }
 
-func dscpMarkingRulesResourceURL(c *gophercloud.ServiceClient, policyID, ruleID string) string {
+func dscpMarkingRulesResourceURL(c gophercloud.Client, policyID, ruleID string) string {
 	return c.ServiceURL(rootPath, policyID, dscpMarkingRulesResourcePath, ruleID)
 }
 
-func listDSCPMarkingRulesURL(c *gophercloud.ServiceClient, policyID string) string {
+func listDSCPMarkingRulesURL(c gophercloud.Client, policyID string) string {
 	return dscpMarkingRulesRootURL(c, policyID)
 }
 
-func getDSCPMarkingRuleURL(c *gophercloud.ServiceClient, policyID, ruleID string) string {
+func getDSCPMarkingRuleURL(c gophercloud.Client, policyID, ruleID string) string {
 	return dscpMarkingRulesResourceURL(c, policyID, ruleID)
 }
 
-func createDSCPMarkingRuleURL(c *gophercloud.ServiceClient, policyID string) string {
+func createDSCPMarkingRuleURL(c gophercloud.Client, policyID string) string {
 	return dscpMarkingRulesRootURL(c, policyID)
 }
 
-func updateDSCPMarkingRuleURL(c *gophercloud.ServiceClient, policyID, ruleID string) string {
+func updateDSCPMarkingRuleURL(c gophercloud.Client, policyID, ruleID string) string {
 	return dscpMarkingRulesResourceURL(c, policyID, ruleID)
 }
 
-func deleteDSCPMarkingRuleURL(c *gophercloud.ServiceClient, policyID, ruleID string) string {
+func deleteDSCPMarkingRuleURL(c gophercloud.Client, policyID, ruleID string) string {
 	return dscpMarkingRulesResourceURL(c, policyID, ruleID)
 }
 
-func minimumBandwidthRulesRootURL(c *gophercloud.ServiceClient, policyID string) string {
+func minimumBandwidthRulesRootURL(c gophercloud.Client, policyID string) string {
 	return c.ServiceURL(rootPath, policyID, minimumBandwidthRulesResourcePath)
 }
 
-func minimumBandwidthRulesResourceURL(c *gophercloud.ServiceClient, policyID, ruleID string) string {
+func minimumBandwidthRulesResourceURL(c gophercloud.Client, policyID, ruleID string) string {
 	return c.ServiceURL(rootPath, policyID, minimumBandwidthRulesResourcePath, ruleID)
 }
 
-func listMinimumBandwidthRulesURL(c *gophercloud.ServiceClient, policyID string) string {
+func listMinimumBandwidthRulesURL(c gophercloud.Client, policyID string) string {
 	return minimumBandwidthRulesRootURL(c, policyID)
 }
 
-func getMinimumBandwidthRuleURL(c *gophercloud.ServiceClient, policyID, ruleID string) string {
+func getMinimumBandwidthRuleURL(c gophercloud.Client, policyID, ruleID string) string {
 	return minimumBandwidthRulesResourceURL(c, policyID, ruleID)
 }
 
-func createMinimumBandwidthRuleURL(c *gophercloud.ServiceClient, policyID string) string {
+func createMinimumBandwidthRuleURL(c gophercloud.Client, policyID string) string {
 	return minimumBandwidthRulesRootURL(c, policyID)
 }
 
-func updateMinimumBandwidthRuleURL(c *gophercloud.ServiceClient, policyID, ruleID string) string {
+func updateMinimumBandwidthRuleURL(c gophercloud.Client, policyID, ruleID string) string {
 	return minimumBandwidthRulesResourceURL(c, policyID, ruleID)
 }
 
-func deleteMinimumBandwidthRuleURL(c *gophercloud.ServiceClient, policyID, ruleID string) string {
+func deleteMinimumBandwidthRuleURL(c gophercloud.Client, policyID, ruleID string) string {
 	return minimumBandwidthRulesResourceURL(c, policyID, ruleID)
 }

--- a/openstack/networking/v2/extensions/qos/ruletypes/requests.go
+++ b/openstack/networking/v2/extensions/qos/ruletypes/requests.go
@@ -8,14 +8,14 @@ import (
 )
 
 // ListRuleTypes returns the list of rule types from the server
-func ListRuleTypes(c *gophercloud.ServiceClient) (result pagination.Pager) {
+func ListRuleTypes(c gophercloud.Client) (result pagination.Pager) {
 	return pagination.NewPager(c, listRuleTypesURL(c), func(r pagination.PageResult) pagination.Page {
 		return ListRuleTypesPage{pagination.SinglePageBase(r)}
 	})
 }
 
 // GetRuleType retrieves a specific QoS RuleType based on its name.
-func GetRuleType(ctx context.Context, c *gophercloud.ServiceClient, name string) (r GetResult) {
+func GetRuleType(ctx context.Context, c gophercloud.Client, name string) (r GetResult) {
 	resp, err := c.Get(ctx, getRuleTypeURL(c, name), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/networking/v2/extensions/qos/ruletypes/urls.go
+++ b/openstack/networking/v2/extensions/qos/ruletypes/urls.go
@@ -2,10 +2,10 @@ package ruletypes
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func listRuleTypesURL(c *gophercloud.ServiceClient) string {
+func listRuleTypesURL(c gophercloud.Client) string {
 	return c.ServiceURL("qos", "rule-types")
 }
 
-func getRuleTypeURL(c *gophercloud.ServiceClient, name string) string {
+func getRuleTypeURL(c gophercloud.Client, name string) string {
 	return c.ServiceURL("qos", "rule-types", name)
 }

--- a/openstack/networking/v2/extensions/quotas/requests.go
+++ b/openstack/networking/v2/extensions/quotas/requests.go
@@ -7,14 +7,14 @@ import (
 )
 
 // Get returns Networking Quotas for a project.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, projectID string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, projectID string) (r GetResult) {
 	resp, err := client.Get(ctx, getURL(client, projectID), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
 // GetDetail returns detailed Networking Quotas for a project.
-func GetDetail(ctx context.Context, client *gophercloud.ServiceClient, projectID string) (r GetDetailResult) {
+func GetDetail(ctx context.Context, client gophercloud.Client, projectID string) (r GetDetailResult) {
 	resp, err := client.Get(ctx, getDetailURL(client, projectID), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -66,7 +66,7 @@ func (opts UpdateOpts) ToQuotaUpdateMap() (map[string]any, error) {
 
 // Update accepts a UpdateOpts struct and updates an existing Networking Quotas using the
 // values provided.
-func Update(ctx context.Context, c *gophercloud.ServiceClient, projectID string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, c gophercloud.Client, projectID string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToQuotaUpdateMap()
 	if err != nil {
 		r.Err = err

--- a/openstack/networking/v2/extensions/quotas/urls.go
+++ b/openstack/networking/v2/extensions/quotas/urls.go
@@ -5,22 +5,22 @@ import "github.com/gophercloud/gophercloud/v2"
 const resourcePath = "quotas"
 const resourcePathDetail = "details.json"
 
-func resourceURL(c *gophercloud.ServiceClient, projectID string) string {
+func resourceURL(c gophercloud.Client, projectID string) string {
 	return c.ServiceURL(resourcePath, projectID)
 }
 
-func resourceDetailURL(c *gophercloud.ServiceClient, projectID string) string {
+func resourceDetailURL(c gophercloud.Client, projectID string) string {
 	return c.ServiceURL(resourcePath, projectID, resourcePathDetail)
 }
 
-func getURL(c *gophercloud.ServiceClient, projectID string) string {
+func getURL(c gophercloud.Client, projectID string) string {
 	return resourceURL(c, projectID)
 }
 
-func getDetailURL(c *gophercloud.ServiceClient, projectID string) string {
+func getDetailURL(c gophercloud.Client, projectID string) string {
 	return resourceDetailURL(c, projectID)
 }
 
-func updateURL(c *gophercloud.ServiceClient, projectID string) string {
+func updateURL(c gophercloud.Client, projectID string) string {
 	return resourceURL(c, projectID)
 }

--- a/openstack/networking/v2/extensions/rbacpolicies/requests.go
+++ b/openstack/networking/v2/extensions/rbacpolicies/requests.go
@@ -44,7 +44,7 @@ func (opts ListOpts) ToRBACPolicyListQuery() (string, error) {
 // List returns a Pager which allows you to iterate over a collection of
 // rbac policies. It accepts a ListOpts struct, which allows you to filter and sort
 // the returned collection for greater efficiency.
-func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(c gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(c)
 	if opts != nil {
 		query, err := opts.ToRBACPolicyListQuery()
@@ -60,7 +60,7 @@ func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 }
 
 // Get retrieves a specific rbac policy based on its unique ID.
-func Get(ctx context.Context, c *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, c gophercloud.Client, id string) (r GetResult) {
 	resp, err := c.Get(ctx, getURL(c, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -102,7 +102,7 @@ func (opts CreateOpts) ToRBACPolicyCreateMap() (map[string]any, error) {
 //
 // The tenant ID that is contained in the URI is the tenant that creates the
 // rbac-policy.
-func Create(ctx context.Context, c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, c gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToRBACPolicyCreateMap()
 	if err != nil {
 		r.Err = err
@@ -114,7 +114,7 @@ func Create(ctx context.Context, c *gophercloud.ServiceClient, opts CreateOptsBu
 }
 
 // Delete accepts a unique ID and deletes the rbac-policy associated with it.
-func Delete(ctx context.Context, c *gophercloud.ServiceClient, rbacPolicyID string) (r DeleteResult) {
+func Delete(ctx context.Context, c gophercloud.Client, rbacPolicyID string) (r DeleteResult) {
 	resp, err := c.Delete(ctx, deleteURL(c, rbacPolicyID), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -138,7 +138,7 @@ func (opts UpdateOpts) ToRBACPolicyUpdateMap() (map[string]any, error) {
 
 // Update accepts a UpdateOpts struct and updates an existing rbac-policy using the
 // values provided.
-func Update(ctx context.Context, c *gophercloud.ServiceClient, rbacPolicyID string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, c gophercloud.Client, rbacPolicyID string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToRBACPolicyUpdateMap()
 	if err != nil {
 		r.Err = err

--- a/openstack/networking/v2/extensions/rbacpolicies/urls.go
+++ b/openstack/networking/v2/extensions/rbacpolicies/urls.go
@@ -2,30 +2,30 @@ package rbacpolicies
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func resourceURL(c *gophercloud.ServiceClient, id string) string {
+func resourceURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("rbac-policies", id)
 }
 
-func rootURL(c *gophercloud.ServiceClient) string {
+func rootURL(c gophercloud.Client) string {
 	return c.ServiceURL("rbac-policies")
 }
 
-func createURL(c *gophercloud.ServiceClient) string {
+func createURL(c gophercloud.Client) string {
 	return rootURL(c)
 }
 
-func listURL(c *gophercloud.ServiceClient) string {
+func listURL(c gophercloud.Client) string {
 	return rootURL(c)
 }
 
-func getURL(c *gophercloud.ServiceClient, id string) string {
+func getURL(c gophercloud.Client, id string) string {
 	return resourceURL(c, id)
 }
 
-func deleteURL(c *gophercloud.ServiceClient, id string) string {
+func deleteURL(c gophercloud.Client, id string) string {
 	return resourceURL(c, id)
 }
 
-func updateURL(c *gophercloud.ServiceClient, id string) string {
+func updateURL(c gophercloud.Client, id string) string {
 	return resourceURL(c, id)
 }

--- a/openstack/networking/v2/extensions/security/groups/requests.go
+++ b/openstack/networking/v2/extensions/security/groups/requests.go
@@ -44,7 +44,7 @@ func (opts ListOpts) ToSecGroupListQuery() (string, error) {
 // List returns a Pager which allows you to iterate over a collection of
 // security groups. It accepts a ListOpts struct, which allows you to filter
 // and sort the returned collection for greater efficiency.
-func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(c gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := rootURL(c)
 	if opts != nil {
 		query, err := opts.ToSecGroupListQuery()
@@ -91,7 +91,7 @@ func (opts CreateOpts) ToSecGroupCreateMap() (map[string]any, error) {
 
 // Create is an operation which provisions a new security group with default
 // security group rules for the IPv4 and IPv6 ether types.
-func Create(ctx context.Context, c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, c gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToSecGroupCreateMap()
 	if err != nil {
 		r.Err = err
@@ -127,7 +127,7 @@ func (opts UpdateOpts) ToSecGroupUpdateMap() (map[string]any, error) {
 }
 
 // Update is an operation which updates an existing security group.
-func Update(ctx context.Context, c *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, c gophercloud.Client, id string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToSecGroupUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -142,7 +142,7 @@ func Update(ctx context.Context, c *gophercloud.ServiceClient, id string, opts U
 }
 
 // Get retrieves a particular security group based on its unique ID.
-func Get(ctx context.Context, c *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, c gophercloud.Client, id string) (r GetResult) {
 	resp, err := c.Get(ctx, resourceURL(c, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -150,7 +150,7 @@ func Get(ctx context.Context, c *gophercloud.ServiceClient, id string) (r GetRes
 
 // Delete will permanently delete a particular security group based on its
 // unique ID.
-func Delete(ctx context.Context, c *gophercloud.ServiceClient, id string) (r DeleteResult) {
+func Delete(ctx context.Context, c gophercloud.Client, id string) (r DeleteResult) {
 	resp, err := c.Delete(ctx, resourceURL(c, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/networking/v2/extensions/security/groups/urls.go
+++ b/openstack/networking/v2/extensions/security/groups/urls.go
@@ -4,10 +4,10 @@ import "github.com/gophercloud/gophercloud/v2"
 
 const rootPath = "security-groups"
 
-func rootURL(c *gophercloud.ServiceClient) string {
+func rootURL(c gophercloud.Client) string {
 	return c.ServiceURL(rootPath)
 }
 
-func resourceURL(c *gophercloud.ServiceClient, id string) string {
+func resourceURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL(rootPath, id)
 }

--- a/openstack/networking/v2/extensions/security/rules/requests.go
+++ b/openstack/networking/v2/extensions/security/rules/requests.go
@@ -34,7 +34,7 @@ type ListOpts struct {
 // List returns a Pager which allows you to iterate over a collection of
 // security group rules. It accepts a ListOpts struct, which allows you to filter
 // and sort the returned collection for greater efficiency.
-func List(c *gophercloud.ServiceClient, opts ListOpts) pagination.Pager {
+func List(c gophercloud.Client, opts ListOpts) pagination.Pager {
 	q, err := gophercloud.BuildQueryString(&opts)
 	if err != nil {
 		return pagination.Pager{Err: err}
@@ -139,7 +139,7 @@ func (opts CreateOpts) ToSecGroupRuleCreateMap() (map[string]any, error) {
 
 // Create is an operation which adds a new security group rule and associates it
 // with an existing security group (whose ID is specified in CreateOpts).
-func Create(ctx context.Context, c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, c gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToSecGroupRuleCreateMap()
 	if err != nil {
 		r.Err = err
@@ -151,7 +151,7 @@ func Create(ctx context.Context, c *gophercloud.ServiceClient, opts CreateOptsBu
 }
 
 // Get retrieves a particular security group rule based on its unique ID.
-func Get(ctx context.Context, c *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, c gophercloud.Client, id string) (r GetResult) {
 	resp, err := c.Get(ctx, resourceURL(c, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -159,7 +159,7 @@ func Get(ctx context.Context, c *gophercloud.ServiceClient, id string) (r GetRes
 
 // Delete will permanently delete a particular security group rule based on its
 // unique ID.
-func Delete(ctx context.Context, c *gophercloud.ServiceClient, id string) (r DeleteResult) {
+func Delete(ctx context.Context, c gophercloud.Client, id string) (r DeleteResult) {
 	resp, err := c.Delete(ctx, resourceURL(c, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/networking/v2/extensions/security/rules/urls.go
+++ b/openstack/networking/v2/extensions/security/rules/urls.go
@@ -4,10 +4,10 @@ import "github.com/gophercloud/gophercloud/v2"
 
 const rootPath = "security-group-rules"
 
-func rootURL(c *gophercloud.ServiceClient) string {
+func rootURL(c gophercloud.Client) string {
 	return c.ServiceURL(rootPath)
 }
 
-func resourceURL(c *gophercloud.ServiceClient, id string) string {
+func resourceURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL(rootPath, id)
 }

--- a/openstack/networking/v2/extensions/subnetpools/requests.go
+++ b/openstack/networking/v2/extensions/subnetpools/requests.go
@@ -56,7 +56,7 @@ func (opts ListOpts) ToSubnetPoolListQuery() (string, error) {
 //
 // Default policy settings return only the subnetpools owned by the project
 // of the user submitting the request, unless the user has the administrative role.
-func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(c gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(c)
 	if opts != nil {
 		query, err := opts.ToSubnetPoolListQuery()
@@ -71,7 +71,7 @@ func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 }
 
 // Get retrieves a specific subnetpool based on its ID.
-func Get(ctx context.Context, c *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, c gophercloud.Client, id string) (r GetResult) {
 	resp, err := c.Get(ctx, getURL(c, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -138,7 +138,7 @@ func (opts CreateOpts) ToSubnetPoolCreateMap() (map[string]any, error) {
 }
 
 // Create requests the creation of a new subnetpool on the server.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToSubnetPoolCreateMap()
 	if err != nil {
 		r.Err = err
@@ -210,7 +210,7 @@ func (opts UpdateOpts) ToSubnetPoolUpdateMap() (map[string]any, error) {
 
 // Update accepts a UpdateOpts struct and updates an existing subnetpool using the
 // values provided.
-func Update(ctx context.Context, c *gophercloud.ServiceClient, subnetPoolID string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, c gophercloud.Client, subnetPoolID string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToSubnetPoolUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -224,7 +224,7 @@ func Update(ctx context.Context, c *gophercloud.ServiceClient, subnetPoolID stri
 }
 
 // Delete accepts a unique ID and deletes the subnetpool associated with it.
-func Delete(ctx context.Context, c *gophercloud.ServiceClient, id string) (r DeleteResult) {
+func Delete(ctx context.Context, c gophercloud.Client, id string) (r DeleteResult) {
 	resp, err := c.Delete(ctx, deleteURL(c, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/networking/v2/extensions/subnetpools/urls.go
+++ b/openstack/networking/v2/extensions/subnetpools/urls.go
@@ -4,30 +4,30 @@ import "github.com/gophercloud/gophercloud/v2"
 
 const resourcePath = "subnetpools"
 
-func resourceURL(c *gophercloud.ServiceClient, id string) string {
+func resourceURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL(resourcePath, id)
 }
 
-func rootURL(c *gophercloud.ServiceClient) string {
+func rootURL(c gophercloud.Client) string {
 	return c.ServiceURL(resourcePath)
 }
 
-func listURL(c *gophercloud.ServiceClient) string {
+func listURL(c gophercloud.Client) string {
 	return rootURL(c)
 }
 
-func getURL(c *gophercloud.ServiceClient, id string) string {
+func getURL(c gophercloud.Client, id string) string {
 	return resourceURL(c, id)
 }
 
-func createURL(c *gophercloud.ServiceClient) string {
+func createURL(c gophercloud.Client) string {
 	return rootURL(c)
 }
 
-func updateURL(c *gophercloud.ServiceClient, id string) string {
+func updateURL(c gophercloud.Client, id string) string {
 	return resourceURL(c, id)
 }
 
-func deleteURL(c *gophercloud.ServiceClient, id string) string {
+func deleteURL(c gophercloud.Client, id string) string {
 	return resourceURL(c, id)
 }

--- a/openstack/networking/v2/extensions/trunks/requests.go
+++ b/openstack/networking/v2/extensions/trunks/requests.go
@@ -32,7 +32,7 @@ func (opts CreateOpts) ToTrunkCreateMap() (map[string]any, error) {
 	return gophercloud.BuildRequestBody(opts, "trunk")
 }
 
-func Create(ctx context.Context, c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, c gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	body, err := opts.ToTrunkCreateMap()
 	if err != nil {
 		r.Err = err
@@ -45,7 +45,7 @@ func Create(ctx context.Context, c *gophercloud.ServiceClient, opts CreateOptsBu
 }
 
 // Delete accepts a unique ID and deletes the trunk associated with it.
-func Delete(ctx context.Context, c *gophercloud.ServiceClient, id string) (r DeleteResult) {
+func Delete(ctx context.Context, c gophercloud.Client, id string) (r DeleteResult) {
 	resp, err := c.Delete(ctx, deleteURL(c, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -93,7 +93,7 @@ func (opts ListOpts) ToTrunkListQuery() (string, error) {
 // Default policy settings return only those trunks that are owned by the tenant
 // who submits the request, unless the request is submitted by a user with
 // administrative rights.
-func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(c gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(c)
 	if opts != nil {
 		query, err := opts.ToTrunkListQuery()
@@ -108,7 +108,7 @@ func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 }
 
 // Get retrieves a specific trunk based on its unique ID.
-func Get(ctx context.Context, c *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, c gophercloud.Client, id string) (r GetResult) {
 	resp, err := c.Get(ctx, getURL(c, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -128,7 +128,7 @@ func (opts UpdateOpts) ToTrunkUpdateMap() (map[string]any, error) {
 	return gophercloud.BuildRequestBody(opts, "trunk")
 }
 
-func Update(ctx context.Context, c *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, c gophercloud.Client, id string, opts UpdateOptsBuilder) (r UpdateResult) {
 	body, err := opts.ToTrunkUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -141,7 +141,7 @@ func Update(ctx context.Context, c *gophercloud.ServiceClient, id string, opts U
 	return
 }
 
-func GetSubports(ctx context.Context, c *gophercloud.ServiceClient, id string) (r GetSubportsResult) {
+func GetSubports(ctx context.Context, c gophercloud.Client, id string) (r GetSubportsResult) {
 	resp, err := c.Get(ctx, getSubportsURL(c, id), &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{200},
 	})
@@ -161,7 +161,7 @@ func (opts AddSubportsOpts) ToTrunkAddSubportsMap() (map[string]any, error) {
 	return gophercloud.BuildRequestBody(opts, "")
 }
 
-func AddSubports(ctx context.Context, c *gophercloud.ServiceClient, id string, opts AddSubportsOptsBuilder) (r UpdateSubportsResult) {
+func AddSubports(ctx context.Context, c gophercloud.Client, id string, opts AddSubportsOptsBuilder) (r UpdateSubportsResult) {
 	body, err := opts.ToTrunkAddSubportsMap()
 	if err != nil {
 		r.Err = err
@@ -190,7 +190,7 @@ func (opts RemoveSubportsOpts) ToTrunkRemoveSubportsMap() (map[string]any, error
 	return gophercloud.BuildRequestBody(opts, "")
 }
 
-func RemoveSubports(ctx context.Context, c *gophercloud.ServiceClient, id string, opts RemoveSubportsOptsBuilder) (r UpdateSubportsResult) {
+func RemoveSubports(ctx context.Context, c gophercloud.Client, id string, opts RemoveSubportsOptsBuilder) (r UpdateSubportsResult) {
 	body, err := opts.ToTrunkRemoveSubportsMap()
 	if err != nil {
 		r.Err = err

--- a/openstack/networking/v2/extensions/trunks/urls.go
+++ b/openstack/networking/v2/extensions/trunks/urls.go
@@ -4,42 +4,42 @@ import "github.com/gophercloud/gophercloud/v2"
 
 const resourcePath = "trunks"
 
-func rootURL(c *gophercloud.ServiceClient) string {
+func rootURL(c gophercloud.Client) string {
 	return c.ServiceURL(resourcePath)
 }
 
-func resourceURL(c *gophercloud.ServiceClient, id string) string {
+func resourceURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL(resourcePath, id)
 }
 
-func createURL(c *gophercloud.ServiceClient) string {
+func createURL(c gophercloud.Client) string {
 	return rootURL(c)
 }
 
-func deleteURL(c *gophercloud.ServiceClient, id string) string {
+func deleteURL(c gophercloud.Client, id string) string {
 	return resourceURL(c, id)
 }
 
-func listURL(c *gophercloud.ServiceClient) string {
+func listURL(c gophercloud.Client) string {
 	return rootURL(c)
 }
 
-func getURL(c *gophercloud.ServiceClient, id string) string {
+func getURL(c gophercloud.Client, id string) string {
 	return resourceURL(c, id)
 }
 
-func updateURL(c *gophercloud.ServiceClient, id string) string {
+func updateURL(c gophercloud.Client, id string) string {
 	return resourceURL(c, id)
 }
 
-func getSubportsURL(c *gophercloud.ServiceClient, id string) string {
+func getSubportsURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL(resourcePath, id, "get_subports")
 }
 
-func addSubportsURL(c *gophercloud.ServiceClient, id string) string {
+func addSubportsURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL(resourcePath, id, "add_subports")
 }
 
-func removeSubportsURL(c *gophercloud.ServiceClient, id string) string {
+func removeSubportsURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL(resourcePath, id, "remove_subports")
 }

--- a/openstack/networking/v2/extensions/vpnaas/endpointgroups/requests.go
+++ b/openstack/networking/v2/extensions/vpnaas/endpointgroups/requests.go
@@ -52,7 +52,7 @@ func (opts CreateOpts) ToEndpointGroupCreateMap() (map[string]any, error) {
 
 // Create accepts a CreateOpts struct and uses the values to create a new
 // endpoint group.
-func Create(ctx context.Context, c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, c gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToEndpointGroupCreateMap()
 	if err != nil {
 		r.Err = err
@@ -64,7 +64,7 @@ func Create(ctx context.Context, c *gophercloud.ServiceClient, opts CreateOptsBu
 }
 
 // Get retrieves a particular endpoint group based on its unique ID.
-func Get(ctx context.Context, c *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, c gophercloud.Client, id string) (r GetResult) {
 	resp, err := c.Get(ctx, resourceURL(c, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -96,7 +96,7 @@ func (opts ListOpts) ToEndpointGroupListQuery() (string, error) {
 // List returns a Pager which allows you to iterate over a collection of
 // Endpoint groups. It accepts a ListOpts struct, which allows you to filter
 // the returned collection for greater efficiency.
-func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(c gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := rootURL(c)
 	if opts != nil {
 		query, err := opts.ToEndpointGroupListQuery()
@@ -112,7 +112,7 @@ func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 
 // Delete will permanently delete a particular endpoint group based on its
 // unique ID.
-func Delete(ctx context.Context, c *gophercloud.ServiceClient, id string) (r DeleteResult) {
+func Delete(ctx context.Context, c gophercloud.Client, id string) (r DeleteResult) {
 	resp, err := c.Delete(ctx, resourceURL(c, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -136,7 +136,7 @@ func (opts UpdateOpts) ToEndpointGroupUpdateMap() (map[string]any, error) {
 }
 
 // Update allows endpoint groups to be updated.
-func Update(ctx context.Context, c *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, c gophercloud.Client, id string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToEndpointGroupUpdateMap()
 	if err != nil {
 		r.Err = err

--- a/openstack/networking/v2/extensions/vpnaas/endpointgroups/urls.go
+++ b/openstack/networking/v2/extensions/vpnaas/endpointgroups/urls.go
@@ -7,10 +7,10 @@ const (
 	resourcePath = "endpoint-groups"
 )
 
-func rootURL(c *gophercloud.ServiceClient) string {
+func rootURL(c gophercloud.Client) string {
 	return c.ServiceURL(rootPath, resourcePath)
 }
 
-func resourceURL(c *gophercloud.ServiceClient, id string) string {
+func resourceURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL(rootPath, resourcePath, id)
 }

--- a/openstack/networking/v2/extensions/vpnaas/ikepolicies/requests.go
+++ b/openstack/networking/v2/extensions/vpnaas/ikepolicies/requests.go
@@ -101,7 +101,7 @@ func (opts CreateOpts) ToPolicyCreateMap() (map[string]any, error) {
 
 // Create accepts a CreateOpts struct and uses the values to create a new
 // IKE policy
-func Create(ctx context.Context, c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, c gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToPolicyCreateMap()
 	if err != nil {
 		r.Err = err
@@ -113,7 +113,7 @@ func Create(ctx context.Context, c *gophercloud.ServiceClient, opts CreateOptsBu
 }
 
 // Get retrieves a particular IKE policy based on its unique ID.
-func Get(ctx context.Context, c *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, c gophercloud.Client, id string) (r GetResult) {
 	resp, err := c.Get(ctx, resourceURL(c, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -121,7 +121,7 @@ func Get(ctx context.Context, c *gophercloud.ServiceClient, id string) (r GetRes
 
 // Delete will permanently delete a particular IKE policy based on its
 // unique ID.
-func Delete(ctx context.Context, c *gophercloud.ServiceClient, id string) (r DeleteResult) {
+func Delete(ctx context.Context, c gophercloud.Client, id string) (r DeleteResult) {
 	resp, err := c.Delete(ctx, resourceURL(c, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -158,7 +158,7 @@ func (opts ListOpts) ToPolicyListQuery() (string, error) {
 // List returns a Pager which allows you to iterate over a collection of
 // IKE policies. It accepts a ListOpts struct, which allows you to filter
 // the returned collection for greater efficiency.
-func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(c gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := rootURL(c)
 	if opts != nil {
 		query, err := opts.ToPolicyListQuery()
@@ -201,7 +201,7 @@ func (opts UpdateOpts) ToPolicyUpdateMap() (map[string]any, error) {
 }
 
 // Update allows IKE policies to be updated.
-func Update(ctx context.Context, c *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, c gophercloud.Client, id string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToPolicyUpdateMap()
 	if err != nil {
 		r.Err = err

--- a/openstack/networking/v2/extensions/vpnaas/ikepolicies/urls.go
+++ b/openstack/networking/v2/extensions/vpnaas/ikepolicies/urls.go
@@ -7,10 +7,10 @@ const (
 	resourcePath = "ikepolicies"
 )
 
-func rootURL(c *gophercloud.ServiceClient) string {
+func rootURL(c gophercloud.Client) string {
 	return c.ServiceURL(rootPath, resourcePath)
 }
 
-func resourceURL(c *gophercloud.ServiceClient, id string) string {
+func resourceURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL(rootPath, resourcePath, id)
 }

--- a/openstack/networking/v2/extensions/vpnaas/ipsecpolicies/requests.go
+++ b/openstack/networking/v2/extensions/vpnaas/ipsecpolicies/requests.go
@@ -104,7 +104,7 @@ func (opts CreateOpts) ToPolicyCreateMap() (map[string]any, error) {
 
 // Create accepts a CreateOpts struct and uses the values to create a new
 // IPSec policy
-func Create(ctx context.Context, c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, c gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToPolicyCreateMap()
 	if err != nil {
 		r.Err = err
@@ -117,14 +117,14 @@ func Create(ctx context.Context, c *gophercloud.ServiceClient, opts CreateOptsBu
 
 // Delete will permanently delete a particular IPSec policy based on its
 // unique ID.
-func Delete(ctx context.Context, c *gophercloud.ServiceClient, id string) (r DeleteResult) {
+func Delete(ctx context.Context, c gophercloud.Client, id string) (r DeleteResult) {
 	resp, err := c.Delete(ctx, resourceURL(c, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
 // Get retrieves a particular IPSec policy based on its unique ID.
-func Get(ctx context.Context, c *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, c gophercloud.Client, id string) (r GetResult) {
 	resp, err := c.Get(ctx, resourceURL(c, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -160,7 +160,7 @@ func (opts ListOpts) ToPolicyListQuery() (string, error) {
 // List returns a Pager which allows you to iterate over a collection of
 // IPSec policies. It accepts a ListOpts struct, which allows you to filter
 // the returned collection for greater efficiency.
-func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(c gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := rootURL(c)
 	if opts != nil {
 		query, err := opts.ToPolicyListQuery()
@@ -203,7 +203,7 @@ func (opts UpdateOpts) ToPolicyUpdateMap() (map[string]any, error) {
 }
 
 // Update allows IPSec policies to be updated.
-func Update(ctx context.Context, c *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, c gophercloud.Client, id string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToPolicyUpdateMap()
 	if err != nil {
 		r.Err = err

--- a/openstack/networking/v2/extensions/vpnaas/ipsecpolicies/urls.go
+++ b/openstack/networking/v2/extensions/vpnaas/ipsecpolicies/urls.go
@@ -7,10 +7,10 @@ const (
 	resourcePath = "ipsecpolicies"
 )
 
-func rootURL(c *gophercloud.ServiceClient) string {
+func rootURL(c gophercloud.Client) string {
 	return c.ServiceURL(rootPath, resourcePath)
 }
 
-func resourceURL(c *gophercloud.ServiceClient, id string) string {
+func resourceURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL(rootPath, resourcePath, id)
 }

--- a/openstack/networking/v2/extensions/vpnaas/services/requests.go
+++ b/openstack/networking/v2/extensions/vpnaas/services/requests.go
@@ -46,7 +46,7 @@ func (opts CreateOpts) ToServiceCreateMap() (map[string]any, error) {
 
 // Create accepts a CreateOpts struct and uses the values to create a new
 // VPN service.
-func Create(ctx context.Context, c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, c gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToServiceCreateMap()
 	if err != nil {
 		r.Err = err
@@ -59,7 +59,7 @@ func Create(ctx context.Context, c *gophercloud.ServiceClient, opts CreateOptsBu
 
 // Delete will permanently delete a particular VPN service based on its
 // unique ID.
-func Delete(ctx context.Context, c *gophercloud.ServiceClient, id string) (r DeleteResult) {
+func Delete(ctx context.Context, c gophercloud.Client, id string) (r DeleteResult) {
 	resp, err := c.Delete(ctx, resourceURL(c, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -89,7 +89,7 @@ func (opts UpdateOpts) ToServiceUpdateMap() (map[string]any, error) {
 }
 
 // Update allows VPN services to be updated.
-func Update(ctx context.Context, c *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, c gophercloud.Client, id string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToServiceUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -134,7 +134,7 @@ func (opts ListOpts) ToServiceListQuery() (string, error) {
 // List returns a Pager which allows you to iterate over a collection of
 // VPN services. It accepts a ListOpts struct, which allows you to filter
 // and sort the returned collection for greater efficiency.
-func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(c gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := rootURL(c)
 	if opts != nil {
 		query, err := opts.ToServiceListQuery()
@@ -149,7 +149,7 @@ func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 }
 
 // Get retrieves a particular VPN service based on its unique ID.
-func Get(ctx context.Context, c *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, c gophercloud.Client, id string) (r GetResult) {
 	resp, err := c.Get(ctx, resourceURL(c, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/networking/v2/extensions/vpnaas/services/urls.go
+++ b/openstack/networking/v2/extensions/vpnaas/services/urls.go
@@ -7,10 +7,10 @@ const (
 	resourcePath = "vpnservices"
 )
 
-func rootURL(c *gophercloud.ServiceClient) string {
+func rootURL(c gophercloud.Client) string {
 	return c.ServiceURL(rootPath, resourcePath)
 }
 
-func resourceURL(c *gophercloud.ServiceClient, id string) string {
+func resourceURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL(rootPath, resourcePath, id)
 }

--- a/openstack/networking/v2/extensions/vpnaas/siteconnections/requests.go
+++ b/openstack/networking/v2/extensions/vpnaas/siteconnections/requests.go
@@ -121,7 +121,7 @@ func (opts CreateOpts) ToConnectionCreateMap() (map[string]any, error) {
 
 // Create accepts a CreateOpts struct and uses the values to create a new
 // IPSec site connection.
-func Create(ctx context.Context, c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, c gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToConnectionCreateMap()
 	if err != nil {
 		r.Err = err
@@ -134,14 +134,14 @@ func Create(ctx context.Context, c *gophercloud.ServiceClient, opts CreateOptsBu
 
 // Delete will permanently delete a particular IPSec site connection based on its
 // unique ID.
-func Delete(ctx context.Context, c *gophercloud.ServiceClient, id string) (r DeleteResult) {
+func Delete(ctx context.Context, c gophercloud.Client, id string) (r DeleteResult) {
 	resp, err := c.Delete(ctx, resourceURL(c, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
 // Get retrieves a particular IPSec site connection based on its unique ID.
-func Get(ctx context.Context, c *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, c gophercloud.Client, id string) (r GetResult) {
 	resp, err := c.Get(ctx, resourceURL(c, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -184,7 +184,7 @@ func (opts ListOpts) ToConnectionListQuery() (string, error) {
 // List returns a Pager which allows you to iterate over a collection of
 // IPSec site connections. It accepts a ListOpts struct, which allows you to filter
 // and sort the returned collection for greater efficiency.
-func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(c gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := rootURL(c)
 	if opts != nil {
 		query, err := opts.ToConnectionListQuery()
@@ -234,7 +234,7 @@ func (opts UpdateOpts) ToConnectionUpdateMap() (map[string]any, error) {
 }
 
 // Update allows IPSec site connections to be updated.
-func Update(ctx context.Context, c *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, c gophercloud.Client, id string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToConnectionUpdateMap()
 	if err != nil {
 		r.Err = err

--- a/openstack/networking/v2/extensions/vpnaas/siteconnections/urls.go
+++ b/openstack/networking/v2/extensions/vpnaas/siteconnections/urls.go
@@ -7,10 +7,10 @@ const (
 	resourcePath = "ipsec-site-connections"
 )
 
-func rootURL(c *gophercloud.ServiceClient) string {
+func rootURL(c gophercloud.Client) string {
 	return c.ServiceURL(rootPath, resourcePath)
 }
 
-func resourceURL(c *gophercloud.ServiceClient, id string) string {
+func resourceURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL(rootPath, resourcePath, id)
 }

--- a/openstack/networking/v2/networks/requests.go
+++ b/openstack/networking/v2/networks/requests.go
@@ -47,7 +47,7 @@ func (opts ListOpts) ToNetworkListQuery() (string, error) {
 // List returns a Pager which allows you to iterate over a collection of
 // networks. It accepts a ListOpts struct, which allows you to filter and sort
 // the returned collection for greater efficiency.
-func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(c gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(c)
 	if opts != nil {
 		query, err := opts.ToNetworkListQuery()
@@ -62,7 +62,7 @@ func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 }
 
 // Get retrieves a specific network based on its unique ID.
-func Get(ctx context.Context, c *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, c gophercloud.Client, id string) (r GetResult) {
 	resp, err := c.Get(ctx, getURL(c, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -97,7 +97,7 @@ func (opts CreateOpts) ToNetworkCreateMap() (map[string]any, error) {
 // The tenant ID that is contained in the URI is the tenant that creates the
 // network. An admin user, however, has the option of specifying another tenant
 // ID in the CreateOpts struct.
-func Create(ctx context.Context, c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, c gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToNetworkCreateMap()
 	if err != nil {
 		r.Err = err
@@ -134,7 +134,7 @@ func (opts UpdateOpts) ToNetworkUpdateMap() (map[string]any, error) {
 
 // Update accepts a UpdateOpts struct and updates an existing network using the
 // values provided. For more information, see the Create function.
-func Update(ctx context.Context, c *gophercloud.ServiceClient, networkID string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, c gophercloud.Client, networkID string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToNetworkUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -159,7 +159,7 @@ func Update(ctx context.Context, c *gophercloud.ServiceClient, networkID string,
 }
 
 // Delete accepts a unique ID and deletes the network associated with it.
-func Delete(ctx context.Context, c *gophercloud.ServiceClient, networkID string) (r DeleteResult) {
+func Delete(ctx context.Context, c gophercloud.Client, networkID string) (r DeleteResult) {
 	resp, err := c.Delete(ctx, deleteURL(c, networkID), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/networking/v2/networks/urls.go
+++ b/openstack/networking/v2/networks/urls.go
@@ -2,30 +2,30 @@ package networks
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func resourceURL(c *gophercloud.ServiceClient, id string) string {
+func resourceURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("networks", id)
 }
 
-func rootURL(c *gophercloud.ServiceClient) string {
+func rootURL(c gophercloud.Client) string {
 	return c.ServiceURL("networks")
 }
 
-func getURL(c *gophercloud.ServiceClient, id string) string {
+func getURL(c gophercloud.Client, id string) string {
 	return resourceURL(c, id)
 }
 
-func listURL(c *gophercloud.ServiceClient) string {
+func listURL(c gophercloud.Client) string {
 	return rootURL(c)
 }
 
-func createURL(c *gophercloud.ServiceClient) string {
+func createURL(c gophercloud.Client) string {
 	return rootURL(c)
 }
 
-func updateURL(c *gophercloud.ServiceClient, id string) string {
+func updateURL(c gophercloud.Client, id string) string {
 	return resourceURL(c, id)
 }
 
-func deleteURL(c *gophercloud.ServiceClient, id string) string {
+func deleteURL(c gophercloud.Client, id string) string {
 	return resourceURL(c, id)
 }

--- a/openstack/networking/v2/ports/requests.go
+++ b/openstack/networking/v2/ports/requests.go
@@ -85,7 +85,7 @@ func (opts ListOpts) ToPortListQuery() (string, error) {
 // Default policy settings return only those ports that are owned by the tenant
 // who submits the request, unless the request is submitted by a user with
 // administrative rights.
-func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(c gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(c)
 	if opts != nil {
 		query, err := opts.ToPortListQuery()
@@ -100,7 +100,7 @@ func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 }
 
 // Get retrieves a specific port based on its unique ID.
-func Get(ctx context.Context, c *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, c gophercloud.Client, id string) (r GetResult) {
 	resp, err := c.Get(ctx, getURL(c, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -167,7 +167,7 @@ func AddValueSpecs(body map[string]any) (map[string]any, error) {
 
 // Create accepts a CreateOpts struct and creates a new network using the values
 // provided. You must remember to provide a NetworkID value.
-func Create(ctx context.Context, c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, c gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToPortCreateMap()
 	if err != nil {
 		r.Err = err
@@ -214,7 +214,7 @@ func (opts UpdateOpts) ToPortUpdateMap() (map[string]any, error) {
 
 // Update accepts a UpdateOpts struct and updates an existing port using the
 // values provided.
-func Update(ctx context.Context, c *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, c gophercloud.Client, id string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToPortUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -239,7 +239,7 @@ func Update(ctx context.Context, c *gophercloud.ServiceClient, id string, opts U
 }
 
 // Delete accepts a unique ID and deletes the port associated with it.
-func Delete(ctx context.Context, c *gophercloud.ServiceClient, id string) (r DeleteResult) {
+func Delete(ctx context.Context, c gophercloud.Client, id string) (r DeleteResult) {
 	resp, err := c.Delete(ctx, deleteURL(c, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/networking/v2/ports/urls.go
+++ b/openstack/networking/v2/ports/urls.go
@@ -2,30 +2,30 @@ package ports
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func resourceURL(c *gophercloud.ServiceClient, id string) string {
+func resourceURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("ports", id)
 }
 
-func rootURL(c *gophercloud.ServiceClient) string {
+func rootURL(c gophercloud.Client) string {
 	return c.ServiceURL("ports")
 }
 
-func listURL(c *gophercloud.ServiceClient) string {
+func listURL(c gophercloud.Client) string {
 	return rootURL(c)
 }
 
-func getURL(c *gophercloud.ServiceClient, id string) string {
+func getURL(c gophercloud.Client, id string) string {
 	return resourceURL(c, id)
 }
 
-func createURL(c *gophercloud.ServiceClient) string {
+func createURL(c gophercloud.Client) string {
 	return rootURL(c)
 }
 
-func updateURL(c *gophercloud.ServiceClient, id string) string {
+func updateURL(c gophercloud.Client, id string) string {
 	return resourceURL(c, id)
 }
 
-func deleteURL(c *gophercloud.ServiceClient, id string) string {
+func deleteURL(c gophercloud.Client, id string) string {
 	return resourceURL(c, id)
 }

--- a/openstack/networking/v2/subnets/requests.go
+++ b/openstack/networking/v2/subnets/requests.go
@@ -57,7 +57,7 @@ func (opts ListOpts) ToSubnetListQuery() (string, error) {
 // Default policy settings return only those subnets that are owned by the tenant
 // who submits the request, unless the request is submitted by a user with
 // administrative rights.
-func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(c gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(c)
 	if opts != nil {
 		query, err := opts.ToSubnetListQuery()
@@ -72,7 +72,7 @@ func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 }
 
 // Get retrieves a specific subnet based on its unique ID.
-func Get(ctx context.Context, c *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, c gophercloud.Client, id string) (r GetResult) {
 	resp, err := c.Get(ctx, getURL(c, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -165,7 +165,7 @@ func (opts CreateOpts) ToSubnetCreateMap() (map[string]any, error) {
 // Create accepts a CreateOpts struct and creates a new subnet using the values
 // provided. You must remember to provide a valid NetworkID, CIDR and IP
 // version.
-func Create(ctx context.Context, c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, c gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToSubnetCreateMap()
 	if err != nil {
 		r.Err = err
@@ -236,7 +236,7 @@ func (opts UpdateOpts) ToSubnetUpdateMap() (map[string]any, error) {
 
 // Update accepts a UpdateOpts struct and updates an existing subnet using the
 // values provided.
-func Update(ctx context.Context, c *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, c gophercloud.Client, id string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToSubnetUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -262,7 +262,7 @@ func Update(ctx context.Context, c *gophercloud.ServiceClient, id string, opts U
 }
 
 // Delete accepts a unique ID and deletes the subnet associated with it.
-func Delete(ctx context.Context, c *gophercloud.ServiceClient, id string) (r DeleteResult) {
+func Delete(ctx context.Context, c gophercloud.Client, id string) (r DeleteResult) {
 	resp, err := c.Delete(ctx, deleteURL(c, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/networking/v2/subnets/urls.go
+++ b/openstack/networking/v2/subnets/urls.go
@@ -2,30 +2,30 @@ package subnets
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func resourceURL(c *gophercloud.ServiceClient, id string) string {
+func resourceURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("subnets", id)
 }
 
-func rootURL(c *gophercloud.ServiceClient) string {
+func rootURL(c gophercloud.Client) string {
 	return c.ServiceURL("subnets")
 }
 
-func listURL(c *gophercloud.ServiceClient) string {
+func listURL(c gophercloud.Client) string {
 	return rootURL(c)
 }
 
-func getURL(c *gophercloud.ServiceClient, id string) string {
+func getURL(c gophercloud.Client, id string) string {
 	return resourceURL(c, id)
 }
 
-func createURL(c *gophercloud.ServiceClient) string {
+func createURL(c gophercloud.Client) string {
 	return rootURL(c)
 }
 
-func updateURL(c *gophercloud.ServiceClient, id string) string {
+func updateURL(c gophercloud.Client, id string) string {
 	return resourceURL(c, id)
 }
 
-func deleteURL(c *gophercloud.ServiceClient, id string) string {
+func deleteURL(c gophercloud.Client, id string) string {
 	return resourceURL(c, id)
 }

--- a/openstack/objectstorage/v1/accounts/requests.go
+++ b/openstack/objectstorage/v1/accounts/requests.go
@@ -27,7 +27,7 @@ func (opts GetOpts) ToAccountGetMap() (map[string]string, error) {
 // custom metadata, call the ExtractMetadata method on the GetResult. To extract
 // all the headers that are returned (including the metadata), call the
 // Extract method on the GetResult.
-func Get(ctx context.Context, c *gophercloud.ServiceClient, opts GetOptsBuilder) (r GetResult) {
+func Get(ctx context.Context, c gophercloud.Client, opts GetOptsBuilder) (r GetResult) {
 	h := make(map[string]string)
 	if opts != nil {
 		headers, err := opts.ToAccountGetMap()
@@ -84,7 +84,7 @@ func (opts UpdateOpts) ToAccountUpdateMap() (map[string]string, error) {
 
 // Update is a function that creates, updates, or deletes an account's metadata.
 // To extract the headers returned, call the Extract method on the UpdateResult.
-func Update(ctx context.Context, c *gophercloud.ServiceClient, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, c gophercloud.Client, opts UpdateOptsBuilder) (r UpdateResult) {
 	h := make(map[string]string)
 	if opts != nil {
 		headers, err := opts.ToAccountUpdateMap()

--- a/openstack/objectstorage/v1/accounts/urls.go
+++ b/openstack/objectstorage/v1/accounts/urls.go
@@ -2,10 +2,10 @@ package accounts
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func getURL(c *gophercloud.ServiceClient) string {
-	return c.Endpoint
+func getURL(c gophercloud.Client) string {
+	return c.EndpointURL()
 }
 
-func updateURL(c *gophercloud.ServiceClient) string {
+func updateURL(c gophercloud.Client) string {
 	return getURL(c)
 }

--- a/openstack/objectstorage/v1/containers/requests.go
+++ b/openstack/objectstorage/v1/containers/requests.go
@@ -40,7 +40,7 @@ func (opts ListOpts) ToContainerListParams() (string, error) {
 // List is a function that retrieves containers associated with the account as
 // well as account metadata. It returns a pager which can be iterated with the
 // EachPage function.
-func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(c gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	headers := map[string]string{"Accept": "application/json", "Content-Type": "application/json"}
 
 	url := listURL(c)
@@ -98,7 +98,7 @@ func (opts CreateOpts) ToContainerCreateMap() (map[string]string, error) {
 }
 
 // Create is a function that creates a new container.
-func Create(ctx context.Context, c *gophercloud.ServiceClient, containerName string, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, c gophercloud.Client, containerName string, opts CreateOptsBuilder) (r CreateResult) {
 	url, err := createURL(c, containerName)
 	if err != nil {
 		r.Err = err
@@ -124,7 +124,7 @@ func Create(ctx context.Context, c *gophercloud.ServiceClient, containerName str
 }
 
 // BulkDelete is a function that bulk deletes containers.
-func BulkDelete(ctx context.Context, c *gophercloud.ServiceClient, containers []string) (r BulkDeleteResult) {
+func BulkDelete(ctx context.Context, c gophercloud.Client, containers []string) (r BulkDeleteResult) {
 	var body bytes.Buffer
 
 	for i := range containers {
@@ -148,7 +148,7 @@ func BulkDelete(ctx context.Context, c *gophercloud.ServiceClient, containers []
 }
 
 // Delete is a function that deletes a container.
-func Delete(ctx context.Context, c *gophercloud.ServiceClient, containerName string) (r DeleteResult) {
+func Delete(ctx context.Context, c gophercloud.Client, containerName string) (r DeleteResult) {
 	url, err := deleteURL(c, containerName)
 	if err != nil {
 		r.Err = err
@@ -205,7 +205,7 @@ func (opts UpdateOpts) ToContainerUpdateMap() (map[string]string, error) {
 
 // Update is a function that creates, updates, or deletes a container's
 // metadata.
-func Update(ctx context.Context, c *gophercloud.ServiceClient, containerName string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, c gophercloud.Client, containerName string, opts UpdateOptsBuilder) (r UpdateResult) {
 	url, err := updateURL(c, containerName)
 	if err != nil {
 		r.Err = err
@@ -250,7 +250,7 @@ func (opts GetOpts) ToContainerGetMap() (map[string]string, error) {
 // Get is a function that retrieves the metadata of a container. To extract just
 // the custom metadata, pass the GetResult response to the ExtractMetadata
 // function.
-func Get(ctx context.Context, c *gophercloud.ServiceClient, containerName string, opts GetOptsBuilder) (r GetResult) {
+func Get(ctx context.Context, c gophercloud.Client, containerName string, opts GetOptsBuilder) (r GetResult) {
 	url, err := getURL(c, containerName)
 	if err != nil {
 		r.Err = err

--- a/openstack/objectstorage/v1/containers/urls.go
+++ b/openstack/objectstorage/v1/containers/urls.go
@@ -7,29 +7,29 @@ import (
 	v1 "github.com/gophercloud/gophercloud/v2/openstack/objectstorage/v1"
 )
 
-func listURL(c *gophercloud.ServiceClient) string {
-	return c.Endpoint
+func listURL(c gophercloud.Client) string {
+	return c.EndpointURL()
 }
 
-func createURL(c *gophercloud.ServiceClient, container string) (string, error) {
+func createURL(c gophercloud.Client, container string) (string, error) {
 	if err := v1.CheckContainerName(container); err != nil {
 		return "", err
 	}
 	return c.ServiceURL(url.PathEscape(container)), nil
 }
 
-func getURL(c *gophercloud.ServiceClient, container string) (string, error) {
+func getURL(c gophercloud.Client, container string) (string, error) {
 	return createURL(c, container)
 }
 
-func deleteURL(c *gophercloud.ServiceClient, container string) (string, error) {
+func deleteURL(c gophercloud.Client, container string) (string, error) {
 	return createURL(c, container)
 }
 
-func updateURL(c *gophercloud.ServiceClient, container string) (string, error) {
+func updateURL(c gophercloud.Client, container string) (string, error) {
 	return createURL(c, container)
 }
 
-func bulkDeleteURL(c *gophercloud.ServiceClient) string {
-	return c.Endpoint + "?bulk-delete=true"
+func bulkDeleteURL(c gophercloud.Client) string {
+	return c.EndpointURL() + "?bulk-delete=true"
 }

--- a/openstack/objectstorage/v1/objects/requests.go
+++ b/openstack/objectstorage/v1/objects/requests.go
@@ -74,7 +74,7 @@ func (opts ListOpts) ToObjectListParams() (string, error) {
 // the details for the container. To extract only the object information or names,
 // pass the ListResult response to the ExtractInfo or ExtractNames function,
 // respectively.
-func List(c *gophercloud.ServiceClient, containerName string, opts ListOptsBuilder) pagination.Pager {
+func List(c gophercloud.Client, containerName string, opts ListOptsBuilder) pagination.Pager {
 	url, err := listURL(c, containerName)
 	if err != nil {
 		return pagination.Pager{Err: err}
@@ -141,7 +141,7 @@ func (opts DownloadOpts) ToObjectDownloadParams() (map[string]string, string, er
 // Download is a function that retrieves the content and metadata for an object.
 // To extract just the content, call the DownloadResult method ExtractContent,
 // after checking DownloadResult's Err field.
-func Download(ctx context.Context, c *gophercloud.ServiceClient, containerName, objectName string, opts DownloadOptsBuilder) (r DownloadResult) {
+func Download(ctx context.Context, c gophercloud.Client, containerName, objectName string, opts DownloadOptsBuilder) (r DownloadResult) {
 	url, err := downloadURL(c, containerName, objectName)
 	if err != nil {
 		r.Err = err
@@ -253,7 +253,7 @@ func (opts CreateOpts) ToObjectCreateParams() (io.Reader, map[string]string, str
 
 // Create is a function that creates a new object or replaces an existing
 // object.
-func Create(ctx context.Context, c *gophercloud.ServiceClient, containerName, objectName string, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, c gophercloud.Client, containerName, objectName string, opts CreateOptsBuilder) (r CreateResult) {
 	url, err := createURL(c, containerName, objectName)
 	if err != nil {
 		r.Err = err
@@ -330,7 +330,7 @@ func (opts CopyOpts) ToObjectCopyQuery() (string, error) {
 }
 
 // Copy is a function that copies one object to another.
-func Copy(ctx context.Context, c *gophercloud.ServiceClient, containerName, objectName string, opts CopyOptsBuilder) (r CopyResult) {
+func Copy(ctx context.Context, c gophercloud.Client, containerName, objectName string, opts CopyOptsBuilder) (r CopyResult) {
 	h := make(map[string]string)
 	headers, err := opts.ToObjectCopyMap()
 	if err != nil {
@@ -402,7 +402,7 @@ func (opts DeleteOpts) ToObjectDeleteQuery() (string, error) {
 }
 
 // Delete is a function that deletes an object.
-func Delete(ctx context.Context, c *gophercloud.ServiceClient, containerName, objectName string, opts DeleteOptsBuilder) (r DeleteResult) {
+func Delete(ctx context.Context, c gophercloud.Client, containerName, objectName string, opts DeleteOptsBuilder) (r DeleteResult) {
 	url, err := deleteURL(c, containerName, objectName)
 	if err != nil {
 		r.Err = err
@@ -452,7 +452,7 @@ func (opts GetOpts) ToObjectGetParams() (map[string]string, string, error) {
 // Get is a function that retrieves the metadata of an object. To extract just
 // the custom metadata, pass the GetResult response to the ExtractMetadata
 // function.
-func Get(ctx context.Context, c *gophercloud.ServiceClient, containerName, objectName string, opts GetOptsBuilder) (r GetResult) {
+func Get(ctx context.Context, c gophercloud.Client, containerName, objectName string, opts GetOptsBuilder) (r GetResult) {
 	url, err := getURL(c, containerName, objectName)
 	if err != nil {
 		r.Err = err
@@ -516,7 +516,7 @@ func (opts UpdateOpts) ToObjectUpdateMap() (map[string]string, error) {
 }
 
 // Update is a function that creates, updates, or deletes an object's metadata.
-func Update(ctx context.Context, c *gophercloud.ServiceClient, containerName, objectName string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, c gophercloud.Client, containerName, objectName string, opts UpdateOptsBuilder) (r UpdateResult) {
 	url, err := updateURL(c, containerName, objectName)
 	if err != nil {
 		r.Err = err
@@ -591,7 +591,7 @@ type CreateTempURLOpts struct {
 // CreateTempURL is a function for creating a temporary URL for an object. It
 // allows users to have "GET" or "POST" access to a particular tenant's object
 // for a limited amount of time.
-func CreateTempURL(ctx context.Context, c *gophercloud.ServiceClient, containerName, objectName string, opts CreateTempURLOpts) (string, error) {
+func CreateTempURL(ctx context.Context, c gophercloud.Client, containerName, objectName string, opts CreateTempURLOpts) (string, error) {
 	url, err := getURL(c, containerName, objectName)
 	if err != nil {
 		return "", err
@@ -662,7 +662,7 @@ func CreateTempURL(ctx context.Context, c *gophercloud.ServiceClient, containerN
 // See:
 // * https://github.com/openstack/swift/blob/6d3d4197151f44bf28b51257c1a4c5d33411dcae/etc/proxy-server.conf-sample#L1029-L1034
 // * https://github.com/openstack/swift/blob/e8cecf7fcc1630ee83b08f9a73e1e59c07f8d372/swift/common/middleware/bulk.py#L309
-func BulkDelete(ctx context.Context, c *gophercloud.ServiceClient, container string, objects []string) (r BulkDeleteResult) {
+func BulkDelete(ctx context.Context, c gophercloud.Client, container string, objects []string) (r BulkDeleteResult) {
 	if err := v1.CheckContainerName(container); err != nil {
 		r.Err = err
 		return

--- a/openstack/objectstorage/v1/objects/urls.go
+++ b/openstack/objectstorage/v1/objects/urls.go
@@ -11,18 +11,18 @@ import (
 // Names must not be URL-encoded in this case.
 //
 // See: https://docs.openstack.org/swift/latest/api/temporary_url_middleware.html#hmac-signature-for-temporary-urls
-func tempURL(c *gophercloud.ServiceClient, container, object string) string {
+func tempURL(c gophercloud.Client, container, object string) string {
 	return c.ServiceURL(container, object)
 }
 
-func listURL(c *gophercloud.ServiceClient, container string) (string, error) {
+func listURL(c gophercloud.Client, container string) (string, error) {
 	if err := v1.CheckContainerName(container); err != nil {
 		return "", err
 	}
 	return c.ServiceURL(url.PathEscape(container)), nil
 }
 
-func copyURL(c *gophercloud.ServiceClient, container, object string) (string, error) {
+func copyURL(c gophercloud.Client, container, object string) (string, error) {
 	if err := v1.CheckContainerName(container); err != nil {
 		return "", err
 	}
@@ -32,26 +32,26 @@ func copyURL(c *gophercloud.ServiceClient, container, object string) (string, er
 	return c.ServiceURL(url.PathEscape(container), url.PathEscape(object)), nil
 }
 
-func createURL(c *gophercloud.ServiceClient, container, object string) (string, error) {
+func createURL(c gophercloud.Client, container, object string) (string, error) {
 	return copyURL(c, container, object)
 }
 
-func getURL(c *gophercloud.ServiceClient, container, object string) (string, error) {
+func getURL(c gophercloud.Client, container, object string) (string, error) {
 	return copyURL(c, container, object)
 }
 
-func deleteURL(c *gophercloud.ServiceClient, container, object string) (string, error) {
+func deleteURL(c gophercloud.Client, container, object string) (string, error) {
 	return copyURL(c, container, object)
 }
 
-func downloadURL(c *gophercloud.ServiceClient, container, object string) (string, error) {
+func downloadURL(c gophercloud.Client, container, object string) (string, error) {
 	return copyURL(c, container, object)
 }
 
-func updateURL(c *gophercloud.ServiceClient, container, object string) (string, error) {
+func updateURL(c gophercloud.Client, container, object string) (string, error) {
 	return copyURL(c, container, object)
 }
 
-func bulkDeleteURL(c *gophercloud.ServiceClient) string {
-	return c.Endpoint + "?bulk-delete=true"
+func bulkDeleteURL(c gophercloud.Client) string {
+	return c.EndpointURL() + "?bulk-delete=true"
 }

--- a/openstack/objectstorage/v1/swauth/requests.go
+++ b/openstack/objectstorage/v1/swauth/requests.go
@@ -49,7 +49,7 @@ func Auth(ctx context.Context, c *gophercloud.ProviderClient, opts AuthOptsBuild
 	return r
 }
 
-// NewObjectStorageV1 creates a Swauth-authenticated *gophercloud.ServiceClient
+// NewObjectStorageV1 creates a Swauth-authenticated gophercloud.Client
 // client that can issue ObjectStorage-based API calls.
 func NewObjectStorageV1(ctx context.Context, pc *gophercloud.ProviderClient, authOpts AuthOpts) (*gophercloud.ServiceClient, error) {
 	auth, err := Auth(ctx, pc, authOpts).Extract()

--- a/openstack/orchestration/v1/apiversions/requests.go
+++ b/openstack/orchestration/v1/apiversions/requests.go
@@ -6,7 +6,7 @@ import (
 )
 
 // ListVersions lists all the Neutron API versions available to end-users
-func ListVersions(c *gophercloud.ServiceClient) pagination.Pager {
+func ListVersions(c gophercloud.Client) pagination.Pager {
 	return pagination.NewPager(c, listURL(c), func(r pagination.PageResult) pagination.Page {
 		return APIVersionPage{pagination.SinglePageBase(r)}
 	})

--- a/openstack/orchestration/v1/apiversions/urls.go
+++ b/openstack/orchestration/v1/apiversions/urls.go
@@ -7,8 +7,8 @@ import (
 	"github.com/gophercloud/gophercloud/v2/openstack/utils"
 )
 
-func listURL(c *gophercloud.ServiceClient) string {
-	baseEndpoint, _ := utils.BaseEndpoint(c.Endpoint)
+func listURL(c gophercloud.Client) string {
+	baseEndpoint, _ := utils.BaseEndpoint(c.EndpointURL())
 	endpoint := strings.TrimRight(baseEndpoint, "/") + "/"
 	return endpoint
 }

--- a/openstack/orchestration/v1/buildinfo/requests.go
+++ b/openstack/orchestration/v1/buildinfo/requests.go
@@ -7,7 +7,7 @@ import (
 )
 
 // Get retreives data for the given stack template.
-func Get(ctx context.Context, c *gophercloud.ServiceClient) (r GetResult) {
+func Get(ctx context.Context, c gophercloud.Client) (r GetResult) {
 	resp, err := c.Get(ctx, getURL(c), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/orchestration/v1/buildinfo/urls.go
+++ b/openstack/orchestration/v1/buildinfo/urls.go
@@ -2,6 +2,6 @@ package buildinfo
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func getURL(c *gophercloud.ServiceClient) string {
+func getURL(c gophercloud.Client) string {
 	return c.ServiceURL("build_info")
 }

--- a/openstack/orchestration/v1/resourcetypes/requests.go
+++ b/openstack/orchestration/v1/resourcetypes/requests.go
@@ -53,7 +53,7 @@ func (opts ListOpts) ToResourceTypeListQuery() (string, error) {
 }
 
 // List makes a request against the API to list available resource types.
-func List(ctx context.Context, client *gophercloud.ServiceClient, opts ListOptsBuilder) (r ListResult) {
+func List(ctx context.Context, client gophercloud.Client, opts ListOptsBuilder) (r ListResult) {
 	url := listURL(client)
 
 	if opts == nil {
@@ -72,7 +72,7 @@ func List(ctx context.Context, client *gophercloud.ServiceClient, opts ListOptsB
 }
 
 // GetSchema retreives the schema for a given resource type.
-func GetSchema(ctx context.Context, client *gophercloud.ServiceClient, resourceType string) (r GetSchemaResult) {
+func GetSchema(ctx context.Context, client gophercloud.Client, resourceType string) (r GetSchemaResult) {
 	resp, err := client.Get(ctx, getSchemaURL(client, resourceType), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -106,7 +106,7 @@ func (opts GenerateTemplateOpts) ToGenerateTemplateQuery() (string, error) {
 }
 
 // GenerateTemplate retreives an example template for a given resource type.
-func GenerateTemplate(ctx context.Context, client *gophercloud.ServiceClient, resourceType string, opts GenerateTemplateOptsBuilder) (r TemplateResult) {
+func GenerateTemplate(ctx context.Context, client gophercloud.Client, resourceType string, opts GenerateTemplateOptsBuilder) (r TemplateResult) {
 	url := generateTemplateURL(client, resourceType)
 	if opts == nil {
 		opts = GenerateTemplateOpts{}

--- a/openstack/orchestration/v1/resourcetypes/urls.go
+++ b/openstack/orchestration/v1/resourcetypes/urls.go
@@ -6,14 +6,14 @@ const (
 	resTypesPath = "resource_types"
 )
 
-func listURL(c *gophercloud.ServiceClient) string {
+func listURL(c gophercloud.Client) string {
 	return c.ServiceURL(resTypesPath)
 }
 
-func getSchemaURL(c *gophercloud.ServiceClient, resourceType string) string {
+func getSchemaURL(c gophercloud.Client, resourceType string) string {
 	return c.ServiceURL(resTypesPath, resourceType)
 }
 
-func generateTemplateURL(c *gophercloud.ServiceClient, resourceType string) string {
+func generateTemplateURL(c gophercloud.Client, resourceType string) string {
 	return c.ServiceURL(resTypesPath, resourceType, "template")
 }

--- a/openstack/orchestration/v1/stackevents/requests.go
+++ b/openstack/orchestration/v1/stackevents/requests.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Find retrieves stack events for the given stack name.
-func Find(ctx context.Context, c *gophercloud.ServiceClient, stackName string) (r FindResult) {
+func Find(ctx context.Context, c gophercloud.Client, stackName string) (r FindResult) {
 	resp, err := c.Get(ctx, findURL(c, stackName), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -105,7 +105,7 @@ func (opts ListOpts) ToStackEventListQuery() (string, error) {
 }
 
 // List makes a request against the API to list resources for the given stack.
-func List(client *gophercloud.ServiceClient, stackName, stackID string, opts ListOptsBuilder) pagination.Pager {
+func List(client gophercloud.Client, stackName, stackID string, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(client, stackName, stackID)
 	if opts != nil {
 		query, err := opts.ToStackEventListQuery()
@@ -162,7 +162,7 @@ func (opts ListResourceEventsOpts) ToResourceEventListQuery() (string, error) {
 }
 
 // ListResourceEvents makes a request against the API to list resources for the given stack.
-func ListResourceEvents(client *gophercloud.ServiceClient, stackName, stackID, resourceName string, opts ListResourceEventsOptsBuilder) pagination.Pager {
+func ListResourceEvents(client gophercloud.Client, stackName, stackID, resourceName string, opts ListResourceEventsOptsBuilder) pagination.Pager {
 	url := listResourceEventsURL(client, stackName, stackID, resourceName)
 	if opts != nil {
 		query, err := opts.ToResourceEventListQuery()
@@ -179,7 +179,7 @@ func ListResourceEvents(client *gophercloud.ServiceClient, stackName, stackID, r
 }
 
 // Get retreives data for the given stack resource.
-func Get(ctx context.Context, c *gophercloud.ServiceClient, stackName, stackID, resourceName, eventID string) (r GetResult) {
+func Get(ctx context.Context, c gophercloud.Client, stackName, stackID, resourceName, eventID string) (r GetResult) {
 	resp, err := c.Get(ctx, getURL(c, stackName, stackID, resourceName, eventID), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/orchestration/v1/stackevents/urls.go
+++ b/openstack/orchestration/v1/stackevents/urls.go
@@ -2,18 +2,18 @@ package stackevents
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func findURL(c *gophercloud.ServiceClient, stackName string) string {
+func findURL(c gophercloud.Client, stackName string) string {
 	return c.ServiceURL("stacks", stackName, "events")
 }
 
-func listURL(c *gophercloud.ServiceClient, stackName, stackID string) string {
+func listURL(c gophercloud.Client, stackName, stackID string) string {
 	return c.ServiceURL("stacks", stackName, stackID, "events")
 }
 
-func listResourceEventsURL(c *gophercloud.ServiceClient, stackName, stackID, resourceName string) string {
+func listResourceEventsURL(c gophercloud.Client, stackName, stackID, resourceName string) string {
 	return c.ServiceURL("stacks", stackName, stackID, "resources", resourceName, "events")
 }
 
-func getURL(c *gophercloud.ServiceClient, stackName, stackID, resourceName, eventID string) string {
+func getURL(c gophercloud.Client, stackName, stackID, resourceName, eventID string) string {
 	return c.ServiceURL("stacks", stackName, stackID, "resources", resourceName, "events", eventID)
 }

--- a/openstack/orchestration/v1/stackresources/requests.go
+++ b/openstack/orchestration/v1/stackresources/requests.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Find retrieves stack resources for the given stack name.
-func Find(ctx context.Context, c *gophercloud.ServiceClient, stackName string) (r FindResult) {
+func Find(ctx context.Context, c gophercloud.Client, stackName string) (r FindResult) {
 	resp, err := c.Get(ctx, findURL(c, stackName), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -34,7 +34,7 @@ func (opts ListOpts) ToStackResourceListQuery() (string, error) {
 }
 
 // List makes a request against the API to list resources for the given stack.
-func List(client *gophercloud.ServiceClient, stackName, stackID string, opts ListOptsBuilder) pagination.Pager {
+func List(client gophercloud.Client, stackName, stackID string, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(client, stackName, stackID)
 	if opts != nil {
 		query, err := opts.ToStackResourceListQuery()
@@ -49,35 +49,35 @@ func List(client *gophercloud.ServiceClient, stackName, stackID string, opts Lis
 }
 
 // Get retreives data for the given stack resource.
-func Get(ctx context.Context, c *gophercloud.ServiceClient, stackName, stackID, resourceName string) (r GetResult) {
+func Get(ctx context.Context, c gophercloud.Client, stackName, stackID, resourceName string) (r GetResult) {
 	resp, err := c.Get(ctx, getURL(c, stackName, stackID, resourceName), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
 // Metadata retreives the metadata for the given stack resource.
-func Metadata(ctx context.Context, c *gophercloud.ServiceClient, stackName, stackID, resourceName string) (r MetadataResult) {
+func Metadata(ctx context.Context, c gophercloud.Client, stackName, stackID, resourceName string) (r MetadataResult) {
 	resp, err := c.Get(ctx, metadataURL(c, stackName, stackID, resourceName), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
 // ListTypes makes a request against the API to list resource types.
-func ListTypes(client *gophercloud.ServiceClient) pagination.Pager {
+func ListTypes(client gophercloud.Client) pagination.Pager {
 	return pagination.NewPager(client, listTypesURL(client), func(r pagination.PageResult) pagination.Page {
 		return ResourceTypePage{pagination.SinglePageBase(r)}
 	})
 }
 
 // Schema retreives the schema for the given resource type.
-func Schema(ctx context.Context, c *gophercloud.ServiceClient, resourceType string) (r SchemaResult) {
+func Schema(ctx context.Context, c gophercloud.Client, resourceType string) (r SchemaResult) {
 	resp, err := c.Get(ctx, schemaURL(c, resourceType), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
 // Template retreives the template representation for the given resource type.
-func Template(ctx context.Context, c *gophercloud.ServiceClient, resourceType string) (r TemplateResult) {
+func Template(ctx context.Context, c gophercloud.Client, resourceType string) (r TemplateResult) {
 	resp, err := c.Get(ctx, templateURL(c, resourceType), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -109,7 +109,7 @@ func (opts MarkUnhealthyOpts) ToMarkUnhealthyMap() (map[string]any, error) {
 }
 
 // MarkUnhealthy marks the specified resource in the stack as unhealthy.
-func MarkUnhealthy(ctx context.Context, c *gophercloud.ServiceClient, stackName, stackID, resourceName string, opts MarkUnhealthyOptsBuilder) (r MarkUnhealthyResult) {
+func MarkUnhealthy(ctx context.Context, c gophercloud.Client, stackName, stackID, resourceName string, opts MarkUnhealthyOptsBuilder) (r MarkUnhealthyResult) {
 	b, err := opts.ToMarkUnhealthyMap()
 	if err != nil {
 		r.Err = err

--- a/openstack/orchestration/v1/stackresources/urls.go
+++ b/openstack/orchestration/v1/stackresources/urls.go
@@ -2,34 +2,34 @@ package stackresources
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func findURL(c *gophercloud.ServiceClient, stackName string) string {
+func findURL(c gophercloud.Client, stackName string) string {
 	return c.ServiceURL("stacks", stackName, "resources")
 }
 
-func listURL(c *gophercloud.ServiceClient, stackName, stackID string) string {
+func listURL(c gophercloud.Client, stackName, stackID string) string {
 	return c.ServiceURL("stacks", stackName, stackID, "resources")
 }
 
-func getURL(c *gophercloud.ServiceClient, stackName, stackID, resourceName string) string {
+func getURL(c gophercloud.Client, stackName, stackID, resourceName string) string {
 	return c.ServiceURL("stacks", stackName, stackID, "resources", resourceName)
 }
 
-func metadataURL(c *gophercloud.ServiceClient, stackName, stackID, resourceName string) string {
+func metadataURL(c gophercloud.Client, stackName, stackID, resourceName string) string {
 	return c.ServiceURL("stacks", stackName, stackID, "resources", resourceName, "metadata")
 }
 
-func listTypesURL(c *gophercloud.ServiceClient) string {
+func listTypesURL(c gophercloud.Client) string {
 	return c.ServiceURL("resource_types")
 }
 
-func schemaURL(c *gophercloud.ServiceClient, typeName string) string {
+func schemaURL(c gophercloud.Client, typeName string) string {
 	return c.ServiceURL("resource_types", typeName)
 }
 
-func templateURL(c *gophercloud.ServiceClient, typeName string) string {
+func templateURL(c gophercloud.Client, typeName string) string {
 	return c.ServiceURL("resource_types", typeName, "template")
 }
 
-func markUnhealthyURL(c *gophercloud.ServiceClient, stackName, stackID, resourceName string) string {
+func markUnhealthyURL(c gophercloud.Client, stackName, stackID, resourceName string) string {
 	return c.ServiceURL("stacks", stackName, stackID, "resources", resourceName)
 }

--- a/openstack/orchestration/v1/stacks/requests.go
+++ b/openstack/orchestration/v1/stacks/requests.go
@@ -86,7 +86,7 @@ func (opts CreateOpts) ToStackCreateMap() (map[string]any, error) {
 
 // Create accepts a CreateOpts struct and creates a new stack using the values
 // provided.
-func Create(ctx context.Context, c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, c gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToStackCreateMap()
 	if err != nil {
 		r.Err = fmt.Errorf("error creating the options map: %w", err)
@@ -174,7 +174,7 @@ func (opts AdoptOpts) ToStackAdoptMap() (map[string]any, error) {
 
 // Adopt accepts an AdoptOpts struct and creates a new stack using the resources
 // from another stack.
-func Adopt(ctx context.Context, c *gophercloud.ServiceClient, opts AdoptOptsBuilder) (r AdoptResult) {
+func Adopt(ctx context.Context, c gophercloud.Client, opts AdoptOptsBuilder) (r AdoptResult) {
 	b, err := opts.ToStackAdoptMap()
 	if err != nil {
 		r.Err = err
@@ -279,7 +279,7 @@ func (opts ListOpts) ToStackListQuery() (string, error) {
 // List returns a Pager which allows you to iterate over a collection of
 // stacks. It accepts a ListOpts struct, which allows you to filter and sort
 // the returned collection for greater efficiency.
-func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(c gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(c)
 	if opts != nil {
 		query, err := opts.ToStackListQuery()
@@ -295,14 +295,14 @@ func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 }
 
 // Get retreives a stack based on the stack name and stack ID.
-func Get(ctx context.Context, c *gophercloud.ServiceClient, stackName, stackID string) (r GetResult) {
+func Get(ctx context.Context, c gophercloud.Client, stackName, stackID string) (r GetResult) {
 	resp, err := c.Get(ctx, getURL(c, stackName, stackID), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
 // Find retrieves a stack based on the stack name or stack ID.
-func Find(ctx context.Context, c *gophercloud.ServiceClient, stackIdentity string) (r GetResult) {
+func Find(ctx context.Context, c gophercloud.Client, stackIdentity string) (r GetResult) {
 	resp, err := c.Get(ctx, findURL(c, stackIdentity), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -402,7 +402,7 @@ func toStackUpdateMap(opts UpdateOpts) (map[string]any, error) {
 // Update accepts an UpdateOpts struct and updates an existing stack using the
 //
 //	http PUT verb with the values provided. opts.TemplateOpts is required.
-func Update(ctx context.Context, c *gophercloud.ServiceClient, stackName, stackID string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, c gophercloud.Client, stackName, stackID string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToStackUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -416,7 +416,7 @@ func Update(ctx context.Context, c *gophercloud.ServiceClient, stackName, stackI
 // Update accepts an UpdateOpts struct and updates an existing stack using the
 //
 //	http PATCH verb with the values provided. opts.TemplateOpts is not required.
-func UpdatePatch(ctx context.Context, c *gophercloud.ServiceClient, stackName, stackID string, opts UpdatePatchOptsBuilder) (r UpdateResult) {
+func UpdatePatch(ctx context.Context, c gophercloud.Client, stackName, stackID string, opts UpdatePatchOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToStackUpdatePatchMap()
 	if err != nil {
 		r.Err = err
@@ -428,7 +428,7 @@ func UpdatePatch(ctx context.Context, c *gophercloud.ServiceClient, stackName, s
 }
 
 // Delete deletes a stack based on the stack name and stack ID.
-func Delete(ctx context.Context, c *gophercloud.ServiceClient, stackName, stackID string) (r DeleteResult) {
+func Delete(ctx context.Context, c gophercloud.Client, stackName, stackID string) (r DeleteResult) {
 	resp, err := c.Delete(ctx, deleteURL(c, stackName, stackID), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -503,7 +503,7 @@ func (opts PreviewOpts) ToStackPreviewMap() (map[string]any, error) {
 
 // Preview accepts a PreviewOptsBuilder interface and creates a preview of a stack using the values
 // provided.
-func Preview(ctx context.Context, c *gophercloud.ServiceClient, opts PreviewOptsBuilder) (r PreviewResult) {
+func Preview(ctx context.Context, c gophercloud.Client, opts PreviewOptsBuilder) (r PreviewResult) {
 	b, err := opts.ToStackPreviewMap()
 	if err != nil {
 		r.Err = err
@@ -518,7 +518,7 @@ func Preview(ctx context.Context, c *gophercloud.ServiceClient, opts PreviewOpts
 
 // Abandon deletes the stack with the provided stackName and stackID, but leaves its
 // resources intact, and returns data describing the stack and its resources.
-func Abandon(ctx context.Context, c *gophercloud.ServiceClient, stackName, stackID string) (r AbandonResult) {
+func Abandon(ctx context.Context, c gophercloud.Client, stackName, stackID string) (r AbandonResult) {
 	resp, err := c.Delete(ctx, abandonURL(c, stackName, stackID), &gophercloud.RequestOpts{
 		JSONResponse: &r.Body,
 		OkCodes:      []int{200},

--- a/openstack/orchestration/v1/stacks/urls.go
+++ b/openstack/orchestration/v1/stacks/urls.go
@@ -2,38 +2,38 @@ package stacks
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func createURL(c *gophercloud.ServiceClient) string {
+func createURL(c gophercloud.Client) string {
 	return c.ServiceURL("stacks")
 }
 
-func adoptURL(c *gophercloud.ServiceClient) string {
+func adoptURL(c gophercloud.Client) string {
 	return createURL(c)
 }
 
-func listURL(c *gophercloud.ServiceClient) string {
+func listURL(c gophercloud.Client) string {
 	return createURL(c)
 }
 
-func getURL(c *gophercloud.ServiceClient, name, id string) string {
+func getURL(c gophercloud.Client, name, id string) string {
 	return c.ServiceURL("stacks", name, id)
 }
 
-func findURL(c *gophercloud.ServiceClient, identity string) string {
+func findURL(c gophercloud.Client, identity string) string {
 	return c.ServiceURL("stacks", identity)
 }
 
-func updateURL(c *gophercloud.ServiceClient, name, id string) string {
+func updateURL(c gophercloud.Client, name, id string) string {
 	return getURL(c, name, id)
 }
 
-func deleteURL(c *gophercloud.ServiceClient, name, id string) string {
+func deleteURL(c gophercloud.Client, name, id string) string {
 	return getURL(c, name, id)
 }
 
-func previewURL(c *gophercloud.ServiceClient) string {
+func previewURL(c gophercloud.Client) string {
 	return c.ServiceURL("stacks", "preview")
 }
 
-func abandonURL(c *gophercloud.ServiceClient, name, id string) string {
+func abandonURL(c gophercloud.Client, name, id string) string {
 	return c.ServiceURL("stacks", name, id, "abandon")
 }

--- a/openstack/orchestration/v1/stacktemplates/requests.go
+++ b/openstack/orchestration/v1/stacktemplates/requests.go
@@ -7,7 +7,7 @@ import (
 )
 
 // Get retreives data for the given stack template.
-func Get(ctx context.Context, c *gophercloud.ServiceClient, stackName, stackID string) (r GetResult) {
+func Get(ctx context.Context, c gophercloud.Client, stackName, stackID string) (r GetResult) {
 	resp, err := c.Get(ctx, getURL(c, stackName, stackID), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -31,7 +31,7 @@ func (opts ValidateOpts) ToStackTemplateValidateMap() (map[string]any, error) {
 }
 
 // Validate validates the given stack template.
-func Validate(ctx context.Context, c *gophercloud.ServiceClient, opts ValidateOptsBuilder) (r ValidateResult) {
+func Validate(ctx context.Context, c gophercloud.Client, opts ValidateOptsBuilder) (r ValidateResult) {
 	b, err := opts.ToStackTemplateValidateMap()
 	if err != nil {
 		r.Err = err

--- a/openstack/orchestration/v1/stacktemplates/urls.go
+++ b/openstack/orchestration/v1/stacktemplates/urls.go
@@ -2,10 +2,10 @@ package stacktemplates
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func getURL(c *gophercloud.ServiceClient, stackName, stackID string) string {
+func getURL(c gophercloud.Client, stackName, stackID string) string {
 	return c.ServiceURL("stacks", stackName, stackID, "template")
 }
 
-func validateURL(c *gophercloud.ServiceClient) string {
+func validateURL(c gophercloud.Client) string {
 	return c.ServiceURL("validate")
 }

--- a/openstack/placement/v1/resourceproviders/requests.go
+++ b/openstack/placement/v1/resourceproviders/requests.go
@@ -45,7 +45,7 @@ func (opts ListOpts) ToResourceProviderListQuery() (string, error) {
 }
 
 // List makes a request against the API to list resource providers.
-func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(client gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := resourceProvidersListURL(client)
 
 	if opts != nil {
@@ -87,7 +87,7 @@ func (opts CreateOpts) ToResourceProviderCreateMap() (map[string]any, error) {
 }
 
 // Create makes a request against the API to create a resource provider
-func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToResourceProviderCreateMap()
 	if err != nil {
 		r.Err = err
@@ -102,14 +102,14 @@ func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateO
 }
 
 // Delete accepts a unique ID and deletes the resource provider associated with it.
-func Delete(ctx context.Context, c *gophercloud.ServiceClient, resourceProviderID string) (r DeleteResult) {
+func Delete(ctx context.Context, c gophercloud.Client, resourceProviderID string) (r DeleteResult) {
 	resp, err := c.Delete(ctx, deleteURL(c, resourceProviderID), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
 // Get retrieves a specific resource provider based on its unique ID.
-func Get(ctx context.Context, c *gophercloud.ServiceClient, resourceProviderID string) (r GetResult) {
+func Get(ctx context.Context, c gophercloud.Client, resourceProviderID string) (r GetResult) {
 	resp, err := c.Get(ctx, getURL(c, resourceProviderID), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -138,7 +138,7 @@ func (opts UpdateOpts) ToResourceProviderUpdateMap() (map[string]any, error) {
 }
 
 // Update makes a request against the API to create a resource provider
-func Update(ctx context.Context, client *gophercloud.ServiceClient, resourceProviderID string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, client gophercloud.Client, resourceProviderID string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToResourceProviderUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -152,25 +152,25 @@ func Update(ctx context.Context, client *gophercloud.ServiceClient, resourceProv
 	return
 }
 
-func GetUsages(ctx context.Context, client *gophercloud.ServiceClient, resourceProviderID string) (r GetUsagesResult) {
+func GetUsages(ctx context.Context, client gophercloud.Client, resourceProviderID string) (r GetUsagesResult) {
 	resp, err := client.Get(ctx, getResourceProviderUsagesURL(client, resourceProviderID), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
-func GetInventories(ctx context.Context, client *gophercloud.ServiceClient, resourceProviderID string) (r GetInventoriesResult) {
+func GetInventories(ctx context.Context, client gophercloud.Client, resourceProviderID string) (r GetInventoriesResult) {
 	resp, err := client.Get(ctx, getResourceProviderInventoriesURL(client, resourceProviderID), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
-func GetAllocations(ctx context.Context, client *gophercloud.ServiceClient, resourceProviderID string) (r GetAllocationsResult) {
+func GetAllocations(ctx context.Context, client gophercloud.Client, resourceProviderID string) (r GetAllocationsResult) {
 	resp, err := client.Get(ctx, getResourceProviderAllocationsURL(client, resourceProviderID), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
-func GetTraits(ctx context.Context, client *gophercloud.ServiceClient, resourceProviderID string) (r GetTraitsResult) {
+func GetTraits(ctx context.Context, client gophercloud.Client, resourceProviderID string) (r GetTraitsResult) {
 	resp, err := client.Get(ctx, getResourceProviderTraitsURL(client, resourceProviderID), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/placement/v1/resourceproviders/urls.go
+++ b/openstack/placement/v1/resourceproviders/urls.go
@@ -6,34 +6,34 @@ const (
 	apiName = "resource_providers"
 )
 
-func resourceProvidersListURL(client *gophercloud.ServiceClient) string {
+func resourceProvidersListURL(client gophercloud.Client) string {
 	return client.ServiceURL(apiName)
 }
 
-func deleteURL(client *gophercloud.ServiceClient, resourceProviderID string) string {
+func deleteURL(client gophercloud.Client, resourceProviderID string) string {
 	return client.ServiceURL(apiName, resourceProviderID)
 }
 
-func getURL(client *gophercloud.ServiceClient, resourceProviderID string) string {
+func getURL(client gophercloud.Client, resourceProviderID string) string {
 	return client.ServiceURL(apiName, resourceProviderID)
 }
 
-func updateURL(client *gophercloud.ServiceClient, resourceProviderID string) string {
+func updateURL(client gophercloud.Client, resourceProviderID string) string {
 	return client.ServiceURL(apiName, resourceProviderID)
 }
 
-func getResourceProviderUsagesURL(client *gophercloud.ServiceClient, resourceProviderID string) string {
+func getResourceProviderUsagesURL(client gophercloud.Client, resourceProviderID string) string {
 	return client.ServiceURL(apiName, resourceProviderID, "usages")
 }
 
-func getResourceProviderInventoriesURL(client *gophercloud.ServiceClient, resourceProviderID string) string {
+func getResourceProviderInventoriesURL(client gophercloud.Client, resourceProviderID string) string {
 	return client.ServiceURL(apiName, resourceProviderID, "inventories")
 }
 
-func getResourceProviderAllocationsURL(client *gophercloud.ServiceClient, resourceProviderID string) string {
+func getResourceProviderAllocationsURL(client gophercloud.Client, resourceProviderID string) string {
 	return client.ServiceURL(apiName, resourceProviderID, "allocations")
 }
 
-func getResourceProviderTraitsURL(client *gophercloud.ServiceClient, resourceProviderID string) string {
+func getResourceProviderTraitsURL(client gophercloud.Client, resourceProviderID string) string {
 	return client.ServiceURL(apiName, resourceProviderID, "traits")
 }

--- a/openstack/sharedfilesystems/apiversions/requests.go
+++ b/openstack/sharedfilesystems/apiversions/requests.go
@@ -8,14 +8,14 @@ import (
 )
 
 // List lists all the API versions available to end-users.
-func List(c *gophercloud.ServiceClient) pagination.Pager {
+func List(c gophercloud.Client) pagination.Pager {
 	return pagination.NewPager(c, listURL(c), func(r pagination.PageResult) pagination.Page {
 		return APIVersionPage{pagination.SinglePageBase(r)}
 	})
 }
 
 // Get will get a specific API version, specified by major ID.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, v string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, v string) (r GetResult) {
 	resp, err := client.Get(ctx, getURL(client, v), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/sharedfilesystems/apiversions/urls.go
+++ b/openstack/sharedfilesystems/apiversions/urls.go
@@ -7,14 +7,14 @@ import (
 	"github.com/gophercloud/gophercloud/v2/openstack/utils"
 )
 
-func getURL(c *gophercloud.ServiceClient, version string) string {
-	baseEndpoint, _ := utils.BaseEndpoint(c.Endpoint)
+func getURL(c gophercloud.Client, version string) string {
+	baseEndpoint, _ := utils.BaseEndpoint(c.EndpointURL())
 	endpoint := strings.TrimRight(baseEndpoint, "/") + "/" + strings.TrimRight(version, "/") + "/"
 	return endpoint
 }
 
-func listURL(c *gophercloud.ServiceClient) string {
-	baseEndpoint, _ := utils.BaseEndpoint(c.Endpoint)
+func listURL(c gophercloud.Client) string {
+	baseEndpoint, _ := utils.BaseEndpoint(c.EndpointURL())
 	endpoint := strings.TrimRight(baseEndpoint, "/") + "/"
 	return endpoint
 }

--- a/openstack/sharedfilesystems/v2/availabilityzones/requests.go
+++ b/openstack/sharedfilesystems/v2/availabilityzones/requests.go
@@ -6,7 +6,7 @@ import (
 )
 
 // List will return the existing availability zones.
-func List(client *gophercloud.ServiceClient) pagination.Pager {
+func List(client gophercloud.Client) pagination.Pager {
 	return pagination.NewPager(client, listURL(client), func(r pagination.PageResult) pagination.Page {
 		return AvailabilityZonePage{pagination.SinglePageBase(r)}
 	})

--- a/openstack/sharedfilesystems/v2/availabilityzones/urls.go
+++ b/openstack/sharedfilesystems/v2/availabilityzones/urls.go
@@ -2,6 +2,6 @@ package availabilityzones
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func listURL(c *gophercloud.ServiceClient) string {
+func listURL(c gophercloud.Client) string {
 	return c.ServiceURL("os-availability-zone")
 }

--- a/openstack/sharedfilesystems/v2/messages/requests.go
+++ b/openstack/sharedfilesystems/v2/messages/requests.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Delete will delete the existing Message with the provided ID.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, id string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, deleteURL(client, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -52,7 +52,7 @@ func (opts ListOpts) ToMessageListQuery() (string, error) {
 }
 
 // List returns Messages optionally limited by the conditions provided in ListOpts.
-func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(client gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(client)
 	if opts != nil {
 		query, err := opts.ToMessageListQuery()
@@ -69,7 +69,7 @@ func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pa
 
 // Get retrieves the Message with the provided ID. To extract the Message
 // object from the response, call the Extract method on the GetResult.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, id string) (r GetResult) {
 	resp, err := client.Get(ctx, getURL(client, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/sharedfilesystems/v2/messages/urls.go
+++ b/openstack/sharedfilesystems/v2/messages/urls.go
@@ -2,14 +2,14 @@ package messages
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func listURL(c *gophercloud.ServiceClient) string {
+func listURL(c gophercloud.Client) string {
 	return c.ServiceURL("messages")
 }
 
-func getURL(c *gophercloud.ServiceClient, id string) string {
+func getURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("messages", id)
 }
 
-func deleteURL(c *gophercloud.ServiceClient, id string) string {
+func deleteURL(c gophercloud.Client, id string) string {
 	return getURL(c, id)
 }

--- a/openstack/sharedfilesystems/v2/replicas/requests.go
+++ b/openstack/sharedfilesystems/v2/replicas/requests.go
@@ -39,7 +39,7 @@ func (opts CreateOpts) ToReplicaCreateMap() (map[string]any, error) {
 // Create will create a new Share Replica based on the values in CreateOpts. To extract
 // the Replica object from the response, call the Extract method on the
 // CreateResult.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToReplicaCreateMap()
 	if err != nil {
 		r.Err = err
@@ -78,7 +78,7 @@ func (opts ListOpts) ToReplicaListQuery() (string, error) {
 }
 
 // List returns []Replica optionally limited by the conditions provided in ListOpts.
-func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(client gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(client)
 	if opts != nil {
 		query, err := opts.ToReplicaListQuery()
@@ -96,7 +96,7 @@ func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pa
 }
 
 // ListDetail returns []Replica optionally limited by the conditions provided in ListOpts.
-func ListDetail(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func ListDetail(client gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := listDetailURL(client)
 	if opts != nil {
 		query, err := opts.ToReplicaListQuery()
@@ -114,14 +114,14 @@ func ListDetail(client *gophercloud.ServiceClient, opts ListOptsBuilder) paginat
 }
 
 // Delete will delete an existing Replica with the given UUID.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, id string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, deleteURL(client, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
 // Get will get a single share with given UUID
-func Get(ctx context.Context, client *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, id string) (r GetResult) {
 	resp, err := client.Get(ctx, getURL(client, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -129,7 +129,7 @@ func Get(ctx context.Context, client *gophercloud.ServiceClient, id string) (r G
 
 // ListExportLocations will list replicaID's export locations.
 // Minimum supported microversion for ListExportLocations is 2.47.
-func ListExportLocations(ctx context.Context, client *gophercloud.ServiceClient, id string) (r ListExportLocationsResult) {
+func ListExportLocations(ctx context.Context, client gophercloud.Client, id string) (r ListExportLocationsResult) {
 	resp, err := client.Get(ctx, listExportLocationsURL(client, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -137,7 +137,7 @@ func ListExportLocations(ctx context.Context, client *gophercloud.ServiceClient,
 
 // GetExportLocation will get replicaID's export location by an ID.
 // Minimum supported microversion for GetExportLocation is 2.47.
-func GetExportLocation(ctx context.Context, client *gophercloud.ServiceClient, replicaID string, id string) (r GetExportLocationResult) {
+func GetExportLocation(ctx context.Context, client gophercloud.Client, replicaID string, id string) (r GetExportLocationResult) {
 	resp, err := client.Get(ctx, getExportLocationURL(client, replicaID, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -165,7 +165,7 @@ func (opts PromoteOpts) ToReplicaPromoteMap() (map[string]any, error) {
 
 // Promote will promote an existing Replica to active state. PromoteResult contains only the error.
 // To extract it, call the ExtractErr method on the PromoteResult.
-func Promote(ctx context.Context, client *gophercloud.ServiceClient, id string, opts PromoteOptsBuilder) (r PromoteResult) {
+func Promote(ctx context.Context, client gophercloud.Client, id string, opts PromoteOptsBuilder) (r PromoteResult) {
 	b, err := opts.ToReplicaPromoteMap()
 	if err != nil {
 		r.Err = err
@@ -181,7 +181,7 @@ func Promote(ctx context.Context, client *gophercloud.ServiceClient, id string, 
 
 // Resync a replica with its active mirror. ResyncResult contains only the error.
 // To extract it, call the ExtractErr method on the ResyncResult.
-func Resync(ctx context.Context, client *gophercloud.ServiceClient, id string) (r ResyncResult) {
+func Resync(ctx context.Context, client gophercloud.Client, id string) (r ResyncResult) {
 	resp, err := client.Post(ctx, actionURL(client, id), map[string]any{"resync": nil}, nil, &gophercloud.RequestOpts{
 		OkCodes: []int{202},
 	})
@@ -212,7 +212,7 @@ func (opts ResetStatusOpts) ToReplicaResetStatusMap() (map[string]any, error) {
 // ResetStatus will reset the Share Replica status with provided information.
 // ResetStatusResult contains only the error. To extract it, call the ExtractErr
 // method on the ResetStatusResult.
-func ResetStatus(ctx context.Context, client *gophercloud.ServiceClient, id string, opts ResetStatusOptsBuilder) (r ResetStatusResult) {
+func ResetStatus(ctx context.Context, client gophercloud.Client, id string, opts ResetStatusOptsBuilder) (r ResetStatusResult) {
 	b, err := opts.ToReplicaResetStatusMap()
 	if err != nil {
 		r.Err = err
@@ -248,7 +248,7 @@ func (opts ResetStateOpts) ToReplicaResetStateMap() (map[string]any, error) {
 // ResetState will reset the Share Replica state with provided information.
 // ResetStateResult contains only the error. To extract it, call the ExtractErr
 // method on the ResetStateResult.
-func ResetState(ctx context.Context, client *gophercloud.ServiceClient, id string, opts ResetStateOptsBuilder) (r ResetStateResult) {
+func ResetState(ctx context.Context, client gophercloud.Client, id string, opts ResetStateOptsBuilder) (r ResetStateResult) {
 	b, err := opts.ToReplicaResetStateMap()
 	if err != nil {
 		r.Err = err
@@ -264,7 +264,7 @@ func ResetState(ctx context.Context, client *gophercloud.ServiceClient, id strin
 // ForceDelete force-deletes a Share Replica in any state. ForceDeleteResult
 // contains only the error. To extract it, call the ExtractErr method on the
 // ForceDeleteResult. Administrator only.
-func ForceDelete(ctx context.Context, client *gophercloud.ServiceClient, id string) (r ForceDeleteResult) {
+func ForceDelete(ctx context.Context, client gophercloud.Client, id string) (r ForceDeleteResult) {
 	resp, err := client.Post(ctx, actionURL(client, id), map[string]any{"force_delete": nil}, nil, &gophercloud.RequestOpts{
 		OkCodes: []int{202},
 	})

--- a/openstack/sharedfilesystems/v2/replicas/testing/request_test.go
+++ b/openstack/sharedfilesystems/v2/replicas/testing/request_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/gophercloud/gophercloud/v2/testhelper/client"
 )
 
-func getClient(microVersion string) *gophercloud.ServiceClient {
+func getClient(microVersion string) gophercloud.Client {
 	c := client.ServiceClient()
 	c.Type = "sharev2"
 	c.Microversion = microVersion

--- a/openstack/sharedfilesystems/v2/replicas/urls.go
+++ b/openstack/sharedfilesystems/v2/replicas/urls.go
@@ -2,34 +2,34 @@ package replicas
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func createURL(c *gophercloud.ServiceClient) string {
+func createURL(c gophercloud.Client) string {
 	return c.ServiceURL("share-replicas")
 }
 
-func listURL(c *gophercloud.ServiceClient) string {
+func listURL(c gophercloud.Client) string {
 	return c.ServiceURL("share-replicas")
 }
 
-func listDetailURL(c *gophercloud.ServiceClient) string {
+func listDetailURL(c gophercloud.Client) string {
 	return c.ServiceURL("share-replicas", "detail")
 }
 
-func deleteURL(c *gophercloud.ServiceClient, id string) string {
+func deleteURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("share-replicas", id)
 }
 
-func getURL(c *gophercloud.ServiceClient, id string) string {
+func getURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("share-replicas", id)
 }
 
-func listExportLocationsURL(c *gophercloud.ServiceClient, id string) string {
+func listExportLocationsURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("share-replicas", id, "export-locations")
 }
 
-func getExportLocationURL(c *gophercloud.ServiceClient, replicaID, id string) string {
+func getExportLocationURL(c gophercloud.Client, replicaID, id string) string {
 	return c.ServiceURL("share-replicas", replicaID, "export-locations", id)
 }
 
-func actionURL(c *gophercloud.ServiceClient, id string) string {
+func actionURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("share-replicas", id, "action")
 }

--- a/openstack/sharedfilesystems/v2/schedulerstats/requests.go
+++ b/openstack/sharedfilesystems/v2/schedulerstats/requests.go
@@ -34,7 +34,7 @@ func (opts ListOpts) ToPoolsListQuery() (string, error) {
 }
 
 // List makes a request against the API to list pool information.
-func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(client gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := poolsListURL(client)
 	if opts != nil {
 		query, err := opts.ToPoolsListQuery()
@@ -77,7 +77,7 @@ func (opts ListDetailOpts) ToPoolsListQuery() (string, error) {
 }
 
 // ListDetail makes a request against the API to list detailed pool information.
-func ListDetail(client *gophercloud.ServiceClient, opts ListDetailOptsBuilder) pagination.Pager {
+func ListDetail(client gophercloud.Client, opts ListDetailOptsBuilder) pagination.Pager {
 	url := poolsListDetailURL(client)
 	if opts != nil {
 		query, err := opts.ToPoolsListQuery()

--- a/openstack/sharedfilesystems/v2/schedulerstats/urls.go
+++ b/openstack/sharedfilesystems/v2/schedulerstats/urls.go
@@ -2,10 +2,10 @@ package schedulerstats
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func poolsListURL(c *gophercloud.ServiceClient) string {
+func poolsListURL(c gophercloud.Client) string {
 	return c.ServiceURL("scheduler-stats", "pools")
 }
 
-func poolsListDetailURL(c *gophercloud.ServiceClient) string {
+func poolsListDetailURL(c gophercloud.Client) string {
 	return c.ServiceURL("scheduler-stats", "pools", "detail")
 }

--- a/openstack/sharedfilesystems/v2/securityservices/requests.go
+++ b/openstack/sharedfilesystems/v2/securityservices/requests.go
@@ -55,7 +55,7 @@ func (opts CreateOpts) ToSecurityServiceCreateMap() (map[string]any, error) {
 // Create will create a new SecurityService based on the values in CreateOpts. To
 // extract the SecurityService object from the response, call the Extract method
 // on the CreateResult.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToSecurityServiceCreateMap()
 	if err != nil {
 		r.Err = err
@@ -69,7 +69,7 @@ func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateO
 }
 
 // Delete will delete the existing SecurityService with the provided ID.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, id string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, deleteURL(client, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -113,7 +113,7 @@ func (opts ListOpts) ToSecurityServiceListQuery() (string, error) {
 }
 
 // List returns SecurityServices optionally limited by the conditions provided in ListOpts.
-func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(client gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(client)
 	if opts != nil {
 		query, err := opts.ToSecurityServiceListQuery()
@@ -130,7 +130,7 @@ func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pa
 
 // Get retrieves the SecurityService with the provided ID. To extract the SecurityService
 // object from the response, call the Extract method on the GetResult.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, id string) (r GetResult) {
 	resp, err := client.Get(ctx, getURL(client, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -174,7 +174,7 @@ func (opts UpdateOpts) ToSecurityServiceUpdateMap() (map[string]any, error) {
 
 // Update will update the SecurityService with provided information. To extract the updated
 // SecurityService from the response, call the Extract method on the UpdateResult.
-func Update(ctx context.Context, client *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, client gophercloud.Client, id string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToSecurityServiceUpdateMap()
 	if err != nil {
 		r.Err = err

--- a/openstack/sharedfilesystems/v2/securityservices/urls.go
+++ b/openstack/sharedfilesystems/v2/securityservices/urls.go
@@ -2,22 +2,22 @@ package securityservices
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func createURL(c *gophercloud.ServiceClient) string {
+func createURL(c gophercloud.Client) string {
 	return c.ServiceURL("security-services")
 }
 
-func deleteURL(c *gophercloud.ServiceClient, id string) string {
+func deleteURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("security-services", id)
 }
 
-func listURL(c *gophercloud.ServiceClient) string {
+func listURL(c gophercloud.Client) string {
 	return c.ServiceURL("security-services", "detail")
 }
 
-func getURL(c *gophercloud.ServiceClient, id string) string {
+func getURL(c gophercloud.Client, id string) string {
 	return deleteURL(c, id)
 }
 
-func updateURL(c *gophercloud.ServiceClient, id string) string {
+func updateURL(c gophercloud.Client, id string) string {
 	return deleteURL(c, id)
 }

--- a/openstack/sharedfilesystems/v2/services/requests.go
+++ b/openstack/sharedfilesystems/v2/services/requests.go
@@ -34,7 +34,7 @@ func (opts ListOpts) ToServiceListQuery() (string, error) {
 }
 
 // List makes a request against the API to list services.
-func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(client gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(client)
 	if opts != nil {
 		query, err := opts.ToServiceListQuery()

--- a/openstack/sharedfilesystems/v2/services/urls.go
+++ b/openstack/sharedfilesystems/v2/services/urls.go
@@ -2,6 +2,6 @@ package services
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func listURL(c *gophercloud.ServiceClient) string {
+func listURL(c gophercloud.Client) string {
 	return c.ServiceURL("services")
 }

--- a/openstack/sharedfilesystems/v2/shareaccessrules/requests.go
+++ b/openstack/sharedfilesystems/v2/shareaccessrules/requests.go
@@ -7,14 +7,14 @@ import (
 )
 
 // Get retrieves details about a share access rule.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, accessID string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, accessID string) (r GetResult) {
 	resp, err := client.Get(ctx, getURL(client, accessID), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
 // List gets all access rules of a share.
-func List(ctx context.Context, client *gophercloud.ServiceClient, shareID string) (r ListResult) {
+func List(ctx context.Context, client gophercloud.Client, shareID string) (r ListResult) {
 	resp, err := client.Get(ctx, listURL(client, shareID), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/sharedfilesystems/v2/shareaccessrules/urls.go
+++ b/openstack/sharedfilesystems/v2/shareaccessrules/urls.go
@@ -8,10 +8,10 @@ import (
 
 const shareAccessRulesEndpoint = "share-access-rules"
 
-func getURL(c *gophercloud.ServiceClient, accessID string) string {
+func getURL(c gophercloud.Client, accessID string) string {
 	return c.ServiceURL(shareAccessRulesEndpoint, accessID)
 }
 
-func listURL(c *gophercloud.ServiceClient, shareID string) string {
+func listURL(c gophercloud.Client, shareID string) string {
 	return fmt.Sprintf("%s?share_id=%s", c.ServiceURL(shareAccessRulesEndpoint), shareID)
 }

--- a/openstack/sharedfilesystems/v2/sharenetworks/requests.go
+++ b/openstack/sharedfilesystems/v2/sharenetworks/requests.go
@@ -38,7 +38,7 @@ func (opts CreateOpts) ToShareNetworkCreateMap() (map[string]any, error) {
 // Create will create a new ShareNetwork based on the values in CreateOpts. To
 // extract the ShareNetwork object from the response, call the Extract method
 // on the CreateResult.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToShareNetworkCreateMap()
 	if err != nil {
 		r.Err = err
@@ -52,7 +52,7 @@ func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateO
 }
 
 // Delete will delete the existing ShareNetwork with the provided ID.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, id string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, deleteURL(client, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -104,7 +104,7 @@ func (opts ListOpts) ToShareNetworkListQuery() (string, error) {
 }
 
 // ListDetail returns ShareNetworks optionally limited by the conditions provided in ListOpts.
-func ListDetail(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func ListDetail(client gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := listDetailURL(client)
 	if opts != nil {
 		query, err := opts.ToShareNetworkListQuery()
@@ -123,7 +123,7 @@ func ListDetail(client *gophercloud.ServiceClient, opts ListOptsBuilder) paginat
 
 // Get retrieves the ShareNetwork with the provided ID. To extract the ShareNetwork
 // object from the response, call the Extract method on the GetResult.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, id string) (r GetResult) {
 	resp, err := client.Get(ctx, getURL(client, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -159,7 +159,7 @@ func (opts UpdateOpts) ToShareNetworkUpdateMap() (map[string]any, error) {
 
 // Update will update the ShareNetwork with provided information. To extract the updated
 // ShareNetwork from the response, call the Extract method on the UpdateResult.
-func Update(ctx context.Context, client *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, client gophercloud.Client, id string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToShareNetworkUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -193,7 +193,7 @@ func (opts AddSecurityServiceOpts) ToShareNetworkAddSecurityServiceMap() (map[st
 
 // AddSecurityService will add the security service to a ShareNetwork. To extract the updated
 // ShareNetwork from the response, call the Extract method on the UpdateResult.
-func AddSecurityService(ctx context.Context, client *gophercloud.ServiceClient, id string, opts AddSecurityServiceOptsBuilder) (r UpdateResult) {
+func AddSecurityService(ctx context.Context, client gophercloud.Client, id string, opts AddSecurityServiceOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToShareNetworkAddSecurityServiceMap()
 	if err != nil {
 		r.Err = err
@@ -227,7 +227,7 @@ func (opts RemoveSecurityServiceOpts) ToShareNetworkRemoveSecurityServiceMap() (
 
 // RemoveSecurityService will remove the security service from a ShareNetwork. To extract the updated
 // ShareNetwork from the response, call the Extract method on the UpdateResult.
-func RemoveSecurityService(ctx context.Context, client *gophercloud.ServiceClient, id string, opts RemoveSecurityServiceOptsBuilder) (r UpdateResult) {
+func RemoveSecurityService(ctx context.Context, client gophercloud.Client, id string, opts RemoveSecurityServiceOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToShareNetworkRemoveSecurityServiceMap()
 	if err != nil {
 		r.Err = err

--- a/openstack/sharedfilesystems/v2/sharenetworks/urls.go
+++ b/openstack/sharedfilesystems/v2/sharenetworks/urls.go
@@ -2,30 +2,30 @@ package sharenetworks
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func createURL(c *gophercloud.ServiceClient) string {
+func createURL(c gophercloud.Client) string {
 	return c.ServiceURL("share-networks")
 }
 
-func deleteURL(c *gophercloud.ServiceClient, id string) string {
+func deleteURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("share-networks", id)
 }
 
-func listDetailURL(c *gophercloud.ServiceClient) string {
+func listDetailURL(c gophercloud.Client) string {
 	return c.ServiceURL("share-networks", "detail")
 }
 
-func getURL(c *gophercloud.ServiceClient, id string) string {
+func getURL(c gophercloud.Client, id string) string {
 	return deleteURL(c, id)
 }
 
-func updateURL(c *gophercloud.ServiceClient, id string) string {
+func updateURL(c gophercloud.Client, id string) string {
 	return deleteURL(c, id)
 }
 
-func addSecurityServiceURL(c *gophercloud.ServiceClient, id string) string {
+func addSecurityServiceURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("share-networks", id, "action")
 }
 
-func removeSecurityServiceURL(c *gophercloud.ServiceClient, id string) string {
+func removeSecurityServiceURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("share-networks", id, "action")
 }

--- a/openstack/sharedfilesystems/v2/shares/requests.go
+++ b/openstack/sharedfilesystems/v2/shares/requests.go
@@ -80,7 +80,7 @@ func (opts CreateOpts) ToShareCreateMap() (map[string]any, error) {
 // Create will create a new Share based on the values in CreateOpts. To extract
 // the Share object from the response, call the Extract method on the
 // CreateResult.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToShareCreateMap()
 	if err != nil {
 		r.Err = err
@@ -169,7 +169,7 @@ func (opts ListOpts) ToShareListQuery() (string, error) {
 }
 
 // ListDetail returns []Share optionally limited by the conditions provided in ListOpts.
-func ListDetail(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func ListDetail(client gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := listDetailURL(client)
 	if opts != nil {
 		query, err := opts.ToShareListQuery()
@@ -187,14 +187,14 @@ func ListDetail(client *gophercloud.ServiceClient, opts ListOptsBuilder) paginat
 }
 
 // Delete will delete an existing Share with the given UUID.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, id string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, deleteURL(client, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
 // Get will get a single share with given UUID
-func Get(ctx context.Context, client *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, id string) (r GetResult) {
 	resp, err := client.Get(ctx, getURL(client, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -202,7 +202,7 @@ func Get(ctx context.Context, client *gophercloud.ServiceClient, id string) (r G
 
 // ListExportLocations will list shareID's export locations.
 // Client must have Microversion set; minimum supported microversion for ListExportLocations is 2.9.
-func ListExportLocations(ctx context.Context, client *gophercloud.ServiceClient, id string) (r ListExportLocationsResult) {
+func ListExportLocations(ctx context.Context, client gophercloud.Client, id string) (r ListExportLocationsResult) {
 	resp, err := client.Get(ctx, listExportLocationsURL(client, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -210,7 +210,7 @@ func ListExportLocations(ctx context.Context, client *gophercloud.ServiceClient,
 
 // GetExportLocation will get shareID's export location by an ID.
 // Client must have Microversion set; minimum supported microversion for GetExportLocation is 2.9.
-func GetExportLocation(ctx context.Context, client *gophercloud.ServiceClient, shareID string, id string) (r GetExportLocationResult) {
+func GetExportLocation(ctx context.Context, client gophercloud.Client, shareID string, id string) (r GetExportLocationResult) {
 	resp, err := client.Get(ctx, getExportLocationURL(client, shareID, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -243,7 +243,7 @@ func (opts GrantAccessOpts) ToGrantAccessMap() (map[string]any, error) {
 // GrantAccess will grant access to a Share based on the values in GrantAccessOpts. To extract
 // the GrantAccess object from the response, call the Extract method on the GrantAccessResult.
 // Client must have Microversion set; minimum supported microversion for GrantAccess is 2.7.
-func GrantAccess(ctx context.Context, client *gophercloud.ServiceClient, id string, opts GrantAccessOptsBuilder) (r GrantAccessResult) {
+func GrantAccess(ctx context.Context, client gophercloud.Client, id string, opts GrantAccessOptsBuilder) (r GrantAccessResult) {
 	b, err := opts.ToGrantAccessMap()
 	if err != nil {
 		r.Err = err
@@ -279,7 +279,7 @@ func (opts RevokeAccessOpts) ToRevokeAccessMap() (map[string]any, error) {
 // RevokeAccessResult contains only the error. To extract it, call the ExtractErr method on
 // the RevokeAccessResult. Client must have Microversion set; minimum supported microversion
 // for RevokeAccess is 2.7.
-func RevokeAccess(ctx context.Context, client *gophercloud.ServiceClient, id string, opts RevokeAccessOptsBuilder) (r RevokeAccessResult) {
+func RevokeAccess(ctx context.Context, client gophercloud.Client, id string, opts RevokeAccessOptsBuilder) (r RevokeAccessResult) {
 	b, err := opts.ToRevokeAccessMap()
 	if err != nil {
 		r.Err = err
@@ -296,7 +296,7 @@ func RevokeAccess(ctx context.Context, client *gophercloud.ServiceClient, id str
 // ListAccessRights lists all access rules assigned to a Share based on its id. To extract
 // the AccessRight slice from the response, call the Extract method on the ListAccessRightsResult.
 // Client must have Microversion set; minimum supported microversion for ListAccessRights is 2.7.
-func ListAccessRights(ctx context.Context, client *gophercloud.ServiceClient, id string) (r ListAccessRightsResult) {
+func ListAccessRights(ctx context.Context, client gophercloud.Client, id string) (r ListAccessRightsResult) {
 	requestBody := map[string]any{"access_list": nil}
 	resp, err := client.Post(ctx, listAccessRightsURL(client, id), requestBody, &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{200},
@@ -328,7 +328,7 @@ func (opts ExtendOpts) ToShareExtendMap() (map[string]any, error) {
 // Extend will extend the capacity of an existing share. ExtendResult contains only the error.
 // To extract it, call the ExtractErr method on the ExtendResult.
 // Client must have Microversion set; minimum supported microversion for Extend is 2.7.
-func Extend(ctx context.Context, client *gophercloud.ServiceClient, id string, opts ExtendOptsBuilder) (r ExtendResult) {
+func Extend(ctx context.Context, client gophercloud.Client, id string, opts ExtendOptsBuilder) (r ExtendResult) {
 	b, err := opts.ToShareExtendMap()
 	if err != nil {
 		r.Err = err
@@ -365,7 +365,7 @@ func (opts ShrinkOpts) ToShareShrinkMap() (map[string]any, error) {
 // Shrink will shrink the capacity of an existing share. ShrinkResult contains only the error.
 // To extract it, call the ExtractErr method on the ShrinkResult.
 // Client must have Microversion set; minimum supported microversion for Shrink is 2.7.
-func Shrink(ctx context.Context, client *gophercloud.ServiceClient, id string, opts ShrinkOptsBuilder) (r ShrinkResult) {
+func Shrink(ctx context.Context, client gophercloud.Client, id string, opts ShrinkOptsBuilder) (r ShrinkResult) {
 	b, err := opts.ToShareShrinkMap()
 	if err != nil {
 		r.Err = err
@@ -405,7 +405,7 @@ func (opts UpdateOpts) ToShareUpdateMap() (map[string]any, error) {
 
 // Update will update the Share with provided information. To extract the updated
 // Share from the response, call the Extract method on the UpdateResult.
-func Update(ctx context.Context, client *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, client gophercloud.Client, id string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToShareUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -420,7 +420,7 @@ func Update(ctx context.Context, client *gophercloud.ServiceClient, id string, o
 
 // GetMetadata retrieves metadata of the specified share. To extract the retrieved
 // metadata from the response, call the Extract method on the MetadataResult.
-func GetMetadata(ctx context.Context, client *gophercloud.ServiceClient, id string) (r MetadataResult) {
+func GetMetadata(ctx context.Context, client gophercloud.Client, id string) (r MetadataResult) {
 	resp, err := client.Get(ctx, getMetadataURL(client, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -428,7 +428,7 @@ func GetMetadata(ctx context.Context, client *gophercloud.ServiceClient, id stri
 
 // GetMetadatum retrieves a single metadata item of the specified share. To extract the retrieved
 // metadata from the response, call the Extract method on the GetMetadatumResult.
-func GetMetadatum(ctx context.Context, client *gophercloud.ServiceClient, id, key string) (r GetMetadatumResult) {
+func GetMetadatum(ctx context.Context, client gophercloud.Client, id, key string) (r GetMetadatumResult) {
 	resp, err := client.Get(ctx, getMetadatumURL(client, id, key), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -457,7 +457,7 @@ type SetMetadataOptsBuilder interface {
 // Existing metadata items are either kept or overwritten by the metadata from the request.
 // To extract the updated metadata from the response, call the Extract
 // method on the MetadataResult.
-func SetMetadata(ctx context.Context, client *gophercloud.ServiceClient, id string, opts SetMetadataOptsBuilder) (r MetadataResult) {
+func SetMetadata(ctx context.Context, client gophercloud.Client, id string, opts SetMetadataOptsBuilder) (r MetadataResult) {
 	b, err := opts.ToSetMetadataMap()
 	if err != nil {
 		r.Err = err
@@ -494,7 +494,7 @@ type UpdateMetadataOptsBuilder interface {
 // All existing metadata items are discarded and replaced by the metadata from the request.
 // To extract the updated metadata from the response, call the Extract
 // method on the MetadataResult.
-func UpdateMetadata(ctx context.Context, client *gophercloud.ServiceClient, id string, opts UpdateMetadataOptsBuilder) (r MetadataResult) {
+func UpdateMetadata(ctx context.Context, client gophercloud.Client, id string, opts UpdateMetadataOptsBuilder) (r MetadataResult) {
 	b, err := opts.ToUpdateMetadataMap()
 	if err != nil {
 		r.Err = err
@@ -509,7 +509,7 @@ func UpdateMetadata(ctx context.Context, client *gophercloud.ServiceClient, id s
 }
 
 // DeleteMetadatum deletes a single key-value pair from the metadata of the specified share.
-func DeleteMetadatum(ctx context.Context, client *gophercloud.ServiceClient, id, key string) (r DeleteMetadatumResult) {
+func DeleteMetadatum(ctx context.Context, client gophercloud.Client, id, key string) (r DeleteMetadatumResult) {
 	resp, err := client.Delete(ctx, deleteMetadatumURL(client, id, key), &gophercloud.RequestOpts{
 		OkCodes: []int{200},
 	})
@@ -541,7 +541,7 @@ func (opts RevertOpts) ToShareRevertMap() (map[string]any, error) {
 // Revert will revert the existing share to a Snapshot. RevertResult contains only the error.
 // To extract it, call the ExtractErr method on the RevertResult.
 // Client must have Microversion set; minimum supported microversion for Revert is 2.27.
-func Revert(ctx context.Context, client *gophercloud.ServiceClient, id string, opts RevertOptsBuilder) (r RevertResult) {
+func Revert(ctx context.Context, client gophercloud.Client, id string, opts RevertOptsBuilder) (r RevertResult) {
 	b, err := opts.ToShareRevertMap()
 	if err != nil {
 		r.Err = err
@@ -578,7 +578,7 @@ func (opts ResetStatusOpts) ToShareResetStatusMap() (map[string]any, error) {
 // ResetStatus will reset the existing share status. ResetStatusResult contains only the error.
 // To extract it, call the ExtractErr method on the ResetStatusResult.
 // Client must have Microversion set; minimum supported microversion for ResetStatus is 2.7.
-func ResetStatus(ctx context.Context, client *gophercloud.ServiceClient, id string, opts ResetStatusOptsBuilder) (r ResetStatusResult) {
+func ResetStatus(ctx context.Context, client gophercloud.Client, id string, opts ResetStatusOptsBuilder) (r ResetStatusResult) {
 	b, err := opts.ToShareResetStatusMap()
 	if err != nil {
 		r.Err = err
@@ -595,7 +595,7 @@ func ResetStatus(ctx context.Context, client *gophercloud.ServiceClient, id stri
 // ForceDelete will delete the existing share in any state. ForceDeleteResult contains only the error.
 // To extract it, call the ExtractErr method on the ForceDeleteResult.
 // Client must have Microversion set; minimum supported microversion for ForceDelete is 2.7.
-func ForceDelete(ctx context.Context, client *gophercloud.ServiceClient, id string) (r ForceDeleteResult) {
+func ForceDelete(ctx context.Context, client gophercloud.Client, id string) (r ForceDeleteResult) {
 	b := map[string]any{
 		"force_delete": nil,
 	}
@@ -610,7 +610,7 @@ func ForceDelete(ctx context.Context, client *gophercloud.ServiceClient, id stri
 // service without deleting the share. UnmanageResult contains only the error.
 // To extract it, call the ExtractErr method on the UnmanageResult.
 // Client must have Microversion set; minimum supported microversion for Unmanage is 2.7.
-func Unmanage(ctx context.Context, client *gophercloud.ServiceClient, id string) (r UnmanageResult) {
+func Unmanage(ctx context.Context, client gophercloud.Client, id string) (r UnmanageResult) {
 	b := map[string]any{
 		"unmanage": nil,
 	}

--- a/openstack/sharedfilesystems/v2/shares/urls.go
+++ b/openstack/sharedfilesystems/v2/shares/urls.go
@@ -2,86 +2,86 @@ package shares
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func createURL(c *gophercloud.ServiceClient) string {
+func createURL(c gophercloud.Client) string {
 	return c.ServiceURL("shares")
 }
 
-func listDetailURL(c *gophercloud.ServiceClient) string {
+func listDetailURL(c gophercloud.Client) string {
 	return c.ServiceURL("shares", "detail")
 }
 
-func deleteURL(c *gophercloud.ServiceClient, id string) string {
+func deleteURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("shares", id)
 }
 
-func getURL(c *gophercloud.ServiceClient, id string) string {
+func getURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("shares", id)
 }
 
-func updateURL(c *gophercloud.ServiceClient, id string) string {
+func updateURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("shares", id)
 }
 
-func listExportLocationsURL(c *gophercloud.ServiceClient, id string) string {
+func listExportLocationsURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("shares", id, "export_locations")
 }
 
-func getExportLocationURL(c *gophercloud.ServiceClient, shareID, id string) string {
+func getExportLocationURL(c gophercloud.Client, shareID, id string) string {
 	return c.ServiceURL("shares", shareID, "export_locations", id)
 }
 
-func grantAccessURL(c *gophercloud.ServiceClient, id string) string {
+func grantAccessURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("shares", id, "action")
 }
 
-func revokeAccessURL(c *gophercloud.ServiceClient, id string) string {
+func revokeAccessURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("shares", id, "action")
 }
 
-func listAccessRightsURL(c *gophercloud.ServiceClient, id string) string {
+func listAccessRightsURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("shares", id, "action")
 }
 
-func extendURL(c *gophercloud.ServiceClient, id string) string {
+func extendURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("shares", id, "action")
 }
 
-func shrinkURL(c *gophercloud.ServiceClient, id string) string {
+func shrinkURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("shares", id, "action")
 }
 
-func revertURL(c *gophercloud.ServiceClient, id string) string {
+func revertURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("shares", id, "action")
 }
 
-func resetStatusURL(c *gophercloud.ServiceClient, id string) string {
+func resetStatusURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("shares", id, "action")
 }
 
-func forceDeleteURL(c *gophercloud.ServiceClient, id string) string {
+func forceDeleteURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("shares", id, "action")
 }
 
-func unmanageURL(c *gophercloud.ServiceClient, id string) string {
+func unmanageURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("shares", id, "action")
 }
 
-func getMetadataURL(c *gophercloud.ServiceClient, id string) string {
+func getMetadataURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("shares", id, "metadata")
 }
 
-func getMetadatumURL(c *gophercloud.ServiceClient, id, key string) string {
+func getMetadatumURL(c gophercloud.Client, id, key string) string {
 	return c.ServiceURL("shares", id, "metadata", key)
 }
 
-func setMetadataURL(c *gophercloud.ServiceClient, id string) string {
+func setMetadataURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("shares", id, "metadata")
 }
 
-func updateMetadataURL(c *gophercloud.ServiceClient, id string) string {
+func updateMetadataURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("shares", id, "metadata")
 }
 
-func deleteMetadatumURL(c *gophercloud.ServiceClient, id, key string) string {
+func deleteMetadatumURL(c gophercloud.Client, id, key string) string {
 	return c.ServiceURL("shares", id, "metadata", key)
 }

--- a/openstack/sharedfilesystems/v2/sharetransfers/requests.go
+++ b/openstack/sharedfilesystems/v2/sharetransfers/requests.go
@@ -29,7 +29,7 @@ func (opts CreateOpts) ToTransferCreateMap() (map[string]any, error) {
 }
 
 // Create will create a share tranfer request based on the values in CreateOpts.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToTransferCreateMap()
 	if err != nil {
 		r.Err = err
@@ -58,7 +58,7 @@ func (opts AcceptOpts) ToAcceptMap() (map[string]any, error) {
 }
 
 // Accept will accept a share tranfer request based on the values in AcceptOpts.
-func Accept(ctx context.Context, client *gophercloud.ServiceClient, id string, opts AcceptOpts) (r AcceptResult) {
+func Accept(ctx context.Context, client gophercloud.Client, id string, opts AcceptOpts) (r AcceptResult) {
 	b, err := opts.ToAcceptMap()
 	if err != nil {
 		r.Err = err
@@ -72,7 +72,7 @@ func Accept(ctx context.Context, client *gophercloud.ServiceClient, id string, o
 }
 
 // Delete deletes a share transfer.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, id string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, deleteURL(client, id), &gophercloud.RequestOpts{
 		// DELETE requests response with a 200 code, adding it here
 		OkCodes: []int{200, 202, 204},
@@ -126,7 +126,7 @@ func (opts ListOpts) ToTransferListQuery() (string, error) {
 }
 
 // List returns Transfers optionally limited by the conditions provided in ListOpts.
-func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(client gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(client)
 	if opts != nil {
 		query, err := opts.ToTransferListQuery()
@@ -145,7 +145,7 @@ func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pa
 
 // List returns Transfers with details optionally limited by the conditions
 // provided in ListOpts.
-func ListDetail(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func ListDetail(client gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := listDetailURL(client)
 	if opts != nil {
 		query, err := opts.ToTransferListQuery()
@@ -164,7 +164,7 @@ func ListDetail(client *gophercloud.ServiceClient, opts ListOptsBuilder) paginat
 
 // Get retrieves the Transfer with the provided ID. To extract the Transfer object
 // from the response, call the Extract method on the GetResult.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, id string) (r GetResult) {
 	resp, err := client.Get(ctx, getURL(client, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/sharedfilesystems/v2/sharetransfers/urls.go
+++ b/openstack/sharedfilesystems/v2/sharetransfers/urls.go
@@ -2,26 +2,26 @@ package sharetransfers
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func transferURL(c *gophercloud.ServiceClient) string {
+func transferURL(c gophercloud.Client) string {
 	return c.ServiceURL("share-transfers")
 }
 
-func acceptURL(c *gophercloud.ServiceClient, id string) string {
+func acceptURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("share-transfers", id, "accept")
 }
 
-func deleteURL(c *gophercloud.ServiceClient, id string) string {
+func deleteURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("share-transfers", id)
 }
 
-func listURL(c *gophercloud.ServiceClient) string {
+func listURL(c gophercloud.Client) string {
 	return c.ServiceURL("share-transfers")
 }
 
-func listDetailURL(c *gophercloud.ServiceClient) string {
+func listDetailURL(c gophercloud.Client) string {
 	return c.ServiceURL("share-transfers", "detail")
 }
 
-func getURL(c *gophercloud.ServiceClient, id string) string {
+func getURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("share-transfers", id)
 }

--- a/openstack/sharedfilesystems/v2/sharetypes/requests.go
+++ b/openstack/sharedfilesystems/v2/sharetypes/requests.go
@@ -42,7 +42,7 @@ func (opts CreateOpts) ToShareTypeCreateMap() (map[string]any, error) {
 // Create will create a new ShareType based on the values in CreateOpts. To
 // extract the ShareType object from the response, call the Extract method
 // on the CreateResult.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToShareTypeCreateMap()
 	if err != nil {
 		r.Err = err
@@ -56,7 +56,7 @@ func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateO
 }
 
 // Delete will delete the existing ShareType with the provided ID.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, id string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, deleteURL(client, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -82,7 +82,7 @@ func (opts ListOpts) ToShareTypeListQuery() (string, error) {
 }
 
 // List returns ShareTypes optionally limited by the conditions provided in ListOpts.
-func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(client gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(client)
 	if opts != nil {
 		query, err := opts.ToShareTypeListQuery()
@@ -98,14 +98,14 @@ func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pa
 }
 
 // GetDefault will retrieve the default ShareType.
-func GetDefault(ctx context.Context, client *gophercloud.ServiceClient) (r GetDefaultResult) {
+func GetDefault(ctx context.Context, client gophercloud.Client) (r GetDefaultResult) {
 	resp, err := client.Get(ctx, getDefaultURL(client), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
 // GetExtraSpecs will retrieve the extra specifications for a given ShareType.
-func GetExtraSpecs(ctx context.Context, client *gophercloud.ServiceClient, id string) (r GetExtraSpecsResult) {
+func GetExtraSpecs(ctx context.Context, client gophercloud.Client, id string) (r GetExtraSpecsResult) {
 	resp, err := client.Get(ctx, getExtraSpecsURL(client, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -131,7 +131,7 @@ func (opts SetExtraSpecsOpts) ToShareTypeSetExtraSpecsMap() (map[string]any, err
 // SetExtraSpecs will set new specifications for a ShareType based on the values
 // in SetExtraSpecsOpts. To extract the extra specifications object from the response,
 // call the Extract method on the SetExtraSpecsResult.
-func SetExtraSpecs(ctx context.Context, client *gophercloud.ServiceClient, id string, opts SetExtraSpecsOptsBuilder) (r SetExtraSpecsResult) {
+func SetExtraSpecs(ctx context.Context, client gophercloud.Client, id string, opts SetExtraSpecsOptsBuilder) (r SetExtraSpecsResult) {
 	b, err := opts.ToShareTypeSetExtraSpecsMap()
 	if err != nil {
 		r.Err = err
@@ -146,14 +146,14 @@ func SetExtraSpecs(ctx context.Context, client *gophercloud.ServiceClient, id st
 }
 
 // UnsetExtraSpecs will unset an extra specification for an existing ShareType.
-func UnsetExtraSpecs(ctx context.Context, client *gophercloud.ServiceClient, id string, key string) (r UnsetExtraSpecsResult) {
+func UnsetExtraSpecs(ctx context.Context, client gophercloud.Client, id string, key string) (r UnsetExtraSpecsResult) {
 	resp, err := client.Delete(ctx, unsetExtraSpecsURL(client, id, key), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
 // ShowAccess will show access details for an existing ShareType.
-func ShowAccess(ctx context.Context, client *gophercloud.ServiceClient, id string) (r ShowAccessResult) {
+func ShowAccess(ctx context.Context, client gophercloud.Client, id string) (r ShowAccessResult) {
 	resp, err := client.Get(ctx, showAccessURL(client, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -178,7 +178,7 @@ func (opts AccessOpts) ToAddAccessMap() (map[string]any, error) {
 
 // AddAccess will add access to a ShareType based on the values
 // in AccessOpts.
-func AddAccess(ctx context.Context, client *gophercloud.ServiceClient, id string, opts AddAccessOptsBuilder) (r AddAccessResult) {
+func AddAccess(ctx context.Context, client gophercloud.Client, id string, opts AddAccessOptsBuilder) (r AddAccessResult) {
 	b, err := opts.ToAddAccessMap()
 	if err != nil {
 		r.Err = err
@@ -206,7 +206,7 @@ func (opts AccessOpts) ToRemoveAccessMap() (map[string]any, error) {
 
 // RemoveAccess will remove access to a ShareType based on the values
 // in AccessOpts.
-func RemoveAccess(ctx context.Context, client *gophercloud.ServiceClient, id string, opts RemoveAccessOptsBuilder) (r RemoveAccessResult) {
+func RemoveAccess(ctx context.Context, client gophercloud.Client, id string, opts RemoveAccessOptsBuilder) (r RemoveAccessResult) {
 	b, err := opts.ToRemoveAccessMap()
 	if err != nil {
 		r.Err = err

--- a/openstack/sharedfilesystems/v2/sharetypes/urls.go
+++ b/openstack/sharedfilesystems/v2/sharetypes/urls.go
@@ -2,42 +2,42 @@ package sharetypes
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func createURL(c *gophercloud.ServiceClient) string {
+func createURL(c gophercloud.Client) string {
 	return c.ServiceURL("types")
 }
 
-func deleteURL(c *gophercloud.ServiceClient, id string) string {
+func deleteURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("types", id)
 }
 
-func listURL(c *gophercloud.ServiceClient) string {
+func listURL(c gophercloud.Client) string {
 	return createURL(c)
 }
 
-func getDefaultURL(c *gophercloud.ServiceClient) string {
+func getDefaultURL(c gophercloud.Client) string {
 	return c.ServiceURL("types", "default")
 }
 
-func getExtraSpecsURL(c *gophercloud.ServiceClient, id string) string {
+func getExtraSpecsURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("types", id, "extra_specs")
 }
 
-func setExtraSpecsURL(c *gophercloud.ServiceClient, id string) string {
+func setExtraSpecsURL(c gophercloud.Client, id string) string {
 	return getExtraSpecsURL(c, id)
 }
 
-func unsetExtraSpecsURL(c *gophercloud.ServiceClient, id string, key string) string {
+func unsetExtraSpecsURL(c gophercloud.Client, id string, key string) string {
 	return c.ServiceURL("types", id, "extra_specs", key)
 }
 
-func showAccessURL(c *gophercloud.ServiceClient, id string) string {
+func showAccessURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("types", id, "share_type_access")
 }
 
-func addAccessURL(c *gophercloud.ServiceClient, id string) string {
+func addAccessURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("types", id, "action")
 }
 
-func removeAccessURL(c *gophercloud.ServiceClient, id string) string {
+func removeAccessURL(c gophercloud.Client, id string) string {
 	return addAccessURL(c, id)
 }

--- a/openstack/sharedfilesystems/v2/snapshots/requests.go
+++ b/openstack/sharedfilesystems/v2/snapshots/requests.go
@@ -41,7 +41,7 @@ func (opts CreateOpts) ToSnapshotCreateMap() (map[string]any, error) {
 // Create will create a new Snapshot based on the values in CreateOpts. To extract
 // the Snapshot object from the response, call the Extract method on the
 // CreateResult.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToSnapshotCreateMap()
 	if err != nil {
 		r.Err = err
@@ -98,7 +98,7 @@ func (opts ListOpts) ToSnapshotListQuery() (string, error) {
 }
 
 // ListDetail returns []Snapshot optionally limited by the conditions provided in ListOpts.
-func ListDetail(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func ListDetail(client gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := listDetailURL(client)
 	if opts != nil {
 		query, err := opts.ToSnapshotListQuery()
@@ -116,14 +116,14 @@ func ListDetail(client *gophercloud.ServiceClient, opts ListOptsBuilder) paginat
 }
 
 // Delete will delete an existing Snapshot with the given UUID.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, id string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, deleteURL(client, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
 // Get will get a single snapshot with given UUID
-func Get(ctx context.Context, client *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, id string) (r GetResult) {
 	resp, err := client.Get(ctx, getURL(client, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -153,7 +153,7 @@ func (opts UpdateOpts) ToSnapshotUpdateMap() (map[string]any, error) {
 
 // Update will update the Snapshot with provided information. To extract the updated
 // Snapshot from the response, call the Extract method on the UpdateResult.
-func Update(ctx context.Context, client *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(ctx context.Context, client gophercloud.Client, id string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToSnapshotUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -190,7 +190,7 @@ func (opts ResetStatusOpts) ToSnapshotResetStatusMap() (map[string]any, error) {
 
 // ResetStatus will reset the existing snapshot status. ResetStatusResult contains only the error.
 // To extract it, call the ExtractErr method on the ResetStatusResult.
-func ResetStatus(ctx context.Context, client *gophercloud.ServiceClient, id string, opts ResetStatusOptsBuilder) (r ResetStatusResult) {
+func ResetStatus(ctx context.Context, client gophercloud.Client, id string, opts ResetStatusOptsBuilder) (r ResetStatusResult) {
 	b, err := opts.ToSnapshotResetStatusMap()
 	if err != nil {
 		r.Err = err
@@ -206,7 +206,7 @@ func ResetStatus(ctx context.Context, client *gophercloud.ServiceClient, id stri
 
 // ForceDelete will delete the existing snapshot in any state. ForceDeleteResult contains only the error.
 // To extract it, call the ExtractErr method on the ForceDeleteResult.
-func ForceDelete(ctx context.Context, client *gophercloud.ServiceClient, id string) (r ForceDeleteResult) {
+func ForceDelete(ctx context.Context, client gophercloud.Client, id string) (r ForceDeleteResult) {
 	b := map[string]any{
 		"force_delete": nil,
 	}

--- a/openstack/sharedfilesystems/v2/snapshots/urls.go
+++ b/openstack/sharedfilesystems/v2/snapshots/urls.go
@@ -2,30 +2,30 @@ package snapshots
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func createURL(c *gophercloud.ServiceClient) string {
+func createURL(c gophercloud.Client) string {
 	return c.ServiceURL("snapshots")
 }
 
-func listDetailURL(c *gophercloud.ServiceClient) string {
+func listDetailURL(c gophercloud.Client) string {
 	return c.ServiceURL("snapshots", "detail")
 }
 
-func deleteURL(c *gophercloud.ServiceClient, id string) string {
+func deleteURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("snapshots", id)
 }
 
-func getURL(c *gophercloud.ServiceClient, id string) string {
+func getURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("snapshots", id)
 }
 
-func updateURL(c *gophercloud.ServiceClient, id string) string {
+func updateURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("snapshots", id)
 }
 
-func resetStatusURL(c *gophercloud.ServiceClient, id string) string {
+func resetStatusURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("snapshots", id, "action")
 }
 
-func forceDeleteURL(c *gophercloud.ServiceClient, id string) string {
+func forceDeleteURL(c gophercloud.Client, id string) string {
 	return c.ServiceURL("snapshots", id, "action")
 }

--- a/openstack/utils/choose_version.go
+++ b/openstack/utils/choose_version.go
@@ -123,7 +123,7 @@ type SupportedMicroversions struct {
 }
 
 // GetSupportedMicroversions returns the minimum and maximum microversion that is supported by the ServiceClient Endpoint.
-func GetSupportedMicroversions(ctx context.Context, client *gophercloud.ServiceClient) (SupportedMicroversions, error) {
+func GetSupportedMicroversions(ctx context.Context, client gophercloud.Client) (SupportedMicroversions, error) {
 	type valueResp struct {
 		ID         string `json:"id"`
 		Status     string `json:"status"`
@@ -138,7 +138,7 @@ func GetSupportedMicroversions(ctx context.Context, client *gophercloud.ServiceC
 	var minVersion, maxVersion string
 	var supportedMicroversions SupportedMicroversions
 	var resp response
-	_, err := client.Get(ctx, client.Endpoint, &resp, &gophercloud.RequestOpts{
+	_, err := client.Get(ctx, client.EndpointURL(), &resp, &gophercloud.RequestOpts{
 		OkCodes: []int{200, 300},
 	})
 

--- a/openstack/workflow/v2/crontriggers/requests.go
+++ b/openstack/workflow/v2/crontriggers/requests.go
@@ -60,7 +60,7 @@ func (opts CreateOpts) ToCronTriggerCreateMap() (map[string]any, error) {
 }
 
 // Create requests the creation of a new cron trigger.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToCronTriggerCreateMap()
 	if err != nil {
 		r.Err = err
@@ -73,7 +73,7 @@ func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateO
 }
 
 // Delete deletes the specified cron trigger.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, id string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, deleteURL(client, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -81,7 +81,7 @@ func Delete(ctx context.Context, client *gophercloud.ServiceClient, id string) (
 
 // Get retrieves details of a single cron trigger.
 // Use Extract to convert its result into an CronTrigger.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, id string) (r GetResult) {
 	resp, err := client.Get(ctx, getURL(client, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -242,7 +242,7 @@ func (opts ListOpts) ToCronTriggerListQuery() (string, error) {
 
 // List performs a call to list cron triggers.
 // You may provide options to filter the results.
-func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(client gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(client)
 	if opts != nil {
 		query, err := opts.ToCronTriggerListQuery()

--- a/openstack/workflow/v2/crontriggers/urls.go
+++ b/openstack/workflow/v2/crontriggers/urls.go
@@ -2,18 +2,18 @@ package crontriggers
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func createURL(client *gophercloud.ServiceClient) string {
+func createURL(client gophercloud.Client) string {
 	return client.ServiceURL("cron_triggers")
 }
 
-func deleteURL(client *gophercloud.ServiceClient, id string) string {
+func deleteURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL("cron_triggers", id)
 }
 
-func getURL(client *gophercloud.ServiceClient, id string) string {
+func getURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL("cron_triggers", id)
 }
 
-func listURL(client *gophercloud.ServiceClient) string {
+func listURL(client gophercloud.Client) string {
 	return client.ServiceURL("cron_triggers")
 }

--- a/openstack/workflow/v2/executions/requests.go
+++ b/openstack/workflow/v2/executions/requests.go
@@ -50,7 +50,7 @@ func (opts CreateOpts) ToExecutionCreateMap() (map[string]any, error) {
 }
 
 // Create requests the creation of a new execution.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToExecutionCreateMap()
 	if err != nil {
 		r.Err = err
@@ -64,14 +64,14 @@ func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateO
 
 // Get retrieves details of a single execution.
 // Use ExtractExecution to convert its result into an Execution.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, id string) (r GetResult) {
 	resp, err := client.Get(ctx, getURL(client, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
 // Delete deletes the specified execution.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, id string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, deleteURL(client, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -226,7 +226,7 @@ func (opts ListOpts) ToExecutionListQuery() (string, error) {
 
 // List performs a call to list executions.
 // You may provide options to filter the executions.
-func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(client gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(client)
 	if opts != nil {
 		query, err := opts.ToExecutionListQuery()

--- a/openstack/workflow/v2/executions/urls.go
+++ b/openstack/workflow/v2/executions/urls.go
@@ -2,18 +2,18 @@ package executions
 
 import "github.com/gophercloud/gophercloud/v2"
 
-func createURL(client *gophercloud.ServiceClient) string {
+func createURL(client gophercloud.Client) string {
 	return client.ServiceURL("executions")
 }
 
-func getURL(client *gophercloud.ServiceClient, id string) string {
+func getURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL("executions", id)
 }
 
-func deleteURL(client *gophercloud.ServiceClient, id string) string {
+func deleteURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL("executions", id)
 }
 
-func listURL(client *gophercloud.ServiceClient) string {
+func listURL(client gophercloud.Client) string {
 	return client.ServiceURL("executions")
 }

--- a/openstack/workflow/v2/workflows/requests.go
+++ b/openstack/workflow/v2/workflows/requests.go
@@ -38,7 +38,7 @@ func (opts CreateOpts) ToWorkflowCreateParams() (io.Reader, string, error) {
 }
 
 // Create requests the creation of a new execution.
-func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(ctx context.Context, client gophercloud.Client, opts CreateOptsBuilder) (r CreateResult) {
 	url := createURL(client)
 	var b io.Reader
 	if opts != nil {
@@ -62,7 +62,7 @@ func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateO
 }
 
 // Delete deletes the specified execution.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+func Delete(ctx context.Context, client gophercloud.Client, id string) (r DeleteResult) {
 	resp, err := client.Delete(ctx, deleteURL(client, id), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -70,7 +70,7 @@ func Delete(ctx context.Context, client *gophercloud.ServiceClient, id string) (
 
 // Get retrieves details of a single execution.
 // Use Extract to convert its result into an Workflow.
-func Get(ctx context.Context, client *gophercloud.ServiceClient, id string) (r GetResult) {
+func Get(ctx context.Context, client gophercloud.Client, id string) (r GetResult) {
 	resp, err := client.Get(ctx, getURL(client, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -199,7 +199,7 @@ func (opts ListOpts) ToWorkflowListQuery() (string, error) {
 
 // List performs a call to list cron triggers.
 // You may provide options to filter the results.
-func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(client gophercloud.Client, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(client)
 	if opts != nil {
 		query, err := opts.ToWorkflowListQuery()

--- a/openstack/workflow/v2/workflows/urls.go
+++ b/openstack/workflow/v2/workflows/urls.go
@@ -4,18 +4,18 @@ import (
 	"github.com/gophercloud/gophercloud/v2"
 )
 
-func createURL(client *gophercloud.ServiceClient) string {
+func createURL(client gophercloud.Client) string {
 	return client.ServiceURL("workflows")
 }
 
-func deleteURL(client *gophercloud.ServiceClient, id string) string {
+func deleteURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL("workflows", id)
 }
 
-func getURL(client *gophercloud.ServiceClient, id string) string {
+func getURL(client gophercloud.Client, id string) string {
 	return client.ServiceURL("workflows", id)
 }
 
-func listURL(client *gophercloud.ServiceClient) string {
+func listURL(client gophercloud.Client) string {
 	return client.ServiceURL("workflows")
 }

--- a/pagination/http.go
+++ b/pagination/http.go
@@ -54,7 +54,7 @@ func PageResultFromParsed(resp *http.Response, body any) PageResult {
 }
 
 // Request performs an HTTP request and extracts the http.Response from the result.
-func Request(ctx context.Context, client *gophercloud.ServiceClient, headers map[string]string, url string) (*http.Response, error) {
+func Request(ctx context.Context, client gophercloud.Client, headers map[string]string, url string) (*http.Response, error) {
 	return client.Get(ctx, url, nil, &gophercloud.RequestOpts{
 		MoreHeaders:      headers,
 		OkCodes:          []int{200, 204, 300},

--- a/pagination/pager.go
+++ b/pagination/pager.go
@@ -36,7 +36,7 @@ type Page interface {
 
 // Pager knows how to advance through a specific resource collection, one page at a time.
 type Pager struct {
-	client *gophercloud.ServiceClient
+	client gophercloud.Client
 
 	initialURL string
 
@@ -52,7 +52,7 @@ type Pager struct {
 
 // NewPager constructs a manually-configured pager.
 // Supply the URL for the first page, a function that requests a specific page given a URL, and a function that counts a page.
-func NewPager(client *gophercloud.ServiceClient, initialURL string, createPage func(r PageResult) Page) Pager {
+func NewPager(client gophercloud.Client, initialURL string, createPage func(r PageResult) Page) Pager {
 	return Pager{
 		client:     client,
 		initialURL: initialURL,

--- a/service_client.go
+++ b/service_client.go
@@ -35,6 +35,10 @@ type ServiceClient struct {
 	MoreHeaders map[string]string
 }
 
+func (client ServiceClient) EndpointURL() string {
+	return client.Endpoint
+}
+
 // ResourceBaseURL returns the base URL of any resources used by this service. It MUST end with a /.
 func (client *ServiceClient) ResourceBaseURL() string {
 	if client.ResourceBase != "" {

--- a/service_client.go
+++ b/service_client.go
@@ -7,6 +7,21 @@ import (
 	"strings"
 )
 
+type Client interface {
+	Request(ctx context.Context, method, url string, options *RequestOpts) (*http.Response, error)
+
+	Get(ctx context.Context, url string, JSONResponse any, opts *RequestOpts) (*http.Response, error)
+	Post(ctx context.Context, url string, JSONBody any, JSONResponse any, opts *RequestOpts) (*http.Response, error)
+	Put(ctx context.Context, url string, JSONBody any, JSONResponse any, opts *RequestOpts) (*http.Response, error)
+	Patch(ctx context.Context, url string, JSONBody any, JSONResponse any, opts *RequestOpts) (*http.Response, error)
+	Delete(ctx context.Context, url string, opts *RequestOpts) (*http.Response, error)
+	Head(ctx context.Context, url string, opts *RequestOpts) (*http.Response, error)
+
+	ResourceBaseURL() string
+	EndpointURL() string
+	ServiceURL(parts ...string) string
+}
+
 // ServiceClient stores details required to interact with a specific service API implemented by a provider.
 // Generally, you'll acquire these by calling the appropriate `New` method on a ProviderClient.
 type ServiceClient struct {

--- a/testing/service_client_test.go
+++ b/testing/service_client_test.go
@@ -10,6 +10,8 @@ import (
 	th "github.com/gophercloud/gophercloud/v2/testhelper"
 )
 
+var _ gophercloud.Client = &gophercloud.ServiceClient{}
+
 func TestServiceURL(t *testing.T) {
 	c := &gophercloud.ServiceClient{Endpoint: "http://123.45.67.8/"}
 	expected := "http://123.45.67.8/more/parts/here"


### PR DESCRIPTION
Allow client libraries to modify the behaviour of ServiceClient or mock calls to the OpenStack API.

This change is targeted at `v3`.