### PR TITLE
Configure and respect service type aliases

### DIFF
--- a/endpoint_search.go
+++ b/endpoint_search.go
@@ -30,14 +30,22 @@ const (
 // package, like "openstack.NewComputeV2()".
 type EndpointOpts struct {
 	// Type [required] is the service type for the client (e.g., "compute",
-	// "object-store"). Generally, this will be supplied by the service client
-	// function, but a user-given value will be honored if provided.
+	// "object-store"), as defined by the OpenStack Service Types Authority.
+	// This will generally be supplied by the service client function, but a
+	// user-given value will be honored if provided.
 	Type string
 
 	// Name [optional] is the service name for the client (e.g., "nova") as it
 	// appears in the service catalog. Services can have the same Type but a
 	// different Name, which is why both Type and Name are sometimes needed.
 	Name string
+
+	// Aliases [optional] is the set of aliases of the service type (e.g.
+	// "volumev2"/"volumev3", "volume" and "block-store" for the
+	// "block-storage" service type), as defined by the OpenStack Service Types
+	// Authority. As with Type, this will generally be supplied by the service
+	// client function, but a user-given value will be honored if provided.
+	Aliases []string
 
 	// Region [required] is the geographic region in which the endpoint resides,
 	// generally specifying which datacenter should house your resources.
@@ -73,4 +81,8 @@ func (eo *EndpointOpts) ApplyDefaults(t string) {
 	if eo.Availability == "" {
 		eo.Availability = AvailabilityPublic
 	}
+}
+
+func (eo *EndpointOpts) Types() []string {
+	return append([]string{eo.Type}, eo.Aliases...)
 }

--- a/openstack/blockstorage/noauth/requests.go
+++ b/openstack/blockstorage/noauth/requests.go
@@ -51,10 +51,10 @@ func initClientOpts(client *gophercloud.ProviderClient, eo EndpointOpts, clientT
 
 // NewBlockStorageNoAuthV2 creates a ServiceClient that may be used to access "noauth" v2 block storage service.
 func NewBlockStorageNoAuthV2(client *gophercloud.ProviderClient, eo EndpointOpts) (*gophercloud.ServiceClient, error) {
-	return initClientOpts(client, eo, "volumev2")
+	return initClientOpts(client, eo, "block-storage")
 }
 
 // NewBlockStorageNoAuthV3 creates a ServiceClient that may be used to access "noauth" v3 block storage service.
 func NewBlockStorageNoAuthV3(client *gophercloud.ProviderClient, eo EndpointOpts) (*gophercloud.ServiceClient, error) {
-	return initClientOpts(client, eo, "volumev3")
+	return initClientOpts(client, eo, "block-storage")
 }

--- a/openstack/client.go
+++ b/openstack/client.go
@@ -344,6 +344,7 @@ func NewIdentityV3(client *gophercloud.ProviderClient, eo gophercloud.EndpointOp
 	}, nil
 }
 
+// TODO(stephenfin): Allow passing aliases to all New${SERVICE}V${VERSION} methods in v3
 func initClientOpts(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, clientType string) (*gophercloud.ServiceClient, error) {
 	sc := new(gophercloud.ServiceClient)
 	eo.ApplyDefaults(clientType)
@@ -393,6 +394,7 @@ func NewNetworkV2(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpt
 	return sc, err
 }
 
+// TODO(stephenfin): Remove this in v3. We no longer support the V1 Block Storage service.
 // NewBlockStorageV1 creates a ServiceClient that may be used to access the v1
 // block storage service.
 func NewBlockStorageV1(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
@@ -402,17 +404,17 @@ func NewBlockStorageV1(client *gophercloud.ProviderClient, eo gophercloud.Endpoi
 // NewBlockStorageV2 creates a ServiceClient that may be used to access the v2
 // block storage service.
 func NewBlockStorageV2(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
-	return initClientOpts(client, eo, "volumev2")
+	return initClientOpts(client, eo, "block-storage")
 }
 
 // NewBlockStorageV3 creates a ServiceClient that may be used to access the v3 block storage service.
 func NewBlockStorageV3(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
-	return initClientOpts(client, eo, "volumev3")
+	return initClientOpts(client, eo, "block-storage")
 }
 
 // NewSharedFileSystemV2 creates a ServiceClient that may be used to access the v2 shared file system service.
 func NewSharedFileSystemV2(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
-	return initClientOpts(client, eo, "sharev2")
+	return initClientOpts(client, eo, "shared-file-system")
 }
 
 // NewOrchestrationV1 creates a ServiceClient that may be used to access the v1
@@ -457,14 +459,14 @@ func NewLoadBalancerV2(client *gophercloud.ProviderClient, eo gophercloud.Endpoi
 // NewMessagingV2 creates a ServiceClient that may be used with the v2 messaging
 // service.
 func NewMessagingV2(client *gophercloud.ProviderClient, clientID string, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
-	sc, err := initClientOpts(client, eo, "messaging")
+	sc, err := initClientOpts(client, eo, "message")
 	sc.MoreHeaders = map[string]string{"Client-ID": clientID}
 	return sc, err
 }
 
 // NewContainerV1 creates a ServiceClient that may be used with v1 container package
 func NewContainerV1(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
-	return initClientOpts(client, eo, "container")
+	return initClientOpts(client, eo, "application-container")
 }
 
 // NewKeyManagerV1 creates a ServiceClient that may be used with the v1 key
@@ -478,12 +480,12 @@ func NewKeyManagerV1(client *gophercloud.ProviderClient, eo gophercloud.Endpoint
 // NewContainerInfraV1 creates a ServiceClient that may be used with the v1 container infra management
 // package.
 func NewContainerInfraV1(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
-	return initClientOpts(client, eo, "container-infra")
+	return initClientOpts(client, eo, "container-infrastructure-management")
 }
 
 // NewWorkflowV2 creates a ServiceClient that may be used with the v2 workflow management package.
 func NewWorkflowV2(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
-	return initClientOpts(client, eo, "workflowv2")
+	return initClientOpts(client, eo, "workflow")
 }
 
 // NewPlacementV1 creates a ServiceClient that may be used with the placement package.

--- a/openstack/endpoint_location.go
+++ b/openstack/endpoint_location.go
@@ -1,6 +1,8 @@
 package openstack
 
 import (
+	"slices"
+
 	"github.com/gophercloud/gophercloud/v2"
 	tokens2 "github.com/gophercloud/gophercloud/v2/openstack/identity/v2/tokens"
 	tokens3 "github.com/gophercloud/gophercloud/v2/openstack/identity/v3/tokens"
@@ -20,7 +22,7 @@ func V2EndpointURL(catalog *tokens2.ServiceCatalog, opts gophercloud.EndpointOpt
 	// Extract Endpoints from the catalog entries that match the requested Type, Name if provided, and Region if provided.
 	var endpoints = make([]tokens2.Endpoint, 0, 1)
 	for _, entry := range catalog.Entries {
-		if (entry.Type == opts.Type) && (opts.Name == "" || entry.Name == opts.Name) {
+		if (slices.Contains(opts.Types(), entry.Type)) && (opts.Name == "" || entry.Name == opts.Name) {
 			for _, endpoint := range entry.Endpoints {
 				if opts.Region == "" || endpoint.Region == opts.Region {
 					endpoints = append(endpoints, endpoint)
@@ -74,7 +76,7 @@ func V3EndpointURL(catalog *tokens3.ServiceCatalog, opts gophercloud.EndpointOpt
 	// Name if provided, and Region if provided.
 	var endpoints = make([]tokens3.Endpoint, 0, 1)
 	for _, entry := range catalog.Entries {
-		if (entry.Type == opts.Type) && (opts.Name == "" || entry.Name == opts.Name) {
+		if (slices.Contains(opts.Types(), entry.Type)) && (opts.Name == "" || entry.Name == opts.Name) {
 			for _, endpoint := range entry.Endpoints {
 				if opts.Availability != gophercloud.AvailabilityAdmin &&
 					opts.Availability != gophercloud.AvailabilityPublic &&

--- a/service_client.go
+++ b/service_client.go
@@ -115,13 +115,17 @@ func (client *ServiceClient) Head(ctx context.Context, url string, opts *Request
 }
 
 func (client *ServiceClient) setMicroversionHeader(opts *RequestOpts) {
+	serviceType := client.Type
+
 	switch client.Type {
 	case "compute":
 		opts.MoreHeaders["X-OpenStack-Nova-API-Version"] = client.Microversion
-	case "sharev2":
+	case "shared-file-system", "sharev2", "share":
 		opts.MoreHeaders["X-OpenStack-Manila-API-Version"] = client.Microversion
-	case "volume":
+	case "block-storage", "block-store", "volume", "volumev3":
 		opts.MoreHeaders["X-OpenStack-Volume-API-Version"] = client.Microversion
+		// cinder should accept block-storage but (as of Dalmatian) does not
+		serviceType = "volume"
 	case "baremetal":
 		opts.MoreHeaders["X-OpenStack-Ironic-API-Version"] = client.Microversion
 	case "baremetal-introspection":
@@ -129,7 +133,7 @@ func (client *ServiceClient) setMicroversionHeader(opts *RequestOpts) {
 	}
 
 	if client.Type != "" {
-		opts.MoreHeaders["OpenStack-API-Version"] = client.Type + " " + client.Microversion
+		opts.MoreHeaders["OpenStack-API-Version"] = serviceType + " " + client.Microversion
 	}
 }
 

--- a/testing/endpoint_search_test.go
+++ b/testing/endpoint_search_test.go
@@ -10,11 +10,11 @@ import (
 func TestApplyDefaultsToEndpointOpts(t *testing.T) {
 	eo := gophercloud.EndpointOpts{Availability: gophercloud.AvailabilityPublic}
 	eo.ApplyDefaults("compute")
-	expected := gophercloud.EndpointOpts{Availability: gophercloud.AvailabilityPublic, Type: "compute"}
+	expected := gophercloud.EndpointOpts{Availability: gophercloud.AvailabilityPublic, Type: "compute", Aliases: []string{}}
 	th.CheckDeepEquals(t, expected, eo)
 
 	eo = gophercloud.EndpointOpts{Type: "compute"}
 	eo.ApplyDefaults("object-store")
-	expected = gophercloud.EndpointOpts{Availability: gophercloud.AvailabilityPublic, Type: "compute"}
+	expected = gophercloud.EndpointOpts{Availability: gophercloud.AvailabilityPublic, Type: "compute", Aliases: []string{}}
 	th.CheckDeepEquals(t, expected, eo)
 }


### PR DESCRIPTION
Fixes #3207

This means we can identify a service by either its type or any of its official aliases, which is the expectation when it comes to navigating the service catalog.
