### PR TITLE
Added address groups to Networking extensions, with tests.

### DIFF
--- a/openstack/networking/v2/extensions/addressgroups/doc.go
+++ b/openstack/networking/v2/extensions/addressgroups/doc.go
@@ -1,0 +1,82 @@
+/*
+Package addressgroups provides information and interaction with Address Groups
+for the OpenStack Networking services.
+
+Example to List Address Groups
+
+	listOpts := addressgroups.ListOpts{
+	}
+
+	allPages, err := addressgroups.List(networkClient, listOpts).AllPages(context.TODO())
+	if err != nil {
+		panic(err)
+	}
+
+	allAddressGroups, err := addressgroups.ExtractGroups(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, addressGroup := range allAddressGroups {
+		fmt.Printf("%+v\n", addressGroup)
+	}
+
+Example to Create an Address Group
+
+	createOpts := addressgroups.CreateOpts{
+		Name:        "addressGroupName",
+		Addresses:   []string{"10.2.30.4/32", "10.2.30.6/32"},
+		Description: "Created address group",
+	}
+
+	addressGroup, err := addressgroups.Create(context.TODO(), networkClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete a Address Group
+
+	groupID := "37d94f8a-d136-465c-ae46-144f0d8ef141"
+	err := addressgroups.Delete(context.TODO(), computeClient, groupID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+
+Example to update an existing Address Group
+
+	groupID := "37d94f8a-d136-465c-ae46-144f0d8ef141"
+	createOpts := addressGroups.CreateOpts{
+		Addresses: []string{"10.2.30.4/32", "10.2.30.6/32"},
+		Description: "new description",
+		Name: "ADDR_GP_2"
+	}
+	addressGroup, err := addressgroups.UpdateAddressGroup(context.TODO(), networkClient, groupID, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to add addresses to an existing Address Group
+
+	groupID := "37d94f8a-d136-465c-ae46-144f0d8ef141"
+	createOpts := addressGroups.CreateOpts{
+		Addresses: []string{"10.2.30.4/32", "10.2.30.6/32"},
+	}
+	addressGroup, err := addressgroups.AddAddresses(context.TODO(), networkClient, groupID, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to remove addresses from an existing Address Group
+
+	groupID := "37d94f8a-d136-465c-ae46-144f0d8ef141"
+	createOpts := addressGroups.CreateOpts{
+		Addresses: []string{"10.2.30.4/32", "10.2.30.6/32"},
+	}
+	addressGroup, err := addressgroups.RemoveAddresses(context.TODO(), networkClient, groupID, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+*/
+
+package addressgroups

--- a/openstack/networking/v2/extensions/addressgroups/requests.go
+++ b/openstack/networking/v2/extensions/addressgroups/requests.go
@@ -1,0 +1,162 @@
+package addressgroups
+
+import (
+	"context"
+
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/pagination"
+)
+
+// ListOptsBuilder allows extensions to add additional parameters to the
+// List request.
+type ListOptsBuilder interface {
+	ToAddressGroupListQuery() (string, error)
+}
+
+// ListOpts allows the filtering and sorting of paginated collections through
+// the API. Filtering is achieved by passing in struct field values that map to
+// the address group attributes you want to see returned. SortKey allows
+// you to sort by a particular network attribute. SortDir sets the direction,
+// and is either `asc' or `desc'. Marker and Limit are used for pagination.
+type ListOpts struct {
+	ID          string   `q:"id"`
+	Name        string   `q:"name"`
+	Description string   `q:"description"`
+	ProjectID   string   `q:"project_id"`
+	Addresses   []string `q:"addresses"`
+	Limit       int      `q:"limit"`
+	Marker      string   `q:"marker"`
+	SortKey     string   `q:"sort_key"`
+	SortDir     string   `q:"sort_dir"`
+}
+
+// ToAddressGroupListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToAddressGroupListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List returns a Pager which allows you to iterate over a collection of
+// address groups. It accepts a ListOpts struct, which allows you to filter
+// and sort the returned collection for greater efficiency.
+func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := rootURL(c)
+	if opts != nil {
+		query, err := opts.ToAddressGroupListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		return AddressGroupPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToAddressGroupCreateMap() (map[string]any, error)
+	ToAddressListCreateMap() (map[string]any, error)
+}
+
+// CreateOpts contains all the values needed to create a new address group.
+type CreateOpts struct {
+
+	// The address group ID to associate with this address group.
+	ID string `json:"id,omitempty"`
+
+	// Human readable name for the address group (255 characters limit). Does not have to be unique.
+	Name string `json:"name,omitempty"`
+
+	// Human readable description for the address group (255 characters limit).
+	Description string `json:"description,omitempty"`
+
+	// Owner of the address group.
+	// Only administrative users can specify a project UUID other than their own.
+	ProjectID string `json:"project_id,omitempty"`
+
+	// Array of address. It supports both CIDR and IP range objects.
+	// An example of addresses: [“132.168.4.12/24”, “132.168.5.12-132.168.5.24”, “2001::db8::f00/64”]
+	Addresses []string `json:"addresses" required:"true"`
+}
+
+// ToAddressGroupCreateMap builds a request body from CreateOpts.
+func (opts CreateOpts) ToAddressGroupCreateMap() (map[string]any, error) {
+	return gophercloud.BuildRequestBody(opts, "address_group")
+}
+
+// ToAddressListCreateMap builds a request body from CreateOpts.
+func (opts CreateOpts) ToAddressListCreateMap() (map[string]any, error) {
+	return gophercloud.BuildRequestBody(opts, "")
+}
+
+// Create is an operation which creates a new address group and associates it
+// with an existing address group (whose ID is specified in CreateOpts).
+func Create(ctx context.Context, c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToAddressGroupCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := c.Post(ctx, rootURL(c), b, &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// Get retrieves a particular address group based on its unique ID.
+func Get(ctx context.Context, c *gophercloud.ServiceClient, id string) (r GetResult) {
+	resp, err := c.Get(ctx, resourceURL(c, id), &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// Delete will permanently delete a particular address group based on its
+// unique ID.
+func Delete(ctx context.Context, c *gophercloud.ServiceClient, id string) (r DeleteResult) {
+	resp, err := c.Delete(ctx, resourceURL(c, id), nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// UpdateAddressGroup will update a particular address group with a complete new set of data.
+func UpdateAddressGroup(ctx context.Context, c *gophercloud.ServiceClient, addressGroupID string, opts CreateOptsBuilder) (r UpdateAddressGroupResult) {
+	b, err := opts.ToAddressGroupCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := c.Put(ctx, resourceURL(c, addressGroupID), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// AddAddresses will add IP addresses to a particular address group.
+func AddAddresses(ctx context.Context, c *gophercloud.ServiceClient, addressGroupID string, opts CreateOptsBuilder) (r AddAddressesResult) {
+	b, err := opts.ToAddressListCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := c.Put(ctx, c.ServiceURL("address-groups", addressGroupID, "add_addresses"), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// RemoveAddresses will remove particular IP addresses from a particular address group.
+func RemoveAddresses(ctx context.Context, c *gophercloud.ServiceClient, addressGroupID string, opts CreateOptsBuilder) (r RemoveAddressesResult) {
+	b, err := opts.ToAddressListCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := c.Put(ctx, c.ServiceURL("address-groups", addressGroupID, "remove_addresses"), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}

--- a/openstack/networking/v2/extensions/addressgroups/results.go
+++ b/openstack/networking/v2/extensions/addressgroups/results.go
@@ -1,0 +1,121 @@
+package addressgroups
+
+import (
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/pagination"
+)
+
+// AddressGroup represents a container for address groups.
+type AddressGroup struct {
+	// Unique identifier for the address_group object.
+	ID string
+
+	// Human readable name for the address group (255 characters limit). Does not have to be unique.
+	Name string
+
+	// Human readable description for the address group (255 characters limit).
+	Description string `json:"description"`
+
+	// ProjectID is the project owner of this address group.
+	ProjectID string `json:"project_id"`
+
+	// Array of address. It supports both CIDR and IP range objects.
+	// An example of addresses: [“132.168.4.12/24”, “132.168.5.12-132.168.5.24”, “2001::db8::f00/64”]
+	Addresses []string `json:"addresses"`
+}
+
+// AddressGroupPage is the page returned by a pager when traversing over a
+// collection of address group addresses.
+type AddressGroupPage struct {
+	pagination.LinkedPageBase
+}
+
+// NextPageURL is invoked when a paginated collection of address groups has
+// reached the end of a page and the pager seeks to traverse over a new one. In
+// order to do this, it needs to construct the next page's URL.
+func (r AddressGroupPage) NextPageURL() (string, error) {
+	var s struct {
+		Links []gophercloud.Link `json:"address_groups_links"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return gophercloud.ExtractNextURL(s.Links)
+}
+
+// IsEmpty checks whether a AddressGroupPage struct is empty.
+func (r AddressGroupPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
+	is, err := ExtractGroups(r)
+	return len(is) == 0, err
+}
+
+// ExtractGroups accepts a Page struct, specifically a AddressGroupPage struct,
+// and extracts the elements into a slice of AddressGroup structs. In other words,
+// a generic collection is mapped into a relevant slice.
+func ExtractGroups(r pagination.Page) ([]AddressGroup, error) {
+	var s struct {
+		AddressGroups []AddressGroup `json:"address_groups"`
+	}
+	err := (r.(AddressGroupPage)).ExtractInto(&s)
+	return s.AddressGroups, err
+}
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// Extract is a function that accepts a result and extracts a address group.
+func (r commonResult) Extract() (*AddressGroup, error) {
+	var s struct {
+		AddressGroup *AddressGroup `json:"address_group"`
+	}
+	err := r.ExtractInto(&s)
+	return s.AddressGroup, err
+}
+
+// CreateResult represents the result of a create operation. Call its Extract
+// method to interpret it as a AddressGroup.
+type CreateResult struct {
+	commonResult
+}
+
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a AddressGroup.
+type GetResult struct {
+	commonResult
+}
+
+// PutResult represents the result of a get operation. Call its Extract
+// method to interpret it as a AddressGroup.
+type PutResult struct {
+	commonResult
+}
+
+// DeleteResult represents the result of a delete operation. Call its
+// ExtractErr method to determine if the request succeeded or failed.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
+// AddAddressesResult represents the result of an add addresses operation. Call its Extract
+// method to interpret it as a AddressGroup.
+type AddAddressesResult struct {
+	commonResult
+}
+
+// RemoveAddressesResult represents the result of a remove addresses operation. Call its Extract
+// method to interpret it as a AddressGroup.
+type RemoveAddressesResult struct {
+	commonResult
+}
+
+// UpdateAddressGroupResult represents the result of an update address group operation. Call its Extract
+// method to interpret it as a AddressGroup.
+type UpdateAddressGroupResult struct {
+	commonResult
+}

--- a/openstack/networking/v2/extensions/addressgroups/testing/doc.go
+++ b/openstack/networking/v2/extensions/addressgroups/testing/doc.go
@@ -1,0 +1,2 @@
+// rules unit tests
+package testing

--- a/openstack/networking/v2/extensions/addressgroups/testing/fixtures_test.go
+++ b/openstack/networking/v2/extensions/addressgroups/testing/fixtures_test.go
@@ -1,0 +1,122 @@
+package testing
+
+const AddressGroupListResponse = `
+{
+    "address_groups": [
+		{
+			"id": "8722e0e0-9cc9-4490-9660-8c9a5732fbb0",
+			"project_id": "45977fa2dbd7482098dd68d0d8970117",
+			"name": "ADDR_GP_1",
+			"addresses": [
+			"132.168.4.12/24"
+			]
+		}
+	]
+}
+`
+
+const AddressGroupGetResponse = `
+{
+   "address_group": {
+        "description": "",
+        "id": "8722e0e0-9cc9-4490-9660-8c9a5732fbb0",
+        "name": "ADDR_GP_1",
+        "project_id": "45977fa2dbd7482098dd68d0d8970117",
+        "addresses": [
+           "132.168.4.12/24"
+        ]
+    }
+}
+`
+
+const AddressGroupCreateRequest = `
+{
+    "address_group": {
+        "name": "ADDR_GP_1",
+        "addresses": [
+           "132.168.4.12/24"
+        ]
+    }
+}
+`
+
+const AddressGroupCreateResponse = `
+{
+   "address_group": {
+        "description": "",
+        "id": "8722e0e0-9cc9-4490-9660-8c9a5732fbb0",
+        "name": "ADDR_GP_1",
+        "project_id": "45977fa2dbd7482098dd68d0d8970117",
+        "addresses": [
+           "132.168.4.12/24"
+        ]
+    }
+}
+`
+
+const AddressGroupUpdateRequest = `
+{
+   "address_group": {
+        "description": "new description",
+        "name": "ADDR_GP_2",
+        "addresses": [
+           "192.168.4.1/32"
+        ]
+    }
+}
+`
+
+const AddressGroupUpdateResponse = `
+{
+   "address_group": {
+        "description": "new description",
+        "id": "8722e0e0-9cc9-4490-9660-8c9a5732fbb0",
+        "name": "ADDR_GP_2",
+        "project_id": "45977fa2dbd7482098dd68d0d8970117",
+        "addresses": [
+           "192.168.4.1/32"
+        ]
+    }
+}
+`
+
+const AddressGroupAddAddressesRequest = `
+{
+	"addresses": ["192.168.4.1/32"]
+}
+`
+
+const AddressGroupAddAddressesResponse = `
+{
+   "address_group": {
+        "description": "original description",
+        "id": "8722e0e0-9cc9-4490-9660-8c9a5732fbb0",
+        "name": "ADDR_GP_1",
+        "project_id": "45977fa2dbd7482098dd68d0d8970117",
+        "addresses": [
+           "132.168.4.12/24",
+		   "192.168.4.1/32"
+        ]
+    }
+}
+`
+
+const AddressGroupRemoveAddressesRequest = `
+{
+    "addresses": ["192.168.4.1/32"]
+}
+`
+
+const AddressGroupRemoveAddressesResponse = `
+{
+   "address_group": {
+        "description": "original description",
+        "id": "8722e0e0-9cc9-4490-9660-8c9a5732fbb0",
+        "name": "ADDR_GP_1",
+        "project_id": "45977fa2dbd7482098dd68d0d8970117",
+        "addresses": [
+           "132.168.4.12/24"
+        ]
+    }
+}
+`

--- a/openstack/networking/v2/extensions/addressgroups/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/addressgroups/testing/requests_test.go
@@ -1,0 +1,215 @@
+package testing
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	fake "github.com/gophercloud/gophercloud/v2/openstack/networking/v2/common"
+	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/addressgroups"
+	"github.com/gophercloud/gophercloud/v2/pagination"
+	th "github.com/gophercloud/gophercloud/v2/testhelper"
+)
+
+func TestList(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/address-groups", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, AddressGroupListResponse)
+	})
+
+	count := 0
+
+	err := addressgroups.List(fake.ServiceClient(), addressgroups.ListOpts{}).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
+		count++
+		actual, err := addressgroups.ExtractGroups(page)
+		if err != nil {
+			t.Errorf("Failed to extract address groups: %v", err)
+			return false, err
+		}
+
+		expected := []addressgroups.AddressGroup{
+			{
+				Description: "",
+				ID:          "8722e0e0-9cc9-4490-9660-8c9a5732fbb0",
+				Name:        "ADDR_GP_1",
+				ProjectID:   "45977fa2dbd7482098dd68d0d8970117",
+				Addresses: []string{
+					"132.168.4.12/24",
+				},
+			},
+		}
+
+		th.CheckDeepEquals(t, expected, actual)
+
+		return true, nil
+	})
+	th.AssertNoErr(t, err)
+
+	if count != 1 {
+		t.Errorf("Expected 1 page, got %d", count)
+	}
+}
+
+func TestCreate(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/address-groups", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, AddressGroupCreateRequest)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+
+		fmt.Fprintf(w, AddressGroupCreateResponse)
+	})
+
+	opts := addressgroups.CreateOpts{
+		Name: "ADDR_GP_1",
+		Addresses: []string{
+			"132.168.4.12/24",
+		},
+	}
+	_, err := addressgroups.Create(context.TODO(), fake.ServiceClient(), opts).Extract()
+	th.AssertNoErr(t, err)
+}
+
+func TestRequiredCreateOpts(t *testing.T) {
+	res := addressgroups.Create(context.TODO(), fake.ServiceClient(), addressgroups.CreateOpts{Addresses: []string{"132.168.4.12/24"}})
+	if res.Err == nil {
+		t.Fatalf("Expected error, got none")
+	}
+}
+
+func TestGet(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/address-groups/8722e0e0-9cc9-4490-9660-8c9a5732fbb0", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, AddressGroupGetResponse)
+	})
+
+	sr, err := addressgroups.Get(context.TODO(), fake.ServiceClient(), "8722e0e0-9cc9-4490-9660-8c9a5732fbb0").Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, "", sr.Description)
+	th.AssertEquals(t, "8722e0e0-9cc9-4490-9660-8c9a5732fbb0", sr.ID)
+	th.AssertEquals(t, "45977fa2dbd7482098dd68d0d8970117", sr.ProjectID)
+	th.CheckDeepEquals(t, []string{"132.168.4.12/24"}, sr.Addresses)
+	th.AssertEquals(t, "ADDR_GP_1", sr.Name)
+}
+
+func TestUpdateAddressGroup(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/address-groups/8722e0e0-9cc9-4490-9660-8c9a5732fbb0",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "PUT")
+			th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+			th.TestHeader(t, r, "Content-Type", "application/json")
+			th.TestHeader(t, r, "Accept", "application/json")
+			th.TestJSONRequest(t, r, AddressGroupUpdateRequest)
+
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+
+			fmt.Fprintf(w, AddressGroupUpdateResponse)
+		})
+
+	opts := addressgroups.CreateOpts{Addresses: []string{"192.168.4.1/32"}, Description: "new description", Name: "ADDR_GP_2"}
+	ag, err := addressgroups.UpdateAddressGroup(context.TODO(), fake.ServiceClient(), "8722e0e0-9cc9-4490-9660-8c9a5732fbb0", opts).Extract()
+	th.AssertNoErr(t, err)
+
+	th.CheckDeepEquals(t, []string{"192.168.4.1/32"}, ag.Addresses)
+	th.AssertEquals(t, "new description", ag.Description)
+	th.AssertEquals(t, "8722e0e0-9cc9-4490-9660-8c9a5732fbb0", ag.ID)
+	th.AssertEquals(t, "45977fa2dbd7482098dd68d0d8970117", ag.ProjectID)
+	th.AssertEquals(t, "ADDR_GP_2", ag.Name)
+}
+
+func TestAddAddresses(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/address-groups/8722e0e0-9cc9-4490-9660-8c9a5732fbb0/add_addresses",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "PUT")
+			th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+			th.TestHeader(t, r, "Content-Type", "application/json")
+			th.TestHeader(t, r, "Accept", "application/json")
+			th.TestJSONRequest(t, r, AddressGroupAddAddressesRequest)
+
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+
+			fmt.Fprintf(w, AddressGroupAddAddressesResponse)
+		})
+
+	opts := addressgroups.CreateOpts{Addresses: []string{"192.168.4.1/32"}}
+	ag, err := addressgroups.AddAddresses(context.TODO(), fake.ServiceClient(), "8722e0e0-9cc9-4490-9660-8c9a5732fbb0", opts).Extract()
+	th.AssertNoErr(t, err)
+
+	th.CheckDeepEquals(t, []string{"132.168.4.12/24", "192.168.4.1/32"}, ag.Addresses)
+	th.AssertEquals(t, "original description", ag.Description)
+	th.AssertEquals(t, "8722e0e0-9cc9-4490-9660-8c9a5732fbb0", ag.ID)
+}
+
+func TestRemoveAddresses(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/address-groups/8722e0e0-9cc9-4490-9660-8c9a5732fbb0/remove_addresses",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "PUT")
+			th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+			th.TestHeader(t, r, "Content-Type", "application/json")
+			th.TestHeader(t, r, "Accept", "application/json")
+			th.TestJSONRequest(t, r, AddressGroupRemoveAddressesRequest)
+
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+
+			fmt.Fprintf(w, AddressGroupRemoveAddressesResponse)
+		})
+
+	opts := addressgroups.CreateOpts{Addresses: []string{"192.168.4.1/32"}}
+	ag, err := addressgroups.RemoveAddresses(context.TODO(), fake.ServiceClient(), "8722e0e0-9cc9-4490-9660-8c9a5732fbb0", opts).Extract()
+	th.AssertNoErr(t, err)
+
+	th.CheckDeepEquals(t, []string{"132.168.4.12/24"}, ag.Addresses)
+	th.AssertEquals(t, "original description", ag.Description)
+	th.AssertEquals(t, "8722e0e0-9cc9-4490-9660-8c9a5732fbb0", ag.ID)
+}
+
+func TestDelete(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v2.0/address-groups/4ec89087-d057-4e2c-911f-60a3b47ee304", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	res := addressgroups.Delete(context.TODO(), fake.ServiceClient(), "4ec89087-d057-4e2c-911f-60a3b47ee304")
+	th.AssertNoErr(t, res.Err)
+}

--- a/openstack/networking/v2/extensions/addressgroups/urls.go
+++ b/openstack/networking/v2/extensions/addressgroups/urls.go
@@ -1,0 +1,13 @@
+package addressgroups
+
+import "github.com/gophercloud/gophercloud/v2"
+
+const rootPath = "address-groups"
+
+func rootURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL(rootPath)
+}
+
+func resourceURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL(rootPath, id)
+}

--- a/openstack/networking/v2/extensions/security/rules/requests.go
+++ b/openstack/networking/v2/extensions/security/rules/requests.go
@@ -13,22 +13,23 @@ import (
 // you to sort by a particular network attribute. SortDir sets the direction,
 // and is either `asc' or `desc'. Marker and Limit are used for pagination.
 type ListOpts struct {
-	Direction      string `q:"direction"`
-	EtherType      string `q:"ethertype"`
-	ID             string `q:"id"`
-	Description    string `q:"description"`
-	PortRangeMax   int    `q:"port_range_max"`
-	PortRangeMin   int    `q:"port_range_min"`
-	Protocol       string `q:"protocol"`
-	RemoteGroupID  string `q:"remote_group_id"`
-	RemoteIPPrefix string `q:"remote_ip_prefix"`
-	SecGroupID     string `q:"security_group_id"`
-	TenantID       string `q:"tenant_id"`
-	ProjectID      string `q:"project_id"`
-	Limit          int    `q:"limit"`
-	Marker         string `q:"marker"`
-	SortKey        string `q:"sort_key"`
-	SortDir        string `q:"sort_dir"`
+	Direction          string `q:"direction"`
+	EtherType          string `q:"ethertype"`
+	ID                 string `q:"id"`
+	Description        string `q:"description"`
+	PortRangeMax       int    `q:"port_range_max"`
+	PortRangeMin       int    `q:"port_range_min"`
+	Protocol           string `q:"protocol"`
+	RemoteAddressGroup string `q:"remote_address_group_id"`
+	RemoteGroupID      string `q:"remote_group_id"`
+	RemoteIPPrefix     string `q:"remote_ip_prefix"`
+	SecGroupID         string `q:"security_group_id"`
+	TenantID           string `q:"tenant_id"`
+	ProjectID          string `q:"project_id"`
+	Limit              int    `q:"limit"`
+	Marker             string `q:"marker"`
+	SortKey            string `q:"sort_key"`
+	SortDir            string `q:"sort_dir"`
 }
 
 // List returns a Pager which allows you to iterate over a collection of
@@ -118,12 +119,16 @@ type CreateOpts struct {
 	// "tcp", "udp", "icmp" or an empty string.
 	Protocol RuleProtocol `json:"protocol,omitempty"`
 
+	// The remote address group ID to be associated with this security group rule.
+	// You can specify either RemoteAddressGroupID, RemoteGroupID, or RemoteIPPrefix
+	RemoteAddressGroupID string `json:"remote_address_group_id,omitempty"`
+
 	// The remote group ID to be associated with this security group rule. You can
-	// specify either RemoteGroupID or RemoteIPPrefix.
+	// specify either RemoteAddressGroupID,RemoteGroupID or RemoteIPPrefix.
 	RemoteGroupID string `json:"remote_group_id,omitempty"`
 
 	// The remote IP prefix to be associated with this security group rule. You can
-	// specify either RemoteGroupID or RemoteIPPrefix. This attribute matches the
+	// specify either RemoteAddressGroupID,RemoteGroupID or RemoteIPPrefix. This attribute matches the
 	// specified IP prefix as the source IP address of the IP packet.
 	RemoteIPPrefix string `json:"remote_ip_prefix,omitempty"`
 

--- a/openstack/networking/v2/extensions/security/rules/results.go
+++ b/openstack/networking/v2/extensions/security/rules/results.go
@@ -42,6 +42,10 @@ type SecGroupRule struct {
 	// "tcp", "udp", "icmp" or an empty string.
 	Protocol string
 
+	// The remote address group ID to be associated with this security group rule.
+	// You can specify either RemoteAddressGroupID, RemoteGroupID, or RemoteIPPrefix
+	RemoteAddressGroupID string `json:"remote_address_group_id,omitempty"`
+
 	// The remote group ID to be associated with this security group rule. You
 	// can specify either RemoteGroupID or RemoteIPPrefix.
 	RemoteGroupID string `json:"remote_group_id"`


### PR DESCRIPTION
Added address groups to Networking extensions, with tests.
Field added to SecGroupRules - Allows security group rule to reference the remote address group as the rule target

Fixes #3200 

API:
https://docs.openstack.org/api-ref/network/v2/index.html#address-groups

List:
https://github.com/Jscott377/gophercloud/blob/add_address_groups_to_networking/openstack/networking/v2/extensions/addressgroups/requests.go#L42

Get:
https://github.com/Jscott377/gophercloud/blob/add_address_groups_to_networking/openstack/networking/v2/extensions/addressgroups/requests.go#L108

Create:
https://github.com/Jscott377/gophercloud/blob/add_address_groups_to_networking/openstack/networking/v2/extensions/addressgroups/requests.go#L96

Update:
https://github.com/Jscott377/gophercloud/blob/add_address_groups_to_networking/openstack/networking/v2/extensions/addressgroups/requests.go#L123

Delete:
https://github.com/Jscott377/gophercloud/blob/add_address_groups_to_networking/openstack/networking/v2/extensions/addressgroups/requests.go#L116

Add Addresses:
https://github.com/Jscott377/gophercloud/blob/add_address_groups_to_networking/openstack/networking/v2/extensions/addressgroups/requests.go#L137

RemoveAddresses:
https://github.com/Jscott377/gophercloud/blob/add_address_groups_to_networking/openstack/networking/v2/extensions/addressgroups/requests.go#L151
