### PR TITLE
Fix clear-needinfo

### DIFF
--- a/.github/workflows/label-issue.yaml
+++ b/.github/workflows/label-issue.yaml
@@ -9,9 +9,11 @@ jobs:
     name: Clear needinfo
     if: ${{ github.event.issue.user.login }} == ${{ github.event.comment.user.login }}
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
-    - run: gh pr edit "$NUMBER" --remove-label "needinfo"
+    - run: gh issue edit "$NUMBER" --remove-label "needinfo"
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GH_REPO: ${{ github.repository }}
-        NUMBER: ${{ github.event.pull_request.number }}
+        NUMBER: ${{ github.event.issue.number }}


### PR DESCRIPTION
The gh tool must be set to operate on an issue rather than on a PR.

cf https://docs.github.com/en/actions/use-cases-and-examples/project-management/adding-labels-to-issues

(thanks @stephenfin)