### PR TITLE
[nova] fix pagination of hypervisors.List()

### DIFF
--- a/openstack/compute/v2/hypervisors/requests.go
+++ b/openstack/compute/v2/hypervisors/requests.go
@@ -53,7 +53,7 @@ func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pa
 	}
 
 	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
-		return HypervisorPage{pagination.SinglePageBase(r)}
+		return HypervisorPage{pagination.LinkedPageBase{PageResult: r}}
 	})
 }
 

--- a/openstack/compute/v2/hypervisors/results.go
+++ b/openstack/compute/v2/hypervisors/results.go
@@ -240,7 +240,7 @@ func (r *Hypervisor) UnmarshalJSON(b []byte) error {
 // HypervisorPage represents a single page of all Hypervisors from a List
 // request.
 type HypervisorPage struct {
-	pagination.SinglePageBase
+	pagination.LinkedPageBase
 }
 
 // IsEmpty determines whether or not a HypervisorPage is empty.
@@ -251,6 +251,19 @@ func (page HypervisorPage) IsEmpty() (bool, error) {
 
 	va, err := ExtractHypervisors(page)
 	return len(va) == 0, err
+}
+
+// NextPageURL uses the response's embedded link reference to navigate to the
+// next page of results.
+func (page HypervisorPage) NextPageURL() (string, error) {
+	var s struct {
+		Links []gophercloud.Link `json:"hypervisors_links"`
+	}
+	err := page.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return gophercloud.ExtractNextURL(s.Links)
 }
 
 // ExtractHypervisors interprets a page of results as a slice of Hypervisors.

--- a/openstack/compute/v2/hypervisors/testing/fixtures_test.go
+++ b/openstack/compute/v2/hypervisors/testing/fixtures_test.go
@@ -85,8 +85,8 @@ const HypervisorListBodyPre253 = `
     ]
 }`
 
-// HypervisorListBody represents a raw hypervisor list result with Pike+ release.
-const HypervisorListBody = `
+// HypervisorListBodyPage1 represents page 1 of a raw hypervisor list result with Pike+ release.
+const HypervisorListBodyPage1 = `
 {
     "hypervisors": [
         {
@@ -127,7 +127,20 @@ const HypervisorListBody = `
             },
             "vcpus": 1,
             "vcpus_used": 0
-        },
+        }
+    ],
+    "hypervisors_links": [
+        {
+            "href": "%s/os-hypervisors/detail?marker=c48f6247-abe4-4a24-824e-ea39e108874f",
+            "rel": "next"
+        }
+    ]
+}`
+
+// HypervisorListBodyPage2 represents page 2 of a raw hypervisor list result with Pike+ release.
+const HypervisorListBodyPage2 = `
+{
+    "hypervisors": [
         {
             "cpu_info": "{\"arch\": \"x86_64\", \"model\": \"Nehalem\", \"vendor\": \"Intel\", \"features\": [\"pge\", \"clflush\"], \"topology\": {\"cores\": 1, \"threads\": 1, \"sockets\": 4}}",
             "current_workload": 0,
@@ -156,6 +169,9 @@ const HypervisorListBody = `
         }
     ]
 }`
+
+// HypervisorListBodyEmpty represents an empty raw hypervisor list result, marking the end of pagination.
+const HypervisorListBodyEmpty = `{ "hypervisors": [] }`
 
 // HypervisorListWithParametersBody represents a raw hypervisor list result with Pike+ release.
 const HypervisorListWithParametersBody = `
@@ -624,8 +640,16 @@ func HandleHypervisorListSuccessfully(t *testing.T) {
 		testhelper.TestMethod(t, r, "GET")
 		testhelper.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
-		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, HypervisorListBody)
+		switch r.URL.Query().Get("marker") {
+		case "":
+			w.Header().Add("Content-Type", "application/json")
+			fmt.Fprintf(w, HypervisorListBodyPage1, testhelper.Server.URL)
+		case "c48f6247-abe4-4a24-824e-ea39e108874f":
+			w.Header().Add("Content-Type", "application/json")
+			fmt.Fprintf(w, HypervisorListBodyPage2)
+		default:
+			http.Error(w, "unexpected marker value", http.StatusInternalServerError)
+		}
 	})
 }
 

--- a/openstack/compute/v2/hypervisors/testing/requests_test.go
+++ b/openstack/compute/v2/hypervisors/testing/requests_test.go
@@ -69,19 +69,18 @@ func TestListHypervisors(t *testing.T) {
 			return false, err
 		}
 
-		if len(actual) != 2 {
-			t.Fatalf("Expected 2 hypervisors, got %d", len(actual))
+		if len(actual) != 1 {
+			t.Fatalf("Expected 1 hypervisors on page %d, got %d", pages, len(actual))
 		}
 		testhelper.CheckDeepEquals(t, HypervisorFake, actual[0])
-		testhelper.CheckDeepEquals(t, HypervisorFake, actual[1])
 
 		return true, nil
 	})
 
 	testhelper.AssertNoErr(t, err)
 
-	if pages != 1 {
-		t.Errorf("Expected 1 page, saw %d", pages)
+	if pages != 2 {
+		t.Errorf("Expected 2 pages, saw %d", pages)
 	}
 }
 


### PR DESCRIPTION
This is a mildly backwards-incompatible change, but since most people only use this API on the level of pagination.Pager, it ought not be a big deal in practice.

Closes #3222.