### PR TITLE
Added required fields for Node API Parity

### DIFF
--- a/openstack/baremetal/v1/nodes/results.go
+++ b/openstack/baremetal/v1/nodes/results.go
@@ -90,12 +90,19 @@ func (r SubscriptionVendorPassthruResult) Extract() (*SubscriptionVendorPassthru
 	return &s, err
 }
 
-// Node represents a node in the OpenStack Bare Metal API.
-type Node struct {
-	// Whether automated cleaning is enabled or disabled on this node.
-	// Requires microversion 1.47 or later.
-	AutomatedClean *bool `json:"automated_clean"`
+// Link represents a hyperlink and its relationship to the current resource.
+type Link struct {
+	// Href is the URL of the related resource.
+	Href string `json:"href"`
 
+	// Rel describes the relationship of the resource to the current
+	// context (e.g., "self", "bookmark").
+	Rel string `json:"rel"`
+}
+
+// Node represents a node in the OpenStack Bare Metal API.
+// https://docs.openstack.org/api-ref/baremetal/#list-nodes-detailed
+type Node struct {
 	// UUID for the resource.
 	UUID string `json:"uuid"`
 
@@ -183,8 +190,17 @@ type Node struct {
 	// Current deploy step.
 	DeployStep map[string]any `json:"deploy_step"`
 
-	// Current service step.
-	ServiceStep map[string]any `json:"service_step"`
+	// A list of relative links. Includes the self and bookmark links.
+	Links []Link `json:"links"`
+
+	// Links to the collection of ports on this node
+	Ports []Link `json:"ports"`
+
+	// Links to the collection of portgroups on this node.
+	PortGroups []Link `json:"portgroups"`
+
+	// Links to the collection of states. Note that this resource is also used to request state transitions.
+	States []Link `json:"states"`
 
 	// String which can be used by external schedulers to identify this Node as a unit of a specific type of resource.
 	// For more details, see: https://docs.openstack.org/ironic/latest/install/configure-nova-flavors.html
@@ -201,9 +217,6 @@ type Node struct {
 
 	// Deploy interface for a node, e.g. “iscsi”.
 	DeployInterface string `json:"deploy_interface"`
-
-	// Firmware interface for a node, e.g. “redfish”.
-	FirmwareInterface string `json:"firmware_interface"`
 
 	// Interface used for node inspection, e.g. “no-inspect”.
 	InspectInterface string `json:"inspect_interface"`
@@ -232,8 +245,14 @@ type Node struct {
 	// For vendor-specific functionality on this node, e.g. “no-vendor”.
 	VendorInterface string `json:"vendor_interface"`
 
+	// Links to the volume resources.
+	Volume []Link `json:"volume"`
+
 	// Conductor group for a node. Case-insensitive string up to 255 characters, containing a-z, 0-9, _, -, and ..
 	ConductorGroup string `json:"conductor_group"`
+
+	// An optional UUID which can be used to denote the “parent” baremetal node.
+	ParentNode string `json:"parent_node"`
 
 	// The node is protected from undeploying, rebuilding and deletion.
 	Protected bool `json:"protected"`
@@ -244,14 +263,42 @@ type Node struct {
 	// A string or UUID of the tenant who owns the baremetal node.
 	Owner string `json:"owner"`
 
+	// A string or UUID of the tenant who is leasing the object.
+	Lessee string `json:"lessee"`
+
+	// A string indicating the shard this node belongs to.
+	Shard string `json:"shard"`
+
+	// Informational text about this node.
+	Description string `json:"description"`
+
+	// The conductor currently servicing a node. This field is read-only.
+	Conductor string `json:"conductor"`
+
+	// The UUID of the allocation associated with the node. If not null, will be the same as instance_uuid
+	// (the opposite is not always true). Unlike instance_uuid, this field is read-only. Please use the
+	// Allocation API to remove allocations.
+	AllocationUUID string `json:"allocation_uuid"`
+
+	// Whether the node is retired. A Node tagged as retired will prevent any further
+	// scheduling of instances, but will still allow for other operations, such as cleaning, to happen
+	Retired bool `json:"retired"`
+
+	// Reason the node is marked as retired.
+	RetiredReason string `json:"retired_reason"`
+
 	// Static network configuration to use during deployment and cleaning.
 	NetworkData map[string]any `json:"network_data"`
 
-	// The UTC date and time when the resource was created, ISO 8601 format.
-	CreatedAt time.Time `json:"created_at"`
+	// Whether automated cleaning is enabled or disabled on this node.
+	// Requires microversion 1.47 or later.
+	AutomatedClean *bool `json:"automated_clean"`
 
-	// The UTC date and time when the resource was updated, ISO 8601 format. May be “null”.
-	UpdatedAt time.Time `json:"updated_at"`
+	// Current service step.
+	ServiceStep map[string]any `json:"service_step"`
+
+	// Firmware interface for a node, e.g. “redfish”.
+	FirmwareInterface string `json:"firmware_interface"`
 
 	// The UTC date and time when the provision state was updated, ISO 8601 format. May be “null”.
 	ProvisionUpdatedAt time.Time `json:"provision_updated_at"`
@@ -262,12 +309,11 @@ type Node struct {
 	// The UTC date and time when the last inspection was finished, ISO 8601 format. May be “null” if inspection hasn't been finished yet.
 	InspectionFinishedAt *time.Time `json:"inspection_finished_at"`
 
-	// Whether the node is retired. A Node tagged as retired will prevent any further
-	// scheduling of instances, but will still allow for other operations, such as cleaning, to happen
-	Retired bool `json:"retired"`
+	// The UTC date and time when the resource was created, ISO 8601 format.
+	CreatedAt time.Time `json:"created_at"`
 
-	// Reason the node is marked as retired.
-	RetiredReason string `json:"retired_reason"`
+	// The UTC date and time when the resource was updated, ISO 8601 format. May be “null”.
+	UpdatedAt time.Time `json:"updated_at"`
 }
 
 // NodePage abstracts the raw results of making a List() request against

--- a/openstack/baremetal/v1/nodes/testing/fixtures_test.go
+++ b/openstack/baremetal/v1/nodes/testing/fixtures_test.go
@@ -925,23 +925,57 @@ var (
 			"deploy_ramdisk": "http://172.22.0.1/images/tinyipa-stable-rocky.gz",
 			"ipmi_password":  "admin",
 		},
-		DriverInternalInfo:  map[string]any{},
-		Properties:          map[string]any{},
-		InstanceInfo:        map[string]any{},
-		InstanceUUID:        "",
-		ChassisUUID:         "",
-		Extra:               map[string]any{},
-		ConsoleEnabled:      false,
-		RAIDConfig:          map[string]any{},
-		TargetRAIDConfig:    map[string]any{},
-		CleanStep:           map[string]any{},
-		DeployStep:          map[string]any{},
+		DriverInternalInfo: map[string]any{},
+		Properties:         map[string]any{},
+		InstanceInfo:       map[string]any{},
+		InstanceUUID:       "",
+		ChassisUUID:        "",
+		Extra:              map[string]any{},
+		ConsoleEnabled:     false,
+		RAIDConfig:         map[string]any{},
+		TargetRAIDConfig:   map[string]any{},
+		CleanStep:          map[string]any{},
+		DeployStep:         map[string]any{},
+		Links: []nodes.Link{
+			{
+				Href: "http://ironic.example.com:6385/v1/nodes/d2630783-6ec8-4836-b556-ab427c4b581e",
+				Rel:  "self",
+			},
+			{
+				Href: "http://ironic.example.com:6385/nodes/d2630783-6ec8-4836-b556-ab427c4b581e",
+				Rel:  "bookmark",
+			},
+		},
+		Ports: []nodes.Link{
+			{
+				Href: "http://ironic.example.com:6385/v1/nodes/d2630783-6ec8-4836-b556-ab427c4b581e/ports",
+				Rel:  "self",
+			},
+			{
+				Href: "http://ironic.example.com:6385/nodes/d2630783-6ec8-4836-b556-ab427c4b581e/ports",
+				Rel:  "bookmark",
+			},
+		},
+		PortGroups: []nodes.Link{
+			{
+				Href: "http://ironic.example.com:6385/v1/nodes/d2630783-6ec8-4836-b556-ab427c4b581e/portgroups",
+				Rel:  "self",
+			},
+			{
+				Href: "http://ironic.example.com:6385/nodes/d2630783-6ec8-4836-b556-ab427c4b581e/portgroups",
+				Rel:  "bookmark"},
+		},
+		States: []nodes.Link{
+			{
+				Href: "http://ironic.example.com:6385/v1/nodes/d2630783-6ec8-4836-b556-ab427c4b581e/states",
+				Rel:  "self",
+			},
+		},
 		ResourceClass:       "",
 		BIOSInterface:       "no-bios",
 		BootInterface:       "pxe",
 		ConsoleInterface:    "no-console",
 		DeployInterface:     "iscsi",
-		FirmwareInterface:   "no-firmware",
 		InspectInterface:    "no-inspect",
 		ManagementInterface: "ipmitool",
 		NetworkInterface:    "flat",
@@ -951,14 +985,33 @@ var (
 		StorageInterface:    "noop",
 		Traits:              []string{},
 		VendorInterface:     "ipmitool",
-		ConductorGroup:      "",
-		Protected:           false,
-		ProtectedReason:     "",
-		CreatedAt:           createdAtFoo,
-		UpdatedAt:           updatedAt,
-		ProvisionUpdatedAt:  provisonUpdatedAt,
-		Retired:             false,
-		RetiredReason:       "No longer needed",
+		Volume: []nodes.Link{
+			{
+				Href: "http://ironic.example.com:6385/v1/nodes/d2630783-6ec8-4836-b556-ab427c4b581e/volume",
+				Rel:  "self",
+			},
+		},
+		ConductorGroup:       "",
+		ParentNode:           "",
+		Protected:            false,
+		ProtectedReason:      "",
+		Owner:                "",
+		Lessee:               "",
+		Shard:                "",
+		Description:          "",
+		Conductor:            "",
+		AllocationUUID:       "",
+		Retired:              false,
+		RetiredReason:        "No longer needed",
+		NetworkData:          map[string]interface{}(nil),
+		AutomatedClean:       nil,
+		ServiceStep:          map[string]interface{}(nil),
+		FirmwareInterface:    "no-firmware",
+		ProvisionUpdatedAt:   provisonUpdatedAt,
+		InspectionStartedAt:  nil,
+		InspectionFinishedAt: nil,
+		CreatedAt:            createdAtFoo,
+		UpdatedAt:            updatedAt,
 	}
 
 	NodeFooValidation = nodes.NodeValidation{
@@ -1070,6 +1123,26 @@ var (
 		InspectionFinishedAt: &InspectionFinishedAt,
 		Retired:              false,
 		RetiredReason:        "No longer needed",
+		Links: []nodes.Link{
+			{Href: "http://ironic.example.com:6385/v1/nodes/08c84581-58f5-4ea2-a0c6-dd2e5d2b3662", Rel: "self"},
+			{Href: "http://ironic.example.com:6385/nodes/08c84581-58f5-4ea2-a0c6-dd2e5d2b3662", Rel: "bookmark"},
+		},
+		Ports: []nodes.Link{
+			{Href: "http://ironic.example.com:6385/v1/nodes/08c84581-58f5-4ea2-a0c6-dd2e5d2b3662/ports", Rel: "self"},
+			{Href: "http://ironic.example.com:6385/nodes/08c84581-58f5-4ea2-a0c6-dd2e5d2b3662/ports", Rel: "bookmark"},
+		},
+		PortGroups: []nodes.Link{
+			{Href: "http://ironic.example.com:6385/v1/nodes/08c84581-58f5-4ea2-a0c6-dd2e5d2b3662/portgroups", Rel: "self"},
+			{Href: "http://ironic.example.com:6385/nodes/08c84581-58f5-4ea2-a0c6-dd2e5d2b3662/portgroups", Rel: "bookmark"},
+		},
+		States: []nodes.Link{
+			{Href: "http://ironic.example.com:6385/v1/nodes/08c84581-58f5-4ea2-a0c6-dd2e5d2b3662/states", Rel: "self"},
+			{Href: "http://ironic.example.com:6385/nodes/08c84581-58f5-4ea2-a0c6-dd2e5d2b3662/states", Rel: "bookmark"},
+		},
+		Volume: []nodes.Link{
+			{Href: "http://ironic.example.com:6385/v1/nodes/08c84581-58f5-4ea2-a0c6-dd2e5d2b3662/volume", Rel: "self"},
+			{Href: "http://ironic.example.com:6385/nodes/08c84581-58f5-4ea2-a0c6-dd2e5d2b3662/volume", Rel: "bookmark"},
+		},
 	}
 
 	NodeBaz = nodes.Node{
@@ -1119,6 +1192,26 @@ var (
 		UpdatedAt:            updatedAt,
 		Retired:              false,
 		RetiredReason:        "No longer needed",
+		Links: []nodes.Link{
+			{Href: "http://ironic.example.com:6385/v1/nodes/c9afd385-5d89-4ecb-9e1c-68194da6b474", Rel: "self"},
+			{Href: "http://ironic.example.com:6385/nodes/c9afd385-5d89-4ecb-9e1c-68194da6b474", Rel: "bookmark"},
+		},
+		Ports: []nodes.Link{
+			{Href: "http://ironic.example.com:6385/v1/nodes/c9afd385-5d89-4ecb-9e1c-68194da6b474/ports", Rel: "self"},
+			{Href: "http://ironic.example.com:6385/nodes/c9afd385-5d89-4ecb-9e1c-68194da6b474/ports", Rel: "bookmark"},
+		},
+		PortGroups: []nodes.Link{
+			{Href: "http://ironic.example.com:6385/v1/nodes/c9afd385-5d89-4ecb-9e1c-68194da6b474/portgroups", Rel: "self"},
+			{Href: "http://ironic.example.com:6385/nodes/c9afd385-5d89-4ecb-9e1c-68194da6b474/portgroups", Rel: "bookmark"},
+		},
+		States: []nodes.Link{
+			{Href: "http://ironic.example.com:6385/v1/nodes/c9afd385-5d89-4ecb-9e1c-68194da6b474/states", Rel: "self"},
+			{Href: "http://ironic.example.com:6385/nodes/c9afd385-5d89-4ecb-9e1c-68194da6b474/states", Rel: "bookmark"},
+		},
+		Volume: []nodes.Link{
+			{Href: "http://ironic.example.com:6385/v1/nodes/c9afd385-5d89-4ecb-9e1c-68194da6b474/volume", Rel: "self"},
+			{Href: "http://ironic.example.com:6385/nodes/c9afd385-5d89-4ecb-9e1c-68194da6b474/volume", Rel: "bookmark"},
+		},
 	}
 
 	ConfigDriveMap = nodes.ConfigDrive{


### PR DESCRIPTION
Fixes https://github.com/gophercloud/gophercloud/issues/3172

I have 1-1 mapped with: https://docs.openstack.org/api-ref/baremetal/#list-nodes-detailed

=========================

Since all the fields I have added were already present in the test fixtures, this was an easy change!

