### PR TITLE
Adding CI job for testing workflow (Mistral)

### DIFF
--- a/.github/workflows/functional-workflow.yaml
+++ b/.github/workflows/functional-workflow.yaml
@@ -1,0 +1,67 @@
+name: functional-workflow
+on:
+  pull_request:
+    paths:
+      - '**workflow**'
+  schedule:
+    - cron: '0 0 */3 * *'
+jobs:
+  functional-workflow:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: "master"
+            openstack_version: "master"
+            ubuntu_version: "22.04"
+            mistral_plugin_version: "master"
+            additional_services: "openstack-cli-server"
+          - name: "dalmatian"
+            openstack_version: "stable/2024.2"
+            ubuntu_version: "22.04"
+            mistral_plugin_version: "stable/2024.2"
+            additional_services: "openstack-cli-server"
+          - name: "caracal"
+            openstack_version: "stable/2024.1"
+            ubuntu_version: "22.04"
+            mistral_plugin_version: "stable/2024.1"
+            additional_services: ""
+          - name: "bobcat"
+            openstack_version: "stable/2023.2"
+            ubuntu_version: "22.04"
+            # Devstack support is broken with Mistral v2023.2, and requires 2 patches:
+            # * https://github.com/openstack/mistral/commit/e343ccb078d8ba261ac70afca93f4358589730d3
+            # * https://github.com/openstack/mistral/commit/ecdeadeb7a1aa87cba2cdb0c1a2bb1ffc4aabf25
+            mistral_plugin_version: "ecdeadeb7a1aa87cba2cdb0c1a2bb1ffc4aabf25"
+            additional_services: ""
+    runs-on: ubuntu-${{ matrix.ubuntu_version }}
+    name: Deploy OpenStack ${{ matrix.name }} with Mistral and run workflow acceptance tests
+    steps:
+      - name: Checkout Gophercloud
+        uses: actions/checkout@v4
+      - name: Deploy devstack
+        uses: EmilienM/devstack-action@e82a9cbead099cba72f99537e82a360c3e319c69
+        with:
+          branch: ${{ matrix.openstack_version }}
+          conf_overrides: |
+            enable_plugin mistral https://github.com/openstack/mistral ${{ matrix.mistral_plugin_version }}
+          enabled_services: "mistral,mistral-api,mistral-engine,mistral-executor,mistral-event-engine,${{ matrix.additional_services }}"
+      - name: Checkout go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '^1.22'
+      - name: Run Gophercloud acceptance tests
+        run: ./script/acceptancetest
+        env:
+          DEVSTACK_PATH: ${{ github.workspace }}/devstack
+          PACKAGE: "./internal/acceptance/openstack/workflow/..."
+          OS_BRANCH: ${{ matrix.openstack_version }}
+      - name: Generate logs on failure
+        run: ./script/collectlogs
+        if: failure()
+      - name: Upload logs artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: functional-workflow-${{ matrix.name }}-${{ github.run_id }}
+          path: /tmp/devstack-logs/*


### PR DESCRIPTION
<!--
Prior to starting a PR, please make sure you have read our
[contributor tutorial](https://github.com/gophercloud/gophercloud/tree/master/docs/contributor-tutorial).

Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

-->
Fixes #3234

Acceptance tests for Workflow/Mistral are missing on CI.

The goal of this PR is to add them to the Gophercloud CI so that they are executed regularly on the Workflow client code.
