### PR TITLE
Address govet 1.24 issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 undefine GOFLAGS
 
-GOLANGCI_LINT_VERSION?=v1.57.1
-GO_TEST?=go run gotest.tools/gotestsum@latest --format testname
+GOLANGCI_LINT_VERSION?=v1.62.2
+GO_TEST?=go run gotest.tools/gotestsum@latest --format testname --
 
 ifeq ($(shell command -v podman 2> /dev/null),)
 	RUNNER=docker
@@ -23,7 +23,7 @@ lint:
 		-v ~/.cache/golangci-lint/$(GOLANGCI_LINT_VERSION):/root/.cache \
 		-w /app \
 		-e GOFLAGS="-tags=acceptance" \
-		golangci/golangci-lint:$(GOLANGCI_LINT_VERSION) golangci-lint run
+		golangci/golangci-lint:$(GOLANGCI_LINT_VERSION) golangci-lint run -v --max-same-issues 50
 .PHONY: lint
 
 format:

--- a/internal/acceptance/clients/clients.go
+++ b/internal/acceptance/clients/clients.go
@@ -107,16 +107,14 @@ func AcceptanceTestChoicesFromEnv() (*AcceptanceTestChoices, error) {
 		notDistinct = "OS_FLAVOR_ID and OS_FLAVOR_ID_RESIZE must be distinct."
 	}
 
-	if len(missing) > 0 || notDistinct != "" {
-		text := "You're missing some important setup:\n"
-		if len(missing) > 0 {
-			text += " * These environment variables must be provided: " + strings.Join(missing, ", ") + "\n"
-		}
-		if notDistinct != "" {
-			text += " * " + notDistinct + "\n"
-		}
+	if len(missing) > 0 {
+		text := "You're missing some important setup:\n * These environment variables must be provided: %s\n"
+		return nil, fmt.Errorf(text, strings.Join(missing, ", "))
+	}
 
-		return nil, fmt.Errorf(text)
+	if notDistinct != "" {
+		text := "You're missing some important setup:\n * %s\n"
+		return nil, fmt.Errorf(text, notDistinct)
 	}
 
 	return &AcceptanceTestChoices{

--- a/internal/acceptance/tools/tools.go
+++ b/internal/acceptance/tools/tools.go
@@ -81,5 +81,5 @@ func Elide(value string) string {
 // PrintResource returns a resource as a readable structure
 func PrintResource(t *testing.T, resource any) {
 	b, _ := json.MarshalIndent(resource, "", "  ")
-	t.Logf(string(b))
+	t.Log(string(b))
 }

--- a/openstack/baremetal/apiversions/testing/fixtures_test.go
+++ b/openstack/baremetal/apiversions/testing/fixtures_test.go
@@ -89,7 +89,7 @@ func MockListResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, IronicAPIAllVersionResponse)
+		fmt.Fprint(w, IronicAPIAllVersionResponse)
 	})
 }
 
@@ -101,6 +101,6 @@ func MockGetResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, IronicAPIVersionResponse)
+		fmt.Fprint(w, IronicAPIVersionResponse)
 	})
 }

--- a/openstack/baremetal/v1/allocations/testing/fixtures_test.go
+++ b/openstack/baremetal/v1/allocations/testing/fixtures_test.go
@@ -120,10 +120,10 @@ func HandleAllocationListSuccessfully(t *testing.T) {
 		marker := r.Form.Get("marker")
 		switch marker {
 		case "":
-			fmt.Fprintf(w, AllocationListBody)
+			fmt.Fprint(w, AllocationListBody)
 
 		case "eff80f47-75f0-4d41-b1aa-cf07c201adac":
-			fmt.Fprintf(w, `{ "allocations": [] }`)
+			fmt.Fprint(w, `{ "allocations": [] }`)
 		default:
 			t.Fatalf("/allocations invoked with unexpected marker=[%s]", marker)
 		}
@@ -145,7 +145,7 @@ func HandleAllocationCreationSuccessfully(t *testing.T, response string) {
 
 		w.WriteHeader(http.StatusAccepted)
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, response)
+		fmt.Fprint(w, response)
 	})
 }
 
@@ -165,6 +165,6 @@ func HandleAllocationGetSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		th.TestHeader(t, r, "Accept", "application/json")
 
-		fmt.Fprintf(w, SingleAllocationBody)
+		fmt.Fprint(w, SingleAllocationBody)
 	})
 }

--- a/openstack/baremetal/v1/conductors/testing/fixtures_test.go
+++ b/openstack/baremetal/v1/conductors/testing/fixtures_test.go
@@ -150,10 +150,10 @@ func HandleConductorListSuccessfully(t *testing.T) {
 		marker := r.Form.Get("marker")
 		switch marker {
 		case "":
-			fmt.Fprintf(w, ConductorListBody)
+			fmt.Fprint(w, ConductorListBody)
 
 		case "9e5476bd-a4ec-4653-93d6-72c93aa682ba":
-			fmt.Fprintf(w, `{ "servers": [] }`)
+			fmt.Fprint(w, `{ "servers": [] }`)
 		default:
 			t.Fatalf("/conductors invoked with unexpected marker=[%s]", marker)
 		}
@@ -170,7 +170,7 @@ func HandleConductorListDetailSuccessfully(t *testing.T) {
 			t.Errorf("Failed to parse request form %v", err)
 		}
 
-		fmt.Fprintf(w, ConductorListDetailBody)
+		fmt.Fprint(w, ConductorListDetailBody)
 	})
 }
 
@@ -180,6 +180,6 @@ func HandleConductorGetSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		th.TestHeader(t, r, "Accept", "application/json")
 
-		fmt.Fprintf(w, SingleConductorBody)
+		fmt.Fprint(w, SingleConductorBody)
 	})
 }

--- a/openstack/baremetal/v1/drivers/testing/fixtures_test.go
+++ b/openstack/baremetal/v1/drivers/testing/fixtures_test.go
@@ -377,7 +377,7 @@ func HandleListDriversSuccessfully(t *testing.T) {
 			t.Errorf("Failed to parse request form %v", err)
 		}
 
-		fmt.Fprintf(w, ListDriversBody)
+		fmt.Fprint(w, ListDriversBody)
 	})
 }
 
@@ -388,7 +388,7 @@ func HandleGetDriverDetailsSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		th.TestHeader(t, r, "Accept", "application/json")
 
-		fmt.Fprintf(w, SingleDriverDetails)
+		fmt.Fprint(w, SingleDriverDetails)
 	})
 }
 
@@ -399,7 +399,7 @@ func HandleGetDriverPropertiesSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		th.TestHeader(t, r, "Accept", "application/json")
 
-		fmt.Fprintf(w, SingleDriverProperties)
+		fmt.Fprint(w, SingleDriverProperties)
 	})
 }
 
@@ -410,6 +410,6 @@ func HandleGetDriverDiskPropertiesSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		th.TestHeader(t, r, "Accept", "application/json")
 
-		fmt.Fprintf(w, SingleDriverDiskProperties)
+		fmt.Fprint(w, SingleDriverDiskProperties)
 	})
 }

--- a/openstack/baremetal/v1/nodes/testing/fixtures_test.go
+++ b/openstack/baremetal/v1/nodes/testing/fixtures_test.go
@@ -1404,10 +1404,10 @@ func HandleNodeListSuccessfully(t *testing.T) {
 		marker := r.Form.Get("marker")
 		switch marker {
 		case "":
-			fmt.Fprintf(w, NodeListBody)
+			fmt.Fprint(w, NodeListBody)
 
 		case "9e5476bd-a4ec-4653-93d6-72c93aa682ba":
-			fmt.Fprintf(w, `{ "servers": [] }`)
+			fmt.Fprint(w, `{ "servers": [] }`)
 		default:
 			t.Fatalf("/nodes invoked with unexpected marker=[%s]", marker)
 		}
@@ -1424,7 +1424,7 @@ func HandleNodeListDetailSuccessfully(t *testing.T) {
 			t.Errorf("Failed to parse request form %v", err)
 		}
 
-		fmt.Fprintf(w, NodeListDetailBody)
+		fmt.Fprint(w, NodeListDetailBody)
 	})
 }
 
@@ -1451,7 +1451,7 @@ func HandleNodeCreationSuccessfully(t *testing.T, response string) {
 
 		w.WriteHeader(http.StatusAccepted)
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, response)
+		fmt.Fprint(w, response)
 	})
 }
 
@@ -1471,7 +1471,7 @@ func HandleNodeGetSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		th.TestHeader(t, r, "Accept", "application/json")
 
-		fmt.Fprintf(w, SingleNodeBody)
+		fmt.Fprint(w, SingleNodeBody)
 	})
 }
 
@@ -1483,7 +1483,7 @@ func HandleNodeUpdateSuccessfully(t *testing.T, response string) {
 		th.TestHeader(t, r, "Content-Type", "application/json")
 		th.TestJSONRequest(t, r, `[{"op": "replace", "path": "/properties", "value": {"root_gb": 25}}]`)
 
-		fmt.Fprintf(w, response)
+		fmt.Fprint(w, response)
 	})
 }
 
@@ -1493,7 +1493,7 @@ func HandleNodeValidateSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		th.TestHeader(t, r, "Accept", "application/json")
 
-		fmt.Fprintf(w, NodeValidationBody)
+		fmt.Fprint(w, NodeValidationBody)
 	})
 }
 
@@ -1525,7 +1525,7 @@ func HandleGetBootDeviceSuccessfully(t *testing.T) {
 		th.TestMethod(t, r, "GET")
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, NodeBootDeviceBody)
+		fmt.Fprint(w, NodeBootDeviceBody)
 	})
 }
 
@@ -1535,7 +1535,7 @@ func HandleGetSupportedBootDeviceSuccessfully(t *testing.T) {
 		th.TestMethod(t, r, "GET")
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, NodeSupportedBootDeviceBody)
+		fmt.Fprint(w, NodeSupportedBootDeviceBody)
 	})
 }
 
@@ -1667,7 +1667,7 @@ func HandleListBIOSSettingsSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		th.TestHeader(t, r, "Accept", "application/json")
 
-		fmt.Fprintf(w, NodeBIOSSettingsBody)
+		fmt.Fprint(w, NodeBIOSSettingsBody)
 	})
 }
 
@@ -1677,7 +1677,7 @@ func HandleListDetailBIOSSettingsSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		th.TestHeader(t, r, "Accept", "application/json")
 
-		fmt.Fprintf(w, NodeDetailBIOSSettingsBody)
+		fmt.Fprint(w, NodeDetailBIOSSettingsBody)
 	})
 }
 
@@ -1687,7 +1687,7 @@ func HandleGetBIOSSettingSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		th.TestHeader(t, r, "Accept", "application/json")
 
-		fmt.Fprintf(w, NodeSingleBIOSSettingBody)
+		fmt.Fprint(w, NodeSingleBIOSSettingBody)
 	})
 }
 
@@ -1697,7 +1697,7 @@ func HandleGetVendorPassthruMethodsSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		th.TestHeader(t, r, "Accept", "application/json")
 
-		fmt.Fprintf(w, NodeVendorPassthruMethodsBody)
+		fmt.Fprint(w, NodeVendorPassthruMethodsBody)
 	})
 }
 
@@ -1708,7 +1708,7 @@ func HandleGetAllSubscriptionsVendorPassthruSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "Accept", "application/json")
 		th.TestFormValues(t, r, map[string]string{"method": "get_all_subscriptions"})
 
-		fmt.Fprintf(w, NodeGetAllSubscriptionsVnedorPassthruBody)
+		fmt.Fprint(w, NodeGetAllSubscriptionsVnedorPassthruBody)
 	})
 }
 
@@ -1724,7 +1724,7 @@ func HandleGetSubscriptionVendorPassthruSuccessfully(t *testing.T) {
 			}
 		`)
 
-		fmt.Fprintf(w, NodeGetSubscriptionVendorPassthruBody)
+		fmt.Fprint(w, NodeGetSubscriptionVendorPassthruBody)
 	})
 }
 
@@ -1744,7 +1744,7 @@ func HandleCreateSubscriptionVendorPassthruAllParametersSuccessfully(t *testing.
 			}
 		`)
 
-		fmt.Fprintf(w, NodeCreateSubscriptionVendorPassthruAllParametersBody)
+		fmt.Fprint(w, NodeCreateSubscriptionVendorPassthruAllParametersBody)
 	})
 }
 
@@ -1760,7 +1760,7 @@ func HandleCreateSubscriptionVendorPassthruRequiredParametersSuccessfully(t *tes
 			}
 		`)
 
-		fmt.Fprintf(w, NodeCreateSubscriptionVendorPassthruRequiredParametersBody)
+		fmt.Fprint(w, NodeCreateSubscriptionVendorPassthruRequiredParametersBody)
 	})
 }
 
@@ -1805,7 +1805,7 @@ func HandleGetInventorySuccessfully(t *testing.T) {
 		th.TestMethod(t, r, "GET")
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, NodeInventoryBody)
+		fmt.Fprint(w, NodeInventoryBody)
 	})
 }
 
@@ -1815,7 +1815,7 @@ func HandleListFirmwareSuccessfully(t *testing.T) {
 		th.TestMethod(t, r, "GET")
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, NodeFirmwareListBody)
+		fmt.Fprint(w, NodeFirmwareListBody)
 	})
 }
 

--- a/openstack/baremetal/v1/ports/testing/fixtures_test.go
+++ b/openstack/baremetal/v1/ports/testing/fixtures_test.go
@@ -181,10 +181,10 @@ func HandlePortListSuccessfully(t *testing.T) {
 		marker := r.Form.Get("marker")
 		switch marker {
 		case "":
-			fmt.Fprintf(w, PortListBody)
+			fmt.Fprint(w, PortListBody)
 
 		case "f2845e11-dbd4-4728-a8c0-30d19f48924a":
-			fmt.Fprintf(w, `{ "ports": [] }`)
+			fmt.Fprint(w, `{ "ports": [] }`)
 		default:
 			t.Fatalf("/ports invoked with unexpected marker=[%s]", marker)
 		}
@@ -201,7 +201,7 @@ func HandlePortListDetailSuccessfully(t *testing.T) {
 			t.Errorf("Failed to parse request form %v", err)
 		}
 
-		fmt.Fprintf(w, PortListDetailBody)
+		fmt.Fprint(w, PortListDetailBody)
 	})
 }
 
@@ -219,7 +219,7 @@ func HandlePortCreationSuccessfully(t *testing.T, response string) {
 
 		w.WriteHeader(http.StatusAccepted)
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, response)
+		fmt.Fprint(w, response)
 	})
 }
 
@@ -239,7 +239,7 @@ func HandlePortGetSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		th.TestHeader(t, r, "Accept", "application/json")
 
-		fmt.Fprintf(w, SinglePortBody)
+		fmt.Fprint(w, SinglePortBody)
 	})
 }
 
@@ -251,6 +251,6 @@ func HandlePortUpdateSuccessfully(t *testing.T, response string) {
 		th.TestHeader(t, r, "Content-Type", "application/json")
 		th.TestJSONRequest(t, r, `[{"op": "replace", "path": "/address", "value": "22:22:22:22:22:22"}]`)
 
-		fmt.Fprintf(w, response)
+		fmt.Fprint(w, response)
 	})
 }

--- a/openstack/baremetalintrospection/v1/introspection/testing/fixtures.go
+++ b/openstack/baremetalintrospection/v1/introspection/testing/fixtures.go
@@ -467,10 +467,10 @@ func HandleListIntrospectionsSuccessfully(t *testing.T) {
 
 		switch marker {
 		case "":
-			fmt.Fprintf(w, IntrospectionListBody)
+			fmt.Fprint(w, IntrospectionListBody)
 
 		case "c244557e-899f-46fa-a1ff-5b2c6718616b":
-			fmt.Fprintf(w, `{ "introspection": [] }`)
+			fmt.Fprint(w, `{ "introspection": [] }`)
 
 		default:
 			t.Fatalf("/introspection invoked with unexpected marker=[%s]", marker)
@@ -484,7 +484,7 @@ func HandleGetIntrospectionStatusSuccessfully(t *testing.T) {
 		th.TestMethod(t, r, "GET")
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		th.TestHeader(t, r, "Accept", "application/json")
-		fmt.Fprintf(w, IntrospectionStatus)
+		fmt.Fprint(w, IntrospectionStatus)
 	})
 }
 
@@ -513,7 +513,7 @@ func HandleGetIntrospectionDataSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		th.TestHeader(t, r, "Accept", "application/json")
 
-		fmt.Fprintf(w, IntrospectionDataJSONSample)
+		fmt.Fprint(w, IntrospectionDataJSONSample)
 	})
 }
 

--- a/openstack/blockstorage/apiversions/testing/fixtures_test.go
+++ b/openstack/blockstorage/apiversions/testing/fixtures_test.go
@@ -124,7 +124,7 @@ func MockListResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, APIListResponse)
+		fmt.Fprint(w, APIListResponse)
 	})
 }
 
@@ -136,6 +136,6 @@ func MockListOldResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, APIListOldResponse)
+		fmt.Fprint(w, APIListOldResponse)
 	})
 }

--- a/openstack/blockstorage/v2/availabilityzones/testing/fixtures_test.go
+++ b/openstack/blockstorage/v2/availabilityzones/testing/fixtures_test.go
@@ -47,6 +47,6 @@ func HandleGetSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, GetOutput)
+		fmt.Fprint(w, GetOutput)
 	})
 }

--- a/openstack/blockstorage/v2/backups/testing/fixtures_test.go
+++ b/openstack/blockstorage/v2/backups/testing/fixtures_test.go
@@ -210,7 +210,7 @@ func MockListResponse(t *testing.T) {
 		case "":
 			fmt.Fprintf(w, ListResponse, th.Server.URL)
 		case "1":
-			fmt.Fprintf(w, `{"backups": []}`)
+			fmt.Fprint(w, `{"backups": []}`)
 		default:
 			t.Fatalf("Unexpected marker: [%s]", marker)
 		}
@@ -233,7 +233,7 @@ func MockListDetailResponse(t *testing.T) {
 		case "":
 			fmt.Fprintf(w, ListDetailResponse, th.Server.URL)
 		case "1":
-			fmt.Fprintf(w, `{"backups": []}`)
+			fmt.Fprint(w, `{"backups": []}`)
 		default:
 			t.Fatalf("Unexpected marker: [%s]", marker)
 		}
@@ -247,7 +247,7 @@ func MockGetResponse(t *testing.T) {
 
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, GetResponse)
+		fmt.Fprint(w, GetResponse)
 	})
 }
 
@@ -262,7 +262,7 @@ func MockCreateResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusAccepted)
 
-		fmt.Fprintf(w, CreateResponse)
+		fmt.Fprint(w, CreateResponse)
 	})
 }
 
@@ -277,7 +277,7 @@ func MockRestoreResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusAccepted)
 
-		fmt.Fprintf(w, RestoreResponse)
+		fmt.Fprint(w, RestoreResponse)
 	})
 }
 
@@ -298,7 +298,7 @@ func MockExportResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, ExportResponse)
+		fmt.Fprint(w, ExportResponse)
 	})
 }
 
@@ -313,7 +313,7 @@ func MockImportResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		fmt.Fprintf(w, ImportResponse)
+		fmt.Fprint(w, ImportResponse)
 	})
 }
 

--- a/openstack/blockstorage/v2/limits/testing/fixtures_test.go
+++ b/openstack/blockstorage/v2/limits/testing/fixtures_test.go
@@ -124,6 +124,6 @@ func HandleGetSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, GetOutput)
+		fmt.Fprint(w, GetOutput)
 	})
 }

--- a/openstack/blockstorage/v2/quotasets/testing/fixtures_test.go
+++ b/openstack/blockstorage/v2/quotasets/testing/fixtures_test.go
@@ -164,7 +164,7 @@ func HandleSuccessfulRequest(t *testing.T, httpMethod, uriPath, jsonOutput strin
 			th.TestFormValues(t, r, uriQueryParams)
 		}
 
-		fmt.Fprintf(w, jsonOutput)
+		fmt.Fprint(w, jsonOutput)
 	})
 }
 

--- a/openstack/blockstorage/v2/schedulerstats/testing/fixtures_test.go
+++ b/openstack/blockstorage/v2/schedulerstats/testing/fixtures_test.go
@@ -104,9 +104,9 @@ func HandleStoragePoolsListSuccessfully(t *testing.T) {
 			t.Errorf("Failed to parse request form %v", err)
 		}
 		if r.FormValue("detail") == "true" {
-			fmt.Fprintf(w, StoragePoolsListBodyDetail)
+			fmt.Fprint(w, StoragePoolsListBodyDetail)
 		} else {
-			fmt.Fprintf(w, StoragePoolsListBody)
+			fmt.Fprint(w, StoragePoolsListBody)
 		}
 	})
 }

--- a/openstack/blockstorage/v2/services/testing/fixtures_test.go
+++ b/openstack/blockstorage/v2/services/testing/fixtures_test.go
@@ -92,6 +92,6 @@ func HandleListSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, ServiceListBody)
+		fmt.Fprint(w, ServiceListBody)
 	})
 }

--- a/openstack/blockstorage/v2/snapshots/testing/fixtures_test.go
+++ b/openstack/blockstorage/v2/snapshots/testing/fixtures_test.go
@@ -17,7 +17,7 @@ func MockListResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
     {
       "snapshots": [
         {
@@ -51,7 +51,7 @@ func MockGetResponse(t *testing.T) {
 
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
     "snapshot": {
         "id": "d32019d3-bc6e-4319-9c1d-6722fc136a22",
@@ -85,7 +85,7 @@ func MockCreateResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusAccepted)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
     "snapshot": {
         "volume_id": "1234",
@@ -115,7 +115,7 @@ func MockUpdateMetadataResponse(t *testing.T) {
     }
     `)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
       {
         "metadata": {
           "key": "v1"

--- a/openstack/blockstorage/v2/transfers/testing/fixtures_test.go
+++ b/openstack/blockstorage/v2/transfers/testing/fixtures_test.go
@@ -167,7 +167,7 @@ func HandleCreateTransfer(t *testing.T) {
 		th.TestJSONRequest(t, r, CreateRequest)
 
 		w.WriteHeader(http.StatusAccepted)
-		fmt.Fprintf(w, CreateResponse)
+		fmt.Fprint(w, CreateResponse)
 	})
 }
 
@@ -179,7 +179,7 @@ func HandleAcceptTransfer(t *testing.T) {
 		th.TestJSONRequest(t, r, AcceptTransferRequest)
 
 		w.WriteHeader(http.StatusAccepted)
-		fmt.Fprintf(w, AcceptTransferResponse)
+		fmt.Fprint(w, AcceptTransferResponse)
 	})
 }
 
@@ -200,7 +200,7 @@ func HandleListTransfers(t *testing.T) {
 		th.TestFormValues(t, r, map[string]string{"all_tenants": "true"})
 
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, ListOutput)
+		fmt.Fprint(w, ListOutput)
 	})
 }
 
@@ -211,6 +211,6 @@ func HandleGetTransfer(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, GetOutput)
+		fmt.Fprint(w, GetOutput)
 	})
 }

--- a/openstack/blockstorage/v2/volumes/testing/fixtures_test.go
+++ b/openstack/blockstorage/v2/volumes/testing/fixtures_test.go
@@ -17,7 +17,7 @@ func MockListResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
   {
   "volumes": [
     {
@@ -93,7 +93,7 @@ func MockGetResponse(t *testing.T) {
 
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
   "volume": {
     "volume_type": "lvmdriver-1",
@@ -152,7 +152,7 @@ func MockCreateResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusAccepted)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
   "volume": {
     "size": 75,
@@ -192,7 +192,7 @@ func MockUpdateResponse(t *testing.T) {
 		th.TestMethod(t, r, "PUT")
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
   "volume": {
     "name": "vol-002"
@@ -223,7 +223,7 @@ func MockAttachResponse(t *testing.T) {
 			w.Header().Add("Content-Type", "application/json")
 			w.WriteHeader(http.StatusAccepted)
 
-			fmt.Fprintf(w, `{}`)
+			fmt.Fprint(w, `{}`)
 		})
 }
 
@@ -243,7 +243,7 @@ func MockBeginDetachingResponse(t *testing.T) {
 			w.Header().Add("Content-Type", "application/json")
 			w.WriteHeader(http.StatusAccepted)
 
-			fmt.Fprintf(w, `{}`)
+			fmt.Fprint(w, `{}`)
 		})
 }
 
@@ -263,7 +263,7 @@ func MockDetachResponse(t *testing.T) {
 			w.Header().Add("Content-Type", "application/json")
 			w.WriteHeader(http.StatusAccepted)
 
-			fmt.Fprintf(w, `{}`)
+			fmt.Fprint(w, `{}`)
 		})
 }
 
@@ -288,7 +288,7 @@ func MockUploadImageResponse(t *testing.T) {
 			w.Header().Add("Content-Type", "application/json")
 			w.WriteHeader(http.StatusAccepted)
 
-			fmt.Fprintf(w, `
+			fmt.Fprint(w, `
 {
     "os-volume_upload_image": {
         "container_format": "bare",
@@ -335,7 +335,7 @@ func MockReserveResponse(t *testing.T) {
 			w.Header().Add("Content-Type", "application/json")
 			w.WriteHeader(http.StatusAccepted)
 
-			fmt.Fprintf(w, `{}`)
+			fmt.Fprint(w, `{}`)
 		})
 }
 
@@ -355,7 +355,7 @@ func MockUnreserveResponse(t *testing.T) {
 			w.Header().Add("Content-Type", "application/json")
 			w.WriteHeader(http.StatusAccepted)
 
-			fmt.Fprintf(w, `{}`)
+			fmt.Fprint(w, `{}`)
 		})
 }
 
@@ -386,7 +386,7 @@ func MockInitializeConnectionResponse(t *testing.T) {
 			w.Header().Add("Content-Type", "application/json")
 			w.WriteHeader(http.StatusAccepted)
 
-			fmt.Fprintf(w, `{
+			fmt.Fprint(w, `{
 "connection_info": {
     "data": {
       "target_portals": [
@@ -443,7 +443,7 @@ func MockTerminateConnectionResponse(t *testing.T) {
 			w.Header().Add("Content-Type", "application/json")
 			w.WriteHeader(http.StatusAccepted)
 
-			fmt.Fprintf(w, `{}`)
+			fmt.Fprint(w, `{}`)
 		})
 }
 
@@ -466,7 +466,7 @@ func MockExtendSizeResponse(t *testing.T) {
 			w.Header().Add("Content-Type", "application/json")
 			w.WriteHeader(http.StatusAccepted)
 
-			fmt.Fprintf(w, `{}`)
+			fmt.Fprint(w, `{}`)
 		})
 }
 
@@ -497,7 +497,7 @@ func MockSetImageMetadataResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `{}`)
+		fmt.Fprint(w, `{}`)
 	})
 }
 
@@ -560,7 +560,7 @@ func MockChangeTypeResponse(t *testing.T) {
 			w.Header().Add("Content-Type", "application/json")
 			w.WriteHeader(http.StatusAccepted)
 
-			fmt.Fprintf(w, `{}`)
+			fmt.Fprint(w, `{}`)
 		})
 }
 

--- a/openstack/blockstorage/v3/attachments/testing/fixtures_test.go
+++ b/openstack/blockstorage/v3/attachments/testing/fixtures_test.go
@@ -64,7 +64,7 @@ func MockListResponse(t *testing.T) {
 }
   `, th.Server.URL)
 		case "1":
-			fmt.Fprintf(w, `{"volumes": []}`)
+			fmt.Fprint(w, `{"volumes": []}`)
 		default:
 			t.Fatalf("Unexpected marker: [%s]", marker)
 		}
@@ -78,7 +78,7 @@ func MockGetResponse(t *testing.T) {
 
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
     "attachment": {
         "status": "attaching",
@@ -123,7 +123,7 @@ func MockCreateResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
     "attachment": {
         "status": "attaching",
@@ -171,7 +171,7 @@ func MockUpdateResponse(t *testing.T) {
       `)
 
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
     "attachment": {
         "status": "attaching",
@@ -202,7 +202,7 @@ func MockUpdateEmptyResponse(t *testing.T) {
       `)
 
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
     "attachment": {
         "status": "attaching",

--- a/openstack/blockstorage/v3/availabilityzones/testing/fixtures_test.go
+++ b/openstack/blockstorage/v3/availabilityzones/testing/fixtures_test.go
@@ -47,6 +47,6 @@ func HandleGetSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, GetOutput)
+		fmt.Fprint(w, GetOutput)
 	})
 }

--- a/openstack/blockstorage/v3/backups/testing/fixtures_test.go
+++ b/openstack/blockstorage/v3/backups/testing/fixtures_test.go
@@ -210,7 +210,7 @@ func MockListResponse(t *testing.T) {
 		case "":
 			fmt.Fprintf(w, ListResponse, th.Server.URL)
 		case "1":
-			fmt.Fprintf(w, `{"backups": []}`)
+			fmt.Fprint(w, `{"backups": []}`)
 		default:
 			t.Fatalf("Unexpected marker: [%s]", marker)
 		}
@@ -233,7 +233,7 @@ func MockListDetailResponse(t *testing.T) {
 		case "":
 			fmt.Fprintf(w, ListDetailResponse, th.Server.URL)
 		case "1":
-			fmt.Fprintf(w, `{"backups": []}`)
+			fmt.Fprint(w, `{"backups": []}`)
 		default:
 			t.Fatalf("Unexpected marker: [%s]", marker)
 		}
@@ -247,7 +247,7 @@ func MockGetResponse(t *testing.T) {
 
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, GetResponse)
+		fmt.Fprint(w, GetResponse)
 	})
 }
 
@@ -262,7 +262,7 @@ func MockCreateResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusAccepted)
 
-		fmt.Fprintf(w, CreateResponse)
+		fmt.Fprint(w, CreateResponse)
 	})
 }
 
@@ -277,7 +277,7 @@ func MockRestoreResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusAccepted)
 
-		fmt.Fprintf(w, RestoreResponse)
+		fmt.Fprint(w, RestoreResponse)
 	})
 }
 
@@ -298,7 +298,7 @@ func MockExportResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, ExportResponse)
+		fmt.Fprint(w, ExportResponse)
 	})
 }
 
@@ -313,7 +313,7 @@ func MockImportResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		fmt.Fprintf(w, ImportResponse)
+		fmt.Fprint(w, ImportResponse)
 	})
 }
 

--- a/openstack/blockstorage/v3/limits/testing/fixtures_test.go
+++ b/openstack/blockstorage/v3/limits/testing/fixtures_test.go
@@ -124,6 +124,6 @@ func HandleGetSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, GetOutput)
+		fmt.Fprint(w, GetOutput)
 	})
 }

--- a/openstack/blockstorage/v3/qos/testing/fixtures_test.go
+++ b/openstack/blockstorage/v3/qos/testing/fixtures_test.go
@@ -47,7 +47,7 @@ func MockCreateResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
   "qos_specs": {
     "id": "d32019d3-bc6e-4319-9c1d-6722fc136a22",
@@ -110,7 +110,7 @@ func MockListResponse(t *testing.T) {
 					}
 				`, th.Server.URL)
 		case "2":
-			fmt.Fprintf(w, `{ "qos_specs": [] }`)
+			fmt.Fprint(w, `{ "qos_specs": [] }`)
 		default:
 			t.Fatalf("Unexpected marker: [%s]", marker)
 		}
@@ -124,7 +124,7 @@ func MockGetResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
   "qos_specs": {
     "id": "d32019d3-bc6e-4319-9c1d-6722fc136a22",
@@ -172,7 +172,7 @@ func MockUpdateResponse(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, UpdateBody)
+		fmt.Fprint(w, UpdateBody)
 	})
 }
 
@@ -219,7 +219,7 @@ func MockListAssociationsResponse(t *testing.T) {
 		th.TestMethod(t, r, "GET")
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 			{
 			  "qos_associations": [
 			    {

--- a/openstack/blockstorage/v3/quotasets/testing/fixtures_test.go
+++ b/openstack/blockstorage/v3/quotasets/testing/fixtures_test.go
@@ -164,7 +164,7 @@ func HandleSuccessfulRequest(t *testing.T, httpMethod, uriPath, jsonOutput strin
 			th.TestFormValues(t, r, uriQueryParams)
 		}
 
-		fmt.Fprintf(w, jsonOutput)
+		fmt.Fprint(w, jsonOutput)
 	})
 }
 

--- a/openstack/blockstorage/v3/schedulerstats/testing/fixtures_test.go
+++ b/openstack/blockstorage/v3/schedulerstats/testing/fixtures_test.go
@@ -104,9 +104,9 @@ func HandleStoragePoolsListSuccessfully(t *testing.T) {
 			t.Errorf("Failed to parse request form %v", err)
 		}
 		if r.FormValue("detail") == "true" {
-			fmt.Fprintf(w, StoragePoolsListBodyDetail)
+			fmt.Fprint(w, StoragePoolsListBodyDetail)
 		} else {
-			fmt.Fprintf(w, StoragePoolsListBody)
+			fmt.Fprint(w, StoragePoolsListBody)
 		}
 	})
 }

--- a/openstack/blockstorage/v3/services/testing/fixtures_test.go
+++ b/openstack/blockstorage/v3/services/testing/fixtures_test.go
@@ -92,6 +92,6 @@ func HandleListSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, ServiceListBody)
+		fmt.Fprint(w, ServiceListBody)
 	})
 }

--- a/openstack/blockstorage/v3/snapshots/testing/fixtures_test.go
+++ b/openstack/blockstorage/v3/snapshots/testing/fixtures_test.go
@@ -54,7 +54,7 @@ func MockListResponse(t *testing.T) {
     }
     `, th.Server.URL)
 		case "1":
-			fmt.Fprintf(w, `{"snapshots": []}`)
+			fmt.Fprint(w, `{"snapshots": []}`)
 		default:
 			t.Fatalf("Unexpected marker: [%s]", marker)
 		}
@@ -69,7 +69,7 @@ func MockGetResponse(t *testing.T) {
 
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
     "snapshot": {
         "id": "d32019d3-bc6e-4319-9c1d-6722fc136a22",
@@ -104,7 +104,7 @@ func MockCreateResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusAccepted)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
     "snapshot": {
         "volume_id": "1234",
@@ -135,7 +135,7 @@ func MockUpdateMetadataResponse(t *testing.T) {
     }
     `)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
       {
         "metadata": {
           "key": "v1"
@@ -162,7 +162,7 @@ func MockUpdateResponse(t *testing.T) {
 
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
     "snapshot": {
         "id": "d32019d3-bc6e-4319-9c1d-6722fc136a22",

--- a/openstack/blockstorage/v3/transfers/testing/fixtures_test.go
+++ b/openstack/blockstorage/v3/transfers/testing/fixtures_test.go
@@ -167,7 +167,7 @@ func HandleCreateTransfer(t *testing.T) {
 		th.TestJSONRequest(t, r, CreateRequest)
 
 		w.WriteHeader(http.StatusAccepted)
-		fmt.Fprintf(w, CreateResponse)
+		fmt.Fprint(w, CreateResponse)
 	})
 }
 
@@ -179,7 +179,7 @@ func HandleAcceptTransfer(t *testing.T) {
 		th.TestJSONRequest(t, r, AcceptTransferRequest)
 
 		w.WriteHeader(http.StatusAccepted)
-		fmt.Fprintf(w, AcceptTransferResponse)
+		fmt.Fprint(w, AcceptTransferResponse)
 	})
 }
 
@@ -200,7 +200,7 @@ func HandleListTransfers(t *testing.T) {
 		th.TestFormValues(t, r, map[string]string{"all_tenants": "true"})
 
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, ListOutput)
+		fmt.Fprint(w, ListOutput)
 	})
 }
 
@@ -211,6 +211,6 @@ func HandleGetTransfer(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, GetOutput)
+		fmt.Fprint(w, GetOutput)
 	})
 }

--- a/openstack/blockstorage/v3/volumes/testing/fixtures_test.go
+++ b/openstack/blockstorage/v3/volumes/testing/fixtures_test.go
@@ -95,7 +95,7 @@ func MockListResponse(t *testing.T) {
 }
   `, th.Server.URL)
 		case "1":
-			fmt.Fprintf(w, `{"volumes": []}`)
+			fmt.Fprint(w, `{"volumes": []}`)
 		default:
 			t.Fatalf("Unexpected marker: [%s]", marker)
 		}
@@ -109,7 +109,7 @@ func MockGetResponse(t *testing.T) {
 
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
   "volume": {
     "volume_type": "lvmdriver-1",
@@ -171,7 +171,7 @@ func MockCreateResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusAccepted)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
   "volume": {
     "size": 75,
@@ -211,7 +211,7 @@ func MockUpdateResponse(t *testing.T) {
 		th.TestMethod(t, r, "PUT")
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
   "volume": {
     "name": "vol-002"
@@ -239,7 +239,7 @@ func MockCreateVolumeFromBackupResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusAccepted)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
   "volume": {
     "size": 30,
@@ -287,7 +287,7 @@ func MockAttachResponse(t *testing.T) {
 			w.Header().Add("Content-Type", "application/json")
 			w.WriteHeader(http.StatusAccepted)
 
-			fmt.Fprintf(w, `{}`)
+			fmt.Fprint(w, `{}`)
 		})
 }
 
@@ -307,7 +307,7 @@ func MockBeginDetachingResponse(t *testing.T) {
 			w.Header().Add("Content-Type", "application/json")
 			w.WriteHeader(http.StatusAccepted)
 
-			fmt.Fprintf(w, `{}`)
+			fmt.Fprint(w, `{}`)
 		})
 }
 
@@ -327,7 +327,7 @@ func MockDetachResponse(t *testing.T) {
 			w.Header().Add("Content-Type", "application/json")
 			w.WriteHeader(http.StatusAccepted)
 
-			fmt.Fprintf(w, `{}`)
+			fmt.Fprint(w, `{}`)
 		})
 }
 
@@ -352,7 +352,7 @@ func MockUploadImageResponse(t *testing.T) {
 			w.Header().Add("Content-Type", "application/json")
 			w.WriteHeader(http.StatusAccepted)
 
-			fmt.Fprintf(w, `
+			fmt.Fprint(w, `
 {
     "os-volume_upload_image": {
         "container_format": "bare",
@@ -399,7 +399,7 @@ func MockReserveResponse(t *testing.T) {
 			w.Header().Add("Content-Type", "application/json")
 			w.WriteHeader(http.StatusAccepted)
 
-			fmt.Fprintf(w, `{}`)
+			fmt.Fprint(w, `{}`)
 		})
 }
 
@@ -419,7 +419,7 @@ func MockUnreserveResponse(t *testing.T) {
 			w.Header().Add("Content-Type", "application/json")
 			w.WriteHeader(http.StatusAccepted)
 
-			fmt.Fprintf(w, `{}`)
+			fmt.Fprint(w, `{}`)
 		})
 }
 
@@ -450,7 +450,7 @@ func MockInitializeConnectionResponse(t *testing.T) {
 			w.Header().Add("Content-Type", "application/json")
 			w.WriteHeader(http.StatusAccepted)
 
-			fmt.Fprintf(w, `{
+			fmt.Fprint(w, `{
 "connection_info": {
     "data": {
       "target_portals": [
@@ -507,7 +507,7 @@ func MockTerminateConnectionResponse(t *testing.T) {
 			w.Header().Add("Content-Type", "application/json")
 			w.WriteHeader(http.StatusAccepted)
 
-			fmt.Fprintf(w, `{}`)
+			fmt.Fprint(w, `{}`)
 		})
 }
 
@@ -530,7 +530,7 @@ func MockExtendSizeResponse(t *testing.T) {
 			w.Header().Add("Content-Type", "application/json")
 			w.WriteHeader(http.StatusAccepted)
 
-			fmt.Fprintf(w, `{}`)
+			fmt.Fprint(w, `{}`)
 		})
 }
 
@@ -561,7 +561,7 @@ func MockSetImageMetadataResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `{}`)
+		fmt.Fprint(w, `{}`)
 	})
 }
 
@@ -624,7 +624,7 @@ func MockChangeTypeResponse(t *testing.T) {
 			w.Header().Add("Content-Type", "application/json")
 			w.WriteHeader(http.StatusAccepted)
 
-			fmt.Fprintf(w, `{}`)
+			fmt.Fprint(w, `{}`)
 		})
 }
 

--- a/openstack/blockstorage/v3/volumetypes/testing/fixtures_test.go
+++ b/openstack/blockstorage/v3/volumetypes/testing/fixtures_test.go
@@ -58,7 +58,7 @@ func MockListResponse(t *testing.T) {
 }
   `, th.Server.URL)
 		case "1":
-			fmt.Fprintf(w, `{"volume_types": []}`)
+			fmt.Fprint(w, `{"volume_types": []}`)
 		default:
 			t.Fatalf("Unexpected marker: [%s]", marker)
 		}
@@ -72,7 +72,7 @@ func MockGetResponse(t *testing.T) {
 
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
     "volume_type": {
         "id": "d32019d3-bc6e-4319-9c1d-6722fc136a22",
@@ -112,7 +112,7 @@ func MockCreateResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
     "volume_type": {
         "name": "test_type",
@@ -143,7 +143,7 @@ func MockUpdateResponse(t *testing.T) {
 		th.TestMethod(t, r, "PUT")
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
     "volume_type": {
         "name": "vol-type-002",
@@ -203,7 +203,7 @@ func HandleExtraSpecsListSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, ExtraSpecsGetBody)
+		fmt.Fprint(w, ExtraSpecsGetBody)
 	})
 }
 
@@ -215,7 +215,7 @@ func HandleExtraSpecGetSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, GetExtraSpecBody)
+		fmt.Fprint(w, GetExtraSpecBody)
 	})
 }
 
@@ -233,7 +233,7 @@ func HandleExtraSpecsCreateSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, ExtraSpecsGetBody)
+		fmt.Fprint(w, ExtraSpecsGetBody)
 	})
 }
 
@@ -248,7 +248,7 @@ func HandleExtraSpecUpdateSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, UpdatedExtraSpecBody)
+		fmt.Fprint(w, UpdatedExtraSpecBody)
 	})
 }
 
@@ -281,7 +281,7 @@ func MockEncryptionCreateResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
     "encryption": {
         "volume_type_id": "a5082c24-2a27-43a4-b48e-fcec1240e36b",
@@ -324,7 +324,7 @@ func MockEncryptionUpdateResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
     "encryption": {
         "control_location": "front-end",
@@ -345,7 +345,7 @@ func MockEncryptionGetResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
     "volume_type_id": "a5082c24-2a27-43a4-b48e-fcec1240e36b",
     "control_location": "front-end",
@@ -370,7 +370,7 @@ func MockEncryptionGetSpecResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
     "cipher": "aes-xts-plain64"
 }

--- a/openstack/blockstorage/v3/volumetypes/testing/requests_test.go
+++ b/openstack/blockstorage/v3/volumetypes/testing/requests_test.go
@@ -190,7 +190,7 @@ func TestVolumeTypeListAccesses(t *testing.T) {
 		th.TestMethod(t, r, "GET")
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 			{
 			  "volume_type_access": [
 			    {

--- a/openstack/common/extensions/testing/fixtures.go
+++ b/openstack/common/extensions/testing/fixtures.go
@@ -71,7 +71,7 @@ func HandleListExtensionsSuccessfully(t *testing.T) {
 
 		w.Header().Add("Content-Type", "application/json")
 
-		fmt.Fprintf(w, ListOutput)
+		fmt.Fprint(w, ListOutput)
 	})
 }
 
@@ -85,6 +85,6 @@ func HandleGetExtensionSuccessfully(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, GetOutput)
+		fmt.Fprint(w, GetOutput)
 	})
 }

--- a/openstack/compute/apiversions/testing/fixtures_test.go
+++ b/openstack/compute/apiversions/testing/fixtures_test.go
@@ -169,7 +169,7 @@ func MockListResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, NovaAllAPIVersionsResponse)
+		fmt.Fprint(w, NovaAllAPIVersionsResponse)
 	})
 }
 
@@ -181,7 +181,7 @@ func MockGetResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, NovaAPIVersionResponse_21)
+		fmt.Fprint(w, NovaAPIVersionResponse_21)
 	})
 }
 
@@ -193,6 +193,6 @@ func MockGetMultipleResponses(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, NovaAPIInvalidVersionResponse)
+		fmt.Fprint(w, NovaAPIInvalidVersionResponse)
 	})
 }

--- a/openstack/compute/v2/aggregates/testing/fixtures_test.go
+++ b/openstack/compute/v2/aggregates/testing/fixtures_test.go
@@ -264,7 +264,7 @@ func HandleListSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, AggregateListBody)
+		fmt.Fprint(w, AggregateListBody)
 	})
 }
 
@@ -274,7 +274,7 @@ func HandleCreateSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, AggregateCreateBody)
+		fmt.Fprint(w, AggregateCreateBody)
 	})
 }
 
@@ -295,7 +295,7 @@ func HandleGetSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, AggregateGetBody)
+		fmt.Fprint(w, AggregateGetBody)
 	})
 }
 
@@ -306,7 +306,7 @@ func HandleUpdateSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, AggregateUpdateBody)
+		fmt.Fprint(w, AggregateUpdateBody)
 	})
 }
 
@@ -317,7 +317,7 @@ func HandleAddHostSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, AggregateAddHostBody)
+		fmt.Fprint(w, AggregateAddHostBody)
 	})
 }
 
@@ -328,7 +328,7 @@ func HandleRemoveHostSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, AggregateRemoveHostBody)
+		fmt.Fprint(w, AggregateRemoveHostBody)
 	})
 }
 
@@ -339,6 +339,6 @@ func HandleSetMetadataSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, AggregateSetMetadataBody)
+		fmt.Fprint(w, AggregateSetMetadataBody)
 	})
 }

--- a/openstack/compute/v2/attachinterfaces/testing/fixtures_test.go
+++ b/openstack/compute/v2/attachinterfaces/testing/fixtures_test.go
@@ -69,7 +69,7 @@ func HandleInterfaceListSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, `{
+		fmt.Fprint(w, `{
 			"interfaceAttachments": [
 				{
 					"port_state":"ACTIVE",
@@ -99,7 +99,7 @@ func HandleInterfaceGetSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, `{
+		fmt.Fprint(w, `{
 			"interfaceAttachment":
 				{
 					"port_state":"ACTIVE",
@@ -133,7 +133,7 @@ func HandleInterfaceCreateSuccessfully(t *testing.T) {
 		}`)
 
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, `{
+		fmt.Fprint(w, `{
 			"interfaceAttachment":
 				{
 					"port_state":"ACTIVE",

--- a/openstack/compute/v2/availabilityzones/testing/fixtures_test.go
+++ b/openstack/compute/v2/availabilityzones/testing/fixtures_test.go
@@ -180,7 +180,7 @@ func HandleGetSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, GetOutput)
+		fmt.Fprint(w, GetOutput)
 	})
 }
 
@@ -192,6 +192,6 @@ func HandleGetDetailSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, GetDetailOutput)
+		fmt.Fprint(w, GetDetailOutput)
 	})
 }

--- a/openstack/compute/v2/extensions/testing/fixtures_test.go
+++ b/openstack/compute/v2/extensions/testing/fixtures_test.go
@@ -16,7 +16,7 @@ func HandleListExtensionsSuccessfully(t *testing.T) {
 
 		w.Header().Add("Content-Type", "application/json")
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
 		"extensions": [
 				{
@@ -41,7 +41,7 @@ func HandleGetExtensionsSuccessfully(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
 		"extension": {
 				"updated": "2013-02-03T10:00:00-00:00",

--- a/openstack/compute/v2/flavors/testing/fixtures_test.go
+++ b/openstack/compute/v2/flavors/testing/fixtures_test.go
@@ -57,7 +57,7 @@ func HandleExtraSpecsListSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, ExtraSpecsGetBody)
+		fmt.Fprint(w, ExtraSpecsGetBody)
 	})
 }
 
@@ -69,7 +69,7 @@ func HandleExtraSpecGetSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, GetExtraSpecBody)
+		fmt.Fprint(w, GetExtraSpecBody)
 	})
 }
 
@@ -87,7 +87,7 @@ func HandleExtraSpecsCreateSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, ExtraSpecsGetBody)
+		fmt.Fprint(w, ExtraSpecsGetBody)
 	})
 }
 
@@ -102,7 +102,7 @@ func HandleExtraSpecUpdateSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, UpdatedExtraSpecBody)
+		fmt.Fprint(w, UpdatedExtraSpecBody)
 	})
 }
 

--- a/openstack/compute/v2/flavors/testing/requests_test.go
+++ b/openstack/compute/v2/flavors/testing/requests_test.go
@@ -76,7 +76,7 @@ func TestListFlavors(t *testing.T) {
 					}
 				`, th.Server.URL)
 		case "2":
-			fmt.Fprintf(w, `{ "flavors": [] }`)
+			fmt.Fprint(w, `{ "flavors": [] }`)
 		default:
 			t.Fatalf("Unexpected marker: [%s]", marker)
 		}
@@ -121,7 +121,7 @@ func TestGetFlavor(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 			{
 				"flavor": {
 					"id": "1",
@@ -170,7 +170,7 @@ func TestCreateFlavor(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 			{
 				"flavor": {
 					"id": "1",
@@ -225,7 +225,7 @@ func TestUpdateFlavor(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 			{
 				"flavor": {
 					"id": "1",
@@ -288,7 +288,7 @@ func TestFlavorAccessesList(t *testing.T) {
 		th.TestMethod(t, r, "GET")
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 			{
 			  "flavor_access": [
 			    {
@@ -336,7 +336,7 @@ func TestFlavorAccessAdd(t *testing.T) {
 
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 			{
 			  "flavor_access": [
 			    {
@@ -385,7 +385,7 @@ func TestFlavorAccessRemove(t *testing.T) {
 
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 			{
 			  "flavor_access": []
 			}

--- a/openstack/compute/v2/hypervisors/testing/fixtures_test.go
+++ b/openstack/compute/v2/hypervisors/testing/fixtures_test.go
@@ -605,7 +605,7 @@ func HandleHypervisorsStatisticsSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, HypervisorsStatisticsBody)
+		fmt.Fprint(w, HypervisorsStatisticsBody)
 	})
 }
 
@@ -615,7 +615,7 @@ func HandleHypervisorListPre253Successfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, HypervisorListBodyPre253)
+		fmt.Fprint(w, HypervisorListBodyPre253)
 	})
 }
 
@@ -625,7 +625,7 @@ func HandleHypervisorListSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, HypervisorListBody)
+		fmt.Fprint(w, HypervisorListBody)
 	})
 }
 
@@ -638,7 +638,7 @@ func HandleHypervisorListWithParametersSuccessfully(t *testing.T) {
 		})
 
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, HypervisorListWithParametersBody)
+		fmt.Fprint(w, HypervisorListWithParametersBody)
 	})
 }
 
@@ -648,7 +648,7 @@ func HandleHypervisorGetSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, HypervisorGetBody)
+		fmt.Fprint(w, HypervisorGetBody)
 	})
 }
 
@@ -658,7 +658,7 @@ func HandleHypervisorGetEmptyCPUInfoSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, HypervisorGetEmptyCPUInfoBody)
+		fmt.Fprint(w, HypervisorGetEmptyCPUInfoBody)
 	})
 }
 
@@ -668,7 +668,7 @@ func HandleHypervisorAfterV287ResponseSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, HypervisorAfterV287ResponseBody)
+		fmt.Fprint(w, HypervisorAfterV287ResponseBody)
 	})
 }
 
@@ -678,6 +678,6 @@ func HandleHypervisorUptimeSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, HypervisorUptimeBody)
+		fmt.Fprint(w, HypervisorUptimeBody)
 	})
 }

--- a/openstack/compute/v2/instanceactions/testing/fixtures_test.go
+++ b/openstack/compute/v2/instanceactions/testing/fixtures_test.go
@@ -40,7 +40,7 @@ func HandleInstanceActionListSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, `{
+		fmt.Fprint(w, `{
 			"instanceActions": [
 				{
 					"action": "stop",
@@ -100,7 +100,7 @@ func HandleInstanceActionGetSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, `{
+		fmt.Fprint(w, `{
 			"instanceAction": 
 			{
 				"action": "stop",

--- a/openstack/compute/v2/keypairs/testing/fixtures_test.go
+++ b/openstack/compute/v2/keypairs/testing/fixtures_test.go
@@ -157,7 +157,7 @@ func HandleListSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, ListOutput)
+		fmt.Fprint(w, ListOutput)
 	})
 }
 
@@ -169,11 +169,11 @@ func HandleGetSuccessfully(t *testing.T) {
 
 		if r.URL.Query().Get("user_id") == "fake2" {
 			w.Header().Add("Content-Type", "application/json")
-			fmt.Fprintf(w, GetOutputOtherUser)
+			fmt.Fprint(w, GetOutputOtherUser)
 
 		} else {
 			w.Header().Add("Content-Type", "application/json")
-			fmt.Fprintf(w, GetOutput)
+			fmt.Fprint(w, GetOutput)
 
 		}
 	})
@@ -188,7 +188,7 @@ func HandleCreateSuccessfully(t *testing.T) {
 		th.TestJSONRequest(t, r, `{ "keypair": { "name": "createdkey" } }`)
 
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, CreateOutput)
+		fmt.Fprint(w, CreateOutput)
 	})
 }
 
@@ -201,7 +201,7 @@ func HandleCreateSuccessfullyOtherUser(t *testing.T) {
 		th.TestJSONRequest(t, r, `{ "keypair": { "name": "createdkey", "user_id": "fake2" } }`)
 
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, CreateOutputOtherUser)
+		fmt.Fprint(w, CreateOutputOtherUser)
 	})
 }
 
@@ -221,7 +221,7 @@ func HandleImportSuccessfully(t *testing.T) {
 		`)
 
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, ImportOutput)
+		fmt.Fprint(w, ImportOutput)
 	})
 }
 

--- a/openstack/compute/v2/limits/testing/fixtures_test.go
+++ b/openstack/compute/v2/limits/testing/fixtures_test.go
@@ -75,6 +75,6 @@ func HandleGetSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, GetOutput)
+		fmt.Fprint(w, GetOutput)
 	})
 }

--- a/openstack/compute/v2/quotasets/testing/fixtures_test.go
+++ b/openstack/compute/v2/quotasets/testing/fixtures_test.go
@@ -167,7 +167,7 @@ func HandleGetSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, GetOutput)
+		fmt.Fprint(w, GetOutput)
 	})
 }
 
@@ -177,7 +177,7 @@ func HandleGetDetailSuccessfully(t *testing.T) {
 		th.TestMethod(t, r, "GET")
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, GetDetailsOutput)
+		fmt.Fprint(w, GetDetailsOutput)
 	})
 }
 
@@ -188,7 +188,7 @@ func HandlePutSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		th.TestJSONRequest(t, r, UpdateOutput)
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, UpdateOutput)
+		fmt.Fprint(w, UpdateOutput)
 	})
 }
 
@@ -199,7 +199,7 @@ func HandlePartialPutSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		th.TestJSONRequest(t, r, PartialUpdateBody)
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, UpdateOutput)
+		fmt.Fprint(w, UpdateOutput)
 	})
 }
 

--- a/openstack/compute/v2/remoteconsoles/testing/requests_test.go
+++ b/openstack/compute/v2/remoteconsoles/testing/requests_test.go
@@ -25,7 +25,7 @@ func TestCreate(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, RemoteConsoleCreateResult)
+		fmt.Fprint(w, RemoteConsoleCreateResult)
 	})
 
 	opts := remoteconsoles.CreateOpts{

--- a/openstack/compute/v2/secgroups/testing/fixtures_test.go
+++ b/openstack/compute/v2/secgroups/testing/fixtures_test.go
@@ -33,7 +33,7 @@ func mockListGroupsResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, listGroupsJSON)
+		fmt.Fprint(w, listGroupsJSON)
 	})
 }
 
@@ -46,7 +46,7 @@ func mockListGroupsByServerResponse(t *testing.T, serverID string) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, listGroupsJSON)
+		fmt.Fprint(w, listGroupsJSON)
 	})
 }
 
@@ -67,7 +67,7 @@ func mockCreateGroupResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
   "security_group": {
     "description": "something",
@@ -99,7 +99,7 @@ func mockUpdateGroupResponse(t *testing.T, groupID string) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
   "security_group": {
     "description": "something",
@@ -122,7 +122,7 @@ func mockGetGroupsResponse(t *testing.T, groupID string) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
   "security_group": {
     "description": "default",
@@ -224,7 +224,7 @@ func mockAddRuleResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
   "security_group_rule": {
     "from_port": 22,
@@ -260,7 +260,7 @@ func mockAddRuleResponseICMPZero(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
   "security_group_rule": {
     "from_port": 0,

--- a/openstack/compute/v2/servergroups/testing/fixtures_test.go
+++ b/openstack/compute/v2/servergroups/testing/fixtures_test.go
@@ -148,7 +148,7 @@ func HandleListSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, ListOutput)
+		fmt.Fprint(w, ListOutput)
 	})
 }
 
@@ -160,7 +160,7 @@ func HandleGetSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, GetOutput)
+		fmt.Fprint(w, GetOutput)
 	})
 }
 
@@ -172,7 +172,7 @@ func HandleGetMicroversionSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, GetOutputMicroversion)
+		fmt.Fprint(w, GetOutputMicroversion)
 	})
 }
 
@@ -194,7 +194,7 @@ func HandleCreateSuccessfully(t *testing.T) {
 `)
 
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, CreateOutput)
+		fmt.Fprint(w, CreateOutput)
 	})
 }
 
@@ -220,7 +220,7 @@ func HandleCreateMicroversionSuccessfully(t *testing.T) {
 `)
 
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, CreateOutputMicroversion)
+		fmt.Fprint(w, CreateOutputMicroversion)
 	})
 }
 

--- a/openstack/compute/v2/servers/testing/fixtures_test.go
+++ b/openstack/compute/v2/servers/testing/fixtures_test.go
@@ -741,7 +741,7 @@ func HandleServerNoNetworkCreationSuccessfully(t *testing.T, response string) {
 
 		w.WriteHeader(http.StatusAccepted)
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, response)
+		fmt.Fprint(w, response)
 	})
 }
 
@@ -761,7 +761,7 @@ func HandleServerCreationSuccessfully(t *testing.T, response string) {
 
 		w.WriteHeader(http.StatusAccepted)
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, response)
+		fmt.Fprint(w, response)
 	})
 
 	th.Mux.HandleFunc("/images/detail", func(w http.ResponseWriter, r *http.Request) {
@@ -775,7 +775,7 @@ func HandleServerCreationSuccessfully(t *testing.T, response string) {
 		marker := r.Form.Get("marker")
 		switch marker {
 		case "":
-			fmt.Fprintf(w, `
+			fmt.Fprint(w, `
 				{
 					"images": [
 						{
@@ -804,7 +804,7 @@ func HandleServerCreationSuccessfully(t *testing.T, response string) {
 				}
 			`)
 		case "2":
-			fmt.Fprintf(w, `{ "images": [] }`)
+			fmt.Fprint(w, `{ "images": [] }`)
 		default:
 			t.Fatalf("Unexpected marker: [%s]", marker)
 		}
@@ -850,7 +850,7 @@ func HandleServerCreationSuccessfully(t *testing.T, response string) {
 						}
 					`, th.Server.URL)
 		case "2":
-			fmt.Fprintf(w, `{ "flavors": [] }`)
+			fmt.Fprint(w, `{ "flavors": [] }`)
 		default:
 			t.Fatalf("Unexpected marker: [%s]", marker)
 		}
@@ -875,7 +875,7 @@ func HandleServersCreationSuccessfully(t *testing.T, response string) {
 
 		w.WriteHeader(http.StatusAccepted)
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, response)
+		fmt.Fprint(w, response)
 	})
 }
 
@@ -896,7 +896,7 @@ func HandleServerCreationWithCustomFieldSuccessfully(t *testing.T, response stri
 
 		w.WriteHeader(http.StatusAccepted)
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, response)
+		fmt.Fprint(w, response)
 	})
 }
 
@@ -915,7 +915,7 @@ func HandleServerCreationWithHostname(t *testing.T, response string) {
 
 		w.WriteHeader(http.StatusAccepted)
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, response)
+		fmt.Fprint(w, response)
 	})
 }
 
@@ -936,7 +936,7 @@ func HandleServerCreationWithUserdata(t *testing.T, response string) {
 
 		w.WriteHeader(http.StatusAccepted)
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, response)
+		fmt.Fprint(w, response)
 	})
 }
 
@@ -959,7 +959,7 @@ func HandleServerCreationWithMetadata(t *testing.T, response string) {
 
 		w.WriteHeader(http.StatusAccepted)
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, response)
+		fmt.Fprint(w, response)
 	})
 }
 
@@ -976,9 +976,9 @@ func HandleServerListSimpleSuccessfully(t *testing.T) {
 		marker := r.Form.Get("marker")
 		switch marker {
 		case "":
-			fmt.Fprintf(w, ServerListBody)
+			fmt.Fprint(w, ServerListBody)
 		case "9e5476bd-a4ec-4653-93d6-72c93aa682ba":
-			fmt.Fprintf(w, `{ "servers": [] }`)
+			fmt.Fprint(w, `{ "servers": [] }`)
 		default:
 			t.Fatalf("/servers invoked with unexpected marker=[%s]", marker)
 		}
@@ -998,9 +998,9 @@ func HandleServerListSuccessfully(t *testing.T) {
 		marker := r.Form.Get("marker")
 		switch marker {
 		case "":
-			fmt.Fprintf(w, ServerListBody)
+			fmt.Fprint(w, ServerListBody)
 		case "9e5476bd-a4ec-4653-93d6-72c93aa682ba":
-			fmt.Fprintf(w, `{ "servers": [] }`)
+			fmt.Fprint(w, `{ "servers": [] }`)
 		default:
 			t.Fatalf("/servers/detail invoked with unexpected marker=[%s]", marker)
 		}
@@ -1036,7 +1036,7 @@ func HandleServerGetSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		th.TestHeader(t, r, "Accept", "application/json")
 
-		fmt.Fprintf(w, SingleServerBody)
+		fmt.Fprint(w, SingleServerBody)
 	})
 }
 
@@ -1048,7 +1048,7 @@ func HandleServerGetFaultSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		th.TestHeader(t, r, "Accept", "application/json")
 
-		fmt.Fprintf(w, FaultyServerBody)
+		fmt.Fprint(w, FaultyServerBody)
 	})
 }
 
@@ -1061,7 +1061,7 @@ func HandleServerUpdateSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "Content-Type", "application/json")
 		th.TestJSONRequest(t, r, `{ "server": { "name": "new-name" } }`)
 
-		fmt.Fprintf(w, SingleServerBody)
+		fmt.Fprint(w, SingleServerBody)
 	})
 }
 
@@ -1097,7 +1097,7 @@ func HandleShowConsoleOutputSuccessfully(t *testing.T, response string) {
 
 		w.WriteHeader(http.StatusOK)
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, response)
+		fmt.Fprint(w, response)
 	})
 }
 
@@ -1119,7 +1119,7 @@ func HandleRebuildSuccessfully(t *testing.T, response string) {
 
 		w.WriteHeader(http.StatusAccepted)
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, response)
+		fmt.Fprint(w, response)
 	})
 }
 
@@ -1243,7 +1243,7 @@ func HandleAddressListSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, `{
+		fmt.Fprint(w, `{
 			"addresses": {
 				"public": [
 				{
@@ -1285,7 +1285,7 @@ func HandleNetworkAddressListSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, `{
+		fmt.Fprint(w, `{
 			"public": [
 			{
 				"version": 4,
@@ -1317,7 +1317,7 @@ func HandlePasswordGetSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		th.TestHeader(t, r, "Accept", "application/json")
 
-		fmt.Fprintf(w, ServerPasswordBody)
+		fmt.Fprint(w, ServerPasswordBody)
 	})
 }
 
@@ -1332,6 +1332,6 @@ func HandleServerWithTagsCreationSuccessfully(t *testing.T) {
 		w.WriteHeader(http.StatusAccepted)
 		w.Header().Add("Content-Type", "application/json")
 
-		fmt.Fprintf(w, SingleServerWithTagsBody)
+		fmt.Fprint(w, SingleServerWithTagsBody)
 	})
 }

--- a/openstack/compute/v2/services/testing/fixtures_test.go
+++ b/openstack/compute/v2/services/testing/fixtures_test.go
@@ -259,7 +259,7 @@ func HandleListPre253Successfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, ServiceListBodyPre253)
+		fmt.Fprint(w, ServiceListBodyPre253)
 	})
 }
 
@@ -271,7 +271,7 @@ func HandleListSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, ServiceListBody)
+		fmt.Fprint(w, ServiceListBody)
 	})
 }
 
@@ -285,7 +285,7 @@ func HandleUpdateSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "Content-Type", "application/json")
 		th.TestJSONRequest(t, r, `{"status": "disabled"}`)
 
-		fmt.Fprintf(w, ServiceUpdate)
+		fmt.Fprint(w, ServiceUpdate)
 	})
 }
 

--- a/openstack/compute/v2/tags/testing/requests_test.go
+++ b/openstack/compute/v2/tags/testing/requests_test.go
@@ -22,7 +22,7 @@ func TestList(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		_, err := fmt.Fprintf(w, TagsListResponse)
+		_, err := fmt.Fprint(w, TagsListResponse)
 		th.AssertNoErr(t, err)
 	})
 
@@ -78,7 +78,7 @@ func TestReplaceAll(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		_, err := fmt.Fprintf(w, TagsReplaceAllResponse)
+		_, err := fmt.Fprint(w, TagsReplaceAllResponse)
 		th.AssertNoErr(t, err)
 	})
 

--- a/openstack/compute/v2/volumeattach/testing/fixtures_test.go
+++ b/openstack/compute/v2/volumeattach/testing/fixtures_test.go
@@ -62,7 +62,7 @@ func HandleListSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, ListOutput)
+		fmt.Fprint(w, ListOutput)
 	})
 }
 
@@ -74,7 +74,7 @@ func HandleGetSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, GetOutput)
+		fmt.Fprint(w, GetOutput)
 	})
 }
 
@@ -96,7 +96,7 @@ func HandleCreateSuccessfully(t *testing.T) {
 `)
 
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, CreateOutput)
+		fmt.Fprint(w, CreateOutput)
 	})
 }
 

--- a/openstack/container/v1/capsules/testing/fixtures_test.go
+++ b/openstack/container/v1/capsules/testing/fixtures_test.go
@@ -609,7 +609,7 @@ func HandleCapsuleGetOldTimeSuccessfully(t *testing.T) {
 
 		w.WriteHeader(http.StatusOK)
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, CapsuleGetBody_OldTime)
+		fmt.Fprint(w, CapsuleGetBody_OldTime)
 	})
 }
 
@@ -621,7 +621,7 @@ func HandleCapsuleGetNewTimeSuccessfully(t *testing.T) {
 
 		w.WriteHeader(http.StatusOK)
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, CapsuleGetBody_NewTime)
+		fmt.Fprint(w, CapsuleGetBody_NewTime)
 	})
 }
 
@@ -633,7 +633,7 @@ func HandleCapsuleCreateSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", fakeclient.TokenID)
 		th.TestHeader(t, r, "Accept", "application/json")
 		w.WriteHeader(http.StatusAccepted)
-		fmt.Fprintf(w, CapsuleGetBody_NewTime)
+		fmt.Fprint(w, CapsuleGetBody_NewTime)
 	})
 }
 
@@ -645,7 +645,7 @@ func HandleCapsuleListSuccessfully(t *testing.T) {
 
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, CapsuleListBody)
+		fmt.Fprint(w, CapsuleListBody)
 	})
 }
 
@@ -657,7 +657,7 @@ func HandleCapsuleV132ListSuccessfully(t *testing.T) {
 
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, CapsuleV132ListBody)
+		fmt.Fprint(w, CapsuleV132ListBody)
 	})
 }
 

--- a/openstack/containerinfra/apiversions/testing/fixtures_test.go
+++ b/openstack/containerinfra/apiversions/testing/fixtures_test.go
@@ -71,7 +71,7 @@ func MockListResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, MagnumAllAPIVersionsResponse)
+		fmt.Fprint(w, MagnumAllAPIVersionsResponse)
 	})
 }
 
@@ -83,6 +83,6 @@ func MockGetResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, MagnumAPIVersionResponse)
+		fmt.Fprint(w, MagnumAPIVersionResponse)
 	})
 }

--- a/openstack/containerinfra/v1/certificates/testing/fixtures_test.go
+++ b/openstack/containerinfra/v1/certificates/testing/fixtures_test.go
@@ -106,6 +106,6 @@ func HandleUpdateCertificateSuccessfully(t *testing.T) {
 			th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 
 			w.WriteHeader(http.StatusAccepted)
-			fmt.Fprintf(w, `{}`)
+			fmt.Fprint(w, `{}`)
 		})
 }

--- a/openstack/containerinfra/v1/nodegroups/testing/fixtures_test.go
+++ b/openstack/containerinfra/v1/nodegroups/testing/fixtures_test.go
@@ -221,7 +221,7 @@ func handleCreateNodeGroupSuccess(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusAccepted)
 
-		fmt.Fprintf(w, nodeGroupCreateResponse)
+		fmt.Fprint(w, nodeGroupCreateResponse)
 	})
 }
 
@@ -233,7 +233,7 @@ func handleCreateNodeGroupDuplicate(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusConflict)
 
-		fmt.Fprintf(w, nodeGroupCreateDuplicateResponse)
+		fmt.Fprint(w, nodeGroupCreateDuplicateResponse)
 	})
 }
 
@@ -245,7 +245,7 @@ func handleCreateNodeGroupMaster(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadRequest)
 
-		fmt.Fprintf(w, nodeGroupCreateMasterResponse)
+		fmt.Fprint(w, nodeGroupCreateMasterResponse)
 	})
 }
 
@@ -257,7 +257,7 @@ func handleCreateNodeGroupBadSizes(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusConflict)
 
-		fmt.Fprintf(w, nodeGroupCreateBadSizesResponse)
+		fmt.Fprint(w, nodeGroupCreateBadSizesResponse)
 	})
 }
 
@@ -269,7 +269,7 @@ func handleUpdateNodeGroupSuccess(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusAccepted)
 
-		fmt.Fprintf(w, nodeGroupUpdateResponse)
+		fmt.Fprint(w, nodeGroupUpdateResponse)
 	})
 }
 
@@ -281,7 +281,7 @@ func handleUpdateNodeGroupInternal(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadRequest)
 
-		fmt.Fprintf(w, nodeGroupUpdateInternalResponse)
+		fmt.Fprint(w, nodeGroupUpdateInternalResponse)
 	})
 }
 
@@ -293,7 +293,7 @@ func handleUpdateNodeGroupBadField(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadRequest)
 
-		fmt.Fprintf(w, nodeGroupUpdateBadFieldResponse)
+		fmt.Fprint(w, nodeGroupUpdateBadFieldResponse)
 	})
 }
 
@@ -305,7 +305,7 @@ func handleUpdateNodeGroupBadMin(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusConflict)
 
-		fmt.Fprintf(w, nodeGroupUpdateBadMinResponse)
+		fmt.Fprint(w, nodeGroupUpdateBadMinResponse)
 	})
 }
 
@@ -326,7 +326,7 @@ func handleDeleteNodeGroupNotFound(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusNotFound)
 
-		fmt.Fprintf(w, nodeGroupDeleteNotFoundResponse)
+		fmt.Fprint(w, nodeGroupDeleteNotFoundResponse)
 	})
 }
 
@@ -338,7 +338,7 @@ func handleDeleteNodeGroupClusterNotFound(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusNotFound)
 
-		fmt.Fprintf(w, nodeGroupDeleteClusterNotFoundResponse)
+		fmt.Fprint(w, nodeGroupDeleteClusterNotFoundResponse)
 	})
 }
 
@@ -350,7 +350,7 @@ func handleDeleteNodeGroupDefault(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadRequest)
 
-		fmt.Fprintf(w, nodeGroupDeleteDefaultResponse)
+		fmt.Fprint(w, nodeGroupDeleteDefaultResponse)
 	})
 }
 

--- a/openstack/dns/v2/recordsets/testing/fixtures_test.go
+++ b/openstack/dns/v2/recordsets/testing/fixtures_test.go
@@ -212,9 +212,9 @@ func HandleListByZoneSuccessfully(t *testing.T) {
 		marker := r.Form.Get("marker")
 		switch marker {
 		case "f7b10e9b-0cae-4a91-b162-562bc6096648":
-			fmt.Fprintf(w, ListByZoneOutputLimited)
+			fmt.Fprint(w, ListByZoneOutputLimited)
 		case "":
-			fmt.Fprintf(w, ListByZoneOutput)
+			fmt.Fprint(w, ListByZoneOutput)
 		}
 	})
 }
@@ -227,7 +227,7 @@ func HandleGetSuccessfully(t *testing.T) {
 			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 			w.Header().Add("Content-Type", "application/json")
-			fmt.Fprintf(w, GetOutput)
+			fmt.Fprint(w, GetOutput)
 		})
 }
 
@@ -282,7 +282,7 @@ func HandleCreateSuccessfully(t *testing.T) {
 
 			w.WriteHeader(http.StatusCreated)
 			w.Header().Add("Content-Type", "application/json")
-			fmt.Fprintf(w, CreateRecordSetResponse)
+			fmt.Fprint(w, CreateRecordSetResponse)
 		})
 }
 
@@ -334,7 +334,7 @@ func HandleUpdateSuccessfully(t *testing.T) {
 
 			w.WriteHeader(http.StatusOK)
 			w.Header().Add("Content-Type", "application/json")
-			fmt.Fprintf(w, UpdateRecordSetResponse)
+			fmt.Fprint(w, UpdateRecordSetResponse)
 		})
 }
 
@@ -373,6 +373,6 @@ func HandleDeleteSuccessfully(t *testing.T) {
 
 			w.WriteHeader(http.StatusAccepted)
 			//w.Header().Add("Content-Type", "application/json")
-			//fmt.Fprintf(w, DeleteZoneResponse)
+			//fmt.Fprint(w, DeleteZoneResponse)
 		})
 }

--- a/openstack/dns/v2/transfer/accept/testing/fixtures_test.go
+++ b/openstack/dns/v2/transfer/accept/testing/fixtures_test.go
@@ -133,7 +133,7 @@ func HandleListSuccessfully(t *testing.T) {
 			th.TestMethod(t, r, "GET")
 			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 			w.Header().Add("Content-Type", "application/json")
-			fmt.Fprintf(w, ListOutput)
+			fmt.Fprint(w, ListOutput)
 		})
 }
 
@@ -145,7 +145,7 @@ func HandleFilteredListSuccessfully(t *testing.T) {
 			th.TestMethod(t, r, "GET")
 			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 			w.Header().Add("Content-Type", "application/json")
-			fmt.Fprintf(w, FilteredListOutput)
+			fmt.Fprint(w, FilteredListOutput)
 		})
 }
 
@@ -157,7 +157,7 @@ func HandleGetSuccessfully(t *testing.T) {
 			th.TestMethod(t, r, "GET")
 			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 			w.Header().Add("Content-Type", "application/json")
-			fmt.Fprintf(w, GetOutput)
+			fmt.Fprint(w, GetOutput)
 		})
 }
 
@@ -200,6 +200,6 @@ func HandleCreateSuccessfully(t *testing.T) {
 
 			w.WriteHeader(http.StatusCreated)
 			w.Header().Add("Content-Type", "application/json")
-			fmt.Fprintf(w, CreateTransferAcceptResponse)
+			fmt.Fprint(w, CreateTransferAcceptResponse)
 		})
 }

--- a/openstack/dns/v2/transfer/request/testing/fixtures_test.go
+++ b/openstack/dns/v2/transfer/request/testing/fixtures_test.go
@@ -119,7 +119,7 @@ func HandleListSuccessfully(t *testing.T) {
 			th.TestMethod(t, r, "GET")
 			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 			w.Header().Add("Content-Type", "application/json")
-			fmt.Fprintf(w, ListOutput)
+			fmt.Fprint(w, ListOutput)
 		})
 }
 
@@ -131,7 +131,7 @@ func HandleGetSuccessfully(t *testing.T) {
 			th.TestMethod(t, r, "GET")
 			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 			w.Header().Add("Content-Type", "application/json")
-			fmt.Fprintf(w, GetOutput)
+			fmt.Fprint(w, GetOutput)
 		})
 }
 
@@ -175,7 +175,7 @@ func HandleCreateSuccessfully(t *testing.T) {
 
 			w.WriteHeader(http.StatusCreated)
 			w.Header().Add("Content-Type", "application/json")
-			fmt.Fprintf(w, CreateTransferRequestResponse)
+			fmt.Fprint(w, CreateTransferRequestResponse)
 		})
 }
 
@@ -215,7 +215,7 @@ func HandleUpdateSuccessfully(t *testing.T) {
 
 			w.WriteHeader(http.StatusOK)
 			w.Header().Add("Content-Type", "application/json")
-			fmt.Fprintf(w, UpdatedTransferRequestResponse)
+			fmt.Fprint(w, UpdatedTransferRequestResponse)
 		})
 }
 

--- a/openstack/dns/v2/zones/testing/fixtures_test.go
+++ b/openstack/dns/v2/zones/testing/fixtures_test.go
@@ -149,7 +149,7 @@ func HandleListSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, ListOutput)
+		fmt.Fprint(w, ListOutput)
 	})
 }
 
@@ -160,7 +160,7 @@ func HandleGetSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, GetOutput)
+		fmt.Fprint(w, GetOutput)
 	})
 }
 
@@ -212,7 +212,7 @@ func HandleCreateSuccessfully(t *testing.T) {
 
 		w.WriteHeader(http.StatusCreated)
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, CreateZoneResponse)
+		fmt.Fprint(w, CreateZoneResponse)
 	})
 }
 
@@ -259,7 +259,7 @@ func HandleUpdateSuccessfully(t *testing.T) {
 
 			w.WriteHeader(http.StatusOK)
 			w.Header().Add("Content-Type", "application/json")
-			fmt.Fprintf(w, UpdateZoneResponse)
+			fmt.Fprint(w, UpdateZoneResponse)
 		})
 }
 
@@ -297,6 +297,6 @@ func HandleDeleteSuccessfully(t *testing.T) {
 
 			w.WriteHeader(http.StatusAccepted)
 			w.Header().Add("Content-Type", "application/json")
-			fmt.Fprintf(w, DeleteZoneResponse)
+			fmt.Fprint(w, DeleteZoneResponse)
 		})
 }

--- a/openstack/identity/v2/extensions/testing/fixtures_test.go
+++ b/openstack/identity/v2/extensions/testing/fixtures_test.go
@@ -37,7 +37,7 @@ func HandleListExtensionsSuccessfully(t *testing.T) {
 
 		w.Header().Add("Content-Type", "application/json")
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
   "extensions": {
     "values": [

--- a/openstack/identity/v2/roles/testing/fixtures_test.go
+++ b/openstack/identity/v2/roles/testing/fixtures_test.go
@@ -17,7 +17,7 @@ func MockListRoleResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
     "roles": [
         {

--- a/openstack/identity/v2/tenants/testing/fixtures_test.go
+++ b/openstack/identity/v2/tenants/testing/fixtures_test.go
@@ -59,7 +59,7 @@ func HandleListTenantsSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, ListOutput)
+		fmt.Fprint(w, ListOutput)
 	})
 }
 
@@ -81,7 +81,7 @@ func mockCreateTenantResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
     "tenant": {
         "name": "new_tenant",
@@ -120,7 +120,7 @@ func mockUpdateTenantResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
 		"tenant": {
 				"name": "new_name",
@@ -141,7 +141,7 @@ func mockGetTenantResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
 		"tenant": {
 				"name": "new_tenant",

--- a/openstack/identity/v2/tokens/testing/fixtures_test.go
+++ b/openstack/identity/v2/tokens/testing/fixtures_test.go
@@ -152,7 +152,7 @@ func HandleTokenPost(t *testing.T, requestJSON string) {
 		}
 
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, TokenCreationResponse)
+		fmt.Fprint(w, TokenCreationResponse)
 	})
 }
 
@@ -165,7 +165,7 @@ func HandleTokenGet(t *testing.T, token string) {
 		th.TestHeader(t, r, "X-Auth-Token", thclient.TokenID)
 
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, TokenGetResponse)
+		fmt.Fprint(w, TokenGetResponse)
 	})
 }
 

--- a/openstack/identity/v2/users/testing/fixtures_test.go
+++ b/openstack/identity/v2/users/testing/fixtures_test.go
@@ -17,7 +17,7 @@ func MockListUserResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
     "users":[
         {
@@ -61,7 +61,7 @@ func mockCreateUserResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
     "user": {
         "name": "new_user",
@@ -83,7 +83,7 @@ func mockGetUserResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
 		"user": {
 				"name": "new_user",
@@ -115,7 +115,7 @@ func mockUpdateUserResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
 		"user": {
 				"name": "new_name",
@@ -145,7 +145,7 @@ func mockListRolesResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
     "roles": [
         {

--- a/openstack/identity/v3/applicationcredentials/testing/fixtures_test.go
+++ b/openstack/identity/v3/applicationcredentials/testing/fixtures_test.go
@@ -415,7 +415,7 @@ func HandleListApplicationCredentialsSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, ListOutput)
+		fmt.Fprint(w, ListOutput)
 	})
 }
 
@@ -429,7 +429,7 @@ func HandleGetApplicationCredentialSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, GetOutput)
+		fmt.Fprint(w, GetOutput)
 	})
 }
 
@@ -442,7 +442,7 @@ func HandleCreateApplicationCredentialSuccessfully(t *testing.T) {
 		th.TestJSONRequest(t, r, CreateRequest)
 
 		w.WriteHeader(http.StatusCreated)
-		fmt.Fprintf(w, CreateResponse)
+		fmt.Fprint(w, CreateResponse)
 	})
 }
 
@@ -455,7 +455,7 @@ func HandleCreateNoSecretApplicationCredentialSuccessfully(t *testing.T) {
 		th.TestJSONRequest(t, r, CreateNoSecretRequest)
 
 		w.WriteHeader(http.StatusCreated)
-		fmt.Fprintf(w, CreateNoSecretResponse)
+		fmt.Fprint(w, CreateNoSecretResponse)
 	})
 }
 
@@ -466,7 +466,7 @@ func HandleCreateUnrestrictedApplicationCredentialSuccessfully(t *testing.T) {
 		th.TestJSONRequest(t, r, CreateUnrestrictedRequest)
 
 		w.WriteHeader(http.StatusCreated)
-		fmt.Fprintf(w, CreateUnrestrictedResponse)
+		fmt.Fprint(w, CreateUnrestrictedResponse)
 	})
 }
 
@@ -491,7 +491,7 @@ func HandleListAccessRulesSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, ListAccessRulesOutput)
+		fmt.Fprint(w, ListAccessRulesOutput)
 	})
 }
 
@@ -505,7 +505,7 @@ func HandleGetAccessRuleSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, GetAccessRuleOutput)
+		fmt.Fprint(w, GetAccessRuleOutput)
 	})
 }
 

--- a/openstack/identity/v3/catalog/testing/fixtures_test.go
+++ b/openstack/identity/v3/catalog/testing/fixtures_test.go
@@ -85,6 +85,6 @@ func HandleListCatalogSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		_, _ = fmt.Fprintf(w, ListOutput)
+		_, _ = fmt.Fprint(w, ListOutput)
 	})
 }

--- a/openstack/identity/v3/credentials/testing/fixtures_test.go
+++ b/openstack/identity/v3/credentials/testing/fixtures_test.go
@@ -161,7 +161,7 @@ func HandleListCredentialsSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, ListOutput)
+		fmt.Fprint(w, ListOutput)
 	})
 }
 
@@ -175,7 +175,7 @@ func HandleGetCredentialSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, GetOutput)
+		fmt.Fprint(w, GetOutput)
 	})
 }
 
@@ -188,7 +188,7 @@ func HandleCreateCredentialSuccessfully(t *testing.T) {
 		th.TestJSONRequest(t, r, CreateRequest)
 
 		w.WriteHeader(http.StatusCreated)
-		fmt.Fprintf(w, GetOutput)
+		fmt.Fprint(w, GetOutput)
 	})
 }
 
@@ -212,6 +212,6 @@ func HandleUpdateCredentialSuccessfully(t *testing.T) {
 		th.TestJSONRequest(t, r, UpdateRequest)
 
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, UpdateOutput)
+		fmt.Fprint(w, UpdateOutput)
 	})
 }

--- a/openstack/identity/v3/domains/testing/fixtures_test.go
+++ b/openstack/identity/v3/domains/testing/fixtures_test.go
@@ -189,7 +189,7 @@ func HandleListAvailableDomainsSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, ListAvailableOutput)
+		fmt.Fprint(w, ListAvailableOutput)
 	})
 }
 
@@ -203,7 +203,7 @@ func HandleListDomainsSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, ListOutput)
+		fmt.Fprint(w, ListOutput)
 	})
 }
 
@@ -217,7 +217,7 @@ func HandleGetDomainSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, GetOutput)
+		fmt.Fprint(w, GetOutput)
 	})
 }
 
@@ -230,7 +230,7 @@ func HandleCreateDomainSuccessfully(t *testing.T) {
 		th.TestJSONRequest(t, r, CreateRequest)
 
 		w.WriteHeader(http.StatusCreated)
-		fmt.Fprintf(w, GetOutput)
+		fmt.Fprint(w, GetOutput)
 	})
 }
 
@@ -254,6 +254,6 @@ func HandleUpdateDomainSuccessfully(t *testing.T) {
 		th.TestJSONRequest(t, r, UpdateRequest)
 
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, UpdateOutput)
+		fmt.Fprint(w, UpdateOutput)
 	})
 }

--- a/openstack/identity/v3/ec2credentials/testing/fixtures_test.go
+++ b/openstack/identity/v3/ec2credentials/testing/fixtures_test.go
@@ -119,7 +119,7 @@ func HandleListEC2CredentialsSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, ListOutput)
+		fmt.Fprint(w, ListOutput)
 	})
 }
 
@@ -133,7 +133,7 @@ func HandleGetEC2CredentialSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, GetOutput)
+		fmt.Fprint(w, GetOutput)
 	})
 }
 
@@ -146,7 +146,7 @@ func HandleCreateEC2CredentialSuccessfully(t *testing.T) {
 		th.TestJSONRequest(t, r, CreateRequest)
 
 		w.WriteHeader(http.StatusCreated)
-		fmt.Fprintf(w, CreateResponse)
+		fmt.Fprint(w, CreateResponse)
 	})
 }
 

--- a/openstack/identity/v3/ec2tokens/testing/requests_test.go
+++ b/openstack/identity/v3/ec2tokens/testing/requests_test.go
@@ -32,7 +32,7 @@ func authTokenPost(t *testing.T, options ec2tokens.AuthOptions, requestJSON stri
 		th.TestJSONRequest(t, r, requestJSON)
 
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, tokens_testing.TokenOutput)
+		fmt.Fprint(w, tokens_testing.TokenOutput)
 	})
 
 	expected := &tokens.Token{

--- a/openstack/identity/v3/endpoints/testing/requests_test.go
+++ b/openstack/identity/v3/endpoints/testing/requests_test.go
@@ -33,7 +33,7 @@ func TestCreateSuccessful(t *testing.T) {
     `)
 
 		w.WriteHeader(http.StatusCreated)
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
       {
         "endpoint": {
           "id": "12",
@@ -82,7 +82,7 @@ func TestListEndpoints(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 			{
 				"endpoints": [
 					{
@@ -170,7 +170,7 @@ func TestUpdateEndpoint(t *testing.T) {
 		}
 	`)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 		{
 			"endpoint": {
 				"id": "12",

--- a/openstack/identity/v3/federation/testing/fixtures_test.go
+++ b/openstack/identity/v3/federation/testing/fixtures_test.go
@@ -289,7 +289,7 @@ func HandleListMappingsSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, ListOutput)
+		fmt.Fprint(w, ListOutput)
 	})
 }
 
@@ -302,7 +302,7 @@ func HandleCreateMappingSuccessfully(t *testing.T) {
 		th.TestJSONRequest(t, r, CreateRequest)
 
 		w.WriteHeader(http.StatusCreated)
-		fmt.Fprintf(w, CreateOutput)
+		fmt.Fprint(w, CreateOutput)
 	})
 }
 
@@ -316,7 +316,7 @@ func HandleGetMappingSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, GetOutput)
+		fmt.Fprint(w, GetOutput)
 	})
 }
 
@@ -329,7 +329,7 @@ func HandleUpdateMappingSuccessfully(t *testing.T) {
 		th.TestJSONRequest(t, r, UpdateRequest)
 
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, UpdateOutput)
+		fmt.Fprint(w, UpdateOutput)
 	})
 }
 

--- a/openstack/identity/v3/groups/testing/fixtures_test.go
+++ b/openstack/identity/v3/groups/testing/fixtures_test.go
@@ -160,7 +160,7 @@ func HandleListGroupsSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, ListOutput)
+		fmt.Fprint(w, ListOutput)
 	})
 }
 
@@ -174,7 +174,7 @@ func HandleGetGroupSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, GetOutput)
+		fmt.Fprint(w, GetOutput)
 	})
 }
 
@@ -187,7 +187,7 @@ func HandleCreateGroupSuccessfully(t *testing.T) {
 		th.TestJSONRequest(t, r, CreateRequest)
 
 		w.WriteHeader(http.StatusCreated)
-		fmt.Fprintf(w, GetOutput)
+		fmt.Fprint(w, GetOutput)
 	})
 }
 
@@ -200,7 +200,7 @@ func HandleUpdateGroupSuccessfully(t *testing.T) {
 		th.TestJSONRequest(t, r, UpdateRequest)
 
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, UpdateOutput)
+		fmt.Fprint(w, UpdateOutput)
 	})
 }
 

--- a/openstack/identity/v3/limits/testing/fixtures_test.go
+++ b/openstack/identity/v3/limits/testing/fixtures_test.go
@@ -183,7 +183,7 @@ func HandleGetEnforcementModelSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, GetEnforcementModelOutput)
+		fmt.Fprint(w, GetEnforcementModelOutput)
 	})
 }
 
@@ -197,7 +197,7 @@ func HandleListLimitsSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, ListOutput)
+		fmt.Fprint(w, ListOutput)
 	})
 }
 
@@ -210,7 +210,7 @@ func HandleCreateLimitSuccessfully(t *testing.T) {
 		th.TestJSONRequest(t, r, CreateRequest)
 
 		w.WriteHeader(http.StatusCreated)
-		fmt.Fprintf(w, CreateOutput)
+		fmt.Fprint(w, CreateOutput)
 	})
 }
 
@@ -224,7 +224,7 @@ func HandleGetLimitSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, GetOutput)
+		fmt.Fprint(w, GetOutput)
 	})
 }
 
@@ -237,7 +237,7 @@ func HandleUpdateLimitSuccessfully(t *testing.T) {
 		th.TestJSONRequest(t, r, UpdateRequest)
 
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, UpdateOutput)
+		fmt.Fprint(w, UpdateOutput)
 	})
 }
 

--- a/openstack/identity/v3/oauth1/testing/fixtures_test.go
+++ b/openstack/identity/v3/oauth1/testing/fixtures_test.go
@@ -228,7 +228,7 @@ func HandleCreateConsumer(t *testing.T) {
 		th.TestJSONRequest(t, r, CreateConsumerRequest)
 
 		w.WriteHeader(http.StatusCreated)
-		_, err := fmt.Fprintf(w, CreateConsumerResponse)
+		_, err := fmt.Fprint(w, CreateConsumerResponse)
 		th.AssertNoErr(t, err)
 	})
 }
@@ -243,7 +243,7 @@ func HandleUpdateConsumer(t *testing.T) {
 		th.TestJSONRequest(t, r, UpdateConsumerRequest)
 
 		w.WriteHeader(http.StatusOK)
-		_, err := fmt.Fprintf(w, UpdateConsumerResponse)
+		_, err := fmt.Fprint(w, UpdateConsumerResponse)
 		th.AssertNoErr(t, err)
 	})
 }
@@ -269,7 +269,7 @@ func HandleGetConsumer(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, GetConsumerResponse)
+		fmt.Fprint(w, GetConsumerResponse)
 	})
 }
 
@@ -306,7 +306,7 @@ func HandleListConsumers(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, ListConsumersResponse)
+		fmt.Fprint(w, ListConsumersResponse)
 	})
 }
 
@@ -329,7 +329,7 @@ func HandleRequestToken(t *testing.T) {
 
 		w.Header().Set("Content-Type", oauth1.OAuth1TokenContentType)
 		w.WriteHeader(http.StatusCreated)
-		fmt.Fprintf(w, `oauth_token=29971f&oauth_token_secret=238eb8&oauth_expires_at=2013-09-11T06:07:51.501805Z`)
+		fmt.Fprint(w, `oauth_token=29971f&oauth_token_secret=238eb8&oauth_expires_at=2013-09-11T06:07:51.501805Z`)
 	})
 }
 
@@ -343,7 +343,7 @@ func HandleAuthorizeToken(t *testing.T) {
 		th.TestJSONRequest(t, r, AuthorizeTokenRequest)
 
 		w.WriteHeader(http.StatusOK)
-		_, err := fmt.Fprintf(w, AuthorizeTokenResponse)
+		_, err := fmt.Fprint(w, AuthorizeTokenResponse)
 		th.AssertNoErr(t, err)
 	})
 }
@@ -366,7 +366,7 @@ func HandleCreateAccessToken(t *testing.T) {
 
 		w.Header().Set("Content-Type", oauth1.OAuth1TokenContentType)
 		w.WriteHeader(http.StatusCreated)
-		fmt.Fprintf(w, `oauth_token=accd36&oauth_token_secret=aa47da&oauth_expires_at=2013-09-11T06:07:51.501805Z`)
+		fmt.Fprint(w, `oauth_token=accd36&oauth_token_secret=aa47da&oauth_expires_at=2013-09-11T06:07:51.501805Z`)
 	})
 }
 
@@ -380,7 +380,7 @@ func HandleGetAccessToken(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, GetUserAccessTokenResponse)
+		fmt.Fprint(w, GetUserAccessTokenResponse)
 	})
 }
 
@@ -405,7 +405,7 @@ func HandleListAccessTokens(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, ListUserAccessTokensResponse)
+		fmt.Fprint(w, ListUserAccessTokensResponse)
 	})
 }
 
@@ -419,7 +419,7 @@ func HandleListAccessTokenRoles(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, ListUserAccessTokenRolesResponse)
+		fmt.Fprint(w, ListUserAccessTokenRolesResponse)
 	})
 }
 
@@ -433,7 +433,7 @@ func HandleGetAccessTokenRole(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, ListUserAccessTokenRoleResponse)
+		fmt.Fprint(w, ListUserAccessTokenRoleResponse)
 	})
 }
 
@@ -449,6 +449,6 @@ func HandleAuthenticate(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
-		fmt.Fprintf(w, tokens.TokenOutput)
+		fmt.Fprint(w, tokens.TokenOutput)
 	})
 }

--- a/openstack/identity/v3/policies/testing/fixtures_test.go
+++ b/openstack/identity/v3/policies/testing/fixtures_test.go
@@ -164,9 +164,9 @@ func HandleListPoliciesSuccessfully(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 		switch r.URL.Query().Get("type") {
 		case "":
-			fmt.Fprintf(w, ListOutput)
+			fmt.Fprint(w, ListOutput)
 		case "application/json":
-			fmt.Fprintf(w, ListWithFilterOutput)
+			fmt.Fprint(w, ListWithFilterOutput)
 		default:
 			w.WriteHeader(http.StatusBadRequest)
 		}
@@ -182,7 +182,7 @@ func HandleCreatePolicySuccessfully(t *testing.T) {
 		th.TestJSONRequest(t, r, CreateRequest)
 
 		w.WriteHeader(http.StatusCreated)
-		fmt.Fprintf(w, GetOutput)
+		fmt.Fprint(w, GetOutput)
 	})
 }
 
@@ -197,7 +197,7 @@ func HandleGetPolicySuccessfully(t *testing.T) {
 
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			fmt.Fprintf(w, GetOutput)
+			fmt.Fprint(w, GetOutput)
 		},
 	)
 }
@@ -212,7 +212,7 @@ func HandleUpdatePolicySuccessfully(t *testing.T) {
 			th.TestJSONRequest(t, r, UpdateRequest)
 
 			w.WriteHeader(http.StatusOK)
-			fmt.Fprintf(w, UpdateOutput)
+			fmt.Fprint(w, UpdateOutput)
 		},
 	)
 }

--- a/openstack/identity/v3/projectendpoints/testing/requests_test.go
+++ b/openstack/identity/v3/projectendpoints/testing/requests_test.go
@@ -37,7 +37,7 @@ func TestListEndpoints(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 		{
 			"endpoints": [
 				{

--- a/openstack/identity/v3/projects/testing/fixtures_test.go
+++ b/openstack/identity/v3/projects/testing/fixtures_test.go
@@ -285,7 +285,7 @@ func HandleListAvailableProjectsSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, ListAvailableOutput)
+		fmt.Fprint(w, ListAvailableOutput)
 	})
 }
 
@@ -299,7 +299,7 @@ func HandleListProjectsSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, ListOutput)
+		fmt.Fprint(w, ListOutput)
 	})
 }
 
@@ -313,7 +313,7 @@ func HandleGetProjectSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, GetOutput)
+		fmt.Fprint(w, GetOutput)
 	})
 }
 
@@ -326,7 +326,7 @@ func HandleCreateProjectSuccessfully(t *testing.T) {
 		th.TestJSONRequest(t, r, CreateRequest)
 
 		w.WriteHeader(http.StatusCreated)
-		fmt.Fprintf(w, GetOutput)
+		fmt.Fprint(w, GetOutput)
 	})
 }
 
@@ -350,7 +350,7 @@ func HandleUpdateProjectSuccessfully(t *testing.T) {
 		th.TestJSONRequest(t, r, UpdateRequest)
 
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, UpdateOutput)
+		fmt.Fprint(w, UpdateOutput)
 	})
 }
 
@@ -360,7 +360,7 @@ func HandleListProjectTagsSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, ListTagsOutput)
+		fmt.Fprint(w, ListTagsOutput)
 	})
 }
 
@@ -371,7 +371,7 @@ func HandleModifyProjectTagsSuccessfully(t *testing.T) {
 		th.TestJSONRequest(t, r, ModifyProjectTagsRequest)
 
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, ModifyProjectTagsOutput)
+		fmt.Fprint(w, ModifyProjectTagsOutput)
 	})
 }
 func HandleDeleteProjectTagsSuccessfully(t *testing.T) {

--- a/openstack/identity/v3/regions/testing/fixtures_test.go
+++ b/openstack/identity/v3/regions/testing/fixtures_test.go
@@ -172,7 +172,7 @@ func HandleListRegionsSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, ListOutput)
+		fmt.Fprint(w, ListOutput)
 	})
 }
 
@@ -186,7 +186,7 @@ func HandleGetRegionSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, GetOutput)
+		fmt.Fprint(w, GetOutput)
 	})
 }
 
@@ -199,7 +199,7 @@ func HandleCreateRegionSuccessfully(t *testing.T) {
 		th.TestJSONRequest(t, r, CreateRequest)
 
 		w.WriteHeader(http.StatusCreated)
-		fmt.Fprintf(w, GetOutput)
+		fmt.Fprint(w, GetOutput)
 	})
 }
 
@@ -212,7 +212,7 @@ func HandleUpdateRegionSuccessfully(t *testing.T) {
 		th.TestJSONRequest(t, r, UpdateRequest)
 
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, UpdateOutput)
+		fmt.Fprint(w, UpdateOutput)
 	})
 }
 

--- a/openstack/identity/v3/registeredlimits/testing/fixtures_test.go
+++ b/openstack/identity/v3/registeredlimits/testing/fixtures_test.go
@@ -163,7 +163,7 @@ func HandleListRegisteredLimitsSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, ListOutput)
+		fmt.Fprint(w, ListOutput)
 	})
 }
 
@@ -177,7 +177,7 @@ func HandleGetRegisteredLimitSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, GetOutput)
+		fmt.Fprint(w, GetOutput)
 	})
 }
 
@@ -190,7 +190,7 @@ func HandleCreateRegisteredLimitSuccessfully(t *testing.T) {
 		th.TestJSONRequest(t, r, CreateRequest)
 
 		w.WriteHeader(http.StatusCreated)
-		fmt.Fprintf(w, CreateOutput)
+		fmt.Fprint(w, CreateOutput)
 	})
 }
 
@@ -214,6 +214,6 @@ func HandleUpdateRegisteredLimitSuccessfully(t *testing.T) {
 		th.TestJSONRequest(t, r, UpdateRequest)
 
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, UpdateOutput)
+		fmt.Fprint(w, UpdateOutput)
 	})
 }

--- a/openstack/identity/v3/roles/testing/fixtures_test.go
+++ b/openstack/identity/v3/roles/testing/fixtures_test.go
@@ -350,7 +350,7 @@ func HandleListRolesSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, ListOutput)
+		fmt.Fprint(w, ListOutput)
 	})
 }
 
@@ -364,7 +364,7 @@ func HandleGetRoleSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, GetOutput)
+		fmt.Fprint(w, GetOutput)
 	})
 }
 
@@ -377,7 +377,7 @@ func HandleCreateRoleSuccessfully(t *testing.T) {
 		th.TestJSONRequest(t, r, CreateRequest)
 
 		w.WriteHeader(http.StatusCreated)
-		fmt.Fprintf(w, GetOutput)
+		fmt.Fprint(w, GetOutput)
 	})
 }
 
@@ -390,7 +390,7 @@ func HandleUpdateRoleSuccessfully(t *testing.T) {
 		th.TestJSONRequest(t, r, UpdateRequest)
 
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, UpdateOutput)
+		fmt.Fprint(w, UpdateOutput)
 	})
 }
 
@@ -499,7 +499,7 @@ func HandleListRoleAssignmentsSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, ListAssignmentOutput)
+		fmt.Fprint(w, ListAssignmentOutput)
 	})
 }
 
@@ -514,7 +514,7 @@ func HandleListRoleAssignmentsWithNamesSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, ListAssignmentWithNamesOutput)
+		fmt.Fprint(w, ListAssignmentWithNamesOutput)
 	})
 }
 
@@ -529,7 +529,7 @@ func HandleListRoleAssignmentsWithSubtreeSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, ListAssignmentOutput)
+		fmt.Fprint(w, ListAssignmentOutput)
 	})
 }
 
@@ -557,7 +557,7 @@ func HandleListAssignmentsOnResourceSuccessfully_ProjectsUsers(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, ListAssignmentsOnResourceOutput)
+		fmt.Fprint(w, ListAssignmentsOnResourceOutput)
 	}
 
 	th.Mux.HandleFunc("/projects/{project_id}/users/{user_id}/roles", fn)
@@ -571,7 +571,7 @@ func HandleListAssignmentsOnResourceSuccessfully_ProjectsGroups(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, ListAssignmentsOnResourceOutput)
+		fmt.Fprint(w, ListAssignmentsOnResourceOutput)
 	}
 
 	th.Mux.HandleFunc("/projects/{project_id}/groups/{group_id}/roles", fn)
@@ -585,7 +585,7 @@ func HandleListAssignmentsOnResourceSuccessfully_DomainsUsers(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, ListAssignmentsOnResourceOutput)
+		fmt.Fprint(w, ListAssignmentsOnResourceOutput)
 	}
 
 	th.Mux.HandleFunc("/domains/{domain_id}/users/{user_id}/roles", fn)
@@ -599,7 +599,7 @@ func HandleListAssignmentsOnResourceSuccessfully_DomainsGroups(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, ListAssignmentsOnResourceOutput)
+		fmt.Fprint(w, ListAssignmentsOnResourceOutput)
 	}
 
 	th.Mux.HandleFunc("/domains/{domain_id}/groups/{group_id}/roles", fn)
@@ -635,7 +635,7 @@ func HandleCreateRoleInferenceRule(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
-		fmt.Fprintf(w, CreateRoleInferenceRuleOutput)
+		fmt.Fprint(w, CreateRoleInferenceRuleOutput)
 	}
 
 	th.Mux.HandleFunc("/roles/7ceab6192ea34a548cc71b24f72e762c/implies/97e2f5d38bc94842bc3da818c16762ed", fn)
@@ -713,7 +713,7 @@ func HandleListRoleInferenceRules(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, ListRoleInferenceRulesOutput)
+		fmt.Fprint(w, ListRoleInferenceRulesOutput)
 	}
 
 	th.Mux.HandleFunc("/role_inferences", fn)
@@ -737,7 +737,7 @@ func HandleGetRoleInferenceRule(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, CreateRoleInferenceRuleOutput)
+		fmt.Fprint(w, CreateRoleInferenceRuleOutput)
 	}
 
 	th.Mux.HandleFunc("/roles/7ceab6192ea34a548cc71b24f72e762c/implies/97e2f5d38bc94842bc3da818c16762ed", fn)

--- a/openstack/identity/v3/services/testing/fixtures_test.go
+++ b/openstack/identity/v3/services/testing/fixtures_test.go
@@ -164,7 +164,7 @@ func HandleListServicesSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, ListOutput)
+		fmt.Fprint(w, ListOutput)
 	})
 }
 
@@ -178,7 +178,7 @@ func HandleGetServiceSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, GetOutput)
+		fmt.Fprint(w, GetOutput)
 	})
 }
 
@@ -191,7 +191,7 @@ func HandleCreateServiceSuccessfully(t *testing.T) {
 		th.TestJSONRequest(t, r, CreateRequest)
 
 		w.WriteHeader(http.StatusCreated)
-		fmt.Fprintf(w, GetOutput)
+		fmt.Fprint(w, GetOutput)
 	})
 }
 
@@ -204,6 +204,6 @@ func HandleUpdateServiceSuccessfully(t *testing.T) {
 		th.TestJSONRequest(t, r, UpdateRequest)
 
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, UpdateOutput)
+		fmt.Fprint(w, UpdateOutput)
 	})
 }

--- a/openstack/identity/v3/tokens/testing/requests_test.go
+++ b/openstack/identity/v3/tokens/testing/requests_test.go
@@ -30,7 +30,7 @@ func authTokenPost(t *testing.T, options tokens.AuthOptions, scope *tokens.Scope
 		th.TestJSONRequest(t, r, requestJSON)
 
 		w.WriteHeader(http.StatusCreated)
-		fmt.Fprintf(w, `{
+		fmt.Fprint(w, `{
 			"token": {
 				"expires_at": "2014-10-02T13:45:00.000000Z"
 			}
@@ -369,7 +369,7 @@ func TestCreateUserIDPasswordTrustID(t *testing.T) {
 		th.TestJSONRequest(t, r, requestJSON)
 
 		w.WriteHeader(http.StatusCreated)
-		fmt.Fprintf(w, responseJSON)
+		fmt.Fprint(w, responseJSON)
 	})
 
 	ao := gophercloud.AuthOptions{
@@ -525,7 +525,7 @@ func TestCreateExtractsTokenFromResponse(t *testing.T) {
 		w.Header().Add("X-Subject-Token", "aaa111")
 
 		w.WriteHeader(http.StatusCreated)
-		fmt.Fprintf(w, `{
+		fmt.Fprint(w, `{
 			"token": {
 				"expires_at": "2014-10-02T13:45:00.000000Z"
 			}
@@ -670,7 +670,7 @@ func TestGetRequest(t *testing.T) {
 		th.TestHeader(t, r, "X-Subject-Token", "abcdef12345")
 
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 			{ "token": { "expires_at": "2014-08-29T13:10:01.000000Z" } }
 		`)
 	})
@@ -779,7 +779,7 @@ func TestNoTokenInResponse(t *testing.T) {
 
 	th.Mux.HandleFunc("/auth/tokens", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusCreated)
-		fmt.Fprintf(w, `{}`)
+		fmt.Fprint(w, `{}`)
 	})
 
 	options := tokens.AuthOptions{UserID: "me", Password: "squirrel!"}

--- a/openstack/identity/v3/trusts/testing/fixtures_test.go
+++ b/openstack/identity/v3/trusts/testing/fixtures_test.go
@@ -207,7 +207,7 @@ func HandleCreateTrust(t *testing.T) {
 		th.TestJSONRequest(t, r, CreateRequest)
 
 		w.WriteHeader(http.StatusCreated)
-		_, err := fmt.Fprintf(w, CreateResponse)
+		_, err := fmt.Fprint(w, CreateResponse)
 		th.AssertNoErr(t, err)
 	})
 }
@@ -221,7 +221,7 @@ func HandleCreateTrustNoExpire(t *testing.T) {
 		th.TestJSONRequest(t, r, CreateRequestNoExpire)
 
 		w.WriteHeader(http.StatusCreated)
-		_, err := fmt.Fprintf(w, CreateResponseNoExpire)
+		_, err := fmt.Fprint(w, CreateResponseNoExpire)
 		th.AssertNoErr(t, err)
 	})
 }
@@ -247,7 +247,7 @@ func HandleGetTrustSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, GetResponse)
+		fmt.Fprint(w, GetResponse)
 	})
 }
 
@@ -317,7 +317,7 @@ func HandleListTrustsSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, ListResponse)
+		fmt.Fprint(w, ListResponse)
 	})
 }
 
@@ -331,7 +331,7 @@ func HandleListTrustRolesSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, ListTrustRolesResponse)
+		fmt.Fprint(w, ListTrustRolesResponse)
 	})
 }
 
@@ -345,7 +345,7 @@ func HandleGetTrustRoleSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, GetTrustRoleResponse)
+		fmt.Fprint(w, GetTrustRoleResponse)
 	})
 }
 

--- a/openstack/identity/v3/users/testing/fixtures_test.go
+++ b/openstack/identity/v3/users/testing/fixtures_test.go
@@ -382,7 +382,7 @@ func HandleListUsersSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, ListOutput)
+		fmt.Fprint(w, ListOutput)
 	})
 }
 
@@ -396,7 +396,7 @@ func HandleGetUserSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, GetOutput)
+		fmt.Fprint(w, GetOutput)
 	})
 }
 
@@ -409,7 +409,7 @@ func HandleCreateUserSuccessfully(t *testing.T) {
 		th.TestJSONRequest(t, r, CreateRequest)
 
 		w.WriteHeader(http.StatusCreated)
-		fmt.Fprintf(w, GetOutput)
+		fmt.Fprint(w, GetOutput)
 	})
 }
 
@@ -422,7 +422,7 @@ func HandleCreateNoOptionsUserSuccessfully(t *testing.T) {
 		th.TestJSONRequest(t, r, CreateNoOptionsRequest)
 
 		w.WriteHeader(http.StatusCreated)
-		fmt.Fprintf(w, GetOutputNoOptions)
+		fmt.Fprint(w, GetOutputNoOptions)
 	})
 }
 
@@ -435,7 +435,7 @@ func HandleUpdateUserSuccessfully(t *testing.T) {
 		th.TestJSONRequest(t, r, UpdateRequest)
 
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, UpdateOutput)
+		fmt.Fprint(w, UpdateOutput)
 	})
 }
 
@@ -472,7 +472,7 @@ func HandleListUserGroupsSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, ListGroupsOutput)
+		fmt.Fprint(w, ListGroupsOutput)
 	})
 }
 
@@ -519,7 +519,7 @@ func HandleListUserProjectsSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, ListProjectsOutput)
+		fmt.Fprint(w, ListProjectsOutput)
 	})
 }
 
@@ -533,6 +533,6 @@ func HandleListInGroupSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, ListOutput)
+		fmt.Fprint(w, ListOutput)
 	})
 }

--- a/openstack/image/v2/imageimport/testing/requests_test.go
+++ b/openstack/image/v2/imageimport/testing/requests_test.go
@@ -22,7 +22,7 @@ func TestGet(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, ImportGetResult)
+		fmt.Fprint(w, ImportGetResult)
 	})
 
 	validImportMethods := []string{
@@ -49,7 +49,7 @@ func TestCreate(t *testing.T) {
 
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusAccepted)
-		fmt.Fprintf(w, `{}`)
+		fmt.Fprint(w, `{}`)
 	})
 
 	opts := imageimport.CreateOpts{

--- a/openstack/image/v2/images/testing/fixtures_test.go
+++ b/openstack/image/v2/images/testing/fixtures_test.go
@@ -130,7 +130,7 @@ func HandleImageListSuccessfully(t *testing.T) {
 		addNext := false
 		var imageJSON []string
 
-		fmt.Fprintf(w, `{"images": [`)
+		fmt.Fprint(w, `{"images": [`)
 
 		for _, i := range images {
 			if marker == "" || addNext {
@@ -149,7 +149,7 @@ func HandleImageListSuccessfully(t *testing.T) {
 			}
 		}
 		t.Logf("Writing out %v image(s)", len(imageJSON))
-		fmt.Fprintf(w, strings.Join(imageJSON, ","))
+		fmt.Fprint(w, strings.Join(imageJSON, ","))
 
 		fmt.Fprintf(w, `],
 			    "next": "/images?marker=%s&limit=%v",
@@ -176,7 +176,7 @@ func HandleImageCreationSuccessfully(t *testing.T) {
 
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
-		fmt.Fprintf(w, `{
+		fmt.Fprint(w, `{
 			"status": "queued",
 			"name": "Ubuntu 12.10",
 			"protected": false,
@@ -224,7 +224,7 @@ func HandleImageCreationSuccessfullyNulls(t *testing.T) {
 		w.Header().Set("OpenStack-image-import-methods", "glance-direct,web-download")
 		w.Header().Set("OpenStack-image-store-ids", "123,456")
 		w.WriteHeader(http.StatusCreated)
-		fmt.Fprintf(w, `{
+		fmt.Fprint(w, `{
 			"architecture": "x86_64",
 			"status": "queued",
 			"name": "Ubuntu 12.10",
@@ -258,7 +258,7 @@ func HandleImageGetSuccessfully(t *testing.T) {
 
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, `{
+		fmt.Fprint(w, `{
 			"status": "active",
 			"name": "cirros-0.3.2-x86_64-disk",
 			"tags": [],
@@ -347,7 +347,7 @@ func HandleImageUpdateSuccessfully(t *testing.T) {
 
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, `{
+		fmt.Fprint(w, `{
 			"id": "da3b75d9-3f4a-40e7-8a2c-bfab23927dea",
 			"name": "Fedora 17",
 			"status": "active",
@@ -389,7 +389,7 @@ func HandleImageListByTagsSuccessfully(t *testing.T) {
 
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `{
+		fmt.Fprint(w, `{
     "images": [
         {
           "status": "active",
@@ -449,7 +449,7 @@ func HandleImageUpdatePropertiesSuccessfully(t *testing.T) {
 
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, `{
+		fmt.Fprint(w, `{
 			"id": "da3b75d9-3f4a-40e7-8a2c-bfab23927dea",
 			"name": "Fedora 17",
 			"status": "active",

--- a/openstack/image/v2/members/testing/fixtures_test.go
+++ b/openstack/image/v2/members/testing/fixtures_test.go
@@ -18,7 +18,7 @@ func HandleCreateImageMemberSuccessfully(t *testing.T) {
 		th.TestJSONRequest(t, r, `{"member": "8989447062e04a818baf9e073fd04fa7"}`)
 
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, `{
+		fmt.Fprint(w, `{
 		    "created_at": "2013-09-20T19:22:19Z",
 		    "image_id": "da3b75d9-3f4a-40e7-8a2c-bfab23927dea",
 		    "member_id": "8989447062e04a818baf9e073fd04fa7",
@@ -37,7 +37,7 @@ func HandleImageMemberList(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", fakeclient.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, `{
+		fmt.Fprint(w, `{
 		    "members": [
 		        {
 		            "created_at": "2013-10-07T17:58:03Z",
@@ -68,7 +68,7 @@ func HandleImageMemberEmptyList(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", fakeclient.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, `{
+		fmt.Fprint(w, `{
 		    "members": [],
 		    "schema": "/v2/schemas/members"
 		}`)
@@ -82,7 +82,7 @@ func HandleImageMemberDetails(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", fakeclient.TokenID)
 
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, `{
+		fmt.Fprint(w, `{
 		    "status": "pending",
 		    "created_at": "2013-11-26T07:21:21Z",
 		    "updated_at": "2013-11-26T07:21:21Z",
@@ -120,7 +120,7 @@ func HandleImageMemberUpdate(t *testing.T) *CallsCounter {
 
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `{
+		fmt.Fprint(w, `{
 		    "status": "accepted",
 		    "created_at": "2013-11-26T07:21:21Z",
 		    "updated_at": "2013-11-26T07:21:21Z",

--- a/openstack/image/v2/tasks/testing/requests_test.go
+++ b/openstack/image/v2/tasks/testing/requests_test.go
@@ -24,7 +24,7 @@ func TestList(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, TasksListResult)
+		fmt.Fprint(w, TasksListResult)
 	})
 
 	count := 0
@@ -64,7 +64,7 @@ func TestGet(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, TasksGetResult)
+		fmt.Fprint(w, TasksGetResult)
 	})
 
 	s, err := tasks.Get(context.TODO(), fakeclient.ServiceClient(), "1252f636-1246-4319-bfba-c47cde0efbe0").Extract()
@@ -102,7 +102,7 @@ func TestCreate(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		fmt.Fprintf(w, TaskCreateResult)
+		fmt.Fprint(w, TaskCreateResult)
 	})
 
 	opts := tasks.CreateOpts{

--- a/openstack/keymanager/v1/acls/testing/fixtures_test.go
+++ b/openstack/keymanager/v1/acls/testing/fixtures_test.go
@@ -75,7 +75,7 @@ func HandleGetSecretACLSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, GetResponse)
+		fmt.Fprint(w, GetResponse)
 	})
 }
 
@@ -89,7 +89,7 @@ func HandleGetContainerACLSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, GetResponse)
+		fmt.Fprint(w, GetResponse)
 	})
 }
 
@@ -102,7 +102,7 @@ func HandleSetSecretACLSuccessfully(t *testing.T) {
 		th.TestJSONRequest(t, r, SetRequest)
 
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, SecretSetResponse)
+		fmt.Fprint(w, SecretSetResponse)
 	})
 }
 
@@ -115,7 +115,7 @@ func HandleSetContainerACLSuccessfully(t *testing.T) {
 		th.TestJSONRequest(t, r, SetRequest)
 
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, ContainerSetResponse)
+		fmt.Fprint(w, ContainerSetResponse)
 	})
 }
 
@@ -128,7 +128,7 @@ func HandleUpdateSecretACLSuccessfully(t *testing.T) {
 		th.TestJSONRequest(t, r, UpdateRequest)
 
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, SecretSetResponse)
+		fmt.Fprint(w, SecretSetResponse)
 	})
 }
 
@@ -141,7 +141,7 @@ func HandleUpdateContainerACLSuccessfully(t *testing.T) {
 		th.TestJSONRequest(t, r, UpdateRequest)
 
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, ContainerSetResponse)
+		fmt.Fprint(w, ContainerSetResponse)
 	})
 }
 

--- a/openstack/keymanager/v1/containers/testing/fixtures_test.go
+++ b/openstack/keymanager/v1/containers/testing/fixtures_test.go
@@ -235,7 +235,7 @@ func HandleListContainersSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, ListResponse)
+		fmt.Fprint(w, ListResponse)
 	})
 }
 
@@ -249,7 +249,7 @@ func HandleGetContainerSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, GetResponse)
+		fmt.Fprint(w, GetResponse)
 	})
 }
 
@@ -262,7 +262,7 @@ func HandleCreateContainerSuccessfully(t *testing.T) {
 		th.TestJSONRequest(t, r, CreateRequest)
 
 		w.WriteHeader(http.StatusCreated)
-		fmt.Fprintf(w, GetResponse)
+		fmt.Fprint(w, GetResponse)
 	})
 }
 
@@ -288,7 +288,7 @@ func HandleListConsumersSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, ListConsumersResponse)
+		fmt.Fprint(w, ListConsumersResponse)
 	})
 }
 
@@ -302,7 +302,7 @@ func HandleCreateConsumerSuccessfully(t *testing.T) {
 		th.TestJSONRequest(t, r, CreateConsumerRequest)
 
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, CreateConsumerResponse)
+		fmt.Fprint(w, CreateConsumerResponse)
 	})
 }
 
@@ -316,6 +316,6 @@ func HandleDeleteConsumerSuccessfully(t *testing.T) {
 		th.TestJSONRequest(t, r, CreateConsumerRequest)
 
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, GetResponse)
+		fmt.Fprint(w, GetResponse)
 	})
 }

--- a/openstack/keymanager/v1/orders/testing/fixtures_test.go
+++ b/openstack/keymanager/v1/orders/testing/fixtures_test.go
@@ -143,7 +143,7 @@ func HandleListOrdersSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, ListResponse)
+		fmt.Fprint(w, ListResponse)
 	})
 }
 
@@ -157,7 +157,7 @@ func HandleGetOrderSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, GetResponse)
+		fmt.Fprint(w, GetResponse)
 	})
 }
 
@@ -170,7 +170,7 @@ func HandleCreateOrderSuccessfully(t *testing.T) {
 		th.TestJSONRequest(t, r, CreateRequest)
 
 		w.WriteHeader(http.StatusAccepted)
-		fmt.Fprintf(w, GetResponse)
+		fmt.Fprint(w, GetResponse)
 	})
 }
 

--- a/openstack/keymanager/v1/secrets/testing/fixtures_test.go
+++ b/openstack/keymanager/v1/secrets/testing/fixtures_test.go
@@ -198,7 +198,7 @@ func HandleListSecretsSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, ListResponse)
+		fmt.Fprint(w, ListResponse)
 	})
 }
 
@@ -212,7 +212,7 @@ func HandleGetSecretSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, GetResponse)
+		fmt.Fprint(w, GetResponse)
 	})
 }
 
@@ -225,7 +225,7 @@ func HandleGetPayloadSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "text/plain")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, GetPayloadResponse)
+		fmt.Fprint(w, GetPayloadResponse)
 	})
 }
 
@@ -238,7 +238,7 @@ func HandleCreateSecretSuccessfully(t *testing.T) {
 		th.TestJSONRequest(t, r, CreateRequest)
 
 		w.WriteHeader(http.StatusCreated)
-		fmt.Fprintf(w, CreateResponse)
+		fmt.Fprint(w, CreateResponse)
 	})
 }
 
@@ -277,7 +277,7 @@ func HandleGetMetadataSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, GetMetadataResponse)
+		fmt.Fprint(w, GetMetadataResponse)
 	})
 }
 
@@ -293,7 +293,7 @@ func HandleCreateMetadataSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
-		fmt.Fprintf(w, CreateMetadataResponse)
+		fmt.Fprint(w, CreateMetadataResponse)
 	})
 }
 
@@ -308,7 +308,7 @@ func HandleGetMetadatumSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, MetadatumResponse)
+		fmt.Fprint(w, MetadatumResponse)
 	})
 }
 
@@ -324,7 +324,7 @@ func HandleCreateMetadatumSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
-		fmt.Fprintf(w, MetadatumResponse)
+		fmt.Fprint(w, MetadatumResponse)
 	})
 }
 
@@ -340,7 +340,7 @@ func HandleUpdateMetadatumSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, MetadatumResponse)
+		fmt.Fprint(w, MetadatumResponse)
 	})
 }
 

--- a/openstack/loadbalancer/v2/amphorae/testing/fixtures_test.go
+++ b/openstack/loadbalancer/v2/amphorae/testing/fixtures_test.go
@@ -150,9 +150,9 @@ func HandleAmphoraListSuccessfully(t *testing.T) {
 		marker := r.Form.Get("marker")
 		switch marker {
 		case "":
-			fmt.Fprintf(w, AmphoraeListBody)
+			fmt.Fprint(w, AmphoraeListBody)
 		case "7f890893-ced0-46ed-8697-33415d070e5a":
-			fmt.Fprintf(w, `{ "amphorae": [] }`)
+			fmt.Fprint(w, `{ "amphorae": [] }`)
 		default:
 			t.Fatalf("/v2.0/octavia/amphorae invoked with unexpected marker=[%s]", marker)
 		}
@@ -166,7 +166,7 @@ func HandleAmphoraGetSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		th.TestHeader(t, r, "Accept", "application/json")
 
-		fmt.Fprintf(w, SingleAmphoraBody)
+		fmt.Fprint(w, SingleAmphoraBody)
 	})
 }
 

--- a/openstack/loadbalancer/v2/apiversions/testing/fixture.go
+++ b/openstack/loadbalancer/v2/apiversions/testing/fixture.go
@@ -88,6 +88,6 @@ func MockListResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, OctaviaAllAPIVersionsResponse)
+		fmt.Fprint(w, OctaviaAllAPIVersionsResponse)
 	})
 }

--- a/openstack/loadbalancer/v2/flavorprofiles/testing/fixtures.go
+++ b/openstack/loadbalancer/v2/flavorprofiles/testing/fixtures.go
@@ -94,9 +94,9 @@ func HandleFlavorProfileListSuccessfully(t *testing.T) {
 		marker := r.Form.Get("marker")
 		switch marker {
 		case "":
-			fmt.Fprintf(w, FlavorProfilesListBody)
+			fmt.Fprint(w, FlavorProfilesListBody)
 		case "3a0d060b-fcec-4250-9ab6-940b806a12dd":
-			fmt.Fprintf(w, `{ "flavors": [] }`)
+			fmt.Fprint(w, `{ "flavors": [] }`)
 		default:
 			t.Fatalf("/v2.0/lbaas/flavors invoked with unexpected marker=[%s]", marker)
 		}
@@ -117,7 +117,7 @@ func HandleFlavorProfileCreationSuccessfully(t *testing.T, response string) {
 
 		w.WriteHeader(http.StatusAccepted)
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, response)
+		fmt.Fprint(w, response)
 	})
 }
 
@@ -127,7 +127,7 @@ func HandleFlavorProfileGetSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		th.TestHeader(t, r, "Accept", "application/json")
 
-		fmt.Fprintf(w, SingleFlavorProfileBody)
+		fmt.Fprint(w, SingleFlavorProfileBody)
 	})
 }
 
@@ -154,6 +154,6 @@ func HandleFlavorProfileUpdateSuccessfully(t *testing.T) {
 			}
 		}`)
 
-		fmt.Fprintf(w, PostUpdateFlavorBody)
+		fmt.Fprint(w, PostUpdateFlavorBody)
 	})
 }

--- a/openstack/loadbalancer/v2/flavors/testing/fixtures.go
+++ b/openstack/loadbalancer/v2/flavors/testing/fixtures.go
@@ -102,9 +102,9 @@ func HandleFlavorListSuccessfully(t *testing.T) {
 		marker := r.Form.Get("marker")
 		switch marker {
 		case "":
-			fmt.Fprintf(w, FlavorsListBody)
+			fmt.Fprint(w, FlavorsListBody)
 		case "3a0d060b-fcec-4250-9ab6-940b806a12dd":
-			fmt.Fprintf(w, `{ "flavors": [] }`)
+			fmt.Fprint(w, `{ "flavors": [] }`)
 		default:
 			t.Fatalf("/v2.0/lbaas/flavors invoked with unexpected marker=[%s]", marker)
 		}
@@ -126,7 +126,7 @@ func HandleFlavorCreationSuccessfully(t *testing.T, response string) {
 
 		w.WriteHeader(http.StatusAccepted)
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, response)
+		fmt.Fprint(w, response)
 	})
 }
 
@@ -136,7 +136,7 @@ func HandleFlavorGetSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		th.TestHeader(t, r, "Accept", "application/json")
 
-		fmt.Fprintf(w, SingleFlavorBody)
+		fmt.Fprint(w, SingleFlavorBody)
 	})
 }
 
@@ -163,6 +163,6 @@ func HandleFlavorUpdateSuccessfully(t *testing.T) {
 			}
 		}`)
 
-		fmt.Fprintf(w, PostUpdateFlavorBody)
+		fmt.Fprint(w, PostUpdateFlavorBody)
 	})
 }

--- a/openstack/loadbalancer/v2/flavors/testing/requests_test.go
+++ b/openstack/loadbalancer/v2/flavors/testing/requests_test.go
@@ -69,7 +69,7 @@ func TestListFlavorsEnabled(t *testing.T) {
 				t.Errorf("Expected enabled=%s got %q", testCases[cases], enabled)
 			}
 			cases++
-			fmt.Fprintf(w, `{"flavorprofiles":[]}`)
+			fmt.Fprint(w, `{"flavorprofiles":[]}`)
 		})
 	}()
 

--- a/openstack/loadbalancer/v2/l7policies/testing/fixtures_test.go
+++ b/openstack/loadbalancer/v2/l7policies/testing/fixtures_test.go
@@ -131,7 +131,7 @@ func HandleL7PolicyCreationSuccessfully(t *testing.T, response string) {
 
 		w.WriteHeader(http.StatusAccepted)
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, response)
+		fmt.Fprint(w, response)
 	})
 }
 
@@ -218,9 +218,9 @@ func HandleL7PolicyListSuccessfully(t *testing.T) {
 		marker := r.Form.Get("marker")
 		switch marker {
 		case "":
-			fmt.Fprintf(w, L7PoliciesListBody)
+			fmt.Fprint(w, L7PoliciesListBody)
 		case "45e08a3e-a78f-4b40-a229-1e7e23eee1ab":
-			fmt.Fprintf(w, `{ "l7policies": [] }`)
+			fmt.Fprint(w, `{ "l7policies": [] }`)
 		default:
 			t.Fatalf("/v2.0/lbaas/l7policies invoked with unexpected marker=[%s]", marker)
 		}
@@ -234,7 +234,7 @@ func HandleL7PolicyGetSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		th.TestHeader(t, r, "Accept", "application/json")
 
-		fmt.Fprintf(w, SingleL7PolicyBody)
+		fmt.Fprint(w, SingleL7PolicyBody)
 	})
 }
 
@@ -263,7 +263,7 @@ func HandleL7PolicyUpdateSuccessfully(t *testing.T) {
 			}
 		}`)
 
-		fmt.Fprintf(w, PostUpdateL7PolicyBody)
+		fmt.Fprint(w, PostUpdateL7PolicyBody)
 	})
 }
 
@@ -281,7 +281,7 @@ func HandleL7PolicyUpdateNullRedirectURLSuccessfully(t *testing.T) {
 			}
 		}`)
 
-		fmt.Fprintf(w, PostUpdateL7PolicyNullRedirectURLBody)
+		fmt.Fprint(w, PostUpdateL7PolicyNullRedirectURLBody)
 	})
 }
 
@@ -317,7 +317,7 @@ func HandleRuleCreationSuccessfully(t *testing.T, response string) {
 
 		w.WriteHeader(http.StatusAccepted)
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, response)
+		fmt.Fprint(w, response)
 	})
 }
 
@@ -362,9 +362,9 @@ func HandleRuleListSuccessfully(t *testing.T) {
 		marker := r.Form.Get("marker")
 		switch marker {
 		case "":
-			fmt.Fprintf(w, RulesListBody)
+			fmt.Fprint(w, RulesListBody)
 		case "45e08a3e-a78f-4b40-a229-1e7e23eee1ab":
-			fmt.Fprintf(w, `{ "rules": [] }`)
+			fmt.Fprint(w, `{ "rules": [] }`)
 		default:
 			t.Fatalf("/v2.0/lbaas/l7policies/8a1412f0-4c32-4257-8b07-af4770b604fd/rules invoked with unexpected marker=[%s]", marker)
 		}
@@ -378,7 +378,7 @@ func HandleRuleGetSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		th.TestHeader(t, r, "Accept", "application/json")
 
-		fmt.Fprintf(w, SingleRuleBody)
+		fmt.Fprint(w, SingleRuleBody)
 	})
 }
 
@@ -425,6 +425,6 @@ func HandleRuleUpdateSuccessfully(t *testing.T) {
 			}
 		}`)
 
-		fmt.Fprintf(w, PostUpdateRuleBody)
+		fmt.Fprint(w, PostUpdateRuleBody)
 	})
 }

--- a/openstack/loadbalancer/v2/listeners/testing/fixtures_test.go
+++ b/openstack/loadbalancer/v2/listeners/testing/fixtures_test.go
@@ -218,9 +218,9 @@ func HandleListenerListSuccessfully(t *testing.T) {
 		marker := r.Form.Get("marker")
 		switch marker {
 		case "":
-			fmt.Fprintf(w, ListenersListBody)
+			fmt.Fprint(w, ListenersListBody)
 		case "45e08a3e-a78f-4b40-a229-1e7e23eee1ab":
-			fmt.Fprintf(w, `{ "listeners": [] }`)
+			fmt.Fprint(w, `{ "listeners": [] }`)
 		default:
 			t.Fatalf("/v2.0/lbaas/listeners invoked with unexpected marker=[%s]", marker)
 		}
@@ -255,7 +255,7 @@ func HandleListenerCreationSuccessfully(t *testing.T, response string) {
 
 		w.WriteHeader(http.StatusAccepted)
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, response)
+		fmt.Fprint(w, response)
 	})
 }
 
@@ -266,7 +266,7 @@ func HandleListenerGetSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		th.TestHeader(t, r, "Accept", "application/json")
 
-		fmt.Fprintf(w, SingleListenerBody)
+		fmt.Fprint(w, SingleListenerBody)
 	})
 }
 
@@ -304,7 +304,7 @@ func HandleListenerUpdateSuccessfully(t *testing.T) {
 			}
 		}`)
 
-		fmt.Fprintf(w, PostUpdateListenerBody)
+		fmt.Fprint(w, PostUpdateListenerBody)
 	})
 }
 
@@ -315,6 +315,6 @@ func HandleListenerGetStatsTree(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		th.TestHeader(t, r, "Accept", "application/json")
 
-		fmt.Fprintf(w, GetListenerStatsBody)
+		fmt.Fprint(w, GetListenerStatsBody)
 	})
 }

--- a/openstack/loadbalancer/v2/loadbalancers/testing/fixtures_test.go
+++ b/openstack/loadbalancer/v2/loadbalancers/testing/fixtures_test.go
@@ -453,9 +453,9 @@ func HandleLoadbalancerListSuccessfully(t *testing.T) {
 		marker := r.Form.Get("marker")
 		switch marker {
 		case "":
-			fmt.Fprintf(w, LoadbalancersListBody)
+			fmt.Fprint(w, LoadbalancersListBody)
 		case "45e08a3e-a78f-4b40-a229-1e7e23eee1ab":
-			fmt.Fprintf(w, `{ "loadbalancers": [] }`)
+			fmt.Fprint(w, `{ "loadbalancers": [] }`)
 		default:
 			t.Fatalf("/v2.0/lbaas/loadbalancers invoked with unexpected marker=[%s]", marker)
 		}
@@ -533,7 +533,7 @@ func HandleFullyPopulatedLoadbalancerCreationSuccessfully(t *testing.T, response
 
 		w.WriteHeader(http.StatusAccepted)
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, response)
+		fmt.Fprint(w, response)
 	})
 }
 
@@ -559,7 +559,7 @@ func HandleLoadbalancerCreationSuccessfully(t *testing.T, response string) {
 
 		w.WriteHeader(http.StatusAccepted)
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, response)
+		fmt.Fprint(w, response)
 	})
 }
 
@@ -570,7 +570,7 @@ func HandleLoadbalancerGetSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		th.TestHeader(t, r, "Accept", "application/json")
 
-		fmt.Fprintf(w, SingleLoadbalancerBody)
+		fmt.Fprint(w, SingleLoadbalancerBody)
 	})
 }
 
@@ -581,7 +581,7 @@ func HandleLoadbalancerGetStatusesTree(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		th.TestHeader(t, r, "Accept", "application/json")
 
-		fmt.Fprintf(w, GetLoadbalancerStatusesBody)
+		fmt.Fprint(w, GetLoadbalancerStatusesBody)
 	})
 }
 
@@ -609,7 +609,7 @@ func HandleLoadbalancerUpdateSuccessfully(t *testing.T) {
 			}
 		}`)
 
-		fmt.Fprintf(w, PostUpdateLoadbalancerBody)
+		fmt.Fprint(w, PostUpdateLoadbalancerBody)
 	})
 }
 
@@ -620,7 +620,7 @@ func HandleLoadbalancerGetStatsTree(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		th.TestHeader(t, r, "Accept", "application/json")
 
-		fmt.Fprintf(w, GetLoadbalancerStatsBody)
+		fmt.Fprint(w, GetLoadbalancerStatsBody)
 	})
 }
 

--- a/openstack/loadbalancer/v2/monitors/testing/fixtures_test.go
+++ b/openstack/loadbalancer/v2/monitors/testing/fixtures_test.go
@@ -152,9 +152,9 @@ func HandleHealthmonitorListSuccessfully(t *testing.T) {
 		marker := r.Form.Get("marker")
 		switch marker {
 		case "":
-			fmt.Fprintf(w, HealthmonitorsListBody)
+			fmt.Fprint(w, HealthmonitorsListBody)
 		case "556c8345-28d8-4f84-a246-e04380b0461d":
-			fmt.Fprintf(w, `{ "healthmonitors": [] }`)
+			fmt.Fprint(w, `{ "healthmonitors": [] }`)
 		default:
 			t.Fatalf("/v2.0/lbaas/healthmonitors invoked with unexpected marker=[%s]", marker)
 		}
@@ -184,7 +184,7 @@ func HandleHealthmonitorCreationSuccessfully(t *testing.T, response string) {
 
 		w.WriteHeader(http.StatusAccepted)
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, response)
+		fmt.Fprint(w, response)
 	})
 }
 
@@ -195,7 +195,7 @@ func HandleHealthmonitorGetSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		th.TestHeader(t, r, "Accept", "application/json")
 
-		fmt.Fprintf(w, SingleHealthmonitorBody)
+		fmt.Fprint(w, SingleHealthmonitorBody)
 	})
 }
 
@@ -228,6 +228,6 @@ func HandleHealthmonitorUpdateSuccessfully(t *testing.T) {
 			}
 		}`)
 
-		fmt.Fprintf(w, PostUpdateHealthmonitorBody)
+		fmt.Fprint(w, PostUpdateHealthmonitorBody)
 	})
 }

--- a/openstack/loadbalancer/v2/pools/testing/fixtures_test.go
+++ b/openstack/loadbalancer/v2/pools/testing/fixtures_test.go
@@ -145,9 +145,9 @@ func HandlePoolListSuccessfully(t *testing.T) {
 		marker := r.Form.Get("marker")
 		switch marker {
 		case "":
-			fmt.Fprintf(w, PoolsListBody)
+			fmt.Fprint(w, PoolsListBody)
 		case "45e08a3e-a78f-4b40-a229-1e7e23eee1ab":
-			fmt.Fprintf(w, `{ "pools": [] }`)
+			fmt.Fprint(w, `{ "pools": [] }`)
 		default:
 			t.Fatalf("/v2.0/lbaas/pools invoked with unexpected marker=[%s]", marker)
 		}
@@ -172,7 +172,7 @@ func HandlePoolCreationSuccessfully(t *testing.T, response string) {
 
 		w.WriteHeader(http.StatusAccepted)
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, response)
+		fmt.Fprint(w, response)
 	})
 }
 
@@ -183,7 +183,7 @@ func HandlePoolGetSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		th.TestHeader(t, r, "Accept", "application/json")
 
-		fmt.Fprintf(w, SinglePoolBody)
+		fmt.Fprint(w, SinglePoolBody)
 	})
 }
 
@@ -211,7 +211,7 @@ func HandlePoolUpdateSuccessfully(t *testing.T) {
 			}
 		}`)
 
-		fmt.Fprintf(w, PostUpdatePoolBody)
+		fmt.Fprint(w, PostUpdatePoolBody)
 	})
 }
 
@@ -342,9 +342,9 @@ func HandleMemberListSuccessfully(t *testing.T) {
 		marker := r.Form.Get("marker")
 		switch marker {
 		case "":
-			fmt.Fprintf(w, MembersListBody)
+			fmt.Fprint(w, MembersListBody)
 		case "45e08a3e-a78f-4b40-a229-1e7e23eee1ab":
-			fmt.Fprintf(w, `{ "members": [] }`)
+			fmt.Fprint(w, `{ "members": [] }`)
 		default:
 			t.Fatalf("/v2.0/lbaas/pools/332abe93-f488-41ba-870b-2ac66be7f853/members invoked with unexpected marker=[%s]", marker)
 		}
@@ -370,7 +370,7 @@ func HandleMemberCreationSuccessfully(t *testing.T, response string) {
 
 		w.WriteHeader(http.StatusAccepted)
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, response)
+		fmt.Fprint(w, response)
 	})
 }
 
@@ -381,7 +381,7 @@ func HandleMemberGetSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		th.TestHeader(t, r, "Accept", "application/json")
 
-		fmt.Fprintf(w, SingleMemberBody)
+		fmt.Fprint(w, SingleMemberBody)
 	})
 }
 
@@ -409,7 +409,7 @@ func HandleMemberUpdateSuccessfully(t *testing.T) {
 			}
 		}`)
 
-		fmt.Fprintf(w, PostUpdateMemberBody)
+		fmt.Fprint(w, PostUpdateMemberBody)
 	})
 }
 

--- a/openstack/loadbalancer/v2/providers/testing/fixtures_test.go
+++ b/openstack/loadbalancer/v2/providers/testing/fixtures_test.go
@@ -50,7 +50,7 @@ func HandleProviderListSuccessfully(t *testing.T) {
 		marker := r.Form.Get("marker")
 		switch marker {
 		case "":
-			fmt.Fprintf(w, ProvidersListBody)
+			fmt.Fprint(w, ProvidersListBody)
 		default:
 			t.Fatalf("/v2.0/lbaas/providers invoked with unexpected marker=[%s]", marker)
 		}

--- a/openstack/loadbalancer/v2/quotas/testing/requests_test.go
+++ b/openstack/loadbalancer/v2/quotas/testing/requests_test.go
@@ -23,7 +23,7 @@ func TestGet_1(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, GetResponseRaw_1)
+		fmt.Fprint(w, GetResponseRaw_1)
 	})
 
 	q, err := quotas.Get(context.TODO(), fake.ServiceClient(), "0a73845280574ad389c292f6a74afa76").Extract()
@@ -42,7 +42,7 @@ func TestGet_2(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, GetResponseRaw_2)
+		fmt.Fprint(w, GetResponseRaw_2)
 	})
 
 	q, err := quotas.Get(context.TODO(), fake.ServiceClient(), "0a73845280574ad389c292f6a74afa76").Extract()
@@ -61,7 +61,7 @@ func TestUpdate_1(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusAccepted)
 
-		fmt.Fprintf(w, UpdateRequestResponseRaw_1)
+		fmt.Fprint(w, UpdateRequestResponseRaw_1)
 	})
 
 	q, err := quotas.Update(context.TODO(), fake.ServiceClient(), "0a73845280574ad389c292f6a74afa76", quotas.UpdateOpts{
@@ -89,7 +89,7 @@ func TestUpdate_2(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusAccepted)
 
-		fmt.Fprintf(w, UpdateRequestResponseRaw_2)
+		fmt.Fprint(w, UpdateRequestResponseRaw_2)
 	})
 
 	q, err := quotas.Update(context.TODO(), fake.ServiceClient(), "0a73845280574ad389c292f6a74afa76", quotas.UpdateOpts{

--- a/openstack/messaging/v2/claims/testing/fixtures_test.go
+++ b/openstack/messaging/v2/claims/testing/fixtures_test.go
@@ -93,7 +93,7 @@ func HandleCreateSuccessfully(t *testing.T) {
 
 			w.WriteHeader(http.StatusCreated)
 			w.Header().Add("Content-Type", "application/json")
-			fmt.Fprintf(w, CreateClaimResponse)
+			fmt.Fprint(w, CreateClaimResponse)
 		})
 }
 
@@ -117,7 +117,7 @@ func HandleGetSuccessfully(t *testing.T) {
 			th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 
 			w.Header().Add("Content-Type", "application/json")
-			fmt.Fprintf(w, GetClaimResponse)
+			fmt.Fprint(w, GetClaimResponse)
 		})
 }
 

--- a/openstack/messaging/v2/messages/testing/fixtures_test.go
+++ b/openstack/messaging/v2/messages/testing/fixtures_test.go
@@ -229,7 +229,7 @@ func HandleCreateSuccessfully(t *testing.T) {
 
 			w.Header().Add("Content-Type", "application/json")
 			w.WriteHeader(http.StatusCreated)
-			fmt.Fprintf(w, CreateMessageResponse)
+			fmt.Fprint(w, CreateMessageResponse)
 		})
 }
 
@@ -245,7 +245,7 @@ func HandleListSuccessfully(t *testing.T) {
 
 			switch next {
 			case fmt.Sprintf("/v2/queues/%s/messages?limit=1", QueueName):
-				fmt.Fprintf(w, ListMessagesResponse1)
+				fmt.Fprint(w, ListMessagesResponse1)
 			case fmt.Sprintf("/v2/queues/%s/messages?marker=1", QueueName):
 				fmt.Fprint(w, ListMessagesResponse2)
 			case fmt.Sprintf("/v2/queues/%s/messages?marker=2", QueueName):
@@ -262,7 +262,7 @@ func HandleGetMessagesSuccessfully(t *testing.T) {
 			th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 
 			w.Header().Add("Content-Type", "application/json")
-			fmt.Fprintf(w, GetMessagesResponse)
+			fmt.Fprint(w, GetMessagesResponse)
 		})
 }
 
@@ -274,7 +274,7 @@ func HandleGetSuccessfully(t *testing.T) {
 			th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 
 			w.Header().Add("Content-Type", "application/json")
-			fmt.Fprintf(w, GetMessageResponse)
+			fmt.Fprint(w, GetMessageResponse)
 		})
 }
 
@@ -299,7 +299,7 @@ func HandlePopSuccessfully(t *testing.T) {
 
 			w.Header().Add("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			fmt.Fprintf(w, PopMessageResponse)
+			fmt.Fprint(w, PopMessageResponse)
 		})
 }
 

--- a/openstack/messaging/v2/queues/testing/fixtures_test.go
+++ b/openstack/messaging/v2/queues/testing/fixtures_test.go
@@ -226,7 +226,7 @@ func HandleListSuccessfully(t *testing.T) {
 
 			switch next {
 			case "/v2/queues?limit=1&with_count=true":
-				fmt.Fprintf(w, ListQueuesResponse1)
+				fmt.Fprint(w, ListQueuesResponse1)
 			case "/v2/queues?marker=london":
 				fmt.Fprint(w, ListQueuesResponse2)
 			case "/v2/queues?marker=beijing":
@@ -256,7 +256,7 @@ func HandleUpdateSuccessfully(t *testing.T) {
 			th.TestJSONRequest(t, r, UpdateQueueRequest)
 
 			w.Header().Add("Content-Type", "application/json")
-			fmt.Fprintf(w, UpdateQueueResponse)
+			fmt.Fprint(w, UpdateQueueResponse)
 		})
 }
 
@@ -268,7 +268,7 @@ func HandleGetSuccessfully(t *testing.T) {
 			th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 
 			w.Header().Add("Content-Type", "application/json")
-			fmt.Fprintf(w, GetQueueResponse)
+			fmt.Fprint(w, GetQueueResponse)
 		})
 }
 
@@ -290,7 +290,7 @@ func HandleGetStatsSuccessfully(t *testing.T) {
 			th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 
 			w.Header().Add("Content-Type", "application/json")
-			fmt.Fprintf(w, GetStatsResponse)
+			fmt.Fprint(w, GetStatsResponse)
 		})
 }
 
@@ -303,7 +303,7 @@ func HandleShareSuccessfully(t *testing.T) {
 			th.TestJSONRequest(t, r, CreateShareRequest)
 
 			w.Header().Add("Content-Type", "application/json")
-			fmt.Fprintf(w, CreateShareResponse)
+			fmt.Fprint(w, CreateShareResponse)
 		})
 }
 

--- a/openstack/networking/v2/apiversions/testing/requests_test.go
+++ b/openstack/networking/v2/apiversions/testing/requests_test.go
@@ -23,7 +23,7 @@ func TestListVersions(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
     "versions": [
         {
@@ -96,7 +96,7 @@ func TestAPIInfo(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
     "resources": [
         {

--- a/openstack/networking/v2/extensions/agents/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/agents/testing/requests_test.go
@@ -25,7 +25,7 @@ func TestList(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, AgentsListResult)
+		fmt.Fprint(w, AgentsListResult)
 	})
 
 	count := 0
@@ -66,7 +66,7 @@ func TestGet(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, AgentsGetResult)
+		fmt.Fprint(w, AgentsGetResult)
 	})
 
 	s, err := agents.Get(context.TODO(), fake.ServiceClient(), "43583cf5-472e-4dc8-af5b-6aed4c94ee3a").Extract()
@@ -106,7 +106,7 @@ func TestUpdate(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, AgentsUpdateResult)
+		fmt.Fprint(w, AgentsUpdateResult)
 	})
 
 	iTrue := true
@@ -149,7 +149,7 @@ func TestListDHCPNetworks(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, AgentDHCPNetworksListResult)
+		fmt.Fprint(w, AgentDHCPNetworksListResult)
 	})
 
 	s, err := agents.ListDHCPNetworks(context.TODO(), fake.ServiceClient(), "43583cf5-472e-4dc8-af5b-6aed4c94ee3a").Extract()
@@ -223,7 +223,7 @@ func TestListBGPSpeakers(t *testing.T) {
 			w.Header().Add("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 
-			fmt.Fprintf(w, ListBGPSpeakersResult)
+			fmt.Fprint(w, ListBGPSpeakersResult)
 		})
 
 	count := 0
@@ -305,7 +305,7 @@ func TestListDRAgentHostingBGPSpeakers(t *testing.T) {
 
 			w.Header().Add("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			fmt.Fprintf(w, ListDRAgentHostingBGPSpeakersResult)
+			fmt.Fprint(w, ListDRAgentHostingBGPSpeakersResult)
 		})
 
 	count := 0
@@ -342,7 +342,7 @@ func TestListL3Routers(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, AgentL3RoutersListResult)
+		fmt.Fprint(w, AgentL3RoutersListResult)
 	})
 
 	s, err := agents.ListL3Routers(context.TODO(), fake.ServiceClient(), "43583cf5-472e-4dc8-af5b-6aed4c94ee3a").Extract()

--- a/openstack/networking/v2/extensions/attributestags/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/attributestags/testing/requests_test.go
@@ -25,7 +25,7 @@ func TestReplaceAll(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, attributestagsReplaceAllResult)
+		fmt.Fprint(w, attributestagsReplaceAllResult)
 	})
 
 	opts := attributestags.ReplaceAllOpts{
@@ -48,7 +48,7 @@ func TestList(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, attributestagsListResult)
+		fmt.Fprint(w, attributestagsListResult)
 	})
 
 	res, err := attributestags.List(context.TODO(), fake.ServiceClient(), "networks", "fakeid").Extract()

--- a/openstack/networking/v2/extensions/bgp/peers/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/bgp/peers/testing/requests_test.go
@@ -23,7 +23,7 @@ func TestList(t *testing.T) {
 
 			w.Header().Add("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			fmt.Fprintf(w, ListBGPPeersResult)
+			fmt.Fprint(w, ListBGPPeersResult)
 		})
 	count := 0
 
@@ -54,7 +54,7 @@ func TestGet(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, GetBGPPeerResult)
+		fmt.Fprint(w, GetBGPPeerResult)
 	})
 
 	s, err := peers.Get(context.TODO(), fake.ServiceClient(), bgpPeerID).Extract()
@@ -74,7 +74,7 @@ func TestCreate(t *testing.T) {
 		th.TestJSONRequest(t, r, CreateRequest)
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
-		fmt.Fprintf(w, CreateResponse)
+		fmt.Fprint(w, CreateResponse)
 	})
 
 	var opts peers.CreateOpts
@@ -124,7 +124,7 @@ func TestUpdate(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, UpdateBGPPeerResponse)
+		fmt.Fprint(w, UpdateBGPPeerResponse)
 	})
 
 	var opts peers.UpdateOpts

--- a/openstack/networking/v2/extensions/bgp/speakers/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/bgp/speakers/testing/requests_test.go
@@ -23,7 +23,7 @@ func TestList(t *testing.T) {
 
 			w.Header().Add("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			fmt.Fprintf(w, ListBGPSpeakerResult)
+			fmt.Fprint(w, ListBGPSpeakerResult)
 		})
 	count := 0
 
@@ -54,7 +54,7 @@ func TestGet(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, GetBGPSpeakerResult)
+		fmt.Fprint(w, GetBGPSpeakerResult)
 	})
 
 	s, err := speakers.Get(context.TODO(), fake.ServiceClient(), bgpSpeakerID).Extract()
@@ -74,7 +74,7 @@ func TestCreate(t *testing.T) {
 		th.TestJSONRequest(t, r, CreateRequest)
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
-		fmt.Fprintf(w, CreateResponse)
+		fmt.Fprint(w, CreateResponse)
 	})
 
 	opts := speakers.CreateOpts{
@@ -124,7 +124,7 @@ func TestUpdate(t *testing.T) {
 			th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 			w.Header().Add("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			fmt.Fprintf(w, GetBGPSpeakerResult)
+			fmt.Fprint(w, GetBGPSpeakerResult)
 		} else if r.Method == "PUT" {
 			th.TestMethod(t, r, "PUT")
 			th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
@@ -134,7 +134,7 @@ func TestUpdate(t *testing.T) {
 
 			w.Header().Add("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			fmt.Fprintf(w, UpdateBGPSpeakerResponse)
+			fmt.Fprint(w, UpdateBGPSpeakerResponse)
 		} else {
 			panic("Unexpected Request")
 		}
@@ -168,7 +168,7 @@ func TestAddBGPPeer(t *testing.T) {
 
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, AddRemoveBGPPeerJSON)
+		fmt.Fprint(w, AddRemoveBGPPeerJSON)
 	})
 
 	opts := speakers.AddBGPPeerOpts{BGPPeerID: bgpPeerID}
@@ -207,7 +207,7 @@ func TestGetAdvertisedRoutes(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, GetAdvertisedRoutesResult)
+		fmt.Fprint(w, GetAdvertisedRoutesResult)
 	})
 
 	count := 0
@@ -249,7 +249,7 @@ func TestAddGatewayNetwork(t *testing.T) {
 
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, AddRemoveGatewayNetworkJSON)
+		fmt.Fprint(w, AddRemoveGatewayNetworkJSON)
 	})
 
 	opts := speakers.AddGatewayNetworkOpts{NetworkID: networkID}
@@ -273,7 +273,7 @@ func TestRemoveGatewayNetwork(t *testing.T) {
 
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, "")
+		fmt.Fprint(w, "")
 	})
 
 	opts := speakers.RemoveGatewayNetworkOpts{NetworkID: networkID}

--- a/openstack/networking/v2/extensions/bgpvpns/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/bgpvpns/testing/requests_test.go
@@ -27,7 +27,9 @@ func TestList(t *testing.T) {
 			th.TestMethod(t, r, "GET")
 			th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 
-			r.ParseForm()
+			if err := r.ParseForm(); err != nil {
+				t.Errorf("Failed to parse request form %v", err)
+			}
 			th.AssertDeepEquals(t, r.Form["fields"], fields)
 			th.AssertDeepEquals(t, r.Form["project_id"], filterProjectID)
 
@@ -177,7 +179,9 @@ func TestListNetworkAssociations(t *testing.T) {
 		th.TestMethod(t, r, "GET")
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 
-		r.ParseForm()
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("Failed to parse request form %v", err)
+		}
 		th.AssertDeepEquals(t, fields, r.Form["fields"])
 
 		w.Header().Add("Content-Type", "application/json")
@@ -278,7 +282,9 @@ func TestListRouterAssociations(t *testing.T) {
 		th.TestMethod(t, r, "GET")
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 
-		r.ParseForm()
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("Failed to parse request form %v", err)
+		}
 		th.AssertDeepEquals(t, fields, r.Form["fields"])
 
 		w.Header().Add("Content-Type", "application/json")
@@ -404,7 +410,9 @@ func TestListPortAssociations(t *testing.T) {
 		th.TestMethod(t, r, "GET")
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 
-		r.ParseForm()
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("Failed to parse request form %v", err)
+		}
 		th.AssertDeepEquals(t, fields, r.Form["fields"])
 
 		w.Header().Add("Content-Type", "application/json")

--- a/openstack/networking/v2/extensions/bgpvpns/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/bgpvpns/testing/requests_test.go
@@ -35,7 +35,7 @@ func TestList(t *testing.T) {
 
 			w.Header().Add("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			fmt.Fprintf(w, ListBGPVPNsResult)
+			fmt.Fprint(w, ListBGPVPNsResult)
 		})
 	count := 0
 
@@ -67,7 +67,7 @@ func TestGet(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, GetBGPVPNResult)
+		fmt.Fprint(w, GetBGPVPNResult)
 	})
 
 	r, err := bgpvpns.Get(context.TODO(), fake.ServiceClient(), bgpVpnID).Extract()
@@ -87,7 +87,7 @@ func TestCreate(t *testing.T) {
 		th.TestJSONRequest(t, r, CreateRequest)
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
-		fmt.Fprintf(w, CreateResponse)
+		fmt.Fprint(w, CreateResponse)
 	})
 
 	opts := bgpvpns.CreateOpts{
@@ -148,7 +148,7 @@ func TestUpdate(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, UpdateBGPVPNResponse)
+		fmt.Fprint(w, UpdateBGPVPNResponse)
 	})
 
 	name := "foo"
@@ -186,7 +186,7 @@ func TestListNetworkAssociations(t *testing.T) {
 
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, ListNetworkAssociationsResult)
+		fmt.Fprint(w, ListNetworkAssociationsResult)
 	})
 
 	count := 0
@@ -223,7 +223,7 @@ func TestCreateNetworkAssociation(t *testing.T) {
 		th.TestJSONRequest(t, r, CreateNetworkAssociationRequest)
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
-		fmt.Fprintf(w, CreateNetworkAssociationResponse)
+		fmt.Fprint(w, CreateNetworkAssociationResponse)
 	})
 
 	opts := bgpvpns.CreateNetworkAssociationOpts{
@@ -245,7 +245,7 @@ func TestGetNetworkAssociation(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, GetNetworkAssociationResult)
+		fmt.Fprint(w, GetNetworkAssociationResult)
 	})
 
 	r, err := bgpvpns.GetNetworkAssociation(context.TODO(), fake.ServiceClient(), bgpVpnID, networkAssociationID).Extract()
@@ -289,7 +289,7 @@ func TestListRouterAssociations(t *testing.T) {
 
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, ListRouterAssociationsResult)
+		fmt.Fprint(w, ListRouterAssociationsResult)
 	})
 
 	count := 0
@@ -326,7 +326,7 @@ func TestCreateRouterAssociation(t *testing.T) {
 		th.TestJSONRequest(t, r, CreateRouterAssociationRequest)
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
-		fmt.Fprintf(w, CreateRouterAssociationResponse)
+		fmt.Fprint(w, CreateRouterAssociationResponse)
 	})
 
 	opts := bgpvpns.CreateRouterAssociationOpts{
@@ -348,7 +348,7 @@ func TestGetRouterAssociation(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, GetRouterAssociationResult)
+		fmt.Fprint(w, GetRouterAssociationResult)
 	})
 
 	r, err := bgpvpns.GetRouterAssociation(context.TODO(), fake.ServiceClient(), bgpVpnID, routerAssociationID).Extract()
@@ -370,7 +370,7 @@ func TestUpdateRouterAssociation(t *testing.T) {
 		th.TestJSONRequest(t, r, UpdateRouterAssociationRequest)
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, UpdateRouterAssociationResponse)
+		fmt.Fprint(w, UpdateRouterAssociationResponse)
 	})
 
 	opts := bgpvpns.UpdateRouterAssociationOpts{
@@ -417,7 +417,7 @@ func TestListPortAssociations(t *testing.T) {
 
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, ListPortAssociationsResult)
+		fmt.Fprint(w, ListPortAssociationsResult)
 	})
 
 	count := 0
@@ -454,7 +454,7 @@ func TestCreatePortAssociation(t *testing.T) {
 		th.TestJSONRequest(t, r, CreatePortAssociationRequest)
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
-		fmt.Fprintf(w, CreatePortAssociationResponse)
+		fmt.Fprint(w, CreatePortAssociationResponse)
 	})
 
 	opts := bgpvpns.CreatePortAssociationOpts{
@@ -476,7 +476,7 @@ func TestGetPortAssociation(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, GetPortAssociationResult)
+		fmt.Fprint(w, GetPortAssociationResult)
 	})
 
 	r, err := bgpvpns.GetPortAssociation(context.TODO(), fake.ServiceClient(), bgpVpnID, portAssociationID).Extract()
@@ -498,7 +498,7 @@ func TestUpdatePortAssociation(t *testing.T) {
 		th.TestJSONRequest(t, r, UpdatePortAssociationRequest)
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, UpdatePortAssociationResponse)
+		fmt.Fprint(w, UpdatePortAssociationResponse)
 	})
 
 	opts := bgpvpns.UpdatePortAssociationOpts{

--- a/openstack/networking/v2/extensions/dns/testing/fixtures_test.go
+++ b/openstack/networking/v2/extensions/dns/testing/fixtures_test.go
@@ -78,7 +78,7 @@ func PortHandleListSuccessfully(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, porttest.ListResponse)
+		fmt.Fprint(w, porttest.ListResponse)
 	})
 }
 
@@ -90,7 +90,7 @@ func PortHandleGet(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, porttest.GetResponse)
+		fmt.Fprint(w, porttest.GetResponse)
 	})
 }
 
@@ -121,7 +121,7 @@ func PortHandleCreate(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
     "port": {
         "status": "DOWN",
@@ -184,7 +184,7 @@ func PortHandleUpdate(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
     "port": {
         "status": "DOWN",
@@ -229,7 +229,7 @@ func FloatingIPHandleList(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, floatingiptest.ListResponseDNS)
+		fmt.Fprint(w, floatingiptest.ListResponseDNS)
 	})
 }
 
@@ -241,7 +241,7 @@ func FloatingIPHandleGet(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, fmt.Sprintf(`{"floatingip": %s}`, floatingiptest.FipDNS))
+		fmt.Fprint(w, fmt.Sprintf(`{"floatingip": %s}`, floatingiptest.FipDNS))
 	})
 }
 
@@ -264,7 +264,7 @@ func FloatingIPHandleCreate(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		fmt.Fprintf(w, fmt.Sprintf(`{"floatingip": %s}`, floatingiptest.FipDNS))
+		fmt.Fprint(w, fmt.Sprintf(`{"floatingip": %s}`, floatingiptest.FipDNS))
 	})
 }
 
@@ -278,7 +278,7 @@ func NetworkHandleList(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, networktest.ListResponse)
+		fmt.Fprint(w, networktest.ListResponse)
 	})
 }
 
@@ -290,7 +290,7 @@ func NetworkHandleGet(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, networktest.GetResponse)
+		fmt.Fprint(w, networktest.GetResponse)
 	})
 }
 
@@ -304,7 +304,7 @@ func NetworkHandleCreate(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		fmt.Fprintf(w, NetworkCreateResponse)
+		fmt.Fprint(w, NetworkCreateResponse)
 	})
 }
 
@@ -319,6 +319,6 @@ func NetworkHandleUpdate(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, NetworkUpdateResponse)
+		fmt.Fprint(w, NetworkUpdateResponse)
 	})
 }

--- a/openstack/networking/v2/extensions/external/testing/results_test.go
+++ b/openstack/networking/v2/extensions/external/testing/results_test.go
@@ -24,7 +24,7 @@ func TestList(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, nettest.ListResponse)
+		fmt.Fprint(w, nettest.ListResponse)
 	})
 
 	type NetworkWithExternalExt struct {
@@ -54,7 +54,7 @@ func TestGet(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, nettest.GetResponse)
+		fmt.Fprint(w, nettest.GetResponse)
 	})
 
 	var s struct {
@@ -83,7 +83,7 @@ func TestCreate(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		fmt.Fprintf(w, CreateResponse)
+		fmt.Fprint(w, CreateResponse)
 	})
 
 	iTrue := true
@@ -118,7 +118,7 @@ func TestUpdate(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, UpdateResponse)
+		fmt.Fprint(w, UpdateResponse)
 	})
 
 	iTrue := true

--- a/openstack/networking/v2/extensions/fwaas_v2/groups/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/fwaas_v2/groups/testing/requests_test.go
@@ -23,7 +23,7 @@ func TestList(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
   "firewall_groups": [
     {
@@ -136,7 +136,7 @@ func TestGet(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
   "firewall_group": {
     "id": "6bfb0f10-07f7-4a40-b534-bad4b4ca3428",
@@ -199,7 +199,7 @@ func TestCreate(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
   "firewall_group": {
     "id": "6bfb0f10-07f7-4a40-b534-bad4b4ca3428",
@@ -260,7 +260,7 @@ func TestUpdate(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
   "firewall_group": {
     "id": "6bfb0f10-07f7-4a40-b534-bad4b4ca3428",
@@ -319,7 +319,7 @@ func TestRemoveIngressPolicy(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
   "firewall_group": {
     "id": "6bfb0f10-07f7-4a40-b534-bad4b4ca3428",
@@ -367,7 +367,7 @@ func TestRemoveEgressPolicy(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
   "firewall_group": {
     "id": "6bfb0f10-07f7-4a40-b534-bad4b4ca3428",

--- a/openstack/networking/v2/extensions/fwaas_v2/policies/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/fwaas_v2/policies/testing/requests_test.go
@@ -24,7 +24,7 @@ func TestList(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
     "firewall_policies": [
         {
@@ -135,7 +135,7 @@ func TestCreate(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
     "firewall_policy":{
         "name": "policy",
@@ -189,7 +189,7 @@ func TestInsertRule(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
     "audited": false,
     "description": "TESTACC-DESC-8P12aLfW",
@@ -252,7 +252,7 @@ func TestGet(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
     "firewall_policy":{
         "name": "www",
@@ -310,7 +310,7 @@ func TestUpdate(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
     "firewall_policy":{
         "name": "policy",
@@ -377,7 +377,7 @@ func TestRemoveRule(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
     "audited": false,
     "description": "TESTACC-DESC-skno2e52",

--- a/openstack/networking/v2/extensions/fwaas_v2/rules/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/fwaas_v2/rules/testing/requests_test.go
@@ -24,7 +24,7 @@ func TestList(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
     "firewall_rules": [
         {
@@ -150,7 +150,7 @@ func TestCreate(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
 	"firewall_rule":{
 		"protocol": "tcp",
@@ -215,7 +215,7 @@ func TestCreateAnyProtocol(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
 	"firewall_rule":{
 		"protocol": null,
@@ -264,7 +264,7 @@ func TestGet(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
 	"firewall_rule":{
 		"protocol": "tcp",
@@ -333,7 +333,7 @@ func TestUpdate(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
 	"firewall_rule":{
 		"protocol": "tcp",

--- a/openstack/networking/v2/extensions/layer3/addressscopes/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/layer3/addressscopes/testing/requests_test.go
@@ -23,7 +23,7 @@ func TestList(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, AddressScopesListResult)
+		fmt.Fprint(w, AddressScopesListResult)
 	})
 
 	count := 0
@@ -63,7 +63,7 @@ func TestGet(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, AddressScopesGetResult)
+		fmt.Fprint(w, AddressScopesGetResult)
 	})
 
 	s, err := addressscopes.Get(context.TODO(), fake.ServiceClient(), "9cc35860-522a-4d35-974d-51d4b011801e").Extract()
@@ -91,7 +91,7 @@ func TestCreate(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		fmt.Fprintf(w, AddressScopeCreateResult)
+		fmt.Fprint(w, AddressScopeCreateResult)
 	})
 
 	opts := addressscopes.CreateOpts{
@@ -124,7 +124,7 @@ func TestUpdate(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, AddressScopeUpdateResult)
+		fmt.Fprint(w, AddressScopeUpdateResult)
 	})
 
 	shared := true

--- a/openstack/networking/v2/extensions/layer3/extraroutes/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/layer3/extraroutes/testing/requests_test.go
@@ -35,7 +35,7 @@ func TestAddExtraRoutes(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
     "router": {
         "name": "name",
@@ -109,7 +109,7 @@ func TestRemoveExtraRoutes(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
     "router": {
         "name": "name",

--- a/openstack/networking/v2/extensions/layer3/floatingips/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/layer3/floatingips/testing/requests_test.go
@@ -24,7 +24,7 @@ func TestList(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, ListResponse)
+		fmt.Fprint(w, ListResponse)
 	})
 
 	count := 0
@@ -88,7 +88,7 @@ func TestInvalidNextPageURLs(t *testing.T) {
 	th.Mux.HandleFunc("/v2.0/floatingips", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, `{"floatingips": [{}], "floatingips_links": {}}`)
+		fmt.Fprint(w, `{"floatingips": [{}], "floatingips_links": {}}`)
 	})
 
 	err := floatingips.List(fake.ServiceClient(), floatingips.ListOpts{}).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
@@ -134,7 +134,7 @@ func TestCreate(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
     "floatingip": {
         "router_id": "d23abc8d-2991-4a55-ba98-2aaea84cc72f",
@@ -189,7 +189,7 @@ func TestCreateEmptyPort(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 				{
 					"floatingip": {
 						"router_id": "d23abc8d-2991-4a55-ba98-2aaea84cc72f",
@@ -243,7 +243,7 @@ func TestCreateWithSubnetID(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
     "floatingip": {
         "router_id": null,
@@ -289,7 +289,7 @@ func TestGet(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
     "floatingip": {
         "floating_network_id": "90f742b1-6d17-487b-ba95-71881dbc0b64",
@@ -342,7 +342,7 @@ func TestAssociate(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
 	"floatingip": {
 			"router_id": "d23abc8d-2991-4a55-ba98-2aaea84cc72f",
@@ -384,7 +384,7 @@ func TestDisassociate(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
     "floatingip": {
         "router_id": "d23abc8d-2991-4a55-ba98-2aaea84cc72f",

--- a/openstack/networking/v2/extensions/layer3/portforwarding/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/layer3/portforwarding/testing/requests_test.go
@@ -23,7 +23,7 @@ func TestPortForwardingList(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, ListResponse)
+		fmt.Fprint(w, ListResponse)
 	})
 
 	count := 0
@@ -91,7 +91,7 @@ func TestCreate(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
 	"port_forwarding": {
     		"protocol": "tcp",
@@ -134,7 +134,7 @@ func TestGet(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
   "port_forwarding": {
     "protocol": "tcp",
@@ -196,7 +196,7 @@ func TestUpdate(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
   "port_forwarding": {
     "protocol": "udp",

--- a/openstack/networking/v2/extensions/layer3/routers/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/layer3/routers/testing/requests_test.go
@@ -24,7 +24,7 @@ func TestList(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
     "routers": [
         {
@@ -156,7 +156,7 @@ func TestCreate(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
     "router": {
         "status": "ACTIVE",
@@ -224,7 +224,7 @@ func TestGet(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
     "router": {
         "status": "ACTIVE",
@@ -301,7 +301,7 @@ func TestUpdate(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
     "router": {
         "status": "ACTIVE",
@@ -367,7 +367,7 @@ func TestUpdateWithoutRoutes(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
     "router": {
         "status": "ACTIVE",
@@ -422,7 +422,7 @@ func TestAllRoutesRemoved(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
     "router": {
         "status": "ACTIVE",
@@ -481,7 +481,7 @@ func TestAddInterface(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
     "subnet_id": "0d32a837-8069-4ec3-84c4-3eef3e10b188",
     "tenant_id": "017d8de156df4177889f31a9bd6edc00",
@@ -530,7 +530,7 @@ func TestRemoveInterface(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
 		"subnet_id": "0d32a837-8069-4ec3-84c4-3eef3e10b188",
 		"tenant_id": "017d8de156df4177889f31a9bd6edc00",
@@ -561,7 +561,7 @@ func TestListL3Agents(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
     "agents": [
         {

--- a/openstack/networking/v2/extensions/mtu/testing/results_test.go
+++ b/openstack/networking/v2/extensions/mtu/testing/results_test.go
@@ -29,7 +29,7 @@ func TestList(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, nettest.ListResponse)
+		fmt.Fprint(w, nettest.ListResponse)
 	})
 
 	type NetworkWithMTUExt struct {
@@ -59,7 +59,7 @@ func TestGet(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, nettest.GetResponse)
+		fmt.Fprint(w, nettest.GetResponse)
 	})
 
 	var s NetworkMTU
@@ -85,7 +85,7 @@ func TestCreate(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		fmt.Fprintf(w, CreateResponse)
+		fmt.Fprint(w, CreateResponse)
 	})
 
 	iTrue := true
@@ -123,7 +123,7 @@ func TestUpdate(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, UpdateResponse)
+		fmt.Fprint(w, UpdateResponse)
 	})
 
 	iTrue := true

--- a/openstack/networking/v2/extensions/networkipavailabilities/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/networkipavailabilities/testing/requests_test.go
@@ -24,7 +24,7 @@ func TestList(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, NetworkIPAvailabilityListResult)
+		fmt.Fprint(w, NetworkIPAvailabilityListResult)
 	})
 
 	count := 0
@@ -65,7 +65,7 @@ func TestGet(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, NetworkIPAvailabilityGetResult)
+		fmt.Fprint(w, NetworkIPAvailabilityGetResult)
 	})
 
 	s, err := networkipavailabilities.Get(context.TODO(), fake.ServiceClient(), "cf11ab78-2302-49fa-870f-851a08c7afb8").Extract()

--- a/openstack/networking/v2/extensions/portsbinding/testing/fixtures_test.go
+++ b/openstack/networking/v2/extensions/portsbinding/testing/fixtures_test.go
@@ -18,7 +18,7 @@ func HandleListSuccessfully(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, porttest.ListResponse)
+		fmt.Fprint(w, porttest.ListResponse)
 	})
 }
 
@@ -30,7 +30,7 @@ func HandleGet(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, porttest.GetResponse)
+		fmt.Fprint(w, porttest.GetResponse)
 	})
 }
 
@@ -62,7 +62,7 @@ func HandleCreate(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
     "port": {
         "status": "DOWN",
@@ -120,7 +120,7 @@ func HandleUpdate(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
     "port": {
         "status": "DOWN",

--- a/openstack/networking/v2/extensions/provider/testing/results_test.go
+++ b/openstack/networking/v2/extensions/provider/testing/results_test.go
@@ -25,7 +25,7 @@ func TestList(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, nettest.ListResponse)
+		fmt.Fprint(w, nettest.ListResponse)
 	})
 
 	type NetworkWithExt struct {
@@ -60,7 +60,7 @@ func TestGet(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, nettest.GetResponse)
+		fmt.Fprint(w, nettest.GetResponse)
 	})
 
 	var s struct {
@@ -91,7 +91,7 @@ func TestCreate(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		fmt.Fprintf(w, nettest.CreateResponse)
+		fmt.Fprint(w, nettest.CreateResponse)
 	})
 
 	var s struct {
@@ -142,7 +142,7 @@ func TestCreateWithMultipleProvider(t *testing.T) {
 		`)
 
 		w.WriteHeader(http.StatusCreated)
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
 	"network": {
 		"status": "ACTIVE",
@@ -227,7 +227,7 @@ func TestUpdate(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, nettest.UpdateResponse)
+		fmt.Fprint(w, nettest.UpdateResponse)
 	})
 
 	var s struct {

--- a/openstack/networking/v2/extensions/qos/policies/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/qos/policies/testing/requests_test.go
@@ -26,7 +26,7 @@ func TestGetPort(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		_, err := fmt.Fprintf(w, GetPortResponse)
+		_, err := fmt.Fprint(w, GetPortResponse)
 		th.AssertNoErr(t, err)
 	})
 
@@ -55,7 +55,7 @@ func TestCreatePort(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		_, err := fmt.Fprintf(w, CreatePortResponse)
+		_, err := fmt.Fprint(w, CreatePortResponse)
 		th.AssertNoErr(t, err)
 	})
 
@@ -93,7 +93,7 @@ func TestUpdatePortWithPolicy(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		_, err := fmt.Fprintf(w, UpdatePortWithPolicyResponse)
+		_, err := fmt.Fprint(w, UpdatePortWithPolicyResponse)
 		th.AssertNoErr(t, err)
 	})
 
@@ -131,7 +131,7 @@ func TestUpdatePortWithoutPolicy(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		_, err := fmt.Fprintf(w, UpdatePortWithoutPolicyResponse)
+		_, err := fmt.Fprint(w, UpdatePortWithoutPolicyResponse)
 		th.AssertNoErr(t, err)
 	})
 
@@ -166,7 +166,7 @@ func TestGetNetwork(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		_, err := fmt.Fprintf(w, GetNetworkResponse)
+		_, err := fmt.Fprint(w, GetNetworkResponse)
 		th.AssertNoErr(t, err)
 	})
 
@@ -195,7 +195,7 @@ func TestCreateNetwork(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		_, err := fmt.Fprintf(w, CreateNetworkResponse)
+		_, err := fmt.Fprint(w, CreateNetworkResponse)
 		th.AssertNoErr(t, err)
 	})
 
@@ -232,7 +232,7 @@ func TestUpdateNetworkWithPolicy(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		_, err := fmt.Fprintf(w, UpdateNetworkWithPolicyResponse)
+		_, err := fmt.Fprint(w, UpdateNetworkWithPolicyResponse)
 		th.AssertNoErr(t, err)
 	})
 
@@ -273,7 +273,7 @@ func TestUpdateNetworkWithoutPolicy(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		_, err := fmt.Fprintf(w, UpdateNetworkWithoutPolicyResponse)
+		_, err := fmt.Fprint(w, UpdateNetworkWithoutPolicyResponse)
 		th.AssertNoErr(t, err)
 	})
 
@@ -307,7 +307,7 @@ func TestListPolicies(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, ListPoliciesResponse)
+		fmt.Fprint(w, ListPoliciesResponse)
 	})
 
 	count := 0
@@ -347,7 +347,7 @@ func TestGetPolicy(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, GetPolicyResponse)
+		fmt.Fprint(w, GetPolicyResponse)
 	})
 
 	p, err := policies.Get(context.TODO(), fake.ServiceClient(), "30a57f4a-336b-4382-8275-d708babd2241").Extract()
@@ -387,7 +387,7 @@ func TestCreatePolicy(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		fmt.Fprintf(w, CreatePolicyResponse)
+		fmt.Fprint(w, CreatePolicyResponse)
 	})
 
 	opts := policies.CreateOpts{
@@ -425,7 +425,7 @@ func TestUpdatePolicy(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, UpdatePolicyResponse)
+		fmt.Fprint(w, UpdatePolicyResponse)
 	})
 
 	shared := true

--- a/openstack/networking/v2/extensions/qos/rules/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/qos/rules/testing/requests_test.go
@@ -23,7 +23,7 @@ func TestListBandwidthLimitRule(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, BandwidthLimitRulesListResult)
+		fmt.Fprint(w, BandwidthLimitRulesListResult)
 	})
 
 	count := 0
@@ -71,7 +71,7 @@ func TestGetBandwidthLimitRule(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, BandwidthLimitRulesGetResult)
+		fmt.Fprint(w, BandwidthLimitRulesGetResult)
 	})
 
 	r, err := rules.GetBandwidthLimitRule(context.TODO(), fake.ServiceClient(), "501005fa-3b56-4061-aaca-3f24995112e1", "30a57f4a-336b-4382-8275-d708babd2241").ExtractBandwidthLimitRule()
@@ -97,7 +97,7 @@ func TestCreateBandwidthLimitRule(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		fmt.Fprintf(w, BandwidthLimitRulesCreateResult)
+		fmt.Fprint(w, BandwidthLimitRulesCreateResult)
 	})
 
 	opts := rules.CreateBandwidthLimitRuleOpts{
@@ -125,7 +125,7 @@ func TestUpdateBandwidthLimitRule(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, BandwidthLimitRulesUpdateResult)
+		fmt.Fprint(w, BandwidthLimitRulesUpdateResult)
 	})
 
 	maxKBps := 500
@@ -166,7 +166,7 @@ func TestListDSCPMarkingRule(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, DSCPMarkingRulesListResult)
+		fmt.Fprint(w, DSCPMarkingRulesListResult)
 	})
 
 	count := 0
@@ -212,7 +212,7 @@ func TestGetDSCPMarkingRule(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, DSCPMarkingRuleGetResult)
+		fmt.Fprint(w, DSCPMarkingRuleGetResult)
 	})
 
 	r, err := rules.GetDSCPMarkingRule(context.TODO(), fake.ServiceClient(), "501005fa-3b56-4061-aaca-3f24995112e1", "30a57f4a-336b-4382-8275-d708babd2241").ExtractDSCPMarkingRule()
@@ -236,7 +236,7 @@ func TestCreateDSCPMarkingRule(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		fmt.Fprintf(w, DSCPMarkingRuleCreateResult)
+		fmt.Fprint(w, DSCPMarkingRuleCreateResult)
 	})
 
 	opts := rules.CreateDSCPMarkingRuleOpts{
@@ -263,7 +263,7 @@ func TestUpdateDSCPMarkingRule(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, DSCPMarkingRuleUpdateResult)
+		fmt.Fprint(w, DSCPMarkingRuleUpdateResult)
 	})
 
 	dscpMark := 26
@@ -302,7 +302,7 @@ func TestListMinimumBandwidthRule(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, MinimumBandwidthRulesListResult)
+		fmt.Fprint(w, MinimumBandwidthRulesListResult)
 	})
 
 	count := 0
@@ -349,7 +349,7 @@ func TestGetMinimumBandwidthRule(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, MinimumBandwidthRulesGetResult)
+		fmt.Fprint(w, MinimumBandwidthRulesGetResult)
 	})
 
 	r, err := rules.GetMinimumBandwidthRule(context.TODO(), fake.ServiceClient(), "501005fa-3b56-4061-aaca-3f24995112e1", "30a57f4a-336b-4382-8275-d708babd2241").ExtractMinimumBandwidthRule()
@@ -374,7 +374,7 @@ func TestCreateMinimumBandwidthRule(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		fmt.Fprintf(w, MinimumBandwidthRulesCreateResult)
+		fmt.Fprint(w, MinimumBandwidthRulesCreateResult)
 	})
 
 	opts := rules.CreateMinimumBandwidthRuleOpts{
@@ -400,7 +400,7 @@ func TestUpdateMinimumBandwidthRule(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, MinimumBandwidthRulesUpdateResult)
+		fmt.Fprint(w, MinimumBandwidthRulesUpdateResult)
 	})
 
 	minKBps := 500

--- a/openstack/networking/v2/extensions/qos/ruletypes/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/qos/ruletypes/testing/requests_test.go
@@ -52,7 +52,7 @@ func TestGetRuleType(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		_, err := fmt.Fprintf(w, GetRuleTypeResponse)
+		_, err := fmt.Fprint(w, GetRuleTypeResponse)
 		th.AssertNoErr(t, err)
 	})
 

--- a/openstack/networking/v2/extensions/quotas/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/quotas/testing/requests_test.go
@@ -23,7 +23,7 @@ func TestGet(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, GetResponseRaw)
+		fmt.Fprint(w, GetResponseRaw)
 	})
 
 	q, err := quotas.Get(context.TODO(), fake.ServiceClient(), "0a73845280574ad389c292f6a74afa76").Extract()
@@ -42,7 +42,7 @@ func TestGetDetail(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, GetDetailedResponseRaw)
+		fmt.Fprint(w, GetDetailedResponseRaw)
 	})
 
 	q, err := quotas.GetDetail(context.TODO(), fake.ServiceClient(), "0a73845280574ad389c292f6a74afa76").Extract()
@@ -61,7 +61,7 @@ func TestUpdate(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, UpdateRequestResponseRaw)
+		fmt.Fprint(w, UpdateRequestResponseRaw)
 	})
 
 	q, err := quotas.Update(context.TODO(), fake.ServiceClient(), "0a73845280574ad389c292f6a74afa76", quotas.UpdateOpts{

--- a/openstack/networking/v2/extensions/rbacpolicies/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/rbacpolicies/testing/requests_test.go
@@ -25,7 +25,7 @@ func TestCreate(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		fmt.Fprintf(w, CreateResponse)
+		fmt.Fprint(w, CreateResponse)
 	})
 
 	options := rbacpolicies.CreateOpts{
@@ -51,7 +51,7 @@ func TestGet(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, GetResponse)
+		fmt.Fprint(w, GetResponse)
 	})
 
 	n, err := rbacpolicies.Get(context.TODO(), fake.ServiceClient(), "2cf7523a-93b5-4e69-9360-6c6bf986bb7c").Extract()
@@ -70,7 +70,7 @@ func TestList(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, ListResponse)
+		fmt.Fprint(w, ListResponse)
 	})
 
 	client := fake.ServiceClient()
@@ -106,7 +106,7 @@ func TestListWithAllPages(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, ListResponse)
+		fmt.Fprint(w, ListResponse)
 	})
 
 	client := fake.ServiceClient()
@@ -159,7 +159,7 @@ func TestUpdate(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, UpdateResponse)
+		fmt.Fprint(w, UpdateResponse)
 	})
 
 	options := rbacpolicies.UpdateOpts{TargetTenant: "9d766060b6354c9e8e2da44cab0e8f38"}

--- a/openstack/networking/v2/extensions/security/groups/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/security/groups/testing/requests_test.go
@@ -24,7 +24,7 @@ func TestList(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, SecurityGroupListResponse)
+		fmt.Fprint(w, SecurityGroupListResponse)
 	})
 
 	count := 0
@@ -64,7 +64,7 @@ func TestCreate(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		fmt.Fprintf(w, SecurityGroupCreateResponse)
+		fmt.Fprint(w, SecurityGroupCreateResponse)
 	})
 
 	opts := groups.CreateOpts{Name: "new-webservers", Description: "security group for webservers"}
@@ -87,7 +87,7 @@ func TestUpdate(t *testing.T) {
 			w.Header().Add("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 
-			fmt.Fprintf(w, SecurityGroupUpdateResponse)
+			fmt.Fprint(w, SecurityGroupUpdateResponse)
 		})
 
 	opts := groups.UpdateOpts{Name: "newer-webservers"}
@@ -112,7 +112,7 @@ func TestGet(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, SecurityGroupGetResponse)
+		fmt.Fprint(w, SecurityGroupGetResponse)
 	})
 
 	sg, err := groups.Get(context.TODO(), fake.ServiceClient(), "85cc3048-abc3-43cc-89b3-377341426ac5").Extract()

--- a/openstack/networking/v2/extensions/security/rules/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/security/rules/testing/requests_test.go
@@ -23,7 +23,7 @@ func TestList(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
     "security_group_rules": [
         {
@@ -131,7 +131,7 @@ func TestCreate(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
     "security_group_rule": {
         "description": "test description of rule",
@@ -190,7 +190,7 @@ func TestCreateAnyProtocol(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
     "security_group_rule": {
         "description": "test description of rule",
@@ -252,7 +252,7 @@ func TestGet(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
     "security_group_rule": {
         "direction": "egress",

--- a/openstack/networking/v2/extensions/subnetpools/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/subnetpools/testing/requests_test.go
@@ -24,7 +24,7 @@ func TestList(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, SubnetPoolsListResult)
+		fmt.Fprint(w, SubnetPoolsListResult)
 	})
 
 	count := 0
@@ -66,7 +66,7 @@ func TestGet(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, SubnetPoolGetResult)
+		fmt.Fprint(w, SubnetPoolGetResult)
 	})
 
 	s, err := subnetpools.Get(context.TODO(), fake.ServiceClient(), "0a738452-8057-4ad3-89c2-92f6a74afa76").Extract()
@@ -106,7 +106,7 @@ func TestCreate(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		fmt.Fprintf(w, SubnetPoolCreateResult)
+		fmt.Fprint(w, SubnetPoolCreateResult)
 	})
 
 	opts := subnetpools.CreateOpts{
@@ -148,7 +148,7 @@ func TestUpdate(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, SubnetPoolUpdateResponse)
+		fmt.Fprint(w, SubnetPoolUpdateResponse)
 	})
 
 	nullString := ""

--- a/openstack/networking/v2/extensions/testing/delegate_test.go
+++ b/openstack/networking/v2/extensions/testing/delegate_test.go
@@ -23,7 +23,7 @@ func TestList(t *testing.T) {
 
 		w.Header().Add("Content-Type", "application/json")
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
     "extensions": [
         {
@@ -83,7 +83,7 @@ func TestGet(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
     "extension": {
         "updated": "2013-02-03T10:00:00-00:00",

--- a/openstack/networking/v2/extensions/trunks/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/trunks/testing/requests_test.go
@@ -25,7 +25,7 @@ func TestCreate(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		fmt.Fprintf(w, CreateResponse)
+		fmt.Fprint(w, CreateResponse)
 	})
 
 	iTrue := true
@@ -73,7 +73,7 @@ func TestCreateNoSubports(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		fmt.Fprintf(w, CreateNoSubportsResponse)
+		fmt.Fprint(w, CreateNoSubportsResponse)
 	})
 
 	iTrue := true
@@ -115,7 +115,7 @@ func TestList(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, ListResponse)
+		fmt.Fprint(w, ListResponse)
 	})
 
 	client := fake.ServiceClient()
@@ -153,7 +153,7 @@ func TestGet(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, GetResponse)
+		fmt.Fprint(w, GetResponse)
 	})
 
 	n, err := trunks.Get(context.TODO(), fake.ServiceClient(), "f6a9718c-5a64-43e3-944f-4deccad8e78c").Extract()
@@ -177,7 +177,7 @@ func TestUpdate(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, UpdateResponse)
+		fmt.Fprint(w, UpdateResponse)
 	})
 
 	iFalse := false
@@ -207,7 +207,7 @@ func TestGetSubports(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, ListSubportsResponse)
+		fmt.Fprint(w, ListSubportsResponse)
 	})
 
 	client := fake.ServiceClient()
@@ -259,7 +259,7 @@ func TestAddSubports(t *testing.T) {
 		th.TestJSONRequest(t, r, AddSubportsRequest)
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, AddSubportsResponse)
+		fmt.Fprint(w, AddSubportsResponse)
 	})
 
 	client := fake.ServiceClient()
@@ -287,7 +287,7 @@ func TestRemoveSubports(t *testing.T) {
 		th.TestJSONRequest(t, r, RemoveSubportsRequest)
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, RemoveSubportsResponse)
+		fmt.Fprint(w, RemoveSubportsResponse)
 	})
 
 	client := fake.ServiceClient()

--- a/openstack/networking/v2/extensions/vlantransparent/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/vlantransparent/testing/requests_test.go
@@ -23,7 +23,7 @@ func TestList(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, NetworksVLANTransparentListResult)
+		fmt.Fprint(w, NetworksVLANTransparentListResult)
 	})
 
 	type networkVLANTransparentExt struct {
@@ -59,7 +59,7 @@ func TestGet(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, NetworksVLANTransparentGetResult)
+		fmt.Fprint(w, NetworksVLANTransparentGetResult)
 	})
 
 	var s struct {
@@ -94,7 +94,7 @@ func TestCreate(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		fmt.Fprintf(w, NetworksVLANTransparentCreateResult)
+		fmt.Fprint(w, NetworksVLANTransparentCreateResult)
 	})
 
 	iTrue := true
@@ -139,7 +139,7 @@ func TestUpdate(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, NetworksVLANTransparentUpdateResult)
+		fmt.Fprint(w, NetworksVLANTransparentUpdateResult)
 	})
 
 	iFalse := false

--- a/openstack/networking/v2/extensions/vpnaas/endpointgroups/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/vpnaas/endpointgroups/testing/requests_test.go
@@ -36,7 +36,7 @@ func TestCreate(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
     "endpoint_group": {
         "description": "",
@@ -90,7 +90,7 @@ func TestGet(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
     "endpoint_group": {
         "description": "",
@@ -135,7 +135,7 @@ func TestList(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 		{
 	"endpoint_groups": [
 		{
@@ -224,7 +224,7 @@ func TestUpdate(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
     "endpoint_group": {
         "description": "updated description",

--- a/openstack/networking/v2/extensions/vpnaas/ikepolicies/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/vpnaas/ikepolicies/testing/requests_test.go
@@ -35,7 +35,7 @@ func TestCreate(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
     "ikepolicy":{
         "name": "policy",
@@ -97,7 +97,7 @@ func TestGet(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
     "ikepolicy":{
         "name": "policy",
@@ -165,7 +165,7 @@ func TestList(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 		{
 	"ikepolicies": [
 		{
@@ -253,7 +253,7 @@ func TestUpdate(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
     "ikepolicy": {
         "name": "updatedname",

--- a/openstack/networking/v2/extensions/vpnaas/ipsecpolicies/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/vpnaas/ipsecpolicies/testing/requests_test.go
@@ -41,7 +41,7 @@ func TestCreate(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
     "ipsecpolicy": {
         "name": "ipsecpolicy1",
@@ -111,7 +111,7 @@ func TestGet(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
     "ipsecpolicy": {
         "name": "ipsecpolicy1",
@@ -180,7 +180,7 @@ func TestList(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 		{
 	"ipsecpolicies": [
 		{
@@ -268,7 +268,7 @@ func TestUpdate(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 
 	{
 		"ipsecpolicy": {

--- a/openstack/networking/v2/extensions/vpnaas/services/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/vpnaas/services/testing/requests_test.go
@@ -36,7 +36,7 @@ func TestCreate(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
     "vpnservice": {
         "router_id": "66e3b16c-8ce5-40fb-bb49-ab6d8dc3f2aa",
@@ -91,7 +91,7 @@ func TestList(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
    "vpnservices":[
         {
@@ -154,7 +154,7 @@ func TestGet(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
     "vpnservice": {
         "router_id": "66e3b16c-8ce5-40fb-bb49-ab6d8dc3f2aa",
@@ -223,7 +223,7 @@ func TestUpdate(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
     "vpnservice": {
         "router_id": "66e3b16c-8ce5-40fb-bb49-ab6d8dc3f2aa",

--- a/openstack/networking/v2/extensions/vpnaas/siteconnections/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/vpnaas/siteconnections/testing/requests_test.go
@@ -45,7 +45,7 @@ func TestCreate(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
     "ipsec_site_connection": {
         "status": "PENDING_CREATE",
@@ -150,7 +150,7 @@ func TestGet(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
     "ipsec_site_connection": {
         "status": "PENDING_CREATE",
@@ -227,7 +227,7 @@ func TestList(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
     "ipsec_site_connections":[
 	{
@@ -336,7 +336,7 @@ func TestUpdate(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 
 	{
     "ipsec_site_connection": {

--- a/openstack/networking/v2/networks/testing/requests_test.go
+++ b/openstack/networking/v2/networks/testing/requests_test.go
@@ -25,7 +25,7 @@ func TestList(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, ListResponse)
+		fmt.Fprint(w, ListResponse)
 	})
 
 	client := fake.ServiceClient()
@@ -62,7 +62,7 @@ func TestListWithExtensions(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, ListResponse)
+		fmt.Fprint(w, ListResponse)
 	})
 
 	client := fake.ServiceClient()
@@ -101,7 +101,7 @@ func TestGet(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, GetResponse)
+		fmt.Fprint(w, GetResponse)
 	})
 
 	n, err := networks.Get(context.TODO(), fake.ServiceClient(), "d32019d3-bc6e-4319-9c1d-6722fc136a22").Extract()
@@ -122,7 +122,7 @@ func TestGetWithExtensions(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, GetResponse)
+		fmt.Fprint(w, GetResponse)
 	})
 
 	var networkWithExtensions struct {
@@ -150,7 +150,7 @@ func TestCreate(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		fmt.Fprintf(w, CreateResponse)
+		fmt.Fprint(w, CreateResponse)
 	})
 
 	iTrue := true
@@ -176,7 +176,7 @@ func TestCreateWithOptionalFields(t *testing.T) {
 		th.TestJSONRequest(t, r, CreateOptionalFieldsRequest)
 
 		w.WriteHeader(http.StatusCreated)
-		fmt.Fprintf(w, `{}`)
+		fmt.Fprint(w, `{}`)
 	})
 
 	iTrue := true
@@ -205,7 +205,7 @@ func TestUpdate(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, UpdateResponse)
+		fmt.Fprint(w, UpdateResponse)
 	})
 
 	iTrue, iFalse := true, false
@@ -237,7 +237,7 @@ func TestUpdateRevision(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, UpdateResponse)
+		fmt.Fprint(w, UpdateResponse)
 	})
 
 	th.Mux.HandleFunc("/v2.0/networks/4e8e5957-649f-477b-9e5b-f1f75b21c03d", func(w http.ResponseWriter, r *http.Request) {
@@ -251,7 +251,7 @@ func TestUpdateRevision(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, UpdateResponse)
+		fmt.Fprint(w, UpdateResponse)
 	})
 
 	iTrue, iFalse := true, false
@@ -293,7 +293,7 @@ func TestCreatePortSecurity(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		fmt.Fprintf(w, CreatePortSecurityResponse)
+		fmt.Fprint(w, CreatePortSecurityResponse)
 	})
 
 	var networkWithExtensions struct {
@@ -330,7 +330,7 @@ func TestUpdatePortSecurity(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, UpdatePortSecurityResponse)
+		fmt.Fprint(w, UpdatePortSecurityResponse)
 	})
 
 	var networkWithExtensions struct {

--- a/openstack/networking/v2/ports/testing/requests_test.go
+++ b/openstack/networking/v2/ports/testing/requests_test.go
@@ -27,7 +27,7 @@ func TestList(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, ListResponse)
+		fmt.Fprint(w, ListResponse)
 	})
 
 	count := 0
@@ -86,7 +86,7 @@ func TestListWithExtensions(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, ListResponse)
+		fmt.Fprint(w, ListResponse)
 	})
 
 	type portWithExt struct {
@@ -117,7 +117,7 @@ func TestGet(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, GetResponse)
+		fmt.Fprint(w, GetResponse)
 	})
 
 	n, err := ports.Get(context.TODO(), fake.ServiceClient(), "46d4bfb9-b26e-41f3-bd2e-e6dcc1ccedb2").Extract()
@@ -152,7 +152,7 @@ func TestGetWithExtensions(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, GetResponse)
+		fmt.Fprint(w, GetResponse)
 	})
 
 	var portWithExtensions struct {
@@ -181,7 +181,7 @@ func TestCreate(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		fmt.Fprintf(w, CreateResponse)
+		fmt.Fprint(w, CreateResponse)
 	})
 
 	asu := true
@@ -231,7 +231,7 @@ func TestCreateOmitSecurityGroups(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		fmt.Fprintf(w, CreateOmitSecurityGroupsResponse)
+		fmt.Fprint(w, CreateOmitSecurityGroupsResponse)
 	})
 
 	asu := true
@@ -280,7 +280,7 @@ func TestCreateWithNoSecurityGroup(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		fmt.Fprintf(w, CreateWithNoSecurityGroupsResponse)
+		fmt.Fprint(w, CreateWithNoSecurityGroupsResponse)
 	})
 
 	asu := true
@@ -329,7 +329,7 @@ func TestCreateWithPropagateUplinkStatus(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		fmt.Fprintf(w, CreatePropagateUplinkStatusResponse)
+		fmt.Fprint(w, CreatePropagateUplinkStatusResponse)
 	})
 
 	asu := true
@@ -374,7 +374,7 @@ func TestCreateWithValueSpecs(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		fmt.Fprintf(w, CreateValueSpecResponse)
+		fmt.Fprint(w, CreateValueSpecResponse)
 	})
 
 	asu := true
@@ -427,7 +427,7 @@ func TestCreateWithInvalidValueSpecs(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		fmt.Fprintf(w, CreateValueSpecResponse)
+		fmt.Fprint(w, CreateValueSpecResponse)
 	})
 
 	asu := true
@@ -483,7 +483,7 @@ func TestCreatePortSecurity(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		fmt.Fprintf(w, CreatePortSecurityResponse)
+		fmt.Fprint(w, CreatePortSecurityResponse)
 	})
 
 	var portWithExt struct {
@@ -531,7 +531,7 @@ func TestUpdate(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, UpdateResponse)
+		fmt.Fprint(w, UpdateResponse)
 	})
 
 	name := "new_port_name"
@@ -573,7 +573,7 @@ func TestUpdateOmitSecurityGroups(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, UpdateOmitSecurityGroupsResponse)
+		fmt.Fprint(w, UpdateOmitSecurityGroupsResponse)
 	})
 
 	name := "new_port_name"
@@ -614,7 +614,7 @@ func TestUpdatePropagateUplinkStatus(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, UpdatePropagateUplinkStatusResponse)
+		fmt.Fprint(w, UpdatePropagateUplinkStatusResponse)
 	})
 
 	propagateUplinkStatus := true
@@ -642,7 +642,7 @@ func TestUpdateValueSpecs(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, UpdateValueSpecsResponse)
+		fmt.Fprint(w, UpdateValueSpecsResponse)
 	})
 
 	options := ports.UpdateOpts{
@@ -669,7 +669,7 @@ func TestUpdatePortSecurity(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, UpdatePortSecurityResponse)
+		fmt.Fprint(w, UpdatePortSecurityResponse)
 	})
 
 	var portWithExt struct {
@@ -707,7 +707,7 @@ func TestUpdateRevision(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, UpdateResponse)
+		fmt.Fprint(w, UpdateResponse)
 	})
 	th.Mux.HandleFunc("/v2.0/ports/65c0ee9f-d634-4522-8954-51021b570b0e", func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "PUT")
@@ -720,7 +720,7 @@ func TestUpdateRevision(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, UpdateResponse)
+		fmt.Fprint(w, UpdateResponse)
 	})
 
 	name := "new_port_name"
@@ -757,7 +757,7 @@ func TestRemoveSecurityGroups(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, RemoveSecurityGroupResponse)
+		fmt.Fprint(w, RemoveSecurityGroupResponse)
 	})
 
 	name := "new_port_name"
@@ -799,7 +799,7 @@ func TestRemoveAllowedAddressPairs(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, RemoveAllowedAddressPairsResponse)
+		fmt.Fprint(w, RemoveAllowedAddressPairsResponse)
 	})
 
 	name := "new_port_name"
@@ -837,7 +837,7 @@ func TestDontUpdateAllowedAddressPairs(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, DontUpdateAllowedAddressPairsResponse)
+		fmt.Fprint(w, DontUpdateAllowedAddressPairsResponse)
 	})
 
 	name := "new_port_name"
@@ -887,7 +887,7 @@ func TestGetWithExtraDHCPOpts(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, GetWithExtraDHCPOptsResponse)
+		fmt.Fprint(w, GetWithExtraDHCPOptsResponse)
 	})
 
 	var s struct {
@@ -933,7 +933,7 @@ func TestCreateWithExtraDHCPOpts(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		fmt.Fprintf(w, CreateWithExtraDHCPOptsResponse)
+		fmt.Fprint(w, CreateWithExtraDHCPOptsResponse)
 	})
 
 	adminStateUp := true
@@ -996,7 +996,7 @@ func TestUpdateWithExtraDHCPOpts(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, UpdateWithExtraDHCPOptsResponse)
+		fmt.Fprint(w, UpdateWithExtraDHCPOptsResponse)
 	})
 
 	name := "updated-port-with-dhcp-opts"

--- a/openstack/networking/v2/subnets/testing/requests_test.go
+++ b/openstack/networking/v2/subnets/testing/requests_test.go
@@ -23,7 +23,7 @@ func TestList(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, SubnetListResult)
+		fmt.Fprint(w, SubnetListResult)
 	})
 
 	count := 0
@@ -65,7 +65,7 @@ func TestGet(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, SubnetGetResult)
+		fmt.Fprint(w, SubnetGetResult)
 	})
 
 	s, err := subnets.Get(context.TODO(), fake.ServiceClient(), "54d6f61d-db07-451c-9ab3-b9609b6b6f0b").Extract()
@@ -104,7 +104,7 @@ func TestCreate(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		fmt.Fprintf(w, SubnetCreateResult)
+		fmt.Fprint(w, SubnetCreateResult)
 	})
 
 	var gatewayIP = "192.168.199.1"
@@ -166,7 +166,7 @@ func TestCreateNoGateway(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		fmt.Fprintf(w, SubnetCreateWithNoGatewayResponse)
+		fmt.Fprint(w, SubnetCreateWithNoGatewayResponse)
 	})
 
 	var noGateway = ""
@@ -217,7 +217,7 @@ func TestCreateDefaultGateway(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		fmt.Fprintf(w, SubnetCreateWithDefaultGatewayResponse)
+		fmt.Fprint(w, SubnetCreateWithDefaultGatewayResponse)
 	})
 
 	opts := subnets.CreateOpts{
@@ -266,7 +266,7 @@ func TestCreateIPv6RaAddressMode(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		fmt.Fprintf(w, SubnetCreateWithIPv6RaAddressModeResponse)
+		fmt.Fprint(w, SubnetCreateWithIPv6RaAddressModeResponse)
 	})
 
 	var gatewayIP = "2001:db8:0:a::1"
@@ -307,7 +307,7 @@ func TestCreateWithNoCIDR(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		fmt.Fprintf(w, SubnetCreateResult)
+		fmt.Fprint(w, SubnetCreateResult)
 	})
 
 	opts := subnets.CreateOpts{
@@ -356,7 +356,7 @@ func TestCreateWithPrefixlen(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		fmt.Fprintf(w, SubnetCreateResult)
+		fmt.Fprint(w, SubnetCreateResult)
 	})
 
 	opts := subnets.CreateOpts{
@@ -423,7 +423,7 @@ func TestUpdate(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		fmt.Fprintf(w, SubnetUpdateResponse)
+		fmt.Fprint(w, SubnetUpdateResponse)
 	})
 
 	dnsNameservers := []string{"foo"}
@@ -456,7 +456,7 @@ func TestUpdateGateway(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		fmt.Fprintf(w, SubnetUpdateGatewayResponse)
+		fmt.Fprint(w, SubnetUpdateGatewayResponse)
 	})
 
 	var gatewayIP = "10.0.0.1"
@@ -487,7 +487,7 @@ func TestUpdateRemoveGateway(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		fmt.Fprintf(w, SubnetUpdateRemoveGatewayResponse)
+		fmt.Fprint(w, SubnetUpdateRemoveGatewayResponse)
 	})
 
 	var noGateway = ""
@@ -518,7 +518,7 @@ func TestUpdateHostRoutes(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		fmt.Fprintf(w, SubnetUpdateHostRoutesResponse)
+		fmt.Fprint(w, SubnetUpdateHostRoutesResponse)
 	})
 
 	HostRoutes := []subnets.HostRoute{
@@ -555,7 +555,7 @@ func TestUpdateRemoveHostRoutes(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		fmt.Fprintf(w, SubnetUpdateRemoveHostRoutesResponse)
+		fmt.Fprint(w, SubnetUpdateRemoveHostRoutesResponse)
 	})
 
 	noHostRoutes := []subnets.HostRoute{}
@@ -584,7 +584,7 @@ func TestUpdateAllocationPool(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		fmt.Fprintf(w, SubnetUpdateAllocationPoolResponse)
+		fmt.Fprint(w, SubnetUpdateAllocationPoolResponse)
 	})
 
 	name := "my_new_subnet"
@@ -625,7 +625,7 @@ func TestUpdateRevision(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		fmt.Fprintf(w, SubnetUpdateResponse)
+		fmt.Fprint(w, SubnetUpdateResponse)
 	})
 
 	th.Mux.HandleFunc("/v2.0/subnets/08eae331-0402-425a-923c-34f7cfe39c1c", func(w http.ResponseWriter, r *http.Request) {
@@ -639,7 +639,7 @@ func TestUpdateRevision(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		fmt.Fprintf(w, SubnetUpdateResponse)
+		fmt.Fprint(w, SubnetUpdateResponse)
 	})
 
 	dnsNameservers := []string{"foo"}

--- a/openstack/objectstorage/v1/containers/testing/fixtures.go
+++ b/openstack/objectstorage/v1/containers/testing/fixtures.go
@@ -56,7 +56,7 @@ func HandleListContainerInfoSuccessfully(t *testing.T) {
 		marker := r.Form.Get("marker")
 		switch marker {
 		case "":
-			fmt.Fprintf(w, `[
+			fmt.Fprint(w, `[
         {
           "count": 0,
           "bytes": 0,
@@ -69,7 +69,7 @@ func HandleListContainerInfoSuccessfully(t *testing.T) {
         }
       ]`)
 		case "janeausten":
-			fmt.Fprintf(w, `[
+			fmt.Fprint(w, `[
 				{
 					"count": 1,
 					"bytes": 14,
@@ -77,7 +77,7 @@ func HandleListContainerInfoSuccessfully(t *testing.T) {
 				}
 			]`)
 		case "marktwain":
-			fmt.Fprintf(w, `[]`)
+			fmt.Fprint(w, `[]`)
 		default:
 			t.Fatalf("Unexpected marker: [%s]", marker)
 		}
@@ -158,7 +158,7 @@ func HandleBulkDeleteSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, bulkDeleteResponse)
+		fmt.Fprint(w, bulkDeleteResponse)
 	})
 }
 

--- a/openstack/objectstorage/v1/objects/testing/fixtures_test.go
+++ b/openstack/objectstorage/v1/objects/testing/fixtures_test.go
@@ -61,7 +61,7 @@ func HandleDownloadObjectSuccessfully(t *testing.T, options ...option) {
 		}
 		w.Header().Set("Last-Modified", date.Format(time.RFC1123))
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, "Successful download with Gophercloud")
+		fmt.Fprint(w, "Successful download with Gophercloud")
 	})
 }
 
@@ -118,7 +118,7 @@ func HandleListObjectsInfoSuccessfully(t *testing.T, options ...option) {
 		marker := r.Form.Get("marker")
 		switch marker {
 		case "":
-			fmt.Fprintf(w, `[
+			fmt.Fprint(w, `[
       {
         "hash": "451e372e48e0f6b1114fa0724aa79fa1",
         "last_modified": "2016-08-17T22:11:58.602650",
@@ -135,7 +135,7 @@ func HandleListObjectsInfoSuccessfully(t *testing.T, options ...option) {
       }
     ]`)
 		case "hello":
-			fmt.Fprintf(w, `[]`)
+			fmt.Fprint(w, `[]`)
 		default:
 			t.Fatalf("Unexpected marker: [%s]", marker)
 		}
@@ -157,13 +157,13 @@ func HandleListSubdirSuccessfully(t *testing.T) {
 		marker := r.Form.Get("marker")
 		switch marker {
 		case "":
-			fmt.Fprintf(w, `[
+			fmt.Fprint(w, `[
       {
         "subdir": "directory/"
       }
     ]`)
 		case "directory/":
-			fmt.Fprintf(w, `[]`)
+			fmt.Fprint(w, `[]`)
 		default:
 			t.Fatalf("Unexpected marker: [%s]", marker)
 		}
@@ -323,7 +323,7 @@ func HandleBulkDeleteSuccessfully(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, bulkDeleteResponse)
+		fmt.Fprint(w, bulkDeleteResponse)
 	})
 }
 

--- a/openstack/objectstorage/v1/swauth/testing/fixtures_test.go
+++ b/openstack/objectstorage/v1/swauth/testing/fixtures_test.go
@@ -24,6 +24,6 @@ func HandleAuthSuccessfully(t *testing.T, authOpts swauth.AuthOpts) {
 
 		w.Header().Add("X-Auth-Token", AuthResult.Token)
 		w.Header().Add("X-Storage-Url", AuthResult.StorageURL)
-		fmt.Fprintf(w, "")
+		fmt.Fprint(w, "")
 	})
 }

--- a/openstack/orchestration/v1/apiversions/testing/requests_test.go
+++ b/openstack/orchestration/v1/apiversions/testing/requests_test.go
@@ -24,7 +24,7 @@ func TestListVersions(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 {
     "versions": [
         {

--- a/openstack/orchestration/v1/buildinfo/testing/fixtures_test.go
+++ b/openstack/orchestration/v1/buildinfo/testing/fixtures_test.go
@@ -41,6 +41,6 @@ func HandleGetSuccessfully(t *testing.T, output string) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, output)
+		fmt.Fprint(w, output)
 	})
 }

--- a/openstack/orchestration/v1/stackevents/testing/fixtures_test.go
+++ b/openstack/orchestration/v1/stackevents/testing/fixtures_test.go
@@ -128,7 +128,7 @@ func HandleFindSuccessfully(t *testing.T, output string) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, output)
+		fmt.Fprint(w, output)
 	})
 }
 
@@ -250,9 +250,9 @@ func HandleListSuccessfully(t *testing.T, output string) {
 		marker := r.Form.Get("marker")
 		switch marker {
 		case "":
-			fmt.Fprintf(w, output)
+			fmt.Fprint(w, output)
 		case "93940999-7d40-44ae-8de4-19624e7b8d18":
-			fmt.Fprintf(w, `{"events":[]}`)
+			fmt.Fprint(w, `{"events":[]}`)
 		default:
 			t.Fatalf("Unexpected marker: [%s]", marker)
 		}
@@ -377,9 +377,9 @@ func HandleListResourceEventsSuccessfully(t *testing.T, output string) {
 		marker := r.Form.Get("marker")
 		switch marker {
 		case "":
-			fmt.Fprintf(w, output)
+			fmt.Fprint(w, output)
 		case "93940999-7d40-44ae-8de4-19624e7b8d18":
-			fmt.Fprintf(w, `{"events":[]}`)
+			fmt.Fprint(w, `{"events":[]}`)
 		default:
 			t.Fatalf("Unexpected marker: [%s]", marker)
 		}
@@ -449,6 +449,6 @@ func HandleGetSuccessfully(t *testing.T, output string) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, output)
+		fmt.Fprint(w, output)
 	})
 }

--- a/openstack/orchestration/v1/stackresources/testing/fixtures_test.go
+++ b/openstack/orchestration/v1/stackresources/testing/fixtures_test.go
@@ -82,7 +82,7 @@ func HandleFindSuccessfully(t *testing.T, output string) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, output)
+		fmt.Fprint(w, output)
 	})
 }
 
@@ -157,9 +157,9 @@ func HandleListSuccessfully(t *testing.T, output string) {
 		marker := r.Form.Get("marker")
 		switch marker {
 		case "":
-			fmt.Fprintf(w, output)
+			fmt.Fprint(w, output)
 		case "49181cd6-169a-4130-9455-31185bbfc5bf":
-			fmt.Fprintf(w, `{"resources":[]}`)
+			fmt.Fprint(w, `{"resources":[]}`)
 		default:
 			t.Fatalf("Unexpected marker: [%s]", marker)
 		}
@@ -227,7 +227,7 @@ func HandleGetSuccessfully(t *testing.T, output string) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, output)
+		fmt.Fprint(w, output)
 	})
 }
 
@@ -256,7 +256,7 @@ func HandleMetadataSuccessfully(t *testing.T, output string) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, output)
+		fmt.Fprint(w, output)
 	})
 }
 
@@ -309,7 +309,7 @@ func HandleListTypesSuccessfully(t *testing.T, output string) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, output)
+		fmt.Fprint(w, output)
 	})
 }
 
@@ -370,7 +370,7 @@ func HandleGetSchemaSuccessfully(t *testing.T, output string) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, output)
+		fmt.Fprint(w, output)
 	})
 }
 
@@ -440,7 +440,7 @@ func HandleGetTemplateSuccessfully(t *testing.T, output string) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, output)
+		fmt.Fprint(w, output)
 	})
 }
 

--- a/openstack/orchestration/v1/stacks/testing/fixtures_test.go
+++ b/openstack/orchestration/v1/stacks/testing/fixtures_test.go
@@ -48,7 +48,7 @@ func HandleCreateSuccessfully(t *testing.T, output string) {
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 		th.TestHeader(t, r, "Accept", "application/json")
 		w.WriteHeader(http.StatusCreated)
-		fmt.Fprintf(w, output)
+		fmt.Fprint(w, output)
 	})
 }
 
@@ -142,9 +142,9 @@ func HandleListSuccessfully(t *testing.T, output string) {
 		marker := r.Form.Get("marker")
 		switch marker {
 		case "":
-			fmt.Fprintf(w, output)
+			fmt.Fprint(w, output)
 		case "db6977b2-27aa-4775-9ae7-6213212d4ada":
-			fmt.Fprintf(w, `[]`)
+			fmt.Fprint(w, `[]`)
 		default:
 			t.Fatalf("Unexpected marker: [%s]", marker)
 		}
@@ -221,7 +221,7 @@ func HandleGetSuccessfully(t *testing.T, output string) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, output)
+		fmt.Fprint(w, output)
 	})
 }
 
@@ -233,7 +233,7 @@ func HandleFindSuccessfully(t *testing.T, output string) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, output)
+		fmt.Fprint(w, output)
 	})
 }
 
@@ -309,7 +309,7 @@ func HandlePreviewSuccessfully(t *testing.T, output string) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, output)
+		fmt.Fprint(w, output)
 	})
 }
 
@@ -432,6 +432,6 @@ func HandleAbandonSuccessfully(t *testing.T, output string) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, output)
+		fmt.Fprint(w, output)
 	})
 }

--- a/openstack/orchestration/v1/stacks/utils_test.go
+++ b/openstack/orchestration/v1/stacks/utils_test.go
@@ -68,7 +68,7 @@ func TestFetch(t *testing.T) {
 		th.TestMethod(t, r, "GET")
 		w.Header().Set("Content-Type", "application/jason")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, "Fee-fi-fo-fum")
+		fmt.Fprint(w, "Fee-fi-fo-fum")
 	})
 
 	client := fakeClient{BaseClient: getHTTPClient()}

--- a/openstack/orchestration/v1/stacktemplates/testing/fixtures_test.go
+++ b/openstack/orchestration/v1/stacktemplates/testing/fixtures_test.go
@@ -48,7 +48,7 @@ func HandleGetSuccessfully(t *testing.T, output string) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, output)
+		fmt.Fprint(w, output)
 	})
 }
 
@@ -91,6 +91,6 @@ func HandleValidateSuccessfully(t *testing.T, output string) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, output)
+		fmt.Fprint(w, output)
 	})
 }

--- a/openstack/placement/v1/resourceproviders/testing/fixtures_test.go
+++ b/openstack/placement/v1/resourceproviders/testing/fixtures_test.go
@@ -277,7 +277,7 @@ func HandleResourceProviderList(t *testing.T) {
 			w.Header().Add("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 
-			fmt.Fprintf(w, ResourceProvidersBody)
+			fmt.Fprint(w, ResourceProvidersBody)
 		})
 }
 
@@ -289,7 +289,7 @@ func HandleResourceProviderCreate(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, ResourceProviderCreateBody)
+		fmt.Fprint(w, ResourceProviderCreateBody)
 	})
 }
 
@@ -301,7 +301,7 @@ func HandleResourceProviderGet(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, ResourceProviderCreateBody)
+		fmt.Fprint(w, ResourceProviderCreateBody)
 	})
 }
 
@@ -324,7 +324,7 @@ func HandleResourceProviderUpdate(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, ResourceProviderUpdateResponse)
+		fmt.Fprint(w, ResourceProviderUpdateResponse)
 	})
 }
 
@@ -339,7 +339,7 @@ func HandleResourceProviderGetUsages(t *testing.T) {
 			w.Header().Add("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 
-			fmt.Fprintf(w, UsagesBody)
+			fmt.Fprint(w, UsagesBody)
 		})
 }
 
@@ -354,7 +354,7 @@ func HandleResourceProviderGetInventories(t *testing.T) {
 			w.Header().Add("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 
-			fmt.Fprintf(w, InventoriesBody)
+			fmt.Fprint(w, InventoriesBody)
 		})
 }
 
@@ -369,7 +369,7 @@ func HandleResourceProviderGetAllocations(t *testing.T) {
 			w.Header().Add("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 
-			fmt.Fprintf(w, AllocationsBody)
+			fmt.Fprint(w, AllocationsBody)
 		})
 }
 
@@ -384,6 +384,6 @@ func HandleResourceProviderGetTraits(t *testing.T) {
 			w.Header().Add("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 
-			fmt.Fprintf(w, TraitsBody)
+			fmt.Fprint(w, TraitsBody)
 		})
 }

--- a/openstack/sharedfilesystems/apiversions/testing/fixtures_test.go
+++ b/openstack/sharedfilesystems/apiversions/testing/fixtures_test.go
@@ -186,7 +186,7 @@ func MockListResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, ManilaAllAPIVersionsResponse)
+		fmt.Fprint(w, ManilaAllAPIVersionsResponse)
 	})
 }
 
@@ -198,7 +198,7 @@ func MockGetResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, ManilaAPIVersionResponse)
+		fmt.Fprint(w, ManilaAPIVersionResponse)
 	})
 }
 
@@ -210,7 +210,7 @@ func MockGetNoResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, ManilaAPIInvalidVersionResponse_1)
+		fmt.Fprint(w, ManilaAPIInvalidVersionResponse_1)
 	})
 }
 
@@ -222,6 +222,6 @@ func MockGetMultipleResponses(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, ManilaAPIInvalidVersionResponse_2)
+		fmt.Fprint(w, ManilaAPIInvalidVersionResponse_2)
 	})
 }

--- a/openstack/sharedfilesystems/v2/availabilityzones/testing/fixtures_test.go
+++ b/openstack/sharedfilesystems/v2/availabilityzones/testing/fixtures_test.go
@@ -17,7 +17,7 @@ func MockListResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
         {
             "availability_zones": [
                 {

--- a/openstack/sharedfilesystems/v2/errors/testing/fixtures_test.go
+++ b/openstack/sharedfilesystems/v2/errors/testing/fixtures_test.go
@@ -37,6 +37,6 @@ func MockCreateResponse(t *testing.T) {
 		th.TestJSONRequest(t, r, createRequest)
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusNotFound)
-		fmt.Fprintf(w, createResponse)
+		fmt.Fprint(w, createResponse)
 	})
 }

--- a/openstack/sharedfilesystems/v2/messages/testing/fixtures_test.go
+++ b/openstack/sharedfilesystems/v2/messages/testing/fixtures_test.go
@@ -25,7 +25,7 @@ func MockListResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
         {
           "messages": [
             {
@@ -67,7 +67,7 @@ func MockFilteredListResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
         {
           "messages": [
             {
@@ -95,7 +95,7 @@ func MockGetResponse(t *testing.T) {
 
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
         {
           "message": {
             "resource_id": "4336d74f-3bdc-4f27-9657-c01ec63680bf",

--- a/openstack/sharedfilesystems/v2/replicas/testing/fixtures_test.go
+++ b/openstack/sharedfilesystems/v2/replicas/testing/fixtures_test.go
@@ -48,7 +48,7 @@ func MockCreateResponse(t *testing.T) {
 		th.TestJSONRequest(t, r, createRequest)
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusAccepted)
-		fmt.Fprintf(w, createResponse)
+		fmt.Fprint(w, createResponse)
 	})
 }
 
@@ -175,7 +175,7 @@ func MockGetResponse(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 		th.TestHeader(t, r, "X-OpenStack-Manila-API-Version", "2.11")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, getResponse)
+		fmt.Fprint(w, getResponse)
 	})
 }
 
@@ -330,7 +330,7 @@ func MockListExportLocationsResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		th.TestHeader(t, r, "X-OpenStack-Manila-API-Version", "2.47")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, listExportLocationsResponse)
+		fmt.Fprint(w, listExportLocationsResponse)
 	})
 }
 
@@ -355,6 +355,6 @@ func MockGetExportLocationResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		th.TestHeader(t, r, "X-OpenStack-Manila-API-Version", "2.47")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, getExportLocationResponse)
+		fmt.Fprint(w, getExportLocationResponse)
 	})
 }

--- a/openstack/sharedfilesystems/v2/schedulerstats/testing/fixtures_test.go
+++ b/openstack/sharedfilesystems/v2/schedulerstats/testing/fixtures_test.go
@@ -274,7 +274,7 @@ func HandlePoolsListSuccessfully(t *testing.T) {
 		if err := r.ParseForm(); err != nil {
 			t.Errorf("Failed to parse request form %v", err)
 		}
-		fmt.Fprintf(w, PoolsListBody)
+		fmt.Fprint(w, PoolsListBody)
 
 	})
 	th.Mux.HandleFunc("/scheduler-stats/pools/detail", func(w http.ResponseWriter, r *http.Request) {
@@ -286,6 +286,6 @@ func HandlePoolsListSuccessfully(t *testing.T) {
 		if err := r.ParseForm(); err != nil {
 			t.Errorf("Failed to parse request form %v", err)
 		}
-		fmt.Fprintf(w, PoolsListBodyDetail)
+		fmt.Fprint(w, PoolsListBodyDetail)
 	})
 }

--- a/openstack/sharedfilesystems/v2/securityservices/testing/fixtures_test.go
+++ b/openstack/sharedfilesystems/v2/securityservices/testing/fixtures_test.go
@@ -30,7 +30,7 @@ func MockCreateResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
         {
             "security_service": {
                 "status": "new",
@@ -67,7 +67,7 @@ func MockListResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
         {
             "security_services": [
                 {
@@ -113,7 +113,7 @@ func MockFilteredListResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
         {
             "security_services": [
                 {
@@ -143,7 +143,7 @@ func MockGetResponse(t *testing.T) {
 
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
         {
             "security_service": {
                 "status": "new",
@@ -169,7 +169,7 @@ func MockUpdateResponse(t *testing.T) {
 		th.TestMethod(t, r, "PUT")
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
             {
                 "security_service": {
                     "status": "new",

--- a/openstack/sharedfilesystems/v2/services/testing/fixtures_test.go
+++ b/openstack/sharedfilesystems/v2/services/testing/fixtures_test.go
@@ -66,6 +66,6 @@ func HandleListSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, ServiceListBody)
+		fmt.Fprint(w, ServiceListBody)
 	})
 }

--- a/openstack/sharedfilesystems/v2/shareaccessrules/testing/fixtures_test.go
+++ b/openstack/sharedfilesystems/v2/shareaccessrules/testing/fixtures_test.go
@@ -40,7 +40,7 @@ func MockGetResponse(t *testing.T) {
 		th.TestHeader(t, r, "Accept", "application/json")
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, getResponse)
+		fmt.Fprint(w, getResponse)
 	})
 }
 

--- a/openstack/sharedfilesystems/v2/shareaccessrules/testing/requests_test.go
+++ b/openstack/sharedfilesystems/v2/shareaccessrules/testing/requests_test.go
@@ -49,6 +49,6 @@ func MockListResponse(t *testing.T) {
 		th.TestHeader(t, r, "Accept", "application/json")
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, listResponse)
+		fmt.Fprint(w, listResponse)
 	})
 }

--- a/openstack/sharedfilesystems/v2/sharenetworks/testing/fixtures_test.go
+++ b/openstack/sharedfilesystems/v2/sharenetworks/testing/fixtures_test.go
@@ -55,7 +55,7 @@ func MockCreateResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusAccepted)
 
-		fmt.Fprintf(w, createResp("my_network",
+		fmt.Fprint(w, createResp("my_network",
 			"This is my share network",
 			"998b42ee-2cee-4d36-8b95-67b5ca1f2109",
 			"53482b62-2c84-4a53-b6ab-30d9d9800d06"))
@@ -85,7 +85,7 @@ func MockListResponse(t *testing.T) {
 
 		switch marker {
 		case "":
-			fmt.Fprintf(w, `{
+			fmt.Fprint(w, `{
             "share_networks": [
                 {
                     "name": "net_my1",
@@ -135,7 +135,7 @@ func MockListResponse(t *testing.T) {
             ]
         }`)
 		default:
-			fmt.Fprintf(w, `
+			fmt.Fprint(w, `
 				{
 					"share_networks": []
 				}`)
@@ -157,7 +157,7 @@ func MockFilteredListResponse(t *testing.T) {
 		marker := r.Form.Get("offset")
 		switch marker {
 		case "":
-			fmt.Fprintf(w, `
+			fmt.Fprint(w, `
 				{
 					"share_networks": [
 						{
@@ -178,7 +178,7 @@ func MockFilteredListResponse(t *testing.T) {
 					]
 				}`)
 		case "1":
-			fmt.Fprintf(w, `
+			fmt.Fprint(w, `
 				{
 					"share_networks": [
 						{
@@ -199,7 +199,7 @@ func MockFilteredListResponse(t *testing.T) {
 					]
 				}`)
 		case "2":
-			fmt.Fprintf(w, `
+			fmt.Fprint(w, `
 				{
 					"share_networks": [
 						{
@@ -220,7 +220,7 @@ func MockFilteredListResponse(t *testing.T) {
 					]
 				}`)
 		default:
-			fmt.Fprintf(w, `
+			fmt.Fprint(w, `
 				{
 					"share_networks": []
 				}`)
@@ -235,7 +235,7 @@ func MockGetResponse(t *testing.T) {
 
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
         {
             "share_network": {
                 "name": "net_my1",
@@ -261,7 +261,7 @@ func MockUpdateNeutronResponse(t *testing.T) {
 		th.TestMethod(t, r, "PUT")
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
             {
                 "share_network": {
                     "name": "net_my2",
@@ -288,7 +288,7 @@ func MockUpdateNovaResponse(t *testing.T) {
 		th.TestMethod(t, r, "PUT")
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
             {
                 "share_network": {
                     "name": "net_my2",
@@ -315,7 +315,7 @@ func MockAddSecurityServiceResponse(t *testing.T) {
 		th.TestMethod(t, r, "POST")
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
         {
             "share_network": {
                 "name": "net2",
@@ -341,7 +341,7 @@ func MockRemoveSecurityServiceResponse(t *testing.T) {
 		th.TestMethod(t, r, "POST")
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
         {
             "share_network": {
                 "name": "net2",

--- a/openstack/sharedfilesystems/v2/shares/testing/fixtures_test.go
+++ b/openstack/sharedfilesystems/v2/shares/testing/fixtures_test.go
@@ -84,7 +84,7 @@ func MockCreateResponse(t *testing.T) {
 		th.TestJSONRequest(t, r, createRequest)
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, createResponse)
+		fmt.Fprint(w, createResponse)
 	})
 }
 
@@ -158,7 +158,7 @@ func MockUpdateResponse(t *testing.T) {
 		th.TestJSONRequest(t, r, updateRequest)
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, updateResponse)
+		fmt.Fprint(w, updateResponse)
 	})
 }
 
@@ -211,7 +211,7 @@ func MockGetResponse(t *testing.T) {
 		th.TestMethod(t, r, "GET")
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, getResponse)
+		fmt.Fprint(w, getResponse)
 	})
 }
 
@@ -304,7 +304,7 @@ func MockListExportLocationsResponse(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, listExportLocationsResponse)
+		fmt.Fprint(w, listExportLocationsResponse)
 	})
 }
 
@@ -325,7 +325,7 @@ func MockGetExportLocationResponse(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, getExportLocationResponse)
+		fmt.Fprint(w, getExportLocationResponse)
 	})
 }
 
@@ -359,7 +359,7 @@ func MockGrantAccessResponse(t *testing.T) {
 		th.TestJSONRequest(t, r, grantAccessRequest)
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, grantAccessResponse)
+		fmt.Fprint(w, grantAccessResponse)
 	})
 }
 
@@ -410,7 +410,7 @@ func MockListAccessRightsResponse(t *testing.T) {
 		th.TestJSONRequest(t, r, listAccessRightsRequest)
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, listAccessRightsResponse)
+		fmt.Fprint(w, listAccessRightsResponse)
 	})
 }
 

--- a/openstack/sharedfilesystems/v2/sharetransfers/testing/fixtures_test.go
+++ b/openstack/sharedfilesystems/v2/sharetransfers/testing/fixtures_test.go
@@ -147,7 +147,7 @@ func HandleCreateTransfer(t *testing.T) {
 		th.TestJSONRequest(t, r, CreateRequest)
 
 		w.WriteHeader(http.StatusAccepted)
-		fmt.Fprintf(w, CreateResponse)
+		fmt.Fprint(w, CreateResponse)
 	})
 }
 
@@ -179,7 +179,7 @@ func HandleListTransfers(t *testing.T) {
 		th.TestFormValues(t, r, map[string]string{"all_tenants": "true"})
 
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, ListOutput)
+		fmt.Fprint(w, ListOutput)
 	})
 }
 
@@ -191,7 +191,7 @@ func HandleListTransfersDetail(t *testing.T) {
 		th.TestFormValues(t, r, map[string]string{"all_tenants": "true"})
 
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, ListOutput)
+		fmt.Fprint(w, ListOutput)
 	})
 }
 
@@ -202,6 +202,6 @@ func HandleGetTransfer(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, GetOutput)
+		fmt.Fprint(w, GetOutput)
 	})
 }

--- a/openstack/sharedfilesystems/v2/sharetypes/testing/fixtures_test.go
+++ b/openstack/sharedfilesystems/v2/sharetypes/testing/fixtures_test.go
@@ -30,7 +30,7 @@ func MockCreateResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusAccepted)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
         {
             "volume_type": {
                 "os-share-type-access:is_public": true,
@@ -76,7 +76,7 @@ func MockListResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
         {
             "volume_types": [
                 {
@@ -141,7 +141,7 @@ func MockGetDefaultResponse(t *testing.T) {
 
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
         {
             "volume_type": {
                 "required_extra_specs": null,
@@ -172,7 +172,7 @@ func MockGetExtraSpecsResponse(t *testing.T) {
 
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
         {
             "extra_specs": {
                 "snapshot_support": "True",
@@ -199,7 +199,7 @@ func MockSetExtraSpecsResponse(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusAccepted)
 
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
         {
             "extra_specs": {
                 "my_key": "my_value"
@@ -223,7 +223,7 @@ func MockShowAccessResponse(t *testing.T) {
 
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
         {
             "share_type_access": [
                 {

--- a/openstack/sharedfilesystems/v2/snapshots/testing/fixtures_test.go
+++ b/openstack/sharedfilesystems/v2/snapshots/testing/fixtures_test.go
@@ -59,7 +59,7 @@ func MockCreateResponse(t *testing.T) {
 		th.TestJSONRequest(t, r, createRequest)
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusAccepted)
-		fmt.Fprintf(w, createResponse)
+		fmt.Fprint(w, createResponse)
 	})
 }
 
@@ -114,7 +114,7 @@ func MockUpdateResponse(t *testing.T) {
 		th.TestJSONRequest(t, r, updateRequest)
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, updateResponse)
+		fmt.Fprint(w, updateResponse)
 	})
 }
 
@@ -150,7 +150,7 @@ func MockGetResponse(t *testing.T) {
 		th.TestMethod(t, r, "GET")
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, getResponse)
+		fmt.Fprint(w, getResponse)
 	})
 }
 

--- a/openstack/testing/client_test.go
+++ b/openstack/testing/client_test.go
@@ -46,7 +46,7 @@ func TestAuthenticatedClientV3(t *testing.T) {
 		w.Header().Add("X-Subject-Token", ID)
 
 		w.WriteHeader(http.StatusCreated)
-		fmt.Fprintf(w, `{ "token": { "expires_at": "2013-02-02T18:30:59.000000Z" } }`)
+		fmt.Fprint(w, `{ "token": { "expires_at": "2013-02-02T18:30:59.000000Z" } }`)
 	})
 
 	options := gophercloud.AuthOptions{
@@ -91,7 +91,7 @@ func TestAuthenticatedClientV2(t *testing.T) {
 	})
 
 	th.Mux.HandleFunc("/v2.0/tokens", func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 			{
 				"access": {
 					"token": {
@@ -197,7 +197,7 @@ func TestIdentityAdminV3Client(t *testing.T) {
 		w.Header().Add("X-Subject-Token", ID)
 
 		w.WriteHeader(http.StatusCreated)
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 	{
     "token": {
         "audit_ids": ["VcxU2JYqT8OzfUVvrjEITQ", "qNUTIJntTzO1-XUk5STybw"],

--- a/openstack/workflow/v2/crontriggers/testing/requests_test.go
+++ b/openstack/workflow/v2/crontriggers/testing/requests_test.go
@@ -25,7 +25,7 @@ func TestCreateCronTrigger(t *testing.T) {
 		w.WriteHeader(http.StatusCreated)
 
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 			{
 				"created_at": "2018-09-12 15:48:18",
 				"first_execution_time": "2018-09-12 17:48:00",
@@ -110,7 +110,7 @@ func TestGetCronTrigger(t *testing.T) {
 		th.TestMethod(t, r, "GET")
 		th.TestHeader(t, r, "X-Auth-token", fake.TokenID)
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 			{
 				"created_at": "2018-09-12 15:48:18",
 				"first_execution_time": "2018-09-12 17:48:00",
@@ -195,7 +195,7 @@ func TestListCronTriggers(t *testing.T) {
 				"next": "%s/cron_triggers?marker=0520ffd8-f7f1-4f2e-845b-55d953a1cf46"
 			}`, th.Server.URL)
 		case "0520ffd8-f7f1-4f2e-845b-55d953a1cf46":
-			fmt.Fprintf(w, `{ "cron_triggers": [] }`)
+			fmt.Fprint(w, `{ "cron_triggers": [] }`)
 		default:
 			t.Fatalf("Unexpected marker: [%s]", marker)
 		}

--- a/openstack/workflow/v2/executions/testing/requests_test.go
+++ b/openstack/workflow/v2/executions/testing/requests_test.go
@@ -25,7 +25,7 @@ func TestCreateExecution(t *testing.T) {
 		w.WriteHeader(http.StatusCreated)
 
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 			{
 				"created_at": "2018-09-12 14:48:49",
 				"description": "description",
@@ -92,7 +92,7 @@ func TestGetExecution(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-token", fake.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 			{
 				"created_at": "2018-09-12 14:48:49",
 				"description": "description",
@@ -189,7 +189,7 @@ func TestListExecutions(t *testing.T) {
 				"next": "%s/executions?marker=50bb59f1-eb77-4017-a77f-6d575b002667"
 			}`, th.Server.URL)
 		case "50bb59f1-eb77-4017-a77f-6d575b002667":
-			fmt.Fprintf(w, `{ "executions": [] }`)
+			fmt.Fprint(w, `{ "executions": [] }`)
 		default:
 			t.Fatalf("Unexpected marker: [%s]", marker)
 		}

--- a/openstack/workflow/v2/workflows/testing/requests_test.go
+++ b/openstack/workflow/v2/workflows/testing/requests_test.go
@@ -46,11 +46,11 @@ workflow_echo:
 		w.WriteHeader(http.StatusCreated)
 		w.Header().Add("Content-Type", "application/json")
 
-		fmt.Fprintf(w, `{
+		fmt.Fprint(w, `{
 			"workflows": [
 				{
 					"created_at": "2018-09-12 15:48:17",
-					"definition": "---\nversion: '2.0'\n\nworkflow_echo:\n  description: Simple workflow example\n  type: direct\n\n  input:\n    - msg\n\n  tasks:\n    test:\n      action: std.echo output=\"<%% $.msg %%>\"",
+					"definition": "---\nversion: '2.0'\n\nworkflow_echo:\n  description: Simple workflow example\n  type: direct\n\n  input:\n    - msg\n\n  tasks:\n    test:\n      action: std.echo output=\"<% $.msg %>\"",
 					"id": "604a3a1e-94e3-4066-a34a-aa56873ef236",
 					"input": "msg",
 					"name": "workflow_echo",
@@ -118,10 +118,10 @@ func TestGetWorkflow(t *testing.T) {
 		th.TestMethod(t, r, "GET")
 		th.TestHeader(t, r, "X-Auth-token", fake.TokenID)
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 			{
 				"created_at": "2018-09-12 15:48:17",
-				"definition": "---\nversion: '2.0'\n\nworkflow_echo:\n  description: Simple workflow example\n  type: direct\n\n  input:\n    - msg\n\n  tasks:\n    test:\n      action: std.echo output=\"<%% $.msg %%>\"",
+				"definition": "---\nversion: '2.0'\n\nworkflow_echo:\n  description: Simple workflow example\n  type: direct\n\n  input:\n    - msg\n\n  tasks:\n    test:\n      action: std.echo output=\"<% $.msg %>\"",
 				"id": "604a3a1e-94e3-4066-a34a-aa56873ef236",
 				"input": "msg",
 				"name": "workflow_echo",
@@ -187,7 +187,7 @@ func TestListWorkflows(t *testing.T) {
 				]
 			}`, th.Server.URL)
 		case "604a3a1e-94e3-4066-a34a-aa56873ef236":
-			fmt.Fprintf(w, `{ "workflows": [] }`)
+			fmt.Fprint(w, `{ "workflows": [] }`)
 		default:
 			t.Fatalf("Unexpected marker: [%s]", marker)
 		}

--- a/pagination/testing/linked_test.go
+++ b/pagination/testing/linked_test.go
@@ -45,7 +45,7 @@ func createLinked() pagination.Pager {
 
 	th.Mux.HandleFunc("/page3", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, `{ "ints": [7, 8, 9], "links": { "next": null } }`)
+		fmt.Fprint(w, `{ "ints": [7, 8, 9], "links": { "next": null } }`)
 	})
 
 	client := createClient()

--- a/pagination/testing/marker_test.go
+++ b/pagination/testing/marker_test.go
@@ -46,11 +46,11 @@ func createMarkerPaged(t *testing.T) pagination.Pager {
 		ms := r.Form["marker"]
 		switch {
 		case len(ms) == 0:
-			fmt.Fprintf(w, "aaa\nbbb\nccc")
+			fmt.Fprint(w, "aaa\nbbb\nccc")
 		case len(ms) == 1 && ms[0] == "ccc":
-			fmt.Fprintf(w, "ddd\neee\nfff")
+			fmt.Fprint(w, "ddd\neee\nfff")
 		case len(ms) == 1 && ms[0] == "fff":
-			fmt.Fprintf(w, "ggg\nhhh\niii")
+			fmt.Fprint(w, "ggg\nhhh\niii")
 		case len(ms) == 1 && ms[0] == "iii":
 			w.WriteHeader(http.StatusNoContent)
 		default:

--- a/pagination/testing/single_test.go
+++ b/pagination/testing/single_test.go
@@ -38,7 +38,7 @@ func setupSinglePaged() pagination.Pager {
 
 	th.Mux.HandleFunc("/only", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, `{ "ints": [1, 2, 3] }`)
+		fmt.Fprint(w, `{ "ints": [1, 2, 3] }`)
 	})
 
 	createPage := func(r pagination.PageResult) pagination.Page {

--- a/testhelper/fixture/helper.go
+++ b/testhelper/fixture/helper.go
@@ -25,7 +25,7 @@ func SetupHandler(t *testing.T, url, method, requestBody, responseBody string, s
 		w.WriteHeader(status)
 
 		if responseBody != "" {
-			fmt.Fprintf(w, responseBody)
+			fmt.Fprint(w, responseBody)
 		}
 	})
 }

--- a/testing/provider_client_test.go
+++ b/testing/provider_client_test.go
@@ -99,7 +99,7 @@ func TestConcurrentReauth(t *testing.T) {
 		}
 
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, `{}`)
+		fmt.Fprint(w, `{}`)
 	})
 
 	wg := new(sync.WaitGroup)
@@ -276,7 +276,7 @@ func TestRequestThatCameDuringReauthWaitsUntilItIsCompleted(t *testing.T) {
 		}
 
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, `{}`)
+		fmt.Fprint(w, `{}`)
 	})
 
 	wg := new(sync.WaitGroup)


### PR DESCRIPTION
Bump golangci-lint, which highlights issues that we will see with go vet 1.24.

Depends-on: https://github.com/gophercloud/gophercloud/pull/3242

**Commits**

- ``lint: Address recent lint issues``
- ``lint: Remove non-constant format string in calls (govet)``
- ``make: Bump golangci-lint``
