### PR TITLE
Drop CI coverage for Antelope

### DIFF
--- a/.github/workflows/functional-baremetal.yaml
+++ b/.github/workflows/functional-baremetal.yaml
@@ -34,11 +34,6 @@ jobs:
             ubuntu_version: "22.04"
             use_system_scope: false
             additional_services: ""
-          - name: "antelope"
-            openstack_version: "stable/2023.1"
-            ubuntu_version: "22.04"
-            use_system_scope: false
-            additional_services: ""
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with Ironic and run baremetal acceptance tests
     steps:

--- a/.github/workflows/functional-basic.yaml
+++ b/.github/workflows/functional-basic.yaml
@@ -30,10 +30,6 @@ jobs:
             openstack_version: "stable/2023.2"
             ubuntu_version: "22.04"
             additional_services: ""
-          - name: "antelope"
-            openstack_version: "stable/2023.1"
-            ubuntu_version: "22.04"
-            additional_services: ""
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with defaults and run basic acceptance tests
     steps:

--- a/.github/workflows/functional-blockstorage.yaml
+++ b/.github/workflows/functional-blockstorage.yaml
@@ -27,10 +27,6 @@ jobs:
             openstack_version: "stable/2023.2"
             ubuntu_version: "22.04"
             additional_services: ""
-          - name: "antelope"
-            openstack_version: "stable/2023.1"
-            ubuntu_version: "22.04"
-            additional_services: ""
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with Cinder and run blockstorage acceptance tests
     steps:

--- a/.github/workflows/functional-compute.yaml
+++ b/.github/workflows/functional-compute.yaml
@@ -27,10 +27,6 @@ jobs:
             openstack_version: "stable/2023.2"
             ubuntu_version: "22.04"
             additional_services: ""
-          - name: "antelope"
-            openstack_version: "stable/2023.1"
-            ubuntu_version: "22.04"
-            additional_services: ""
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with Nova and run compute acceptance tests
     steps:

--- a/.github/workflows/functional-containerinfra.yaml
+++ b/.github/workflows/functional-containerinfra.yaml
@@ -39,13 +39,6 @@ jobs:
               enable_plugin magnum https://github.com/openstack/magnum stable/2023.2
               MAGNUMCLIENT_BRANCH=stable/2023.2
             additional_services: ""
-          - name: "antelope"
-            openstack_version: "stable/2023.1"
-            ubuntu_version: "22.04"
-            devstack_conf_overrides: |
-              enable_plugin magnum https://github.com/openstack/magnum stable/2023.1
-              MAGNUMCLIENT_BRANCH=stable/2023.1
-            additional_services: ""
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with Magnum and run containerinfra acceptance tests
     steps:

--- a/.github/workflows/functional-dns.yaml
+++ b/.github/workflows/functional-dns.yaml
@@ -28,10 +28,6 @@ jobs:
             openstack_version: "stable/2023.2"
             ubuntu_version: "22.04"
             additional_services: ""
-          - name: "antelope"
-            openstack_version: "stable/2023.1"
-            ubuntu_version: "22.04"
-            additional_services: ""
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with Designate and run dns acceptance tests
     steps:

--- a/.github/workflows/functional-fwaas_v2.yaml
+++ b/.github/workflows/functional-fwaas_v2.yaml
@@ -27,10 +27,6 @@ jobs:
             openstack_version: "stable/2023.2"
             ubuntu_version: "22.04"
             additional_services: ""
-          - name: "antelope"
-            openstack_version: "stable/2023.1"
-            ubuntu_version: "22.04"
-            additional_services: ""
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with enabled FWaaS_v2 and run networking acceptance tests
     steps:

--- a/.github/workflows/functional-identity.yaml
+++ b/.github/workflows/functional-identity.yaml
@@ -27,10 +27,6 @@ jobs:
             openstack_version: "stable/2023.2"
             ubuntu_version: "22.04"
             additional_services: ""
-          - name: "antelope"
-            openstack_version: "stable/2023.1"
-            ubuntu_version: "22.04"
-            additional_services: ""
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with Keystone and run identity acceptance tests
     steps:

--- a/.github/workflows/functional-image.yaml
+++ b/.github/workflows/functional-image.yaml
@@ -27,10 +27,6 @@ jobs:
             openstack_version: "stable/2023.2"
             ubuntu_version: "22.04"
             additional_services: ""
-          - name: "antelope"
-            openstack_version: "stable/2023.1"
-            ubuntu_version: "22.04"
-            additional_services: ""
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with Glance and run image acceptance tests
     steps:

--- a/.github/workflows/functional-keymanager.yaml
+++ b/.github/workflows/functional-keymanager.yaml
@@ -27,10 +27,6 @@ jobs:
             openstack_version: "stable/2023.2"
             ubuntu_version: "22.04"
             additional_services: ""
-          - name: "antelope"
-            openstack_version: "stable/2023.1"
-            ubuntu_version: "22.04"
-            additional_services: ""
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with Barbican and run keymanager acceptance tests
     steps:

--- a/.github/workflows/functional-loadbalancer.yaml
+++ b/.github/workflows/functional-loadbalancer.yaml
@@ -27,10 +27,6 @@ jobs:
             openstack_version: "stable/2023.2"
             ubuntu_version: "22.04"
             additional_services: ""
-          - name: "antelope"
-            openstack_version: "stable/2023.1"
-            ubuntu_version: "22.04"
-            additional_services: ""
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with Octavia and run loadbalancer acceptance tests
     steps:

--- a/.github/workflows/functional-messaging.yaml
+++ b/.github/workflows/functional-messaging.yaml
@@ -27,10 +27,6 @@ jobs:
             openstack_version: "stable/2023.2"
             ubuntu_version: "22.04"
             additional_services: ""
-          - name: "antelope"
-            openstack_version: "stable/2023.1"
-            ubuntu_version: "22.04"
-            additional_services: ""
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with Zaqar and run messaging acceptance tests
     steps:

--- a/.github/workflows/functional-networking.yaml
+++ b/.github/workflows/functional-networking.yaml
@@ -27,10 +27,6 @@ jobs:
             openstack_version: "stable/2023.2"
             ubuntu_version: "22.04"
             additional_services: ""
-          - name: "antelope"
-            openstack_version: "stable/2023.1"
-            ubuntu_version: "22.04"
-            additional_services: ""
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with Neutron and run networking acceptance tests
     steps:

--- a/.github/workflows/functional-objectstorage.yaml
+++ b/.github/workflows/functional-objectstorage.yaml
@@ -27,10 +27,6 @@ jobs:
             openstack_version: "stable/2023.2"
             ubuntu_version: "22.04"
             additional_services: ""
-          - name: "antelope"
-            openstack_version: "stable/2023.1"
-            ubuntu_version: "22.04"
-            additional_services: ""
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with Swift and run objectstorage acceptance tests
     steps:

--- a/.github/workflows/functional-orchestration.yaml
+++ b/.github/workflows/functional-orchestration.yaml
@@ -27,10 +27,6 @@ jobs:
             openstack_version: "stable/2023.2"
             ubuntu_version: "22.04"
             additional_services: ""
-          - name: "antelope"
-            openstack_version: "stable/2023.1"
-            ubuntu_version: "22.04"
-            additional_services: ""
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with Heat and run orchestration acceptance tests
     steps:

--- a/.github/workflows/functional-placement.yaml
+++ b/.github/workflows/functional-placement.yaml
@@ -27,10 +27,6 @@ jobs:
             openstack_version: "stable/2023.2"
             ubuntu_version: "22.04"
             additional_services: ""
-          - name: "antelope"
-            openstack_version: "stable/2023.1"
-            ubuntu_version: "22.04"
-            additional_services: ""
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with Placement and run placement acceptance tests
     steps:

--- a/.github/workflows/functional-sharedfilesystems.yaml
+++ b/.github/workflows/functional-sharedfilesystems.yaml
@@ -27,10 +27,6 @@ jobs:
             openstack_version: "stable/2023.2"
             ubuntu_version: "22.04"
             additional_services: ""
-          - name: "antelope"
-            openstack_version: "stable/2023.1"
-            ubuntu_version: "22.04"
-            additional_services: ""
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with Manila and run sharedfilesystems acceptance tests
     steps:


### PR DESCRIPTION
Antelope has entered the unmaintained [1] phase. We can no longer rely on this for testing.

[1] https://docs.openstack.org/project-team-guide/stable-branches.html#unmaintained
