### PR TITLE
Add support for disable_power_off

### DIFF
--- a/openstack/baremetal/v1/nodes/requests.go
+++ b/openstack/baremetal/v1/nodes/requests.go
@@ -274,6 +274,10 @@ type CreateOpts struct {
 
 	// Static network configuration to use during deployment and cleaning.
 	NetworkData map[string]any `json:"network_data,omitempty"`
+
+	// Whether disable_power_off is enabled or disabled on this node.
+	// Requires microversion 1.95 or later.
+	DisablePowerOff *bool `json:"disable_power_off,omitempty"`
 }
 
 // ToNodeCreateMap assembles a request body based on the contents of a CreateOpts.

--- a/openstack/baremetal/v1/nodes/results.go
+++ b/openstack/baremetal/v1/nodes/results.go
@@ -314,6 +314,10 @@ type Node struct {
 
 	// The UTC date and time when the resource was updated, ISO 8601 format. May be “null”.
 	UpdatedAt time.Time `json:"updated_at"`
+
+	// Whether disable_power_off is enabled or disabled on this node.
+	// Requires microversion 1.95 or later.
+	DisablePowerOff bool `json:"disable_power_off"`
 }
 
 // NodePage abstracts the raw results of making a List() request against

--- a/openstack/baremetal/v1/nodes/testing/fixtures_test.go
+++ b/openstack/baremetal/v1/nodes/testing/fixtures_test.go
@@ -87,6 +87,7 @@ const NodeListDetailBody = `
       "created_at": "2019-01-31T19:59:28+00:00",
       "deploy_interface": "iscsi",
       "deploy_step": {},
+      "disable_power_off": false,
       "driver": "ipmi",
       "driver_info": {
         "ipmi_port": "6230",
@@ -195,6 +196,7 @@ const NodeListDetailBody = `
       "created_at": "2019-01-31T19:59:29+00:00",
       "deploy_interface": "iscsi",
       "deploy_step": {},
+      "disable_power_off": false,
       "driver": "ipmi",
       "driver_info": {},
       "driver_internal_info": {},
@@ -295,6 +297,7 @@ const NodeListDetailBody = `
       "created_at": "2019-01-31T19:59:30+00:00",
       "deploy_interface": "iscsi",
       "deploy_step": {},
+      "disable_power_off": true,
       "driver": "ipmi",
       "driver_info": {},
       "driver_internal_info": {},
@@ -1123,6 +1126,7 @@ var (
 		InspectionFinishedAt: &InspectionFinishedAt,
 		Retired:              false,
 		RetiredReason:        "No longer needed",
+		DisablePowerOff:      false,
 		Links: []nodes.Link{
 			{Href: "http://ironic.example.com:6385/v1/nodes/08c84581-58f5-4ea2-a0c6-dd2e5d2b3662", Rel: "self"},
 			{Href: "http://ironic.example.com:6385/nodes/08c84581-58f5-4ea2-a0c6-dd2e5d2b3662", Rel: "bookmark"},
@@ -1192,6 +1196,7 @@ var (
 		UpdatedAt:            updatedAt,
 		Retired:              false,
 		RetiredReason:        "No longer needed",
+		DisablePowerOff:      true,
 		Links: []nodes.Link{
 			{Href: "http://ironic.example.com:6385/v1/nodes/c9afd385-5d89-4ecb-9e1c-68194da6b474", Rel: "self"},
 			{Href: "http://ironic.example.com:6385/nodes/c9afd385-5d89-4ecb-9e1c-68194da6b474", Rel: "bookmark"},


### PR DESCRIPTION
Added in baremetal api v1.95 disable_power_off expcicitly prevents a node from being powered off by ironic.

See https://specs.openstack.org/openstack/ironic-specs/specs/approved/nc-si.html


Fixes #3246

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://review.opendev.org/c/openstack/ironic/+/934740