### PR TITLE
labels: Add edit:testinfra

### DIFF
--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -106,6 +106,9 @@
   description: This PR updates sharedfilesystems code
   name: edit:sharedfilesystems
 - color: '000000'
+  description: This PR updates testing infrastructure code
+  name: edit:testinfra
+- color: '000000'
   description: This PR updates testing code
   name: edit:testing
 - color: '000000'


### PR DESCRIPTION
The `edit:testinfra` label was added to `labeler.yaml` for automatic
labeling based on path, but not to the list of managed labels.

With this change `edit:testinfra` is added to the list of managed
labels, so that automation doesn't fight to create and remove it.