### PR TITLE
labels: Add no-backport

### DIFF
--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -4,6 +4,9 @@
 - color: 'E99695'
   description: This PR will be backported to v2
   name: backport-v2
+- color: '563B40'
+  description: This PR will not be backported
+  name: no-backport
 - color: 'BCF611'
   description: A good issue for first-time contributors
   name: good first issue


### PR DESCRIPTION
This label serves as manual triage for the PRs that legitimately shouldn't be backported.

Once we start labeling PRs that we actively don't want backported, it will be easier to identify which PRs we forgot to backport.
