### PR TITLE
bulk security group rule creation: Allow using CreateOptsBuilder

### DIFF
--- a/openstack/networking/v2/extensions/security/rules/requests.go
+++ b/openstack/networking/v2/extensions/security/rules/requests.go
@@ -155,7 +155,7 @@ func Create(ctx context.Context, c *gophercloud.ServiceClient, opts CreateOptsBu
 // As of Dalmatian (2024.2) neutron only allows bulk creation of rules when
 // they all belong to the same tenant and security group.
 // https://github.com/openstack/neutron/blob/6183792/neutron/db/securitygroups_db.py#L814-L828
-func CreateBulk(ctx context.Context, c *gophercloud.ServiceClient, opts []CreateOpts) (r CreateBulkResult) {
+func CreateBulk[createOpts CreateOptsBuilder](ctx context.Context, c *gophercloud.ServiceClient, opts []createOpts) (r CreateBulkResult) {
 	body, err := gophercloud.BuildRequestBody(opts, "security_group_rules")
 	if err != nil {
 		r.Err = err

--- a/openstack/networking/v2/extensions/security/rules/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/security/rules/testing/requests_test.go
@@ -313,8 +313,19 @@ func TestCreateBulk(t *testing.T) {
 			SecGroupID:   "a7734e61-b545-452d-a3cd-0189cbd9747a",
 		},
 	}
-	_, err := rules.CreateBulk(context.TODO(), fake.ServiceClient(), opts).Extract()
-	th.AssertNoErr(t, err)
+	{
+		_, err := rules.CreateBulk(context.TODO(), fake.ServiceClient(), opts).Extract()
+		th.AssertNoErr(t, err)
+	}
+
+	{
+		optsBuilder := make([]rules.CreateOptsBuilder, len(opts))
+		for i := range opts {
+			optsBuilder[i] = opts[i]
+		}
+		_, err := rules.CreateBulk(context.TODO(), fake.ServiceClient(), optsBuilder).Extract()
+		th.AssertNoErr(t, err)
+	}
 }
 
 func TestRequiredCreateOpts(t *testing.T) {


### PR DESCRIPTION
Before this patch, security group rules could only be created in a batch when using slices of plain `rules.CreateOpts`. With this change, a slice of any type implementing `rules.CreateOptsBuilder` can be used to create security group rules in a batch.