### PR TITLE
Fix JSON field name hints in APIVersion structs

### DIFF
--- a/openstack/loadbalancer/v2/apiversions/results.go
+++ b/openstack/loadbalancer/v2/apiversions/results.go
@@ -5,7 +5,7 @@ import "github.com/gophercloud/gophercloud/v2/pagination"
 // APIVersion represents an API version for load balancer. It contains
 // the status of the API, and its unique ID.
 type APIVersion struct {
-	Status string `son:"status"`
+	Status string `json:"status"`
 	ID     string `json:"id"`
 }
 

--- a/openstack/networking/v2/apiversions/results.go
+++ b/openstack/networking/v2/apiversions/results.go
@@ -7,7 +7,7 @@ import (
 // APIVersion represents an API version for Neutron. It contains the status of
 // the API, and its unique ID.
 type APIVersion struct {
-	Status string `son:"status"`
+	Status string `json:"status"`
 	ID     string `json:"id"`
 }
 


### PR DESCRIPTION
`son:"status"` is not a valid hint for JSON (de/en)coder.

There's no actual issue, everything works as expected - but only because no one ever needs to marshal those APIVersion structs back to JSON.
