### PR TITLE
block_storage: get quotausage for blockstorage volume_types

### DIFF
--- a/internal/acceptance/openstack/blockstorage/v3/quotaset_test.go
+++ b/internal/acceptance/openstack/blockstorage/v3/quotaset_test.go
@@ -46,6 +46,7 @@ func TestQuotasetGetUsage(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	tools.PrintResource(t, quotaSetUsage)
+	tools.PrintResource(t, quotaSetUsage.Extra)
 }
 
 var UpdateQuotaOpts = quotasets.UpdateOpts{

--- a/openstack/blockstorage/v2/quotasets/testing/fixtures_test.go
+++ b/openstack/blockstorage/v2/quotasets/testing/fixtures_test.go
@@ -76,7 +76,22 @@ var getUsageExpectedJSONBody = `
             "limit": 41,
             "reserved": 42
         }
-	}
+        "gigabytes_hdd" : {
+            "in_use": 50,
+            "limit": 51,
+            "reserved": 52
+        },
+        "volumes_hdd" : {
+            "in_use": 53,
+            "limit": 54,
+            "reserved": 55
+        },
+        "snapshots_hdd": {
+            "in_use": 56,
+            "limit": 57,
+            "reserved": 58
+        }
+    }
 }`
 
 var getUsageExpectedQuotaSet = quotasets.QuotaUsageSet{
@@ -88,6 +103,11 @@ var getUsageExpectedQuotaSet = quotasets.QuotaUsageSet{
 	Backups:            quotasets.QuotaUsage{InUse: 27, Limit: 28, Reserved: 29},
 	BackupGigabytes:    quotasets.QuotaUsage{InUse: 30, Limit: 31, Reserved: 32},
 	Groups:             quotasets.QuotaUsage{InUse: 40, Limit: 41, Reserved: 42},
+	Extra: map[string]quotasets.QuotaUsage{
+		"gigabytes_hdd": {InUse: 50, Limit: 51, Reserved: 52},
+		"volumes_hdd":   {InUse: 53, Limit: 54, Reserved: 55},
+		"snapshots_hdd": {InUse: 56, Limit: 57, Reserved: 58},
+	},
 }
 
 var fullUpdateExpectedJSONBody = `
@@ -147,7 +167,7 @@ var partialUpdateOpts = quotasets.UpdateOpts{
 	Extra:              make(map[string]any),
 }
 
-var partiualUpdateExpectedQuotaSet = quotasets.QuotaSet{
+var partialUpdateExpectedQuotaSet = quotasets.QuotaSet{
 	Volumes: 200,
 	Extra:   make(map[string]any),
 }

--- a/openstack/blockstorage/v2/quotasets/testing/fixtures_test.go
+++ b/openstack/blockstorage/v2/quotasets/testing/fixtures_test.go
@@ -75,7 +75,7 @@ var getUsageExpectedJSONBody = `
             "in_use": 40,
             "limit": 41,
             "reserved": 42
-        }
+        },
         "gigabytes_hdd" : {
             "in_use": 50,
             "limit": 51,

--- a/openstack/blockstorage/v2/quotasets/testing/requests_test.go
+++ b/openstack/blockstorage/v2/quotasets/testing/requests_test.go
@@ -51,7 +51,7 @@ func TestPartialUpdate(t *testing.T) {
 	HandleSuccessfulRequest(t, "PUT", "/os-quota-sets/"+FirstTenantID, partialUpdateExpectedJSONBody, uriQueryParms)
 	actual, err := quotasets.Update(context.TODO(), client.ServiceClient(), FirstTenantID, partialUpdateOpts).Extract()
 	th.AssertNoErr(t, err)
-	th.CheckDeepEquals(t, &partiualUpdateExpectedQuotaSet, actual)
+	th.CheckDeepEquals(t, &partialUpdateExpectedQuotaSet, actual)
 }
 
 type ErrorUpdateOpts quotasets.UpdateOpts

--- a/openstack/blockstorage/v3/quotasets/testing/fixtures_test.go
+++ b/openstack/blockstorage/v3/quotasets/testing/fixtures_test.go
@@ -75,8 +75,23 @@ var getUsageExpectedJSONBody = `
             "in_use": 40,
             "limit": 41,
             "reserved": 42
+        },
+        "gigabytes_hdd" : {
+            "in_use": 50,
+            "limit": 51,
+            "reserved": 52
+        },
+        "volumes_hdd" : {
+            "in_use": 53,
+            "limit": 54,
+            "reserved": 55
+        },
+        "snapshots_hdd": {
+            "in_use": 56,
+            "limit": 57,
+            "reserved": 58
         }
-	}
+    }
 }`
 
 var getUsageExpectedQuotaSet = quotasets.QuotaUsageSet{
@@ -88,6 +103,11 @@ var getUsageExpectedQuotaSet = quotasets.QuotaUsageSet{
 	Backups:            quotasets.QuotaUsage{InUse: 27, Limit: 28, Reserved: 29},
 	BackupGigabytes:    quotasets.QuotaUsage{InUse: 30, Limit: 31, Reserved: 32},
 	Groups:             quotasets.QuotaUsage{InUse: 40, Limit: 41, Reserved: 42},
+	Extra: map[string]quotasets.QuotaUsage{
+		"gigabytes_hdd": {InUse: 50, Limit: 51, Reserved: 52},
+		"volumes_hdd":   {InUse: 53, Limit: 54, Reserved: 55},
+		"snapshots_hdd": {InUse: 56, Limit: 57, Reserved: 58},
+	},
 }
 
 var fullUpdateExpectedJSONBody = `
@@ -147,7 +167,7 @@ var partialUpdateOpts = quotasets.UpdateOpts{
 	Extra:              make(map[string]any),
 }
 
-var partiualUpdateExpectedQuotaSet = quotasets.QuotaSet{
+var partialUpdateExpectedQuotaSet = quotasets.QuotaSet{
 	Volumes: 200,
 	Extra:   make(map[string]any),
 }

--- a/openstack/blockstorage/v3/quotasets/testing/requests_test.go
+++ b/openstack/blockstorage/v3/quotasets/testing/requests_test.go
@@ -51,7 +51,7 @@ func TestPartialUpdate(t *testing.T) {
 	HandleSuccessfulRequest(t, "PUT", "/os-quota-sets/"+FirstTenantID, partialUpdateExpectedJSONBody, uriQueryParms)
 	actual, err := quotasets.Update(context.TODO(), client.ServiceClient(), FirstTenantID, partialUpdateOpts).Extract()
 	th.AssertNoErr(t, err)
-	th.CheckDeepEquals(t, &partiualUpdateExpectedQuotaSet, actual)
+	th.CheckDeepEquals(t, &partialUpdateExpectedQuotaSet, actual)
 }
 
 type ErrorUpdateOpts quotasets.UpdateOpts


### PR DESCRIPTION
The volume_type attributes are currently only set for QuotaSet objects.

Hence, implemented per `volume_type` QuotaUsage as a nested object 
of `QuotaUsageSet`for block storage. 

See API docs for refs.

block-storage v3
https://docs.openstack.org/api-ref/block-storage/v3/#show-quota-usage-for-a-project

block-storage v2
https://docs.openstack.org/api-ref/block-storage/v2/#show-quotas