### PR TITLE
Add support for zone sharing in DNS v2

### DIFF
--- a/openstack/dns/v2/zones/results.go
+++ b/openstack/dns/v2/zones/results.go
@@ -50,6 +50,11 @@ type ZonePage struct {
 	pagination.LinkedPageBase
 }
 
+// ErrResult represents a generic error result.
+type ErrResult struct {
+	gophercloud.ErrResult
+}
+
 // IsEmpty returns true if the page contains no results.
 func (r ZonePage) IsEmpty() (bool, error) {
 	if r.StatusCode == 204 {

--- a/openstack/dns/v2/zones/urls.go
+++ b/openstack/dns/v2/zones/urls.go
@@ -6,6 +6,6 @@ func baseURL(c *gophercloud.ServiceClient) string {
 	return c.ServiceURL("zones")
 }
 
-func zoneURL(c *gophercloud.ServiceClient, zoneID string) string {
-	return c.ServiceURL("zones", zoneID)
+func ZoneURL(client *gophercloud.ServiceClient, parts ...string) string {
+	return client.ServiceURL(append([]string{"zones"}, parts...)...)
 }


### PR DESCRIPTION
This commit introduces functionality to share and unshare DNS zones with other projects using the OpenStack DNS v2 API. The following changes are included:
- Added `Share` and `Unshare` methods in `requests.go` to handle API calls.
- Updated `results.go` to include parsing for share/unshare responses.
- Enhanced `urls.go` to generate proper URLs for share-related operations.
- Created unit tests in `requests_test.go` to validate `Share` and `Unshare`.

These additions allow users to manage shared zones programmatically and align Gophercloud with the DNS v2 API capabilities.

Fixes #3048

Links to the line numbers/files in the OpenStack source code that support the code in this PR:

- [DNS Zones Share API (POST)](https://github.com/openstack/designate/blob/master/designate/api/v2/controllers/zones/sharedzones.py#L73-L100)
- [DNS Zones Unshare API (DELETE)](https://github.com/openstack/designate/blob/master/designate/api/v2/controllers/zones/sharedzones.py#L101-L110)
- [Shared Zones Documentation](https://docs.openstack.org/designate/latest/user/shared-zones.html)
- [Zone Shares API Reference](https://docs.openstack.org/api-ref/dns/#zone-share)
