### PR TITLE
Add permissions to the label-issue workflow

### DIFF
--- a/.github/workflows/label-issue.yaml
+++ b/.github/workflows/label-issue.yaml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write
+      pull-requests: write
     steps:
     - run: gh issue edit "$NUMBER" --remove-label "needinfo"
       env:


### PR DESCRIPTION
It needs write permissions on PRs as well otherwise it fails to runs.