### PR TITLE
Added support for `hypervisor_hostname`

### DIFF
--- a/openstack/compute/v2/servers/requests.go
+++ b/openstack/compute/v2/servers/requests.go
@@ -511,6 +511,9 @@ type CreateOpts struct {
 
 	// KeyName is the name of the key pair.
 	KeyName string `json:"key_name,omitempty"`
+
+	// HypervisorHostname is the name of the hypervisor to which the server is scheduled.
+	HypervisorHostname string `json:"hypervisor_hostname,omitempty"`
 }
 
 // ToServerCreateMap assembles a request body based on the contents of a

--- a/openstack/compute/v2/servers/testing/requests_test.go
+++ b/openstack/compute/v2/servers/testing/requests_test.go
@@ -1161,3 +1161,25 @@ func TestCreateServerWithTags(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.CheckDeepEquals(t, ServerDerpTags, *actualServer)
 }
+
+func TestCreateServerWithHypervisorHostname(t *testing.T) {
+	opts := servers.CreateOpts{
+		Name:               "createdserver",
+		FlavorRef:          "performance1-1",
+		ImageRef:           "asdfasdfasdf",
+		HypervisorHostname: "test-hypervisor",
+	}
+	expected := `
+    {
+        "server": {
+            "name":"createdserver",
+            "flavorRef":"performance1-1",
+            "imageRef":"asdfasdfasdf",
+            "hypervisor_hostname":"test-hypervisor"
+        }
+    }
+    `
+	actual, err := opts.ToServerCreateMap()
+	th.AssertNoErr(t, err)
+	th.CheckJSONEquals(t, expected, actual)
+}


### PR DESCRIPTION
<!--
Prior to starting a PR, please make sure you have read our
[contributor tutorial](https://github.com/gophercloud/gophercloud/tree/main/docs/contributor-tutorial).

Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

-->
Fixes #2499

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

[openstack api ref](https://docs.openstack.org/api-ref/compute/?expanded=list-hypervisors-detail,create-server-detail#create-server)
[openstack python client](https://github.com/openstack/python-openstackclient/blob/f1cb66a476b948093986afd18a00941b7807a9c4/openstackclient/compute/v2/server.py#L1685-L1694)