### PR TITLE
Enhance Snapshot struct and add ListDetail function in V3 blockstorage

### DIFF
--- a/internal/acceptance/openstack/blockstorage/v3/snapshots_test.go
+++ b/internal/acceptance/openstack/blockstorage/v3/snapshots_test.go
@@ -73,7 +73,24 @@ func TestSnapshots(t *testing.T) {
 
 		return true, nil
 	})
+	th.AssertNoErr(t, err)
 
+	err = snapshots.ListDetail(client, listOpts).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
+		actual, err := snapshots.ExtractSnapshots(page)
+		th.AssertNoErr(t, err)
+		th.AssertEquals(t, 1, len(actual))
+
+		var found bool
+		for _, v := range actual {
+			if v.ID == snapshot1.ID || v.ID == snapshot2.ID {
+				found = true
+			}
+		}
+
+		th.AssertEquals(t, found, true)
+
+		return true, nil
+	})
 	th.AssertNoErr(t, err)
 }
 

--- a/openstack/blockstorage/v3/snapshots/requests.go
+++ b/openstack/blockstorage/v3/snapshots/requests.go
@@ -122,6 +122,21 @@ func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pa
 	})
 }
 
+// ListDetail returns Snapshots with additional details optionally limited by the conditions provided in ListOpts.
+func ListDetail(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listDetailsURL(client)
+	if opts != nil {
+		query, err := opts.ToSnapshotListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return SnapshotPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
 // UpdateOptsBuilder allows extensions to add additional parameters to the
 // Update request.
 type UpdateOptsBuilder interface {

--- a/openstack/blockstorage/v3/snapshots/results.go
+++ b/openstack/blockstorage/v3/snapshots/results.go
@@ -36,6 +36,21 @@ type Snapshot struct {
 
 	// User-defined key-value pairs.
 	Metadata map[string]string `json:"metadata"`
+
+	// Progress of the snapshot creation.
+	Progress string `json:"os-extended-snapshot-attributes:progress"`
+
+	// Project ID that owns the snapshot.
+	ProjectID string `json:"os-extended-snapshot-attributes:project_id"`
+
+	// ID of the group snapshot, if applicable.
+	GroupSnapshotID string `json:"group_snapshot_id"`
+
+	// User ID that created the snapshot.
+	UserID string `json:"user_id"`
+
+	// Indicates whether the snapshot consumes quota.
+	ConsumesQuota bool `json:"consumes_quota"`
 }
 
 // CreateResult contains the response body and error from a Create request.

--- a/openstack/blockstorage/v3/snapshots/testing/fixtures_test.go
+++ b/openstack/blockstorage/v3/snapshots/testing/fixtures_test.go
@@ -61,6 +61,62 @@ func MockListResponse(t *testing.T) {
 	})
 }
 
+func MockListDetailsResponse(t *testing.T) {
+	th.Mux.HandleFunc("/snapshots/detail", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("Failed to parse request form %v", err)
+		}
+		marker := r.Form.Get("marker")
+		switch marker {
+		case "":
+			fmt.Fprint(w, `
+    {
+      "snapshots": [
+        {
+          "id": "289da7f8-6440-407c-9fb4-7db01ec49164",
+          "name": "snapshot-001",
+          "volume_id": "521752a6-acf6-4b2d-bc7a-119f9148cd8c",
+          "description": "Daily Backup",
+          "status": "available",
+          "size": 30,
+		      "created_at": "2017-05-30T03:35:03.000000",
+          "os-extended-snapshot-attributes:progress": "100%",
+          "os-extended-snapshot-attributes:project_id": "84b8950a-8594-4e5b-8dce-0dfa9c696357",
+          "group_snapshot_id": null,
+          "user_id": "075da7f8-6440-407c-9fb4-7db01ec49531",
+          "consumes_quota": true
+        },
+        {
+          "id": "96c3bda7-c82a-4f50-be73-ca7621794835",
+          "name": "snapshot-002",
+          "volume_id": "76b8950a-8594-4e5b-8dce-0dfa9c696358",
+          "description": "Weekly Backup",
+          "status": "available",
+          "size": 25,
+		      "created_at": "2017-05-30T03:35:03.000000",
+          "os-extended-snapshot-attributes:progress": "50%",
+          "os-extended-snapshot-attributes:project_id": "84b8950a-8594-4e5b-8dce-0dfa9c696357",
+          "group_snapshot_id": "865da7f8-6440-407c-9fb4-7db01ec40876",
+          "user_id": "075da7f8-6440-407c-9fb4-7db01ec49531",
+          "consumes_quota": false
+        }
+      ]
+    }
+    `)
+		case "1":
+			fmt.Fprint(w, `{"snapshots": []}`)
+		default:
+			t.Fatalf("Unexpected marker: [%s]", marker)
+		}
+	})
+}
+
 // MockGetResponse provides mock response for get snapshot API call
 func MockGetResponse(t *testing.T) {
 	th.Mux.HandleFunc("/snapshots/d32019d3-bc6e-4319-9c1d-6722fc136a22", func(w http.ResponseWriter, r *http.Request) {

--- a/openstack/blockstorage/v3/snapshots/testing/requests_test.go
+++ b/openstack/blockstorage/v3/snapshots/testing/requests_test.go
@@ -59,6 +59,62 @@ func TestList(t *testing.T) {
 	}
 }
 
+func TestDetailList(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockListDetailsResponse(t)
+
+	count := 0
+
+	err := snapshots.ListDetail(client.ServiceClient(), &snapshots.ListOpts{}).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
+		count++
+		actual, err := snapshots.ExtractSnapshots(page)
+		if err != nil {
+			t.Errorf("Failed to extract snapshots: %v", err)
+			return false, err
+		}
+		expected := []snapshots.Snapshot{
+			{
+				ID:              "289da7f8-6440-407c-9fb4-7db01ec49164",
+				Name:            "snapshot-001",
+				VolumeID:        "521752a6-acf6-4b2d-bc7a-119f9148cd8c",
+				Status:          "available",
+				Size:            30,
+				CreatedAt:       time.Date(2017, 5, 30, 3, 35, 3, 0, time.UTC),
+				Description:     "Daily Backup",
+				Progress:        "100%",
+				ProjectID:       "84b8950a-8594-4e5b-8dce-0dfa9c696357",
+				GroupSnapshotID: "",
+				UserID:          "075da7f8-6440-407c-9fb4-7db01ec49531",
+				ConsumesQuota:   true,
+			},
+			{
+				ID:              "96c3bda7-c82a-4f50-be73-ca7621794835",
+				Name:            "snapshot-002",
+				VolumeID:        "76b8950a-8594-4e5b-8dce-0dfa9c696358",
+				Status:          "available",
+				Size:            25,
+				CreatedAt:       time.Date(2017, 5, 30, 3, 35, 3, 0, time.UTC),
+				Description:     "Weekly Backup",
+				Progress:        "50%",
+				ProjectID:       "84b8950a-8594-4e5b-8dce-0dfa9c696357",
+				GroupSnapshotID: "865da7f8-6440-407c-9fb4-7db01ec40876",
+				UserID:          "075da7f8-6440-407c-9fb4-7db01ec49531",
+				ConsumesQuota:   false,
+			},
+		}
+		th.CheckDeepEquals(t, expected, actual)
+
+		return true, nil
+	})
+	th.AssertNoErr(t, err)
+
+	if count != 1 {
+		t.Errorf("Expected 1 page, got %d", count)
+	}
+}
+
 func TestGet(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()

--- a/openstack/blockstorage/v3/snapshots/urls.go
+++ b/openstack/blockstorage/v3/snapshots/urls.go
@@ -18,6 +18,10 @@ func listURL(c *gophercloud.ServiceClient) string {
 	return createURL(c)
 }
 
+func listDetailsURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("snapshots", "detail")
+}
+
 func updateURL(c *gophercloud.ServiceClient, id string) string {
 	return deleteURL(c, id)
 }


### PR DESCRIPTION
- Extended Snapshot struct to include additional fields: Progress, ProjectID, GroupSnapshotID, UserID, ConsumesQuota
- Implemented ListDetail function to retrieve detailed snapshot information from the snapshots/detail endpoint
- Added new test to validate the inclusion of additional fields and the functionality of  ListDetails

<!--
Prior to starting a PR, please make sure you have read our
[contributor tutorial](https://github.com/gophercloud/gophercloud/tree/main/docs/contributor-tutorial).

Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

-->
Fixes #2403

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

Documentation: https://docs.openstack.org/api-ref/block-storage/v3/#list-snapshots-and-details
