### PR TITLE
Backport: Added support for hypervisor_hostname to v2

### DIFF
--- a/openstack/compute/v2/servers/requests.go
+++ b/openstack/compute/v2/servers/requests.go
@@ -508,6 +508,9 @@ type CreateOpts struct {
 
 	// DiskConfig [optional] controls how the created server's disk is partitioned.
 	DiskConfig DiskConfig `json:"OS-DCF:diskConfig,omitempty"`
+
+	// HypervisorHostname is the name of the hypervisor to which the server is scheduled.
+	HypervisorHostname string `json:"hypervisor_hostname,omitempty"`
 }
 
 // ToServerCreateMap assembles a request body based on the contents of a

--- a/openstack/compute/v2/servers/testing/requests_test.go
+++ b/openstack/compute/v2/servers/testing/requests_test.go
@@ -1160,3 +1160,25 @@ func TestCreateServerWithTags(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.CheckDeepEquals(t, ServerDerpTags, *actualServer)
 }
+
+func TestCreateServerWithHypervisorHostname(t *testing.T) {
+	opts := servers.CreateOpts{
+		Name:               "createdserver",
+		FlavorRef:          "performance1-1",
+		ImageRef:           "asdfasdfasdf",
+		HypervisorHostname: "test-hypervisor",
+	}
+	expected := `
+    {
+        "server": {
+            "name":"createdserver",
+            "flavorRef":"performance1-1",
+            "imageRef":"asdfasdfasdf",
+            "hypervisor_hostname":"test-hypervisor"
+        }
+    }
+    `
+	actual, err := opts.ToServerCreateMap()
+	th.AssertNoErr(t, err)
+	th.CheckJSONEquals(t, expected, actual)
+}


### PR DESCRIPTION
<!--
Prior to starting a PR, please make sure you have read our
[contributor tutorial](https://github.com/gophercloud/gophercloud/tree/main/docs/contributor-tutorial).

Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

-->
Fixes #3307