### PR TITLE
ci: Update unit test workflow to use Go 1.x instead of 1.23

### DIFF
--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -13,7 +13,6 @@ jobs:
       fail-fast: false
       matrix:
         go-version:
-          - "1.23.0"
           - "1"
 
     steps:


### PR DESCRIPTION
- Removed Go 1.23 from the GitHub Actions test matrix.
- Retained only "1" to always fetch the latest stable Go 1.x version.
- This ensures compatibility with stable branches, which use older Go versions where dependencies in `go.mod` may not be compatible with the latest Go releases.

This change helps maintain stability across branches while allowing tests to run with an appropriate Go version.
