### PR TITLE
build(v2): Set Go toolchain to 1.23.6 in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/gophercloud/gophercloud/v2
 
 go 1.22
 
+toolchain go1.23.6
+
 require (
 	golang.org/x/crypto v0.33.0
 	gopkg.in/yaml.v2 v2.4.0


### PR DESCRIPTION
- Added `go 1.23.6` toolchain directive in `go.mod`.
- Ensures compatibility with `golang.org/x/tools@v0.31.0`, which requires Go >= 1.23.0.
