### PR TITLE
ci(v2): Fallback to Go 1.22 compatible goimports version

### DIFF
--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -32,6 +32,9 @@ jobs:
 
           go install github.com/wadey/gocovmerge@master
 
+          # Fallback to a go1.22 compatible version for gophercloud v2
+          go install golang.org/x/tools/cmd/goimports@latest || go install golang.org/x/tools/cmd/goimports@v0.30.0
+
       - name: Run unit tests
         run: |
           ./script/coverage


### PR DESCRIPTION
- Updated `goimports` installation to fallback to `v0.30.0` if `latest` requires Go 1.23+.
- Ensures compatibility with Go 1.22 for Gophercloud v2.
- Prevents CI failures when running in environments with older Go versions.

This change allows CI and developers using Go 1.22 to continue using `goimports` without version conflicts.
