### PR TITLE
[v2] Switch to a version of gocovmerge compatible with go 1.22

### DIFF
--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -30,7 +30,7 @@ jobs:
           cd "$(mktemp -d)"
           go mod init unit_tests
 
-          go install github.com/wadey/gocovmerge@master
+          go install github.com/alexfalkowski/gocovmerge@v1.4.0
 
       - name: Run unit tests
         run: |


### PR DESCRIPTION
The original `gocovmerge` repository [1] has not seen a commit in 9 years and should be considered unmaintained.

Switch to fork has a go.mod pinned to go 1.22. Please review the diff [2] between the two repos to check if it's safe to use in gophercloud.

[1] https://github.com/wadey/gocovmerge
[2] https://github.com/wadey/gocovmerge/compare/master...alexfalkowski:gocovmerge:v1.4.0