### PR TITLE
CI: skip TestLayer3RouterRevision on bobcat

### DIFF
--- a/internal/acceptance/clients/conditions.go
+++ b/internal/acceptance/clients/conditions.go
@@ -119,7 +119,7 @@ func getReleaseFromEnv(t *testing.T) string {
 // release. Releases are named such as 'stable/mitaka', master, etc.
 func SkipRelease(t *testing.T, release string) {
 	current := getReleaseFromEnv(t)
-	if current == release {
+	if current == strings.TrimPrefix(release, "stable/") {
 		t.Skipf("this is not supported in %s", release)
 	}
 }

--- a/internal/acceptance/openstack/networking/v2/extensions/layer3/routers_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/layer3/routers_test.go
@@ -216,6 +216,8 @@ func TestLayer3RouterAgents(t *testing.T) {
 }
 
 func TestLayer3RouterRevision(t *testing.T) {
+	// https://bugs.launchpad.net/neutron/+bug/2101871
+	clients.SkipRelease(t, "stable/2023.2")
 	client, err := clients.NewNetworkV2Client()
 	th.AssertNoErr(t, err)
 


### PR DESCRIPTION
Due to https://bugs.launchpad.net/neutron/+bug/2101871, which causes neutron to return a 500 error.