### PR TITLE
networking: add constants for statuses

### DIFF
--- a/openstack/networking/v2/apiversions/constants.go
+++ b/openstack/networking/v2/apiversions/constants.go
@@ -1,0 +1,7 @@
+package apiversions
+
+const (
+	StatusCurrent    = "CURRENT"
+	StatusDeprecated = "DEPRECATED"
+	StatusStable     = "STABLE"
+)

--- a/openstack/networking/v2/extensions/layer3/floatingips/constants.go
+++ b/openstack/networking/v2/extensions/layer3/floatingips/constants.go
@@ -1,0 +1,7 @@
+package floatingips
+
+const (
+	StatusActive = "ACTIVE"
+	StatusDown   = "DOWN"
+	StatusError  = "ERROR"
+)

--- a/openstack/networking/v2/extensions/trunks/constants.go
+++ b/openstack/networking/v2/extensions/trunks/constants.go
@@ -1,0 +1,9 @@
+package trunks
+
+const (
+	StatusActive   = "ACTIVE"
+	StatusBuild    = "BUILD"
+	StatusDegraded = "DEGRADED"
+	StatusDown     = "DOWN"
+	StatusError    = "ERROR"
+)

--- a/openstack/networking/v2/extensions/vpnaas/services/constants.go
+++ b/openstack/networking/v2/extensions/vpnaas/services/constants.go
@@ -1,0 +1,11 @@
+package services
+
+const (
+	StatusActive        = "ACTIVE"
+	StatusBuild         = "BUILD"
+	StatusDown          = "DOWN"
+	StatusError         = "ERROR"
+	StatusPendingCreate = "PENDING_CREATE"
+	StatusPendingDelete = "PENDING_DELETE"
+	StatusPendingUpdate = "PENDING_UPDATE"
+)

--- a/openstack/networking/v2/extensions/vpnaas/siteconnections/constants.go
+++ b/openstack/networking/v2/extensions/vpnaas/siteconnections/constants.go
@@ -1,0 +1,11 @@
+package siteconnections
+
+const (
+	StatusActive        = "ACTIVE"
+	StatusBuild         = "BUILD"
+	StatusDown          = "DOWN"
+	StatusError         = "ERROR"
+	StatusPendingCreate = "PENDING_CREATE"
+	StatusPendingDelete = "PENDING_DELETE"
+	StatusPendingUpdate = "PENDING_UPDATE"
+)

--- a/openstack/networking/v2/networks/constants.go
+++ b/openstack/networking/v2/networks/constants.go
@@ -1,0 +1,8 @@
+package networks
+
+const (
+	StatusActive = "ACTIVE"
+	StatusBuild  = "BUILD"
+	StatusDown   = "DOWN"
+	StatusError  = "ERROR"
+)

--- a/openstack/networking/v2/ports/constants.go
+++ b/openstack/networking/v2/ports/constants.go
@@ -1,0 +1,8 @@
+package ports
+
+const (
+	StatusActive = "ACTIVE"
+	StatusBuild  = "BUILD"
+	StatusDown   = "DOWN"
+	StatusError  = "ERROR"
+)


### PR DESCRIPTION
This avoids the need to define these constants in consumer code.

Router also has a status field, but there's no documentation for it, so
let's not guess what the valid statuses are.