### PR TITLE
Prefer versioned service type aliases

### DIFF
--- a/endpoint_search.go
+++ b/endpoint_search.go
@@ -118,10 +118,21 @@ func (eo *EndpointOpts) ApplyDefaults(t string) {
 			// TODO(stephenfin): This should probably be an error in v3
 			for t, aliases := range ServiceTypeAliases {
 				if slices.Contains(aliases, eo.Type) {
-					// we intentionally override the service type, even if it
-					// was explicitly requested by the user
-					eo.Type = t
-					eo.Aliases = aliases
+					// we pretend the alias is the official service type and the
+					// official service type is an alias which allows us to prefer
+					// what the user requested
+					// TODO(stephenfin): We should stop doing this once we have
+					// proper version discovery
+					// https://github.com/gophercloud/gophercloud/issues/3349
+					altAliases := []string{t}
+					for _, alias := range aliases {
+						if alias == eo.Type {
+							continue
+						}
+						altAliases = append(altAliases, alias)
+					}
+					eo.Aliases = altAliases
+					continue
 				}
 			}
 		}

--- a/openstack/client.go
+++ b/openstack/client.go
@@ -404,17 +404,17 @@ func NewBlockStorageV1(client *gophercloud.ProviderClient, eo gophercloud.Endpoi
 // NewBlockStorageV2 creates a ServiceClient that may be used to access the v2
 // block storage service.
 func NewBlockStorageV2(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
-	return initClientOpts(client, eo, "block-storage")
+	return initClientOpts(client, eo, "volumev2")
 }
 
 // NewBlockStorageV3 creates a ServiceClient that may be used to access the v3 block storage service.
 func NewBlockStorageV3(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
-	return initClientOpts(client, eo, "block-storage")
+	return initClientOpts(client, eo, "volumev3")
 }
 
 // NewSharedFileSystemV2 creates a ServiceClient that may be used to access the v2 shared file system service.
 func NewSharedFileSystemV2(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
-	return initClientOpts(client, eo, "shared-file-system")
+	return initClientOpts(client, eo, "sharev2")
 }
 
 // NewOrchestrationV1 creates a ServiceClient that may be used to access the v1
@@ -485,7 +485,7 @@ func NewContainerInfraV1(client *gophercloud.ProviderClient, eo gophercloud.Endp
 
 // NewWorkflowV2 creates a ServiceClient that may be used with the v2 workflow management package.
 func NewWorkflowV2(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
-	return initClientOpts(client, eo, "workflow")
+	return initClientOpts(client, eo, "workflowv2")
 }
 
 // NewPlacementV1 creates a ServiceClient that may be used with the placement package.

--- a/openstack/endpoint_location.go
+++ b/openstack/endpoint_location.go
@@ -79,12 +79,20 @@ func V3EndpointURL(catalog *tokens3.ServiceCatalog, opts gophercloud.EndpointOpt
 	// Extract Endpoints from the catalog entries that match the requested Type, Interface,
 	// Name if provided, and Region if provided.
 	var endpoints = make([]tokens3.Endpoint, 0, 1)
+
+	entriesByType := map[string][]tokens3.CatalogEntry{}
 	for _, entry := range catalog.Entries {
-		if (slices.Contains(opts.Types(), entry.Type)) && (opts.Name == "" || entry.Name == opts.Name) {
-			for _, endpoint := range entry.Endpoints {
-				if (opts.Availability == gophercloud.Availability(endpoint.Interface)) &&
-					(opts.Region == "" || endpoint.Region == opts.Region || endpoint.RegionID == opts.Region) {
-					endpoints = append(endpoints, endpoint)
+		entriesByType[entry.Type] = append(entriesByType[entry.Type], entry)
+	}
+
+	for _, serviceType := range opts.Types() {
+		if entries, ok := entriesByType[serviceType]; ok {
+			for _, entry := range entries {
+				for _, endpoint := range entry.Endpoints {
+					if (opts.Availability == gophercloud.Availability(endpoint.Interface)) &&
+						(opts.Region == "" || endpoint.Region == opts.Region || endpoint.RegionID == opts.Region) {
+						endpoints = append(endpoints, endpoint)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
As discussed in #3349, Gophercloud currently lacks support for version discovery. This means it is reliant on the use of versioned service type aliases (e.g. `volumev3`) in deployments where there are multiple API versions (and therefore multiple service catalog entries) present for a given service, something that #3209 (and the #3327 backport) failed to account for.

The long-term fix is to add the missing version discovery feature, but that's going to involve a bit of work and rigorous testing. Until we get that done, let's rework things so that we start preferring versioned service types aliases but still fallback to the official service type and the other unversioned service types aliases if necessary. This is achieved via a few discrete steps:

- We stop overwriting a requested service type when that service type is an alias. Instead, we look for this alias and fallback to using the official service.
- We sort discovered endpoint in order of the requested service type. This means if we request a service by its service type alias then we will prefer the service that matches this exactly, even if there's another service using the official service type.
- If we request a service type by a versioned service type alias, ignore services that use a versioned service type with a different version.
- Finally, revert to using versioned service type aliases for the `NewFooVX` helpers, thus triggering all of the above.

Fixes #3347
