### PR TITLE
Add versioned endpoint discovery

### DIFF
--- a/endpoint_search.go
+++ b/endpoint_search.go
@@ -79,6 +79,11 @@ type EndpointOpts struct {
 	// Required only for services that span multiple regions.
 	Region string
 
+	// Version [optional] is the major version of the service required. It it not
+	// a microversion. Use this to ensure the correct endpoint is selected when
+	// multiple API versions are available.
+	Version int
+
 	// Availability [optional] is the visibility of the endpoint to be returned.
 	// Valid types include the constants AvailabilityPublic, AvailabilityInternal,
 	// or AvailabilityAdmin from this package.

--- a/internal/acceptance/openstack/baremetal/httpbasic/portgroups_test.go
+++ b/internal/acceptance/openstack/baremetal/httpbasic/portgroups_test.go
@@ -1,3 +1,5 @@
+//go:build acceptance || baremetal || portgroups
+
 package httpbasic
 
 import (

--- a/internal/acceptance/openstack/baremetal/noauth/portgroups_test.go
+++ b/internal/acceptance/openstack/baremetal/noauth/portgroups_test.go
@@ -1,3 +1,5 @@
+//go:build acceptance || baremetal || ports
+
 package noauth
 
 import (

--- a/internal/acceptance/openstack/baremetal/v1/portgroups_test.go
+++ b/internal/acceptance/openstack/baremetal/v1/portgroups_test.go
@@ -1,3 +1,5 @@
+//go:build acceptance || baremetal || portgroups
+
 package v1
 
 import (

--- a/openstack/client.go
+++ b/openstack/client.go
@@ -163,7 +163,7 @@ func v2auth(ctx context.Context, client *gophercloud.ProviderClient, endpoint st
 		}
 	}
 	client.EndpointLocator = func(opts gophercloud.EndpointOpts) (string, error) {
-		return V2EndpointURL(catalog, opts)
+		return V2Endpoint(ctx, client, catalog, opts)
 	}
 
 	return nil
@@ -284,7 +284,7 @@ func v3auth(ctx context.Context, client *gophercloud.ProviderClient, endpoint st
 		}
 	}
 	client.EndpointLocator = func(opts gophercloud.EndpointOpts) (string, error) {
-		return V3EndpointURL(catalog, opts)
+		return V3Endpoint(ctx, client, catalog, opts)
 	}
 
 	return nil

--- a/openstack/client.go
+++ b/openstack/client.go
@@ -2,6 +2,7 @@ package openstack
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -345,13 +346,20 @@ func NewIdentityV3(client *gophercloud.ProviderClient, eo gophercloud.EndpointOp
 }
 
 // TODO(stephenfin): Allow passing aliases to all New${SERVICE}V${VERSION} methods in v3
-func initClientOpts(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, clientType string) (*gophercloud.ServiceClient, error) {
+func initClientOpts(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, clientType string, version int) (*gophercloud.ServiceClient, error) {
 	sc := new(gophercloud.ServiceClient)
+
 	eo.ApplyDefaults(clientType)
+	if eo.Version != 0 && eo.Version != version {
+		return sc, errors.New("Conflict between requested service major version and manually set version")
+	}
+	eo.Version = version
+
 	url, err := client.EndpointLocator(eo)
 	if err != nil {
 		return sc, err
 	}
+
 	sc.ProviderClient = client
 	sc.Endpoint = url
 	sc.Type = clientType
@@ -361,7 +369,7 @@ func initClientOpts(client *gophercloud.ProviderClient, eo gophercloud.EndpointO
 // NewBareMetalV1 creates a ServiceClient that may be used with the v1
 // bare metal package.
 func NewBareMetalV1(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
-	sc, err := initClientOpts(client, eo, "baremetal")
+	sc, err := initClientOpts(client, eo, "baremetal", 1)
 	if !strings.HasSuffix(strings.TrimSuffix(sc.Endpoint, "/"), "v1") {
 		sc.ResourceBase = sc.Endpoint + "v1/"
 	}
@@ -371,25 +379,25 @@ func NewBareMetalV1(client *gophercloud.ProviderClient, eo gophercloud.EndpointO
 // NewBareMetalIntrospectionV1 creates a ServiceClient that may be used with the v1
 // bare metal introspection package.
 func NewBareMetalIntrospectionV1(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
-	return initClientOpts(client, eo, "baremetal-introspection")
+	return initClientOpts(client, eo, "baremetal-introspection", 1)
 }
 
 // NewObjectStorageV1 creates a ServiceClient that may be used with the v1
 // object storage package.
 func NewObjectStorageV1(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
-	return initClientOpts(client, eo, "object-store")
+	return initClientOpts(client, eo, "object-store", 1)
 }
 
 // NewComputeV2 creates a ServiceClient that may be used with the v2 compute
 // package.
 func NewComputeV2(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
-	return initClientOpts(client, eo, "compute")
+	return initClientOpts(client, eo, "compute", 2)
 }
 
 // NewNetworkV2 creates a ServiceClient that may be used with the v2 network
 // package.
 func NewNetworkV2(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
-	sc, err := initClientOpts(client, eo, "network")
+	sc, err := initClientOpts(client, eo, "network", 2)
 	sc.ResourceBase = sc.Endpoint + "v2.0/"
 	return sc, err
 }
@@ -398,40 +406,40 @@ func NewNetworkV2(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpt
 // NewBlockStorageV1 creates a ServiceClient that may be used to access the v1
 // block storage service.
 func NewBlockStorageV1(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
-	return initClientOpts(client, eo, "volume")
+	return initClientOpts(client, eo, "volume", 1)
 }
 
 // NewBlockStorageV2 creates a ServiceClient that may be used to access the v2
 // block storage service.
 func NewBlockStorageV2(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
-	return initClientOpts(client, eo, "block-storage")
+	return initClientOpts(client, eo, "block-storage", 2)
 }
 
 // NewBlockStorageV3 creates a ServiceClient that may be used to access the v3 block storage service.
 func NewBlockStorageV3(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
-	return initClientOpts(client, eo, "block-storage")
+	return initClientOpts(client, eo, "block-storage", 3)
 }
 
 // NewSharedFileSystemV2 creates a ServiceClient that may be used to access the v2 shared file system service.
 func NewSharedFileSystemV2(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
-	return initClientOpts(client, eo, "shared-file-system")
+	return initClientOpts(client, eo, "shared-file-system", 2)
 }
 
 // NewOrchestrationV1 creates a ServiceClient that may be used to access the v1
 // orchestration service.
 func NewOrchestrationV1(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
-	return initClientOpts(client, eo, "orchestration")
+	return initClientOpts(client, eo, "orchestration", 1)
 }
 
 // NewDBV1 creates a ServiceClient that may be used to access the v1 DB service.
 func NewDBV1(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
-	return initClientOpts(client, eo, "database")
+	return initClientOpts(client, eo, "database", 1)
 }
 
 // NewDNSV2 creates a ServiceClient that may be used to access the v2 DNS
 // service.
 func NewDNSV2(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
-	sc, err := initClientOpts(client, eo, "dns")
+	sc, err := initClientOpts(client, eo, "dns", 2)
 	sc.ResourceBase = sc.Endpoint + "v2/"
 	return sc, err
 }
@@ -439,7 +447,7 @@ func NewDNSV2(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (
 // NewImageV2 creates a ServiceClient that may be used to access the v2 image
 // service.
 func NewImageV2(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
-	sc, err := initClientOpts(client, eo, "image")
+	sc, err := initClientOpts(client, eo, "image", 2)
 	sc.ResourceBase = sc.Endpoint + "v2/"
 	return sc, err
 }
@@ -447,7 +455,7 @@ func NewImageV2(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts)
 // NewLoadBalancerV2 creates a ServiceClient that may be used to access the v2
 // load balancer service.
 func NewLoadBalancerV2(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
-	sc, err := initClientOpts(client, eo, "load-balancer")
+	sc, err := initClientOpts(client, eo, "load-balancer", 2)
 
 	// Fixes edge case having an OpenStack lb endpoint with trailing version number.
 	endpoint := strings.Replace(sc.Endpoint, "v2.0/", "", -1)
@@ -459,20 +467,20 @@ func NewLoadBalancerV2(client *gophercloud.ProviderClient, eo gophercloud.Endpoi
 // NewMessagingV2 creates a ServiceClient that may be used with the v2 messaging
 // service.
 func NewMessagingV2(client *gophercloud.ProviderClient, clientID string, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
-	sc, err := initClientOpts(client, eo, "message")
+	sc, err := initClientOpts(client, eo, "message", 2)
 	sc.MoreHeaders = map[string]string{"Client-ID": clientID}
 	return sc, err
 }
 
 // NewContainerV1 creates a ServiceClient that may be used with v1 container package
 func NewContainerV1(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
-	return initClientOpts(client, eo, "application-container")
+	return initClientOpts(client, eo, "application-container", 1)
 }
 
 // NewKeyManagerV1 creates a ServiceClient that may be used with the v1 key
 // manager service.
 func NewKeyManagerV1(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
-	sc, err := initClientOpts(client, eo, "key-manager")
+	sc, err := initClientOpts(client, eo, "key-manager", 1)
 	sc.ResourceBase = sc.Endpoint + "v1/"
 	return sc, err
 }
@@ -480,15 +488,15 @@ func NewKeyManagerV1(client *gophercloud.ProviderClient, eo gophercloud.Endpoint
 // NewContainerInfraV1 creates a ServiceClient that may be used with the v1 container infra management
 // package.
 func NewContainerInfraV1(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
-	return initClientOpts(client, eo, "container-infrastructure-management")
+	return initClientOpts(client, eo, "container-infrastructure-management", 1)
 }
 
 // NewWorkflowV2 creates a ServiceClient that may be used with the v2 workflow management package.
 func NewWorkflowV2(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
-	return initClientOpts(client, eo, "workflow")
+	return initClientOpts(client, eo, "workflow", 2)
 }
 
 // NewPlacementV1 creates a ServiceClient that may be used with the placement package.
 func NewPlacementV1(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
-	return initClientOpts(client, eo, "placement")
+	return initClientOpts(client, eo, "placement", 1)
 }

--- a/openstack/endpoint.go
+++ b/openstack/endpoint.go
@@ -1,0 +1,101 @@
+package openstack
+
+import (
+	"slices"
+
+	"github.com/gophercloud/gophercloud/v2"
+	tokens2 "github.com/gophercloud/gophercloud/v2/openstack/identity/v2/tokens"
+	tokens3 "github.com/gophercloud/gophercloud/v2/openstack/identity/v3/tokens"
+)
+
+/*
+V2Endpoint discovers the endpoint URL for a specific service from a
+ServiceCatalog acquired during the v2 identity service.
+
+The specified EndpointOpts are used to identify a unique, unambiguous endpoint
+to return. It's an error both when multiple endpoints match the provided
+criteria and when none do. The minimum that can be specified is a Type, but you
+will also often need to specify a Name and/or a Region depending on what's
+available on your OpenStack deployment.
+*/
+func V2Endpoint(catalog *tokens2.ServiceCatalog, opts gophercloud.EndpointOpts) (string, error) {
+	// Extract Endpoints from the catalog entries that match the requested Type, Name if provided, and Region if provided.
+	//
+	// If multiple endpoints are found, we return the first result and disregard the rest.
+	// This behavior matches the Python library. See GH-1764.
+	for _, entry := range catalog.Entries {
+		if (slices.Contains(opts.Types(), entry.Type)) && (opts.Name == "" || entry.Name == opts.Name) {
+			for _, endpoint := range entry.Endpoints {
+				if opts.Region != "" && endpoint.Region != opts.Region {
+					continue
+				}
+
+				var endpointURL string
+				switch opts.Availability {
+				case gophercloud.AvailabilityPublic:
+					endpointURL = gophercloud.NormalizeURL(endpoint.PublicURL)
+				case gophercloud.AvailabilityInternal:
+					endpointURL = gophercloud.NormalizeURL(endpoint.InternalURL)
+				case gophercloud.AvailabilityAdmin:
+					endpointURL = gophercloud.NormalizeURL(endpoint.AdminURL)
+				default:
+					err := &ErrInvalidAvailabilityProvided{}
+					err.Argument = "Availability"
+					err.Value = opts.Availability
+					return "", err
+				}
+
+				return endpointURL, nil
+			}
+		}
+	}
+
+	// Report an error if there were no matching endpoints.
+	err := &gophercloud.ErrEndpointNotFound{}
+	return "", err
+}
+
+/*
+V3Endpoint discovers the endpoint URL for a specific service from a Catalog
+acquired during the v3 identity service.
+
+The specified EndpointOpts are used to identify a unique, unambiguous endpoint
+to return. It's an error both when multiple endpoints match the provided
+criteria and when none do. The minimum that can be specified is a Type, but you
+will also often need to specify a Name and/or a Region depending on what's
+available on your OpenStack deployment.
+*/
+func V3Endpoint(catalog *tokens3.ServiceCatalog, opts gophercloud.EndpointOpts) (string, error) {
+	if opts.Availability != gophercloud.AvailabilityAdmin &&
+		opts.Availability != gophercloud.AvailabilityPublic &&
+		opts.Availability != gophercloud.AvailabilityInternal {
+		err := &ErrInvalidAvailabilityProvided{}
+		err.Argument = "Availability"
+		err.Value = opts.Availability
+		return "", err
+	}
+
+	// Extract Endpoints from the catalog entries that match the requested Type, Interface,
+	// Name if provided, and Region if provided.
+	//
+	// If multiple endpoints are found, we return the first result and disregard the rest.
+	// This behavior matches the Python library. See GH-1764.
+	for _, entry := range catalog.Entries {
+		if (slices.Contains(opts.Types(), entry.Type)) && (opts.Name == "" || entry.Name == opts.Name) {
+			for _, endpoint := range entry.Endpoints {
+				if opts.Availability != gophercloud.Availability(endpoint.Interface) {
+					continue
+				}
+				if opts.Region != "" && endpoint.Region != opts.Region && endpoint.RegionID != opts.Region {
+					continue
+				}
+
+				return gophercloud.NormalizeURL(endpoint.URL), nil
+			}
+		}
+	}
+
+	// Report an error if there were no matching endpoints.
+	err := &gophercloud.ErrEndpointNotFound{}
+	return "", err
+}

--- a/openstack/endpoint_location.go
+++ b/openstack/endpoint_location.go
@@ -8,6 +8,8 @@ import (
 	tokens3 "github.com/gophercloud/gophercloud/v2/openstack/identity/v3/tokens"
 )
 
+// TODO(stephenfin): Remove this module in v3. The functions below are no longer used.
+
 /*
 V2EndpointURL discovers the endpoint URL for a specific service from a
 ServiceCatalog acquired during the v2 identity service.

--- a/openstack/endpoint_location.go
+++ b/openstack/endpoint_location.go
@@ -20,39 +20,33 @@ available on your OpenStack deployment.
 */
 func V2EndpointURL(catalog *tokens2.ServiceCatalog, opts gophercloud.EndpointOpts) (string, error) {
 	// Extract Endpoints from the catalog entries that match the requested Type, Name if provided, and Region if provided.
-	var endpoints = make([]tokens2.Endpoint, 0, 1)
+	//
+	// If multiple endpoints are found, we return the first result and disregard the rest.
+	// This behavior matches the Python library. See GH-1764.
 	for _, entry := range catalog.Entries {
 		if (slices.Contains(opts.Types(), entry.Type)) && (opts.Name == "" || entry.Name == opts.Name) {
 			for _, endpoint := range entry.Endpoints {
-				if opts.Region == "" || endpoint.Region == opts.Region {
-					endpoints = append(endpoints, endpoint)
+				if opts.Region != "" && endpoint.Region != opts.Region {
+					continue
 				}
+
+				var endpointURL string
+				switch opts.Availability {
+				case gophercloud.AvailabilityPublic:
+					endpointURL = gophercloud.NormalizeURL(endpoint.PublicURL)
+				case gophercloud.AvailabilityInternal:
+					endpointURL = gophercloud.NormalizeURL(endpoint.InternalURL)
+				case gophercloud.AvailabilityAdmin:
+					endpointURL = gophercloud.NormalizeURL(endpoint.AdminURL)
+				default:
+					err := &ErrInvalidAvailabilityProvided{}
+					err.Argument = "Availability"
+					err.Value = opts.Availability
+					return "", err
+				}
+
+				return endpointURL, nil
 			}
-		}
-	}
-
-	// If multiple endpoints were found, use the first result
-	// and disregard the other endpoints.
-	//
-	// This behavior matches the Python library. See GH-1764.
-	if len(endpoints) > 1 {
-		endpoints = endpoints[0:1]
-	}
-
-	// Extract the appropriate URL from the matching Endpoint.
-	for _, endpoint := range endpoints {
-		switch opts.Availability {
-		case gophercloud.AvailabilityPublic:
-			return gophercloud.NormalizeURL(endpoint.PublicURL), nil
-		case gophercloud.AvailabilityInternal:
-			return gophercloud.NormalizeURL(endpoint.InternalURL), nil
-		case gophercloud.AvailabilityAdmin:
-			return gophercloud.NormalizeURL(endpoint.AdminURL), nil
-		default:
-			err := &ErrInvalidAvailabilityProvided{}
-			err.Argument = "Availability"
-			err.Value = opts.Availability
-			return "", err
 		}
 	}
 
@@ -72,39 +66,33 @@ will also often need to specify a Name and/or a Region depending on what's
 available on your OpenStack deployment.
 */
 func V3EndpointURL(catalog *tokens3.ServiceCatalog, opts gophercloud.EndpointOpts) (string, error) {
+	if opts.Availability != gophercloud.AvailabilityAdmin &&
+		opts.Availability != gophercloud.AvailabilityPublic &&
+		opts.Availability != gophercloud.AvailabilityInternal {
+		err := &ErrInvalidAvailabilityProvided{}
+		err.Argument = "Availability"
+		err.Value = opts.Availability
+		return "", err
+	}
+
 	// Extract Endpoints from the catalog entries that match the requested Type, Interface,
 	// Name if provided, and Region if provided.
-	var endpoints = make([]tokens3.Endpoint, 0, 1)
+	//
+	// If multiple endpoints are found, we return the first result and disregard the rest.
+	// This behavior matches the Python library. See GH-1764.
 	for _, entry := range catalog.Entries {
 		if (slices.Contains(opts.Types(), entry.Type)) && (opts.Name == "" || entry.Name == opts.Name) {
 			for _, endpoint := range entry.Endpoints {
-				if opts.Availability != gophercloud.AvailabilityAdmin &&
-					opts.Availability != gophercloud.AvailabilityPublic &&
-					opts.Availability != gophercloud.AvailabilityInternal {
-					err := &ErrInvalidAvailabilityProvided{}
-					err.Argument = "Availability"
-					err.Value = opts.Availability
-					return "", err
+				if opts.Availability != gophercloud.Availability(endpoint.Interface) {
+					continue
 				}
-				if (opts.Availability == gophercloud.Availability(endpoint.Interface)) &&
-					(opts.Region == "" || endpoint.Region == opts.Region || endpoint.RegionID == opts.Region) {
-					endpoints = append(endpoints, endpoint)
+				if opts.Region != "" && endpoint.Region != opts.Region && endpoint.RegionID != opts.Region {
+					continue
 				}
+
+				return gophercloud.NormalizeURL(endpoint.URL), nil
 			}
 		}
-	}
-
-	// If multiple endpoints were found, use the first result
-	// and disregard the other endpoints.
-	//
-	// This behavior matches the Python library. See GH-1764.
-	if len(endpoints) > 1 {
-		endpoints = endpoints[0:1]
-	}
-
-	// Extract the URL from the matching Endpoint.
-	for _, endpoint := range endpoints {
-		return gophercloud.NormalizeURL(endpoint.URL), nil
 	}
 
 	// Report an error if there were no matching endpoints.

--- a/openstack/utils/base_endpoint.go
+++ b/openstack/utils/base_endpoint.go
@@ -6,9 +6,7 @@ import (
 	"strings"
 )
 
-// BaseEndpoint will return a URL without the /vX.Y
-// portion of the URL.
-func BaseEndpoint(endpoint string) (string, error) {
+func parseEndpoint(endpoint string, includeVersion bool) (string, error) {
 	u, err := url.Parse(endpoint)
 	if err != nil {
 		return "", err
@@ -21,8 +19,23 @@ func BaseEndpoint(endpoint string) (string, error) {
 
 	if version := versionRe.FindString(path); version != "" {
 		versionIndex := strings.Index(path, version)
+		if includeVersion {
+			versionIndex += len(version)
+		}
 		u.Path = path[:versionIndex]
 	}
 
 	return u.String(), nil
+}
+
+// BaseEndpoint will return a URL without the /vX.Y
+// portion of the URL.
+func BaseEndpoint(endpoint string) (string, error) {
+	return parseEndpoint(endpoint, false)
+}
+
+// BaseVersionedEndpoint will return a URL with the /vX.Y portion of the URL,
+// if present, but without a project ID or similar
+func BaseVersionedEndpoint(endpoint string) (string, error) {
+	return parseEndpoint(endpoint, true)
 }


### PR DESCRIPTION
This is an alternative or successor to #3350. We expand upon our endpoint negotiation to add support for version discovery.

There's a lot of context in the commits but in effect, we add a new `EndpointsOpts.Version` field which is compared against both the implicit version encoded in some service type aliases (like `volumev3`) and the explicit version presented by service's version document, which we now fetch.

We may wish to build on this in the future to allow filtering of endpoints by a minimum microversion (allowing for early failure) or to add support for keystoneauth's URL-derived "version hack" (though I'm hoping the world has moved on enough not to make that necessary).

While the logic here is quite similar to what is done in keystoneauth, this PR should be *thoroughly* tested against a few different clouds before we merge it, due to the many nuances involved here.

Fixes #3349
