### PR TITLE
dns: implement shared zones list

### DIFF
--- a/internal/acceptance/openstack/dns/v2/shares_test.go
+++ b/internal/acceptance/openstack/dns/v2/shares_test.go
@@ -1,0 +1,66 @@
+//go:build acceptance || dns || zone_shares
+
+package v2
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/v2/internal/acceptance/clients"
+	identity "github.com/gophercloud/gophercloud/v2/internal/acceptance/openstack/identity/v3"
+	"github.com/gophercloud/gophercloud/v2/internal/acceptance/tools"
+	"github.com/gophercloud/gophercloud/v2/openstack/dns/v2/zones"
+	th "github.com/gophercloud/gophercloud/v2/testhelper"
+)
+
+func TestShareCRD(t *testing.T) {
+	// Create new project
+	identityClient, err := clients.NewIdentityV3Client()
+	th.AssertNoErr(t, err)
+
+	project, err := identity.CreateProject(t, identityClient, nil)
+	th.AssertNoErr(t, err)
+	defer identity.DeleteProject(t, identityClient, project.ID)
+
+	// Create new Zone
+	client, err := clients.NewDNSV2Client()
+	th.AssertNoErr(t, err)
+
+	zone, err := CreateZone(t, client)
+	th.AssertNoErr(t, err)
+	defer DeleteZone(t, client, zone)
+
+	// Create a zone share to new tenant
+	share, err := CreateShare(t, client, zone, project.ID)
+	th.AssertNoErr(t, err)
+	tools.PrintResource(t, share)
+	defer UnshareZone(t, client, share)
+
+	// Get the share
+	getShare, err := zones.GetShare(context.TODO(), client, share.ZoneID, share.ID).Extract()
+	th.AssertNoErr(t, err)
+	tools.PrintResource(t, getShare)
+	th.AssertDeepEquals(t, *share, *getShare)
+
+	// List shares
+	allPages, err := zones.ListShares(client, share.ZoneID, nil).AllPages(context.TODO())
+	th.AssertNoErr(t, err)
+
+	allShares, err := zones.ExtractZoneShares(allPages)
+	th.AssertNoErr(t, err)
+	tools.PrintResource(t, allShares)
+
+	foundShare := -1
+	for i, s := range allShares {
+		tools.PrintResource(t, &s)
+		if share.ID == s.ID {
+			foundShare = i
+			break
+		}
+	}
+	if foundShare == -1 {
+		t.Fatalf("Share %s not found in list", share.ID)
+	}
+
+	th.AssertDeepEquals(t, *share, allShares[foundShare])
+}

--- a/openstack/dns/v2/zones/testing/fixtures_test.go
+++ b/openstack/dns/v2/zones/testing/fixtures_test.go
@@ -300,3 +300,57 @@ func HandleDeleteSuccessfully(t *testing.T, fakeServer th.FakeServer) {
 			fmt.Fprint(w, DeleteZoneResponse)
 		})
 }
+
+// ShareZoneResponse is a sample response to share a zone.
+const ShareZoneResponse = `
+{
+    "id": "fd40b017-bf97-461c-8d30-d4e922b28edd",
+    "zone_id": "a3365b47-ee93-43ad-9a60-2b2ca96b1898",
+    "project_id": "16ade46c85a1435bb86d9138d37da57e",
+    "target_project_id": "232e37df46af42089710e2ae39111c2f",
+    "created_at": "2022-11-30T22:20:27.000000",
+    "updated_at": null,
+    "links": {
+        "self": "http://127.0.0.1:60053/v2/zones/a3365b47-ee93-43ad-9a60-2b2ca96b1898/shares/fd40b017-bf97-461c-8d30-d4e922b28edd",
+        "zone": "http://127.0.0.1:60053/v2/zones/a3365b47-ee93-43ad-9a60-2b2ca96b1898"
+    }
+}
+`
+
+// ShareZoneCreatedAt is the expected created at time for the shared zone
+var ShareZoneCreatedAt, _ = time.Parse(gophercloud.RFC3339MilliNoZ, "2022-11-30T22:20:27.000000")
+
+// ShareZone is the expected shared zone
+var ShareZone = zones.ZoneShare{
+	ID:              "fd40b017-bf97-461c-8d30-d4e922b28edd",
+	ZoneID:          "a3365b47-ee93-43ad-9a60-2b2ca96b1898",
+	ProjectID:       "16ade46c85a1435bb86d9138d37da57e",
+	TargetProjectID: "232e37df46af42089710e2ae39111c2f",
+	CreatedAt:       ShareZoneCreatedAt,
+}
+
+// ListSharesResponse is a sample response to list zone shares.
+const ListSharesResponse = `
+{
+  "shared_zones": [
+    {
+      "id": "fd40b017-bf97-461c-8d30-d4e922b28edd",
+      "zone_id": "a3365b47-ee93-43ad-9a60-2b2ca96b1898",
+      "project_id": "16ade46c85a1435bb86d9138d37da57e",
+      "target_project_id": "232e37df46af42089710e2ae39111c2f",
+      "created_at": "2022-11-30T22:20:27.000000",
+      "updated_at": null,
+      "links": {
+        "self": "http://127.0.0.1:60053/v2/zones/a3365b47-ee93-43ad-9a60-2b2ca96b1898/shares/fd40b017-bf97-461c-8d30-d4e922b28edd",
+        "zone": "http://127.0.0.1:60053/v2/zones/a3365b47-ee93-43ad-9a60-2b2ca96b1898"
+      }
+    }
+  ],
+  "links": {
+    "self": "http://127.0.0.1:60053/v2/zones/a3365b47-ee93-43ad-9a60-2b2ca96b1898/shares"
+  }
+}
+`
+
+// ListZoneShares is the expected list of shared zones
+var ListZoneShares = []zones.ZoneShare{ShareZone}

--- a/openstack/dns/v2/zones/testing/requests_test.go
+++ b/openstack/dns/v2/zones/testing/requests_test.go
@@ -3,6 +3,7 @@ package testing
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"testing"
@@ -127,11 +128,14 @@ func TestShare(t *testing.T) {
 		th.CheckDeepEquals(t, expectedBody, reqBody)
 
 		w.WriteHeader(http.StatusCreated)
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprint(w, ShareZoneResponse)
 	})
 
 	opts := zones.ShareZoneOpts{TargetProjectID: "project-id"}
-	err := zones.Share(context.TODO(), client.ServiceClient(fakeServer), "zone-id", opts).ExtractErr()
+	zone, err := zones.Share(context.TODO(), client.ServiceClient(fakeServer), "zone-id", opts).Extract()
 	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, ShareZone, *zone)
 }
 
 func TestUnshare(t *testing.T) {
@@ -145,4 +149,26 @@ func TestUnshare(t *testing.T) {
 
 	err := zones.Unshare(context.TODO(), client.ServiceClient(fakeServer), "zone-id", "share-id").ExtractErr()
 	th.AssertNoErr(t, err)
+}
+
+func TestListShares(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	fakeServer.Mux.HandleFunc("/zones/zone-id/shares", func(w http.ResponseWriter, r *http.Request) {
+		th.AssertEquals(t, r.Method, "GET")
+		th.AssertEquals(t, "true", r.Header.Get("X-Auth-All-Projects"))
+
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprint(w, ListSharesResponse)
+	})
+
+	opts := zones.ListSharesOpts{
+		AllProjects: true,
+	}
+	pages, err := zones.ListShares(client.ServiceClient(fakeServer), "zone-id", opts).AllPages(context.TODO())
+	th.AssertNoErr(t, err)
+	actual, err := zones.ExtractZoneShares(pages)
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, ListZoneShares, actual)
 }

--- a/openstack/dns/v2/zones/urls.go
+++ b/openstack/dns/v2/zones/urls.go
@@ -12,12 +12,12 @@ func zoneURL(c *gophercloud.ServiceClient, zoneID string) string {
 	return c.ServiceURL("zones", zoneID)
 }
 
-// zoneShareURL returns the URL for sharing a zone.
-func zoneShareURL(c *gophercloud.ServiceClient, zoneID string) string {
+// sharesBaseURL returns the URL for shared zones.
+func sharesBaseURL(c *gophercloud.ServiceClient, zoneID string) string {
 	return c.ServiceURL("zones", zoneID, "shares")
 }
 
-// zoneUnshareURL returns the URL for unsharing a zone.
-func zoneUnshareURL(c *gophercloud.ServiceClient, zoneID, shareID string) string {
-	return c.ServiceURL("zones", zoneID, "shares", shareID)
+// shareURL returns the URL for a shared zone.
+func shareURL(c *gophercloud.ServiceClient, zoneID, sharedZoneID string) string {
+	return c.ServiceURL("zones", zoneID, "shares", sharedZoneID)
 }


### PR DESCRIPTION
<!--
Prior to starting a PR, please make sure you have read our
[contributor tutorial](https://github.com/gophercloud/gophercloud/tree/main/docs/contributor-tutorial).

Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

-->
Fixes #3048

This PR adds zone share list and proper body read in the `Share` func. Previously this call leaked request bodies, because the response was not read.

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://docs.openstack.org/api-ref/dns/dns-api-v2-index.html#get-all-shared-zones