### PR TITLE
neutron: add segment_id support to subnets

### DIFF
--- a/openstack/networking/v2/subnets/requests.go
+++ b/openstack/networking/v2/subnets/requests.go
@@ -43,6 +43,7 @@ type ListOpts struct {
 	NotTags           string `q:"not-tags"`
 	NotTagsAny        string `q:"not-tags-any"`
 	RevisionNumber    *int   `q:"revision_number"`
+	SegmentID         string `q:"segment_id"`
 }
 
 // ToSubnetListQuery formats a ListOpts into a query string.
@@ -147,6 +148,10 @@ type CreateOpts struct {
 	// Prefixlen is used when user creates a subnet from the subnetpool. It will
 	// overwrite the "default_prefixlen" value of the referenced subnetpool.
 	Prefixlen int `json:"prefixlen,omitempty"`
+
+	// SegmentID is a network segment the subnet is associated with. It is
+	// available when segment extension is enabled.
+	SegmentID string `json:"segment_id,omitempty"`
 }
 
 // ToSubnetCreateMap builds a request body from CreateOpts.
@@ -219,6 +224,10 @@ type UpdateOpts struct {
 	// will set revision_number=%s. If the revision number does not match, the
 	// update will fail.
 	RevisionNumber *int `json:"-" h:"If-Match"`
+
+	// SegmentID is a network segment the subnet is associated with. It is
+	// available when segment extension is enabled.
+	SegmentID *string `json:"segment_id,omitempty"`
 }
 
 // ToSubnetUpdateMap builds a request body from UpdateOpts.

--- a/openstack/networking/v2/subnets/results.go
+++ b/openstack/networking/v2/subnets/results.go
@@ -124,6 +124,10 @@ type Subnet struct {
 	// RevisionNumber optionally set via extensions/standard-attr-revisions
 	RevisionNumber int `json:"revision_number"`
 
+	// SegmentID of a network segment the subnet is associated with. It is
+	// available when segment extension is enabled.
+	SegmentID string `json:"segment_id"`
+
 	// Timestamp when the subnet was created
 	CreatedAt time.Time `json:"created_at"`
 


### PR DESCRIPTION
<!--
Prior to starting a PR, please make sure you have read our
[contributor tutorial](https://github.com/gophercloud/gophercloud/tree/main/docs/contributor-tutorial).

Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

-->
Fixes #3402 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/neutron/commit/f494de47fcef7776f7d29d5ceb2cc4db96bd1efd