### PR TITLE
Bump gophercloud/devstack-action

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,6 +7,6 @@ updates:
   open-pull-requests-limit: 10
 - package-ecosystem: "github-actions"
   directory: "/"
-  schedule: 
+  schedule:
     interval: daily
   open-pull-requests-limit: 10

--- a/.github/workflows/functional-baremetal.yaml
+++ b/.github/workflows/functional-baremetal.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Work around broken dnsmasq
         run: sudo apt-get purge -y dnsmasq-base
       - name: Deploy devstack
-        uses: gophercloud/devstack-action@v0.17
+        uses: gophercloud/devstack-action@v0.18
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |

--- a/.github/workflows/functional-basic.yaml
+++ b/.github/workflows/functional-basic.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Checkout Gophercloud
         uses: actions/checkout@v4
       - name: Deploy devstack
-        uses: gophercloud/devstack-action@v0.17
+        uses: gophercloud/devstack-action@v0.18
         with:
           branch: ${{ matrix.openstack_version }}
           enabled_services: 's-account,s-container,s-object,s-proxy,${{ matrix.additional_services }}'

--- a/.github/workflows/functional-blockstorage.yaml
+++ b/.github/workflows/functional-blockstorage.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Checkout Gophercloud
         uses: actions/checkout@v4
       - name: Deploy devstack
-        uses: gophercloud/devstack-action@v0.17
+        uses: gophercloud/devstack-action@v0.18
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |

--- a/.github/workflows/functional-compute.yaml
+++ b/.github/workflows/functional-compute.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Checkout Gophercloud
         uses: actions/checkout@v4
       - name: Deploy devstack
-        uses: gophercloud/devstack-action@v0.17
+        uses: gophercloud/devstack-action@v0.18
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |

--- a/.github/workflows/functional-containerinfra.yaml
+++ b/.github/workflows/functional-containerinfra.yaml
@@ -58,7 +58,7 @@ jobs:
       - name: Checkout Gophercloud
         uses: actions/checkout@v4
       - name: Deploy devstack
-        uses: gophercloud/devstack-action@v0.17
+        uses: gophercloud/devstack-action@v0.18
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |

--- a/.github/workflows/functional-dns.yaml
+++ b/.github/workflows/functional-dns.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Checkout Gophercloud
         uses: actions/checkout@v4
       - name: Deploy devstack
-        uses: gophercloud/devstack-action@v0.17
+        uses: gophercloud/devstack-action@v0.18
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |

--- a/.github/workflows/functional-fwaas_v2.yaml
+++ b/.github/workflows/functional-fwaas_v2.yaml
@@ -46,7 +46,7 @@ jobs:
           "update_port:binding:profile": "rule:admin_only or rule:service_api"
           EOF
       - name: Deploy devstack
-        uses: gophercloud/devstack-action@v0.17
+        uses: gophercloud/devstack-action@v0.18
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |

--- a/.github/workflows/functional-identity.yaml
+++ b/.github/workflows/functional-identity.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Checkout Gophercloud
         uses: actions/checkout@v4
       - name: Deploy devstack
-        uses: gophercloud/devstack-action@v0.17
+        uses: gophercloud/devstack-action@v0.18
         with:
           branch: ${{ matrix.openstack_version }}
           enabled_services: "${{ matrix.additional_services }}"

--- a/.github/workflows/functional-image.yaml
+++ b/.github/workflows/functional-image.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Checkout Gophercloud
         uses: actions/checkout@v4
       - name: Deploy devstack
-        uses: gophercloud/devstack-action@v0.17
+        uses: gophercloud/devstack-action@v0.18
         with:
           branch: ${{ matrix.openstack_version }}
           enabled_services: "${{ matrix.additional_services }}"

--- a/.github/workflows/functional-keymanager.yaml
+++ b/.github/workflows/functional-keymanager.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: Checkout Gophercloud
         uses: actions/checkout@v4
       - name: Deploy devstack
-        uses: gophercloud/devstack-action@v0.17
+        uses: gophercloud/devstack-action@v0.18
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |

--- a/.github/workflows/functional-loadbalancer.yaml
+++ b/.github/workflows/functional-loadbalancer.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Checkout Gophercloud
         uses: actions/checkout@v4
       - name: Deploy devstack
-        uses: gophercloud/devstack-action@v0.17
+        uses: gophercloud/devstack-action@v0.18
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |

--- a/.github/workflows/functional-messaging.yaml
+++ b/.github/workflows/functional-messaging.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Checkout Gophercloud
         uses: actions/checkout@v4
       - name: Deploy devstack
-        uses: gophercloud/devstack-action@v0.17
+        uses: gophercloud/devstack-action@v0.18
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |

--- a/.github/workflows/functional-networking.yaml
+++ b/.github/workflows/functional-networking.yaml
@@ -42,7 +42,7 @@ jobs:
           "update_port:binding:profile": "rule:admin_only or rule:service_api"
           EOF
       - name: Deploy devstack
-        uses: gophercloud/devstack-action@v0.17
+        uses: gophercloud/devstack-action@v0.18
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |

--- a/.github/workflows/functional-objectstorage.yaml
+++ b/.github/workflows/functional-objectstorage.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Checkout Gophercloud
         uses: actions/checkout@v4
       - name: Deploy devstack
-        uses: gophercloud/devstack-action@v0.17
+        uses: gophercloud/devstack-action@v0.18
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |

--- a/.github/workflows/functional-orchestration.yaml
+++ b/.github/workflows/functional-orchestration.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Checkout Gophercloud
         uses: actions/checkout@v4
       - name: Deploy devstack
-        uses: gophercloud/devstack-action@v0.17
+        uses: gophercloud/devstack-action@v0.18
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |

--- a/.github/workflows/functional-placement.yaml
+++ b/.github/workflows/functional-placement.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Checkout Gophercloud
         uses: actions/checkout@v4
       - name: Deploy devstack
-        uses: gophercloud/devstack-action@v0.17
+        uses: gophercloud/devstack-action@v0.18
         with:
           branch: ${{ matrix.openstack_version }}
           enabled_services: "${{ matrix.additional_services }}"

--- a/.github/workflows/functional-sharedfilesystems.yaml
+++ b/.github/workflows/functional-sharedfilesystems.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Checkout Gophercloud
         uses: actions/checkout@v4
       - name: Deploy devstack
-        uses: gophercloud/devstack-action@v0.17
+        uses: gophercloud/devstack-action@v0.18
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |

--- a/.github/workflows/functional-workflow.yaml
+++ b/.github/workflows/functional-workflow.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Checkout Gophercloud
         uses: actions/checkout@v4
       - name: Deploy devstack
-        uses: gophercloud/devstack-action@v0.17
+        uses: gophercloud/devstack-action@v0.18
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |


### PR DESCRIPTION
v0.18 dumps the local.conf used, which enables easier reproduction locally [1].

[1] https://github.com/gophercloud/devstack-action/pull/31
