### PR TITLE
neutron: fix BGP peers and speakers struct member types

### DIFF
--- a/internal/acceptance/openstack/networking/v2/extensions/bgp/peers/bgppeers_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/bgp/peers/bgppeers_test.go
@@ -34,9 +34,10 @@ func TestBGPPeerCRUD(t *testing.T) {
 
 	// Update a BGP Peer
 	newBGPPeerName := tools.RandomString("TESTACC-BGPPEER-", 10)
+	pass := tools.MakeNewPassword("")
 	updateBGPOpts := peers.UpdateOpts{
-		Name:     newBGPPeerName,
-		Password: tools.MakeNewPassword(""),
+		Name:     &newBGPPeerName,
+		Password: &pass,
 	}
 	bgpPeerUpdated, err := peers.Update(context.TODO(), client, bgpPeerGot.ID, updateBGPOpts).Extract()
 	th.AssertNoErr(t, err)

--- a/internal/acceptance/openstack/networking/v2/extensions/bgp/speakers/bgpspeakers_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/bgp/speakers/bgpspeakers_test.go
@@ -48,21 +48,23 @@ func TestBGPSpeakerCRUD(t *testing.T) {
 	defer networking.DeleteNetwork(t, client, network.ID)
 
 	// Update BGP Speaker
+	name := tools.RandomString("TESTACC-BGPSPEAKER-", 10)
+	iTrue := true
 	opts := speakers.UpdateOpts{
-		Name:                          tools.RandomString("TESTACC-BGPSPEAKER-", 10),
-		AdvertiseTenantNetworks:       false,
-		AdvertiseFloatingIPHostRoutes: true,
+		Name:                          &name,
+		AdvertiseTenantNetworks:       new(bool),
+		AdvertiseFloatingIPHostRoutes: &iTrue,
 	}
 	speakerUpdated, err := speakers.Update(context.TODO(), client, bgpSpeaker.ID, opts).Extract()
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, speakerUpdated.Name, opts.Name)
+	th.AssertEquals(t, speakerUpdated.Name, *opts.Name)
 	t.Logf("Updated the BGP Speaker, name set from %s to %s", bgpSpeaker.Name, speakerUpdated.Name)
 
 	// Get a BGP Speaker
 	bgpSpeakerGot, err := speakers.Get(context.TODO(), client, bgpSpeaker.ID).Extract()
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, bgpSpeaker.ID, bgpSpeakerGot.ID)
-	th.AssertEquals(t, opts.Name, bgpSpeakerGot.Name)
+	th.AssertEquals(t, *opts.Name, bgpSpeakerGot.Name)
 
 	// AddBGPPeer
 	addBGPPeerOpts := speakers.AddBGPPeerOpts{BGPPeerID: bgpPeer.ID}

--- a/internal/acceptance/openstack/networking/v2/extensions/bgp/speakers/speakers.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/bgp/speakers/speakers.go
@@ -2,7 +2,6 @@ package speakers
 
 import (
 	"context"
-	"strconv"
 	"testing"
 
 	"github.com/gophercloud/gophercloud/v2"
@@ -12,13 +11,13 @@ import (
 )
 
 func CreateBGPSpeaker(t *testing.T, client *gophercloud.ServiceClient) (*speakers.BGPSpeaker, error) {
+	iTrue := true
 	opts := speakers.CreateOpts{
 		IPVersion:                     4,
-		AdvertiseFloatingIPHostRoutes: false,
-		AdvertiseTenantNetworks:       true,
+		AdvertiseFloatingIPHostRoutes: new(bool),
+		AdvertiseTenantNetworks:       &iTrue,
 		Name:                          tools.RandomString("TESTACC-BGPSPEAKER-", 8),
-		LocalAS:                       "3000",
-		Networks:                      []string{},
+		LocalAS:                       3000,
 	}
 
 	t.Logf("Attempting to create BGP Speaker: %s", opts.Name)
@@ -27,12 +26,11 @@ func CreateBGPSpeaker(t *testing.T, client *gophercloud.ServiceClient) (*speaker
 		return bgpSpeaker, err
 	}
 
-	localas, err := strconv.Atoi(opts.LocalAS)
 	th.AssertEquals(t, bgpSpeaker.Name, opts.Name)
-	th.AssertEquals(t, bgpSpeaker.LocalAS, localas)
+	th.AssertEquals(t, bgpSpeaker.LocalAS, opts.LocalAS)
 	th.AssertEquals(t, bgpSpeaker.IPVersion, opts.IPVersion)
-	th.AssertEquals(t, bgpSpeaker.AdvertiseTenantNetworks, opts.AdvertiseTenantNetworks)
-	th.AssertEquals(t, bgpSpeaker.AdvertiseFloatingIPHostRoutes, opts.AdvertiseFloatingIPHostRoutes)
+	th.AssertEquals(t, bgpSpeaker.AdvertiseTenantNetworks, *opts.AdvertiseTenantNetworks)
+	th.AssertEquals(t, bgpSpeaker.AdvertiseFloatingIPHostRoutes, *opts.AdvertiseFloatingIPHostRoutes)
 	t.Logf("Successfully created BGP Speaker")
 	tools.PrintResource(t, bgpSpeaker)
 	return bgpSpeaker, err

--- a/openstack/networking/v2/extensions/bgp/peers/requests.go
+++ b/openstack/networking/v2/extensions/bgp/peers/requests.go
@@ -32,9 +32,10 @@ type CreateOptsBuilder interface {
 type CreateOpts struct {
 	AuthType string `json:"auth_type"`
 	RemoteAS int    `json:"remote_as"`
-	Name     string `json:"name"`
+	Name     string `json:"name,omitempty"`
 	Password string `json:"password,omitempty"`
 	PeerIP   string `json:"peer_ip"`
+	TenantID string `json:"tenant_id,omitempty"`
 }
 
 // ToPeerCreateMap builds a request body from CreateOpts.
@@ -69,8 +70,8 @@ type UpdateOptsBuilder interface {
 
 // UpdateOpts represents options used to update a BGP Peer.
 type UpdateOpts struct {
-	Name     string `json:"name,omitempty"`
-	Password string `json:"password,omitempty"`
+	Name     *string `json:"name,omitempty"`
+	Password *string `json:"password,omitempty"`
 }
 
 // ToPeerUpdateMap builds a request body from UpdateOpts.

--- a/openstack/networking/v2/extensions/bgp/peers/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/bgp/peers/testing/requests_test.go
@@ -127,11 +127,14 @@ func TestUpdate(t *testing.T) {
 		fmt.Fprint(w, UpdateBGPPeerResponse)
 	})
 
-	var opts peers.UpdateOpts
-	opts.Name = "test-rename-bgp-peer"
-	opts.Password = "superStrong"
+	name := "test-rename-bgp-peer"
+	password := "superStrong"
+	opts := peers.UpdateOpts{
+		Name:     &name,
+		Password: &password,
+	}
 
 	r, err := peers.Update(context.TODO(), fake.ServiceClient(fakeServer), bgpPeerID, opts).Extract()
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, r.Name, opts.Name)
+	th.AssertEquals(t, r.Name, *opts.Name)
 }

--- a/openstack/networking/v2/extensions/bgp/speakers/requests.go
+++ b/openstack/networking/v2/extensions/bgp/speakers/requests.go
@@ -24,12 +24,12 @@ func Get(ctx context.Context, c *gophercloud.ServiceClient, id string) (r GetRes
 
 // CreateOpts represents options used to create a BGP Speaker.
 type CreateOpts struct {
-	Name                          string   `json:"name"`
-	IPVersion                     int      `json:"ip_version"`
-	AdvertiseFloatingIPHostRoutes bool     `json:"advertise_floating_ip_host_routes"`
-	AdvertiseTenantNetworks       bool     `json:"advertise_tenant_networks"`
-	LocalAS                       string   `json:"local_as"`
-	Networks                      []string `json:"networks,omitempty"`
+	Name                          string `json:"name,omitempty"`
+	IPVersion                     int    `json:"ip_version,omitempty"`
+	AdvertiseFloatingIPHostRoutes *bool  `json:"advertise_floating_ip_host_routes,omitempty"`
+	AdvertiseTenantNetworks       *bool  `json:"advertise_tenant_networks,omitempty"`
+	LocalAS                       int    `json:"local_as"`
+	TenantID                      string `json:"tenant_id,omitempty"`
 }
 
 // CreateOptsBuilder declare a function that build CreateOpts into a Create request body.
@@ -63,9 +63,9 @@ func Delete(ctx context.Context, c *gophercloud.ServiceClient, speakerID string)
 
 // UpdateOpts represents options used to update a BGP Speaker.
 type UpdateOpts struct {
-	Name                          string `json:"name,omitempty"`
-	AdvertiseFloatingIPHostRoutes bool   `json:"advertise_floating_ip_host_routes"`
-	AdvertiseTenantNetworks       bool   `json:"advertise_tenant_networks"`
+	Name                          *string `json:"name,omitempty"`
+	AdvertiseFloatingIPHostRoutes *bool   `json:"advertise_floating_ip_host_routes,omitempty"`
+	AdvertiseTenantNetworks       *bool   `json:"advertise_tenant_networks,omitempty"`
 }
 
 // ToSpeakerUpdateMap build a request body from UpdateOpts

--- a/openstack/networking/v2/extensions/bgp/speakers/testing/fixture.go
+++ b/openstack/networking/v2/extensions/bgp/speakers/testing/fixture.go
@@ -67,7 +67,7 @@ const CreateRequest = `
     "advertise_floating_ip_host_routes": false,
     "advertise_tenant_networks": true,
     "ip_version": 6,
-    "local_as": "2000",
+    "local_as": 2000,
     "name": "gophercloud-testing-bgp-speaker"
   }
 }

--- a/openstack/networking/v2/extensions/bgp/speakers/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/bgp/speakers/testing/requests_test.go
@@ -77,13 +77,13 @@ func TestCreate(t *testing.T) {
 		fmt.Fprint(w, CreateResponse)
 	})
 
+	iTrue := true
 	opts := speakers.CreateOpts{
 		IPVersion:                     6,
-		AdvertiseFloatingIPHostRoutes: false,
-		AdvertiseTenantNetworks:       true,
+		AdvertiseFloatingIPHostRoutes: new(bool),
+		AdvertiseTenantNetworks:       &iTrue,
 		Name:                          "gophercloud-testing-bgp-speaker",
-		LocalAS:                       "2000",
-		Networks:                      []string{},
+		LocalAS:                       2000,
 	}
 	r, err := speakers.Create(context.TODO(), fake.ServiceClient(fakeServer), opts).Extract()
 	th.AssertNoErr(t, err)
@@ -91,8 +91,8 @@ func TestCreate(t *testing.T) {
 	th.AssertEquals(t, r.LocalAS, 2000)
 	th.AssertEquals(t, len(r.Networks), 0)
 	th.AssertEquals(t, r.IPVersion, opts.IPVersion)
-	th.AssertEquals(t, r.AdvertiseFloatingIPHostRoutes, opts.AdvertiseFloatingIPHostRoutes)
-	th.AssertEquals(t, r.AdvertiseTenantNetworks, opts.AdvertiseTenantNetworks)
+	th.AssertEquals(t, r.AdvertiseFloatingIPHostRoutes, *opts.AdvertiseFloatingIPHostRoutes)
+	th.AssertEquals(t, r.AdvertiseTenantNetworks, *opts.AdvertiseTenantNetworks)
 }
 
 func TestDelete(t *testing.T) {
@@ -141,17 +141,19 @@ func TestUpdate(t *testing.T) {
 		}
 	})
 
+	name := "testing-bgp-speaker"
+	iTrue := true
 	opts := speakers.UpdateOpts{
-		Name:                          "testing-bgp-speaker",
-		AdvertiseTenantNetworks:       false,
-		AdvertiseFloatingIPHostRoutes: true,
+		Name:                          &name,
+		AdvertiseTenantNetworks:       new(bool),
+		AdvertiseFloatingIPHostRoutes: &iTrue,
 	}
 
 	r, err := speakers.Update(context.TODO(), fake.ServiceClient(fakeServer), bgpSpeakerID, opts).Extract()
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, r.Name, opts.Name)
-	th.AssertEquals(t, r.AdvertiseTenantNetworks, opts.AdvertiseTenantNetworks)
-	th.AssertEquals(t, r.AdvertiseFloatingIPHostRoutes, opts.AdvertiseFloatingIPHostRoutes)
+	th.AssertEquals(t, r.Name, *opts.Name)
+	th.AssertEquals(t, r.AdvertiseTenantNetworks, *opts.AdvertiseTenantNetworks)
+	th.AssertEquals(t, r.AdvertiseFloatingIPHostRoutes, *opts.AdvertiseFloatingIPHostRoutes)
 }
 
 func TestAddBGPPeer(t *testing.T) {


### PR DESCRIPTION
During the work on the the https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1892 PR I discovered that speakers create opts:
* don't support networks
* local AS must have an int type
* support tenant id
* AdvertiseFloatingIPHostRoutes and AdvertiseTenantNetworks must be a pointer to allow setting `false` values

peers create opts:
* support tenant id

Also update opts must contain pointers in order to allow updates to an empty string or false boolean value.