### PR TITLE
neutron: support security group empty name update

### DIFF
--- a/internal/acceptance/openstack/networking/v2/extensions/security_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/security_test.go
@@ -39,7 +39,7 @@ func TestSecurityGroupsCreateUpdateDelete(t *testing.T) {
 	var name = "Update group"
 	var description = ""
 	updateOpts := groups.UpdateOpts{
-		Name:        name,
+		Name:        &name,
 		Description: &description,
 		Stateful:    new(bool),
 	}
@@ -115,7 +115,7 @@ func TestSecurityGroupsRevision(t *testing.T) {
 	newName := tools.RandomString("TESTACC-", 8)
 	newDescription := ""
 	updateOpts := &groups.UpdateOpts{
-		Name:        newName,
+		Name:        &newName,
 		Description: &newDescription,
 	}
 	group, err = groups.Update(context.TODO(), client, group.ID, updateOpts).Extract()
@@ -126,7 +126,6 @@ func TestSecurityGroupsRevision(t *testing.T) {
 	// This should fail due to an old revision number.
 	newDescription = "new description"
 	updateOpts = &groups.UpdateOpts{
-		Name:           newName,
 		Description:    &newDescription,
 		RevisionNumber: &oldRevisionNumber,
 	}
@@ -145,7 +144,7 @@ func TestSecurityGroupsRevision(t *testing.T) {
 	// This should work because now we do provide a valid revision number.
 	newDescription = "new description"
 	updateOpts = &groups.UpdateOpts{
-		Name:           newName,
+		Name:           new(string),
 		Description:    &newDescription,
 		RevisionNumber: &group.RevisionNumber,
 	}
@@ -154,7 +153,7 @@ func TestSecurityGroupsRevision(t *testing.T) {
 
 	tools.PrintResource(t, group)
 
-	th.AssertEquals(t, group.Name, newName)
+	th.AssertEquals(t, group.Name, "")
 	th.AssertEquals(t, group.Description, newDescription)
 }
 

--- a/openstack/networking/v2/extensions/security/groups/requests.go
+++ b/openstack/networking/v2/extensions/security/groups/requests.go
@@ -114,7 +114,7 @@ type UpdateOptsBuilder interface {
 // group.
 type UpdateOpts struct {
 	// Human-readable name for the Security Group. Does not have to be unique.
-	Name string `json:"name,omitempty"`
+	Name *string `json:"name,omitempty"`
 
 	// Describes the security group.
 	Description *string `json:"description,omitempty"`

--- a/openstack/networking/v2/extensions/security/groups/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/security/groups/testing/requests_test.go
@@ -90,7 +90,8 @@ func TestUpdate(t *testing.T) {
 			fmt.Fprint(w, SecurityGroupUpdateResponse)
 		})
 
-	opts := groups.UpdateOpts{Name: "newer-webservers"}
+	name := "newer-webservers"
+	opts := groups.UpdateOpts{Name: &name}
 	sg, err := groups.Update(context.TODO(), fake.ServiceClient(fakeServer), "2076db17-a522-4506-91de-c6dd8e837028", opts).Extract()
 	th.AssertNoErr(t, err)
 


### PR DESCRIPTION
It was not possible to update the security group name