### PR TITLE
Use container-infra for OpenStack-API-Version

### DIFF
--- a/service_client.go
+++ b/service_client.go
@@ -130,6 +130,9 @@ func (client *ServiceClient) setMicroversionHeader(opts *RequestOpts) {
 		opts.MoreHeaders["X-OpenStack-Ironic-API-Version"] = client.Microversion
 	case "baremetal-introspection":
 		opts.MoreHeaders["X-OpenStack-Ironic-Inspector-API-Version"] = client.Microversion
+	case "container-infrastructure-management", "container-infrastructure", "container-infra":
+		// magnum should accept container-infrastructure-management but (as of Epoxy) does not
+		serviceType = "container-infra"
 	}
 
 	if client.Type != "" {


### PR DESCRIPTION
Due to a bug in Magnum, we are currently unable to use the official service types in this header. The fix is in progress [[1][1]] but even once that lands we will need to support older deployments without the fix.

Closes #3429

[1]: https://review.opendev.org/c/openstack/magnum/+/952804
