### PR TITLE
make: Use fixed version of gotestsum

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 undefine GOFLAGS
 
 GOLANGCI_LINT_VERSION?=v1.62.2
-GO_TEST?=go run gotest.tools/gotestsum@latest --format testname --
+GOTESTSUM_VERSION?=v1.12.2
+GO_TEST?=go run gotest.tools/gotestsum@$(GOTESTSUM_VERSION) --format testname --
 TIMEOUT := "60m"
 
 ifeq ($(shell command -v podman 2> /dev/null),)


### PR DESCRIPTION
The latest version bump the minimum go version to 1.23 [[1][1]], which breaks jobs on the v2 branch.

This should be backported to v2.

[1]: https://github.com/gotestyourself/gotestsum/compare/v1.12.2...v1.12.3#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6
