### PR TITLE
Deprecate `ChooseVersion` helper

### DIFF
--- a/openstack/utils/choose_version.go
+++ b/openstack/utils/choose_version.go
@@ -27,8 +27,10 @@ var goodStatus = map[string]bool{
 // endpoint that is among the recognized versions, it will be used regardless of priority.
 // It returns the highest-Priority Version, OR exact match with client endpoint,
 // among the alternatives that are provided, as well as its corresponding endpoint.
+//
+// Deprecated: This function is specific to the identity service and is no longer used internally
+// in Gophercloud. Consider using GetServiceVersions instead.
 func ChooseVersion(ctx context.Context, client *gophercloud.ProviderClient, recognized []*Version) (*Version, string, error) {
-	// TODO(stephenfin): This could be removed since we can accomplish this with GetServiceVersions now.
 	type linkResp struct {
 		Href string `json:"href"`
 		Rel  string `json:"rel"`

--- a/openstack/utils/discovery.go
+++ b/openstack/utils/discovery.go
@@ -360,6 +360,8 @@ func ParseStatus(status string) (Status, error) {
 	switch strings.ToUpper(status) {
 	case "CURRENT", "STABLE": // keystone uses STABLE instead of CURRENT
 		return StatusCurrent, nil
+	case "EXPERIMENTAL":
+		return StatusExperimental, nil
 	case "SUPPORTED":
 		return StatusSupported, nil
 	case "DEPRECATED":

--- a/openstack/utils/testing/choose_version_test.go
+++ b/openstack/utils/testing/choose_version_test.go
@@ -21,7 +21,7 @@ func TestChooseVersion(t *testing.T) {
 		IdentityBase:     fakeServer.Endpoint(),
 		IdentityEndpoint: "",
 	}
-	v, endpoint, err := utils.ChooseVersion(context.TODO(), c, []*utils.Version{v2, v3})
+	v, endpoint, err := utils.ChooseVersion(context.TODO(), c, []*utils.Version{v2, v3}) //nolint
 
 	if err != nil {
 		t.Fatalf("Unexpected error from ChooseVersion: %v", err)
@@ -49,7 +49,7 @@ func TestChooseVersionOpinionatedLink(t *testing.T) {
 		IdentityBase:     fakeServer.Endpoint(),
 		IdentityEndpoint: fakeServer.Endpoint() + "v2.0/",
 	}
-	v, endpoint, err := utils.ChooseVersion(context.TODO(), c, []*utils.Version{v2, v3})
+	v, endpoint, err := utils.ChooseVersion(context.TODO(), c, []*utils.Version{v2, v3}) //nolint
 	if err != nil {
 		t.Fatalf("Unexpected error from ChooseVersion: %v", err)
 	}
@@ -75,7 +75,7 @@ func TestChooseVersionFromSuffix(t *testing.T) {
 		IdentityBase:     fakeServer.Endpoint(),
 		IdentityEndpoint: fakeServer.Endpoint() + "v2.0/",
 	}
-	v, endpoint, err := utils.ChooseVersion(context.TODO(), c, []*utils.Version{v2, v3})
+	v, endpoint, err := utils.ChooseVersion(context.TODO(), c, []*utils.Version{v2, v3}) //nolint
 	if err != nil {
 		t.Fatalf("Unexpected error from ChooseVersion: %v", err)
 	}

--- a/openstack/utils/testing/discovery_test.go
+++ b/openstack/utils/testing/discovery_test.go
@@ -28,9 +28,11 @@ func TestGetServiceVersions(t *testing.T) {
 			discoverVersions: true,
 			expectedVersions: []utils.SupportedVersion{
 				{
+					ID:     "v3.14",
 					Major:  3,
 					Minor:  14,
 					Status: utils.StatusCurrent,
+					URL:    fakeServer.Endpoint() + "identity/v3/",
 				},
 			},
 		},
@@ -41,9 +43,11 @@ func TestGetServiceVersions(t *testing.T) {
 			// we will still run discovery since we can't extract the version from the URL
 			expectedVersions: []utils.SupportedVersion{
 				{
+					ID:     "v3.14",
 					Major:  3,
 					Minor:  14,
 					Status: utils.StatusCurrent,
+					URL:    fakeServer.Endpoint() + "identity/v3/",
 				},
 			},
 		},
@@ -53,9 +57,11 @@ func TestGetServiceVersions(t *testing.T) {
 			discoverVersions: true,
 			expectedVersions: []utils.SupportedVersion{
 				{
+					ID:     "v3.14",
 					Major:  3,
 					Minor:  14,
 					Status: utils.StatusCurrent,
+					URL:    fakeServer.Endpoint() + "identity/v3/",
 				},
 			},
 		},
@@ -66,9 +72,11 @@ func TestGetServiceVersions(t *testing.T) {
 			// we will skip discovery since we can extract a version from the URL
 			expectedVersions: []utils.SupportedVersion{
 				{
+					ID:     "",
 					Major:  3,
 					Minor:  0,
 					Status: utils.StatusUnknown,
+					URL:    fakeServer.Endpoint() + "identity/v3/",
 				},
 			},
 		},
@@ -78,17 +86,21 @@ func TestGetServiceVersions(t *testing.T) {
 			discoverVersions: true,
 			expectedVersions: []utils.SupportedVersion{
 				{
+					ID:     "v2.1",
 					Major:  2,
 					Minor:  1,
 					Status: utils.StatusCurrent,
 					SupportedMicroversions: utils.SupportedMicroversions{
 						MaxMajor: 2, MaxMinor: 90, MinMajor: 2, MinMinor: 1,
 					},
+					URL: fakeServer.Endpoint() + "compute/v2.1/",
 				},
 				{
+					ID:     "v2.0",
 					Major:  2,
 					Minor:  0,
 					Status: utils.StatusSupported,
+					URL:    fakeServer.Endpoint() + "compute/v2/",
 				},
 			},
 		},
@@ -98,9 +110,11 @@ func TestGetServiceVersions(t *testing.T) {
 			discoverVersions: true,
 			expectedVersions: []utils.SupportedVersion{
 				{
+					ID:     "v2.0",
 					Major:  2,
 					Minor:  0,
 					Status: utils.StatusSupported,
+					URL:    fakeServer.Endpoint() + "compute/v2/",
 				},
 			},
 		},
@@ -110,12 +124,14 @@ func TestGetServiceVersions(t *testing.T) {
 			discoverVersions: true,
 			expectedVersions: []utils.SupportedVersion{
 				{
+					ID:     "v2.1",
 					Major:  2,
 					Minor:  1,
 					Status: utils.StatusCurrent,
 					SupportedMicroversions: utils.SupportedMicroversions{
 						MaxMajor: 2, MaxMinor: 90, MinMajor: 2, MinMinor: 1,
 					},
+					URL: fakeServer.Endpoint() + "compute/v2.1/",
 				},
 			},
 		},
@@ -125,12 +141,14 @@ func TestGetServiceVersions(t *testing.T) {
 			discoverVersions: true,
 			expectedVersions: []utils.SupportedVersion{
 				{
+					ID:     "v1",
 					Major:  1,
 					Minor:  0,
 					Status: utils.StatusCurrent,
 					SupportedMicroversions: utils.SupportedMicroversions{
 						MaxMajor: 1, MaxMinor: 11, MinMajor: 1, MinMinor: 1,
 					},
+					URL: fakeServer.Endpoint() + "container-infra/v1/",
 				},
 			},
 		},
@@ -140,9 +158,11 @@ func TestGetServiceVersions(t *testing.T) {
 			discoverVersions: true,
 			expectedVersions: []utils.SupportedVersion{
 				{
+					ID:     "",
 					Major:  1,
 					Minor:  0,
 					Status: utils.StatusUnknown,
+					URL:    fakeServer.Endpoint() + "container-infra/v1/",
 				},
 			},
 		},
@@ -152,9 +172,11 @@ func TestGetServiceVersions(t *testing.T) {
 			discoverVersions: true,
 			expectedVersions: []utils.SupportedVersion{
 				{
+					ID:     "v1.0",
 					Major:  1,
 					Minor:  0,
 					Status: utils.StatusCurrent,
+					URL:    fakeServer.Endpoint() + "heat-api/v1/",
 				},
 			},
 		},
@@ -164,9 +186,11 @@ func TestGetServiceVersions(t *testing.T) {
 			discoverVersions: true,
 			expectedVersions: []utils.SupportedVersion{
 				{
+					ID:     "",
 					Major:  1,
 					Minor:  0,
 					Status: utils.StatusUnknown,
+					URL:    fakeServer.Endpoint() + "heat-api/v1/",
 				},
 			},
 		},
@@ -176,14 +200,18 @@ func TestGetServiceVersions(t *testing.T) {
 			discoverVersions: true,
 			expectedVersions: []utils.SupportedVersion{
 				{
+					ID:     "2",
 					Major:  2,
 					Minor:  0,
 					Status: utils.StatusCurrent,
+					URL:    fakeServer.Endpoint() + "messaging/v2/",
 				},
 				{
+					ID:     "1.1",
 					Major:  1,
 					Minor:  1,
 					Status: utils.StatusDeprecated,
+					URL:    fakeServer.Endpoint() + "messaging/v1.1/",
 				},
 			},
 		},
@@ -193,9 +221,11 @@ func TestGetServiceVersions(t *testing.T) {
 			discoverVersions: true,
 			expectedVersions: []utils.SupportedVersion{
 				{
+					ID:     "",
 					Major:  2,
 					Minor:  0,
 					Status: utils.StatusUnknown,
+					URL:    fakeServer.Endpoint() + "messaging/v2/",
 				},
 			},
 		},
@@ -205,9 +235,11 @@ func TestGetServiceVersions(t *testing.T) {
 			discoverVersions: true,
 			expectedVersions: []utils.SupportedVersion{
 				{
+					ID:     "v2.0",
 					Major:  2,
 					Minor:  0,
 					Status: utils.StatusCurrent,
+					URL:    fakeServer.Endpoint() + "workflow/v2/",
 				},
 			},
 		},
@@ -217,9 +249,11 @@ func TestGetServiceVersions(t *testing.T) {
 			discoverVersions: true,
 			expectedVersions: []utils.SupportedVersion{
 				{
+					ID:     "",
 					Major:  2,
 					Minor:  0,
 					Status: utils.StatusUnknown,
+					URL:    fakeServer.Endpoint() + "workflow/v2/",
 				},
 			},
 		},
@@ -229,12 +263,14 @@ func TestGetServiceVersions(t *testing.T) {
 			discoverVersions: true,
 			expectedVersions: []utils.SupportedVersion{
 				{
+					ID:     "v1",
 					Major:  1,
 					Minor:  0,
 					Status: utils.StatusCurrent,
 					SupportedMicroversions: utils.SupportedMicroversions{
 						MaxMajor: 1, MaxMinor: 87, MinMajor: 1, MinMinor: 1,
 					},
+					URL: fakeServer.Endpoint() + "baremetal/v1/",
 				},
 			},
 		},
@@ -244,12 +280,14 @@ func TestGetServiceVersions(t *testing.T) {
 			discoverVersions: true,
 			expectedVersions: []utils.SupportedVersion{
 				{
+					ID:     "v1",
 					Major:  1,
 					Minor:  0,
 					Status: utils.StatusCurrent,
 					SupportedMicroversions: utils.SupportedMicroversions{
 						MaxMajor: 1, MaxMinor: 87, MinMajor: 1, MinMinor: 1,
 					},
+					URL: fakeServer.Endpoint() + "baremetal/v1/",
 				},
 			},
 		},
@@ -259,35 +297,41 @@ func TestGetServiceVersions(t *testing.T) {
 			discoverVersions: true,
 			expectedVersions: []utils.SupportedVersion{
 				{
+					ID:     "v1",
 					Major:  1,
 					Minor:  0,
 					Status: utils.StatusCurrent,
 					SupportedMicroversions: utils.SupportedMicroversions{
 						MaxMajor: 1, MaxMinor: 87, MinMajor: 1, MinMinor: 1,
 					},
+					URL: fakeServer.Endpoint() + "baremetal/v1/",
 				},
 			},
 		},
 		{
 			name:             "fictional multi-version endpoint",
-			endpoint:         fakeServer.Endpoint() + "multi-version/v1.2/",
+			endpoint:         fakeServer.Endpoint() + "multi-version/",
 			discoverVersions: true,
 			expectedVersions: []utils.SupportedVersion{
 				{
+					ID:     "v1.2",
 					Major:  1,
 					Minor:  2,
 					Status: utils.StatusCurrent,
 					SupportedMicroversions: utils.SupportedMicroversions{
 						MaxMajor: 1, MaxMinor: 90, MinMajor: 1, MinMinor: 2,
 					},
+					URL: fakeServer.Endpoint() + "multi-version/v1/",
 				},
 				{
+					ID:     "v1",
 					Major:  1,
 					Minor:  0,
 					Status: utils.StatusCurrent,
 					SupportedMicroversions: utils.SupportedMicroversions{
 						MaxMajor: 1, MaxMinor: 87, MinMajor: 1, MinMinor: 1,
 					},
+					URL: fakeServer.Endpoint() + "multi-version/v1/",
 				},
 			},
 		},

--- a/openstack/utils/testing/discovery_test.go
+++ b/openstack/utils/testing/discovery_test.go
@@ -171,6 +171,35 @@ func TestGetServiceVersions(t *testing.T) {
 			},
 		},
 		{
+			name:             "messaging unversioned endpoint",
+			endpoint:         fakeServer.Endpoint() + "messaging/",
+			discoverVersions: true,
+			expectedVersions: []utils.SupportedVersion{
+				{
+					Major:  2,
+					Minor:  0,
+					Status: utils.StatusCurrent,
+				},
+				{
+					Major:  1,
+					Minor:  1,
+					Status: utils.StatusDeprecated,
+				},
+			},
+		},
+		{
+			name:             "messaging versioned endpoint",
+			endpoint:         fakeServer.Endpoint() + "messaging/v2/",
+			discoverVersions: true,
+			expectedVersions: []utils.SupportedVersion{
+				{
+					Major:  2,
+					Minor:  0,
+					Status: utils.StatusUnknown,
+				},
+			},
+		},
+		{
 			name:             "workflow unversioned endpoint",
 			endpoint:         fakeServer.Endpoint() + "workflow/",
 			discoverVersions: true,

--- a/openstack/utils/testing/fixtures_test.go
+++ b/openstack/utils/testing/fixtures_test.go
@@ -500,7 +500,7 @@ func setupMultiServiceVersionHandler(fakeServer th.FakeServer) {
 	})
 
 	// Fictional multi-version API
-	fakeServer.Mux.HandleFunc("/multi-version/v1.2/", func(w http.ResponseWriter, r *http.Request) {
+	fakeServer.Mux.HandleFunc("/multi-version/", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, `
 		{
 			"name": "Multi-version API",


### PR DESCRIPTION
Resolve a TODO from #3420 and both deprecate the function and migrate our sole user of it away.
