### PR TITLE
Prepare for merge queues

### DIFF
--- a/.github/actions/file-filter/Dockerfile
+++ b/.github/actions/file-filter/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.11-slim
+WORKDIR /app
+RUN pip install 'PyGithub~=2.7.0' 'requests~=2.32'
+COPY file_filter_action.py ./
+ENTRYPOINT ["python", "/app/file_filter_action.py"]

--- a/.github/actions/file-filter/action.yml
+++ b/.github/actions/file-filter/action.yml
@@ -1,0 +1,24 @@
+name: 'File Filter'
+description: 'Filter PR files by glob patterns and return true/false if any files match'
+inputs:
+  patterns:
+    description: 'String containing one or more glob patterns separated by spaces'
+    required: true
+  exclude:
+    description: 'Whether patterns is a list of glob patterns to *exclude* rather than *include*'
+    required: false
+    default: false
+  token:
+    description: 'GitHub token for API access'
+    required: false
+    default: ${{ github.token }}
+outputs:
+  matches:
+    description: 'True if any files match the patterns or if event_type is schedule, false otherwise (boolean)'
+  count:
+    description: 'Number of files that matched the patterns; will be unset if event_type is schedule (integer)'
+  files:
+    description: 'Files that matched the patterns; will unset if event_type is schedule (JSON array of strings)'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'

--- a/.github/actions/file-filter/file_filter_action.py
+++ b/.github/actions/file-filter/file_filter_action.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+
+import argparse
+import fnmatch
+import json
+import os
+import sys
+
+import github
+
+
+def parse_patterns(patterns_input: str) -> list[str]:
+    """Parse glob patterns from newline- or space-separated string input."""
+    if not patterns_input:
+        return []
+
+    patterns = [p.strip() for p in patterns_input.split() if p.strip()]
+
+    if not patterns:
+        raise ValueError('No valid patterns found in input')
+
+    return patterns
+
+
+def get_changed_files(
+    github_client: github.Github, repo_name: str,
+) -> list[str]:
+    """Get list of changed files between base and head refs."""
+    try:
+        repo = github_client.get_repo(repo_name)
+
+        # Try to get PR context first
+        if 'GITHUB_EVENT_PATH' in os.environ:
+            try:
+                with open(os.environ['GITHUB_EVENT_PATH']) as f:
+                    event_data = json.load(f)
+
+                if 'pull_request' in event_data:
+                    pr_number = event_data['pull_request']['number']
+                    pr = repo.get_pull(pr_number)
+                    files = pr.get_files()
+                    return [f.filename for f in files]
+            except (FileNotFoundError, KeyError, json.JSONDecodeError):
+                pass
+
+        base_ref = os.environ.get('GITHUB_BASE_REF', 'main')
+        head_ref = os.environ.get('GITHUB_HEAD_REF', os.environ.get('GITHUB_SHA'))
+
+        if head_ref:
+            comparison = repo.compare(base_ref, head_ref)
+            return [f.filename for f in comparison.files]
+
+        print('Warning: Could not determine changed files', file=sys.stderr)
+        return []
+    except github.GithubException as e:
+        print(f'GitHub API error: {e}', file=sys.stderr)
+        return []
+    except Exception as e:
+        print(f'Error getting changed files: {e}', file=sys.stderr)
+        return []
+
+
+def match_files(files: list[str], patterns: list[str], exclude: bool) -> list[str]:
+    """Match files against glob patterns."""
+    matches = []
+
+    for file_path in files:
+        for pattern in patterns:
+            if (fnmatch.fnmatch(file_path, pattern) and not exclude) or exclude:
+                matches.append(file_path)
+                break
+
+    return matches
+
+
+def set_output(name: str, value: str) -> None:
+    """Set GitHub Actions output."""
+    if 'GITHUB_OUTPUT' in os.environ:
+        with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
+            f.write(f'{name}={value}\n')
+    else:
+        # Fallback for older runners
+        print(f'::set-output name={name}::{value}')
+
+
+def main() -> None:
+    """Main function."""
+    parser = argparse.ArgumentParser(
+        description=(
+            'A utility script to retrieve the list of changed files in the '
+            'current PR, intended to be run as part of a GitHub Actions '
+            'pipeline.'
+        ),
+    )
+    parser.parse_args()
+
+    try:
+        patterns_input = os.environ.get('INPUT_PATTERNS', '')
+        token = os.environ.get('INPUT_TOKEN', os.environ.get('GITHUB_TOKEN', ''))
+        exclude = os.environ.get('INPUT_EXCLUDE')
+        repo_name = os.environ.get('GITHUB_REPOSITORY', '')
+        event_type = os.environ.get('GITHUB_EVENT_NAME')
+
+        print(f'Event type: {event_type}')
+        if event_type in ('schedule',):
+            print(f'Skipping file check for event_type={event_type}')
+            set_output('matches', 'true')
+            set_output('count', '')
+            set_output('files', '')
+            sys.exit(0)
+
+        if not patterns_input:
+            print('Error: No patterns provided', file=sys.stderr)
+            sys.exit(1)
+
+        if not token:
+            print('Error: No GitHub token provided', file=sys.stderr)
+            sys.exit(1)
+
+        if not repo_name:
+            print('Error: No repository name found', file=sys.stderr)
+            sys.exit(1)
+
+        if exclude and exclude not in ('true', 'false'):
+            print('Error: exclude must be one of: true, false', file=sys.stderr)
+            sys.exit(1)
+
+        patterns = parse_patterns(patterns_input)
+        print(f'Parsed patterns: {patterns}')
+
+        github_client = github.Github(token)
+        changed_files = get_changed_files(github_client, repo_name)
+        matched_files = match_files(changed_files, patterns, exclude == 'true')
+
+        print(f'Has matches? {"true" if matched_files else "false"}')
+        print(f'Matched files: {matched_files}')
+
+        set_output('matches', 'true' if matched_files else 'false')
+        set_output('count', str(len(matched_files)))
+        set_output('files', json.dumps(matched_files))
+        sys.exit(0)
+    except Exception as e:
+        print(f'Error: {e}', file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/.github/workflows/functional-baremetal.yaml
+++ b/.github/workflows/functional-baremetal.yaml
@@ -2,16 +2,6 @@ name: functional-baremetal
 on:
   merge_group:
   pull_request:
-    paths:
-      - 'openstack/auth_env.go'
-      - 'openstack/client.go'
-      - 'openstack/endpoint.go'
-      - 'openstack/endpoint_location.go'
-      - 'openstack/config/provider_client.go'
-      - 'openstack/utils/choose_version.go'
-      - 'openstack/utils/discovery.go'
-      - '**baremetal**'
-      - '.github/workflows/functional-baremetal.yaml'
   schedule:
     - cron: '0 0 */3 * *'
 jobs:
@@ -41,9 +31,34 @@ jobs:
     steps:
       - name: Checkout Gophercloud
         uses: actions/checkout@v5
+
+      - name: Check changed files
+        uses: ./.github/actions/file-filter
+        id: changed-files
+        with:
+          patterns: |
+            openstack/auth_env.go
+            openstack/client.go
+            openstack/endpoint.go
+            openstack/endpoint_location.go
+            openstack/config/provider_client.go
+            openstack/utils/choose_version.go
+            openstack/utils/discovery.go
+            **baremetal**
+            .github/workflows/functional-baremetal.yaml
+
+      - name: Skip tests for unrelated changed-files
+        if: ${{ ! fromJSON(steps.changed-files.outputs.matches) }}
+        run: |
+          echo "No relevant files changed - skipping tests for ${{ matrix.name }}"
+          echo "TESTS_SKIPPED=true" >> $GITHUB_ENV
+
       - name: Work around broken dnsmasq
+        if: ${{ fromJSON(steps.changed-files.outputs.matches) }}
         run: sudo apt-get purge -y dnsmasq-base
+
       - name: Deploy devstack
+        if: ${{ fromJSON(steps.changed-files.outputs.matches) }}
         uses: gophercloud/devstack-action@60ca1042045c0c9e3e001c64575d381654ffcba1
         with:
           branch: ${{ matrix.openstack_version }}
@@ -82,25 +97,42 @@ jobs:
             SWIFT_ENABLE_TEMPURLS=True
             SWIFT_TEMPURL_KEY=secretkey
           enabled_services: "ir-api,ir-cond,s-account,s-container,s-object,s-proxy,q-svc,q-agt,q-dhcp,q-l3,q-meta,-cinder,-c-sch,-c-api,-c-vol,-c-bak,-ovn,-ovn-controller,-ovn-northd,-q-ovn-metadata-agent,${{ matrix.additional_services }}"
+
       - name: Checkout go
+        if: ${{ fromJSON(steps.changed-files.outputs.matches) }}
         uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
           cache: true
+
       - name: Run Gophercloud acceptance tests
+        if: ${{ fromJSON(steps.changed-files.outputs.matches) }}
         run: |
           source ${{ github.workspace }}/script/stackenv
           make acceptance-baremetal
+          echo "TESTS_RUN=true" >> $GITHUB_ENV
         env:
           DEVSTACK_PATH: ${{ github.workspace }}/devstack
           OS_BRANCH: ${{ matrix.openstack_version }}
           USE_SYSTEM_SCOPE: true
+
       - name: Generate logs on failure
         run: ./script/collectlogs
-        if: failure()
+        if: ${{ failure() && fromJSON(steps.changed-files.outputs.matches) }}
+
       - name: Upload logs artifacts on failure
-        if: failure()
+        if: ${{ failure() && fromJSON(steps.changed-files.outputs.matches) }}
         uses: actions/upload-artifact@v4
         with:
           name: functional-baremetal-${{ matrix.name }}-${{ github.run_id }}
           path: /tmp/devstack-logs/*
+
+      - name: Set job status
+        run: |
+          if [[ "${{ env.TESTS_SKIPPED }}" == "true" || "${{ env.TESTS_RUN }}" == "true" ]]; then
+            echo "Job completed successfully (either ran tests or skipped appropriately)"
+            exit 0
+          else
+            echo "Job failed - neither tests ran nor were properly skipped"
+            exit 1
+          fi

--- a/.github/workflows/functional-baremetal.yaml
+++ b/.github/workflows/functional-baremetal.yaml
@@ -1,5 +1,6 @@
 name: functional-baremetal
 on:
+  merge_group:
   pull_request:
     paths:
       - 'openstack/auth_env.go'

--- a/.github/workflows/functional-basic.yaml
+++ b/.github/workflows/functional-basic.yaml
@@ -1,5 +1,6 @@
 name: functional-basic
 on:
+  merge_group:
   pull_request:
     paths-ignore:
       - 'docs/**'

--- a/.github/workflows/functional-basic.yaml
+++ b/.github/workflows/functional-basic.yaml
@@ -2,11 +2,6 @@ name: functional-basic
 on:
   merge_group:
   pull_request:
-    paths-ignore:
-      - 'docs/**'
-      - '**.md'
-      - '**.gitignore'
-      - '**LICENSE'
   schedule:
     - cron: '0 0 */3 * *'
 jobs:
@@ -36,29 +31,65 @@ jobs:
     steps:
       - name: Checkout Gophercloud
         uses: actions/checkout@v5
+
+      - name: Check changed files
+        uses: ./.github/actions/file-filter
+        id: changed-files
+        with:
+          patterns: |
+            docs/**
+            **.md
+            **.gitignore
+            **LICENSE
+          exclude: true
+
+      - name: Skip tests for unrelated changed-files
+        if: ${{ ! fromJSON(steps.changed-files.outputs.matches) }}
+        run: |
+          echo "No relevant files changed - skipping tests for ${{ matrix.name }}"
+          echo "TESTS_SKIPPED=true" >> $GITHUB_ENV
+
       - name: Deploy devstack
+        if: ${{ fromJSON(steps.changed-files.outputs.matches) }}
         uses: gophercloud/devstack-action@60ca1042045c0c9e3e001c64575d381654ffcba1
         with:
           branch: ${{ matrix.openstack_version }}
           enabled_services: 's-account,s-container,s-object,s-proxy,${{ matrix.additional_services }}'
+
       - name: Checkout go
+        if: ${{ fromJSON(steps.changed-files.outputs.matches) }}
         uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
           cache: true
+
       - name: Run Gophercloud acceptance tests
+        if: ${{ fromJSON(steps.changed-files.outputs.matches) }}
         run: |
           source ${{ github.workspace }}/script/stackenv
           make acceptance-basic
+          echo "TESTS_RUN=true" >> $GITHUB_ENV
         env:
           DEVSTACK_PATH: ${{ github.workspace }}/devstack
           OS_BRANCH: ${{ matrix.openstack_version }}
+
       - name: Generate logs on failure
         run: ./script/collectlogs
-        if: failure()
+        if: ${{ failure() && fromJSON(steps.changed-files.outputs.matches) }}
+
       - name: Upload logs artifacts on failure
-        if: failure()
+        if: ${{ failure() && fromJSON(steps.changed-files.outputs.matches) }}
         uses: actions/upload-artifact@v4
         with:
           name: functional-basic-${{ matrix.name }}-${{ github.run_id }}
           path: /tmp/devstack-logs/*
+
+      - name: Set job status
+        run: |
+          if [[ "${{ env.TESTS_SKIPPED }}" == "true" || "${{ env.TESTS_RUN }}" == "true" ]]; then
+            echo "Job completed successfully (either ran tests or skipped appropriately)"
+            exit 0
+          else
+            echo "Job failed - neither tests ran nor were properly skipped"
+            exit 1
+          fi

--- a/.github/workflows/functional-blockstorage.yaml
+++ b/.github/workflows/functional-blockstorage.yaml
@@ -2,16 +2,6 @@ name: functional-blockstorage
 on:
   merge_group:
   pull_request:
-    paths:
-      - 'openstack/auth_env.go'
-      - 'openstack/client.go'
-      - 'openstack/endpoint.go'
-      - 'openstack/endpoint_location.go'
-      - 'openstack/config/provider_client.go'
-      - 'openstack/utils/choose_version.go'
-      - 'openstack/utils/discovery.go'
-      - '**blockstorage**'
-      - '.github/workflows/functional-blockstorage.yaml'
   schedule:
     - cron: '0 0 */3 * *'
 jobs:
@@ -41,31 +31,71 @@ jobs:
     steps:
       - name: Checkout Gophercloud
         uses: actions/checkout@v5
+
+      - name: Check changed files
+        uses: ./.github/actions/file-filter
+        id: changed-files
+        with:
+          patterns: |
+            openstack/auth_env.go
+            openstack/client.go
+            openstack/endpoint.go
+            openstack/endpoint_location.go
+            openstack/config/provider_client.go
+            openstack/utils/choose_version.go
+            openstack/utils/discovery.go
+            **blockstorage**
+            .github/workflows/functional-blockstorage.yaml
+
+      - name: Skip tests for unrelated changed-files
+        if: ${{ ! fromJSON(steps.changed-files.outputs.matches) }}
+        run: |
+          echo "No relevant files changed - skipping tests for ${{ matrix.name }}"
+          echo "TESTS_SKIPPED=true" >> $GITHUB_ENV
+
       - name: Deploy devstack
+        if: ${{ fromJSON(steps.changed-files.outputs.matches) }}
         uses: gophercloud/devstack-action@60ca1042045c0c9e3e001c64575d381654ffcba1
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |
             CINDER_ISCSI_HELPER=lioadm
           enabled_services: "s-account,s-container,s-object,s-proxy,c-bak,${{ matrix.additional_services }}"
+
       - name: Checkout go
+        if: ${{ fromJSON(steps.changed-files.outputs.matches) }}
         uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
           cache: true
+
       - name: Run Gophercloud acceptance tests
+        if: ${{ fromJSON(steps.changed-files.outputs.matches) }}
         run: |
           source ${{ github.workspace }}/script/stackenv
           make acceptance-blockstorage
+          echo "TESTS_RUN=true" >> $GITHUB_ENV
         env:
           DEVSTACK_PATH: ${{ github.workspace }}/devstack
           OS_BRANCH: ${{ matrix.openstack_version }}
+
       - name: Generate logs on failure
         run: ./script/collectlogs
-        if: failure()
+        if: ${{ failure() && fromJSON(steps.changed-files.outputs.matches) }}
+
       - name: Upload logs artifacts on failure
-        if: failure()
+        if: ${{ failure() && fromJSON(steps.changed-files.outputs.matches) }}
         uses: actions/upload-artifact@v4
         with:
           name: functional-blockstorage-${{ matrix.name }}-${{ github.run_id }}
           path: /tmp/devstack-logs/*
+
+      - name: Set job status
+        run: |
+          if [[ "${{ env.TESTS_SKIPPED }}" == "true" || "${{ env.TESTS_RUN }}" == "true" ]]; then
+            echo "Job completed successfully (either ran tests or skipped appropriately)"
+            exit 0
+          else
+            echo "Job failed - neither tests ran nor were properly skipped"
+            exit 1
+          fi

--- a/.github/workflows/functional-blockstorage.yaml
+++ b/.github/workflows/functional-blockstorage.yaml
@@ -1,5 +1,6 @@
 name: functional-blockstorage
 on:
+  merge_group:
   pull_request:
     paths:
       - 'openstack/auth_env.go'

--- a/.github/workflows/functional-compute.yaml
+++ b/.github/workflows/functional-compute.yaml
@@ -2,16 +2,6 @@ name: functional-compute
 on:
   merge_group:
   pull_request:
-    paths:
-      - 'openstack/auth_env.go'
-      - 'openstack/client.go'
-      - 'openstack/endpoint.go'
-      - 'openstack/endpoint_location.go'
-      - 'openstack/config/provider_client.go'
-      - 'openstack/utils/choose_version.go'
-      - 'openstack/utils/discovery.go'
-      - '**compute**'
-      - '.github/workflows/functional-compute.yaml'
   schedule:
     - cron: '0 0 */3 * *'
 jobs:
@@ -41,31 +31,71 @@ jobs:
     steps:
       - name: Checkout Gophercloud
         uses: actions/checkout@v5
+
+      - name: Check changed files
+        uses: ./.github/actions/file-filter
+        id: changed-files
+        with:
+          patterns: |
+            openstack/auth_env.go
+            openstack/client.go
+            openstack/endpoint.go
+            openstack/endpoint_location.go
+            openstack/config/provider_client.go
+            openstack/utils/choose_version.go
+            openstack/utils/discovery.go
+            **compute**
+            .github/workflows/functional-compute.yaml
+
+      - name: Skip tests for unrelated changed-files
+        if: ${{ ! fromJSON(steps.changed-files.outputs.matches) }}
+        run: |
+          echo "No relevant files changed - skipping tests for ${{ matrix.name }}"
+          echo "TESTS_SKIPPED=true" >> $GITHUB_ENV
+
       - name: Deploy devstack
+        if: ${{ fromJSON(steps.changed-files.outputs.matches) }}
         uses: gophercloud/devstack-action@60ca1042045c0c9e3e001c64575d381654ffcba1
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |
             CINDER_ISCSI_HELPER=lioadm
           enabled_services: "${{ matrix.additional_services }}"
+
       - name: Checkout go
+        if: ${{ fromJSON(steps.changed-files.outputs.matches) }}
         uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
           cache: true
+
       - name: Run Gophercloud acceptance tests
+        if: ${{ fromJSON(steps.changed-files.outputs.matches) }}
         run: |
           source ${{ github.workspace }}/script/stackenv
           make acceptance-compute
+          echo "TESTS_RUN=true" >> $GITHUB_ENV
         env:
           DEVSTACK_PATH: ${{ github.workspace }}/devstack
           OS_BRANCH: ${{ matrix.openstack_version }}
+
       - name: Generate logs on failure
         run: ./script/collectlogs
-        if: failure()
+        if: ${{ failure() && fromJSON(steps.changed-files.outputs.matches) }}
+
       - name: Upload logs artifacts on failure
-        if: failure()
+        if: ${{ failure() && fromJSON(steps.changed-files.outputs.matches) }}
         uses: actions/upload-artifact@v4
         with:
           name: functional-compute-${{ matrix.name }}-${{ github.run_id }}
           path: /tmp/devstack-logs/*
+
+      - name: Set job status
+        run: |
+          if [[ "${{ env.TESTS_SKIPPED }}" == "true" || "${{ env.TESTS_RUN }}" == "true" ]]; then
+            echo "Job completed successfully (either ran tests or skipped appropriately)"
+            exit 0
+          else
+            echo "Job failed - neither tests ran nor were properly skipped"
+            exit 1
+          fi

--- a/.github/workflows/functional-compute.yaml
+++ b/.github/workflows/functional-compute.yaml
@@ -1,5 +1,6 @@
 name: functional-compute
 on:
+  merge_group:
   pull_request:
     paths:
       - 'openstack/auth_env.go'

--- a/.github/workflows/functional-containerinfra.yaml
+++ b/.github/workflows/functional-containerinfra.yaml
@@ -1,5 +1,6 @@
 name: functional-containerinfra
 on:
+  merge_group:
   pull_request:
     paths:
       - 'openstack/auth_env.go'

--- a/.github/workflows/functional-containerinfra.yaml
+++ b/.github/workflows/functional-containerinfra.yaml
@@ -2,16 +2,6 @@ name: functional-containerinfra
 on:
   merge_group:
   pull_request:
-    paths:
-      - 'openstack/auth_env.go'
-      - 'openstack/client.go'
-      - 'openstack/endpoint.go'
-      - 'openstack/endpoint_location.go'
-      - 'openstack/config/provider_client.go'
-      - 'openstack/utils/choose_version.go'
-      - 'openstack/utils/discovery.go'
-      - '**containerinfra**'
-      - '.github/workflows/functional-containerinfra.yaml'
   schedule:
     - cron: '0 0 */3 * *'
 jobs:
@@ -65,7 +55,30 @@ jobs:
     steps:
       - name: Checkout Gophercloud
         uses: actions/checkout@v5
+
+      - name: Check changed files
+        uses: ./.github/actions/file-filter
+        id: changed-files
+        with:
+          patterns: |
+            openstack/auth_env.go
+            openstack/client.go
+            openstack/endpoint.go
+            openstack/endpoint_location.go
+            openstack/config/provider_client.go
+            openstack/utils/choose_version.go
+            openstack/utils/discovery.go
+            **containerinfra**
+            .github/workflows/functional-containerinfra.yaml
+
+      - name: Skip tests for unrelated changed-files
+        if: ${{ ! fromJSON(steps.changed-files.outputs.matches) }}
+        run: |
+          echo "No relevant files changed - skipping tests for ${{ matrix.name }}"
+          echo "TESTS_SKIPPED=true" >> $GITHUB_ENV
+
       - name: Deploy devstack
+        if: ${{ fromJSON(steps.changed-files.outputs.matches) }}
         uses: gophercloud/devstack-action@60ca1042045c0c9e3e001c64575d381654ffcba1
         with:
           branch: ${{ matrix.openstack_version }}
@@ -78,24 +91,41 @@ jobs:
 
             ${{ matrix.devstack_conf_overrides }}
           enabled_services: "h-eng,h-api,h-api-cfn,h-api-cw,${{ matrix.additional_services }}"
+
       - name: Checkout go
+        if: ${{ fromJSON(steps.changed-files.outputs.matches) }}
         uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
           cache: true
+
       - name: Run Gophercloud acceptance tests
+        if: ${{ fromJSON(steps.changed-files.outputs.matches) }}
         run: |
           source ${{ github.workspace }}/script/stackenv
           make acceptance-containerinfra
+          echo "TESTS_RUN=true" >> $GITHUB_ENV
         env:
           DEVSTACK_PATH: ${{ github.workspace }}/devstack
           OS_BRANCH: ${{ matrix.openstack_version }}
+
       - name: Generate logs on failure
         run: ./script/collectlogs
-        if: failure()
+        if: ${{ failure() && fromJSON(steps.changed-files.outputs.matches) }}
+
       - name: Upload logs artifacts on failure
-        if: failure()
+        if: ${{ failure() && fromJSON(steps.changed-files.outputs.matches) }}
         uses: actions/upload-artifact@v4
         with:
           name: functional-containerinfra-${{ matrix.name }}-${{ github.run_id }}
           path: /tmp/devstack-logs/*
+
+      - name: Set job status
+        run: |
+          if [[ "${{ env.TESTS_SKIPPED }}" == "true" || "${{ env.TESTS_RUN }}" == "true" ]]; then
+            echo "Job completed successfully (either ran tests or skipped appropriately)"
+            exit 0
+          else
+            echo "Job failed - neither tests ran nor were properly skipped"
+            exit 1
+          fi

--- a/.github/workflows/functional-dns.yaml
+++ b/.github/workflows/functional-dns.yaml
@@ -2,16 +2,6 @@ name: functional-dns
 on:
   merge_group:
   pull_request:
-    paths:
-      - 'openstack/auth_env.go'
-      - 'openstack/client.go'
-      - 'openstack/endpoint.go'
-      - 'openstack/endpoint_location.go'
-      - 'openstack/config/provider_client.go'
-      - 'openstack/utils/choose_version.go'
-      - 'openstack/utils/discovery.go'
-      - '**dns**'
-      - '.github/workflows/functional-dns.yaml'
   schedule:
     - cron: '0 0 */3 * *'
 jobs:
@@ -47,7 +37,30 @@ jobs:
     steps:
       - name: Checkout Gophercloud
         uses: actions/checkout@v5
+
+      - name: Check changed files
+        uses: ./.github/actions/file-filter
+        id: changed-files
+        with:
+          patterns: |
+            openstack/auth_env.go
+            openstack/client.go
+            openstack/endpoint.go
+            openstack/endpoint_location.go
+            openstack/config/provider_client.go
+            openstack/utils/choose_version.go
+            openstack/utils/discovery.go
+            **dns**
+            .github/workflows/functional-dns.yaml
+
+      - name: Skip tests for unrelated changed-files
+        if: ${{ ! fromJSON(steps.changed-files.outputs.matches) }}
+        run: |
+          echo "No relevant files changed - skipping tests for ${{ matrix.name }}"
+          echo "TESTS_SKIPPED=true" >> $GITHUB_ENV
+
       - name: Deploy devstack
+        if: ${{ fromJSON(steps.changed-files.outputs.matches) }}
         uses: gophercloud/devstack-action@60ca1042045c0c9e3e001c64575d381654ffcba1
         with:
           branch: ${{ matrix.openstack_version }}
@@ -56,24 +69,41 @@ jobs:
 
             ${{ matrix.devstack_conf_overrides }}
           enabled_services: "designate,designate-central,designate-api,designate-worker,designate-producer,designate-mdns,${{ matrix.additional_services }}"
+
       - name: Checkout go
+        if: ${{ fromJSON(steps.changed-files.outputs.matches) }}
         uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
           cache: true
+
       - name: Run Gophercloud acceptance tests
+        if: ${{ fromJSON(steps.changed-files.outputs.matches) }}
         run: |
           source ${{ github.workspace }}/script/stackenv
           make acceptance-dns
+          echo "TESTS_RUN=true" >> $GITHUB_ENV
         env:
           DEVSTACK_PATH: ${{ github.workspace }}/devstack
           OS_BRANCH: ${{ matrix.openstack_version }}
+
       - name: Generate logs on failure
         run: ./script/collectlogs
-        if: failure()
+        if: ${{ failure() && fromJSON(steps.changed-files.outputs.matches) }}
+
       - name: Upload logs artifacts on failure
-        if: failure()
+        if: ${{ failure() && fromJSON(steps.changed-files.outputs.matches) }}
         uses: actions/upload-artifact@v4
         with:
           name: functional-dns-${{ matrix.name }}-${{ github.run_id }}
           path: /tmp/devstack-logs/*
+
+      - name: Set job status
+        run: |
+          if [[ "${{ env.TESTS_SKIPPED }}" == "true" || "${{ env.TESTS_RUN }}" == "true" ]]; then
+            echo "Job completed successfully (either ran tests or skipped appropriately)"
+            exit 0
+          else
+            echo "Job failed - neither tests ran nor were properly skipped"
+            exit 1
+          fi

--- a/.github/workflows/functional-dns.yaml
+++ b/.github/workflows/functional-dns.yaml
@@ -1,5 +1,6 @@
 name: functional-dns
 on:
+  merge_group:
   pull_request:
     paths:
       - 'openstack/auth_env.go'

--- a/.github/workflows/functional-fwaas_v2.yaml
+++ b/.github/workflows/functional-fwaas_v2.yaml
@@ -4,6 +4,7 @@
 # [1] https://bugs.launchpad.net/neutron/+bug/1971958
 name: functional-fwaas_v2
 on:
+  merge_group:
   pull_request:
     paths:
       - 'openstack/auth_env.go'

--- a/.github/workflows/functional-fwaas_v2.yaml
+++ b/.github/workflows/functional-fwaas_v2.yaml
@@ -6,16 +6,6 @@ name: functional-fwaas_v2
 on:
   merge_group:
   pull_request:
-    paths:
-      - 'openstack/auth_env.go'
-      - 'openstack/client.go'
-      - 'openstack/endpoint.go'
-      - 'openstack/endpoint_location.go'
-      - 'openstack/config/provider_client.go'
-      - 'openstack/utils/choose_version.go'
-      - 'openstack/utils/discovery.go'
-      - '**networking/v2/extensions/fwaas_v2**'
-      - '.github/workflows/functional-fwaas_v2.yaml'
   schedule:
     - cron: '0 0 */3 * *'
 jobs:
@@ -45,7 +35,30 @@ jobs:
     steps:
       - name: Checkout Gophercloud
         uses: actions/checkout@v5
+
+      - name: Check changed files
+        uses: ./.github/actions/file-filter
+        id: changed-files
+        with:
+          patterns: |
+            openstack/auth_env.go
+            openstack/client.go
+            openstack/endpoint.go
+            openstack/endpoint_location.go
+            openstack/config/provider_client.go
+            openstack/utils/choose_version.go
+            openstack/utils/discovery.go
+            **networking/v2/extensions/fwaas_v2**
+            .github/workflows/functional-fwaas_v2.yaml
+
+      - name: Skip tests for unrelated changed-files
+        if: ${{ ! fromJSON(steps.changed-files.outputs.matches) }}
+        run: |
+          echo "No relevant files changed - skipping tests for ${{ matrix.name }}"
+          echo "TESTS_SKIPPED=true" >> $GITHUB_ENV
+
       - name: Create additional neutron policies
+        if: ${{ fromJSON(steps.changed-files.outputs.matches) }}
         run: |
           mkdir /tmp/neutron-policies
           cat << EOF >> /tmp/neutron-policies/port_binding.yaml
@@ -53,7 +66,9 @@ jobs:
           "create_port:binding:profile": "rule:admin_only or rule:service_api"
           "update_port:binding:profile": "rule:admin_only or rule:service_api"
           EOF
+
       - name: Deploy devstack
+        if: ${{ fromJSON(steps.changed-files.outputs.matches) }}
         uses: gophercloud/devstack-action@60ca1042045c0c9e3e001c64575d381654ffcba1
         with:
           branch: ${{ matrix.openstack_version }}
@@ -69,24 +84,41 @@ jobs:
             [oslo_policy]
             policy_dirs = /tmp/neutron-policies
           enabled_services: 'q-svc,q-agt,q-dhcp,q-l3,q-meta,q-fwaas-v2,-cinder,-horizon,-tempest,-swift,-c-sch,-c-api,-c-vol,-c-bak,-ovn,-ovn-controller,-ovn-northd,-q-ovn-metadata-agent,${{ matrix.additional_services }}'
+
       - name: Checkout go
+        if: ${{ fromJSON(steps.changed-files.outputs.matches) }}
         uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
           cache: true
+
       - name: Run Gophercloud acceptance tests
+        if: ${{ fromJSON(steps.changed-files.outputs.matches) }}
         run: |
           source ${{ github.workspace }}/script/stackenv
           make acceptance-networking
+          echo "TESTS_RUN=true" >> $GITHUB_ENV
         env:
           DEVSTACK_PATH: ${{ github.workspace }}/devstack
           OS_BRANCH: ${{ matrix.openstack_version }}
+
       - name: Generate logs on failure
         run: ./script/collectlogs
-        if: failure()
+        if: ${{ failure() && fromJSON(steps.changed-files.outputs.matches) }}
+
       - name: Upload logs artifacts on failure
-        if: failure()
+        if: ${{ failure() && fromJSON(steps.changed-files.outputs.matches) }}
         uses: actions/upload-artifact@v4
         with:
           name: functional-fwaas_v2-${{ matrix.name }}-${{ github.run_id }}
           path: /tmp/devstack-logs/*
+
+      - name: Set job status
+        run: |
+          if [[ "${{ env.TESTS_SKIPPED }}" == "true" || "${{ env.TESTS_RUN }}" == "true" ]]; then
+            echo "Job completed successfully (either ran tests or skipped appropriately)"
+            exit 0
+          else
+            echo "Job failed - neither tests ran nor were properly skipped"
+            exit 1
+          fi

--- a/.github/workflows/functional-identity.yaml
+++ b/.github/workflows/functional-identity.yaml
@@ -2,16 +2,6 @@ name: functional-identity
 on:
   merge_group:
   pull_request:
-    paths:
-      - 'openstack/auth_env.go'
-      - 'openstack/client.go'
-      - 'openstack/endpoint.go'
-      - 'openstack/endpoint_location.go'
-      - 'openstack/config/provider_client.go'
-      - 'openstack/utils/choose_version.go'
-      - 'openstack/utils/discovery.go'
-      - '**identity**'
-      - '.github/workflows/functional-identity.yaml'
   schedule:
     - cron: '0 0 */3 * *'
 jobs:
@@ -41,29 +31,69 @@ jobs:
     steps:
       - name: Checkout Gophercloud
         uses: actions/checkout@v5
+
+      - name: Check changed files
+        uses: ./.github/actions/file-filter
+        id: changed-files
+        with:
+          patterns: |
+            openstack/auth_env.go
+            openstack/client.go
+            openstack/endpoint.go
+            openstack/endpoint_location.go
+            openstack/config/provider_client.go
+            openstack/utils/choose_version.go
+            openstack/utils/discovery.go
+            **identity**
+            .github/workflows/functional-identity.yaml
+
+      - name: Skip tests for unrelated changed-files
+        if: ${{ ! fromJSON(steps.changed-files.outputs.matches) }}
+        run: |
+          echo "No relevant files changed - skipping tests for ${{ matrix.name }}"
+          echo "TESTS_SKIPPED=true" >> $GITHUB_ENV
+
       - name: Deploy devstack
+        if: ${{ fromJSON(steps.changed-files.outputs.matches) }}
         uses: gophercloud/devstack-action@60ca1042045c0c9e3e001c64575d381654ffcba1
         with:
           branch: ${{ matrix.openstack_version }}
           enabled_services: "${{ matrix.additional_services }}"
+
       - name: Checkout go
+        if: ${{ fromJSON(steps.changed-files.outputs.matches) }}
         uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
           cache: true
+
       - name: Run Gophercloud acceptance tests
+        if: ${{ fromJSON(steps.changed-files.outputs.matches) }}
         run: |
           source ${{ github.workspace }}/script/stackenv
           make acceptance-identity
+          echo "TESTS_RUN=true" >> $GITHUB_ENV
         env:
           DEVSTACK_PATH: ${{ github.workspace }}/devstack
           OS_BRANCH: ${{ matrix.openstack_version }}
+
       - name: Generate logs on failure
         run: ./script/collectlogs
-        if: failure()
+        if: ${{ failure() && fromJSON(steps.changed-files.outputs.matches) }}
+
       - name: Upload logs artifacts on failure
-        if: failure()
+        if: ${{ failure() && fromJSON(steps.changed-files.outputs.matches) }}
         uses: actions/upload-artifact@v4
         with:
           name: functional-identity-${{ matrix.name }}-${{ github.run_id }}
           path: /tmp/devstack-logs/*
+
+      - name: Set job status
+        run: |
+          if [[ "${{ env.TESTS_SKIPPED }}" == "true" || "${{ env.TESTS_RUN }}" == "true" ]]; then
+            echo "Job completed successfully (either ran tests or skipped appropriately)"
+            exit 0
+          else
+            echo "Job failed - neither tests ran nor were properly skipped"
+            exit 1
+          fi

--- a/.github/workflows/functional-identity.yaml
+++ b/.github/workflows/functional-identity.yaml
@@ -1,5 +1,6 @@
 name: functional-identity
 on:
+  merge_group:
   pull_request:
     paths:
       - 'openstack/auth_env.go'

--- a/.github/workflows/functional-image.yaml
+++ b/.github/workflows/functional-image.yaml
@@ -2,16 +2,6 @@ name: functional-image
 on:
   merge_group:
   pull_request:
-    paths:
-      - 'openstack/auth_env.go'
-      - 'openstack/client.go'
-      - 'openstack/endpoint.go'
-      - 'openstack/endpoint_location.go'
-      - 'openstack/config/provider_client.go'
-      - 'openstack/utils/choose_version.go'
-      - 'openstack/utils/discovery.go'
-      - '**image**'
-      - '.github/workflows/functional-image.yaml'
   schedule:
     - cron: '0 0 */3 * *'
 jobs:
@@ -41,29 +31,69 @@ jobs:
     steps:
       - name: Checkout Gophercloud
         uses: actions/checkout@v5
+
+      - name: Check changed files
+        uses: ./.github/actions/file-filter
+        id: changed-files
+        with:
+          patterns: |
+            openstack/auth_env.go
+            openstack/client.go
+            openstack/endpoint.go
+            openstack/endpoint_location.go
+            openstack/config/provider_client.go
+            openstack/utils/choose_version.go
+            openstack/utils/discovery.go
+            **image**
+            .github/workflows/functional-image.yaml
+
+      - name: Skip tests for unrelated changed-files
+        if: ${{ ! fromJSON(steps.changed-files.outputs.matches) }}
+        run: |
+          echo "No relevant files changed - skipping tests for ${{ matrix.name }}"
+          echo "TESTS_SKIPPED=true" >> $GITHUB_ENV
+
       - name: Deploy devstack
+        if: ${{ fromJSON(steps.changed-files.outputs.matches) }}
         uses: gophercloud/devstack-action@60ca1042045c0c9e3e001c64575d381654ffcba1
         with:
           branch: ${{ matrix.openstack_version }}
           enabled_services: "${{ matrix.additional_services }}"
+
       - name: Checkout go
+        if: ${{ fromJSON(steps.changed-files.outputs.matches) }}
         uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
           cache: true
+
       - name: Run Gophercloud acceptance tests
+        if: ${{ fromJSON(steps.changed-files.outputs.matches) }}
         run: |
           source ${{ github.workspace }}/script/stackenv
           make acceptance-image
+          echo "TESTS_RUN=true" >> $GITHUB_ENV
         env:
           DEVSTACK_PATH: ${{ github.workspace }}/devstack
           OS_BRANCH: ${{ matrix.openstack_version }}
+
       - name: Generate logs on failure
         run: ./script/collectlogs
-        if: failure()
+        if: ${{ failure() && fromJSON(steps.changed-files.outputs.matches) }}
+
       - name: Upload logs artifacts on failure
-        if: failure()
+        if: ${{ failure() && fromJSON(steps.changed-files.outputs.matches) }}
         uses: actions/upload-artifact@v4
         with:
           name: functional-image-${{ matrix.name }}-${{ github.run_id }}
           path: /tmp/devstack-logs/*
+
+      - name: Set job status
+        run: |
+          if [[ "${{ env.TESTS_SKIPPED }}" == "true" || "${{ env.TESTS_RUN }}" == "true" ]]; then
+            echo "Job completed successfully (either ran tests or skipped appropriately)"
+            exit 0
+          else
+            echo "Job failed - neither tests ran nor were properly skipped"
+            exit 1
+          fi

--- a/.github/workflows/functional-image.yaml
+++ b/.github/workflows/functional-image.yaml
@@ -1,5 +1,6 @@
 name: functional-image
 on:
+  merge_group:
   pull_request:
     paths:
       - 'openstack/auth_env.go'

--- a/.github/workflows/functional-keymanager.yaml
+++ b/.github/workflows/functional-keymanager.yaml
@@ -1,5 +1,6 @@
 name: functional-keymanager
 on:
+  merge_group:
   pull_request:
     paths:
       - 'openstack/auth_env.go'

--- a/.github/workflows/functional-keymanager.yaml
+++ b/.github/workflows/functional-keymanager.yaml
@@ -2,16 +2,6 @@ name: functional-keymanager
 on:
   merge_group:
   pull_request:
-    paths:
-      - 'openstack/auth_env.go'
-      - 'openstack/client.go'
-      - 'openstack/endpoint.go'
-      - 'openstack/endpoint_location.go'
-      - 'openstack/config/provider_client.go'
-      - 'openstack/utils/choose_version.go'
-      - 'openstack/utils/discovery.go'
-      - '**keymanager**'
-      - '.github/workflows/functional-keymanager.yaml'
   schedule:
     - cron: '0 0 */3 * *'
 jobs:
@@ -53,7 +43,30 @@ jobs:
     steps:
       - name: Checkout Gophercloud
         uses: actions/checkout@v5
+
+      - name: Check changed files
+        uses: ./.github/actions/file-filter
+        id: changed-files
+        with:
+          patterns: |
+            openstack/auth_env.go
+            openstack/client.go
+            openstack/endpoint.go
+            openstack/endpoint_location.go
+            openstack/config/provider_client.go
+            openstack/utils/choose_version.go
+            openstack/utils/discovery.go
+            **keymanager**
+            .github/workflows/functional-keymanager.yaml
+
+      - name: Skip tests for unrelated changed-files
+        if: ${{ ! fromJSON(steps.changed-files.outputs.matches) }}
+        run: |
+          echo "No relevant files changed - skipping tests for ${{ matrix.name }}"
+          echo "TESTS_SKIPPED=true" >> $GITHUB_ENV
+
       - name: Deploy devstack
+        if: ${{ fromJSON(steps.changed-files.outputs.matches) }}
         uses: gophercloud/devstack-action@60ca1042045c0c9e3e001c64575d381654ffcba1
         with:
           branch: ${{ matrix.openstack_version }}
@@ -62,24 +75,41 @@ jobs:
 
             ${{ matrix.devstack_conf_overrides }}
           enabled_services: "barbican-svc,barbican-retry,barbican-keystone-listener,${{ matrix.additional_services }}"
+
       - name: Checkout go
+        if: ${{ fromJSON(steps.changed-files.outputs.matches) }}
         uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
           cache: true
+
       - name: Run Gophercloud acceptance tests
+        if: ${{ fromJSON(steps.changed-files.outputs.matches) }}
         run: |
           source ${{ github.workspace }}/script/stackenv
           make acceptance-keymanager
+          echo "TESTS_RUN=true" >> $GITHUB_ENV
         env:
           DEVSTACK_PATH: ${{ github.workspace }}/devstack
           OS_BRANCH: ${{ matrix.openstack_version }}
+
       - name: Generate logs on failure
         run: ./script/collectlogs
-        if: failure()
+        if: ${{ failure() && fromJSON(steps.changed-files.outputs.matches) }}
+
       - name: Upload logs artifacts on failure
-        if: failure()
+        if: ${{ failure() && fromJSON(steps.changed-files.outputs.matches) }}
         uses: actions/upload-artifact@v4
         with:
           name: functional-keymanager-${{ matrix.name }}-${{ github.run_id }}
           path: /tmp/devstack-logs/*
+
+      - name: Set job status
+        run: |
+          if [[ "${{ env.TESTS_SKIPPED }}" == "true" || "${{ env.TESTS_RUN }}" == "true" ]]; then
+            echo "Job completed successfully (either ran tests or skipped appropriately)"
+            exit 0
+          else
+            echo "Job failed - neither tests ran nor were properly skipped"
+            exit 1
+          fi

--- a/.github/workflows/functional-loadbalancer.yaml
+++ b/.github/workflows/functional-loadbalancer.yaml
@@ -2,16 +2,6 @@ name: functional-loadbalancer
 on:
   merge_group:
   pull_request:
-    paths:
-      - 'openstack/auth_env.go'
-      - 'openstack/client.go'
-      - 'openstack/endpoint.go'
-      - 'openstack/endpoint_location.go'
-      - 'openstack/config/provider_client.go'
-      - 'openstack/utils/choose_version.go'
-      - 'openstack/utils/discovery.go'
-      - '**loadbalancer**'
-      - '.github/workflows/functional-loadbalancer.yaml'
   schedule:
     - cron: '0 0 */3 * *'
 jobs:
@@ -47,7 +37,30 @@ jobs:
     steps:
       - name: Checkout Gophercloud
         uses: actions/checkout@v5
+
+      - name: Check changed files
+        uses: ./.github/actions/file-filter
+        id: changed-files
+        with:
+          patterns: |
+            openstack/auth_env.go
+            openstack/client.go
+            openstack/endpoint.go
+            openstack/endpoint_location.go
+            openstack/config/provider_client.go
+            openstack/utils/choose_version.go
+            openstack/utils/discovery.go
+            **loadbalancer**
+            .github/workflows/functional-loadbalancer.yaml
+
+      - name: Skip tests for unrelated changed-files
+        if: ${{ ! fromJSON(steps.changed-files.outputs.matches) }}
+        run: |
+          echo "No relevant files changed - skipping tests for ${{ matrix.name }}"
+          echo "TESTS_SKIPPED=true" >> $GITHUB_ENV
+
       - name: Deploy devstack
+        if: ${{ fromJSON(steps.changed-files.outputs.matches) }}
         uses: gophercloud/devstack-action@60ca1042045c0c9e3e001c64575d381654ffcba1
         with:
           branch: ${{ matrix.openstack_version }}
@@ -57,24 +70,41 @@ jobs:
 
             ${{ matrix.devstack_conf_overrides }}
           enabled_services: "octavia,o-api,o-cw,o-hk,o-hm,o-da,neutron-qos,${{ matrix.additional_services }}"
+
       - name: Checkout go
+        if: ${{ fromJSON(steps.changed-files.outputs.matches) }}
         uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
           cache: true
+
       - name: Run Gophercloud acceptance tests
+        if: ${{ fromJSON(steps.changed-files.outputs.matches) }}
         run: |
           source ${{ github.workspace }}/script/stackenv
           make acceptance-loadbalancer
+          echo "TESTS_RUN=true" >> $GITHUB_ENV
         env:
           DEVSTACK_PATH: ${{ github.workspace }}/devstack
           OS_BRANCH: ${{ matrix.openstack_version }}
+
       - name: Generate logs on failure
         run: ./script/collectlogs
-        if: failure()
+        if: ${{ failure() && fromJSON(steps.changed-files.outputs.matches) }}
+
       - name: Upload logs artifacts on failure
-        if: failure()
+        if: ${{ failure() && fromJSON(steps.changed-files.outputs.matches) }}
         uses: actions/upload-artifact@v4
         with:
           name: functional-loadbalancer-${{ matrix.name }}-${{ github.run_id }}
           path: /tmp/devstack-logs/*
+
+      - name: Set job status
+        run: |
+          if [[ "${{ env.TESTS_SKIPPED }}" == "true" || "${{ env.TESTS_RUN }}" == "true" ]]; then
+            echo "Job completed successfully (either ran tests or skipped appropriately)"
+            exit 0
+          else
+            echo "Job failed - neither tests ran nor were properly skipped"
+            exit 1
+          fi

--- a/.github/workflows/functional-loadbalancer.yaml
+++ b/.github/workflows/functional-loadbalancer.yaml
@@ -1,5 +1,6 @@
 name: functional-loadbalancer
 on:
+  merge_group:
   pull_request:
     paths:
       - 'openstack/auth_env.go'

--- a/.github/workflows/functional-messaging.yaml
+++ b/.github/workflows/functional-messaging.yaml
@@ -1,5 +1,6 @@
 name: functional-messaging
 on:
+  merge_group:
   pull_request:
     paths:
       - 'openstack/auth_env.go'

--- a/.github/workflows/functional-messaging.yaml
+++ b/.github/workflows/functional-messaging.yaml
@@ -2,16 +2,6 @@ name: functional-messaging
 on:
   merge_group:
   pull_request:
-    paths:
-      - 'openstack/auth_env.go'
-      - 'openstack/client.go'
-      - 'openstack/endpoint.go'
-      - 'openstack/endpoint_location.go'
-      - 'openstack/config/provider_client.go'
-      - 'openstack/utils/choose_version.go'
-      - 'openstack/utils/discovery.go'
-      - '**messaging**'
-      - '.github/workflows/functional-messaging.yaml'
   schedule:
     - cron: '0 0 */3 * *'
 jobs:
@@ -41,7 +31,30 @@ jobs:
     steps:
       - name: Checkout Gophercloud
         uses: actions/checkout@v5
+
+      - name: Check changed files
+        uses: ./.github/actions/file-filter
+        id: changed-files
+        with:
+          patterns: |
+            openstack/auth_env.go
+            openstack/client.go
+            openstack/endpoint.go
+            openstack/endpoint_location.go
+            openstack/config/provider_client.go
+            openstack/utils/choose_version.go
+            openstack/utils/discovery.go
+            **messaging**
+            .github/workflows/functional-messaging.yaml
+
+      - name: Skip tests for unrelated changed-files
+        if: ${{ ! fromJSON(steps.changed-files.outputs.matches) }}
+        run: |
+          echo "No relevant files changed - skipping tests for ${{ matrix.name }}"
+          echo "TESTS_SKIPPED=true" >> $GITHUB_ENV
+
       - name: Deploy devstack
+        if: ${{ fromJSON(steps.changed-files.outputs.matches) }}
         uses: gophercloud/devstack-action@60ca1042045c0c9e3e001c64575d381654ffcba1
         with:
           branch: ${{ matrix.openstack_version }}
@@ -49,24 +62,41 @@ jobs:
             enable_plugin zaqar https://github.com/openstack/zaqar ${{ matrix.openstack_version }}
             ZAQARCLIENT_BRANCH=${{ matrix.openstack_version }}
           enabled_services: "${{ matrix.additional_services }}"
+
       - name: Checkout go
+        if: ${{ fromJSON(steps.changed-files.outputs.matches) }}
         uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
           cache: true
+
       - name: Run Gophercloud acceptance tests
+        if: ${{ fromJSON(steps.changed-files.outputs.matches) }}
         run: |
           source ${{ github.workspace }}/script/stackenv
           make acceptance-messaging
+          echo "TESTS_RUN=true" >> $GITHUB_ENV
         env:
           DEVSTACK_PATH: ${{ github.workspace }}/devstack
           OS_BRANCH: ${{ matrix.openstack_version }}
+
       - name: Generate logs on failure
         run: ./script/collectlogs
-        if: failure()
+        if: ${{ failure() && fromJSON(steps.changed-files.outputs.matches) }}
+
       - name: Upload logs artifacts on failure
-        if: failure()
+        if: ${{ failure() && fromJSON(steps.changed-files.outputs.matches) }}
         uses: actions/upload-artifact@v4
         with:
           name: functional-messaging-${{ matrix.name }}-${{ github.run_id }}
           path: /tmp/devstack-logs/*
+
+      - name: Set job status
+        run: |
+          if [[ "${{ env.TESTS_SKIPPED }}" == "true" || "${{ env.TESTS_RUN }}" == "true" ]]; then
+            echo "Job completed successfully (either ran tests or skipped appropriately)"
+            exit 0
+          else
+            echo "Job failed - neither tests ran nor were properly skipped"
+            exit 1
+          fi

--- a/.github/workflows/functional-networking.yaml
+++ b/.github/workflows/functional-networking.yaml
@@ -2,16 +2,6 @@ name: functional-networking
 on:
   merge_group:
   pull_request:
-    paths:
-      - 'openstack/auth_env.go'
-      - 'openstack/client.go'
-      - 'openstack/endpoint.go'
-      - 'openstack/endpoint_location.go'
-      - 'openstack/config/provider_client.go'
-      - 'openstack/utils/choose_version.go'
-      - 'openstack/utils/discovery.go'
-      - '**networking**'
-      - '.github/workflows/functional-networking.yaml'
   schedule:
     - cron: '0 0 */3 * *'
 jobs:
@@ -41,7 +31,30 @@ jobs:
     steps:
       - name: Checkout Gophercloud
         uses: actions/checkout@v5
+
+      - name: Check changed files
+        uses: ./.github/actions/file-filter
+        id: changed-files
+        with:
+          patterns: |
+            openstack/auth_env.go
+            openstack/client.go
+            openstack/endpoint.go
+            openstack/endpoint_location.go
+            openstack/config/provider_client.go
+            openstack/utils/choose_version.go
+            openstack/utils/discovery.go
+            **networking**
+            .github/workflows/functional-networking.yaml
+
+      - name: Skip tests for unrelated changed-files
+        if: ${{ ! fromJSON(steps.changed-files.outputs.matches) }}
+        run: |
+          echo "No relevant files changed - skipping tests for ${{ matrix.name }}"
+          echo "TESTS_SKIPPED=true" >> $GITHUB_ENV
+
       - name: Create additional neutron policies
+        if: ${{ fromJSON(steps.changed-files.outputs.matches) }}
         run: |
           mkdir /tmp/neutron-policies
           cat << EOF >> /tmp/neutron-policies/port_binding.yaml
@@ -49,7 +62,9 @@ jobs:
           "create_port:binding:profile": "rule:admin_only or rule:service_api"
           "update_port:binding:profile": "rule:admin_only or rule:service_api"
           EOF
+
       - name: Deploy devstack
+        if: ${{ fromJSON(steps.changed-files.outputs.matches) }}
         uses: gophercloud/devstack-action@60ca1042045c0c9e3e001c64575d381654ffcba1
         with:
           branch: ${{ matrix.openstack_version }}
@@ -64,24 +79,41 @@ jobs:
             [oslo_policy]
             policy_dirs = /tmp/neutron-policies
           enabled_services: "neutron-dns,neutron-qos,neutron-segments,neutron-trunk,neutron-uplink-status-propagation,neutron-network-segment-range,neutron-port-forwarding,${{ matrix.additional_services }}"
+
       - name: Checkout go
+        if: ${{ fromJSON(steps.changed-files.outputs.matches) }}
         uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
           cache: true
+
       - name: Run Gophercloud acceptance tests
+        if: ${{ fromJSON(steps.changed-files.outputs.matches) }}
         run: |
           source ${{ github.workspace }}/script/stackenv
           make acceptance-networking
+          echo "TESTS_RUN=true" >> $GITHUB_ENV
         env:
           DEVSTACK_PATH: ${{ github.workspace }}/devstack
           OS_BRANCH: ${{ matrix.openstack_version }}
+
       - name: Generate logs on failure
         run: ./script/collectlogs
-        if: failure()
+        if: ${{ failure() && fromJSON(steps.changed-files.outputs.matches) }}
+
       - name: Upload logs artifacts on failure
-        if: failure()
+        if: ${{ failure() && fromJSON(steps.changed-files.outputs.matches) }}
         uses: actions/upload-artifact@v4
         with:
           name: functional-networking-${{ matrix.name }}-${{ github.run_id }}
           path: /tmp/devstack-logs/*
+
+      - name: Set job status
+        run: |
+          if [[ "${{ env.TESTS_SKIPPED }}" == "true" || "${{ env.TESTS_RUN }}" == "true" ]]; then
+            echo "Job completed successfully (either ran tests or skipped appropriately)"
+            exit 0
+          else
+            echo "Job failed - neither tests ran nor were properly skipped"
+            exit 1
+          fi

--- a/.github/workflows/functional-networking.yaml
+++ b/.github/workflows/functional-networking.yaml
@@ -1,5 +1,6 @@
 name: functional-networking
 on:
+  merge_group:
   pull_request:
     paths:
       - 'openstack/auth_env.go'

--- a/.github/workflows/functional-objectstorage.yaml
+++ b/.github/workflows/functional-objectstorage.yaml
@@ -2,16 +2,6 @@ name: functional-objectstorage
 on:
   merge_group:
   pull_request:
-    paths:
-      - 'openstack/auth_env.go'
-      - 'openstack/client.go'
-      - 'openstack/endpoint.go'
-      - 'openstack/endpoint_location.go'
-      - 'openstack/config/provider_client.go'
-      - 'openstack/utils/choose_version.go'
-      - 'openstack/utils/discovery.go'
-      - '**objectstorage**'
-      - '.github/workflows/functional-objectstorage.yaml'
   schedule:
     - cron: '0 0 */3 * *'
 jobs:
@@ -41,7 +31,30 @@ jobs:
     steps:
       - name: Checkout Gophercloud
         uses: actions/checkout@v5
+
+      - name: Check changed files
+        uses: ./.github/actions/file-filter
+        id: changed-files
+        with:
+          patterns: |
+            openstack/auth_env.go
+            openstack/client.go
+            openstack/endpoint.go
+            openstack/endpoint_location.go
+            openstack/config/provider_client.go
+            openstack/utils/choose_version.go
+            openstack/utils/discovery.go
+            **objectstorage**
+            .github/workflows/functional-objectstorage.yaml
+
+      - name: Skip tests for unrelated changed-files
+        if: ${{ ! fromJSON(steps.changed-files.outputs.matches) }}
+        run: |
+          echo "No relevant files changed - skipping tests for ${{ matrix.name }}"
+          echo "TESTS_SKIPPED=true" >> $GITHUB_ENV
+
       - name: Deploy devstack
+        if: ${{ fromJSON(steps.changed-files.outputs.matches) }}
         uses: gophercloud/devstack-action@60ca1042045c0c9e3e001c64575d381654ffcba1
         with:
           branch: ${{ matrix.openstack_version }}
@@ -52,24 +65,41 @@ jobs:
             [filter:versioned_writes]
             allow_object_versioning = true
           enabled_services: 's-account,s-container,s-object,s-proxy,${{ matrix.additional_services }}'
+
       - name: Checkout go
+        if: ${{ fromJSON(steps.changed-files.outputs.matches) }}
         uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
           cache: true
+
       - name: Run Gophercloud acceptance tests
+        if: ${{ fromJSON(steps.changed-files.outputs.matches) }}
         run: |
           source ${{ github.workspace }}/script/stackenv
           make acceptance-objectstorage
+          echo "TESTS_RUN=true" >> $GITHUB_ENV
         env:
           DEVSTACK_PATH: ${{ github.workspace }}/devstack
           OS_BRANCH: ${{ matrix.openstack_version }}
+
       - name: Generate logs on failure
         run: ./script/collectlogs
-        if: failure()
+        if: ${{ failure() && fromJSON(steps.changed-files.outputs.matches) }}
+
       - name: Upload logs artifacts on failure
-        if: failure()
+        if: ${{ failure() && fromJSON(steps.changed-files.outputs.matches) }}
         uses: actions/upload-artifact@v4
         with:
           name: functional-objectstorage-${{ matrix.name }}-${{ github.run_id }}
           path: /tmp/devstack-logs/*
+
+      - name: Set job status
+        run: |
+          if [[ "${{ env.TESTS_SKIPPED }}" == "true" || "${{ env.TESTS_RUN }}" == "true" ]]; then
+            echo "Job completed successfully (either ran tests or skipped appropriately)"
+            exit 0
+          else
+            echo "Job failed - neither tests ran nor were properly skipped"
+            exit 1
+          fi

--- a/.github/workflows/functional-objectstorage.yaml
+++ b/.github/workflows/functional-objectstorage.yaml
@@ -1,5 +1,6 @@
 name: functional-objectstorage
 on:
+  merge_group:
   pull_request:
     paths:
       - 'openstack/auth_env.go'

--- a/.github/workflows/functional-orchestration.yaml
+++ b/.github/workflows/functional-orchestration.yaml
@@ -1,5 +1,6 @@
 name: functional-orchestration
 on:
+  merge_group:
   pull_request:
     paths:
       - 'openstack/auth_env.go'

--- a/.github/workflows/functional-orchestration.yaml
+++ b/.github/workflows/functional-orchestration.yaml
@@ -2,16 +2,6 @@ name: functional-orchestration
 on:
   merge_group:
   pull_request:
-    paths:
-      - 'openstack/auth_env.go'
-      - 'openstack/client.go'
-      - 'openstack/endpoint.go'
-      - 'openstack/endpoint_location.go'
-      - 'openstack/config/provider_client.go'
-      - 'openstack/utils/choose_version.go'
-      - 'openstack/utils/discovery.go'
-      - '**orchestration**'
-      - '.github/workflows/functional-orchestration.yaml'
   schedule:
     - cron: '0 0 */3 * *'
 jobs:
@@ -41,31 +31,71 @@ jobs:
     steps:
       - name: Checkout Gophercloud
         uses: actions/checkout@v5
+
+      - name: Check changed files
+        uses: ./.github/actions/file-filter
+        id: changed-files
+        with:
+          patterns: |
+            openstack/auth_env.go
+            openstack/client.go
+            openstack/endpoint.go
+            openstack/endpoint_location.go
+            openstack/config/provider_client.go
+            openstack/utils/choose_version.go
+            openstack/utils/discovery.go
+            **orchestration**
+            .github/workflows/functional-orchestration.yaml
+
+      - name: Skip tests for unrelated changed-files
+        if: ${{ ! fromJSON(steps.changed-files.outputs.matches) }}
+        run: |
+          echo "No relevant files changed - skipping tests for ${{ matrix.name }}"
+          echo "TESTS_SKIPPED=true" >> $GITHUB_ENV
+
       - name: Deploy devstack
+        if: ${{ fromJSON(steps.changed-files.outputs.matches) }}
         uses: gophercloud/devstack-action@60ca1042045c0c9e3e001c64575d381654ffcba1
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |
             enable_plugin heat https://github.com/openstack/heat ${{ matrix.openstack_version }}
           enabled_services: 'h-eng,h-api,h-api-cfn,h-api-cw,${{ matrix.additional_services }}'
+
       - name: Checkout go
+        if: ${{ fromJSON(steps.changed-files.outputs.matches) }}
         uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
           cache: true
+
       - name: Run Gophercloud acceptance tests
+        if: ${{ fromJSON(steps.changed-files.outputs.matches) }}
         run: |
           source ${{ github.workspace }}/script/stackenv
           make acceptance-orchestration
+          echo "TESTS_RUN=true" >> $GITHUB_ENV
         env:
           DEVSTACK_PATH: ${{ github.workspace }}/devstack
           OS_BRANCH: ${{ matrix.openstack_version }}
+
       - name: Generate logs on failure
         run: ./script/collectlogs
-        if: failure()
+        if: ${{ failure() && fromJSON(steps.changed-files.outputs.matches) }}
+
       - name: Upload logs artifacts on failure
-        if: failure()
+        if: ${{ failure() && fromJSON(steps.changed-files.outputs.matches) }}
         uses: actions/upload-artifact@v4
         with:
           name: functional-orchestration-${{ matrix.name }}-${{ github.run_id }}
           path: /tmp/devstack-logs/*
+
+      - name: Set job status
+        run: |
+          if [[ "${{ env.TESTS_SKIPPED }}" == "true" || "${{ env.TESTS_RUN }}" == "true" ]]; then
+            echo "Job completed successfully (either ran tests or skipped appropriately)"
+            exit 0
+          else
+            echo "Job failed - neither tests ran nor were properly skipped"
+            exit 1
+          fi

--- a/.github/workflows/functional-placement.yaml
+++ b/.github/workflows/functional-placement.yaml
@@ -1,5 +1,6 @@
 name: functional-placement
 on:
+  merge_group:
   pull_request:
     paths:
       - 'openstack/auth_env.go'

--- a/.github/workflows/functional-placement.yaml
+++ b/.github/workflows/functional-placement.yaml
@@ -2,16 +2,6 @@ name: functional-placement
 on:
   merge_group:
   pull_request:
-    paths:
-      - 'openstack/auth_env.go'
-      - 'openstack/client.go'
-      - 'openstack/endpoint.go'
-      - 'openstack/endpoint_location.go'
-      - 'openstack/config/provider_client.go'
-      - 'openstack/utils/choose_version.go'
-      - 'openstack/utils/discovery.go'
-      - '**placement**'
-      - '.github/workflows/functional-placement.yaml'
   schedule:
     - cron: '0 0 */3 * *'
 jobs:
@@ -41,29 +31,69 @@ jobs:
     steps:
       - name: Checkout Gophercloud
         uses: actions/checkout@v5
+
+      - name: Check changed files
+        uses: ./.github/actions/file-filter
+        id: changed-files
+        with:
+          patterns: |
+            openstack/auth_env.go
+            openstack/client.go
+            openstack/endpoint.go
+            openstack/endpoint_location.go
+            openstack/config/provider_client.go
+            openstack/utils/choose_version.go
+            openstack/utils/discovery.go
+            **placement**
+            .github/workflows/functional-placement.yaml
+
+      - name: Skip tests for unrelated changed-files
+        if: ${{ ! fromJSON(steps.changed-files.outputs.matches) }}
+        run: |
+          echo "No relevant files changed - skipping tests for ${{ matrix.name }}"
+          echo "TESTS_SKIPPED=true" >> $GITHUB_ENV
+
       - name: Deploy devstack
+        if: ${{ fromJSON(steps.changed-files.outputs.matches) }}
         uses: gophercloud/devstack-action@60ca1042045c0c9e3e001c64575d381654ffcba1
         with:
           branch: ${{ matrix.openstack_version }}
           enabled_services: "${{ matrix.additional_services }}"
+
       - name: Checkout go
+        if: ${{ fromJSON(steps.changed-files.outputs.matches) }}
         uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
           cache: true
+
       - name: Run Gophercloud acceptance tests
+        if: ${{ fromJSON(steps.changed-files.outputs.matches) }}
         run: |
           source ${{ github.workspace }}/script/stackenv
           make acceptance-placement
+          echo "TESTS_RUN=true" >> $GITHUB_ENV
         env:
           DEVSTACK_PATH: ${{ github.workspace }}/devstack
           OS_BRANCH: ${{ matrix.openstack_version }}
+
       - name: Generate logs on failure
         run: ./script/collectlogs
-        if: failure()
+        if: ${{ failure() && fromJSON(steps.changed-files.outputs.matches) }}
+
       - name: Upload logs artifacts on failure
-        if: failure()
+        if: ${{ failure() && fromJSON(steps.changed-files.outputs.matches) }}
         uses: actions/upload-artifact@v4
         with:
           name: functional-placement-${{ matrix.name }}-${{ github.run_id }}
           path: /tmp/devstack-logs/*
+
+      - name: Set job status
+        run: |
+          if [[ "${{ env.TESTS_SKIPPED }}" == "true" || "${{ env.TESTS_RUN }}" == "true" ]]; then
+            echo "Job completed successfully (either ran tests or skipped appropriately)"
+            exit 0
+          else
+            echo "Job failed - neither tests ran nor were properly skipped"
+            exit 1
+          fi

--- a/.github/workflows/functional-sharedfilesystems.yaml
+++ b/.github/workflows/functional-sharedfilesystems.yaml
@@ -2,16 +2,6 @@ name: functional-sharedfilesystems
 on:
   merge_group:
   pull_request:
-    paths:
-      - 'openstack/auth_env.go'
-      - 'openstack/client.go'
-      - 'openstack/endpoint.go'
-      - 'openstack/endpoint_location.go'
-      - 'openstack/config/provider_client.go'
-      - 'openstack/utils/choose_version.go'
-      - 'openstack/utils/discovery.go'
-      - '**sharedfilesystems**'
-      - '.github/workflows/functional-sharedfilesystems.yaml'
   schedule:
     - cron: '0 0 */3 * *'
 jobs:
@@ -47,7 +37,30 @@ jobs:
     steps:
       - name: Checkout Gophercloud
         uses: actions/checkout@v5
+
+      - name: Check changed files
+        uses: ./.github/actions/file-filter
+        id: changed-files
+        with:
+          patterns: |
+            openstack/auth_env.go
+            openstack/client.go
+            openstack/endpoint.go
+            openstack/endpoint_location.go
+            openstack/config/provider_client.go
+            openstack/utils/choose_version.go
+            openstack/utils/discovery.go
+            **sharedfilesystems**
+            .github/workflows/functional-sharedfilesystems.yaml
+
+      - name: Skip tests for unrelated changed-files
+        if: ${{ ! fromJSON(steps.changed-files.outputs.matches) }}
+        run: |
+          echo "No relevant files changed - skipping tests for ${{ matrix.name }}"
+          echo "TESTS_SKIPPED=true" >> $GITHUB_ENV
+
       - name: Deploy devstack
+        if: ${{ fromJSON(steps.changed-files.outputs.matches) }}
         uses: gophercloud/devstack-action@60ca1042045c0c9e3e001c64575d381654ffcba1
         with:
           branch: ${{ matrix.openstack_version }}
@@ -70,24 +83,41 @@ jobs:
 
             ${{ matrix.devstack_conf_overrides }}
           enabled_services: "${{ matrix.additional_services }}"
+
       - name: Checkout go
+        if: ${{ fromJSON(steps.changed-files.outputs.matches) }}
         uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
           cache: true
+
       - name: Run Gophercloud acceptance tests
+        if: ${{ fromJSON(steps.changed-files.outputs.matches) }}
         run: |
           source ${{ github.workspace }}/script/stackenv
           make acceptance-sharedfilesystems
+          echo "TESTS_RUN=true" >> $GITHUB_ENV
         env:
           DEVSTACK_PATH: ${{ github.workspace }}/devstack
           OS_BRANCH: ${{ matrix.openstack_version }}
+
       - name: Generate logs on failure
         run: ./script/collectlogs
-        if: failure()
+        if: ${{ failure() && fromJSON(steps.changed-files.outputs.matches) }}
+
       - name: Upload logs artifacts on failure
-        if: failure()
+        if: ${{ failure() && fromJSON(steps.changed-files.outputs.matches) }}
         uses: actions/upload-artifact@v4
         with:
           name: functional-sharedfilesystems-${{ matrix.name }}-${{ github.run_id }}
           path: /tmp/devstack-logs/*
+
+      - name: Set job status
+        run: |
+          if [[ "${{ env.TESTS_SKIPPED }}" == "true" || "${{ env.TESTS_RUN }}" == "true" ]]; then
+            echo "Job completed successfully (either ran tests or skipped appropriately)"
+            exit 0
+          else
+            echo "Job failed - neither tests ran nor were properly skipped"
+            exit 1
+          fi

--- a/.github/workflows/functional-sharedfilesystems.yaml
+++ b/.github/workflows/functional-sharedfilesystems.yaml
@@ -1,5 +1,6 @@
 name: functional-sharedfilesystems
 on:
+  merge_group:
   pull_request:
     paths:
       - 'openstack/auth_env.go'

--- a/.github/workflows/functional-workflow.yaml
+++ b/.github/workflows/functional-workflow.yaml
@@ -1,5 +1,6 @@
 name: functional-workflow
 on:
+  merge_group:
   pull_request:
     paths:
       - 'openstack/auth_env.go'

--- a/.github/workflows/functional-workflow.yaml
+++ b/.github/workflows/functional-workflow.yaml
@@ -2,16 +2,6 @@ name: functional-workflow
 on:
   merge_group:
   pull_request:
-    paths:
-      - 'openstack/auth_env.go'
-      - 'openstack/client.go'
-      - 'openstack/endpoint.go'
-      - 'openstack/endpoint_location.go'
-      - 'openstack/config/provider_client.go'
-      - 'openstack/utils/choose_version.go'
-      - 'openstack/utils/discovery.go'
-      - '**workflow**'
-      - '.github/workflows/functional-workflow.yaml'
   schedule:
     - cron: '0 0 */3 * *'
 jobs:
@@ -45,31 +35,71 @@ jobs:
     steps:
       - name: Checkout Gophercloud
         uses: actions/checkout@v5
+
+      - name: Check changed files
+        uses: ./.github/actions/file-filter
+        id: changed-files
+        with:
+          patterns: |
+            openstack/auth_env.go
+            openstack/client.go
+            openstack/endpoint.go
+            openstack/endpoint_location.go
+            openstack/config/provider_client.go
+            openstack/utils/choose_version.go
+            openstack/utils/discovery.go
+            **workflow**
+            .github/workflows/functional-workflow.yaml
+
+      - name: Skip tests for unrelated changed-files
+        if: ${{ ! fromJSON(steps.changed-files.outputs.matches) }}
+        run: |
+          echo "No relevant files changed - skipping tests for ${{ matrix.name }}"
+          echo "TESTS_SKIPPED=true" >> $GITHUB_ENV
+
       - name: Deploy devstack
+        if: ${{ fromJSON(steps.changed-files.outputs.matches) }}
         uses: gophercloud/devstack-action@60ca1042045c0c9e3e001c64575d381654ffcba1
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |
             enable_plugin mistral https://github.com/openstack/mistral ${{ matrix.mistral_plugin_version }}
           enabled_services: "mistral,mistral-api,mistral-engine,mistral-executor,mistral-event-engine,${{ matrix.additional_services }}"
+
       - name: Checkout go
+        if: ${{ fromJSON(steps.changed-files.outputs.matches) }}
         uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
           cache: true
+
       - name: Run Gophercloud acceptance tests
+        if: ${{ fromJSON(steps.changed-files.outputs.matches) }}
         run: |
           source ${{ github.workspace }}/script/stackenv
           make acceptance-workflow
+          echo "TESTS_RUN=true" >> $GITHUB_ENV
         env:
           DEVSTACK_PATH: ${{ github.workspace }}/devstack
           OS_BRANCH: ${{ matrix.openstack_version }}
+
       - name: Generate logs on failure
         run: ./script/collectlogs
-        if: failure()
+        if: ${{ failure() && fromJSON(steps.changed-files.outputs.matches) }}
+
       - name: Upload logs artifacts on failure
-        if: failure()
+        if: ${{ failure() && fromJSON(steps.changed-files.outputs.matches) }}
         uses: actions/upload-artifact@v4
         with:
           name: functional-workflow-${{ matrix.name }}-${{ github.run_id }}
           path: /tmp/devstack-logs/*
+
+      - name: Set job status
+        run: |
+          if [[ "${{ env.TESTS_SKIPPED }}" == "true" || "${{ env.TESTS_RUN }}" == "true" ]]; then
+            echo "Job completed successfully (either ran tests or skipped appropriately)"
+            exit 0
+          else
+            echo "Job failed - neither tests ran nor were properly skipped"
+            exit 1
+          fi

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,5 +1,6 @@
 name: Linters
 on:
+  - merge_group
   - push
   - pull_request
 permissions:

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -1,5 +1,6 @@
 name: Unit Testing
 on:
+  - merge_group
   - push
   - pull_request
 permissions:


### PR DESCRIPTION
We'd like to enable [merge queues](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue) so that we can ensure all jobs are run on a PR prior to merging that PR. To do this, we need to mark most of our jobs as *required*. However, we are currently only running those jobs on changes to specific files e.g.:


```yaml
name: functional-baremetal
on:
  pull_request:
    paths:
      - 'openstack/auth_env.go'
      - 'openstack/client.go'
      - 'openstack/endpoint.go'
      - 'openstack/endpoint_location.go'
      - 'openstack/config/provider_client.go'
      - 'openstack/utils/choose_version.go'
      - 'openstack/utils/discovery.go'
      - '**baremetal**'
      - '.github/workflows/functional-baremetal.yaml'
jobs:
    # ... rest of job definition
```

However, this causes jobs to never run rather than be "skipped". If the job is required for e.g. a merge queue, then the PR will never merge because it will wait forever for the job result.

This PR adds a local plugin to allow us to filter on files and skip steps when none of the affected files are checked. This only happens on pull requests, since during scheduled jobs we expect all jobs to run. Once this merges, we can mark all but the ironic and octavia master jobs as required.