### PR TITLE
nova: add support for hostname updates

### DIFF
--- a/openstack/compute/v2/servers/requests.go
+++ b/openstack/compute/v2/servers/requests.go
@@ -654,6 +654,12 @@ type UpdateOpts struct {
 
 	// AccessIPv6 provides a new IPv6 address for the instance.
 	AccessIPv6 *string `json:"accessIPv6,omitempty"`
+
+	// Hostname changes the hostname of the server.
+	// Requires microversion 2.90 or later.
+	// Note: This information is published via the metadata service and requires
+	// application such as cloud-init to propagate it through to the instance.
+	Hostname *string `json:"hostname,omitempty"`
 }
 
 // ToServerUpdateMap formats an UpdateOpts structure into a request body.

--- a/openstack/compute/v2/servers/testing/fixtures_test.go
+++ b/openstack/compute/v2/servers/testing/fixtures_test.go
@@ -1338,3 +1338,17 @@ func HandleServerWithTagsCreationSuccessfully(t *testing.T, fakeServer th.FakeSe
 		fmt.Fprint(w, SingleServerWithTagsBody)
 	})
 }
+
+// HandleServerHostnameUpdateSuccessfully sets up the test server to respond to a server update
+// request changing the hostname.
+func HandleServerHostnameUpdateSuccessfully(t *testing.T, fakeServer th.FakeServer) {
+	fakeServer.Mux.HandleFunc("/servers/1234asdf", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestJSONRequest(t, r, `{ "server": { "hostname": "new-hostname" } }`)
+
+		fmt.Fprint(w, SingleServerBody)
+	})
+}

--- a/openstack/compute/v2/servers/testing/requests_test.go
+++ b/openstack/compute/v2/servers/testing/requests_test.go
@@ -1183,3 +1183,17 @@ func TestCreateServerWithHypervisorHostname(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.CheckJSONEquals(t, expected, actual)
 }
+
+func TestUpdateServerHostname(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	HandleServerHostnameUpdateSuccessfully(t, fakeServer)
+
+	client := client.ServiceClient(fakeServer)
+	actual, err := servers.Update(context.TODO(), client, "1234asdf", servers.UpdateOpts{Hostname: ptr.To("new-hostname")}).Extract()
+	if err != nil {
+		t.Fatalf("Unexpected Update error: %v", err)
+	}
+
+	th.CheckDeepEquals(t, ServerDerp, *actual)
+}


### PR DESCRIPTION
<!--
Prior to starting a PR, please make sure you have read our
[contributor tutorial](https://github.com/gophercloud/gophercloud/tree/main/docs/contributor-tutorial).

Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

-->
Fixes #3444

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

* [hostname](https://github.com/openstack/nova/blob/0d586ccca88ae90b9634ee00b8f7f86a78b09cd0/nova/objects/instance.py#L131)

I've ran all compute acceptance tests against a 2025.1 DevStack environment and all passed.

Once this is accepted merged I'll also create a pull request to backport this into the v2 branch.