### PR TITLE
neutron: add new router attributes

### DIFF
--- a/openstack/networking/v2/extensions/layer3/routers/requests.go
+++ b/openstack/networking/v2/extensions/layer3/routers/requests.go
@@ -77,14 +77,20 @@ type CreateOptsBuilder interface {
 // CreateOpts contains all the values needed to create a new router. There are
 // no required values.
 type CreateOpts struct {
-	Name                  string       `json:"name,omitempty"`
-	Description           string       `json:"description,omitempty"`
-	AdminStateUp          *bool        `json:"admin_state_up,omitempty"`
-	Distributed           *bool        `json:"distributed,omitempty"`
-	TenantID              string       `json:"tenant_id,omitempty"`
-	ProjectID             string       `json:"project_id,omitempty"`
-	GatewayInfo           *GatewayInfo `json:"external_gateway_info,omitempty"`
-	AvailabilityZoneHints []string     `json:"availability_zone_hints,omitempty"`
+	Name                   string       `json:"name,omitempty"`
+	Description            string       `json:"description,omitempty"`
+	AdminStateUp           *bool        `json:"admin_state_up,omitempty"`
+	Distributed            *bool        `json:"distributed,omitempty"`
+	TenantID               string       `json:"tenant_id,omitempty"`
+	ProjectID              string       `json:"project_id,omitempty"`
+	HA                     *bool        `json:"ha,omitempty"`
+	ServiceTypeID          string       `json:"service_type_id,omitempty"`
+	FlavorID               string       `json:"flavor_id,omitempty"`
+	EnableNDPProxy         *bool        `json:"enable_ndp_proxy,omitempty"`
+	EnableDefaultRouteBFD  *bool        `json:"enable_default_route_bfd,omitempty"`
+	EnableDefaultRouteECMP *bool        `json:"enable_default_route_ecmp,omitempty"`
+	GatewayInfo            *GatewayInfo `json:"external_gateway_info,omitempty"`
+	AvailabilityZoneHints  []string     `json:"availability_zone_hints,omitempty"`
 }
 
 // ToRouterCreateMap builds a create request body from CreateOpts.
@@ -126,12 +132,16 @@ type UpdateOptsBuilder interface {
 
 // UpdateOpts contains the values used when updating a router.
 type UpdateOpts struct {
-	Name         string       `json:"name,omitempty"`
-	Description  *string      `json:"description,omitempty"`
-	AdminStateUp *bool        `json:"admin_state_up,omitempty"`
-	Distributed  *bool        `json:"distributed,omitempty"`
-	GatewayInfo  *GatewayInfo `json:"external_gateway_info,omitempty"`
-	Routes       *[]Route     `json:"routes,omitempty"`
+	Name                   string       `json:"name,omitempty"`
+	Description            *string      `json:"description,omitempty"`
+	AdminStateUp           *bool        `json:"admin_state_up,omitempty"`
+	Distributed            *bool        `json:"distributed,omitempty"`
+	HA                     *bool        `json:"ha,omitempty"`
+	EnableNDPProxy         *bool        `json:"enable_ndp_proxy,omitempty"`
+	EnableDefaultRouteBFD  *bool        `json:"enable_default_route_bfd,omitempty"`
+	EnableDefaultRouteECMP *bool        `json:"enable_default_route_ecmp,omitempty"`
+	GatewayInfo            *GatewayInfo `json:"external_gateway_info,omitempty"`
+	Routes                 *[]Route     `json:"routes,omitempty"`
 
 	// RevisionNumber implements extension:standard-attr-revisions. If != "" it
 	// will set revision_number=%s. If the revision number does not match, the

--- a/openstack/networking/v2/extensions/layer3/routers/results.go
+++ b/openstack/networking/v2/extensions/layer3/routers/results.go
@@ -68,12 +68,43 @@ type Router struct {
 	// ProjectID is the project owner of the router.
 	ProjectID string `json:"project_id"`
 
+	// HA indicates a highly-available router. It is available when l3-ha
+	// extension is enabled.
+	HA bool `json:"ha"`
+
+	// ServiceTypeID of the service type associated with the router.
+	ServiceTypeID string `json:"service_type_id"`
+
+	// FlavorID of the flavor associated with the router.
+	FlavorID string `json:"flavor_id"`
+
+	// EnableNDPProxy indicates the NDP proxy attribute. Available when
+	// router-extend-ndp-proxy extension is enabled.
+	EnableNDPProxy bool `json:"enable_ndp_proxy"`
+
+	// EnableDefaultRouteBFD indicates that Neutron will enable BFD
+	// sessions for default routes inferred from the external gateway port
+	// subnets. Available when external-gateway-multihoming extension is
+	// enabled.
+	EnableDefaultRouteBFD bool `json:"enable_default_route_bfd"`
+
+	// EnableDefaultRouteECMP indicates that Neutron will add ECMP default
+	// routes if multiple are available via different gateway ports.
+	// Available when external-gateway-multihoming extension is enabled.
+	EnableDefaultRouteECMP bool `json:"enable_default_route_ecmp"`
+
 	// Routes are a collection of static routes that the router will host.
 	Routes []Route `json:"routes"`
 
-	// Availability zone hints groups network nodes that run services like DHCP, L3, FW, and others.
-	// Used to make network resources highly available.
+	// Availability zone candidates hints groups network nodes that run
+	// services like DHCP, L3, FW, and others. Used to make network
+	// resources highly available. It is available when
+	// router_availability_zone extension is enabled.
 	AvailabilityZoneHints []string `json:"availability_zone_hints"`
+
+	// AvailabilityZones for the router. It is available when
+	// router_availability_zone extension is enabled.
+	AvailabilityZones []string `json:"availability_zones"`
 
 	// Tags optionally set via extensions/attributestags
 	Tags []string `json:"tags"`


### PR DESCRIPTION
Add new extension fields. Not sure if to put them as separate extensions, since other extension fields like `distributed` or `availability_zone_hints` were already implemented directly inside the routers package.

Likewise in #3424, if user doesn't specify these parameters, they won't be sent to API. Therefore from my perspective it is safe to keep them here, otherwise the consumer code complexity will be increased.