### PR TITLE
neutron: allow omission of subnet_id for IP address

### DIFF
--- a/openstack/networking/v2/extensions/layer3/routers/results.go
+++ b/openstack/networking/v2/extensions/layer3/routers/results.go
@@ -21,7 +21,7 @@ type GatewayInfo struct {
 // router.
 type ExternalFixedIP struct {
 	IPAddress string `json:"ip_address,omitempty"`
-	SubnetID  string `json:"subnet_id"`
+	SubnetID  string `json:"subnet_id,omitempty"`
 }
 
 // Route is a possible route in a router.

--- a/openstack/networking/v2/ports/results.go
+++ b/openstack/networking/v2/ports/results.go
@@ -49,7 +49,7 @@ type DeleteResult struct {
 
 // IP is a sub-struct that represents an individual IP.
 type IP struct {
-	SubnetID  string `json:"subnet_id"`
+	SubnetID  string `json:"subnet_id,omitempty"`
 	IPAddress string `json:"ip_address,omitempty"`
 }
 


### PR DESCRIPTION
I could not find any docs about `external_fixed_ip` struct to support omitted `subnet_id`, but I created test case in terraform provider and it works as expected, see https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1915

As for the port's `subnet_id`, the omission behavior is documented [here](https://docs.openstack.org/api-ref/network/v2/#create-port):

> The IP addresses for the port. If you would like to assign multiple IP addresses for the port, specify multiple entries in this field. Each entry consists of IP address (ip_address) and the subnet ID from which the IP address is assigned (subnet_id).
> If you specify both a subnet ID and an IP address, OpenStack Networking tries to allocate the IP address on that subnet to the port.
> If you specify only a subnet ID, OpenStack Networking allocates an available IP from that subnet to the port.
> If you specify only an IP address, OpenStack Networking tries to allocate the IP address if the address is a valid IP for any of the subnets on the specified network.