### PR TITLE
Fix pagination for messaging client

### DIFF
--- a/openstack/messaging/v2/messages/requests.go
+++ b/openstack/messaging/v2/messages/requests.go
@@ -48,7 +48,10 @@ func List(client *gophercloud.ServiceClient, queueName string, opts ListOptsBuil
 	}
 
 	pager := pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
-		return MessagePage{pagination.LinkedPageBase{PageResult: r}}
+		return MessagePage{
+			serviceURL:     client.ServiceURL(),
+			LinkedPageBase: pagination.LinkedPageBase{PageResult: r},
+		}
 	})
 	return pager
 }

--- a/openstack/messaging/v2/messages/results.go
+++ b/openstack/messaging/v2/messages/results.go
@@ -12,6 +12,7 @@ type CreateResult struct {
 
 // MessagePage contains a single page of all clusters from a ListDetails call.
 type MessagePage struct {
+	serviceURL string
 	pagination.LinkedPageBase
 }
 
@@ -127,5 +128,5 @@ func (r MessagePage) NextPageURL() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return nextPageURL(r.String(), next)
+	return nextPageURL(r.serviceURL, next)
 }

--- a/openstack/messaging/v2/messages/urls.go
+++ b/openstack/messaging/v2/messages/urls.go
@@ -35,9 +35,9 @@ func messageURL(client *gophercloud.ServiceClient, queueName string, messageID s
 	return client.ServiceURL(apiVersion, apiName, queueName, "messages", messageID)
 }
 
-// Builds next page full url based on current url.
-func nextPageURL(currentURL string, next string) (string, error) {
-	base, err := url.Parse(currentURL)
+// builds next page full url based on service endpoint
+func nextPageURL(serviceURL, next string) (string, error) {
+	base, err := url.Parse(serviceURL)
 	if err != nil {
 		return "", err
 	}
@@ -45,5 +45,7 @@ func nextPageURL(currentURL string, next string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return base.ResolveReference(rel).String(), nil
+	combined := base.JoinPath(rel.Path)
+	combined.RawQuery = rel.RawQuery
+	return combined.String(), nil
 }

--- a/openstack/messaging/v2/queues/requests.go
+++ b/openstack/messaging/v2/queues/requests.go
@@ -49,7 +49,10 @@ func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pa
 	}
 
 	pager := pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
-		return QueuePage{pagination.LinkedPageBase{PageResult: r}}
+		return QueuePage{
+			serviceURL:     client.ServiceURL(),
+			LinkedPageBase: pagination.LinkedPageBase{PageResult: r},
+		}
 
 	})
 	return pager

--- a/openstack/messaging/v2/queues/results.go
+++ b/openstack/messaging/v2/queues/results.go
@@ -14,6 +14,7 @@ type commonResult struct {
 
 // QueuePage contains a single page of all queues from a List operation.
 type QueuePage struct {
+	serviceURL string
 	pagination.LinkedPageBase
 }
 
@@ -173,7 +174,7 @@ func (r QueuePage) NextPageURL() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return nextPageURL(r.String(), next)
+	return nextPageURL(r.serviceURL, next)
 }
 
 // GetCount value if it request was supplied `WithCount` param

--- a/openstack/messaging/v2/queues/urls.go
+++ b/openstack/messaging/v2/queues/urls.go
@@ -47,9 +47,9 @@ func purgeURL(client *gophercloud.ServiceClient, queueName string) string {
 	return client.ServiceURL(apiVersion, apiName, queueName, "purge")
 }
 
-// builds next page full url based on current url
-func nextPageURL(currentURL string, next string) (string, error) {
-	base, err := url.Parse(currentURL)
+// builds next page full url based on service endpoint
+func nextPageURL(serviceURL string, next string) (string, error) {
+	base, err := url.Parse(serviceURL)
 	if err != nil {
 		return "", err
 	}
@@ -57,5 +57,7 @@ func nextPageURL(currentURL string, next string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return base.ResolveReference(rel).String(), nil
+	combined := base.JoinPath(rel.Path)
+	combined.RawQuery = rel.RawQuery
+	return combined.String(), nil
 }


### PR DESCRIPTION
<!--
Prior to starting a PR, please make sure you have read our
[contributor tutorial](https://github.com/gophercloud/gophercloud/tree/main/docs/contributor-tutorial).

Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

-->
Fixes #3336

Zaqar returns paths rather than URLs in `links` response fields and the `Location` header. In addition, since Dalmatian, it deploys under a path (`/messaging`) rather then behind a port. This combination has highlighted a bug in our pagination page handling, namely that we are ignoring the path element of the endpoint URL. While this is not an issue when the `next` link is an absolute URL, as with most other services, it results in incomplete URLs when the link URL is relative (`/v2/messages`) and the endpoint URL contains a path (`https://example.com/messaging`).

Fix this by concatenating the two paths, rather than overwriting the endpoint URLs path.
