### PR TITLE
Always pass endpoint URL when paginating

### DIFF
--- a/openstack/baremetal/v1/allocations/results.go
+++ b/openstack/baremetal/v1/allocations/results.go
@@ -81,7 +81,7 @@ func (r AllocationPage) IsEmpty() (bool, error) {
 
 // NextPageURL uses the response's embedded link reference to navigate to the
 // next page of results.
-func (r AllocationPage) NextPageURL() (string, error) {
+func (r AllocationPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links []gophercloud.Link `json:"allocations_links"`
 	}

--- a/openstack/baremetal/v1/conductors/results.go
+++ b/openstack/baremetal/v1/conductors/results.go
@@ -67,7 +67,7 @@ func (r ConductorPage) IsEmpty() (bool, error) {
 
 // NextPageURL uses the response's embedded link reference to navigate to the
 // next page of results.
-func (r ConductorPage) NextPageURL() (string, error) {
+func (r ConductorPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links []gophercloud.Link `json:"conductor_links"`
 	}

--- a/openstack/baremetal/v1/drivers/results.go
+++ b/openstack/baremetal/v1/drivers/results.go
@@ -151,7 +151,7 @@ func (r DriverPage) IsEmpty() (bool, error) {
 
 // NextPageURL uses the response's embedded link reference to navigate to the
 // next page of results.
-func (r DriverPage) NextPageURL() (string, error) {
+func (r DriverPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links []gophercloud.Link `json:"drivers_links"`
 	}

--- a/openstack/baremetal/v1/nodes/results.go
+++ b/openstack/baremetal/v1/nodes/results.go
@@ -340,7 +340,7 @@ func (r NodePage) IsEmpty() (bool, error) {
 
 // NextPageURL uses the response's embedded link reference to navigate to the
 // next page of results.
-func (r NodePage) NextPageURL() (string, error) {
+func (r NodePage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links []gophercloud.Link `json:"nodes_links"`
 	}

--- a/openstack/baremetal/v1/portgroups/results.go
+++ b/openstack/baremetal/v1/portgroups/results.go
@@ -95,7 +95,7 @@ func (r PortGroupsPage) IsEmpty() (bool, error) {
 
 // NextPageURL uses the response's embedded link reference to navigate to the
 // next page of results.
-func (r PortGroupsPage) NextPageURL() (string, error) {
+func (r PortGroupsPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links []gophercloud.Link `json:"portgroups_links"`
 	}

--- a/openstack/baremetal/v1/ports/results.go
+++ b/openstack/baremetal/v1/ports/results.go
@@ -92,7 +92,7 @@ func (r PortPage) IsEmpty() (bool, error) {
 
 // NextPageURL uses the response's embedded link reference to navigate to the
 // next page of results.
-func (r PortPage) NextPageURL() (string, error) {
+func (r PortPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links []gophercloud.Link `json:"ports_links"`
 	}

--- a/openstack/baremetalintrospection/v1/introspection/results.go
+++ b/openstack/baremetalintrospection/v1/introspection/results.go
@@ -83,7 +83,7 @@ func (r IntrospectionPage) IsEmpty() (bool, error) {
 
 // NextPageURL uses the response's embedded link reference to navigate to the
 // next page of results.
-func (r IntrospectionPage) NextPageURL() (string, error) {
+func (r IntrospectionPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links []gophercloud.Link `json:"introspection_links"`
 	}

--- a/openstack/blockstorage/v2/backups/results.go
+++ b/openstack/blockstorage/v2/backups/results.go
@@ -121,7 +121,7 @@ func (r BackupPage) IsEmpty() (bool, error) {
 	return len(volumes) == 0, err
 }
 
-func (page BackupPage) NextPageURL() (string, error) {
+func (page BackupPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links []gophercloud.Link `json:"backups_links"`
 	}

--- a/openstack/blockstorage/v2/transfers/results.go
+++ b/openstack/blockstorage/v2/transfers/results.go
@@ -94,7 +94,7 @@ func (r TransferPage) IsEmpty() (bool, error) {
 	return len(transfers) == 0, err
 }
 
-func (page TransferPage) NextPageURL() (string, error) {
+func (page TransferPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links []gophercloud.Link `json:"transfers_links"`
 	}

--- a/openstack/blockstorage/v2/volumes/results.go
+++ b/openstack/blockstorage/v2/volumes/results.go
@@ -117,7 +117,7 @@ func (r VolumePage) IsEmpty() (bool, error) {
 
 // NextPageURL uses the response's embedded link reference to navigate to the
 // next page of results.
-func (r VolumePage) NextPageURL() (string, error) {
+func (r VolumePage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links []gophercloud.Link `json:"volumes_links"`
 	}

--- a/openstack/blockstorage/v3/backups/results.go
+++ b/openstack/blockstorage/v3/backups/results.go
@@ -121,7 +121,7 @@ func (r BackupPage) IsEmpty() (bool, error) {
 	return len(volumes) == 0, err
 }
 
-func (page BackupPage) NextPageURL() (string, error) {
+func (page BackupPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links []gophercloud.Link `json:"backups_links"`
 	}

--- a/openstack/blockstorage/v3/qos/results.go
+++ b/openstack/blockstorage/v3/qos/results.go
@@ -59,7 +59,7 @@ func (page QoSPage) IsEmpty() (bool, error) {
 
 // NextPageURL uses the response's embedded link reference to navigate to the
 // next page of results.
-func (page QoSPage) NextPageURL() (string, error) {
+func (page QoSPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links []gophercloud.Link `json:"qos_specs_links"`
 	}

--- a/openstack/blockstorage/v3/snapshots/results.go
+++ b/openstack/blockstorage/v3/snapshots/results.go
@@ -110,7 +110,7 @@ func (r SnapshotPage) IsEmpty() (bool, error) {
 
 // NextPageURL uses the response's embedded link reference to navigate to the
 // next page of results.
-func (r SnapshotPage) NextPageURL() (string, error) {
+func (r SnapshotPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links []gophercloud.Link `json:"snapshots_links"`
 	}

--- a/openstack/blockstorage/v3/transfers/results.go
+++ b/openstack/blockstorage/v3/transfers/results.go
@@ -94,7 +94,7 @@ func (r TransferPage) IsEmpty() (bool, error) {
 	return len(transfers) == 0, err
 }
 
-func (page TransferPage) NextPageURL() (string, error) {
+func (page TransferPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links []gophercloud.Link `json:"transfers_links"`
 	}

--- a/openstack/blockstorage/v3/volumes/results.go
+++ b/openstack/blockstorage/v3/volumes/results.go
@@ -123,7 +123,7 @@ func (r VolumePage) IsEmpty() (bool, error) {
 	return len(volumes) == 0, err
 }
 
-func (page VolumePage) NextPageURL() (string, error) {
+func (page VolumePage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links []gophercloud.Link `json:"volumes_links"`
 	}

--- a/openstack/blockstorage/v3/volumetypes/results.go
+++ b/openstack/blockstorage/v3/volumetypes/results.go
@@ -38,7 +38,7 @@ func (r VolumeTypePage) IsEmpty() (bool, error) {
 	return len(volumetypes) == 0, err
 }
 
-func (page VolumeTypePage) NextPageURL() (string, error) {
+func (page VolumeTypePage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links []gophercloud.Link `json:"volume_type_links"`
 	}

--- a/openstack/compute/v2/flavors/results.go
+++ b/openstack/compute/v2/flavors/results.go
@@ -137,7 +137,7 @@ func (page FlavorPage) IsEmpty() (bool, error) {
 
 // NextPageURL uses the response's embedded link reference to navigate to the
 // next page of results.
-func (page FlavorPage) NextPageURL() (string, error) {
+func (page FlavorPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links []gophercloud.Link `json:"flavors_links"`
 	}

--- a/openstack/compute/v2/hypervisors/results.go
+++ b/openstack/compute/v2/hypervisors/results.go
@@ -255,7 +255,7 @@ func (page HypervisorPage) IsEmpty() (bool, error) {
 
 // NextPageURL uses the response's embedded link reference to navigate to the
 // next page of results.
-func (page HypervisorPage) NextPageURL() (string, error) {
+func (page HypervisorPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links []gophercloud.Link `json:"hypervisors_links"`
 	}

--- a/openstack/compute/v2/servers/results.go
+++ b/openstack/compute/v2/servers/results.go
@@ -387,7 +387,7 @@ func (r ServerPage) IsEmpty() (bool, error) {
 
 // NextPageURL uses the response's embedded link reference to navigate to the
 // next page of results.
-func (r ServerPage) NextPageURL() (string, error) {
+func (r ServerPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links []gophercloud.Link `json:"servers_links"`
 	}

--- a/openstack/compute/v2/usage/results.go
+++ b/openstack/compute/v2/usage/results.go
@@ -132,7 +132,7 @@ func (r SingleTenantPage) IsEmpty() (bool, error) {
 
 // NextPageURL uses the response's embedded link reference to navigate to the
 // next page of results.
-func (r SingleTenantPage) NextPageURL() (string, error) {
+func (r SingleTenantPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links []gophercloud.Link `json:"tenant_usage_links"`
 	}
@@ -179,7 +179,7 @@ func (r AllTenantsPage) IsEmpty() (bool, error) {
 
 // NextPageURL uses the response's embedded link reference to navigate to the
 // next page of results.
-func (r AllTenantsPage) NextPageURL() (string, error) {
+func (r AllTenantsPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links []gophercloud.Link `json:"tenant_usages_links"`
 	}

--- a/openstack/container/v1/capsules/results.go
+++ b/openstack/container/v1/capsules/results.go
@@ -228,7 +228,7 @@ type Address struct {
 // NextPageURL is invoked when a paginated collection of capsules has reached
 // the end of a page and the pager seeks to traverse over a new one. In order
 // to do this, it needs to construct the next page's URL.
-func (r CapsulePage) NextPageURL() (string, error) {
+func (r CapsulePage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Next string `json:"next"`
 	}

--- a/openstack/containerinfra/v1/clusters/results.go
+++ b/openstack/containerinfra/v1/clusters/results.go
@@ -123,7 +123,7 @@ type ClusterPage struct {
 	pagination.LinkedPageBase
 }
 
-func (r ClusterPage) NextPageURL() (string, error) {
+func (r ClusterPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Next string `json:"next"`
 	}

--- a/openstack/containerinfra/v1/clustertemplates/results.go
+++ b/openstack/containerinfra/v1/clustertemplates/results.go
@@ -86,7 +86,7 @@ type ClusterTemplatePage struct {
 // NextPageURL is invoked when a paginated collection of cluster template has reached
 // the end of a page and the pager seeks to traverse over a new one. In order
 // to do this, it needs to construct the next page's URL.
-func (r ClusterTemplatePage) NextPageURL() (string, error) {
+func (r ClusterTemplatePage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Next string `json:"next"`
 	}

--- a/openstack/containerinfra/v1/nodegroups/results.go
+++ b/openstack/containerinfra/v1/nodegroups/results.go
@@ -74,7 +74,7 @@ type NodeGroupPage struct {
 	pagination.LinkedPageBase
 }
 
-func (r NodeGroupPage) NextPageURL() (string, error) {
+func (r NodeGroupPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Next string `json:"next"`
 	}

--- a/openstack/db/v1/databases/results.go
+++ b/openstack/db/v1/databases/results.go
@@ -44,7 +44,7 @@ func (page DBPage) IsEmpty() (bool, error) {
 }
 
 // NextPageURL will retrieve the next page URL.
-func (page DBPage) NextPageURL() (string, error) {
+func (page DBPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links []gophercloud.Link `json:"databases_links"`
 	}

--- a/openstack/db/v1/flavors/results.go
+++ b/openstack/db/v1/flavors/results.go
@@ -54,7 +54,7 @@ func (page FlavorPage) IsEmpty() (bool, error) {
 }
 
 // NextPageURL uses the response's embedded link reference to navigate to the next page of results.
-func (page FlavorPage) NextPageURL() (string, error) {
+func (page FlavorPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links []gophercloud.Link `json:"flavors_links"`
 	}

--- a/openstack/db/v1/instances/results.go
+++ b/openstack/db/v1/instances/results.go
@@ -182,7 +182,7 @@ func (page InstancePage) IsEmpty() (bool, error) {
 }
 
 // NextPageURL will retrieve the next page URL.
-func (page InstancePage) NextPageURL() (string, error) {
+func (page InstancePage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links []gophercloud.Link `json:"instances_links"`
 	}

--- a/openstack/db/v1/users/results.go
+++ b/openstack/db/v1/users/results.go
@@ -44,7 +44,7 @@ func (page UserPage) IsEmpty() (bool, error) {
 }
 
 // NextPageURL will retrieve the next page URL.
-func (page UserPage) NextPageURL() (string, error) {
+func (page UserPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links []gophercloud.Link `json:"users_links"`
 	}

--- a/openstack/dns/v2/recordsets/testing/requests_test.go
+++ b/openstack/dns/v2/recordsets/testing/requests_test.go
@@ -82,7 +82,7 @@ func TestNextPageURL(t *testing.T) {
 	}
 	page.Body = body
 	expected := "http://127.0.0.1:9001/v2/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets?limit=1&marker=f7b10e9b-0cae-4a91-b162-562bc6096648"
-	actual, err := page.NextPageURL()
+	actual, err := page.NextPageURL("http://127.0.0.1:9001")
 	th.AssertNoErr(t, err)
 	th.CheckEquals(t, expected, actual)
 }

--- a/openstack/identity/v2/tenants/results.go
+++ b/openstack/identity/v2/tenants/results.go
@@ -36,7 +36,7 @@ func (r TenantPage) IsEmpty() (bool, error) {
 }
 
 // NextPageURL extracts the "next" link from the tenants_links section of the result.
-func (r TenantPage) NextPageURL() (string, error) {
+func (r TenantPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links []gophercloud.Link `json:"tenants_links"`
 	}

--- a/openstack/identity/v3/applicationcredentials/results.go
+++ b/openstack/identity/v3/applicationcredentials/results.go
@@ -114,7 +114,7 @@ func (r ApplicationCredentialPage) IsEmpty() (bool, error) {
 }
 
 // NextPageURL extracts the "next" link from the links section of the result.
-func (r ApplicationCredentialPage) NextPageURL() (string, error) {
+func (r ApplicationCredentialPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links struct {
 			Next     string `json:"next"`
@@ -168,7 +168,7 @@ func (r AccessRulePage) IsEmpty() (bool, error) {
 }
 
 // NextPageURL extracts the "next" link from the links section of the result.
-func (r AccessRulePage) NextPageURL() (string, error) {
+func (r AccessRulePage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links struct {
 			Next     string `json:"next"`

--- a/openstack/identity/v3/credentials/results.go
+++ b/openstack/identity/v3/credentials/results.go
@@ -65,7 +65,7 @@ func (r CredentialPage) IsEmpty() (bool, error) {
 }
 
 // NextPageURL extracts the "next" link from the links section of the result.
-func (r CredentialPage) NextPageURL() (string, error) {
+func (r CredentialPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links struct {
 			Next     string `json:"next"`

--- a/openstack/identity/v3/domains/results.go
+++ b/openstack/identity/v3/domains/results.go
@@ -67,7 +67,7 @@ func (r DomainPage) IsEmpty() (bool, error) {
 }
 
 // NextPageURL extracts the "next" link from the links section of the result.
-func (r DomainPage) NextPageURL() (string, error) {
+func (r DomainPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links struct {
 			Next     string `json:"next"`

--- a/openstack/identity/v3/ec2credentials/results.go
+++ b/openstack/identity/v3/ec2credentials/results.go
@@ -59,7 +59,7 @@ func (r CredentialPage) IsEmpty() (bool, error) {
 }
 
 // NextPageURL extracts the "next" link from the links section of the result.
-func (r CredentialPage) NextPageURL() (string, error) {
+func (r CredentialPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links struct {
 			Next     string `json:"next"`

--- a/openstack/identity/v3/federation/results.go
+++ b/openstack/identity/v3/federation/results.go
@@ -184,7 +184,7 @@ func (c MappingsPage) IsEmpty() (bool, error) {
 }
 
 // NextPageURL extracts the "next" link from the links section of the result.
-func (c MappingsPage) NextPageURL() (string, error) {
+func (c MappingsPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links struct {
 			Next     string `json:"next"`

--- a/openstack/identity/v3/groups/results.go
+++ b/openstack/identity/v3/groups/results.go
@@ -102,7 +102,7 @@ func (r GroupPage) IsEmpty() (bool, error) {
 }
 
 // NextPageURL extracts the "next" link from the links section of the result.
-func (r GroupPage) NextPageURL() (string, error) {
+func (r GroupPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links struct {
 			Next     string `json:"next"`

--- a/openstack/identity/v3/limits/results.go
+++ b/openstack/identity/v3/limits/results.go
@@ -113,7 +113,7 @@ func (r LimitPage) IsEmpty() (bool, error) {
 }
 
 // NextPageURL extracts the "next" link from the links section of the result.
-func (r LimitPage) NextPageURL() (string, error) {
+func (r LimitPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links struct {
 			Next     string `json:"next"`

--- a/openstack/identity/v3/oauth1/results.go
+++ b/openstack/identity/v3/oauth1/results.go
@@ -61,7 +61,7 @@ func (c ConsumersPage) IsEmpty() (bool, error) {
 }
 
 // NextPageURL extracts the "next" link from the links section of the result.
-func (c ConsumersPage) NextPageURL() (string, error) {
+func (c ConsumersPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links struct {
 			Next     string `json:"next"`
@@ -221,7 +221,7 @@ func (r AccessTokensPage) IsEmpty() (bool, error) {
 }
 
 // NextPageURL extracts the "next" link from the links section of the result.
-func (r AccessTokensPage) NextPageURL() (string, error) {
+func (r AccessTokensPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links struct {
 			Next     string `json:"next"`
@@ -268,7 +268,7 @@ func (r AccessTokenRolesPage) IsEmpty() (bool, error) {
 }
 
 // NextPageURL extracts the "next" link from the links section of the result.
-func (r AccessTokenRolesPage) NextPageURL() (string, error) {
+func (r AccessTokenRolesPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links struct {
 			Next     string `json:"next"`

--- a/openstack/identity/v3/policies/results.go
+++ b/openstack/identity/v3/policies/results.go
@@ -100,7 +100,7 @@ func (r PolicyPage) IsEmpty() (bool, error) {
 }
 
 // NextPageURL extracts the "next" link from the links section of the result.
-func (r PolicyPage) NextPageURL() (string, error) {
+func (r PolicyPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links struct {
 			Next     string `json:"next"`

--- a/openstack/identity/v3/projects/results.go
+++ b/openstack/identity/v3/projects/results.go
@@ -122,7 +122,7 @@ func (r ProjectPage) IsEmpty() (bool, error) {
 }
 
 // NextPageURL extracts the "next" link from the links section of the result.
-func (r ProjectPage) NextPageURL() (string, error) {
+func (r ProjectPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links struct {
 			Next     string `json:"next"`

--- a/openstack/identity/v3/regions/results.go
+++ b/openstack/identity/v3/regions/results.go
@@ -99,7 +99,7 @@ func (r RegionPage) IsEmpty() (bool, error) {
 }
 
 // NextPageURL extracts the "next" link from the links section of the result.
-func (r RegionPage) NextPageURL() (string, error) {
+func (r RegionPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links struct {
 			Next     string `json:"next"`

--- a/openstack/identity/v3/registeredlimits/results.go
+++ b/openstack/identity/v3/registeredlimits/results.go
@@ -107,7 +107,7 @@ func (r RegisteredLimitPage) IsEmpty() (bool, error) {
 }
 
 // NextPageURL extracts the "next" link from the links section of the result.
-func (r RegisteredLimitPage) NextPageURL() (string, error) {
+func (r RegisteredLimitPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links struct {
 			Next     string `json:"next"`

--- a/openstack/identity/v3/roles/results.go
+++ b/openstack/identity/v3/roles/results.go
@@ -99,7 +99,7 @@ func (r RolePage) IsEmpty() (bool, error) {
 }
 
 // NextPageURL extracts the "next" link from the links section of the result.
-func (r RolePage) NextPageURL() (string, error) {
+func (r RolePage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links struct {
 			Next     string `json:"next"`
@@ -196,7 +196,7 @@ func (r RoleAssignmentPage) IsEmpty() (bool, error) {
 
 // NextPageURL uses the response's embedded link reference to navigate to
 // the next page of results.
-func (r RoleAssignmentPage) NextPageURL() (string, error) {
+func (r RoleAssignmentPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links struct {
 			Next string `json:"next"`

--- a/openstack/identity/v3/services/results.go
+++ b/openstack/identity/v3/services/results.go
@@ -109,7 +109,7 @@ func (p ServicePage) IsEmpty() (bool, error) {
 }
 
 // NextPageURL extracts the "next" link from the links section of the result.
-func (r ServicePage) NextPageURL() (string, error) {
+func (r ServicePage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links struct {
 			Next     string `json:"next"`

--- a/openstack/identity/v3/trusts/results.go
+++ b/openstack/identity/v3/trusts/results.go
@@ -45,7 +45,7 @@ func (t TrustPage) IsEmpty() (bool, error) {
 }
 
 // NextPageURL extracts the "next" link from the links section of the result.
-func (t TrustPage) NextPageURL() (string, error) {
+func (t TrustPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links struct {
 			Next     string `json:"next"`
@@ -122,7 +122,7 @@ func (r RolesPage) IsEmpty() (bool, error) {
 }
 
 // NextPageURL extracts the "next" link from the links section of the result.
-func (r RolesPage) NextPageURL() (string, error) {
+func (r RolesPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links struct {
 			Next     string `json:"next"`

--- a/openstack/identity/v3/users/results.go
+++ b/openstack/identity/v3/users/results.go
@@ -161,7 +161,7 @@ func (r UserPage) IsEmpty() (bool, error) {
 }
 
 // NextPageURL extracts the "next" link from the links section of the result.
-func (r UserPage) NextPageURL() (string, error) {
+func (r UserPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links struct {
 			Next     string `json:"next"`

--- a/openstack/image/v2/images/requests.go
+++ b/openstack/image/v2/images/requests.go
@@ -133,12 +133,7 @@ func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 		url += query
 	}
 	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
-		imagePage := ImagePage{
-			serviceURL:     c.ServiceURL(),
-			LinkedPageBase: pagination.LinkedPageBase{PageResult: r},
-		}
-
-		return imagePage
+		return ImagePage{pagination.LinkedPageBase{PageResult: r}}
 	})
 }
 

--- a/openstack/image/v2/images/results.go
+++ b/openstack/image/v2/images/results.go
@@ -198,7 +198,6 @@ type DeleteResult struct {
 
 // ImagePage represents the results of a List request.
 type ImagePage struct {
-	serviceURL string
 	pagination.LinkedPageBase
 }
 
@@ -227,7 +226,7 @@ func (r ImagePage) NextPageURL(endpointURL string) (string, error) {
 		return "", nil
 	}
 
-	return nextPageURL(r.serviceURL, s.Next)
+	return nextPageURL(endpointURL, s.Next)
 }
 
 // ExtractImages interprets the results of a single page from a List() call,

--- a/openstack/image/v2/images/results.go
+++ b/openstack/image/v2/images/results.go
@@ -214,7 +214,7 @@ func (r ImagePage) IsEmpty() (bool, error) {
 
 // NextPageURL uses the response's embedded link reference to navigate to
 // the next page of results.
-func (r ImagePage) NextPageURL() (string, error) {
+func (r ImagePage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Next string `json:"next"`
 	}

--- a/openstack/image/v2/images/urls.go
+++ b/openstack/image/v2/images/urls.go
@@ -40,8 +40,8 @@ func deleteURL(c *gophercloud.ServiceClient, imageID string) string {
 }
 
 // builds next page full url based on current url
-func nextPageURL(serviceURL, requestedNext string) (string, error) {
-	base, err := utils.BaseEndpoint(serviceURL)
+func nextPageURL(endpointURL, requestedNext string) (string, error) {
+	base, err := utils.BaseEndpoint(endpointURL)
 	if err != nil {
 		return "", err
 	}

--- a/openstack/image/v2/tasks/requests.go
+++ b/openstack/image/v2/tasks/requests.go
@@ -81,12 +81,7 @@ func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 		url += query
 	}
 	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
-		taskPage := TaskPage{
-			serviceURL:     c.ServiceURL(),
-			LinkedPageBase: pagination.LinkedPageBase{PageResult: r},
-		}
-
-		return taskPage
+		return TaskPage{pagination.LinkedPageBase{PageResult: r}}
 	})
 }
 

--- a/openstack/image/v2/tasks/results.go
+++ b/openstack/image/v2/tasks/results.go
@@ -75,7 +75,6 @@ func (r commonResult) Extract() (*Task, error) {
 
 // TaskPage represents the results of a List request.
 type TaskPage struct {
-	serviceURL string
 	pagination.LinkedPageBase
 }
 
@@ -104,7 +103,7 @@ func (r TaskPage) NextPageURL(endpointURL string) (string, error) {
 		return "", nil
 	}
 
-	return nextPageURL(r.serviceURL, s.Next)
+	return nextPageURL(endpointURL, s.Next)
 }
 
 // ExtractTasks interprets the results of a single page from a List() call,

--- a/openstack/image/v2/tasks/results.go
+++ b/openstack/image/v2/tasks/results.go
@@ -91,7 +91,7 @@ func (r TaskPage) IsEmpty() (bool, error) {
 
 // NextPageURL uses the response's embedded link reference to navigate to
 // the next page of results.
-func (r TaskPage) NextPageURL() (string, error) {
+func (r TaskPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Next string `json:"next"`
 	}

--- a/openstack/image/v2/tasks/urls.go
+++ b/openstack/image/v2/tasks/urls.go
@@ -30,8 +30,8 @@ func createURL(c *gophercloud.ServiceClient) string {
 	return rootURL(c)
 }
 
-func nextPageURL(serviceURL, requestedNext string) (string, error) {
-	base, err := utils.BaseEndpoint(serviceURL)
+func nextPageURL(endpointURL, requestedNext string) (string, error) {
+	base, err := utils.BaseEndpoint(endpointURL)
 	if err != nil {
 		return "", err
 	}

--- a/openstack/keymanager/v1/containers/results.go
+++ b/openstack/keymanager/v1/containers/results.go
@@ -117,7 +117,7 @@ func (r ContainerPage) IsEmpty() (bool, error) {
 }
 
 // NextPageURL extracts the "next" link from the links section of the result.
-func (r ContainerPage) NextPageURL() (string, error) {
+func (r ContainerPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Next     string `json:"next"`
 		Previous string `json:"previous"`
@@ -206,7 +206,7 @@ func (r ConsumerPage) IsEmpty() (bool, error) {
 }
 
 // NextPageURL extracts the "next" link from the links section of the result.
-func (r ConsumerPage) NextPageURL() (string, error) {
+func (r ConsumerPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Next     string `json:"next"`
 		Previous string `json:"previous"`

--- a/openstack/keymanager/v1/orders/results.go
+++ b/openstack/keymanager/v1/orders/results.go
@@ -144,7 +144,7 @@ func (r OrderPage) IsEmpty() (bool, error) {
 }
 
 // NextPageURL extracts the "next" link from the links section of the result.
-func (r OrderPage) NextPageURL() (string, error) {
+func (r OrderPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Next     string `json:"next"`
 		Previous string `json:"previous"`

--- a/openstack/keymanager/v1/secrets/results.go
+++ b/openstack/keymanager/v1/secrets/results.go
@@ -144,7 +144,7 @@ func (r SecretPage) IsEmpty() (bool, error) {
 }
 
 // NextPageURL extracts the "next" link from the links section of the result.
-func (r SecretPage) NextPageURL() (string, error) {
+func (r SecretPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Next     string `json:"next"`
 		Previous string `json:"previous"`

--- a/openstack/loadbalancer/v2/amphorae/results.go
+++ b/openstack/loadbalancer/v2/amphorae/results.go
@@ -100,7 +100,7 @@ type AmphoraPage struct {
 // NextPageURL is invoked when a paginated collection of amphoraes has
 // reached the end of a page and the pager seeks to traverse over a new one.
 // In order to do this, it needs to construct the next page's URL.
-func (r AmphoraPage) NextPageURL() (string, error) {
+func (r AmphoraPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links []gophercloud.Link `json:"amphorae_links"`
 	}

--- a/openstack/loadbalancer/v2/flavorprofiles/results.go
+++ b/openstack/loadbalancer/v2/flavorprofiles/results.go
@@ -29,7 +29,7 @@ type FlavorProfilePage struct {
 // NextPageURL is invoked when a paginated collection of flavor profiles has
 // reached the end of a page and the pager seeks to traverse over a new one.
 // In order to do this, it needs to construct the next page's URL.
-func (r FlavorProfilePage) NextPageURL() (string, error) {
+func (r FlavorProfilePage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links []gophercloud.Link `json:"flavorprofiles_links"`
 	}

--- a/openstack/loadbalancer/v2/flavors/results.go
+++ b/openstack/loadbalancer/v2/flavors/results.go
@@ -32,7 +32,7 @@ type FlavorPage struct {
 // NextPageURL is invoked when a paginated collection of flavors has
 // reached the end of a page and the pager seeks to traverse over a new one.
 // In order to do this, it needs to construct the next page's URL.
-func (r FlavorPage) NextPageURL() (string, error) {
+func (r FlavorPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links []gophercloud.Link `json:"flavors_links"`
 	}

--- a/openstack/loadbalancer/v2/l7policies/results.go
+++ b/openstack/loadbalancer/v2/l7policies/results.go
@@ -132,7 +132,7 @@ type L7PolicyPage struct {
 // NextPageURL is invoked when a paginated collection of l7policies has reached
 // the end of a page and the pager seeks to traverse over a new one. In order
 // to do this, it needs to construct the next page's URL.
-func (r L7PolicyPage) NextPageURL() (string, error) {
+func (r L7PolicyPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links []gophercloud.Link `json:"l7policies_links"`
 	}
@@ -210,7 +210,7 @@ type RulePage struct {
 // NextPageURL is invoked when a paginated collection of rules has reached
 // the end of a page and the pager seeks to traverse over a new one. In order
 // to do this, it needs to construct the next page's URL.
-func (r RulePage) NextPageURL() (string, error) {
+func (r RulePage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links []gophercloud.Link `json:"rules_links"`
 	}

--- a/openstack/loadbalancer/v2/listeners/results.go
+++ b/openstack/loadbalancer/v2/listeners/results.go
@@ -162,7 +162,7 @@ type ListenerPage struct {
 // NextPageURL is invoked when a paginated collection of listeners has reached
 // the end of a page and the pager seeks to traverse over a new one. In order
 // to do this, it needs to construct the next page's URL.
-func (r ListenerPage) NextPageURL() (string, error) {
+func (r ListenerPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links []gophercloud.Link `json:"listeners_links"`
 	}

--- a/openstack/loadbalancer/v2/loadbalancers/results.go
+++ b/openstack/loadbalancer/v2/loadbalancers/results.go
@@ -158,7 +158,7 @@ type LoadBalancerPage struct {
 // NextPageURL is invoked when a paginated collection of load balancers has
 // reached the end of a page and the pager seeks to traverse over a new one.
 // In order to do this, it needs to construct the next page's URL.
-func (r LoadBalancerPage) NextPageURL() (string, error) {
+func (r LoadBalancerPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links []gophercloud.Link `json:"loadbalancers_links"`
 	}

--- a/openstack/loadbalancer/v2/monitors/results.go
+++ b/openstack/loadbalancer/v2/monitors/results.go
@@ -128,7 +128,7 @@ type MonitorPage struct {
 // NextPageURL is invoked when a paginated collection of monitors has reached
 // the end of a page and the pager seeks to traverse over a new one. In order
 // to do this, it needs to construct the next page's URL.
-func (r MonitorPage) NextPageURL() (string, error) {
+func (r MonitorPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links []gophercloud.Link `json:"healthmonitors_links"`
 	}

--- a/openstack/loadbalancer/v2/pools/results.go
+++ b/openstack/loadbalancer/v2/pools/results.go
@@ -153,7 +153,7 @@ type PoolPage struct {
 // NextPageURL is invoked when a paginated collection of pools has reached
 // the end of a page and the pager seeks to traverse over a new one. In order
 // to do this, it needs to construct the next page's URL.
-func (r PoolPage) NextPageURL() (string, error) {
+func (r PoolPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links []gophercloud.Link `json:"pools_links"`
 	}
@@ -287,7 +287,7 @@ type MemberPage struct {
 // NextPageURL is invoked when a paginated collection of members has reached
 // the end of a page and the pager seeks to traverse over a new one. In order
 // to do this, it needs to construct the next page's URL.
-func (r MemberPage) NextPageURL() (string, error) {
+func (r MemberPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links []gophercloud.Link `json:"members_links"`
 	}

--- a/openstack/loadbalancer/v2/providers/results.go
+++ b/openstack/loadbalancer/v2/providers/results.go
@@ -23,7 +23,7 @@ type ProviderPage struct {
 // NextPageURL is invoked when a paginated collection of providers has
 // reached the end of a page and the pager seeks to traverse over a new one.
 // In order to do this, it needs to construct the next page's URL.
-func (r ProviderPage) NextPageURL() (string, error) {
+func (r ProviderPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links []gophercloud.Link `json:"providers_links"`
 	}

--- a/openstack/messaging/v2/messages/requests.go
+++ b/openstack/messaging/v2/messages/requests.go
@@ -48,10 +48,7 @@ func List(client *gophercloud.ServiceClient, queueName string, opts ListOptsBuil
 	}
 
 	pager := pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
-		return MessagePage{
-			serviceURL:     client.ServiceURL(),
-			LinkedPageBase: pagination.LinkedPageBase{PageResult: r},
-		}
+		return MessagePage{pagination.LinkedPageBase{PageResult: r}}
 	})
 	return pager
 }

--- a/openstack/messaging/v2/messages/results.go
+++ b/openstack/messaging/v2/messages/results.go
@@ -12,7 +12,6 @@ type CreateResult struct {
 
 // MessagePage contains a single page of all clusters from a ListDetails call.
 type MessagePage struct {
-	serviceURL string
 	pagination.LinkedPageBase
 }
 
@@ -128,5 +127,5 @@ func (r MessagePage) NextPageURL(endpointURL string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return nextPageURL(r.serviceURL, next)
+	return nextPageURL(endpointURL, next)
 }

--- a/openstack/messaging/v2/messages/results.go
+++ b/openstack/messaging/v2/messages/results.go
@@ -115,7 +115,7 @@ func (r MessagePage) IsEmpty() (bool, error) {
 
 // NextPageURL uses the response's embedded link reference to navigate to the
 // next page of results.
-func (r MessagePage) NextPageURL() (string, error) {
+func (r MessagePage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links []gophercloud.Link `json:"links"`
 	}

--- a/openstack/messaging/v2/messages/urls.go
+++ b/openstack/messaging/v2/messages/urls.go
@@ -36,8 +36,8 @@ func messageURL(client *gophercloud.ServiceClient, queueName string, messageID s
 }
 
 // builds next page full url based on service endpoint
-func nextPageURL(serviceURL, next string) (string, error) {
-	base, err := url.Parse(serviceURL)
+func nextPageURL(endpointURL, next string) (string, error) {
+	base, err := url.Parse(endpointURL)
 	if err != nil {
 		return "", err
 	}

--- a/openstack/messaging/v2/queues/requests.go
+++ b/openstack/messaging/v2/queues/requests.go
@@ -49,11 +49,7 @@ func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pa
 	}
 
 	pager := pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
-		return QueuePage{
-			serviceURL:     client.ServiceURL(),
-			LinkedPageBase: pagination.LinkedPageBase{PageResult: r},
-		}
-
+		return QueuePage{pagination.LinkedPageBase{PageResult: r}}
 	})
 	return pager
 }

--- a/openstack/messaging/v2/queues/results.go
+++ b/openstack/messaging/v2/queues/results.go
@@ -161,7 +161,7 @@ func (r QueuePage) IsEmpty() (bool, error) {
 
 // NextPageURL uses the response's embedded link reference to navigate to the
 // next page of results.
-func (r QueuePage) NextPageURL() (string, error) {
+func (r QueuePage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links []gophercloud.Link `json:"links"`
 	}

--- a/openstack/messaging/v2/queues/results.go
+++ b/openstack/messaging/v2/queues/results.go
@@ -14,7 +14,6 @@ type commonResult struct {
 
 // QueuePage contains a single page of all queues from a List operation.
 type QueuePage struct {
-	serviceURL string
 	pagination.LinkedPageBase
 }
 
@@ -174,7 +173,7 @@ func (r QueuePage) NextPageURL(endpointURL string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return nextPageURL(r.serviceURL, next)
+	return nextPageURL(endpointURL, next)
 }
 
 // GetCount value if it request was supplied `WithCount` param

--- a/openstack/messaging/v2/queues/urls.go
+++ b/openstack/messaging/v2/queues/urls.go
@@ -48,8 +48,8 @@ func purgeURL(client *gophercloud.ServiceClient, queueName string) string {
 }
 
 // builds next page full url based on service endpoint
-func nextPageURL(serviceURL string, next string) (string, error) {
-	base, err := url.Parse(serviceURL)
+func nextPageURL(baseURL string, next string) (string, error) {
+	base, err := url.Parse(baseURL)
 	if err != nil {
 		return "", err
 	}

--- a/openstack/networking/v2/extensions/agents/results.go
+++ b/openstack/networking/v2/extensions/agents/results.go
@@ -147,7 +147,7 @@ type AgentPage struct {
 // NextPageURL is invoked when a paginated collection of agent has
 // reached the end of a page and the pager seeks to traverse over a new one.
 // In order to do this, it needs to construct the next page's URL.
-func (r AgentPage) NextPageURL() (string, error) {
+func (r AgentPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links []gophercloud.Link `json:"agents_links"`
 	}

--- a/openstack/networking/v2/extensions/bgpvpns/results.go
+++ b/openstack/networking/v2/extensions/bgpvpns/results.go
@@ -89,7 +89,7 @@ type BGPVPNPage struct {
 }
 
 // NextPageURL generates the URL for the page of results after this one.
-func (r BGPVPNPage) NextPageURL() (string, error) {
+func (r BGPVPNPage) NextPageURL(endpointURL string) (string, error) {
 	currentURL := r.URL
 	mark, err := r.Owner.LastMarker()
 	if err != nil {
@@ -207,7 +207,7 @@ type NetworkAssociationPage struct {
 }
 
 // NextPageURL generates the URL for the page of results after this one.
-func (r NetworkAssociationPage) NextPageURL() (string, error) {
+func (r NetworkAssociationPage) NextPageURL(endpointURL string) (string, error) {
 	currentURL := r.URL
 	mark, err := r.Owner.LastMarker()
 	if err != nil {
@@ -316,7 +316,7 @@ type RouterAssociationPage struct {
 }
 
 // NextPageURL generates the URL for the page of results after this one.
-func (r RouterAssociationPage) NextPageURL() (string, error) {
+func (r RouterAssociationPage) NextPageURL(endpointURL string) (string, error) {
 	currentURL := r.URL
 	mark, err := r.Owner.LastMarker()
 	if err != nil {
@@ -432,7 +432,7 @@ type PortAssociationPage struct {
 }
 
 // NextPageURL generates the URL for the page of results after this one.
-func (r PortAssociationPage) NextPageURL() (string, error) {
+func (r PortAssociationPage) NextPageURL(endpointURL string) (string, error) {
 	currentURL := r.URL
 	mark, err := r.Owner.LastMarker()
 	if err != nil {

--- a/openstack/networking/v2/extensions/fwaas_v2/groups/results.go
+++ b/openstack/networking/v2/extensions/fwaas_v2/groups/results.go
@@ -42,7 +42,7 @@ type GroupPage struct {
 // NextPageURL is invoked when a paginated collection of firewall groups has
 // reached the end of a page and the pager seeks to traverse over a new one.
 // In order to do this, it needs to construct the next page's URL.
-func (r GroupPage) NextPageURL() (string, error) {
+func (r GroupPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links []gophercloud.Link `json:"firewall_groups_links"`
 	}

--- a/openstack/networking/v2/extensions/fwaas_v2/policies/results.go
+++ b/openstack/networking/v2/extensions/fwaas_v2/policies/results.go
@@ -50,7 +50,7 @@ type PolicyPage struct {
 // NextPageURL is invoked when a paginated collection of firewall policies has
 // reached the end of a page and the pager seeks to traverse over a new one.
 // In order to do this, it needs to construct the next page's URL.
-func (r PolicyPage) NextPageURL() (string, error) {
+func (r PolicyPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links []gophercloud.Link `json:"firewall_policies_links"`
 	}

--- a/openstack/networking/v2/extensions/fwaas_v2/rules/results.go
+++ b/openstack/networking/v2/extensions/fwaas_v2/rules/results.go
@@ -33,7 +33,7 @@ type RulePage struct {
 // NextPageURL is invoked when a paginated collection of firewall rules has
 // reached the end of a page and the pager seeks to traverse over a new one.
 // In order to do this, it needs to construct the next page's URL.
-func (r RulePage) NextPageURL() (string, error) {
+func (r RulePage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links []gophercloud.Link `json:"firewall_rules_links"`
 	}

--- a/openstack/networking/v2/extensions/layer3/addressscopes/results.go
+++ b/openstack/networking/v2/extensions/layer3/addressscopes/results.go
@@ -71,7 +71,7 @@ type AddressScopePage struct {
 // NextPageURL is invoked when a paginated collection of address-scope has
 // reached the end of a page and the pager seeks to traverse over a new one.
 // In order to do this, it needs to construct the next page's URL.
-func (r AddressScopePage) NextPageURL() (string, error) {
+func (r AddressScopePage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links []gophercloud.Link `json:"address_scopes_links"`
 	}

--- a/openstack/networking/v2/extensions/layer3/floatingips/results.go
+++ b/openstack/networking/v2/extensions/layer3/floatingips/results.go
@@ -147,7 +147,7 @@ type FloatingIPPage struct {
 // NextPageURL is invoked when a paginated collection of floating IPs has
 // reached the end of a page and the pager seeks to traverse over a new one.
 // In order to do this, it needs to construct the next page's URL.
-func (r FloatingIPPage) NextPageURL() (string, error) {
+func (r FloatingIPPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links []gophercloud.Link `json:"floatingips_links"`
 	}

--- a/openstack/networking/v2/extensions/layer3/portforwarding/results.go
+++ b/openstack/networking/v2/extensions/layer3/portforwarding/results.go
@@ -79,7 +79,7 @@ type PortForwardingPage struct {
 // NextPageURL is invoked when a paginated collection of port forwardings has
 // reached the end of a page and the pager seeks to traverse over a new one.
 // In order to do this, it needs to construct the next page's URL.
-func (r PortForwardingPage) NextPageURL() (string, error) {
+func (r PortForwardingPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links []gophercloud.Link `json:"port_forwarding_links"`
 	}

--- a/openstack/networking/v2/extensions/layer3/routers/results.go
+++ b/openstack/networking/v2/extensions/layer3/routers/results.go
@@ -97,7 +97,7 @@ type RouterPage struct {
 // NextPageURL is invoked when a paginated collection of routers has reached
 // the end of a page and the pager seeks to traverse over a new one. In order
 // to do this, it needs to construct the next page's URL.
-func (r RouterPage) NextPageURL() (string, error) {
+func (r RouterPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links []gophercloud.Link `json:"routers_links"`
 	}

--- a/openstack/networking/v2/extensions/qos/policies/results.go
+++ b/openstack/networking/v2/extensions/qos/policies/results.go
@@ -97,7 +97,7 @@ type PolicyPage struct {
 // NextPageURL is invoked when a paginated collection of policies has reached
 // the end of a page and the pager seeks to traverse over a new one.
 // In order to do this, it needs to construct the next page's URL.
-func (r PolicyPage) NextPageURL() (string, error) {
+func (r PolicyPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links []gophercloud.Link `json:"policies_links"`
 	}

--- a/openstack/networking/v2/extensions/security/addressgroups/results.go
+++ b/openstack/networking/v2/extensions/security/addressgroups/results.go
@@ -33,7 +33,7 @@ type AddressGroupPage struct {
 // NextPageURL is invoked when a paginated collection of address groups has
 // reached the end of a page and the pager seeks to traverse over a new one. In
 // order to do this, it needs to construct the next page's URL.
-func (r AddressGroupPage) NextPageURL() (string, error) {
+func (r AddressGroupPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links []gophercloud.Link `json:"address_groups_links"`
 	}

--- a/openstack/networking/v2/extensions/security/groups/results.go
+++ b/openstack/networking/v2/extensions/security/groups/results.go
@@ -93,7 +93,7 @@ type SecGroupPage struct {
 // NextPageURL is invoked when a paginated collection of security groups has
 // reached the end of a page and the pager seeks to traverse over a new one. In
 // order to do this, it needs to construct the next page's URL.
-func (r SecGroupPage) NextPageURL() (string, error) {
+func (r SecGroupPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links []gophercloud.Link `json:"security_groups_links"`
 	}

--- a/openstack/networking/v2/extensions/security/rules/results.go
+++ b/openstack/networking/v2/extensions/security/rules/results.go
@@ -82,7 +82,7 @@ type SecGroupRulePage struct {
 // NextPageURL is invoked when a paginated collection of security group rules has
 // reached the end of a page and the pager seeks to traverse over a new one. In
 // order to do this, it needs to construct the next page's URL.
-func (r SecGroupRulePage) NextPageURL() (string, error) {
+func (r SecGroupRulePage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links []gophercloud.Link `json:"security_group_rules_links"`
 	}

--- a/openstack/networking/v2/extensions/subnetpools/results.go
+++ b/openstack/networking/v2/extensions/subnetpools/results.go
@@ -238,7 +238,7 @@ type SubnetPoolPage struct {
 // NextPageURL is invoked when a paginated collection of subnetpools has reached
 // the end of a page and the pager seeks to traverse over a new one.
 // In order to do this, it needs to construct the next page's URL.
-func (r SubnetPoolPage) NextPageURL() (string, error) {
+func (r SubnetPoolPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links []gophercloud.Link `json:"subnetpools_links"`
 	}

--- a/openstack/networking/v2/extensions/vpnaas/endpointgroups/results.go
+++ b/openstack/networking/v2/extensions/vpnaas/endpointgroups/results.go
@@ -51,7 +51,7 @@ type EndpointGroupPage struct {
 // NextPageURL is invoked when a paginated collection of Endpoint groups has
 // reached the end of a page and the pager seeks to traverse over a new one.
 // In order to do this, it needs to construct the next page's URL.
-func (r EndpointGroupPage) NextPageURL() (string, error) {
+func (r EndpointGroupPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links []gophercloud.Link `json:"endpoint_groups_links"`
 	}

--- a/openstack/networking/v2/extensions/vpnaas/ikepolicies/results.go
+++ b/openstack/networking/v2/extensions/vpnaas/ikepolicies/results.go
@@ -72,7 +72,7 @@ type PolicyPage struct {
 // NextPageURL is invoked when a paginated collection of IKE policies has
 // reached the end of a page and the pager seeks to traverse over a new one.
 // In order to do this, it needs to construct the next page's URL.
-func (r PolicyPage) NextPageURL() (string, error) {
+func (r PolicyPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links []gophercloud.Link `json:"ikepolicies_links"`
 	}

--- a/openstack/networking/v2/extensions/vpnaas/ipsecpolicies/results.go
+++ b/openstack/networking/v2/extensions/vpnaas/ipsecpolicies/results.go
@@ -91,7 +91,7 @@ type PolicyPage struct {
 // NextPageURL is invoked when a paginated collection of IPSec policies has
 // reached the end of a page and the pager seeks to traverse over a new one.
 // In order to do this, it needs to construct the next page's URL.
-func (r PolicyPage) NextPageURL() (string, error) {
+func (r PolicyPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links []gophercloud.Link `json:"ipsecpolicies_links"`
 	}

--- a/openstack/networking/v2/extensions/vpnaas/services/results.go
+++ b/openstack/networking/v2/extensions/vpnaas/services/results.go
@@ -59,7 +59,7 @@ type ServicePage struct {
 // NextPageURL is invoked when a paginated collection of VPN services has
 // reached the end of a page and the pager seeks to traverse over a new one.
 // In order to do this, it needs to construct the next page's URL.
-func (r ServicePage) NextPageURL() (string, error) {
+func (r ServicePage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links []gophercloud.Link `json:"vpnservices_links"`
 	}

--- a/openstack/networking/v2/extensions/vpnaas/siteconnections/results.go
+++ b/openstack/networking/v2/extensions/vpnaas/siteconnections/results.go
@@ -101,7 +101,7 @@ type ConnectionPage struct {
 // NextPageURL is invoked when a paginated collection of IPSec site connections has
 // reached the end of a page and the pager seeks to traverse over a new one.
 // In order to do this, it needs to construct the next page's URL.
-func (r ConnectionPage) NextPageURL() (string, error) {
+func (r ConnectionPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links []gophercloud.Link `json:"ipsec_site_connections_links"`
 	}

--- a/openstack/networking/v2/networks/results.go
+++ b/openstack/networking/v2/networks/results.go
@@ -142,7 +142,7 @@ type NetworkPage struct {
 // NextPageURL is invoked when a paginated collection of networks has reached
 // the end of a page and the pager seeks to traverse over a new one. In order
 // to do this, it needs to construct the next page's URL.
-func (r NetworkPage) NextPageURL() (string, error) {
+func (r NetworkPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links []gophercloud.Link `json:"networks_links"`
 	}

--- a/openstack/networking/v2/ports/results.go
+++ b/openstack/networking/v2/ports/results.go
@@ -171,7 +171,7 @@ type PortPage struct {
 // NextPageURL is invoked when a paginated collection of ports has reached
 // the end of a page and the pager seeks to traverse over a new one. In order
 // to do this, it needs to construct the next page's URL.
-func (r PortPage) NextPageURL() (string, error) {
+func (r PortPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links []gophercloud.Link `json:"ports_links"`
 	}

--- a/openstack/networking/v2/subnets/results.go
+++ b/openstack/networking/v2/subnets/results.go
@@ -144,7 +144,7 @@ type SubnetPage struct {
 // NextPageURL is invoked when a paginated collection of subnets has reached
 // the end of a page and the pager seeks to traverse over a new one. In order
 // to do this, it needs to construct the next page's URL.
-func (r SubnetPage) NextPageURL() (string, error) {
+func (r SubnetPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Links []gophercloud.Link `json:"subnets_links"`
 	}

--- a/openstack/sharedfilesystems/v2/replicas/results.go
+++ b/openstack/sharedfilesystems/v2/replicas/results.go
@@ -83,7 +83,7 @@ type ReplicaPage struct {
 }
 
 // NextPageURL generates the URL for the page of results after this one.
-func (r ReplicaPage) NextPageURL() (string, error) {
+func (r ReplicaPage) NextPageURL(endpointURL string) (string, error) {
 	currentURL := r.URL
 	mark, err := r.Owner.LastMarker()
 	if err != nil {

--- a/openstack/sharedfilesystems/v2/sharenetworks/results.go
+++ b/openstack/sharedfilesystems/v2/sharenetworks/results.go
@@ -70,7 +70,7 @@ type ShareNetworkPage struct {
 }
 
 // NextPageURL generates the URL for the page of results after this one.
-func (r ShareNetworkPage) NextPageURL() (string, error) {
+func (r ShareNetworkPage) NextPageURL(endpointURL string) (string, error) {
 	currentURL := r.URL
 	mark, err := r.Owner.LastMarker()
 	if err != nil {

--- a/openstack/sharedfilesystems/v2/shares/results.go
+++ b/openstack/sharedfilesystems/v2/shares/results.go
@@ -122,7 +122,7 @@ type SharePage struct {
 }
 
 // NextPageURL generates the URL for the page of results after this one.
-func (r SharePage) NextPageURL() (string, error) {
+func (r SharePage) NextPageURL(endpointURL string) (string, error) {
 	currentURL := r.URL
 	mark, err := r.Owner.LastMarker()
 	if err != nil {

--- a/openstack/sharedfilesystems/v2/sharetransfers/results.go
+++ b/openstack/sharedfilesystems/v2/sharetransfers/results.go
@@ -103,7 +103,7 @@ type TransferPage struct {
 }
 
 // NextPageURL generates the URL for the page of results after this one.
-func (r TransferPage) NextPageURL() (string, error) {
+func (r TransferPage) NextPageURL(endpointURL string) (string, error) {
 	currentURL := r.URL
 	mark, err := r.Owner.LastMarker()
 	if err != nil {

--- a/openstack/sharedfilesystems/v2/snapshots/results.go
+++ b/openstack/sharedfilesystems/v2/snapshots/results.go
@@ -81,7 +81,7 @@ type SnapshotPage struct {
 }
 
 // NextPageURL generates the URL for the page of results after this one.
-func (r SnapshotPage) NextPageURL() (string, error) {
+func (r SnapshotPage) NextPageURL(endpointURL string) (string, error) {
 	currentURL := r.URL
 	mark, err := r.Owner.LastMarker()
 	if err != nil {

--- a/openstack/workflow/v2/crontriggers/results.go
+++ b/openstack/workflow/v2/crontriggers/results.go
@@ -139,7 +139,7 @@ func (r CronTriggerPage) IsEmpty() (bool, error) {
 }
 
 // NextPageURL finds the next page URL in a page in order to navigate to the next page of results.
-func (r CronTriggerPage) NextPageURL() (string, error) {
+func (r CronTriggerPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Next string `json:"next"`
 	}

--- a/openstack/workflow/v2/executions/results.go
+++ b/openstack/workflow/v2/executions/results.go
@@ -141,7 +141,7 @@ func (r ExecutionPage) IsEmpty() (bool, error) {
 }
 
 // NextPageURL finds the next page URL in a page in order to navigate to the next page of results.
-func (r ExecutionPage) NextPageURL() (string, error) {
+func (r ExecutionPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Next string `json:"next"`
 	}

--- a/openstack/workflow/v2/workflows/results.go
+++ b/openstack/workflow/v2/workflows/results.go
@@ -115,7 +115,7 @@ func (r WorkflowPage) IsEmpty() (bool, error) {
 }
 
 // NextPageURL finds the next page URL in a page in order to navigate to the next page of results.
-func (r WorkflowPage) NextPageURL() (string, error) {
+func (r WorkflowPage) NextPageURL(endpointURL string) (string, error) {
 	var s struct {
 		Next string `json:"next"`
 	}

--- a/pagination/linked.go
+++ b/pagination/linked.go
@@ -21,7 +21,7 @@ type LinkedPageBase struct {
 // NextPageURL extracts the pagination structure from a JSON response and returns the "next" link, if one is present.
 // It assumes that the links are available in a "links" element of the top-level response object.
 // If this is not the case, override NextPageURL on your result type.
-func (current LinkedPageBase) NextPageURL() (string, error) {
+func (current LinkedPageBase) NextPageURL(endpointURL string) (string, error) {
 	var path []string
 	var key string
 

--- a/pagination/marker.go
+++ b/pagination/marker.go
@@ -25,7 +25,7 @@ type MarkerPageBase struct {
 }
 
 // NextPageURL generates the URL for the page of results after this one.
-func (current MarkerPageBase) NextPageURL() (string, error) {
+func (current MarkerPageBase) NextPageURL(endpointURL string) (string, error) {
 	currentURL := current.URL
 
 	mark, err := current.Owner.LastMarker()

--- a/pagination/pager.go
+++ b/pagination/pager.go
@@ -25,7 +25,7 @@ var (
 type Page interface {
 	// NextPageURL generates the URL for the page of data that follows this collection.
 	// Return "" if no such page exists.
-	NextPageURL() (string, error)
+	NextPageURL(endpointURL string) (string, error)
 
 	// IsEmpty returns true if this Page has no items in it.
 	IsEmpty() (bool, error)
@@ -123,7 +123,7 @@ func (p Pager) EachPage(ctx context.Context, handler func(context.Context, Page)
 			return nil
 		}
 
-		currentURL, err = currentPage.NextPageURL()
+		currentURL, err = currentPage.NextPageURL(p.client.ServiceURL())
 		if err != nil {
 			return err
 		}

--- a/pagination/single.go
+++ b/pagination/single.go
@@ -11,7 +11,7 @@ import (
 type SinglePageBase PageResult
 
 // NextPageURL always returns "" to indicate that there are no more pages to return.
-func (current SinglePageBase) NextPageURL() (string, error) {
+func (current SinglePageBase) NextPageURL(endpointURL string) (string, error) {
 	return "", nil
 }
 


### PR DESCRIPTION
As seen recently in https://github.com/gophercloud/gophercloud/pull/3456, sometimes we need access to the endpoint URL to build pagination URLs. Rather than doing this on a service-by-service basis, do it once globally.

This is likely a major version change so it should not go back to `v2`.
