### PR TITLE
[v2] tests: Fix TestVLANTransparentCRUD test

### DIFF
--- a/internal/acceptance/openstack/networking/v2/extensions/vlantransparent/vlantransparent.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/vlantransparent/vlantransparent.go
@@ -75,33 +75,3 @@ func CreateVLANTransparentNetwork(t *testing.T, client *gophercloud.ServiceClien
 
 	return &network, nil
 }
-
-// UpdateVLANTransparentNetwork will update a network with the
-// "vlan-transparent" extension. An error will be returned if the network could
-// not be updated.
-func UpdateVLANTransparentNetwork(t *testing.T, client *gophercloud.ServiceClient, networkID string) (*VLANTransparentNetwork, error) {
-	networkName := tools.RandomString("TESTACC-NEW-", 6)
-	networkUpdateOpts := networks.UpdateOpts{
-		Name: &networkName,
-	}
-
-	iFalse := false
-	updateOpts := vlantransparent.UpdateOptsExt{
-		UpdateOptsBuilder: &networkUpdateOpts,
-		VLANTransparent:   &iFalse,
-	}
-
-	t.Logf("Attempting to update a VLAN-transparent network: %s", networkID)
-
-	var network VLANTransparentNetwork
-	err := networks.Update(context.TODO(), client, networkID, updateOpts).ExtractInto(&network)
-	if err != nil {
-		return nil, err
-	}
-
-	t.Logf("Successfully updated the network.")
-
-	th.AssertEquals(t, networkName, network.Name)
-
-	return &network, nil
-}

--- a/internal/acceptance/openstack/networking/v2/extensions/vlantransparent/vlantransparent_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/vlantransparent/vlantransparent_test.go
@@ -25,11 +25,7 @@ func TestVLANTransparentCRUD(t *testing.T) {
 
 	tools.PrintResource(t, network)
 
-	// Update the created VLAN transparent network.
-	newNetwork, err := UpdateVLANTransparentNetwork(t, client, network.ID)
-	th.AssertNoErr(t, err)
-
-	tools.PrintResource(t, newNetwork)
+	// The vlan_transparent field is read-only so no update test
 
 	// Check that the created VLAN transparent network exists.
 	vlanTransparentNetworks, err := ListVLANTransparentNetworks(t, client)


### PR DESCRIPTION
The 'vlan-transparent' extension is now enabled by default [1]. This is highlighting a bug in the aforementioned test: namely, that we are trying to update an attribute which is read-only [2]. Remove the update step of the job and fix the test.

[1] https://github.com/openstack/neutron/commit/11ff4f2f981969cf56ffcafa0a2f9a8fe11eabce
[2] https://github.com/openstack/neutron-lib/blob/fd011c955dfae1072555c69b6ba742b85f041736/neutron_lib/api/definitions/vlantransparent.py#L49