### PR TITLE
tests: shorten GH-A job names

### DIFF
--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -17,13 +17,14 @@ jobs:
         language: [ 'go' ]
 
     steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
     - name: Setup Go
       uses: actions/setup-go@v5
       with:
-        go-version: "1.23"
-
-    - name: Checkout repository
-      uses: actions/checkout@v4
+        go-version-file: 'go.mod'
+        cache: true
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3

--- a/.github/workflows/functional-baremetal.yaml
+++ b/.github/workflows/functional-baremetal.yaml
@@ -36,7 +36,7 @@ jobs:
             ubuntu_version: "22.04"
             additional_services: ""
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
-    name: Deploy OpenStack ${{ matrix.name }} with Ironic and run baremetal acceptance tests
+    name: Ironic on OpenStack ${{ matrix.name }}
     steps:
       - name: Checkout Gophercloud
         uses: actions/checkout@v4
@@ -84,7 +84,8 @@ jobs:
       - name: Checkout go
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.23'
+          go-version-file: 'go.mod'
+          cache: true
       - name: Run Gophercloud acceptance tests
         run: |
           source ${{ github.workspace }}/script/stackenv

--- a/.github/workflows/functional-basic.yaml
+++ b/.github/workflows/functional-basic.yaml
@@ -31,7 +31,7 @@ jobs:
             ubuntu_version: "22.04"
             additional_services: ""
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
-    name: Deploy OpenStack ${{ matrix.name }} with defaults and run basic acceptance tests
+    name: basic tests on OpenStack ${{ matrix.name }}
     steps:
       - name: Checkout Gophercloud
         uses: actions/checkout@v4
@@ -43,7 +43,8 @@ jobs:
       - name: Checkout go
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.23'
+          go-version-file: 'go.mod'
+          cache: true
       - name: Run Gophercloud acceptance tests
         run: |
           source ${{ github.workspace }}/script/stackenv

--- a/.github/workflows/functional-blockstorage.yaml
+++ b/.github/workflows/functional-blockstorage.yaml
@@ -36,7 +36,7 @@ jobs:
             ubuntu_version: "22.04"
             additional_services: ""
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
-    name: Deploy OpenStack ${{ matrix.name }} with Cinder and run blockstorage acceptance tests
+    name: Cinder on OpenStack ${{ matrix.name }}
     steps:
       - name: Checkout Gophercloud
         uses: actions/checkout@v4
@@ -50,7 +50,8 @@ jobs:
       - name: Checkout go
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.23'
+          go-version-file: 'go.mod'
+          cache: true
       - name: Run Gophercloud acceptance tests
         run: |
           source ${{ github.workspace }}/script/stackenv

--- a/.github/workflows/functional-compute.yaml
+++ b/.github/workflows/functional-compute.yaml
@@ -36,7 +36,7 @@ jobs:
             ubuntu_version: "22.04"
             additional_services: ""
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
-    name: Deploy OpenStack ${{ matrix.name }} with Nova and run compute acceptance tests
+    name: Nova on OpenStack ${{ matrix.name }}
     steps:
       - name: Checkout Gophercloud
         uses: actions/checkout@v4
@@ -50,7 +50,8 @@ jobs:
       - name: Checkout go
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.23'
+          go-version-file: 'go.mod'
+          cache: true
       - name: Run Gophercloud acceptance tests
         run: |
           source ${{ github.workspace }}/script/stackenv

--- a/.github/workflows/functional-containerinfra.yaml
+++ b/.github/workflows/functional-containerinfra.yaml
@@ -60,7 +60,7 @@ jobs:
               MAGNUMCLIENT_BRANCH=stable/2024.1
             additional_services: ""
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
-    name: Deploy OpenStack ${{ matrix.name }} with Magnum and run containerinfra acceptance tests
+    name: Magnum on OpenStack ${{ matrix.name }}
     steps:
       - name: Checkout Gophercloud
         uses: actions/checkout@v4
@@ -80,7 +80,8 @@ jobs:
       - name: Checkout go
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.23'
+          go-version-file: 'go.mod'
+          cache: true
       - name: Run Gophercloud acceptance tests
         run: |
           source ${{ github.workspace }}/script/stackenv

--- a/.github/workflows/functional-dns.yaml
+++ b/.github/workflows/functional-dns.yaml
@@ -42,7 +42,7 @@ jobs:
             ubuntu_version: "22.04"
             additional_services: ""
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
-    name: Deploy OpenStack ${{ matrix.name }} with Designate and run dns acceptance tests
+    name: Designate on OpenStack ${{ matrix.name }}
     steps:
       - name: Checkout Gophercloud
         uses: actions/checkout@v4
@@ -58,7 +58,8 @@ jobs:
       - name: Checkout go
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.23'
+          go-version-file: 'go.mod'
+          cache: true
       - name: Run Gophercloud acceptance tests
         run: |
           source ${{ github.workspace }}/script/stackenv

--- a/.github/workflows/functional-fwaas_v2.yaml
+++ b/.github/workflows/functional-fwaas_v2.yaml
@@ -40,7 +40,7 @@ jobs:
             ubuntu_version: "22.04"
             additional_services: ""
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
-    name: Deploy OpenStack ${{ matrix.name }} with enabled FWaaS_v2 and run networking acceptance tests
+    name: FWaaS_v2 on OpenStack ${{ matrix.name }}
     steps:
       - name: Checkout Gophercloud
         uses: actions/checkout@v4
@@ -71,7 +71,8 @@ jobs:
       - name: Checkout go
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.23'
+          go-version-file: 'go.mod'
+          cache: true
       - name: Run Gophercloud acceptance tests
         run: |
           source ${{ github.workspace }}/script/stackenv

--- a/.github/workflows/functional-identity.yaml
+++ b/.github/workflows/functional-identity.yaml
@@ -36,7 +36,7 @@ jobs:
             ubuntu_version: "22.04"
             additional_services: ""
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
-    name: Deploy OpenStack ${{ matrix.name }} with Keystone and run identity acceptance tests
+    name: Keystone on OpenStack ${{ matrix.name }}
     steps:
       - name: Checkout Gophercloud
         uses: actions/checkout@v4
@@ -48,7 +48,8 @@ jobs:
       - name: Checkout go
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.23'
+          go-version-file: 'go.mod'
+          cache: true
       - name: Run Gophercloud acceptance tests
         run: |
           source ${{ github.workspace }}/script/stackenv

--- a/.github/workflows/functional-image.yaml
+++ b/.github/workflows/functional-image.yaml
@@ -36,7 +36,7 @@ jobs:
             ubuntu_version: "22.04"
             additional_services: ""
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
-    name: Deploy OpenStack ${{ matrix.name }} with Glance and run image acceptance tests
+    name: Glance on OpenStack ${{ matrix.name }}
     steps:
       - name: Checkout Gophercloud
         uses: actions/checkout@v4
@@ -48,7 +48,8 @@ jobs:
       - name: Checkout go
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.23'
+          go-version-file: 'go.mod'
+          cache: true
       - name: Run Gophercloud acceptance tests
         run: |
           source ${{ github.workspace }}/script/stackenv

--- a/.github/workflows/functional-keymanager.yaml
+++ b/.github/workflows/functional-keymanager.yaml
@@ -48,7 +48,7 @@ jobs:
             ubuntu_version: "22.04"
             additional_services: ""
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
-    name: Deploy OpenStack ${{ matrix.name }} with Barbican and run keymanager acceptance tests
+    name: Barbican on OpenStack ${{ matrix.name }}
     steps:
       - name: Checkout Gophercloud
         uses: actions/checkout@v4
@@ -64,7 +64,8 @@ jobs:
       - name: Checkout go
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.23'
+          go-version-file: 'go.mod'
+          cache: true
       - name: Run Gophercloud acceptance tests
         run: |
           source ${{ github.workspace }}/script/stackenv

--- a/.github/workflows/functional-loadbalancer.yaml
+++ b/.github/workflows/functional-loadbalancer.yaml
@@ -42,7 +42,7 @@ jobs:
             ubuntu_version: "22.04"
             additional_services: ""
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
-    name: Deploy OpenStack ${{ matrix.name }} with Octavia and run loadbalancer acceptance tests
+    name: Octavia on OpenStack ${{ matrix.name }}
     steps:
       - name: Checkout Gophercloud
         uses: actions/checkout@v4
@@ -59,7 +59,8 @@ jobs:
       - name: Checkout go
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.23'
+          go-version-file: 'go.mod'
+          cache: true
       - name: Run Gophercloud acceptance tests
         run: |
           source ${{ github.workspace }}/script/stackenv

--- a/.github/workflows/functional-messaging.yaml
+++ b/.github/workflows/functional-messaging.yaml
@@ -36,7 +36,7 @@ jobs:
             ubuntu_version: "22.04"
             additional_services: ""
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
-    name: Deploy OpenStack ${{ matrix.name }} with Zaqar and run messaging acceptance tests
+    name: Zaqar on OpenStack ${{ matrix.name }}
     steps:
       - name: Checkout Gophercloud
         uses: actions/checkout@v4
@@ -51,7 +51,8 @@ jobs:
       - name: Checkout go
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.23'
+          go-version-file: 'go.mod'
+          cache: true
       - name: Run Gophercloud acceptance tests
         run: |
           source ${{ github.workspace }}/script/stackenv

--- a/.github/workflows/functional-networking.yaml
+++ b/.github/workflows/functional-networking.yaml
@@ -36,7 +36,7 @@ jobs:
             ubuntu_version: "22.04"
             additional_services: ""
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
-    name: Deploy OpenStack ${{ matrix.name }} with Neutron and run networking acceptance tests
+    name: Neutron on OpenStack ${{ matrix.name }}
     steps:
       - name: Checkout Gophercloud
         uses: actions/checkout@v4
@@ -66,7 +66,8 @@ jobs:
       - name: Checkout go
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.23'
+          go-version-file: 'go.mod'
+          cache: true
       - name: Run Gophercloud acceptance tests
         run: |
           source ${{ github.workspace }}/script/stackenv

--- a/.github/workflows/functional-objectstorage.yaml
+++ b/.github/workflows/functional-objectstorage.yaml
@@ -36,7 +36,7 @@ jobs:
             ubuntu_version: "22.04"
             additional_services: ""
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
-    name: Deploy OpenStack ${{ matrix.name }} with Swift and run objectstorage acceptance tests
+    name: Swift on OpenStack ${{ matrix.name }}
     steps:
       - name: Checkout Gophercloud
         uses: actions/checkout@v4
@@ -54,7 +54,8 @@ jobs:
       - name: Checkout go
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.23'
+          go-version-file: 'go.mod'
+          cache: true
       - name: Run Gophercloud acceptance tests
         run: |
           source ${{ github.workspace }}/script/stackenv

--- a/.github/workflows/functional-orchestration.yaml
+++ b/.github/workflows/functional-orchestration.yaml
@@ -36,7 +36,7 @@ jobs:
             ubuntu_version: "22.04"
             additional_services: ""
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
-    name: Deploy OpenStack ${{ matrix.name }} with Heat and run orchestration acceptance tests
+    name: Heat on OpenStack ${{ matrix.name }}
     steps:
       - name: Checkout Gophercloud
         uses: actions/checkout@v4
@@ -50,7 +50,8 @@ jobs:
       - name: Checkout go
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.23'
+          go-version-file: 'go.mod'
+          cache: true
       - name: Run Gophercloud acceptance tests
         run: |
           source ${{ github.workspace }}/script/stackenv

--- a/.github/workflows/functional-placement.yaml
+++ b/.github/workflows/functional-placement.yaml
@@ -36,7 +36,7 @@ jobs:
             ubuntu_version: "22.04"
             additional_services: ""
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
-    name: Deploy OpenStack ${{ matrix.name }} with Placement and run placement acceptance tests
+    name: Placement on OpenStack ${{ matrix.name }}
     steps:
       - name: Checkout Gophercloud
         uses: actions/checkout@v4
@@ -48,7 +48,8 @@ jobs:
       - name: Checkout go
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.23'
+          go-version-file: 'go.mod'
+          cache: true
       - name: Run Gophercloud acceptance tests
         run: |
           source ${{ github.workspace }}/script/stackenv

--- a/.github/workflows/functional-sharedfilesystems.yaml
+++ b/.github/workflows/functional-sharedfilesystems.yaml
@@ -42,7 +42,7 @@ jobs:
             ubuntu_version: "22.04"
             additional_services: ""
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
-    name: Deploy OpenStack ${{ matrix.name }} with Manila and run sharedfilesystems acceptance tests
+    name: Manila on OpenStack ${{ matrix.name }}
     steps:
       - name: Checkout Gophercloud
         uses: actions/checkout@v4
@@ -72,7 +72,8 @@ jobs:
       - name: Checkout go
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.23'
+          go-version-file: 'go.mod'
+          cache: true
       - name: Run Gophercloud acceptance tests
         run: |
           source ${{ github.workspace }}/script/stackenv

--- a/.github/workflows/functional-workflow.yaml
+++ b/.github/workflows/functional-workflow.yaml
@@ -40,7 +40,7 @@ jobs:
             mistral_plugin_version: "stable/2024.1"
             additional_services: ""
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
-    name: Deploy OpenStack ${{ matrix.name }} with Mistral and run workflow acceptance tests
+    name: Mistral on Deploy OpenStack ${{ matrix.name }}
     steps:
       - name: Checkout Gophercloud
         uses: actions/checkout@v4
@@ -54,7 +54,8 @@ jobs:
       - name: Checkout go
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.23'
+          go-version-file: 'go.mod'
+          cache: true
       - name: Run Gophercloud acceptance tests
         run: |
           source ${{ github.workspace }}/script/stackenv

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -16,8 +16,6 @@ jobs:
       - name: Run linters
         run: |
           make lint
-      # TODO: Use 'go mod tidy -diff' instead once go 1.23 is out
-      # https://github.com/golang/go/issues/27005
       - name: Ensure go.mod is up-to-date
         run: |
-          if [ $(go mod tidy && git diff | wc -l) -gt 0 ]; then git diff && exit 1; fi
+          if [ $(go mod tidy -diff | wc -l) -gt 0 ]; then git diff && exit 1; fi

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -12,17 +12,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        go-version:
-          - "1.23.0"
-          - "1"
     steps:
       - name: Checkout Gophercloud
         uses: actions/checkout@v4
-      - name: Setup Go ${{ matrix.go-version }}
+      - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version-file: 'go.mod'
+          cache: true
       - name: Setup environment
         run: |
           # Changing into a different directory to avoid polluting go.sum with "go get"
@@ -37,7 +34,6 @@ jobs:
         uses: coverallsapp/github-action@v2
         with:
           file: cover.out
-          flag-name: Go-${{ matrix.go-version }}
           parallel: true
   finish:
     permissions:
@@ -50,4 +46,3 @@ jobs:
       uses: coverallsapp/github-action@v2
       with:
         parallel-finished: true
-        carryforward: Go-${{ join(matrix.go-version.*, '-') }}


### PR DESCRIPTION
and use go-version-file: 'go.mod' for go version source

before:

<img width="882" height="158" alt="Screenshot_20250718_121217" src="https://github.com/user-attachments/assets/d9f0a633-5c2a-4728-929f-afa0f8d164af" />

after:

<img width="882" height="120" alt="Screenshot_20250718_121239" src="https://github.com/user-attachments/assets/1814dc2d-df48-4759-824e-cb4edde6983d" />
