### PR TITLE
Change compute services UpdateOpts fields ForceDown to pointer

### DIFF
--- a/openstack/compute/v2/services/requests.go
+++ b/openstack/compute/v2/services/requests.go
@@ -67,7 +67,7 @@ type UpdateOpts struct {
 
 	// ForcedDown is a manual override to tell nova that the service in question
 	// has been fenced manually by the operations team.
-	ForcedDown bool `json:"forced_down,omitempty"`
+	ForcedDown *bool `json:"forced_down,omitempty"`
 }
 
 // ToServiceUpdateMap formats an UpdateOpts structure into a request body.

--- a/openstack/compute/v2/services/testing/fixtures_test.go
+++ b/openstack/compute/v2/services/testing/fixtures_test.go
@@ -238,11 +238,40 @@ const ServiceUpdate = `
 }
 `
 
+const ServiceUpdateForceDown = `
+{
+	"service":
+	{
+		"id": 1,
+		"binary": "nova-scheduler",
+		"disabled_reason": "test1",
+		"host": "host1",
+		"state": "up",
+		"status": "disabled",
+		"updated_at": "2012-10-29T13:42:02.000000",
+		"forced_down": true,
+		"zone": "internal"
+	}
+}
+`
+
 // FakeServiceUpdateBody represents the updated service
 var FakeServiceUpdateBody = services.Service{
 	Binary:         "nova-scheduler",
 	DisabledReason: "test1",
 	ForcedDown:     false,
+	Host:           "host1",
+	ID:             "1",
+	State:          "up",
+	Status:         "disabled",
+	UpdatedAt:      time.Date(2012, 10, 29, 13, 42, 2, 0, time.UTC),
+	Zone:           "internal",
+}
+
+var FakeServiceUpdateForceDownBody = services.Service{
+	Binary:         "nova-scheduler",
+	DisabledReason: "test1",
+	ForcedDown:     true,
 	Host:           "host1",
 	ID:             "1",
 	State:          "up",
@@ -284,6 +313,34 @@ func HandleUpdateSuccessfully(t *testing.T, fakeServer th.FakeServer) {
 		th.TestHeader(t, r, "Accept", "application/json")
 		th.TestHeader(t, r, "Content-Type", "application/json")
 		th.TestJSONRequest(t, r, `{"status": "disabled"}`)
+
+		fmt.Fprint(w, ServiceUpdate)
+	})
+}
+
+// HandleForceDownSuccessfully configures the test server to respond to a Update
+// request to a Compute server with Pike+ release.
+func HandleForceDownSuccessfully(t *testing.T, fakeServer th.FakeServer) {
+	fakeServer.Mux.HandleFunc("/os-services/fake-service-id", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestJSONRequest(t, r, `{"forced_down": true}`)
+
+		fmt.Fprint(w, ServiceUpdateForceDown)
+	})
+}
+
+// HandleDisableForceDownSuccessfully configures the test server to respond to a Update
+// request to a Compute server with Pike+ release.
+func HandleDisableForceDownSuccessfully(t *testing.T, fakeServer th.FakeServer) {
+	fakeServer.Mux.HandleFunc("/os-services/fake-service-id", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestJSONRequest(t, r, `{"forced_down": false}`)
 
 		fmt.Fprint(w, ServiceUpdate)
 	})

--- a/openstack/compute/v2/services/testing/requests_test.go
+++ b/openstack/compute/v2/services/testing/requests_test.go
@@ -92,6 +92,36 @@ func TestUpdateService(t *testing.T) {
 	th.CheckDeepEquals(t, FakeServiceUpdateBody, *actual)
 }
 
+func TestUpdateServiceForceDown(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	HandleForceDownSuccessfully(t, fakeServer)
+
+	client := client.ServiceClient(fakeServer)
+	trueVal := true
+	actual, err := services.Update(context.TODO(), client, "fake-service-id", services.UpdateOpts{ForcedDown: &trueVal}).Extract()
+	if err != nil {
+		t.Fatalf("Unexpected Update error: %v", err)
+	}
+
+	th.CheckDeepEquals(t, FakeServiceUpdateForceDownBody, *actual)
+}
+
+func TestUpdateServiceDisableForceDown(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	HandleDisableForceDownSuccessfully(t, fakeServer)
+
+	client := client.ServiceClient(fakeServer)
+	falseVal := false
+	actual, err := services.Update(context.TODO(), client, "fake-service-id", services.UpdateOpts{ForcedDown: &falseVal}).Extract()
+	if err != nil {
+		t.Fatalf("Unexpected Update error: %v", err)
+	}
+
+	th.CheckDeepEquals(t, FakeServiceUpdateBody, *actual)
+}
+
 func TestDeleteService(t *testing.T) {
 	fakeServer := th.SetupHTTP()
 	defer fakeServer.Teardown()


### PR DESCRIPTION
This follows the same pattern as in the rest of the code and uses a pointer to fix #3471 and allow the caller to unset a prior ForceDown.

This unfortunately changes though the API in a breaking way.

Fixes  #3471 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/nova/blob/master/nova/api/openstack/compute/services.py#L473-L479
