### PR TITLE
Implement update & delete traits on resource provider

### DIFF
--- a/openstack/placement/v1/resourceproviders/requests.go
+++ b/openstack/placement/v1/resourceproviders/requests.go
@@ -175,3 +175,38 @@ func GetTraits(ctx context.Context, client *gophercloud.ServiceClient, resourceP
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
+
+// UpdateTraitsOptsBuilder allows extensions to add additional parameters to the
+// UpdateTraits request.
+type UpdateTraitsOptsBuilder interface {
+	ToResourceProviderUpdateTraitsMap() (map[string]any, error)
+}
+
+// UpdateTraitsOpts represents options used to update traits of a resource provider.
+type UpdateTraitsOpts = ResourceProviderTraits
+
+// ToResourceProviderUpdateTraitsMap constructs a request body from UpdateTraitsOpts.
+func (opts UpdateTraitsOpts) ToResourceProviderUpdateTraitsMap() (map[string]any, error) {
+	return gophercloud.BuildRequestBody(opts, "")
+}
+
+func UpdateTraits(ctx context.Context, client *gophercloud.ServiceClient, resourceProviderID string, opts UpdateTraitsOptsBuilder) (r GetTraitsResult) {
+	b, err := opts.ToResourceProviderUpdateTraitsMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := client.Put(ctx, getResourceProviderTraitsURL(client, resourceProviderID), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+func DeleteTraits(ctx context.Context, client *gophercloud.ServiceClient, resourceProviderID string) (r DeleteResult) {
+	resp, err := client.Delete(ctx, getResourceProviderTraitsURL(client, resourceProviderID), &gophercloud.RequestOpts{
+		OkCodes: []int{204},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}

--- a/openstack/placement/v1/resourceproviders/testing/fixtures_test.go
+++ b/openstack/placement/v1/resourceproviders/testing/fixtures_test.go
@@ -387,3 +387,29 @@ func HandleResourceProviderGetTraits(t *testing.T, fakeServer th.FakeServer) {
 			fmt.Fprint(w, TraitsBody)
 		})
 }
+
+func HandleResourceProviderPutTraits(t *testing.T, fakeServer th.FakeServer) {
+	traitsTestUrl := fmt.Sprintf("/resource_providers/%s/traits", ResourceProviderTestID)
+
+	fakeServer.Mux.HandleFunc(traitsTestUrl,
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "PUT")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+
+			fmt.Fprint(w, TraitsBody)
+		})
+}
+
+func HandleResourceProviderDeleteTraits(t *testing.T, fakeServer th.FakeServer) {
+	traitsTestUrl := fmt.Sprintf("/resource_providers/%s/traits", ResourceProviderTestID)
+
+	fakeServer.Mux.HandleFunc(traitsTestUrl,
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "DELETE")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+			w.WriteHeader(http.StatusNoContent)
+		})
+}

--- a/openstack/placement/v1/resourceproviders/testing/requests_test.go
+++ b/openstack/placement/v1/resourceproviders/testing/requests_test.go
@@ -145,3 +145,25 @@ func TestGetResourceProvidersTraits(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.AssertDeepEquals(t, ExpectedTraits, *actual)
 }
+
+func TestUpdateResourceProvidersTraits(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	HandleResourceProviderPutTraits(t, fakeServer)
+
+	opts := resourceproviders.UpdateTraitsOpts(ExpectedTraits)
+	actual, err := resourceproviders.UpdateTraits(context.TODO(), client.ServiceClient(fakeServer), ResourceProviderTestID, opts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, ExpectedTraits, *actual)
+}
+
+func TestDeleteResourceProvidersTraits(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	HandleResourceProviderDeleteTraits(t, fakeServer)
+
+	err := resourceproviders.DeleteTraits(context.TODO(), client.ServiceClient(fakeServer), ResourceProviderTestID).ExtractErr()
+	th.AssertNoErr(t, err)
+}


### PR DESCRIPTION
This implements #2420.
The relevant server side code can be found here:
https://github.com/openstack/placement/blob/stable/2025.1/placement/handlers/trait.py#L216-L274

Fixes #2420.

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/placement/blob/stable/2025.1/placement/handlers/trait.py#L216-L274
