### PR TITLE
Fix incorrect ICMP field description in PortRangeMax comment

### DIFF
--- a/openstack/networking/v2/extensions/security/rules/requests.go
+++ b/openstack/networking/v2/extensions/security/rules/requests.go
@@ -125,7 +125,7 @@ type CreateOpts struct {
 
 	// The maximum port number in the range that is matched by the security group
 	// rule. The PortRangeMin attribute constrains the PortRangeMax attribute. If
-	// the protocol is ICMP, this value must be an ICMP type.
+	// the protocol is ICMP, this value must be an ICMP code.
 	PortRangeMax int `json:"port_range_max,omitempty"`
 
 	// The minimum port number in the range that is matched by the security group


### PR DESCRIPTION
This PR fixes a minor documentation issue in the PortRangeMax field of the security group rule. When the protocol is ICMP, this field actually represents the ICMP code, but the comment incorrectly stated it as the ICMP type. This change corrects that.