### PR TITLE
Closes #2321 - Fix TestRolesCRUD by including DomainID to TestRolesCRUD 

### DIFF
--- a/internal/acceptance/openstack/identity/v3/roles_test.go
+++ b/internal/acceptance/openstack/identity/v3/roles_test.go
@@ -58,7 +58,8 @@ func TestRolesCRUD(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	createOpts := roles.CreateOpts{
-		Name: "testrole",
+		Name:     "testrole",
+		DomainID: "default",
 		Extra: map[string]any{
 			"description": "test role description",
 		},
@@ -72,7 +73,9 @@ func TestRolesCRUD(t *testing.T) {
 	tools.PrintResource(t, role)
 	tools.PrintResource(t, role.Extra)
 
-	listOpts := roles.ListOpts{}
+	listOpts := roles.ListOpts{
+		DomainID: "default",
+	}
 	allPages, err := roles.List(client, listOpts).AllPages(context.TODO())
 	th.AssertNoErr(t, err)
 


### PR DESCRIPTION
Fixes #[[2321](https://github.com/gophercloud/gophercloud/issues/2321)]

The original issue said that Gophercloud did not support deleting roles from a specific domain. This isn't really the case as to create a role, a domain must be specified also.  The API allows deletion by role ID without specifying a domain,but this is fine as the role ID is all that is needed for the role to be deleted from a specific domain.
[API call refs]( https://docs.openstack.org/api-ref/identity/v3/)
 
To make the Acceptance test consistent with this API behaviour, "DomainID" was added to both calls CreateOpts & ListOpts in roles_test.go.

So going to close this issue as no new feature needed because Delete Role works as expected.
