### PR TITLE
refactor: Trivial fixes

### DIFF
--- a/pagination/testing/doc.go
+++ b/pagination/testing/doc.go
@@ -1,2 +1,0 @@
-// pagination
-package testing

--- a/provider_client.go
+++ b/provider_client.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"slices"
 	"strings"
 	"sync"
 )
@@ -437,16 +438,8 @@ func (client *ProviderClient) doRequest(ctx context.Context, method, url string,
 		okc = defaultOkCodes(method)
 	}
 
-	// Validate the HTTP response status.
-	var ok bool
-	for _, code := range okc {
-		if resp.StatusCode == code {
-			ok = true
-			break
-		}
-	}
-
-	if !ok {
+	// Check the response code against the acceptable codes
+	if !slices.Contains(okc, resp.StatusCode) {
 		body, _ := io.ReadAll(resp.Body)
 		resp.Body.Close()
 		respErr := ErrUnexpectedResponseCode{

--- a/util.go
+++ b/util.go
@@ -37,9 +37,6 @@ func NormalizePathURL(basePath, rawPath string) (string, error) {
 
 	absPathSys = filepath.Join(basePath, rawPath)
 	u.Path = filepath.ToSlash(absPathSys)
-	if err != nil {
-		return "", err
-	}
 	u.Scheme = "file"
 	return u.String(), nil
 }


### PR DESCRIPTION
Address some gopls suggestions. The behaviour of the code is expected to remain unchanged.

* That `docs.go` file is a noop
* The use of `slices` in `provider_client.go` makes the code easier to read
* The `err` check I remove happened where `err` is untouched after the previous check.