### PR TITLE
Migrate epoxy jobs to Ubuntu 24.04 (Noble), drop caracal jobs

### DIFF
--- a/.github/workflows/functional-baremetal.yaml
+++ b/.github/workflows/functional-baremetal.yaml
@@ -13,15 +13,12 @@ jobs:
           - name: "master"
             openstack_version: "master"
             ubuntu_version: "24.04"
-            additional_services: "openstack-cli-server"
           - name: "epoxy"
             openstack_version: "stable/2025.1"
             ubuntu_version: "24.04"
-            additional_services: "openstack-cli-server"
           - name: "dalmatian"
             openstack_version: "stable/2024.2"
             ubuntu_version: "22.04"
-            additional_services: "openstack-cli-server"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Ironic on OpenStack ${{ matrix.name }}
     steps:
@@ -96,7 +93,7 @@ jobs:
             IRONIC_ENABLED_DEPLOY_INTERFACES=direct,fake
             SWIFT_ENABLE_TEMPURLS=True
             SWIFT_TEMPURL_KEY=secretkey
-          enabled_services: "ir-api,ir-cond,s-account,s-container,s-object,s-proxy,q-svc,q-agt,q-dhcp,q-l3,q-meta,-cinder,-c-sch,-c-api,-c-vol,-c-bak,-ovn,-ovn-controller,-ovn-northd,-q-ovn-metadata-agent,${{ matrix.additional_services }}"
+          enabled_services: "ir-api,ir-cond,s-account,s-container,s-object,s-proxy,q-svc,q-agt,q-dhcp,q-l3,q-meta,-cinder,-c-sch,-c-api,-c-vol,-c-bak,-ovn,-ovn-controller,-ovn-northd,-q-ovn-metadata-agent,openstack-cli-server"
 
       - name: Checkout go
         if: ${{ fromJSON(steps.changed-files.outputs.matches) }}

--- a/.github/workflows/functional-basic.yaml
+++ b/.github/workflows/functional-basic.yaml
@@ -13,15 +13,12 @@ jobs:
           - name: "master"
             openstack_version: "master"
             ubuntu_version: "24.04"
-            additional_services: "openstack-cli-server"
           - name: "epoxy"
             openstack_version: "stable/2025.1"
             ubuntu_version: "24.04"
-            additional_services: "openstack-cli-server"
           - name: "dalmatian"
             openstack_version: "stable/2024.2"
             ubuntu_version: "22.04"
-            additional_services: "openstack-cli-server"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: basic tests on OpenStack ${{ matrix.name }}
     steps:
@@ -50,7 +47,7 @@ jobs:
         uses: gophercloud/devstack-action@60ca1042045c0c9e3e001c64575d381654ffcba1
         with:
           branch: ${{ matrix.openstack_version }}
-          enabled_services: 's-account,s-container,s-object,s-proxy,${{ matrix.additional_services }}'
+          enabled_services: 's-account,s-container,s-object,s-proxy,openstack-cli-server'
 
       - name: Checkout go
         if: ${{ fromJSON(steps.changed-files.outputs.matches) }}

--- a/.github/workflows/functional-blockstorage.yaml
+++ b/.github/workflows/functional-blockstorage.yaml
@@ -13,15 +13,12 @@ jobs:
           - name: "master"
             openstack_version: "master"
             ubuntu_version: "24.04"
-            additional_services: "openstack-cli-server"
           - name: "epoxy"
             openstack_version: "stable/2025.1"
             ubuntu_version: "24.04"
-            additional_services: "openstack-cli-server"
           - name: "dalmatian"
             openstack_version: "stable/2024.2"
             ubuntu_version: "22.04"
-            additional_services: "openstack-cli-server"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Cinder on OpenStack ${{ matrix.name }}
     steps:
@@ -56,7 +53,7 @@ jobs:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |
             CINDER_ISCSI_HELPER=lioadm
-          enabled_services: "s-account,s-container,s-object,s-proxy,c-bak,${{ matrix.additional_services }}"
+          enabled_services: "s-account,s-container,s-object,s-proxy,c-bak,openstack-cli-server"
 
       - name: Checkout go
         if: ${{ fromJSON(steps.changed-files.outputs.matches) }}

--- a/.github/workflows/functional-compute.yaml
+++ b/.github/workflows/functional-compute.yaml
@@ -13,15 +13,12 @@ jobs:
           - name: "master"
             openstack_version: "master"
             ubuntu_version: "24.04"
-            additional_services: "openstack-cli-server"
           - name: "epoxy"
             openstack_version: "stable/2025.1"
             ubuntu_version: "24.04"
-            additional_services: "openstack-cli-server"
           - name: "dalmatian"
             openstack_version: "stable/2024.2"
             ubuntu_version: "22.04"
-            additional_services: "openstack-cli-server"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Nova on OpenStack ${{ matrix.name }}
     steps:
@@ -56,7 +53,7 @@ jobs:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |
             CINDER_ISCSI_HELPER=lioadm
-          enabled_services: "${{ matrix.additional_services }}"
+          enabled_services: "openstack-cli-server"
 
       - name: Checkout go
         if: ${{ fromJSON(steps.changed-files.outputs.matches) }}

--- a/.github/workflows/functional-containerinfra.yaml
+++ b/.github/workflows/functional-containerinfra.yaml
@@ -22,7 +22,6 @@ jobs:
 
               enable_plugin magnum https://github.com/openstack/magnum master
               MAGNUMCLIENT_BRANCH=master
-            additional_services: "openstack-cli-server"
           - name: "epoxy"
             openstack_version: "stable/2025.1"
             ubuntu_version: "24.04"
@@ -35,14 +34,12 @@ jobs:
 
               enable_plugin magnum https://github.com/openstack/magnum stable/2025.1
               MAGNUMCLIENT_BRANCH=stable/2025.1
-            additional_services: "openstack-cli-server"
           - name: "dalmatian"
             openstack_version: "stable/2024.2"
             ubuntu_version: "22.04"
             devstack_conf_overrides: |
               enable_plugin magnum https://github.com/openstack/magnum stable/2024.2
               MAGNUMCLIENT_BRANCH=stable/2024.2
-            additional_services: "openstack-cli-server"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Magnum on OpenStack ${{ matrix.name }}
     steps:
@@ -83,7 +80,7 @@ jobs:
             KEYSTONE_ADMIN_ENDPOINT=true
 
             ${{ matrix.devstack_conf_overrides }}
-          enabled_services: "h-eng,h-api,h-api-cfn,h-api-cw,${{ matrix.additional_services }}"
+          enabled_services: "h-eng,h-api,h-api-cfn,h-api-cw,openstack-cli-server"
 
       - name: Checkout go
         if: ${{ fromJSON(steps.changed-files.outputs.matches) }}

--- a/.github/workflows/functional-dns.yaml
+++ b/.github/workflows/functional-dns.yaml
@@ -19,15 +19,12 @@ jobs:
                 sed -i 's/setuptools\[core\]$/setuptools[core]==79.0.1/g' \$TOP_DIR/lib/infra \$TOP_DIR/inc/python
                 sed -i 's/pip_install "-U" "pbr"/pip_install "-U" "pbr" "setuptools[core]==79.0.1"/g' \$TOP_DIR/lib/infra
               fi
-            additional_services: "openstack-cli-server"
           - name: "epoxy"
             openstack_version: "stable/2025.1"
             ubuntu_version: "24.04"
-            additional_services: "openstack-cli-server"
           - name: "dalmatian"
             openstack_version: "stable/2024.2"
             ubuntu_version: "22.04"
-            additional_services: "openstack-cli-server"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Designate on OpenStack ${{ matrix.name }}
     steps:
@@ -64,7 +61,7 @@ jobs:
             enable_plugin designate https://github.com/openstack/designate ${{ matrix.openstack_version }}
 
             ${{ matrix.devstack_conf_overrides }}
-          enabled_services: "designate,designate-central,designate-api,designate-worker,designate-producer,designate-mdns,${{ matrix.additional_services }}"
+          enabled_services: "designate,designate-central,designate-api,designate-worker,designate-producer,designate-mdns,openstack-cli-server"
 
       - name: Checkout go
         if: ${{ fromJSON(steps.changed-files.outputs.matches) }}

--- a/.github/workflows/functional-fwaas_v2.yaml
+++ b/.github/workflows/functional-fwaas_v2.yaml
@@ -17,15 +17,12 @@ jobs:
           - name: "master"
             openstack_version: "master"
             ubuntu_version: "24.04"
-            additional_services: "openstack-cli-server"
           - name: "epoxy"
             openstack_version: "stable/2025.1"
             ubuntu_version: "24.04"
-            additional_services: "openstack-cli-server"
           - name: "dalmatian"
             openstack_version: "stable/2024.2"
             ubuntu_version: "22.04"
-            additional_services: "openstack-cli-server"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: FWaaS_v2 on OpenStack ${{ matrix.name }}
     steps:
@@ -79,7 +76,7 @@ jobs:
             [[post-config|\$NEUTRON_CONF]]
             [oslo_policy]
             policy_dirs = /tmp/neutron-policies
-          enabled_services: 'q-svc,q-agt,q-dhcp,q-l3,q-meta,q-fwaas-v2,-cinder,-horizon,-tempest,-swift,-c-sch,-c-api,-c-vol,-c-bak,-ovn,-ovn-controller,-ovn-northd,-q-ovn-metadata-agent,${{ matrix.additional_services }}'
+          enabled_services: 'q-svc,q-agt,q-dhcp,q-l3,q-meta,q-fwaas-v2,-cinder,-horizon,-tempest,-swift,-c-sch,-c-api,-c-vol,-c-bak,-ovn,-ovn-controller,-ovn-northd,-q-ovn-metadata-agent,openstack-cli-server'
 
       - name: Checkout go
         if: ${{ fromJSON(steps.changed-files.outputs.matches) }}

--- a/.github/workflows/functional-identity.yaml
+++ b/.github/workflows/functional-identity.yaml
@@ -13,15 +13,12 @@ jobs:
           - name: "master"
             openstack_version: "master"
             ubuntu_version: "24.04"
-            additional_services: "openstack-cli-server"
           - name: "epoxy"
             openstack_version: "stable/2025.1"
             ubuntu_version: "24.04"
-            additional_services: "openstack-cli-server"
           - name: "dalmatian"
             openstack_version: "stable/2024.2"
             ubuntu_version: "22.04"
-            additional_services: "openstack-cli-server"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Keystone on OpenStack ${{ matrix.name }}
     steps:
@@ -54,7 +51,7 @@ jobs:
         uses: gophercloud/devstack-action@60ca1042045c0c9e3e001c64575d381654ffcba1
         with:
           branch: ${{ matrix.openstack_version }}
-          enabled_services: "${{ matrix.additional_services }}"
+          enabled_services: "openstack-cli-server"
 
       - name: Checkout go
         if: ${{ fromJSON(steps.changed-files.outputs.matches) }}

--- a/.github/workflows/functional-image.yaml
+++ b/.github/workflows/functional-image.yaml
@@ -13,15 +13,12 @@ jobs:
           - name: "master"
             openstack_version: "master"
             ubuntu_version: "24.04"
-            additional_services: "openstack-cli-server"
           - name: "epoxy"
             openstack_version: "stable/2025.1"
             ubuntu_version: "24.04"
-            additional_services: "openstack-cli-server"
           - name: "dalmatian"
             openstack_version: "stable/2024.2"
             ubuntu_version: "22.04"
-            additional_services: "openstack-cli-server"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Glance on OpenStack ${{ matrix.name }}
     steps:
@@ -54,7 +51,7 @@ jobs:
         uses: gophercloud/devstack-action@60ca1042045c0c9e3e001c64575d381654ffcba1
         with:
           branch: ${{ matrix.openstack_version }}
-          enabled_services: "${{ matrix.additional_services }}"
+          enabled_services: "openstack-cli-server"
 
       - name: Checkout go
         if: ${{ fromJSON(steps.changed-files.outputs.matches) }}

--- a/.github/workflows/functional-keymanager.yaml
+++ b/.github/workflows/functional-keymanager.yaml
@@ -19,7 +19,6 @@ jobs:
                 sed -i 's/setuptools\[core\]$/setuptools[core]==79.0.1/g' \$TOP_DIR/lib/infra \$TOP_DIR/inc/python
                 sed -i 's/pip_install "-U" "pbr"/pip_install "-U" "pbr" "setuptools[core]==79.0.1"/g' \$TOP_DIR/lib/infra
               fi
-            additional_services: "openstack-cli-server"
           - name: "epoxy"
             openstack_version: "stable/2025.1"
             ubuntu_version: "24.04"
@@ -29,11 +28,9 @@ jobs:
                 sed -i 's/setuptools\[core\]$/setuptools[core]==79.0.1/g' \$TOP_DIR/lib/infra \$TOP_DIR/inc/python
                 sed -i 's/pip_install "-U" "pbr"/pip_install "-U" "pbr" "setuptools[core]==79.0.1"/g' \$TOP_DIR/lib/infra
               fi
-            additional_services: "openstack-cli-server"
           - name: "dalmatian"
             openstack_version: "stable/2024.2"
             ubuntu_version: "22.04"
-            additional_services: "openstack-cli-server"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Barbican on OpenStack ${{ matrix.name }}
     steps:
@@ -70,7 +67,7 @@ jobs:
             enable_plugin barbican https://github.com/openstack/barbican ${{ matrix.openstack_version }}
 
             ${{ matrix.devstack_conf_overrides }}
-          enabled_services: "barbican-svc,barbican-retry,barbican-keystone-listener,${{ matrix.additional_services }}"
+          enabled_services: "barbican-svc,barbican-retry,barbican-keystone-listener,openstack-cli-server"
 
       - name: Checkout go
         if: ${{ fromJSON(steps.changed-files.outputs.matches) }}

--- a/.github/workflows/functional-loadbalancer.yaml
+++ b/.github/workflows/functional-loadbalancer.yaml
@@ -19,15 +19,12 @@ jobs:
                 sed -i 's/setuptools\[core\]$/setuptools[core]==79.0.1/g' \$TOP_DIR/lib/infra \$TOP_DIR/inc/python
                 sed -i 's/pip_install "-U" "pbr"/pip_install "-U" "pbr" "setuptools[core]==79.0.1"/g' \$TOP_DIR/lib/infra
               fi
-            additional_services: "openstack-cli-server"
           - name: "epoxy"
             openstack_version: "stable/2025.1"
             ubuntu_version: "24.04"
-            additional_services: "openstack-cli-server"
           - name: "dalmatian"
             openstack_version: "stable/2024.2"
             ubuntu_version: "22.04"
-            additional_services: "openstack-cli-server"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Octavia on OpenStack ${{ matrix.name }}
     steps:
@@ -65,7 +62,7 @@ jobs:
             enable_plugin neutron https://github.com/openstack/neutron ${{ matrix.openstack_version }}
 
             ${{ matrix.devstack_conf_overrides }}
-          enabled_services: "octavia,o-api,o-cw,o-hk,o-hm,o-da,neutron-qos,${{ matrix.additional_services }}"
+          enabled_services: "octavia,o-api,o-cw,o-hk,o-hm,o-da,neutron-qos,openstack-cli-server"
 
       - name: Checkout go
         if: ${{ fromJSON(steps.changed-files.outputs.matches) }}

--- a/.github/workflows/functional-messaging.yaml
+++ b/.github/workflows/functional-messaging.yaml
@@ -13,15 +13,12 @@ jobs:
           - name: "master"
             openstack_version: "master"
             ubuntu_version: "24.04"
-            additional_services: "openstack-cli-server"
           - name: "epoxy"
             openstack_version: "stable/2025.1"
             ubuntu_version: "24.04"
-            additional_services: "openstack-cli-server"
           - name: "dalmatian"
             openstack_version: "stable/2024.2"
             ubuntu_version: "22.04"
-            additional_services: "openstack-cli-server"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Zaqar on OpenStack ${{ matrix.name }}
     steps:
@@ -57,7 +54,7 @@ jobs:
           conf_overrides: |
             enable_plugin zaqar https://github.com/openstack/zaqar ${{ matrix.openstack_version }}
             ZAQARCLIENT_BRANCH=${{ matrix.openstack_version }}
-          enabled_services: "${{ matrix.additional_services }}"
+          enabled_services: "openstack-cli-server"
 
       - name: Checkout go
         if: ${{ fromJSON(steps.changed-files.outputs.matches) }}

--- a/.github/workflows/functional-networking.yaml
+++ b/.github/workflows/functional-networking.yaml
@@ -13,15 +13,12 @@ jobs:
           - name: "master"
             openstack_version: "master"
             ubuntu_version: "24.04"
-            additional_services: "openstack-cli-server"
           - name: "epoxy"
             openstack_version: "stable/2025.1"
             ubuntu_version: "24.04"
-            additional_services: "openstack-cli-server"
           - name: "dalmatian"
             openstack_version: "stable/2024.2"
             ubuntu_version: "22.04"
-            additional_services: "openstack-cli-server"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Neutron on OpenStack ${{ matrix.name }}
     steps:
@@ -74,7 +71,7 @@ jobs:
             [[post-config|\$NEUTRON_CONF]]
             [oslo_policy]
             policy_dirs = /tmp/neutron-policies
-          enabled_services: "neutron-dns,neutron-qos,neutron-segments,neutron-trunk,neutron-uplink-status-propagation,neutron-network-segment-range,neutron-port-forwarding,${{ matrix.additional_services }}"
+          enabled_services: "neutron-dns,neutron-qos,neutron-segments,neutron-trunk,neutron-uplink-status-propagation,neutron-network-segment-range,neutron-port-forwarding,openstack-cli-server"
 
       - name: Checkout go
         if: ${{ fromJSON(steps.changed-files.outputs.matches) }}

--- a/.github/workflows/functional-objectstorage.yaml
+++ b/.github/workflows/functional-objectstorage.yaml
@@ -13,15 +13,12 @@ jobs:
           - name: "master"
             openstack_version: "master"
             ubuntu_version: "24.04"
-            additional_services: "openstack-cli-server"
           - name: "epoxy"
             openstack_version: "stable/2025.1"
             ubuntu_version: "24.04"
-            additional_services: "openstack-cli-server"
           - name: "dalmatian"
             openstack_version: "stable/2024.2"
             ubuntu_version: "22.04"
-            additional_services: "openstack-cli-server"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Swift on OpenStack ${{ matrix.name }}
     steps:
@@ -60,7 +57,7 @@ jobs:
             [[post-config|\$SWIFT_CONFIG_PROXY_SERVER]]
             [filter:versioned_writes]
             allow_object_versioning = true
-          enabled_services: 's-account,s-container,s-object,s-proxy,${{ matrix.additional_services }}'
+          enabled_services: 's-account,s-container,s-object,s-proxy,openstack-cli-server'
 
       - name: Checkout go
         if: ${{ fromJSON(steps.changed-files.outputs.matches) }}

--- a/.github/workflows/functional-orchestration.yaml
+++ b/.github/workflows/functional-orchestration.yaml
@@ -13,15 +13,12 @@ jobs:
           - name: "master"
             openstack_version: "master"
             ubuntu_version: "24.04"
-            additional_services: "openstack-cli-server"
           - name: "epoxy"
             openstack_version: "stable/2025.1"
             ubuntu_version: "24.04"
-            additional_services: "openstack-cli-server"
           - name: "dalmatian"
             openstack_version: "stable/2024.2"
             ubuntu_version: "22.04"
-            additional_services: "openstack-cli-server"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Heat on OpenStack ${{ matrix.name }}
     steps:
@@ -56,7 +53,7 @@ jobs:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |
             enable_plugin heat https://github.com/openstack/heat ${{ matrix.openstack_version }}
-          enabled_services: 'h-eng,h-api,h-api-cfn,h-api-cw,${{ matrix.additional_services }}'
+          enabled_services: 'h-eng,h-api,h-api-cfn,h-api-cw,openstack-cli-server'
 
       - name: Checkout go
         if: ${{ fromJSON(steps.changed-files.outputs.matches) }}

--- a/.github/workflows/functional-placement.yaml
+++ b/.github/workflows/functional-placement.yaml
@@ -13,15 +13,12 @@ jobs:
           - name: "master"
             openstack_version: "master"
             ubuntu_version: "24.04"
-            additional_services: "openstack-cli-server"
           - name: "epoxy"
             openstack_version: "stable/2025.1"
             ubuntu_version: "24.04"
-            additional_services: "openstack-cli-server"
           - name: "dalmatian"
             openstack_version: "stable/2024.2"
             ubuntu_version: "22.04"
-            additional_services: "openstack-cli-server"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Placement on OpenStack ${{ matrix.name }}
     steps:
@@ -54,7 +51,7 @@ jobs:
         uses: gophercloud/devstack-action@60ca1042045c0c9e3e001c64575d381654ffcba1
         with:
           branch: ${{ matrix.openstack_version }}
-          enabled_services: "${{ matrix.additional_services }}"
+          enabled_services: "openstack-cli-server"
 
       - name: Checkout go
         if: ${{ fromJSON(steps.changed-files.outputs.matches) }}

--- a/.github/workflows/functional-sharedfilesystems.yaml
+++ b/.github/workflows/functional-sharedfilesystems.yaml
@@ -19,15 +19,12 @@ jobs:
                 sed -i 's/setuptools\[core\]$/setuptools[core]==79.0.1/g' \$TOP_DIR/lib/infra \$TOP_DIR/inc/python
                 sed -i 's/pip_install "-U" "pbr"/pip_install "-U" "pbr" "setuptools[core]==79.0.1"/g' \$TOP_DIR/lib/infra
               fi
-            additional_services: "openstack-cli-server"
           - name: "epoxy"
             openstack_version: "stable/2025.1"
             ubuntu_version: "24.04"
-            additional_services: "openstack-cli-server"
           - name: "dalmatian"
             openstack_version: "stable/2024.2"
             ubuntu_version: "22.04"
-            additional_services: "openstack-cli-server"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Manila on OpenStack ${{ matrix.name }}
     steps:
@@ -78,7 +75,7 @@ jobs:
             MANILA_INSTALL_TEMPEST_PLUGIN_SYSTEMWIDE=false
 
             ${{ matrix.devstack_conf_overrides }}
-          enabled_services: "${{ matrix.additional_services }}"
+          enabled_services: "openstack-cli-server"
 
       - name: Checkout go
         if: ${{ fromJSON(steps.changed-files.outputs.matches) }}

--- a/.github/workflows/functional-workflow.yaml
+++ b/.github/workflows/functional-workflow.yaml
@@ -14,17 +14,14 @@ jobs:
             openstack_version: "master"
             ubuntu_version: "24.04"
             mistral_plugin_version: "master"
-            additional_services: "openstack-cli-server"
           - name: "epoxy"
             openstack_version: "stable/2025.1"
             ubuntu_version: "24.04"
             mistral_plugin_version: "stable/2025.1"
-            additional_services: "openstack-cli-server"
           - name: "dalmatian"
             openstack_version: "stable/2024.2"
             ubuntu_version: "22.04"
             mistral_plugin_version: "stable/2024.2"
-            additional_services: "openstack-cli-server"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Mistral on Deploy OpenStack ${{ matrix.name }}
     steps:
@@ -59,7 +56,7 @@ jobs:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |
             enable_plugin mistral https://github.com/openstack/mistral ${{ matrix.mistral_plugin_version }}
-          enabled_services: "mistral,mistral-api,mistral-engine,mistral-executor,mistral-event-engine,${{ matrix.additional_services }}"
+          enabled_services: "mistral,mistral-api,mistral-engine,mistral-executor,mistral-event-engine,openstack-cli-server"
 
       - name: Checkout go
         if: ${{ fromJSON(steps.changed-files.outputs.matches) }}


### PR DESCRIPTION
This is a follow-up to #3368 and #3374. Per $subject, we migrate Epoxy jobs to Ubuntu 24.04 (Noble) (which is now possible since the necessary fixes have long since landed in DevStack) and drop ~Dalmatian~ Caracal jobs to reduce our test matrix somewhat.

*EDIT:* Updated to drop Caracal instead of Dalmatian since Caracal is now EOL.
