### PR TITLE
fix: handle Nova create image response for microversion 2.45 and above

### DIFF
--- a/openstack/compute/v2/servers/requests.go
+++ b/openstack/compute/v2/servers/requests.go
@@ -1,10 +1,12 @@
 package servers
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
 	"maps"
 	"net"
 	"regexp"
@@ -1053,10 +1055,35 @@ func CreateImage(ctx context.Context, client *gophercloud.ServiceClient, id stri
 		r.Err = err
 		return
 	}
+
 	resp, err := client.Post(ctx, actionURL(client, id), b, nil, &gophercloud.RequestOpts{
-		OkCodes: []int{202},
+		OkCodes:          []int{202},
+		KeepResponseBody: true,
 	})
+
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	if r.Err != nil {
+		return
+	}
+	defer resp.Body.Close()
+
+	if v := r.Header.Get("Content-Type"); v != "application/json" {
+		return
+	}
+
+	// The response body is expected to be a small JSON object containing only "image_id".
+	// Read it fully into memory so the response body can be closed immediately.
+	// If the caller doesn't read from the buffer, it can still be safely garbage collected.
+
+	var buf bytes.Buffer
+
+	_, r.Err = io.Copy(&buf, resp.Body)
+	if r.Err != nil {
+		return
+	}
+
+	r.Body = &buf
+
 	return
 }
 

--- a/openstack/compute/v2/servers/results.go
+++ b/openstack/compute/v2/servers/results.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/openstack/utils"
 	"github.com/gophercloud/gophercloud/v2/pagination"
 )
 
@@ -132,16 +133,47 @@ func (r CreateImageResult) ExtractImageID() (string, error) {
 	if r.Err != nil {
 		return "", r.Err
 	}
-	// Get the image id from the header
+
+	microversion := r.Header.Get("X-OpenStack-Nova-API-Version")
+
+	major, minor, err := utils.ParseMicroversion(microversion)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse X-OpenStack-Nova-API-Version header: %s", err)
+	}
+
+	// In microversions prior to 2.45, the image ID was provided in the Location header.
+	if major < 2 || (major == 2 && minor < 45) {
+		return r.extractImageIDFromLocationHeader()
+	}
+
+	// Starting from 2.45, it is included in the response body.
+	return r.extractImageIDFromResponseBody()
+}
+
+func (r CreateImageResult) extractImageIDFromLocationHeader() (string, error) {
 	u, err := url.ParseRequestURI(r.Header.Get("Location"))
 	if err != nil {
 		return "", err
 	}
+
 	imageID := path.Base(u.Path)
 	if imageID == "." || imageID == "/" {
 		return "", fmt.Errorf("failed to parse the ID of newly created image: %s", u)
 	}
+
 	return imageID, nil
+}
+
+func (r CreateImageResult) extractImageIDFromResponseBody() (string, error) {
+	var response struct {
+		ImageID string `json:"image_id"`
+	}
+
+	if err := r.ExtractInto(&response); err != nil {
+		return "", err
+	}
+
+	return response.ImageID, nil
 }
 
 // Server represents a server/instance in the OpenStack cloud.

--- a/openstack/compute/v2/servers/testing/fixtures_test.go
+++ b/openstack/compute/v2/servers/testing/fixtures_test.go
@@ -1303,14 +1303,39 @@ func HandleNetworkAddressListSuccessfully(t *testing.T, fakeServer th.FakeServer
 	})
 }
 
-// HandleCreateServerImageSuccessfully sets up the test server to respond to a TestCreateServerImage request.
-func HandleCreateServerImageSuccessfully(t *testing.T, fakeServer th.FakeServer) {
+// HandleCreateServerImageSuccessfullyBeforeMicroversion_2_45 sets up the test server to respond to a TestCreateServerImageBeforeMicroversion_2_45 request.
+func HandleCreateServerImageSuccessfullyBeforeMicroversion_2_45(t *testing.T, fakeServer th.FakeServer) string {
+	imageID := "xxxx-xxxxx-xxxxx-xxxx"
+
 	fakeServer.Mux.HandleFunc("/servers/serverimage/action", func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "POST")
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
-		w.Header().Add("Location", "https://0.0.0.0/images/xxxx-xxxxx-xxxxx-xxxx")
+
+		w.Header().Set("Location", fmt.Sprintf("https://0.0.0.0/images/%s", imageID))
+		w.Header().Set("X-OpenStack-Nova-API-Version", "2.44")
 		w.WriteHeader(http.StatusAccepted)
 	})
+
+	return imageID
+}
+
+// HandleCreateServerImageSuccessfullySinceMicroversion_2_45 sets up the test server to respond to a TestCreateServerImageSinceMicroversion_2_45 request.
+func HandleCreateServerImageSuccessfullySinceMicroversion_2_45(t *testing.T, fakeServer th.FakeServer) string {
+	imageID := "yyyy-yyyyy-yyyyy-yyyyy"
+
+	fakeServer.Mux.HandleFunc("/servers/serverimage/action", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-OpenStack-Nova-API-Version", "2.45")
+		w.WriteHeader(http.StatusAccepted)
+
+		_, err := w.Write(fmt.Appendf(nil, `{"image_id":"%s"}`, imageID))
+		th.AssertNoErr(t, err)
+	})
+
+	return imageID
 }
 
 // HandlePasswordGetSuccessfully sets up the test server to respond to a password Get request.

--- a/openstack/compute/v2/servers/testing/requests_test.go
+++ b/openstack/compute/v2/servers/testing/requests_test.go
@@ -1092,13 +1092,24 @@ func TestListAddressesByNetwork(t *testing.T) {
 	th.CheckEquals(t, 1, pages)
 }
 
-func TestCreateServerImage(t *testing.T) {
+func TestCreateServerImageBeforeMicroversion_2_45(t *testing.T) {
 	fakeServer := th.SetupHTTP()
 	defer fakeServer.Teardown()
-	HandleCreateServerImageSuccessfully(t, fakeServer)
+	expected := HandleCreateServerImageSuccessfullyBeforeMicroversion_2_45(t, fakeServer)
 
-	_, err := servers.CreateImage(context.TODO(), client.ServiceClient(fakeServer), "serverimage", servers.CreateImageOpts{Name: "test"}).ExtractImageID()
+	imageID, err := servers.CreateImage(context.TODO(), client.ServiceClient(fakeServer), "serverimage", servers.CreateImageOpts{Name: "test"}).ExtractImageID()
 	th.AssertNoErr(t, err)
+	th.AssertEquals(t, expected, imageID)
+}
+
+func TestCreateServerImageSinceMicroversion_2_45(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	expected := HandleCreateServerImageSuccessfullySinceMicroversion_2_45(t, fakeServer)
+
+	imageID, err := servers.CreateImage(context.TODO(), client.ServiceClient(fakeServer), "serverimage", servers.CreateImageOpts{Name: "test"}).ExtractImageID()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, expected, imageID)
 }
 
 func TestMarshalPersonality(t *testing.T) {


### PR DESCRIPTION
## Description

This change addresses an issue where the Nova [CreateImage](https://pkg.go.dev/github.com/gophercloud/gophercloud/v2@v2.8.0/openstack/compute/v2/servers#CreateImage) API response was not handled correctly for microversion 2.45 and above.

Prior to microversion 2.45, the image ID was extracted from the Location header. Starting with 2.45, Nova no longer includes the Location header. Instead, the image ID is returned in the response body as a small JSON object. (see [API reference](https://docs.openstack.org/api-ref/compute/#create-image-createimage-action))

The `CreateImage` function has been updated to:
- Read and store the response body in `CreateImageResult`.
- Extract the image ID based on the `X-OpenStack-Nova-API-Version` header:
  - For microversions prior to 2.45, extract from the `Location` header.
  - For microversion 2.45 and above, extract from the response body.

This fix resolves the issue where the image ID was previously empty for Nova 2.45+, while maintaining compatibility with older microversions.

<!--
Prior to starting a PR, please make sure you have read our
[contributor tutorial](https://github.com/gophercloud/gophercloud/tree/main/docs/contributor-tutorial).

Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

-->
Fixes https://github.com/gophercloud/gophercloud/issues/3542
