### PR TITLE
compute: add cpu info topology cells entry

### DIFF
--- a/openstack/compute/v2/hypervisors/results.go
+++ b/openstack/compute/v2/hypervisors/results.go
@@ -11,6 +11,7 @@ import (
 
 // Topology represents a CPU Topology.
 type Topology struct {
+	Cells   int `json:"cells"`
 	Sockets int `json:"sockets"`
 	Cores   int `json:"cores"`
 	Threads int `json:"threads"`


### PR DESCRIPTION
Fixes #3545

Probably better to default value to 1, so `Cells * Sockets * Cores * Threads` would always work as expected.

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/nova/blob/41ae5b7f70481ad1a63eb1cbdba1e890be850ec5/nova/virt/libvirt/driver.py#L8478-L8482