### PR TITLE
Fix EC2 authentication to work with new Keystone auth requirement

### DIFF
--- a/internal/acceptance/openstack/client_test.go
+++ b/internal/acceptance/openstack/client_test.go
@@ -94,7 +94,8 @@ func TestEC2AuthMethod(t *testing.T) {
 	defer credentials.Delete(context.TODO(), client, credential.ID)
 	tools.PrintResource(t, credential)
 
-	newClient, err := clients.NewIdentityV3UnauthenticatedClient()
+	// Create a new provider client for EC2 authentication using the existing token
+	newClient, err := clients.NewIdentityV3Client()
 	th.AssertNoErr(t, err)
 
 	ec2AuthOptions := &ec2tokens.AuthOptions{

--- a/openstack/identity/v3/ec2tokens/requests.go
+++ b/openstack/identity/v3/ec2tokens/requests.go
@@ -300,8 +300,7 @@ func Create(ctx context.Context, c *gophercloud.ServiceClient, opts tokens.AuthO
 	deleteBodyElements(b, "token")
 
 	resp, err := c.Post(ctx, ec2tokensURL(c), b, &r.Body, &gophercloud.RequestOpts{
-		MoreHeaders: map[string]string{"X-Auth-Token": ""},
-		OkCodes:     []int{200},
+		OkCodes: []int{200},
 	})
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -320,8 +319,7 @@ func ValidateS3Token(ctx context.Context, c *gophercloud.ServiceClient, opts tok
 	deleteBodyElements(b, "body_hash", "headers", "host", "params", "path", "verb")
 
 	resp, err := c.Post(ctx, s3tokensURL(c), b, &r.Body, &gophercloud.RequestOpts{
-		MoreHeaders: map[string]string{"X-Auth-Token": ""},
-		OkCodes:     []int{200},
+		OkCodes: []int{200},
 	})
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return


### PR DESCRIPTION
Keystone recently changed to require authentication for the EC2 tokens endpoint [1]. Previously, the EC2 tokens endpoint could be accessed without authentication, but now it requires a valid token.

Fixes #3555

[1] https://review.opendev.org/q/Ic84b84247e05f29874e2c5636a033aaedd4de83c