### PR TITLE
identity/role: restore backward compatibility for description

### DIFF
--- a/openstack/identity/v3/roles/results.go
+++ b/openstack/identity/v3/roles/results.go
@@ -55,6 +55,12 @@ func (r *Role) UnmarshalJSON(b []byte) error {
 		}
 		if resultMap, ok := result.(map[string]any); ok {
 			r.Extra = gophercloud.RemainingKeys(Role{}, resultMap)
+
+			// the following code is required for backward compatibility with the
+			// old behavior, when description was in extra
+			if description, ok := resultMap["description"]; ok {
+				r.Extra["description"] = description
+			}
 		}
 	}
 


### PR DESCRIPTION
This is a follow-up to
https://github.com/gophercloud/gophercloud/pull/3532/ that restores the backward compatibility with the old behavior, where `description` was returned in the `Extra` field. We will drop this for the next major release.