### PR TITLE
Tokens: Add access rules support for application credentials

### DIFF
--- a/internal/acceptance/openstack/client_test.go
+++ b/internal/acceptance/openstack/client_test.go
@@ -71,11 +71,11 @@ func TestEC2AuthMethod(t *testing.T) {
 	th.AssertNoErr(t, err)
 	tools.PrintResource(t, token)
 
-	user, err := tokens.Get(context.TODO(), client, token.ID).ExtractUser()
+	user, err := tokens.Get(context.TODO(), client, token.ID, nil).ExtractUser()
 	th.AssertNoErr(t, err)
 	tools.PrintResource(t, user)
 
-	project, err := tokens.Get(context.TODO(), client, token.ID).ExtractProject()
+	project, err := tokens.Get(context.TODO(), client, token.ID, nil).ExtractProject()
 	th.AssertNoErr(t, err)
 	tools.PrintResource(t, project)
 

--- a/internal/acceptance/openstack/identity/v3/applicationcredentials_test.go
+++ b/internal/acceptance/openstack/identity/v3/applicationcredentials_test.go
@@ -50,15 +50,15 @@ func TestApplicationCredentialsCRD(t *testing.T) {
 	th.AssertNoErr(t, err)
 	tools.PrintResource(t, token)
 
-	user, err := tokens.Get(context.TODO(), client, token.ID).ExtractUser()
+	user, err := tokens.Get(context.TODO(), client, token.ID, nil).ExtractUser()
 	th.AssertNoErr(t, err)
 	tools.PrintResource(t, user)
 
-	roles, err := tokens.Get(context.TODO(), client, token.ID).ExtractRoles()
+	roles, err := tokens.Get(context.TODO(), client, token.ID, nil).ExtractRoles()
 	th.AssertNoErr(t, err)
 	tools.PrintResource(t, roles)
 
-	project, err := tokens.Get(context.TODO(), client, token.ID).ExtractProject()
+	project, err := tokens.Get(context.TODO(), client, token.ID, nil).ExtractProject()
 	th.AssertNoErr(t, err)
 	tools.PrintResource(t, project)
 
@@ -194,7 +194,7 @@ func TestApplicationCredentialsAccessRules(t *testing.T) {
 	th.AssertNoErr(t, err)
 	tools.PrintResource(t, token)
 
-	user, err := tokens.Get(context.TODO(), client, token.ID).ExtractUser()
+	user, err := tokens.Get(context.TODO(), client, token.ID, nil).ExtractUser()
 	th.AssertNoErr(t, err)
 	tools.PrintResource(t, user)
 

--- a/internal/acceptance/openstack/identity/v3/credentials_test.go
+++ b/internal/acceptance/openstack/identity/v3/credentials_test.go
@@ -39,11 +39,11 @@ func TestCredentialsCRUD(t *testing.T) {
 	th.AssertNoErr(t, err)
 	tools.PrintResource(t, token)
 
-	user, err := tokens.Get(context.TODO(), client, token.ID).ExtractUser()
+	user, err := tokens.Get(context.TODO(), client, token.ID, nil).ExtractUser()
 	th.AssertNoErr(t, err)
 	tools.PrintResource(t, user)
 
-	project, err := tokens.Get(context.TODO(), client, token.ID).ExtractProject()
+	project, err := tokens.Get(context.TODO(), client, token.ID, nil).ExtractProject()
 	th.AssertNoErr(t, err)
 	tools.PrintResource(t, project)
 
@@ -116,11 +116,11 @@ func TestCredentialsValidateS3(t *testing.T) {
 	th.AssertNoErr(t, err)
 	tools.PrintResource(t, token)
 
-	user, err := tokens.Get(context.TODO(), client, token.ID).ExtractUser()
+	user, err := tokens.Get(context.TODO(), client, token.ID, nil).ExtractUser()
 	th.AssertNoErr(t, err)
 	tools.PrintResource(t, user)
 
-	project, err := tokens.Get(context.TODO(), client, token.ID).ExtractProject()
+	project, err := tokens.Get(context.TODO(), client, token.ID, nil).ExtractProject()
 	th.AssertNoErr(t, err)
 	tools.PrintResource(t, project)
 

--- a/internal/acceptance/openstack/identity/v3/oauth1_test.go
+++ b/internal/acceptance/openstack/identity/v3/oauth1_test.go
@@ -215,7 +215,7 @@ func oauth1MethodTest(t *testing.T, client *gophercloud.ServiceClient, consumer 
 		tokens.Token
 		oauth1.TokenExt
 	}
-	tokenRes := tokens.Get(context.TODO(), newClient, newClient.TokenID)
+	tokenRes := tokens.Get(context.TODO(), newClient, newClient.TokenID, nil)
 	err = tokenRes.ExtractInto(&token)
 	th.AssertNoErr(t, err)
 	oauth1Roles, err := tokenRes.ExtractRoles()

--- a/internal/acceptance/openstack/identity/v3/token_test.go
+++ b/internal/acceptance/openstack/identity/v3/token_test.go
@@ -40,19 +40,19 @@ func TestTokensGet(t *testing.T) {
 	th.AssertNoErr(t, err)
 	tools.PrintResource(t, token)
 
-	catalog, err := tokens.Get(context.TODO(), client, token.ID).ExtractServiceCatalog()
+	catalog, err := tokens.Get(context.TODO(), client, token.ID, nil).ExtractServiceCatalog()
 	th.AssertNoErr(t, err)
 	tools.PrintResource(t, catalog)
 
-	user, err := tokens.Get(context.TODO(), client, token.ID).ExtractUser()
+	user, err := tokens.Get(context.TODO(), client, token.ID, nil).ExtractUser()
 	th.AssertNoErr(t, err)
 	tools.PrintResource(t, user)
 
-	roles, err := tokens.Get(context.TODO(), client, token.ID).ExtractRoles()
+	roles, err := tokens.Get(context.TODO(), client, token.ID, nil).ExtractRoles()
 	th.AssertNoErr(t, err)
 	tools.PrintResource(t, roles)
 
-	project, err := tokens.Get(context.TODO(), client, token.ID).ExtractProject()
+	project, err := tokens.Get(context.TODO(), client, token.ID, nil).ExtractProject()
 	th.AssertNoErr(t, err)
 	tools.PrintResource(t, project)
 }

--- a/internal/acceptance/openstack/identity/v3/trusts_test.go
+++ b/internal/acceptance/openstack/identity/v3/trusts_test.go
@@ -43,7 +43,7 @@ func TestTrustCRUD(t *testing.T) {
 
 	token, err := tokens.Create(context.TODO(), client, &authOptions).Extract()
 	th.AssertNoErr(t, err)
-	adminUser, err := tokens.Get(context.TODO(), client, token.ID).ExtractUser()
+	adminUser, err := tokens.Get(context.TODO(), client, token.ID, nil).ExtractUser()
 	th.AssertNoErr(t, err)
 
 	// Get the admin and member role IDs.

--- a/openstack/client.go
+++ b/openstack/client.go
@@ -206,7 +206,7 @@ func v3auth(ctx context.Context, client *gophercloud.ProviderClient, endpoint st
 		}
 
 		v3Client.SetToken(tokenID)
-		result := tokens3.Get(ctx, v3Client, tokenID)
+		result := tokens3.Get(ctx, v3Client, tokenID, nil)
 		if result.Err != nil {
 			return result.Err
 		}

--- a/openstack/identity/v3/tokens/doc.go
+++ b/openstack/identity/v3/tokens/doc.go
@@ -103,5 +103,53 @@ Example to Create a Token from a Username and Password with Project Name Scope
 	if err != nil {
 		panic(err)
 	}
+
+Example to Get a Token
+
+	token, err := tokens.Get(context.TODO(), identityClient, "token_id", nil).ExtractToken()
+	if err != nil {
+		panic(err)
+	}
+
+# Example to Get a Token Created with Application Credentials Access Rules
+
+When validating or retrieving tokens that were created using application
+credentials with access rules, the OpenStack-Identity-Access-Rules header
+must be sent. Without this header, Keystone will return a 404 Not Found error.
+
+See https://docs.openstack.org/keystone/latest/user/application_credentials.html
+
+	getOpts := tokens.GetOpts{
+		AccessRulesVersion: "1.0",
+	}
+	token, err := tokens.Get(context.TODO(), identityClient, "token_id", getOpts).ExtractToken()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Validate a Token
+
+	ok, err := tokens.Validate(context.TODO(), identityClient, "token_id", nil)
+	if err != nil {
+		panic(err)
+	}
+
+	if ok {
+		fmt.Println("Token is valid")
+	}
+
+Example to Validate a Token Created with Application Credentials Access Rules
+
+	validateOpts := tokens.ValidateOpts{
+		AccessRulesVersion: "1.0",
+	}
+	ok, err := tokens.Validate(context.TODO(), identityClient, "token_id", validateOpts)
+	if err != nil {
+		panic(err)
+	}
+
+	if ok {
+		fmt.Println("Token is valid")
+	}
 */
 package tokens

--- a/openstack/identity/v3/tokens/results.go
+++ b/openstack/identity/v3/tokens/results.go
@@ -88,6 +88,33 @@ type Trust struct {
 	TrustorUserID TrustUser `json:"trustor_user"`
 }
 
+// AccessRule represents an access rule for an application credential.
+type AccessRule struct {
+	// The ID of the access rule.
+	ID string `json:"id"`
+	// The API path that the application credential is permitted to access.
+	Path string `json:"path"`
+	// The request method that the application credential is permitted to use
+	// for a given API endpoint.
+	Method string `json:"method"`
+	// The service type identifier for the service that the application
+	// credential is permitted to access.
+	Service string `json:"service"`
+}
+
+// ApplicationCredential represents the application credential information
+// included in a token when the token was created using an application credential.
+type ApplicationCredential struct {
+	// The ID of the application credential.
+	ID string `json:"id"`
+	// The name of the application credential.
+	Name string `json:"name"`
+	// A flag indicating whether the application credential is restricted.
+	Restricted bool `json:"restricted"`
+	// A list of access rules for the application credential.
+	AccessRules []AccessRule `json:"access_rules"`
+}
+
 // commonResult is the response from a request. A commonResult has various
 // methods which can be used to extract different details about the result.
 type commonResult struct {
@@ -179,6 +206,17 @@ func (r commonResult) ExtractTrust() (*Trust, error) {
 	}
 	err := r.ExtractInto(&s)
 	return s.Trust, err
+}
+
+// ExtractApplicationCredential returns the ApplicationCredential that was used
+// to create the token. This is only present when the token was created using
+// an application credential.
+func (r commonResult) ExtractApplicationCredential() (*ApplicationCredential, error) {
+	var s struct {
+		ApplicationCredential *ApplicationCredential `json:"application_credential"`
+	}
+	err := r.ExtractInto(&s)
+	return s.ApplicationCredential, err
 }
 
 // CreateResult is the response from a Create request. Use ExtractToken()

--- a/openstack/identity/v3/tokens/testing/fixtures.go
+++ b/openstack/identity/v3/tokens/testing/fixtures.go
@@ -323,3 +323,73 @@ func getGetDomainResult(t *testing.T) tokens.GetResult {
 	th.AssertNoErr(t, err)
 	return result
 }
+
+// ApplicationCredentialTokenOutput is a sample response to a Token call
+// using application credentials with access rules.
+const ApplicationCredentialTokenOutput = `
+{
+   "token":{
+      "methods":["application_credential"],
+      "expires_at":"2017-06-03T02:19:49.000000Z",
+      "user":{
+         "domain":{
+            "id":"default",
+            "name":"Default"
+         },
+         "id":"0fe36e73809d46aeae6705c39077b1b3",
+         "name":"admin"
+      },
+      "application_credential":{
+         "id":"d832f05beee743c696672ef65ee073ff",
+         "name":"test",
+         "restricted":true,
+         "access_rules":[
+            {
+               "id":"4641f614301d48bfae1ad323e3e1c44c",
+               "service":"identity",
+               "path":"/v3/auth/tokens",
+               "method":"GET"
+            },
+            {
+               "id":"968c404cb9b44672a574e5ee9d3db987",
+               "service":"identity",
+               "path":"/v3/**",
+               "method":"HEAD"
+            }
+         ]
+      },
+      "issued_at":"2017-06-03T01:19:49.000000Z"
+   }
+}`
+
+// ExpectedApplicationCredential contains expected application credential
+// extracted from token response.
+var ExpectedApplicationCredential = tokens.ApplicationCredential{
+	ID:         "d832f05beee743c696672ef65ee073ff",
+	Name:       "test",
+	Restricted: true,
+	AccessRules: []tokens.AccessRule{
+		{
+			ID:      "4641f614301d48bfae1ad323e3e1c44c",
+			Service: "identity",
+			Path:    "/v3/auth/tokens",
+			Method:  "GET",
+		},
+		{
+			ID:      "968c404cb9b44672a574e5ee9d3db987",
+			Service: "identity",
+			Path:    "/v3/**",
+			Method:  "HEAD",
+		},
+	},
+}
+
+func getGetApplicationCredentialResult(t *testing.T) tokens.GetResult {
+	result := tokens.GetResult{}
+	result.Header = http.Header{
+		"X-Subject-Token": []string{testTokenID},
+	}
+	err := json.Unmarshal([]byte(ApplicationCredentialTokenOutput), &result.Body)
+	th.AssertNoErr(t, err)
+	return result
+}

--- a/openstack/identity/v3/tokens/testing/results_test.go
+++ b/openstack/identity/v3/tokens/testing/results_test.go
@@ -59,3 +59,23 @@ func TestExtractDomain(t *testing.T) {
 
 	th.CheckDeepEquals(t, &ExpectedDomain, domain)
 }
+
+func TestExtractApplicationCredential(t *testing.T) {
+	result := getGetApplicationCredentialResult(t)
+
+	appCred, err := result.ExtractApplicationCredential()
+	th.AssertNoErr(t, err)
+
+	th.CheckDeepEquals(t, &ExpectedApplicationCredential, appCred)
+}
+
+func TestExtractApplicationCredentialNotPresent(t *testing.T) {
+	result := getGetResult(t)
+
+	appCred, err := result.ExtractApplicationCredential()
+	th.AssertNoErr(t, err)
+
+	if appCred != nil {
+		t.Errorf("Expected nil application credential, got %v", appCred)
+	}
+}


### PR DESCRIPTION
This change adds support for the OpenStack-Identity-Access-Rules header
when getting or validating tokens created with application credentials
that have access rules configured.

Changes:
- Add GetOptsBuilder interface and GetOpts struct for Get() function
- Add ValidateOptsBuilder interface and ValidateOpts struct for Validate()
- Both structs contain AccessRulesVersion (float64) field to specify the
  header version. Pass nil to skip access rules validation, or provide
  opts with a version >= 1 to enable it.
- Add float64 support to BuildHeaders() in params.go
- Add AccessRule and ApplicationCredential types to represent the
  application credential information in token responses
- Add ExtractApplicationCredential() method to extract application
  credential details including access rules from token responses
- Update all usages across tests and client code

The decision to use an opts struct pattern instead of passing the
parameter directly was made to align with the rest of the gophercloud
codebase conventions, although it may feel like overkill for a single
optional parameter.

This fixes the issue where tokens created with application credentials
that have access rules would return 404 Not Found when fetched without
the OpenStack-Identity-Access-Rules header.

See: https://docs.openstack.org/keystone/latest/user/application_credentials.html


[feature spec](https://specs.openstack.org/openstack/keystone-specs/specs/keystone/train/capabilities-app-creds.html) it is mentioned that:

> 1. When requesting token validation, keystonemiddleware (or any 3rd party application that supports access rule enforcement) sets an Openstack-Identity-Access-Rules header with a version string as its value. Token validation for an application credential with a access rule list will only succeed if this header is present. The version string will allow us to safely extend this feature by invalidating tokens using the extended version in situations where keystonemiddleware only supports an older version of this feature.
> 
> 2. If there is no Openstack-Identity-Access-Rules header in the token validation request, token validation fails.

Closes: #3573 

Assisted by: claude
