### PR TITLE
network.v2.Port: add support for update mac_address

### DIFF
--- a/internal/acceptance/openstack/networking/v2/ports_test.go
+++ b/internal/acceptance/openstack/networking/v2/ports_test.go
@@ -45,9 +45,11 @@ func TestPortsCRUD(t *testing.T) {
 	// Update port
 	newPortName := ""
 	newPortDescription := ""
+	newMACAddress := "aa:bb:cc:dd:ee:ff"
 	updateOpts := ports.UpdateOpts{
 		Name:        &newPortName,
 		Description: &newPortDescription,
+		MACAddress:  &newMACAddress,
 	}
 	newPort, err := ports.Update(context.TODO(), client, port.ID, updateOpts).Extract()
 	th.AssertNoErr(t, err)
@@ -56,6 +58,7 @@ func TestPortsCRUD(t *testing.T) {
 
 	th.AssertEquals(t, newPort.Name, newPortName)
 	th.AssertEquals(t, newPort.Description, newPortDescription)
+	th.AssertEquals(t, newPort.MACAddress, newMACAddress)
 
 	allPages, err := ports.List(client, nil).AllPages(context.TODO())
 	th.AssertNoErr(t, err)

--- a/openstack/networking/v2/ports/requests.go
+++ b/openstack/networking/v2/ports/requests.go
@@ -197,6 +197,7 @@ type UpdateOpts struct {
 	AllowedAddressPairs   *[]AddressPair     `json:"allowed_address_pairs,omitempty"`
 	PropagateUplinkStatus *bool              `json:"propagate_uplink_status,omitempty"`
 	ValueSpecs            *map[string]string `json:"value_specs,omitempty"`
+	MACAddress            *string            `json:"mac_address,omitempty"`
 
 	// RevisionNumber implements extension:standard-attr-revisions. If != "" it
 	// will set revision_number=%s. If the revision number does not match, the

--- a/openstack/networking/v2/ports/testing/fixtures.go
+++ b/openstack/networking/v2/ports/testing/fixtures.go
@@ -409,7 +409,8 @@ const UpdateRequest = `
         ],
         "security_groups": [
             "f0ac4394-7e4a-4409-9701-ba8be283dbc3"
-        ]
+        ],
+        "mac_address": "fa:16:3e:c9:cb:f4"
     }
 }
 `
@@ -423,7 +424,7 @@ const UpdateResponse = `
         "network_id": "a87cc70a-3e15-4acf-8205-9b711a3531b7",
         "tenant_id": "d6700c0c9ffa4f1cb322cd4a1f3906fa",
         "device_owner": "",
-        "mac_address": "fa:16:3e:c9:cb:f0",
+        "mac_address": "fa:16:3e:c9:cb:f4",
         "fixed_ips": [
             {
                 "subnet_id": "a0304c3a-4f08-4c43-88af-d796509c97d2",

--- a/openstack/networking/v2/ports/testing/requests_test.go
+++ b/openstack/networking/v2/ports/testing/requests_test.go
@@ -538,6 +538,7 @@ func TestUpdate(t *testing.T) {
 	})
 
 	name := "new_port_name"
+	newMACAddress := "fa:16:3e:c9:cb:f4"
 	options := ports.UpdateOpts{
 		Name: &name,
 		FixedIPs: []ports.IP{
@@ -547,6 +548,7 @@ func TestUpdate(t *testing.T) {
 		AllowedAddressPairs: &[]ports.AddressPair{
 			{IPAddress: "10.0.0.4", MACAddress: "fa:16:3e:c9:cb:f0"},
 		},
+		MACAddress: &newMACAddress,
 	}
 
 	s, err := ports.Update(context.TODO(), fake.ServiceClient(fakeServer), "65c0ee9f-d634-4522-8954-51021b570b0d", options).Extract()
@@ -727,6 +729,7 @@ func TestUpdateRevision(t *testing.T) {
 	})
 
 	name := "new_port_name"
+	newMACAddress := "fa:16:3e:c9:cb:f4"
 	options := ports.UpdateOpts{
 		Name: &name,
 		FixedIPs: []ports.IP{
@@ -736,6 +739,7 @@ func TestUpdateRevision(t *testing.T) {
 		AllowedAddressPairs: &[]ports.AddressPair{
 			{IPAddress: "10.0.0.4", MACAddress: "fa:16:3e:c9:cb:f0"},
 		},
+		MACAddress: &newMACAddress,
 	}
 	_, err := ports.Update(context.TODO(), fake.ServiceClient(fakeServer), "65c0ee9f-d634-4522-8954-51021b570b0d", options).Extract()
 	th.AssertNoErr(t, err)


### PR DESCRIPTION
Fixes #3499

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://docs.openstack.org/api-ref/network/v2/index.html#update-port
