### PR TITLE
identity.v3.Endpoint: make name as optional on creation

### DIFF
--- a/openstack/identity/v3/endpoints/requests.go
+++ b/openstack/identity/v3/endpoints/requests.go
@@ -26,7 +26,7 @@ type CreateOpts struct {
 	Enabled *bool `json:"enabled,omitempty"`
 
 	// Name is the name of the Endpoint.
-	Name string `json:"name" required:"true"`
+	Name string `json:"name,omitempty"`
 
 	// Region is the region the Endpoint is located in.
 	// This field can be omitted or left as a blank string.

--- a/openstack/identity/v3/endpoints/testing/requests_test.go
+++ b/openstack/identity/v3/endpoints/testing/requests_test.go
@@ -23,7 +23,6 @@ func TestCreateSuccessful(t *testing.T) {
 		th.TestJSONRequest(t, r, `{
 			"endpoint": {
 				"interface": "public",
-				"name": "the-endiest-of-points",
 				"region": "underground",
 				"url": "https://1.2.3.4:9000/",
 				"service_id": "asdfasdfasdfasdf",
@@ -41,7 +40,6 @@ func TestCreateSuccessful(t *testing.T) {
 				"links": {
 					"self": "https://localhost:5000/v3/endpoints/12"
 				},
-				"name": "the-endiest-of-points",
 				"region": "underground",
 				"service_id": "asdfasdfasdfasdf",
 				"url": "https://1.2.3.4:9000/",
@@ -53,7 +51,6 @@ func TestCreateSuccessful(t *testing.T) {
 	enabled := false
 	actual, err := endpoints.Create(context.TODO(), client.ServiceClient(fakeServer), endpoints.CreateOpts{
 		Availability: gophercloud.AvailabilityPublic,
-		Name:         "the-endiest-of-points",
 		Region:       "underground",
 		URL:          "https://1.2.3.4:9000/",
 		ServiceID:    "asdfasdfasdfasdf",
@@ -65,7 +62,6 @@ func TestCreateSuccessful(t *testing.T) {
 	expected := &endpoints.Endpoint{
 		ID:           "12",
 		Availability: gophercloud.AvailabilityPublic,
-		Name:         "the-endiest-of-points",
 		Enabled:      false,
 		Region:       "underground",
 		ServiceID:    "asdfasdfasdfasdf",


### PR DESCRIPTION
The `name` field is optional on Endpoint creation following the [API reference](https://docs.openstack.org/api-ref/identity/v3/index.html#create-endpoint), but Gophercloud defines this field as required.

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://docs.openstack.org/api-ref/identity/v3/index.html#create-endpoint
