### PR TITLE
identity.v3.Endpoint: add enabled field on creation and on update

### DIFF
--- a/internal/acceptance/openstack/identity/v3/endpoint_test.go
+++ b/internal/acceptance/openstack/identity/v3/endpoint_test.go
@@ -115,10 +115,12 @@ func TestEndpointCRUD(t *testing.T) {
 	th.AssertNoErr(t, err)
 	defer DeleteService(t, client, service.ID)
 
+	enabled := false
 	endpoint, err := CreateEndpoint(t, client, &endpoints.CreateOpts{
 		Availability: gophercloud.Availability("internal"),
 		ServiceID:    service.ID,
 		URL:          "https://example.com",
+		Enabled:      &enabled,
 	})
 	th.AssertNoErr(t, err)
 	defer DeleteEndpoint(t, client, endpoint.ID)
@@ -126,10 +128,12 @@ func TestEndpointCRUD(t *testing.T) {
 	tools.PrintResource(t, endpoint)
 	tools.PrintResource(t, endpoint.URL)
 
+	enabled = true
 	newEndpoint, err := endpoints.Update(context.TODO(), client, endpoint.ID, &endpoints.UpdateOpts{
 		Name:        "new-endpoint",
 		URL:         "https://example-updated.com",
 		Description: "Updated Endpoint",
+		Enabled:     &enabled,
 	}).Extract()
 	th.AssertNoErr(t, err)
 

--- a/openstack/identity/v3/endpoints/requests.go
+++ b/openstack/identity/v3/endpoints/requests.go
@@ -18,6 +18,13 @@ type CreateOpts struct {
 	// or public), referenced by the gophercloud.Availability type.
 	Availability gophercloud.Availability `json:"interface" required:"true"`
 
+	// Description is the description of the Endpoint.
+	Description string `json:"description,omitempty"`
+
+	// Enabled indicates whether the Endpoint appears in the service
+	// or not.
+	Enabled *bool `json:"enabled,omitempty"`
+
 	// Name is the name of the Endpoint.
 	Name string `json:"name" required:"true"`
 
@@ -30,9 +37,6 @@ type CreateOpts struct {
 
 	// ServiceID is the ID of the service the Endpoint refers to.
 	ServiceID string `json:"service_id" required:"true"`
-
-	// Description is the description of the Endpoint.
-	Description string `json:"description,omitempty"`
 }
 
 // ToEndpointCreateMap builds a request body from the Endpoint Create options.
@@ -114,6 +118,10 @@ type UpdateOpts struct {
 
 	// Name is the name of the Endpoint.
 	Name string `json:"name,omitempty"`
+
+	// Enabled indicates whether the Endpoint appears in the service
+	// or not.
+	Enabled *bool `json:"enabled,omitempty"`
 
 	// Region is the region the Endpoint is located in.
 	// This field can be omitted or left as a blank string.

--- a/openstack/identity/v3/endpoints/testing/requests_test.go
+++ b/openstack/identity/v3/endpoints/testing/requests_test.go
@@ -27,7 +27,8 @@ func TestCreateSuccessful(t *testing.T) {
 				"region": "underground",
 				"url": "https://1.2.3.4:9000/",
 				"service_id": "asdfasdfasdfasdf",
-				"description": "Test description"
+				"description": "Test description",
+				"enabled": false
 			}
 		}`)
 
@@ -36,7 +37,7 @@ func TestCreateSuccessful(t *testing.T) {
 			"endpoint": {
 				"id": "12",
 				"interface": "public",
-				"enabled": true,
+				"enabled": false,
 				"links": {
 					"self": "https://localhost:5000/v3/endpoints/12"
 				},
@@ -49,6 +50,7 @@ func TestCreateSuccessful(t *testing.T) {
 		}`)
 	})
 
+	enabled := false
 	actual, err := endpoints.Create(context.TODO(), client.ServiceClient(fakeServer), endpoints.CreateOpts{
 		Availability: gophercloud.AvailabilityPublic,
 		Name:         "the-endiest-of-points",
@@ -56,14 +58,15 @@ func TestCreateSuccessful(t *testing.T) {
 		URL:          "https://1.2.3.4:9000/",
 		ServiceID:    "asdfasdfasdfasdf",
 		Description:  "Test description",
+		Enabled:      &enabled,
 	}).Extract()
 	th.AssertNoErr(t, err)
 
 	expected := &endpoints.Endpoint{
 		ID:           "12",
 		Availability: gophercloud.AvailabilityPublic,
-		Enabled:      true,
 		Name:         "the-endiest-of-points",
+		Enabled:      false,
 		Region:       "underground",
 		ServiceID:    "asdfasdfasdfasdf",
 		URL:          "https://1.2.3.4:9000/",
@@ -210,7 +213,8 @@ func TestUpdateEndpoint(t *testing.T) {
 			"endpoint": {
 				"name": "renamed",
 				"region": "somewhere-else",
-				"description": "Changed description"
+				"description": "Changed description",
+				"enabled": false
 			}
 		}`)
 
@@ -218,7 +222,7 @@ func TestUpdateEndpoint(t *testing.T) {
 			"endpoint": {
 				"id": "12",
 				"interface": "public",
-				"enabled": true,
+				"enabled": false,
 				"links": {
 					"self": "https://localhost:5000/v3/endpoints/12"
 				},
@@ -231,10 +235,12 @@ func TestUpdateEndpoint(t *testing.T) {
 		}`)
 	})
 
+	enabled := false
 	actual, err := endpoints.Update(context.TODO(), client.ServiceClient(fakeServer), "12", endpoints.UpdateOpts{
 		Name:        "renamed",
 		Region:      "somewhere-else",
 		Description: "Changed description",
+		Enabled:     &enabled,
 	}).Extract()
 	if err != nil {
 		t.Fatalf("Unexpected error from Update: %v", err)
@@ -243,7 +249,7 @@ func TestUpdateEndpoint(t *testing.T) {
 	expected := &endpoints.Endpoint{
 		ID:           "12",
 		Availability: gophercloud.AvailabilityPublic,
-		Enabled:      true,
+		Enabled:      false,
 		Name:         "renamed",
 		Region:       "somewhere-else",
 		ServiceID:    "asdfasdfasdfasdf",


### PR DESCRIPTION
There are some operations that don't implement the `Enabled` field on the Endpoint API. This same field is also missing from the Openstack API Reference. I've created [this](https://review.opendev.org/c/openstack/keystone/+/971148) patch to address it.

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/keystone/blob/master/keystone/catalog/schema.py#L239
https://github.com/openstack/keystone/blob/master/keystone/catalog/schema.py#L394-L400
