### PR TITLE
[v2] Add new fields for ListOpts volumetypes

### DIFF
--- a/internal/acceptance/openstack/blockstorage/v3/blockstorage.go
+++ b/internal/acceptance/openstack/blockstorage/v3/blockstorage.go
@@ -158,7 +158,7 @@ func CreateVolumeType(t *testing.T, client *gophercloud.ServiceClient) (*volumet
 
 	createOpts := volumetypes.CreateOpts{
 		Name:        name,
-		ExtraSpecs:  map[string]string{"volume_backend_name": "fake_backend_name"},
+		ExtraSpecs:  map[string]string{"volume_backend_name": "fake_backend_name", "RESKEY:availability_zones": "zone", "multiattach": "<is> True"},
 		Description: description,
 	}
 

--- a/openstack/blockstorage/v3/volumetypes/requests.go
+++ b/openstack/blockstorage/v3/volumetypes/requests.go
@@ -73,6 +73,10 @@ type ListOptsBuilder interface {
 // ListOpts holds options for listing Volume Types. It is passed to the volumetypes.List
 // function.
 type ListOpts struct {
+	// Name will filter by the specified volume type name.
+	Name string `q:"name"`
+	// Description will filter by the specified volume type description.
+	Description string `q:"description"`
 	// Specifies whether the query should include public or private Volume Types.
 	// By default, it queries both types.
 	IsPublic visibility `q:"is_public"`

--- a/openstack/blockstorage/v3/volumetypes/testing/requests_test.go
+++ b/openstack/blockstorage/v3/volumetypes/testing/requests_test.go
@@ -162,6 +162,52 @@ func TestListIsPublicParam(t *testing.T) {
 	th.AssertNoErr(t, err)
 }
 
+func TestListNameParam(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	result := make(map[string]string)
+	HandleListWithNameFilter(t, fakeServer, result)
+
+	result["is_public"] = "None"
+	result["name"] = "test-type"
+	allPages, err := volumetypes.List(client.ServiceClient(fakeServer), volumetypes.ListOpts{
+		Name: "test-type",
+	}).AllPages(context.TODO())
+	th.AssertNoErr(t, err)
+	actual, err := volumetypes.ExtractVolumeTypes(allPages)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, 1, len(actual))
+	th.AssertEquals(t, "test-type", actual[0].Name)
+	th.AssertEquals(t, "996af3df-92fd-4814-a0ee-ba5f899aa1ec", actual[0].ID)
+	th.AssertEquals(t, "test", actual[0].Description)
+	th.AssertEquals(t, true, actual[0].IsPublic)
+	th.AssertEquals(t, true, actual[0].PublicAccess)
+	th.AssertEquals(t, "nfs", actual[0].ExtraSpecs["storage_protocol"])
+}
+
+func TestListDescriptionParam(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	result := make(map[string]string)
+	HandleListWithDescriptionFilter(t, fakeServer, result)
+
+	result["is_public"] = "None"
+	result["description"] = "test"
+	allPages, err := volumetypes.List(client.ServiceClient(fakeServer), volumetypes.ListOpts{
+		Description: "test",
+	}).AllPages(context.TODO())
+	th.AssertNoErr(t, err)
+	actual, err := volumetypes.ExtractVolumeTypes(allPages)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, 1, len(actual))
+	th.AssertEquals(t, "test", actual[0].Description)
+	th.AssertEquals(t, "test-type", actual[0].Name)
+	th.AssertEquals(t, "ab948f0a-13ed-47c8-b9be-cade0beb0706", actual[0].ID)
+	th.AssertEquals(t, true, actual[0].IsPublic)
+	th.AssertEquals(t, true, actual[0].PublicAccess)
+	th.AssertEquals(t, "<is> True", actual[0].ExtraSpecs["multiattach"])
+}
+
 func TestVolumeTypeExtraSpecsList(t *testing.T) {
 	fakeServer := th.SetupHTTP()
 	defer fakeServer.Teardown()


### PR DESCRIPTION
Added fields: name, description
extra_specs was left out as it would cause an API change.

Manual backport of https://github.com/gophercloud/gophercloud/pull/3587 due to conflicts.