### PR TITLE
endpoint: add missing pointer to description on update

### DIFF
--- a/internal/acceptance/openstack/identity/v3/endpoint_test.go
+++ b/internal/acceptance/openstack/identity/v3/endpoint_test.go
@@ -129,14 +129,15 @@ func TestEndpointCRUD(t *testing.T) {
 	tools.PrintResource(t, endpoint.URL)
 
 	enabled = true
+	description := ""
 	newEndpoint, err := endpoints.Update(context.TODO(), client, endpoint.ID, &endpoints.UpdateOpts{
 		Name:        "new-endpoint",
 		URL:         "https://example-updated.com",
-		Description: "Updated Endpoint",
+		Description: &description,
 		Enabled:     &enabled,
 	}).Extract()
 	th.AssertNoErr(t, err)
 
 	th.AssertEquals(t, newEndpoint.URL, "https://example-updated.com")
-	th.AssertEquals(t, newEndpoint.Description, "Updated Endpoint")
+	th.AssertEquals(t, newEndpoint.Description, description)
 }

--- a/openstack/identity/v3/endpoints/requests.go
+++ b/openstack/identity/v3/endpoints/requests.go
@@ -134,7 +134,7 @@ type UpdateOpts struct {
 	ServiceID string `json:"service_id,omitempty"`
 
 	// Description is an updated description of the endpoint.
-	Description string `json:"description,omitempty"`
+	Description *string `json:"description,omitempty"`
 }
 
 // ToEndpointUpdateMap builds an update request body from the Update options.

--- a/openstack/identity/v3/endpoints/testing/requests_test.go
+++ b/openstack/identity/v3/endpoints/testing/requests_test.go
@@ -232,10 +232,11 @@ func TestUpdateEndpoint(t *testing.T) {
 	})
 
 	enabled := false
+	description := "Changed description"
 	actual, err := endpoints.Update(context.TODO(), client.ServiceClient(fakeServer), "12", endpoints.UpdateOpts{
 		Name:        "renamed",
 		Region:      "somewhere-else",
-		Description: "Changed description",
+		Description: &description,
 		Enabled:     &enabled,
 	}).Extract()
 	if err != nil {


### PR DESCRIPTION
This PR adds a missing pointer in description when updating that field. We weren't able to set the description as an empty string.