### PR TITLE
         Networking V2: Added support for ML2 extension port_trusted_vif

### DIFF
--- a/.github/workflows/functional-networking.yaml
+++ b/.github/workflows/functional-networking.yaml
@@ -65,7 +65,7 @@ jobs:
             enable_plugin neutron-dynamic-routing https://github.com/openstack/neutron-dynamic-routing ${{ matrix.openstack_version }}
             enable_plugin neutron-vpnaas https://github.com/openstack/neutron-vpnaas ${{ matrix.openstack_version }}
             enable_plugin networking-bgpvpn https://github.com/openstack/networking-bgpvpn.git ${{ matrix.openstack_version }}
-            Q_ML2_PLUGIN_EXT_DRIVERS=qos,port_security,dns_domain_keywords
+            Q_ML2_PLUGIN_EXT_DRIVERS=qos,port_security,dns_domain_keywords,port_trusted
             BGP_SCHEDULER_DRIVER=neutron_dynamic_routing.services.bgp.scheduler.bgp_dragent_scheduler.StaticScheduler
 
             [[post-config|\$NEUTRON_CONF]]

--- a/openstack/networking/v2/extensions/portstrustedvif/doc.go
+++ b/openstack/networking/v2/extensions/portstrustedvif/doc.go
@@ -1,0 +1,74 @@
+/*
+Package portstrustedvif provides information and interaction with the port
+trusted vif extension which adds trusted attributes to the port resource
+for the OpenStack Networking service.
+
+Example to Get a Port with a Port Trusted VIF
+
+	var portWithPortTrustedVIFExtension struct {
+		ports.Port
+		portstrustedvif.PortTrustedVIFExt
+	}
+
+	portID := "46d4bfb9-b26e-41f3-bd2e-e6dcc1ccedb2"
+
+	err := ports.Get(context.TODO(), networkingClient, portID).ExtractInto(&portWithPortTrustedVIFExtension)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v\n", portWithPortTrustedVIFExtension)
+
+Example to Create a Port With Port Trusted VIF set as true
+
+	var portWithPortTrustedVIFExtension struct {
+		ports.Port
+		portstrustedvif.PortTrustedVIFExt
+	}
+
+	iTrue := true
+	networkID := "4e8e5957-649f-477b-9e5b-f1f75b21c03c"
+	subnetID := "a87cc70a-3e15-4acf-8205-9b711a3531b7"
+
+	portCreateOpts := ports.CreateOpts{
+		NetworkID: networkID,
+		FixedIPs:  []ports.IP{ports.IP{SubnetID: subnetID}},
+	}
+
+	createOpts := portstrustedvif.PortCreateOptsExt{
+		CreateOptsBuilder:   portCreateOpts,
+		PortTrustedVIF: &iTrue,
+	}
+
+	err := ports.Create(context.TODO(), networkingClient, createOpts).ExtractInto(&portWithPortTrustedVIFExtension)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v\n", portWithPortTrustedVIFExtension)
+
+Example to Update the status of the Port Trusted VIF to false on an Existing Port
+
+	var portWithPortTrustedVIDExtension struct {
+		ports.Port
+		portstrustedvif.PortTrustedVIFExt
+	}
+
+	iFalse := false
+	portID := "65c0ee9f-d634-4522-8954-51021b570b0d"
+
+	portUpdateOpts := ports.UpdateOpts{}
+	updateOpts := portstrustedvif.PortUpdateOptsExt{
+		UpdateOptsBuilder:   portUpdateOpts,
+		PortTrustedVIF: &iFalse,
+	}
+
+	err := ports.Update(context.TODO(), networkingClient, portID, updateOpts).ExtractInto(&portWithPortTrustedVIFExtension)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v\n", portWithPortTrustedVIFExtension)
+*/
+
+package portstrustedvif

--- a/openstack/networking/v2/extensions/portstrustedvif/requests.go
+++ b/openstack/networking/v2/extensions/portstrustedvif/requests.go
@@ -1,0 +1,53 @@
+package portstrustedvif
+
+import (
+	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/ports"
+)
+
+// PortCreateOptsExt adds port trusted VIF options to the base ports.CreateOpts.
+type PortCreateOptsExt struct {
+	ports.CreateOptsBuilder
+
+	// PortTrustedVIF toggles the port's trusted VIF status.
+	PortTrustedVIF *bool `json:"trusted,omitempty"`
+}
+
+// To PortCreateMap casts a CreateOpts struct to a map
+func (opts PortCreateOptsExt) ToPortCreateMap() (map[string]any, error) {
+	base, err := opts.CreateOptsBuilder.ToPortCreateMap()
+	if err != nil {
+		return nil, err
+	}
+
+	port := base["port"].(map[string]any)
+
+	if opts.PortTrustedVIF != nil {
+		port["trusted"] = *opts.PortTrustedVIF
+	}
+
+	return base, nil
+}
+
+// PortUpdateOptsExt adds port trusted VIF options to the base ports.UpdateOpts.
+type PortUpdateOptsExt struct {
+	ports.UpdateOptsBuilder
+
+	// PortTrustedVIF updates the port's trusted VIF status.
+	PortTrustedVIF *bool `json:"trusted,omitempty"`
+}
+
+// ToPortUpdateMap casts a UpdateOpts struct to a map.
+func (opts PortUpdateOptsExt) ToPortUpdateMap() (map[string]any, error) {
+	base, err := opts.UpdateOptsBuilder.ToPortUpdateMap()
+	if err != nil {
+		return nil, err
+	}
+
+	port := base["port"].(map[string]any)
+
+	if opts.PortTrustedVIF != nil {
+		port["trusted"] = *opts.PortTrustedVIF
+	}
+
+	return base, nil
+}

--- a/openstack/networking/v2/extensions/portstrustedvif/results.go
+++ b/openstack/networking/v2/extensions/portstrustedvif/results.go
@@ -1,0 +1,6 @@
+package portstrustedvif
+
+type PortTrustedVIFExt struct {
+	// PortTrustedVIF stores information about whether a SR-IOV port should be trusted
+	PortTrustedVIF *bool `json:"trusted"`
+}

--- a/openstack/networking/v2/extensions/portstrustedvif/testing/fixtures_test.go
+++ b/openstack/networking/v2/extensions/portstrustedvif/testing/fixtures_test.go
@@ -1,0 +1,161 @@
+package testing
+
+const ListResponse = `
+{
+    "ports": [
+        {
+            "status": "ACTIVE",
+            "binding:host_id": "devstack",
+            "name": "",
+            "admin_state_up": true,
+            "network_id": "70c1db1f-b701-45bd-96e0-a313ee3430b3",
+            "tenant_id": "",
+            "device_owner": "network:router_gateway",
+            "mac_address": "fa:16:3e:58:42:ed",
+            "binding:vnic_type": "normal",
+            "fixed_ips": [
+                {
+                    "subnet_id": "008ba151-0b8c-4a67-98b5-0d2b87666062",
+                    "ip_address": "172.24.4.2"
+                }
+            ],
+            "id": "d80b1a3b-4fc1-49f3-952e-1e2ab7081d8b",
+            "security_groups": [],
+            "dns_name": "test-port",
+            "dns_assignment": [
+              {
+                "hostname": "test-port",
+                "ip_address": "172.24.4.2",
+                "fqdn": "test-port.openstack.local."
+              }
+            ],
+            "device_id": "9ae135f4-b6e0-4dad-9e91-3c223e385824",
+            "port_security_enabled": false,
+			"trusted": true,
+            "created_at": "2019-06-30T04:15:37",
+            "updated_at": "2019-06-30T05:18:49"
+        }
+    ]
+}
+`
+
+const GetPortTrustedVIFStatusResponse = `
+{
+    "port": {
+        "status": "DOWN",
+        "name": "private-port",
+        "admin_state_up": true,
+        "network_id": "a87cc70a-3e15-4acf-8205-9b711a3531b7",
+        "tenant_id": "d6700c0c9ffa4f1cb322cd4a1f3906fa",
+        "device_owner": "",
+        "mac_address": "fa:16:3e:c9:cb:f0",
+        "fixed_ips": [
+            {
+                "subnet_id": "a0304c3a-4f08-4c43-88af-d796509c97d2",
+                "ip_address": "10.0.0.1"
+            }
+        ],
+        "id": "46d4bfb9-b26e-41f3-bd2e-e6dcc1ccedb2",
+        "trusted": false,
+        "device_id": ""
+    }
+}
+`
+const GetPortTrustedVIFUnsetResponse = `
+{
+    "port": {
+        "status": "DOWN",
+        "name": "private-port",
+        "admin_state_up": true,
+        "network_id": "a87cc70a-3e15-4acf-8205-9b711a3531b7",
+        "tenant_id": "d6700c0c9ffa4f1cb322cd4a1f3906fa",
+        "device_owner": "",
+        "mac_address": "fa:16:3e:c9:cb:f0",
+        "fixed_ips": [
+            {
+                "subnet_id": "a0304c3a-4f08-4c43-88af-d796509c97d2",
+                "ip_address": "10.0.0.1"
+            }
+        ],
+        "id": "46d4bfb9-b26e-41f3-bd2e-e6dcc1ccedb2",
+        "device_id": ""
+    }
+}
+`
+
+const CreatePortTrustedVIFRequest = `
+{
+    "port": {
+        "network_id": "a87cc70a-3e15-4acf-8205-9b711a3531b7",
+        "name": "private-port",
+        "admin_state_up": true,
+        "fixed_ips": [
+            {
+                "subnet_id": "a0304c3a-4f08-4c43-88af-d796509c97d2",
+                "ip_address": "10.0.0.2"
+            }
+        ],
+        "trusted": true
+    }
+}`
+
+const CreatePortTrustedVIFResponse = `
+{
+    "port": {
+        "status": "DOWN",
+        "name": "private-port",
+        "admin_state_up": true,
+        "network_id": "a87cc70a-3e15-4acf-8205-9b711a3531b7",
+        "tenant_id": "d6700c0c9ffa4f1cb322cd4a1f3906fa",
+        "device_owner": "",
+        "mac_address": "fa:16:3e:c9:cb:f0",
+        "fixed_ips": [
+            {
+                "subnet_id": "a0304c3a-4f08-4c43-88af-d796509c97d2",
+                "ip_address": "10.0.0.2"
+            }
+        ],
+        "id": "65c0ee9f-d634-4522-8954-51021b570b0d",
+        "trusted": true,
+        "device_id": ""
+    }
+}`
+
+const UpdatePortTrustedVIFRequest = `
+{
+    "port": {
+        "trusted": false
+    }
+}`
+
+const UpdatePortTrustedVIFResponse = `
+{
+    "port": {
+        "status": "DOWN",
+        "name": "private-port",
+        "admin_state_up": true,
+        "network_id": "a87cc70a-3e15-4acf-8205-9b711a3531b7",
+        "tenant_id": "d6700c0c9ffa4f1cb322cd4a1f3906fa",
+        "device_owner": "",
+        "mac_address": "fa:16:3e:c9:cb:f0",
+        "fixed_ips": [
+            {
+                "subnet_id": "a0304c3a-4f08-4c43-88af-d796509c97d2",
+                "ip_address": "10.0.0.3"
+            }
+        ],
+        "allowed_address_pairs": [
+          {
+            "ip_address": "10.0.0.4",
+            "mac_address": "fa:16:3e:c9:cb:f0"
+          }
+        ],
+        "id": "65c0ee9f-d634-4522-8954-51021b570b0d",
+        "security_groups": [
+            "f0ac4394-7e4a-4409-9701-ba8be283dbc3"
+        ],
+        "trusted": false,
+        "device_id": ""
+    }
+}
+`

--- a/openstack/networking/v2/extensions/portstrustedvif/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/portstrustedvif/testing/requests_test.go
@@ -1,0 +1,242 @@
+package testing
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	fake "github.com/gophercloud/gophercloud/v2/openstack/networking/v2/common"
+	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/portstrustedvif"
+	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/ports"
+	th "github.com/gophercloud/gophercloud/v2/testhelper"
+)
+
+func TestList(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	fakeServer.Mux.HandleFunc("/v2.0/ports", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprint(w, ListResponse)
+	})
+
+	type PortWithExt struct {
+		ports.Port
+		portstrustedvif.PortTrustedVIFExt
+	}
+	var actual []PortWithExt
+
+	iTrue := true
+	expected := []PortWithExt{
+		{
+			Port: ports.Port{
+				Status:       "ACTIVE",
+				Name:         "",
+				AdminStateUp: true,
+				NetworkID:    "70c1db1f-b701-45bd-96e0-a313ee3430b3",
+				TenantID:     "",
+				DeviceOwner:  "network:router_gateway",
+				MACAddress:   "fa:16:3e:58:42:ed",
+				FixedIPs: []ports.IP{
+					{
+						SubnetID:  "008ba151-0b8c-4a67-98b5-0d2b87666062",
+						IPAddress: "172.24.4.2",
+					},
+				},
+				ID:             "d80b1a3b-4fc1-49f3-952e-1e2ab7081d8b",
+				SecurityGroups: []string{},
+				DeviceID:       "9ae135f4-b6e0-4dad-9e91-3c223e385824",
+				CreatedAt:      time.Date(2019, time.June, 30, 4, 15, 37, 0, time.UTC),
+				UpdatedAt:      time.Date(2019, time.June, 30, 5, 18, 49, 0, time.UTC),
+			},
+			PortTrustedVIFExt: portstrustedvif.PortTrustedVIFExt{
+				PortTrustedVIF: &iTrue,
+			},
+		},
+	}
+
+	allPages, err := ports.List(fake.ServiceClient(fakeServer), ports.ListOpts{}).AllPages(context.TODO())
+	th.AssertNoErr(t, err)
+
+	err = ports.ExtractPortsInto(allPages, &actual)
+	th.AssertNoErr(t, err)
+
+	th.CheckDeepEquals(t, expected, actual)
+}
+
+func TestGet(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	fakeServer.Mux.HandleFunc("/v2.0/ports/46d4bfb9-b26e-41f3-bd2e-e6dcc1ccedb2", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprint(w, GetPortTrustedVIFStatusResponse)
+	})
+
+	var s struct {
+		ports.Port
+		portstrustedvif.PortTrustedVIFExt
+	}
+
+	err := ports.Get(context.TODO(), fake.ServiceClient(fakeServer), "46d4bfb9-b26e-41f3-bd2e-e6dcc1ccedb2").ExtractInto(&s)
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, s.Status, "DOWN")
+	th.AssertEquals(t, s.Name, "private-port")
+	th.AssertEquals(t, s.AdminStateUp, true)
+	th.AssertEquals(t, s.NetworkID, "a87cc70a-3e15-4acf-8205-9b711a3531b7")
+	th.AssertEquals(t, s.TenantID, "d6700c0c9ffa4f1cb322cd4a1f3906fa")
+	th.AssertEquals(t, s.DeviceOwner, "")
+	th.AssertEquals(t, s.MACAddress, "fa:16:3e:c9:cb:f0")
+	th.AssertDeepEquals(t, s.FixedIPs, []ports.IP{
+		{SubnetID: "a0304c3a-4f08-4c43-88af-d796509c97d2", IPAddress: "10.0.0.1"},
+	})
+	th.AssertEquals(t, s.ID, "46d4bfb9-b26e-41f3-bd2e-e6dcc1ccedb2")
+	th.AssertEquals(t, s.DeviceID, "")
+
+	if s.PortTrustedVIF == nil {
+		t.Fatalf("Expected s.PortTrustedVIF to be not nil")
+	}
+	th.AssertEquals(t, *s.PortTrustedVIF, false)
+}
+
+func TestGetUnset(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	fakeServer.Mux.HandleFunc("/v2.0/ports/46d4bfb9-b26e-41f3-bd2e-e6dcc1ccedb2", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprint(w, GetPortTrustedVIFUnsetResponse)
+	})
+
+	var s struct {
+		ports.Port
+		portstrustedvif.PortTrustedVIFExt
+	}
+
+	err := ports.Get(context.TODO(), fake.ServiceClient(fakeServer), "46d4bfb9-b26e-41f3-bd2e-e6dcc1ccedb2").ExtractInto(&s)
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, s.Status, "DOWN")
+	th.AssertEquals(t, s.Name, "private-port")
+	th.AssertEquals(t, s.AdminStateUp, true)
+	th.AssertEquals(t, s.NetworkID, "a87cc70a-3e15-4acf-8205-9b711a3531b7")
+	th.AssertEquals(t, s.TenantID, "d6700c0c9ffa4f1cb322cd4a1f3906fa")
+	th.AssertEquals(t, s.DeviceOwner, "")
+	th.AssertEquals(t, s.MACAddress, "fa:16:3e:c9:cb:f0")
+	th.AssertDeepEquals(t, s.FixedIPs, []ports.IP{
+		{SubnetID: "a0304c3a-4f08-4c43-88af-d796509c97d2", IPAddress: "10.0.0.1"},
+	})
+	th.AssertEquals(t, s.ID, "46d4bfb9-b26e-41f3-bd2e-e6dcc1ccedb2")
+	th.AssertEquals(t, s.DeviceID, "")
+
+	if s.PortTrustedVIF != nil {
+		t.Fatalf("Expected s.PortTrustedVIF to be nil")
+	}
+}
+
+func TestCreateWithPortTrustedVIF(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	fakeServer.Mux.HandleFunc("/v2.0/ports", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, CreatePortTrustedVIFRequest)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+
+		fmt.Fprint(w, CreatePortTrustedVIFResponse)
+	})
+
+	var portWithExt struct {
+		ports.Port
+		portstrustedvif.PortTrustedVIFExt
+	}
+
+	asu := true
+	portTrustedVIFStatus := true
+	options := ports.CreateOpts{
+		Name:         "private-port",
+		AdminStateUp: &asu,
+		NetworkID:    "a87cc70a-3e15-4acf-8205-9b711a3531b7",
+		FixedIPs: []ports.IP{
+			{SubnetID: "a0304c3a-4f08-4c43-88af-d796509c97d2", IPAddress: "10.0.0.2"},
+		},
+	}
+	createOpts := portstrustedvif.PortCreateOptsExt{
+		CreateOptsBuilder: options,
+		PortTrustedVIF:    &portTrustedVIFStatus,
+	}
+	err := ports.Create(context.TODO(), fake.ServiceClient(fakeServer), createOpts).ExtractInto(&portWithExt)
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, portWithExt.Status, "DOWN")
+	th.AssertEquals(t, portWithExt.Name, "private-port")
+	th.AssertEquals(t, portWithExt.AdminStateUp, true)
+	th.AssertEquals(t, portWithExt.NetworkID, "a87cc70a-3e15-4acf-8205-9b711a3531b7")
+	th.AssertEquals(t, portWithExt.TenantID, "d6700c0c9ffa4f1cb322cd4a1f3906fa")
+	th.AssertEquals(t, portWithExt.DeviceOwner, "")
+	th.AssertEquals(t, portWithExt.MACAddress, "fa:16:3e:c9:cb:f0")
+	th.AssertDeepEquals(t, portWithExt.FixedIPs, []ports.IP{
+		{SubnetID: "a0304c3a-4f08-4c43-88af-d796509c97d2", IPAddress: "10.0.0.2"},
+	})
+	th.AssertEquals(t, portWithExt.ID, "65c0ee9f-d634-4522-8954-51021b570b0d")
+	th.AssertEquals(t, *portWithExt.PortTrustedVIF, true)
+}
+
+func TestUpdatePortTrustedVIF(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	fakeServer.Mux.HandleFunc("/v2.0/ports/65c0ee9f-d634-4522-8954-51021b570b0d", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, UpdatePortTrustedVIFRequest)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprint(w, UpdatePortTrustedVIFResponse)
+	})
+
+	var portWithExt struct {
+		ports.Port
+		portstrustedvif.PortTrustedVIFExt
+	}
+
+	portTrustedVIFStatus := false
+	portUpdateOpts := ports.UpdateOpts{}
+	updateOpts := portstrustedvif.PortUpdateOptsExt{
+		UpdateOptsBuilder: portUpdateOpts,
+		PortTrustedVIF:    &portTrustedVIFStatus,
+	}
+
+	err := ports.Update(context.TODO(), fake.ServiceClient(fakeServer), "65c0ee9f-d634-4522-8954-51021b570b0d", updateOpts).ExtractInto(&portWithExt)
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, portWithExt.Name, "private-port")
+	th.AssertDeepEquals(t, *portWithExt.PortTrustedVIF, false)
+}


### PR DESCRIPTION
Fixes: #3597 

Added Trusted VIF, The port-trusted-vif extension adds `trusted` attribute to the port resource.
Was implemented as an extension similar to how the `port_security_enabled` extension is currently implemented in gophercloud.

API Reference: [here](https://docs.openstack.org/api-ref/network/v2/index.html#ports:~:text=its%20connected%20to.-,Trusted%20VIF%C2%B6,-The%20port%2Dtrusted)

Links to the line numbers/files in the OpenStack source code that support the
code in this PR: 
https://opendev.org/openstack/neutron/src/commit/762694d1bd6092060ce08c29d12575e303ae2973/neutron/plugins/ml2/extensions/port_trusted.py