### PR TITLE
gomod: bump golang to 1.25.6

### DIFF
--- a/.github/workflows/label-pr.yaml
+++ b/.github/workflows/label-pr.yaml
@@ -26,7 +26,8 @@ jobs:
 
     - uses: actions/setup-go@v6
       with:
-        go-version: '1'
+        go-version-file: 'go.mod'
+        cache: true
 
     - name: Checking Go API Compatibility
       id: go-apidiff

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,7 +13,8 @@ jobs:
         uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '1'
+          go-version-file: 'go.mod'
+          cache: true
       - name: Run linters
         run: |
           make lint

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gophercloud/gophercloud/v2
 
-go 1.24.0
+go 1.25.6
 
 require (
 	go.yaml.in/yaml/v3 v3.0.4


### PR DESCRIPTION
Go 1.24 will reach end-of-life next month (https://endoflife.date/go)