### PR TITLE
feat: add network segment range extension to networking v2

### DIFF
--- a/openstack/networking/v2/extensions/networksegmentranges/doc.go
+++ b/openstack/networking/v2/extensions/networksegmentranges/doc.go
@@ -1,0 +1,71 @@
+/*
+Package networksegmentranges provides the ability to retrieve and manage
+network segment ranges through the Neutron API.
+
+Network segment ranges define pools of segmentation IDs that can be used for
+dynamic segment allocation in provider networks.
+
+Example of Listing Network Segment Ranges
+
+	listOpts := networksegmentranges.ListOpts{
+		NetworkType: "vxlan",
+	}
+
+	allPages, err := networksegmentranges.List(networkClient, listOpts).AllPages(context.TODO())
+	if err != nil {
+		panic(err)
+	}
+
+	allRanges, err := networksegmentranges.ExtractNetworkSegmentRanges(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, r := range allRanges {
+		fmt.Printf("%+v\n", r)
+	}
+
+Example to Get a Network Segment Range
+
+	rangeID := "59b2f3a1-09aa-49e4-b9f7-8d7c81f7c7e5"
+	segmentRange, err := networksegmentranges.Get(context.TODO(), networkClient, rangeID).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Create a Network Segment Range
+
+	createOpts := networksegmentranges.CreateOpts{
+		Name:        "vxlan-range",
+		NetworkType: "vxlan",
+		Minimum:     1000,
+		Maximum:     2000,
+	}
+	segmentRange, err := networksegmentranges.Create(context.TODO(), networkClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Update a Network Segment Range
+
+	rangeID := "59b2f3a1-09aa-49e4-b9f7-8d7c81f7c7e5"
+	name := "updated-range"
+	minimum := 1500
+	updateOpts := networksegmentranges.UpdateOpts{
+		Name:    &name,
+		Minimum: &minimum,
+	}
+	segmentRange, err := networksegmentranges.Update(context.TODO(), networkClient, rangeID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete a Network Segment Range
+
+	rangeID := "59b2f3a1-09aa-49e4-b9f7-8d7c81f7c7e5"
+	err := networksegmentranges.Delete(context.TODO(), networkClient, rangeID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+*/
+package networksegmentranges

--- a/openstack/networking/v2/extensions/networksegmentranges/requests.go
+++ b/openstack/networking/v2/extensions/networksegmentranges/requests.go
@@ -1,0 +1,127 @@
+package networksegmentranges
+
+import (
+	"context"
+
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/pagination"
+)
+
+// ListOpts allows filtering when listing network segment ranges.
+type ListOpts struct {
+	ID              string `q:"id"`
+	Name            string `q:"name"`
+	Default         *bool  `q:"default"`
+	Shared          *bool  `q:"shared"`
+	ProjectID       string `q:"project_id"`
+	NetworkType     string `q:"network_type"`
+	PhysicalNetwork string `q:"physical_network"`
+	Minimum         int    `q:"minimum"`
+	Maximum         int    `q:"maximum"`
+	SortDir         string `q:"sort_dir"`
+	SortKey         string `q:"sort_key"`
+}
+
+type ListOptsBuilder interface {
+	ToNetworkSegmentRangeListQuery() (string, error)
+}
+
+func (opts ListOpts) ToNetworkSegmentRangeListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	if err != nil {
+		return "", err
+	}
+	return q.String(), nil
+}
+
+// List retrieves a list of network segment ranges.
+func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(c)
+	if opts != nil {
+		query, err := opts.ToNetworkSegmentRangeListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		return NetworkSegmentRangePage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+type CreateOptsBuilder interface {
+	ToNetworkSegmentRangeCreateMap() (map[string]any, error)
+}
+
+// CreateOpts represents options for creating a network segment range.
+type CreateOpts struct {
+	Name            string `json:"name,omitempty"`
+	Default         *bool  `json:"default,omitempty"`
+	Shared          *bool  `json:"shared,omitempty"`
+	ProjectID       string `json:"project_id,omitempty"`
+	NetworkType     string `json:"network_type" required:"true"`
+	PhysicalNetwork string `json:"physical_network,omitempty"`
+	Minimum         int    `json:"minimum" required:"true"`
+	Maximum         int    `json:"maximum" required:"true"`
+}
+
+func (opts CreateOpts) ToNetworkSegmentRangeCreateMap() (map[string]any, error) {
+	return gophercloud.BuildRequestBody(opts, "network_segment_range")
+}
+
+// Create creates a new network segment range.
+func Create(ctx context.Context, c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToNetworkSegmentRangeCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := c.Post(ctx, createURL(c), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{201},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// Get retrieves a specific network segment range.
+func Get(ctx context.Context, c *gophercloud.ServiceClient, id string) (r GetResult) {
+	resp, err := c.Get(ctx, getURL(c, id), &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+type UpdateOptsBuilder interface {
+	ToNetworkSegmentRangeUpdateMap() (map[string]any, error)
+}
+
+// UpdateOpts represents options for updating a network segment range.
+type UpdateOpts struct {
+	Name    *string `json:"name,omitempty"`
+	Minimum *int    `json:"minimum,omitempty"`
+	Maximum *int    `json:"maximum,omitempty"`
+}
+
+func (opts UpdateOpts) ToNetworkSegmentRangeUpdateMap() (map[string]any, error) {
+	return gophercloud.BuildRequestBody(opts, "network_segment_range")
+}
+
+// Update modifies a network segment range.
+func Update(ctx context.Context, c *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToNetworkSegmentRangeUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := c.Put(ctx, updateURL(c, id), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// Delete removes a network segment range.
+func Delete(ctx context.Context, c *gophercloud.ServiceClient, id string) (r DeleteResult) {
+	resp, err := c.Delete(ctx, deleteURL(c, id), nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}

--- a/openstack/networking/v2/extensions/networksegmentranges/results.go
+++ b/openstack/networking/v2/extensions/networksegmentranges/results.go
@@ -1,0 +1,74 @@
+package networksegmentranges
+
+import (
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/pagination"
+)
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// Extract interprets a network segment range result as a NetworkSegmentRange.
+func (r commonResult) Extract() (*NetworkSegmentRange, error) {
+	var s struct {
+		NetworkSegmentRange *NetworkSegmentRange `json:"network_segment_range"`
+	}
+	err := r.ExtractInto(&s)
+	return s.NetworkSegmentRange, err
+}
+
+// CreateResult represents the result of a create operation.
+type CreateResult struct {
+	commonResult
+}
+
+// GetResult represents the result of a get operation.
+type GetResult struct {
+	commonResult
+}
+
+// UpdateResult represents the result of an update operation.
+type UpdateResult struct {
+	commonResult
+}
+
+// DeleteResult represents the result of a delete operation.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
+// NetworkSegmentRange represents a network segment range.
+type NetworkSegmentRange struct {
+	ID              string         `json:"id"`
+	Name            string         `json:"name"`
+	Default         bool           `json:"default"`
+	Shared          bool           `json:"shared"`
+	ProjectID       string         `json:"project_id"`
+	NetworkType     string         `json:"network_type"`
+	PhysicalNetwork string         `json:"physical_network"`
+	Minimum         int            `json:"minimum"`
+	Maximum         int            `json:"maximum"`
+	Used            map[int]string `json:"used"`
+	Available       []int          `json:"available"`
+}
+
+// NetworkSegmentRangePage is the page returned by a pager when traversing over a collection of network segment ranges.
+type NetworkSegmentRangePage struct {
+	pagination.LinkedPageBase
+}
+
+// IsEmpty checks whether a NetworkSegmentRangePage struct is empty.
+func (r NetworkSegmentRangePage) IsEmpty() (bool, error) {
+	is, err := ExtractNetworkSegmentRanges(r)
+	return len(is) == 0, err
+}
+
+// ExtractNetworkSegmentRanges accepts a Page struct and extracts the elements into a slice of NetworkSegmentRange structs.
+func ExtractNetworkSegmentRanges(r pagination.Page) ([]NetworkSegmentRange, error) {
+	var s struct {
+		NetworkSegmentRanges []NetworkSegmentRange `json:"network_segment_ranges"`
+	}
+	err := (r.(NetworkSegmentRangePage)).ExtractInto(&s)
+	return s.NetworkSegmentRanges, err
+}

--- a/openstack/networking/v2/extensions/networksegmentranges/testing/doc.go
+++ b/openstack/networking/v2/extensions/networksegmentranges/testing/doc.go
@@ -1,0 +1,2 @@
+// networksegmentranges unit tests
+package testing

--- a/openstack/networking/v2/extensions/networksegmentranges/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/networksegmentranges/testing/requests_test.go
@@ -1,0 +1,253 @@
+package testing
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	fake "github.com/gophercloud/gophercloud/v2/openstack/networking/v2/common"
+	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/networksegmentranges"
+	"github.com/gophercloud/gophercloud/v2/pagination"
+	th "github.com/gophercloud/gophercloud/v2/testhelper"
+)
+
+func TestList(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	fakeServer.Mux.HandleFunc("/v2.0/network_segment_ranges", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		_, err := w.Write([]byte(`
+{
+    "network_segment_ranges": [
+        {
+            "id": "59b2f3a1-09aa-49e4-b9f7-8d7c81f7c7e5",
+            "name": "range1",
+            "default": false,
+            "shared": false,
+            "project_id": "3e2f3a1-09aa-49e4-b9f7-8d7c81f7c7e5",
+            "network_type": "vxlan",
+            "physical_network": "",
+            "minimum": 100,
+            "maximum": 200,
+            "used": {},
+            "available": [100, 101, 102]
+        }
+    ]
+}`))
+		th.AssertNoErr(t, err)
+	})
+
+	count := 0
+	err := networksegmentranges.List(fake.ServiceClient(fakeServer), nil).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
+		count++
+		actual, err := networksegmentranges.ExtractNetworkSegmentRanges(page)
+		if err != nil {
+			t.Errorf("Failed to extract network segment ranges: %v", err)
+			return false, err
+		}
+
+		expected := []networksegmentranges.NetworkSegmentRange{
+			{
+				ID:              "59b2f3a1-09aa-49e4-b9f7-8d7c81f7c7e5",
+				Name:            "range1",
+				Default:         false,
+				Shared:          false,
+				ProjectID:       "3e2f3a1-09aa-49e4-b9f7-8d7c81f7c7e5",
+				NetworkType:     "vxlan",
+				PhysicalNetwork: "",
+				Minimum:         100,
+				Maximum:         200,
+				Used:            map[int]string{},
+				Available:       []int{100, 101, 102},
+			},
+		}
+
+		th.CheckDeepEquals(t, expected, actual)
+
+		return true, nil
+	})
+
+	th.AssertNoErr(t, err)
+
+	if count != 1 {
+		t.Errorf("Expected 1 page, got %d", count)
+	}
+}
+
+func TestCreate(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	fakeServer.Mux.HandleFunc("/v2.0/network_segment_ranges", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, `
+{
+    "network_segment_range": {
+        "name": "range1",
+        "network_type": "vxlan",
+        "minimum": 100,
+        "maximum": 200
+    }
+}
+		`)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+
+		_, err := w.Write([]byte(`
+{
+    "network_segment_range": {
+        "id": "59b2f3a1-09aa-49e4-b9f7-8d7c81f7c7e5",
+        "name": "range1",
+        "default": false,
+        "shared": false,
+        "project_id": "3e2f3a1-09aa-49e4-b9f7-8d7c81f7c7e5",
+        "network_type": "vxlan",
+        "physical_network": "",
+        "minimum": 100,
+        "maximum": 200,
+        "used": {},
+        "available": []
+    }
+}
+		`))
+		th.AssertNoErr(t, err)
+	})
+
+	opts := networksegmentranges.CreateOpts{
+		Name:        "range1",
+		NetworkType: "vxlan",
+		Minimum:     100,
+		Maximum:     200,
+	}
+	n, err := networksegmentranges.Create(context.TODO(), fake.ServiceClient(fakeServer), opts).Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, "59b2f3a1-09aa-49e4-b9f7-8d7c81f7c7e5", n.ID)
+	th.AssertEquals(t, "range1", n.Name)
+	th.AssertEquals(t, "vxlan", n.NetworkType)
+	th.AssertEquals(t, 100, n.Minimum)
+	th.AssertEquals(t, 200, n.Maximum)
+}
+
+func TestGet(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	fakeServer.Mux.HandleFunc("/v2.0/network_segment_ranges/59b2f3a1-09aa-49e4-b9f7-8d7c81f7c7e5", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		_, err := w.Write([]byte(`
+{
+    "network_segment_range": {
+        "id": "59b2f3a1-09aa-49e4-b9f7-8d7c81f7c7e5",
+        "name": "range1",
+        "default": false,
+        "shared": false,
+        "project_id": "3e2f3a1-09aa-49e4-b9f7-8d7c81f7c7e5",
+        "network_type": "vxlan",
+        "physical_network": "",
+        "minimum": 100,
+        "maximum": 200,
+        "used": {},
+        "available": [100, 101, 102]
+    }
+}
+		`))
+		th.AssertNoErr(t, err)
+	})
+
+	n, err := networksegmentranges.Get(context.TODO(), fake.ServiceClient(fakeServer), "59b2f3a1-09aa-49e4-b9f7-8d7c81f7c7e5").Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, "59b2f3a1-09aa-49e4-b9f7-8d7c81f7c7e5", n.ID)
+	th.AssertEquals(t, "range1", n.Name)
+	th.AssertEquals(t, "vxlan", n.NetworkType)
+	th.AssertEquals(t, 100, n.Minimum)
+	th.AssertEquals(t, 200, n.Maximum)
+}
+
+func TestUpdate(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	fakeServer.Mux.HandleFunc("/v2.0/network_segment_ranges/59b2f3a1-09aa-49e4-b9f7-8d7c81f7c7e5", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, `
+{
+    "network_segment_range": {
+        "name": "range1-updated",
+        "minimum": 150,
+        "maximum": 250
+    }
+}
+		`)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		_, err := w.Write([]byte(`
+{
+    "network_segment_range": {
+        "id": "59b2f3a1-09aa-49e4-b9f7-8d7c81f7c7e5",
+        "name": "range1-updated",
+        "default": false,
+        "shared": false,
+        "project_id": "3e2f3a1-09aa-49e4-b9f7-8d7c81f7c7e5",
+        "network_type": "vxlan",
+        "physical_network": "",
+        "minimum": 150,
+        "maximum": 250,
+        "used": {},
+        "available": []
+    }
+}
+		`))
+		th.AssertNoErr(t, err)
+	})
+
+	name := "range1-updated"
+	minimum := 150
+	maximum := 250
+	opts := networksegmentranges.UpdateOpts{
+		Name:    &name,
+		Minimum: &minimum,
+		Maximum: &maximum,
+	}
+	n, err := networksegmentranges.Update(context.TODO(), fake.ServiceClient(fakeServer), "59b2f3a1-09aa-49e4-b9f7-8d7c81f7c7e5", opts).Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, "range1-updated", n.Name)
+	th.AssertEquals(t, 150, n.Minimum)
+	th.AssertEquals(t, 250, n.Maximum)
+}
+
+func TestDelete(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	fakeServer.Mux.HandleFunc("/v2.0/network_segment_ranges/59b2f3a1-09aa-49e4-b9f7-8d7c81f7c7e5", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	res := networksegmentranges.Delete(context.TODO(), fake.ServiceClient(fakeServer), "59b2f3a1-09aa-49e4-b9f7-8d7c81f7c7e5")
+	th.AssertNoErr(t, res.Err)
+}

--- a/openstack/networking/v2/extensions/networksegmentranges/urls.go
+++ b/openstack/networking/v2/extensions/networksegmentranges/urls.go
@@ -1,0 +1,31 @@
+package networksegmentranges
+
+import "github.com/gophercloud/gophercloud/v2"
+
+func rootURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("network_segment_ranges")
+}
+
+func resourceURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("network_segment_ranges", id)
+}
+
+func listURL(c *gophercloud.ServiceClient) string {
+	return rootURL(c)
+}
+
+func createURL(c *gophercloud.ServiceClient) string {
+	return rootURL(c)
+}
+
+func getURL(c *gophercloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
+}
+
+func updateURL(c *gophercloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
+}
+
+func deleteURL(c *gophercloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
+}


### PR DESCRIPTION
Add support for Neutron's network segment range extension to the networking/v2 module.

Fixes #3613

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://docs.openstack.org/neutron/2025.2//admin/config-network-segment-ranges.html
https://github.com/openstack/neutron/blob/master/neutron/extensions/network_segment_range.py
https://docs.openstack.org/api-ref/network/v2/index.html#network-segment-ranges

