### PR TITLE
Add TSIG key support for OpenStack DNS v2 API

### DIFF
--- a/internal/acceptance/openstack/dns/v2/dns.go
+++ b/internal/acceptance/openstack/dns/v2/dns.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gophercloud/gophercloud/v2/openstack/dns/v2/recordsets"
 	transferAccepts "github.com/gophercloud/gophercloud/v2/openstack/dns/v2/transfer/accept"
 	transferRequests "github.com/gophercloud/gophercloud/v2/openstack/dns/v2/transfer/request"
+	"github.com/gophercloud/gophercloud/v2/openstack/dns/v2/tsigkeys"
 	"github.com/gophercloud/gophercloud/v2/openstack/dns/v2/zones"
 	th "github.com/gophercloud/gophercloud/v2/testhelper"
 )
@@ -307,4 +308,49 @@ func WaitForZoneStatus(client *gophercloud.ServiceClient, zone *zones.Zone, stat
 
 		return false, nil
 	})
+}
+
+// CreateTSIGKey will create a TSIG key with a random name. An error will
+// be returned if the TSIG key was unable to be created.
+func CreateTSIGKey(t *testing.T, client *gophercloud.ServiceClient) (*tsigkeys.TSIGKey, error) {
+	keyName := tools.RandomString("ACPTTEST", 8)
+
+	t.Logf("Attempting to create TSIG key: %s", keyName)
+	createOpts := tsigkeys.CreateOpts{
+		Name:      keyName,
+		Algorithm: "hmac-sha256",
+		Secret:    "example-test-secret-key==",
+		Scope:     "POOL",
+		// Default pool ID from designate/conf/central.py
+		ResourceID: "794ccc2c-d751-44fe-b57f-8894c9f5c842",
+	}
+
+	tsigkey, err := tsigkeys.Create(context.TODO(), client, createOpts).Extract()
+	if err != nil {
+		return tsigkey, err
+	}
+
+	newTSIGKey, err := tsigkeys.Get(context.TODO(), client, tsigkey.ID).Extract()
+	if err != nil {
+		return tsigkey, err
+	}
+
+	t.Logf("Created TSIG key: %s", keyName)
+
+	th.AssertEquals(t, newTSIGKey.Name, keyName)
+	th.AssertEquals(t, newTSIGKey.Algorithm, "hmac-sha256")
+
+	return newTSIGKey, nil
+}
+
+// DeleteTSIGKey will delete a specified TSIG key. A fatal error will occur if
+// the TSIG key failed to be deleted. This works best when used as a deferred
+// function.
+func DeleteTSIGKey(t *testing.T, client *gophercloud.ServiceClient, tsigkey *tsigkeys.TSIGKey) {
+	err := tsigkeys.Delete(context.TODO(), client, tsigkey.ID).ExtractErr()
+	if err != nil {
+		t.Fatalf("Unable to delete TSIG key %s: %v", tsigkey.ID, err)
+	}
+
+	t.Logf("Deleted TSIG key: %s", tsigkey.ID)
 }

--- a/internal/acceptance/openstack/dns/v2/tsigkeys_test.go
+++ b/internal/acceptance/openstack/dns/v2/tsigkeys_test.go
@@ -1,0 +1,56 @@
+//go:build acceptance || dns || tsigkeys
+
+package v2
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/v2/internal/acceptance/clients"
+	"github.com/gophercloud/gophercloud/v2/internal/acceptance/tools"
+	"github.com/gophercloud/gophercloud/v2/openstack/dns/v2/tsigkeys"
+	th "github.com/gophercloud/gophercloud/v2/testhelper"
+)
+
+func TestTSIGKeysCRUD(t *testing.T) {
+	clients.RequireAdmin(t)
+
+	client, err := clients.NewDNSV2Client()
+	th.AssertNoErr(t, err)
+
+	tsigkey, err := CreateTSIGKey(t, client)
+	th.AssertNoErr(t, err)
+	defer DeleteTSIGKey(t, client, tsigkey)
+
+	tools.PrintResource(t, &tsigkey)
+
+	allPages, err := tsigkeys.List(client, nil).AllPages(context.TODO())
+	th.AssertNoErr(t, err)
+
+	allTSIGKeys, err := tsigkeys.ExtractTSIGKeys(allPages)
+	th.AssertNoErr(t, err)
+
+	var found bool
+	for _, k := range allTSIGKeys {
+		tools.PrintResource(t, &k)
+
+		if tsigkey.Name == k.Name {
+			found = true
+		}
+	}
+
+	th.AssertEquals(t, found, true)
+
+	updateOpts := tsigkeys.UpdateOpts{
+		Name:   tsigkey.Name + "-updated",
+		Secret: "updated-test-secret-key==",
+	}
+
+	newTSIGKey, err := tsigkeys.Update(context.TODO(), client, tsigkey.ID, updateOpts).Extract()
+	th.AssertNoErr(t, err)
+
+	tools.PrintResource(t, &newTSIGKey)
+
+	th.AssertEquals(t, newTSIGKey.Name, tsigkey.Name+"-updated")
+	th.AssertEquals(t, newTSIGKey.Secret, "updated-test-secret-key==")
+}

--- a/openstack/dns/v2/tsigkeys/doc.go
+++ b/openstack/dns/v2/tsigkeys/doc.go
@@ -1,0 +1,72 @@
+/*
+Package tsigkeys provides information and interaction with the TSIG key API
+resource for the OpenStack DNS service.
+
+TSIG (Transaction SIGnature) keys are used to authenticate DNS transactions
+between servers, such as zone transfers and dynamic updates.
+
+Example to List TSIG Keys
+
+	listOpts := tsigkeys.ListOpts{
+		Scope: "POOL",
+	}
+
+	allPages, err := tsigkeys.List(dnsClient, listOpts).AllPages(context.TODO())
+	if err != nil {
+		panic(err)
+	}
+
+	allTSIGKeys, err := tsigkeys.ExtractTSIGKeys(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, tsigkey := range allTSIGKeys {
+		fmt.Printf("%+v\n", tsigkey)
+	}
+
+Example to Create a TSIG Key
+
+	createOpts := tsigkeys.CreateOpts{
+		Name:       "mytsigkey",
+		Algorithm:  "hmac-sha256",
+		Secret:     "example-secret-key-value==",
+		Scope:      "POOL",
+		ResourceID: "pool-id-here",
+	}
+
+	tsigkey, err := tsigkeys.Create(context.TODO(), dnsClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Get a TSIG Key
+
+	tsigkeyID := "99d10f68-5623-4491-91a0-6daafa32b60e"
+	tsigkey, err := tsigkeys.Get(context.TODO(), dnsClient, tsigkeyID).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Update a TSIG Key
+
+	tsigkeyID := "99d10f68-5623-4491-91a0-6daafa32b60e"
+	updateOpts := tsigkeys.UpdateOpts{
+		Name:   "updatedname",
+		Secret: "updated-secret-key-value==",
+	}
+
+	tsigkey, err := tsigkeys.Update(context.TODO(), dnsClient, tsigkeyID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete a TSIG Key
+
+	tsigkeyID := "99d10f68-5623-4491-91a0-6daafa32b60e"
+	err := tsigkeys.Delete(context.TODO(), dnsClient, tsigkeyID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+*/
+package tsigkeys

--- a/openstack/dns/v2/tsigkeys/requests.go
+++ b/openstack/dns/v2/tsigkeys/requests.go
@@ -1,0 +1,158 @@
+package tsigkeys
+
+import (
+	"context"
+
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/pagination"
+)
+
+// ListOptsBuilder allows extensions to add parameters to the List request.
+type ListOptsBuilder interface {
+	ToTSIGKeyListQuery() (string, error)
+}
+
+// ListOpts allows the filtering and sorting of paginated collections through
+// the API. Filtering is achieved by passing in struct field values that map to
+// the server attributes you want to see returned. Marker and Limit are used
+// for pagination.
+// https://docs.openstack.org/api-ref/dns/
+type ListOpts struct {
+	// Integer value for the limit of values to return.
+	Limit int `q:"limit"`
+
+	// UUID of the TSIG key at which you want to set a marker.
+	Marker string `q:"marker"`
+
+	// Name of the TSIG key.
+	Name string `q:"name"`
+
+	// Algorithm used by the TSIG key.
+	Algorithm string `q:"algorithm"`
+
+	// Scope of the TSIG key (ZONE or POOL).
+	Scope string `q:"scope"`
+}
+
+// ToTSIGKeyListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToTSIGKeyListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List implements a TSIG key List request.
+func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := baseURL(client)
+	if opts != nil {
+		query, err := opts.ToTSIGKeyListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return TSIGKeyPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// Get returns information about a TSIG key, given its ID.
+func Get(ctx context.Context, client *gophercloud.ServiceClient, tsigkeyID string) (r GetResult) {
+	resp, err := client.Get(ctx, tsigkeyURL(client, tsigkeyID), &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// CreateOptsBuilder allows extensions to add additional attributes to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToTSIGKeyCreateMap() (map[string]any, error)
+}
+
+// CreateOpts specifies the attributes used to create a TSIG key.
+type CreateOpts struct {
+	// Name of the TSIG key.
+	Name string `json:"name" required:"true"`
+
+	// Algorithm is the TSIG algorithm (e.g., hmac-sha256, hmac-sha512).
+	Algorithm string `json:"algorithm" required:"true"`
+
+	// Secret is the base64-encoded secret key.
+	Secret string `json:"secret" required:"true"`
+
+	// Scope defines the scope of the TSIG key (ZONE or POOL).
+	Scope string `json:"scope" required:"true"`
+
+	// ResourceID is the ID of the resource (zone or pool) this key is associated with.
+	ResourceID string `json:"resource_id" required:"true"`
+}
+
+// ToTSIGKeyCreateMap formats a CreateOpts structure into a request body.
+func (opts CreateOpts) ToTSIGKeyCreateMap() (map[string]any, error) {
+	return gophercloud.BuildRequestBody(opts, "")
+}
+
+// Create implements a TSIG key create request.
+func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToTSIGKeyCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := client.Post(ctx, baseURL(client), &b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{201},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// UpdateOptsBuilder allows extensions to add additional attributes to the
+// Update request.
+type UpdateOptsBuilder interface {
+	ToTSIGKeyUpdateMap() (map[string]any, error)
+}
+
+// UpdateOpts specifies the attributes to update a TSIG key.
+type UpdateOpts struct {
+	// Name of the TSIG key.
+	Name string `json:"name,omitempty"`
+
+	// Algorithm is the TSIG algorithm.
+	Algorithm string `json:"algorithm,omitempty"`
+
+	// Secret is the base64-encoded secret key.
+	Secret string `json:"secret,omitempty"`
+
+	// Scope defines the scope of the TSIG key.
+	Scope string `json:"scope,omitempty"`
+
+	// ResourceID is the ID of the resource this key is associated with.
+	ResourceID string `json:"resource_id,omitempty"`
+}
+
+// ToTSIGKeyUpdateMap formats an UpdateOpts structure into a request body.
+func (opts UpdateOpts) ToTSIGKeyUpdateMap() (map[string]any, error) {
+	return gophercloud.BuildRequestBody(opts, "")
+}
+
+// Update implements a TSIG key update request.
+func Update(ctx context.Context, client *gophercloud.ServiceClient, tsigkeyID string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToTSIGKeyUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := client.Patch(ctx, tsigkeyURL(client, tsigkeyID), &b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// Delete implements a TSIG key delete request.
+func Delete(ctx context.Context, client *gophercloud.ServiceClient, tsigkeyID string) (r DeleteResult) {
+	resp, err := client.Delete(ctx, tsigkeyURL(client, tsigkeyID), &gophercloud.RequestOpts{
+		OkCodes: []int{204},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}

--- a/openstack/dns/v2/tsigkeys/results.go
+++ b/openstack/dns/v2/tsigkeys/results.go
@@ -1,0 +1,119 @@
+package tsigkeys
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/pagination"
+)
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// Extract interprets a GetResult, CreateResult or UpdateResult as a TSIGKey.
+// An error is returned if the original call or the extraction failed.
+func (r commonResult) Extract() (*TSIGKey, error) {
+	var s *TSIGKey
+	err := r.ExtractInto(&s)
+	return s, err
+}
+
+// CreateResult is the result of a Create request. Call its Extract method
+// to interpret the result as a TSIGKey.
+type CreateResult struct {
+	commonResult
+}
+
+// GetResult is the result of a Get request. Call its Extract method
+// to interpret the result as a TSIGKey.
+type GetResult struct {
+	commonResult
+}
+
+// UpdateResult is the result of an Update request. Call its Extract method
+// to interpret the result as a TSIGKey.
+type UpdateResult struct {
+	commonResult
+}
+
+// DeleteResult is the result of a Delete request. Call its ExtractErr method
+// to determine if the request succeeded or failed.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
+// TSIGKeyPage is a single page of TSIGKey results.
+type TSIGKeyPage struct {
+	pagination.LinkedPageBase
+}
+
+// IsEmpty returns true if the page contains no results.
+func (r TSIGKeyPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
+	s, err := ExtractTSIGKeys(r)
+	return len(s) == 0, err
+}
+
+// ExtractTSIGKeys extracts a slice of TSIGKeys from a List result.
+func ExtractTSIGKeys(r pagination.Page) ([]TSIGKey, error) {
+	var s struct {
+		TSIGKeys []TSIGKey `json:"tsigkeys"`
+	}
+	err := (r.(TSIGKeyPage)).ExtractInto(&s)
+	return s.TSIGKeys, err
+}
+
+// TSIGKey represents a TSIG key for DNS transaction authentication.
+type TSIGKey struct {
+	// ID uniquely identifies this TSIG key.
+	ID string `json:"id"`
+
+	// Name is the name of the TSIG key.
+	Name string `json:"name"`
+
+	// Algorithm is the TSIG algorithm used (e.g., hmac-sha256, hmac-sha512).
+	Algorithm string `json:"algorithm"`
+
+	// Secret is the base64-encoded secret key.
+	Secret string `json:"secret"`
+
+	// Scope defines the scope of the TSIG key (ZONE or POOL).
+	Scope string `json:"scope"`
+
+	// ResourceID is the ID of the resource (zone or pool) this key is associated with.
+	ResourceID string `json:"resource_id"`
+
+	// CreatedAt is the date when the TSIG key was created.
+	CreatedAt time.Time `json:"-"`
+
+	// UpdatedAt is the date when the TSIG key was last updated.
+	UpdatedAt time.Time `json:"-"`
+
+	// Links includes HTTP references to the itself.
+	Links map[string]any `json:"links"`
+}
+
+func (r *TSIGKey) UnmarshalJSON(b []byte) error {
+	type tmp TSIGKey
+	var s struct {
+		tmp
+		CreatedAt gophercloud.JSONRFC3339MilliNoZ `json:"created_at"`
+		UpdatedAt gophercloud.JSONRFC3339MilliNoZ `json:"updated_at"`
+	}
+
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	*r = TSIGKey(s.tmp)
+
+	r.CreatedAt = time.Time(s.CreatedAt)
+	r.UpdatedAt = time.Time(s.UpdatedAt)
+
+	return nil
+}

--- a/openstack/dns/v2/tsigkeys/testing/doc.go
+++ b/openstack/dns/v2/tsigkeys/testing/doc.go
@@ -1,0 +1,2 @@
+// tsigkeys unit tests
+package testing

--- a/openstack/dns/v2/tsigkeys/testing/fixtures_test.go
+++ b/openstack/dns/v2/tsigkeys/testing/fixtures_test.go
@@ -1,0 +1,224 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/openstack/dns/v2/tsigkeys"
+	th "github.com/gophercloud/gophercloud/v2/testhelper"
+	"github.com/gophercloud/gophercloud/v2/testhelper/client"
+)
+
+// ListOutput is a sample response to a List call.
+const ListOutput = `
+{
+    "links": {
+        "self": "http://example.com:9001/v2/tsigkeys"
+    },
+    "metadata": {
+        "total_count": 2
+    },
+    "tsigkeys": [
+        {
+            "id": "8add45a3-0f29-489f-854e-7609baf8d7a1",
+            "name": "poolsecondarykey",
+            "algorithm": "hmac-sha256",
+            "secret": "my-base64-secret-example==",
+            "scope": "POOL",
+            "resource_id": "adcc2fb6-7984-4453-a6f9-2cc2a24a38bb",
+            "created_at": "2025-08-13T15:54:18.000000",
+            "updated_at": null,
+            "links": {
+                "self": "http://127.0.0.1:9001/v2/tsigkeys/8add45a3-0f29-489f-854e-7609baf8d7a1"
+            }
+        },
+        {
+            "id": "9bef46b4-1f3a-59a0-965f-8710caf9e8b2",
+            "name": "zonekey",
+            "algorithm": "hmac-sha512",
+            "secret": "another-base64-secret-example==",
+            "scope": "ZONE",
+            "resource_id": "c4d5e6f7-8a9b-0c1d-2e3f-4a5b6c7d8e9f",
+            "created_at": "2025-08-14T10:30:45.000000",
+            "updated_at": "2025-08-15T14:22:33.000000",
+            "links": {
+                "self": "http://127.0.0.1:9001/v2/tsigkeys/9bef46b4-1f3a-59a0-965f-8710caf9e8b2"
+            }
+        }
+    ]
+}
+`
+
+// GetOutput is a sample response to a Get call.
+const GetOutput = `
+{
+    "id": "8add45a3-0f29-489f-854e-7609baf8d7a1",
+    "name": "poolsecondarykey",
+    "algorithm": "hmac-sha256",
+    "secret": "my-base64-secret-example==",
+    "scope": "POOL",
+    "resource_id": "adcc2fb6-7984-4453-a6f9-2cc2a24a38bb",
+    "created_at": "2025-08-13T15:54:18.000000",
+    "updated_at": null,
+    "links": {
+        "self": "http://127.0.0.1:9001/v2/tsigkeys/8add45a3-0f29-489f-854e-7609baf8d7a1"
+    }
+}
+`
+
+// FirstTSIGKeyCreatedAt is the created at time for the first TSIG key
+var FirstTSIGKeyCreatedAt, _ = time.Parse(gophercloud.RFC3339MilliNoZ, "2025-08-13T15:54:18.000000")
+
+// FirstTSIGKey is the first result in ListOutput
+var FirstTSIGKey = tsigkeys.TSIGKey{
+	ID:         "8add45a3-0f29-489f-854e-7609baf8d7a1",
+	Name:       "poolsecondarykey",
+	Algorithm:  "hmac-sha256",
+	Secret:     "my-base64-secret-example==",
+	Scope:      "POOL",
+	ResourceID: "adcc2fb6-7984-4453-a6f9-2cc2a24a38bb",
+	CreatedAt:  FirstTSIGKeyCreatedAt,
+	Links: map[string]any{
+		"self": "http://127.0.0.1:9001/v2/tsigkeys/8add45a3-0f29-489f-854e-7609baf8d7a1",
+	},
+}
+
+var SecondTSIGKeyCreatedAt, _ = time.Parse(gophercloud.RFC3339MilliNoZ, "2025-08-14T10:30:45.000000")
+var SecondTSIGKeyUpdatedAt, _ = time.Parse(gophercloud.RFC3339MilliNoZ, "2025-08-15T14:22:33.000000")
+
+var SecondTSIGKey = tsigkeys.TSIGKey{
+	ID:         "9bef46b4-1f3a-59a0-965f-8710caf9e8b2",
+	Name:       "zonekey",
+	Algorithm:  "hmac-sha512",
+	Secret:     "another-base64-secret-example==",
+	Scope:      "ZONE",
+	ResourceID: "c4d5e6f7-8a9b-0c1d-2e3f-4a5b6c7d8e9f",
+	CreatedAt:  SecondTSIGKeyCreatedAt,
+	UpdatedAt:  SecondTSIGKeyUpdatedAt,
+	Links: map[string]any{
+		"self": "http://127.0.0.1:9001/v2/tsigkeys/9bef46b4-1f3a-59a0-965f-8710caf9e8b2",
+	},
+}
+
+// ExpectedTSIGKeysSlice is the slice of results that should be parsed
+// from ListOutput, in the expected order.
+var ExpectedTSIGKeysSlice = []tsigkeys.TSIGKey{FirstTSIGKey, SecondTSIGKey}
+
+// HandleListSuccessfully configures the test server to respond to a List request.
+func HandleListSuccessfully(t *testing.T, fakeServer th.FakeServer) {
+	fakeServer.Mux.HandleFunc("/tsigkeys", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprint(w, ListOutput)
+	})
+}
+
+// HandleGetSuccessfully configures the test server to respond to a Get request.
+func HandleGetSuccessfully(t *testing.T, fakeServer th.FakeServer) {
+	fakeServer.Mux.HandleFunc("/tsigkeys/8add45a3-0f29-489f-854e-7609baf8d7a1", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprint(w, GetOutput)
+	})
+}
+
+// CreateTSIGKeyRequest is a sample request to create a TSIG key.
+const CreateTSIGKeyRequest = `
+{
+    "name": "poolsecondarykey",
+    "algorithm": "hmac-sha256",
+    "secret": "my-base64-secret-example==",
+    "scope": "POOL",
+    "resource_id": "adcc2fb6-7984-4453-a6f9-2cc2a24a38bb"
+}
+`
+
+// CreateTSIGKeyResponse is a sample response to a create request.
+const CreateTSIGKeyResponse = `
+{
+    "id": "8add45a3-0f29-489f-854e-7609baf8d7a1",
+    "name": "poolsecondarykey",
+    "algorithm": "hmac-sha256",
+    "secret": "my-base64-secret-example==",
+    "scope": "POOL",
+    "resource_id": "adcc2fb6-7984-4453-a6f9-2cc2a24a38bb",
+    "created_at": "2025-08-13T15:54:18.000000",
+    "updated_at": null,
+    "links": {
+        "self": "http://127.0.0.1:9001/v2/tsigkeys/8add45a3-0f29-489f-854e-7609baf8d7a1"
+    }
+}
+`
+
+// CreatedTSIGKey is the expected created TSIG key
+var CreatedTSIGKey = FirstTSIGKey
+
+// HandleCreateSuccessfully configures the test server to respond to a Create request.
+func HandleCreateSuccessfully(t *testing.T, fakeServer th.FakeServer) {
+	fakeServer.Mux.HandleFunc("/tsigkeys", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, CreateTSIGKeyRequest)
+
+		w.WriteHeader(http.StatusCreated)
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprint(w, CreateTSIGKeyResponse)
+	})
+}
+
+// UpdateTSIGKeyRequest is a sample request to update a TSIG key.
+const UpdateTSIGKeyRequest = `
+{
+    "name": "updatedsecondarykey",
+    "secret": "new-base64-secret-example=="
+}
+`
+
+// UpdateTSIGKeyResponse is a sample response to update a TSIG key.
+const UpdateTSIGKeyResponse = `
+{
+    "id": "8add45a3-0f29-489f-854e-7609baf8d7a1",
+    "name": "updatedsecondarykey",
+    "algorithm": "hmac-sha256",
+    "secret": "new-base64-secret-example==",
+    "scope": "POOL",
+    "resource_id": "adcc2fb6-7984-4453-a6f9-2cc2a24a38bb",
+    "created_at": "2025-08-13T15:54:18.000000",
+    "updated_at": "2025-08-16T09:15:22.000000",
+    "links": {
+        "self": "http://127.0.0.1:9001/v2/tsigkeys/8add45a3-0f29-489f-854e-7609baf8d7a1"
+    }
+}
+`
+
+// HandleUpdateSuccessfully configures the test server to respond to an Update request.
+func HandleUpdateSuccessfully(t *testing.T, fakeServer th.FakeServer) {
+	fakeServer.Mux.HandleFunc("/tsigkeys/8add45a3-0f29-489f-854e-7609baf8d7a1",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "PATCH")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+			th.TestJSONRequest(t, r, UpdateTSIGKeyRequest)
+
+			w.WriteHeader(http.StatusOK)
+			w.Header().Add("Content-Type", "application/json")
+			fmt.Fprint(w, UpdateTSIGKeyResponse)
+		})
+}
+
+// HandleDeleteSuccessfully configures the test server to respond to a Delete request.
+func HandleDeleteSuccessfully(t *testing.T, fakeServer th.FakeServer) {
+	fakeServer.Mux.HandleFunc("/tsigkeys/8add45a3-0f29-489f-854e-7609baf8d7a1",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "DELETE")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+			w.WriteHeader(http.StatusNoContent)
+		})
+}

--- a/openstack/dns/v2/tsigkeys/testing/requests_test.go
+++ b/openstack/dns/v2/tsigkeys/testing/requests_test.go
@@ -1,0 +1,98 @@
+package testing
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/v2/openstack/dns/v2/tsigkeys"
+	"github.com/gophercloud/gophercloud/v2/pagination"
+	th "github.com/gophercloud/gophercloud/v2/testhelper"
+	"github.com/gophercloud/gophercloud/v2/testhelper/client"
+)
+
+func TestList(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	HandleListSuccessfully(t, fakeServer)
+
+	count := 0
+	err := tsigkeys.List(client.ServiceClient(fakeServer), nil).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
+		count++
+		actual, err := tsigkeys.ExtractTSIGKeys(page)
+		th.AssertNoErr(t, err)
+		th.CheckDeepEquals(t, ExpectedTSIGKeysSlice, actual)
+
+		return true, nil
+	})
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, 1, count)
+}
+
+func TestListAllPages(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	HandleListSuccessfully(t, fakeServer)
+
+	allPages, err := tsigkeys.List(client.ServiceClient(fakeServer), nil).AllPages(context.TODO())
+	th.AssertNoErr(t, err)
+	allTSIGKeys, err := tsigkeys.ExtractTSIGKeys(allPages)
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, 2, len(allTSIGKeys))
+}
+
+func TestGet(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	HandleGetSuccessfully(t, fakeServer)
+
+	actual, err := tsigkeys.Get(context.TODO(), client.ServiceClient(fakeServer), "8add45a3-0f29-489f-854e-7609baf8d7a1").Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, &FirstTSIGKey, actual)
+}
+
+func TestCreate(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	HandleCreateSuccessfully(t, fakeServer)
+
+	createOpts := tsigkeys.CreateOpts{
+		Name:       "poolsecondarykey",
+		Algorithm:  "hmac-sha256",
+		Secret:     "my-base64-secret-example==",
+		Scope:      "POOL",
+		ResourceID: "adcc2fb6-7984-4453-a6f9-2cc2a24a38bb",
+	}
+
+	actual, err := tsigkeys.Create(context.TODO(), client.ServiceClient(fakeServer), createOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, &CreatedTSIGKey, actual)
+}
+
+func TestUpdate(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	HandleUpdateSuccessfully(t, fakeServer)
+
+	updateOpts := tsigkeys.UpdateOpts{
+		Name:   "updatedsecondarykey",
+		Secret: "new-base64-secret-example==",
+	}
+
+	UpdatedTSIGKey := CreatedTSIGKey
+	UpdatedTSIGKey.Name = "updatedsecondarykey"
+	UpdatedTSIGKey.Secret = "new-base64-secret-example=="
+
+	actual, err := tsigkeys.Update(context.TODO(), client.ServiceClient(fakeServer), UpdatedTSIGKey.ID, updateOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, UpdatedTSIGKey.Name, actual.Name)
+	th.CheckEquals(t, UpdatedTSIGKey.Secret, actual.Secret)
+}
+
+func TestDelete(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	HandleDeleteSuccessfully(t, fakeServer)
+
+	err := tsigkeys.Delete(context.TODO(), client.ServiceClient(fakeServer), "8add45a3-0f29-489f-854e-7609baf8d7a1").ExtractErr()
+	th.AssertNoErr(t, err)
+}

--- a/openstack/dns/v2/tsigkeys/urls.go
+++ b/openstack/dns/v2/tsigkeys/urls.go
@@ -1,0 +1,13 @@
+package tsigkeys
+
+import "github.com/gophercloud/gophercloud/v2"
+
+// baseURL returns the base URL for TSIG keys.
+func baseURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("tsigkeys")
+}
+
+// tsigkeyURL returns the URL for a specific TSIG key.
+func tsigkeyURL(c *gophercloud.ServiceClient, tsigkeyID string) string {
+	return c.ServiceURL("tsigkeys", tsigkeyID)
+}


### PR DESCRIPTION
Implement TSIG (Transaction SIGnature) key management for the Designate DNS service, enabling authentication of DNS transactions between servers for zone transfers and dynamic updates.

Fixes #3622


Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

API Controller (REST endpoints):
[https://github.com/openstack/designate/blob/master/designate/api/v2/controllers/tsigkeys.py                                                                                ](https://github.com/openstack/designate/blob/master/designate/api/v2/controllers/tsigkeys.py                                                                                )

Service Implementation (CRUD methods):                      [https://github.com/openstack/designate/blob/master/designate/central/service.py#L618-L670](https://github.com/openstack/designate/blob/master/designate/central/service.py#L618-L670)

TSIG Key Object Definition:                             
[https://github.com/openstack/designate/blob/master/designate/objects/tsigkey.py](https://github.com/openstack/designate/blob/master/designate/objects/tsigkey.py)

Python Client Reference:
[https://github.com/openstack/python-designateclient/blob/master/designateclient/v2/tsigkeys.py](https://github.com/openstack/python-designateclient/blob/master/designateclient/v2/tsigkeys.py)
