### PR TITLE
[v2] CI: Fix fwaas jobs

### DIFF
--- a/.github/workflows/functional-fwaas_v2.yaml
+++ b/.github/workflows/functional-fwaas_v2.yaml
@@ -69,7 +69,7 @@ jobs:
       - name: Run Gophercloud acceptance tests
         run: |
           source ${{ github.workspace }}/script/stackenv
-          make acceptance-networking
+          make acceptance-fwaas
         env:
           DEVSTACK_PATH: ${{ github.workspace }}/devstack
           OS_BRANCH: ${{ matrix.openstack_version }}

--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,10 @@ acceptance-dns:
 	$(GO_TEST) -timeout $(TIMEOUT) -tags "fixtures acceptance" ./internal/acceptance/openstack/dns/...
 .PHONY: acceptance-dns
 
+acceptance-fwaas:
+	$(GO_TEST) -timeout $(TIMEOUT) -tags "fixtures acceptance" ./internal/acceptance/openstack/networking/v2/extensions/fwaas_v2/...
+.PHONY: acceptance-fwaas
+
 acceptance-identity:
 	$(GO_TEST) -timeout $(TIMEOUT) -tags "fixtures acceptance" ./internal/acceptance/openstack/identity/...
 .PHONY: acceptance-identity


### PR DESCRIPTION
They were configured to run the whole networking test suite without devstack being configured for it. Furthermore, it's redundant with the networking job.

Restore the job to only run the fwaas_v2 tests as it was previous to commit 90cded10439a88581c9cd5afbbca206bc20c3230.

Manual backport of https://github.com/gophercloud/gophercloud/pull/3631