### PR TITLE
networking.v2.addressScope: remove description from ListOpts

### DIFF
--- a/openstack/networking/v2/extensions/layer3/addressscopes/requests.go
+++ b/openstack/networking/v2/extensions/layer3/addressscopes/requests.go
@@ -20,17 +20,16 @@ type ListOptsBuilder interface {
 // SortDir sets the direction, and is either `asc' or `desc'.
 // Marker and Limit are used for the pagination.
 type ListOpts struct {
-	ID          string `q:"id"`
-	Name        string `q:"name"`
-	TenantID    string `q:"tenant_id"`
-	ProjectID   string `q:"project_id"`
-	IPVersion   int    `q:"ip_version"`
-	Shared      *bool  `q:"shared"`
-	Description string `q:"description"`
-	Limit       int    `q:"limit"`
-	Marker      string `q:"marker"`
-	SortKey     string `q:"sort_key"`
-	SortDir     string `q:"sort_dir"`
+	ID        string `q:"id"`
+	Name      string `q:"name"`
+	TenantID  string `q:"tenant_id"`
+	ProjectID string `q:"project_id"`
+	IPVersion int    `q:"ip_version"`
+	Shared    *bool  `q:"shared"`
+	Limit     int    `q:"limit"`
+	Marker    string `q:"marker"`
+	SortKey   string `q:"sort_key"`
+	SortDir   string `q:"sort_dir"`
 }
 
 // ToAddressScopeListQuery formats a ListOpts into a query string.


### PR DESCRIPTION
<!--
Prior to starting a PR, please make sure you have read our
[contributor tutorial](https://github.com/gophercloud/gophercloud/tree/main/docs/contributor-tutorial).

Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

-->
Considering the Network API, we cannot filter AddressScope by description. Actually, looking into the code, this resource doesn't have any `description` field.

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://github.com/openstack/neutron-lib/blob/master/neutron_lib/api/definitions/address_scope.py#L34
https://github.com/openstack/neutron/blob/master/neutron/db/models/address_scope.py
