### PR TITLE
Add metric-storage (Aetos) v1 service support

### DIFF
--- a/.github/workflows/functional-metric.yaml
+++ b/.github/workflows/functional-metric.yaml
@@ -1,0 +1,105 @@
+name: functional-metric
+on:
+  merge_group:
+  pull_request:
+  schedule:
+    - cron: '0 0 */3 * *'
+jobs:
+  functional-metric:
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: "master"
+            openstack_version: "master"
+            ubuntu_version: "24.04"
+            devstack_conf_overrides: |
+              # ensure we're using a working version of setuptools
+              if [ -n "\$TOP_DIR" ]; then
+                sed -i 's/setuptools\[core\]$/setuptools[core]==79.0.1/g' \$TOP_DIR/lib/infra \$TOP_DIR/inc/python
+                sed -i 's/pip_install "-U" "pbr"/pip_install "-U" "pbr" "setuptools[core]==79.0.1"/g' \$TOP_DIR/lib/infra
+              fi
+    runs-on: ubuntu-${{ matrix.ubuntu_version }}
+    name: Aetos on OpenStack ${{ matrix.name }}
+    steps:
+      - name: Checkout Gophercloud
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Check changed files
+        uses: ./.github/actions/file-filter
+        id: changed-files
+        with:
+          patterns: |
+            openstack/auth_env.go
+            openstack/client.go
+            openstack/endpoint.go
+            openstack/endpoint_location.go
+            openstack/config/provider_client.go
+            openstack/utils/choose_version.go
+            openstack/utils/discovery.go
+            **metric**
+            .github/workflows/functional-metric.yaml
+
+      - name: Skip tests for unrelated changed-files
+        if: ${{ ! fromJSON(steps.changed-files.outputs.matches) }}
+        run: |
+          echo "No relevant files changed - skipping tests for ${{ matrix.name }}"
+          echo "TESTS_SKIPPED=true" >> $GITHUB_ENV
+
+      - name: Deploy devstack
+        if: ${{ fromJSON(steps.changed-files.outputs.matches) }}
+        uses: gophercloud/devstack-action@60ca1042045c0c9e3e001c64575d381654ffcba1 # v0.19
+        with:
+          branch: ${{ matrix.openstack_version }}
+          conf_overrides: |
+            enable_plugin devstack-plugin-prometheus https://opendev.org/openstack/devstack-plugin-prometheus ${{ matrix.openstack_version }}
+            enable_plugin ceilometer https://opendev.org/openstack/ceilometer ${{ matrix.openstack_version }}
+            CEILOMETER_BACKEND=sg-core
+            PROMETHEUS_CUSTOM_SCRAPE_TARGETS="localhost:3000"
+            enable_plugin sg-core https://github.com/openstack-k8s-operators/sg-core main
+            enable_plugin aetos https://opendev.org/openstack/aetos ${{ matrix.openstack_version }}
+
+            ${{ matrix.devstack_conf_overrides }}
+          enabled_services: "prometheus,node_exporter,openstack_exporter,ceilometer-acompute,ceilometer-acentral,ceilometer-anotification,sg-core,aetos,openstack-cli-server"
+
+      - name: Checkout go
+        if: ${{ fromJSON(steps.changed-files.outputs.matches) }}
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - name: Run Gophercloud acceptance tests
+        if: ${{ fromJSON(steps.changed-files.outputs.matches) }}
+        run: |
+          source ${{ github.workspace }}/script/stackenv
+          make acceptance-metric
+          echo "TESTS_RUN=true" >> $GITHUB_ENV
+        env:
+          DEVSTACK_PATH: ${{ github.workspace }}/devstack
+          OS_BRANCH: ${{ matrix.openstack_version }}
+
+      - name: Generate logs on failure
+        run: ./script/collectlogs
+        if: ${{ failure() && fromJSON(steps.changed-files.outputs.matches) }}
+
+      - name: Upload logs artifacts on failure
+        if: ${{ failure() && fromJSON(steps.changed-files.outputs.matches) }}
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: functional-metric-${{ matrix.name }}-${{ github.run_id }}
+          path: /tmp/devstack-logs/*
+
+      - name: Set job status
+        run: |
+          if [[ "$TESTS_SKIPPED" == "true" || "$TESTS_RUN" == "true" ]]; then
+            echo "Job completed successfully (either ran tests or skipped appropriately)"
+            exit 0
+          else
+            echo "Job failed - neither tests ran nor were properly skipped"
+            exit 1
+          fi

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ coverage:
 	$(GO_TEST) -shuffle on -covermode count -coverprofile cover.out -coverpkg=./... ./...
 .PHONY: coverage
 
-acceptance: acceptance-basic acceptance-baremetal acceptance-blockstorage acceptance-compute acceptance-container acceptance-containerinfra acceptance-db acceptance-dns acceptance-identity acceptance-image acceptance-keymanager acceptance-loadbalancer acceptance-messaging acceptance-networking acceptance-objectstorage acceptance-orchestration acceptance-placement acceptance-sharedfilesystems acceptance-workflow
+acceptance: acceptance-basic acceptance-baremetal acceptance-blockstorage acceptance-compute acceptance-container acceptance-containerinfra acceptance-db acceptance-dns acceptance-identity acceptance-image acceptance-keymanager acceptance-loadbalancer acceptance-messaging acceptance-metric acceptance-networking acceptance-objectstorage acceptance-orchestration acceptance-placement acceptance-sharedfilesystems acceptance-workflow
 .PHONY: acceptance
 
 acceptance-basic:
@@ -101,6 +101,10 @@ acceptance-loadbalancer:
 acceptance-messaging:
 	$(GO_TEST) -timeout $(TIMEOUT) -tags "fixtures acceptance" ./internal/acceptance/openstack/messaging/...
 .PHONY: acceptance-messaging
+
+acceptance-metric:
+	$(GO_TEST) -timeout $(TIMEOUT) -tags "fixtures acceptance" ./internal/acceptance/openstack/metric/...
+.PHONY: acceptance-metric
 
 acceptance-networking:
 	$(GO_TEST) -timeout $(TIMEOUT) -tags "fixtures acceptance" ./internal/acceptance/openstack/networking/...

--- a/internal/acceptance/clients/clients.go
+++ b/internal/acceptance/clients/clients.go
@@ -585,6 +585,27 @@ func NewMessagingV2Client(clientID string) (*gophercloud.ServiceClient, error) {
 	})
 }
 
+// NewMetricV1Client returns a *ServiceClient for making calls
+// to the OpenStack Metric v1 API. An error will be returned
+// if authentication or client creation was not possible.
+func NewMetricV1Client() (*gophercloud.ServiceClient, error) {
+	ao, err := openstack.AuthOptionsFromEnv()
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := openstack.AuthenticatedClient(context.TODO(), ao)
+	if err != nil {
+		return nil, err
+	}
+
+	client = configureDebug(client)
+
+	return openstack.NewMetricV1(context.TODO(), client, gophercloud.EndpointOpts{
+		Region: os.Getenv("OS_REGION_NAME"),
+	})
+}
+
 // NewContainerV1Client returns a *ServiceClient for making calls
 // to the OpenStack Container V1 API. An error will be returned
 // if authentication or client creation was not possible.

--- a/internal/acceptance/openstack/metric/v1/metrics_test.go
+++ b/internal/acceptance/openstack/metric/v1/metrics_test.go
@@ -1,0 +1,80 @@
+//go:build acceptance || metric || metrics
+
+package v1
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/v2/internal/acceptance/clients"
+	"github.com/gophercloud/gophercloud/v2/internal/acceptance/tools"
+	"github.com/gophercloud/gophercloud/v2/openstack/metric/v1/metrics"
+	th "github.com/gophercloud/gophercloud/v2/testhelper"
+)
+
+func TestMetricQuery(t *testing.T) {
+	client, err := clients.NewMetricV1Client()
+	th.AssertNoErr(t, err)
+
+	result, err := metrics.Query(context.TODO(), client, metrics.QueryOpts{
+		Query: "up",
+	}).Extract()
+	th.AssertNoErr(t, err)
+
+	tools.PrintResource(t, result)
+	th.AssertEquals(t, result.ResultType, "vector")
+}
+
+func TestMetricLabels(t *testing.T) {
+	client, err := clients.NewMetricV1Client()
+	th.AssertNoErr(t, err)
+
+	result, err := metrics.Labels(context.TODO(), client, nil).Extract()
+	th.AssertNoErr(t, err)
+
+	tools.PrintResource(t, result)
+	if len(result) == 0 {
+		t.Fatal("expected at least one label")
+	}
+}
+
+func TestMetricLabelValues(t *testing.T) {
+	client, err := clients.NewMetricV1Client()
+	th.AssertNoErr(t, err)
+
+	result, err := metrics.LabelValues(context.TODO(), client, "__name__", nil).Extract()
+	th.AssertNoErr(t, err)
+
+	tools.PrintResource(t, result)
+	if len(result) == 0 {
+		t.Fatal("expected at least one label value")
+	}
+}
+
+func TestMetricSeries(t *testing.T) {
+	client, err := clients.NewMetricV1Client()
+	th.AssertNoErr(t, err)
+
+	result, err := metrics.Series(context.TODO(), client, metrics.SeriesOpts{
+		Match: []string{`{__name__="up"}`},
+	}).Extract()
+	th.AssertNoErr(t, err)
+
+	tools.PrintResource(t, result)
+	if len(result) == 0 {
+		t.Fatal("expected at least one series")
+	}
+}
+
+func TestMetricRuntimeInfo(t *testing.T) {
+	client, err := clients.NewMetricV1Client()
+	th.AssertNoErr(t, err)
+
+	result, err := metrics.RuntimeInfo(context.TODO(), client).Extract()
+	th.AssertNoErr(t, err)
+
+	tools.PrintResource(t, result)
+	if result.StorageRetention == "" {
+		t.Fatal("expected non-empty StorageRetention")
+	}
+}

--- a/internal/acceptance/openstack/metric/v1/pkg.go
+++ b/internal/acceptance/openstack/metric/v1/pkg.go
@@ -1,0 +1,4 @@
+//go:build acceptance || metric
+
+// Package v1 contains acceptance tests for the OpenStack metric-storage v1 service.
+package v1

--- a/openstack/client.go
+++ b/openstack/client.go
@@ -464,6 +464,14 @@ func NewLoadBalancerV2(ctx context.Context, client *gophercloud.ProviderClient, 
 	return sc, err
 }
 
+// NewMetricV1 creates a ServiceClient that may be used with the v1 metric-storage
+// service (Aetos).
+func NewMetricV1(ctx context.Context, client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
+	sc, err := initClientOpts(ctx, client, eo, "metric-storage", 1)
+	sc.ResourceBase = sc.Endpoint + "api/v1/"
+	return sc, err
+}
+
 // NewMessagingV2 creates a ServiceClient that may be used with the v2 messaging
 // service.
 func NewMessagingV2(ctx context.Context, client *gophercloud.ProviderClient, clientID string, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {

--- a/openstack/metric/v1/metrics/doc.go
+++ b/openstack/metric/v1/metrics/doc.go
@@ -1,0 +1,59 @@
+/*
+Package metrics provides interaction with the Prometheus HTTP API through the
+OpenStack Aetos service (metric-storage).
+
+Aetos acts as a Keystone-authenticated reverse proxy for Prometheus, enforcing
+multi-tenant RBAC on all Prometheus queries. It exposes the Prometheus HTTP API
+under /api/v1/ with OpenStack authentication.
+
+Example to Create a Metric Service Client
+
+	metricClient, err := openstack.NewMetricV1(ctx, providerClient, gophercloud.EndpointOpts{
+		Region: "RegionOne",
+	})
+	if err != nil {
+		panic(err)
+	}
+
+Example to Query Metrics
+
+	opts := metrics.QueryOpts{
+		Query: "up",
+	}
+
+	result, err := metrics.Query(ctx, metricClient, opts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	for _, v := range result.Result {
+		fmt.Printf("%s: %v\n", v.Metric["__name__"], v.Value)
+	}
+
+Example to List Label Names
+
+	labels, err := metrics.Labels(ctx, metricClient, nil).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	for _, label := range labels {
+		fmt.Println(label)
+	}
+
+Example to Find Series by Label Matchers
+
+	opts := metrics.SeriesOpts{
+		Match: []string{"up", `process_start_time_seconds{job="prometheus"}`},
+	}
+
+	series, err := metrics.Series(ctx, metricClient, opts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	for _, s := range series {
+		fmt.Printf("%v\n", s)
+	}
+*/
+package metrics

--- a/openstack/metric/v1/metrics/requests.go
+++ b/openstack/metric/v1/metrics/requests.go
@@ -1,0 +1,263 @@
+package metrics
+
+import (
+	"context"
+
+	"github.com/gophercloud/gophercloud/v2"
+)
+
+// QueryOptsBuilder allows extensions to add parameters to the Query request.
+type QueryOptsBuilder interface {
+	ToMetricQueryQuery() (string, error)
+}
+
+// QueryOpts contains the options for a Prometheus instant query.
+type QueryOpts struct {
+	// Query is the PromQL query string.
+	Query string `q:"query" required:"true"`
+
+	// Time is the evaluation timestamp (RFC3339 or Unix timestamp).
+	Time string `q:"time"`
+
+	// Timeout is the evaluation timeout.
+	Timeout string `q:"timeout"`
+}
+
+// ToMetricQueryQuery formats QueryOpts into a query string.
+func (opts QueryOpts) ToMetricQueryQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// Query performs a Prometheus instant query.
+func Query(ctx context.Context, client *gophercloud.ServiceClient, opts QueryOptsBuilder) (r QueryResult) {
+	url := queryURL(client)
+	if opts != nil {
+		query, err := opts.ToMetricQueryQuery()
+		if err != nil {
+			r.Err = err
+			return
+		}
+		url += query
+	}
+	resp, err := client.Get(ctx, url, &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// LabelsOptsBuilder allows extensions to add parameters to the Labels request.
+type LabelsOptsBuilder interface {
+	ToMetricLabelsQuery() (string, error)
+}
+
+// LabelsOpts contains the options for listing label names.
+type LabelsOpts struct {
+	// Match is a list of series selectors to filter labels by.
+	Match []string `q:"match[]"`
+
+	// Start is the start timestamp (RFC3339 or Unix timestamp).
+	Start string `q:"start"`
+
+	// End is the end timestamp (RFC3339 or Unix timestamp).
+	End string `q:"end"`
+}
+
+// ToMetricLabelsQuery formats LabelsOpts into a query string.
+func (opts LabelsOpts) ToMetricLabelsQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// Labels returns a list of label names.
+func Labels(ctx context.Context, client *gophercloud.ServiceClient, opts LabelsOptsBuilder) (r LabelsResult) {
+	url := labelsURL(client)
+	if opts != nil {
+		query, err := opts.ToMetricLabelsQuery()
+		if err != nil {
+			r.Err = err
+			return
+		}
+		url += query
+	}
+	resp, err := client.Get(ctx, url, &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// LabelValuesOptsBuilder allows extensions to add parameters to the LabelValues request.
+type LabelValuesOptsBuilder interface {
+	ToMetricLabelValuesQuery() (string, error)
+}
+
+// LabelValuesOpts contains the options for listing label values.
+type LabelValuesOpts struct {
+	// Match is a list of series selectors to filter label values by.
+	Match []string `q:"match[]"`
+
+	// Start is the start timestamp (RFC3339 or Unix timestamp).
+	Start string `q:"start"`
+
+	// End is the end timestamp (RFC3339 or Unix timestamp).
+	End string `q:"end"`
+}
+
+// ToMetricLabelValuesQuery formats LabelValuesOpts into a query string.
+func (opts LabelValuesOpts) ToMetricLabelValuesQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// LabelValues returns a list of label values for a given label name.
+func LabelValues(ctx context.Context, client *gophercloud.ServiceClient, name string, opts LabelValuesOptsBuilder) (r LabelValuesResult) {
+	url := labelValuesURL(client, name)
+	if opts != nil {
+		query, err := opts.ToMetricLabelValuesQuery()
+		if err != nil {
+			r.Err = err
+			return
+		}
+		url += query
+	}
+	resp, err := client.Get(ctx, url, &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// SeriesOptsBuilder allows extensions to add parameters to the Series request.
+type SeriesOptsBuilder interface {
+	ToMetricSeriesQuery() (string, error)
+}
+
+// SeriesOpts contains the options for finding series by label matchers.
+type SeriesOpts struct {
+	// Match is a list of series selectors. At least one must be provided.
+	Match []string `q:"match[]" required:"true"`
+
+	// Start is the start timestamp (RFC3339 or Unix timestamp).
+	Start string `q:"start"`
+
+	// End is the end timestamp (RFC3339 or Unix timestamp).
+	End string `q:"end"`
+}
+
+// ToMetricSeriesQuery formats SeriesOpts into a query string.
+func (opts SeriesOpts) ToMetricSeriesQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// Series returns the list of time series that match certain label sets.
+func Series(ctx context.Context, client *gophercloud.ServiceClient, opts SeriesOptsBuilder) (r SeriesResult) {
+	url := seriesURL(client)
+	if opts != nil {
+		query, err := opts.ToMetricSeriesQuery()
+		if err != nil {
+			r.Err = err
+			return
+		}
+		url += query
+	}
+	resp, err := client.Get(ctx, url, &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// TargetsOptsBuilder allows extensions to add parameters to the Targets request.
+type TargetsOptsBuilder interface {
+	ToMetricTargetsQuery() (string, error)
+}
+
+// TargetsOpts contains the options for listing targets.
+type TargetsOpts struct {
+	// State filters targets by state ("active", "dropped", "any").
+	State string `q:"state"`
+}
+
+// ToMetricTargetsQuery formats TargetsOpts into a query string.
+func (opts TargetsOpts) ToMetricTargetsQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// Targets returns an overview of the current state of Prometheus target discovery.
+func Targets(ctx context.Context, client *gophercloud.ServiceClient, opts TargetsOptsBuilder) (r TargetsResult) {
+	url := targetsURL(client)
+	if opts != nil {
+		query, err := opts.ToMetricTargetsQuery()
+		if err != nil {
+			r.Err = err
+			return
+		}
+		url += query
+	}
+	resp, err := client.Get(ctx, url, &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// RuntimeInfo returns runtime information about the Prometheus server.
+func RuntimeInfo(ctx context.Context, client *gophercloud.ServiceClient) (r RuntimeInfoResult) {
+	resp, err := client.Get(ctx, runtimeInfoURL(client), &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// CleanTombstones removes deleted data from disk and cleans up the existing tombstones.
+func CleanTombstones(ctx context.Context, client *gophercloud.ServiceClient) (r CleanTombstonesResult) {
+	resp, err := client.Post(ctx, cleanTombstonesURL(client), nil, nil, &gophercloud.RequestOpts{
+		OkCodes: []int{204},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// DeleteSeriesOptsBuilder allows extensions to add parameters to the DeleteSeries request.
+type DeleteSeriesOptsBuilder interface {
+	ToMetricDeleteSeriesQuery() (string, error)
+}
+
+// DeleteSeriesOpts contains the options for deleting time series.
+type DeleteSeriesOpts struct {
+	// Match is a list of series selectors. At least one must be provided.
+	Match []string `q:"match[]" required:"true"`
+
+	// Start is the start timestamp (RFC3339 or Unix timestamp).
+	Start string `q:"start"`
+
+	// End is the end timestamp (RFC3339 or Unix timestamp).
+	End string `q:"end"`
+}
+
+// ToMetricDeleteSeriesQuery formats DeleteSeriesOpts into a query string.
+func (opts DeleteSeriesOpts) ToMetricDeleteSeriesQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// DeleteSeries deletes data for a selection of series in a time range.
+func DeleteSeries(ctx context.Context, client *gophercloud.ServiceClient, opts DeleteSeriesOptsBuilder) (r DeleteSeriesResult) {
+	url := deleteSeriesURL(client)
+	if opts != nil {
+		query, err := opts.ToMetricDeleteSeriesQuery()
+		if err != nil {
+			r.Err = err
+			return
+		}
+		url += query
+	}
+	resp, err := client.Post(ctx, url, nil, nil, &gophercloud.RequestOpts{
+		OkCodes: []int{204},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// Snapshot creates a snapshot of all current data into snapshots/<datetime>-<rand>
+// under the TSDB's data directory and returns the directory as response.
+func Snapshot(ctx context.Context, client *gophercloud.ServiceClient) (r SnapshotResult) {
+	resp, err := client.Post(ctx, snapshotURL(client), nil, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}

--- a/openstack/metric/v1/metrics/results.go
+++ b/openstack/metric/v1/metrics/results.go
@@ -1,0 +1,298 @@
+package metrics
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/gophercloud/gophercloud/v2"
+)
+
+// prometheusResponse is the common envelope for all Prometheus HTTP API responses.
+type prometheusResponse struct {
+	Status    string          `json:"status"`
+	Data      json.RawMessage `json:"data"`
+	ErrorType string          `json:"errorType"`
+	Error     string          `json:"error"`
+}
+
+// checkResponse unmarshals the Prometheus envelope and returns an error if
+// the response status is "error".
+func checkResponse(body any) (*prometheusResponse, error) {
+	b, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	var resp prometheusResponse
+	if err := json.Unmarshal(b, &resp); err != nil {
+		return nil, err
+	}
+	if resp.Status == "error" {
+		return &resp, fmt.Errorf("prometheus %s: %s", resp.ErrorType, resp.Error)
+	}
+	return &resp, nil
+}
+
+// QueryResult is the result of a Query request.
+type QueryResult struct {
+	gophercloud.Result
+}
+
+// Extract interprets a QueryResult as QueryData.
+func (r QueryResult) Extract() (*QueryData, error) {
+	if r.Err != nil {
+		return nil, r.Err
+	}
+	resp, err := checkResponse(r.Body)
+	if err != nil {
+		return nil, err
+	}
+	var data QueryData
+	if err := json.Unmarshal(resp.Data, &data); err != nil {
+		return nil, err
+	}
+	return &data, nil
+}
+
+// LabelsResult is the result of a Labels request.
+type LabelsResult struct {
+	gophercloud.Result
+}
+
+// Extract interprets a LabelsResult as a slice of label name strings.
+func (r LabelsResult) Extract() ([]string, error) {
+	if r.Err != nil {
+		return nil, r.Err
+	}
+	resp, err := checkResponse(r.Body)
+	if err != nil {
+		return nil, err
+	}
+	var data []string
+	if err := json.Unmarshal(resp.Data, &data); err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+// LabelValuesResult is the result of a LabelValues request.
+type LabelValuesResult struct {
+	gophercloud.Result
+}
+
+// Extract interprets a LabelValuesResult as a slice of label value strings.
+func (r LabelValuesResult) Extract() ([]string, error) {
+	if r.Err != nil {
+		return nil, r.Err
+	}
+	resp, err := checkResponse(r.Body)
+	if err != nil {
+		return nil, err
+	}
+	var data []string
+	if err := json.Unmarshal(resp.Data, &data); err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+// SeriesResult is the result of a Series request.
+type SeriesResult struct {
+	gophercloud.Result
+}
+
+// Extract interprets a SeriesResult as a slice of label-set maps.
+func (r SeriesResult) Extract() ([]map[string]string, error) {
+	if r.Err != nil {
+		return nil, r.Err
+	}
+	resp, err := checkResponse(r.Body)
+	if err != nil {
+		return nil, err
+	}
+	var data []map[string]string
+	if err := json.Unmarshal(resp.Data, &data); err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+// TargetsResult is the result of a Targets request.
+type TargetsResult struct {
+	gophercloud.Result
+}
+
+// Extract interprets a TargetsResult as TargetsData.
+func (r TargetsResult) Extract() (*TargetsData, error) {
+	if r.Err != nil {
+		return nil, r.Err
+	}
+	resp, err := checkResponse(r.Body)
+	if err != nil {
+		return nil, err
+	}
+	var data TargetsData
+	if err := json.Unmarshal(resp.Data, &data); err != nil {
+		return nil, err
+	}
+	return &data, nil
+}
+
+// RuntimeInfoResult is the result of a RuntimeInfo request.
+type RuntimeInfoResult struct {
+	gophercloud.Result
+}
+
+// Extract interprets a RuntimeInfoResult as RuntimeInfoData.
+func (r RuntimeInfoResult) Extract() (*RuntimeInfoData, error) {
+	if r.Err != nil {
+		return nil, r.Err
+	}
+	resp, err := checkResponse(r.Body)
+	if err != nil {
+		return nil, err
+	}
+	var data RuntimeInfoData
+	if err := json.Unmarshal(resp.Data, &data); err != nil {
+		return nil, err
+	}
+	return &data, nil
+}
+
+// CleanTombstonesResult is the result of a CleanTombstones request.
+type CleanTombstonesResult struct {
+	gophercloud.ErrResult
+}
+
+// DeleteSeriesResult is the result of a DeleteSeries request.
+type DeleteSeriesResult struct {
+	gophercloud.ErrResult
+}
+
+// SnapshotResult is the result of a Snapshot request.
+type SnapshotResult struct {
+	gophercloud.Result
+}
+
+// Extract interprets a SnapshotResult as SnapshotData.
+func (r SnapshotResult) Extract() (*SnapshotData, error) {
+	if r.Err != nil {
+		return nil, r.Err
+	}
+	resp, err := checkResponse(r.Body)
+	if err != nil {
+		return nil, err
+	}
+	var data SnapshotData
+	if err := json.Unmarshal(resp.Data, &data); err != nil {
+		return nil, err
+	}
+	return &data, nil
+}
+
+// QueryData represents the data field of a Prometheus instant query response.
+type QueryData struct {
+	// ResultType is the type of result (e.g., "vector", "matrix", "scalar", "string").
+	ResultType string `json:"resultType"`
+
+	// Result is the list of metric values returned by the query.
+	Result []MetricValue `json:"result"`
+}
+
+// MetricValue represents a single metric result with its labels and value.
+type MetricValue struct {
+	// Metric contains the label set identifying this metric.
+	Metric map[string]string `json:"metric"`
+
+	// Value contains a single sample value as [timestamp, "string_value"].
+	Value []any `json:"value"`
+}
+
+// TargetsData represents the data field of a Prometheus targets response.
+type TargetsData struct {
+	// ActiveTargets is the list of currently active scrape targets.
+	ActiveTargets []ActiveTarget `json:"activeTargets"`
+
+	// DroppedTargets is the list of targets that were dropped during relabeling.
+	DroppedTargets []DroppedTarget `json:"droppedTargets"`
+}
+
+// ActiveTarget represents an active Prometheus scrape target.
+type ActiveTarget struct {
+	// DiscoveredLabels are the unmodified labels from service discovery.
+	DiscoveredLabels map[string]string `json:"discoveredLabels"`
+
+	// Labels are the labels after relabeling.
+	Labels map[string]string `json:"labels"`
+
+	// ScrapePool is the name of the scrape configuration.
+	ScrapePool string `json:"scrapePool"`
+
+	// ScrapeURL is the URL being scraped.
+	ScrapeURL string `json:"scrapeUrl"`
+
+	// GlobalURL is the URL as available from other Prometheus instances.
+	GlobalURL string `json:"globalUrl"`
+
+	// LastError is the last error encountered during scraping.
+	LastError string `json:"lastError"`
+
+	// LastScrape is the time of the last scrape.
+	LastScrape string `json:"lastScrape"`
+
+	// LastScrapeDuration is the duration of the last scrape in seconds.
+	LastScrapeDuration float64 `json:"lastScrapeDuration"`
+
+	// Health is the health status of the target ("up", "down", "unknown").
+	Health string `json:"health"`
+
+	// ScrapeInterval is the configured scrape interval.
+	ScrapeInterval string `json:"scrapeInterval"`
+
+	// ScrapeTimeout is the configured scrape timeout.
+	ScrapeTimeout string `json:"scrapeTimeout"`
+}
+
+// DroppedTarget represents a target that was dropped during relabeling.
+type DroppedTarget struct {
+	// DiscoveredLabels are the unmodified labels from service discovery.
+	DiscoveredLabels map[string]string `json:"discoveredLabels"`
+}
+
+// RuntimeInfoData represents the data field of a Prometheus runtime info response.
+type RuntimeInfoData struct {
+	// StartTime is when the Prometheus server started.
+	StartTime string `json:"startTime"`
+
+	// CWD is the current working directory of the Prometheus server.
+	CWD string `json:"CWD"`
+
+	// ReloadConfigSuccess indicates if the last config reload was successful.
+	ReloadConfigSuccess bool `json:"reloadConfigSuccess"`
+
+	// LastConfigTime is the time of the last config reload.
+	LastConfigTime string `json:"lastConfigTime"`
+
+	// CorruptionCount is the number of WAL corruptions encountered.
+	CorruptionCount int `json:"corruptionCount"`
+
+	// GoroutineCount is the number of goroutines.
+	GoroutineCount int `json:"goroutineCount"`
+
+	// GOMAXPROCS is the configured GOMAXPROCS value.
+	GOMAXPROCS int `json:"GOMAXPROCS"`
+
+	// GOGC is the configured GOGC value.
+	GOGC string `json:"GOGC"`
+
+	// GODEBUG is the configured GODEBUG value.
+	GODEBUG string `json:"GODEBUG"`
+
+	// StorageRetention is the configured storage retention.
+	StorageRetention string `json:"storageRetention"`
+}
+
+// SnapshotData represents the data field of a Prometheus snapshot response.
+type SnapshotData struct {
+	// Name is the filename of the snapshot created.
+	Name string `json:"name"`
+}

--- a/openstack/metric/v1/metrics/testing/doc.go
+++ b/openstack/metric/v1/metrics/testing/doc.go
@@ -1,0 +1,2 @@
+// metrics unit tests
+package testing

--- a/openstack/metric/v1/metrics/testing/fixtures_test.go
+++ b/openstack/metric/v1/metrics/testing/fixtures_test.go
@@ -1,0 +1,327 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/openstack/metric/v1/metrics"
+	th "github.com/gophercloud/gophercloud/v2/testhelper"
+	"github.com/gophercloud/gophercloud/v2/testhelper/client"
+)
+
+// serviceClient returns a ServiceClient with ResourceBase set to include api/v1/.
+func serviceClient(fakeServer th.FakeServer) *gophercloud.ServiceClient {
+	sc := client.ServiceClient(fakeServer)
+	sc.ResourceBase = sc.Endpoint + "api/v1/"
+	return sc
+}
+
+// QueryOutput is a sample response to a Query call.
+const QueryOutput = `
+{
+    "status": "success",
+    "data": {
+        "resultType": "vector",
+        "result": [
+            {
+                "metric": {
+                    "__name__": "up",
+                    "instance": "localhost:9090",
+                    "job": "prometheus"
+                },
+                "value": [1435781451.781, "1"]
+            }
+        ]
+    }
+}
+`
+
+// ExpectedQueryData is the expected result from QueryOutput.
+var ExpectedQueryData = &metrics.QueryData{
+	ResultType: "vector",
+	Result: []metrics.MetricValue{
+		{
+			Metric: map[string]string{
+				"__name__": "up",
+				"instance": "localhost:9090",
+				"job":      "prometheus",
+			},
+			Value: []any{1435781451.781, "1"},
+		},
+	},
+}
+
+// LabelsOutput is a sample response to a Labels call.
+const LabelsOutput = `
+{
+    "status": "success",
+    "data": ["__name__", "instance", "job"]
+}
+`
+
+// ExpectedLabels is the expected result from LabelsOutput.
+var ExpectedLabels = []string{"__name__", "instance", "job"}
+
+// LabelValuesOutput is a sample response to a LabelValues call.
+const LabelValuesOutput = `
+{
+    "status": "success",
+    "data": ["node", "prometheus"]
+}
+`
+
+// ExpectedLabelValues is the expected result from LabelValuesOutput.
+var ExpectedLabelValues = []string{"node", "prometheus"}
+
+// SeriesOutput is a sample response to a Series call.
+const SeriesOutput = `
+{
+    "status": "success",
+    "data": [
+        {
+            "__name__": "up",
+            "instance": "localhost:9090",
+            "job": "prometheus"
+        },
+        {
+            "__name__": "up",
+            "instance": "localhost:9100",
+            "job": "node"
+        }
+    ]
+}
+`
+
+// ExpectedSeries is the expected result from SeriesOutput.
+var ExpectedSeries = []map[string]string{
+	{
+		"__name__": "up",
+		"instance": "localhost:9090",
+		"job":      "prometheus",
+	},
+	{
+		"__name__": "up",
+		"instance": "localhost:9100",
+		"job":      "node",
+	},
+}
+
+// TargetsOutput is a sample response to a Targets call.
+const TargetsOutput = `
+{
+    "status": "success",
+    "data": {
+        "activeTargets": [
+            {
+                "discoveredLabels": {
+                    "__address__": "localhost:9090",
+                    "__scheme__": "http",
+                    "job": "prometheus"
+                },
+                "labels": {
+                    "instance": "localhost:9090",
+                    "job": "prometheus"
+                },
+                "scrapePool": "prometheus",
+                "scrapeUrl": "http://localhost:9090/metrics",
+                "globalUrl": "http://localhost:9090/metrics",
+                "lastError": "",
+                "lastScrape": "2025-08-20T10:30:00.000Z",
+                "lastScrapeDuration": 0.003145,
+                "health": "up",
+                "scrapeInterval": "15s",
+                "scrapeTimeout": "10s"
+            }
+        ],
+        "droppedTargets": [
+            {
+                "discoveredLabels": {
+                    "__address__": "localhost:9091",
+                    "job": "dropped"
+                }
+            }
+        ]
+    }
+}
+`
+
+// ExpectedTargetsData is the expected result from TargetsOutput.
+var ExpectedTargetsData = &metrics.TargetsData{
+	ActiveTargets: []metrics.ActiveTarget{
+		{
+			DiscoveredLabels: map[string]string{
+				"__address__": "localhost:9090",
+				"__scheme__":  "http",
+				"job":         "prometheus",
+			},
+			Labels: map[string]string{
+				"instance": "localhost:9090",
+				"job":      "prometheus",
+			},
+			ScrapePool:         "prometheus",
+			ScrapeURL:          "http://localhost:9090/metrics",
+			GlobalURL:          "http://localhost:9090/metrics",
+			LastError:          "",
+			LastScrape:         "2025-08-20T10:30:00.000Z",
+			LastScrapeDuration: 0.003145,
+			Health:             "up",
+			ScrapeInterval:     "15s",
+			ScrapeTimeout:      "10s",
+		},
+	},
+	DroppedTargets: []metrics.DroppedTarget{
+		{
+			DiscoveredLabels: map[string]string{
+				"__address__": "localhost:9091",
+				"job":         "dropped",
+			},
+		},
+	},
+}
+
+// RuntimeInfoOutput is a sample response to a RuntimeInfo call.
+const RuntimeInfoOutput = `
+{
+    "status": "success",
+    "data": {
+        "startTime": "2025-08-20T10:00:00.000Z",
+        "CWD": "/prometheus",
+        "reloadConfigSuccess": true,
+        "lastConfigTime": "2025-08-20T10:00:00.000Z",
+        "corruptionCount": 0,
+        "goroutineCount": 42,
+        "GOMAXPROCS": 4,
+        "GOGC": "",
+        "GODEBUG": "",
+        "storageRetention": "15d"
+    }
+}
+`
+
+// ExpectedRuntimeInfoData is the expected result from RuntimeInfoOutput.
+var ExpectedRuntimeInfoData = &metrics.RuntimeInfoData{
+	StartTime:           "2025-08-20T10:00:00.000Z",
+	CWD:                 "/prometheus",
+	ReloadConfigSuccess: true,
+	LastConfigTime:      "2025-08-20T10:00:00.000Z",
+	CorruptionCount:     0,
+	GoroutineCount:      42,
+	GOMAXPROCS:          4,
+	GOGC:                "",
+	GODEBUG:             "",
+	StorageRetention:    "15d",
+}
+
+// SnapshotOutput is a sample response to a Snapshot call.
+const SnapshotOutput = `
+{
+    "status": "success",
+    "data": {
+        "name": "20250820T100000Z-abcdef1234567890"
+    }
+}
+`
+
+// ExpectedSnapshotData is the expected result from SnapshotOutput.
+var ExpectedSnapshotData = &metrics.SnapshotData{
+	Name: "20250820T100000Z-abcdef1234567890",
+}
+
+// HandleQuerySuccessfully configures the test server to respond to a Query request.
+func HandleQuerySuccessfully(t *testing.T, fakeServer th.FakeServer) {
+	fakeServer.Mux.HandleFunc("/api/v1/query", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprint(w, QueryOutput)
+	})
+}
+
+// HandleLabelsSuccessfully configures the test server to respond to a Labels request.
+func HandleLabelsSuccessfully(t *testing.T, fakeServer th.FakeServer) {
+	fakeServer.Mux.HandleFunc("/api/v1/labels", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprint(w, LabelsOutput)
+	})
+}
+
+// HandleLabelValuesSuccessfully configures the test server to respond to a LabelValues request.
+func HandleLabelValuesSuccessfully(t *testing.T, fakeServer th.FakeServer) {
+	fakeServer.Mux.HandleFunc("/api/v1/label/job/values", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprint(w, LabelValuesOutput)
+	})
+}
+
+// HandleSeriesSuccessfully configures the test server to respond to a Series request.
+func HandleSeriesSuccessfully(t *testing.T, fakeServer th.FakeServer) {
+	fakeServer.Mux.HandleFunc("/api/v1/series", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprint(w, SeriesOutput)
+	})
+}
+
+// HandleTargetsSuccessfully configures the test server to respond to a Targets request.
+func HandleTargetsSuccessfully(t *testing.T, fakeServer th.FakeServer) {
+	fakeServer.Mux.HandleFunc("/api/v1/targets", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprint(w, TargetsOutput)
+	})
+}
+
+// HandleRuntimeInfoSuccessfully configures the test server to respond to a RuntimeInfo request.
+func HandleRuntimeInfoSuccessfully(t *testing.T, fakeServer th.FakeServer) {
+	fakeServer.Mux.HandleFunc("/api/v1/status/runtimeinfo", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprint(w, RuntimeInfoOutput)
+	})
+}
+
+// HandleCleanTombstonesSuccessfully configures the test server to respond to a CleanTombstones request.
+func HandleCleanTombstonesSuccessfully(t *testing.T, fakeServer th.FakeServer) {
+	fakeServer.Mux.HandleFunc("/api/v1/admin/tsdb/clean_tombstones", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.WriteHeader(http.StatusNoContent)
+	})
+}
+
+// HandleDeleteSeriesSuccessfully configures the test server to respond to a DeleteSeries request.
+func HandleDeleteSeriesSuccessfully(t *testing.T, fakeServer th.FakeServer) {
+	fakeServer.Mux.HandleFunc("/api/v1/admin/tsdb/delete_series", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.WriteHeader(http.StatusNoContent)
+	})
+}
+
+// HandleSnapshotSuccessfully configures the test server to respond to a Snapshot request.
+func HandleSnapshotSuccessfully(t *testing.T, fakeServer th.FakeServer) {
+	fakeServer.Mux.HandleFunc("/api/v1/admin/tsdb/snapshot", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprint(w, SnapshotOutput)
+	})
+}

--- a/openstack/metric/v1/metrics/testing/requests_test.go
+++ b/openstack/metric/v1/metrics/testing/requests_test.go
@@ -1,0 +1,109 @@
+package testing
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/v2/openstack/metric/v1/metrics"
+	th "github.com/gophercloud/gophercloud/v2/testhelper"
+)
+
+func TestQuery(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	HandleQuerySuccessfully(t, fakeServer)
+
+	opts := metrics.QueryOpts{
+		Query: "up",
+	}
+
+	actual, err := metrics.Query(context.TODO(), serviceClient(fakeServer), opts).Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, ExpectedQueryData, actual)
+}
+
+func TestLabels(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	HandleLabelsSuccessfully(t, fakeServer)
+
+	actual, err := metrics.Labels(context.TODO(), serviceClient(fakeServer), nil).Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, ExpectedLabels, actual)
+}
+
+func TestLabelValues(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	HandleLabelValuesSuccessfully(t, fakeServer)
+
+	actual, err := metrics.LabelValues(context.TODO(), serviceClient(fakeServer), "job", nil).Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, ExpectedLabelValues, actual)
+}
+
+func TestSeries(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	HandleSeriesSuccessfully(t, fakeServer)
+
+	opts := metrics.SeriesOpts{
+		Match: []string{"up"},
+	}
+
+	actual, err := metrics.Series(context.TODO(), serviceClient(fakeServer), opts).Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, ExpectedSeries, actual)
+}
+
+func TestTargets(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	HandleTargetsSuccessfully(t, fakeServer)
+
+	actual, err := metrics.Targets(context.TODO(), serviceClient(fakeServer), nil).Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, ExpectedTargetsData, actual)
+}
+
+func TestRuntimeInfo(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	HandleRuntimeInfoSuccessfully(t, fakeServer)
+
+	actual, err := metrics.RuntimeInfo(context.TODO(), serviceClient(fakeServer)).Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, ExpectedRuntimeInfoData, actual)
+}
+
+func TestCleanTombstones(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	HandleCleanTombstonesSuccessfully(t, fakeServer)
+
+	err := metrics.CleanTombstones(context.TODO(), serviceClient(fakeServer)).ExtractErr()
+	th.AssertNoErr(t, err)
+}
+
+func TestDeleteSeries(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	HandleDeleteSeriesSuccessfully(t, fakeServer)
+
+	opts := metrics.DeleteSeriesOpts{
+		Match: []string{"up"},
+	}
+
+	err := metrics.DeleteSeries(context.TODO(), serviceClient(fakeServer), opts).ExtractErr()
+	th.AssertNoErr(t, err)
+}
+
+func TestSnapshot(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	HandleSnapshotSuccessfully(t, fakeServer)
+
+	actual, err := metrics.Snapshot(context.TODO(), serviceClient(fakeServer)).Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, ExpectedSnapshotData, actual)
+}

--- a/openstack/metric/v1/metrics/urls.go
+++ b/openstack/metric/v1/metrics/urls.go
@@ -1,0 +1,39 @@
+package metrics
+
+import "github.com/gophercloud/gophercloud/v2"
+
+func queryURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("query")
+}
+
+func labelsURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("labels")
+}
+
+func labelValuesURL(c *gophercloud.ServiceClient, name string) string {
+	return c.ServiceURL("label", name, "values")
+}
+
+func seriesURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("series")
+}
+
+func targetsURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("targets")
+}
+
+func runtimeInfoURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("status", "runtimeinfo")
+}
+
+func cleanTombstonesURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("admin", "tsdb", "clean_tombstones")
+}
+
+func deleteSeriesURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("admin", "tsdb", "delete_series")
+}
+
+func snapshotURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("admin", "tsdb", "snapshot")
+}


### PR DESCRIPTION
Aetos is a Keystone-authenticated reverse proxy for Prometheus that enforces multi-tenant RBAC on all Prometheus queries. This adds Go bindings for the Prometheus HTTP API exposed under /api/v1/ with OpenStack authentication.

Supported operations: Query, Labels, LabelValues, Series, Targets, RuntimeInfo, CleanTombstones, DeleteSeries, Snapshot.

Fixes #3636

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

- [Aetos](https://opendev.org/openstack/aetos)
