### PR TITLE
fix: networkipavailabilities: handle scientific notation in IP counts

### DIFF
--- a/openstack/networking/v2/extensions/networkipavailabilities/results.go
+++ b/openstack/networking/v2/extensions/networkipavailabilities/results.go
@@ -2,6 +2,7 @@ package networkipavailabilities
 
 import (
 	"encoding/json"
+	"fmt"
 	"math/big"
 
 	"github.com/gophercloud/gophercloud/v2"
@@ -52,12 +53,35 @@ type NetworkIPAvailability struct {
 	UsedIPs string `json:"-"`
 }
 
+// Go's encoding/json decodes all JSON numbers into float64 when the target is
+// interface{}. For large integers (abs >= 1e21), re-encoding that float64
+// produces scientific notation (e.g. "1.1805916207174113e+21"), which
+// big.Int.UnmarshalJSON cannot parse. This function handles both plain integer
+// and scientific notation forms.
+func parseBigIntFromNumber(n json.Number) (*big.Int, error) {
+	s := string(n)
+
+	// Fast path: plain integer notation
+	bi := new(big.Int)
+	if _, ok := bi.SetString(s, 10); ok {
+		return bi, nil
+	}
+
+	// Slow path: scientific notation from float64 round-trip
+	bf := new(big.Float).SetPrec(256)
+	if _, _, err := bf.Parse(s, 10); err != nil {
+		return nil, fmt.Errorf("networkipavailabilities: cannot parse %q as an integer: %w", s, err)
+	}
+	result, _ := bf.Int(nil)
+	return result, nil
+}
+
 func (r *NetworkIPAvailability) UnmarshalJSON(b []byte) error {
 	type tmp NetworkIPAvailability
 	var s struct {
 		tmp
-		TotalIPs big.Int `json:"total_ips"`
-		UsedIPs  big.Int `json:"used_ips"`
+		TotalIPs json.Number `json:"total_ips"`
+		UsedIPs  json.Number `json:"used_ips"`
 	}
 
 	err := json.Unmarshal(b, &s)
@@ -66,10 +90,19 @@ func (r *NetworkIPAvailability) UnmarshalJSON(b []byte) error {
 	}
 	*r = NetworkIPAvailability(s.tmp)
 
-	r.TotalIPs = s.TotalIPs.String()
-	r.UsedIPs = s.UsedIPs.String()
+	totalIPs, err := parseBigIntFromNumber(s.TotalIPs)
+	if err != nil {
+		return err
+	}
+	r.TotalIPs = totalIPs.String()
 
-	return err
+	usedIPs, err := parseBigIntFromNumber(s.UsedIPs)
+	if err != nil {
+		return err
+	}
+	r.UsedIPs = usedIPs.String()
+
+	return nil
 }
 
 // SubnetIPAvailability represents availability details for a single subnet.
@@ -97,8 +130,8 @@ func (r *SubnetIPAvailability) UnmarshalJSON(b []byte) error {
 	type tmp SubnetIPAvailability
 	var s struct {
 		tmp
-		TotalIPs big.Int `json:"total_ips"`
-		UsedIPs  big.Int `json:"used_ips"`
+		TotalIPs json.Number `json:"total_ips"`
+		UsedIPs  json.Number `json:"used_ips"`
 	}
 
 	err := json.Unmarshal(b, &s)
@@ -107,10 +140,19 @@ func (r *SubnetIPAvailability) UnmarshalJSON(b []byte) error {
 	}
 	*r = SubnetIPAvailability(s.tmp)
 
-	r.TotalIPs = s.TotalIPs.String()
-	r.UsedIPs = s.UsedIPs.String()
+	totalIPs, err := parseBigIntFromNumber(s.TotalIPs)
+	if err != nil {
+		return err
+	}
+	r.TotalIPs = totalIPs.String()
 
-	return err
+	usedIPs, err := parseBigIntFromNumber(s.UsedIPs)
+	if err != nil {
+		return err
+	}
+	r.UsedIPs = usedIPs.String()
+
+	return nil
 }
 
 // NetworkIPAvailabilityPage stores a single page of NetworkIPAvailabilities

--- a/openstack/networking/v2/extensions/networkipavailabilities/testing/fixtures_test.go
+++ b/openstack/networking/v2/extensions/networkipavailabilities/testing/fixtures_test.go
@@ -15,11 +15,11 @@ const NetworkIPAvailabilityListResult = `
             "project_id": "fb57277ef2f84a0e85b9018ec2dedbf7",
             "subnet_ip_availability": [
                 {
-                    "cidr": "fdbc:bf53:567e::/64",
+                    "cidr": "fdbc:bf53:567e::/56",
                     "ip_version": 6,
                     "subnet_id": "497ac4d3-0b92-42cf-82de-71302ab2b656",
                     "subnet_name": "ipv6-private-subnet",
-                    "total_ips": 18446744073709552000,
+                    "total_ips": 4722366482869645213696,
                     "used_ips": 2
                 },
                 {
@@ -69,10 +69,14 @@ var NetworkIPAvailability1 = networkipavailabilities.NetworkIPAvailability{
 		{
 			SubnetID:   "497ac4d3-0b92-42cf-82de-71302ab2b656",
 			SubnetName: "ipv6-private-subnet",
-			CIDR:       "fdbc:bf53:567e::/64",
+			CIDR:       "fdbc:bf53:567e::/56",
 			IPVersion:  int(gophercloud.IPv6),
-			TotalIPs:   "18446744073709552000",
-			UsedIPs:    "2",
+			// 4722366482869645213696 is 2^72 (a /56 IPv6 subnet).
+			// After gophercloud's float64 round-trip (numbers >= 1e21 are
+			// re-encoded in scientific notation), the value loses the last
+			// few digits of precision but no longer crashes.
+			TotalIPs: "4722366482869645000000",
+			UsedIPs:  "2",
 		},
 		{
 			SubnetID:   "521f47e7-c4fb-452c-b71a-851da38cc571",


### PR DESCRIPTION
Go's JSON decoder converts large integers to float64 when decoding into
interface{}, which causes values ≥ 1e21 to be re-encoded in scientific notation.
big.Int cannot parse that notation, crashing
any List() call that includes a network with a large IPv6 prefix such as /56 or shorter.

Fixes #2233 

