### PR TITLE
Do not specify go patch version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gophercloud/gophercloud/v2
 
-go 1.25.6
+go 1.25.0
 
 require (
 	go.yaml.in/yaml/v3 v3.0.4


### PR DESCRIPTION
There's no good reason for this, and makes it harder to consume.