### PR TITLE
Implement GET/UPDATE/DELETE operations on Placement resource providers inventories

### DIFF
--- a/internal/acceptance/openstack/placement/v1/resourceproviders_test.go
+++ b/internal/acceptance/openstack/placement/v1/resourceproviders_test.go
@@ -251,6 +251,108 @@ func TestResourceProviderUpdateInventoryNotFound(t *testing.T) {
 	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
 }
 
+func TestResourceProviderDeleteInventorySuccess(t *testing.T) {
+	clients.RequireAdmin(t)
+
+	client, err := clients.NewPlacementV1Client()
+	th.AssertNoErr(t, err)
+
+	resourceProvider, err := CreateResourceProvider(t, client)
+	th.AssertNoErr(t, err)
+	defer DeleteResourceProvider(t, client, resourceProvider.UUID)
+
+	// Arrange: Get the current inventory to retrieve the generation
+	inventories, err := resourceproviders.GetInventories(context.TODO(), client, resourceProvider.UUID).Extract()
+	th.AssertNoErr(t, err)
+
+	_, err = resourceproviders.UpdateInventories(context.TODO(), client, resourceProvider.UUID, resourceproviders.UpdateInventoriesOpts{
+		ResourceProviderGeneration: inventories.ResourceProviderGeneration,
+		Inventories: map[string]resourceproviders.Inventory{
+			InventoryResourceClass: {
+				AllocationRatio: 1.0,
+				MaxUnit:         4,
+				MinUnit:         1,
+				Reserved:        0,
+				StepSize:        1,
+				Total:           4,
+			},
+		},
+	}).Extract()
+	th.AssertNoErr(t, err)
+
+	err = resourceproviders.DeleteInventory(context.TODO(), client, resourceProvider.UUID, InventoryResourceClass).ExtractErr()
+	th.AssertNoErr(t, err)
+
+	// Assert: The inventory should no longer be found
+	updatedInventories, err := resourceproviders.GetInventories(context.TODO(), client, resourceProvider.UUID).Extract()
+	th.AssertNoErr(t, err)
+
+	_, found := updatedInventories.Inventories[InventoryResourceClass]
+	th.AssertEquals(t, false, found)
+}
+
+func TestResourceProviderDeleteInventoryNotFound(t *testing.T) {
+	clients.RequireAdmin(t)
+
+	client, err := clients.NewPlacementV1Client()
+	th.AssertNoErr(t, err)
+
+	resourceProvider, err := CreateResourceProvider(t, client)
+	th.AssertNoErr(t, err)
+	defer DeleteResourceProvider(t, client, resourceProvider.UUID)
+
+	err = resourceproviders.DeleteInventory(context.TODO(), client, resourceProvider.UUID, MissingInventoryResourceClass).ExtractErr()
+	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
+}
+
+func TestResourceProviderDeleteInventoriesSuccess(t *testing.T) {
+	clients.RequireAdmin(t)
+
+	client, err := clients.NewPlacementV1Client()
+	th.AssertNoErr(t, err)
+
+	resourceProvider, err := CreateResourceProvider(t, client)
+	th.AssertNoErr(t, err)
+	defer DeleteResourceProvider(t, client, resourceProvider.UUID)
+
+	inventories, err := resourceproviders.GetInventories(context.TODO(), client, resourceProvider.UUID).Extract()
+	th.AssertNoErr(t, err)
+
+	_, err = resourceproviders.UpdateInventories(context.TODO(), client, resourceProvider.UUID, resourceproviders.UpdateInventoriesOpts{
+		ResourceProviderGeneration: inventories.ResourceProviderGeneration,
+		Inventories: map[string]resourceproviders.Inventory{
+			InventoryResourceClass: {
+				AllocationRatio: 1.0,
+				MaxUnit:         4,
+				MinUnit:         1,
+				Reserved:        0,
+				StepSize:        1,
+				Total:           4,
+			},
+			"MEMORY_MB": {
+				AllocationRatio: 1.0,
+				MaxUnit:         1024,
+				MinUnit:         1,
+				Reserved:        0,
+				StepSize:        1,
+				Total:           1024,
+			},
+		},
+	}).Extract()
+	th.AssertNoErr(t, err)
+
+	seededInventories, err := resourceproviders.GetInventories(context.TODO(), client, resourceProvider.UUID).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, 2, len(seededInventories.Inventories))
+
+	err = resourceproviders.DeleteInventories(context.TODO(), client, resourceProvider.UUID).ExtractErr()
+	th.AssertNoErr(t, err)
+
+	updatedInventories, err := resourceproviders.GetInventories(context.TODO(), client, resourceProvider.UUID).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, 0, len(updatedInventories.Inventories))
+}
+
 func TestResourceProviderUpdateInventories(t *testing.T) {
 	clients.RequireAdmin(t)
 

--- a/internal/acceptance/openstack/placement/v1/resourceproviders_test.go
+++ b/internal/acceptance/openstack/placement/v1/resourceproviders_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 const InventoryResourceClass = "VCPU"
+const MissingInventoryResourceClass = "NO_SUCH_CLASS"
 const NonExistentRPUUID = "00000000-0000-0000-0000-000000000000"
 
 func TestResourceProviderList(t *testing.T) {
@@ -103,6 +104,72 @@ func TestResourceProviderInventories(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	tools.PrintResource(t, usage)
+}
+
+func TestResourceProviderInventory(t *testing.T) {
+	clients.RequireAdmin(t)
+
+	client, err := clients.NewPlacementV1Client()
+	th.AssertNoErr(t, err)
+
+	resourceProvider, err := CreateResourceProvider(t, client)
+	th.AssertNoErr(t, err)
+	defer DeleteResourceProvider(t, client, resourceProvider.UUID)
+
+	inventories, err := resourceproviders.GetInventories(context.TODO(), client, resourceProvider.UUID).Extract()
+	th.AssertNoErr(t, err)
+
+	seededInventories, err := resourceproviders.UpdateInventories(context.TODO(), client, resourceProvider.UUID, resourceproviders.UpdateInventoriesOpts{
+		ResourceProviderGeneration: inventories.ResourceProviderGeneration,
+		Inventories: map[string]resourceproviders.Inventory{
+			InventoryResourceClass: {
+				AllocationRatio: 1.0,
+				MaxUnit:         4,
+				MinUnit:         1,
+				Reserved:        0,
+				StepSize:        1,
+				Total:           4,
+			},
+		},
+	}).Extract()
+	th.AssertNoErr(t, err)
+
+	inventory, err := resourceproviders.GetInventory(context.TODO(), client, resourceProvider.UUID, InventoryResourceClass).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, seededInventories.ResourceProviderGeneration, inventory.ResourceProviderGeneration)
+	th.AssertDeepEquals(t, seededInventories.Inventories[InventoryResourceClass], inventory.Inventory)
+}
+
+func TestResourceProviderInventoryNotFound(t *testing.T) {
+	clients.RequireAdmin(t)
+
+	client, err := clients.NewPlacementV1Client()
+	th.AssertNoErr(t, err)
+
+	resourceProvider, err := CreateResourceProvider(t, client)
+	th.AssertNoErr(t, err)
+	defer DeleteResourceProvider(t, client, resourceProvider.UUID)
+
+	inventories, err := resourceproviders.GetInventories(context.TODO(), client, resourceProvider.UUID).Extract()
+	th.AssertNoErr(t, err)
+
+	_, err = resourceproviders.UpdateInventories(context.TODO(), client, resourceProvider.UUID, resourceproviders.UpdateInventoriesOpts{
+		ResourceProviderGeneration: inventories.ResourceProviderGeneration,
+		Inventories: map[string]resourceproviders.Inventory{
+			InventoryResourceClass: {
+				AllocationRatio: 1.0,
+				MaxUnit:         4,
+				MinUnit:         1,
+				Reserved:        0,
+				StepSize:        1,
+				Total:           4,
+			},
+		},
+	}).Extract()
+	th.AssertNoErr(t, err)
+
+	_, err = resourceproviders.GetInventory(context.TODO(), client, resourceProvider.UUID, MissingInventoryResourceClass).Extract()
+	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
 }
 
 func TestResourceProviderUpdateInventory(t *testing.T) {

--- a/internal/acceptance/openstack/placement/v1/resourceproviders_test.go
+++ b/internal/acceptance/openstack/placement/v1/resourceproviders_test.go
@@ -4,13 +4,18 @@ package v1
 
 import (
 	"context"
+	"net/http"
 	"testing"
 
+	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/internal/acceptance/clients"
 	"github.com/gophercloud/gophercloud/v2/internal/acceptance/tools"
 	"github.com/gophercloud/gophercloud/v2/openstack/placement/v1/resourceproviders"
 	th "github.com/gophercloud/gophercloud/v2/testhelper"
 )
+
+const InventoryResourceClass = "VCPU"
+const NonExistentRPUUID = "00000000-0000-0000-0000-000000000000"
 
 func TestResourceProviderList(t *testing.T) {
 	clients.RequireAdmin(t)
@@ -98,6 +103,148 @@ func TestResourceProviderInventories(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	tools.PrintResource(t, usage)
+}
+
+func TestResourceProviderUpdateInventory(t *testing.T) {
+	clients.RequireAdmin(t)
+
+	client, err := clients.NewPlacementV1Client()
+	th.AssertNoErr(t, err)
+
+	resourceProvider, err := CreateResourceProvider(t, client)
+	th.AssertNoErr(t, err)
+	defer DeleteResourceProvider(t, client, resourceProvider.UUID)
+
+	// Arrange: Get the current inventory to retrieve the generation
+	inventories, err := resourceproviders.GetInventories(context.TODO(), client, resourceProvider.UUID).Extract()
+	th.AssertNoErr(t, err)
+
+	// Arrange: The resource class on this provider must exist first
+	seedOpts := resourceproviders.UpdateInventoriesOpts{
+		ResourceProviderGeneration: inventories.ResourceProviderGeneration,
+		Inventories: map[string]resourceproviders.Inventory{
+			InventoryResourceClass: {
+				AllocationRatio: 1.0,
+				MaxUnit:         4,
+				MinUnit:         1,
+				Reserved:        0,
+				StepSize:        1,
+				Total:           4,
+			},
+		},
+	}
+
+	seededInventories, err := resourceproviders.UpdateInventories(context.TODO(), client, resourceProvider.UUID, seedOpts).Extract()
+	th.AssertNoErr(t, err)
+
+	expectedInventory := resourceproviders.Inventory{
+		AllocationRatio: 1.0,
+		MaxUnit:         8,
+		MinUnit:         1,
+		Reserved:        0,
+		StepSize:        1,
+		Total:           8,
+	}
+
+	updateOpts := resourceproviders.UpdateInventoryOpts{
+		ResourceProviderGeneration: seededInventories.ResourceProviderGeneration,
+		Inventory:                  expectedInventory,
+	}
+
+	_, err = resourceproviders.UpdateInventory(context.TODO(), client, resourceProvider.UUID, InventoryResourceClass, updateOpts).Extract()
+	th.AssertNoErr(t, err)
+
+	updatedInventories, err := resourceproviders.GetInventories(context.TODO(), client, resourceProvider.UUID).Extract()
+	th.AssertNoErr(t, err)
+
+	actualInventory, ok := updatedInventories.Inventories[InventoryResourceClass]
+	th.AssertEquals(t, true, ok)
+	th.AssertDeepEquals(t, expectedInventory, actualInventory)
+}
+
+func TestResourceProviderUpdateInventoryNotFound(t *testing.T) {
+	clients.RequireAdmin(t)
+
+	client, err := clients.NewPlacementV1Client()
+	th.AssertNoErr(t, err)
+
+	updateOpts := resourceproviders.UpdateInventoryOpts{
+		ResourceProviderGeneration: 0,
+		Inventory: resourceproviders.Inventory{
+			AllocationRatio: 1.0,
+			MaxUnit:         1,
+			MinUnit:         1,
+			Reserved:        0,
+			StepSize:        1,
+			Total:           1,
+		},
+	}
+
+	_, err = resourceproviders.UpdateInventory(context.TODO(), client, NonExistentRPUUID, InventoryResourceClass, updateOpts).Extract()
+	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
+}
+
+func TestResourceProviderUpdateInventories(t *testing.T) {
+	clients.RequireAdmin(t)
+
+	client, err := clients.NewPlacementV1Client()
+	th.AssertNoErr(t, err)
+
+	resourceProvider, err := CreateResourceProvider(t, client)
+	th.AssertNoErr(t, err)
+	defer DeleteResourceProvider(t, client, resourceProvider.UUID)
+
+	// Arrange: Get the current inventory to retrieve the generation
+	inventories, err := resourceproviders.GetInventories(context.TODO(), client, resourceProvider.UUID).Extract()
+	th.AssertNoErr(t, err)
+
+	expectedInventories := map[string]resourceproviders.Inventory{
+		"DISK_GB": {
+			AllocationRatio: 1.0,
+			MaxUnit:         100,
+			MinUnit:         1,
+			Reserved:        0,
+			StepSize:        1,
+			Total:           100,
+		},
+	}
+
+	updateOpts := resourceproviders.UpdateInventoriesOpts{
+		ResourceProviderGeneration: inventories.ResourceProviderGeneration,
+		Inventories:                expectedInventories,
+	}
+
+	_, err = resourceproviders.UpdateInventories(context.TODO(), client, resourceProvider.UUID, updateOpts).Extract()
+	th.AssertNoErr(t, err)
+
+	updatedInventories, err := resourceproviders.GetInventories(context.TODO(), client, resourceProvider.UUID).Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertDeepEquals(t, expectedInventories, updatedInventories.Inventories)
+}
+
+func TestResourceProviderUpdateInventoriesNotFound(t *testing.T) {
+	clients.RequireAdmin(t)
+
+	client, err := clients.NewPlacementV1Client()
+	th.AssertNoErr(t, err)
+
+	updateOpts := resourceproviders.UpdateInventoriesOpts{
+		ResourceProviderGeneration: 0,
+		Inventories: map[string]resourceproviders.Inventory{
+			InventoryResourceClass: {
+				AllocationRatio: 1.0,
+				MaxUnit:         1,
+				MinUnit:         1,
+				Reserved:        0,
+				StepSize:        1,
+				Total:           1,
+			},
+		},
+	}
+
+	_, err = resourceproviders.UpdateInventories(context.TODO(), client, NonExistentRPUUID, updateOpts).Extract()
+	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
 }
 
 func TestResourceProviderTraits(t *testing.T) {

--- a/openstack/placement/v1/resourceproviders/doc.go
+++ b/openstack/placement/v1/resourceproviders/doc.go
@@ -75,6 +75,57 @@ Example to get resource providers inventories
 		panic(err)
 	}
 
+Example to update (replace) all resource provider inventories
+
+	inventories, err := resourceproviders.GetInventories(context.TODO(), placementClient, resourceProviderID).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	updateInventoriesOpts := resourceproviders.UpdateInventoriesOpts{
+		ResourceProviderGeneration: inventories.ResourceProviderGeneration,
+		Inventories: map[string]resourceproviders.Inventory{
+			"VCPU": {
+				Total:           4,
+				Reserved:        0,
+				MinUnit:         1,
+				MaxUnit:         4,
+				StepSize:        1,
+				AllocationRatio: 16.0,
+			},
+		},
+	}
+
+	rp, err = resourceproviders.UpdateInventories(context.TODO(), placementClient, resourceProviderID, updateInventoriesOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to update one existing resource provider inventory
+
+	inventories, err := resourceproviders.GetInventories(context.TODO(), placementClient, resourceProviderID).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	// UpdateInventory updates an existing resource class inventory.
+	updateInventoryOpts := resourceproviders.UpdateInventoryOpts{
+		ResourceProviderGeneration: inventories.ResourceProviderGeneration,
+		Inventory: resourceproviders.Inventory{
+			Total:           4,
+			Reserved:        0,
+			MinUnit:         1,
+			MaxUnit:         4,
+			StepSize:        1,
+			AllocationRatio: 16.0,
+		},
+	}
+
+	rpInventory, err := resourceproviders.UpdateInventory(context.TODO(), placementClient, resourceProviderID, "VCPU", updateInventoryOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
 Example to get resource providers traits
 
 	rp, err := resourceproviders.GetTraits(context.TODO(), placementClient, resourceProviderID).Extract()

--- a/openstack/placement/v1/resourceproviders/doc.go
+++ b/openstack/placement/v1/resourceproviders/doc.go
@@ -75,6 +75,13 @@ Example to get resource providers inventories
 		panic(err)
 	}
 
+Example to get one resource provider inventory
+
+	rpInventory, err := resourceproviders.GetInventory(context.TODO(), placementClient, resourceProviderID, "VCPU").Extract()
+	if err != nil {
+		panic(err)
+	}
+
 Example to update (replace) all resource provider inventories
 
 	inventories, err := resourceproviders.GetInventories(context.TODO(), placementClient, resourceProviderID).Extract()

--- a/openstack/placement/v1/resourceproviders/doc.go
+++ b/openstack/placement/v1/resourceproviders/doc.go
@@ -133,6 +133,22 @@ Example to update one existing resource provider inventory
 		panic(err)
 	}
 
+Example to delete one existing resource provider inventory
+Since this request does not accept the resource provider generation, it is not safe to use when multiple threads are managing inventories for a single provider. In such situations use UpdateInventories with the empty inventory.
+
+	err = resourceproviders.DeleteInventory(context.TODO(), placementClient, resourceProviderID, "VCPU").ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+
+Example to delete all resource provider inventories
+Since this request does not accept the resource provider generation, it is not safe to use when multiple threads are managing inventories for a single provider. In such situations use UpdateInventories with an empty inventory map.
+
+	err = resourceproviders.DeleteInventories(context.TODO(), placementClient, resourceProviderID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+
 Example to get resource providers traits
 
 	rp, err := resourceproviders.GetTraits(context.TODO(), placementClient, resourceProviderID).Extract()

--- a/openstack/placement/v1/resourceproviders/requests.go
+++ b/openstack/placement/v1/resourceproviders/requests.go
@@ -199,6 +199,13 @@ func UpdateInventories(ctx context.Context, client *gophercloud.ServiceClient, r
 	return
 }
 
+// DeleteInventories deletes all inventories from a resource provider.
+func DeleteInventories(ctx context.Context, client *gophercloud.ServiceClient, resourceProviderID string) (r DeleteResult) {
+	resp, err := client.Delete(ctx, deleteResourceProviderInventoriesURL(client, resourceProviderID), &gophercloud.RequestOpts{OkCodes: []int{204}})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
 // UpdateInventoryOptsBuilder allows extensions to add additional parameters to the
 // UpdateInventory request.
 type UpdateInventoryOptsBuilder interface {
@@ -224,6 +231,13 @@ func UpdateInventory(ctx context.Context, client *gophercloud.ServiceClient, res
 	resp, err := client.Put(ctx, updateResourceProviderInventoryURL(client, resourceProviderID, resourceClass), b, &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{200},
 	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// DeleteInventory deletes one inventory from a resource provider.
+func DeleteInventory(ctx context.Context, client *gophercloud.ServiceClient, resourceProviderID, resourceClass string) (r DeleteResult) {
+	resp, err := client.Delete(ctx, deleteResourceProviderInventoryURL(client, resourceProviderID, resourceClass), &gophercloud.RequestOpts{OkCodes: []int{204}})
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }

--- a/openstack/placement/v1/resourceproviders/requests.go
+++ b/openstack/placement/v1/resourceproviders/requests.go
@@ -164,6 +164,64 @@ func GetInventories(ctx context.Context, client *gophercloud.ServiceClient, reso
 	return
 }
 
+// UpdateInventoriesOptsBuilder allows extensions to add additional parameters to the
+// UpdateInventories request.
+type UpdateInventoriesOptsBuilder interface {
+	ToResourceProviderUpdateInventoriesMap() (map[string]any, error)
+}
+
+// UpdateInventoriesOpts represents options used to update all inventories of a resource provider.
+type UpdateInventoriesOpts = ResourceProviderInventories
+
+// ToResourceProviderUpdateInventoriesMap constructs a request body from UpdateInventoriesOpts.
+func (opts UpdateInventoriesOpts) ToResourceProviderUpdateInventoriesMap() (map[string]any, error) {
+	return gophercloud.BuildRequestBody(opts, "")
+}
+
+// UpdateInventories updates all inventories of a resource provider.
+func UpdateInventories(ctx context.Context, client *gophercloud.ServiceClient, resourceProviderID string, opts UpdateInventoriesOptsBuilder) (r GetInventoriesResult) {
+	b, err := opts.ToResourceProviderUpdateInventoriesMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	resp, err := client.Put(ctx, getResourceProviderInventoriesURL(client, resourceProviderID), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// UpdateInventoryOptsBuilder allows extensions to add additional parameters to the
+// UpdateInventory request.
+type UpdateInventoryOptsBuilder interface {
+	ToResourceProviderUpdateInventoryMap() (map[string]any, error)
+}
+
+// UpdateInventoryOpts represents options used to update one inventory of a resource provider.
+type UpdateInventoryOpts = ResourceProviderInventory
+
+// ToResourceProviderUpdateInventoryMap constructs a request body from UpdateInventoryOpts.
+func (opts UpdateInventoryOpts) ToResourceProviderUpdateInventoryMap() (map[string]any, error) {
+	return gophercloud.BuildRequestBody(opts, "")
+}
+
+// UpdateInventory updates one inventory of a resource provider.
+func UpdateInventory(ctx context.Context, client *gophercloud.ServiceClient, resourceProviderID, resourceClass string, opts UpdateInventoryOptsBuilder) (r UpdateInventoryResult) {
+	b, err := opts.ToResourceProviderUpdateInventoryMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	resp, err := client.Put(ctx, updateResourceProviderInventoryURL(client, resourceProviderID, resourceClass), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
 func GetAllocations(ctx context.Context, client *gophercloud.ServiceClient, resourceProviderID string) (r GetAllocationsResult) {
 	resp, err := client.Get(ctx, getResourceProviderAllocationsURL(client, resourceProviderID), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)

--- a/openstack/placement/v1/resourceproviders/requests.go
+++ b/openstack/placement/v1/resourceproviders/requests.go
@@ -164,6 +164,12 @@ func GetInventories(ctx context.Context, client *gophercloud.ServiceClient, reso
 	return
 }
 
+func GetInventory(ctx context.Context, client *gophercloud.ServiceClient, resourceProviderID, resourceClass string) (r GetInventoryResult) {
+	resp, err := client.Get(ctx, getResourceProviderInventoryURL(client, resourceProviderID, resourceClass), &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
 // UpdateInventoriesOptsBuilder allows extensions to add additional parameters to the
 // UpdateInventories request.
 type UpdateInventoriesOptsBuilder interface {

--- a/openstack/placement/v1/resourceproviders/results.go
+++ b/openstack/placement/v1/resourceproviders/results.go
@@ -158,6 +158,19 @@ func (r GetInventoriesResult) Extract() (*ResourceProviderInventories, error) {
 	return &s, err
 }
 
+// GetInventoryResult is the response of a Get inventory operation. Call its Extract method
+// to interpret it as a ResourceProviderInventory.
+type GetInventoryResult struct {
+	gophercloud.Result
+}
+
+// Extract interprets a GetInventoryResult as a ResourceProviderInventory.
+func (r GetInventoryResult) Extract() (*ResourceProviderInventory, error) {
+	var s ResourceProviderInventory
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
 // UpdateInventoryResult is the response of an Update inventory operation. Call its Extract method
 // to interpret it as a ResourceProviderInventory.
 type UpdateInventoryResult struct {

--- a/openstack/placement/v1/resourceproviders/results.go
+++ b/openstack/placement/v1/resourceproviders/results.go
@@ -56,6 +56,11 @@ type ResourceProviderInventories struct {
 	Inventories                map[string]Inventory `json:"inventories"`
 }
 
+type ResourceProviderInventory struct {
+	ResourceProviderGeneration int `json:"resource_provider_generation"`
+	Inventory
+}
+
 type ResourceProviderAllocations struct {
 	ResourceProviderGeneration int                   `json:"resource_provider_generation"`
 	Allocations                map[string]Allocation `json:"allocations"`
@@ -149,6 +154,19 @@ type GetInventoriesResult struct {
 // Extract interprets a GetInventoriesResult as a ResourceProviderInventories.
 func (r GetInventoriesResult) Extract() (*ResourceProviderInventories, error) {
 	var s ResourceProviderInventories
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+// UpdateInventoryResult is the response of an Update inventory operation. Call its Extract method
+// to interpret it as a ResourceProviderInventory.
+type UpdateInventoryResult struct {
+	gophercloud.Result
+}
+
+// Extract interprets a UpdateInventoryResult as a ResourceProviderInventory.
+func (r UpdateInventoryResult) Extract() (*ResourceProviderInventory, error) {
+	var s ResourceProviderInventory
 	err := r.ExtractInto(&s)
 	return &s, err
 }

--- a/openstack/placement/v1/resourceproviders/testing/fixtures_test.go
+++ b/openstack/placement/v1/resourceproviders/testing/fixtures_test.go
@@ -517,6 +517,58 @@ func HandleResourceProviderPutInventoryNotFound(t *testing.T, fakeServer th.Fake
 		})
 }
 
+func HandleResourceProviderDeleteInventorySuccess(t *testing.T, fakeServer th.FakeServer) {
+	inventoryDeleteURL := fmt.Sprintf("/resource_providers/%s/inventories/%s", ResourceProviderTestID, PresentInventoryResourceClass)
+
+	fakeServer.Mux.HandleFunc(inventoryDeleteURL,
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "DELETE")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+			th.AssertEquals(t, "", r.URL.RawQuery)
+			w.WriteHeader(http.StatusNoContent)
+		})
+}
+
+func HandleResourceProviderDeleteInventoryInUse(t *testing.T, fakeServer th.FakeServer) {
+	inventoryDeleteURL := fmt.Sprintf("/resource_providers/%s/inventories/%s", ResourceProviderTestID, PresentInventoryResourceClass)
+
+	fakeServer.Mux.HandleFunc(inventoryDeleteURL,
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "DELETE")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+			th.AssertEquals(t, "", r.URL.RawQuery)
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusConflict)
+			fmt.Fprint(w, `{"errors":[{"status":409,"title":"Conflict","detail":"Inventory is in use.","code":"placement.inventory.inuse"}]}`)
+		})
+}
+
+func HandleResourceProviderDeleteInventoriesSuccess(t *testing.T, fakeServer th.FakeServer) {
+	inventoriesDeleteURL := fmt.Sprintf("/resource_providers/%s/inventories", ResourceProviderTestID)
+
+	fakeServer.Mux.HandleFunc(inventoriesDeleteURL,
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "DELETE")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+			th.AssertEquals(t, "", r.URL.RawQuery)
+			w.WriteHeader(http.StatusNoContent)
+		})
+}
+
+func HandleResourceProviderDeleteInventoriesConflict(t *testing.T, fakeServer th.FakeServer) {
+	inventoriesDeleteURL := fmt.Sprintf("/resource_providers/%s/inventories", ResourceProviderTestID)
+
+	fakeServer.Mux.HandleFunc(inventoriesDeleteURL,
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "DELETE")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+			th.AssertEquals(t, "", r.URL.RawQuery)
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusConflict)
+			fmt.Fprint(w, `{"errors":[{"status":409,"title":"Conflict","detail":"Inventory is in use.","code":"placement.inventory.inuse"}]}`)
+		})
+}
+
 func HandleResourceProviderGetAllocations(t *testing.T, fakeServer th.FakeServer) {
 	allocationsTestUrl := fmt.Sprintf("/resource_providers/%s/allocations", ResourceProviderTestID)
 

--- a/openstack/placement/v1/resourceproviders/testing/fixtures_test.go
+++ b/openstack/placement/v1/resourceproviders/testing/fixtures_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 const ResourceProviderTestID = "99c09379-6e52-4ef8-9a95-b9ce6f68452e"
+const PresentInventoryResourceClass = "VCPU"
+const NonExistentRPID = "00000000-0000-0000-0000-000000000000"
 
 const ResourceProvidersBody = `
 {
@@ -128,6 +130,62 @@ const InventoriesBody = `
 }
 `
 
+const UpdateInventoriesRequest = `
+{
+	"resource_provider_generation": 7,
+	"inventories": {
+		"DISK_GB": {
+			"allocation_ratio": 1.0,
+			"max_unit": 35,
+			"min_unit": 1,
+			"reserved": 0,
+			"step_size": 1,
+			"total": 35
+		},
+		"MEMORY_MB": {
+			"allocation_ratio": 1.5,
+			"max_unit": 5825,
+			"min_unit": 1,
+			"reserved": 512,
+			"step_size": 1,
+			"total": 5825
+		},
+		"VCPU": {
+			"allocation_ratio": 16.0,
+			"max_unit": 4,
+			"min_unit": 1,
+			"reserved": 0,
+			"step_size": 1,
+			"total": 4
+		}
+	}
+}
+`
+
+const InventoryBody = `
+{
+	"resource_provider_generation": 7,
+	"allocation_ratio": 16.0,
+	"max_unit": 4,
+	"min_unit": 1,
+	"reserved": 0,
+	"step_size": 1,
+	"total": 4
+}
+`
+
+const UpdateInventoryRequest = `
+{
+	"resource_provider_generation": 7,
+	"allocation_ratio": 16.0,
+	"max_unit": 4,
+	"min_unit": 1,
+	"reserved": 0,
+	"step_size": 1,
+	"total": 4
+}
+`
+
 const AllocationsBody = `
 {
     "allocations": {
@@ -233,6 +291,18 @@ var ExpectedInventories = resourceproviders.ResourceProviderInventories{
 			StepSize:        1,
 			Total:           4,
 		},
+	},
+}
+
+var ExpectedInventory = resourceproviders.ResourceProviderInventory{
+	ResourceProviderGeneration: 7,
+	Inventory: resourceproviders.Inventory{
+		AllocationRatio: 16.0,
+		MaxUnit:         4,
+		MinUnit:         1,
+		Reserved:        0,
+		StepSize:        1,
+		Total:           4,
 	},
 }
 
@@ -355,6 +425,68 @@ func HandleResourceProviderGetInventories(t *testing.T, fakeServer th.FakeServer
 			w.WriteHeader(http.StatusOK)
 
 			fmt.Fprint(w, InventoriesBody)
+		})
+}
+
+func HandleResourceProviderPutInventories(t *testing.T, fakeServer th.FakeServer) {
+	inventoriesTestURL := fmt.Sprintf("/resource_providers/%s/inventories", ResourceProviderTestID)
+
+	fakeServer.Mux.HandleFunc(inventoriesTestURL,
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "PUT")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+			th.TestHeader(t, r, "Content-Type", "application/json")
+			th.TestHeader(t, r, "Accept", "application/json")
+			th.TestJSONRequest(t, r, UpdateInventoriesRequest)
+
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+
+			fmt.Fprint(w, InventoriesBody)
+		})
+}
+
+func HandleResourceProviderPutInventoriesNotFound(t *testing.T, fakeServer th.FakeServer) {
+	inventoriesNotFoundURL := fmt.Sprintf("/resource_providers/%s/inventories", NonExistentRPID)
+
+	fakeServer.Mux.HandleFunc(inventoriesNotFoundURL,
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "PUT")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, `{"errors":[{"status":404,"title":"Not Found"}]}`)
+		})
+}
+
+func HandleResourceProviderPutInventory(t *testing.T, fakeServer th.FakeServer) {
+	inventoryTestURL := fmt.Sprintf("/resource_providers/%s/inventories/%s", ResourceProviderTestID, PresentInventoryResourceClass)
+
+	fakeServer.Mux.HandleFunc(inventoryTestURL,
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "PUT")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+			th.TestHeader(t, r, "Content-Type", "application/json")
+			th.TestHeader(t, r, "Accept", "application/json")
+			th.TestJSONRequest(t, r, UpdateInventoryRequest)
+
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+
+			fmt.Fprint(w, InventoryBody)
+		})
+}
+
+func HandleResourceProviderPutInventoryNotFound(t *testing.T, fakeServer th.FakeServer) {
+	inventoryNotFoundURL := fmt.Sprintf("/resource_providers/%s/inventories/%s", NonExistentRPID, PresentInventoryResourceClass)
+
+	fakeServer.Mux.HandleFunc(inventoryNotFoundURL,
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "PUT")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, `{"errors":[{"status":404,"title":"Not Found"}]}`)
 		})
 }
 

--- a/openstack/placement/v1/resourceproviders/testing/fixtures_test.go
+++ b/openstack/placement/v1/resourceproviders/testing/fixtures_test.go
@@ -13,6 +13,7 @@ import (
 
 const ResourceProviderTestID = "99c09379-6e52-4ef8-9a95-b9ce6f68452e"
 const PresentInventoryResourceClass = "VCPU"
+const MissingInventoryResourceClass = "NO_SUCH_CLASS"
 const NonExistentRPID = "00000000-0000-0000-0000-000000000000"
 
 const ResourceProvidersBody = `
@@ -425,6 +426,32 @@ func HandleResourceProviderGetInventories(t *testing.T, fakeServer th.FakeServer
 			w.WriteHeader(http.StatusOK)
 
 			fmt.Fprint(w, InventoriesBody)
+		})
+}
+
+func HandleResourceProviderGetInventory(t *testing.T, fakeServer th.FakeServer) {
+	inventoryTestURL := fmt.Sprintf("/resource_providers/%s/inventories/%s", ResourceProviderTestID, PresentInventoryResourceClass)
+
+	fakeServer.Mux.HandleFunc(inventoryTestURL,
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "GET")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+
+			fmt.Fprint(w, InventoryBody)
+		})
+}
+
+func HandleResourceProviderGetInventoryNotFound(t *testing.T, fakeServer th.FakeServer) {
+	inventoryNotFoundURL := fmt.Sprintf("/resource_providers/%s/inventories/%s", ResourceProviderTestID, MissingInventoryResourceClass)
+
+	fakeServer.Mux.HandleFunc(inventoryNotFoundURL,
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "GET")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+			w.WriteHeader(http.StatusNotFound)
 		})
 }
 

--- a/openstack/placement/v1/resourceproviders/testing/requests_test.go
+++ b/openstack/placement/v1/resourceproviders/testing/requests_test.go
@@ -2,8 +2,10 @@ package testing
 
 import (
 	"context"
+	"net/http"
 	"testing"
 
+	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/openstack/placement/v1/resourceproviders"
 
 	"github.com/gophercloud/gophercloud/v2/pagination"
@@ -122,6 +124,52 @@ func TestGetResourceProvidersInventories(t *testing.T) {
 	actual, err := resourceproviders.GetInventories(context.TODO(), client.ServiceClient(fakeServer), ResourceProviderTestID).Extract()
 	th.AssertNoErr(t, err)
 	th.AssertDeepEquals(t, ExpectedInventories, *actual)
+}
+
+func TestUpdateResourceProvidersInventories(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	HandleResourceProviderPutInventories(t, fakeServer)
+
+	opts := resourceproviders.UpdateInventoriesOpts(ExpectedInventories)
+	actual, err := resourceproviders.UpdateInventories(context.TODO(), client.ServiceClient(fakeServer), ResourceProviderTestID, opts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, ExpectedInventories, *actual)
+}
+
+func TestUpdateResourceProvidersInventoriesNotFound(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	HandleResourceProviderPutInventoriesNotFound(t, fakeServer)
+
+	opts := resourceproviders.UpdateInventoriesOpts(ExpectedInventories)
+	_, err := resourceproviders.UpdateInventories(context.TODO(), client.ServiceClient(fakeServer), NonExistentRPID, opts).Extract()
+	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
+}
+
+func TestUpdateResourceProviderInventory(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	HandleResourceProviderPutInventory(t, fakeServer)
+
+	opts := resourceproviders.UpdateInventoryOpts(ExpectedInventory)
+	actual, err := resourceproviders.UpdateInventory(context.TODO(), client.ServiceClient(fakeServer), ResourceProviderTestID, PresentInventoryResourceClass, opts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, ExpectedInventory, *actual)
+}
+
+func TestUpdateResourceProviderInventoryNotFound(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	HandleResourceProviderPutInventoryNotFound(t, fakeServer)
+
+	opts := resourceproviders.UpdateInventoryOpts(ExpectedInventory)
+	_, err := resourceproviders.UpdateInventory(context.TODO(), client.ServiceClient(fakeServer), NonExistentRPID, PresentInventoryResourceClass, opts).Extract()
+	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
 }
 
 func TestGetResourceProvidersAllocations(t *testing.T) {

--- a/openstack/placement/v1/resourceproviders/testing/requests_test.go
+++ b/openstack/placement/v1/resourceproviders/testing/requests_test.go
@@ -126,6 +126,27 @@ func TestGetResourceProvidersInventories(t *testing.T) {
 	th.AssertDeepEquals(t, ExpectedInventories, *actual)
 }
 
+func TestGetResourceProviderInventory(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	HandleResourceProviderGetInventory(t, fakeServer)
+
+	actual, err := resourceproviders.GetInventory(context.TODO(), client.ServiceClient(fakeServer), ResourceProviderTestID, PresentInventoryResourceClass).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, ExpectedInventory, *actual)
+}
+
+func TestGetResourceProviderInventoryNotFound(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	HandleResourceProviderGetInventoryNotFound(t, fakeServer)
+
+	_, err := resourceproviders.GetInventory(context.TODO(), client.ServiceClient(fakeServer), ResourceProviderTestID, MissingInventoryResourceClass).Extract()
+	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
+}
+
 func TestUpdateResourceProvidersInventories(t *testing.T) {
 	fakeServer := th.SetupHTTP()
 	defer fakeServer.Teardown()

--- a/openstack/placement/v1/resourceproviders/testing/requests_test.go
+++ b/openstack/placement/v1/resourceproviders/testing/requests_test.go
@@ -193,6 +193,46 @@ func TestUpdateResourceProviderInventoryNotFound(t *testing.T) {
 	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
 }
 
+func TestDeleteResourceProviderInventorySuccess(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	HandleResourceProviderDeleteInventorySuccess(t, fakeServer)
+
+	err := resourceproviders.DeleteInventory(context.TODO(), client.ServiceClient(fakeServer), ResourceProviderTestID, PresentInventoryResourceClass).ExtractErr()
+	th.AssertNoErr(t, err)
+}
+
+func TestDeleteResourceProviderInventoryInUse(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	HandleResourceProviderDeleteInventoryInUse(t, fakeServer)
+
+	err := resourceproviders.DeleteInventory(context.TODO(), client.ServiceClient(fakeServer), ResourceProviderTestID, PresentInventoryResourceClass).ExtractErr()
+	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusConflict))
+}
+
+func TestDeleteResourceProviderInventoriesSuccess(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	HandleResourceProviderDeleteInventoriesSuccess(t, fakeServer)
+
+	err := resourceproviders.DeleteInventories(context.TODO(), client.ServiceClient(fakeServer), ResourceProviderTestID).ExtractErr()
+	th.AssertNoErr(t, err)
+}
+
+func TestDeleteResourceProviderInventoriesConflict(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	HandleResourceProviderDeleteInventoriesConflict(t, fakeServer)
+
+	err := resourceproviders.DeleteInventories(context.TODO(), client.ServiceClient(fakeServer), ResourceProviderTestID).ExtractErr()
+	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusConflict))
+}
+
 func TestGetResourceProvidersAllocations(t *testing.T) {
 	fakeServer := th.SetupHTTP()
 	defer fakeServer.Teardown()

--- a/openstack/placement/v1/resourceproviders/urls.go
+++ b/openstack/placement/v1/resourceproviders/urls.go
@@ -30,11 +30,19 @@ func getResourceProviderInventoriesURL(client *gophercloud.ServiceClient, resour
 	return client.ServiceURL(apiName, resourceProviderID, "inventories")
 }
 
+func deleteResourceProviderInventoriesURL(client *gophercloud.ServiceClient, resourceProviderID string) string {
+	return client.ServiceURL(apiName, resourceProviderID, "inventories")
+}
+
 func getResourceProviderInventoryURL(client *gophercloud.ServiceClient, resourceProviderID, resourceClass string) string {
 	return client.ServiceURL(apiName, resourceProviderID, "inventories", resourceClass)
 }
 
 func updateResourceProviderInventoryURL(client *gophercloud.ServiceClient, resourceProviderID, resourceClass string) string {
+	return client.ServiceURL(apiName, resourceProviderID, "inventories", resourceClass)
+}
+
+func deleteResourceProviderInventoryURL(client *gophercloud.ServiceClient, resourceProviderID, resourceClass string) string {
 	return client.ServiceURL(apiName, resourceProviderID, "inventories", resourceClass)
 }
 

--- a/openstack/placement/v1/resourceproviders/urls.go
+++ b/openstack/placement/v1/resourceproviders/urls.go
@@ -30,6 +30,10 @@ func getResourceProviderInventoriesURL(client *gophercloud.ServiceClient, resour
 	return client.ServiceURL(apiName, resourceProviderID, "inventories")
 }
 
+func updateResourceProviderInventoryURL(client *gophercloud.ServiceClient, resourceProviderID, resourceClass string) string {
+	return client.ServiceURL(apiName, resourceProviderID, "inventories", resourceClass)
+}
+
 func getResourceProviderAllocationsURL(client *gophercloud.ServiceClient, resourceProviderID string) string {
 	return client.ServiceURL(apiName, resourceProviderID, "allocations")
 }

--- a/openstack/placement/v1/resourceproviders/urls.go
+++ b/openstack/placement/v1/resourceproviders/urls.go
@@ -30,6 +30,10 @@ func getResourceProviderInventoriesURL(client *gophercloud.ServiceClient, resour
 	return client.ServiceURL(apiName, resourceProviderID, "inventories")
 }
 
+func getResourceProviderInventoryURL(client *gophercloud.ServiceClient, resourceProviderID, resourceClass string) string {
+	return client.ServiceURL(apiName, resourceProviderID, "inventories", resourceClass)
+}
+
 func updateResourceProviderInventoryURL(client *gophercloud.ServiceClient, resourceProviderID, resourceClass string) string {
 	return client.ServiceURL(apiName, resourceProviderID, "inventories", resourceClass)
 }


### PR DESCRIPTION
Related: https://github.com/gophercloud/gophercloud/issues/526

API reference:
https://docs.openstack.org/api-ref/placement/#update-resource-provider-inventories
https://docs.openstack.org/api-ref/placement/#update-resource-provider-inventory

Code reference:
https://opendev.org/openstack/placement/src/branch/stable/2026.1/placement/handlers/inventory.py#L257-L277
https://opendev.org/openstack/placement/src/branch/stable/2026.1/placement/handlers/inventory.py#L280-L307