### PR TITLE
Add support for listing recordsets across all zones

### DIFF
--- a/internal/acceptance/openstack/dns/v2/recordsets_test.go
+++ b/internal/acceptance/openstack/dns/v2/recordsets_test.go
@@ -52,6 +52,49 @@ func TestRecordSetsListByZone(t *testing.T) {
 	th.AssertNoErr(t, err)
 }
 
+func TestRecordSetsListAll(t *testing.T) {
+	client, err := clients.NewDNSV2Client()
+	th.AssertNoErr(t, err)
+
+	zone, err := CreateZone(t, client)
+	th.AssertNoErr(t, err)
+	defer DeleteZone(t, client, zone)
+
+	rs, err := CreateRecordSet(t, client, zone)
+	th.AssertNoErr(t, err)
+	defer DeleteRecordSet(t, client, rs)
+
+	allPages, err := recordsets.ListAll(client, nil).AllPages(context.TODO())
+	th.AssertNoErr(t, err)
+
+	allRecordSets, err := recordsets.ExtractRecordSets(allPages)
+	th.AssertNoErr(t, err)
+
+	var found bool
+	for _, recordset := range allRecordSets {
+		tools.PrintResource(t, &recordset)
+
+		if recordset.ID == rs.ID {
+			found = true
+		}
+	}
+
+	th.AssertEquals(t, found, true)
+
+	listOpts := recordsets.ListOpts{
+		Limit: 1,
+	}
+
+	pager := recordsets.ListAll(client, listOpts)
+	err = pager.EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
+		rr, err := recordsets.ExtractRecordSets(page)
+		th.AssertNoErr(t, err)
+		th.AssertEquals(t, len(rr), 1)
+		return false, nil
+	})
+	th.AssertNoErr(t, err)
+}
+
 func TestRecordSetsCRUD(t *testing.T) {
 	client, err := clients.NewDNSV2Client()
 	th.AssertNoErr(t, err)

--- a/openstack/dns/v2/recordsets/requests.go
+++ b/openstack/dns/v2/recordsets/requests.go
@@ -42,9 +42,24 @@ func (opts ListOpts) ToRecordSetListQuery() (string, error) {
 	return q.String(), err
 }
 
-// ListByZone implements the recordset list request.
+// ListByZone implements the recordset list request for a specific zone.
 func ListByZone(client *gophercloud.ServiceClient, zoneID string, opts ListOptsBuilder) pagination.Pager {
 	url := baseURL(client, zoneID)
+	if opts != nil {
+		query, err := opts.ToRecordSetListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return RecordSetPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// ListAll implements the recordset list request across all zones.
+func ListAll(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listAllRecordSetsURL(client)
 	if opts != nil {
 		query, err := opts.ToRecordSetListQuery()
 		if err != nil {
@@ -155,7 +170,7 @@ func (opts UpdateOpts) ToRecordSetUpdateMap() (map[string]any, error) {
 	return b, nil
 }
 
-// Update updates a recordset in a given zone
+// Update updates a recordset in a given zone.
 func Update(ctx context.Context, client *gophercloud.ServiceClient, zoneID string, rrsetID string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToRecordSetUpdateMap()
 	if err != nil {

--- a/openstack/dns/v2/recordsets/testing/fixtures_test.go
+++ b/openstack/dns/v2/recordsets/testing/fixtures_test.go
@@ -199,23 +199,34 @@ var ExpectedRecordSetSlice = []recordsets.RecordSet{FirstRecordSet, SecondRecord
 // from ListByZoneOutput.
 var ExpectedRecordSetSliceLimited = []recordsets.RecordSet{SecondRecordSet}
 
+func handleListSuccessfully(t *testing.T, w http.ResponseWriter, r *http.Request) {
+	th.TestMethod(t, r, "GET")
+	th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+	w.Header().Add("Content-Type", "application/json")
+	if err := r.ParseForm(); err != nil {
+		t.Errorf("Failed to parse request form %v", err)
+	}
+	marker := r.Form.Get("marker")
+	switch marker {
+	case "f7b10e9b-0cae-4a91-b162-562bc6096648":
+		fmt.Fprint(w, ListByZoneOutputLimited)
+	case "":
+		fmt.Fprint(w, ListByZoneOutput)
+	}
+}
+
 // HandleListByZoneSuccessfully configures the test server to respond to a ListByZone request.
 func HandleListByZoneSuccessfully(t *testing.T, fakeServer th.FakeServer) {
 	fakeServer.Mux.HandleFunc("/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets", func(w http.ResponseWriter, r *http.Request) {
-		th.TestMethod(t, r, "GET")
-		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		handleListSuccessfully(t, w, r)
+	})
+}
 
-		w.Header().Add("Content-Type", "application/json")
-		if err := r.ParseForm(); err != nil {
-			t.Errorf("Failed to parse request form %v", err)
-		}
-		marker := r.Form.Get("marker")
-		switch marker {
-		case "f7b10e9b-0cae-4a91-b162-562bc6096648":
-			fmt.Fprint(w, ListByZoneOutputLimited)
-		case "":
-			fmt.Fprint(w, ListByZoneOutput)
-		}
+// HandleListAllSuccessfully configures the test server to respond to a ListAll request.
+func HandleListAllSuccessfully(t *testing.T, fakeServer th.FakeServer) {
+	fakeServer.Mux.HandleFunc("/recordsets", func(w http.ResponseWriter, r *http.Request) {
+		handleListSuccessfully(t, w, r)
 	})
 }
 

--- a/openstack/dns/v2/recordsets/testing/requests_test.go
+++ b/openstack/dns/v2/recordsets/testing/requests_test.go
@@ -63,6 +63,58 @@ func TestListByZoneAllPages(t *testing.T) {
 	th.CheckEquals(t, 2, len(allRecordSets))
 }
 
+func TestListAll(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	HandleListAllSuccessfully(t, fakeServer)
+
+	count := 0
+	err := recordsets.ListAll(client.ServiceClient(fakeServer), nil).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
+		count++
+		actual, err := recordsets.ExtractRecordSets(page)
+		th.AssertNoErr(t, err)
+		th.CheckDeepEquals(t, ExpectedRecordSetSlice, actual)
+
+		return true, nil
+	})
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, 1, count)
+}
+
+func TestListAllLimited(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	HandleListAllSuccessfully(t, fakeServer)
+
+	count := 0
+	listOpts := recordsets.ListOpts{
+		Limit:  1,
+		Marker: "f7b10e9b-0cae-4a91-b162-562bc6096648",
+	}
+	err := recordsets.ListAll(client.ServiceClient(fakeServer), listOpts).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
+		count++
+		actual, err := recordsets.ExtractRecordSets(page)
+		th.AssertNoErr(t, err)
+		th.CheckDeepEquals(t, ExpectedRecordSetSliceLimited, actual)
+
+		return true, nil
+	})
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, 1, count)
+}
+
+func TestListAllPages(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	HandleListAllSuccessfully(t, fakeServer)
+
+	allPages, err := recordsets.ListAll(client.ServiceClient(fakeServer), nil).AllPages(context.TODO())
+	th.AssertNoErr(t, err)
+	allRecordSets, err := recordsets.ExtractRecordSets(allPages)
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, 2, len(allRecordSets))
+}
+
 func TestGet(t *testing.T) {
 	fakeServer := th.SetupHTTP()
 	defer fakeServer.Teardown()

--- a/openstack/dns/v2/recordsets/urls.go
+++ b/openstack/dns/v2/recordsets/urls.go
@@ -6,6 +6,10 @@ func baseURL(c *gophercloud.ServiceClient, zoneID string) string {
 	return c.ServiceURL("zones", zoneID, "recordsets")
 }
 
+func listAllRecordSetsURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("recordsets")
+}
+
 func rrsetURL(c *gophercloud.ServiceClient, zoneID string, rrsetID string) string {
 	return c.ServiceURL("zones", zoneID, "recordsets", rrsetID)
 }


### PR DESCRIPTION
This change introduces a new ListAll function and helper URL builder to expose the Designate /recordsets endpoint via gophercloud. This allows callers to retrieve recordsets across all zones, in addition to the existing per-zone ListByZone helper.

The new ListAll function:
- Reuses the existing ListOpts/ListOptsBuilder types for filtering, sorting, and pagination.
- Returns a pagination.Pager consistent with other list operations in this package.

<!--
Prior to starting a PR, please make sure you have read our
[contributor tutorial](https://github.com/gophercloud/gophercloud/tree/main/docs/contributor-tutorial).

Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

-->
Fixes #3687

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

TODO
