### PR TITLE
[v2] Implement resource provider aggregates v2

### DIFF
--- a/internal/acceptance/openstack/placement/v1/resourceproviders_test.go
+++ b/internal/acceptance/openstack/placement/v1/resourceproviders_test.go
@@ -587,3 +587,72 @@ func TestResourceProviderAggregatesUpdateNegative(t *testing.T) {
 	_, err = resourceproviders.UpdateAggregates(context.TODO(), client, resourceProvider.UUID, updateOpts).Extract()
 	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusConflict))
 }
+
+func TestResourceProviderAggregatesUpdatePreGenerationSuccess(t *testing.T) {
+	// Before microversion 1.19, the PUT request body is just a list of aggregate UUIDs.
+	clients.SkipReleasesBelow(t, "stable/ocata")
+	clients.RequireAdmin(t)
+
+	client, err := clients.NewPlacementV1Client()
+	th.AssertNoErr(t, err)
+
+	resourceProvider, err := CreateResourceProvider(t, client)
+	th.AssertNoErr(t, err)
+	defer DeleteResourceProvider(t, client, resourceProvider.UUID)
+
+	client.Microversion = "1.1"
+
+	updateOpts := resourceproviders.UpdateAggregatesOpts{
+		Aggregates: []string{
+			"6d84f6f6-7736-40ff-84d2-7db47f18ea25",
+			"f11f14bc-6f17-4f0a-b7c2-44b3e685ccf4",
+		},
+	}
+
+	_, err = resourceproviders.UpdateAggregates(context.TODO(), client, resourceProvider.UUID, updateOpts).Extract()
+	th.AssertNoErr(t, err)
+
+	after, err := resourceproviders.GetAggregates(context.TODO(), client, resourceProvider.UUID).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, len(updateOpts.Aggregates), len(after.Aggregates))
+
+	for _, aggregate := range updateOpts.Aggregates {
+		th.AssertEquals(t, true, slices.Contains(after.Aggregates, aggregate))
+	}
+}
+
+func TestResourceProviderAggregatesUpdatePreGenerationWithGenerationSuccess(t *testing.T) {
+	// Before microversion 1.19, ResourceProviderGeneration in opts is silently stripped from
+	// the request body, so the operation must succeed even when the caller supplies it.
+	clients.SkipReleasesBelow(t, "stable/ocata")
+	clients.RequireAdmin(t)
+
+	client, err := clients.NewPlacementV1Client()
+	th.AssertNoErr(t, err)
+
+	resourceProvider, err := CreateResourceProvider(t, client)
+	th.AssertNoErr(t, err)
+	defer DeleteResourceProvider(t, client, resourceProvider.UUID)
+
+	client.Microversion = "1.1"
+
+	gen := 1
+	updateOpts := resourceproviders.UpdateAggregatesOpts{
+		ResourceProviderGeneration: &gen,
+		Aggregates: []string{
+			"6d84f6f6-7736-40ff-84d2-7db47f18ea25",
+			"f11f14bc-6f17-4f0a-b7c2-44b3e685ccf4",
+		},
+	}
+
+	_, err = resourceproviders.UpdateAggregates(context.TODO(), client, resourceProvider.UUID, updateOpts).Extract()
+	th.AssertNoErr(t, err)
+
+	after, err := resourceproviders.GetAggregates(context.TODO(), client, resourceProvider.UUID).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, len(updateOpts.Aggregates), len(after.Aggregates))
+
+	for _, aggregate := range updateOpts.Aggregates {
+		th.AssertEquals(t, true, slices.Contains(after.Aggregates, aggregate))
+	}
+}

--- a/internal/acceptance/openstack/placement/v1/resourceproviders_test.go
+++ b/internal/acceptance/openstack/placement/v1/resourceproviders_test.go
@@ -451,3 +451,70 @@ func TestResourceProviderAllocations(t *testing.T) {
 
 	tools.PrintResource(t, usage)
 }
+
+func TestResourceProviderAggregatesGetSuccess(t *testing.T) {
+	// Resource_provider_generation in the aggregates response was introduced in microversion 1.19.
+	clients.SkipReleasesBelow(t, "stable/ocata")
+	clients.RequireAdmin(t)
+
+	client, err := clients.NewPlacementV1Client()
+	th.AssertNoErr(t, err)
+
+	resourceProvider, err := CreateResourceProvider(t, client)
+	th.AssertNoErr(t, err)
+	defer DeleteResourceProvider(t, client, resourceProvider.UUID)
+
+	client.Microversion = "1.19"
+
+	aggregates, err := resourceproviders.GetAggregates(context.TODO(), client, resourceProvider.UUID).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, true, aggregates.ResourceProviderGeneration != nil)
+}
+
+func TestResourceProviderAggregatesGetPreGenerationSuccess(t *testing.T) {
+	// Resource provider aggregates operations were introduced in microversion 1.1.
+	clients.SkipReleasesBelow(t, "stable/ocata")
+	clients.RequireAdmin(t)
+
+	client, err := clients.NewPlacementV1Client()
+	th.AssertNoErr(t, err)
+
+	resourceProvider, err := CreateResourceProvider(t, client)
+	th.AssertNoErr(t, err)
+	defer DeleteResourceProvider(t, client, resourceProvider.UUID)
+
+	client.Microversion = "1.1"
+
+	aggregates, err := resourceproviders.GetAggregates(context.TODO(), client, resourceProvider.UUID).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, 0, len(aggregates.Aggregates))
+	th.AssertDeepEquals(t, (*int)(nil), aggregates.ResourceProviderGeneration)
+}
+
+func TestResourceProviderAggregatesGetNegative(t *testing.T) {
+	// Resource_provider_generation in the aggregates response was introduced in microversion 1.19.
+	clients.SkipReleasesBelow(t, "stable/ocata")
+	clients.RequireAdmin(t)
+
+	client, err := clients.NewPlacementV1Client()
+	th.AssertNoErr(t, err)
+
+	client.Microversion = "1.19"
+
+	_, err = resourceproviders.GetAggregates(context.TODO(), client, "00000000-0000-0000-0000-000000000000").Extract()
+	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
+}
+
+func TestResourceProviderAggregatesGetPreGenerationNegative(t *testing.T) {
+	// Resource provider aggregates operations were introduced in microversion 1.1.
+	clients.SkipReleasesBelow(t, "stable/ocata")
+	clients.RequireAdmin(t)
+
+	client, err := clients.NewPlacementV1Client()
+	th.AssertNoErr(t, err)
+
+	client.Microversion = "1.1"
+
+	_, err = resourceproviders.GetAggregates(context.TODO(), client, "00000000-0000-0000-0000-000000000000").Extract()
+	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
+}

--- a/internal/acceptance/openstack/placement/v1/resourceproviders_test.go
+++ b/internal/acceptance/openstack/placement/v1/resourceproviders_test.go
@@ -5,6 +5,7 @@ package v1
 import (
 	"context"
 	"net/http"
+	"slices"
 	"testing"
 
 	"github.com/gophercloud/gophercloud/v2"
@@ -517,4 +518,72 @@ func TestResourceProviderAggregatesGetPreGenerationNegative(t *testing.T) {
 
 	_, err = resourceproviders.GetAggregates(context.TODO(), client, "00000000-0000-0000-0000-000000000000").Extract()
 	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
+}
+
+func TestResourceProviderAggregatesUpdateSuccess(t *testing.T) {
+	// resource_provider_generation is required in the PUT request body from microversion 1.19.
+	clients.SkipReleasesBelow(t, "stable/ocata")
+	clients.RequireAdmin(t)
+
+	client, err := clients.NewPlacementV1Client()
+	th.AssertNoErr(t, err)
+
+	resourceProvider, err := CreateResourceProvider(t, client)
+	th.AssertNoErr(t, err)
+	defer DeleteResourceProvider(t, client, resourceProvider.UUID)
+
+	client.Microversion = "1.19"
+
+	before, err := resourceproviders.GetAggregates(context.TODO(), client, resourceProvider.UUID).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, true, before.ResourceProviderGeneration != nil)
+
+	updateOpts := resourceproviders.UpdateAggregatesOpts{
+		ResourceProviderGeneration: before.ResourceProviderGeneration,
+		Aggregates: []string{
+			"6d84f6f6-7736-40ff-84d2-7db47f18ea25",
+			"f11f14bc-6f17-4f0a-b7c2-44b3e685ccf4",
+		},
+	}
+
+	_, err = resourceproviders.UpdateAggregates(context.TODO(), client, resourceProvider.UUID, updateOpts).Extract()
+	th.AssertNoErr(t, err)
+
+	after, err := resourceproviders.GetAggregates(context.TODO(), client, resourceProvider.UUID).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, len(updateOpts.Aggregates), len(after.Aggregates))
+
+	for _, aggregate := range updateOpts.Aggregates {
+		th.AssertEquals(t, true, slices.Contains(after.Aggregates, aggregate))
+	}
+}
+
+func TestResourceProviderAggregatesUpdateNegative(t *testing.T) {
+	// resource_provider_generation is required in the PUT request body from microversion 1.19.
+	clients.SkipReleasesBelow(t, "stable/ocata")
+	clients.RequireAdmin(t)
+
+	client, err := clients.NewPlacementV1Client()
+	th.AssertNoErr(t, err)
+
+	resourceProvider, err := CreateResourceProvider(t, client)
+	th.AssertNoErr(t, err)
+	defer DeleteResourceProvider(t, client, resourceProvider.UUID)
+
+	client.Microversion = "1.19"
+
+	current, err := resourceproviders.GetAggregates(context.TODO(), client, resourceProvider.UUID).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, true, current.ResourceProviderGeneration != nil)
+	wrongGeneration := *current.ResourceProviderGeneration + 100
+
+	updateOpts := resourceproviders.UpdateAggregatesOpts{
+		ResourceProviderGeneration: &wrongGeneration,
+		Aggregates: []string{
+			"6d84f6f6-7736-40ff-84d2-7db47f18ea25",
+		},
+	}
+
+	_, err = resourceproviders.UpdateAggregates(context.TODO(), client, resourceProvider.UUID, updateOpts).Extract()
+	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusConflict))
 }

--- a/openstack/placement/v1/resourceproviders/doc.go
+++ b/openstack/placement/v1/resourceproviders/doc.go
@@ -171,5 +171,22 @@ Example to get resource providers aggregates
 	if err != nil {
 		panic(err)
 	}
+
+Example to update resource providers aggregates
+
+	placementClient.Microversion = "1.1"
+
+	updateOpts := resourceproviders.UpdateAggregatesOpts{
+		ResourceProviderGeneration: rp.ResourceProviderGeneration,
+		Aggregates: []string{
+			"6d84f6f6-7736-40ff-84d2-7db47f18ea25",
+			"f11f14bc-6f17-4f0a-b7c2-44b3e685ccf4",
+		},
+	}
+
+	rp, err = resourceproviders.UpdateAggregates(context.TODO(), placementClient, resourceProviderID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
 */
 package resourceproviders

--- a/openstack/placement/v1/resourceproviders/doc.go
+++ b/openstack/placement/v1/resourceproviders/doc.go
@@ -162,5 +162,14 @@ Example to get resource providers allocations
 	if err != nil {
 		panic(err)
 	}
+
+Example to get resource providers aggregates
+
+	placementClient.Microversion = "1.1"
+
+	rp, err := resourceproviders.GetAggregates(context.TODO(), placementClient, resourceProviderID).Extract()
+	if err != nil {
+		panic(err)
+	}
 */
 package resourceproviders

--- a/openstack/placement/v1/resourceproviders/doc.go
+++ b/openstack/placement/v1/resourceproviders/doc.go
@@ -172,9 +172,12 @@ Example to get resource providers aggregates
 		panic(err)
 	}
 
-Example to update resource providers aggregates
+# Example to update resource providers aggregates
 
-	placementClient.Microversion = "1.1"
+For microversion 1.18 and earlier the ResourceProviderGeneration is optional and would be ignored if provided,
+as it was not supported pre-1.19. For greater safety, it is recommended to use the newer microversion.
+
+	placementClient.Microversion = "1.19"
 
 	updateOpts := resourceproviders.UpdateAggregatesOpts{
 		ResourceProviderGeneration: rp.ResourceProviderGeneration,

--- a/openstack/placement/v1/resourceproviders/requests.go
+++ b/openstack/placement/v1/resourceproviders/requests.go
@@ -285,7 +285,11 @@ func UpdateAggregates(ctx context.Context, client *gophercloud.ServiceClient, re
 		return
 	}
 
-	resp, err := client.Put(ctx, updateResourceProviderAggregatesURL(client, resourceProviderID), b, &r.Body, &gophercloud.RequestOpts{
+	var body any = b
+	if useGenerations := microversionAtLeast(client, 1, 19); !useGenerations {
+		body = b["aggregates"]
+	}
+	resp, err := client.Put(ctx, updateResourceProviderAggregatesURL(client, resourceProviderID), body, &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{200},
 	})
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)

--- a/openstack/placement/v1/resourceproviders/requests.go
+++ b/openstack/placement/v1/resourceproviders/requests.go
@@ -254,6 +254,12 @@ func GetTraits(ctx context.Context, client *gophercloud.ServiceClient, resourceP
 	return
 }
 
+func GetAggregates(ctx context.Context, client *gophercloud.ServiceClient, resourceProviderID string) (r GetAggregatesResult) {
+	resp, err := client.Get(ctx, getResourceProviderAggregatesURL(client, resourceProviderID), &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
 // UpdateTraitsOptsBuilder allows extensions to add additional parameters to the
 // UpdateTraits request.
 type UpdateTraitsOptsBuilder interface {

--- a/openstack/placement/v1/resourceproviders/requests.go
+++ b/openstack/placement/v1/resourceproviders/requests.go
@@ -260,6 +260,38 @@ func GetAggregates(ctx context.Context, client *gophercloud.ServiceClient, resou
 	return
 }
 
+// UpdateAggregatesOptsBuilder allows extensions to add additional parameters to the
+// UpdateAggregates request.
+type UpdateAggregatesOptsBuilder interface {
+	ToResourceProviderUpdateAggregatesMap() (map[string]any, error)
+}
+
+// UpdateAggregatesOpts represents options used to update aggregates of a resource provider.
+type UpdateAggregatesOpts struct {
+	// ResourceProviderGeneration is required from microversion 1.19 and later.
+	ResourceProviderGeneration *int     `json:"resource_provider_generation,omitempty"`
+	Aggregates                 []string `json:"aggregates"`
+}
+
+// ToResourceProviderUpdateAggregatesMap constructs a request body from UpdateAggregatesOpts.
+func (opts UpdateAggregatesOpts) ToResourceProviderUpdateAggregatesMap() (map[string]any, error) {
+	return gophercloud.BuildRequestBody(opts, "")
+}
+
+func UpdateAggregates(ctx context.Context, client *gophercloud.ServiceClient, resourceProviderID string, opts UpdateAggregatesOptsBuilder) (r GetAggregatesResult) {
+	b, err := opts.ToResourceProviderUpdateAggregatesMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	resp, err := client.Put(ctx, updateResourceProviderAggregatesURL(client, resourceProviderID), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
 // UpdateTraitsOptsBuilder allows extensions to add additional parameters to the
 // UpdateTraits request.
 type UpdateTraitsOptsBuilder interface {

--- a/openstack/placement/v1/resourceproviders/results.go
+++ b/openstack/placement/v1/resourceproviders/results.go
@@ -71,6 +71,12 @@ type ResourceProviderTraits struct {
 	Traits                     []string `json:"traits"`
 }
 
+type ResourceProviderAggregates struct {
+	// ResourceProviderGeneration is available from microversion 1.19 and later.
+	ResourceProviderGeneration *int     `json:"resource_provider_generation"`
+	Aggregates                 []string `json:"aggregates"`
+}
+
 // resourceProviderResult is the response of a base ResourceProvider result.
 type resourceProviderResult struct {
 	gophercloud.Result
@@ -206,6 +212,19 @@ type GetTraitsResult struct {
 // Extract interprets a GetTraitsResult as a ResourceProviderTraits.
 func (r GetTraitsResult) Extract() (*ResourceProviderTraits, error) {
 	var s ResourceProviderTraits
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+// GetAggregatesResult is the response of a Get aggregates operations. Call its Extract method
+// to interpret it as a ResourceProviderAggregates.
+type GetAggregatesResult struct {
+	gophercloud.Result
+}
+
+// Extract interprets a GetAggregatesResult as a ResourceProviderAggregates.
+func (r GetAggregatesResult) Extract() (*ResourceProviderAggregates, error) {
+	var s ResourceProviderAggregates
 	err := r.ExtractInto(&s)
 	return &s, err
 }

--- a/openstack/placement/v1/resourceproviders/testing/fixtures_test.go
+++ b/openstack/placement/v1/resourceproviders/testing/fixtures_test.go
@@ -233,7 +233,35 @@ const AggregatesBody = `
 }
 `
 
-const AbsentResourceProviderID = "non-existent-rp"
+const AggregatesBodyPreGeneration = `
+{
+	"aggregates": [
+		"6d84f6f6-7736-40ff-84d2-7db47f18ea25",
+		"f11f14bc-6f17-4f0a-b7c2-44b3e685ccf4"
+	]
+}
+`
+
+const AggregatesUpdateBody = `
+{
+	"resource_provider_generation": 1,
+	"aggregates": [
+		"89f68995-4fd8-4f8b-a03e-7d5980762ff2",
+		"16d0e5f2-7f66-4f32-9040-b09de2f40afd"
+	]
+}
+`
+
+const AggregatesUpdateBodyPreGeneration = `
+{
+	"aggregates": [
+		"89f68995-4fd8-4f8b-a03e-7d5980762ff2",
+		"16d0e5f2-7f66-4f32-9040-b09de2f40afd"
+	]
+}
+`
+
+const AbsentResourceProviderID = "00000000-0000-0000-0000-000000000000"
 
 var ExpectedResourceProvider1 = resourceproviders.ResourceProvider{
 	Generation: 1,
@@ -351,11 +379,38 @@ var ExpectedTraits = resourceproviders.ResourceProviderTraits{
 	},
 }
 
+var expectedAggregatesGeneration = 1
+
 var ExpectedAggregates = resourceproviders.ResourceProviderAggregates{
-	ResourceProviderGeneration: 1,
+	ResourceProviderGeneration: &expectedAggregatesGeneration,
 	Aggregates: []string{
 		"6d84f6f6-7736-40ff-84d2-7db47f18ea25",
 		"f11f14bc-6f17-4f0a-b7c2-44b3e685ccf4",
+	},
+}
+
+var ExpectedAggregatesPreGeneration = resourceproviders.ResourceProviderAggregates{
+	ResourceProviderGeneration: nil,
+	Aggregates: []string{
+		"6d84f6f6-7736-40ff-84d2-7db47f18ea25",
+		"f11f14bc-6f17-4f0a-b7c2-44b3e685ccf4",
+	},
+}
+
+var expectedUpdatedAggregatesGeneration = 1
+
+var ExpectedUpdatedAggregates = resourceproviders.ResourceProviderAggregates{
+	ResourceProviderGeneration: &expectedUpdatedAggregatesGeneration,
+	Aggregates: []string{
+		"89f68995-4fd8-4f8b-a03e-7d5980762ff2",
+		"16d0e5f2-7f66-4f32-9040-b09de2f40afd",
+	},
+}
+
+var ExpectedUpdatedAggregatesPreGeneration = resourceproviders.ResourceProviderAggregates{
+	Aggregates: []string{
+		"89f68995-4fd8-4f8b-a03e-7d5980762ff2",
+		"16d0e5f2-7f66-4f32-9040-b09de2f40afd",
 	},
 }
 
@@ -660,6 +715,21 @@ func HandleResourceProviderGetAggregatesSuccess(t *testing.T, fakeServer th.Fake
 		})
 }
 
+func HandleResourceProviderGetAggregatesPreGenerationSuccess(t *testing.T, fakeServer th.FakeServer) {
+	aggregatesTestURL := fmt.Sprintf("/resource_providers/%s/aggregates", ResourceProviderTestID)
+
+	fakeServer.Mux.HandleFunc(aggregatesTestURL,
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "GET")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+
+			fmt.Fprint(w, AggregatesBodyPreGeneration)
+		})
+}
+
 func HandleResourceProviderGetAggregatesNotFound(t *testing.T, fakeServer th.FakeServer) {
 	aggregatesTestURL := fmt.Sprintf("/resource_providers/%s/aggregates", AbsentResourceProviderID)
 
@@ -669,5 +739,81 @@ func HandleResourceProviderGetAggregatesNotFound(t *testing.T, fakeServer th.Fak
 			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 			w.WriteHeader(http.StatusNotFound)
+		})
+}
+
+func HandleResourceProviderUpdateAndGetAggregatesSuccess(t *testing.T, fakeServer th.FakeServer) {
+	aggregatesTestURL := fmt.Sprintf("/resource_providers/%s/aggregates", ResourceProviderTestID)
+
+	// This handler must cover PUT and GET because the test updates and then fetches on the same path.
+	body := AggregatesBody
+
+	fakeServer.Mux.HandleFunc(aggregatesTestURL,
+		func(w http.ResponseWriter, r *http.Request) {
+			switch r.Method {
+			case http.MethodGet:
+				th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+				w.Header().Add("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				fmt.Fprint(w, body)
+			case http.MethodPut:
+				th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+				th.TestHeader(t, r, "Content-Type", "application/json")
+				th.TestHeader(t, r, "Accept", "application/json")
+				th.TestJSONRequest(t, r, AggregatesUpdateBody)
+
+				body = AggregatesUpdateBody
+
+				w.Header().Add("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				fmt.Fprint(w, body)
+			default:
+				w.WriteHeader(http.StatusMethodNotAllowed)
+			}
+		})
+}
+
+func HandleResourceProviderUpdateAndGetAggregatesPreGenerationSuccess(t *testing.T, fakeServer th.FakeServer) {
+	aggregatesTestURL := fmt.Sprintf("/resource_providers/%s/aggregates", ResourceProviderTestID)
+
+	// Pre-generation variant of the same update-then-fetch flow on a shared endpoint.
+	body := AggregatesBodyPreGeneration
+
+	fakeServer.Mux.HandleFunc(aggregatesTestURL,
+		func(w http.ResponseWriter, r *http.Request) {
+			switch r.Method {
+			case http.MethodGet:
+				th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+				w.Header().Add("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				fmt.Fprint(w, body)
+			case http.MethodPut:
+				th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+				th.TestHeader(t, r, "Content-Type", "application/json")
+				th.TestHeader(t, r, "Accept", "application/json")
+				th.TestJSONRequest(t, r, AggregatesUpdateBodyPreGeneration)
+
+				body = AggregatesUpdateBodyPreGeneration
+
+				w.Header().Add("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				fmt.Fprint(w, body)
+			default:
+				w.WriteHeader(http.StatusMethodNotAllowed)
+			}
+		})
+}
+
+func HandleResourceProviderUpdateAggregatesConflict(t *testing.T, fakeServer th.FakeServer) {
+	aggregatesTestURL := fmt.Sprintf("/resource_providers/%s/aggregates", ResourceProviderTestID)
+
+	fakeServer.Mux.HandleFunc(aggregatesTestURL,
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "PUT")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+			w.WriteHeader(http.StatusConflict)
 		})
 }

--- a/openstack/placement/v1/resourceproviders/testing/fixtures_test.go
+++ b/openstack/placement/v1/resourceproviders/testing/fixtures_test.go
@@ -223,6 +223,18 @@ const TraitsBody = `
 }
 `
 
+const AggregatesBody = `
+{
+	"resource_provider_generation": 1,
+	"aggregates": [
+		"6d84f6f6-7736-40ff-84d2-7db47f18ea25",
+		"f11f14bc-6f17-4f0a-b7c2-44b3e685ccf4"
+	]
+}
+`
+
+const AbsentResourceProviderID = "non-existent-rp"
+
 var ExpectedResourceProvider1 = resourceproviders.ResourceProvider{
 	Generation: 1,
 	UUID:       "99c09379-6e52-4ef8-9a95-b9ce6f68452e",
@@ -336,6 +348,14 @@ var ExpectedTraits = resourceproviders.ResourceProviderTraits{
 	Traits: []string{
 		"CUSTOM_HW_FPGA_CLASS1",
 		"CUSTOM_HW_FPGA_CLASS3",
+	},
+}
+
+var ExpectedAggregates = resourceproviders.ResourceProviderAggregates{
+	ResourceProviderGeneration: 1,
+	Aggregates: []string{
+		"6d84f6f6-7736-40ff-84d2-7db47f18ea25",
+		"f11f14bc-6f17-4f0a-b7c2-44b3e685ccf4",
 	},
 }
 
@@ -622,5 +642,32 @@ func HandleResourceProviderDeleteTraits(t *testing.T, fakeServer th.FakeServer) 
 			th.TestMethod(t, r, "DELETE")
 			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 			w.WriteHeader(http.StatusNoContent)
+		})
+}
+
+func HandleResourceProviderGetAggregatesSuccess(t *testing.T, fakeServer th.FakeServer) {
+	aggregatesTestURL := fmt.Sprintf("/resource_providers/%s/aggregates", ResourceProviderTestID)
+
+	fakeServer.Mux.HandleFunc(aggregatesTestURL,
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "GET")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+
+			fmt.Fprint(w, AggregatesBody)
+		})
+}
+
+func HandleResourceProviderGetAggregatesNotFound(t *testing.T, fakeServer th.FakeServer) {
+	aggregatesTestURL := fmt.Sprintf("/resource_providers/%s/aggregates", AbsentResourceProviderID)
+
+	fakeServer.Mux.HandleFunc(aggregatesTestURL,
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "GET")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+			w.WriteHeader(http.StatusNotFound)
 		})
 }

--- a/openstack/placement/v1/resourceproviders/testing/fixtures_test.go
+++ b/openstack/placement/v1/resourceproviders/testing/fixtures_test.go
@@ -252,7 +252,13 @@ const AggregatesUpdateBody = `
 }
 `
 
-const AggregatesUpdateBodyPreGeneration = `
+// AggregatesUpdateRequestPreGeneration is the raw JSON array sent as the PUT request body
+// for microversions < 1.19, where the payload is just a list of aggregate UUIDs.
+const AggregatesUpdateRequestPreGeneration = `["89f68995-4fd8-4f8b-a03e-7d5980762ff2","16d0e5f2-7f66-4f32-9040-b09de2f40afd"]`
+
+// AggregatesUpdateBodyWithoutGeneration is the pre-1.19 server response body for an aggregates update.
+// Unlike the request, the response is not flat.
+const AggregatesUpdateBodyWithoutGeneration = `
 {
 	"aggregates": [
 		"89f68995-4fd8-4f8b-a03e-7d5980762ff2",
@@ -793,9 +799,9 @@ func HandleResourceProviderUpdateAndGetAggregatesPreGenerationSuccess(t *testing
 				th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 				th.TestHeader(t, r, "Content-Type", "application/json")
 				th.TestHeader(t, r, "Accept", "application/json")
-				th.TestJSONRequest(t, r, AggregatesUpdateBodyPreGeneration)
+				th.TestJSONRequest(t, r, AggregatesUpdateRequestPreGeneration)
 
-				body = AggregatesUpdateBodyPreGeneration
+				body = AggregatesUpdateBodyWithoutGeneration
 
 				w.Header().Add("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)

--- a/openstack/placement/v1/resourceproviders/testing/requests_test.go
+++ b/openstack/placement/v1/resourceproviders/testing/requests_test.go
@@ -288,6 +288,17 @@ func TestGetResourceProviderAggregatesSuccess(t *testing.T) {
 	th.AssertDeepEquals(t, ExpectedAggregates, *actual)
 }
 
+func TestGetResourceProviderAggregatesPreGenerationSuccess(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	HandleResourceProviderGetAggregatesPreGenerationSuccess(t, fakeServer)
+
+	actual, err := resourceproviders.GetAggregates(context.TODO(), client.ServiceClient(fakeServer), ResourceProviderTestID).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, ExpectedAggregatesPreGeneration, *actual)
+}
+
 func TestGetResourceProviderAggregatesNotFound(t *testing.T) {
 	fakeServer := th.SetupHTTP()
 	defer fakeServer.Teardown()
@@ -296,4 +307,47 @@ func TestGetResourceProviderAggregatesNotFound(t *testing.T) {
 
 	_, err := resourceproviders.GetAggregates(context.TODO(), client.ServiceClient(fakeServer), AbsentResourceProviderID).Extract()
 	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
+}
+
+func TestUpdateResourceProviderAggregatesSuccess(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	HandleResourceProviderUpdateAndGetAggregatesSuccess(t, fakeServer)
+
+	updateOpts := resourceproviders.UpdateAggregatesOpts(ExpectedUpdatedAggregates)
+	_, err := resourceproviders.UpdateAggregates(context.TODO(), client.ServiceClient(fakeServer), ResourceProviderTestID, updateOpts).Extract()
+	th.AssertNoErr(t, err)
+
+	actual, err := resourceproviders.GetAggregates(context.TODO(), client.ServiceClient(fakeServer), ResourceProviderTestID).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, ExpectedUpdatedAggregates, *actual)
+}
+
+func TestUpdateResourceProviderAggregatesPreGenerationSuccess(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	HandleResourceProviderUpdateAndGetAggregatesPreGenerationSuccess(t, fakeServer)
+
+	updateOpts := resourceproviders.UpdateAggregatesOpts{
+		Aggregates: ExpectedUpdatedAggregatesPreGeneration.Aggregates,
+	}
+	_, err := resourceproviders.UpdateAggregates(context.TODO(), client.ServiceClient(fakeServer), ResourceProviderTestID, updateOpts).Extract()
+	th.AssertNoErr(t, err)
+
+	actual, err := resourceproviders.GetAggregates(context.TODO(), client.ServiceClient(fakeServer), ResourceProviderTestID).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, ExpectedUpdatedAggregatesPreGeneration, *actual)
+}
+
+func TestUpdateResourceProviderAggregatesConflict(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	HandleResourceProviderUpdateAggregatesConflict(t, fakeServer)
+
+	updateOpts := resourceproviders.UpdateAggregatesOpts(ExpectedUpdatedAggregates)
+	_, err := resourceproviders.UpdateAggregates(context.TODO(), client.ServiceClient(fakeServer), ResourceProviderTestID, updateOpts).Extract()
+	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusConflict))
 }

--- a/openstack/placement/v1/resourceproviders/testing/requests_test.go
+++ b/openstack/placement/v1/resourceproviders/testing/requests_test.go
@@ -276,3 +276,24 @@ func TestDeleteResourceProvidersTraits(t *testing.T) {
 	err := resourceproviders.DeleteTraits(context.TODO(), client.ServiceClient(fakeServer), ResourceProviderTestID).ExtractErr()
 	th.AssertNoErr(t, err)
 }
+
+func TestGetResourceProviderAggregatesSuccess(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	HandleResourceProviderGetAggregatesSuccess(t, fakeServer)
+
+	actual, err := resourceproviders.GetAggregates(context.TODO(), client.ServiceClient(fakeServer), ResourceProviderTestID).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, ExpectedAggregates, *actual)
+}
+
+func TestGetResourceProviderAggregatesNotFound(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	HandleResourceProviderGetAggregatesNotFound(t, fakeServer)
+
+	_, err := resourceproviders.GetAggregates(context.TODO(), client.ServiceClient(fakeServer), AbsentResourceProviderID).Extract()
+	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
+}

--- a/openstack/placement/v1/resourceproviders/testing/requests_test.go
+++ b/openstack/placement/v1/resourceproviders/testing/requests_test.go
@@ -315,11 +315,14 @@ func TestUpdateResourceProviderAggregatesSuccess(t *testing.T) {
 
 	HandleResourceProviderUpdateAndGetAggregatesSuccess(t, fakeServer)
 
+	sc := client.ServiceClient(fakeServer)
+	sc.Microversion = "1.19"
+
 	updateOpts := resourceproviders.UpdateAggregatesOpts(ExpectedUpdatedAggregates)
-	_, err := resourceproviders.UpdateAggregates(context.TODO(), client.ServiceClient(fakeServer), ResourceProviderTestID, updateOpts).Extract()
+	_, err := resourceproviders.UpdateAggregates(context.TODO(), sc, ResourceProviderTestID, updateOpts).Extract()
 	th.AssertNoErr(t, err)
 
-	actual, err := resourceproviders.GetAggregates(context.TODO(), client.ServiceClient(fakeServer), ResourceProviderTestID).Extract()
+	actual, err := resourceproviders.GetAggregates(context.TODO(), sc, ResourceProviderTestID).Extract()
 	th.AssertNoErr(t, err)
 	th.AssertDeepEquals(t, ExpectedUpdatedAggregates, *actual)
 }
@@ -330,13 +333,42 @@ func TestUpdateResourceProviderAggregatesPreGenerationSuccess(t *testing.T) {
 
 	HandleResourceProviderUpdateAndGetAggregatesPreGenerationSuccess(t, fakeServer)
 
+	sc := client.ServiceClient(fakeServer)
+	sc.Microversion = "1.10"
+
 	updateOpts := resourceproviders.UpdateAggregatesOpts{
 		Aggregates: ExpectedUpdatedAggregatesPreGeneration.Aggregates,
 	}
-	_, err := resourceproviders.UpdateAggregates(context.TODO(), client.ServiceClient(fakeServer), ResourceProviderTestID, updateOpts).Extract()
+	_, err := resourceproviders.UpdateAggregates(context.TODO(), sc, ResourceProviderTestID, updateOpts).Extract()
 	th.AssertNoErr(t, err)
 
-	actual, err := resourceproviders.GetAggregates(context.TODO(), client.ServiceClient(fakeServer), ResourceProviderTestID).Extract()
+	actual, err := resourceproviders.GetAggregates(context.TODO(), sc, ResourceProviderTestID).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, ExpectedUpdatedAggregatesPreGeneration, *actual)
+}
+
+// TestUpdateResourceProviderAggregatesPreGenerationWithGenerationInOptsSuccess validates that
+// when the microversion is < 1.19 but the caller supplies ResourceProviderGeneration in opts,
+// the generation field is stripped from the request body and the operation succeeds.
+func TestUpdateResourceProviderAggregatesPreGenerationWithGenerationInOptsSuccess(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	// Reuse the same handler: it validates the request body contains only aggregates (no generation).
+	HandleResourceProviderUpdateAndGetAggregatesPreGenerationSuccess(t, fakeServer)
+
+	sc := client.ServiceClient(fakeServer)
+	sc.Microversion = "1.10"
+
+	gen := 1
+	updateOpts := resourceproviders.UpdateAggregatesOpts{
+		ResourceProviderGeneration: &gen,
+		Aggregates:                 ExpectedUpdatedAggregatesPreGeneration.Aggregates,
+	}
+	_, err := resourceproviders.UpdateAggregates(context.TODO(), sc, ResourceProviderTestID, updateOpts).Extract()
+	th.AssertNoErr(t, err)
+
+	actual, err := resourceproviders.GetAggregates(context.TODO(), sc, ResourceProviderTestID).Extract()
 	th.AssertNoErr(t, err)
 	th.AssertDeepEquals(t, ExpectedUpdatedAggregatesPreGeneration, *actual)
 }

--- a/openstack/placement/v1/resourceproviders/urls.go
+++ b/openstack/placement/v1/resourceproviders/urls.go
@@ -57,3 +57,7 @@ func getResourceProviderTraitsURL(client *gophercloud.ServiceClient, resourcePro
 func getResourceProviderAggregatesURL(client *gophercloud.ServiceClient, resourceProviderID string) string {
 	return client.ServiceURL(apiName, resourceProviderID, "aggregates")
 }
+
+func updateResourceProviderAggregatesURL(client *gophercloud.ServiceClient, resourceProviderID string) string {
+	return client.ServiceURL(apiName, resourceProviderID, "aggregates")
+}

--- a/openstack/placement/v1/resourceproviders/urls.go
+++ b/openstack/placement/v1/resourceproviders/urls.go
@@ -53,3 +53,7 @@ func getResourceProviderAllocationsURL(client *gophercloud.ServiceClient, resour
 func getResourceProviderTraitsURL(client *gophercloud.ServiceClient, resourceProviderID string) string {
 	return client.ServiceURL(apiName, resourceProviderID, "traits")
 }
+
+func getResourceProviderAggregatesURL(client *gophercloud.ServiceClient, resourceProviderID string) string {
+	return client.ServiceURL(apiName, resourceProviderID, "aggregates")
+}

--- a/openstack/placement/v1/resourceproviders/util.go
+++ b/openstack/placement/v1/resourceproviders/util.go
@@ -1,0 +1,14 @@
+package resourceproviders
+
+import (
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/openstack/utils"
+)
+
+func microversionAtLeast(client *gophercloud.ServiceClient, major, minor int) bool {
+	M, m, err := utils.ParseMicroversion(client.Microversion)
+	if err != nil {
+		return false
+	}
+	return M > major || (M == major && m >= minor)
+}


### PR DESCRIPTION
Related: https://github.com/gophercloud/gophercloud/issues/526

API reference:
https://docs.openstack.org/api-ref/placement/#update-resource-provider-aggregates
https://docs.openstack.org/api-ref/placement/#list-resource-provider-aggregates

Code reference:
https://opendev.org/openstack/placement/src/branch/stable/2026.1/placement/handlers/aggregate.py#L102-L132
https://opendev.org/openstack/placement/src/branch/stable/2026.1/placement/handlers/aggregate.py#L81-L99

Manual backport of https://github.com/gophercloud/gophercloud/pull/3685.