### PR TITLE
secgroup: add pointer to port_range_* on CreateOpts

### DIFF
--- a/internal/acceptance/openstack/networking/v2/extensions/extensions.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/extensions.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/internal/acceptance/tools"
+	"github.com/gophercloud/gophercloud/v2/internal/ptr"
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/external"
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/security/addressgroups"
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/security/groups"
@@ -123,8 +124,8 @@ func CreateSecurityGroupRule(t *testing.T, client *gophercloud.ServiceClient, se
 		Direction:    "ingress",
 		EtherType:    "IPv4",
 		SecGroupID:   secGroupID,
-		PortRangeMin: fromPort,
-		PortRangeMax: toPort,
+		PortRangeMin: ptr.To(fromPort),
+		PortRangeMax: ptr.To(toPort),
 		Protocol:     rules.ProtocolTCP,
 	}
 
@@ -156,8 +157,8 @@ func CreateSecurityGroupRulesBulk(t *testing.T, client *gophercloud.ServiceClien
 			Direction:    "ingress",
 			EtherType:    "IPv4",
 			SecGroupID:   secGroupID,
-			PortRangeMin: fromPort,
-			PortRangeMax: toPort,
+			PortRangeMin: ptr.To(fromPort),
+			PortRangeMax: ptr.To(toPort),
 			Protocol:     rules.ProtocolTCP,
 		}
 	}

--- a/internal/acceptance/openstack/networking/v2/extensions/extensions.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/extensions.go
@@ -123,8 +123,8 @@ func CreateSecurityGroupRule(t *testing.T, client *gophercloud.ServiceClient, se
 		Direction:    "ingress",
 		EtherType:    "IPv4",
 		SecGroupID:   secGroupID,
-		PortRangeMin: fromPort,
-		PortRangeMax: toPort,
+		PortRangeMin: th.ToPtr(fromPort),
+		PortRangeMax: th.ToPtr(toPort),
 		Protocol:     rules.ProtocolTCP,
 	}
 
@@ -156,8 +156,8 @@ func CreateSecurityGroupRulesBulk(t *testing.T, client *gophercloud.ServiceClien
 			Direction:    "ingress",
 			EtherType:    "IPv4",
 			SecGroupID:   secGroupID,
-			PortRangeMin: fromPort,
-			PortRangeMax: toPort,
+			PortRangeMin: th.ToPtr(fromPort),
+			PortRangeMax: th.ToPtr(toPort),
 			Protocol:     rules.ProtocolTCP,
 		}
 	}

--- a/openstack/networking/v2/extensions/security/rules/requests.go
+++ b/openstack/networking/v2/extensions/security/rules/requests.go
@@ -126,13 +126,13 @@ type CreateOpts struct {
 	// The maximum port number in the range that is matched by the security group
 	// rule. The PortRangeMin attribute constrains the PortRangeMax attribute. If
 	// the protocol is ICMP, this value must be an ICMP code.
-	PortRangeMax int `json:"port_range_max,omitempty"`
+	PortRangeMax *int `json:"port_range_max,omitempty"`
 
 	// The minimum port number in the range that is matched by the security group
 	// rule. If the protocol is TCP or UDP, this value must be less than or equal
 	// to the value of the PortRangeMax attribute. If the protocol is ICMP, this
 	// value must be an ICMP type.
-	PortRangeMin int `json:"port_range_min,omitempty"`
+	PortRangeMin *int `json:"port_range_min,omitempty"`
 
 	// The protocol that is matched by the security group rule. Valid values are
 	// "tcp", "udp", "icmp" or an empty string.

--- a/openstack/networking/v2/extensions/security/rules/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/security/rules/testing/requests_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gophercloud/gophercloud/v2/internal/ptr"
 	fake "github.com/gophercloud/gophercloud/v2/openstack/networking/v2/common"
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/security/rules"
 	"github.com/gophercloud/gophercloud/v2/pagination"
@@ -162,9 +163,9 @@ func TestCreate(t *testing.T) {
 	opts := rules.CreateOpts{
 		Description:   "test description of rule",
 		Direction:     "ingress",
-		PortRangeMin:  80,
+		PortRangeMin:  ptr.To(80),
 		EtherType:     rules.EtherType4,
-		PortRangeMax:  80,
+		PortRangeMax:  ptr.To(80),
 		Protocol:      "tcp",
 		RemoteGroupID: "85cc3048-abc3-43cc-89b3-377341426ac5",
 		SecGroupID:    "a7734e61-b545-452d-a3cd-0189cbd9747a",
@@ -220,15 +221,78 @@ func TestCreateAnyProtocol(t *testing.T) {
 	opts := rules.CreateOpts{
 		Description:   "test description of rule",
 		Direction:     "ingress",
-		PortRangeMin:  80,
+		PortRangeMin:  ptr.To(80),
 		EtherType:     rules.EtherType4,
-		PortRangeMax:  80,
+		PortRangeMax:  ptr.To(80),
 		Protocol:      rules.ProtocolAny,
 		RemoteGroupID: "85cc3048-abc3-43cc-89b3-377341426ac5",
 		SecGroupID:    "a7734e61-b545-452d-a3cd-0189cbd9747a",
 	}
 	_, err := rules.Create(context.TODO(), fake.ServiceClient(fakeServer), opts).Extract()
 	th.AssertNoErr(t, err)
+}
+
+func TestCreateEchoReply(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	fakeServer.Mux.HandleFunc("/v2.0/security-group-rules", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, `
+{
+    "security_group_rule": {
+        "description": "test description of rule",
+        "direction": "ingress",
+        "port_range_min": 0,
+        "ethertype": "IPv4",
+        "port_range_max": 0,
+        "remote_group_id": "85cc3048-abc3-43cc-89b3-377341426ac5",
+        "security_group_id": "a7734e61-b545-452d-a3cd-0189cbd9747a",
+		"protocol": "icmp"
+    }
+}
+      `)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+
+		fmt.Fprint(w, `
+{
+    "security_group_rule": {
+        "description": "test description of rule",
+        "direction": "ingress",
+        "ethertype": "IPv4",
+		"protocol": "icmp",
+        "id": "2bc0accf-312e-429a-956e-e4407625eb62",
+        "port_range_max": 0,
+        "port_range_min": 0,
+        "remote_group_id": "85cc3048-abc3-43cc-89b3-377341426ac5",
+        "remote_ip_prefix": null,
+        "security_group_id": "a7734e61-b545-452d-a3cd-0189cbd9747a",
+        "tenant_id": "e4f50856753b4dc6afee5fa6b9b6c550"
+    }
+}
+    `)
+	})
+
+	opts := rules.CreateOpts{
+		Description:   "test description of rule",
+		Direction:     "ingress",
+		PortRangeMin:  ptr.To(0),
+		EtherType:     rules.EtherType4,
+		PortRangeMax:  ptr.To(0),
+		Protocol:      rules.ProtocolICMP,
+		RemoteGroupID: "85cc3048-abc3-43cc-89b3-377341426ac5",
+		SecGroupID:    "a7734e61-b545-452d-a3cd-0189cbd9747a",
+	}
+	rule, err := rules.Create(context.TODO(), fake.ServiceClient(fakeServer), opts).Extract()
+
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, 0, rule.PortRangeMax)
+	th.AssertEquals(t, 0, rule.PortRangeMin)
 }
 
 func TestCreateBulk(t *testing.T) {
@@ -305,9 +369,9 @@ func TestCreateBulk(t *testing.T) {
 		{
 			Description:   "test description of rule",
 			Direction:     "ingress",
-			PortRangeMin:  80,
+			PortRangeMin:  ptr.To(80),
 			EtherType:     rules.EtherType4,
-			PortRangeMax:  80,
+			PortRangeMax:  ptr.To(80),
 			Protocol:      "tcp",
 			RemoteGroupID: "85cc3048-abc3-43cc-89b3-377341426ac5",
 			SecGroupID:    "a7734e61-b545-452d-a3cd-0189cbd9747a",
@@ -315,9 +379,9 @@ func TestCreateBulk(t *testing.T) {
 		{
 			Description:  "test description of rule",
 			Direction:    "ingress",
-			PortRangeMin: 443,
+			PortRangeMin: ptr.To(443),
 			EtherType:    rules.EtherType4,
-			PortRangeMax: 443,
+			PortRangeMax: ptr.To(443),
 			Protocol:     "tcp",
 			SecGroupID:   "a7734e61-b545-452d-a3cd-0189cbd9747a",
 		},

--- a/openstack/networking/v2/extensions/security/rules/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/security/rules/testing/requests_test.go
@@ -162,9 +162,9 @@ func TestCreate(t *testing.T) {
 	opts := rules.CreateOpts{
 		Description:   "test description of rule",
 		Direction:     "ingress",
-		PortRangeMin:  80,
+		PortRangeMin:  th.ToPtr(80),
 		EtherType:     rules.EtherType4,
-		PortRangeMax:  80,
+		PortRangeMax:  th.ToPtr(80),
 		Protocol:      "tcp",
 		RemoteGroupID: "85cc3048-abc3-43cc-89b3-377341426ac5",
 		SecGroupID:    "a7734e61-b545-452d-a3cd-0189cbd9747a",
@@ -220,15 +220,78 @@ func TestCreateAnyProtocol(t *testing.T) {
 	opts := rules.CreateOpts{
 		Description:   "test description of rule",
 		Direction:     "ingress",
-		PortRangeMin:  80,
+		PortRangeMin:  th.ToPtr(80),
 		EtherType:     rules.EtherType4,
-		PortRangeMax:  80,
+		PortRangeMax:  th.ToPtr(80),
 		Protocol:      rules.ProtocolAny,
 		RemoteGroupID: "85cc3048-abc3-43cc-89b3-377341426ac5",
 		SecGroupID:    "a7734e61-b545-452d-a3cd-0189cbd9747a",
 	}
 	_, err := rules.Create(context.TODO(), fake.ServiceClient(fakeServer), opts).Extract()
 	th.AssertNoErr(t, err)
+}
+
+func TestCreateEchoReply(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	fakeServer.Mux.HandleFunc("/v2.0/security-group-rules", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, `
+{
+    "security_group_rule": {
+        "description": "test description of rule",
+        "direction": "ingress",
+        "port_range_min": 0,
+        "ethertype": "IPv4",
+        "port_range_max": 0,
+        "remote_group_id": "85cc3048-abc3-43cc-89b3-377341426ac5",
+        "security_group_id": "a7734e61-b545-452d-a3cd-0189cbd9747a",
+		"protocol": "icmp"
+    }
+}
+      `)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+
+		fmt.Fprint(w, `
+{
+    "security_group_rule": {
+        "description": "test description of rule",
+        "direction": "ingress",
+        "ethertype": "IPv4",
+		"protocol": "icmp",
+        "id": "2bc0accf-312e-429a-956e-e4407625eb62",
+        "port_range_max": 0,
+        "port_range_min": 0,
+        "remote_group_id": "85cc3048-abc3-43cc-89b3-377341426ac5",
+        "remote_ip_prefix": null,
+        "security_group_id": "a7734e61-b545-452d-a3cd-0189cbd9747a",
+        "tenant_id": "e4f50856753b4dc6afee5fa6b9b6c550"
+    }
+}
+    `)
+	})
+
+	opts := rules.CreateOpts{
+		Description:   "test description of rule",
+		Direction:     "ingress",
+		PortRangeMin:  th.ToPtr(0),
+		EtherType:     rules.EtherType4,
+		PortRangeMax:  th.ToPtr(0),
+		Protocol:      rules.ProtocolICMP,
+		RemoteGroupID: "85cc3048-abc3-43cc-89b3-377341426ac5",
+		SecGroupID:    "a7734e61-b545-452d-a3cd-0189cbd9747a",
+	}
+	rule, err := rules.Create(context.TODO(), fake.ServiceClient(fakeServer), opts).Extract()
+
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, 0, rule.PortRangeMax)
+	th.AssertEquals(t, 0, rule.PortRangeMin)
 }
 
 func TestCreateBulk(t *testing.T) {
@@ -305,9 +368,9 @@ func TestCreateBulk(t *testing.T) {
 		{
 			Description:   "test description of rule",
 			Direction:     "ingress",
-			PortRangeMin:  80,
+			PortRangeMin:  th.ToPtr(80),
 			EtherType:     rules.EtherType4,
-			PortRangeMax:  80,
+			PortRangeMax:  th.ToPtr(80),
 			Protocol:      "tcp",
 			RemoteGroupID: "85cc3048-abc3-43cc-89b3-377341426ac5",
 			SecGroupID:    "a7734e61-b545-452d-a3cd-0189cbd9747a",
@@ -315,9 +378,9 @@ func TestCreateBulk(t *testing.T) {
 		{
 			Description:  "test description of rule",
 			Direction:    "ingress",
-			PortRangeMin: 443,
+			PortRangeMin: th.ToPtr(443),
 			EtherType:    rules.EtherType4,
-			PortRangeMax: 443,
+			PortRangeMax: th.ToPtr(443),
 			Protocol:     "tcp",
 			SecGroupID:   "a7734e61-b545-452d-a3cd-0189cbd9747a",
 		},

--- a/testhelper/convenience.go
+++ b/testhelper/convenience.go
@@ -446,3 +446,7 @@ func AssertIntGreaterOrEqual(t *testing.T, v1 int, v2 int) {
 		logFatal(t, fmt.Sprintf("The first value \"%v\" is lesser than the second value \"%v\"", v1, v2))
 	}
 }
+
+func ToPtr[T any](v T) *T {
+	return &v
+}


### PR DESCRIPTION
Currently, it is not possible to create a security group rule with `PortRangeMin: 0` and `PortRangeMax: 0`, which are valid values when using ICMP as a protocol.

This PR adds a missing pointer so we can differentiate between 0 and `nil` when creating a new rule.

Fixes #3644 #1775