### PR TITLE
fix(clouds): separate user domain from project domain in clouds.yaml parser

### DIFF
--- a/openstack/config/clouds/clouds.go
+++ b/openstack/config/clouds/clouds.go
@@ -159,6 +159,17 @@ func Parse(opts ...ParseOption) (gophercloud.AuthOptions, gophercloud.EndpointOp
 		scope = &gophercloud.AuthScope{
 			TrustID: trustID,
 		}
+	} else if projectName := coalesce(options.projectName, cloud.AuthInfo.ProjectName); projectName != "" && (cloud.AuthInfo.ProjectDomainID != "" || cloud.AuthInfo.ProjectDomainName != "") {
+		// project_domain_id/name is set explicitly alongside a project name.
+		// Build the scope directly so the project domain is not inherited from
+		// the user-auth DomainID/DomainName fields. This matters when the user
+		// and project live in different domains (e.g. user_domain_name=corp.example.com
+		// with project_domain_name=Default).
+		scope = &gophercloud.AuthScope{
+			ProjectName: projectName,
+			DomainID:    cloud.AuthInfo.ProjectDomainID,
+			DomainName:  cloud.AuthInfo.ProjectDomainName,
+		}
 	}
 
 	return gophercloud.AuthOptions{
@@ -166,8 +177,8 @@ func Parse(opts ...ParseOption) (gophercloud.AuthOptions, gophercloud.EndpointOp
 			Username:                    coalesce(options.username, cloud.AuthInfo.Username),
 			UserID:                      coalesce(options.userID, cloud.AuthInfo.UserID),
 			Password:                    coalesce(options.password, cloud.AuthInfo.Password),
-			DomainID:                    coalesce(options.domainID, cloud.AuthInfo.UserDomainID, cloud.AuthInfo.ProjectDomainID, cloud.AuthInfo.DomainID),
-			DomainName:                  coalesce(options.domainName, cloud.AuthInfo.UserDomainName, cloud.AuthInfo.ProjectDomainName, cloud.AuthInfo.DomainName),
+			DomainID:                    coalesce(options.domainID, cloud.AuthInfo.UserDomainID, cloud.AuthInfo.DomainID),
+			DomainName:                  coalesce(options.domainName, cloud.AuthInfo.UserDomainName, cloud.AuthInfo.DomainName),
 			TenantID:                    coalesce(options.projectID, cloud.AuthInfo.ProjectID),
 			TenantName:                  coalesce(options.projectName, cloud.AuthInfo.ProjectName),
 			TokenID:                     coalesce(options.token, cloud.AuthInfo.Token),

--- a/openstack/config/clouds/clouds_test.go
+++ b/openstack/config/clouds/clouds_test.go
@@ -66,6 +66,108 @@ func ExampleWithRegion() {
 	// Output: mars
 }
 
+func TestParseProjectDomain(t *testing.T) {
+	t.Run("project_domain_id with user_domain_name builds correct scope", func(t *testing.T) {
+		const cloudsYAML = `clouds:
+  test:
+    auth:
+      auth_url: https://example.com/v3
+      username: alice
+      password: secret
+      user_domain_name: corp.example.com
+      project_name: myproject
+      project_domain_id: default`
+
+		ao, _, _, err := clouds.Parse(
+			clouds.WithCloudsYAML(strings.NewReader(cloudsYAML)),
+			clouds.WithCloudName("test"),
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if got := ao.DomainName; got != "corp.example.com" {
+			t.Errorf("DomainName: want %q, got %q", "corp.example.com", got)
+		}
+		if got := ao.DomainID; got != "" {
+			t.Errorf("DomainID: want empty, got %q", got)
+		}
+
+		if ao.Scope == nil {
+			t.Fatal("Scope is nil; expected a pre-built scope with project domain")
+		}
+		if got := ao.Scope.ProjectName; got != "myproject" {
+			t.Errorf("Scope.ProjectName: want %q, got %q", "myproject", got)
+		}
+		if got := ao.Scope.DomainID; got != "default" {
+			t.Errorf("Scope.DomainID: want %q, got %q", "default", got)
+		}
+	})
+
+	t.Run("project_domain_name with differing user_domain_name builds correct scope", func(t *testing.T) {
+		const cloudsYAML = `clouds:
+  test:
+    auth:
+      auth_url: https://example.com/v3
+      username: alice
+      password: secret
+      user_domain_name: corp.example.com
+      project_name: myproject
+      project_domain_name: Default`
+
+		ao, _, _, err := clouds.Parse(
+			clouds.WithCloudsYAML(strings.NewReader(cloudsYAML)),
+			clouds.WithCloudName("test"),
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if got := ao.DomainName; got != "corp.example.com" {
+			t.Errorf("DomainName: want %q, got %q", "corp.example.com", got)
+		}
+		if got := ao.DomainID; got != "" {
+			t.Errorf("DomainID: want empty, got %q", got)
+		}
+
+		if ao.Scope == nil {
+			t.Fatal("Scope is nil; expected a pre-built scope with project domain")
+		}
+		if got := ao.Scope.ProjectName; got != "myproject" {
+			t.Errorf("Scope.ProjectName: want %q, got %q", "myproject", got)
+		}
+		if got := ao.Scope.DomainName; got != "Default" {
+			t.Errorf("Scope.DomainName: want %q, got %q", "Default", got)
+		}
+	})
+
+	t.Run("project_domain_name does not populate user DomainName", func(t *testing.T) {
+		const cloudsYAML = `clouds:
+  test:
+    auth:
+      auth_url: https://example.com/v3
+      username: bob
+      password: secret
+      project_name: myproject
+      project_domain_name: Default`
+
+		ao, _, _, err := clouds.Parse(
+			clouds.WithCloudsYAML(strings.NewReader(cloudsYAML)),
+			clouds.WithCloudName("test"),
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if got := ao.DomainName; got != "" {
+			t.Errorf("DomainName: want empty, got %q", got)
+		}
+		if got := ao.DomainID; got != "" {
+			t.Errorf("DomainID: want empty, got %q", got)
+		}
+	})
+}
+
 func TestParse(t *testing.T) {
 	const tempDirPrefix = "gophercloud-test-"
 


### PR DESCRIPTION
<!--
Prior to starting a PR, please make sure you have read our
[contributor tutorial](https://github.com/gophercloud/gophercloud/tree/main/docs/contributor-tutorial).

Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

-->
Fixes #3724

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:
- https://github.com/openstack/keystoneauth/blob/a1b8db95952a5e6df3c96908413b784fb3257e35/keystoneauth1/identity/v3/password.py
- https://github.com/openstack/keystoneauth/blob/a1b8db95952a5e6df3c96908413b784fb3257e35/keystoneauth1/identity/v3/base.py#L205-L214


Made two changes to `openstack/config/clouds/clouds.go`:

1. **Removed `ProjectDomainID` and `ProjectDomainName` from the `DomainID`/`DomainName` coalesces.**
   These fields now carry only the user's domain (`user_domain_id` / `user_domain_name`)

2. **Pre-building an explicit `AuthScope`** when `project_domain_id` or `project_domain_name` is set
   alongside a project name. This passes the project domain directly to the scope, bypassing
   `ToTokenV3ScopeMap`'s fallback that would otherwise inherit the user domain.

## Test cases

- `project_domain_id` + `user_domain_name`: verifies `DomainID` is empty (no bleed) and scope
  carries the correct project domain ID.
- `project_domain_name` differing from `user_domain_name`: verifies scope carries the project
  domain name, not the user domain.
- `project_domain_name` without `user_domain_name`: verifies `DomainName` is empty — project
  domain must not silently substitute for the user domain.