### PR TITLE
fix: skip non-struct fields in extractIntoPtr slice path to prevent unmarshal panic

### DIFF
--- a/results.go
+++ b/results.go
@@ -117,6 +117,9 @@ func (r Result) extractIntoPtr(to any, label string) error {
 						// a struct that is never used, but it's good enough to
 						// trigger the UnmarshalJSON method.
 						for i := 0; i < newType.NumField(); i++ {
+							if newType.Field(i).Kind() != reflect.Struct {
+								continue
+							}
 							s := newType.Field(i).Addr().Interface()
 
 							// Unmarshal is used rather than NewDecoder to also work


### PR DESCRIPTION
In extractIntoPtr function ([link](https://github.com/gophercloud/gophercloud/blob/main/results.go#L70)), [the slice path](https://github.com/gophercloud/gophercloud/blob/main/results.go#L119-L128) iterates over all fields of the target struct and attempts to unmarshal the full JSON body into each one. When the target struct contains a non-struct field, such as a *bool (as described below), the code attempts to unmarshal a JSON object into it, causing a type mismatch error.

```go
type PortExt struct {
	ports.Port
	portsecurity.PortSecurityExt
	portsbinding.PortsBindingExt

	PropagateUplinkStatusPtr *bool `json:"propagate_uplink_status,omitempty"`
}

```

```go
for i := 0; i < newType.NumField(); i++ {
    // newType.Field(3) = PropagateUplinkStatusPtr (*bool)
	s := newType.Field(i).Addr()

	// Unmarshal is used rather than NewDecoder to also work
	// around the above-mentioned bug
	err = json.Unmarshal(b, s) // json.Unmarshal(b, **bool)
	if err != nil {
		return err
	}
}
```

This PR proposes a fix to only decode embedded structs in the loop, adding a check that skips non-struct types. All other field types are handled correctly by [this](https://github.com/gophercloud/gophercloud/blob/main/results.go#L119-L128) `ExtractInto` call and by the final json.Unmarshal call after the loop.

