### PR TITLE
Use devstack-plugin-prometheus from opendev

### DIFF
--- a/.github/workflows/functional-metric.yaml
+++ b/.github/workflows/functional-metric.yaml
@@ -50,7 +50,7 @@ jobs:
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |
-            enable_plugin devstack-plugin-prometheus https://github.com/openstack/devstack-plugin-prometheus ${{ matrix.openstack_version }}
+            enable_plugin devstack-plugin-prometheus https://opendev.org/openstack/devstack-plugin-prometheus ${{ matrix.openstack_version }}
             enable_plugin ceilometer https://github.com/openstack/ceilometer ${{ matrix.openstack_version }}
             CEILOMETER_BACKEND=sg-core
             PROMETHEUS_CUSTOM_SCRAPE_TARGETS="localhost:3000"


### PR DESCRIPTION
The devstack-plugin-prometheus mirror on github is empty, which is causing an error in the CI when trying to fetch refs from the remote repository.

https://github.com/gophercloud/gophercloud/actions/runs/24142847910/job/70512838723