### PR TITLE
db/instances: remove hardcoded 300GB size cap

### DIFF
--- a/openstack/db/v1/instances/requests.go
+++ b/openstack/db/v1/instances/requests.go
@@ -56,8 +56,8 @@ type CreateOpts struct {
 	// Either the integer UUID (in string form) of the flavor, or its URI
 	// reference as specified in the response from the List() call. Required.
 	FlavorRef string
-	// Specifies the volume size in gigabytes (GB). The value must be between 1
-	// and 300. Required.
+	// Specifies the volume size in gigabytes (GB). The value must be > 1.
+	// Required.
 	Size int
 	// Specifies the volume type.
 	VolumeType string
@@ -77,11 +77,11 @@ type CreateOpts struct {
 
 // ToInstanceCreateMap will render a JSON map.
 func (opts CreateOpts) ToInstanceCreateMap() (map[string]any, error) {
-	if opts.Size > 300 || opts.Size < 1 {
+	if opts.Size < 1 {
 		err := gophercloud.ErrInvalidInput{}
 		err.Argument = "instances.CreateOpts.Size"
 		err.Value = opts.Size
-		err.Info = "Size (GB) must be between 1-300"
+		err.Info = "Size (GB) must be >= 1"
 		return nil, err
 	}
 

--- a/openstack/db/v1/instances/requests.go
+++ b/openstack/db/v1/instances/requests.go
@@ -56,7 +56,7 @@ type CreateOpts struct {
 	// Either the integer UUID (in string form) of the flavor, or its URI
 	// reference as specified in the response from the List() call. Required.
 	FlavorRef string
-	// Specifies the volume size in gigabytes (GB). The value must be > 1.
+	// Specifies the volume size in gigabytes (GB). The value must be >= 1. The upper limit is specific to each OpenStack environment.
 	// Required.
 	Size int
 	// Specifies the volume type.

--- a/openstack/db/v1/instances/testing/requests_test.go
+++ b/openstack/db/v1/instances/testing/requests_test.go
@@ -78,6 +78,32 @@ func TestCreateWithFault(t *testing.T) {
 	th.AssertDeepEquals(t, &expectedInstanceWithFault, instance)
 }
 
+func TestCreateOptsToInstanceCreateMapAllowsSizeAbove300(t *testing.T) {
+	opts := instances.CreateOpts{
+		FlavorRef: "1",
+		Size:      301,
+	}
+
+	body, err := opts.ToInstanceCreateMap()
+	th.AssertNoErr(t, err)
+
+	instance := body["instance"].(map[string]any)
+	volume := instance["volume"].(map[string]any)
+	th.AssertEquals(t, 301, volume["size"])
+}
+
+func TestCreateOptsToInstanceCreateMapRejectsSizeBelow1(t *testing.T) {
+	opts := instances.CreateOpts{
+		FlavorRef: "1",
+		Size:      0,
+	}
+
+	_, err := opts.ToInstanceCreateMap()
+	if err == nil {
+		t.Fatalf("expected error for invalid size, got nil")
+	}
+}
+
 func TestInstanceList(t *testing.T) {
 	fakeServer := th.SetupHTTP()
 	defer fakeServer.Teardown()


### PR DESCRIPTION
This PR removes the hardcoded upper limit (300 GB) from `instances.CreateOpts.Size`
client-side validation in `openstack/db/v1/instances`.
Current behavior rejects `Size > 300` before request is sent.
New behavior validates only `Size >= 1` and leaves deployment-specific maximum
validation to the OpenStack/Trove API.
Tests added:
- allow `Size: 301` in `ToInstanceCreateMap()`
- reject `Size: 0` in `ToInstanceCreateMap()`

Fixes #3733