### PR TITLE
Make fields in Placement inventory update optional

### DIFF
--- a/internal/acceptance/openstack/placement/v1/allocationcandidates_test.go
+++ b/internal/acceptance/openstack/placement/v1/allocationcandidates_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gophercloud/gophercloud/v2/internal/acceptance/clients"
 	"github.com/gophercloud/gophercloud/v2/internal/acceptance/tools"
+	"github.com/gophercloud/gophercloud/v2/internal/ptr"
 	"github.com/gophercloud/gophercloud/v2/openstack/placement/v1/allocationcandidates"
 	"github.com/gophercloud/gophercloud/v2/openstack/placement/v1/resourceproviders"
 	th "github.com/gophercloud/gophercloud/v2/testhelper"
@@ -32,13 +33,13 @@ func createRPWithVCPUInventory(t *testing.T, microversion string) (string, func(
 
 	inventories, err = resourceproviders.UpdateInventories(context.TODO(), client, rp.UUID, resourceproviders.UpdateInventoriesOpts{
 		ResourceProviderGeneration: inventories.ResourceProviderGeneration,
-		Inventories: map[string]resourceproviders.Inventory{
+		Inventories: map[string]resourceproviders.InventoryUpdateBase{
 			"VCPU": {
-				AllocationRatio: 1.0,
-				MaxUnit:         8,
-				MinUnit:         1,
-				Reserved:        0,
-				StepSize:        1,
+				AllocationRatio: ptr.To(float32(1.0)),
+				MaxUnit:         ptr.To(8),
+				MinUnit:         ptr.To(1),
+				Reserved:        ptr.To(0),
+				StepSize:        ptr.To(1),
 				Total:           8,
 			},
 		},

--- a/internal/acceptance/openstack/placement/v1/placement.go
+++ b/internal/acceptance/openstack/placement/v1/placement.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/internal/acceptance/tools"
+	"github.com/gophercloud/gophercloud/v2/internal/ptr"
 	"github.com/gophercloud/gophercloud/v2/openstack/placement/v1/resourceproviders"
 	th "github.com/gophercloud/gophercloud/v2/testhelper"
 )
@@ -87,21 +88,21 @@ func CreateResourceProviderWithVCPUInventory(t *testing.T, client *gophercloud.S
 
 	updatedInventories, err := resourceproviders.UpdateInventories(context.TODO(), client, resourceProvider.UUID, resourceproviders.UpdateInventoriesOpts{
 		ResourceProviderGeneration: inventories.ResourceProviderGeneration,
-		Inventories: map[string]resourceproviders.Inventory{
+		Inventories: map[string]resourceproviders.InventoryUpdateBase{
 			"VCPU": {
-				AllocationRatio: 1.0,
-				MaxUnit:         8,
-				MinUnit:         1,
-				Reserved:        0,
-				StepSize:        1,
+				AllocationRatio: ptr.To(float32(1.0)),
+				MaxUnit:         ptr.To(8),
+				MinUnit:         ptr.To(1),
+				Reserved:        ptr.To(0),
+				StepSize:        ptr.To(1),
 				Total:           8,
 			},
 			"MEMORY_MB": {
-				AllocationRatio: 1.0,
-				MaxUnit:         8192,
-				MinUnit:         1,
-				Reserved:        0,
-				StepSize:        1,
+				AllocationRatio: ptr.To(float32(1.0)),
+				MaxUnit:         ptr.To(8192),
+				MinUnit:         ptr.To(1),
+				Reserved:        ptr.To(0),
+				StepSize:        ptr.To(1),
 				Total:           8192,
 			},
 		},

--- a/internal/acceptance/openstack/placement/v1/resourceproviders_test.go
+++ b/internal/acceptance/openstack/placement/v1/resourceproviders_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/internal/acceptance/clients"
 	"github.com/gophercloud/gophercloud/v2/internal/acceptance/tools"
+	"github.com/gophercloud/gophercloud/v2/internal/ptr"
 	"github.com/gophercloud/gophercloud/v2/openstack/placement/v1/resourceproviders"
 	th "github.com/gophercloud/gophercloud/v2/testhelper"
 )
@@ -121,13 +122,13 @@ func TestResourceProviderInventory(t *testing.T) {
 
 	seededInventories, err := resourceproviders.UpdateInventories(context.TODO(), client, resourceProvider.UUID, resourceproviders.UpdateInventoriesOpts{
 		ResourceProviderGeneration: inventories.ResourceProviderGeneration,
-		Inventories: map[string]resourceproviders.Inventory{
+		Inventories: map[string]resourceproviders.InventoryUpdateBase{
 			InventoryResourceClass: {
-				AllocationRatio: 1.0,
-				MaxUnit:         4,
-				MinUnit:         1,
-				Reserved:        0,
-				StepSize:        1,
+				AllocationRatio: ptr.To(float32(1.0)),
+				MaxUnit:         ptr.To(4),
+				MinUnit:         ptr.To(1),
+				Reserved:        ptr.To(0),
+				StepSize:        ptr.To(1),
 				Total:           4,
 			},
 		},
@@ -155,13 +156,13 @@ func TestResourceProviderInventoryNotFound(t *testing.T) {
 
 	_, err = resourceproviders.UpdateInventories(context.TODO(), client, resourceProvider.UUID, resourceproviders.UpdateInventoriesOpts{
 		ResourceProviderGeneration: inventories.ResourceProviderGeneration,
-		Inventories: map[string]resourceproviders.Inventory{
+		Inventories: map[string]resourceproviders.InventoryUpdateBase{
 			InventoryResourceClass: {
-				AllocationRatio: 1.0,
-				MaxUnit:         4,
-				MinUnit:         1,
-				Reserved:        0,
-				StepSize:        1,
+				AllocationRatio: ptr.To(float32(1.0)),
+				MaxUnit:         ptr.To(4),
+				MinUnit:         ptr.To(1),
+				Reserved:        ptr.To(0),
+				StepSize:        ptr.To(1),
 				Total:           4,
 			},
 		},
@@ -189,14 +190,14 @@ func TestResourceProviderUpdateInventory(t *testing.T) {
 	// Arrange: The resource class on this provider must exist first
 	seedOpts := resourceproviders.UpdateInventoriesOpts{
 		ResourceProviderGeneration: inventories.ResourceProviderGeneration,
-		Inventories: map[string]resourceproviders.Inventory{
+		Inventories: map[string]resourceproviders.InventoryUpdateBase{
 			InventoryResourceClass: {
-				AllocationRatio: 1.0,
-				MaxUnit:         4,
-				MinUnit:         1,
-				Reserved:        0,
-				StepSize:        1,
-				Total:           4,
+				AllocationRatio: ptr.To(float32(1.0)),
+				MaxUnit:         ptr.To(4),
+				MinUnit:         ptr.To(1),
+				// Skipping Reserved on purpose
+				StepSize: ptr.To(1),
+				Total:    4,
 			},
 		},
 	}
@@ -215,7 +216,13 @@ func TestResourceProviderUpdateInventory(t *testing.T) {
 
 	updateOpts := resourceproviders.UpdateInventoryOpts{
 		ResourceProviderGeneration: seededInventories.ResourceProviderGeneration,
-		Inventory:                  expectedInventory,
+		InventoryUpdateBase: resourceproviders.InventoryUpdateBase{
+			AllocationRatio: ptr.To(expectedInventory.AllocationRatio),
+			MaxUnit:         ptr.To(expectedInventory.MaxUnit),
+			MinUnit:         ptr.To(expectedInventory.MinUnit),
+			StepSize:        ptr.To(expectedInventory.StepSize),
+			Total:           expectedInventory.Total,
+		},
 	}
 
 	_, err = resourceproviders.UpdateInventory(context.TODO(), client, resourceProvider.UUID, InventoryResourceClass, updateOpts).Extract()
@@ -237,12 +244,12 @@ func TestResourceProviderUpdateInventoryNotFound(t *testing.T) {
 
 	updateOpts := resourceproviders.UpdateInventoryOpts{
 		ResourceProviderGeneration: 0,
-		Inventory: resourceproviders.Inventory{
-			AllocationRatio: 1.0,
-			MaxUnit:         1,
-			MinUnit:         1,
-			Reserved:        0,
-			StepSize:        1,
+		InventoryUpdateBase: resourceproviders.InventoryUpdateBase{
+			AllocationRatio: ptr.To(float32(1.0)),
+			MaxUnit:         ptr.To(1),
+			MinUnit:         ptr.To(1),
+			Reserved:        ptr.To(0),
+			StepSize:        ptr.To(1),
 			Total:           1,
 		},
 	}
@@ -267,13 +274,13 @@ func TestResourceProviderDeleteInventorySuccess(t *testing.T) {
 
 	_, err = resourceproviders.UpdateInventories(context.TODO(), client, resourceProvider.UUID, resourceproviders.UpdateInventoriesOpts{
 		ResourceProviderGeneration: inventories.ResourceProviderGeneration,
-		Inventories: map[string]resourceproviders.Inventory{
+		Inventories: map[string]resourceproviders.InventoryUpdateBase{
 			InventoryResourceClass: {
-				AllocationRatio: 1.0,
-				MaxUnit:         4,
-				MinUnit:         1,
-				Reserved:        0,
-				StepSize:        1,
+				AllocationRatio: ptr.To(float32(1.0)),
+				MaxUnit:         ptr.To(4),
+				MinUnit:         ptr.To(1),
+				Reserved:        ptr.To(0),
+				StepSize:        ptr.To(1),
 				Total:           4,
 			},
 		},
@@ -320,21 +327,21 @@ func TestResourceProviderDeleteInventoriesSuccess(t *testing.T) {
 
 	_, err = resourceproviders.UpdateInventories(context.TODO(), client, resourceProvider.UUID, resourceproviders.UpdateInventoriesOpts{
 		ResourceProviderGeneration: inventories.ResourceProviderGeneration,
-		Inventories: map[string]resourceproviders.Inventory{
+		Inventories: map[string]resourceproviders.InventoryUpdateBase{
 			InventoryResourceClass: {
-				AllocationRatio: 1.0,
-				MaxUnit:         4,
-				MinUnit:         1,
-				Reserved:        0,
-				StepSize:        1,
+				AllocationRatio: ptr.To(float32(1.0)),
+				MaxUnit:         ptr.To(4),
+				MinUnit:         ptr.To(1),
+				Reserved:        ptr.To(0),
+				StepSize:        ptr.To(1),
 				Total:           4,
 			},
 			"MEMORY_MB": {
-				AllocationRatio: 1.0,
-				MaxUnit:         1024,
-				MinUnit:         1,
-				Reserved:        0,
-				StepSize:        1,
+				AllocationRatio: ptr.To(float32(1.0)),
+				MaxUnit:         ptr.To(1024),
+				MinUnit:         ptr.To(1),
+				Reserved:        ptr.To(0),
+				StepSize:        ptr.To(1),
 				Total:           1024,
 			},
 		},
@@ -380,7 +387,16 @@ func TestResourceProviderUpdateInventories(t *testing.T) {
 
 	updateOpts := resourceproviders.UpdateInventoriesOpts{
 		ResourceProviderGeneration: inventories.ResourceProviderGeneration,
-		Inventories:                expectedInventories,
+		Inventories: map[string]resourceproviders.InventoryUpdateBase{
+			"DISK_GB": {
+				AllocationRatio: ptr.To(float32(1.0)),
+				MaxUnit:         ptr.To(100),
+				MinUnit:         ptr.To(1),
+				Reserved:        ptr.To(0),
+				StepSize:        ptr.To(1),
+				Total:           100,
+			},
+		},
 	}
 
 	_, err = resourceproviders.UpdateInventories(context.TODO(), client, resourceProvider.UUID, updateOpts).Extract()
@@ -400,13 +416,13 @@ func TestResourceProviderUpdateInventoriesNotFound(t *testing.T) {
 
 	updateOpts := resourceproviders.UpdateInventoriesOpts{
 		ResourceProviderGeneration: 0,
-		Inventories: map[string]resourceproviders.Inventory{
+		Inventories: map[string]resourceproviders.InventoryUpdateBase{
 			InventoryResourceClass: {
-				AllocationRatio: 1.0,
-				MaxUnit:         1,
-				MinUnit:         1,
-				Reserved:        0,
-				StepSize:        1,
+				AllocationRatio: ptr.To(float32(1.0)),
+				MaxUnit:         ptr.To(1),
+				MinUnit:         ptr.To(1),
+				Reserved:        ptr.To(0),
+				StepSize:        ptr.To(1),
 				Total:           1,
 			},
 		},

--- a/openstack/placement/v1/resourceproviders/doc.go
+++ b/openstack/placement/v1/resourceproviders/doc.go
@@ -89,16 +89,22 @@ Example to update (replace) all resource provider inventories
 		panic(err)
 	}
 
+	allocationRatio := float32(16.0)
+	maxUnit := 4
+	minUnit := 1
+	reserved := 0
+	stepSize := 1
+
 	updateInventoriesOpts := resourceproviders.UpdateInventoriesOpts{
 		ResourceProviderGeneration: inventories.ResourceProviderGeneration,
-		Inventories: map[string]resourceproviders.Inventory{
+		Inventories: map[string]resourceproviders.InventoryUpdateBase{
 			"VCPU": {
 				Total:           4,
-				Reserved:        0,
-				MinUnit:         1,
-				MaxUnit:         4,
-				StepSize:        1,
-				AllocationRatio: 16.0,
+				Reserved:        &reserved,
+				MinUnit:         &minUnit,
+				MaxUnit:         &maxUnit,
+				StepSize:        &stepSize,
+				AllocationRatio: &allocationRatio,
 			},
 		},
 	}
@@ -115,16 +121,22 @@ Example to update one existing resource provider inventory
 		panic(err)
 	}
 
+	allocationRatio := float32(16.0)
+	maxUnit := 4
+	minUnit := 1
+	reserved := 0
+	stepSize := 1
+
 	// UpdateInventory updates an existing resource class inventory.
 	updateInventoryOpts := resourceproviders.UpdateInventoryOpts{
 		ResourceProviderGeneration: inventories.ResourceProviderGeneration,
-		Inventory: resourceproviders.Inventory{
+		InventoryUpdateBase: resourceproviders.InventoryUpdateBase{
 			Total:           4,
-			Reserved:        0,
-			MinUnit:         1,
-			MaxUnit:         4,
-			StepSize:        1,
-			AllocationRatio: 16.0,
+			Reserved:        &reserved,
+			MinUnit:         &minUnit,
+			MaxUnit:         &maxUnit,
+			StepSize:        &stepSize,
+			AllocationRatio: &allocationRatio,
 		},
 	}
 

--- a/openstack/placement/v1/resourceproviders/requests.go
+++ b/openstack/placement/v1/resourceproviders/requests.go
@@ -177,8 +177,21 @@ type UpdateInventoriesOptsBuilder interface {
 	ToResourceProviderUpdateInventoriesMap() (map[string]any, error)
 }
 
+// InventoryUpdateBase contains inventory fields shared by update operations.
+type InventoryUpdateBase struct {
+	AllocationRatio *float32 `json:"allocation_ratio,omitempty"`
+	MaxUnit         *int     `json:"max_unit,omitempty"`
+	MinUnit         *int     `json:"min_unit,omitempty"`
+	Reserved        *int     `json:"reserved,omitempty"`
+	StepSize        *int     `json:"step_size,omitempty"`
+	Total           int      `json:"total"`
+}
+
 // UpdateInventoriesOpts represents options used to update all inventories of a resource provider.
-type UpdateInventoriesOpts = ResourceProviderInventories
+type UpdateInventoriesOpts struct {
+	ResourceProviderGeneration int                            `json:"resource_provider_generation"`
+	Inventories                map[string]InventoryUpdateBase `json:"inventories"`
+}
 
 // ToResourceProviderUpdateInventoriesMap constructs a request body from UpdateInventoriesOpts.
 func (opts UpdateInventoriesOpts) ToResourceProviderUpdateInventoriesMap() (map[string]any, error) {
@@ -214,7 +227,10 @@ type UpdateInventoryOptsBuilder interface {
 }
 
 // UpdateInventoryOpts represents options used to update one inventory of a resource provider.
-type UpdateInventoryOpts = ResourceProviderInventory
+type UpdateInventoryOpts struct {
+	ResourceProviderGeneration int `json:"resource_provider_generation"`
+	InventoryUpdateBase
+}
 
 // ToResourceProviderUpdateInventoryMap constructs a request body from UpdateInventoryOpts.
 func (opts UpdateInventoryOpts) ToResourceProviderUpdateInventoryMap() (map[string]any, error) {

--- a/openstack/placement/v1/resourceproviders/testing/fixtures_test.go
+++ b/openstack/placement/v1/resourceproviders/testing/fixtures_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/gophercloud/gophercloud/v2/internal/ptr"
 	"github.com/gophercloud/gophercloud/v2/openstack/placement/v1/resourceproviders"
 
 	th "github.com/gophercloud/gophercloud/v2/testhelper"
@@ -822,4 +823,41 @@ func HandleResourceProviderUpdateAggregatesConflict(t *testing.T, fakeServer th.
 
 			w.WriteHeader(http.StatusConflict)
 		})
+}
+
+// ToInventoryUpdateBase converts a ResourceProvider Inventory result into its
+// corresponding Update (pointer) version. This is used in tests to facilitate
+// the mapping between API results (which contain values) and Update operations
+// (which use pointers for optionality).
+func ToInventoryUpdateBase(inv resourceproviders.Inventory) resourceproviders.InventoryUpdateBase {
+	return resourceproviders.InventoryUpdateBase{
+		AllocationRatio: ptr.To(inv.AllocationRatio),
+		MaxUnit:         ptr.To(inv.MaxUnit),
+		MinUnit:         ptr.To(inv.MinUnit),
+		Reserved:        ptr.To(inv.Reserved),
+		StepSize:        ptr.To(inv.StepSize),
+		Total:           inv.Total,
+	}
+}
+
+// ToUpdateInventoriesOpts converts a ResourceProviderInventories result into UpdateInventoriesOpts.
+func ToUpdateInventoriesOpts(inventories resourceproviders.ResourceProviderInventories) resourceproviders.UpdateInventoriesOpts {
+	opts := resourceproviders.UpdateInventoriesOpts{
+		ResourceProviderGeneration: inventories.ResourceProviderGeneration,
+		Inventories:                make(map[string]resourceproviders.InventoryUpdateBase, len(inventories.Inventories)),
+	}
+
+	for resourceClass, inv := range inventories.Inventories {
+		opts.Inventories[resourceClass] = ToInventoryUpdateBase(inv)
+	}
+
+	return opts
+}
+
+// ToUpdateInventoryOpts converts a ResourceProviderInventory result into UpdateInventoryOpts.
+func ToUpdateInventoryOpts(inventory resourceproviders.ResourceProviderInventory) resourceproviders.UpdateInventoryOpts {
+	return resourceproviders.UpdateInventoryOpts{
+		ResourceProviderGeneration: inventory.ResourceProviderGeneration,
+		InventoryUpdateBase:        ToInventoryUpdateBase(inventory.Inventory),
+	}
 }

--- a/openstack/placement/v1/resourceproviders/testing/requests_test.go
+++ b/openstack/placement/v1/resourceproviders/testing/requests_test.go
@@ -153,7 +153,7 @@ func TestUpdateResourceProvidersInventories(t *testing.T) {
 
 	HandleResourceProviderPutInventories(t, fakeServer)
 
-	opts := resourceproviders.UpdateInventoriesOpts(ExpectedInventories)
+	opts := ToUpdateInventoriesOpts(ExpectedInventories)
 	actual, err := resourceproviders.UpdateInventories(context.TODO(), client.ServiceClient(fakeServer), ResourceProviderTestID, opts).Extract()
 	th.AssertNoErr(t, err)
 	th.AssertDeepEquals(t, ExpectedInventories, *actual)
@@ -165,7 +165,7 @@ func TestUpdateResourceProvidersInventoriesNotFound(t *testing.T) {
 
 	HandleResourceProviderPutInventoriesNotFound(t, fakeServer)
 
-	opts := resourceproviders.UpdateInventoriesOpts(ExpectedInventories)
+	opts := ToUpdateInventoriesOpts(ExpectedInventories)
 	_, err := resourceproviders.UpdateInventories(context.TODO(), client.ServiceClient(fakeServer), NonExistentRPID, opts).Extract()
 	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
 }
@@ -176,7 +176,7 @@ func TestUpdateResourceProviderInventory(t *testing.T) {
 
 	HandleResourceProviderPutInventory(t, fakeServer)
 
-	opts := resourceproviders.UpdateInventoryOpts(ExpectedInventory)
+	opts := ToUpdateInventoryOpts(ExpectedInventory)
 	actual, err := resourceproviders.UpdateInventory(context.TODO(), client.ServiceClient(fakeServer), ResourceProviderTestID, PresentInventoryResourceClass, opts).Extract()
 	th.AssertNoErr(t, err)
 	th.AssertDeepEquals(t, ExpectedInventory, *actual)
@@ -188,7 +188,7 @@ func TestUpdateResourceProviderInventoryNotFound(t *testing.T) {
 
 	HandleResourceProviderPutInventoryNotFound(t, fakeServer)
 
-	opts := resourceproviders.UpdateInventoryOpts(ExpectedInventory)
+	opts := ToUpdateInventoryOpts(ExpectedInventory)
 	_, err := resourceproviders.UpdateInventory(context.TODO(), client.ServiceClient(fakeServer), NonExistentRPID, PresentInventoryResourceClass, opts).Extract()
 	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
 }


### PR DESCRIPTION
Previously, the inventory update opts were incorrectly aliased to the return struct. This disallowed the SDK users to omit its values which is something API permits for all arguments but total.

Fixes #3742
