### PR TITLE
Allow clearing Placement resource provider parent_provider_uuid

### DIFF
--- a/internal/acceptance/openstack/placement/v1/resourceproviders_test.go
+++ b/internal/acceptance/openstack/placement/v1/resourceproviders_test.go
@@ -627,3 +627,41 @@ func TestResourceProviderUpdateAggregatesPreGenerationWithGenerationSuccess(t *t
 		th.AssertEquals(t, true, slices.Contains(after.Aggregates, aggregate))
 	}
 }
+
+func TestResourceProviderParentDetach(t *testing.T) {
+	clients.RequireAdmin(t)
+
+	client, err := clients.NewPlacementV1Client()
+	th.AssertNoErr(t, err)
+
+	// Arrange: Create a parent resource provider
+	parentProvider, err := CreateResourceProvider(t, client)
+	th.AssertNoErr(t, err)
+	defer DeleteResourceProvider(t, client, parentProvider.UUID)
+
+	// Arrange: Create a child resource provider with that parent
+	childProvider, err := CreateResourceProviderWithParent(t, client, parentProvider.UUID)
+	th.AssertNoErr(t, err)
+	defer DeleteResourceProvider(t, client, childProvider.UUID)
+
+	// Sanity check: Verify that the child provider has the correct parent before the update
+	th.AssertEquals(t, parentProvider.UUID, childProvider.ParentProviderUUID)
+
+	// Act: Update the child resource provider to remove the parent (transform to root)
+	client.Microversion = "1.37"
+	empty := ""
+	updateOpts := resourceproviders.UpdateOpts{
+		Name:               &childProvider.Name,
+		ParentProviderUUID: &empty,
+	}
+	updatedChild, err := resourceproviders.Update(context.TODO(), client, childProvider.UUID, updateOpts).Extract()
+	th.AssertNoErr(t, err)
+
+	// Assert: Verify that the ParentProviderUUID is now null (empty string in Gophercloud result struct)
+	th.AssertEquals(t, "", updatedChild.ParentProviderUUID)
+
+	// Assert: Double check with a Get request
+	childGet, err := resourceproviders.Get(context.TODO(), client, childProvider.UUID).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, "", childGet.ParentProviderUUID)
+}

--- a/openstack/placement/v1/resourceproviders/doc.go
+++ b/openstack/placement/v1/resourceproviders/doc.go
@@ -20,9 +20,9 @@ Example to list resource providers
 Example to create resource providers
 
 	createOpts := resourceproviders.CreateOpts{
-		Name: "new-rp",
-		UUID: "b99b3ab4-3aa6-4fba-b827-69b88b9c544a",
-		ParentProvider: "c7f50b40-6f32-4d7a-9f32-9384057be83b"
+		Name:               "new-rp",
+		UUID:               "b99b3ab4-3aa6-4fba-b827-69b88b9c544a",
+		ParentProviderUUID: "c7f50b40-6f32-4d7a-9f32-9384057be83b",
 	}
 
 	rp, err := resourceproviders.Create(context.TODO(), placementClient, createOpts).Extract()
@@ -49,14 +49,35 @@ Example to Get a resource provider
 Example to Update a resource provider
 
 	resourceProviderID := "b99b3ab4-3aa6-4fba-b827-69b88b9c544a"
+	name := "new-rp"
+	parent := "c7f50b40-6f32-4d7a-9f32-9384057be83b"
 
 	updateOpts := resourceproviders.UpdateOpts{
-		Name: "new-rp",
-		ParentProvider: "c7f50b40-6f32-4d7a-9f32-9384057be83b"
+		Name:               &name,
+		ParentProviderUUID: &parent,
 	}
 
 	placementClient.Microversion = "1.37"
-	resourceProvider, err := resourceproviders.Update(context.TODO(), placementClient, resourceProviderID).Extract()
+	resourceProvider, err := resourceproviders.Update(context.TODO(), placementClient, resourceProviderID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to transform a provider to a new root provider (set parent_provider_uuid to null).
+Note that Gophercloud uses an empty string as a sentinel value to represent JSON null
+for this optional field.
+
+	resourceProviderID := "b99b3ab4-3aa6-4fba-b827-69b88b9c544a"
+	name := "existing-rp"
+	parent := ""
+
+	updateOpts := resourceproviders.UpdateOpts{
+		Name:               &name,
+		ParentProviderUUID: &parent,
+	}
+
+	placementClient.Microversion = "1.37"
+	resourceProvider, err = resourceproviders.Update(context.TODO(), placementClient, resourceProviderID, updateOpts).Extract()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/placement/v1/resourceproviders/requests.go
+++ b/openstack/placement/v1/resourceproviders/requests.go
@@ -126,16 +126,24 @@ type UpdateOptsBuilder interface {
 type UpdateOpts struct {
 	Name *string `json:"name,omitempty"`
 	// Available in version >= 1.37. It can be set to any existing provider UUID
-	// except to providers that would cause a loop. Also it can be set to null
-	// to transform the provider to a new root provider. This operation needs to
-	// be used carefully. Moving providers can mean that the original rules used
-	// to create the existing resource allocations may be invalidated by that move.
+	// except to providers that would cause a loop. Using an empty string
+	// transforms the provider to a new root provider.
 	ParentProviderUUID *string `json:"parent_provider_uuid,omitempty"`
 }
 
 // ToResourceProviderUpdateMap constructs a request body from UpdateOpts.
 func (opts UpdateOpts) ToResourceProviderUpdateMap() (map[string]any, error) {
-	return gophercloud.BuildRequestBody(opts, "")
+	b, err := gophercloud.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	// In order to set this to null, use an empty string as a value.
+	if opts.ParentProviderUUID != nil && *opts.ParentProviderUUID == "" {
+		b["parent_provider_uuid"] = nil
+	}
+
+	return b, nil
 }
 
 // Update makes a request against the API to create a resource provider

--- a/openstack/placement/v1/resourceproviders/testing/requests_test.go
+++ b/openstack/placement/v1/resourceproviders/testing/requests_test.go
@@ -104,6 +104,39 @@ func TestUpdate(t *testing.T) {
 	th.AssertEquals(t, rp.ParentProviderUUID, parentProviderUUID)
 }
 
+func TestUpdateParentProviderUUID(t *testing.T) {
+	// 1. Test non-empty UUID
+	uuid := "b99b3ab4-3aa6-4fba-b827-69b88b9c544a"
+	opts := resourceproviders.UpdateOpts{
+		ParentProviderUUID: &uuid,
+	}
+	actual, err := opts.ToResourceProviderUpdateMap()
+	th.AssertNoErr(t, err)
+	expected := map[string]any{
+		"parent_provider_uuid": uuid,
+	}
+	th.AssertDeepEquals(t, expected, actual)
+
+	// 2. Test empty string sentinel (should be null)
+	empty := ""
+	opts = resourceproviders.UpdateOpts{
+		ParentProviderUUID: &empty,
+	}
+	actual, err = opts.ToResourceProviderUpdateMap()
+	th.AssertNoErr(t, err)
+	expected = map[string]any{
+		"parent_provider_uuid": nil,
+	}
+	th.AssertDeepEquals(t, expected, actual)
+
+	// 3. Test nil (should be omitted)
+	opts = resourceproviders.UpdateOpts{}
+	actual, err = opts.ToResourceProviderUpdateMap()
+	th.AssertNoErr(t, err)
+	expected = map[string]any{}
+	th.AssertDeepEquals(t, expected, actual)
+}
+
 func TestGetResourceProvidersUsages(t *testing.T) {
 	fakeServer := th.SetupHTTP()
 	defer fakeServer.Teardown()


### PR DESCRIPTION
Current implementation describes the possibility to set parent_provider_uuid for a child resource provider to detach it from its parent, but actually doesn't allow it due to the use of omitempty which would clear such nil input.
To allow for this operation, I introduce the empty value of "" replaced by nil before being sent. This pattern allows for parent_provider_uuid to remain an optional argument just as in the API. Such pattern was previously introduced in DNS recordsets.

Fixes #3746
Related #526