### PR TITLE
fix(vpnaas): change encryption and auth method in acceptance tests

### DIFF
--- a/internal/acceptance/openstack/networking/v2/extensions/vpnaas/vpnaas.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/vpnaas/vpnaas.go
@@ -61,7 +61,9 @@ func CreateIPSecPolicy(t *testing.T, client *gophercloud.ServiceClient) (*ipsecp
 	t.Logf("Attempting to create IPSec policy %s", policyName)
 
 	createOpts := ipsecpolicies.CreateOpts{
-		Name: policyName,
+		Name:                policyName,
+		EncryptionAlgorithm: ipsecpolicies.EncryptionAlgorithmAES128,
+		AuthAlgorithm:       ipsecpolicies.AuthAlgorithmAESCMAC,
 	}
 
 	policy, err := ipsecpolicies.Create(context.TODO(), client, createOpts).Extract()
@@ -85,8 +87,9 @@ func CreateIKEPolicy(t *testing.T, client *gophercloud.ServiceClient) (*ikepolic
 
 	createOpts := ikepolicies.CreateOpts{
 		Name:                policyName,
-		EncryptionAlgorithm: ikepolicies.EncryptionAlgorithm3DES,
+		EncryptionAlgorithm: ikepolicies.EncryptionAlgorithmAES128,
 		PFS:                 ikepolicies.PFSGroup5,
+		AuthAlgorithm:       ikepolicies.AuthAlgorithmSHA256,
 	}
 
 	policy, err := ikepolicies.Create(context.TODO(), client, createOpts).Extract()
@@ -195,7 +198,6 @@ func DeleteEndpointGroup(t *testing.T, client *gophercloud.ServiceClient, epGrou
 	}
 
 	t.Logf("Deleted endpoint group: %s", epGroupID)
-
 }
 
 // CreateEndpointGroupWithSubnet will create an endpoint group with a random name.


### PR DESCRIPTION
The SHA1, MD5, DES, and 3DES were deprecated in a recent neutron-vpnaas patch[1], leading functional-network tests to fail[2], because it was still using the deprecated algorithms when creating IKEPolicies and IPSecPolicies.

The following is from neutron-api logs.

```bash
May 13 01:59:33 runnervmeorf1 devstack@neutron-api.service[68404]: ERROR neutron.api.v2.resource [None req-dad20a39-9d4e-4865-8313-fee6e3d275bd admin admin] create failed: No details.: oslo_db.exception.DBDataError: (pymysql.err.DataError) (1265, "Data truncated for column 'auth_algorithm' at row 1")
May 13 01:59:33 runnervmeorf1 devstack@neutron-api.service[68404]: [SQL: INSERT INTO ikepolicies (name, description, auth_algorithm, encryption_algorithm, phase1_negotiation_mode, lifetime_units, lifetime_value, ike_version, pfs, id, project_id) VALUES (%(name)s, %(description)s, %(auth_algorithm)s, %(encryption_algorithm)s, %(phase1_negotiation_mode)s, %(lifetime_units)s, %(lifetime_value)s, %(ike_version)s, %(pfs)s, %(id)s, %(project_id)s)]
May 13 01:59:33 runnervmeorf1 devstack@neutron-api.service[68404]: [parameters: {'name': 'TESTACC-qNb7XM52', 'description': '', 'auth_algorithm': 'sha1', 'encryption_algorithm': '3des', 'phase1_negotiation_mode': 'main', 'lifetime_units': 'seconds', 'lifetime_value': 3600, 'ike_version': 'v1', 'pfs': 'group5', 'id': 'a8e5f9f2-3a0a-429d-9ce5-aad7349f6819', 'project_id': '3bbedded112b4b71af57426f50e1edba'}]
May 13 01:59:33 runnervmeorf1 devstack@neutron-api.service[68404]: (Background on this error at: https://sqlalche.me/e/20/9h9h)
May 13 01:59:33 runnervmeorf1 devstack@neutron-api.service[68404]: ERROR neutron.api.v2.resource Traceback (most recent call last):
May 13 01:59:33 runnervmeorf1 devstack@neutron-api.service[68404]: ERROR neutron.api.v2.resource   File "/opt/stack/data/venv/lib/python3.12/site-packages/sqlalchemy/engine/base.py", line 1967, in _exec_single_context
May 13 01:59:33 runnervmeorf1 devstack@neutron-api.service[68404]: ERROR neutron.api.v2.resource     self.dialect.do_execute(
May 13 01:59:33 runnervmeorf1 devstack@neutron-api.service[68404]: ERROR neutron.api.v2.resource   File "/opt/stack/data/venv/lib/python3.12/site-packages/sqlalchemy/engine/default.py", line 952, in do_execute
May 13 01:59:33 runnervmeorf1 devstack@neutron-api.service[68404]: ERROR neutron.api.v2.resource     cursor.execute(statement, parameters)
May 13 01:59:33 runnervmeorf1 devstack@neutron-api.service[68404]: ERROR neutron.api.v2.resource   File "/opt/stack/data/venv/lib/python3.12/site-packages/pymysql/cursors.py", line 157, in execute
May 13 01:59:33 runnervmeorf1 devstack@neutron-api.service[68404]: ERROR neutron.api.v2.resource     result = self._query(query)
May 13 01:59:33 runnervmeorf1 devstack@neutron-api.service[68404]: ERROR neutron.api.v2.resource              ^^^^^^^^^^^^^^^^^^
May 13 01:59:33 runnervmeorf1 devstack@neutron-api.service[68404]: ERROR neutron.api.v2.resource   File "/opt/stack/data/venv/lib/python3.12/site-packages/pymysql/cursors.py", line 328, in _query
May 13 01:59:33 runnervmeorf1 devstack@neutron-api.service[68404]: ERROR neutron.api.v2.resource     conn.query(q)
May 13 01:59:33 runnervmeorf1 devstack@neutron-api.service[68404]: ERROR neutron.api.v2.resource   File "/opt/stack/data/venv/lib/python3.12/site-packages/pymysql/connections.py", line 575, in query
May 13 01:59:33 runnervmeorf1 devstack@neutron-api.service[68404]: ERROR neutron.api.v2.resource     self._affected_rows = self._read_query_result(unbuffered=unbuffered)
May 13 01:59:33 runnervmeorf1 devstack@neutron-api.service[68404]: ERROR neutron.api.v2.resource                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
May 13 01:59:33 runnervmeorf1 devstack@neutron-api.service[68404]: ERROR neutron.api.v2.resource   File "/opt/stack/data/venv/lib/python3.12/site-packages/pymysql/connections.py", line 826, in _read_query_result
May 13 01:59:33 runnervmeorf1 devstack@neutron-api.service[68404]: ERROR neutron.api.v2.resource     result.read()
May 13 01:59:33 runnervmeorf1 devstack@neutron-api.service[68404]: ERROR neutron.api.v2.resource   File "/opt/stack/data/venv/lib/python3.12/site-packages/pymysql/connections.py", line 1203, in read
May 13 01:59:33 runnervmeorf1 devstack@neutron-api.service[68404]: ERROR neutron.api.v2.resource     first_packet = self.connection._read_packet()
May 13 01:59:33 runnervmeorf1 devstack@neutron-api.service[68404]: ERROR neutron.api.v2.resource                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
May 13 01:59:33 runnervmeorf1 devstack@neutron-api.service[68404]: ERROR neutron.api.v2.resource   File "/opt/stack/data/venv/lib/python3.12/site-packages/pymysql/connections.py", line 782, in _read_packet
May 13 01:59:33 runnervmeorf1 devstack@neutron-api.service[68404]: ERROR neutron.api.v2.resource     packet.raise_for_error()
May 13 01:59:33 runnervmeorf1 devstack@neutron-api.service[68404]: ERROR neutron.api.v2.resource   File "/opt/stack/data/venv/lib/python3.12/site-packages/pymysql/protocol.py", line 219, in raise_for_error
May 13 01:59:33 runnervmeorf1 devstack@neutron-api.service[68404]: ERROR neutron.api.v2.resource     err.raise_mysql_exception(self._data)
May 13 01:59:33 runnervmeorf1 devstack@neutron-api.service[68404]: ERROR neutron.api.v2.resource   File "/opt/stack/data/venv/lib/python3.12/site-packages/pymysql/err.py", line 150, in raise_mysql_exception
May 13 01:59:33 runnervmeorf1 devstack@neutron-api.service[68404]: ERROR neutron.api.v2.resource     raise errorclass(errno, errval)
May 13 01:59:33 runnervmeorf1 devstack@neutron-api.service[68404]: ERROR neutron.api.v2.resource pymysql.err.DataError: (1265, "Data truncated for column 'auth_algorithm' at row 1")
```

[1] https://review.opendev.org/c/openstack/neutron-vpnaas/+/982383
[2] https://github.com/gophercloud/gophercloud/actions/runs/25773190059/job/75700393995
