### PR TITLE
allow port ranges in floating ip portforwarding

### DIFF
--- a/internal/acceptance/openstack/networking/v2/extensions/layer3/layer3.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/layer3/layer3.go
@@ -97,6 +97,35 @@ func CreatePortForwarding(t *testing.T, client *gophercloud.ServiceClient, fipID
 	return pf, err
 }
 
+// CreatePortRangeForwarding creates a port range forwarding for a given floating IP
+// and port. An error will be returned if the creation failed.
+func CreatePortRangeForwarding(t *testing.T, client *gophercloud.ServiceClient, fipID string, portID string, portFixedIPs []ports.IP) (*portforwarding.PortForwarding, error) {
+	t.Logf("Attempting to create Port Range forwarding for floating IP with ID: %s", fipID)
+
+	fixedIP := portFixedIPs[0]
+	internalIP := fixedIP.IPAddress
+	pfDescription := "Test description range"
+	createOpts := &portforwarding.CreateOpts{
+		Description:       pfDescription,
+		Protocol:          "tcp",
+		InternalPortRange: "1200:1299",
+		ExternalPortRange: "1200:1299",
+		InternalIPAddress: internalIP,
+		InternalPortID:    portID,
+	}
+
+	pf, err := portforwarding.Create(context.TODO(), client, fipID, createOpts).Extract()
+	if err != nil {
+		return pf, err
+	}
+
+	t.Logf("Created Port Range Forwarding.")
+
+	th.AssertEquals(t, pf.Protocol, "tcp")
+
+	return pf, err
+}
+
 // DeletePortForwarding deletes a Port Forwarding with a given ID and a given floating IP ID.
 // A fatal error is returned if the deletion fails. Works best as a deferred function
 func DeletePortForwarding(t *testing.T, client *gophercloud.ServiceClient, fipID string, pfID string) {

--- a/internal/acceptance/openstack/networking/v2/extensions/layer3/portforwardings_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/layer3/portforwardings_test.go
@@ -60,6 +60,13 @@ func TestLayer3PortForwardingsCreateDelete(t *testing.T) {
 	defer DeletePortForwarding(t, client, fip.ID, pf.ID)
 	tools.PrintResource(t, pf)
 
+	pfRange, err := CreatePortRangeForwarding(t, client, fip.ID, port.ID, port.FixedIPs)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, pfRange.Description, "Test description range")
+	defer DeletePortForwarding(t, client, fip.ID, pfRange.ID)
+	tools.PrintResource(t, pfRange)
+
+	// Test updating port
 	newPf, err := portforwarding.Get(context.TODO(), client, fip.ID, pf.ID).Extract()
 	th.AssertNoErr(t, err)
 
@@ -77,6 +84,27 @@ func TestLayer3PortForwardingsCreateDelete(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, newPf.Description, "")
 
+	// Test updating port range
+	newRangePf, err := portforwarding.Get(context.TODO(), client, fip.ID, pfRange.ID).Extract()
+	th.AssertNoErr(t, err)
+
+	updateOpts = portforwarding.UpdateOpts{
+		Description:       new(string),
+		Protocol:          "tcp",
+		InternalPortRange: "1300:1399",
+		ExternalPortRange: "1300:1399",
+	}
+
+	_, err = portforwarding.Update(context.TODO(), client, fip.ID, newRangePf.ID, updateOpts).Extract()
+	th.AssertNoErr(t, err)
+
+	newRangePf, err = portforwarding.Get(context.TODO(), client, fip.ID, pfRange.ID).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, newRangePf.Description, "")
+	th.AssertEquals(t, newRangePf.Protocol, "tcp")
+	th.AssertEquals(t, newRangePf.InternalPortRange, "1300:1399")
+	th.AssertEquals(t, newRangePf.ExternalPortRange, "1300:1399")
+
 	allPages, err := portforwarding.List(client, portforwarding.ListOpts{}, fip.ID).AllPages(context.TODO())
 	th.AssertNoErr(t, err)
 
@@ -86,6 +114,15 @@ func TestLayer3PortForwardingsCreateDelete(t *testing.T) {
 	var found bool
 	for _, pf := range allPFs {
 		if pf.ID == newPf.ID {
+			found = true
+		}
+	}
+
+	th.AssertEquals(t, true, found)
+
+	found = false
+	for _, pf := range allPFs {
+		if pf.ID == newRangePf.ID {
 			found = true
 		}
 	}

--- a/openstack/networking/v2/extensions/layer3/portforwarding/doc.go
+++ b/openstack/networking/v2/extensions/layer3/portforwarding/doc.go
@@ -44,6 +44,22 @@ Example to Create a Port Forwarding for a floating IP
 		panic(err)
 	}
 
+or, for port ranges
+
+	createOpts := &portforwarding.CreateOpts{
+		Protocol:          "tcp",
+		InternalPortRange: "100:199",
+		ExternalPortRange: "1500:1599",
+		InternalIPAddress: internalIP,
+		InternalPortID:    portID,
+	}
+
+	pf, err := portforwarding.Create(context.TODO(), networkingClient, floatingIPID, createOpts).Extract()
+
+	if err != nil {
+		panic(err)
+	}
+
 Example to Update a Port Forwarding
 
 	updateOpts := portforwarding.UpdateOpts{

--- a/openstack/networking/v2/extensions/layer3/portforwarding/requests.go
+++ b/openstack/networking/v2/extensions/layer3/portforwarding/requests.go
@@ -21,6 +21,7 @@ type ListOpts struct {
 	Description       string `q:"description"`
 	InternalPortID    string `q:"internal_port_id"`
 	ExternalPort      string `q:"external_port"`
+	ExternalPortRange string `q:"external_port_range"`
 	InternalIPAddress string `q:"internal_ip_address"`
 	Protocol          string `q:"protocol"`
 	InternalPort      string `q:"internal_port"`
@@ -62,13 +63,15 @@ func Get(ctx context.Context, c *gophercloud.ServiceClient, floatingIpId string,
 }
 
 // CreateOpts contains all the values needed to create a new port forwarding
-// resource. All attributes are required.
+// resource. Internal/External ports and port ranges are mutually exclusive.
 type CreateOpts struct {
 	Description       string `json:"description,omitempty"`
 	InternalPortID    string `json:"internal_port_id"`
 	InternalIPAddress string `json:"internal_ip_address"`
-	InternalPort      int    `json:"internal_port"`
-	ExternalPort      int    `json:"external_port"`
+	InternalPort      int    `json:"internal_port,omitempty"`
+	InternalPortRange string `json:"internal_port_range,omitempty"`
+	ExternalPort      int    `json:"external_port,omitempty"`
+	ExternalPortRange string `json:"external_port_range,omitempty"`
 	Protocol          string `json:"protocol"`
 }
 
@@ -98,12 +101,15 @@ func Create(ctx context.Context, c *gophercloud.ServiceClient, floatingIpId stri
 }
 
 // UpdateOpts contains the values used when updating a port forwarding resource.
+// Only Internal/External port values OR range values should be specified, not both or mixed.
 type UpdateOpts struct {
 	Description       *string `json:"description,omitempty"`
 	InternalPortID    string  `json:"internal_port_id,omitempty"`
 	InternalIPAddress string  `json:"internal_ip_address,omitempty"`
 	InternalPort      int     `json:"internal_port,omitempty"`
+	InternalPortRange string  `json:"internal_port_range,omitempty"`
 	ExternalPort      int     `json:"external_port,omitempty"`
+	ExternalPortRange string  `json:"external_port_range,omitempty"`
 	Protocol          string  `json:"protocol,omitempty"`
 }
 

--- a/openstack/networking/v2/extensions/layer3/portforwarding/results.go
+++ b/openstack/networking/v2/extensions/layer3/portforwarding/results.go
@@ -19,12 +19,19 @@ type PortForwarding struct {
 	// The TCP/UDP/other protocol port number of the port forwarding’s floating IP address.
 	ExternalPort int `json:"external_port"`
 
+	// The TCP/UDP/other protocol port range of the port forwarding’s floating IP address.
+	ExternalPortRange string `json:"external_port_range"`
+
 	// The IP protocol used in the floating IP port forwarding.
 	Protocol string `json:"protocol"`
 
 	// The TCP/UDP/other protocol port number of the Neutron port fixed
 	// IP address associated to the floating ip port forwarding.
 	InternalPort int `json:"internal_port"`
+
+	// The TCP/UDP/other protocol port range of the Neutron port fixed
+	// IP address associated to the floating ip port forwarding.
+	InternalPortRange string `json:"internal_port_range"`
 
 	// The fixed IPv4 address of the Neutron port associated
 	// to the floating IP port forwarding.

--- a/openstack/networking/v2/extensions/layer3/portforwarding/testing/fixtures_test.go
+++ b/openstack/networking/v2/extensions/layer3/portforwarding/testing/fixtures_test.go
@@ -20,11 +20,21 @@ const PoFw_second = `{
       "id": "e0a0274e-4d19-4eab-9e12-9e77a8caf3ea"
     }`
 
+const PoFw_third = `{
+      "protocol": "tcp",
+      "internal_ip_address": "10.0.0.19",
+      "internal_port_range": "1200:1299",
+      "internal_port_id": "dba563d2-aa9e-4a21-8cc2-3e0bdec9015a",
+      "external_port_range": "1100:1199",
+      "id": "f3a9f921-6bed-492b-a3fa-32a76fdd0159"
+    }`
+
 var ListResponse = fmt.Sprintf(`
 {
     "port_forwardings": [
 %s,
+%s,
 %s
     ]
 }
-`, PoFw, PoFw_second)
+`, PoFw, PoFw_second, PoFw_third)

--- a/openstack/networking/v2/extensions/layer3/portforwarding/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/layer3/portforwarding/testing/requests_test.go
@@ -53,6 +53,14 @@ func TestPortForwardingList(t *testing.T) {
 				ExternalPort:      2230,
 				ID:                "e0a0274e-4d19-4eab-9e12-9e77a8caf3ea",
 			},
+			{
+				Protocol:          "tcp",
+				InternalIPAddress: "10.0.0.19",
+				InternalPortRange: "1200:1299",
+				InternalPortID:    "dba563d2-aa9e-4a21-8cc2-3e0bdec9015a",
+				ExternalPortRange: "1100:1199",
+				ID:                "f3a9f921-6bed-492b-a3fa-32a76fdd0159",
+			},
 		}
 
 		th.CheckDeepEquals(t, expected, actual)
@@ -77,7 +85,7 @@ func TestCreate(t *testing.T) {
 		th.TestHeader(t, r, "Accept", "application/json")
 		th.TestJSONRequest(t, r, `
 {
-  	"port_forwarding": {
+  "port_forwarding": {
       "protocol": "tcp",
       "internal_ip_address": "10.0.0.11",
       "internal_port": 25,
@@ -85,21 +93,20 @@ func TestCreate(t *testing.T) {
       "external_port": 2230
   }
 }
-		
-			`)
+`)
 
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
 		fmt.Fprint(w, `
 {
-	"port_forwarding": {
-    		"protocol": "tcp",
-    		"internal_ip_address": "10.0.0.11",
-    		"internal_port": 25,
-    		"internal_port_id": "1238be08-a2a8-4b8d-addf-fb5e2250e480",
-    		"external_port": 2230,
-    		"id": "725ade3c-9760-4880-8080-8fc2dbab9acc"
+  "port_forwarding": {
+      "protocol": "tcp",
+      "internal_ip_address": "10.0.0.11",
+      "internal_port": 25,
+      "internal_port_id": "1238be08-a2a8-4b8d-addf-fb5e2250e480",
+      "external_port": 2230,
+      "id": "725ade3c-9760-4880-8080-8fc2dbab9acc"
   }
 }`)
 	})
@@ -120,6 +127,62 @@ func TestCreate(t *testing.T) {
 	th.AssertEquals(t, 25, pf.InternalPort)
 	th.AssertEquals(t, "1238be08-a2a8-4b8d-addf-fb5e2250e480", pf.InternalPortID)
 	th.AssertEquals(t, 2230, pf.ExternalPort)
+	th.AssertEquals(t, "tcp", pf.Protocol)
+}
+
+func TestCreateRange(t *testing.T) {
+	// Test port range
+	fakeServerRange := th.SetupHTTP()
+	defer fakeServerRange.Teardown()
+	fakeServerRange.Mux.HandleFunc("/v2.0/floatingips/f40600c2-f240-4bb0-aa76-f6f18b2aaab1/port_forwardings", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, `
+{
+      "port_forwarding": {
+          "protocol": "tcp",
+          "internal_ip_address": "10.0.0.19",
+          "internal_port_range": "1200:1299",
+          "internal_port_id": "dba563d2-aa9e-4a21-8cc2-3e0bdec9015a",
+          "external_port_range": "1100:1199"
+      }
+}
+`)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+
+		fmt.Fprint(w, `
+{
+      "port_forwarding": {
+          "protocol": "tcp",
+          "internal_ip_address": "10.0.0.19",
+          "internal_port_range": "1200:1299",
+          "internal_port_id": "dba563d2-aa9e-4a21-8cc2-3e0bdec9015a",
+          "external_port_range": "1100:1199",
+          "id": "f3a9f921-6bed-492b-a3fa-32a76fdd0159"
+      }
+}`)
+	})
+
+	options := portforwarding.CreateOpts{
+		Protocol:          "tcp",
+		InternalIPAddress: "10.0.0.19",
+		InternalPortRange: "1200:1299",
+		ExternalPortRange: "1100:1199",
+		InternalPortID:    "dba563d2-aa9e-4a21-8cc2-3e0bdec9015a",
+	}
+
+	pf, err := portforwarding.Create(context.TODO(), fake.ServiceClient(fakeServerRange), "f40600c2-f240-4bb0-aa76-f6f18b2aaab1", options).Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, "f3a9f921-6bed-492b-a3fa-32a76fdd0159", pf.ID)
+	th.AssertEquals(t, "10.0.0.19", pf.InternalIPAddress)
+	th.AssertEquals(t, "1200:1299", pf.InternalPortRange)
+	th.AssertEquals(t, "dba563d2-aa9e-4a21-8cc2-3e0bdec9015a", pf.InternalPortID)
+	th.AssertEquals(t, "1100:1199", pf.ExternalPortRange)
 	th.AssertEquals(t, "tcp", pf.Protocol)
 }
 
@@ -157,6 +220,42 @@ func TestGet(t *testing.T) {
 	th.AssertEquals(t, 25, pf.InternalPort)
 	th.AssertEquals(t, "1238be08-a2a8-4b8d-addf-fb5e2250e480", pf.InternalPortID)
 	th.AssertEquals(t, 2230, pf.ExternalPort)
+}
+
+func TestGetRange(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	fakeServer.Mux.HandleFunc("/v2.0/floatingips/2f245a7b-796b-4f26-9cf9-9e82d248fda7/port_forwardings/725ade3c-9760-4880-8080-8fc2dbab9acc", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprint(w, `
+{
+  "port_forwarding": {
+    "protocol": "tcp",
+    "internal_ip_address": "10.0.0.11",
+    "internal_port_range": "1200:1299",
+    "internal_port_id": "1238be08-a2a8-4b8d-addf-fb5e2250e480",
+    "external_port_range": "1100:1199",
+    "id": "725ade3c-9760-4880-8080-8fc2dbab9acc"
+  }
+}
+      `)
+	})
+
+	pf, err := portforwarding.Get(context.TODO(), fake.ServiceClient(fakeServer), "2f245a7b-796b-4f26-9cf9-9e82d248fda7", "725ade3c-9760-4880-8080-8fc2dbab9acc").Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, "tcp", pf.Protocol)
+	th.AssertEquals(t, "725ade3c-9760-4880-8080-8fc2dbab9acc", pf.ID)
+	th.AssertEquals(t, "10.0.0.11", pf.InternalIPAddress)
+	th.AssertEquals(t, "1200:1299", pf.InternalPortRange)
+	th.AssertEquals(t, "1238be08-a2a8-4b8d-addf-fb5e2250e480", pf.InternalPortID)
+	th.AssertEquals(t, "1100:1199", pf.ExternalPortRange)
 }
 
 func TestDelete(t *testing.T) {
@@ -230,6 +329,67 @@ func TestUpdate(t *testing.T) {
 		ID:                "725ade3c-9760-4880-8080-8fc2dbab9acc",
 		InternalPortID:    "99889dc2-19a7-4edb-b9d0-d2ace8d1e144",
 		ExternalPort:      1960,
+	}
+	th.AssertDeepEquals(t, expected, *actual)
+}
+
+func TestUpdateRange(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	fakeServer.Mux.HandleFunc("/v2.0/floatingips/2f245a7b-796b-4f26-9cf9-9e82d248fda7/port_forwardings/f3a9f921-6bed-492b-a3fa-32a76fdd0159", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, `
+{
+  "port_forwarding": {
+    "protocol": "udp",
+    "internal_port_range": "1500:1599",
+    "internal_port_id": "99889dc2-19a7-4edb-b9d0-d2ace8d1e144",
+    "external_port_range": "23000:23099"
+  }
+}
+`)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprint(w, `
+{
+  "port_forwarding": {
+    "protocol": "udp",
+    "internal_ip_address": "10.0.0.14",
+    "internal_port_range": "1500:1599",
+    "internal_port_id": "99889dc2-19a7-4edb-b9d0-d2ace8d1e144",
+    "external_port_range": "23000:23099",
+    "id": "f3a9f921-6bed-492b-a3fa-32a76fdd0159"
+  }
+}
+`)
+	})
+
+	updatedProtocol := "udp"
+	updatedInternalPortRange := "1500:1599"
+	updatedInternalPortID := "99889dc2-19a7-4edb-b9d0-d2ace8d1e144"
+	updatedExternalPortRange := "23000:23099"
+	options := portforwarding.UpdateOpts{
+		Protocol:          updatedProtocol,
+		InternalPortRange: updatedInternalPortRange,
+		InternalPortID:    updatedInternalPortID,
+		ExternalPortRange: updatedExternalPortRange,
+	}
+
+	actual, err := portforwarding.Update(context.TODO(), fake.ServiceClient(fakeServer), "2f245a7b-796b-4f26-9cf9-9e82d248fda7", "f3a9f921-6bed-492b-a3fa-32a76fdd0159", options).Extract()
+	th.AssertNoErr(t, err)
+	expected := portforwarding.PortForwarding{
+		Protocol:          "udp",
+		InternalIPAddress: "10.0.0.14",
+		InternalPortRange: "1500:1599",
+		ID:                "f3a9f921-6bed-492b-a3fa-32a76fdd0159",
+		InternalPortID:    "99889dc2-19a7-4edb-b9d0-d2ace8d1e144",
+		ExternalPortRange: "23000:23099",
 	}
 	th.AssertDeepEquals(t, expected, *actual)
 }


### PR DESCRIPTION

Fixes #3750

Added acceptance tests ranges:

=== RUN   TestLayer3PortForwardingsCreateDelete
    networking.go:35: Attempting to create network: TESTACC-OSTY0pea
    networking.go:42: Successfully created network.
    networking.go:305: Attempting to create subnet: TESTACC-3C9Bc0xM
    networking.go:312: Successfully created subnet.
    layer3.go:155: Attempting to create external router: TESTACC-6aVUKGog
    layer3.go:178: Created router: TESTACC-6aVUKGog
    networking.go:85: Attempting to create port: TESTACC-ysyRcBdk
    networking.go:109: Successfully created port: TESTACC-ysyRcBdk
    layer3.go:221: Attempting to add port b510e931-d475-45fd-a34a-4585b82bd1dd to router a257972a-fda3-484c-91eb-6060bd78006f
    layer3.go:236: Successfully added port b510e931-d475-45fd-a34a-4585b82bd1dd to router a257972a-fda3-484c-91eb-6060bd78006f
    layer3.go:24: Attempting to create floating IP on port: 
    layer3.go:38: Created floating IP.
    tools.go:89: {
          "id": "04f3adc1-7c84-4c41-8abc-9998c9040dfe",
          "description": "Test floating IP",
          "floating_network_id": "97a60fd4-aa21-436f-ba06-97b00865c6b0",
          "floating_ip_address": "149.255.36.136",
          "port_id": "",
          "fixed_ip_address": "",
          "tenant_id": "ba25a7a11cda4a3f8f88681a9fed7934",
          "project_id": "ba25a7a11cda4a3f8f88681a9fed7934",
          "status": "DOWN",
          "router_id": "",
          "tags": [],
          "revision_number": 0
        }
    layer3.go:74: Attempting to create Port forwarding for floating IP with ID: 04f3adc1-7c84-4c41-8abc-9998c9040dfe
    layer3.go:93: Created Port Forwarding.
    tools.go:89: {
          "id": "59000e6a-7642-47d5-8b1f-1532520b8eab",
          "description": "Test description",
          "internal_port_id": "b510e931-d475-45fd-a34a-4585b82bd1dd",
          "external_port": 2230,
          "external_port_range": "2230:2230",
          "protocol": "tcp",
          "internal_port": 25,
          "internal_port_range": "25:25",
          "internal_ip_address": "192.168.54.184"
        }
    layer3.go:103: Attempting to create Port Range forwarding for floating IP with ID: 04f3adc1-7c84-4c41-8abc-9998c9040dfe
    layer3.go:122: Created Port Range Forwarding.
    tools.go:89: {
          "id": "3172eb85-a518-465b-93f9-c2e23cf1a111",
          "description": "Test description range",
          "internal_port_id": "b510e931-d475-45fd-a34a-4585b82bd1dd",
          "external_port": 0,
          "external_port_range": "1200:1299",
          "protocol": "tcp",
          "internal_port": 0,
          "internal_port_range": "1200:1299",
          "internal_ip_address": "192.168.54.184"
        }
    layer3.go:132: Attempting to delete the port forwarding with ID 3172eb85-a518-465b-93f9-c2e23cf1a111 for floating IP with ID 04f3adc1-7c84-4c41-8abc-9998c9040dfe
    layer3.go:138: Successfully deleted the port forwarding with ID 3172eb85-a518-465b-93f9-c2e23cf1a111 for floating IP with ID 04f3adc1-7c84-4c41-8abc-9998c9040dfe
    layer3.go:132: Attempting to delete the port forwarding with ID 59000e6a-7642-47d5-8b1f-1532520b8eab for floating IP with ID 04f3adc1-7c84-4c41-8abc-9998c9040dfe
    layer3.go:138: Successfully deleted the port forwarding with ID 59000e6a-7642-47d5-8b1f-1532520b8eab for floating IP with ID 04f3adc1-7c84-4c41-8abc-9998c9040dfe
    layer3.go:305: Attempting to delete floating IP: 04f3adc1-7c84-4c41-8abc-9998c9040dfe
    layer3.go:312: Deleted floating IP: 04f3adc1-7c84-4c41-8abc-9998c9040dfe
    layer3.go:283: Attempting to detach port b510e931-d475-45fd-a34a-4585b82bd1dd from router a257972a-fda3-484c-91eb-6060bd78006f
    layer3.go:298: Successfully detached port b510e931-d475-45fd-a34a-4585b82bd1dd from router a257972a-fda3-484c-91eb-6060bd78006f
    layer3.go:265: Attempting to delete router: a257972a-fda3-484c-91eb-6060bd78006f
    layer3.go:276: Deleted router: a257972a-fda3-484c-91eb-6060bd78006f
    networking.go:553: Attempting to delete subnet: 53265daf-13bd-4bed-ac97-480d865bfefb
    networking.go:560: Deleted subnet: 53265daf-13bd-4bed-ac97-480d865bfefb
    networking.go:525: Attempting to delete network: 724286e5-306a-448e-9d9a-d1b7289b91c6
    networking.go:532: Deleted network: 724286e5-306a-448e-9d9a-d1b7289b91c6
--- PASS: TestLayer3PortForwardingsCreateDelete (17.72s)
PASS
ok  	github.com/gophercloud/gophercloud/v2/internal/acceptance/openstack/networking/v2/extensions/layer3	17.722s