### PR TITLE
Add Placement resourceprovider list post 1.39

### DIFF
--- a/internal/acceptance/openstack/placement/v1/placement.go
+++ b/internal/acceptance/openstack/placement/v1/placement.go
@@ -10,6 +10,13 @@ import (
 	th "github.com/gophercloud/gophercloud/v2/testhelper"
 )
 
+func restoreClientMicroversion(client *gophercloud.ServiceClient) func() {
+	originalMicroversion := client.Microversion
+	return func() {
+		client.Microversion = originalMicroversion
+	}
+}
+
 func CreateResourceProvider(t *testing.T, client *gophercloud.ServiceClient) (*resourceproviders.ResourceProvider, error) {
 	name := tools.RandomString("TESTACC-", 8)
 	t.Logf("Attempting to create resource provider: %s", name)
@@ -17,6 +24,8 @@ func CreateResourceProvider(t *testing.T, client *gophercloud.ServiceClient) (*r
 	createOpts := resourceproviders.CreateOpts{
 		Name: name,
 	}
+
+	defer restoreClientMicroversion(client)()
 
 	client.Microversion = "1.20"
 	resourceProvider, err := resourceproviders.Create(context.TODO(), client, createOpts).Extract()
@@ -40,6 +49,8 @@ func CreateResourceProviderWithParent(t *testing.T, client *gophercloud.ServiceC
 		Name:               name,
 		ParentProviderUUID: parentUUID,
 	}
+
+	defer restoreClientMicroversion(client)()
 
 	client.Microversion = "1.20"
 	resourceProvider, err := resourceproviders.Create(context.TODO(), client, createOpts).Extract()

--- a/internal/acceptance/openstack/placement/v1/resourceproviders_test.go
+++ b/internal/acceptance/openstack/placement/v1/resourceproviders_test.go
@@ -6,12 +6,14 @@ import (
 	"context"
 	"net/http"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/internal/acceptance/clients"
 	"github.com/gophercloud/gophercloud/v2/internal/acceptance/tools"
 	"github.com/gophercloud/gophercloud/v2/openstack/placement/v1/resourceproviders"
+	"github.com/gophercloud/gophercloud/v2/openstack/placement/v1/traits"
 	th "github.com/gophercloud/gophercloud/v2/testhelper"
 )
 
@@ -33,6 +35,76 @@ func TestResourceProviderList(t *testing.T) {
 	for _, v := range allResourceProviders {
 		tools.PrintResource(t, v)
 	}
+}
+
+func TestResourceProviderList139(t *testing.T) {
+	clients.RequireAdmin(t)
+
+	client, err := clients.NewPlacementV1Client()
+	th.AssertNoErr(t, err)
+
+	client.Microversion = "1.39"
+
+	// Arrange: Create a resource provider, traits, and aggregates.
+	// Assign them to the created RP.
+	resourceProvider, err := CreateResourceProvider(t, client)
+	th.AssertNoErr(t, err)
+	defer DeleteResourceProvider(t, client, resourceProvider.UUID)
+
+	trait1 := strings.ToUpper(tools.RandomString("CUSTOM_", 8))
+	trait2 := strings.ToUpper(tools.RandomString("CUSTOM_", 8))
+	err = traits.Create(context.TODO(), client, trait1).ExtractErr()
+	th.AssertNoErr(t, err)
+	defer traits.Delete(context.TODO(), client, trait1)
+	err = traits.Create(context.TODO(), client, trait2).ExtractErr()
+	th.AssertNoErr(t, err)
+	defer traits.Delete(context.TODO(), client, trait2)
+
+	currentTraits, err := resourceproviders.GetTraits(context.TODO(), client, resourceProvider.UUID).Extract()
+	th.AssertNoErr(t, err)
+
+	_, err = resourceproviders.UpdateTraits(context.TODO(), client, resourceProvider.UUID, resourceproviders.UpdateTraitsOpts{
+		ResourceProviderGeneration: currentTraits.ResourceProviderGeneration,
+		Traits:                     []string{trait1, trait2},
+	}).Extract()
+	th.AssertNoErr(t, err)
+
+	currentAggregates, err := resourceproviders.GetAggregates(context.TODO(), client, resourceProvider.UUID).Extract()
+	th.AssertNoErr(t, err)
+
+	aggregate1 := tools.RandomUUID()
+	aggregate2 := tools.RandomUUID()
+	aggregate3 := tools.RandomUUID()
+	_, err = resourceproviders.UpdateAggregates(context.TODO(), client, resourceProvider.UUID, resourceproviders.UpdateAggregatesOpts{
+		ResourceProviderGeneration: currentAggregates.ResourceProviderGeneration,
+		Aggregates:                 []string{aggregate1, aggregate2},
+	}).Extract()
+	th.AssertNoErr(t, err)
+
+	listOpts := resourceproviders.ListOpts139{
+		// Repeating member_of means AND: provider must be in aggregate1 and in any of (aggregate2, aggregate3).
+		// We'll expect list to return our provider.
+		MemberOf: []string{aggregate1, "in:" + aggregate2 + "," + aggregate3},
+		Required: []string{trait1, trait2},
+	}
+
+	// Act: List resource providers with the above traits and aggregates as filters.
+	allPages, err := resourceproviders.List(client, listOpts).AllPages(context.TODO())
+	th.AssertNoErr(t, err)
+
+	// Assert: Our resource provider is in the results and has the traits and aggregates we set.
+	allResourceProviders, err := resourceproviders.ExtractResourceProviders(allPages)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, true, len(allResourceProviders) > 0)
+
+	found := false
+	for _, rp := range allResourceProviders {
+		if rp.UUID == resourceProvider.UUID {
+			found = true
+			break
+		}
+	}
+	th.AssertEquals(t, true, found)
 }
 
 func TestResourceProvider(t *testing.T) {
@@ -311,6 +383,8 @@ func TestResourceProviderDeleteInventoriesSuccess(t *testing.T) {
 	client, err := clients.NewPlacementV1Client()
 	th.AssertNoErr(t, err)
 
+	client.Microversion = "1.20"
+
 	resourceProvider, err := CreateResourceProvider(t, client)
 	th.AssertNoErr(t, err)
 	defer DeleteResourceProvider(t, client, resourceProvider.UUID)
@@ -421,6 +495,8 @@ func TestResourceProviderTraits(t *testing.T) {
 
 	client, err := clients.NewPlacementV1Client()
 	th.AssertNoErr(t, err)
+
+	client.Microversion = "1.20"
 
 	// first create new resource provider
 	resourceProvider, err := CreateResourceProvider(t, client)

--- a/openstack/placement/v1/resourceproviders/doc.go
+++ b/openstack/placement/v1/resourceproviders/doc.go
@@ -17,6 +17,29 @@ Example to list resource providers
 		fmt.Printf("%+v\n", r)
 	}
 
+Example to list resource providers with repeating member_of and required parameters (microversion >= 1.39)
+
+	placementClient.Microversion = "1.39"
+
+	listOpts := resourceproviders.ListOpts139{
+		MemberOf: []string{"42896e0d-205d-4fe3-bd1e-100924931787", "in:7834d585-31d4-486f-be8c-b3c1a58ca710,5e08ea53-c4c6-448e-9334-ac4953de3cfa"},
+		Required: []string{"CUSTOM_TRAIT1", "CUSTOM_TRAIT2"},
+	}
+
+	allPages, err := resourceproviders.List(placementClient, listOpts).AllPages(context.TODO())
+	if err != nil {
+		panic(err)
+	}
+
+	allResourceProviders, err := resourceproviders.ExtractResourceProviders(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, r := range allResourceProviders {
+		fmt.Printf("%+v\n", r)
+	}
+
 Example to create resource providers
 
 	createOpts := resourceproviders.CreateOpts{

--- a/openstack/placement/v1/resourceproviders/microversions.go
+++ b/openstack/placement/v1/resourceproviders/microversions.go
@@ -1,0 +1,40 @@
+package resourceproviders
+
+import "github.com/gophercloud/gophercloud/v2"
+
+// ListOpts139 allows filtering resource providers. Filtering is achieved by
+// passing in struct field values that map to the resource provider
+// attributes you want to see returned.
+// ListOpts139 is available in version >= 1.39.
+type ListOpts139 struct {
+	// Name is the name of the resource provider to filter the list
+	Name string `q:"name"`
+
+	// UUID is the uuid of the resource provider to filter the list
+	UUID string `q:"uuid"`
+
+	// MemberOf is a list representing aggregate uuids that a provider must be
+	// associated with to be returned.
+	// Alternative is defined using the in: syntax, e.g. member_of=in:agg1,agg2,agg3.
+	// Forbidden aggregates are prefixed with !.
+	// Starting with microversion 1.24, the member_of parameter may be repeated.
+	MemberOf []string `q:"member_of"`
+
+	// Resources is a comma-separated list of string indicating an amount of resource
+	// of a specified class that a provider must have the capacity and availability to serve
+	Resources string `q:"resources"`
+
+	// InTree is a string that represents a resource provider UUID.  The returned resource
+	// providers will be in the same provider tree as the specified provider.
+	InTree string `q:"in_tree"`
+
+	// Required is a list of trait names.
+	// Microversion 1.39 added support for repeating the required parameter and for the in: syntax.
+	Required []string `q:"required"`
+}
+
+// ToResourceProviderListQuery formats a ListOpts139 into a query string.
+func (opts ListOpts139) ToResourceProviderListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}

--- a/openstack/placement/v1/resourceproviders/testing/fixtures_test.go
+++ b/openstack/placement/v1/resourceproviders/testing/fixtures_test.go
@@ -433,6 +433,25 @@ func HandleResourceProviderList(t *testing.T, fakeServer th.FakeServer) {
 		})
 }
 
+func HandleResourceProviderList139(t *testing.T, fakeServer th.FakeServer) {
+	fakeServer.Mux.HandleFunc("/resource_providers",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "GET")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+			q := r.URL.Query()
+			th.AssertDeepEquals(t,
+				[]string{"a09ba171-9405-40ca-bfe1-a8d1208af2ed", "47abce38-8a58-47b3-81e0-c647e37e03ae"},
+				q["member_of"])
+			th.AssertDeepEquals(t, []string{"HW:A_TRAIT", "CUSTOM_TRAIT"}, q["required"])
+
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+
+			fmt.Fprint(w, ResourceProvidersBody)
+		})
+}
+
 func HandleResourceProviderCreate(t *testing.T, fakeServer th.FakeServer) {
 	fakeServer.Mux.HandleFunc("/resource_providers", func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "POST")

--- a/openstack/placement/v1/resourceproviders/testing/requests_test.go
+++ b/openstack/placement/v1/resourceproviders/testing/requests_test.go
@@ -40,6 +40,33 @@ func TestListResourceProviders(t *testing.T) {
 	}
 }
 
+func TestListResourceProviders139(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	HandleResourceProviderList139(t, fakeServer)
+
+	count := 0
+	opts := resourceproviders.ListOpts139{
+		MemberOf: []string{"a09ba171-9405-40ca-bfe1-a8d1208af2ed", "47abce38-8a58-47b3-81e0-c647e37e03ae"},
+		Required: []string{"HW:A_TRAIT", "CUSTOM_TRAIT"},
+	}
+	err := resourceproviders.List(client.ServiceClient(fakeServer), opts).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
+		count++
+
+		actual, err := resourceproviders.ExtractResourceProviders(page)
+		if err != nil {
+			t.Errorf("Failed to extract resource providers: %v", err)
+			return false, err
+		}
+		th.AssertDeepEquals(t, ExpectedResourceProviders, actual)
+
+		return true, nil
+	})
+
+	th.AssertNoErr(t, err)
+}
+
 func TestCreateResourceProvider(t *testing.T) {
 	fakeServer := th.SetupHTTP()
 	defer fakeServer.Teardown()


### PR DESCRIPTION
Allows for repeating required and member_of arguments. Change of the type of field, microversions.go required.

Related #526