### PR TITLE
ci(magnum): deprecate heat and use magnum-cluster-api driver

### DIFF
--- a/.github/workflows/functional-containerinfra.yaml
+++ b/.github/workflows/functional-containerinfra.yaml
@@ -15,21 +15,12 @@ jobs:
           - name: "master"
             openstack_version: "master"
             ubuntu_version: "24.04"
-            devstack_conf_overrides: |
-              enable_plugin magnum https://github.com/openstack/magnum master
-              MAGNUMCLIENT_BRANCH=master
           - name: "gazpacho"
             openstack_version: "stable/2026.1"
             ubuntu_version: "24.04"
-            devstack_conf_overrides: |
-              enable_plugin magnum https://github.com/openstack/magnum stable/2026.1
-              MAGNUMCLIENT_BRANCH=stable/2026.1
           - name: "epoxy"
             openstack_version: "stable/2025.1"
             ubuntu_version: "24.04"
-            devstack_conf_overrides: |
-              enable_plugin magnum https://github.com/openstack/magnum stable/2025.1
-              MAGNUMCLIENT_BRANCH=stable/2025.1
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Magnum on OpenStack ${{ matrix.name }}
     steps:
@@ -65,14 +56,17 @@ jobs:
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |
+            enable_plugin magnum https://github.com/openstack/magnum ${{ matrix.openstack_version }}
+            enable_plugin magnum-cluster-api https://github.com/vexxhost/magnum-cluster-api main
             enable_plugin barbican https://github.com/openstack/barbican ${{ matrix.openstack_version }}
-            enable_plugin heat https://github.com/openstack/heat ${{ matrix.openstack_version }}
+
+            MAGNUMCLIENT_BRANCH=${{ matrix.openstack_version }}
+            MAGNUM_GUEST_IMAGE_URL=https://github.com/vexxhost/capo-image-elements/releases/download/2026.05-1/ubuntu-24.04-v1.35.4.qcow2
+
             GLANCE_LIMIT_IMAGE_SIZE_TOTAL=5000
             SWIFT_MAX_FILE_SIZE=5368709122
             KEYSTONE_ADMIN_ENDPOINT=true
-
-            ${{ matrix.devstack_conf_overrides }}
-          enabled_services: "h-eng,h-api,h-api-cfn,h-api-cw,openstack-cli-server"
+          enabled_services: "openstack-cli-server"
 
       - name: Checkout go
         if: ${{ fromJSON(steps.changed-files.outputs.matches) }}

--- a/.github/workflows/functional-containerinfra.yaml
+++ b/.github/workflows/functional-containerinfra.yaml
@@ -15,12 +15,27 @@ jobs:
           - name: "master"
             openstack_version: "master"
             ubuntu_version: "24.04"
+            devstack_conf_overrides: |
+              enable_plugin magnum https://github.com/openstack/magnum master
+              enable_plugin magnum-cluster-api https://github.com/vexxhost/magnum-cluster-api main
+
+              MAGNUM_GUEST_IMAGE_URL=https://github.com/vexxhost/capo-image-elements/releases/download/2026.05-1/ubuntu-24.04-v1.35.4.qcow2
           - name: "gazpacho"
             openstack_version: "stable/2026.1"
             ubuntu_version: "24.04"
+            devstack_conf_overrides: |
+              enable_plugin magnum https://github.com/openstack/magnum stable/2026.1
+              enable_plugin magnum-cluster-api https://github.com/vexxhost/magnum-cluster-api main
+
+              MAGNUM_GUEST_IMAGE_URL=https://github.com/vexxhost/capo-image-elements/releases/download/2026.05-1/ubuntu-24.04-v1.35.4.qcow2
           - name: "epoxy"
             openstack_version: "stable/2025.1"
             ubuntu_version: "24.04"
+            devstack_conf_overrides: |
+              enable_plugin magnum https://github.com/openstack/magnum stable/2025.1
+
+              enable_plugin heat https://github.com/openstack/heat stable/2025.1
+              ENABLED_SERVICES+=h-eng,h-api,h-api-cfn,h-api,cw
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Magnum on OpenStack ${{ matrix.name }}
     steps:
@@ -43,6 +58,7 @@ jobs:
             openstack/utils/discovery.go
             **containerinfra**
             .github/workflows/functional-containerinfra.yaml
+            script/stackenv
 
       - name: Skip tests for unrelated changed-files
         if: ${{ ! fromJSON(steps.changed-files.outputs.matches) }}
@@ -56,16 +72,15 @@ jobs:
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |
-            enable_plugin magnum https://github.com/openstack/magnum ${{ matrix.openstack_version }}
-            enable_plugin magnum-cluster-api https://github.com/vexxhost/magnum-cluster-api main
             enable_plugin barbican https://github.com/openstack/barbican ${{ matrix.openstack_version }}
 
             MAGNUMCLIENT_BRANCH=${{ matrix.openstack_version }}
-            MAGNUM_GUEST_IMAGE_URL=https://github.com/vexxhost/capo-image-elements/releases/download/2026.05-1/ubuntu-24.04-v1.35.4.qcow2
 
             GLANCE_LIMIT_IMAGE_SIZE_TOTAL=5000
             SWIFT_MAX_FILE_SIZE=5368709122
             KEYSTONE_ADMIN_ENDPOINT=true
+
+            ${{ matrix.devstack_conf_overrides }}
           enabled_services: "openstack-cli-server"
 
       - name: Checkout go

--- a/script/stackenv
+++ b/script/stackenv
@@ -71,10 +71,7 @@ EOL
 fi
 
 if _=$(openstack service list | grep container-infra); then
-    _MAGNUM_IMAGE_ID=$(openstack image list --format value -c Name -c ID | grep coreos | cut -d ' ' -f 1)
-    if [ -z "$_MAGNUM_IMAGE_ID" ]; then
-        _MAGNUM_IMAGE_ID=$(openstack image list --format value -c Name -c ID | grep -i atomic | cut -d ' ' -f 1)
-    fi
+    _MAGNUM_IMAGE_ID=$(openstack image list --format value -c Name -c ID | grep ubuntu | cut -d ' ' -f 1)
     cat >> "openrc" <<EOL
 export OS_MAGNUM_IMAGE_ID="$_MAGNUM_IMAGE_ID"
 export OS_MAGNUM_KEYPAIR=magnum

--- a/script/stackenv
+++ b/script/stackenv
@@ -71,7 +71,12 @@ EOL
 fi
 
 if _=$(openstack service list | grep container-infra); then
-    _MAGNUM_IMAGE_ID=$(openstack image list --format value -c Name -c ID | grep ubuntu | cut -d ' ' -f 1)
+    _MAGNUM_IMAGE_ID=$(openstack image list --format value -c Name -c ID | grep ubuntu | cut -d ' ' -f 1 || true)
+
+    if [[ -z "${_MAGNUM_IMAGE_ID}" ]]; then
+        # Fallback to the CoreOS image used on Epoxy release.
+        _MAGNUM_IMAGE_ID=$(openstack image list --format value -c Name -c ID | grep coreos | cut -d ' ' -f 1)
+    fi
     cat >> "openrc" <<EOL
 export OS_MAGNUM_IMAGE_ID="$_MAGNUM_IMAGE_ID"
 export OS_MAGNUM_KEYPAIR=magnum


### PR DESCRIPTION
As Magnum moved towards removing the Heat driver to use out-of-tree drivers instead[1], we cannot rely on it anymore in our CI. This pull request changes the `functional-containerinfra` job to use the `vexxhost/magnum-cluster-api`[2] plugin that's also being used upstream[3].

The Vexxhost's driver spins up a Kubernetes cluster using Kind, installs all the dependencies, such as: kubectl, clusterctl, and CAPI, with OpenStack as the infrastructure provider (so we also have ORC here 🤩 ).

Let's see how it goes.

[1] https://review.opendev.org/c/openstack/magnum/+/985348
[2] https://github.com/vexxhost/magnum-cluster-api
[3] https://review.opendev.org/c/openstack/magnum-tempest-plugin/+/987846


