### PR TITLE
openstack/db: add Trove datastore admin and backup APIs

### DIFF
--- a/openstack/db/v1/backups/doc.go
+++ b/openstack/db/v1/backups/doc.go
@@ -1,0 +1,3 @@
+// Package backups provides information and interaction with database backups
+// for the OpenStack Database service.
+package backups

--- a/openstack/db/v1/backups/requests.go
+++ b/openstack/db/v1/backups/requests.go
@@ -1,0 +1,119 @@
+package backups
+
+import (
+	"context"
+
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/pagination"
+)
+
+// ListOptsBuilder allows extensions to add additional parameters to the List
+// request.
+type ListOptsBuilder interface {
+	ToBackupListQuery() (string, error)
+}
+
+// ListOpts represents options for listing database backups.
+type ListOpts struct {
+	// Return the list of backups for a particular database instance.
+	InstanceID string `q:"instance_id"`
+	// Return the list of backups for all projects. Admin only.
+	AllProjects bool `q:"all_projects"`
+	// Return backups for a particular datastore.
+	Datastore string `q:"datastore"`
+	// Return backups for a particular project. Admin only.
+	ProjectID string `q:"project_id"`
+}
+
+// ToBackupListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToBackupListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List will list database backups.
+func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := baseURL(client)
+	if opts != nil {
+		query, err := opts.ToBackupListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return BackupPage{pagination.SinglePageBase(r)}
+	})
+}
+
+// ListByInstance will list backups for a database instance.
+func ListByInstance(client *gophercloud.ServiceClient, instanceID string) pagination.Pager {
+	return pagination.NewPager(client, instanceURL(client, instanceID), func(r pagination.PageResult) pagination.Page {
+		return BackupPage{pagination.SinglePageBase(r)}
+	})
+}
+
+// CreateOptsBuilder is the top-level interface for create backup options.
+type CreateOptsBuilder interface {
+	ToBackupCreateMap() (map[string]any, error)
+}
+
+// RestoreFromOpts contains information for restoring a backup from a remote
+// location.
+type RestoreFromOpts struct {
+	RemoteLocation          string  `json:"remote_location,omitempty"`
+	LocalDatastoreVersionID string  `json:"local_datastore_version_id,omitempty"`
+	Size                    float64 `json:"size,omitempty"`
+}
+
+// CreateOpts represents options for creating a database backup.
+type CreateOpts struct {
+	// Name of the backup.
+	Name string `json:"name" required:"true"`
+	// ID of the instance to create a backup for.
+	InstanceID string `json:"instance,omitempty"`
+	// ID of the parent backup to perform an incremental backup from.
+	ParentID string `json:"parent_id,omitempty"`
+	// Set to 1 to create an incremental backup based on the last full backup.
+	Incremental *int `json:"incremental,omitempty"`
+	// An optional description for the backup.
+	Description string `json:"description,omitempty"`
+	// User-defined Swift container name.
+	SwiftContainer string `json:"swift_container,omitempty"`
+	// Information needed to restore a remote backup.
+	RestoreFrom *RestoreFromOpts `json:"restore_from,omitempty"`
+	// Backup storage driver.
+	StorageDriver string `json:"storage_driver,omitempty"`
+}
+
+// ToBackupCreateMap converts a CreateOpts struct into a request body.
+func (opts CreateOpts) ToBackupCreateMap() (map[string]any, error) {
+	return gophercloud.BuildRequestBody(opts, "backup")
+}
+
+// Create creates a database backup.
+func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToBackupCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := client.Post(ctx, baseURL(client), &b, &r.Body, &gophercloud.RequestOpts{OkCodes: []int{202}})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// Get retrieves details for a database backup.
+func Get(ctx context.Context, client *gophercloud.ServiceClient, backupID string) (r GetResult) {
+	resp, err := client.Get(ctx, resourceURL(client, backupID), &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// Delete deletes a database backup.
+func Delete(ctx context.Context, client *gophercloud.ServiceClient, backupID string) (r DeleteResult) {
+	resp, err := client.Delete(ctx, resourceURL(client, backupID), &gophercloud.RequestOpts{OkCodes: []int{202}})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}

--- a/openstack/db/v1/backups/results.go
+++ b/openstack/db/v1/backups/results.go
@@ -1,0 +1,98 @@
+package backups
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/openstack/db/v1/datastores"
+	"github.com/gophercloud/gophercloud/v2/pagination"
+)
+
+// Backup represents a database backup.
+type Backup struct {
+	Created       time.Time `json:"-"`
+	Datastore     datastores.DatastorePartial
+	Description   string
+	ID            string
+	InstanceID    string `json:"instance_id"`
+	LocationRef   string `json:"locationRef"`
+	Name          string
+	ParentID      string `json:"parent_id"`
+	ProjectID     string `json:"project_id"`
+	Size          float64
+	Status        string
+	StorageDriver string    `json:"storage_driver"`
+	Updated       time.Time `json:"-"`
+}
+
+// UnmarshalJSON converts backup timestamps to time.Time.
+func (r *Backup) UnmarshalJSON(b []byte) error {
+	type tmp Backup
+	var s struct {
+		tmp
+		Created gophercloud.JSONRFC3339NoZ `json:"created"`
+		Updated gophercloud.JSONRFC3339NoZ `json:"updated"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	*r = Backup(s.tmp)
+	r.Created = time.Time(s.Created)
+	r.Updated = time.Time(s.Updated)
+	return nil
+}
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// Extract retrieves a Backup resource from an operation result.
+func (r commonResult) Extract() (*Backup, error) {
+	var s struct {
+		Backup *Backup `json:"backup"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Backup, err
+}
+
+// CreateResult represents the result of a Create operation.
+type CreateResult struct {
+	commonResult
+}
+
+// GetResult represents the result of a Get operation.
+type GetResult struct {
+	commonResult
+}
+
+// DeleteResult represents the result of a Delete operation.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
+// BackupPage represents a page of database backups.
+type BackupPage struct {
+	pagination.SinglePageBase
+}
+
+// IsEmpty indicates whether a BackupPage is empty.
+func (r BackupPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
+	backups, err := ExtractBackups(r)
+	return len(backups) == 0, err
+}
+
+// ExtractBackups retrieves a slice of Backup structs from a paginated
+// collection.
+func ExtractBackups(r pagination.Page) ([]Backup, error) {
+	var s struct {
+		Backups []Backup `json:"backups"`
+	}
+	err := (r.(BackupPage)).ExtractInto(&s)
+	return s.Backups, err
+}

--- a/openstack/db/v1/backups/testing/doc.go
+++ b/openstack/db/v1/backups/testing/doc.go
@@ -1,0 +1,2 @@
+// db_backups_v1
+package testing

--- a/openstack/db/v1/backups/testing/fixtures_test.go
+++ b/openstack/db/v1/backups/testing/fixtures_test.go
@@ -1,0 +1,74 @@
+package testing
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/openstack/db/v1/backups"
+	"github.com/gophercloud/gophercloud/v2/openstack/db/v1/datastores"
+)
+
+var (
+	timestamp  = "2014-10-30T12:30:00"
+	timeVal, _ = time.Parse(gophercloud.RFC3339NoZ, timestamp)
+)
+
+const singleBackupJSON = `
+{
+  "created": "2014-10-30T12:30:00",
+  "datastore": {
+    "type": "mysql",
+    "version": "5.5",
+    "version_id": "b00000b0-00b0-0b00-00b0-000b000000bb"
+  },
+  "description": "My Backup",
+  "id": "a9832168-7541-4536-b8d9-a8a9b79cf1b4",
+  "instance_id": "44b277eb-39be-4921-be31-3d61b43651d7",
+  "locationRef": "http://localhost/path/to/backup",
+  "name": "snapshot",
+  "parent_id": "",
+  "project_id": "922b47766bcb448f83a760358337f2b4",
+  "size": 0.14,
+  "status": "COMPLETED",
+  "updated": "2014-10-30T12:30:00",
+  "storage_driver": "swift"
+}
+`
+
+var (
+	ListBackupsJSON  = fmt.Sprintf(`{"backups": [%s]}`, singleBackupJSON)
+	GetBackupJSON    = fmt.Sprintf(`{"backup": %s}`, singleBackupJSON)
+	CreateBackupJSON = fmt.Sprintf(`{"backup": %s}`, singleBackupJSON)
+)
+
+var CreateBackupReq = `
+{
+  "backup": {
+    "description": "My Backup",
+    "incremental": 0,
+    "instance": "44b277eb-39be-4921-be31-3d61b43651d7",
+    "name": "snapshot",
+    "storage_driver": "swift"
+  }
+}
+`
+
+var ExampleBackup = backups.Backup{
+	Created: timeVal,
+	Datastore: datastores.DatastorePartial{
+		Type:      "mysql",
+		Version:   "5.5",
+		VersionID: "b00000b0-00b0-0b00-00b0-000b000000bb",
+	},
+	Description:   "My Backup",
+	ID:            "a9832168-7541-4536-b8d9-a8a9b79cf1b4",
+	InstanceID:    "44b277eb-39be-4921-be31-3d61b43651d7",
+	LocationRef:   "http://localhost/path/to/backup",
+	Name:          "snapshot",
+	ProjectID:     "922b47766bcb448f83a760358337f2b4",
+	Size:          0.14,
+	Status:        "COMPLETED",
+	StorageDriver: "swift",
+	Updated:       timeVal,
+}

--- a/openstack/db/v1/backups/testing/requests_test.go
+++ b/openstack/db/v1/backups/testing/requests_test.go
@@ -1,0 +1,102 @@
+package testing
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/v2/openstack/db/v1/backups"
+	"github.com/gophercloud/gophercloud/v2/pagination"
+	th "github.com/gophercloud/gophercloud/v2/testhelper"
+	"github.com/gophercloud/gophercloud/v2/testhelper/client"
+	"github.com/gophercloud/gophercloud/v2/testhelper/fixture"
+)
+
+const (
+	rootURL     = "/backups"
+	backupID    = "a9832168-7541-4536-b8d9-a8a9b79cf1b4"
+	resourceURL = rootURL + "/" + backupID
+	instanceID  = "44b277eb-39be-4921-be31-3d61b43651d7"
+	instanceURL = "/instances/" + instanceID + "/backups"
+)
+
+func TestList(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	fixture.SetupHandler(t, fakeServer, rootURL, "GET", "", ListBackupsJSON, 200)
+
+	pages := 0
+	err := backups.List(client.ServiceClient(fakeServer), nil).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
+		pages++
+
+		actual, err := backups.ExtractBackups(page)
+		if err != nil {
+			return false, err
+		}
+
+		th.AssertDeepEquals(t, []backups.Backup{ExampleBackup}, actual)
+		return true, nil
+	})
+
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, 1, pages)
+}
+
+func TestListByInstance(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	fixture.SetupHandler(t, fakeServer, instanceURL, "GET", "", ListBackupsJSON, 200)
+
+	pages := 0
+	err := backups.ListByInstance(client.ServiceClient(fakeServer), instanceID).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
+		pages++
+
+		actual, err := backups.ExtractBackups(page)
+		if err != nil {
+			return false, err
+		}
+
+		th.AssertDeepEquals(t, []backups.Backup{ExampleBackup}, actual)
+		return true, nil
+	})
+
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, 1, pages)
+}
+
+func TestCreate(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	fixture.SetupHandler(t, fakeServer, rootURL, "POST", CreateBackupReq, CreateBackupJSON, 202)
+
+	incremental := 0
+	opts := backups.CreateOpts{
+		Name:          "snapshot",
+		InstanceID:    instanceID,
+		Description:   "My Backup",
+		Incremental:   &incremental,
+		StorageDriver: "swift",
+	}
+
+	backup, err := backups.Create(context.TODO(), client.ServiceClient(fakeServer), opts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, &ExampleBackup, backup)
+}
+
+func TestGet(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	fixture.SetupHandler(t, fakeServer, resourceURL, "GET", "", GetBackupJSON, 200)
+
+	backup, err := backups.Get(context.TODO(), client.ServiceClient(fakeServer), backupID).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, &ExampleBackup, backup)
+}
+
+func TestDelete(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	fixture.SetupHandler(t, fakeServer, resourceURL, "DELETE", "", "", 202)
+
+	err := backups.Delete(context.TODO(), client.ServiceClient(fakeServer), backupID).ExtractErr()
+	th.AssertNoErr(t, err)
+}

--- a/openstack/db/v1/backups/urls.go
+++ b/openstack/db/v1/backups/urls.go
@@ -1,0 +1,15 @@
+package backups
+
+import "github.com/gophercloud/gophercloud/v2"
+
+func baseURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("backups")
+}
+
+func resourceURL(c *gophercloud.ServiceClient, backupID string) string {
+	return c.ServiceURL("backups", backupID)
+}
+
+func instanceURL(c *gophercloud.ServiceClient, instanceID string) string {
+	return c.ServiceURL("instances", instanceID, "backups")
+}

--- a/openstack/db/v1/backupstrategies/doc.go
+++ b/openstack/db/v1/backupstrategies/doc.go
@@ -1,0 +1,3 @@
+// Package backupstrategies provides information and interaction with database
+// backup strategies for the OpenStack Database service.
+package backupstrategies

--- a/openstack/db/v1/backupstrategies/requests.go
+++ b/openstack/db/v1/backupstrategies/requests.go
@@ -1,0 +1,113 @@
+package backupstrategies
+
+import (
+	"context"
+
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/pagination"
+)
+
+// ListOptsBuilder allows extensions to add additional parameters to the List
+// request.
+type ListOptsBuilder interface {
+	ToBackupStrategyListQuery() (string, error)
+}
+
+// ListOpts represents options for listing backup strategies.
+type ListOpts struct {
+	// Return the strategy for a particular database instance.
+	InstanceID string `q:"instance_id"`
+	// Return strategies for a particular project. Admin only.
+	ProjectID string `q:"project_id"`
+}
+
+// ToBackupStrategyListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToBackupStrategyListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List lists backup strategies.
+func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := baseURL(client)
+	if opts != nil {
+		query, err := opts.ToBackupStrategyListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return BackupStrategyPage{pagination.SinglePageBase(r)}
+	})
+}
+
+// CreateOptsBuilder is the top-level interface for create backup strategy
+// options.
+type CreateOptsBuilder interface {
+	ToBackupStrategyCreateMap() (map[string]any, error)
+}
+
+// CreateOpts represents options for creating a backup strategy.
+type CreateOpts struct {
+	// The database instance ID. When omitted, the strategy applies at project
+	// scope.
+	InstanceID string `json:"instance_id,omitempty"`
+	// User-defined Swift container name.
+	SwiftContainer string `json:"swift_container" required:"true"`
+}
+
+// ToBackupStrategyCreateMap converts a CreateOpts struct into a request body.
+func (opts CreateOpts) ToBackupStrategyCreateMap() (map[string]any, error) {
+	return gophercloud.BuildRequestBody(opts, "backup_strategy")
+}
+
+// Create creates a backup strategy.
+func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToBackupStrategyCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := client.Post(ctx, baseURL(client), &b, &r.Body, &gophercloud.RequestOpts{OkCodes: []int{200}})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// DeleteOptsBuilder allows extensions to add additional parameters to the
+// Delete request.
+type DeleteOptsBuilder interface {
+	ToBackupStrategyDeleteQuery() (string, error)
+}
+
+// DeleteOpts represents options for deleting backup strategies.
+type DeleteOpts struct {
+	// Delete the strategy for a particular database instance.
+	InstanceID string `q:"instance_id"`
+	// Delete strategies for a particular project. Admin only.
+	ProjectID string `q:"project_id"`
+}
+
+// ToBackupStrategyDeleteQuery formats a DeleteOpts into a query string.
+func (opts DeleteOpts) ToBackupStrategyDeleteQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// Delete deletes a backup strategy.
+func Delete(ctx context.Context, client *gophercloud.ServiceClient, opts DeleteOptsBuilder) (r DeleteResult) {
+	url := baseURL(client)
+	if opts != nil {
+		query, err := opts.ToBackupStrategyDeleteQuery()
+		if err != nil {
+			r.Err = err
+			return
+		}
+		url += query
+	}
+
+	resp, err := client.Delete(ctx, url, &gophercloud.RequestOpts{OkCodes: []int{202}})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}

--- a/openstack/db/v1/backupstrategies/results.go
+++ b/openstack/db/v1/backupstrategies/results.go
@@ -1,0 +1,58 @@
+package backupstrategies
+
+import (
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/pagination"
+)
+
+// BackupStrategy represents a database backup strategy.
+type BackupStrategy struct {
+	ProjectID      string `json:"project_id"`
+	InstanceID     string `json:"instance_id"`
+	Backend        string
+	SwiftContainer string `json:"swift_container"`
+}
+
+// CreateResult represents the result of a Create operation.
+type CreateResult struct {
+	gophercloud.Result
+}
+
+// Extract retrieves a BackupStrategy resource from an operation result.
+func (r CreateResult) Extract() (*BackupStrategy, error) {
+	var s struct {
+		BackupStrategy *BackupStrategy `json:"backup_strategy"`
+	}
+	err := r.ExtractInto(&s)
+	return s.BackupStrategy, err
+}
+
+// DeleteResult represents the result of a Delete operation.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
+// BackupStrategyPage represents a page of backup strategies.
+type BackupStrategyPage struct {
+	pagination.SinglePageBase
+}
+
+// IsEmpty indicates whether a BackupStrategyPage is empty.
+func (r BackupStrategyPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
+	strategies, err := ExtractBackupStrategies(r)
+	return len(strategies) == 0, err
+}
+
+// ExtractBackupStrategies retrieves a slice of BackupStrategy structs from a
+// paginated collection.
+func ExtractBackupStrategies(r pagination.Page) ([]BackupStrategy, error) {
+	var s struct {
+		BackupStrategies []BackupStrategy `json:"backup_strategies"`
+	}
+	err := (r.(BackupStrategyPage)).ExtractInto(&s)
+	return s.BackupStrategies, err
+}

--- a/openstack/db/v1/backupstrategies/testing/doc.go
+++ b/openstack/db/v1/backupstrategies/testing/doc.go
@@ -1,0 +1,2 @@
+// db_backupstrategies_v1
+package testing

--- a/openstack/db/v1/backupstrategies/testing/fixtures_test.go
+++ b/openstack/db/v1/backupstrategies/testing/fixtures_test.go
@@ -1,0 +1,37 @@
+package testing
+
+import (
+	"fmt"
+
+	"github.com/gophercloud/gophercloud/v2/openstack/db/v1/backupstrategies"
+)
+
+const singleBackupStrategyJSON = `
+{
+  "project_id": "922b47766bcb448f83a760358337f2b4",
+  "instance_id": "0602db72-c63d-11ea-b87c-00224d6b7bc1",
+  "backend": "swift",
+  "swift_container": "my_trove_backups"
+}
+`
+
+var (
+	ListBackupStrategiesJSON = fmt.Sprintf(`{"backup_strategies": [%s]}`, singleBackupStrategyJSON)
+	CreateBackupStrategyJSON = fmt.Sprintf(`{"backup_strategy": %s}`, singleBackupStrategyJSON)
+)
+
+var CreateBackupStrategyReq = `
+{
+  "backup_strategy": {
+    "instance_id": "0602db72-c63d-11ea-b87c-00224d6b7bc1",
+    "swift_container": "my_trove_backups"
+  }
+}
+`
+
+var ExampleBackupStrategy = backupstrategies.BackupStrategy{
+	ProjectID:      "922b47766bcb448f83a760358337f2b4",
+	InstanceID:     "0602db72-c63d-11ea-b87c-00224d6b7bc1",
+	Backend:        "swift",
+	SwiftContainer: "my_trove_backups",
+}

--- a/openstack/db/v1/backupstrategies/testing/requests_test.go
+++ b/openstack/db/v1/backupstrategies/testing/requests_test.go
@@ -1,0 +1,63 @@
+package testing
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/v2/openstack/db/v1/backupstrategies"
+	"github.com/gophercloud/gophercloud/v2/pagination"
+	th "github.com/gophercloud/gophercloud/v2/testhelper"
+	"github.com/gophercloud/gophercloud/v2/testhelper/client"
+	"github.com/gophercloud/gophercloud/v2/testhelper/fixture"
+)
+
+const (
+	rootURL    = "/backup_strategies"
+	instanceID = "0602db72-c63d-11ea-b87c-00224d6b7bc1"
+)
+
+func TestList(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	fixture.SetupHandler(t, fakeServer, rootURL, "GET", "", ListBackupStrategiesJSON, 200)
+
+	pages := 0
+	err := backupstrategies.List(client.ServiceClient(fakeServer), nil).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
+		pages++
+
+		actual, err := backupstrategies.ExtractBackupStrategies(page)
+		if err != nil {
+			return false, err
+		}
+
+		th.AssertDeepEquals(t, []backupstrategies.BackupStrategy{ExampleBackupStrategy}, actual)
+		return true, nil
+	})
+
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, 1, pages)
+}
+
+func TestCreate(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	fixture.SetupHandler(t, fakeServer, rootURL, "POST", CreateBackupStrategyReq, CreateBackupStrategyJSON, 200)
+
+	opts := backupstrategies.CreateOpts{
+		InstanceID:     instanceID,
+		SwiftContainer: "my_trove_backups",
+	}
+
+	strategy, err := backupstrategies.Create(context.TODO(), client.ServiceClient(fakeServer), opts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, &ExampleBackupStrategy, strategy)
+}
+
+func TestDelete(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	fixture.SetupHandler(t, fakeServer, rootURL, "DELETE", "", "", 202)
+
+	err := backupstrategies.Delete(context.TODO(), client.ServiceClient(fakeServer), nil).ExtractErr()
+	th.AssertNoErr(t, err)
+}

--- a/openstack/db/v1/backupstrategies/urls.go
+++ b/openstack/db/v1/backupstrategies/urls.go
@@ -1,0 +1,7 @@
+package backupstrategies
+
+import "github.com/gophercloud/gophercloud/v2"
+
+func baseURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("backup_strategies")
+}

--- a/openstack/db/v1/configurations/requests.go
+++ b/openstack/db/v1/configurations/requests.go
@@ -126,50 +126,42 @@ type CreateParamOptsBuilder interface {
 	ToParamCreateMap() (map[string]any, error)
 }
 
+type createParamRequest struct {
+	Name            string `json:"name" required:"true"`
+	DataType        string `json:"data_type" required:"true"`
+	MinSize         *int   `json:"min_size,omitempty"`
+	MaxSize         *int   `json:"max_size,omitempty"`
+	RestartRequired *int   `json:"restart_required" required:"true"`
+}
+
 // CreateParamOpts represents options for registering a configuration parameter
 // for a datastore version.
 type CreateParamOpts struct {
 	// The name of the configuration parameter.
-	Name string
+	Name string `json:"name" required:"true"`
 	// The configuration parameter data type, for example "integer", "string",
 	// "float", or "boolean".
-	DataType string
+	DataType string `json:"data_type" required:"true"`
 	// The minimum value for integer parameters.
-	MinSize *int
+	MinSize *int `json:"min_size,omitempty"`
 	// The maximum value for integer parameters.
-	MaxSize *int
+	MaxSize *int `json:"max_size,omitempty"`
 	// Whether the database service needs to restart after this parameter
 	// changes.
-	RestartRequired bool
+	RestartRequired bool `json:"restart_required"`
 }
 
 // ToParamCreateMap converts a CreateParamOpts struct into a request body.
 func (opts CreateParamOpts) ToParamCreateMap() (map[string]any, error) {
-	if opts.Name == "" {
-		return nil, gophercloud.ErrMissingInput{Argument: "Name"}
-	}
-	if opts.DataType == "" {
-		return nil, gophercloud.ErrMissingInput{Argument: "DataType"}
-	}
-
-	restartRequired := 0
-	if opts.RestartRequired {
-		restartRequired = 1
+	paramOpts := createParamRequest{
+		Name:            opts.Name,
+		DataType:        opts.DataType,
+		MinSize:         opts.MinSize,
+		MaxSize:         opts.MaxSize,
+		RestartRequired: restartRequiredToInt(opts.RestartRequired),
 	}
 
-	param := map[string]any{
-		"name":             opts.Name,
-		"data_type":        opts.DataType,
-		"restart_required": restartRequired,
-	}
-	if opts.MinSize != nil {
-		param["min_size"] = *opts.MinSize
-	}
-	if opts.MaxSize != nil {
-		param["max_size"] = *opts.MaxSize
-	}
-
-	return map[string]any{"configuration-parameter": param}, nil
+	return gophercloud.BuildRequestBody(paramOpts, "configuration-parameter")
 }
 
 // CreateDatastoreVersionParam registers a configuration parameter for a
@@ -185,10 +177,54 @@ func CreateDatastoreVersionParam(ctx context.Context, client *gophercloud.Servic
 	return
 }
 
+// UpdateParamOptsBuilder is the top-level interface for update parameter
+// options.
+type UpdateParamOptsBuilder interface {
+	ToParamUpdateMap() (map[string]any, error)
+}
+
+type updateParamRequest struct {
+	Name            string `json:"name,omitempty"`
+	DataType        string `json:"data_type,omitempty"`
+	MinSize         *int   `json:"min_size,omitempty"`
+	MaxSize         *int   `json:"max_size,omitempty"`
+	RestartRequired *int   `json:"restart_required,omitempty"`
+}
+
+// UpdateParamOpts represents options for updating a configuration parameter
+// for a datastore version.
+type UpdateParamOpts struct {
+	// The name of the configuration parameter.
+	Name string `json:"name,omitempty"`
+	// The configuration parameter data type, for example "integer", "string",
+	// "float", or "boolean".
+	DataType string `json:"data_type,omitempty"`
+	// The minimum value for integer parameters.
+	MinSize *int `json:"min_size,omitempty"`
+	// The maximum value for integer parameters.
+	MaxSize *int `json:"max_size,omitempty"`
+	// Whether the database service needs to restart after this parameter
+	// changes.
+	RestartRequired *bool `json:"restart_required,omitempty"`
+}
+
+// ToParamUpdateMap converts an UpdateParamOpts struct into a request body.
+func (opts UpdateParamOpts) ToParamUpdateMap() (map[string]any, error) {
+	paramOpts := updateParamRequest{
+		Name:            opts.Name,
+		DataType:        opts.DataType,
+		MinSize:         opts.MinSize,
+		MaxSize:         opts.MaxSize,
+		RestartRequired: restartRequiredToIntPtr(opts.RestartRequired),
+	}
+
+	return gophercloud.BuildRequestBody(paramOpts, "configuration-parameter")
+}
+
 // UpdateDatastoreVersionParam updates a configuration parameter for a
 // datastore version. This is an admin-only API.
-func UpdateDatastoreVersionParam(ctx context.Context, client *gophercloud.ServiceClient, versionID, paramID string, opts CreateParamOptsBuilder) (r UpdateParamResult) {
-	b, err := opts.ToParamCreateMap()
+func UpdateDatastoreVersionParam(ctx context.Context, client *gophercloud.ServiceClient, versionID, paramID string, opts UpdateParamOptsBuilder) (r UpdateParamResult) {
+	b, err := opts.ToParamUpdateMap()
 	if err != nil {
 		r.Err = err
 		return
@@ -196,6 +232,23 @@ func UpdateDatastoreVersionParam(ctx context.Context, client *gophercloud.Servic
 	resp, err := client.Put(ctx, updateDSParamURL(client, versionID, paramID), &b, &r.Body, &gophercloud.RequestOpts{OkCodes: []int{200}})
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
+}
+
+func restartRequiredToInt(restartRequired bool) *int {
+	value := 0
+	if restartRequired {
+		value = 1
+	}
+
+	return &value
+}
+
+func restartRequiredToIntPtr(restartRequired *bool) *int {
+	if restartRequired == nil {
+		return nil
+	}
+
+	return restartRequiredToInt(*restartRequired)
 }
 
 // DeleteDatastoreVersionParam deletes a configuration parameter for a

--- a/openstack/db/v1/configurations/requests.go
+++ b/openstack/db/v1/configurations/requests.go
@@ -120,6 +120,92 @@ func Replace(ctx context.Context, client *gophercloud.ServiceClient, configID st
 	return
 }
 
+// CreateParamOptsBuilder is the top-level interface for create parameter
+// options.
+type CreateParamOptsBuilder interface {
+	ToParamCreateMap() (map[string]any, error)
+}
+
+// CreateParamOpts represents options for registering a configuration parameter
+// for a datastore version.
+type CreateParamOpts struct {
+	// The name of the configuration parameter.
+	Name string
+	// The configuration parameter data type, for example "integer", "string",
+	// "float", or "boolean".
+	DataType string
+	// The minimum value for integer parameters.
+	MinSize *int
+	// The maximum value for integer parameters.
+	MaxSize *int
+	// Whether the database service needs to restart after this parameter
+	// changes.
+	RestartRequired bool
+}
+
+// ToParamCreateMap converts a CreateParamOpts struct into a request body.
+func (opts CreateParamOpts) ToParamCreateMap() (map[string]any, error) {
+	if opts.Name == "" {
+		return nil, gophercloud.ErrMissingInput{Argument: "Name"}
+	}
+	if opts.DataType == "" {
+		return nil, gophercloud.ErrMissingInput{Argument: "DataType"}
+	}
+
+	restartRequired := 0
+	if opts.RestartRequired {
+		restartRequired = 1
+	}
+
+	param := map[string]any{
+		"name":             opts.Name,
+		"data_type":        opts.DataType,
+		"restart_required": restartRequired,
+	}
+	if opts.MinSize != nil {
+		param["min_size"] = *opts.MinSize
+	}
+	if opts.MaxSize != nil {
+		param["max_size"] = *opts.MaxSize
+	}
+
+	return map[string]any{"configuration-parameter": param}, nil
+}
+
+// CreateDatastoreVersionParam registers a configuration parameter for a
+// datastore version. This is an admin-only API.
+func CreateDatastoreVersionParam(ctx context.Context, client *gophercloud.ServiceClient, versionID string, opts CreateParamOptsBuilder) (r CreateParamResult) {
+	b, err := opts.ToParamCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := client.Post(ctx, createDSParamURL(client, versionID), &b, &r.Body, &gophercloud.RequestOpts{OkCodes: []int{200}})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// UpdateDatastoreVersionParam updates a configuration parameter for a
+// datastore version. This is an admin-only API.
+func UpdateDatastoreVersionParam(ctx context.Context, client *gophercloud.ServiceClient, versionID, paramID string, opts CreateParamOptsBuilder) (r UpdateParamResult) {
+	b, err := opts.ToParamCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := client.Put(ctx, updateDSParamURL(client, versionID, paramID), &b, &r.Body, &gophercloud.RequestOpts{OkCodes: []int{200}})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// DeleteDatastoreVersionParam deletes a configuration parameter for a
+// datastore version. This is an admin-only API.
+func DeleteDatastoreVersionParam(ctx context.Context, client *gophercloud.ServiceClient, versionID, paramID string) (r DeleteParamResult) {
+	resp, err := client.Delete(ctx, updateDSParamURL(client, versionID, paramID), &gophercloud.RequestOpts{OkCodes: []int{204}})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
 // Delete will permanently delete a configuration group. Please note that
 // config groups cannot be deleted whilst still attached to running instances -
 // you must detach and then delete them.

--- a/openstack/db/v1/configurations/results.go
+++ b/openstack/db/v1/configurations/results.go
@@ -102,6 +102,24 @@ type DeleteResult struct {
 	gophercloud.ErrResult
 }
 
+// CreateParamResult represents the result of creating a configuration
+// parameter.
+type CreateParamResult struct {
+	gophercloud.Result
+}
+
+// UpdateParamResult represents the result of updating a configuration
+// parameter.
+type UpdateParamResult struct {
+	gophercloud.Result
+}
+
+// DeleteParamResult represents the result of deleting a configuration
+// parameter.
+type DeleteParamResult struct {
+	gophercloud.ErrResult
+}
+
 // Param represents a configuration parameter API resource.
 type Param struct {
 	Max             float64
@@ -109,6 +127,29 @@ type Param struct {
 	Name            string
 	RestartRequired bool `json:"restart_required"`
 	Type            string
+}
+
+// UnmarshalJSON supports Trove responses that may return max/min fields as
+// either max/min or max_size/min_size.
+func (r *Param) UnmarshalJSON(b []byte) error {
+	type tmp Param
+	var s struct {
+		tmp
+		MaxSize *float64 `json:"max_size"`
+		MinSize *float64 `json:"min_size"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	*r = Param(s.tmp)
+	if s.MaxSize != nil {
+		r.Max = *s.MaxSize
+	}
+	if s.MinSize != nil {
+		r.Min = *s.MinSize
+	}
+	return nil
 }
 
 // ParamPage contains a page of Param resources in a paginated collection.
@@ -143,6 +184,22 @@ type ParamResult struct {
 
 // Extract will retrieve a param from an operation result.
 func (r ParamResult) Extract() (*Param, error) {
+	var s *Param
+	err := r.ExtractInto(&s)
+	return s, err
+}
+
+// Extract will retrieve created params from an operation result.
+func (r CreateParamResult) Extract() ([]Param, error) {
+	var s struct {
+		Params []Param `json:"configuration-parameters"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Params, err
+}
+
+// Extract will retrieve an updated param from an operation result.
+func (r UpdateParamResult) Extract() (*Param, error) {
 	var s *Param
 	err := r.ExtractInto(&s)
 	return s, err

--- a/openstack/db/v1/configurations/testing/fixtures_test.go
+++ b/openstack/db/v1/configurations/testing/fixtures_test.go
@@ -145,6 +145,18 @@ var CreateParamReq = `
 }
 `
 
+var CreateParamZeroReq = `
+{
+  "configuration-parameter": {
+    "data_type": "integer",
+    "max_size": 0,
+    "min_size": 0,
+    "name": "connect_timeout",
+    "restart_required": 0
+  }
+}
+`
+
 var CreateParamJSON = `
 {
   "configuration-parameters": [
@@ -157,6 +169,33 @@ var CreateParamJSON = `
       "type": "integer"
     }
   ]
+}
+`
+
+var CreateParamZeroJSON = `
+{
+  "configuration-parameters": [
+    {
+      "datastore_version_id": "b00000b0-00b0-0b00-00b0-000b000000bb",
+      "max": 0,
+      "min": 0,
+      "name": "connect_timeout",
+      "restart_required": false,
+      "type": "integer"
+    }
+  ]
+}
+`
+
+var UpdateParamReq = `
+{
+  "configuration-parameter": {
+    "data_type": "integer",
+    "max_size": 65535,
+    "min_size": 64,
+    "name": "connect_timeout",
+    "restart_required": 0
+  }
 }
 `
 

--- a/openstack/db/v1/configurations/testing/fixtures_test.go
+++ b/openstack/db/v1/configurations/testing/fixtures_test.go
@@ -133,6 +133,46 @@ var GetParamJSON = `
 }
 `
 
+var CreateParamReq = `
+{
+  "configuration-parameter": {
+    "data_type": "integer",
+    "max_size": 65535,
+    "min_size": 64,
+    "name": "connect_timeout",
+    "restart_required": 0
+  }
+}
+`
+
+var CreateParamJSON = `
+{
+  "configuration-parameters": [
+    {
+      "datastore_version_id": "b00000b0-00b0-0b00-00b0-000b000000bb",
+      "max": 65535,
+      "min": 64,
+      "name": "connect_timeout",
+      "restart_required": false,
+      "type": "integer"
+    }
+  ]
+}
+`
+
+var UpdateParamJSON = `
+{
+  "datastore_version_id": "b00000b0-00b0-0b00-00b0-000b000000bb",
+  "deleted": 0,
+  "deleted_at": null,
+  "max_size": 65535,
+  "min_size": 64,
+  "name": "connect_timeout",
+  "restart_required": false,
+  "type": "integer"
+}
+`
+
 var ExampleConfig = configurations.Config{
 	Created:              timeVal,
 	DatastoreName:        "mysql",

--- a/openstack/db/v1/configurations/testing/requests_test.go
+++ b/openstack/db/v1/configurations/testing/requests_test.go
@@ -21,6 +21,7 @@ var (
 	versionID          = "{versionID}"
 	paramID            = "{paramID}"
 	dsParamListURL     = "/datastores/" + dsID + "/versions/" + versionID + "/parameters"
+	dsParamCreateURL   = "/mgmt/datastores/versions/" + versionID + "/parameters"
 	dsParamGetURL      = "/datastores/" + dsID + "/versions/" + versionID + "/parameters/" + paramID
 	globalParamListURL = "/datastores/versions/" + versionID + "/parameters"
 	globalParamGetURL  = "/datastores/versions/" + versionID + "/parameters/" + paramID
@@ -190,6 +191,63 @@ func TestGetDSParam(t *testing.T) {
 	}
 
 	th.AssertDeepEquals(t, expected, param)
+}
+
+func TestCreateDatastoreVersionParam(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	fixture.SetupHandler(t, fakeServer, dsParamCreateURL, "POST", CreateParamReq, CreateParamJSON, 200)
+
+	minSize := 64
+	maxSize := 65535
+	opts := configurations.CreateParamOpts{
+		Name:     "connect_timeout",
+		DataType: "integer",
+		MinSize:  &minSize,
+		MaxSize:  &maxSize,
+	}
+
+	params, err := configurations.CreateDatastoreVersionParam(context.TODO(), client.ServiceClient(fakeServer), versionID, opts).Extract()
+	th.AssertNoErr(t, err)
+
+	expected := []configurations.Param{
+		{Max: 65535, Min: 64, Name: "connect_timeout", RestartRequired: false, Type: "integer"},
+	}
+
+	th.AssertDeepEquals(t, expected, params)
+}
+
+func TestUpdateDatastoreVersionParam(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	fixture.SetupHandler(t, fakeServer, dsParamCreateURL+"/"+paramID, "PUT", CreateParamReq, UpdateParamJSON, 200)
+
+	minSize := 64
+	maxSize := 65535
+	opts := configurations.CreateParamOpts{
+		Name:     "connect_timeout",
+		DataType: "integer",
+		MinSize:  &minSize,
+		MaxSize:  &maxSize,
+	}
+
+	param, err := configurations.UpdateDatastoreVersionParam(context.TODO(), client.ServiceClient(fakeServer), versionID, paramID, opts).Extract()
+	th.AssertNoErr(t, err)
+
+	expected := &configurations.Param{
+		Max: 65535, Min: 64, Name: "connect_timeout", RestartRequired: false, Type: "integer",
+	}
+
+	th.AssertDeepEquals(t, expected, param)
+}
+
+func TestDeleteDatastoreVersionParam(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	fixture.SetupHandler(t, fakeServer, dsParamCreateURL+"/"+paramID, "DELETE", "", "", 204)
+
+	err := configurations.DeleteDatastoreVersionParam(context.TODO(), client.ServiceClient(fakeServer), versionID, paramID).ExtractErr()
+	th.AssertNoErr(t, err)
 }
 
 func TestListGlobalParams(t *testing.T) {

--- a/openstack/db/v1/configurations/testing/requests_test.go
+++ b/openstack/db/v1/configurations/testing/requests_test.go
@@ -217,18 +217,44 @@ func TestCreateDatastoreVersionParam(t *testing.T) {
 	th.AssertDeepEquals(t, expected, params)
 }
 
-func TestUpdateDatastoreVersionParam(t *testing.T) {
+func TestCreateDatastoreVersionParamWithZeroSizes(t *testing.T) {
 	fakeServer := th.SetupHTTP()
 	defer fakeServer.Teardown()
-	fixture.SetupHandler(t, fakeServer, dsParamCreateURL+"/"+paramID, "PUT", CreateParamReq, UpdateParamJSON, 200)
+	fixture.SetupHandler(t, fakeServer, dsParamCreateURL, "POST", CreateParamZeroReq, CreateParamZeroJSON, 200)
 
-	minSize := 64
-	maxSize := 65535
+	minSize := 0
+	maxSize := 0
 	opts := configurations.CreateParamOpts{
 		Name:     "connect_timeout",
 		DataType: "integer",
 		MinSize:  &minSize,
 		MaxSize:  &maxSize,
+	}
+
+	params, err := configurations.CreateDatastoreVersionParam(context.TODO(), client.ServiceClient(fakeServer), versionID, opts).Extract()
+	th.AssertNoErr(t, err)
+
+	expected := []configurations.Param{
+		{Max: 0, Min: 0, Name: "connect_timeout", RestartRequired: false, Type: "integer"},
+	}
+
+	th.AssertDeepEquals(t, expected, params)
+}
+
+func TestUpdateDatastoreVersionParam(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	fixture.SetupHandler(t, fakeServer, dsParamCreateURL+"/"+paramID, "PUT", UpdateParamReq, UpdateParamJSON, 200)
+
+	minSize := 64
+	maxSize := 65535
+	restartRequired := false
+	opts := configurations.UpdateParamOpts{
+		Name:            "connect_timeout",
+		DataType:        "integer",
+		MinSize:         &minSize,
+		MaxSize:         &maxSize,
+		RestartRequired: &restartRequired,
 	}
 
 	param, err := configurations.UpdateDatastoreVersionParam(context.TODO(), client.ServiceClient(fakeServer), versionID, paramID, opts).Extract()

--- a/openstack/db/v1/configurations/urls.go
+++ b/openstack/db/v1/configurations/urls.go
@@ -18,6 +18,14 @@ func listDSParamsURL(c *gophercloud.ServiceClient, datastoreID, versionID string
 	return c.ServiceURL("datastores", datastoreID, "versions", versionID, "parameters")
 }
 
+func createDSParamURL(c *gophercloud.ServiceClient, versionID string) string {
+	return c.ServiceURL("mgmt", "datastores", "versions", versionID, "parameters")
+}
+
+func updateDSParamURL(c *gophercloud.ServiceClient, versionID, paramID string) string {
+	return c.ServiceURL("mgmt", "datastores", "versions", versionID, "parameters", paramID)
+}
+
 func getDSParamURL(c *gophercloud.ServiceClient, datastoreID, versionID, paramID string) string {
 	return c.ServiceURL("datastores", datastoreID, "versions", versionID, "parameters", paramID)
 }

--- a/openstack/db/v1/datastores/requests.go
+++ b/openstack/db/v1/datastores/requests.go
@@ -7,6 +7,118 @@ import (
 	"github.com/gophercloud/gophercloud/v2/pagination"
 )
 
+// CreateVersionOptsBuilder is the top-level interface for create version
+// options.
+type CreateVersionOptsBuilder interface {
+	ToVersionCreateMap() (map[string]any, error)
+}
+
+// CreateVersionOpts represents options for registering a datastore version.
+//
+// This is an admin-only API. When the datastore specified by DatastoreName does
+// not exist, Trove creates it automatically.
+type CreateVersionOpts struct {
+	// The name of the datastore version.
+	Name string `json:"name" required:"true"`
+	// The name of the datastore.
+	DatastoreName string `json:"datastore_name" required:"true"`
+	// The datastore manager type.
+	DatastoreManager string `json:"datastore_manager" required:"true"`
+	// The ID of an image. Either Image or ImageTags must be provided.
+	Image string `json:"image,omitempty" or:"ImageTags"`
+	// Image tags used to find the latest matching image. Either Image or
+	// ImageTags must be provided.
+	ImageTags []string `json:"image_tags,omitempty"`
+	// Whether the datastore version is enabled.
+	Active gophercloud.EnabledState `json:"active" required:"true"`
+	// Whether this datastore version is the default for the datastore.
+	Default gophercloud.EnabledState `json:"default,omitempty"`
+	// Packages associated with the datastore version.
+	Packages []string `json:"packages,omitempty"`
+	// The database engine version number.
+	Version string `json:"version,omitempty"`
+}
+
+// ToVersionCreateMap converts a CreateVersionOpts struct into a request body.
+func (opts CreateVersionOpts) ToVersionCreateMap() (map[string]any, error) {
+	return gophercloud.BuildRequestBody(opts, "version")
+}
+
+// CreateVersion registers a new datastore version. This is an admin-only API.
+// Trove automatically creates the datastore when DatastoreName does not already
+// exist.
+func CreateVersion(ctx context.Context, client *gophercloud.ServiceClient, opts CreateVersionOptsBuilder) (r CreateVersionResult) {
+	b, err := opts.ToVersionCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := client.Post(ctx, createVersionURL(client), &b, &r.Body, &gophercloud.RequestOpts{OkCodes: []int{202}})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// ListAllVersions lists all datastore versions. This is an admin-only API.
+func ListAllVersions(client *gophercloud.ServiceClient) pagination.Pager {
+	return pagination.NewPager(client, createVersionURL(client), func(r pagination.PageResult) pagination.Page {
+		return VersionPage{pagination.SinglePageBase(r)}
+	})
+}
+
+// GetVersionByID retrieves a datastore version by ID. This is an admin-only
+// API.
+func GetVersionByID(ctx context.Context, client *gophercloud.ServiceClient, versionID string) (r GetVersionResult) {
+	resp, err := client.Get(ctx, mgmtVersionURL(client, versionID), &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// UpdateVersionOptsBuilder is the top-level interface for update version
+// options.
+type UpdateVersionOptsBuilder interface {
+	ToVersionUpdateMap() (map[string]any, error)
+}
+
+// UpdateVersionOpts represents options for updating a datastore version.
+type UpdateVersionOpts struct {
+	// The name of the datastore version.
+	Name string `json:"name,omitempty"`
+	// The datastore manager type.
+	DatastoreManager string `json:"datastore_manager,omitempty"`
+	// The ID of an image.
+	Image string `json:"image,omitempty"`
+	// Image tags used to find the latest matching image.
+	ImageTags []string `json:"image_tags,omitempty"`
+	// Whether the datastore version is enabled.
+	Active gophercloud.EnabledState `json:"active,omitempty"`
+	// Whether this datastore version is the default for the datastore.
+	Default gophercloud.EnabledState `json:"default,omitempty"`
+}
+
+// ToVersionUpdateMap converts an UpdateVersionOpts struct into a request body.
+func (opts UpdateVersionOpts) ToVersionUpdateMap() (map[string]any, error) {
+	return gophercloud.BuildRequestBody(opts, "")
+}
+
+// UpdateVersion updates a datastore version. This is an admin-only API.
+func UpdateVersion(ctx context.Context, client *gophercloud.ServiceClient, versionID string, opts UpdateVersionOptsBuilder) (r UpdateVersionResult) {
+	b, err := opts.ToVersionUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := client.Patch(ctx, mgmtVersionURL(client, versionID), &b, &r.Body, &gophercloud.RequestOpts{OkCodes: []int{202}})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// DeleteVersion deletes a datastore version. This is an admin-only API.
+func DeleteVersion(ctx context.Context, client *gophercloud.ServiceClient, versionID string) (r DeleteVersionResult) {
+	resp, err := client.Delete(ctx, mgmtVersionURL(client, versionID), &gophercloud.RequestOpts{OkCodes: []int{202}})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
 // List will list all available datastore types that instances can use.
 func List(client *gophercloud.ServiceClient) pagination.Pager {
 	return pagination.NewPager(client, baseURL(client), func(r pagination.PageResult) pagination.Page {

--- a/openstack/db/v1/datastores/results.go
+++ b/openstack/db/v1/datastores/results.go
@@ -1,15 +1,54 @@
 package datastores
 
 import (
+	"encoding/json"
+
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/pagination"
 )
 
+// PackageList represents packages associated with a datastore version.
+type PackageList []string
+
+// UnmarshalJSON supports Trove responses that may return packages as either a
+// list or a single string.
+func (r *PackageList) UnmarshalJSON(b []byte) error {
+	var packages []string
+	if err := json.Unmarshal(b, &packages); err == nil {
+		*r = packages
+		return nil
+	}
+
+	var pkg string
+	if err := json.Unmarshal(b, &pkg); err != nil {
+		return err
+	}
+	if pkg == "" {
+		*r = nil
+		return nil
+	}
+
+	*r = []string{pkg}
+	return nil
+}
+
 // Version represents a version API resource. Multiple versions belong to a Datastore.
 type Version struct {
-	ID    string
-	Links []gophercloud.Link
-	Name  string
+	Active           bool
+	Datastore        string
+	DatastoreID      string `json:"datastore_id"`
+	DatastoreManager string `json:"datastore_manager"`
+	DatastoreName    string `json:"datastore_name"`
+	Default          bool
+	ID               string
+	Image            string
+	ImageTags        []string `json:"image_tags"`
+	Links            []gophercloud.Link
+	Name             string
+	Packages         PackageList
+	RegistryExt      string `json:"registry_ext"`
+	ReplStrategy     string `json:"repl_strategy"`
+	Version          string
 }
 
 // Datastore represents a Datastore API resource.
@@ -38,6 +77,21 @@ type GetResult struct {
 // GetVersionResult represents the result of getting a version.
 type GetVersionResult struct {
 	gophercloud.Result
+}
+
+// CreateVersionResult represents the result of creating a version.
+type CreateVersionResult struct {
+	gophercloud.Result
+}
+
+// UpdateVersionResult represents the result of updating a version.
+type UpdateVersionResult struct {
+	gophercloud.Result
+}
+
+// DeleteVersionResult represents the result of deleting a version.
+type DeleteVersionResult struct {
+	gophercloud.ErrResult
 }
 
 // DatastorePage represents a page of datastore resources.
@@ -100,6 +154,24 @@ func ExtractVersions(r pagination.Page) ([]Version, error) {
 
 // Extract retrieves a single Version struct from an operation result.
 func (r GetVersionResult) Extract() (*Version, error) {
+	var s struct {
+		Version *Version `json:"version"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Version, err
+}
+
+// Extract retrieves a single Version struct from a create result.
+func (r CreateVersionResult) Extract() (*Version, error) {
+	var s struct {
+		Version *Version `json:"version"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Version, err
+}
+
+// Extract retrieves a single Version struct from an update result.
+func (r UpdateVersionResult) Extract() (*Version, error) {
 	var s struct {
 		Version *Version `json:"version"`
 	}

--- a/openstack/db/v1/datastores/testing/fixtures_test.go
+++ b/openstack/db/v1/datastores/testing/fixtures_test.go
@@ -41,6 +41,60 @@ const version2JSON = `
 }
 `
 
+const createVersionReq = `
+{
+	"version": {
+		"datastore_name": "mysql",
+		"datastore_manager": "mysql",
+		"name": "mysql-5.7",
+		"image_tags": ["trove", "mysql"],
+		"active": true,
+		"default": false,
+		"packages": ["mysql-server"],
+		"version": "5.7.30"
+	}
+}
+`
+
+const createdVersionJSON = `
+{
+	"active": true,
+	"datastore_id": "10000000-0000-0000-0000-000000000001",
+	"datastore_manager": "mysql",
+	"datastore_name": "mysql",
+	"default": false,
+	"id": "b00000b0-00b0-0b00-00b0-000b000000bb",
+	"image": "",
+	"image_tags": ["trove", "mysql"],
+	"name": "mysql-5.7",
+	"packages": ["mysql-server"],
+	"version": "5.7.30"
+}
+`
+
+const updateVersionReq = `
+{
+	"name": "mysql-5.7-updated",
+	"active": true
+}
+`
+
+const updatedVersionJSON = `
+{
+	"active": true,
+	"datastore_id": "10000000-0000-0000-0000-000000000001",
+	"datastore_manager": "mysql",
+	"datastore_name": "mysql",
+	"default": false,
+	"id": "b00000b0-00b0-0b00-00b0-000b000000bb",
+	"image": "",
+	"image_tags": ["trove", "mysql"],
+	"name": "mysql-5.7-updated",
+	"packages": ["mysql-server"],
+	"version": "5.7.30"
+}
+`
+
 var versionsJSON = fmt.Sprintf(`"versions": [%s, %s]`, version1JSON, version2JSON)
 
 var singleDSJSON = fmt.Sprintf(`
@@ -63,10 +117,13 @@ var singleDSJSON = fmt.Sprintf(`
 `, versionsJSON)
 
 var (
-	ListDSResp       = fmt.Sprintf(`{"datastores":[%s]}`, singleDSJSON)
-	GetDSResp        = fmt.Sprintf(`{"datastore":%s}`, singleDSJSON)
-	ListVersionsResp = fmt.Sprintf(`{%s}`, versionsJSON)
-	GetVersionResp   = fmt.Sprintf(`{"version":%s}`, version1JSON)
+	ListDSResp          = fmt.Sprintf(`{"datastores":[%s]}`, singleDSJSON)
+	GetDSResp           = fmt.Sprintf(`{"datastore":%s}`, singleDSJSON)
+	ListVersionsResp    = fmt.Sprintf(`{%s}`, versionsJSON)
+	GetVersionResp      = fmt.Sprintf(`{"version":%s}`, version1JSON)
+	CreateVersionResp   = fmt.Sprintf(`{"version":%s}`, createdVersionJSON)
+	ListAllVersionsResp = fmt.Sprintf(`{"versions":[%s]}`, createdVersionJSON)
+	UpdateVersionResp   = fmt.Sprintf(`{"version":%s}`, updatedVersionJSON)
 )
 
 var ExampleVersion1 = datastores.Version{
@@ -88,6 +145,30 @@ var exampleVersion2 = datastores.Version{
 }
 
 var ExampleVersions = []datastores.Version{ExampleVersion1, exampleVersion2}
+
+var ExampleCreatedVersion = datastores.Version{
+	Active:           true,
+	DatastoreID:      "10000000-0000-0000-0000-000000000001",
+	DatastoreManager: "mysql",
+	DatastoreName:    "mysql",
+	ID:               "b00000b0-00b0-0b00-00b0-000b000000bb",
+	ImageTags:        []string{"trove", "mysql"},
+	Name:             "mysql-5.7",
+	Packages:         datastores.PackageList{"mysql-server"},
+	Version:          "5.7.30",
+}
+
+var ExampleUpdatedVersion = datastores.Version{
+	Active:           true,
+	DatastoreID:      "10000000-0000-0000-0000-000000000001",
+	DatastoreManager: "mysql",
+	DatastoreName:    "mysql",
+	ID:               "b00000b0-00b0-0b00-00b0-000b000000bb",
+	ImageTags:        []string{"trove", "mysql"},
+	Name:             "mysql-5.7-updated",
+	Packages:         datastores.PackageList{"mysql-server"},
+	Version:          "5.7.30",
+}
 
 var ExampleDatastore = datastores.Datastore{
 	DefaultVersion: "c00000b0-00c0-0c00-00c0-000b000000cc",

--- a/openstack/db/v1/datastores/testing/requests_test.go
+++ b/openstack/db/v1/datastores/testing/requests_test.go
@@ -4,12 +4,90 @@ import (
 	"context"
 	"testing"
 
+	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/openstack/db/v1/datastores"
 	"github.com/gophercloud/gophercloud/v2/pagination"
 	th "github.com/gophercloud/gophercloud/v2/testhelper"
 	"github.com/gophercloud/gophercloud/v2/testhelper/client"
 	"github.com/gophercloud/gophercloud/v2/testhelper/fixture"
 )
+
+func TestCreateVersion(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	fixture.SetupHandler(t, fakeServer, "/mgmt/datastore-versions", "POST", createVersionReq, CreateVersionResp, 202)
+
+	opts := datastores.CreateVersionOpts{
+		Name:             "mysql-5.7",
+		DatastoreName:    "mysql",
+		DatastoreManager: "mysql",
+		ImageTags:        []string{"trove", "mysql"},
+		Active:           gophercloud.Enabled,
+		Default:          gophercloud.Disabled,
+		Packages:         []string{"mysql-server"},
+		Version:          "5.7.30",
+	}
+
+	version, err := datastores.CreateVersion(context.TODO(), client.ServiceClient(fakeServer), opts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, &ExampleCreatedVersion, version)
+}
+
+func TestListAllVersions(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	fixture.SetupHandler(t, fakeServer, "/mgmt/datastore-versions", "GET", "", ListAllVersionsResp, 200)
+
+	pages := 0
+	err := datastores.ListAllVersions(client.ServiceClient(fakeServer)).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
+		pages++
+
+		actual, err := datastores.ExtractVersions(page)
+		if err != nil {
+			return false, err
+		}
+
+		th.AssertDeepEquals(t, []datastores.Version{ExampleCreatedVersion}, actual)
+		return true, nil
+	})
+
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, 1, pages)
+}
+
+func TestGetVersionByID(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	fixture.SetupHandler(t, fakeServer, "/mgmt/datastore-versions/{versionID}", "GET", "", CreateVersionResp, 200)
+
+	version, err := datastores.GetVersionByID(context.TODO(), client.ServiceClient(fakeServer), "{versionID}").Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, &ExampleCreatedVersion, version)
+}
+
+func TestUpdateVersion(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	fixture.SetupHandler(t, fakeServer, "/mgmt/datastore-versions/{versionID}", "PATCH", updateVersionReq, UpdateVersionResp, 202)
+
+	opts := datastores.UpdateVersionOpts{
+		Name:   "mysql-5.7-updated",
+		Active: gophercloud.Enabled,
+	}
+
+	version, err := datastores.UpdateVersion(context.TODO(), client.ServiceClient(fakeServer), "{versionID}", opts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, &ExampleUpdatedVersion, version)
+}
+
+func TestDeleteVersion(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	fixture.SetupHandler(t, fakeServer, "/mgmt/datastore-versions/{versionID}", "DELETE", "", "", 202)
+
+	err := datastores.DeleteVersion(context.TODO(), client.ServiceClient(fakeServer), "{versionID}").ExtractErr()
+	th.AssertNoErr(t, err)
+}
 
 func TestList(t *testing.T) {
 	fakeServer := th.SetupHTTP()

--- a/openstack/db/v1/datastores/urls.go
+++ b/openstack/db/v1/datastores/urls.go
@@ -6,6 +6,14 @@ func baseURL(c *gophercloud.ServiceClient) string {
 	return c.ServiceURL("datastores")
 }
 
+func createVersionURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("mgmt", "datastore-versions")
+}
+
+func mgmtVersionURL(c *gophercloud.ServiceClient, versionID string) string {
+	return c.ServiceURL("mgmt", "datastore-versions", versionID)
+}
+
 func resourceURL(c *gophercloud.ServiceClient, dsID string) string {
 	return c.ServiceURL("datastores", dsID)
 }


### PR DESCRIPTION
  Links to the line numbers/files in the OpenStack source code that support the
  code in this PR:

  - Trove datastore version and datastore version configuration parameter management routes:
    https://opendev.org/openstack/trove/src/branch/master/trove/extensions/routes/mgmt.py#L68-L79

  - Trove API reference: create/update/delete datastore version configuration parameters:
    https://docs.openstack.org/api-ref/database/#create-datastore-version-configuration-parameters
    https://docs.openstack.org/api-ref/database/#update-a-datastore-version-configuration-parameter
    https://docs.openstack.org/api-ref/database/#delete-a-datastore-version-configuration-parameter

  - Trove API reference: create/list/show/update/delete datastore versions:
    https://docs.openstack.org/api-ref/database/#create-datastore-version
    https://docs.openstack.org/api-ref/database/#list-datastore-versions
    https://docs.openstack.org/api-ref/database/#show-datastore-version-details
    https://docs.openstack.org/api-ref/database/#update-datastore-version-details
    https://docs.openstack.org/api-ref/database/#delete-datastore-version

  - Trove API reference: list/create/show/delete database backups:
    https://docs.openstack.org/api-ref/database/#list-database-backups
    https://docs.openstack.org/api-ref/database/#create-database-backup
    https://docs.openstack.org/api-ref/database/#show-database-backup-details
    https://docs.openstack.org/api-ref/database/#delete-database-backup

  - Trove API reference: list/create/delete backup strategies:
    https://docs.openstack.org/api-ref/database/#list-backup-strategies
    https://docs.openstack.org/api-ref/database/#create-backup-strategy
    https://docs.openstack.org/api-ref/database/#delete-database-strategy