### PR TITLE
Add Ironic vendor passthru helpers

### DIFF
--- a/internal/acceptance/openstack/baremetal/v1/vendor_passthru_test.go
+++ b/internal/acceptance/openstack/baremetal/v1/vendor_passthru_test.go
@@ -1,0 +1,74 @@
+//go:build acceptance || baremetal || nodes || drivers
+
+package v1
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/v2/internal/acceptance/clients"
+	"github.com/gophercloud/gophercloud/v2/internal/acceptance/tools"
+	"github.com/gophercloud/gophercloud/v2/openstack/baremetal/v1/drivers"
+	"github.com/gophercloud/gophercloud/v2/openstack/baremetal/v1/nodes"
+	"github.com/gophercloud/gophercloud/v2/pagination"
+	th "github.com/gophercloud/gophercloud/v2/testhelper"
+)
+
+func TestVendorPassthruMethods(t *testing.T) {
+	clients.RequireLong(t)
+
+	client, err := clients.NewBareMetalV1Client()
+	th.AssertNoErr(t, err)
+	client.Microversion = "1.38"
+
+	node, err := CreateFakeNode(t, client)
+	th.AssertNoErr(t, err)
+	defer DeleteNode(t, client, node)
+
+	nodeMethods, err := nodes.ListVendorPassthruMethods(context.TODO(), client, node.UUID).Extract()
+	th.AssertNoErr(t, err)
+	tools.PrintResource(t, nodeMethods)
+
+	err = nodes.CallVendorPassthru(context.TODO(), client, node.UUID, http.MethodPost, nodes.VendorPassthruCallOpts{
+		Method: "gophercloud_acceptance_missing_method",
+		Body: map[string]any{
+			"noop": true,
+		},
+	}).Err
+	if err == nil {
+		t.Fatalf("expected missing node vendor passthru method to fail")
+	}
+
+	var driverName string
+	err = drivers.ListDrivers(client, drivers.ListDriversOpts{}).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
+		driverList, err := drivers.ExtractDrivers(page)
+		if err != nil {
+			return false, err
+		}
+		if len(driverList) == 0 {
+			return true, nil
+		}
+
+		driverName = driverList[0].Name
+		return false, nil
+	})
+	th.AssertNoErr(t, err)
+	if driverName == "" {
+		t.Skip("no baremetal drivers available")
+	}
+
+	driverMethods, err := drivers.ListVendorPassthruMethods(context.TODO(), client, driverName).Extract()
+	th.AssertNoErr(t, err)
+	tools.PrintResource(t, driverMethods)
+
+	err = drivers.CallVendorPassthru(context.TODO(), client, driverName, http.MethodPost, drivers.VendorPassthruCallOpts{
+		Method: "gophercloud_acceptance_missing_method",
+		Body: map[string]any{
+			"noop": true,
+		},
+	}).Err
+	if err == nil {
+		t.Fatalf("expected missing driver vendor passthru method to fail")
+	}
+}

--- a/openstack/baremetal/v1/drivers/requests.go
+++ b/openstack/baremetal/v1/drivers/requests.go
@@ -2,6 +2,8 @@ package drivers
 
 import (
 	"context"
+	"encoding/json"
+	"io"
 
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/pagination"
@@ -72,4 +74,68 @@ func GetDriverDiskProperties(ctx context.Context, client *gophercloud.ServiceCli
 	})
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
+}
+
+// ListVendorPassthruMethods retrieves all vendor passthru methods available for the given Driver.
+func ListVendorPassthruMethods(ctx context.Context, client *gophercloud.ServiceClient, driverName string) (r ListVendorPassthruMethodsResult) {
+	resp, err := client.Get(ctx, vendorPassthruMethodsURL(client, driverName), &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// VendorPassthruCallOpts defines options for invoking a vendor passthru method.
+type VendorPassthruCallOpts struct {
+	// Method is the driver-specific passthru method name.
+	Method string
+
+	// Body is the JSON body forwarded to the driver.
+	Body any
+}
+
+// CallVendorPassthru invokes a vendor passthru method for the given Driver.
+func CallVendorPassthru(ctx context.Context, client *gophercloud.ServiceClient, driverName string, httpMethod string, opts VendorPassthruCallOpts) (r CallVendorPassthruResult) {
+	query, err := vendorPassthruCallQuery(opts.Method)
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	url := vendorPassthruCallURL(client, driverName) + query
+	resp, err := client.Request(ctx, httpMethod, url, &gophercloud.RequestOpts{
+		JSONBody:         opts.Body,
+		OkCodes:          []int{200, 202, 204},
+		KeepResponseBody: true,
+	})
+	if resp != nil {
+		r.Header = resp.Header
+		r.StatusCode = resp.StatusCode
+	}
+	if err != nil {
+		r.Err = err
+		return
+	}
+	if resp == nil || resp.Body == nil {
+		return
+	}
+	defer resp.Body.Close()
+
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		r.Err = err
+		return
+	}
+	if len(responseBody) == 0 {
+		return
+	}
+	r.Err = json.Unmarshal(responseBody, &r.Body)
+	return
+}
+
+func vendorPassthruCallQuery(method string) (string, error) {
+	q, err := gophercloud.BuildQueryString(struct {
+		Method string `q:"method" required:"true"`
+	}{Method: method})
+	return q.String(), err
 }

--- a/openstack/baremetal/v1/drivers/results.go
+++ b/openstack/baremetal/v1/drivers/results.go
@@ -207,3 +207,34 @@ func (r GetDiskPropertiesResult) Extract() (*DiskProperties, error) {
 type GetDiskPropertiesResult struct {
 	gophercloud.Result
 }
+
+type VendorPassthruMethod struct {
+	HTTPMethods []string `json:"http_methods"`
+	Async       bool     `json:"async"`
+	Description string   `json:"description"`
+	Attach      bool     `json:"attach"`
+}
+
+// Extract interprets a ListVendorPassthruMethodsResult as generic vendor passthru method metadata.
+func (r ListVendorPassthruMethodsResult) Extract() (map[string]VendorPassthruMethod, error) {
+	var s map[string]VendorPassthruMethod
+	err := r.ExtractInto(&s)
+	return s, err
+}
+
+// Extract interprets a CallVendorPassthruResult as an arbitrary JSON object.
+func (r CallVendorPassthruResult) Extract() (map[string]any, error) {
+	var s map[string]any
+	err := r.ExtractInto(&s)
+	return s, err
+}
+
+// ListVendorPassthruMethodsResult is the response from a ListVendorPassthruMethods operation.
+type ListVendorPassthruMethodsResult struct {
+	gophercloud.Result
+}
+
+// CallVendorPassthruResult is the response from a CallVendorPassthru operation.
+type CallVendorPassthruResult struct {
+	gophercloud.Result
+}

--- a/openstack/baremetal/v1/drivers/testing/fixtures_test.go
+++ b/openstack/baremetal/v1/drivers/testing/fixtures_test.go
@@ -224,6 +224,19 @@ const SingleDriverDiskProperties = `
 }
 `
 
+const DriverVendorPassthruMethodsBody = `
+{
+  "driver_reset": {
+    "http_methods": [
+      "POST"
+    ],
+    "async": false,
+    "description": "Reset all nodes managed by the driver.",
+    "attach": false
+  }
+}
+`
+
 var (
 	DriverAgentIpmitool = drivers.Driver{
 		Name:  "agent_ipmitool",
@@ -411,5 +424,28 @@ func HandleGetDriverDiskPropertiesSuccessfully(t *testing.T, fakeServer th.FakeS
 		th.TestHeader(t, r, "Accept", "application/json")
 
 		fmt.Fprint(w, SingleDriverDiskProperties)
+	})
+}
+
+func HandleListVendorPassthruMethodsSuccessfully(t *testing.T, fakeServer th.FakeServer) {
+	fakeServer.Mux.HandleFunc("/drivers/ipmi/vendor_passthru/methods", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+
+		fmt.Fprint(w, DriverVendorPassthruMethodsBody)
+	})
+}
+
+func HandleCallVendorPassthruSuccessfully(t *testing.T, fakeServer th.FakeServer) {
+	fakeServer.Mux.HandleFunc("/drivers/ipmi/vendor_passthru", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestFormValues(t, r, map[string]string{"method": "driver_reset"})
+		th.TestJSONRequest(t, r, `{"force": true}`)
+
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprint(w, `{"result":"ok"}`)
 	})
 }

--- a/openstack/baremetal/v1/drivers/testing/requests_test.go
+++ b/openstack/baremetal/v1/drivers/testing/requests_test.go
@@ -2,6 +2,7 @@ package testing
 
 import (
 	"context"
+	"net/http"
 	"testing"
 
 	"github.com/gophercloud/gophercloud/v2/openstack/baremetal/v1/drivers"
@@ -82,4 +83,31 @@ func TestGetDriverDiskProperties(t *testing.T) {
 	}
 
 	th.CheckDeepEquals(t, DriverIpmiToolDisk, *actual)
+}
+
+func TestListVendorPassthruMethods(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	HandleListVendorPassthruMethodsSuccessfully(t, fakeServer)
+
+	c := client.ServiceClient(fakeServer)
+	actual, err := drivers.ListVendorPassthruMethods(context.TODO(), c, "ipmi").Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, "Reset all nodes managed by the driver.", actual["driver_reset"].Description)
+}
+
+func TestCallVendorPassthru(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	HandleCallVendorPassthruSuccessfully(t, fakeServer)
+
+	c := client.ServiceClient(fakeServer)
+	actual, err := drivers.CallVendorPassthru(context.TODO(), c, "ipmi", http.MethodPost, drivers.VendorPassthruCallOpts{
+		Method: "driver_reset",
+		Body: map[string]any{
+			"force": true,
+		},
+	}).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, "ok", actual["result"])
 }

--- a/openstack/baremetal/v1/drivers/urls.go
+++ b/openstack/baremetal/v1/drivers/urls.go
@@ -17,3 +17,11 @@ func driverPropertiesURL(client *gophercloud.ServiceClient, driverName string) s
 func driverDiskPropertiesURL(client *gophercloud.ServiceClient, driverName string) string {
 	return client.ServiceURL("drivers", driverName, "raid", "logical_disk_properties")
 }
+
+func vendorPassthruMethodsURL(client *gophercloud.ServiceClient, driverName string) string {
+	return client.ServiceURL("drivers", driverName, "vendor_passthru", "methods")
+}
+
+func vendorPassthruCallURL(client *gophercloud.ServiceClient, driverName string) string {
+	return client.ServiceURL("drivers", driverName, "vendor_passthru")
+}

--- a/openstack/baremetal/v1/nodes/requests.go
+++ b/openstack/baremetal/v1/nodes/requests.go
@@ -2,7 +2,9 @@ package nodes
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/pagination"
@@ -747,6 +749,74 @@ func GetVendorPassthruMethods(ctx context.Context, client *gophercloud.ServiceCl
 	})
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
+}
+
+// ListVendorPassthruMethods retrieves all generic vendor passthru methods available for the given Node.
+func ListVendorPassthruMethods(ctx context.Context, client *gophercloud.ServiceClient, id string) (r ListVendorPassthruMethodsResult) {
+	resp, err := client.Get(ctx, vendorPassthruMethodsURL(client, id), &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// VendorPassthruCallOpts defines options for invoking a vendor passthru method.
+type VendorPassthruCallOpts struct {
+	// Method is the driver-specific passthru method name.
+	Method string
+
+	// Body is the JSON body forwarded to the driver.
+	Body any
+}
+
+// CallVendorPassthru invokes a vendor passthru method for the given Node.
+func CallVendorPassthru(ctx context.Context, client *gophercloud.ServiceClient, id string, httpMethod string, opts VendorPassthruCallOpts) (r CallVendorPassthruResult) {
+	query, err := vendorPassthruCallQuery(opts.Method)
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	url := vendorPassthruCallURL(client, id) + query
+	callVendorPassthru(ctx, client, httpMethod, url, opts.Body, &r)
+	return
+}
+
+func vendorPassthruCallQuery(method string) (string, error) {
+	q, err := gophercloud.BuildQueryString(struct {
+		Method string `q:"method" required:"true"`
+	}{Method: method})
+	return q.String(), err
+}
+
+func callVendorPassthru(ctx context.Context, client *gophercloud.ServiceClient, httpMethod string, url string, body any, r *CallVendorPassthruResult) {
+	resp, err := client.Request(ctx, httpMethod, url, &gophercloud.RequestOpts{
+		JSONBody:         body,
+		OkCodes:          []int{200, 202, 204},
+		KeepResponseBody: true,
+	})
+	if resp != nil {
+		r.Header = resp.Header
+		r.StatusCode = resp.StatusCode
+	}
+	if err != nil {
+		r.Err = err
+		return
+	}
+	if resp == nil || resp.Body == nil {
+		return
+	}
+	defer resp.Body.Close()
+
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		r.Err = err
+		return
+	}
+	if len(responseBody) == 0 {
+		return
+	}
+	r.Err = json.Unmarshal(responseBody, &r.Body)
 }
 
 // Get all subscriptions available for the given Node.

--- a/openstack/baremetal/v1/nodes/results.go
+++ b/openstack/baremetal/v1/nodes/results.go
@@ -78,6 +78,20 @@ func (r VendorPassthruMethodsResult) Extract() (*VendorPassthruMethods, error) {
 	return &s, err
 }
 
+// Extract interprets a ListVendorPassthruMethodsResult as generic vendor passthru method metadata.
+func (r ListVendorPassthruMethodsResult) Extract() (map[string]VendorPassthruMethod, error) {
+	var s map[string]VendorPassthruMethod
+	err := r.ExtractInto(&s)
+	return s, err
+}
+
+// Extract interprets a CallVendorPassthruResult as an arbitrary JSON object.
+func (r CallVendorPassthruResult) Extract() (map[string]any, error) {
+	var s map[string]any
+	err := r.ExtractInto(&s)
+	return s, err
+}
+
 func (r GetAllSubscriptionsVendorPassthruResult) Extract() (*GetAllSubscriptionsVendorPassthru, error) {
 	var s GetAllSubscriptionsVendorPassthru
 	err := r.ExtractInto(&s)
@@ -541,6 +555,14 @@ type VendorPassthruMethods struct {
 	GetAllSubscriptions GetAllSubscriptionsMethod `json:"get_all_subscriptions,omitempty"`
 }
 
+type VendorPassthruMethod struct {
+	HTTPMethods          []string `json:"http_methods"`
+	Async                bool     `json:"async"`
+	Description          string   `json:"description"`
+	Attach               bool     `json:"attach"`
+	RequireExclusiveLock bool     `json:"require_exclusive_lock"`
+}
+
 // Below you can find all vendor passthru methods structs
 
 type CreateSubscriptionMethod struct {
@@ -594,6 +616,16 @@ type SubscriptionVendorPassthru struct {
 	Destination string   `json:"Destination"`
 	EventTypes  []string `json:"EventTypes"`
 	Protocol    string   `json:"Protocol"`
+}
+
+// ListVendorPassthruMethodsResult is the response from a ListVendorPassthruMethods operation.
+type ListVendorPassthruMethodsResult struct {
+	gophercloud.Result
+}
+
+// CallVendorPassthruResult is the response from a CallVendorPassthru operation.
+type CallVendorPassthruResult struct {
+	gophercloud.Result
 }
 
 // SetMaintenanceResult is the response from a SetMaintenance operation. Call its ExtractErr

--- a/openstack/baremetal/v1/nodes/testing/fixtures_test.go
+++ b/openstack/baremetal/v1/nodes/testing/fixtures_test.go
@@ -1731,6 +1731,31 @@ func HandleGetVendorPassthruMethodsSuccessfully(t *testing.T, fakeServer th.Fake
 	})
 }
 
+func HandleCallNodeVendorPassthruSuccessfully(t *testing.T, fakeServer th.FakeServer) {
+	fakeServer.Mux.HandleFunc("/nodes/1234asdf/vendor_passthru", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestFormValues(t, r, map[string]string{"method": "reset_bmc"})
+		th.TestJSONRequest(t, r, `{"force": true}`)
+
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprint(w, `{"result":"ok"}`)
+	})
+}
+
+func HandleCallAsyncNodeVendorPassthruSuccessfully(t *testing.T, fakeServer th.FakeServer) {
+	fakeServer.Mux.HandleFunc("/nodes/1234asdf/vendor_passthru", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestFormValues(t, r, map[string]string{"method": "async_reset"})
+		th.TestJSONRequest(t, r, `{"force": true}`)
+
+		w.WriteHeader(http.StatusAccepted)
+	})
+}
+
 func HandleGetAllSubscriptionsVendorPassthruSuccessfully(t *testing.T, fakeServer th.FakeServer) {
 	fakeServer.Mux.HandleFunc("/nodes/1234asdf/vendor_passthru", func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "GET")

--- a/openstack/baremetal/v1/nodes/testing/requests_test.go
+++ b/openstack/baremetal/v1/nodes/testing/requests_test.go
@@ -641,6 +641,50 @@ func TestGetVendorPassthruMethods(t *testing.T) {
 	th.CheckDeepEquals(t, NodeVendorPassthruMethods, *actual)
 }
 
+func TestListVendorPassthruMethods(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	HandleGetVendorPassthruMethodsSuccessfully(t, fakeServer)
+
+	c := client.ServiceClient(fakeServer)
+	actual, err := nodes.ListVendorPassthruMethods(context.TODO(), c, "1234asdf").Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, []string{"POST"}, actual["create_subscription"].HTTPMethods)
+	th.AssertEquals(t, true, actual["create_subscription"].RequireExclusiveLock)
+}
+
+func TestCallVendorPassthru(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	HandleCallNodeVendorPassthruSuccessfully(t, fakeServer)
+
+	c := client.ServiceClient(fakeServer)
+	actual, err := nodes.CallVendorPassthru(context.TODO(), c, "1234asdf", http.MethodPost, nodes.VendorPassthruCallOpts{
+		Method: "reset_bmc",
+		Body: map[string]any{
+			"force": true,
+		},
+	}).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, "ok", actual["result"])
+}
+
+func TestCallAsyncVendorPassthru(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	HandleCallAsyncNodeVendorPassthruSuccessfully(t, fakeServer)
+
+	c := client.ServiceClient(fakeServer)
+	result := nodes.CallVendorPassthru(context.TODO(), c, "1234asdf", http.MethodPost, nodes.VendorPassthruCallOpts{
+		Method: "async_reset",
+		Body: map[string]any{
+			"force": true,
+		},
+	})
+	th.AssertNoErr(t, result.Err)
+	th.AssertEquals(t, http.StatusAccepted, result.StatusCode)
+}
+
 func TestGetAllSubscriptions(t *testing.T) {
 	fakeServer := th.SetupHTTP()
 	defer fakeServer.Teardown()


### PR DESCRIPTION
## Summary

This PR adds generic Ironic vendor passthru support for both node and driver endpoints:

- list vendor passthru methods for nodes and drivers
- call vendor passthru methods with arbitrary HTTP methods and JSON request bodies
- handle synchronous JSON responses and asynchronous/no-content responses
- add acceptance coverage for vendor passthru method discovery and safe missing-method calls

This was created with assistance from OpenAI Codex.

Closes part of #1429.

## Testing

- `env GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod go test ./openstack/baremetal/v1/nodes/testing ./openstack/baremetal/v1/drivers/testing`
- `env GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod go test -tags 'acceptance baremetal nodes drivers' ./internal/acceptance/openstack/baremetal/v1 -run TestNonexistent -count=0`