### PR TITLE
dns: add AllProjects support to zones.List via X-Auth-All-Projects header

### DIFF
--- a/internal/acceptance/openstack/dns/v2/zones_test.go
+++ b/internal/acceptance/openstack/dns/v2/zones_test.go
@@ -53,3 +53,30 @@ func TestZonesCRUD(t *testing.T) {
 	th.AssertEquals(t, newZone.Description, description)
 	th.AssertEquals(t, 3600, newZone.TTL)
 }
+
+func TestZonesListWithAllProjects(t *testing.T) {
+	clients.RequireAdmin(t)
+
+	client, err := clients.NewDNSV2Client()
+	th.AssertNoErr(t, err)
+
+	zone, err := CreateZone(t, client)
+	th.AssertNoErr(t, err)
+	defer DeleteZone(t, client, zone)
+
+	listOpts := zones.ListOpts{AllProjects: true}
+	allPages, err := zones.List(client, listOpts).AllPages(context.TODO())
+	th.AssertNoErr(t, err)
+
+	allZones, err := zones.ExtractZones(allPages)
+	th.AssertNoErr(t, err)
+
+	var found bool
+	for _, z := range allZones {
+		if zone.Name == z.Name {
+			found = true
+		}
+	}
+
+	th.AssertTrue(t, found)
+}

--- a/openstack/dns/v2/zones/doc.go
+++ b/openstack/dns/v2/zones/doc.go
@@ -22,6 +22,26 @@ Example to List Zones
 		fmt.Printf("%+v\n", zone)
 	}
 
+Example to List Zones Across All Projects
+
+	listOpts := zones.ListOpts{
+		AllProjects: true,
+	}
+
+	allPages, err := zones.List(dnsClient, listOpts).AllPages(context.TODO())
+	if err != nil {
+		panic(err)
+	}
+
+	allZones, err := zones.ExtractZones(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, zone := range allZones {
+		fmt.Printf("%+v\n", zone)
+	}
+
 Example to Create a Zone
 
 	createOpts := zones.CreateOpts{

--- a/openstack/dns/v2/zones/requests.go
+++ b/openstack/dns/v2/zones/requests.go
@@ -12,6 +12,11 @@ type ListOptsBuilder interface {
 	ToZoneListQuery() (string, error)
 }
 
+// ListOptsHeadersBuilder allows extensions to add additional headers to the List request.
+type ListOptsHeadersBuilder interface {
+	ToZoneListHeaders() (map[string]string, error)
+}
+
 // ListOpts allows the filtering and sorting of paginated collections through
 // the API. Filtering is achieved by passing in struct field values that map to
 // the server attributes you want to see returned. Marker and Limit are used
@@ -32,6 +37,12 @@ type ListOpts struct {
 	Status      string `q:"status"`
 	TTL         int    `q:"ttl"`
 	Type        string `q:"type"`
+
+	// All projects header
+	AllProjects bool `h:"X-Auth-All-Projects"`
+
+	// Sudo tenant ID
+	SudoTenantID bool `h:"X-Auth-Sudo-Tenant-ID"`
 }
 
 // ToZoneListQuery formats a ListOpts into a query string.
@@ -40,19 +51,37 @@ func (opts ListOpts) ToZoneListQuery() (string, error) {
 	return q.String(), err
 }
 
+// ToZoneListHeaders formats a ListOpts into header parameters.
+func (opts ListOpts) ToZoneListHeaders() (map[string]string, error) {
+	return gophercloud.BuildHeaders(opts)
+}
+
 // List implements a zone List request.
 func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 	url := baseURL(client)
+	var h map[string]string
+
 	if opts != nil {
 		query, err := opts.ToZoneListQuery()
 		if err != nil {
 			return pagination.Pager{Err: err}
 		}
 		url += query
+
+		// Check if opts implements the optional headers interface
+		if optsWithHeaders, ok := opts.(ListOptsHeadersBuilder); ok {
+			h, err = optsWithHeaders.ToZoneListHeaders()
+			if err != nil {
+				return pagination.Pager{Err: err}
+			}
+		}
 	}
-	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+
+	pager := pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
 		return ZonePage{pagination.LinkedPageBase{PageResult: r}}
 	})
+	pager.Headers = h
+	return pager
 }
 
 // Get returns information about a zone, given its ID.

--- a/openstack/dns/v2/zones/testing/fixtures_test.go
+++ b/openstack/dns/v2/zones/testing/fixtures_test.go
@@ -153,6 +153,19 @@ func HandleListSuccessfully(t *testing.T, fakeServer th.FakeServer) {
 	})
 }
 
+// HandleListAllProjectsSuccessfully configures the test server to respond to a List request
+// with the X-Auth-All-Projects header set.
+func HandleListAllProjectsSuccessfully(t *testing.T, fakeServer th.FakeServer) {
+	fakeServer.Mux.HandleFunc("/zones", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestHeader(t, r, "X-Auth-All-Projects", "true")
+
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprint(w, ListOutput)
+	})
+}
+
 // HandleGetSuccessfully configures the test server to respond to a List request.
 func HandleGetSuccessfully(t *testing.T, fakeServer th.FakeServer) {
 	fakeServer.Mux.HandleFunc("/zones/a86dba58-0043-4cc6-a1bb-69d5e86f3ca3", func(w http.ResponseWriter, r *http.Request) {

--- a/openstack/dns/v2/zones/testing/requests_test.go
+++ b/openstack/dns/v2/zones/testing/requests_test.go
@@ -44,6 +44,19 @@ func TestListAllPages(t *testing.T) {
 	th.CheckEquals(t, 2, len(allZones))
 }
 
+func TestListWithAllProjects(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	HandleListAllProjectsSuccessfully(t, fakeServer)
+
+	opts := zones.ListOpts{AllProjects: true}
+	allPages, err := zones.List(client.ServiceClient(fakeServer), opts).AllPages(context.TODO())
+	th.AssertNoErr(t, err)
+	allZones, err := zones.ExtractZones(allPages)
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, 2, len(allZones))
+}
+
 func TestGet(t *testing.T) {
 	fakeServer := th.SetupHTTP()
 	defer fakeServer.Teardown()


### PR DESCRIPTION
Fixes #3800

Links to the line numbers/files in the OpenStack source code that support the code in this PR:

https://opendev.org/openstack/designate/src/commit/12a5256eb51a22acc414fe7082f857355c736d5a/designate/api/middleware.py#L62-L72