### PR TITLE
dns: add X-Auth-All-Projects header support to recordsets

### DIFF
--- a/internal/acceptance/openstack/dns/v2/dns.go
+++ b/internal/acceptance/openstack/dns/v2/dns.go
@@ -235,7 +235,16 @@ func UnshareZone(t *testing.T, client *gophercloud.ServiceClient, share *zones.Z
 // the record set failed to be deleted. This works best when used as a deferred
 // function.
 func DeleteRecordSet(t *testing.T, client *gophercloud.ServiceClient, rs *recordsets.RecordSet) {
-	err := recordsets.Delete(context.TODO(), client, rs.ZoneID, rs.ID).ExtractErr()
+	err := recordsets.Delete(context.TODO(), client, rs.ZoneID, rs.ID, nil).ExtractErr()
+	if err != nil {
+		t.Fatalf("Unable to delete record set %s: %v", rs.ID, err)
+	}
+
+	t.Logf("Deleted record set: %s", rs.ID)
+}
+
+func DeleteRecordSetAllProjects(t *testing.T, client *gophercloud.ServiceClient, rs *recordsets.RecordSet) {
+	err := recordsets.Delete(context.TODO(), client, rs.ZoneID, rs.ID, recordsets.DeleteOpts{AllProjects: true}).ExtractErr()
 	if err != nil {
 		t.Fatalf("Unable to delete record set %s: %v", rs.ID, err)
 	}

--- a/internal/acceptance/openstack/dns/v2/recordsets_test.go
+++ b/internal/acceptance/openstack/dns/v2/recordsets_test.go
@@ -149,3 +149,65 @@ func TestRecordSetsCRUD(t *testing.T) {
 	th.AssertDeepEquals(t, newRS.Records, records)
 	th.AssertEquals(t, newRS.TTL, ttl)
 }
+
+func TestRecordSetsListByZoneWithAllProjects(t *testing.T) {
+	clients.RequireAdmin(t)
+
+	client, err := clients.NewDNSV2Client()
+	th.AssertNoErr(t, err)
+
+	zone, err := CreateZone(t, client)
+	th.AssertNoErr(t, err)
+	defer DeleteZone(t, client, zone)
+
+	rs, err := CreateRecordSet(t, client, zone)
+	th.AssertNoErr(t, err)
+	defer DeleteRecordSetAllProjects(t, client, rs)
+
+	listOpts := recordsets.ListOpts{AllProjects: true}
+	allPages, err := recordsets.ListByZone(client, zone.ID, listOpts).AllPages(context.TODO())
+	th.AssertNoErr(t, err)
+
+	allRecordSets, err := recordsets.ExtractRecordSets(allPages)
+	th.AssertNoErr(t, err)
+
+	var found bool
+	for _, recordset := range allRecordSets {
+		if recordset.ID == rs.ID {
+			found = true
+		}
+	}
+
+	th.AssertTrue(t, found)
+}
+
+func TestRecordSetsListAllWithAllProjects(t *testing.T) {
+	clients.RequireAdmin(t)
+
+	client, err := clients.NewDNSV2Client()
+	th.AssertNoErr(t, err)
+
+	zone, err := CreateZone(t, client)
+	th.AssertNoErr(t, err)
+	defer DeleteZone(t, client, zone)
+
+	rs, err := CreateRecordSet(t, client, zone)
+	th.AssertNoErr(t, err)
+	defer DeleteRecordSetAllProjects(t, client, rs)
+
+	listOpts := recordsets.ListOpts{AllProjects: true}
+	allPages, err := recordsets.ListAll(client, listOpts).AllPages(context.TODO())
+	th.AssertNoErr(t, err)
+
+	allRecordSets, err := recordsets.ExtractRecordSets(allPages)
+	th.AssertNoErr(t, err)
+
+	var found bool
+	for _, recordset := range allRecordSets {
+		if recordset.ID == rs.ID {
+			found = true
+		}
+	}
+
+	th.AssertTrue(t, found)
+}

--- a/openstack/dns/v2/recordsets/doc.go
+++ b/openstack/dns/v2/recordsets/doc.go
@@ -15,7 +15,49 @@ Example to List RecordSets by Zone
 		panic(err)
 	}
 
-	allRRs, err := recordsets.ExtractRecordSets(allPages()
+	allRRs, err := recordsets.ExtractRecordSets(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, rr := range allRRs {
+		fmt.Printf("%+v\n", rr)
+	}
+
+Example to List RecordSets by Zone across projects (admin)
+
+	listOpts := recordsets.ListOpts{
+		AllProjects: true,
+	}
+
+	zoneID := "fff121f5-c506-410a-a69e-2d73ef9cbdbd"
+
+	allPages, err := recordsets.ListByZone(dnsClient, zoneID, listOpts).AllPages(context.TODO())
+	if err != nil {
+		panic(err)
+	}
+
+	allRRs, err := recordsets.ExtractRecordSets(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, rr := range allRRs {
+		fmt.Printf("%+v\n", rr)
+	}
+
+Example to List all RecordSets across zones and all projects (admin)
+
+	listOpts := recordsets.ListOpts{
+		AllProjects: true,
+	}
+
+	allPages, err := recordsets.ListAll(dnsClient, listOpts).AllPages(context.TODO())
+	if err != nil {
+		panic(err)
+	}
+
+	allRRs, err := recordsets.ExtractRecordSets(allPages)
 	if err != nil {
 		panic(err)
 	}
@@ -41,12 +83,69 @@ Example to Create a RecordSet
 		panic(err)
 	}
 
+Example to Create a RecordSet across projects (admin)
+
+	createOpts := recordsets.CreateOpts{
+		Name:        "example.com.",
+		Type:        "A",
+		TTL:         3600,
+		Description: "This is a recordset.",
+		Records:     []string{"10.1.0.2"},
+		AllProjects: true,
+	}
+
+	zoneID := "fff121f5-c506-410a-a69e-2d73ef9cbdbd"
+
+	rr, err := recordsets.Create(context.TODO(), dnsClient, zoneID, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Update a RecordSet
+
+	recordsetID := "d96ed01a-b439-4eb8-9b90-7a9f71017f7b"
+	zoneID := "fff121f5-c506-410a-a69e-2d73ef9cbdbd"
+
+	updateOpts := recordsets.UpdateOpts{
+		Records: []string{"10.1.0.3"},
+	}
+
+	rr, err := recordsets.Update(context.TODO(), dnsClient, zoneID, recordsetID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Update a RecordSet across projects (admin)
+
+	recordsetID := "d96ed01a-b439-4eb8-9b90-7a9f71017f7b"
+	zoneID := "fff121f5-c506-410a-a69e-2d73ef9cbdbd"
+
+	updateOpts := recordsets.UpdateOpts{
+		Records:     []string{"10.1.0.3"},
+		AllProjects: true,
+	}
+
+	rr, err := recordsets.Update(context.TODO(), dnsClient, zoneID, recordsetID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
 Example to Delete a RecordSet
 
 	zoneID := "fff121f5-c506-410a-a69e-2d73ef9cbdbd"
 	recordsetID := "d96ed01a-b439-4eb8-9b90-7a9f71017f7b"
 
-	err := recordsets.Delete(context.TODO(), dnsClient, zoneID, recordsetID).ExtractErr()
+	err := recordsets.Delete(context.TODO(), dnsClient, zoneID, recordsetID, nil).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete a RecordSet across projects (admin)
+
+	zoneID := "fff121f5-c506-410a-a69e-2d73ef9cbdbd"
+	recordsetID := "d96ed01a-b439-4eb8-9b90-7a9f71017f7b"
+
+	err := recordsets.Delete(context.TODO(), dnsClient, zoneID, recordsetID, recordsets.DeleteOpts{AllProjects: true}).ExtractErr()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/dns/v2/recordsets/requests.go
+++ b/openstack/dns/v2/recordsets/requests.go
@@ -13,6 +13,37 @@ type ListOptsBuilder interface {
 	ToRecordSetListQuery() (string, error)
 }
 
+// ListOptsHeadersBuilder allows extensions to add additional headers to the List request.
+type ListOptsHeadersBuilder interface {
+	ToRecordSetListHeaders() (map[string]string, error)
+}
+
+// RequestOptsHeadersBuilder allows extensions to add additional headers to
+// Create and Update requests.
+type RequestOptsHeadersBuilder interface {
+	ToRecordSetRequestHeaders() (map[string]string, error)
+}
+
+// DeleteOptsBuilder allows extensions to add additional headers to the
+// Delete request.
+type DeleteOptsBuilder interface {
+	ToRecordSetDeleteHeaders() (map[string]string, error)
+}
+
+// DeleteOpts specifies headers that may be set on a Delete request.
+type DeleteOpts struct {
+	// AllProjects header.
+	AllProjects bool `h:"X-Auth-All-Projects"`
+
+	// SudoTenantID impersonates the given project.
+	SudoTenantID string `h:"X-Auth-Sudo-Tenant-ID"`
+}
+
+// ToRecordSetDeleteHeaders formats a DeleteOpts into header parameters.
+func (opts DeleteOpts) ToRecordSetDeleteHeaders() (map[string]string, error) {
+	return gophercloud.BuildHeaders(opts)
+}
+
 // ListOpts allows the filtering and sorting of paginated collections through
 // the API. Filtering is achieved by passing in struct field values that map to
 // the server attributes you want to see returned. Marker and Limit are used
@@ -25,15 +56,17 @@ type ListOpts struct {
 	// UUID of the recordset at which you want to set a marker.
 	Marker string `q:"marker"`
 
-	Data        string `q:"data"`
-	Description string `q:"description"`
-	Name        string `q:"name"`
-	SortDir     string `q:"sort_dir"`
-	SortKey     string `q:"sort_key"`
-	Status      string `q:"status"`
-	TTL         int    `q:"ttl"`
-	Type        string `q:"type"`
-	ZoneID      string `q:"zone_id"`
+	Data         string `q:"data"`
+	Description  string `q:"description"`
+	Name         string `q:"name"`
+	SortDir      string `q:"sort_dir"`
+	SortKey      string `q:"sort_key"`
+	Status       string `q:"status"`
+	TTL          int    `q:"ttl"`
+	Type         string `q:"type"`
+	ZoneID       string `q:"zone_id"`
+	AllProjects  bool   `h:"X-Auth-All-Projects"`
+	SudoTenantID string `h:"X-Auth-Sudo-Tenant-ID"`
 }
 
 // ToRecordSetListQuery formats a ListOpts into a query string.
@@ -42,34 +75,65 @@ func (opts ListOpts) ToRecordSetListQuery() (string, error) {
 	return q.String(), err
 }
 
+// ToRecordSetListHeaders formats a ListOpts into header parameters.
+func (opts ListOpts) ToRecordSetListHeaders() (map[string]string, error) {
+	return gophercloud.BuildHeaders(opts)
+}
+
 // ListByZone implements the recordset list request for a specific zone.
 func ListByZone(client *gophercloud.ServiceClient, zoneID string, opts ListOptsBuilder) pagination.Pager {
 	url := baseURL(client, zoneID)
+	var h map[string]string
+
 	if opts != nil {
 		query, err := opts.ToRecordSetListQuery()
 		if err != nil {
 			return pagination.Pager{Err: err}
 		}
 		url += query
+
+		// Check if opts implements the optional headers interface
+		if optsWithHeaders, ok := opts.(ListOptsHeadersBuilder); ok {
+			h, err = optsWithHeaders.ToRecordSetListHeaders()
+			if err != nil {
+				return pagination.Pager{Err: err}
+			}
+		}
 	}
-	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+
+	pager := pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
 		return RecordSetPage{pagination.LinkedPageBase{PageResult: r}}
 	})
+	pager.Headers = h
+	return pager
 }
 
 // ListAll implements the recordset list request across all zones.
 func ListAll(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 	url := listAllRecordSetsURL(client)
+	var h map[string]string
+
 	if opts != nil {
 		query, err := opts.ToRecordSetListQuery()
 		if err != nil {
 			return pagination.Pager{Err: err}
 		}
 		url += query
+
+		// Check if opts implements the optional headers interface
+		if optsWithHeaders, ok := opts.(ListOptsHeadersBuilder); ok {
+			h, err = optsWithHeaders.ToRecordSetListHeaders()
+			if err != nil {
+				return pagination.Pager{Err: err}
+			}
+		}
 	}
-	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+
+	pager := pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
 		return RecordSetPage{pagination.LinkedPageBase{PageResult: r}}
 	})
+	pager.Headers = h
+	return pager
 }
 
 // Get implements the recordset Get request.
@@ -102,6 +166,12 @@ type CreateOpts struct {
 
 	// Type is the RRTYPE of the RecordSet.
 	Type string `json:"type,omitempty"`
+
+	// AllProjects header.
+	AllProjects bool `h:"X-Auth-All-Projects" json:"-"`
+
+	// SudoTenantID impersonates the given project.
+	SudoTenantID string `h:"X-Auth-Sudo-Tenant-ID" json:"-"`
 }
 
 // ToRecordSetCreateMap formats an CreateOpts structure into a request body.
@@ -114,6 +184,11 @@ func (opts CreateOpts) ToRecordSetCreateMap() (map[string]any, error) {
 	return b, nil
 }
 
+// ToRecordSetRequestHeaders formats a CreateOpts into header parameters.
+func (opts CreateOpts) ToRecordSetRequestHeaders() (map[string]string, error) {
+	return gophercloud.BuildHeaders(opts)
+}
+
 // Create creates a recordset in a given zone.
 func Create(ctx context.Context, client *gophercloud.ServiceClient, zoneID string, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToRecordSetCreateMap()
@@ -121,9 +196,16 @@ func Create(ctx context.Context, client *gophercloud.ServiceClient, zoneID strin
 		r.Err = err
 		return
 	}
-	resp, err := client.Post(ctx, baseURL(client, zoneID), &b, &r.Body, &gophercloud.RequestOpts{
-		OkCodes: []int{201, 202},
-	})
+	reqOpts := &gophercloud.RequestOpts{OkCodes: []int{201, 202}}
+	// Check if opts implements the optional headers interface
+	if optsWithHeaders, ok := opts.(RequestOptsHeadersBuilder); ok {
+		reqOpts.MoreHeaders, err = optsWithHeaders.ToRecordSetRequestHeaders()
+		if err != nil {
+			r.Err = err
+			return
+		}
+	}
+	resp, err := client.Post(ctx, baseURL(client, zoneID), &b, &r.Body, reqOpts)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
@@ -145,6 +227,17 @@ type UpdateOpts struct {
 
 	// Records are the DNS records of the RecordSet.
 	Records []string `json:"records,omitempty"`
+
+	// AllProjects header.
+	AllProjects bool `h:"X-Auth-All-Projects" json:"-"`
+
+	// SudoTenantID impersonates the given project.
+	SudoTenantID string `h:"X-Auth-Sudo-Tenant-ID" json:"-"`
+}
+
+// ToRecordSetRequestHeaders formats an UpdateOpts into header parameters.
+func (opts UpdateOpts) ToRecordSetRequestHeaders() (map[string]string, error) {
+	return gophercloud.BuildHeaders(opts)
 }
 
 // ToRecordSetUpdateMap formats an UpdateOpts structure into a request body.
@@ -177,18 +270,32 @@ func Update(ctx context.Context, client *gophercloud.ServiceClient, zoneID strin
 		r.Err = err
 		return
 	}
-	resp, err := client.Put(ctx, rrsetURL(client, zoneID, rrsetID), &b, &r.Body, &gophercloud.RequestOpts{
-		OkCodes: []int{200, 202},
-	})
+	reqOpts := &gophercloud.RequestOpts{OkCodes: []int{200, 202}}
+	// Check if opts implements the optional headers interface
+	if optsWithHeaders, ok := opts.(RequestOptsHeadersBuilder); ok {
+		reqOpts.MoreHeaders, err = optsWithHeaders.ToRecordSetRequestHeaders()
+		if err != nil {
+			r.Err = err
+			return
+		}
+	}
+	resp, err := client.Put(ctx, rrsetURL(client, zoneID, rrsetID), &b, &r.Body, reqOpts)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
 
 // Delete removes an existing RecordSet.
-func Delete(ctx context.Context, client *gophercloud.ServiceClient, zoneID string, rrsetID string) (r DeleteResult) {
-	resp, err := client.Delete(ctx, rrsetURL(client, zoneID, rrsetID), &gophercloud.RequestOpts{
-		OkCodes: []int{202},
-	})
+func Delete(ctx context.Context, client *gophercloud.ServiceClient, zoneID string, rrsetID string, opts DeleteOptsBuilder) (r DeleteResult) {
+	reqOpts := &gophercloud.RequestOpts{OkCodes: []int{202}}
+	if opts != nil {
+		h, err := opts.ToRecordSetDeleteHeaders()
+		if err != nil {
+			r.Err = err
+			return
+		}
+		reqOpts.MoreHeaders = h
+	}
+	resp, err := client.Delete(ctx, rrsetURL(client, zoneID, rrsetID), reqOpts)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }

--- a/openstack/dns/v2/recordsets/testing/fixtures_test.go
+++ b/openstack/dns/v2/recordsets/testing/fixtures_test.go
@@ -223,10 +223,36 @@ func HandleListByZoneSuccessfully(t *testing.T, fakeServer th.FakeServer) {
 	})
 }
 
+// HandleListByZoneAllProjectsSuccessfully configures the test server to respond to a ListByZone
+// request with the X-Auth-All-Projects header set.
+func HandleListByZoneAllProjectsSuccessfully(t *testing.T, fakeServer th.FakeServer) {
+	fakeServer.Mux.HandleFunc("/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestHeader(t, r, "X-Auth-All-Projects", "true")
+
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprint(w, ListByZoneOutput)
+	})
+}
+
 // HandleListAllSuccessfully configures the test server to respond to a ListAll request.
 func HandleListAllSuccessfully(t *testing.T, fakeServer th.FakeServer) {
 	fakeServer.Mux.HandleFunc("/recordsets", func(w http.ResponseWriter, r *http.Request) {
 		handleListSuccessfully(t, w, r)
+	})
+}
+
+// HandleListAllAllProjectsSuccessfully configures the test server to respond to a ListAll
+// request with the X-Auth-All-Projects header set.
+func HandleListAllAllProjectsSuccessfully(t *testing.T, fakeServer th.FakeServer) {
+	fakeServer.Mux.HandleFunc("/recordsets", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestHeader(t, r, "X-Auth-All-Projects", "true")
+
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprint(w, ListByZoneOutput)
 	})
 }
 
@@ -297,6 +323,22 @@ func HandleCreateSuccessfully(t *testing.T, fakeServer th.FakeServer) {
 		})
 }
 
+// HandleCreateAllProjectsSuccessfully configures the test server to respond to a Create request
+// with the X-Auth-All-Projects header set.
+func HandleCreateAllProjectsSuccessfully(t *testing.T, fakeServer th.FakeServer) {
+	fakeServer.Mux.HandleFunc("/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "POST")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+			th.TestHeader(t, r, "X-Auth-All-Projects", "true")
+			th.TestJSONRequest(t, r, CreateRecordSetRequest)
+
+			w.WriteHeader(http.StatusCreated)
+			w.Header().Add("Content-Type", "application/json")
+			fmt.Fprint(w, CreateRecordSetResponse)
+		})
+}
+
 // UpdateRecordSetRequest is a sample request to update a record set.
 const UpdateRecordSetRequest = `
 {
@@ -349,6 +391,22 @@ func HandleUpdateSuccessfully(t *testing.T, fakeServer th.FakeServer) {
 		})
 }
 
+// HandleUpdateAllProjectsSuccessfully configures the test server to respond to an Update request
+// with the X-Auth-All-Projects header set.
+func HandleUpdateAllProjectsSuccessfully(t *testing.T, fakeServer th.FakeServer) {
+	fakeServer.Mux.HandleFunc("/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets/f7b10e9b-0cae-4a91-b162-562bc6096648",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "PUT")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+			th.TestHeader(t, r, "X-Auth-All-Projects", "true")
+			th.TestJSONRequest(t, r, UpdateRecordSetRequest)
+
+			w.WriteHeader(http.StatusOK)
+			w.Header().Add("Content-Type", "application/json")
+			fmt.Fprint(w, UpdateRecordSetResponse)
+		})
+}
+
 // DeleteRecordSetResponse is a sample response to a delete request.
 const DeleteRecordSetResponse = `
 {
@@ -385,5 +443,18 @@ func HandleDeleteSuccessfully(t *testing.T, fakeServer th.FakeServer) {
 			w.WriteHeader(http.StatusAccepted)
 			//w.Header().Add("Content-Type", "application/json")
 			//fmt.Fprint(w, DeleteZoneResponse)
+		})
+}
+
+// HandleDeleteAllProjectsSuccessfully configures the test server to respond to a Delete request
+// with the X-Auth-All-Projects header set.
+func HandleDeleteAllProjectsSuccessfully(t *testing.T, fakeServer th.FakeServer) {
+	fakeServer.Mux.HandleFunc("/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets/f7b10e9b-0cae-4a91-b162-562bc6096648",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "DELETE")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+			th.TestHeader(t, r, "X-Auth-All-Projects", "true")
+
+			w.WriteHeader(http.StatusAccepted)
 		})
 }

--- a/openstack/dns/v2/recordsets/testing/requests_test.go
+++ b/openstack/dns/v2/recordsets/testing/requests_test.go
@@ -63,6 +63,19 @@ func TestListByZoneAllPages(t *testing.T) {
 	th.CheckEquals(t, 2, len(allRecordSets))
 }
 
+func TestListByZoneWithAllProjects(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	HandleListByZoneAllProjectsSuccessfully(t, fakeServer)
+
+	opts := recordsets.ListOpts{AllProjects: true}
+	allPages, err := recordsets.ListByZone(client.ServiceClient(fakeServer), "2150b1bf-dee2-4221-9d85-11f7886fb15f", opts).AllPages(context.TODO())
+	th.AssertNoErr(t, err)
+	allRecordSets, err := recordsets.ExtractRecordSets(allPages)
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, 2, len(allRecordSets))
+}
+
 func TestListAll(t *testing.T) {
 	fakeServer := th.SetupHTTP()
 	defer fakeServer.Teardown()
@@ -194,7 +207,74 @@ func TestDelete(t *testing.T) {
 	DeletedRecordSet.Records = []string{"10.1.0.2", "10.1.0.3"}
 	DeletedRecordSet.Version = 2
 
-	err := recordsets.Delete(context.TODO(), client.ServiceClient(fakeServer), DeletedRecordSet.ZoneID, DeletedRecordSet.ID).ExtractErr()
+	err := recordsets.Delete(context.TODO(), client.ServiceClient(fakeServer), DeletedRecordSet.ZoneID, DeletedRecordSet.ID, nil).ExtractErr()
 	th.AssertNoErr(t, err)
 	//th.CheckDeepEquals(t, &DeletedZone, actual)
+}
+
+func TestListAllWithAllProjects(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	HandleListAllAllProjectsSuccessfully(t, fakeServer)
+
+	opts := recordsets.ListOpts{AllProjects: true}
+	allPages, err := recordsets.ListAll(client.ServiceClient(fakeServer), opts).AllPages(context.TODO())
+	th.AssertNoErr(t, err)
+	allRecordSets, err := recordsets.ExtractRecordSets(allPages)
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, 2, len(allRecordSets))
+}
+
+func TestCreateWithAllProjects(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	HandleCreateAllProjectsSuccessfully(t, fakeServer)
+
+	createOpts := recordsets.CreateOpts{
+		Name:        "example.org.",
+		Type:        "A",
+		TTL:         3600,
+		Description: "This is an example record set.",
+		Records:     []string{"10.1.0.2"},
+		AllProjects: true,
+	}
+
+	actual, err := recordsets.Create(context.TODO(), client.ServiceClient(fakeServer), "2150b1bf-dee2-4221-9d85-11f7886fb15f", createOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, &CreatedRecordSet, actual)
+}
+
+func TestUpdateWithAllProjects(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	HandleUpdateAllProjectsSuccessfully(t, fakeServer)
+
+	var description = "Updated description"
+	ttl := 0
+	updateOpts := recordsets.UpdateOpts{
+		TTL:         &ttl,
+		Description: &description,
+		Records:     []string{"10.1.0.2", "10.1.0.3"},
+		AllProjects: true,
+	}
+
+	UpdatedRecordSet := CreatedRecordSet
+	UpdatedRecordSet.Status = "PENDING"
+	UpdatedRecordSet.Action = "UPDATE"
+	UpdatedRecordSet.Description = "Updated description"
+	UpdatedRecordSet.Records = []string{"10.1.0.2", "10.1.0.3"}
+	UpdatedRecordSet.Version = 2
+
+	actual, err := recordsets.Update(context.TODO(), client.ServiceClient(fakeServer), UpdatedRecordSet.ZoneID, UpdatedRecordSet.ID, updateOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, &UpdatedRecordSet, actual)
+}
+
+func TestDeleteWithAllProjects(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	HandleDeleteAllProjectsSuccessfully(t, fakeServer)
+
+	err := recordsets.Delete(context.TODO(), client.ServiceClient(fakeServer), "2150b1bf-dee2-4221-9d85-11f7886fb15f", "f7b10e9b-0cae-4a91-b162-562bc6096648", recordsets.DeleteOpts{AllProjects: true}).ExtractErr()
+	th.AssertNoErr(t, err)
 }


### PR DESCRIPTION
Fixes #3803

Links to the line numbers/files in the OpenStack source code that support the code in this PR:

https://opendev.org/openstack/designate/src/commit/12a5256eb51a22acc414fe7082f857355c736d5a/designate/api/middleware.py#L62-L72