### PR TITLE
dns: fix SudoTenantID type in zones ListOpts

### DIFF
--- a/openstack/dns/v2/zones/requests.go
+++ b/openstack/dns/v2/zones/requests.go
@@ -41,8 +41,8 @@ type ListOpts struct {
 	// All projects header
 	AllProjects bool `h:"X-Auth-All-Projects"`
 
-	// Sudo tenant ID
-	SudoTenantID bool `h:"X-Auth-Sudo-Tenant-ID"`
+	// SudoTenantID impersonates the given project.
+	SudoTenantID string `h:"X-Auth-Sudo-Tenant-ID"`
 }
 
 // ToZoneListQuery formats a ListOpts into a query string.


### PR DESCRIPTION
Fixes #3805

Change `SudoTenantID` field type from `bool` to `string` in zones `ListOpts`. The field carries a tenant UUID via `X-Auth-Sudo-Tenant-ID` header, not a boolean flag.