### PR TITLE
openstack/db: add Trove backup APIs

### DIFF
--- a/openstack/db/v1/backups/doc.go
+++ b/openstack/db/v1/backups/doc.go
@@ -1,0 +1,3 @@
+// Package backups provides information and interaction with database backups
+// for the OpenStack Database service.
+package backups

--- a/openstack/db/v1/backups/requests.go
+++ b/openstack/db/v1/backups/requests.go
@@ -1,0 +1,119 @@
+package backups
+
+import (
+	"context"
+
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/pagination"
+)
+
+// ListOptsBuilder allows extensions to add additional parameters to the List
+// request.
+type ListOptsBuilder interface {
+	ToBackupListQuery() (string, error)
+}
+
+// ListOpts represents options for listing database backups.
+type ListOpts struct {
+	// Return the list of backups for a particular database instance.
+	InstanceID string `q:"instance_id"`
+	// Return the list of backups for all projects. Admin only.
+	AllProjects bool `q:"all_projects"`
+	// Return backups for a particular datastore.
+	Datastore string `q:"datastore"`
+	// Return backups for a particular project. Admin only.
+	ProjectID string `q:"project_id"`
+}
+
+// ToBackupListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToBackupListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List will list database backups.
+func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := baseURL(client)
+	if opts != nil {
+		query, err := opts.ToBackupListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return BackupPage{pagination.SinglePageBase(r)}
+	})
+}
+
+// ListByInstance will list backups for a database instance.
+func ListByInstance(client *gophercloud.ServiceClient, instanceID string) pagination.Pager {
+	return pagination.NewPager(client, instanceURL(client, instanceID), func(r pagination.PageResult) pagination.Page {
+		return BackupPage{pagination.SinglePageBase(r)}
+	})
+}
+
+// CreateOptsBuilder is the top-level interface for create backup options.
+type CreateOptsBuilder interface {
+	ToBackupCreateMap() (map[string]any, error)
+}
+
+// RestoreFromOpts contains information for restoring a backup from a remote
+// location.
+type RestoreFromOpts struct {
+	RemoteLocation          string  `json:"remote_location,omitempty"`
+	LocalDatastoreVersionID string  `json:"local_datastore_version_id,omitempty"`
+	Size                    float64 `json:"size,omitempty"`
+}
+
+// CreateOpts represents options for creating a database backup.
+type CreateOpts struct {
+	// Name of the backup.
+	Name string `json:"name" required:"true"`
+	// ID of the instance to create a backup for.
+	InstanceID string `json:"instance,omitempty"`
+	// ID of the parent backup to perform an incremental backup from.
+	ParentID string `json:"parent_id,omitempty"`
+	// Set to 1 to create an incremental backup based on the last full backup.
+	Incremental *int `json:"incremental,omitempty"`
+	// An optional description for the backup.
+	Description string `json:"description,omitempty"`
+	// User-defined Swift container name.
+	SwiftContainer string `json:"swift_container,omitempty"`
+	// Information needed to restore a remote backup.
+	RestoreFrom *RestoreFromOpts `json:"restore_from,omitempty"`
+	// Backup storage driver.
+	StorageDriver string `json:"storage_driver,omitempty"`
+}
+
+// ToBackupCreateMap converts a CreateOpts struct into a request body.
+func (opts CreateOpts) ToBackupCreateMap() (map[string]any, error) {
+	return gophercloud.BuildRequestBody(opts, "backup")
+}
+
+// Create creates a database backup.
+func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToBackupCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := client.Post(ctx, baseURL(client), &b, &r.Body, &gophercloud.RequestOpts{OkCodes: []int{202}})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// Get retrieves details for a database backup.
+func Get(ctx context.Context, client *gophercloud.ServiceClient, backupID string) (r GetResult) {
+	resp, err := client.Get(ctx, resourceURL(client, backupID), &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// Delete deletes a database backup.
+func Delete(ctx context.Context, client *gophercloud.ServiceClient, backupID string) (r DeleteResult) {
+	resp, err := client.Delete(ctx, resourceURL(client, backupID), &gophercloud.RequestOpts{OkCodes: []int{202}})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}

--- a/openstack/db/v1/backups/results.go
+++ b/openstack/db/v1/backups/results.go
@@ -1,0 +1,98 @@
+package backups
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/openstack/db/v1/datastores"
+	"github.com/gophercloud/gophercloud/v2/pagination"
+)
+
+// Backup represents a database backup.
+type Backup struct {
+	Created       time.Time `json:"-"`
+	Datastore     datastores.DatastorePartial
+	Description   string
+	ID            string
+	InstanceID    string `json:"instance_id"`
+	LocationRef   string `json:"locationRef"`
+	Name          string
+	ParentID      string `json:"parent_id"`
+	ProjectID     string `json:"project_id"`
+	Size          float64
+	Status        string
+	StorageDriver string    `json:"storage_driver"`
+	Updated       time.Time `json:"-"`
+}
+
+// UnmarshalJSON converts backup timestamps to time.Time.
+func (r *Backup) UnmarshalJSON(b []byte) error {
+	type tmp Backup
+	var s struct {
+		tmp
+		Created gophercloud.JSONRFC3339NoZ `json:"created"`
+		Updated gophercloud.JSONRFC3339NoZ `json:"updated"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	*r = Backup(s.tmp)
+	r.Created = time.Time(s.Created)
+	r.Updated = time.Time(s.Updated)
+	return nil
+}
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// Extract retrieves a Backup resource from an operation result.
+func (r commonResult) Extract() (*Backup, error) {
+	var s struct {
+		Backup *Backup `json:"backup"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Backup, err
+}
+
+// CreateResult represents the result of a Create operation.
+type CreateResult struct {
+	commonResult
+}
+
+// GetResult represents the result of a Get operation.
+type GetResult struct {
+	commonResult
+}
+
+// DeleteResult represents the result of a Delete operation.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
+// BackupPage represents a page of database backups.
+type BackupPage struct {
+	pagination.SinglePageBase
+}
+
+// IsEmpty indicates whether a BackupPage is empty.
+func (r BackupPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
+	backups, err := ExtractBackups(r)
+	return len(backups) == 0, err
+}
+
+// ExtractBackups retrieves a slice of Backup structs from a paginated
+// collection.
+func ExtractBackups(r pagination.Page) ([]Backup, error) {
+	var s struct {
+		Backups []Backup `json:"backups"`
+	}
+	err := (r.(BackupPage)).ExtractInto(&s)
+	return s.Backups, err
+}

--- a/openstack/db/v1/backups/testing/doc.go
+++ b/openstack/db/v1/backups/testing/doc.go
@@ -1,0 +1,2 @@
+// db_backups_v1
+package testing

--- a/openstack/db/v1/backups/testing/fixtures_test.go
+++ b/openstack/db/v1/backups/testing/fixtures_test.go
@@ -1,0 +1,74 @@
+package testing
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/openstack/db/v1/backups"
+	"github.com/gophercloud/gophercloud/v2/openstack/db/v1/datastores"
+)
+
+var (
+	timestamp  = "2014-10-30T12:30:00"
+	timeVal, _ = time.Parse(gophercloud.RFC3339NoZ, timestamp)
+)
+
+const singleBackupJSON = `
+{
+  "created": "2014-10-30T12:30:00",
+  "datastore": {
+    "type": "mysql",
+    "version": "5.5",
+    "version_id": "b00000b0-00b0-0b00-00b0-000b000000bb"
+  },
+  "description": "My Backup",
+  "id": "a9832168-7541-4536-b8d9-a8a9b79cf1b4",
+  "instance_id": "44b277eb-39be-4921-be31-3d61b43651d7",
+  "locationRef": "http://localhost/path/to/backup",
+  "name": "snapshot",
+  "parent_id": "",
+  "project_id": "922b47766bcb448f83a760358337f2b4",
+  "size": 0.14,
+  "status": "COMPLETED",
+  "updated": "2014-10-30T12:30:00",
+  "storage_driver": "swift"
+}
+`
+
+var (
+	ListBackupsJSON  = fmt.Sprintf(`{"backups": [%s]}`, singleBackupJSON)
+	GetBackupJSON    = fmt.Sprintf(`{"backup": %s}`, singleBackupJSON)
+	CreateBackupJSON = fmt.Sprintf(`{"backup": %s}`, singleBackupJSON)
+)
+
+var CreateBackupReq = `
+{
+  "backup": {
+    "description": "My Backup",
+    "incremental": 0,
+    "instance": "44b277eb-39be-4921-be31-3d61b43651d7",
+    "name": "snapshot",
+    "storage_driver": "swift"
+  }
+}
+`
+
+var ExampleBackup = backups.Backup{
+	Created: timeVal,
+	Datastore: datastores.DatastorePartial{
+		Type:      "mysql",
+		Version:   "5.5",
+		VersionID: "b00000b0-00b0-0b00-00b0-000b000000bb",
+	},
+	Description:   "My Backup",
+	ID:            "a9832168-7541-4536-b8d9-a8a9b79cf1b4",
+	InstanceID:    "44b277eb-39be-4921-be31-3d61b43651d7",
+	LocationRef:   "http://localhost/path/to/backup",
+	Name:          "snapshot",
+	ProjectID:     "922b47766bcb448f83a760358337f2b4",
+	Size:          0.14,
+	Status:        "COMPLETED",
+	StorageDriver: "swift",
+	Updated:       timeVal,
+}

--- a/openstack/db/v1/backups/testing/requests_test.go
+++ b/openstack/db/v1/backups/testing/requests_test.go
@@ -1,0 +1,102 @@
+package testing
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/v2/openstack/db/v1/backups"
+	"github.com/gophercloud/gophercloud/v2/pagination"
+	th "github.com/gophercloud/gophercloud/v2/testhelper"
+	"github.com/gophercloud/gophercloud/v2/testhelper/client"
+	"github.com/gophercloud/gophercloud/v2/testhelper/fixture"
+)
+
+const (
+	rootURL     = "/backups"
+	backupID    = "a9832168-7541-4536-b8d9-a8a9b79cf1b4"
+	resourceURL = rootURL + "/" + backupID
+	instanceID  = "44b277eb-39be-4921-be31-3d61b43651d7"
+	instanceURL = "/instances/" + instanceID + "/backups"
+)
+
+func TestList(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	fixture.SetupHandler(t, fakeServer, rootURL, "GET", "", ListBackupsJSON, 200)
+
+	pages := 0
+	err := backups.List(client.ServiceClient(fakeServer), nil).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
+		pages++
+
+		actual, err := backups.ExtractBackups(page)
+		if err != nil {
+			return false, err
+		}
+
+		th.AssertDeepEquals(t, []backups.Backup{ExampleBackup}, actual)
+		return true, nil
+	})
+
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, 1, pages)
+}
+
+func TestListByInstance(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	fixture.SetupHandler(t, fakeServer, instanceURL, "GET", "", ListBackupsJSON, 200)
+
+	pages := 0
+	err := backups.ListByInstance(client.ServiceClient(fakeServer), instanceID).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
+		pages++
+
+		actual, err := backups.ExtractBackups(page)
+		if err != nil {
+			return false, err
+		}
+
+		th.AssertDeepEquals(t, []backups.Backup{ExampleBackup}, actual)
+		return true, nil
+	})
+
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, 1, pages)
+}
+
+func TestCreate(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	fixture.SetupHandler(t, fakeServer, rootURL, "POST", CreateBackupReq, CreateBackupJSON, 202)
+
+	incremental := 0
+	opts := backups.CreateOpts{
+		Name:          "snapshot",
+		InstanceID:    instanceID,
+		Description:   "My Backup",
+		Incremental:   &incremental,
+		StorageDriver: "swift",
+	}
+
+	backup, err := backups.Create(context.TODO(), client.ServiceClient(fakeServer), opts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, &ExampleBackup, backup)
+}
+
+func TestGet(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	fixture.SetupHandler(t, fakeServer, resourceURL, "GET", "", GetBackupJSON, 200)
+
+	backup, err := backups.Get(context.TODO(), client.ServiceClient(fakeServer), backupID).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, &ExampleBackup, backup)
+}
+
+func TestDelete(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	fixture.SetupHandler(t, fakeServer, resourceURL, "DELETE", "", "", 202)
+
+	err := backups.Delete(context.TODO(), client.ServiceClient(fakeServer), backupID).ExtractErr()
+	th.AssertNoErr(t, err)
+}

--- a/openstack/db/v1/backups/urls.go
+++ b/openstack/db/v1/backups/urls.go
@@ -1,0 +1,15 @@
+package backups
+
+import "github.com/gophercloud/gophercloud/v2"
+
+func baseURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("backups")
+}
+
+func resourceURL(c *gophercloud.ServiceClient, backupID string) string {
+	return c.ServiceURL("backups", backupID)
+}
+
+func instanceURL(c *gophercloud.ServiceClient, instanceID string) string {
+	return c.ServiceURL("instances", instanceID, "backups")
+}


### PR DESCRIPTION
For #3809

Split out from #3767.

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

- Backup routes:
  https://github.com/openstack/trove/blob/stable/2026.1/trove/common/api.py#L191-L208
- Backup controller actions and request fields:
  https://github.com/openstack/trove/blob/stable/2026.1/trove/backup/service.py#L40-L129
- Backup response fields:
  https://github.com/openstack/trove/blob/stable/2026.1/trove/backup/views.py#L17-L57
- Backup model fields, including storage_driver:
  https://github.com/openstack/trove/blob/stable/2026.1/trove/backup/models.py#L422-L429
