### PR TITLE
openstack/db: add Trove backup strategy APIs

### DIFF
--- a/openstack/db/v1/backupstrategies/doc.go
+++ b/openstack/db/v1/backupstrategies/doc.go
@@ -1,0 +1,3 @@
+// Package backupstrategies provides information and interaction with database
+// backup strategies for the OpenStack Database service.
+package backupstrategies

--- a/openstack/db/v1/backupstrategies/requests.go
+++ b/openstack/db/v1/backupstrategies/requests.go
@@ -1,0 +1,113 @@
+package backupstrategies
+
+import (
+	"context"
+
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/pagination"
+)
+
+// ListOptsBuilder allows extensions to add additional parameters to the List
+// request.
+type ListOptsBuilder interface {
+	ToBackupStrategyListQuery() (string, error)
+}
+
+// ListOpts represents options for listing backup strategies.
+type ListOpts struct {
+	// Return the strategy for a particular database instance.
+	InstanceID string `q:"instance_id"`
+	// Return strategies for a particular project. Admin only.
+	ProjectID string `q:"project_id"`
+}
+
+// ToBackupStrategyListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToBackupStrategyListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List lists backup strategies.
+func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := baseURL(client)
+	if opts != nil {
+		query, err := opts.ToBackupStrategyListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return BackupStrategyPage{pagination.SinglePageBase(r)}
+	})
+}
+
+// CreateOptsBuilder is the top-level interface for create backup strategy
+// options.
+type CreateOptsBuilder interface {
+	ToBackupStrategyCreateMap() (map[string]any, error)
+}
+
+// CreateOpts represents options for creating a backup strategy.
+type CreateOpts struct {
+	// The database instance ID. When omitted, the strategy applies at project
+	// scope.
+	InstanceID string `json:"instance_id,omitempty"`
+	// User-defined Swift container name.
+	SwiftContainer string `json:"swift_container" required:"true"`
+}
+
+// ToBackupStrategyCreateMap converts a CreateOpts struct into a request body.
+func (opts CreateOpts) ToBackupStrategyCreateMap() (map[string]any, error) {
+	return gophercloud.BuildRequestBody(opts, "backup_strategy")
+}
+
+// Create creates a backup strategy.
+func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToBackupStrategyCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := client.Post(ctx, baseURL(client), &b, &r.Body, &gophercloud.RequestOpts{OkCodes: []int{200}})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// DeleteOptsBuilder allows extensions to add additional parameters to the
+// Delete request.
+type DeleteOptsBuilder interface {
+	ToBackupStrategyDeleteQuery() (string, error)
+}
+
+// DeleteOpts represents options for deleting backup strategies.
+type DeleteOpts struct {
+	// Delete the strategy for a particular database instance.
+	InstanceID string `q:"instance_id"`
+	// Delete strategies for a particular project. Admin only.
+	ProjectID string `q:"project_id"`
+}
+
+// ToBackupStrategyDeleteQuery formats a DeleteOpts into a query string.
+func (opts DeleteOpts) ToBackupStrategyDeleteQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// Delete deletes a backup strategy.
+func Delete(ctx context.Context, client *gophercloud.ServiceClient, opts DeleteOptsBuilder) (r DeleteResult) {
+	url := baseURL(client)
+	if opts != nil {
+		query, err := opts.ToBackupStrategyDeleteQuery()
+		if err != nil {
+			r.Err = err
+			return
+		}
+		url += query
+	}
+
+	resp, err := client.Delete(ctx, url, &gophercloud.RequestOpts{OkCodes: []int{202}})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}

--- a/openstack/db/v1/backupstrategies/results.go
+++ b/openstack/db/v1/backupstrategies/results.go
@@ -1,0 +1,58 @@
+package backupstrategies
+
+import (
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/pagination"
+)
+
+// BackupStrategy represents a database backup strategy.
+type BackupStrategy struct {
+	ProjectID      string `json:"project_id"`
+	InstanceID     string `json:"instance_id"`
+	Backend        string
+	SwiftContainer string `json:"swift_container"`
+}
+
+// CreateResult represents the result of a Create operation.
+type CreateResult struct {
+	gophercloud.Result
+}
+
+// Extract retrieves a BackupStrategy resource from an operation result.
+func (r CreateResult) Extract() (*BackupStrategy, error) {
+	var s struct {
+		BackupStrategy *BackupStrategy `json:"backup_strategy"`
+	}
+	err := r.ExtractInto(&s)
+	return s.BackupStrategy, err
+}
+
+// DeleteResult represents the result of a Delete operation.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
+// BackupStrategyPage represents a page of backup strategies.
+type BackupStrategyPage struct {
+	pagination.SinglePageBase
+}
+
+// IsEmpty indicates whether a BackupStrategyPage is empty.
+func (r BackupStrategyPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
+	strategies, err := ExtractBackupStrategies(r)
+	return len(strategies) == 0, err
+}
+
+// ExtractBackupStrategies retrieves a slice of BackupStrategy structs from a
+// paginated collection.
+func ExtractBackupStrategies(r pagination.Page) ([]BackupStrategy, error) {
+	var s struct {
+		BackupStrategies []BackupStrategy `json:"backup_strategies"`
+	}
+	err := (r.(BackupStrategyPage)).ExtractInto(&s)
+	return s.BackupStrategies, err
+}

--- a/openstack/db/v1/backupstrategies/testing/doc.go
+++ b/openstack/db/v1/backupstrategies/testing/doc.go
@@ -1,0 +1,2 @@
+// db_backupstrategies_v1
+package testing

--- a/openstack/db/v1/backupstrategies/testing/fixtures_test.go
+++ b/openstack/db/v1/backupstrategies/testing/fixtures_test.go
@@ -1,0 +1,37 @@
+package testing
+
+import (
+	"fmt"
+
+	"github.com/gophercloud/gophercloud/v2/openstack/db/v1/backupstrategies"
+)
+
+const singleBackupStrategyJSON = `
+{
+  "project_id": "922b47766bcb448f83a760358337f2b4",
+  "instance_id": "0602db72-c63d-11ea-b87c-00224d6b7bc1",
+  "backend": "swift",
+  "swift_container": "my_trove_backups"
+}
+`
+
+var (
+	ListBackupStrategiesJSON = fmt.Sprintf(`{"backup_strategies": [%s]}`, singleBackupStrategyJSON)
+	CreateBackupStrategyJSON = fmt.Sprintf(`{"backup_strategy": %s}`, singleBackupStrategyJSON)
+)
+
+var CreateBackupStrategyReq = `
+{
+  "backup_strategy": {
+    "instance_id": "0602db72-c63d-11ea-b87c-00224d6b7bc1",
+    "swift_container": "my_trove_backups"
+  }
+}
+`
+
+var ExampleBackupStrategy = backupstrategies.BackupStrategy{
+	ProjectID:      "922b47766bcb448f83a760358337f2b4",
+	InstanceID:     "0602db72-c63d-11ea-b87c-00224d6b7bc1",
+	Backend:        "swift",
+	SwiftContainer: "my_trove_backups",
+}

--- a/openstack/db/v1/backupstrategies/testing/requests_test.go
+++ b/openstack/db/v1/backupstrategies/testing/requests_test.go
@@ -1,0 +1,63 @@
+package testing
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/v2/openstack/db/v1/backupstrategies"
+	"github.com/gophercloud/gophercloud/v2/pagination"
+	th "github.com/gophercloud/gophercloud/v2/testhelper"
+	"github.com/gophercloud/gophercloud/v2/testhelper/client"
+	"github.com/gophercloud/gophercloud/v2/testhelper/fixture"
+)
+
+const (
+	rootURL    = "/backup_strategies"
+	instanceID = "0602db72-c63d-11ea-b87c-00224d6b7bc1"
+)
+
+func TestList(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	fixture.SetupHandler(t, fakeServer, rootURL, "GET", "", ListBackupStrategiesJSON, 200)
+
+	pages := 0
+	err := backupstrategies.List(client.ServiceClient(fakeServer), nil).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
+		pages++
+
+		actual, err := backupstrategies.ExtractBackupStrategies(page)
+		if err != nil {
+			return false, err
+		}
+
+		th.AssertDeepEquals(t, []backupstrategies.BackupStrategy{ExampleBackupStrategy}, actual)
+		return true, nil
+	})
+
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, 1, pages)
+}
+
+func TestCreate(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	fixture.SetupHandler(t, fakeServer, rootURL, "POST", CreateBackupStrategyReq, CreateBackupStrategyJSON, 200)
+
+	opts := backupstrategies.CreateOpts{
+		InstanceID:     instanceID,
+		SwiftContainer: "my_trove_backups",
+	}
+
+	strategy, err := backupstrategies.Create(context.TODO(), client.ServiceClient(fakeServer), opts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, &ExampleBackupStrategy, strategy)
+}
+
+func TestDelete(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	fixture.SetupHandler(t, fakeServer, rootURL, "DELETE", "", "", 202)
+
+	err := backupstrategies.Delete(context.TODO(), client.ServiceClient(fakeServer), nil).ExtractErr()
+	th.AssertNoErr(t, err)
+}

--- a/openstack/db/v1/backupstrategies/urls.go
+++ b/openstack/db/v1/backupstrategies/urls.go
@@ -1,0 +1,7 @@
+package backupstrategies
+
+import "github.com/gophercloud/gophercloud/v2"
+
+func baseURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("backup_strategies")
+}


### PR DESCRIPTION
For #3809

Split out from #3767.

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

- Backup strategy routes:
  https://github.com/openstack/trove/blob/stable/2026.1/trove/common/api.py#L210-L223
- Backup strategy controller actions and request fields:
  https://github.com/openstack/trove/blob/stable/2026.1/trove/backup/service.py#L132-L182
- Backup strategy response fields:
  https://github.com/openstack/trove/blob/stable/2026.1/trove/backup/views.py#L60-L85
