### PR TITLE
openstack/db: add Trove datastore version APIs

### DIFF
--- a/openstack/db/v1/datastores/requests.go
+++ b/openstack/db/v1/datastores/requests.go
@@ -7,6 +7,118 @@ import (
 	"github.com/gophercloud/gophercloud/v2/pagination"
 )
 
+// CreateVersionOptsBuilder is the top-level interface for create version
+// options.
+type CreateVersionOptsBuilder interface {
+	ToVersionCreateMap() (map[string]any, error)
+}
+
+// CreateVersionOpts represents options for registering a datastore version.
+//
+// This is an admin-only API. When the datastore specified by DatastoreName does
+// not exist, Trove creates it automatically.
+type CreateVersionOpts struct {
+	// The name of the datastore version.
+	Name string `json:"name" required:"true"`
+	// The name of the datastore.
+	DatastoreName string `json:"datastore_name" required:"true"`
+	// The datastore manager type.
+	DatastoreManager string `json:"datastore_manager" required:"true"`
+	// The ID of an image. Either Image or ImageTags must be provided.
+	Image string `json:"image,omitempty" or:"ImageTags"`
+	// Image tags used to find the latest matching image. Either Image or
+	// ImageTags must be provided.
+	ImageTags []string `json:"image_tags,omitempty"`
+	// Whether the datastore version is enabled.
+	Active gophercloud.EnabledState `json:"active" required:"true"`
+	// Whether this datastore version is the default for the datastore.
+	Default gophercloud.EnabledState `json:"default,omitempty"`
+	// Packages associated with the datastore version.
+	Packages []string `json:"packages,omitempty"`
+	// The database engine version number.
+	Version string `json:"version,omitempty"`
+}
+
+// ToVersionCreateMap converts a CreateVersionOpts struct into a request body.
+func (opts CreateVersionOpts) ToVersionCreateMap() (map[string]any, error) {
+	return gophercloud.BuildRequestBody(opts, "version")
+}
+
+// CreateVersion registers a new datastore version. This is an admin-only API.
+// Trove automatically creates the datastore when DatastoreName does not already
+// exist.
+func CreateVersion(ctx context.Context, client *gophercloud.ServiceClient, opts CreateVersionOptsBuilder) (r CreateVersionResult) {
+	b, err := opts.ToVersionCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := client.Post(ctx, createVersionURL(client), &b, &r.Body, &gophercloud.RequestOpts{OkCodes: []int{202}})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// ListAllVersions lists all datastore versions. This is an admin-only API.
+func ListAllVersions(client *gophercloud.ServiceClient) pagination.Pager {
+	return pagination.NewPager(client, createVersionURL(client), func(r pagination.PageResult) pagination.Page {
+		return VersionPage{pagination.SinglePageBase(r)}
+	})
+}
+
+// GetVersionByID retrieves a datastore version by ID. This is an admin-only
+// API.
+func GetVersionByID(ctx context.Context, client *gophercloud.ServiceClient, versionID string) (r GetVersionResult) {
+	resp, err := client.Get(ctx, mgmtVersionURL(client, versionID), &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// UpdateVersionOptsBuilder is the top-level interface for update version
+// options.
+type UpdateVersionOptsBuilder interface {
+	ToVersionUpdateMap() (map[string]any, error)
+}
+
+// UpdateVersionOpts represents options for updating a datastore version.
+type UpdateVersionOpts struct {
+	// The name of the datastore version.
+	Name string `json:"name,omitempty"`
+	// The datastore manager type.
+	DatastoreManager string `json:"datastore_manager,omitempty"`
+	// The ID of an image.
+	Image string `json:"image,omitempty"`
+	// Image tags used to find the latest matching image.
+	ImageTags []string `json:"image_tags,omitempty"`
+	// Whether the datastore version is enabled.
+	Active gophercloud.EnabledState `json:"active,omitempty"`
+	// Whether this datastore version is the default for the datastore.
+	Default gophercloud.EnabledState `json:"default,omitempty"`
+}
+
+// ToVersionUpdateMap converts an UpdateVersionOpts struct into a request body.
+func (opts UpdateVersionOpts) ToVersionUpdateMap() (map[string]any, error) {
+	return gophercloud.BuildRequestBody(opts, "")
+}
+
+// UpdateVersion updates a datastore version. This is an admin-only API.
+func UpdateVersion(ctx context.Context, client *gophercloud.ServiceClient, versionID string, opts UpdateVersionOptsBuilder) (r UpdateVersionResult) {
+	b, err := opts.ToVersionUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := client.Patch(ctx, mgmtVersionURL(client, versionID), &b, &r.Body, &gophercloud.RequestOpts{OkCodes: []int{202}})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// DeleteVersion deletes a datastore version. This is an admin-only API.
+func DeleteVersion(ctx context.Context, client *gophercloud.ServiceClient, versionID string) (r DeleteVersionResult) {
+	resp, err := client.Delete(ctx, mgmtVersionURL(client, versionID), &gophercloud.RequestOpts{OkCodes: []int{202}})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
 // List will list all available datastore types that instances can use.
 func List(client *gophercloud.ServiceClient) pagination.Pager {
 	return pagination.NewPager(client, baseURL(client), func(r pagination.PageResult) pagination.Page {

--- a/openstack/db/v1/datastores/results.go
+++ b/openstack/db/v1/datastores/results.go
@@ -1,15 +1,54 @@
 package datastores
 
 import (
+	"encoding/json"
+
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/pagination"
 )
 
+// PackageList represents packages associated with a datastore version.
+type PackageList []string
+
+// UnmarshalJSON supports Trove responses that may return packages as either a
+// list or a single string.
+func (r *PackageList) UnmarshalJSON(b []byte) error {
+	var packages []string
+	if err := json.Unmarshal(b, &packages); err == nil {
+		*r = packages
+		return nil
+	}
+
+	var pkg string
+	if err := json.Unmarshal(b, &pkg); err != nil {
+		return err
+	}
+	if pkg == "" {
+		*r = nil
+		return nil
+	}
+
+	*r = []string{pkg}
+	return nil
+}
+
 // Version represents a version API resource. Multiple versions belong to a Datastore.
 type Version struct {
-	ID    string
-	Links []gophercloud.Link
-	Name  string
+	Active           bool
+	Datastore        string
+	DatastoreID      string `json:"datastore_id"`
+	DatastoreManager string `json:"datastore_manager"`
+	DatastoreName    string `json:"datastore_name"`
+	Default          bool
+	ID               string
+	Image            string
+	ImageTags        []string `json:"image_tags"`
+	Links            []gophercloud.Link
+	Name             string
+	Packages         PackageList
+	RegistryExt      string `json:"registry_ext"`
+	ReplStrategy     string `json:"repl_strategy"`
+	Version          string
 }
 
 // Datastore represents a Datastore API resource.
@@ -38,6 +77,21 @@ type GetResult struct {
 // GetVersionResult represents the result of getting a version.
 type GetVersionResult struct {
 	gophercloud.Result
+}
+
+// CreateVersionResult represents the result of creating a version.
+type CreateVersionResult struct {
+	gophercloud.Result
+}
+
+// UpdateVersionResult represents the result of updating a version.
+type UpdateVersionResult struct {
+	gophercloud.Result
+}
+
+// DeleteVersionResult represents the result of deleting a version.
+type DeleteVersionResult struct {
+	gophercloud.ErrResult
 }
 
 // DatastorePage represents a page of datastore resources.
@@ -100,6 +154,24 @@ func ExtractVersions(r pagination.Page) ([]Version, error) {
 
 // Extract retrieves a single Version struct from an operation result.
 func (r GetVersionResult) Extract() (*Version, error) {
+	var s struct {
+		Version *Version `json:"version"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Version, err
+}
+
+// Extract retrieves a single Version struct from a create result.
+func (r CreateVersionResult) Extract() (*Version, error) {
+	var s struct {
+		Version *Version `json:"version"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Version, err
+}
+
+// Extract retrieves a single Version struct from an update result.
+func (r UpdateVersionResult) Extract() (*Version, error) {
 	var s struct {
 		Version *Version `json:"version"`
 	}

--- a/openstack/db/v1/datastores/testing/fixtures_test.go
+++ b/openstack/db/v1/datastores/testing/fixtures_test.go
@@ -41,6 +41,60 @@ const version2JSON = `
 }
 `
 
+const createVersionReq = `
+{
+	"version": {
+		"datastore_name": "mysql",
+		"datastore_manager": "mysql",
+		"name": "mysql-5.7",
+		"image_tags": ["trove", "mysql"],
+		"active": true,
+		"default": false,
+		"packages": ["mysql-server"],
+		"version": "5.7.30"
+	}
+}
+`
+
+const createdVersionJSON = `
+{
+	"active": true,
+	"datastore_id": "10000000-0000-0000-0000-000000000001",
+	"datastore_manager": "mysql",
+	"datastore_name": "mysql",
+	"default": false,
+	"id": "b00000b0-00b0-0b00-00b0-000b000000bb",
+	"image": "",
+	"image_tags": ["trove", "mysql"],
+	"name": "mysql-5.7",
+	"packages": ["mysql-server"],
+	"version": "5.7.30"
+}
+`
+
+const updateVersionReq = `
+{
+	"name": "mysql-5.7-updated",
+	"active": true
+}
+`
+
+const updatedVersionJSON = `
+{
+	"active": true,
+	"datastore_id": "10000000-0000-0000-0000-000000000001",
+	"datastore_manager": "mysql",
+	"datastore_name": "mysql",
+	"default": false,
+	"id": "b00000b0-00b0-0b00-00b0-000b000000bb",
+	"image": "",
+	"image_tags": ["trove", "mysql"],
+	"name": "mysql-5.7-updated",
+	"packages": ["mysql-server"],
+	"version": "5.7.30"
+}
+`
+
 var versionsJSON = fmt.Sprintf(`"versions": [%s, %s]`, version1JSON, version2JSON)
 
 var singleDSJSON = fmt.Sprintf(`
@@ -63,10 +117,13 @@ var singleDSJSON = fmt.Sprintf(`
 `, versionsJSON)
 
 var (
-	ListDSResp       = fmt.Sprintf(`{"datastores":[%s]}`, singleDSJSON)
-	GetDSResp        = fmt.Sprintf(`{"datastore":%s}`, singleDSJSON)
-	ListVersionsResp = fmt.Sprintf(`{%s}`, versionsJSON)
-	GetVersionResp   = fmt.Sprintf(`{"version":%s}`, version1JSON)
+	ListDSResp          = fmt.Sprintf(`{"datastores":[%s]}`, singleDSJSON)
+	GetDSResp           = fmt.Sprintf(`{"datastore":%s}`, singleDSJSON)
+	ListVersionsResp    = fmt.Sprintf(`{%s}`, versionsJSON)
+	GetVersionResp      = fmt.Sprintf(`{"version":%s}`, version1JSON)
+	CreateVersionResp   = fmt.Sprintf(`{"version":%s}`, createdVersionJSON)
+	ListAllVersionsResp = fmt.Sprintf(`{"versions":[%s]}`, createdVersionJSON)
+	UpdateVersionResp   = fmt.Sprintf(`{"version":%s}`, updatedVersionJSON)
 )
 
 var ExampleVersion1 = datastores.Version{
@@ -88,6 +145,30 @@ var exampleVersion2 = datastores.Version{
 }
 
 var ExampleVersions = []datastores.Version{ExampleVersion1, exampleVersion2}
+
+var ExampleCreatedVersion = datastores.Version{
+	Active:           true,
+	DatastoreID:      "10000000-0000-0000-0000-000000000001",
+	DatastoreManager: "mysql",
+	DatastoreName:    "mysql",
+	ID:               "b00000b0-00b0-0b00-00b0-000b000000bb",
+	ImageTags:        []string{"trove", "mysql"},
+	Name:             "mysql-5.7",
+	Packages:         datastores.PackageList{"mysql-server"},
+	Version:          "5.7.30",
+}
+
+var ExampleUpdatedVersion = datastores.Version{
+	Active:           true,
+	DatastoreID:      "10000000-0000-0000-0000-000000000001",
+	DatastoreManager: "mysql",
+	DatastoreName:    "mysql",
+	ID:               "b00000b0-00b0-0b00-00b0-000b000000bb",
+	ImageTags:        []string{"trove", "mysql"},
+	Name:             "mysql-5.7-updated",
+	Packages:         datastores.PackageList{"mysql-server"},
+	Version:          "5.7.30",
+}
 
 var ExampleDatastore = datastores.Datastore{
 	DefaultVersion: "c00000b0-00c0-0c00-00c0-000b000000cc",

--- a/openstack/db/v1/datastores/testing/requests_test.go
+++ b/openstack/db/v1/datastores/testing/requests_test.go
@@ -4,12 +4,90 @@ import (
 	"context"
 	"testing"
 
+	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/openstack/db/v1/datastores"
 	"github.com/gophercloud/gophercloud/v2/pagination"
 	th "github.com/gophercloud/gophercloud/v2/testhelper"
 	"github.com/gophercloud/gophercloud/v2/testhelper/client"
 	"github.com/gophercloud/gophercloud/v2/testhelper/fixture"
 )
+
+func TestCreateVersion(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	fixture.SetupHandler(t, fakeServer, "/mgmt/datastore-versions", "POST", createVersionReq, CreateVersionResp, 202)
+
+	opts := datastores.CreateVersionOpts{
+		Name:             "mysql-5.7",
+		DatastoreName:    "mysql",
+		DatastoreManager: "mysql",
+		ImageTags:        []string{"trove", "mysql"},
+		Active:           gophercloud.Enabled,
+		Default:          gophercloud.Disabled,
+		Packages:         []string{"mysql-server"},
+		Version:          "5.7.30",
+	}
+
+	version, err := datastores.CreateVersion(context.TODO(), client.ServiceClient(fakeServer), opts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, &ExampleCreatedVersion, version)
+}
+
+func TestListAllVersions(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	fixture.SetupHandler(t, fakeServer, "/mgmt/datastore-versions", "GET", "", ListAllVersionsResp, 200)
+
+	pages := 0
+	err := datastores.ListAllVersions(client.ServiceClient(fakeServer)).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
+		pages++
+
+		actual, err := datastores.ExtractVersions(page)
+		if err != nil {
+			return false, err
+		}
+
+		th.AssertDeepEquals(t, []datastores.Version{ExampleCreatedVersion}, actual)
+		return true, nil
+	})
+
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, 1, pages)
+}
+
+func TestGetVersionByID(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	fixture.SetupHandler(t, fakeServer, "/mgmt/datastore-versions/{versionID}", "GET", "", CreateVersionResp, 200)
+
+	version, err := datastores.GetVersionByID(context.TODO(), client.ServiceClient(fakeServer), "{versionID}").Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, &ExampleCreatedVersion, version)
+}
+
+func TestUpdateVersion(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	fixture.SetupHandler(t, fakeServer, "/mgmt/datastore-versions/{versionID}", "PATCH", updateVersionReq, UpdateVersionResp, 202)
+
+	opts := datastores.UpdateVersionOpts{
+		Name:   "mysql-5.7-updated",
+		Active: gophercloud.Enabled,
+	}
+
+	version, err := datastores.UpdateVersion(context.TODO(), client.ServiceClient(fakeServer), "{versionID}", opts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, &ExampleUpdatedVersion, version)
+}
+
+func TestDeleteVersion(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	fixture.SetupHandler(t, fakeServer, "/mgmt/datastore-versions/{versionID}", "DELETE", "", "", 202)
+
+	err := datastores.DeleteVersion(context.TODO(), client.ServiceClient(fakeServer), "{versionID}").ExtractErr()
+	th.AssertNoErr(t, err)
+}
 
 func TestList(t *testing.T) {
 	fakeServer := th.SetupHTTP()

--- a/openstack/db/v1/datastores/urls.go
+++ b/openstack/db/v1/datastores/urls.go
@@ -6,6 +6,14 @@ func baseURL(c *gophercloud.ServiceClient) string {
 	return c.ServiceURL("datastores")
 }
 
+func createVersionURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("mgmt", "datastore-versions")
+}
+
+func mgmtVersionURL(c *gophercloud.ServiceClient, versionID string) string {
+	return c.ServiceURL("mgmt", "datastore-versions", versionID)
+}
+
 func resourceURL(c *gophercloud.ServiceClient, dsID string) string {
 	return c.ServiceURL("datastores", dsID)
 }


### PR DESCRIPTION
For #3809

Split out from #3767.

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

- Datastore version management route:
  https://github.com/openstack/trove/blob/stable/2026.1/trove/extensions/routes/mgmt.py#L79-L83
- Datastore version controller actions and request fields:
  https://github.com/openstack/trove/blob/stable/2026.1/trove/extensions/mgmt/datastores/service.py#L33-L207
- Datastore version response fields:
  https://github.com/openstack/trove/blob/stable/2026.1/trove/extensions/mgmt/datastores/views.py#L16-L53
