### PR TITLE
openstack/db: add Trove configuration parameter APIs

### DIFF
--- a/openstack/db/v1/configurations/requests.go
+++ b/openstack/db/v1/configurations/requests.go
@@ -120,6 +120,145 @@ func Replace(ctx context.Context, client *gophercloud.ServiceClient, configID st
 	return
 }
 
+// CreateParamOptsBuilder is the top-level interface for create parameter
+// options.
+type CreateParamOptsBuilder interface {
+	ToParamCreateMap() (map[string]any, error)
+}
+
+type createParamRequest struct {
+	Name            string `json:"name" required:"true"`
+	DataType        string `json:"data_type" required:"true"`
+	MinSize         *int   `json:"min_size,omitempty"`
+	MaxSize         *int   `json:"max_size,omitempty"`
+	RestartRequired *int   `json:"restart_required" required:"true"`
+}
+
+// CreateParamOpts represents options for registering a configuration parameter
+// for a datastore version.
+type CreateParamOpts struct {
+	// The name of the configuration parameter.
+	Name string `json:"name" required:"true"`
+	// The configuration parameter data type, for example "integer", "string",
+	// "float", or "boolean".
+	DataType string `json:"data_type" required:"true"`
+	// The minimum value for integer parameters.
+	MinSize *int `json:"min_size,omitempty"`
+	// The maximum value for integer parameters.
+	MaxSize *int `json:"max_size,omitempty"`
+	// Whether the database service needs to restart after this parameter
+	// changes.
+	RestartRequired bool `json:"restart_required"`
+}
+
+// ToParamCreateMap converts a CreateParamOpts struct into a request body.
+func (opts CreateParamOpts) ToParamCreateMap() (map[string]any, error) {
+	paramOpts := createParamRequest{
+		Name:            opts.Name,
+		DataType:        opts.DataType,
+		MinSize:         opts.MinSize,
+		MaxSize:         opts.MaxSize,
+		RestartRequired: restartRequiredToInt(opts.RestartRequired),
+	}
+
+	return gophercloud.BuildRequestBody(paramOpts, "configuration-parameter")
+}
+
+// CreateDatastoreVersionParam registers a configuration parameter for a
+// datastore version. This is an admin-only API.
+func CreateDatastoreVersionParam(ctx context.Context, client *gophercloud.ServiceClient, versionID string, opts CreateParamOptsBuilder) (r CreateParamResult) {
+	b, err := opts.ToParamCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := client.Post(ctx, createDSParamURL(client, versionID), &b, &r.Body, &gophercloud.RequestOpts{OkCodes: []int{200}})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// UpdateParamOptsBuilder is the top-level interface for update parameter
+// options.
+type UpdateParamOptsBuilder interface {
+	ToParamUpdateMap() (map[string]any, error)
+}
+
+type updateParamRequest struct {
+	Name            string `json:"name,omitempty"`
+	DataType        string `json:"data_type,omitempty"`
+	MinSize         *int   `json:"min_size,omitempty"`
+	MaxSize         *int   `json:"max_size,omitempty"`
+	RestartRequired *int   `json:"restart_required,omitempty"`
+}
+
+// UpdateParamOpts represents options for updating a configuration parameter
+// for a datastore version.
+type UpdateParamOpts struct {
+	// The name of the configuration parameter.
+	Name string `json:"name,omitempty"`
+	// The configuration parameter data type, for example "integer", "string",
+	// "float", or "boolean".
+	DataType string `json:"data_type,omitempty"`
+	// The minimum value for integer parameters.
+	MinSize *int `json:"min_size,omitempty"`
+	// The maximum value for integer parameters.
+	MaxSize *int `json:"max_size,omitempty"`
+	// Whether the database service needs to restart after this parameter
+	// changes.
+	RestartRequired *bool `json:"restart_required,omitempty"`
+}
+
+// ToParamUpdateMap converts an UpdateParamOpts struct into a request body.
+func (opts UpdateParamOpts) ToParamUpdateMap() (map[string]any, error) {
+	paramOpts := updateParamRequest{
+		Name:            opts.Name,
+		DataType:        opts.DataType,
+		MinSize:         opts.MinSize,
+		MaxSize:         opts.MaxSize,
+		RestartRequired: restartRequiredToIntPtr(opts.RestartRequired),
+	}
+
+	return gophercloud.BuildRequestBody(paramOpts, "configuration-parameter")
+}
+
+// UpdateDatastoreVersionParam updates a configuration parameter for a
+// datastore version. This is an admin-only API.
+func UpdateDatastoreVersionParam(ctx context.Context, client *gophercloud.ServiceClient, versionID, paramID string, opts UpdateParamOptsBuilder) (r UpdateParamResult) {
+	b, err := opts.ToParamUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := client.Put(ctx, updateDSParamURL(client, versionID, paramID), &b, &r.Body, &gophercloud.RequestOpts{OkCodes: []int{200}})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+func restartRequiredToInt(restartRequired bool) *int {
+	value := 0
+	if restartRequired {
+		value = 1
+	}
+
+	return &value
+}
+
+func restartRequiredToIntPtr(restartRequired *bool) *int {
+	if restartRequired == nil {
+		return nil
+	}
+
+	return restartRequiredToInt(*restartRequired)
+}
+
+// DeleteDatastoreVersionParam deletes a configuration parameter for a
+// datastore version. This is an admin-only API.
+func DeleteDatastoreVersionParam(ctx context.Context, client *gophercloud.ServiceClient, versionID, paramID string) (r DeleteParamResult) {
+	resp, err := client.Delete(ctx, updateDSParamURL(client, versionID, paramID), &gophercloud.RequestOpts{OkCodes: []int{204}})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
 // Delete will permanently delete a configuration group. Please note that
 // config groups cannot be deleted whilst still attached to running instances -
 // you must detach and then delete them.

--- a/openstack/db/v1/configurations/results.go
+++ b/openstack/db/v1/configurations/results.go
@@ -102,6 +102,24 @@ type DeleteResult struct {
 	gophercloud.ErrResult
 }
 
+// CreateParamResult represents the result of creating a configuration
+// parameter.
+type CreateParamResult struct {
+	gophercloud.Result
+}
+
+// UpdateParamResult represents the result of updating a configuration
+// parameter.
+type UpdateParamResult struct {
+	gophercloud.Result
+}
+
+// DeleteParamResult represents the result of deleting a configuration
+// parameter.
+type DeleteParamResult struct {
+	gophercloud.ErrResult
+}
+
 // Param represents a configuration parameter API resource.
 type Param struct {
 	Max             float64
@@ -109,6 +127,29 @@ type Param struct {
 	Name            string
 	RestartRequired bool `json:"restart_required"`
 	Type            string
+}
+
+// UnmarshalJSON supports Trove responses that may return max/min fields as
+// either max/min or max_size/min_size.
+func (r *Param) UnmarshalJSON(b []byte) error {
+	type tmp Param
+	var s struct {
+		tmp
+		MaxSize *float64 `json:"max_size"`
+		MinSize *float64 `json:"min_size"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	*r = Param(s.tmp)
+	if s.MaxSize != nil {
+		r.Max = *s.MaxSize
+	}
+	if s.MinSize != nil {
+		r.Min = *s.MinSize
+	}
+	return nil
 }
 
 // ParamPage contains a page of Param resources in a paginated collection.
@@ -143,6 +184,22 @@ type ParamResult struct {
 
 // Extract will retrieve a param from an operation result.
 func (r ParamResult) Extract() (*Param, error) {
+	var s *Param
+	err := r.ExtractInto(&s)
+	return s, err
+}
+
+// Extract will retrieve created params from an operation result.
+func (r CreateParamResult) Extract() ([]Param, error) {
+	var s struct {
+		Params []Param `json:"configuration-parameters"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Params, err
+}
+
+// Extract will retrieve an updated param from an operation result.
+func (r UpdateParamResult) Extract() (*Param, error) {
 	var s *Param
 	err := r.ExtractInto(&s)
 	return s, err

--- a/openstack/db/v1/configurations/testing/fixtures_test.go
+++ b/openstack/db/v1/configurations/testing/fixtures_test.go
@@ -133,6 +133,85 @@ var GetParamJSON = `
 }
 `
 
+var CreateParamReq = `
+{
+  "configuration-parameter": {
+    "data_type": "integer",
+    "max_size": 65535,
+    "min_size": 64,
+    "name": "connect_timeout",
+    "restart_required": 0
+  }
+}
+`
+
+var CreateParamZeroReq = `
+{
+  "configuration-parameter": {
+    "data_type": "integer",
+    "max_size": 0,
+    "min_size": 0,
+    "name": "connect_timeout",
+    "restart_required": 0
+  }
+}
+`
+
+var CreateParamJSON = `
+{
+  "configuration-parameters": [
+    {
+      "datastore_version_id": "b00000b0-00b0-0b00-00b0-000b000000bb",
+      "max": 65535,
+      "min": 64,
+      "name": "connect_timeout",
+      "restart_required": false,
+      "type": "integer"
+    }
+  ]
+}
+`
+
+var CreateParamZeroJSON = `
+{
+  "configuration-parameters": [
+    {
+      "datastore_version_id": "b00000b0-00b0-0b00-00b0-000b000000bb",
+      "max": 0,
+      "min": 0,
+      "name": "connect_timeout",
+      "restart_required": false,
+      "type": "integer"
+    }
+  ]
+}
+`
+
+var UpdateParamReq = `
+{
+  "configuration-parameter": {
+    "data_type": "integer",
+    "max_size": 65535,
+    "min_size": 64,
+    "name": "connect_timeout",
+    "restart_required": 0
+  }
+}
+`
+
+var UpdateParamJSON = `
+{
+  "datastore_version_id": "b00000b0-00b0-0b00-00b0-000b000000bb",
+  "deleted": 0,
+  "deleted_at": null,
+  "max_size": 65535,
+  "min_size": 64,
+  "name": "connect_timeout",
+  "restart_required": false,
+  "type": "integer"
+}
+`
+
 var ExampleConfig = configurations.Config{
 	Created:              timeVal,
 	DatastoreName:        "mysql",

--- a/openstack/db/v1/configurations/testing/requests_test.go
+++ b/openstack/db/v1/configurations/testing/requests_test.go
@@ -21,6 +21,7 @@ var (
 	versionID          = "{versionID}"
 	paramID            = "{paramID}"
 	dsParamListURL     = "/datastores/" + dsID + "/versions/" + versionID + "/parameters"
+	dsParamCreateURL   = "/mgmt/datastores/versions/" + versionID + "/parameters"
 	dsParamGetURL      = "/datastores/" + dsID + "/versions/" + versionID + "/parameters/" + paramID
 	globalParamListURL = "/datastores/versions/" + versionID + "/parameters"
 	globalParamGetURL  = "/datastores/versions/" + versionID + "/parameters/" + paramID
@@ -190,6 +191,89 @@ func TestGetDSParam(t *testing.T) {
 	}
 
 	th.AssertDeepEquals(t, expected, param)
+}
+
+func TestCreateDatastoreVersionParam(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	fixture.SetupHandler(t, fakeServer, dsParamCreateURL, "POST", CreateParamReq, CreateParamJSON, 200)
+
+	minSize := 64
+	maxSize := 65535
+	opts := configurations.CreateParamOpts{
+		Name:     "connect_timeout",
+		DataType: "integer",
+		MinSize:  &minSize,
+		MaxSize:  &maxSize,
+	}
+
+	params, err := configurations.CreateDatastoreVersionParam(context.TODO(), client.ServiceClient(fakeServer), versionID, opts).Extract()
+	th.AssertNoErr(t, err)
+
+	expected := []configurations.Param{
+		{Max: 65535, Min: 64, Name: "connect_timeout", RestartRequired: false, Type: "integer"},
+	}
+
+	th.AssertDeepEquals(t, expected, params)
+}
+
+func TestCreateDatastoreVersionParamWithZeroSizes(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	fixture.SetupHandler(t, fakeServer, dsParamCreateURL, "POST", CreateParamZeroReq, CreateParamZeroJSON, 200)
+
+	minSize := 0
+	maxSize := 0
+	opts := configurations.CreateParamOpts{
+		Name:     "connect_timeout",
+		DataType: "integer",
+		MinSize:  &minSize,
+		MaxSize:  &maxSize,
+	}
+
+	params, err := configurations.CreateDatastoreVersionParam(context.TODO(), client.ServiceClient(fakeServer), versionID, opts).Extract()
+	th.AssertNoErr(t, err)
+
+	expected := []configurations.Param{
+		{Max: 0, Min: 0, Name: "connect_timeout", RestartRequired: false, Type: "integer"},
+	}
+
+	th.AssertDeepEquals(t, expected, params)
+}
+
+func TestUpdateDatastoreVersionParam(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	fixture.SetupHandler(t, fakeServer, dsParamCreateURL+"/"+paramID, "PUT", UpdateParamReq, UpdateParamJSON, 200)
+
+	minSize := 64
+	maxSize := 65535
+	restartRequired := false
+	opts := configurations.UpdateParamOpts{
+		Name:            "connect_timeout",
+		DataType:        "integer",
+		MinSize:         &minSize,
+		MaxSize:         &maxSize,
+		RestartRequired: &restartRequired,
+	}
+
+	param, err := configurations.UpdateDatastoreVersionParam(context.TODO(), client.ServiceClient(fakeServer), versionID, paramID, opts).Extract()
+	th.AssertNoErr(t, err)
+
+	expected := &configurations.Param{
+		Max: 65535, Min: 64, Name: "connect_timeout", RestartRequired: false, Type: "integer",
+	}
+
+	th.AssertDeepEquals(t, expected, param)
+}
+
+func TestDeleteDatastoreVersionParam(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	fixture.SetupHandler(t, fakeServer, dsParamCreateURL+"/"+paramID, "DELETE", "", "", 204)
+
+	err := configurations.DeleteDatastoreVersionParam(context.TODO(), client.ServiceClient(fakeServer), versionID, paramID).ExtractErr()
+	th.AssertNoErr(t, err)
 }
 
 func TestListGlobalParams(t *testing.T) {

--- a/openstack/db/v1/configurations/urls.go
+++ b/openstack/db/v1/configurations/urls.go
@@ -18,6 +18,14 @@ func listDSParamsURL(c *gophercloud.ServiceClient, datastoreID, versionID string
 	return c.ServiceURL("datastores", datastoreID, "versions", versionID, "parameters")
 }
 
+func createDSParamURL(c *gophercloud.ServiceClient, versionID string) string {
+	return c.ServiceURL("mgmt", "datastores", "versions", versionID, "parameters")
+}
+
+func updateDSParamURL(c *gophercloud.ServiceClient, versionID, paramID string) string {
+	return c.ServiceURL("mgmt", "datastores", "versions", versionID, "parameters", paramID)
+}
+
 func getDSParamURL(c *gophercloud.ServiceClient, datastoreID, versionID, paramID string) string {
 	return c.ServiceURL("datastores", datastoreID, "versions", versionID, "parameters", paramID)
 }


### PR DESCRIPTION
For #3809

Split out from #3767.

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

- Datastore version configuration parameter management route:
  https://github.com/openstack/trove/blob/stable/2026.1/trove/extensions/routes/mgmt.py#L73-L77
- Datastore version configuration parameter controller actions and request fields:
  https://github.com/openstack/trove/blob/stable/2026.1/trove/extensions/mgmt/configuration/service.py#L32-L135
- Datastore version configuration parameter response fields:
  https://github.com/openstack/trove/blob/stable/2026.1/trove/extensions/mgmt/configuration/views.py#L21-L53
