### PR TITLE
CI: mark failing CI jobs as not required

### DIFF
--- a/script/configure-required-github-jobs
+++ b/script/configure-required-github-jobs
@@ -55,8 +55,8 @@ declare -A EXPECTED_SETTINGS=(
 # their workflow has an `on: merge_group` trigger. Add entries using the exact
 # name format: "<Job name>" (with resolved matrix values).
 SKIP_CHECKS=(
-    "Magnum on OpenStack master"
-    "Zaqar on OpenStack master"
+    "Magnum on OpenStack master"   # https://github.com/gophercloud/gophercloud/issues/3818
+    "Neutron on OpenStack master"  # https://github.com/gophercloud/gophercloud/issues/3817
     "finish"   # coveralls parallel-finish job, not a test gate
 )
 


### PR DESCRIPTION
The zaqar job is back to green, but now neutron is failing.