### PR TITLE
ci: add functional CI workflow for Zun (container)

### DIFF
--- a/.github/workflows/functional-container.yaml
+++ b/.github/workflows/functional-container.yaml
@@ -1,0 +1,106 @@
+name: functional-container
+on:
+  merge_group:
+  pull_request:
+  schedule:
+    - cron: '0 0 */3 * *'
+jobs:
+  functional-container:
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: "master"
+            openstack_version: "master"
+            ubuntu_version: "24.04"
+          - name: "gazpacho"
+            openstack_version: "stable/2026.1"
+            ubuntu_version: "24.04"
+          - name: "epoxy"
+            openstack_version: "stable/2025.1"
+            ubuntu_version: "24.04"
+    runs-on: ubuntu-${{ matrix.ubuntu_version }}
+    name: Zun on OpenStack ${{ matrix.name }}
+    steps:
+      - name: Checkout Gophercloud
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Check changed files
+        uses: ./.github/actions/file-filter
+        id: changed-files
+        with:
+          patterns: |
+            openstack/auth_env.go
+            openstack/client.go
+            openstack/endpoint.go
+            openstack/endpoint_location.go
+            openstack/config/provider_client.go
+            openstack/utils/choose_version.go
+            openstack/utils/discovery.go
+            **container/**
+            .github/workflows/functional-container.yaml
+
+      - name: Skip tests for unrelated changed-files
+        if: ${{ ! fromJSON(steps.changed-files.outputs.matches) }}
+        run: |
+          echo "No relevant files changed - skipping tests for ${{ matrix.name }}"
+          echo "TESTS_SKIPPED=true" >> $GITHUB_ENV
+
+      - name: Deploy devstack
+        if: ${{ fromJSON(steps.changed-files.outputs.matches) }}
+        uses: gophercloud/devstack-action@60ca1042045c0c9e3e001c64575d381654ffcba1 # v0.19
+        with:
+          branch: ${{ matrix.openstack_version }}
+          enable_workaround_docker_io: false
+          conf_overrides: |
+            enable_plugin zun https://github.com/openstack/zun ${{ matrix.openstack_version }}
+            enable_plugin devstack-plugin-container https://github.com/openstack/devstack-plugin-container ${{ matrix.openstack_version }}
+            enable_plugin kuryr-libnetwork https://github.com/openstack/kuryr-libnetwork ${{ matrix.openstack_version }}
+            KURYR_CONFIG_DIR=/etc/kuryr-libnetwork
+            ZUN_DRIVER=docker
+            ZUN_CAPSULE_DRIVER=docker
+            ZUN_DB_TYPE=sql
+            ENABLE_CONTAINERD_CRI=true
+          enabled_services: "zun-api,zun-compute,zun-wsproxy,openstack-cli-server"
+
+      - name: Checkout go
+        if: ${{ fromJSON(steps.changed-files.outputs.matches) }}
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - name: Run Gophercloud acceptance tests
+        if: ${{ fromJSON(steps.changed-files.outputs.matches) }}
+        run: |
+          source ${{ github.workspace }}/script/stackenv
+          make acceptance-container
+          echo "TESTS_RUN=true" >> $GITHUB_ENV
+        env:
+          DEVSTACK_PATH: ${{ github.workspace }}/devstack
+          OS_BRANCH: ${{ matrix.openstack_version }}
+
+      - name: Generate logs on failure
+        run: ./script/collectlogs
+        if: ${{ failure() && fromJSON(steps.changed-files.outputs.matches) }}
+
+      - name: Upload logs artifacts on failure
+        if: ${{ failure() && fromJSON(steps.changed-files.outputs.matches) }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: functional-container-${{ matrix.name }}-${{ github.run_id }}
+          path: /tmp/devstack-logs/*
+
+      - name: Set job status
+        run: |
+          if [[ "$TESTS_SKIPPED" == "true" || "$TESTS_RUN" == "true" ]]; then
+            echo "Job completed successfully (either ran tests or skipped appropriately)"
+            exit 0
+          else
+            echo "Job failed - neither tests ran nor were properly skipped"
+            exit 1
+          fi

--- a/.github/workflows/functional-container.yaml
+++ b/.github/workflows/functional-container.yaml
@@ -65,6 +65,9 @@ jobs:
             ZUN_CAPSULE_DRIVER=docker
             ZUN_DB_TYPE=sql
             ENABLE_CONTAINERD_CRI=true
+            [[post-config|\$ZUN_CONF]]
+            [DEFAULT]
+            sandbox_image = registry.k8s.io/pause:3.9
           enabled_services: "zun-api,zun-compute,zun-wsproxy,openstack-cli-server"
 
       - name: Checkout go

--- a/internal/acceptance/openstack/container/v1/capsules_test.go
+++ b/internal/acceptance/openstack/container/v1/capsules_test.go
@@ -13,8 +13,6 @@ import (
 )
 
 func TestCapsuleBase(t *testing.T) {
-	t.Skip("Currently failing in OpenLab")
-
 	clients.SkipRelease(t, "stable/mitaka")
 	clients.SkipRelease(t, "stable/newton")
 	clients.SkipRelease(t, "stable/ocata")
@@ -64,8 +62,6 @@ func TestCapsuleBase(t *testing.T) {
 }
 
 func TestCapsuleV132(t *testing.T) {
-	t.Skip("Currently failing in OpenLab")
-
 	clients.SkipRelease(t, "stable/mitaka")
 	clients.SkipRelease(t, "stable/newton")
 	clients.SkipRelease(t, "stable/ocata")

--- a/script/configure-required-github-jobs
+++ b/script/configure-required-github-jobs
@@ -57,6 +57,7 @@ declare -A EXPECTED_SETTINGS=(
 SKIP_CHECKS=(
     "Magnum on OpenStack master"   # https://github.com/gophercloud/gophercloud/issues/3818
     "Neutron on OpenStack master"  # https://github.com/gophercloud/gophercloud/issues/3817
+    "Zun on OpenStack master"       # https://bugs.launchpad.net/zun/+bug/2158372
     "finish"   # coveralls parallel-finish job, not a test gate
 )
 

--- a/service_client.go
+++ b/service_client.go
@@ -133,6 +133,9 @@ func (client *ServiceClient) setMicroversionHeader(opts *RequestOpts) {
 	case "container-infrastructure-management", "container-infrastructure", "container-infra":
 		// magnum should accept container-infrastructure-management but (as of Epoxy) does not
 		serviceType = "container-infra"
+	case "application-container":
+		// zun expects "container" in the OpenStack-API-Version header
+		serviceType = "container"
 	}
 
 	if client.Type != "" {


### PR DESCRIPTION
Add a new GitHub Actions workflow that runs Zun acceptance tests against three OpenStack releases (master, gazpacho, epoxy).

The workflow enables the Zun DevStack plugin and runs the existing acceptance-container Makefile target. The t.Skip calls that were unconditionally skipping both capsule tests are removed so the tests actually run in CI.