### PR TITLE
subnetpool: add missing pointer in DefaultQuota

### DIFF
--- a/internal/acceptance/openstack/networking/v2/extensions/subnetpools/subnetpools.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/subnetpools/subnetpools.go
@@ -42,6 +42,39 @@ func CreateSubnetPool(t *testing.T, client *gophercloud.ServiceClient) (*subnetp
 	return subnetPool, nil
 }
 
+func CreateSubnetPoolDefaultQuotaZero(t *testing.T, client *gophercloud.ServiceClient) (*subnetpools.SubnetPool, error) {
+	subnetPoolName := tools.RandomString("TESTACC-", 8)
+	subnetPoolDescription := tools.RandomString("TESTACC-DESC-", 8)
+	subnetPoolPrefixes := []string{
+		"192.168.10.0/24",
+	}
+	defaultQuota := 0
+	createOpts := subnetpools.CreateOpts{
+		Name:             subnetPoolName,
+		Description:      subnetPoolDescription,
+		Prefixes:         subnetPoolPrefixes,
+		DefaultPrefixLen: 24,
+		DefaultQuota:     &defaultQuota,
+	}
+
+	t.Logf("Attempting to create a subnetpool: %s", subnetPoolName)
+
+	subnetPool, err := subnetpools.Create(context.TODO(), client, createOpts).Extract()
+	if err != nil {
+		return nil, err
+	}
+
+	t.Logf("Successfully created the subnetpool.")
+
+	th.AssertEquals(t, subnetPool.Name, subnetPoolName)
+	th.AssertEquals(t, subnetPool.Description, subnetPoolDescription)
+	th.AssertDeepEquals(t, subnetPoolPrefixes, subnetPool.Prefixes)
+	th.AssertEquals(t, 24, subnetPool.DefaultPrefixLen)
+	th.AssertEquals(t, 0, *subnetPool.DefaultQuota)
+
+	return subnetPool, nil
+}
+
 // DeleteSubnetPool will delete a subnetpool with a specified ID.
 // A fatal error will occur if the delete was not successful.
 func DeleteSubnetPool(t *testing.T, client *gophercloud.ServiceClient, subnetPoolID string) {

--- a/internal/acceptance/openstack/networking/v2/extensions/subnetpools/subnetpools_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/subnetpools/subnetpools_test.go
@@ -57,6 +57,23 @@ func TestSubnetPoolsCRUD(t *testing.T) {
 	th.AssertTrue(t, found)
 }
 
+func TestSubnetPoolsDefaultQuotaZeroCreate(t *testing.T) {
+	client, err := clients.NewNetworkV2Client()
+	th.AssertNoErr(t, err)
+
+	// Create a subnetpool
+	subnetPool, err := CreateSubnetPoolDefaultQuotaZero(t, client)
+	th.AssertNoErr(t, err)
+	defer DeleteSubnetPool(t, client, subnetPool.ID)
+
+	tools.PrintResource(t, subnetPool)
+
+	sb, err := subnetpools.Get(context.TODO(), client, subnetPool.ID).Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, 0, *sb.DefaultQuota)
+}
+
 func TestSubnetPoolsRevision(t *testing.T) {
 	client, err := clients.NewNetworkV2Client()
 	th.AssertNoErr(t, err)

--- a/openstack/networking/v2/extensions/subnetpools/requests.go
+++ b/openstack/networking/v2/extensions/subnetpools/requests.go
@@ -92,7 +92,7 @@ type CreateOpts struct {
 
 	// DefaultQuota is the per-project quota on the prefix space
 	// that can be allocated from the subnetpool for project subnets.
-	DefaultQuota int `json:"default_quota,omitempty"`
+	DefaultQuota *int `json:"default_quota,omitempty"`
 
 	// TenantID is the id of the Identity project.
 	TenantID string `json:"tenant_id,omitempty"`

--- a/openstack/networking/v2/extensions/subnetpools/results.go
+++ b/openstack/networking/v2/extensions/subnetpools/results.go
@@ -58,7 +58,7 @@ type SubnetPool struct {
 
 	// DefaultQuota is the per-project quota on the prefix space
 	// that can be allocated from the subnetpool for project subnets.
-	DefaultQuota int `json:"default_quota"`
+	DefaultQuota *int `json:"default_quota"`
 
 	// TenantID is the id of the Identity project.
 	TenantID string `json:"tenant_id"`
@@ -265,6 +265,6 @@ func ExtractSubnetPools(r pagination.Page) ([]SubnetPool, error) {
 	var s struct {
 		SubnetPools []SubnetPool `json:"subnetpools"`
 	}
-	err := (r.(SubnetPoolPage)).ExtractInto(&s)
+	err := r.(SubnetPoolPage).ExtractInto(&s)
 	return s.SubnetPools, err
 }

--- a/openstack/networking/v2/extensions/subnetpools/testing/fixtures_test.go
+++ b/openstack/networking/v2/extensions/subnetpools/testing/fixtures_test.go
@@ -204,6 +204,33 @@ const SubnetPoolCreateDefaultQuotaZeroRequest = `
 }
 `
 
+const SubnetPoolCreateDefaultQuotaZeroResult = `
+{
+    "subnetpool": {
+        "address_scope_id": "3d4e2e2a-552b-42ad-a16d-820bbf3edaf3",
+        "created_at": "2018-01-01T00:00:15Z",
+        "default_prefixlen": "25",
+        "default_quota": 0,
+        "description": "ipv4 prefixes",
+        "id": "55b5999c-c2fe-42cd-bce0-961a551b80f5",
+        "ip_version": 4,
+        "is_default": false,
+        "max_prefixlen": "30",
+        "min_prefixlen": "25",
+        "name": "my_ipv4_pool",
+        "prefixes": [
+            "10.10.0.0/16",
+            "10.11.11.0/24"
+        ],
+        "project_id": "1e2b9857295a4a3e841809ef492812c5",
+        "revision_number": 1,
+        "shared": false,
+        "tenant_id": "1e2b9857295a4a3e841809ef492812c5",
+        "updated_at": "2018-01-01T00:00:15Z"
+    }
+}
+`
+
 const SubnetPoolCreateResult = `
 {
     "subnetpool": {

--- a/openstack/networking/v2/extensions/subnetpools/testing/fixtures_test.go
+++ b/openstack/networking/v2/extensions/subnetpools/testing/fixtures_test.go
@@ -3,6 +3,7 @@ package testing
 import (
 	"time"
 
+	"github.com/gophercloud/gophercloud/v2/internal/ptr"
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/subnetpools"
 )
 
@@ -82,7 +83,6 @@ var SubnetPool1 = subnetpools.SubnetPool{
 	AddressScopeID:   "",
 	CreatedAt:        time.Date(2017, 12, 28, 7, 21, 41, 0, time.UTC),
 	DefaultPrefixLen: 8,
-	DefaultQuota:     0,
 	Description:      "IPv4",
 	ID:               "d43a57fe-3390-4608-b437-b1307b0adb40",
 	IPversion:        4,
@@ -105,7 +105,6 @@ var SubnetPool2 = subnetpools.SubnetPool{
 	AddressScopeID:   "0bc38e22-be49-4e67-969e-fec3f36508bd",
 	CreatedAt:        time.Date(2017, 12, 28, 7, 21, 34, 0, time.UTC),
 	DefaultPrefixLen: 64,
-	DefaultQuota:     0,
 	Description:      "IPv6",
 	ID:               "832cb7f3-59fe-40cf-8f64-8350ffc03272",
 	IPversion:        6,
@@ -128,7 +127,7 @@ var SubnetPool3 = subnetpools.SubnetPool{
 	AddressScopeID:   "",
 	CreatedAt:        time.Date(2017, 12, 28, 7, 21, 27, 0, time.UTC),
 	DefaultPrefixLen: 64,
-	DefaultQuota:     4,
+	DefaultQuota:     ptr.To(4),
 	Description:      "PublicPool",
 	ID:               "2fe18ae6-58c2-4a85-8bfb-566d6426749b",
 	IPversion:        6,
@@ -188,6 +187,23 @@ const SubnetPoolCreateRequest = `
 }
 `
 
+const SubnetPoolCreateDefaultQuotaZeroRequest = `
+{
+    "subnetpool": {
+        "name": "my_ipv4_pool",
+        "prefixes": [
+            "10.10.0.0/16",
+            "10.11.11.0/24"
+        ],
+        "address_scope_id": "3d4e2e2a-552b-42ad-a16d-820bbf3edaf3",
+        "min_prefixlen": 25,
+        "max_prefixlen": 30,
+        "description": "ipv4 prefixes",
+		"default_quota": 0
+    }
+}
+`
+
 const SubnetPoolCreateResult = `
 {
     "subnetpool": {
@@ -237,7 +253,7 @@ const SubnetPoolUpdateResponse = `
         "address_scope_id": null,
         "created_at": "2018-01-03T07:21:34Z",
         "default_prefixlen": 8,
-        "default_quota": null,
+        "default_quota": 0,
         "description": null,
         "id": "099546ca-788d-41e5-a76d-17d8cd282d3e",
         "ip_version": 4,

--- a/openstack/networking/v2/extensions/subnetpools/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/subnetpools/testing/requests_test.go
@@ -74,7 +74,7 @@ func TestGet(t *testing.T) {
 
 	th.AssertEquals(t, "0a738452-8057-4ad3-89c2-92f6a74afa76", s.ID)
 	th.AssertEquals(t, "my-ipv6-pool", s.Name)
-	th.AssertEquals(t, 2, s.DefaultQuota)
+	th.AssertEquals(t, 2, *s.DefaultQuota)
 	th.AssertEquals(t, "1e2b9857295a4a3e841809ef492812c5", s.TenantID)
 	th.AssertEquals(t, "1e2b9857295a4a3e841809ef492812c5", s.ProjectID)
 	th.AssertEquals(t, s.CreatedAt, time.Date(2018, 1, 1, 0, 0, 1, 0, time.UTC))
@@ -92,6 +92,7 @@ func TestGet(t *testing.T) {
 	th.AssertTrue(t, s.IsDefault)
 	th.AssertEquals(t, 2, s.RevisionNumber)
 }
+
 func TestCreate(t *testing.T) {
 	fakeServer := th.SetupHTTP()
 	defer fakeServer.Teardown()
@@ -176,7 +177,7 @@ func TestUpdate(t *testing.T) {
 	th.AssertEquals(t, 16, n.MaxPrefixLen)
 	th.AssertEquals(t, "099546ca-788d-41e5-a76d-17d8cd282d3e", n.ID)
 	th.AssertEquals(t, "", n.AddressScopeID)
-	th.AssertEquals(t, 0, n.DefaultQuota)
+	th.AssertEquals(t, 0, *n.DefaultQuota)
 	th.AssertEquals(t, "", n.Description)
 }
 

--- a/openstack/networking/v2/extensions/subnetpools/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/subnetpools/testing/requests_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gophercloud/gophercloud/v2/internal/ptr"
 	fake "github.com/gophercloud/gophercloud/v2/openstack/networking/v2/common"
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/subnetpools"
 	"github.com/gophercloud/gophercloud/v2/pagination"
@@ -133,6 +134,50 @@ func TestCreate(t *testing.T) {
 	th.AssertEquals(t, 30, s.MaxPrefixLen)
 	th.AssertEquals(t, "3d4e2e2a-552b-42ad-a16d-820bbf3edaf3", s.AddressScopeID)
 	th.AssertEquals(t, "ipv4 prefixes", s.Description)
+}
+
+func TestCreateDefaultQuotaZero(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	fakeServer.Mux.HandleFunc("/v2.0/subnetpools", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, SubnetPoolCreateDefaultQuotaZeroRequest)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+
+		fmt.Fprint(w, SubnetPoolCreateDefaultQuotaZeroResult)
+	})
+
+	opts := subnetpools.CreateOpts{
+		Name: "my_ipv4_pool",
+		Prefixes: []string{
+			"10.10.0.0/16",
+			"10.11.11.0/24",
+		},
+		MinPrefixLen:   25,
+		MaxPrefixLen:   30,
+		AddressScopeID: "3d4e2e2a-552b-42ad-a16d-820bbf3edaf3",
+		Description:    "ipv4 prefixes",
+		DefaultQuota:   ptr.To(0),
+	}
+	s, err := subnetpools.Create(context.TODO(), fake.ServiceClient(fakeServer), opts).Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, "my_ipv4_pool", s.Name)
+	th.AssertDeepEquals(t, []string{
+		"10.10.0.0/16",
+		"10.11.11.0/24",
+	}, s.Prefixes)
+	th.AssertEquals(t, 25, s.MinPrefixLen)
+	th.AssertEquals(t, 30, s.MaxPrefixLen)
+	th.AssertEquals(t, "3d4e2e2a-552b-42ad-a16d-820bbf3edaf3", s.AddressScopeID)
+	th.AssertEquals(t, "ipv4 prefixes", s.Description)
+	th.AssertEquals(t, 0, *s.DefaultQuota)
 }
 
 func TestUpdate(t *testing.T) {


### PR DESCRIPTION
The subnet pool API has a quota system that controls how many addresses a project can consume from one subnet. Per [1], the API accepts zero as a valid value and it skips the quota enforcement when set. Currently, Gophercloud doesn't accept zero as value.

Fixes #3791 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

[1] https://github.com/openstack/neutron/blob/570efdbe1886c202f5b1bcaadc14acc4c9ca9da2/neutron/ipam/subnet_alloc.py#L109-L120