### PR TITLE
feat(stackenv): add os_distro-based image lookups for magnum images

### DIFF
--- a/script/stackenv
+++ b/script/stackenv
@@ -71,9 +71,9 @@ EOL
 fi
 
 if _=$(openstack service list | grep container-infra); then
-    _MAGNUM_IMAGE_ID=$(openstack image list --format value -c Name -c ID | grep coreos | cut -d ' ' -f 1)
+    _MAGNUM_IMAGE_ID=$(openstack image list --property os_distro=ubuntu --format value -c ID | head -n 1)
     if [ -z "$_MAGNUM_IMAGE_ID" ]; then
-        _MAGNUM_IMAGE_ID=$(openstack image list --format value -c Name -c ID | grep -i atomic | cut -d ' ' -f 1)
+        _MAGNUM_IMAGE_ID=$(openstack image list --property os_distro=fedora-coreos --format value -c ID | head -n 1)
     fi
     cat >> "openrc" <<EOL
 export OS_MAGNUM_IMAGE_ID="$_MAGNUM_IMAGE_ID"


### PR DESCRIPTION
Fixes #3818

Before: magnum registered an image named/tagged fedora-coreos. Gophercloud's script/stackenv did `openstack image list ... | grep coreos`, which matched.

After [31b8432](https://github.com/openstack/magnum/commit/31b84327db8867ce67df6b7cf0189ad46e8a4f87) (master only): the guest image is noble-server-cloudimg-amd64, tagged os_distro=ubuntu. grep coreos matches nothing.

The fix looks up the image by --property os_distro=ubuntu (the new tag from this very commit), and also keeps the fedora-coreos/coreos/atomic fallbacks so stable branches (which might still use CoreOS) keep working

https://github.com/openstack/magnum/commit/31b84327db8867ce67df6b7cf0189ad46e8a4f87

