### PR TITLE
Create an external router when testing L3RouterScheduling

### DIFF
--- a/internal/acceptance/openstack/networking/v2/extensions/layer3/l3_scheduling_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/layer3/l3_scheduling_test.go
@@ -29,7 +29,7 @@ func TestLayer3RouterScheduling(t *testing.T) {
 	th.AssertNoErr(t, err)
 	defer v2.DeleteSubnet(t, client, subnet.ID)
 
-	router, err := CreateRouter(t, client, network.ID)
+	router, err := CreateExternalRouter(t, client)
 	th.AssertNoErr(t, err)
 	defer DeleteRouter(t, client, router.ID)
 	tools.PrintResource(t, router)


### PR DESCRIPTION
The ML2/OVN plugin provides information about the agent binding from the chassis binding. If we don't create an external router, the logical router port would not exist and thus not binding to any host.

Fixes #3817 
