### PR TITLE
Get and Update methods for Manila sharetype

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ The above code sample creates a new server with the parameters, and returns a
 |         Messaging        |       Zaqar      |        `openstack/messaging`       |    ✔    |    ✔    |
 |        Networking        |      Neutron     |       `openstack/networking`       |    ✔    |    ✔    |
 |      Object Storage      |       Swift      |      `openstack/objectstorage`     |    ✔    |    ✔    |
+|   Shared File Systems    |      Manila      |   `openstack/sharedfilesystems`    |    ✔    |    ✔    |
 
 ## Advanced Usage
 

--- a/internal/acceptance/openstack/sharedfilesystems/v2/sharetypes.go
+++ b/internal/acceptance/openstack/sharedfilesystems/v2/sharetypes.go
@@ -19,8 +19,9 @@ func CreateShareType(t *testing.T, client *gophercloud.ServiceClient) (*sharetyp
 	shareTypeName := tools.RandomString("ACPTTEST", 16)
 	t.Logf("Attempting to create share type: %s", shareTypeName)
 
+	dhss := true
 	extraSpecsOps := sharetypes.ExtraSpecsOpts{
-		DriverHandlesShareServers: true,
+		DriverHandlesShareServers: &dhss,
 	}
 
 	createOpts := sharetypes.CreateOpts{

--- a/openstack/containerinfra/v1/certificates/testing/fixtures_test.go
+++ b/openstack/containerinfra/v1/certificates/testing/fixtures_test.go
@@ -85,7 +85,7 @@ func HandleGetCertificateSuccessfully(t *testing.T, fakeServer th.FakeServer) {
 
 func HandleCreateCertificateSuccessfully(t *testing.T, fakeServer th.FakeServer) {
 	fakeServer.Mux.HandleFunc("/v1/certificates/", func(w http.ResponseWriter, r *http.Request) {
-		th.TestMethod(t, r, "GET")
+		th.TestMethod(t, r, "POST")
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")

--- a/openstack/sharedfilesystems/v2/sharetypes/requests.go
+++ b/openstack/sharedfilesystems/v2/sharetypes/requests.go
@@ -62,6 +62,54 @@ func Delete(ctx context.Context, client *gophercloud.ServiceClient, id string) (
 	return
 }
 
+// Get will retrieve the existing ShareType with the provided ID.
+func Get(ctx context.Context, client *gophercloud.ServiceClient, id string) (r GetResult) {
+	resp, err := client.Get(ctx, getURL(client, id), &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
+type UpdateOptsBuilder interface {
+	ToShareTypeUpdateMap() (map[string]any, error)
+}
+
+// UpdateOpts contains options for updating a ShareType. This object is
+// passed to the sharetypes.Update function. Only the fields which are
+// specified are updated; all fields are optional so that a partial update
+// can be performed.
+type UpdateOpts struct {
+	// The share type name.
+	Name *string `json:"name,omitempty"`
+	// The share type description.
+	Description *string `json:"description,omitempty"`
+	// Indicates whether a share type is publicly accessible.
+	IsPublic *bool `json:"os-share-type-access:is_public,omitempty"`
+}
+
+// ToShareTypeUpdateMap assembles a request body based on the contents of an
+// UpdateOpts.
+func (opts UpdateOpts) ToShareTypeUpdateMap() (map[string]any, error) {
+	return gophercloud.BuildRequestBody(opts, "share_type")
+}
+
+// Update will update an existing ShareType based on the values in
+// UpdateOpts. To extract the ShareType object from the response, call the
+// Extract method on the UpdateResult.
+func Update(ctx context.Context, client *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToShareTypeUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := client.Put(ctx, updateURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
 // ListOptsBuilder allows extensions to add additional parameters to the List
 // request.
 type ListOptsBuilder interface {

--- a/openstack/sharedfilesystems/v2/sharetypes/requests.go
+++ b/openstack/sharedfilesystems/v2/sharetypes/requests.go
@@ -28,7 +28,7 @@ type CreateOpts struct {
 // ExtraSpecsOpts represent the extra specifications that can be selected for a share type
 type ExtraSpecsOpts struct {
 	// An extra specification that defines the driver mode for share server, or storage, life cycle management
-	DriverHandlesShareServers bool `json:"driver_handles_share_servers" required:"true"`
+	DriverHandlesShareServers *bool `json:"driver_handles_share_servers" required:"true"`
 	// An extra specification that filters back ends by whether they do or do not support share snapshots
 	SnapshotSupport *bool `json:"snapshot_support,omitempty"`
 }

--- a/openstack/sharedfilesystems/v2/sharetypes/results.go
+++ b/openstack/sharedfilesystems/v2/sharetypes/results.go
@@ -18,6 +18,10 @@ type ShareType struct {
 	RequiredExtraSpecs map[string]any `json:"required_extra_specs"`
 	// The extra specifications for the share type
 	ExtraSpecs map[string]any `json:"extra_specs"`
+	// The human-readable description for the share type
+	Description *string `json:"description"`
+	// Indicates whether the share type is the default one
+	IsDefault bool `json:"is_default"`
 }
 
 type commonResult struct {
@@ -41,6 +45,16 @@ type CreateResult struct {
 // DeleteResult contains the response body and error from a Delete request.
 type DeleteResult struct {
 	gophercloud.ErrResult
+}
+
+// GetResult contains the response body and error from a Get request.
+type GetResult struct {
+	commonResult
+}
+
+// UpdateResult contains the response body and error from an Update request.
+type UpdateResult struct {
+	commonResult
 }
 
 // ShareTypePage is a pagination.pager that is returned from a call to the List function.

--- a/openstack/sharedfilesystems/v2/sharetypes/testing/fixtures_test.go
+++ b/openstack/sharedfilesystems/v2/sharetypes/testing/fixtures_test.go
@@ -134,6 +134,33 @@ func MockListResponse(t *testing.T, fakeServer th.FakeServer) {
 	})
 }
 
+func MockGetResponse(t *testing.T, fakeServer th.FakeServer) {
+	fakeServer.Mux.HandleFunc("/types/shareTypeID", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `
+        {
+            "share_type": {
+                "os-share-type-access:is_public": true,
+                "required_extra_specs": {
+                    "driver_handles_share_servers": "True"
+                },
+                "extra_specs": {
+                    "snapshot_support": "True",
+                    "driver_handles_share_servers": "True"
+                },
+                "name": "my_share_type",
+                "id": "1d600d02-26a7-4b23-af3d-7d51860fe858",
+                "description": "my share type description",
+                "is_default": false
+            }
+        }`)
+	})
+}
+
 func MockGetDefaultResponse(t *testing.T, fakeServer th.FakeServer) {
 	fakeServer.Mux.HandleFunc("/types/default", func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "GET")
@@ -178,6 +205,44 @@ func MockGetExtraSpecsResponse(t *testing.T, fakeServer th.FakeServer) {
                 "snapshot_support": "True",
                 "driver_handles_share_servers": "True",
                 "my_custom_extra_spec": "False"
+            }
+        }`)
+	})
+}
+
+func MockUpdateResponse(t *testing.T, fakeServer th.FakeServer) {
+	fakeServer.Mux.HandleFunc("/types/shareTypeID", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, `
+        {
+            "share_type": {
+                "name": "my_new_share_type_name",
+                "description": "my new share type description",
+                "os-share-type-access:is_public": false
+            }
+        }`)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprint(w, `
+        {
+            "share_type": {
+                "os-share-type-access:is_public": false,
+                "required_extra_specs": {
+                    "driver_handles_share_servers": "True"
+                },
+                "extra_specs": {
+                    "snapshot_support": "True",
+                    "driver_handles_share_servers": "True"
+                },
+                "name": "my_new_share_type_name",
+                "id": "1d600d02-26a7-4b23-af3d-7d51860fe858",
+                "description": "my new share type description",
+                "is_default": false
             }
         }`)
 	})

--- a/openstack/sharedfilesystems/v2/sharetypes/testing/fixtures_test.go
+++ b/openstack/sharedfilesystems/v2/sharetypes/testing/fixtures_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/gophercloud/gophercloud/v2/testhelper/client"
 )
 
-func MockCreateResponse(t *testing.T, fakeServer th.FakeServer) {
+func MockCreateResponseTrue(t *testing.T, fakeServer th.FakeServer) {
 	fakeServer.Mux.HandleFunc("/types", func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "POST")
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
@@ -52,6 +52,57 @@ func MockCreateResponse(t *testing.T, fakeServer th.FakeServer) {
                 "extra_specs": {
                     "snapshot_support": "True",
                     "driver_handles_share_servers": "True"
+                },
+                "name": "my_new_share_type",
+                "id": "1d600d02-26a7-4b23-af3d-7d51860fe858"
+            }
+        }`)
+	})
+}
+
+func MockCreateResponseFalse(t *testing.T, fakeServer th.FakeServer) {
+	fakeServer.Mux.HandleFunc("/types", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, `
+        {
+            "share_type": {
+                "os-share-type-access:is_public": false,
+                "extra_specs": {
+                    "driver_handles_share_servers": false,
+                    "snapshot_support": false
+                },
+                "name": "my_new_share_type"
+            }
+        }`)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+
+		fmt.Fprint(w, `
+        {
+            "volume_type": {
+                "os-share-type-access:is_public": false,
+                "required_extra_specs": {
+                    "driver_handles_share_servers": false
+                },
+                "extra_specs": {
+                    "snapshot_support": "False",
+                    "driver_handles_share_servers": "False"
+                },
+                "name": "my_new_share_type",
+                "id": "1d600d02-26a7-4b23-af3d-7d51860fe858"
+            },
+            "share_type": {
+                "os-share-type-access:is_public": false,
+                "required_extra_specs": {
+                    "driver_handles_share_servers": false
+                },
+                "extra_specs": {
+                    "snapshot_support": "False",
+                    "driver_handles_share_servers": "False"
                 },
                 "name": "my_new_share_type",
                 "id": "1d600d02-26a7-4b23-af3d-7d51860fe858"

--- a/openstack/sharedfilesystems/v2/sharetypes/testing/requests_test.go
+++ b/openstack/sharedfilesystems/v2/sharetypes/testing/requests_test.go
@@ -17,9 +17,10 @@ func TestCreate(t *testing.T) {
 
 	MockCreateResponse(t, fakeServer)
 
+	dhss := true
 	snapshotSupport := true
 	extraSpecs := sharetypes.ExtraSpecsOpts{
-		DriverHandlesShareServers: true,
+		DriverHandlesShareServers: &dhss,
 		SnapshotSupport:           &snapshotSupport,
 	}
 
@@ -50,8 +51,9 @@ func TestRequiredCreateOpts(t *testing.T) {
 		t.Fatal("ErrMissingInput was expected to occur")
 	}
 
+	dhss := true
 	extraSpecs := sharetypes.ExtraSpecsOpts{
-		DriverHandlesShareServers: true,
+		DriverHandlesShareServers: &dhss,
 	}
 
 	options = &sharetypes.CreateOpts{

--- a/openstack/sharedfilesystems/v2/sharetypes/testing/requests_test.go
+++ b/openstack/sharedfilesystems/v2/sharetypes/testing/requests_test.go
@@ -11,11 +11,11 @@ import (
 )
 
 // Verifies that a share type can be created correctly
-func TestCreate(t *testing.T) {
+func TestCreateTrue(t *testing.T) {
 	fakeServer := th.SetupHTTP()
 	defer fakeServer.Teardown()
 
-	MockCreateResponse(t, fakeServer)
+	MockCreateResponseTrue(t, fakeServer)
 
 	dhss := true
 	snapshotSupport := true
@@ -35,6 +35,33 @@ func TestCreate(t *testing.T) {
 
 	th.AssertEquals(t, st.Name, "my_new_share_type")
 	th.AssertEquals(t, st.IsPublic, true)
+}
+
+// Verifies that a share type can be created correctly
+func TestCreateFalse(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	MockCreateResponseFalse(t, fakeServer)
+
+	dhss := false
+	snapshotSupport := false
+	extraSpecs := sharetypes.ExtraSpecsOpts{
+		DriverHandlesShareServers: &dhss,
+		SnapshotSupport:           &snapshotSupport,
+	}
+
+	options := &sharetypes.CreateOpts{
+		Name:       "my_new_share_type",
+		IsPublic:   false,
+		ExtraSpecs: extraSpecs,
+	}
+
+	st, err := sharetypes.Create(context.TODO(), client.ServiceClient(fakeServer), options).Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, st.Name, "my_new_share_type")
+	th.AssertEquals(t, st.IsPublic, false)
 }
 
 // Verifies that a share type can't be created if the required parameters are missing

--- a/openstack/sharedfilesystems/v2/sharetypes/testing/requests_test.go
+++ b/openstack/sharedfilesystems/v2/sharetypes/testing/requests_test.go
@@ -64,6 +64,31 @@ func TestRequiredCreateOpts(t *testing.T) {
 	}
 }
 
+// Verifies that a share type can be updated
+func TestUpdate(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	MockUpdateResponse(t, fakeServer)
+
+	name := "my_new_share_type_name"
+	description := "my new share type description"
+	isPublic := false
+
+	options := &sharetypes.UpdateOpts{
+		Name:        &name,
+		Description: &description,
+		IsPublic:    &isPublic,
+	}
+
+	st, err := sharetypes.Update(context.TODO(), client.ServiceClient(fakeServer), "shareTypeID", options).Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, "my_new_share_type_name", st.Name)
+	th.AssertEquals(t, "my new share type description", *st.Description)
+	th.AssertEquals(t, false, st.IsPublic)
+}
+
 // Verifies that share type deletion works
 func TestDelete(t *testing.T) {
 	fakeServer := th.SetupHTTP()
@@ -103,6 +128,29 @@ func TestList(t *testing.T) {
 	}
 
 	th.CheckDeepEquals(t, expected, actual)
+}
+
+// Verifies that a share type can be retrieved by ID
+func TestGet(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	MockGetResponse(t, fakeServer)
+
+	description := "my share type description"
+	expected := sharetypes.ShareType{
+		ID:                 "1d600d02-26a7-4b23-af3d-7d51860fe858",
+		Name:               "my_share_type",
+		IsPublic:           true,
+		ExtraSpecs:         map[string]any{"snapshot_support": "True", "driver_handles_share_servers": "True"},
+		RequiredExtraSpecs: map[string]any{"driver_handles_share_servers": "True"},
+		Description:        &description,
+		IsDefault:          false,
+	}
+
+	actual, err := sharetypes.Get(context.TODO(), client.ServiceClient(fakeServer), "shareTypeID").Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, &expected, actual)
 }
 
 // Verifies that it is possible to get the default share type

--- a/openstack/sharedfilesystems/v2/sharetypes/urls.go
+++ b/openstack/sharedfilesystems/v2/sharetypes/urls.go
@@ -10,6 +10,14 @@ func deleteURL(c *gophercloud.ServiceClient, id string) string {
 	return c.ServiceURL("types", id)
 }
 
+func getURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("types", id)
+}
+
+func updateURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("types", id)
+}
+
 func listURL(c *gophercloud.ServiceClient) string {
 	return createURL(c)
 }


### PR DESCRIPTION
Fixes #3842 

Implement Manila share type get and update API methods.

API reference for share types: https://docs.openstack.org/api-ref/shared-file-system/#share-types

Further unit tests have been added to improve parameter coverage and some minor issues resolved with the existing unit tests.