### PR TITLE
compute: Add shareattach package for Nova microversion 2.97

### DIFF
--- a/.github/workflows/functional-sharedfilesystems.yaml
+++ b/.github/workflows/functional-sharedfilesystems.yaml
@@ -42,6 +42,8 @@ jobs:
             openstack/utils/choose_version.go
             openstack/utils/discovery.go
             **sharedfilesystems**
+            openstack/compute/v2/shareattach/**
+            internal/acceptance/openstack/compute/v2/compute.go
             .github/workflows/functional-sharedfilesystems.yaml
 
       - name: Skip tests for unrelated changed-files
@@ -49,6 +51,10 @@ jobs:
         run: |
           echo "No relevant files changed - skipping tests for ${{ matrix.name }}"
           echo "TESTS_SKIPPED=true" >> $GITHUB_ENV
+
+      - name: Install virtiofsd
+        if: ${{ fromJSON(steps.changed-files.outputs.matches) }}
+        run: sudo apt-get update && sudo apt-get install -y virtiofsd
 
       - name: Deploy devstack
         if: ${{ fromJSON(steps.changed-files.outputs.matches) }}
@@ -71,6 +77,15 @@ jobs:
             MANILA_DEFAULT_SHARE_TYPE_EXTRA_SPECS='snapshot_support=True create_share_from_snapshot_support=True revert_to_snapshot_support=True mount_snapshot_support=True'
             MANILA_CONFIGURE_DEFAULT_TYPES=True
             MANILA_INSTALL_TEMPEST_PLUGIN_SYSTEMWIDE=false
+
+            [[post-config|\$NOVA_CONF]]
+            [DEFAULT]
+            reserved_host_memory_mb = 0
+            ram_allocation_ratio = 1.0
+
+            [libvirt]
+            file_backed_memory = 4096
+            mem_stats_period_s = 0
 
             ${{ matrix.devstack_conf_overrides }}
           enabled_services: "openstack-cli-server"

--- a/.github/workflows/functional-sharedfilesystems.yaml
+++ b/.github/workflows/functional-sharedfilesystems.yaml
@@ -80,7 +80,6 @@ jobs:
 
             [[post-config|\$NOVA_CONF]]
             [DEFAULT]
-            reserved_host_memory_mb = 0
             ram_allocation_ratio = 1.0
 
             [libvirt]

--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,7 @@ acceptance-placement:
 
 acceptance-sharedfilesystems:
 	$(GO_TEST) -timeout $(TIMEOUT) -tags "fixtures acceptance" ./internal/acceptance/openstack/sharedfilesystems/...
+	$(GO_TEST) -timeout $(TIMEOUT) -tags "fixtures acceptance shareattach" -run TestShareAttach ./internal/acceptance/openstack/compute/v2/
 .PHONY: acceptance-sharefilesystems
 
 acceptance-workflow:

--- a/internal/acceptance/openstack/compute/v2/compute.go
+++ b/internal/acceptance/openstack/compute/v2/compute.go
@@ -24,8 +24,10 @@ import (
 	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/secgroups"
 	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/servergroups"
 	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/servers"
+	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/shareattach"
 	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/volumeattach"
 	neutron "github.com/gophercloud/gophercloud/v2/openstack/networking/v2/networks"
+	"github.com/gophercloud/gophercloud/v2/openstack/sharedfilesystems/v2/shares"
 	th "github.com/gophercloud/gophercloud/v2/testhelper"
 
 	"golang.org/x/crypto/ssh"
@@ -881,6 +883,68 @@ func DeleteVolumeAttachment(t *testing.T, client *gophercloud.ServiceClient, blo
 	t.Logf("Deleted volume: %s", volumeAttachment.VolumeID)
 }
 
+// CreateShareAttachment will attach a share to a server. The server must be in
+// SHUTOFF status. An error will be returned if the share failed to attach.
+func CreateShareAttachment(t *testing.T, client *gophercloud.ServiceClient, server *servers.Server, share *shares.Share) (*shareattach.ShareAttachment, error) {
+	tag := tools.RandomString("ACPTTEST", 16)
+
+	t.Logf("Attempting to attach share %s to server %s", share.ID, server.ID)
+
+	shareAttachment, err := shareattach.Create(context.TODO(), client, server.ID, shareattach.CreateOpts{
+		ShareID: share.ID,
+		Tag:     tag,
+	}).Extract()
+	if err != nil {
+		return shareAttachment, err
+	}
+
+	if err := WaitForShareAttachmentStatus(client, server.ID, share.ID, "inactive"); err != nil {
+		return shareAttachment, err
+	}
+
+	th.AssertEquals(t, share.ID, shareAttachment.ShareID)
+	th.AssertEquals(t, tag, shareAttachment.Tag)
+
+	got, err := shareattach.Get(context.TODO(), client, server.ID, share.ID).Extract()
+	if err != nil {
+		return shareAttachment, err
+	}
+
+	th.AssertEquals(t, share.ID, got.ShareID)
+	th.AssertEquals(t, tag, got.Tag)
+	th.AssertEquals(t, "inactive", got.Status)
+
+	return got, nil
+}
+
+// DeleteShareAttachment will detach a share from a server. A fatal error will
+// occur if the share failed to detach. The server must be in SHUTOFF status.
+// This works best when used as a deferred function.
+func DeleteShareAttachment(t *testing.T, client *gophercloud.ServiceClient, server *servers.Server, shareAttachment *shareattach.ShareAttachment) {
+	t.Logf("Attempting to detach share %s from server %s", shareAttachment.ShareID, server.ID)
+
+	err := shareattach.Delete(context.TODO(), client, server.ID, shareAttachment.ShareID).ExtractErr()
+	if err != nil {
+		t.Fatalf("Unable to detach share: %v", err)
+	}
+
+	err = tools.WaitFor(func(ctx context.Context) (bool, error) {
+		_, err := shareattach.Get(ctx, client, server.ID, shareAttachment.ShareID).Extract()
+		if err != nil {
+			if gophercloud.ResponseCodeIs(err, http.StatusNotFound) {
+				return true, nil
+			}
+			return false, err
+		}
+		return false, nil
+	})
+	if err != nil {
+		t.Fatalf("Unable to wait for share detachment: %v", err)
+	}
+
+	t.Logf("Deleted share attachment: %s", shareAttachment.ShareID)
+}
+
 // DetachInterface will detach an interface from a server. A fatal
 // error will occur if the interface could not be detached. This works best
 // when used as a deferred function.
@@ -961,6 +1025,27 @@ func ResizeServer(t *testing.T, client *gophercloud.ServiceClient, server *serve
 	}
 
 	return nil
+}
+
+// WaitForShareAttachmentStatus will poll a share attachment's status until it
+// either matches the specified status or the status becomes error.
+func WaitForShareAttachmentStatus(client *gophercloud.ServiceClient, serverID, shareID, status string) error {
+	return tools.WaitFor(func(ctx context.Context) (bool, error) {
+		sa, err := shareattach.Get(ctx, client, serverID, shareID).Extract()
+		if err != nil {
+			return false, err
+		}
+
+		if sa.Status == status {
+			return true, nil
+		}
+
+		if sa.Status == "error" {
+			return false, fmt.Errorf("share attachment in error state")
+		}
+
+		return false, nil
+	})
 }
 
 // WaitForComputeStatus will poll an instance's status until it either matches

--- a/internal/acceptance/openstack/compute/v2/shareattach_test.go
+++ b/internal/acceptance/openstack/compute/v2/shareattach_test.go
@@ -1,0 +1,49 @@
+//go:build acceptance || compute || shareattach
+
+package v2
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/v2/internal/acceptance/clients"
+	sfs "github.com/gophercloud/gophercloud/v2/internal/acceptance/openstack/sharedfilesystems/v2"
+	"github.com/gophercloud/gophercloud/v2/internal/acceptance/tools"
+	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/servers"
+	th "github.com/gophercloud/gophercloud/v2/testhelper"
+)
+
+func TestShareAttach(t *testing.T) {
+	clients.RequireLong(t)
+
+	client, err := clients.NewComputeV2Client()
+	th.AssertNoErr(t, err)
+
+	shareClient, err := clients.NewSharedFileSystemV2Client()
+	th.AssertNoErr(t, err)
+
+	server, err := CreateMicroversionServer(t, client)
+	th.AssertNoErr(t, err)
+
+	share, err := sfs.CreateShare(t, shareClient)
+	th.AssertNoErr(t, err)
+	defer sfs.DeleteShare(t, shareClient, share)
+
+	defer DeleteServer(t, client, server)
+
+	client.Microversion = "2.97"
+
+	err = servers.Stop(context.TODO(), client, server.ID).ExtractErr()
+	th.AssertNoErr(t, err)
+
+	err = WaitForComputeStatus(client, server, "SHUTOFF")
+	th.AssertNoErr(t, err)
+
+	shareAttachment, err := CreateShareAttachment(t, client, server, share)
+	th.AssertNoErr(t, err)
+	defer DeleteShareAttachment(t, client, server, shareAttachment)
+
+	tools.PrintResource(t, shareAttachment)
+
+	th.AssertEquals(t, share.ID, shareAttachment.ShareID)
+}

--- a/internal/acceptance/openstack/compute/v2/shareattach_test.go
+++ b/internal/acceptance/openstack/compute/v2/shareattach_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance || compute || shareattach
+//go:build sharedfilesystems || shareattach
 
 package v2
 

--- a/internal/acceptance/openstack/compute/v2/shareattach_test.go
+++ b/internal/acceptance/openstack/compute/v2/shareattach_test.go
@@ -10,6 +10,7 @@ import (
 	sfs "github.com/gophercloud/gophercloud/v2/internal/acceptance/openstack/sharedfilesystems/v2"
 	"github.com/gophercloud/gophercloud/v2/internal/acceptance/tools"
 	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/servers"
+	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/shareattach"
 	th "github.com/gophercloud/gophercloud/v2/testhelper"
 )
 
@@ -46,4 +47,23 @@ func TestShareAttach(t *testing.T) {
 	tools.PrintResource(t, shareAttachment)
 
 	th.AssertEquals(t, share.ID, shareAttachment.ShareID)
+
+	allPages, err := shareattach.List(client, server.ID).AllPages(context.TODO())
+	th.AssertNoErr(t, err)
+
+	allAttachments, err := shareattach.ExtractShareAttachments(allPages)
+	th.AssertNoErr(t, err)
+
+	tools.PrintResource(t, allAttachments)
+
+	found := false
+	for _, sa := range allAttachments {
+		if sa.ShareID == share.ID {
+			found = true
+			th.AssertEquals(t, shareAttachment.Tag, sa.Tag)
+			th.AssertEquals(t, shareAttachment.Status, sa.Status)
+			break
+		}
+	}
+	th.AssertEquals(t, true, found)
 }

--- a/openstack/compute/v2/shareattach/doc.go
+++ b/openstack/compute/v2/shareattach/doc.go
@@ -1,0 +1,35 @@
+/*
+Package shareattach provides the ability to attach and detach Manila shares
+from servers. This requires the client to be set to microversion 2.97 or later.
+The instance must be in SHUTOFF status to attach or detach a share.
+
+Example to Attach a Share
+
+	serverID := "7ac8686c-de71-4acb-9600-ec18b1a1ed6d"
+	shareID := "87463836-f0e2-4029-abf6-20c8892a3103"
+
+	computeClient.Microversion = "2.97"
+
+	createOpts := shareattach.CreateOpts{
+		ShareID: shareID,
+		Tag:     "my-share",
+	}
+
+	result, err := shareattach.Create(context.TODO(), computeClient, serverID, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Detach a Share
+
+	serverID := "7ac8686c-de71-4acb-9600-ec18b1a1ed6d"
+	shareID := "ed081613-1c9b-4231-aa5e-ebfd4d87f983"
+
+	computeClient.Microversion = "2.97"
+
+	err := shareattach.Delete(context.TODO(), computeClient, serverID, shareID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+*/
+package shareattach

--- a/openstack/compute/v2/shareattach/requests.go
+++ b/openstack/compute/v2/shareattach/requests.go
@@ -1,0 +1,65 @@
+package shareattach
+
+import (
+	"context"
+
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/pagination"
+)
+
+// List returns a Pager that allows you to iterate over a collection of
+// ShareAttachments.
+func List(client *gophercloud.ServiceClient, serverID string) pagination.Pager {
+	return pagination.NewPager(client, listURL(client, serverID), func(r pagination.PageResult) pagination.Page {
+		return ShareAttachmentPage{pagination.SinglePageBase(r)}
+	})
+}
+
+// CreateOptsBuilder allows extensions to add parameters to the Create request.
+type CreateOptsBuilder interface {
+	ToShareAttachmentCreateMap() (map[string]any, error)
+}
+
+// CreateOpts specifies share attachment creation parameters.
+type CreateOpts struct {
+	// ShareID is the UUID of the Manila share to attach to the instance.
+	ShareID string `json:"share_id" required:"true"`
+
+	// Tag is the device tag used to mount the share within the instance.
+	Tag string `json:"tag,omitempty"`
+}
+
+// ToShareAttachmentCreateMap constructs a request body from CreateOpts.
+func (opts CreateOpts) ToShareAttachmentCreateMap() (map[string]any, error) {
+	return gophercloud.BuildRequestBody(opts, "share")
+}
+
+// Create requests the creation of a new share attachment on the server.
+func Create(ctx context.Context, client *gophercloud.ServiceClient, serverID string, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToShareAttachmentCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := client.Post(ctx, createURL(client, serverID), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{201},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// Get returns public data about a previously created ShareAttachment.
+func Get(ctx context.Context, client *gophercloud.ServiceClient, serverID, shareID string) (r GetResult) {
+	resp, err := client.Get(ctx, getURL(client, serverID, shareID), &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// Delete requests the deletion of a previously stored ShareAttachment from the server.
+func Delete(ctx context.Context, client *gophercloud.ServiceClient, serverID, shareID string) (r DeleteResult) {
+	resp, err := client.Delete(ctx, deleteURL(client, serverID, shareID), &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}

--- a/openstack/compute/v2/shareattach/results.go
+++ b/openstack/compute/v2/shareattach/results.go
@@ -1,0 +1,85 @@
+package shareattach
+
+import (
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/pagination"
+)
+
+// ShareAttachment contains attachment information between a share
+// and server.
+type ShareAttachment struct {
+	// ShareID is the UUID of the attached Manila share.
+	ShareID string `json:"share_id"`
+
+	// Status is the status of the attached share.
+	Status string `json:"status"`
+
+	// Tag is a tag that can be applied to the attached share.
+	Tag string `json:"tag"`
+
+	// UUID is the UUID of the share attachment. This field is only visible to admins.
+	UUID *string `json:"uuid"`
+
+	// ExportLocation is the export location used to attach the share to the underlying host.
+	// This field is only visible to admins.
+	ExportLocation *string `json:"export_location"`
+}
+
+// ShareAttachmentPage stores a single page all of ShareAttachment
+// results from a List call.
+type ShareAttachmentPage struct {
+	pagination.SinglePageBase
+}
+
+// IsEmpty determines whether or not a ShareAttachmentPage is empty.
+func (page ShareAttachmentPage) IsEmpty() (bool, error) {
+	if page.StatusCode == 204 {
+		return true, nil
+	}
+
+	sa, err := ExtractShareAttachments(page)
+	return len(sa) == 0, err
+}
+
+// ExtractShareAttachments interprets a page of results as a slice of
+// ShareAttachment.
+func ExtractShareAttachments(r pagination.Page) ([]ShareAttachment, error) {
+	var s struct {
+		Shares []ShareAttachment `json:"shares"`
+	}
+	err := (r.(ShareAttachmentPage)).ExtractInto(&s)
+	return s.Shares, err
+}
+
+// ShareAttachmentResult is the result from a share attachment operation.
+type ShareAttachmentResult struct {
+	gophercloud.Result
+}
+
+// Extract is a method that attempts to interpret any ShareAttachment resource
+// response as a ShareAttachment struct.
+func (r ShareAttachmentResult) Extract() (*ShareAttachment, error) {
+	var s struct {
+		Share *ShareAttachment `json:"share"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Share, err
+}
+
+// CreateResult is the response from a Create operation. Call its Extract method
+// to interpret it as a ShareAttachment.
+type CreateResult struct {
+	ShareAttachmentResult
+}
+
+// GetResult is the response from a Get operation. Call its Extract method to
+// interpret it as a ShareAttachment.
+type GetResult struct {
+	ShareAttachmentResult
+}
+
+// DeleteResult is the response from a Delete operation. Call its ExtractErr
+// method to determine if the call succeeded or failed.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}

--- a/openstack/compute/v2/shareattach/testing/doc.go
+++ b/openstack/compute/v2/shareattach/testing/doc.go
@@ -1,0 +1,2 @@
+// shareattach unit tests
+package testing

--- a/openstack/compute/v2/shareattach/testing/fixtures_test.go
+++ b/openstack/compute/v2/shareattach/testing/fixtures_test.go
@@ -1,0 +1,162 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	th "github.com/gophercloud/gophercloud/v2/testhelper"
+	"github.com/gophercloud/gophercloud/v2/testhelper/client"
+)
+
+// ListOutput is a sample response to a List call.
+const ListOutput = `
+{
+  "shares": [
+    {
+      "share_id": "e8debdc0-447a-4376-a10a-4cd9122d7986",
+      "status": "inactive",
+      "tag": "e8debdc0-447a-4376-a10a-4cd9122d7986"
+    },
+    {
+      "share_id": "a26887c6-c47b-4654-abb5-dfadf7d3f803",
+      "status": "active",
+      "tag": "a26887c6-c47b-4654-abb5-dfadf7d3f803"
+    }
+  ]
+}
+`
+
+// GetOutput is a sample response to a Get call.
+const GetOutput = `
+{
+  "share": {
+    "share_id": "e8debdc0-447a-4376-a10a-4cd9122d7986",
+    "status": "inactive",
+    "tag": "e8debdc0-447a-4376-a10a-4cd9122d7986"
+  }
+}
+`
+
+// GetOutputAdmin is a sample response to a Get call for an admin.
+const GetOutputAdmin = `
+{
+  "share": {
+    "uuid": "68ba1762-fd6d-4221-8311-f3193dd93404",
+    "share_id": "e8debdc0-447a-4376-a10a-4cd9122d7986",
+    "status": "inactive",
+    "export_location": "10.0.0.50:/mnt/foo",
+    "tag": "e8debdc0-447a-4376-a10a-4cd9122d7986"
+  }
+}
+`
+
+// CreateOutput is a sample response to a Create call.
+const CreateOutput = `
+{
+  "share": {
+    "share_id": "e8debdc0-447a-4376-a10a-4cd9122d7986",
+    "status": "attaching",
+    "tag": "my-share"
+  }
+}
+`
+
+// CreateOutputWithoutTag is a sample response to a Create call when the request
+// omits tag. Nova returns tag equal to share_id.
+const CreateOutputWithoutTag = `
+{
+  "share": {
+    "share_id": "e8debdc0-447a-4376-a10a-4cd9122d7986",
+    "status": "attaching",
+    "tag": "e8debdc0-447a-4376-a10a-4cd9122d7986"
+  }
+}
+`
+
+// HandleListSuccessfully configures the test server to respond to a List request.
+func HandleListSuccessfully(t *testing.T, fakeServer th.FakeServer) {
+	fakeServer.Mux.HandleFunc("/servers/4d8c3732-a248-40ed-bebc-539a6ffd25c0/shares", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprint(w, ListOutput)
+	})
+}
+
+// HandleGetSuccessfully configures the test server to respond to a Get request
+// for an existing attachment
+func HandleGetSuccessfully(t *testing.T, fakeServer th.FakeServer) {
+	fakeServer.Mux.HandleFunc("/servers/4d8c3732-a248-40ed-bebc-539a6ffd25c0/shares/e8debdc0-447a-4376-a10a-4cd9122d7986", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprint(w, GetOutput)
+	})
+}
+
+// HandleGetSuccessfullyAdmin configures the test server to respond to a Get request
+// for an existing attachment for an admin
+func HandleGetSuccessfullyAdmin(t *testing.T, fakeServer th.FakeServer) {
+	fakeServer.Mux.HandleFunc("/servers/4d8c3732-a248-40ed-bebc-539a6ffd25c0/shares/e8debdc0-447a-4376-a10a-4cd9122d7986", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprint(w, GetOutputAdmin)
+	})
+}
+
+// HandleCreateSuccessfully configures the test server to respond to a Create request
+// for a new attachment
+func HandleCreateSuccessfully(t *testing.T, fakeServer th.FakeServer) {
+	fakeServer.Mux.HandleFunc("/servers/4d8c3732-a248-40ed-bebc-539a6ffd25c0/shares", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, `
+{
+    "share": {
+        "share_id": "3cdf5132-64f2-4584-876a-bd296ae7eabd",
+        "tag": "my-share"
+    }
+}
+`)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprint(w, CreateOutput)
+	})
+}
+
+// HandleCreateSuccessfullyWithoutTag configures the test server to respond to a Create
+// request that omits tag in the request body.
+func HandleCreateSuccessfullyWithoutTag(t *testing.T, fakeServer th.FakeServer) {
+	fakeServer.Mux.HandleFunc("/servers/4d8c3732-a248-40ed-bebc-539a6ffd25c0/shares", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, `
+{
+    "share": {
+        "share_id": "3cdf5132-64f2-4584-876a-bd296ae7eabd"
+    }
+}
+`)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprint(w, CreateOutputWithoutTag)
+	})
+}
+
+// HandleDeleteSuccessfully configures the test server to respond to a Delete request for
+// an existing attachment
+func HandleDeleteSuccessfully(t *testing.T, fakeServer th.FakeServer) {
+	fakeServer.Mux.HandleFunc("/servers/4d8c3732-a248-40ed-bebc-539a6ffd25c0/shares/e8debdc0-447a-4376-a10a-4cd9122d7986", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.WriteHeader(http.StatusOK)
+	})
+}

--- a/openstack/compute/v2/shareattach/testing/requests_test.go
+++ b/openstack/compute/v2/shareattach/testing/requests_test.go
@@ -1,0 +1,149 @@
+package testing
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/shareattach"
+	"github.com/gophercloud/gophercloud/v2/pagination"
+	th "github.com/gophercloud/gophercloud/v2/testhelper"
+	"github.com/gophercloud/gophercloud/v2/testhelper/client"
+)
+
+var adminExportLocation = "10.0.0.50:/mnt/foo"
+var adminUUID = "68ba1762-fd6d-4221-8311-f3193dd93404"
+
+// FirstShareAttachment is the first result in ListOutput.
+var FirstShareAttachment = shareattach.ShareAttachment{
+	ShareID: "e8debdc0-447a-4376-a10a-4cd9122d7986",
+	Status:  "inactive",
+	Tag:     "e8debdc0-447a-4376-a10a-4cd9122d7986",
+}
+
+// SecondShareAttachment is the 2nd result in ListOutput.
+var SecondShareAttachment = shareattach.ShareAttachment{
+	ShareID: "a26887c6-c47b-4654-abb5-dfadf7d3f803",
+	Status:  "active",
+	Tag:     "a26887c6-c47b-4654-abb5-dfadf7d3f803",
+}
+
+// FirstShareAttachmentAdmin is the parsed result from GetOutputAdmin.
+var FirstShareAttachmentAdmin = shareattach.ShareAttachment{
+	ShareID:        "e8debdc0-447a-4376-a10a-4cd9122d7986",
+	Status:         "inactive",
+	Tag:            "e8debdc0-447a-4376-a10a-4cd9122d7986",
+	ExportLocation: &adminExportLocation,
+	UUID:           &adminUUID,
+}
+
+// ExpectedShareAttachmentSlice is the slice of results that should be parsed
+// from ListOutput, in the expected order.
+var ExpectedShareAttachmentSlice = []shareattach.ShareAttachment{FirstShareAttachment, SecondShareAttachment}
+
+// CreatedShareAttachment is the parsed result from CreateOutput.
+var CreatedShareAttachment = shareattach.ShareAttachment{
+	ShareID: "e8debdc0-447a-4376-a10a-4cd9122d7986",
+	Status:  "attaching",
+	Tag:     "my-share",
+}
+
+// CreatedShareAttachmentWithoutTag is the parsed result from CreateOutputWithoutTag.
+// Nova returns tag equal to share_id when the client omits tag on create.
+var CreatedShareAttachmentWithoutTag = shareattach.ShareAttachment{
+	ShareID: "e8debdc0-447a-4376-a10a-4cd9122d7986",
+	Status:  "attaching",
+	Tag:     "e8debdc0-447a-4376-a10a-4cd9122d7986",
+}
+
+func TestList(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	HandleListSuccessfully(t, fakeServer)
+
+	serverID := "4d8c3732-a248-40ed-bebc-539a6ffd25c0"
+
+	count := 0
+	err := shareattach.List(client.ServiceClient(fakeServer), serverID).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
+		count++
+		actual, err := shareattach.ExtractShareAttachments(page)
+		th.AssertNoErr(t, err)
+		th.CheckDeepEquals(t, ExpectedShareAttachmentSlice, actual)
+
+		return true, nil
+	})
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, 1, count)
+}
+
+func TestCreate(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	HandleCreateSuccessfully(t, fakeServer)
+
+	serverID := "4d8c3732-a248-40ed-bebc-539a6ffd25c0"
+
+	actual, err := shareattach.Create(context.TODO(), client.ServiceClient(fakeServer), serverID, shareattach.CreateOpts{
+		ShareID: "3cdf5132-64f2-4584-876a-bd296ae7eabd",
+		Tag:     "my-share",
+	}).Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, &CreatedShareAttachment, actual)
+}
+
+func TestCreateWithoutTag(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	HandleCreateSuccessfullyWithoutTag(t, fakeServer)
+
+	serverID := "4d8c3732-a248-40ed-bebc-539a6ffd25c0"
+
+	actual, err := shareattach.Create(context.TODO(), client.ServiceClient(fakeServer), serverID, shareattach.CreateOpts{
+		ShareID: "3cdf5132-64f2-4584-876a-bd296ae7eabd",
+	}).Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, &CreatedShareAttachmentWithoutTag, actual)
+}
+
+func TestGet(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	HandleGetSuccessfully(t, fakeServer)
+
+	shareID := "e8debdc0-447a-4376-a10a-4cd9122d7986"
+	serverID := "4d8c3732-a248-40ed-bebc-539a6ffd25c0"
+
+	actual, err := shareattach.Get(context.TODO(), client.ServiceClient(fakeServer), serverID, shareID).Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, &FirstShareAttachment, actual)
+}
+
+func TestGetAdmin(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	HandleGetSuccessfullyAdmin(t, fakeServer)
+
+	shareID := "e8debdc0-447a-4376-a10a-4cd9122d7986"
+	serverID := "4d8c3732-a248-40ed-bebc-539a6ffd25c0"
+
+	actual, err := shareattach.Get(context.TODO(), client.ServiceClient(fakeServer), serverID, shareID).Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, &FirstShareAttachmentAdmin, actual)
+}
+
+func TestDelete(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	HandleDeleteSuccessfully(t, fakeServer)
+
+	shareID := "e8debdc0-447a-4376-a10a-4cd9122d7986"
+	serverID := "4d8c3732-a248-40ed-bebc-539a6ffd25c0"
+
+	err := shareattach.Delete(context.TODO(), client.ServiceClient(fakeServer), serverID, shareID).ExtractErr()
+	th.AssertNoErr(t, err)
+}

--- a/openstack/compute/v2/shareattach/urls.go
+++ b/openstack/compute/v2/shareattach/urls.go
@@ -1,0 +1,25 @@
+package shareattach
+
+import "github.com/gophercloud/gophercloud/v2"
+
+const resourcePath = "shares"
+
+func resourceURL(c *gophercloud.ServiceClient, serverID string) string {
+	return c.ServiceURL("servers", serverID, resourcePath)
+}
+
+func listURL(c *gophercloud.ServiceClient, serverID string) string {
+	return resourceURL(c, serverID)
+}
+
+func createURL(c *gophercloud.ServiceClient, serverID string) string {
+	return resourceURL(c, serverID)
+}
+
+func getURL(c *gophercloud.ServiceClient, serverID, shareID string) string {
+	return c.ServiceURL("servers", serverID, resourcePath, shareID)
+}
+
+func deleteURL(c *gophercloud.ServiceClient, serverID, shareID string) string {
+	return getURL(c, serverID, shareID)
+}


### PR DESCRIPTION
Add the `shareattach` package under `compute/v2` to support attaching and
detaching Manila shares on servers via Nova microversion 2.97.
Includes List, Create, Get, and Delete operations, unit tests, and an
acceptance test (`TestShareAttach`) with helpers in compute acceptance code.
The instance must be in `SHUTOFF` status to attach or detach a share.
Acceptance testing was validated against DevStack with Manila enabled and
in CI via `functional-sharedfilesystems` (all three matrix legs passed).
## CI
- `TestShareAttach` runs in `functional-sharedfilesystems` (not
  `functional-compute`) with DevStack `file_backed_memory` config for Nova
  share attach.
- Build tag `sharedfilesystems || shareattach` excludes the test from the
  compute job.
## OpenStack references
- https://docs.openstack.org/nova/2025.1/reference/api-microversion-history.html#id97 (microversion 2.97)
- https://github.com/openstack/nova/blob/stable/2026.1/nova/api/openstack/compute/server_shares.py
- https://docs.openstack.org/api-ref/compute/#servers-with-shares-attachments-servers-shares