### PR TITLE
baremetal: add vendor/model/serial_number to FirmwareComponent

### DIFF
--- a/openstack/baremetal/v1/nodes/results.go
+++ b/openstack/baremetal/v1/nodes/results.go
@@ -696,6 +696,12 @@ type FirmwareComponent struct {
 	CurrentVersion string `json:"current_version"`
 	// The last firmware version updated for the component.
 	LastVersionFlashed string `json:"last_version_flashed,omitempty"`
+	// The vendor of the firmware component.
+	Vendor *string `json:"vendor,omitempty"`
+	// The model of the firmware component.
+	Model *string `json:"model,omitempty"`
+	// The serial number of the firmware component.
+	SerialNumber *string `json:"serial_number,omitempty"`
 }
 
 // Extract interprets a ListFirmwareResult as an array of FirmwareComponent structs, if possible.

--- a/openstack/baremetal/v1/nodes/results.go
+++ b/openstack/baremetal/v1/nodes/results.go
@@ -728,6 +728,12 @@ type FirmwareComponent struct {
 	CurrentVersion string `json:"current_version"`
 	// The last firmware version updated for the component.
 	LastVersionFlashed string `json:"last_version_flashed,omitempty"`
+	// The vendor of the firmware component.
+	Vendor *string `json:"vendor,omitempty"`
+	// The model of the firmware component.
+	Model *string `json:"model,omitempty"`
+	// The serial number of the firmware component.
+	SerialNumber *string `json:"serial_number,omitempty"`
 }
 
 // Extract interprets a ListFirmwareResult as an array of FirmwareComponent structs, if possible.

--- a/openstack/baremetal/v1/nodes/testing/fixtures_test.go
+++ b/openstack/baremetal/v1/nodes/testing/fixtures_test.go
@@ -873,7 +873,10 @@ const NodeFirmwareListBody = `
       "component": "bios",
       "initial_version": "U30 v2.36 (07/16/2020)",
       "current_version": "U30 v2.36 (07/16/2020)",
-      "last_version_flashed": null
+      "last_version_flashed": null,
+      "vendor": "HPE",
+      "model": "ProLiant DL380 Gen10",
+      "serial_number": "CZ12345678"
    },
    {
       "created_at": "2023-10-03T18:30:00+00:00",
@@ -1401,6 +1404,9 @@ var (
 	createdAtFirmware, _ = time.Parse(time.RFC3339, "2023-10-03T18:30:00+00:00")
 	updatedAtFirmware, _ = time.Parse(time.RFC3339, "2023-10-03T18:45:54+00:00")
 	lastVersion          = "iLO 5 v2.81"
+	firmwareVendor       = "HPE"
+	firmwareModel        = "ProLiant DL380 Gen10"
+	firmwareSerial       = "CZ12345678"
 	NodeFirmwareList     = []nodes.FirmwareComponent{
 		{
 			CreatedAt:          createdAtFirmware,
@@ -1409,6 +1415,9 @@ var (
 			InitialVersion:     "U30 v2.36 (07/16/2020)",
 			CurrentVersion:     "U30 v2.36 (07/16/2020)",
 			LastVersionFlashed: "",
+			Vendor:             &firmwareVendor,
+			Model:              &firmwareModel,
+			SerialNumber:       &firmwareSerial,
 		},
 		{
 			CreatedAt:          createdAtFirmware,


### PR DESCRIPTION
## Summary
- Add `Vendor`, `Model`, `SerialNumber` pointer fields to `FirmwareComponent` struct
- Prepares gophercloud for Ironic microversion 1.114 which adds hardware identity fields to `GET /v1/nodes/{ident}/firmware`
- Fields use `*string` per gophercloud convention: nil when API does not return them (microversion < 1.114)

## Reference
- Ironic implementation: https://review.opendev.org/c/openstack/ironic/+/992034

## Test plan
- [x] Unit tests updated with new fields in fixture

Assisted-By: Claude <noreply@anthropic.com>