### PR TITLE
Fix sharetype creation failing when DriverHandlesShareServers is false 

### DIFF
--- a/internal/acceptance/openstack/sharedfilesystems/v2/sharetypes.go
+++ b/internal/acceptance/openstack/sharedfilesystems/v2/sharetypes.go
@@ -20,8 +20,9 @@ func CreateShareType(t *testing.T, client *gophercloud.ServiceClient) (*sharetyp
 	shareTypeName := tools.RandomString("ACPTTEST", 16)
 	t.Logf("Attempting to create share type: %s", shareTypeName)
 
+	dhss := true
 	extraSpecsOps := sharetypes.ExtraSpecsOpts{
-		DriverHandlesShareServers: true,
+		DriverHandlesShareServers: &dhss,
 	}
 
 	createOpts := sharetypes.CreateOpts{

--- a/openstack/sharedfilesystems/v2/sharetypes/requests.go
+++ b/openstack/sharedfilesystems/v2/sharetypes/requests.go
@@ -28,7 +28,7 @@ type CreateOpts struct {
 // ExtraSpecsOpts represent the extra specifications that can be selected for a share type
 type ExtraSpecsOpts struct {
 	// An extra specification that defines the driver mode for share server, or storage, life cycle management
-	DriverHandlesShareServers bool `json:"driver_handles_share_servers" required:"true"`
+	DriverHandlesShareServers *bool `json:"driver_handles_share_servers" required:"true"`
 	// An extra specification that filters back ends by whether they do or do not support share snapshots
 	SnapshotSupport *bool `json:"snapshot_support,omitempty"`
 }

--- a/openstack/sharedfilesystems/v2/sharetypes/testing/fixtures_test.go
+++ b/openstack/sharedfilesystems/v2/sharetypes/testing/fixtures_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/gophercloud/gophercloud/v2/testhelper/client"
 )
 
-func MockCreateResponse(t *testing.T, fakeServer th.FakeServer) {
+func MockCreateResponseTrue(t *testing.T, fakeServer th.FakeServer) {
 	fakeServer.Mux.HandleFunc("/types", func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "POST")
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
@@ -52,6 +52,57 @@ func MockCreateResponse(t *testing.T, fakeServer th.FakeServer) {
                 "extra_specs": {
                     "snapshot_support": "True",
                     "driver_handles_share_servers": "True"
+                },
+                "name": "my_new_share_type",
+                "id": "1d600d02-26a7-4b23-af3d-7d51860fe858"
+            }
+        }`)
+	})
+}
+
+func MockCreateResponseFalse(t *testing.T, fakeServer th.FakeServer) {
+	fakeServer.Mux.HandleFunc("/types", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, `
+        {
+            "share_type": {
+                "os-share-type-access:is_public": false,
+                "extra_specs": {
+                    "driver_handles_share_servers": false,
+                    "snapshot_support": false
+                },
+                "name": "my_new_share_type"
+            }
+        }`)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+
+		fmt.Fprint(w, `
+        {
+            "volume_type": {
+                "os-share-type-access:is_public": false,
+                "required_extra_specs": {
+                    "driver_handles_share_servers": false
+                },
+                "extra_specs": {
+                    "snapshot_support": "False",
+                    "driver_handles_share_servers": "False"
+                },
+                "name": "my_new_share_type",
+                "id": "1d600d02-26a7-4b23-af3d-7d51860fe858"
+            },
+            "share_type": {
+                "os-share-type-access:is_public": false,
+                "required_extra_specs": {
+                    "driver_handles_share_servers": false
+                },
+                "extra_specs": {
+                    "snapshot_support": "False",
+                    "driver_handles_share_servers": "False"
                 },
                 "name": "my_new_share_type",
                 "id": "1d600d02-26a7-4b23-af3d-7d51860fe858"

--- a/openstack/sharedfilesystems/v2/sharetypes/testing/requests_test.go
+++ b/openstack/sharedfilesystems/v2/sharetypes/testing/requests_test.go
@@ -61,7 +61,7 @@ func TestCreateFalse(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	th.AssertEquals(t, st.Name, "my_new_share_type")
-	th.AssertEquals(t, st.IsPublic, false)
+	th.AssertFalse(t, st.IsPublic)
 }
 
 // Verifies that a share type can't be created if the required parameters are missing

--- a/openstack/sharedfilesystems/v2/sharetypes/testing/requests_test.go
+++ b/openstack/sharedfilesystems/v2/sharetypes/testing/requests_test.go
@@ -60,7 +60,7 @@ func TestCreateFalse(t *testing.T) {
 	st, err := sharetypes.Create(context.TODO(), client.ServiceClient(fakeServer), options).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, st.Name, "my_new_share_type")
+	th.AssertEquals(t, "my_new_share_type", st.Name)
 	th.AssertFalse(t, st.IsPublic)
 }
 

--- a/openstack/sharedfilesystems/v2/sharetypes/testing/requests_test.go
+++ b/openstack/sharedfilesystems/v2/sharetypes/testing/requests_test.go
@@ -17,9 +17,10 @@ func TestCreateTrue(t *testing.T) {
 
 	MockCreateResponseTrue(t, fakeServer)
 
+	dhss := true
 	snapshotSupport := true
 	extraSpecs := sharetypes.ExtraSpecsOpts{
-		DriverHandlesShareServers: true,
+		DriverHandlesShareServers: &dhss,
 		SnapshotSupport:           &snapshotSupport,
 	}
 
@@ -43,9 +44,10 @@ func TestCreateFalse(t *testing.T) {
 
 	MockCreateResponseFalse(t, fakeServer)
 
+	dhss := false
 	snapshotSupport := false
 	extraSpecs := sharetypes.ExtraSpecsOpts{
-		DriverHandlesShareServers: false,
+		DriverHandlesShareServers: &dhss,
 		SnapshotSupport:           &snapshotSupport,
 	}
 
@@ -76,8 +78,9 @@ func TestRequiredCreateOpts(t *testing.T) {
 		t.Fatal("ErrMissingInput was expected to occur")
 	}
 
+	dhss := true
 	extraSpecs := sharetypes.ExtraSpecsOpts{
-		DriverHandlesShareServers: true,
+		DriverHandlesShareServers: &dhss,
 	}
 
 	options = &sharetypes.CreateOpts{

--- a/openstack/sharedfilesystems/v2/sharetypes/testing/requests_test.go
+++ b/openstack/sharedfilesystems/v2/sharetypes/testing/requests_test.go
@@ -11,11 +11,11 @@ import (
 )
 
 // Verifies that a share type can be created correctly
-func TestCreate(t *testing.T) {
+func TestCreateTrue(t *testing.T) {
 	fakeServer := th.SetupHTTP()
 	defer fakeServer.Teardown()
 
-	MockCreateResponse(t, fakeServer)
+	MockCreateResponseTrue(t, fakeServer)
 
 	snapshotSupport := true
 	extraSpecs := sharetypes.ExtraSpecsOpts{
@@ -34,6 +34,32 @@ func TestCreate(t *testing.T) {
 
 	th.AssertEquals(t, "my_new_share_type", st.Name)
 	th.AssertTrue(t, st.IsPublic)
+}
+
+// Verifies that a share type can be created correctly
+func TestCreateFalse(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	MockCreateResponseFalse(t, fakeServer)
+
+	snapshotSupport := false
+	extraSpecs := sharetypes.ExtraSpecsOpts{
+		DriverHandlesShareServers: false,
+		SnapshotSupport:           &snapshotSupport,
+	}
+
+	options := &sharetypes.CreateOpts{
+		Name:       "my_new_share_type",
+		IsPublic:   false,
+		ExtraSpecs: extraSpecs,
+	}
+
+	st, err := sharetypes.Create(context.TODO(), client.ServiceClient(fakeServer), options).Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, st.Name, "my_new_share_type")
+	th.AssertEquals(t, st.IsPublic, false)
 }
 
 // Verifies that a share type can't be created if the required parameters are missing

--- a/openstack/sharedfilesystems/v2/sharetypes/testing/requests_test.go
+++ b/openstack/sharedfilesystems/v2/sharetypes/testing/requests_test.go
@@ -35,6 +35,9 @@ func TestCreateTrue(t *testing.T) {
 
 	th.AssertEquals(t, "my_new_share_type", st.Name)
 	th.AssertTrue(t, st.IsPublic)
+
+	expected := map[string]any{"driver_handles_share_servers": true}
+	th.CheckDeepEquals(t, expected, st.RequiredExtraSpecs)
 }
 
 // Verifies that a share type can be created correctly
@@ -62,6 +65,9 @@ func TestCreateFalse(t *testing.T) {
 
 	th.AssertEquals(t, "my_new_share_type", st.Name)
 	th.AssertFalse(t, st.IsPublic)
+
+	expected := map[string]any{"driver_handles_share_servers": false}
+	th.CheckDeepEquals(t, expected, st.RequiredExtraSpecs)
 }
 
 // Verifies that a share type can't be created if the required parameters are missing


### PR DESCRIPTION
Fixes #3851 

Change DriverHandlesShareServers to a pointer so that false values aren't detected as a missing input.

Unit tests:
Adds a second sharetype creation test to test passing in false values.
