### PR TITLE
subnetpool: Support for add and remove prefixes operations

### DIFF
--- a/internal/acceptance/openstack/networking/v2/extensions/subnetpools/subnetpools_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/subnetpools/subnetpools_test.go
@@ -4,6 +4,7 @@ package v2
 
 import (
 	"context"
+	"slices"
 	"strings"
 	"testing"
 
@@ -72,6 +73,66 @@ func TestSubnetPoolsDefaultQuotaZeroCreate(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	th.AssertEquals(t, 0, *sb.DefaultQuota)
+}
+
+func TestSubnetPoolsAddRemovePrefixes(t *testing.T) {
+	client, err := clients.NewNetworkV2Client()
+	th.AssertNoErr(t, err)
+
+	// Create a subnetpool with an initial prefix.
+	subnetPool, err := CreateSubnetPool(t, client)
+	th.AssertNoErr(t, err)
+	defer DeleteSubnetPool(t, client, subnetPool.ID)
+
+	tools.PrintResource(t, subnetPool)
+
+	// Add new prefixes to the pool.
+	addOpts := subnetpools.PrefixesOpsOpts{
+		Prefixes: []string{
+			"172.16.0.0/16",
+			"192.168.0.0/16",
+		},
+	}
+
+	t.Logf("Attempting to add prefixes to subnetpool %s", subnetPool.ID)
+
+	addedPrefixes, err := subnetpools.AddPrefixes(context.TODO(), client, subnetPool.ID, addOpts).Extract()
+	th.AssertNoErr(t, err)
+
+	t.Logf("Successfully added prefixes to subnetpool %s: %v", subnetPool.ID, addedPrefixes)
+
+	updatedPool, err := subnetpools.Get(context.TODO(), client, subnetPool.ID).Extract()
+	th.AssertNoErr(t, err)
+
+	tools.PrintResource(t, updatedPool)
+
+	th.AssertEquals(t, true, slices.Contains(updatedPool.Prefixes, "172.16.0.0/16"))
+	th.AssertEquals(t, true, slices.Contains(updatedPool.Prefixes, "192.168.0.0/16"))
+	th.AssertEquals(t, true, slices.Contains(updatedPool.Prefixes, "10.0.0.0/8"))
+
+	// Remove one of the prefixes.
+	removeOpts := subnetpools.PrefixesOpsOpts{
+		Prefixes: []string{
+			"192.168.0.0/16",
+		},
+	}
+
+	t.Logf("Attempting to remove prefixes from subnetpool %s", subnetPool.ID)
+
+	remainingPrefixes, err := subnetpools.RemovePrefixes(context.TODO(), client, subnetPool.ID, removeOpts).Extract()
+	th.AssertNoErr(t, err)
+
+	t.Logf("Successfully removed prefixes from subnetpool %s: %v", subnetPool.ID, remainingPrefixes)
+
+	// Verify via Get that the subnetpool reflects the removal.
+	finalPool, err := subnetpools.Get(context.TODO(), client, subnetPool.ID).Extract()
+	th.AssertNoErr(t, err)
+
+	tools.PrintResource(t, finalPool)
+
+	th.AssertEquals(t, false, slices.Contains(finalPool.Prefixes, "192.168.0.0/16"))
+	th.AssertEquals(t, true, slices.Contains(finalPool.Prefixes, "172.16.0.0/16"))
+	th.AssertEquals(t, true, slices.Contains(finalPool.Prefixes, "10.0.0.0/8"))
 }
 
 func TestSubnetPoolsRevision(t *testing.T) {

--- a/internal/acceptance/openstack/networking/v2/extensions/subnetpools/subnetpools_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/subnetpools/subnetpools_test.go
@@ -4,6 +4,7 @@ package v2
 
 import (
 	"context"
+	"slices"
 	"strings"
 	"testing"
 
@@ -55,6 +56,66 @@ func TestSubnetPoolsCRUD(t *testing.T) {
 	}
 
 	th.AssertTrue(t, found)
+}
+
+func TestSubnetPoolsAddRemovePrefixes(t *testing.T) {
+	client, err := clients.NewNetworkV2Client()
+	th.AssertNoErr(t, err)
+
+	// Create a subnetpool with an initial prefix.
+	subnetPool, err := CreateSubnetPool(t, client)
+	th.AssertNoErr(t, err)
+	defer DeleteSubnetPool(t, client, subnetPool.ID)
+
+	tools.PrintResource(t, subnetPool)
+
+	// Add new prefixes to the pool.
+	addOpts := subnetpools.PrefixesOpsOpts{
+		Prefixes: []string{
+			"172.16.0.0/16",
+			"192.168.0.0/16",
+		},
+	}
+
+	t.Logf("Attempting to add prefixes to subnetpool %s", subnetPool.ID)
+
+	addedPrefixes, err := subnetpools.AddPrefixes(context.TODO(), client, subnetPool.ID, addOpts).Extract()
+	th.AssertNoErr(t, err)
+
+	t.Logf("Successfully added prefixes to subnetpool %s: %v", subnetPool.ID, addedPrefixes)
+
+	updatedPool, err := subnetpools.Get(context.TODO(), client, subnetPool.ID).Extract()
+	th.AssertNoErr(t, err)
+
+	tools.PrintResource(t, updatedPool)
+
+	th.AssertEquals(t, true, slices.Contains(updatedPool.Prefixes, "172.16.0.0/16"))
+	th.AssertEquals(t, true, slices.Contains(updatedPool.Prefixes, "192.168.0.0/16"))
+	th.AssertEquals(t, true, slices.Contains(updatedPool.Prefixes, "10.0.0.0/8"))
+
+	// Remove one of the prefixes.
+	removeOpts := subnetpools.PrefixesOpsOpts{
+		Prefixes: []string{
+			"192.168.0.0/16",
+		},
+	}
+
+	t.Logf("Attempting to remove prefixes from subnetpool %s", subnetPool.ID)
+
+	remainingPrefixes, err := subnetpools.RemovePrefixes(context.TODO(), client, subnetPool.ID, removeOpts).Extract()
+	th.AssertNoErr(t, err)
+
+	t.Logf("Successfully removed prefixes from subnetpool %s: %v", subnetPool.ID, remainingPrefixes)
+
+	// Verify via Get that the subnetpool reflects the removal.
+	finalPool, err := subnetpools.Get(context.TODO(), client, subnetPool.ID).Extract()
+	th.AssertNoErr(t, err)
+
+	tools.PrintResource(t, finalPool)
+
+	th.AssertEquals(t, false, slices.Contains(finalPool.Prefixes, "192.168.0.0/16"))
+	th.AssertEquals(t, true, slices.Contains(finalPool.Prefixes, "172.16.0.0/16"))
+	th.AssertEquals(t, true, slices.Contains(finalPool.Prefixes, "10.0.0.0/8"))
 }
 
 func TestSubnetPoolsRevision(t *testing.T) {

--- a/openstack/networking/v2/extensions/subnetpools/requests.go
+++ b/openstack/networking/v2/extensions/subnetpools/requests.go
@@ -252,11 +252,12 @@ type PrefixesOpsOpts struct {
 	Prefixes []string `json:"prefixes,omitempty"`
 }
 
+// ToSubnetPoolPrefixesOpsMap builds a request body from PrefixesOpsOpts.
 func (opts PrefixesOpsOpts) ToSubnetPoolPrefixesOpsMap() (map[string]any, error) {
 	return gophercloud.BuildRequestBody(opts, "")
 }
 
-// AddPrefixes accepts and PrefixesOpsOpts and add new prefixes for an
+// AddPrefixes accepts a PrefixesOpsOpts and adds new prefixes to an
 // existing subnet.
 func AddPrefixes(ctx context.Context, c *gophercloud.ServiceClient, subnetPoolID string, opts PrefixesOpsOptsBuilder) (r PrefixesOpsResult) {
 	b, err := opts.ToSubnetPoolPrefixesOpsMap()
@@ -271,8 +272,8 @@ func AddPrefixes(ctx context.Context, c *gophercloud.ServiceClient, subnetPoolID
 	return
 }
 
-// RemovePrefixes accepts and PrefixesOpsOpts and remove prefixes for an
-// existing subnet.
+// RemovePrefixes accepts a PrefixesOpsOpts and removes prefixes for
+// an existing subnet.
 func RemovePrefixes(ctx context.Context, c *gophercloud.ServiceClient, subnetPoolID string, opts PrefixesOpsOptsBuilder) (r PrefixesOpsResult) {
 	b, err := opts.ToSubnetPoolPrefixesOpsMap()
 	if err != nil {

--- a/openstack/networking/v2/extensions/subnetpools/requests.go
+++ b/openstack/networking/v2/extensions/subnetpools/requests.go
@@ -210,21 +210,9 @@ type UpdateOpts struct {
 	RevisionNumber *int `json:"-" h:"If-Match"`
 }
 
-// PrefixesOpsOpts represents the prefixes passed to the operation.
-type PrefixesOpsOpts struct {
-	// Prefixes is a list of subnet prefixes to add or remove from the
-	// subnet pool.
-	Prefixes []string `json:"prefixes,omitempty"`
-}
-
 // ToSubnetPoolUpdateMap builds a request body from UpdateOpts.
 func (opts UpdateOpts) ToSubnetPoolUpdateMap() (map[string]any, error) {
 	return gophercloud.BuildRequestBody(opts, "subnetpool")
-}
-
-// ToSubnetPoolUpdateMap builds a request body from UpdateOpts.
-func (opts PrefixesOpsOpts) ToSubnetPoolUpdateMap() (map[string]any, error) {
-	return gophercloud.BuildRequestBody(opts, "")
 }
 
 // Update accepts a UpdateOpts struct and updates an existing subnetpool using the
@@ -253,10 +241,25 @@ func Update(ctx context.Context, c *gophercloud.ServiceClient, subnetPoolID stri
 	return
 }
 
+type PrefixesOpsOptsBuilder interface {
+	ToSubnetPoolPrefixesOpsMap() (map[string]any, error)
+}
+
+// PrefixesOpsOpts represents the prefixes passed to the operation.
+type PrefixesOpsOpts struct {
+	// Prefixes is a list of subnet prefixes to add or remove from the
+	// subnet pool.
+	Prefixes []string `json:"prefixes,omitempty"`
+}
+
+func (opts PrefixesOpsOpts) ToSubnetPoolPrefixesOpsMap() (map[string]any, error) {
+	return gophercloud.BuildRequestBody(opts, "")
+}
+
 // AddPrefixes accepts and PrefixesOpsOpts and add new prefixes for an
 // existing subnet.
-func AddPrefixes(ctx context.Context, c *gophercloud.ServiceClient, subnetPoolID string, opts UpdateOptsBuilder) (r PrefixesOpsResult) {
-	b, err := opts.ToSubnetPoolUpdateMap()
+func AddPrefixes(ctx context.Context, c *gophercloud.ServiceClient, subnetPoolID string, opts PrefixesOpsOptsBuilder) (r PrefixesOpsResult) {
+	b, err := opts.ToSubnetPoolPrefixesOpsMap()
 	if err != nil {
 		r.Err = err
 		return
@@ -270,8 +273,8 @@ func AddPrefixes(ctx context.Context, c *gophercloud.ServiceClient, subnetPoolID
 
 // RemovePrefixes accepts and PrefixesOpsOpts and remove prefixes for an
 // existing subnet.
-func RemovePrefixes(ctx context.Context, c *gophercloud.ServiceClient, subnetPoolID string, opts UpdateOptsBuilder) (r PrefixesOpsResult) {
-	b, err := opts.ToSubnetPoolUpdateMap()
+func RemovePrefixes(ctx context.Context, c *gophercloud.ServiceClient, subnetPoolID string, opts PrefixesOpsOptsBuilder) (r PrefixesOpsResult) {
+	b, err := opts.ToSubnetPoolPrefixesOpsMap()
 	if err != nil {
 		r.Err = err
 		return

--- a/openstack/networking/v2/extensions/subnetpools/requests.go
+++ b/openstack/networking/v2/extensions/subnetpools/requests.go
@@ -210,9 +210,21 @@ type UpdateOpts struct {
 	RevisionNumber *int `json:"-" h:"If-Match"`
 }
 
+// PrefixesOpsOpts represents the prefixes passed to the operation.
+type PrefixesOpsOpts struct {
+	// Prefixes is a list of subnet prefixes to add or remove from the
+	// subnet pool.
+	Prefixes []string `json:"prefixes,omitempty"`
+}
+
 // ToSubnetPoolUpdateMap builds a request body from UpdateOpts.
 func (opts UpdateOpts) ToSubnetPoolUpdateMap() (map[string]any, error) {
 	return gophercloud.BuildRequestBody(opts, "subnetpool")
+}
+
+// ToSubnetPoolUpdateMap builds a request body from UpdateOpts.
+func (opts PrefixesOpsOpts) ToSubnetPoolUpdateMap() (map[string]any, error) {
+	return gophercloud.BuildRequestBody(opts, "")
 }
 
 // Update accepts a UpdateOpts struct and updates an existing subnetpool using the
@@ -236,6 +248,36 @@ func Update(ctx context.Context, c *gophercloud.ServiceClient, subnetPoolID stri
 	resp, err := c.Put(ctx, updateURL(c, subnetPoolID), b, &r.Body, &gophercloud.RequestOpts{
 		MoreHeaders: h,
 		OkCodes:     []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// AddPrefixes accepts and PrefixesOpsOpts and add new prefixes for an
+// existing subnet.
+func AddPrefixes(ctx context.Context, c *gophercloud.ServiceClient, subnetPoolID string, opts UpdateOptsBuilder) (r PrefixesOpsResult) {
+	b, err := opts.ToSubnetPoolUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := c.Put(ctx, addPrefixesURL(c, subnetPoolID), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// RemovePrefixes accepts and PrefixesOpsOpts and remove prefixes for an
+// existing subnet.
+func RemovePrefixes(ctx context.Context, c *gophercloud.ServiceClient, subnetPoolID string, opts UpdateOptsBuilder) (r PrefixesOpsResult) {
+	b, err := opts.ToSubnetPoolUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := c.Put(ctx, removePrefixesURL(c, subnetPoolID), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
 	})
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/openstack/networking/v2/extensions/subnetpools/results.go
+++ b/openstack/networking/v2/extensions/subnetpools/results.go
@@ -23,6 +23,15 @@ func (r commonResult) Extract() (*SubnetPool, error) {
 	return s.SubnetPool, err
 }
 
+// Extract interprets a PrefixesOpsResult as a slice of prefix strings.
+func (r PrefixesOpsResult) Extract() ([]string, error) {
+	var s struct {
+		Prefixes []string `json:"prefixes"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Prefixes, err
+}
+
 // GetResult represents the result of a get operation. Call its Extract
 // method to interpret it as a SubnetPool.
 type GetResult struct {
@@ -38,6 +47,12 @@ type CreateResult struct {
 // UpdateResult represents the result of an update operation. Call its Extract
 // method to interpret it as a SubnetPool.
 type UpdateResult struct {
+	commonResult
+}
+
+// PrefixesOpsResult represents the result of an add/remove prefixes
+// operation. Call its Extract method to interpret it as a []string.
+type PrefixesOpsResult struct {
 	commonResult
 }
 

--- a/openstack/networking/v2/extensions/subnetpools/testing/fixtures_test.go
+++ b/openstack/networking/v2/extensions/subnetpools/testing/fixtures_test.go
@@ -145,8 +145,6 @@ var SubnetPool3 = subnetpools.SubnetPool{
 	UpdatedAt:      time.Date(2017, 12, 28, 7, 21, 27, 0, time.UTC),
 }
 
-var Prefixes1 = []string{"192.168.0.0/23", "172.16.0.0/21"}
-
 const SubnetPoolGetResult = `
 {
     "subnetpool": {

--- a/openstack/networking/v2/extensions/subnetpools/testing/fixtures_test.go
+++ b/openstack/networking/v2/extensions/subnetpools/testing/fixtures_test.go
@@ -146,6 +146,8 @@ var SubnetPool3 = subnetpools.SubnetPool{
 	UpdatedAt:      time.Date(2017, 12, 28, 7, 21, 27, 0, time.UTC),
 }
 
+var Prefixes1 = []string{"192.168.0.0/23", "172.16.0.0/21"}
+
 const SubnetPoolGetResult = `
 {
     "subnetpool": {
@@ -255,5 +257,29 @@ const SubnetPoolUpdateResponse = `
         "tenant_id": "1e2b9857295a4a3e841809ef492812c5",
         "updated_at": "2018-01-05T09:56:56Z"
     }
+}
+`
+
+const PrefixesAddRequest = `
+{
+  "prefixes": ["192.168.0.0/24", "192.168.1.0/24", "172.16.0.0/21"]
+}
+`
+
+const PrefixesRemoveRequest = `
+{
+  "prefixes": ["192.168.0.0/24"]
+}
+`
+
+const PrefixesAddResponse = `
+{
+  "prefixes": ["192.168.0.0/23", "172.16.0.0/21"]
+}
+`
+
+const PrefixesRemoveResponse = `
+{
+ "prefixes": ["192.168.1.0/24", "172.16.0.0/21"]
 }
 `

--- a/openstack/networking/v2/extensions/subnetpools/testing/fixtures_test.go
+++ b/openstack/networking/v2/extensions/subnetpools/testing/fixtures_test.go
@@ -145,6 +145,8 @@ var SubnetPool3 = subnetpools.SubnetPool{
 	UpdatedAt:      time.Date(2017, 12, 28, 7, 21, 27, 0, time.UTC),
 }
 
+var Prefixes1 = []string{"192.168.0.0/23", "172.16.0.0/21"}
+
 const SubnetPoolGetResult = `
 {
     "subnetpool": {
@@ -298,5 +300,29 @@ const SubnetPoolUpdateResponse = `
         "tenant_id": "1e2b9857295a4a3e841809ef492812c5",
         "updated_at": "2018-01-05T09:56:56Z"
     }
+}
+`
+
+const PrefixesAddRequest = `
+{
+  "prefixes": ["192.168.0.0/24", "192.168.1.0/24", "172.16.0.0/21"]
+}
+`
+
+const PrefixesRemoveRequest = `
+{
+  "prefixes": ["192.168.0.0/24"]
+}
+`
+
+const PrefixesAddResponse = `
+{
+  "prefixes": ["192.168.0.0/23", "172.16.0.0/21"]
+}
+`
+
+const PrefixesRemoveResponse = `
+{
+ "prefixes": ["192.168.1.0/24", "172.16.0.0/21"]
 }
 `

--- a/openstack/networking/v2/extensions/subnetpools/testing/fixtures_test.go
+++ b/openstack/networking/v2/extensions/subnetpools/testing/fixtures_test.go
@@ -146,8 +146,6 @@ var SubnetPool3 = subnetpools.SubnetPool{
 	UpdatedAt:      time.Date(2017, 12, 28, 7, 21, 27, 0, time.UTC),
 }
 
-var Prefixes1 = []string{"192.168.0.0/23", "172.16.0.0/21"}
-
 const SubnetPoolGetResult = `
 {
     "subnetpool": {

--- a/openstack/networking/v2/extensions/subnetpools/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/subnetpools/testing/requests_test.go
@@ -193,3 +193,53 @@ func TestDelete(t *testing.T) {
 	res := subnetpools.Delete(context.TODO(), fake.ServiceClient(fakeServer), "099546ca-788d-41e5-a76d-17d8cd282d3e")
 	th.AssertNoErr(t, res.Err)
 }
+
+func TestAddPrefixes(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	fakeServer.Mux.HandleFunc("/v2.0/subnetpools/099546ca-788d-41e5-a76d-17d8cd282d3e/add_prefixes", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, PrefixesAddRequest)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprint(w, PrefixesAddResponse)
+	})
+
+	n, err := subnetpools.AddPrefixes(context.TODO(), fake.ServiceClient(fakeServer), "099546ca-788d-41e5-a76d-17d8cd282d3e", subnetpools.PrefixesOpsOpts{
+		Prefixes: []string{"192.168.0.0/24", "192.168.1.0/24", "172.16.0.0/21"},
+	}).Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertDeepEquals(t, []string{"192.168.0.0/23", "172.16.0.0/21"}, n)
+}
+
+func TestRemovePrefixes(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	fakeServer.Mux.HandleFunc("/v2.0/subnetpools/099546ca-788d-41e5-a76d-17d8cd282d3e/remove_prefixes", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, PrefixesRemoveRequest)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprint(w, PrefixesRemoveResponse)
+	})
+
+	n, err := subnetpools.RemovePrefixes(context.TODO(), fake.ServiceClient(fakeServer), "099546ca-788d-41e5-a76d-17d8cd282d3e", subnetpools.PrefixesOpsOpts{
+		Prefixes: []string{"192.168.0.0/24"},
+	}).Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertDeepEquals(t, []string{"192.168.1.0/24", "172.16.0.0/21"}, n)
+}

--- a/openstack/networking/v2/extensions/subnetpools/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/subnetpools/testing/requests_test.go
@@ -239,3 +239,53 @@ func TestDelete(t *testing.T) {
 	res := subnetpools.Delete(context.TODO(), fake.ServiceClient(fakeServer), "099546ca-788d-41e5-a76d-17d8cd282d3e")
 	th.AssertNoErr(t, res.Err)
 }
+
+func TestAddPrefixes(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	fakeServer.Mux.HandleFunc("/v2.0/subnetpools/099546ca-788d-41e5-a76d-17d8cd282d3e/add_prefixes", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, PrefixesAddRequest)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprint(w, PrefixesAddResponse)
+	})
+
+	n, err := subnetpools.AddPrefixes(context.TODO(), fake.ServiceClient(fakeServer), "099546ca-788d-41e5-a76d-17d8cd282d3e", subnetpools.PrefixesOpsOpts{
+		Prefixes: []string{"192.168.0.0/24", "192.168.1.0/24", "172.16.0.0/21"},
+	}).Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertDeepEquals(t, []string{"192.168.0.0/23", "172.16.0.0/21"}, n)
+}
+
+func TestRemovePrefixes(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	fakeServer.Mux.HandleFunc("/v2.0/subnetpools/099546ca-788d-41e5-a76d-17d8cd282d3e/remove_prefixes", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, PrefixesRemoveRequest)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprint(w, PrefixesRemoveResponse)
+	})
+
+	n, err := subnetpools.RemovePrefixes(context.TODO(), fake.ServiceClient(fakeServer), "099546ca-788d-41e5-a76d-17d8cd282d3e", subnetpools.PrefixesOpsOpts{
+		Prefixes: []string{"192.168.0.0/24"},
+	}).Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertDeepEquals(t, []string{"192.168.1.0/24", "172.16.0.0/21"}, n)
+}

--- a/openstack/networking/v2/extensions/subnetpools/urls.go
+++ b/openstack/networking/v2/extensions/subnetpools/urls.go
@@ -31,3 +31,11 @@ func updateURL(c *gophercloud.ServiceClient, id string) string {
 func deleteURL(c *gophercloud.ServiceClient, id string) string {
 	return resourceURL(c, id)
 }
+
+func addPrefixesURL(c *gophercloud.ServiceClient, id string) string {
+	return resourceURL(c, id) + "/add_prefixes"
+}
+
+func removePrefixesURL(c *gophercloud.ServiceClient, id string) string {
+	return resourceURL(c, id) + "/remove_prefixes"
+}


### PR DESCRIPTION
This PR adds the API calls for add and remove prefixes within the Subnet Pool API

Fixes #3850 

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://docs.openstack.org/api-ref/network/v2/index.html#subnet-pool-prefix-operations-subnetpool-prefix-ops
