### PR TITLE
auth: don't send scope with application credentials

### DIFF
--- a/auth_options.go
+++ b/auth_options.go
@@ -401,6 +401,13 @@ func (opts *AuthOptions) ToTokenV3CreateMap(scope map[string]any) (map[string]an
 // ToTokenV3ScopeMap builds a scope from AuthOptions and satisfies interface in
 // the v3 tokens package.
 func (opts *AuthOptions) ToTokenV3ScopeMap() (map[string]any, error) {
+	// Application credentials carry an implicit project scope in Keystone.
+	// Sending an explicit scope alongside them results in a 401 error:
+	// "Application credentials cannot request a scope."
+	if opts.ApplicationCredentialID != "" || opts.ApplicationCredentialName != "" {
+		return map[string]any{}, nil
+	}
+
 	// For backwards compatibility.
 	// If AuthOptions.Scope was not set, try to determine it.
 	// This works well for common scenarios.

--- a/auth_options.go
+++ b/auth_options.go
@@ -405,7 +405,7 @@ func (opts *AuthOptions) ToTokenV3ScopeMap() (map[string]any, error) {
 	// Sending an explicit scope alongside them results in a 401 error:
 	// "Application credentials cannot request a scope."
 	if opts.ApplicationCredentialID != "" || opts.ApplicationCredentialName != "" {
-		return map[string]any{}, nil
+		return nil, nil
 	}
 
 	// For backwards compatibility.

--- a/testing/auth_options_test.go
+++ b/testing/auth_options_test.go
@@ -145,7 +145,7 @@ func TestToTokenV3ScopeMap(t *testing.T) {
 					DomainName:  "Default",
 				},
 			},
-			map[string]any{},
+			nil,
 		},
 		{
 			"Application credential by name: no scope sent",
@@ -159,7 +159,7 @@ func TestToTokenV3ScopeMap(t *testing.T) {
 					DomainName:  "Default",
 				},
 			},
-			map[string]any{},
+			nil,
 		},
 	}
 	for _, successCase := range successCases {

--- a/testing/auth_options_test.go
+++ b/testing/auth_options_test.go
@@ -135,6 +135,32 @@ func TestToTokenV3ScopeMap(t *testing.T) {
 			},
 			nil,
 		},
+		{
+			"Application credential by ID: no scope sent",
+			gophercloud.AuthOptions{
+				ApplicationCredentialID:     "26bb287fd56a41f8a577c47f79221187",
+				ApplicationCredentialSecret: "secret",
+				Scope: &gophercloud.AuthScope{
+					ProjectName: "admin",
+					DomainName:  "Default",
+				},
+			},
+			map[string]any{},
+		},
+		{
+			"Application credential by name: no scope sent",
+			gophercloud.AuthOptions{
+				ApplicationCredentialName:   "myappcred",
+				ApplicationCredentialSecret: "secret",
+				Username:                    "someuser",
+				DomainName:                  "Default",
+				Scope: &gophercloud.AuthScope{
+					ProjectName: "admin",
+					DomainName:  "Default",
+				},
+			},
+			map[string]any{},
+		},
 	}
 	for _, successCase := range successCases {
 		t.Run(successCase.name, func(t *testing.T) {


### PR DESCRIPTION
Fixes #3868

When authenticating with application credentials, `ToTokenV3ScopeMap` was including a project scope in the token request. Keystone rejects this with HTTP 401: `Application credentials cannot request a scope.`

Application credentials carry an implicit project scope already. The fix returns an empty scope map early when application credentials are present.

Links to OpenStack source confirming that scopes are rejected with application credentials:
https://opendev.org/openstack/keystone/src/branch/stable/2025.1/keystone/auth/plugins/application_credential.py