### PR TITLE
Support compute default microversion in clouds.yaml

### DIFF
--- a/openstack/config/clouds/clouds_test.go
+++ b/openstack/config/clouds/clouds_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/gophercloud/gophercloud/v2/openstack/config/clouds"
+	"go.yaml.in/yaml/v3"
 )
 
 func ExampleWithCloudName() {
@@ -64,6 +65,32 @@ func ExampleWithRegion() {
 
 	fmt.Println(eo.Region)
 	// Output: mars
+}
+
+func TestCloudDefaultMicroversion(t *testing.T) {
+	const exampleClouds = `clouds:
+  openstack:
+    auth:
+      auth_url: https://example.com:13000
+    compute_default_microversion: "2.87"
+    regions:
+      - name: mars
+        values:
+          compute_default_microversion: "2.79"`
+
+	var parsed clouds.Clouds
+	if err := yaml.Unmarshal([]byte(exampleClouds), &parsed); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	cloud := parsed.Clouds["openstack"]
+	if got := cloud.ComputeDefaultMicroversion; got != "2.87" {
+		t.Errorf("unexpected compute default microversion: %q", got)
+	}
+
+	if got := cloud.Regions[0].Values.ComputeDefaultMicroversion; got != "2.79" {
+		t.Errorf("unexpected regional compute default microversion: %q", got)
+	}
 }
 
 func TestParse(t *testing.T) {

--- a/openstack/config/clouds/types.go
+++ b/openstack/config/clouds/types.go
@@ -28,6 +28,9 @@ type Cloud struct {
 	IdentityAPIVersion string `yaml:"identity_api_version,omitempty" json:"identity_api_version,omitempty"`
 	VolumeAPIVersion   string `yaml:"volume_api_version,omitempty" json:"volume_api_version,omitempty"`
 
+	// Service default microversion overrides.
+	ComputeDefaultMicroversion string `yaml:"compute_default_microversion,omitempty" json:"compute_default_microversion,omitempty"`
+
 	// Verify whether or not SSL API requests should be verified.
 	Verify *bool `yaml:"verify,omitempty" json:"verify,omitempty"`
 


### PR DESCRIPTION
## Summary

Add `compute_default_microversion` to the clouds.yaml parser as the first concrete service default microversion field.

This is intended as a small compute example while we work toward general `{service_type}_default_microversion` support.

Related: #3882

## Testing

- `go test ./openstack/config/clouds`