### PR TITLE
Add full OS-FEDERATION resource support

### DIFF
--- a/internal/acceptance/openstack/identity/v3/federation_test.go
+++ b/internal/acceptance/openstack/identity/v3/federation_test.go
@@ -120,3 +120,197 @@ func TestMappingsCRUD(t *testing.T) {
 	resp := federation.GetMapping(context.TODO(), client, mappingName)
 	th.AssertTrue(t, gophercloud.ResponseCodeIs(resp.Err, http.StatusNotFound))
 }
+
+func TestIdentityProvidersCRUD(t *testing.T) {
+	clients.RequireAdmin(t)
+
+	identityProviderID := tools.RandomString("TESTIDP-", 8)
+
+	client, err := clients.NewIdentityV3Client()
+	th.AssertNoErr(t, err)
+
+	createOpts := federation.CreateIdentityProviderOpts{
+		Description: "Gophercloud acceptance test identity provider",
+		Enabled:     gophercloud.Enabled,
+		RemoteIDs:   []string{tools.RandomString("remote-", 8)},
+	}
+	created, err := federation.CreateIdentityProvider(context.TODO(), client, identityProviderID, createOpts).Extract()
+	th.AssertNoErr(t, err)
+	defer federation.DeleteIdentityProvider(context.TODO(), client, identityProviderID)
+
+	th.CheckEquals(t, identityProviderID, created.ID)
+	th.AssertTrue(t, created.Description != nil)
+	th.CheckEquals(t, createOpts.Description, *created.Description)
+	th.CheckEquals(t, true, created.Enabled)
+	th.CheckDeepEquals(t, createOpts.RemoteIDs, created.RemoteIDs)
+
+	actual, err := federation.GetIdentityProvider(context.TODO(), client, identityProviderID).Extract()
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, identityProviderID, actual.ID)
+
+	allPages, err := federation.ListIdentityProviders(client).AllPages(context.TODO())
+	th.AssertNoErr(t, err)
+	identityProviders, err := federation.ExtractIdentityProviders(allPages)
+	th.AssertNoErr(t, err)
+	tools.PrintResource(t, identityProviders)
+
+	description := "Updated Gophercloud acceptance test identity provider"
+	remoteIDs := []string{tools.RandomString("updated-remote-", 8)}
+	updateOpts := federation.UpdateIdentityProviderOpts{
+		Description: &description,
+		Enabled:     gophercloud.Disabled,
+		RemoteIDs:   &remoteIDs,
+	}
+	updated, err := federation.UpdateIdentityProvider(context.TODO(), client, identityProviderID, updateOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertTrue(t, updated.Description != nil)
+	th.CheckEquals(t, description, *updated.Description)
+	th.CheckEquals(t, false, updated.Enabled)
+	th.CheckDeepEquals(t, remoteIDs, updated.RemoteIDs)
+
+	err = federation.DeleteIdentityProvider(context.TODO(), client, identityProviderID).ExtractErr()
+	th.AssertNoErr(t, err)
+
+	resp := federation.GetIdentityProvider(context.TODO(), client, identityProviderID)
+	th.AssertTrue(t, gophercloud.ResponseCodeIs(resp.Err, http.StatusNotFound))
+}
+
+func TestProtocolsCRUD(t *testing.T) {
+	clients.RequireAdmin(t)
+
+	identityProviderID := tools.RandomString("TESTIDP-", 8)
+	mappingID := tools.RandomString("TESTMAPPING-", 8)
+	updatedMappingID := tools.RandomString("TESTMAPPING-", 8)
+	protocolID := tools.RandomString("testprotocol-", 8)
+
+	client, err := clients.NewIdentityV3Client()
+	th.AssertNoErr(t, err)
+
+	mappingOpts := federation.CreateMappingOpts{
+		Rules: []federation.MappingRule{
+			{
+				Local: []federation.RuleLocal{
+					{User: &federation.RuleUser{Name: "{0}"}},
+				},
+				Remote: []federation.RuleRemote{
+					{Type: "UserName"},
+				},
+			},
+		},
+	}
+	_, err = federation.CreateMapping(context.TODO(), client, mappingID, mappingOpts).Extract()
+	th.AssertNoErr(t, err)
+	defer federation.DeleteMapping(context.TODO(), client, mappingID)
+
+	_, err = federation.CreateMapping(context.TODO(), client, updatedMappingID, mappingOpts).Extract()
+	th.AssertNoErr(t, err)
+	defer federation.DeleteMapping(context.TODO(), client, updatedMappingID)
+
+	_, err = federation.CreateIdentityProvider(context.TODO(), client, identityProviderID, federation.CreateIdentityProviderOpts{
+		Enabled: gophercloud.Enabled,
+	}).Extract()
+	th.AssertNoErr(t, err)
+	defer federation.DeleteIdentityProvider(context.TODO(), client, identityProviderID)
+
+	createOpts := federation.CreateProtocolOpts{
+		MappingID:         mappingID,
+		RemoteIDAttribute: "HTTP_OIDC_ISS",
+	}
+	created, err := federation.CreateProtocol(context.TODO(), client, identityProviderID, protocolID, createOpts).Extract()
+	th.AssertNoErr(t, err)
+	defer federation.DeleteProtocol(context.TODO(), client, identityProviderID, protocolID)
+
+	th.CheckEquals(t, protocolID, created.ID)
+	th.CheckEquals(t, mappingID, created.MappingID)
+
+	actual, err := federation.GetProtocol(context.TODO(), client, identityProviderID, protocolID).Extract()
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, protocolID, actual.ID)
+
+	allPages, err := federation.ListProtocols(client, identityProviderID).AllPages(context.TODO())
+	th.AssertNoErr(t, err)
+	protocols, err := federation.ExtractProtocols(allPages)
+	th.AssertNoErr(t, err)
+	tools.PrintResource(t, protocols)
+
+	remoteIDAttribute := "HTTP_UPDATED_OIDC_ISS"
+	updateOpts := federation.UpdateProtocolOpts{
+		MappingID:         updatedMappingID,
+		RemoteIDAttribute: &remoteIDAttribute,
+	}
+	updated, err := federation.UpdateProtocol(context.TODO(), client, identityProviderID, protocolID, updateOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, updatedMappingID, updated.MappingID)
+
+	err = federation.DeleteProtocol(context.TODO(), client, identityProviderID, protocolID).ExtractErr()
+	th.AssertNoErr(t, err)
+
+	resp := federation.GetProtocol(context.TODO(), client, identityProviderID, protocolID)
+	th.AssertTrue(t, gophercloud.ResponseCodeIs(resp.Err, http.StatusNotFound))
+}
+
+func TestServiceProvidersCRUD(t *testing.T) {
+	clients.RequireAdmin(t)
+
+	serviceProviderID := tools.RandomString("TESTSP-", 8)
+
+	client, err := clients.NewIdentityV3Client()
+	th.AssertNoErr(t, err)
+
+	createOpts := federation.CreateServiceProviderOpts{
+		AuthURL:          "https://example.com/v3/OS-FEDERATION/identity_providers/acme/protocols/saml2/auth",
+		Description:      "Gophercloud acceptance test service provider",
+		Enabled:          gophercloud.Enabled,
+		RelayStatePrefix: "ss:mem:",
+		SPURL:            "https://example.com/Shibboleth.sso/SAML2/ECP",
+	}
+	created, err := federation.CreateServiceProvider(context.TODO(), client, serviceProviderID, createOpts).Extract()
+	th.AssertNoErr(t, err)
+	defer federation.DeleteServiceProvider(context.TODO(), client, serviceProviderID)
+
+	th.CheckEquals(t, serviceProviderID, created.ID)
+	th.CheckEquals(t, createOpts.AuthURL, created.AuthURL)
+	th.AssertTrue(t, created.Description != nil)
+	th.CheckEquals(t, createOpts.Description, *created.Description)
+	th.CheckEquals(t, true, created.Enabled)
+	th.AssertTrue(t, created.RelayStatePrefix != nil)
+	th.CheckEquals(t, createOpts.RelayStatePrefix, *created.RelayStatePrefix)
+	th.CheckEquals(t, createOpts.SPURL, created.SPURL)
+
+	actual, err := federation.GetServiceProvider(context.TODO(), client, serviceProviderID).Extract()
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, serviceProviderID, actual.ID)
+
+	allPages, err := federation.ListServiceProviders(client).AllPages(context.TODO())
+	th.AssertNoErr(t, err)
+	serviceProviders, err := federation.ExtractServiceProviders(allPages)
+	th.AssertNoErr(t, err)
+	tools.PrintResource(t, serviceProviders)
+
+	authURL := "https://new.example.com/v3/OS-FEDERATION/identity_providers/acme/protocols/saml2/auth"
+	description := "Updated Gophercloud acceptance test service provider"
+	relayStatePrefix := "ss:temp:"
+	spURL := "https://new.example.com/Shibboleth.sso/SAML2/ECP"
+	updateOpts := federation.UpdateServiceProviderOpts{
+		AuthURL:          &authURL,
+		Description:      &description,
+		Enabled:          gophercloud.Disabled,
+		RelayStatePrefix: &relayStatePrefix,
+		SPURL:            &spURL,
+	}
+	updated, err := federation.UpdateServiceProvider(context.TODO(), client, serviceProviderID, updateOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, authURL, updated.AuthURL)
+	th.AssertTrue(t, updated.Description != nil)
+	th.CheckEquals(t, description, *updated.Description)
+	th.CheckEquals(t, false, updated.Enabled)
+	th.AssertTrue(t, updated.RelayStatePrefix != nil)
+	th.CheckEquals(t, relayStatePrefix, *updated.RelayStatePrefix)
+	th.CheckEquals(t, spURL, updated.SPURL)
+
+	err = federation.DeleteServiceProvider(context.TODO(), client, serviceProviderID).ExtractErr()
+	th.AssertNoErr(t, err)
+
+	resp := federation.GetServiceProvider(context.TODO(), client, serviceProviderID)
+	th.AssertTrue(t, gophercloud.ResponseCodeIs(resp.Err, http.StatusNotFound))
+}

--- a/internal/acceptance/openstack/identity/v3/federation_test.go
+++ b/internal/acceptance/openstack/identity/v3/federation_test.go
@@ -148,10 +148,16 @@ func TestIdentityProvidersCRUD(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.CheckEquals(t, identityProviderID, actual.ID)
 
-	allPages, err := federation.ListIdentityProviders(client).AllPages(context.TODO())
+	listOpts := federation.ListIdentityProvidersOpts{
+		ID:      identityProviderID,
+		Enabled: gophercloud.Enabled,
+	}
+	allPages, err := federation.ListIdentityProviders(client, listOpts).AllPages(context.TODO())
 	th.AssertNoErr(t, err)
 	identityProviders, err := federation.ExtractIdentityProviders(allPages)
 	th.AssertNoErr(t, err)
+	th.AssertEquals(t, 1, len(identityProviders))
+	th.CheckEquals(t, identityProviderID, identityProviders[0].ID)
 	tools.PrintResource(t, identityProviders)
 
 	description := "Updated Gophercloud acceptance test identity provider"
@@ -281,10 +287,16 @@ func TestServiceProvidersCRUD(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.CheckEquals(t, serviceProviderID, actual.ID)
 
-	allPages, err := federation.ListServiceProviders(client).AllPages(context.TODO())
+	listOpts := federation.ListServiceProvidersOpts{
+		ID:      serviceProviderID,
+		Enabled: gophercloud.Enabled,
+	}
+	allPages, err := federation.ListServiceProviders(client, listOpts).AllPages(context.TODO())
 	th.AssertNoErr(t, err)
 	serviceProviders, err := federation.ExtractServiceProviders(allPages)
 	th.AssertNoErr(t, err)
+	th.AssertEquals(t, 1, len(serviceProviders))
+	th.CheckEquals(t, serviceProviderID, serviceProviders[0].ID)
 	tools.PrintResource(t, serviceProviders)
 
 	authURL := "https://new.example.com/v3/OS-FEDERATION/identity_providers/acme/protocols/saml2/auth"

--- a/openstack/identity/v3/federation/doc.go
+++ b/openstack/identity/v3/federation/doc.go
@@ -1,6 +1,31 @@
 /*
-Package federation provides information and interaction with OS-FEDERATION API for the
-Openstack Identity service.
+Package federation provides information and interaction with the OS-FEDERATION
+API for the OpenStack Identity service.
+
+Example to Create an Identity Provider
+
+	createOpts := federation.CreateIdentityProviderOpts{
+		Description: "Stores ACME identities",
+		Enabled:     gophercloud.Enabled,
+		RemoteIDs:   []string{"acme_id_1", "acme_id_2"},
+	}
+	identityProvider, err := federation.CreateIdentityProvider(
+		context.TODO(), identityClient, "ACME", createOpts,
+	).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to List Identity Providers
+
+	allPages, err := federation.ListIdentityProviders(identityClient).AllPages(context.TODO())
+	if err != nil {
+		panic(err)
+	}
+	allIdentityProviders, err := federation.ExtractIdentityProviders(allPages)
+	if err != nil {
+		panic(err)
+	}
 
 Example to List Mappings
 
@@ -98,6 +123,35 @@ Example to Update a Mapping
 Example to Delete a Mapping
 
 	err := federation.DeleteMapping(context.TODO(), identityClient, "ACME").ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Add a Protocol to an Identity Provider
+
+	createOpts := federation.CreateProtocolOpts{
+		MappingID:         "ACME",
+		RemoteIDAttribute: "HTTP_OIDC_ISS",
+	}
+	protocol, err := federation.CreateProtocol(
+		context.TODO(), identityClient, "ACME", "openid", createOpts,
+	).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Create a Service Provider
+
+	createOpts := federation.CreateServiceProviderOpts{
+		AuthURL:          "https://example.com/v3/OS-FEDERATION/identity_providers/acme/protocols/saml2/auth",
+		Description:      "Remote Service Provider",
+		Enabled:          gophercloud.Enabled,
+		RelayStatePrefix: "ss:mem:",
+		SPURL:            "https://example.com/Shibboleth.sso/SAML2/ECP",
+	}
+	serviceProvider, err := federation.CreateServiceProvider(
+		context.TODO(), identityClient, "ACME", createOpts,
+	).Extract()
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/identity/v3/federation/doc.go
+++ b/openstack/identity/v3/federation/doc.go
@@ -18,7 +18,10 @@ Example to Create an Identity Provider
 
 Example to List Identity Providers
 
-	allPages, err := federation.ListIdentityProviders(identityClient).AllPages(context.TODO())
+	listOpts := federation.ListIdentityProvidersOpts{
+		Enabled: gophercloud.Enabled,
+	}
+	allPages, err := federation.ListIdentityProviders(identityClient, listOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/identity/v3/federation/requests.go
+++ b/openstack/identity/v3/federation/requests.go
@@ -7,9 +7,39 @@ import (
 	"github.com/gophercloud/gophercloud/v2/pagination"
 )
 
+// ListIdentityProvidersOptsBuilder allows extensions to add additional
+// parameters to the ListIdentityProviders request.
+type ListIdentityProvidersOptsBuilder interface {
+	ToIdentityProviderListQuery() (string, error)
+}
+
+// ListIdentityProvidersOpts provides options for filtering identity providers.
+type ListIdentityProvidersOpts struct {
+	// ID filters the response by identity provider ID.
+	ID string `q:"id"`
+
+	// Enabled filters the response by whether identity providers are enabled.
+	Enabled *bool `q:"enabled"`
+}
+
+// ToIdentityProviderListQuery formats ListIdentityProvidersOpts into a query
+// string.
+func (opts ListIdentityProvidersOpts) ToIdentityProviderListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
 // ListIdentityProviders enumerates the identity providers.
-func ListIdentityProviders(client *gophercloud.ServiceClient) pagination.Pager {
-	return pagination.NewPager(client, identityProvidersRootURL(client), func(r pagination.PageResult) pagination.Page {
+func ListIdentityProviders(client *gophercloud.ServiceClient, opts ListIdentityProvidersOptsBuilder) pagination.Pager {
+	url := identityProvidersRootURL(client)
+	if opts != nil {
+		query, err := opts.ToIdentityProviderListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
 		return IdentityProvidersPage{pagination.LinkedPageBase{PageResult: r}}
 	})
 }
@@ -323,9 +353,39 @@ func DeleteProtocol(ctx context.Context, client *gophercloud.ServiceClient, iden
 	return
 }
 
+// ListServiceProvidersOptsBuilder allows extensions to add additional
+// parameters to the ListServiceProviders request.
+type ListServiceProvidersOptsBuilder interface {
+	ToServiceProviderListQuery() (string, error)
+}
+
+// ListServiceProvidersOpts provides options for filtering service providers.
+type ListServiceProvidersOpts struct {
+	// ID filters the response by service provider ID.
+	ID string `q:"id"`
+
+	// Enabled filters the response by whether service providers are enabled.
+	Enabled *bool `q:"enabled"`
+}
+
+// ToServiceProviderListQuery formats ListServiceProvidersOpts into a query
+// string.
+func (opts ListServiceProvidersOpts) ToServiceProviderListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
 // ListServiceProviders enumerates the service providers.
-func ListServiceProviders(client *gophercloud.ServiceClient) pagination.Pager {
-	return pagination.NewPager(client, serviceProvidersRootURL(client), func(r pagination.PageResult) pagination.Page {
+func ListServiceProviders(client *gophercloud.ServiceClient, opts ListServiceProvidersOptsBuilder) pagination.Pager {
+	url := serviceProvidersRootURL(client)
+	if opts != nil {
+		query, err := opts.ToServiceProviderListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
 		return ServiceProvidersPage{pagination.LinkedPageBase{PageResult: r}}
 	})
 }

--- a/openstack/identity/v3/federation/requests.go
+++ b/openstack/identity/v3/federation/requests.go
@@ -7,6 +7,143 @@ import (
 	"github.com/gophercloud/gophercloud/v2/pagination"
 )
 
+// ListIdentityProviders enumerates the identity providers.
+func ListIdentityProviders(client *gophercloud.ServiceClient) pagination.Pager {
+	return pagination.NewPager(client, identityProvidersRootURL(client), func(r pagination.PageResult) pagination.Page {
+		return IdentityProvidersPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// CreateIdentityProviderOptsBuilder allows extensions to add additional
+// parameters to the CreateIdentityProvider request.
+type CreateIdentityProviderOptsBuilder interface {
+	ToIdentityProviderCreateMap() (map[string]any, error)
+}
+
+// CreateIdentityProviderOpts provides options for creating an identity
+// provider.
+type CreateIdentityProviderOpts struct {
+	// AuthorizationTTL is the length of validity, in minutes, for group
+	// memberships carried over through mapping and persisted in the database.
+	AuthorizationTTL *int `json:"authorization_ttl,omitempty"`
+
+	// DomainID is the ID of the domain associated with the identity provider.
+	// If omitted, the Identity service creates a domain automatically.
+	DomainID string `json:"domain_id,omitempty"`
+
+	// Description describes the identity provider.
+	Description string `json:"description,omitempty"`
+
+	// Enabled indicates whether the identity provider accepts federated
+	// authentication requests.
+	Enabled *bool `json:"enabled,omitempty"`
+
+	// RemoteIDs is the list of unique IDs used by the remote identity provider.
+	RemoteIDs []string `json:"remote_ids,omitempty"`
+}
+
+// ToIdentityProviderCreateMap formats CreateIdentityProviderOpts into a create
+// request.
+func (opts CreateIdentityProviderOpts) ToIdentityProviderCreateMap() (map[string]any, error) {
+	return gophercloud.BuildRequestBody(opts, "identity_provider")
+}
+
+// CreateIdentityProvider registers a new identity provider.
+func CreateIdentityProvider(ctx context.Context, client *gophercloud.ServiceClient, identityProviderID string, opts CreateIdentityProviderOptsBuilder) (r CreateIdentityProviderResult) {
+	b, err := opts.ToIdentityProviderCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := client.Put(ctx, identityProvidersResourceURL(client, identityProviderID), &b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{201},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// GetIdentityProvider retrieves details about an identity provider.
+func GetIdentityProvider(ctx context.Context, client *gophercloud.ServiceClient, identityProviderID string) (r GetIdentityProviderResult) {
+	resp, err := client.Get(ctx, identityProvidersResourceURL(client, identityProviderID), &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// UpdateIdentityProviderOptsBuilder allows extensions to add additional
+// parameters to the UpdateIdentityProvider request.
+type UpdateIdentityProviderOptsBuilder interface {
+	ToIdentityProviderUpdateMap() (map[string]any, error)
+}
+
+// UpdateIdentityProviderOpts provides options for updating an identity
+// provider. The associated domain cannot be updated.
+type UpdateIdentityProviderOpts struct {
+	// AuthorizationTTL is the length of validity, in minutes, for group
+	// memberships carried over through mapping and persisted in the database.
+	// Set this to -1 to reset the value to the Identity service configured
+	// default.
+	AuthorizationTTL *int `json:"authorization_ttl,omitempty"`
+
+	// Description describes the identity provider.
+	// Set this to an empty string to remove the description.
+	Description *string `json:"description,omitempty"`
+
+	// Enabled indicates whether the identity provider accepts federated
+	// authentication requests.
+	Enabled *bool `json:"enabled,omitempty"`
+
+	// RemoteIDs is the list of unique IDs used by the remote identity provider.
+	// A pointer to an empty slice removes all remote IDs.
+	RemoteIDs *[]string `json:"remote_ids,omitempty"`
+}
+
+// ToIdentityProviderUpdateMap formats UpdateIdentityProviderOpts into an update
+// request.
+func (opts UpdateIdentityProviderOpts) ToIdentityProviderUpdateMap() (map[string]any, error) {
+	b, err := gophercloud.BuildRequestBody(opts, "identity_provider")
+	if err != nil {
+		return nil, err
+	}
+
+	m := b["identity_provider"].(map[string]any)
+
+	// Keystone distinguishes an omitted authorization_ttl from a null value.
+	// The former leaves the current value unchanged, while the latter resets it
+	// to the configured default. Zero is a valid value, so -1 is used as the
+	// sentinel for null.
+	if opts.AuthorizationTTL != nil && *opts.AuthorizationTTL == -1 {
+		m["authorization_ttl"] = nil
+	}
+
+	// An empty string is used as the sentinel for a null description.
+	if opts.Description != nil && *opts.Description == "" {
+		m["description"] = nil
+	}
+
+	return b, nil
+}
+
+// UpdateIdentityProvider updates an existing identity provider.
+func UpdateIdentityProvider(ctx context.Context, client *gophercloud.ServiceClient, identityProviderID string, opts UpdateIdentityProviderOptsBuilder) (r UpdateIdentityProviderResult) {
+	b, err := opts.ToIdentityProviderUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := client.Patch(ctx, identityProvidersResourceURL(client, identityProviderID), &b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// DeleteIdentityProvider deletes an identity provider.
+func DeleteIdentityProvider(ctx context.Context, client *gophercloud.ServiceClient, identityProviderID string) (r DeleteIdentityProviderResult) {
+	resp, err := client.Delete(ctx, identityProvidersResourceURL(client, identityProviderID), nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
 // ListMappings enumerates the mappings.
 func ListMappings(client *gophercloud.ServiceClient) pagination.Pager {
 	return pagination.NewPager(client, mappingsRootURL(client), func(r pagination.PageResult) pagination.Page {
@@ -20,7 +157,7 @@ type CreateMappingOptsBuilder interface {
 	ToMappingCreateMap() (map[string]any, error)
 }
 
-// UpdateMappingOpts provides options for creating a mapping.
+// CreateMappingOpts provides options for creating a mapping.
 type CreateMappingOpts struct {
 	// The list of rules used to map remote users into local users
 	Rules []MappingRule `json:"rules"`
@@ -64,7 +201,7 @@ type UpdateMappingOpts struct {
 	Rules []MappingRule `json:"rules"`
 }
 
-// ToMappingUpdateMap formats a UpdateOpts into an update request.
+// ToMappingUpdateMap formats an UpdateMappingOpts into an update request.
 func (opts UpdateMappingOpts) ToMappingUpdateMap() (map[string]any, error) {
 	return gophercloud.BuildRequestBody(opts, "mapping")
 }
@@ -86,6 +223,232 @@ func UpdateMapping(ctx context.Context, client *gophercloud.ServiceClient, mappi
 // DeleteMapping deletes a mapping.
 func DeleteMapping(ctx context.Context, client *gophercloud.ServiceClient, mappingID string) (r DeleteMappingResult) {
 	resp, err := client.Delete(ctx, mappingsResourceURL(client, mappingID), nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// ListProtocols enumerates the federation protocols associated with an
+// identity provider.
+func ListProtocols(client *gophercloud.ServiceClient, identityProviderID string) pagination.Pager {
+	return pagination.NewPager(client, protocolsRootURL(client, identityProviderID), func(r pagination.PageResult) pagination.Page {
+		return ProtocolsPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// CreateProtocolOptsBuilder allows extensions to add additional parameters to
+// the CreateProtocol request.
+type CreateProtocolOptsBuilder interface {
+	ToProtocolCreateMap() (map[string]any, error)
+}
+
+// CreateProtocolOpts provides options for adding a protocol to an identity
+// provider.
+type CreateProtocolOpts struct {
+	// MappingID is the ID of the mapping used to process federated
+	// authentication requests.
+	MappingID string `json:"mapping_id" required:"true"`
+
+	// RemoteIDAttribute is the name of the attribute used to obtain the remote
+	// identity provider ID.
+	RemoteIDAttribute string `json:"remote_id_attribute,omitempty"`
+}
+
+// ToProtocolCreateMap formats CreateProtocolOpts into a create request.
+func (opts CreateProtocolOpts) ToProtocolCreateMap() (map[string]any, error) {
+	return gophercloud.BuildRequestBody(opts, "protocol")
+}
+
+// CreateProtocol adds a protocol to an identity provider.
+func CreateProtocol(ctx context.Context, client *gophercloud.ServiceClient, identityProviderID, protocolID string, opts CreateProtocolOptsBuilder) (r CreateProtocolResult) {
+	b, err := opts.ToProtocolCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := client.Put(ctx, protocolsResourceURL(client, identityProviderID, protocolID), &b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{201},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// GetProtocol retrieves details about a protocol associated with an identity
+// provider.
+func GetProtocol(ctx context.Context, client *gophercloud.ServiceClient, identityProviderID, protocolID string) (r GetProtocolResult) {
+	resp, err := client.Get(ctx, protocolsResourceURL(client, identityProviderID, protocolID), &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// UpdateProtocolOptsBuilder allows extensions to add additional parameters to
+// the UpdateProtocol request.
+type UpdateProtocolOptsBuilder interface {
+	ToProtocolUpdateMap() (map[string]any, error)
+}
+
+// UpdateProtocolOpts provides options for updating a protocol.
+type UpdateProtocolOpts struct {
+	// MappingID is the ID of the mapping used to process federated
+	// authentication requests.
+	MappingID string `json:"mapping_id,omitempty"`
+
+	// RemoteIDAttribute is the name of the attribute used to obtain the remote
+	// identity provider ID.
+	RemoteIDAttribute *string `json:"remote_id_attribute,omitempty"`
+}
+
+// ToProtocolUpdateMap formats UpdateProtocolOpts into an update request.
+func (opts UpdateProtocolOpts) ToProtocolUpdateMap() (map[string]any, error) {
+	return gophercloud.BuildRequestBody(opts, "protocol")
+}
+
+// UpdateProtocol updates a protocol associated with an identity provider.
+func UpdateProtocol(ctx context.Context, client *gophercloud.ServiceClient, identityProviderID, protocolID string, opts UpdateProtocolOptsBuilder) (r UpdateProtocolResult) {
+	b, err := opts.ToProtocolUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := client.Patch(ctx, protocolsResourceURL(client, identityProviderID, protocolID), &b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// DeleteProtocol deletes a protocol from an identity provider.
+func DeleteProtocol(ctx context.Context, client *gophercloud.ServiceClient, identityProviderID, protocolID string) (r DeleteProtocolResult) {
+	resp, err := client.Delete(ctx, protocolsResourceURL(client, identityProviderID, protocolID), nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// ListServiceProviders enumerates the service providers.
+func ListServiceProviders(client *gophercloud.ServiceClient) pagination.Pager {
+	return pagination.NewPager(client, serviceProvidersRootURL(client), func(r pagination.PageResult) pagination.Page {
+		return ServiceProvidersPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// CreateServiceProviderOptsBuilder allows extensions to add additional
+// parameters to the CreateServiceProvider request.
+type CreateServiceProviderOptsBuilder interface {
+	ToServiceProviderCreateMap() (map[string]any, error)
+}
+
+// CreateServiceProviderOpts provides options for creating a service provider.
+type CreateServiceProviderOpts struct {
+	// AuthURL is the protected URL where tokens can be retrieved after the user
+	// is authenticated.
+	AuthURL string `json:"auth_url" required:"true"`
+
+	// Description describes the service provider.
+	Description string `json:"description,omitempty"`
+
+	// Enabled indicates whether bursting into the service provider is enabled.
+	Enabled *bool `json:"enabled,omitempty"`
+
+	// RelayStatePrefix is the relay state prefix used in ECP-wrapped SAML
+	// messages.
+	RelayStatePrefix string `json:"relay_state_prefix,omitempty"`
+
+	// SPURL is the URL at the remote peer where the assertion is sent.
+	SPURL string `json:"sp_url" required:"true"`
+}
+
+// ToServiceProviderCreateMap formats CreateServiceProviderOpts into a create
+// request.
+func (opts CreateServiceProviderOpts) ToServiceProviderCreateMap() (map[string]any, error) {
+	return gophercloud.BuildRequestBody(opts, "service_provider")
+}
+
+// CreateServiceProvider registers a new service provider.
+func CreateServiceProvider(ctx context.Context, client *gophercloud.ServiceClient, serviceProviderID string, opts CreateServiceProviderOptsBuilder) (r CreateServiceProviderResult) {
+	b, err := opts.ToServiceProviderCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := client.Put(ctx, serviceProvidersResourceURL(client, serviceProviderID), &b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{201},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// GetServiceProvider retrieves details about a service provider.
+func GetServiceProvider(ctx context.Context, client *gophercloud.ServiceClient, serviceProviderID string) (r GetServiceProviderResult) {
+	resp, err := client.Get(ctx, serviceProvidersResourceURL(client, serviceProviderID), &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// UpdateServiceProviderOptsBuilder allows extensions to add additional
+// parameters to the UpdateServiceProvider request.
+type UpdateServiceProviderOptsBuilder interface {
+	ToServiceProviderUpdateMap() (map[string]any, error)
+}
+
+// UpdateServiceProviderOpts provides options for updating a service provider.
+type UpdateServiceProviderOpts struct {
+	// AuthURL is the protected URL where tokens can be retrieved after the user
+	// is authenticated.
+	AuthURL *string `json:"auth_url,omitempty"`
+
+	// Description describes the service provider.
+	// Set this to an empty string to remove the description.
+	Description *string `json:"description,omitempty"`
+
+	// Enabled indicates whether bursting into the service provider is enabled.
+	Enabled *bool `json:"enabled,omitempty"`
+
+	// RelayStatePrefix is the relay state prefix used in ECP-wrapped SAML
+	// messages.
+	// Set this to an empty string to reset the relay state prefix.
+	RelayStatePrefix *string `json:"relay_state_prefix,omitempty"`
+
+	// SPURL is the URL at the remote peer where the assertion is sent.
+	SPURL *string `json:"sp_url,omitempty"`
+}
+
+// ToServiceProviderUpdateMap formats UpdateServiceProviderOpts into an update
+// request.
+func (opts UpdateServiceProviderOpts) ToServiceProviderUpdateMap() (map[string]any, error) {
+	b, err := gophercloud.BuildRequestBody(opts, "service_provider")
+	if err != nil {
+		return nil, err
+	}
+
+	m := b["service_provider"].(map[string]any)
+
+	// Empty strings are used as sentinels for nullable fields.
+	if opts.Description != nil && *opts.Description == "" {
+		m["description"] = nil
+	}
+	if opts.RelayStatePrefix != nil && *opts.RelayStatePrefix == "" {
+		m["relay_state_prefix"] = nil
+	}
+
+	return b, nil
+}
+
+// UpdateServiceProvider updates an existing service provider.
+func UpdateServiceProvider(ctx context.Context, client *gophercloud.ServiceClient, serviceProviderID string, opts UpdateServiceProviderOptsBuilder) (r UpdateServiceProviderResult) {
+	b, err := opts.ToServiceProviderUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := client.Patch(ctx, serviceProvidersResourceURL(client, serviceProviderID), &b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// DeleteServiceProvider deletes a service provider.
+func DeleteServiceProvider(ctx context.Context, client *gophercloud.ServiceClient, serviceProviderID string) (r DeleteServiceProviderResult) {
+	resp, err := client.Delete(ctx, serviceProvidersResourceURL(client, serviceProviderID), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }

--- a/openstack/identity/v3/federation/results.go
+++ b/openstack/identity/v3/federation/results.go
@@ -8,9 +8,42 @@ import (
 type UserType string
 
 const (
+	// UserTypeEphemeral represents a federated user that does not exist in the
+	// Identity service.
 	UserTypeEphemeral UserType = "ephemeral"
-	UserTypeLocal     UserType = "local"
+
+	// UserTypeLocal represents an existing user in the Identity service.
+	UserTypeLocal UserType = "local"
 )
+
+// IdentityProvider represents an identity provider trusted by the Identity
+// service.
+type IdentityProvider struct {
+	// AuthorizationTTL is the length of validity, in minutes, for group
+	// memberships carried over through mapping and persisted in the database.
+	// It is nil when the Identity service configured default is used.
+	AuthorizationTTL *int `json:"authorization_ttl"`
+
+	// DomainID is the ID of the domain associated with the identity provider.
+	DomainID string `json:"domain_id"`
+
+	// Description describes the identity provider. It is nil when no
+	// description is set.
+	Description *string `json:"description"`
+
+	// Enabled indicates whether the identity provider accepts federated
+	// authentication requests.
+	Enabled bool `json:"enabled"`
+
+	// ID is the unique ID of the identity provider.
+	ID string `json:"id"`
+
+	// Links contains links related to the identity provider.
+	Links map[string]any `json:"links"`
+
+	// RemoteIDs is the list of unique IDs used by the remote identity provider.
+	RemoteIDs []string `json:"remote_ids"`
+}
 
 // Mapping a set of rules to map federation protocol attributes to
 // Identity API objects.
@@ -18,7 +51,7 @@ type Mapping struct {
 	// The Federation Mapping unique ID
 	ID string `json:"id"`
 
-	// Links contains referencing links to the limit.
+	// Links contains links related to the mapping.
 	Links map[string]any `json:"links"`
 
 	// The list of rules used to map remote users into local users
@@ -168,6 +201,79 @@ type DeleteMappingResult struct {
 	gophercloud.ErrResult
 }
 
+type identityProviderResult struct {
+	gophercloud.Result
+}
+
+// Extract interprets an identity provider result as an IdentityProvider.
+func (r identityProviderResult) Extract() (*IdentityProvider, error) {
+	var s struct {
+		IdentityProvider *IdentityProvider `json:"identity_provider"`
+	}
+	err := r.ExtractInto(&s)
+	return s.IdentityProvider, err
+}
+
+// CreateIdentityProviderResult is the response from a CreateIdentityProvider
+// operation.
+type CreateIdentityProviderResult struct {
+	identityProviderResult
+}
+
+// GetIdentityProviderResult is the response from a GetIdentityProvider
+// operation.
+type GetIdentityProviderResult struct {
+	identityProviderResult
+}
+
+// UpdateIdentityProviderResult is the response from an UpdateIdentityProvider
+// operation.
+type UpdateIdentityProviderResult struct {
+	identityProviderResult
+}
+
+// DeleteIdentityProviderResult is the response from a DeleteIdentityProvider
+// operation.
+type DeleteIdentityProviderResult struct {
+	gophercloud.ErrResult
+}
+
+// IdentityProvidersPage is a single page of IdentityProvider results.
+type IdentityProvidersPage struct {
+	pagination.LinkedPageBase
+}
+
+// IsEmpty determines whether an IdentityProvidersPage contains any results.
+func (r IdentityProvidersPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
+	identityProviders, err := ExtractIdentityProviders(r)
+	return len(identityProviders) == 0, err
+}
+
+// NextPageURL extracts the next link from an IdentityProvidersPage.
+func (r IdentityProvidersPage) NextPageURL(endpointURL string) (string, error) {
+	var s struct {
+		Links struct {
+			Next string `json:"next"`
+		} `json:"links"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Links.Next, err
+}
+
+// ExtractIdentityProviders extracts a slice of IdentityProvider values from a
+// page returned by ListIdentityProviders.
+func ExtractIdentityProviders(r pagination.Page) ([]IdentityProvider, error) {
+	var s struct {
+		IdentityProviders []IdentityProvider `json:"identity_providers"`
+	}
+	err := (r.(IdentityProvidersPage)).ExtractInto(&s)
+	return s.IdentityProviders, err
+}
+
 // MappingsPage is a single page of Mapping results.
 type MappingsPage struct {
 	pagination.LinkedPageBase
@@ -206,4 +312,192 @@ func ExtractMappings(r pagination.Page) ([]Mapping, error) {
 	}
 	err := (r.(MappingsPage)).ExtractInto(&s)
 	return s.Mappings, err
+}
+
+// Protocol represents a federation protocol associated with an identity
+// provider.
+type Protocol struct {
+	// ID is the unique ID of the protocol.
+	ID string `json:"id"`
+
+	// Links contains links related to the protocol.
+	Links map[string]any `json:"links"`
+
+	// MappingID is the ID of the mapping used by the protocol.
+	MappingID string `json:"mapping_id"`
+
+	// RemoteIDAttribute is the name of the attribute used to obtain the remote
+	// identity provider ID. It is nil when the Identity service omits the
+	// attribute from the response.
+	RemoteIDAttribute *string `json:"remote_id_attribute"`
+}
+
+type protocolResult struct {
+	gophercloud.Result
+}
+
+// Extract interprets a protocol result as a Protocol.
+func (r protocolResult) Extract() (*Protocol, error) {
+	var s struct {
+		Protocol *Protocol `json:"protocol"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Protocol, err
+}
+
+// CreateProtocolResult is the response from a CreateProtocol operation.
+type CreateProtocolResult struct {
+	protocolResult
+}
+
+// GetProtocolResult is the response from a GetProtocol operation.
+type GetProtocolResult struct {
+	protocolResult
+}
+
+// UpdateProtocolResult is the response from an UpdateProtocol operation.
+type UpdateProtocolResult struct {
+	protocolResult
+}
+
+// DeleteProtocolResult is the response from a DeleteProtocol operation.
+type DeleteProtocolResult struct {
+	gophercloud.ErrResult
+}
+
+// ProtocolsPage is a single page of Protocol results.
+type ProtocolsPage struct {
+	pagination.LinkedPageBase
+}
+
+// IsEmpty determines whether a ProtocolsPage contains any results.
+func (r ProtocolsPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
+	protocols, err := ExtractProtocols(r)
+	return len(protocols) == 0, err
+}
+
+// NextPageURL extracts the next link from a ProtocolsPage.
+func (r ProtocolsPage) NextPageURL(endpointURL string) (string, error) {
+	var s struct {
+		Links struct {
+			Next string `json:"next"`
+		} `json:"links"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Links.Next, err
+}
+
+// ExtractProtocols extracts a slice of Protocol values from a page returned by
+// ListProtocols.
+func ExtractProtocols(r pagination.Page) ([]Protocol, error) {
+	var s struct {
+		Protocols []Protocol `json:"protocols"`
+	}
+	err := (r.(ProtocolsPage)).ExtractInto(&s)
+	return s.Protocols, err
+}
+
+// ServiceProvider represents a service provider trusted by the Identity
+// service.
+type ServiceProvider struct {
+	// AuthURL is the protected URL where tokens can be retrieved after the user
+	// is authenticated.
+	AuthURL string `json:"auth_url"`
+
+	// Description describes the service provider. It is nil when no
+	// description is set.
+	Description *string `json:"description"`
+
+	// Enabled indicates whether bursting into the service provider is enabled.
+	Enabled bool `json:"enabled"`
+
+	// ID is the unique ID of the service provider.
+	ID string `json:"id"`
+
+	// Links contains links related to the service provider.
+	Links map[string]any `json:"links"`
+
+	// RelayStatePrefix is the relay state prefix used in ECP-wrapped SAML
+	// messages. It is nil when no relay state prefix is set.
+	RelayStatePrefix *string `json:"relay_state_prefix"`
+
+	// SPURL is the URL at the remote peer where the assertion is sent.
+	SPURL string `json:"sp_url"`
+}
+
+type serviceProviderResult struct {
+	gophercloud.Result
+}
+
+// Extract interprets a service provider result as a ServiceProvider.
+func (r serviceProviderResult) Extract() (*ServiceProvider, error) {
+	var s struct {
+		ServiceProvider *ServiceProvider `json:"service_provider"`
+	}
+	err := r.ExtractInto(&s)
+	return s.ServiceProvider, err
+}
+
+// CreateServiceProviderResult is the response from a CreateServiceProvider
+// operation.
+type CreateServiceProviderResult struct {
+	serviceProviderResult
+}
+
+// GetServiceProviderResult is the response from a GetServiceProvider
+// operation.
+type GetServiceProviderResult struct {
+	serviceProviderResult
+}
+
+// UpdateServiceProviderResult is the response from an UpdateServiceProvider
+// operation.
+type UpdateServiceProviderResult struct {
+	serviceProviderResult
+}
+
+// DeleteServiceProviderResult is the response from a DeleteServiceProvider
+// operation.
+type DeleteServiceProviderResult struct {
+	gophercloud.ErrResult
+}
+
+// ServiceProvidersPage is a single page of ServiceProvider results.
+type ServiceProvidersPage struct {
+	pagination.LinkedPageBase
+}
+
+// IsEmpty determines whether a ServiceProvidersPage contains any results.
+func (r ServiceProvidersPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
+	serviceProviders, err := ExtractServiceProviders(r)
+	return len(serviceProviders) == 0, err
+}
+
+// NextPageURL extracts the next link from a ServiceProvidersPage.
+func (r ServiceProvidersPage) NextPageURL(endpointURL string) (string, error) {
+	var s struct {
+		Links struct {
+			Next string `json:"next"`
+		} `json:"links"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Links.Next, err
+}
+
+// ExtractServiceProviders extracts a slice of ServiceProvider values from a
+// page returned by ListServiceProviders.
+func ExtractServiceProviders(r pagination.Page) ([]ServiceProvider, error) {
+	var s struct {
+		ServiceProviders []ServiceProvider `json:"service_providers"`
+	}
+	err := (r.(ServiceProvidersPage)).ExtractInto(&s)
+	return s.ServiceProviders, err
 }

--- a/openstack/identity/v3/federation/testing/resources_test.go
+++ b/openstack/identity/v3/federation/testing/resources_test.go
@@ -51,6 +51,10 @@ func TestIdentityProviders(t *testing.T) {
 		th.TestMethod(t, r, http.MethodGet)
 		th.TestHeader(t, r, "Accept", "application/json")
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestFormValues(t, r, map[string]string{
+			"enabled": "false",
+			"id":      "ACME",
+		})
 		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprintf(w, `{"identity_providers":[%s],"links":{"next":null,"previous":null}}`,
 			`{"authorization_ttl":null,"domain_id":"1789d1","description":null,"enabled":true,"id":"ACME","links":{"self":"http://example.com/OS-FEDERATION/identity_providers/ACME"},"remote_ids":["acme_id_1","acme_id_2"]}`)
@@ -91,7 +95,11 @@ func TestIdentityProviders(t *testing.T) {
 		}
 	})
 
-	allPages, err := federation.ListIdentityProviders(client.ServiceClient(fakeServer)).AllPages(context.TODO())
+	listOpts := federation.ListIdentityProvidersOpts{
+		ID:      "ACME",
+		Enabled: gophercloud.Disabled,
+	}
+	allPages, err := federation.ListIdentityProviders(client.ServiceClient(fakeServer), listOpts).AllPages(context.TODO())
 	th.AssertNoErr(t, err)
 	identityProviders, err := federation.ExtractIdentityProviders(allPages)
 	th.AssertNoErr(t, err)
@@ -353,6 +361,10 @@ func TestServiceProviders(t *testing.T) {
 		th.TestMethod(t, r, http.MethodGet)
 		th.TestHeader(t, r, "Accept", "application/json")
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestFormValues(t, r, map[string]string{
+			"enabled": "true",
+			"id":      "ACME",
+		})
 		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprint(w, `{
 			"service_providers": [{
@@ -406,7 +418,11 @@ func TestServiceProviders(t *testing.T) {
 		}
 	})
 
-	allPages, err := federation.ListServiceProviders(client.ServiceClient(fakeServer)).AllPages(context.TODO())
+	listOpts := federation.ListServiceProvidersOpts{
+		ID:      "ACME",
+		Enabled: gophercloud.Enabled,
+	}
+	allPages, err := federation.ListServiceProviders(client.ServiceClient(fakeServer), listOpts).AllPages(context.TODO())
 	th.AssertNoErr(t, err)
 	serviceProviders, err := federation.ExtractServiceProviders(allPages)
 	th.AssertNoErr(t, err)

--- a/openstack/identity/v3/federation/testing/resources_test.go
+++ b/openstack/identity/v3/federation/testing/resources_test.go
@@ -1,0 +1,498 @@
+package testing
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/openstack/identity/v3/federation"
+	th "github.com/gophercloud/gophercloud/v2/testhelper"
+	"github.com/gophercloud/gophercloud/v2/testhelper/client"
+)
+
+func TestIdentityProviders(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	const createOutput = `
+{
+	"identity_provider": {
+		"authorization_ttl": 30,
+		"domain_id": "1789d1",
+		"description": "Stores ACME identities",
+		"enabled": true,
+		"id": "ACME",
+		"links": {
+			"protocols": "http://example.com/OS-FEDERATION/identity_providers/ACME/protocols",
+			"self": "http://example.com/OS-FEDERATION/identity_providers/ACME"
+		},
+		"remote_ids": ["acme_id_1", "acme_id_2"]
+	}
+}`
+	const updateOutput = `
+{
+	"identity_provider": {
+		"authorization_ttl": 15,
+		"domain_id": "1789d1",
+		"description": "Updated ACME identities",
+		"enabled": false,
+		"id": "ACME",
+		"links": {
+			"protocols": "http://example.com/OS-FEDERATION/identity_providers/ACME/protocols",
+			"self": "http://example.com/OS-FEDERATION/identity_providers/ACME"
+		},
+		"remote_ids": []
+	}
+}`
+
+	fakeServer.Mux.HandleFunc("/OS-FEDERATION/identity_providers", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, http.MethodGet)
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"identity_providers":[%s],"links":{"next":null,"previous":null}}`,
+			`{"authorization_ttl":null,"domain_id":"1789d1","description":null,"enabled":true,"id":"ACME","links":{"self":"http://example.com/OS-FEDERATION/identity_providers/ACME"},"remote_ids":["acme_id_1","acme_id_2"]}`)
+	})
+
+	fakeServer.Mux.HandleFunc("/OS-FEDERATION/identity_providers/ACME", func(w http.ResponseWriter, r *http.Request) {
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		switch r.Method {
+		case http.MethodPut:
+			th.TestJSONRequest(t, r, `{
+				"identity_provider": {
+					"authorization_ttl": 30,
+					"domain_id": "1789d1",
+					"description": "Stores ACME identities",
+					"enabled": true,
+					"remote_ids": ["acme_id_1", "acme_id_2"]
+				}
+			}`)
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, createOutput)
+		case http.MethodGet:
+			th.TestHeader(t, r, "Accept", "application/json")
+			fmt.Fprint(w, createOutput)
+		case http.MethodPatch:
+			th.TestJSONRequest(t, r, `{
+				"identity_provider": {
+					"authorization_ttl": 15,
+					"description": "Updated ACME identities",
+					"enabled": false,
+					"remote_ids": []
+				}
+			}`)
+			fmt.Fprint(w, updateOutput)
+		case http.MethodDelete:
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+	})
+
+	allPages, err := federation.ListIdentityProviders(client.ServiceClient(fakeServer)).AllPages(context.TODO())
+	th.AssertNoErr(t, err)
+	identityProviders, err := federation.ExtractIdentityProviders(allPages)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, 1, len(identityProviders))
+	th.CheckEquals(t, (*int)(nil), identityProviders[0].AuthorizationTTL)
+	th.CheckEquals(t, "1789d1", identityProviders[0].DomainID)
+	th.CheckEquals(t, (*string)(nil), identityProviders[0].Description)
+	th.CheckEquals(t, true, identityProviders[0].Enabled)
+	th.CheckEquals(t, "ACME", identityProviders[0].ID)
+	th.CheckDeepEquals(t, map[string]any{
+		"self": "http://example.com/OS-FEDERATION/identity_providers/ACME",
+	}, identityProviders[0].Links)
+	th.CheckDeepEquals(t, []string{"acme_id_1", "acme_id_2"}, identityProviders[0].RemoteIDs)
+
+	createOpts := federation.CreateIdentityProviderOpts{
+		AuthorizationTTL: gophercloud.IntToPointer(30),
+		DomainID:         "1789d1",
+		Description:      "Stores ACME identities",
+		Enabled:          gophercloud.Enabled,
+		RemoteIDs:        []string{"acme_id_1", "acme_id_2"},
+	}
+	created, err := federation.CreateIdentityProvider(context.TODO(), client.ServiceClient(fakeServer), "ACME", createOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, "ACME", created.ID)
+	th.CheckEquals(t, "1789d1", created.DomainID)
+	th.AssertTrue(t, created.Description != nil)
+	th.CheckEquals(t, "Stores ACME identities", *created.Description)
+	th.CheckEquals(t, true, created.Enabled)
+	th.CheckEquals(t, 30, *created.AuthorizationTTL)
+	th.CheckDeepEquals(t, map[string]any{
+		"protocols": "http://example.com/OS-FEDERATION/identity_providers/ACME/protocols",
+		"self":      "http://example.com/OS-FEDERATION/identity_providers/ACME",
+	}, created.Links)
+	th.CheckDeepEquals(t, []string{"acme_id_1", "acme_id_2"}, created.RemoteIDs)
+
+	actual, err := federation.GetIdentityProvider(context.TODO(), client.ServiceClient(fakeServer), "ACME").Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, created, actual)
+
+	description := "Updated ACME identities"
+	remoteIDs := []string{}
+	updateOpts := federation.UpdateIdentityProviderOpts{
+		AuthorizationTTL: gophercloud.IntToPointer(15),
+		Description:      &description,
+		Enabled:          gophercloud.Disabled,
+		RemoteIDs:        &remoteIDs,
+	}
+	updated, err := federation.UpdateIdentityProvider(context.TODO(), client.ServiceClient(fakeServer), "ACME", updateOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, 15, *updated.AuthorizationTTL)
+	th.AssertTrue(t, updated.Description != nil)
+	th.CheckEquals(t, "Updated ACME identities", *updated.Description)
+	th.CheckEquals(t, false, updated.Enabled)
+	th.CheckDeepEquals(t, []string{}, updated.RemoteIDs)
+
+	err = federation.DeleteIdentityProvider(context.TODO(), client.ServiceClient(fakeServer), "ACME").ExtractErr()
+	th.AssertNoErr(t, err)
+}
+
+func TestIdentityProviderUpdateOptsNullableFields(t *testing.T) {
+	actual, err := (federation.UpdateIdentityProviderOpts{}).ToIdentityProviderUpdateMap()
+	th.AssertNoErr(t, err)
+	th.AssertJSONEquals(t, `{"identity_provider": {}}`, actual)
+
+	description := ""
+	remoteIDs := []string{}
+	opts := federation.UpdateIdentityProviderOpts{
+		AuthorizationTTL: gophercloud.IntToPointer(-1),
+		Description:      &description,
+		Enabled:          gophercloud.Disabled,
+		RemoteIDs:        &remoteIDs,
+	}
+	actual, err = opts.ToIdentityProviderUpdateMap()
+	th.AssertNoErr(t, err)
+	th.AssertJSONEquals(t, `{
+		"identity_provider": {
+			"authorization_ttl": null,
+			"description": null,
+			"enabled": false,
+			"remote_ids": []
+		}
+	}`, actual)
+
+	opts = federation.UpdateIdentityProviderOpts{
+		AuthorizationTTL: gophercloud.IntToPointer(0),
+	}
+	actual, err = opts.ToIdentityProviderUpdateMap()
+	th.AssertNoErr(t, err)
+	th.AssertJSONEquals(t, `{
+		"identity_provider": {
+			"authorization_ttl": 0
+		}
+	}`, actual)
+}
+
+func TestProtocols(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	const createOutput = `
+{
+	"protocol": {
+		"id": "saml2",
+		"links": {
+			"identity_provider": "http://example.com/OS-FEDERATION/identity_providers/ACME",
+			"self": "http://example.com/OS-FEDERATION/identity_providers/ACME/protocols/saml2"
+		},
+		"mapping_id": "mapping-1",
+		"remote_id_attribute": "Shib-Identity-Provider"
+	}
+}`
+	const updateOutput = `
+{
+	"protocol": {
+		"id": "saml2",
+		"links": {
+			"identity_provider": "http://example.com/OS-FEDERATION/identity_providers/ACME",
+			"self": "http://example.com/OS-FEDERATION/identity_providers/ACME/protocols/saml2"
+		},
+		"mapping_id": "mapping-2",
+		"remote_id_attribute": "HTTP_OIDC_ISS"
+	}
+}`
+
+	fakeServer.Mux.HandleFunc("/OS-FEDERATION/identity_providers/ACME/protocols", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, http.MethodGet)
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{
+			"protocols": [{
+				"id": "saml2",
+				"links": {
+					"identity_provider": "http://example.com/OS-FEDERATION/identity_providers/ACME",
+					"self": "http://example.com/OS-FEDERATION/identity_providers/ACME/protocols/saml2"
+				},
+				"mapping_id": "mapping-1"
+			}],
+			"links": {"next": null, "previous": null}
+		}`)
+	})
+
+	fakeServer.Mux.HandleFunc("/OS-FEDERATION/identity_providers/ACME/protocols/saml2", func(w http.ResponseWriter, r *http.Request) {
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		switch r.Method {
+		case http.MethodPut:
+			th.TestJSONRequest(t, r, `{
+				"protocol": {
+					"mapping_id": "mapping-1",
+					"remote_id_attribute": "Shib-Identity-Provider"
+				}
+			}`)
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, createOutput)
+		case http.MethodGet:
+			th.TestHeader(t, r, "Accept", "application/json")
+			fmt.Fprint(w, createOutput)
+		case http.MethodPatch:
+			th.TestJSONRequest(t, r, `{
+				"protocol": {
+					"mapping_id": "mapping-2",
+					"remote_id_attribute": "HTTP_OIDC_ISS"
+				}
+			}`)
+			fmt.Fprint(w, updateOutput)
+		case http.MethodDelete:
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+	})
+
+	allPages, err := federation.ListProtocols(client.ServiceClient(fakeServer), "ACME").AllPages(context.TODO())
+	th.AssertNoErr(t, err)
+	protocols, err := federation.ExtractProtocols(allPages)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, 1, len(protocols))
+	th.CheckEquals(t, "saml2", protocols[0].ID)
+	th.CheckDeepEquals(t, map[string]any{
+		"identity_provider": "http://example.com/OS-FEDERATION/identity_providers/ACME",
+		"self":              "http://example.com/OS-FEDERATION/identity_providers/ACME/protocols/saml2",
+	}, protocols[0].Links)
+	th.CheckEquals(t, "mapping-1", protocols[0].MappingID)
+	th.CheckEquals(t, (*string)(nil), protocols[0].RemoteIDAttribute)
+
+	createOpts := federation.CreateProtocolOpts{
+		MappingID:         "mapping-1",
+		RemoteIDAttribute: "Shib-Identity-Provider",
+	}
+	created, err := federation.CreateProtocol(context.TODO(), client.ServiceClient(fakeServer), "ACME", "saml2", createOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, "saml2", created.ID)
+	th.CheckEquals(t, "mapping-1", created.MappingID)
+	th.CheckDeepEquals(t, map[string]any{
+		"identity_provider": "http://example.com/OS-FEDERATION/identity_providers/ACME",
+		"self":              "http://example.com/OS-FEDERATION/identity_providers/ACME/protocols/saml2",
+	}, created.Links)
+	th.AssertTrue(t, created.RemoteIDAttribute != nil)
+	th.CheckEquals(t, "Shib-Identity-Provider", *created.RemoteIDAttribute)
+
+	actual, err := federation.GetProtocol(context.TODO(), client.ServiceClient(fakeServer), "ACME", "saml2").Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, created, actual)
+
+	remoteIDAttribute := "HTTP_OIDC_ISS"
+	updateOpts := federation.UpdateProtocolOpts{
+		MappingID:         "mapping-2",
+		RemoteIDAttribute: &remoteIDAttribute,
+	}
+	updated, err := federation.UpdateProtocol(context.TODO(), client.ServiceClient(fakeServer), "ACME", "saml2", updateOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, "mapping-2", updated.MappingID)
+	th.AssertTrue(t, updated.RemoteIDAttribute != nil)
+	th.CheckEquals(t, "HTTP_OIDC_ISS", *updated.RemoteIDAttribute)
+
+	err = federation.DeleteProtocol(context.TODO(), client.ServiceClient(fakeServer), "ACME", "saml2").ExtractErr()
+	th.AssertNoErr(t, err)
+}
+
+func TestProtocolCreateOptsValidation(t *testing.T) {
+	_, err := (federation.CreateProtocolOpts{}).ToProtocolCreateMap()
+	th.AssertErr(t, err)
+}
+
+func TestServiceProviders(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	const createOutput = `
+{
+	"service_provider": {
+		"auth_url": "https://example.com/v3/OS-FEDERATION/identity_providers/acme/protocols/saml2/auth",
+		"description": "Remote Service Provider",
+		"enabled": true,
+		"id": "ACME",
+		"links": {
+			"self": "https://example.com/v3/OS-FEDERATION/service_providers/ACME"
+		},
+		"relay_state_prefix": "ss:mem:",
+		"sp_url": "https://example.com/Shibboleth.sso/SAML2/ECP"
+	}
+}`
+	const updateOutput = `
+{
+	"service_provider": {
+		"auth_url": "https://new.example.com/v3/OS-FEDERATION/identity_providers/acme/protocols/saml2/auth",
+		"description": "Updated Service Provider",
+		"enabled": false,
+		"id": "ACME",
+		"links": {
+			"self": "https://example.com/v3/OS-FEDERATION/service_providers/ACME"
+		},
+		"relay_state_prefix": "ss:temp:",
+		"sp_url": "https://new.example.com/Shibboleth.sso/SAML2/ECP"
+	}
+}`
+
+	fakeServer.Mux.HandleFunc("/OS-FEDERATION/service_providers", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, http.MethodGet)
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{
+			"service_providers": [{
+				"auth_url": "https://example.com/auth",
+				"description": null,
+				"enabled": true,
+				"id": "ACME",
+				"links": {
+					"self": "https://example.com/v3/OS-FEDERATION/service_providers/ACME"
+				},
+				"relay_state_prefix": null,
+				"sp_url": "https://example.com/sp"
+			}],
+			"links": {"next": null, "previous": null}
+		}`)
+	})
+
+	fakeServer.Mux.HandleFunc("/OS-FEDERATION/service_providers/ACME", func(w http.ResponseWriter, r *http.Request) {
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		switch r.Method {
+		case http.MethodPut:
+			th.TestJSONRequest(t, r, `{
+				"service_provider": {
+					"auth_url": "https://example.com/v3/OS-FEDERATION/identity_providers/acme/protocols/saml2/auth",
+					"description": "Remote Service Provider",
+					"enabled": true,
+					"relay_state_prefix": "ss:mem:",
+					"sp_url": "https://example.com/Shibboleth.sso/SAML2/ECP"
+				}
+			}`)
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, createOutput)
+		case http.MethodGet:
+			th.TestHeader(t, r, "Accept", "application/json")
+			fmt.Fprint(w, createOutput)
+		case http.MethodPatch:
+			th.TestJSONRequest(t, r, `{
+				"service_provider": {
+					"auth_url": "https://new.example.com/v3/OS-FEDERATION/identity_providers/acme/protocols/saml2/auth",
+					"description": "Updated Service Provider",
+					"enabled": false,
+					"relay_state_prefix": "ss:temp:",
+					"sp_url": "https://new.example.com/Shibboleth.sso/SAML2/ECP"
+				}
+			}`)
+			fmt.Fprint(w, updateOutput)
+		case http.MethodDelete:
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+	})
+
+	allPages, err := federation.ListServiceProviders(client.ServiceClient(fakeServer)).AllPages(context.TODO())
+	th.AssertNoErr(t, err)
+	serviceProviders, err := federation.ExtractServiceProviders(allPages)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, 1, len(serviceProviders))
+	th.CheckEquals(t, "https://example.com/auth", serviceProviders[0].AuthURL)
+	th.CheckEquals(t, (*string)(nil), serviceProviders[0].Description)
+	th.CheckEquals(t, true, serviceProviders[0].Enabled)
+	th.CheckEquals(t, "ACME", serviceProviders[0].ID)
+	th.CheckDeepEquals(t, map[string]any{
+		"self": "https://example.com/v3/OS-FEDERATION/service_providers/ACME",
+	}, serviceProviders[0].Links)
+	th.CheckEquals(t, (*string)(nil), serviceProviders[0].RelayStatePrefix)
+	th.CheckEquals(t, "https://example.com/sp", serviceProviders[0].SPURL)
+
+	createOpts := federation.CreateServiceProviderOpts{
+		AuthURL:          "https://example.com/v3/OS-FEDERATION/identity_providers/acme/protocols/saml2/auth",
+		Description:      "Remote Service Provider",
+		Enabled:          gophercloud.Enabled,
+		RelayStatePrefix: "ss:mem:",
+		SPURL:            "https://example.com/Shibboleth.sso/SAML2/ECP",
+	}
+	created, err := federation.CreateServiceProvider(context.TODO(), client.ServiceClient(fakeServer), "ACME", createOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, "ACME", created.ID)
+	th.CheckEquals(t, createOpts.AuthURL, created.AuthURL)
+	th.AssertTrue(t, created.Description != nil)
+	th.CheckEquals(t, createOpts.Description, *created.Description)
+	th.CheckEquals(t, true, created.Enabled)
+	th.CheckDeepEquals(t, map[string]any{
+		"self": "https://example.com/v3/OS-FEDERATION/service_providers/ACME",
+	}, created.Links)
+	th.AssertTrue(t, created.RelayStatePrefix != nil)
+	th.CheckEquals(t, createOpts.RelayStatePrefix, *created.RelayStatePrefix)
+	th.CheckEquals(t, createOpts.SPURL, created.SPURL)
+
+	actual, err := federation.GetServiceProvider(context.TODO(), client.ServiceClient(fakeServer), "ACME").Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, created, actual)
+
+	authURL := "https://new.example.com/v3/OS-FEDERATION/identity_providers/acme/protocols/saml2/auth"
+	description := "Updated Service Provider"
+	relayStatePrefix := "ss:temp:"
+	spURL := "https://new.example.com/Shibboleth.sso/SAML2/ECP"
+	updateOpts := federation.UpdateServiceProviderOpts{
+		AuthURL:          &authURL,
+		Description:      &description,
+		Enabled:          gophercloud.Disabled,
+		RelayStatePrefix: &relayStatePrefix,
+		SPURL:            &spURL,
+	}
+	updated, err := federation.UpdateServiceProvider(context.TODO(), client.ServiceClient(fakeServer), "ACME", updateOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, authURL, updated.AuthURL)
+	th.AssertTrue(t, updated.Description != nil)
+	th.CheckEquals(t, description, *updated.Description)
+	th.CheckEquals(t, false, updated.Enabled)
+	th.AssertTrue(t, updated.RelayStatePrefix != nil)
+	th.CheckEquals(t, relayStatePrefix, *updated.RelayStatePrefix)
+	th.CheckEquals(t, spURL, updated.SPURL)
+
+	err = federation.DeleteServiceProvider(context.TODO(), client.ServiceClient(fakeServer), "ACME").ExtractErr()
+	th.AssertNoErr(t, err)
+}
+
+func TestServiceProviderUpdateOptsNullableFields(t *testing.T) {
+	actual, err := (federation.UpdateServiceProviderOpts{}).ToServiceProviderUpdateMap()
+	th.AssertNoErr(t, err)
+	th.AssertJSONEquals(t, `{"service_provider": {}}`, actual)
+
+	description := ""
+	relayStatePrefix := ""
+	opts := federation.UpdateServiceProviderOpts{
+		Description:      &description,
+		RelayStatePrefix: &relayStatePrefix,
+	}
+	actual, err = opts.ToServiceProviderUpdateMap()
+	th.AssertNoErr(t, err)
+	th.AssertJSONEquals(t, `{
+		"service_provider": {
+			"description": null,
+			"relay_state_prefix": null
+		}
+	}`, actual)
+}
+
+func TestServiceProviderCreateOptsValidation(t *testing.T) {
+	_, err := (federation.CreateServiceProviderOpts{}).ToServiceProviderCreateMap()
+	th.AssertErr(t, err)
+}

--- a/openstack/identity/v3/federation/urls.go
+++ b/openstack/identity/v3/federation/urls.go
@@ -3,9 +3,20 @@ package federation
 import "github.com/gophercloud/gophercloud/v2"
 
 const (
-	rootPath     = "OS-FEDERATION"
-	mappingsPath = "mappings"
+	rootPath              = "OS-FEDERATION"
+	identityProvidersPath = "identity_providers"
+	mappingsPath          = "mappings"
+	protocolsPath         = "protocols"
+	serviceProvidersPath  = "service_providers"
 )
+
+func identityProvidersRootURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL(rootPath, identityProvidersPath)
+}
+
+func identityProvidersResourceURL(c *gophercloud.ServiceClient, identityProviderID string) string {
+	return c.ServiceURL(rootPath, identityProvidersPath, identityProviderID)
+}
 
 func mappingsRootURL(c *gophercloud.ServiceClient) string {
 	return c.ServiceURL(rootPath, mappingsPath)
@@ -13,4 +24,20 @@ func mappingsRootURL(c *gophercloud.ServiceClient) string {
 
 func mappingsResourceURL(c *gophercloud.ServiceClient, mappingID string) string {
 	return c.ServiceURL(rootPath, mappingsPath, mappingID)
+}
+
+func protocolsRootURL(c *gophercloud.ServiceClient, identityProviderID string) string {
+	return c.ServiceURL(rootPath, identityProvidersPath, identityProviderID, protocolsPath)
+}
+
+func protocolsResourceURL(c *gophercloud.ServiceClient, identityProviderID, protocolID string) string {
+	return c.ServiceURL(rootPath, identityProvidersPath, identityProviderID, protocolsPath, protocolID)
+}
+
+func serviceProvidersRootURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL(rootPath, serviceProvidersPath)
+}
+
+func serviceProvidersResourceURL(c *gophercloud.ServiceClient, serviceProviderID string) string {
+	return c.ServiceURL(rootPath, serviceProvidersPath, serviceProviderID)
 }


### PR DESCRIPTION
## Summary

  Add full OS-FEDERATION resource support for:

  - Identity providers
  - Federation protocols
  - Service providers

  Includes CRUD/list operations, pagination, nullable field handling, documentation, unit tests, and acceptance tests.

  ## Testing

  - go test ./openstack/identity/v3/...
  - Acceptance tests compile with the federation tag
  - go vet

  For [3889](https://github.com/gophercloud/gophercloud/issues/3889)

  OpenStack reference:
  - [Keystone OS-FEDERATION API implementation (stable/2025.1)](https://opendev.org/openstack/keystone/src/branch/stable%2F2025.1/keystone/api/os_federation.py)
  - [OS-FEDERATION API reference](https://docs.openstack.org/api-ref/identity/v3-ext/#os-federation-api)