### PR TITLE
core: validation for missing response keys in extractIntoPtr

### DIFF
--- a/results.go
+++ b/results.go
@@ -78,7 +78,15 @@ func (r Result) extractIntoPtr(to any, label string) error {
 		return err
 	}
 
-	b, err := json.Marshal(m[label])
+	// Check if the expected label exists in the response
+	value, exists := m[label]
+	if !exists && len(m) > 0 {
+		// Key doesn't exist but response has other data - this is an error
+		// If len(m) == 0, we allow empty responses (e.g., tokens API where data is in headers)
+		return fmt.Errorf("expected response key %q not found in response", label)
+	}
+
+	b, err := json.Marshal(value)
 	if err != nil {
 		return err
 	}

--- a/testing/results_test.go
+++ b/testing/results_test.go
@@ -2,6 +2,7 @@ package testing
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/gophercloud/gophercloud/v2"
@@ -239,4 +240,66 @@ func TestUnmarshalSliceOfNamedStructs(t *testing.T) {
 	th.AssertEquals(t, "", actual[0].TestPersonExt.Location)
 	th.AssertEquals(t, "", actual[1].TestPerson.Name)
 	th.AssertEquals(t, "", actual[1].TestPersonExt.Location)
+}
+
+// TestExtractMissingKeyWithPlural tests that when a singular key is missing
+// but other data exists in the response, it returns a helpful error message.
+// This catches cases where Get("") hits a List endpoint or any wrong endpoint.
+func TestExtractMissingKeyWithPlural(t *testing.T) {
+	// Simulate what happens when we call Get with empty ID
+	// and get a List response (or any other mismatched response)
+	body := map[string]interface{}{
+		"networks": []interface{}{
+			map[string]interface{}{"id": "123", "name": "test"},
+		},
+	}
+
+	r := gophercloud.Result{Body: body}
+
+	var network struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	}
+
+	// This is what commonResult.Extract() does
+	err := r.ExtractIntoStructPtr(&network, "network") // looking for "network" key
+	th.AssertErr(t, err)
+	th.CheckEquals(t, true, strings.Contains(err.Error(), `expected response key "network" not found`))
+}
+
+// TestExtractValidKey tests that valid extractions still work correctly.
+func TestExtractValidKey(t *testing.T) {
+	body := map[string]interface{}{
+		"network": map[string]interface{}{"id": "123", "name": "test"},
+	}
+
+	r := gophercloud.Result{Body: body}
+
+	var network struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	}
+
+	err := r.ExtractIntoStructPtr(&network, "network")
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, "123", network.ID)
+	th.AssertEquals(t, "test", network.Name)
+}
+
+// TestExtractEmptyResponse tests that empty responses are allowed (e.g., for tokens API).
+func TestExtractEmptyResponse(t *testing.T) {
+	body := map[string]interface{}{}
+
+	r := gophercloud.Result{Body: body}
+
+	var network struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	}
+
+	err := r.ExtractIntoStructPtr(&network, "network")
+	th.AssertNoErr(t, err)
+	// Should have zero values
+	th.AssertEquals(t, "", network.ID)
+	th.AssertEquals(t, "", network.Name)
 }


### PR DESCRIPTION
This prevents silent failures when an empty or invalid resource ID causes a wrong API endpoint to be called. The fix detects when the expected response key is missing but other data exists in the response, returning a clear error instead of allowing nil values to propagate.

The validation allows empty responses (for APIs like tokens where data is in headers) while catching all cases where the wrong endpoint was called due to invalid parameters.

<!--
Prior to starting a PR, please make sure you have read our
[contributor tutorial](https://github.com/gophercloud/gophercloud/tree/main/docs/contributor-tutorial).

Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

-->

Fixes: https://github.com/kubernetes/cloud-provider-openstack/issues/3101
