### PR TITLE
Add Identity v3 system-scoped role assignment support for users and groups

### DIFF
--- a/internal/acceptance/openstack/identity/v3/identity.go
+++ b/internal/acceptance/openstack/identity/v3/identity.go
@@ -367,7 +367,7 @@ func DeleteService(t *testing.T, client *gophercloud.ServiceClient, serviceID st
 	t.Logf("Deleted service: %s", serviceID)
 }
 
-// UnassignRole will delete a role assigned to a user/group on a project/domain
+// UnassignRole will delete a role assigned to a user/group on a project/domain/system.
 // A fatal error will occur if it fails to delete the assignment.
 // This works best when using it as a deferred function.
 func UnassignRole(t *testing.T, client *gophercloud.ServiceClient, roleID string, opts *roles.UnassignOpts) {

--- a/internal/acceptance/openstack/identity/v3/roles_test.go
+++ b/internal/acceptance/openstack/identity/v3/roles_test.go
@@ -315,6 +315,152 @@ func TestRoleListAssignmentForUserOnProject(t *testing.T) {
 	th.AssertTrue(t, found)
 }
 
+func TestRolesAssignToUserOnSystem(t *testing.T) {
+	clients.RequireAdmin(t)
+
+	client, err := clients.NewIdentityV3Client()
+	th.AssertNoErr(t, err)
+
+	role, err := CreateRole(t, client, &roles.CreateOpts{})
+	th.AssertNoErr(t, err)
+	defer DeleteRole(t, client, role.ID)
+
+	user, err := CreateUser(t, client, nil)
+	th.AssertNoErr(t, err)
+	defer DeleteUser(t, client, user.ID)
+
+	assignOpts := roles.AssignOpts{
+		UserID: user.ID,
+		System: true,
+	}
+	err = roles.Assign(context.TODO(), client, role.ID, assignOpts).ExtractErr()
+	th.AssertNoErr(t, err)
+	defer UnassignRole(t, client, role.ID, &roles.UnassignOpts{
+		UserID: user.ID,
+		System: true,
+	})
+
+	err = roles.Validate(context.TODO(), client, role.ID, roles.ValidateOpts{
+		UserID: user.ID,
+		System: true,
+	}).ExtractErr()
+	th.AssertNoErr(t, err)
+
+	allPages, err := roles.ListAssignmentsOnResource(client, roles.ListAssignmentsOnResourceOpts{
+		UserID: user.ID,
+		System: true,
+	}).AllPages(context.TODO())
+	th.AssertNoErr(t, err)
+
+	allRoles, err := roles.ExtractRoles(allPages)
+	th.AssertNoErr(t, err)
+
+	var found bool
+	for _, r := range allRoles {
+		tools.PrintResource(t, r)
+		if r.ID == role.ID {
+			found = true
+		}
+	}
+	th.AssertTrue(t, found)
+
+	allPages, err = roles.ListAssignments(client, roles.ListAssignmentsOpts{
+		RoleID:      role.ID,
+		ScopeSystem: "all",
+		UserID:      user.ID,
+	}).AllPages(context.TODO())
+	th.AssertNoErr(t, err)
+
+	allRoleAssignments, err := roles.ExtractRoleAssignments(allPages)
+	th.AssertNoErr(t, err)
+
+	found = false
+	for _, roleAssignment := range allRoleAssignments {
+		tools.PrintResource(t, roleAssignment)
+		if roleAssignment.Role.ID == role.ID &&
+			roleAssignment.User.ID == user.ID &&
+			roleAssignment.Scope.System != nil &&
+			roleAssignment.Scope.System.All {
+			found = true
+		}
+	}
+	th.AssertTrue(t, found)
+}
+
+func TestRolesAssignToGroupOnSystem(t *testing.T) {
+	clients.RequireAdmin(t)
+
+	client, err := clients.NewIdentityV3Client()
+	th.AssertNoErr(t, err)
+
+	role, err := CreateRole(t, client, &roles.CreateOpts{})
+	th.AssertNoErr(t, err)
+	defer DeleteRole(t, client, role.ID)
+
+	group, err := CreateGroup(t, client, &groups.CreateOpts{
+		DomainID: "default",
+	})
+	th.AssertNoErr(t, err)
+	defer DeleteGroup(t, client, group.ID)
+
+	assignOpts := roles.AssignOpts{
+		GroupID: group.ID,
+		System:  true,
+	}
+	err = roles.Assign(context.TODO(), client, role.ID, assignOpts).ExtractErr()
+	th.AssertNoErr(t, err)
+	defer UnassignRole(t, client, role.ID, &roles.UnassignOpts{
+		GroupID: group.ID,
+		System:  true,
+	})
+
+	err = roles.Validate(context.TODO(), client, role.ID, roles.ValidateOpts{
+		GroupID: group.ID,
+		System:  true,
+	}).ExtractErr()
+	th.AssertNoErr(t, err)
+
+	allPages, err := roles.ListAssignmentsOnResource(client, roles.ListAssignmentsOnResourceOpts{
+		GroupID: group.ID,
+		System:  true,
+	}).AllPages(context.TODO())
+	th.AssertNoErr(t, err)
+
+	allRoles, err := roles.ExtractRoles(allPages)
+	th.AssertNoErr(t, err)
+
+	var found bool
+	for _, r := range allRoles {
+		tools.PrintResource(t, r)
+		if r.ID == role.ID {
+			found = true
+		}
+	}
+	th.AssertTrue(t, found)
+
+	allPages, err = roles.ListAssignments(client, roles.ListAssignmentsOpts{
+		GroupID:     group.ID,
+		RoleID:      role.ID,
+		ScopeSystem: "all",
+	}).AllPages(context.TODO())
+	th.AssertNoErr(t, err)
+
+	allRoleAssignments, err := roles.ExtractRoleAssignments(allPages)
+	th.AssertNoErr(t, err)
+
+	found = false
+	for _, roleAssignment := range allRoleAssignments {
+		tools.PrintResource(t, roleAssignment)
+		if roleAssignment.Group.ID == group.ID &&
+			roleAssignment.Role.ID == role.ID &&
+			roleAssignment.Scope.System != nil &&
+			roleAssignment.Scope.System.All {
+			found = true
+		}
+	}
+	th.AssertTrue(t, found)
+}
+
 func TestRoleListAssignmentForUserOnDomain(t *testing.T) {
 	clients.RequireAdmin(t)
 

--- a/openstack/identity/v3/roles/doc.go
+++ b/openstack/identity/v3/roles/doc.go
@@ -117,6 +117,20 @@ Example to Assign a Role to a User in a Project
 		panic(err)
 	}
 
+Example to Assign a Role to a User on the System
+
+	userID := "9df1a02f5eb2416a9781e8b0c022d3ae"
+	roleID := "9fe2ff9ee4384b1894a90878d3e92bab"
+
+	err := roles.Assign(context.TODO(), identityClient, roleID, roles.AssignOpts{
+		UserID: userID,
+		System: true,
+	}).ExtractErr()
+
+	if err != nil {
+		panic(err)
+	}
+
 Example to Unassign a Role From a User in a Project
 
 	projectID := "a99e9b4e620e4db09a2dfb6e42a01e66"

--- a/openstack/identity/v3/roles/requests.go
+++ b/openstack/identity/v3/roles/requests.go
@@ -203,9 +203,9 @@ type ListAssignmentsOptsBuilder interface {
 }
 
 // ListAssignmentsOpts allows you to query the ListAssignments method.
-// Specify one of or a combination of GroupId, RoleId, ScopeDomainId,
-// ScopeProjectId, and/or UserId to search for roles assigned to corresponding
-// entities.
+// Specify one of or a combination of GroupID, RoleID, ScopeDomainID,
+// ScopeProjectID, ScopeSystem, and/or UserID to search for roles assigned to
+// corresponding entities.
 type ListAssignmentsOpts struct {
 	// GroupID is the group ID to query.
 	GroupID string `q:"group.id"`
@@ -219,7 +219,12 @@ type ListAssignmentsOpts struct {
 	// ScopeProjectID filters the results by the given Project ID.
 	ScopeProjectID string `q:"scope.project.id"`
 
-	// UserID filterst he results by the given User ID.
+	// ScopeSystem filters the results by system scope.
+	// The only supported value is "all".
+	// Available since Identity API v3.10.
+	ScopeSystem string `q:"scope.system"`
+
+	// UserID filters the results by the given User ID.
 	UserID string `q:"user.id"`
 
 	// Effective lists effective assignments at the user, project, and domain
@@ -258,7 +263,7 @@ func ListAssignments(client *gophercloud.ServiceClient, opts ListAssignmentsOpts
 }
 
 // ListAssignmentsOnResourceOpts provides options to list role assignments
-// for a user/group on a project/domain
+// for a user/group on a project/domain/system.
 type ListAssignmentsOnResourceOpts struct {
 	// UserID is the ID of a user to assign a role
 	// Note: exactly one of UserID or GroupID must be provided
@@ -269,12 +274,17 @@ type ListAssignmentsOnResourceOpts struct {
 	GroupID string `xor:"UserID"`
 
 	// ProjectID is the ID of a project to assign a role on
-	// Note: exactly one of ProjectID or DomainID must be provided
-	ProjectID string `xor:"DomainID"`
+	// Note: exactly one of ProjectID, DomainID, or System must be provided
+	ProjectID string
 
 	// DomainID is the ID of a domain to assign a role on
-	// Note: exactly one of ProjectID or DomainID must be provided
-	DomainID string `xor:"ProjectID"`
+	// Note: exactly one of ProjectID, DomainID, or System must be provided
+	DomainID string
+
+	// System specifies whether to list role assignments on the system.
+	// Note: exactly one of ProjectID, DomainID, or System must be provided.
+	// Available since Identity API v3.10.
+	System bool
 }
 
 // AssignOpts provides options to assign a role
@@ -288,12 +298,41 @@ type AssignOpts struct {
 	GroupID string `xor:"UserID"`
 
 	// ProjectID is the ID of a project to assign a role on
-	// Note: exactly one of ProjectID or DomainID must be provided
-	ProjectID string `xor:"DomainID"`
+	// Note: exactly one of ProjectID, DomainID, or System must be provided
+	ProjectID string
 
 	// DomainID is the ID of a domain to assign a role on
-	// Note: exactly one of ProjectID or DomainID must be provided
-	DomainID string `xor:"ProjectID"`
+	// Note: exactly one of ProjectID, DomainID, or System must be provided
+	DomainID string
+
+	// System specifies whether to assign a role on the system.
+	// Note: exactly one of ProjectID, DomainID, or System must be provided.
+	// Available since Identity API v3.10.
+	System bool
+}
+
+// ValidateOpts provides options to validate a role assignment.
+type ValidateOpts struct {
+	// UserID is the ID of a user to validate a role assignment for.
+	// Note: exactly one of UserID or GroupID must be provided.
+	UserID string `xor:"GroupID"`
+
+	// GroupID is the ID of a group to validate a role assignment for.
+	// Note: exactly one of UserID or GroupID must be provided.
+	GroupID string `xor:"UserID"`
+
+	// ProjectID is the ID of a project to validate a role assignment on.
+	// Note: exactly one of ProjectID, DomainID, or System must be provided.
+	ProjectID string
+
+	// DomainID is the ID of a domain to validate a role assignment on.
+	// Note: exactly one of ProjectID, DomainID, or System must be provided.
+	DomainID string
+
+	// System specifies whether to validate a role assignment on the system.
+	// Note: exactly one of ProjectID, DomainID, or System must be provided.
+	// Available since Identity API v3.10.
+	System bool
 }
 
 // UnassignOpts provides options to unassign a role
@@ -307,42 +346,27 @@ type UnassignOpts struct {
 	GroupID string `xor:"UserID"`
 
 	// ProjectID is the ID of a project to unassign a role on
-	// Note: exactly one of ProjectID or DomainID must be provided
-	ProjectID string `xor:"DomainID"`
+	// Note: exactly one of ProjectID, DomainID, or System must be provided
+	ProjectID string
 
 	// DomainID is the ID of a domain to unassign a role on
-	// Note: exactly one of ProjectID or DomainID must be provided
-	DomainID string `xor:"ProjectID"`
+	// Note: exactly one of ProjectID, DomainID, or System must be provided
+	DomainID string
+
+	// System specifies whether to unassign a role on the system.
+	// Note: exactly one of ProjectID, DomainID, or System must be provided.
+	// Available since Identity API v3.10.
+	System bool
 }
 
 // ListAssignmentsOnResource is the operation responsible for listing role
-// assignments for a user/group on a project/domain.
+// assignments for a user/group on a project/domain/system.
 func ListAssignmentsOnResource(client *gophercloud.ServiceClient, opts ListAssignmentsOnResourceOpts) pagination.Pager {
-	// Check xor conditions
-	_, err := gophercloud.BuildRequestBody(opts, "")
+	targetType, targetID, actorType, actorID, err := assignmentURLParts(
+		opts.UserID, opts.GroupID, opts.ProjectID, opts.DomainID, opts.System,
+	)
 	if err != nil {
 		return pagination.Pager{Err: err}
-	}
-
-	// Get corresponding URL
-	var targetID string
-	var targetType string
-	if opts.ProjectID != "" {
-		targetID = opts.ProjectID
-		targetType = "projects"
-	} else {
-		targetID = opts.DomainID
-		targetType = "domains"
-	}
-
-	var actorID string
-	var actorType string
-	if opts.UserID != "" {
-		actorID = opts.UserID
-		actorType = "users"
-	} else {
-		actorID = opts.GroupID
-		actorType = "groups"
 	}
 
 	url := listAssignmentsOnResourceURL(client, targetType, targetID, actorType, actorID)
@@ -352,34 +376,14 @@ func ListAssignmentsOnResource(client *gophercloud.ServiceClient, opts ListAssig
 }
 
 // Assign is the operation responsible for assigning a role
-// to a user/group on a project/domain.
+// to a user/group on a project/domain/system.
 func Assign(ctx context.Context, client *gophercloud.ServiceClient, roleID string, opts AssignOpts) (r AssignmentResult) {
-	// Check xor conditions
-	_, err := gophercloud.BuildRequestBody(opts, "")
+	targetType, targetID, actorType, actorID, err := assignmentURLParts(
+		opts.UserID, opts.GroupID, opts.ProjectID, opts.DomainID, opts.System,
+	)
 	if err != nil {
 		r.Err = err
 		return
-	}
-
-	// Get corresponding URL
-	var targetID string
-	var targetType string
-	if opts.ProjectID != "" {
-		targetID = opts.ProjectID
-		targetType = "projects"
-	} else {
-		targetID = opts.DomainID
-		targetType = "domains"
-	}
-
-	var actorID string
-	var actorType string
-	if opts.UserID != "" {
-		actorID = opts.UserID
-		actorType = "users"
-	} else {
-		actorID = opts.GroupID
-		actorType = "groups"
 	}
 
 	resp, err := client.Put(ctx, assignURL(client, targetType, targetID, actorType, actorID, roleID), nil, nil, &gophercloud.RequestOpts{
@@ -389,35 +393,33 @@ func Assign(ctx context.Context, client *gophercloud.ServiceClient, roleID strin
 	return
 }
 
-// Unassign is the operation responsible for unassigning a role
-// from a user/group on a project/domain.
-func Unassign(ctx context.Context, client *gophercloud.ServiceClient, roleID string, opts UnassignOpts) (r UnassignmentResult) {
-	// Check xor conditions
-	_, err := gophercloud.BuildRequestBody(opts, "")
+// Validate checks whether a user/group has a role assignment on a
+// project/domain/system.
+func Validate(ctx context.Context, client *gophercloud.ServiceClient, roleID string, opts ValidateOpts) (r ValidateResult) {
+	targetType, targetID, actorType, actorID, err := assignmentURLParts(
+		opts.UserID, opts.GroupID, opts.ProjectID, opts.DomainID, opts.System,
+	)
 	if err != nil {
 		r.Err = err
 		return
 	}
 
-	// Get corresponding URL
-	var targetID string
-	var targetType string
-	if opts.ProjectID != "" {
-		targetID = opts.ProjectID
-		targetType = "projects"
-	} else {
-		targetID = opts.DomainID
-		targetType = "domains"
-	}
+	resp, err := client.Head(ctx, assignURL(client, targetType, targetID, actorType, actorID, roleID), &gophercloud.RequestOpts{
+		OkCodes: []int{204},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
 
-	var actorID string
-	var actorType string
-	if opts.UserID != "" {
-		actorID = opts.UserID
-		actorType = "users"
-	} else {
-		actorID = opts.GroupID
-		actorType = "groups"
+// Unassign is the operation responsible for unassigning a role
+// from a user/group on a project/domain/system.
+func Unassign(ctx context.Context, client *gophercloud.ServiceClient, roleID string, opts UnassignOpts) (r UnassignmentResult) {
+	targetType, targetID, actorType, actorID, err := assignmentURLParts(
+		opts.UserID, opts.GroupID, opts.ProjectID, opts.DomainID, opts.System,
+	)
+	if err != nil {
+		r.Err = err
+		return
 	}
 
 	resp, err := client.Delete(ctx, assignURL(client, targetType, targetID, actorType, actorID, roleID), &gophercloud.RequestOpts{
@@ -425,6 +427,54 @@ func Unassign(ctx context.Context, client *gophercloud.ServiceClient, roleID str
 	})
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
+}
+
+func assignmentURLParts(userID, groupID, projectID, domainID string, system bool) (string, string, string, string, error) {
+	type actorOpts struct {
+		UserID  string `xor:"GroupID"`
+		GroupID string `xor:"UserID"`
+	}
+
+	_, err := gophercloud.BuildRequestBody(actorOpts{UserID: userID, GroupID: groupID}, "")
+	if err != nil {
+		return "", "", "", "", err
+	}
+
+	scopeCount := 0
+	if projectID != "" {
+		scopeCount++
+	}
+	if domainID != "" {
+		scopeCount++
+	}
+	if system {
+		scopeCount++
+	}
+	if scopeCount != 1 {
+		return "", "", "", "", gophercloud.ErrMissingInput{
+			BaseError: gophercloud.BaseError{
+				Info: "Exactly one of ProjectID, DomainID, and System must be provided",
+			},
+			Argument: "ProjectID/DomainID/System",
+		}
+	}
+
+	var targetType, targetID string
+	switch {
+	case projectID != "":
+		targetType = "projects"
+		targetID = projectID
+	case domainID != "":
+		targetType = "domains"
+		targetID = domainID
+	default:
+		targetType = "system"
+	}
+
+	if userID != "" {
+		return targetType, targetID, "users", userID, nil
+	}
+	return targetType, targetID, "groups", groupID, nil
 }
 
 func CreateRoleInferenceRule(ctx context.Context, client *gophercloud.ServiceClient, priorRoleID, impliedRoleID string) (r CreateImpliedRoleResult) {

--- a/openstack/identity/v3/roles/results.go
+++ b/openstack/identity/v3/roles/results.go
@@ -156,6 +156,16 @@ type AssignedRole struct {
 type Scope struct {
 	Domain  Domain  `json:"domain,omitempty"`
 	Project Project `json:"project,omitempty"`
+
+	// System contains system scope details.
+	// Available since Identity API v3.10.
+	System *System `json:"system,omitempty"`
+}
+
+// System represents the system in a role assignment scope.
+type System struct {
+	// All is true when the role assignment applies to the entire system.
+	All bool `json:"all"`
 }
 
 // Domain represents a domain in a role assignment scope.
@@ -225,6 +235,12 @@ func ExtractRoleAssignments(r pagination.Page) ([]RoleAssignment, error) {
 // AssignmentResult represents the result of an assign operation.
 // Call ExtractErr method to determine if the request succeeded or failed.
 type AssignmentResult struct {
+	gophercloud.ErrResult
+}
+
+// ValidateResult represents the result of a validate operation.
+// Call ExtractErr method to determine if the request succeeded or failed.
+type ValidateResult struct {
 	gophercloud.ErrResult
 }
 

--- a/openstack/identity/v3/roles/testing/fixtures_test.go
+++ b/openstack/identity/v3/roles/testing/fixtures_test.go
@@ -232,6 +232,39 @@ const ListAssignmentWithNamesOutput = `
 }
 `
 
+// ListAssignmentSystemOutput provides a result of a ListAssignment request
+// filtered by system scope.
+const ListAssignmentSystemOutput = `
+{
+    "role_assignments": [
+        {
+            "links": {
+                "assignment": "http://identity:35357/v3/system/groups/101112/roles/123456"
+            },
+            "role": {
+                "id": "123456"
+            },
+            "scope": {
+                "system": {
+                    "all": true
+                }
+            },
+            "group": {
+                "domain": {
+                    "id": "161718"
+                },
+                "id": "101112"
+            }
+        }
+    ],
+    "links": {
+        "self": "http://identity:35357/v3/role_assignments?scope.system=all",
+        "previous": null,
+        "next": null
+    }
+}
+`
+
 // ListAssignmentsOnResourceOutput provides a result of ListAssignmentsOnResource request.
 const ListAssignmentsOnResourceOutput = `
 {
@@ -508,6 +541,37 @@ func HandleAssignSuccessfully(t *testing.T, fakeServer th.FakeServer) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		w.WriteHeader(http.StatusNoContent)
 	})
+
+	fakeServer.Mux.HandleFunc("/system/users/{user_id}/roles/{role_id}", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	fakeServer.Mux.HandleFunc("/system/groups/{group_id}/roles/{role_id}", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		w.WriteHeader(http.StatusNoContent)
+	})
+}
+
+func HandleValidateSuccessfully(t *testing.T, fakeServer th.FakeServer) {
+	paths := []string{
+		"/projects/{project_id}/users/{user_id}/roles/{role_id}",
+		"/projects/{project_id}/groups/{group_id}/roles/{role_id}",
+		"/domains/{domain_id}/users/{user_id}/roles/{role_id}",
+		"/domains/{domain_id}/groups/{group_id}/roles/{role_id}",
+		"/system/users/{user_id}/roles/{role_id}",
+		"/system/groups/{group_id}/roles/{role_id}",
+	}
+
+	for _, path := range paths {
+		fakeServer.Mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "HEAD")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+			w.WriteHeader(http.StatusNoContent)
+		})
+	}
 }
 
 func HandleUnassignSuccessfully(t *testing.T, fakeServer th.FakeServer) {
@@ -530,6 +594,18 @@ func HandleUnassignSuccessfully(t *testing.T, fakeServer th.FakeServer) {
 	})
 
 	fakeServer.Mux.HandleFunc("/domains/{domain_id}/groups/{group_id}/roles/{role_id}", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	fakeServer.Mux.HandleFunc("/system/users/{user_id}/roles/{role_id}", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	fakeServer.Mux.HandleFunc("/system/groups/{group_id}/roles/{role_id}", func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "DELETE")
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		w.WriteHeader(http.StatusNoContent)
@@ -560,6 +636,14 @@ var ThirdRoleAssignment = roles.RoleAssignment{
 	Group: roles.Group{},
 }
 
+// SystemRoleAssignment is a role assignment with system scope.
+var SystemRoleAssignment = roles.RoleAssignment{
+	Role:  roles.AssignedRole{ID: "123456"},
+	Scope: roles.Scope{System: &roles.System{All: true}},
+	User:  roles.User{},
+	Group: roles.Group{Domain: roles.Domain{ID: "161718"}, ID: "101112"},
+}
+
 // ExpectedRoleAssignmentsSlice is the slice of role assignments expected to be
 // returned from ListAssignmentOutput.
 var ExpectedRoleAssignmentsSlice = []roles.RoleAssignment{FirstRoleAssignment, SecondRoleAssignment}
@@ -567,6 +651,10 @@ var ExpectedRoleAssignmentsSlice = []roles.RoleAssignment{FirstRoleAssignment, S
 // ExpectedRoleAssignmentsWithNamesSlice is the slice of role assignments expected to be
 // returned from ListAssignmentWithNamesOutput.
 var ExpectedRoleAssignmentsWithNamesSlice = []roles.RoleAssignment{ThirdRoleAssignment}
+
+// ExpectedSystemRoleAssignmentsSlice is the slice of system role assignments
+// expected to be returned from ListAssignmentSystemOutput.
+var ExpectedSystemRoleAssignmentsSlice = []roles.RoleAssignment{SystemRoleAssignment}
 
 // HandleListRoleAssignmentsSuccessfully creates an HTTP handler at `/role_assignments` on the
 // test handler mux that responds with a list of two role assignments.
@@ -609,6 +697,21 @@ func HandleListRoleAssignmentsWithSubtreeSuccessfully(t *testing.T, fakeServer t
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprint(w, ListAssignmentOutput)
+	})
+}
+
+// HandleListRoleAssignmentsWithSystemSuccessfully creates an HTTP handler at
+// `/role_assignments` that responds with a system-scoped role assignment.
+func HandleListRoleAssignmentsWithSystemSuccessfully(t *testing.T, fakeServer th.FakeServer) {
+	fakeServer.Mux.HandleFunc("/role_assignments", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.AssertEquals(t, "scope.system=all", r.URL.RawQuery)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, ListAssignmentSystemOutput)
 	})
 }
 
@@ -682,6 +785,34 @@ func HandleListAssignmentsOnResourceSuccessfully_DomainsGroups(t *testing.T, fak
 	}
 
 	fakeServer.Mux.HandleFunc("/domains/{domain_id}/groups/{group_id}/roles", fn)
+}
+
+func HandleListAssignmentsOnResourceSuccessfully_SystemUsers(t *testing.T, fakeServer th.FakeServer) {
+	fn := func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, ListAssignmentsOnResourceOutput)
+	}
+
+	fakeServer.Mux.HandleFunc("/system/users/{user_id}/roles", fn)
+}
+
+func HandleListAssignmentsOnResourceSuccessfully_SystemGroups(t *testing.T, fakeServer th.FakeServer) {
+	fn := func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, ListAssignmentsOnResourceOutput)
+	}
+
+	fakeServer.Mux.HandleFunc("/system/groups/{group_id}/roles", fn)
 }
 
 var expectedRoleInferenceRule = roles.RoleInferenceRule{

--- a/openstack/identity/v3/roles/testing/requests_test.go
+++ b/openstack/identity/v3/roles/testing/requests_test.go
@@ -222,6 +222,29 @@ func TestListAssignmentsWithSubtreeSinglePage(t *testing.T) {
 	th.CheckEquals(t, 1, count)
 }
 
+func TestListAssignmentsWithSystemScopeSinglePage(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	HandleListRoleAssignmentsWithSystemSuccessfully(t, fakeServer)
+
+	listOpts := roles.ListAssignmentsOpts{
+		ScopeSystem: "all",
+	}
+
+	count := 0
+	err := roles.ListAssignments(client.ServiceClient(fakeServer), listOpts).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
+		count++
+		actual, err := roles.ExtractRoleAssignments(page)
+		th.AssertNoErr(t, err)
+
+		th.CheckDeepEquals(t, ExpectedSystemRoleAssignmentsSlice, actual)
+
+		return true, nil
+	})
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, 1, count)
+}
+
 func TestListAssignmentsOnResource_ProjectsUsers(t *testing.T) {
 	fakeServer := th.SetupHTTP()
 	defer fakeServer.Teardown()
@@ -310,6 +333,50 @@ func TestListAssignmentsOnResource_DomainsGroups(t *testing.T) {
 	th.CheckEquals(t, 1, count)
 }
 
+func TestListAssignmentsOnResource_SystemUsers(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	HandleListAssignmentsOnResourceSuccessfully_SystemUsers(t, fakeServer)
+
+	count := 0
+	err := roles.ListAssignmentsOnResource(client.ServiceClient(fakeServer), roles.ListAssignmentsOnResourceOpts{
+		UserID: "{user_id}",
+		System: true,
+	}).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
+		count++
+
+		actual, err := roles.ExtractRoles(page)
+		th.AssertNoErr(t, err)
+		th.CheckDeepEquals(t, ExpectedRolesOnResourceSlice, actual)
+
+		return true, nil
+	})
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, 1, count)
+}
+
+func TestListAssignmentsOnResource_SystemGroups(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	HandleListAssignmentsOnResourceSuccessfully_SystemGroups(t, fakeServer)
+
+	count := 0
+	err := roles.ListAssignmentsOnResource(client.ServiceClient(fakeServer), roles.ListAssignmentsOnResourceOpts{
+		GroupID: "{group_id}",
+		System:  true,
+	}).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
+		count++
+
+		actual, err := roles.ExtractRoles(page)
+		th.AssertNoErr(t, err)
+		th.CheckDeepEquals(t, ExpectedRolesOnResourceSlice, actual)
+
+		return true, nil
+	})
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, 1, count)
+}
+
 func TestAssign(t *testing.T) {
 	fakeServer := th.SetupHTTP()
 	defer fakeServer.Teardown()
@@ -338,6 +405,38 @@ func TestAssign(t *testing.T) {
 		DomainID: "{domain_id}",
 	}).ExtractErr()
 	th.AssertNoErr(t, err)
+
+	err = roles.Assign(context.TODO(), client.ServiceClient(fakeServer), "{role_id}", roles.AssignOpts{
+		UserID: "{user_id}",
+		System: true,
+	}).ExtractErr()
+	th.AssertNoErr(t, err)
+
+	err = roles.Assign(context.TODO(), client.ServiceClient(fakeServer), "{role_id}", roles.AssignOpts{
+		GroupID: "{group_id}",
+		System:  true,
+	}).ExtractErr()
+	th.AssertNoErr(t, err)
+}
+
+func TestValidate(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	HandleValidateSuccessfully(t, fakeServer)
+
+	tests := []roles.ValidateOpts{
+		{UserID: "{user_id}", ProjectID: "{project_id}"},
+		{UserID: "{user_id}", DomainID: "{domain_id}"},
+		{GroupID: "{group_id}", ProjectID: "{project_id}"},
+		{GroupID: "{group_id}", DomainID: "{domain_id}"},
+		{UserID: "{user_id}", System: true},
+		{GroupID: "{group_id}", System: true},
+	}
+
+	for _, opts := range tests {
+		err := roles.Validate(context.TODO(), client.ServiceClient(fakeServer), "{role_id}", opts).ExtractErr()
+		th.AssertNoErr(t, err)
+	}
 }
 
 func TestUnassign(t *testing.T) {
@@ -368,6 +467,42 @@ func TestUnassign(t *testing.T) {
 		DomainID: "{domain_id}",
 	}).ExtractErr()
 	th.AssertNoErr(t, err)
+
+	err = roles.Unassign(context.TODO(), client.ServiceClient(fakeServer), "{role_id}", roles.UnassignOpts{
+		UserID: "{user_id}",
+		System: true,
+	}).ExtractErr()
+	th.AssertNoErr(t, err)
+
+	err = roles.Unassign(context.TODO(), client.ServiceClient(fakeServer), "{role_id}", roles.UnassignOpts{
+		GroupID: "{group_id}",
+		System:  true,
+	}).ExtractErr()
+	th.AssertNoErr(t, err)
+}
+
+func TestAssignmentOptsValidation(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	err := roles.Assign(context.TODO(), client.ServiceClient(fakeServer), "{role_id}", roles.AssignOpts{
+		UserID: "{user_id}",
+	}).ExtractErr()
+	th.AssertErr(t, err)
+
+	err = roles.Assign(context.TODO(), client.ServiceClient(fakeServer), "{role_id}", roles.AssignOpts{
+		UserID:    "{user_id}",
+		ProjectID: "{project_id}",
+		System:    true,
+	}).ExtractErr()
+	th.AssertErr(t, err)
+
+	err = roles.Assign(context.TODO(), client.ServiceClient(fakeServer), "{role_id}", roles.AssignOpts{
+		UserID:    "{user_id}",
+		GroupID:   "{group_id}",
+		ProjectID: "{project_id}",
+	}).ExtractErr()
+	th.AssertErr(t, err)
 }
 
 func TestCreateRoleInferenceRule(t *testing.T) {

--- a/openstack/identity/v3/roles/urls.go
+++ b/openstack/identity/v3/roles/urls.go
@@ -31,10 +31,16 @@ func listAssignmentsURL(client *gophercloud.ServiceClient) string {
 }
 
 func listAssignmentsOnResourceURL(client *gophercloud.ServiceClient, targetType, targetID, actorType, actorID string) string {
+	if targetType == "system" {
+		return client.ServiceURL(targetType, actorType, actorID, rolePath)
+	}
 	return client.ServiceURL(targetType, targetID, actorType, actorID, rolePath)
 }
 
 func assignURL(client *gophercloud.ServiceClient, targetType, targetID, actorType, actorID, roleID string) string {
+	if targetType == "system" {
+		return client.ServiceURL(targetType, actorType, actorID, rolePath, roleID)
+	}
 	return client.ServiceURL(targetType, targetID, actorType, actorID, rolePath, roleID)
 }
 


### PR DESCRIPTION
  For #3846

  Add Identity v3 system-scoped role assignment support for users and groups.

  This adds:
  - list, assign, validate, and unassign operations for system roles;
  - `scope.system=all` filtering;
  - system scope extraction from role assignment responses;
  - unit and acceptance tests.

  Keystone implementation:
  https://github.com/openstack/keystone/blob/4172e784581e71b468325c05f4e9023c0fefd9b5/keystone/api/system.py