### PR TITLE
Manila sharetype getset backport

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ The above code sample creates a new server with the parameters, and returns a
 |         Messaging        |       Zaqar      |        `openstack/messaging`       |    ✔    |    ✔    |
 |        Networking        |      Neutron     |       `openstack/networking`       |    ✔    |    ✔    |
 |      Object Storage      |       Swift      |      `openstack/objectstorage`     |    ✔    |    ✔    |
+|   Shared File Systems    |      Manila      |   `openstack/sharedfilesystems`    |    ✔    |    ✔    |
 
 ## Advanced Usage
 

--- a/internal/acceptance/openstack/sharedfilesystems/v2/sharetypes_test.go
+++ b/internal/acceptance/openstack/sharedfilesystems/v2/sharetypes_test.go
@@ -55,7 +55,7 @@ func TestShareTypeUpdateGet(t *testing.T) {
 
 	th.AssertEquals(t, "ACPTTEST_new_share_type_name", st.Name)
 	th.AssertEquals(t, "my new share type description", *st.Description)
-	th.AssertTrue(t, st.IsPublic)
+	th.AssertEquals(t, true, st.IsPublic)
 
 	tools.PrintResource(t, shareType)
 }

--- a/internal/acceptance/openstack/sharedfilesystems/v2/sharetypes_test.go
+++ b/internal/acceptance/openstack/sharedfilesystems/v2/sharetypes_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gophercloud/gophercloud/v2/internal/acceptance/clients"
 	"github.com/gophercloud/gophercloud/v2/internal/acceptance/tools"
 	"github.com/gophercloud/gophercloud/v2/openstack/sharedfilesystems/v2/sharetypes"
+	th "github.com/gophercloud/gophercloud/v2/testhelper"
 )
 
 func TestShareTypeCreateDestroy(t *testing.T) {
@@ -25,6 +26,38 @@ func TestShareTypeCreateDestroy(t *testing.T) {
 	tools.PrintResource(t, shareType)
 
 	defer DeleteShareType(t, client, shareType)
+}
+
+func TestShareTypeUpdateGet(t *testing.T) {
+	client, err := clients.NewSharedFileSystemV2Client()
+	th.AssertNoErr(t, err)
+	client.Microversion = "2.50"
+
+	shareType, err := CreateShareType(t, client)
+	th.AssertNoErr(t, err)
+	defer DeleteShareType(t, client, shareType)
+
+	name := "ACPTTEST_new_share_type_name"
+	description := "my new share type description"
+	isPublic := true
+
+	options := sharetypes.UpdateOpts{
+		Name:        &name,
+		Description: &description,
+		IsPublic:    &isPublic,
+	}
+
+	_, err = sharetypes.Update(context.TODO(), client, shareType.ID, options).Extract()
+	th.AssertNoErr(t, err)
+
+	st, err := sharetypes.Get(context.TODO(), client, shareType.ID).Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, "ACPTTEST_new_share_type_name", st.Name)
+	th.AssertEquals(t, "my new share type description", *st.Description)
+	th.AssertTrue(t, st.IsPublic)
+
+	tools.PrintResource(t, shareType)
 }
 
 func TestShareTypeList(t *testing.T) {

--- a/openstack/sharedfilesystems/v2/sharetypes/requests.go
+++ b/openstack/sharedfilesystems/v2/sharetypes/requests.go
@@ -62,6 +62,54 @@ func Delete(ctx context.Context, client *gophercloud.ServiceClient, id string) (
 	return
 }
 
+// Get will retrieve the existing ShareType with the provided ID.
+func Get(ctx context.Context, client *gophercloud.ServiceClient, id string) (r GetResult) {
+	resp, err := client.Get(ctx, getURL(client, id), &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
+type UpdateOptsBuilder interface {
+	ToShareTypeUpdateMap() (map[string]any, error)
+}
+
+// UpdateOpts contains options for updating a ShareType. This object is
+// passed to the sharetypes.Update function. Only the fields which are
+// specified are updated; all fields are optional so that a partial update
+// can be performed.
+type UpdateOpts struct {
+	// The share type name.
+	Name *string `json:"name,omitempty"`
+	// The share type description.
+	Description *string `json:"description,omitempty"`
+	// Indicates whether a share type is publicly accessible.
+	IsPublic *bool `json:"share_type_access:is_public,omitempty"`
+}
+
+// ToShareTypeUpdateMap assembles a request body based on the contents of an
+// UpdateOpts.
+func (opts UpdateOpts) ToShareTypeUpdateMap() (map[string]any, error) {
+	return gophercloud.BuildRequestBody(opts, "share_type")
+}
+
+// Update will update an existing ShareType based on the values in
+// UpdateOpts. To extract the ShareType object from the response, call the
+// Extract method on the UpdateResult.
+func Update(ctx context.Context, client *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToShareTypeUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := client.Put(ctx, updateURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
 // ListOptsBuilder allows extensions to add additional parameters to the List
 // request.
 type ListOptsBuilder interface {

--- a/openstack/sharedfilesystems/v2/sharetypes/results.go
+++ b/openstack/sharedfilesystems/v2/sharetypes/results.go
@@ -18,6 +18,17 @@ type ShareType struct {
 	RequiredExtraSpecs map[string]any `json:"required_extra_specs"`
 	// The extra specifications for the share type
 	ExtraSpecs map[string]any `json:"extra_specs"`
+	// The human-readable description for the share type
+	Description *string `json:"description"`
+	// Indicates whether the share type is the default one
+	IsDefault *bool `json:"is_default"`
+}
+
+// shareTypeV6Compat provides compatibility for os-share-type-access:is_public
+// being renamed to share_type_access:is_public at microversion v6 or greater.
+type shareTypeV6Compat struct {
+	// Indicates whether a share type is publicly accessible
+	IsPublic *bool `json:"share_type_access:is_public"`
 }
 
 type commonResult struct {
@@ -30,6 +41,24 @@ func (r commonResult) Extract() (*ShareType, error) {
 		ShareType *ShareType `json:"share_type"`
 	}
 	err := r.ExtractInto(&s)
+	if err != nil {
+		return s.ShareType, err
+	}
+
+	var sV6 struct {
+		ShareTypeCompat *shareTypeV6Compat `json:"share_type"`
+	}
+	err = r.ExtractInto(&sV6)
+	if err != nil {
+		return s.ShareType, err
+	}
+
+	// Overwrite IsPublic if a value for share_type_access:is_public is found.
+	// Otherwise IsPublic is always false at microversion v6 or greater.
+	if sV6.ShareTypeCompat.IsPublic != nil {
+		s.ShareType.IsPublic = *sV6.ShareTypeCompat.IsPublic
+	}
+
 	return s.ShareType, err
 }
 
@@ -41,6 +70,16 @@ type CreateResult struct {
 // DeleteResult contains the response body and error from a Delete request.
 type DeleteResult struct {
 	gophercloud.ErrResult
+}
+
+// GetResult contains the response body and error from a Get request.
+type GetResult struct {
+	commonResult
+}
+
+// UpdateResult contains the response body and error from an Update request.
+type UpdateResult struct {
+	commonResult
 }
 
 // ShareTypePage is a pagination.pager that is returned from a call to the List function.

--- a/openstack/sharedfilesystems/v2/sharetypes/testing/fixtures_test.go
+++ b/openstack/sharedfilesystems/v2/sharetypes/testing/fixtures_test.go
@@ -134,6 +134,60 @@ func MockListResponse(t *testing.T, fakeServer th.FakeServer) {
 	})
 }
 
+func MockGetResponse(t *testing.T, fakeServer th.FakeServer) {
+	fakeServer.Mux.HandleFunc("/types/shareTypeID", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `
+        {
+            "share_type": {
+                "os-share-type-access:is_public": true,
+                "required_extra_specs": {
+                    "driver_handles_share_servers": "True"
+                },
+                "extra_specs": {
+                    "snapshot_support": "True",
+                    "driver_handles_share_servers": "True"
+                },
+                "name": "my_share_type",
+                "id": "1d600d02-26a7-4b23-af3d-7d51860fe858",
+                "description": "my share type description",
+                "is_default": false
+            }
+        }`)
+	})
+}
+
+func MockGetResponseV6(t *testing.T, fakeServer th.FakeServer) {
+	fakeServer.Mux.HandleFunc("/types/shareTypeID", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `
+        {
+            "share_type": {
+                "share_type_access:is_public": true,
+                "required_extra_specs": {
+                    "driver_handles_share_servers": "True"
+                },
+                "extra_specs": {
+                    "snapshot_support": "True",
+                    "driver_handles_share_servers": "True"
+                },
+                "name": "my_share_type",
+                "id": "1d600d02-26a7-4b23-af3d-7d51860fe858",
+                "description": "my share type description",
+                "is_default": false
+            }
+        }`)
+	})
+}
+
 func MockGetDefaultResponse(t *testing.T, fakeServer th.FakeServer) {
 	fakeServer.Mux.HandleFunc("/types/default", func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "GET")
@@ -178,6 +232,44 @@ func MockGetExtraSpecsResponse(t *testing.T, fakeServer th.FakeServer) {
                 "snapshot_support": "True",
                 "driver_handles_share_servers": "True",
                 "my_custom_extra_spec": "False"
+            }
+        }`)
+	})
+}
+
+func MockUpdateResponse(t *testing.T, fakeServer th.FakeServer) {
+	fakeServer.Mux.HandleFunc("/types/shareTypeID", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, `
+        {
+            "share_type": {
+                "name": "my_new_share_type_name",
+                "description": "my new share type description",
+                "share_type_access:is_public": false
+            }
+        }`)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprint(w, `
+        {
+            "share_type": {
+                "share_type_access:is_public": false,
+                "required_extra_specs": {
+                    "driver_handles_share_servers": "True"
+                },
+                "extra_specs": {
+                    "snapshot_support": "True",
+                    "driver_handles_share_servers": "True"
+                },
+                "name": "my_new_share_type_name",
+                "id": "1d600d02-26a7-4b23-af3d-7d51860fe858",
+                "description": "my new share type description",
+                "is_default": false
             }
         }`)
 	})

--- a/openstack/sharedfilesystems/v2/sharetypes/testing/requests_test.go
+++ b/openstack/sharedfilesystems/v2/sharetypes/testing/requests_test.go
@@ -64,6 +64,31 @@ func TestRequiredCreateOpts(t *testing.T) {
 	}
 }
 
+// Verifies that a share type can be updated
+func TestUpdate(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	MockUpdateResponse(t, fakeServer)
+
+	name := "my_new_share_type_name"
+	description := "my new share type description"
+	isPublic := false
+
+	options := &sharetypes.UpdateOpts{
+		Name:        &name,
+		Description: &description,
+		IsPublic:    &isPublic,
+	}
+
+	st, err := sharetypes.Update(context.TODO(), client.ServiceClient(fakeServer), "shareTypeID", options).Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, "my_new_share_type_name", st.Name)
+	th.AssertEquals(t, "my new share type description", *st.Description)
+	th.AssertEquals(t, false, st.IsPublic)
+}
+
 // Verifies that share type deletion works
 func TestDelete(t *testing.T) {
 	fakeServer := th.SetupHTTP()
@@ -103,6 +128,55 @@ func TestList(t *testing.T) {
 	}
 
 	th.CheckDeepEquals(t, expected, actual)
+}
+
+// Verifies that a share type can be retrieved by ID
+func TestGet(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	MockGetResponse(t, fakeServer)
+
+	description := "my share type description"
+	isDefault := false
+	expected := sharetypes.ShareType{
+		ID:                 "1d600d02-26a7-4b23-af3d-7d51860fe858",
+		Name:               "my_share_type",
+		IsPublic:           true,
+		ExtraSpecs:         map[string]any{"snapshot_support": "True", "driver_handles_share_servers": "True"},
+		RequiredExtraSpecs: map[string]any{"driver_handles_share_servers": "True"},
+		Description:        &description,
+		IsDefault:          &isDefault,
+	}
+
+	actual, err := sharetypes.Get(context.TODO(), client.ServiceClient(fakeServer), "shareTypeID").Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, &expected, actual)
+}
+
+// Verifies that a share type can be retrieved by ID at microversion v6 or greater.
+func TestGetV6(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	MockGetResponseV6(t, fakeServer)
+
+	description := "my share type description"
+	isDefault := false
+	expected := sharetypes.ShareType{
+		ID:                 "1d600d02-26a7-4b23-af3d-7d51860fe858",
+		Name:               "my_share_type",
+		IsPublic:           true,
+		ExtraSpecs:         map[string]any{"snapshot_support": "True", "driver_handles_share_servers": "True"},
+		RequiredExtraSpecs: map[string]any{"driver_handles_share_servers": "True"},
+		Description:        &description,
+		IsDefault:          &isDefault,
+	}
+
+	testClient := client.ServiceClient(fakeServer)
+	actual, err := sharetypes.Get(context.TODO(), testClient, "shareTypeID").Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, &expected, actual)
 }
 
 // Verifies that it is possible to get the default share type

--- a/openstack/sharedfilesystems/v2/sharetypes/urls.go
+++ b/openstack/sharedfilesystems/v2/sharetypes/urls.go
@@ -10,6 +10,14 @@ func deleteURL(c *gophercloud.ServiceClient, id string) string {
 	return c.ServiceURL("types", id)
 }
 
+func getURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("types", id)
+}
+
+func updateURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("types", id)
+}
+
 func listURL(c *gophercloud.ServiceClient) string {
 	return createURL(c)
 }


### PR DESCRIPTION
Backport of https://github.com/gophercloud/gophercloud/pull/3853

Fixes https://github.com/gophercloud/gophercloud/issues/3842

Implement Manila share type get and update API methods.

API reference for share types: https://docs.openstack.org/api-ref/shared-file-system/#share-types

Unit tests:
Adds unit tests for getting and updating sharetypes