### PR TITLE
feat: Add advanced tag filters on listing l7policy

### DIFF
--- a/internal/acceptance/openstack/loadbalancer/v2/l7policies_test.go
+++ b/internal/acceptance/openstack/loadbalancer/v2/l7policies_test.go
@@ -7,8 +7,10 @@ import (
 	"testing"
 
 	"github.com/gophercloud/gophercloud/v2/internal/acceptance/clients"
+	networking "github.com/gophercloud/gophercloud/v2/internal/acceptance/openstack/networking/v2"
 	"github.com/gophercloud/gophercloud/v2/internal/acceptance/tools"
 	"github.com/gophercloud/gophercloud/v2/openstack/loadbalancer/v2/l7policies"
+	th "github.com/gophercloud/gophercloud/v2/testhelper"
 )
 
 func TestL7PoliciesList(t *testing.T) {
@@ -29,5 +31,165 @@ func TestL7PoliciesList(t *testing.T) {
 
 	for _, policy := range allL7Policies {
 		tools.PrintResource(t, policy)
+	}
+}
+
+func TestL7PoliciesListByTags(t *testing.T) {
+	netClient, err := clients.NewNetworkV2Client()
+	th.AssertNoErr(t, err)
+
+	lbClient, err := clients.NewLoadBalancerV2Client()
+	th.AssertNoErr(t, err)
+
+	network, err := networking.CreateNetwork(t, netClient)
+	th.AssertNoErr(t, err)
+	defer networking.DeleteNetwork(t, netClient, network.ID)
+
+	subnet, err := networking.CreateSubnet(t, netClient, network.ID)
+	th.AssertNoErr(t, err)
+	defer networking.DeleteSubnet(t, netClient, subnet.ID)
+
+	lb, err := CreateLoadBalancer(t, lbClient, subnet.ID, nil, "", nil)
+	th.AssertNoErr(t, err)
+	defer DeleteLoadBalancer(t, lbClient, lb.ID)
+
+	listener, err := CreateListenerHTTP(t, lbClient, lb)
+	th.AssertNoErr(t, err)
+	defer DeleteListener(t, lbClient, lb.ID, listener.ID)
+
+	tags := []string{
+		tools.RandomString("TESTACCT-TAG-", 8),
+		tools.RandomString("TESTACCT-TAG-", 8),
+	}
+	missingTag := tools.RandomString("TESTACCT-MISSING-TAG-", 8)
+
+	policy, err := CreateL7Policy(t, lbClient, listener, lb, tags)
+	th.AssertNoErr(t, err)
+	defer DeleteL7Policy(t, lbClient, lb.ID, policy.ID)
+
+	rule, err := CreateL7Rule(t, lbClient, policy.ID, lb, tags)
+	th.AssertNoErr(t, err)
+	defer DeleteL7Rule(t, lbClient, lb.ID, policy.ID, rule.ID)
+
+	policyTests := []struct {
+		name string
+		opts l7policies.ListOpts
+		want int
+	}{
+		{
+			name: "tags-match",
+			opts: l7policies.ListOpts{ListenerID: listener.ID, Tags: tags},
+			want: 1,
+		},
+		{
+			name: "tags-no-match",
+			opts: l7policies.ListOpts{ListenerID: listener.ID, Tags: []string{tags[0], missingTag}},
+			want: 0,
+		},
+		{
+			name: "tags-any-match",
+			opts: l7policies.ListOpts{ListenerID: listener.ID, TagsAny: []string{tags[0], missingTag}},
+			want: 1,
+		},
+		{
+			name: "tags-any-no-match",
+			opts: l7policies.ListOpts{ListenerID: listener.ID, TagsAny: []string{missingTag}},
+			want: 0,
+		},
+		{
+			name: "not-tags-excluded",
+			opts: l7policies.ListOpts{ListenerID: listener.ID, TagsNot: tags},
+			want: 0,
+		},
+		{
+			name: "not-tags-included",
+			opts: l7policies.ListOpts{ListenerID: listener.ID, TagsNot: []string{tags[0], missingTag}},
+			want: 1,
+		},
+		{
+			name: "not-tags-any-excluded",
+			opts: l7policies.ListOpts{ListenerID: listener.ID, TagsNotAny: []string{tags[0], missingTag}},
+			want: 0,
+		},
+		{
+			name: "not-tags-any-included",
+			opts: l7policies.ListOpts{ListenerID: listener.ID, TagsNotAny: []string{missingTag}},
+			want: 1,
+		},
+	}
+
+	for _, tt := range policyTests {
+		t.Run("L7Policies/"+tt.name, func(t *testing.T) {
+			allPages, err := l7policies.List(lbClient, tt.opts).AllPages(context.TODO())
+			th.AssertNoErr(t, err)
+
+			allPolicies, err := l7policies.ExtractL7Policies(allPages)
+			th.AssertNoErr(t, err)
+			th.AssertEquals(t, tt.want, len(allPolicies))
+			if tt.want > 0 {
+				th.AssertEquals(t, policy.ID, allPolicies[0].ID)
+			}
+		})
+	}
+
+	ruleTests := []struct {
+		name string
+		opts l7policies.ListRulesOpts
+		want int
+	}{
+		{
+			name: "tags-match",
+			opts: l7policies.ListRulesOpts{Tags: tags},
+			want: 1,
+		},
+		{
+			name: "tags-no-match",
+			opts: l7policies.ListRulesOpts{Tags: []string{tags[0], missingTag}},
+			want: 0,
+		},
+		{
+			name: "tags-any-match",
+			opts: l7policies.ListRulesOpts{TagsAny: []string{tags[0], missingTag}},
+			want: 1,
+		},
+		{
+			name: "tags-any-no-match",
+			opts: l7policies.ListRulesOpts{TagsAny: []string{missingTag}},
+			want: 0,
+		},
+		{
+			name: "not-tags-excluded",
+			opts: l7policies.ListRulesOpts{TagsNot: tags},
+			want: 0,
+		},
+		{
+			name: "not-tags-included",
+			opts: l7policies.ListRulesOpts{TagsNot: []string{tags[0], missingTag}},
+			want: 1,
+		},
+		{
+			name: "not-tags-any-excluded",
+			opts: l7policies.ListRulesOpts{TagsNotAny: []string{tags[0], missingTag}},
+			want: 0,
+		},
+		{
+			name: "not-tags-any-included",
+			opts: l7policies.ListRulesOpts{TagsNotAny: []string{missingTag}},
+			want: 1,
+		},
+	}
+
+	for _, tt := range ruleTests {
+		t.Run("L7Rules/"+tt.name, func(t *testing.T) {
+			allPages, err := l7policies.ListRules(lbClient, policy.ID, tt.opts).AllPages(context.TODO())
+			th.AssertNoErr(t, err)
+
+			allRules, err := l7policies.ExtractRules(allPages)
+			th.AssertNoErr(t, err)
+			th.AssertEquals(t, tt.want, len(allRules))
+			if tt.want > 0 {
+				th.AssertEquals(t, rule.ID, allRules[0].ID)
+			}
+		})
 	}
 }

--- a/internal/acceptance/openstack/loadbalancer/v2/loadbalancer.go
+++ b/internal/acceptance/openstack/loadbalancer/v2/loadbalancer.go
@@ -479,7 +479,7 @@ func CreateL7Policy(t *testing.T, client *gophercloud.ServiceClient, listener *l
 	th.AssertEquals(t, policy.ListenerID, listener.ID)
 	th.AssertEquals(t, policy.Action, string(l7policies.ActionRedirectToURL))
 	th.AssertEquals(t, "http://www.example.com", policy.RedirectURL)
-	th.AssertDeepEquals(t, policy.Tags, tags)
+	th.AssertTagsEqual(t, tags, policy.Tags)
 
 	return policy, nil
 }
@@ -509,7 +509,7 @@ func CreateL7Rule(t *testing.T, client *gophercloud.ServiceClient, policyID stri
 	th.AssertEquals(t, rule.RuleType, string(l7policies.TypePath))
 	th.AssertEquals(t, rule.CompareType, string(l7policies.CompareTypeStartWith))
 	th.AssertEquals(t, "/api", rule.Value)
-	th.AssertDeepEquals(t, rule.Tags, tags)
+	th.AssertTagsEqual(t, tags, rule.Tags)
 
 	return rule, nil
 }

--- a/openstack/loadbalancer/v2/l7policies/requests.go
+++ b/openstack/loadbalancer/v2/l7policies/requests.go
@@ -133,6 +133,22 @@ type ListOpts struct {
 	Marker         string `q:"marker"`
 	SortKey        string `q:"sort_key"`
 	SortDir        string `q:"sort_dir"`
+
+	// Tags filters L7 policies that contain all of the given tags.
+	// Requires Octavia API version 2.5 or later.
+	Tags []string `q:"tags"`
+
+	// TagsAny filters L7 policies that contain at least one of the given tags.
+	// Requires Octavia API version 2.5 or later.
+	TagsAny []string `q:"tags-any"`
+
+	// TagsNot excludes L7 policies that contain all of the given tags.
+	// Requires Octavia API version 2.5 or later.
+	TagsNot []string `q:"not-tags"`
+
+	// TagsNotAny excludes L7 policies that contain any of the given tags.
+	// Requires Octavia API version 2.5 or later.
+	TagsNotAny []string `q:"not-tags-any"`
 }
 
 // ToL7PolicyListQuery formats a ListOpts into a query string.
@@ -338,6 +354,22 @@ type ListRulesOpts struct {
 	Marker       string      `q:"marker"`
 	SortKey      string      `q:"sort_key"`
 	SortDir      string      `q:"sort_dir"`
+
+	// Tags filters L7 rules that contain all of the given tags.
+	// Requires Octavia API version 2.5 or later.
+	Tags []string `q:"tags"`
+
+	// TagsAny filters L7 rules that contain at least one of the given tags.
+	// Requires Octavia API version 2.5 or later.
+	TagsAny []string `q:"tags-any"`
+
+	// TagsNot excludes L7 rules that contain all of the given tags.
+	// Requires Octavia API version 2.5 or later.
+	TagsNot []string `q:"not-tags"`
+
+	// TagsNotAny excludes L7 rules that contain any of the given tags.
+	// Requires Octavia API version 2.5 or later.
+	TagsNotAny []string `q:"not-tags-any"`
 }
 
 // ToRulesListQuery formats a ListOpts into a query string.

--- a/openstack/loadbalancer/v2/l7policies/testing/requests_test.go
+++ b/openstack/loadbalancer/v2/l7policies/testing/requests_test.go
@@ -76,6 +76,20 @@ func TestListL7Policies(t *testing.T) {
 	}
 }
 
+func TestListL7PolicyOpts(t *testing.T) {
+	listOpts := l7policies.ListOpts{
+		Tags:       []string{"tag1", "tag2"},
+		TagsAny:    []string{"tag3", "tag4"},
+		TagsNot:    []string{"tag5", "tag6"},
+		TagsNotAny: []string{"tag7", "tag8"},
+	}
+
+	expected := "?not-tags=tag5&not-tags=tag6&not-tags-any=tag7&not-tags-any=tag8&tags=tag1&tags=tag2&tags-any=tag3&tags-any=tag4"
+	actual, err := listOpts.ToL7PolicyListQuery()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, expected, actual)
+}
+
 func TestListAllL7Policies(t *testing.T) {
 	fakeServer := th.SetupHTTP()
 	defer fakeServer.Teardown()
@@ -240,6 +254,20 @@ func TestListRules(t *testing.T) {
 	if pages != 1 {
 		t.Errorf("Expected 1 page, saw %d", pages)
 	}
+}
+
+func TestListRulesOpts(t *testing.T) {
+	listOpts := l7policies.ListRulesOpts{
+		Tags:       []string{"tag1", "tag2"},
+		TagsAny:    []string{"tag3", "tag4"},
+		TagsNot:    []string{"tag5", "tag6"},
+		TagsNotAny: []string{"tag7", "tag8"},
+	}
+
+	expected := "?not-tags=tag5&not-tags=tag6&not-tags-any=tag7&not-tags-any=tag8&tags=tag1&tags=tag2&tags-any=tag3&tags-any=tag4"
+	actual, err := listOpts.ToRulesListQuery()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, expected, actual)
 }
 
 func TestListAllRules(t *testing.T) {

--- a/testhelper/convenience.go
+++ b/testhelper/convenience.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"sort"
 	"strings"
 	"testing"
 )
@@ -318,6 +319,20 @@ func AssertDeepEquals(t *testing.T, expected, actual any) {
 	if differed {
 		logFatal(t, "The structures were different.")
 	}
+}
+
+// AssertTagsEqual compares two slices of tags without regard to order.
+// If they are not equal, a fatal error is raised.
+func AssertTagsEqual(t *testing.T, expected, actual []string) {
+	t.Helper()
+
+	expected = append([]string(nil), expected...)
+	actual = append([]string(nil), actual...)
+
+	sort.Strings(expected)
+	sort.Strings(actual)
+
+	AssertDeepEquals(t, expected, actual)
 }
 
 // CheckDeepEquals is similar to AssertDeepEquals, except with a non-fatal error

--- a/testhelper/convenience_test.go
+++ b/testhelper/convenience_test.go
@@ -1,0 +1,20 @@
+package testhelper
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestAssertTagsEqual(t *testing.T) {
+	expected := []string{"tag1", "tag2"}
+	actual := []string{"tag2", "tag1"}
+
+	AssertTagsEqual(t, expected, actual)
+
+	if !reflect.DeepEqual(expected, []string{"tag1", "tag2"}) {
+		t.Fatalf("expected slice was modified: %v", expected)
+	}
+	if !reflect.DeepEqual(actual, []string{"tag2", "tag1"}) {
+		t.Fatalf("actual slice was modified: %v", actual)
+	}
+}


### PR DESCRIPTION
<!--
Prior to starting a PR, please make sure you have read our
[contributor tutorial](https://github.com/gophercloud/gophercloud/tree/main/docs/contributor-tutorial).

Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

-->
Fixes #3913 

Add the Octavia 2.5 advanced tag filters (`tags`, `tags-any`, `not-tags`, and `not-tags-any`) to L7policy and L7rule list options.

Includes unit tests for query generation and an acceptance test covering all filters.

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

API reference: https://docs.openstack.org/api-ref/load-balancer/v2/#filtering-by-tags
