### PR TITLE
Use slices for tag qs filters

### DIFF
--- a/internal/acceptance/openstack/identity/v3/projects_test.go
+++ b/internal/acceptance/openstack/identity/v3/projects_test.go
@@ -229,7 +229,7 @@ func TestProjectsTags(t *testing.T) {
 
 	// Search using all tags
 	listOpts := projects.ListOpts{
-		Tags: "Tag1,Tag2",
+		Tags: []string{"Tag1", "Tag2"},
 	}
 
 	allPages, err := projects.List(client, listOpts).AllPages(context.TODO())
@@ -251,7 +251,7 @@ func TestProjectsTags(t *testing.T) {
 
 	// Search using all tags, including a not existing one
 	listOpts = projects.ListOpts{
-		Tags: "Tag1,Tag2,Tag3",
+		Tags: []string{"Tag1", "Tag2", "Tag3"},
 	}
 
 	allPages, err = projects.List(client, listOpts).AllPages(context.TODO())
@@ -264,7 +264,7 @@ func TestProjectsTags(t *testing.T) {
 
 	// Search matching at least one tag
 	listOpts = projects.ListOpts{
-		TagsAny: "Tag1,Tag2,Tag3",
+		TagsAny: []string{"Tag1", "Tag2", "Tag3"},
 	}
 
 	allPages, err = projects.List(client, listOpts).AllPages(context.TODO())
@@ -286,7 +286,7 @@ func TestProjectsTags(t *testing.T) {
 
 	// Search not matching any single tag
 	listOpts = projects.ListOpts{
-		NotTagsAny: "Tag1",
+		NotTagsAny: []string{"Tag1"},
 	}
 
 	allPages, err = projects.List(client, listOpts).AllPages(context.TODO())
@@ -308,7 +308,7 @@ func TestProjectsTags(t *testing.T) {
 
 	// Search matching not all tags
 	listOpts = projects.ListOpts{
-		NotTags: "Tag1,Tag2,Tag3",
+		NotTags: []string{"Tag1", "Tag2", "Tag3"},
 	}
 
 	allPages, err = projects.List(client, listOpts).AllPages(context.TODO())

--- a/internal/acceptance/openstack/networking/v2/extensions/attributestags_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/attributestags_test.go
@@ -4,7 +4,6 @@ package extensions
 
 import (
 	"context"
-	"fmt"
 	"sort"
 	"testing"
 
@@ -108,26 +107,30 @@ func TestQueryByTags(t *testing.T) {
 
 	// Tags - Networks that match all tags will be returned
 	listOpts := networks.ListOpts{
-		Tags: fmt.Sprintf("a,b,c,%s", testtag)}
+		Tags: []string{"a", "b", "c", testtag}}
 	ids := listNetworkWithTagOpts(t, client, listOpts)
 	th.AssertDeepEquals(t, []string{network1.ID}, ids)
 
 	// TagsAny - Networks that match any tag will be returned
 	listOpts = networks.ListOpts{
 		SortKey: "id", SortDir: "asc",
-		TagsAny: fmt.Sprintf("a,b,c,%s", testtag)}
+		TagsAny: []string{"a", "b", "c", testtag}}
 	ids = listNetworkWithTagOpts(t, client, listOpts)
 	expected_ids := []string{network1.ID, network2.ID}
 	sort.Strings(expected_ids)
 	th.AssertDeepEquals(t, expected_ids, ids)
 
 	// NotTags - Networks that match all tags will be excluded
-	listOpts = networks.ListOpts{Tags: testtag, NotTags: "a,b,c"}
+	listOpts = networks.ListOpts{
+		Tags:    []string{testtag},
+		NotTags: []string{"a", "b", "c"}}
 	ids = listNetworkWithTagOpts(t, client, listOpts)
 	th.AssertDeepEquals(t, []string{network2.ID}, ids)
 
 	// NotTagsAny - Networks that match any tag will be excluded.
-	listOpts = networks.ListOpts{Tags: testtag, NotTagsAny: "d"}
+	listOpts = networks.ListOpts{
+		Tags:       []string{testtag},
+		NotTagsAny: []string{"d"}}
 	ids = listNetworkWithTagOpts(t, client, listOpts)
 	th.AssertDeepEquals(t, []string{network1.ID}, ids)
 }

--- a/openstack/compute/v2/servers/requests.go
+++ b/openstack/compute/v2/servers/requests.go
@@ -77,19 +77,19 @@ type ListOpts struct {
 
 	// This requires the client to be set to microversion 2.26 or later.
 	// Tags filters on specific server tags. All tags must be present for the server.
-	Tags string `q:"tags"`
+	Tags []string `q:"tags" format:"comma-separated"`
 
 	// This requires the client to be set to microversion 2.26 or later.
 	// TagsAny filters on specific server tags. At least one of the tags must be present for the server.
-	TagsAny string `q:"tags-any"`
+	TagsAny []string `q:"tags-any" format:"comma-separated"`
 
 	// This requires the client to be set to microversion 2.26 or later.
 	// NotTags filters on specific server tags. All tags must be absent for the server.
-	NotTags string `q:"not-tags"`
+	NotTags []string `q:"not-tags" format:"comma-separated"`
 
 	// This requires the client to be set to microversion 2.26 or later.
 	// NotTagsAny filters on specific server tags. At least one of the tags must be absent for the server.
-	NotTagsAny string `q:"not-tags-any"`
+	NotTagsAny []string `q:"not-tags-any" format:"comma-separated"`
 
 	// Display servers based on their availability zone (Admin only until microversion 2.82).
 	AvailabilityZone string `q:"availability_zone"`

--- a/openstack/identity/v3/projects/requests.go
+++ b/openstack/identity/v3/projects/requests.go
@@ -34,16 +34,16 @@ type ListOpts struct {
 	ParentID string `q:"parent_id"`
 
 	// Tags filters on specific project tags. All tags must be present for the project.
-	Tags string `q:"tags"`
+	Tags []string `q:"tags" format:"comma-separated"`
 
 	// TagsAny filters on specific project tags. At least one of the tags must be present for the project.
-	TagsAny string `q:"tags-any"`
+	TagsAny []string `q:"tags-any" format:"comma-separated"`
 
 	// NotTags filters on specific project tags. All tags must be absent for the project.
-	NotTags string `q:"not-tags"`
+	NotTags []string `q:"not-tags" format:"comma-separated"`
 
 	// NotTagsAny filters on specific project tags. At least one of the tags must be absent for the project.
-	NotTagsAny string `q:"not-tags-any"`
+	NotTagsAny []string `q:"not-tags-any" format:"comma-separated"`
 
 	// Limit limits the number of projects returned per page.
 	Limit int `q:"limit"`

--- a/openstack/networking/v2/extensions/layer3/floatingips/requests.go
+++ b/openstack/networking/v2/extensions/layer3/floatingips/requests.go
@@ -20,25 +20,25 @@ type ListOptsBuilder interface {
 // sort by a particular network attribute. SortDir sets the direction, and is
 // either `asc' or `desc'. Marker and Limit are used for pagination.
 type ListOpts struct {
-	ID                string `q:"id"`
-	Description       string `q:"description"`
-	FloatingNetworkID string `q:"floating_network_id"`
-	PortID            string `q:"port_id"`
-	FixedIP           string `q:"fixed_ip_address"`
-	FloatingIP        string `q:"floating_ip_address"`
-	TenantID          string `q:"tenant_id"`
-	ProjectID         string `q:"project_id"`
-	Limit             int    `q:"limit"`
-	Marker            string `q:"marker"`
-	SortKey           string `q:"sort_key"`
-	SortDir           string `q:"sort_dir"`
-	RouterID          string `q:"router_id"`
-	Status            string `q:"status"`
-	Tags              string `q:"tags"`
-	TagsAny           string `q:"tags-any"`
-	NotTags           string `q:"not-tags"`
-	NotTagsAny        string `q:"not-tags-any"`
-	RevisionNumber    *int   `q:"revision_number"`
+	ID                string   `q:"id"`
+	Description       string   `q:"description"`
+	FloatingNetworkID string   `q:"floating_network_id"`
+	PortID            string   `q:"port_id"`
+	FixedIP           string   `q:"fixed_ip_address"`
+	FloatingIP        string   `q:"floating_ip_address"`
+	TenantID          string   `q:"tenant_id"`
+	ProjectID         string   `q:"project_id"`
+	Limit             int      `q:"limit"`
+	Marker            string   `q:"marker"`
+	SortKey           string   `q:"sort_key"`
+	SortDir           string   `q:"sort_dir"`
+	RouterID          string   `q:"router_id"`
+	Status            string   `q:"status"`
+	Tags              []string `q:"tags" format:"comma-separated"`
+	TagsAny           []string `q:"tags-any" format:"comma-separated"`
+	NotTags           []string `q:"not-tags" format:"comma-separated"`
+	NotTagsAny        []string `q:"not-tags-any" format:"comma-separated"`
+	RevisionNumber    *int     `q:"revision_number"`
 }
 
 // ToNetworkListQuery formats a ListOpts into a query string.

--- a/openstack/networking/v2/extensions/layer3/routers/requests.go
+++ b/openstack/networking/v2/extensions/layer3/routers/requests.go
@@ -20,23 +20,23 @@ type ListOptsBuilder interface {
 // sort by a particular network attribute. SortDir sets the direction, and is
 // either `asc' or `desc'. Marker and Limit are used for pagination.
 type ListOpts struct {
-	ID             string `q:"id"`
-	Name           string `q:"name"`
-	Description    string `q:"description"`
-	AdminStateUp   *bool  `q:"admin_state_up"`
-	Distributed    *bool  `q:"distributed"`
-	Status         string `q:"status"`
-	TenantID       string `q:"tenant_id"`
-	ProjectID      string `q:"project_id"`
-	Limit          int    `q:"limit"`
-	Marker         string `q:"marker"`
-	SortKey        string `q:"sort_key"`
-	SortDir        string `q:"sort_dir"`
-	Tags           string `q:"tags"`
-	TagsAny        string `q:"tags-any"`
-	NotTags        string `q:"not-tags"`
-	NotTagsAny     string `q:"not-tags-any"`
-	RevisionNumber *int   `q:"revision_number"`
+	ID             string   `q:"id"`
+	Name           string   `q:"name"`
+	Description    string   `q:"description"`
+	AdminStateUp   *bool    `q:"admin_state_up"`
+	Distributed    *bool    `q:"distributed"`
+	Status         string   `q:"status"`
+	TenantID       string   `q:"tenant_id"`
+	ProjectID      string   `q:"project_id"`
+	Limit          int      `q:"limit"`
+	Marker         string   `q:"marker"`
+	SortKey        string   `q:"sort_key"`
+	SortDir        string   `q:"sort_dir"`
+	Tags           []string `q:"tags" format:"comma-separated"`
+	TagsAny        []string `q:"tags-any" format:"comma-separated"`
+	NotTags        []string `q:"not-tags" format:"comma-separated"`
+	NotTagsAny     []string `q:"not-tags-any" format:"comma-separated"`
+	RevisionNumber *int     `q:"revision_number"`
 }
 
 // ToRouterListQuery formats a ListOpts into a query string.

--- a/openstack/networking/v2/extensions/qos/policies/requests.go
+++ b/openstack/networking/v2/extensions/qos/policies/requests.go
@@ -130,22 +130,22 @@ type PolicyListOptsBuilder interface {
 // SortDir sets the direction, and is either `asc' or `desc'.
 // Marker and Limit are used for the pagination.
 type ListOpts struct {
-	ID             string `q:"id"`
-	TenantID       string `q:"tenant_id"`
-	ProjectID      string `q:"project_id"`
-	Name           string `q:"name"`
-	Description    string `q:"description"`
-	IsDefault      *bool  `q:"is_default"`
-	Shared         *bool  `q:"shared"`
-	Limit          int    `q:"limit"`
-	Marker         string `q:"marker"`
-	SortKey        string `q:"sort_key"`
-	SortDir        string `q:"sort_dir"`
-	Tags           string `q:"tags"`
-	TagsAny        string `q:"tags-any"`
-	NotTags        string `q:"not-tags"`
-	NotTagsAny     string `q:"not-tags-any"`
-	RevisionNumber *int   `q:"revision_number"`
+	ID             string   `q:"id"`
+	TenantID       string   `q:"tenant_id"`
+	ProjectID      string   `q:"project_id"`
+	Name           string   `q:"name"`
+	Description    string   `q:"description"`
+	IsDefault      *bool    `q:"is_default"`
+	Shared         *bool    `q:"shared"`
+	Limit          int      `q:"limit"`
+	Marker         string   `q:"marker"`
+	SortKey        string   `q:"sort_key"`
+	SortDir        string   `q:"sort_dir"`
+	Tags           []string `q:"tags" format:"comma-separated"`
+	TagsAny        []string `q:"tags-any" format:"comma-separated"`
+	NotTags        []string `q:"not-tags" format:"comma-separated"`
+	NotTagsAny     []string `q:"not-tags-any" format:"comma-separated"`
+	RevisionNumber *int     `q:"revision_number"`
 }
 
 // ToPolicyListQuery formats a ListOpts into a query string.

--- a/openstack/networking/v2/extensions/qos/rules/requests.go
+++ b/openstack/networking/v2/extensions/qos/rules/requests.go
@@ -20,19 +20,19 @@ type BandwidthLimitRulesListOptsBuilder interface {
 // SortDir sets the direction, and is either `asc' or `desc'.
 // Marker and Limit are used for the pagination.
 type BandwidthLimitRulesListOpts struct {
-	ID           string `q:"id"`
-	TenantID     string `q:"tenant_id"`
-	MaxKBps      int    `q:"max_kbps"`
-	MaxBurstKBps int    `q:"max_burst_kbps"`
-	Direction    string `q:"direction"`
-	Limit        int    `q:"limit"`
-	Marker       string `q:"marker"`
-	SortKey      string `q:"sort_key"`
-	SortDir      string `q:"sort_dir"`
-	Tags         string `q:"tags"`
-	TagsAny      string `q:"tags-any"`
-	NotTags      string `q:"not-tags"`
-	NotTagsAny   string `q:"not-tags-any"`
+	ID           string   `q:"id"`
+	TenantID     string   `q:"tenant_id"`
+	MaxKBps      int      `q:"max_kbps"`
+	MaxBurstKBps int      `q:"max_burst_kbps"`
+	Direction    string   `q:"direction"`
+	Limit        int      `q:"limit"`
+	Marker       string   `q:"marker"`
+	SortKey      string   `q:"sort_key"`
+	SortDir      string   `q:"sort_dir"`
+	Tags         []string `q:"tags" format:"comma-separated"`
+	TagsAny      []string `q:"tags-any" format:"comma-separated"`
+	NotTags      []string `q:"not-tags" format:"comma-separated"`
+	NotTagsAny   []string `q:"not-tags-any" format:"comma-separated"`
 }
 
 // ToBandwidthLimitRulesListQuery formats a ListOpts into a query string.
@@ -160,17 +160,17 @@ type DSCPMarkingRulesListOptsBuilder interface {
 // SortDir sets the direction, and is either `asc' or `desc'.
 // Marker and Limit are used for the pagination.
 type DSCPMarkingRulesListOpts struct {
-	ID         string `q:"id"`
-	TenantID   string `q:"tenant_id"`
-	DSCPMark   int    `q:"dscp_mark"`
-	Limit      int    `q:"limit"`
-	Marker     string `q:"marker"`
-	SortKey    string `q:"sort_key"`
-	SortDir    string `q:"sort_dir"`
-	Tags       string `q:"tags"`
-	TagsAny    string `q:"tags-any"`
-	NotTags    string `q:"not-tags"`
-	NotTagsAny string `q:"not-tags-any"`
+	ID         string   `q:"id"`
+	TenantID   string   `q:"tenant_id"`
+	DSCPMark   int      `q:"dscp_mark"`
+	Limit      int      `q:"limit"`
+	Marker     string   `q:"marker"`
+	SortKey    string   `q:"sort_key"`
+	SortDir    string   `q:"sort_dir"`
+	Tags       []string `q:"tags" format:"comma-separated"`
+	TagsAny    []string `q:"tags-any" format:"comma-separated"`
+	NotTags    []string `q:"not-tags" format:"comma-separated"`
+	NotTagsAny []string `q:"not-tags-any" format:"comma-separated"`
 }
 
 // ToDSCPMarkingRulesListQuery formats a ListOpts into a query string.
@@ -286,18 +286,18 @@ type MinimumBandwidthRulesListOptsBuilder interface {
 // SortDir sets the direction, and is either `asc' or `desc'.
 // Marker and Limit are used for the pagination.
 type MinimumBandwidthRulesListOpts struct {
-	ID         string `q:"id"`
-	TenantID   string `q:"tenant_id"`
-	MinKBps    int    `q:"min_kbps"`
-	Direction  string `q:"direction"`
-	Limit      int    `q:"limit"`
-	Marker     string `q:"marker"`
-	SortKey    string `q:"sort_key"`
-	SortDir    string `q:"sort_dir"`
-	Tags       string `q:"tags"`
-	TagsAny    string `q:"tags-any"`
-	NotTags    string `q:"not-tags"`
-	NotTagsAny string `q:"not-tags-any"`
+	ID         string   `q:"id"`
+	TenantID   string   `q:"tenant_id"`
+	MinKBps    int      `q:"min_kbps"`
+	Direction  string   `q:"direction"`
+	Limit      int      `q:"limit"`
+	Marker     string   `q:"marker"`
+	SortKey    string   `q:"sort_key"`
+	SortDir    string   `q:"sort_dir"`
+	Tags       []string `q:"tags" format:"comma-separated"`
+	TagsAny    []string `q:"tags-any" format:"comma-separated"`
+	NotTags    []string `q:"not-tags" format:"comma-separated"`
+	NotTagsAny []string `q:"not-tags-any" format:"comma-separated"`
 }
 
 // ToMinimumBandwidthRulesListQuery formats a ListOpts into a query string.

--- a/openstack/networking/v2/extensions/rbacpolicies/requests.go
+++ b/openstack/networking/v2/extensions/rbacpolicies/requests.go
@@ -29,10 +29,10 @@ type ListOpts struct {
 	Limit        int          `q:"limit"`
 	SortKey      string       `q:"sort_key"`
 	SortDir      string       `q:"sort_dir"`
-	Tags         string       `q:"tags"`
-	TagsAny      string       `q:"tags-any"`
-	NotTags      string       `q:"not-tags"`
-	NotTagsAny   string       `q:"not-tags-any"`
+	Tags         []string     `q:"tags" format:"comma-separated"`
+	TagsAny      []string     `q:"tags-any" format:"comma-separated"`
+	NotTags      []string     `q:"not-tags" format:"comma-separated"`
+	NotTagsAny   []string     `q:"not-tags-any" format:"comma-separated"`
 }
 
 // ToRBACPolicyListQuery formats a ListOpts into a query string.

--- a/openstack/networking/v2/extensions/security/groups/requests.go
+++ b/openstack/networking/v2/extensions/security/groups/requests.go
@@ -20,21 +20,21 @@ type ListOptsBuilder interface {
 // sort by a particular network attribute. SortDir sets the direction, and is
 // either `asc' or `desc'. Marker and Limit are used for pagination.
 type ListOpts struct {
-	ID             string `q:"id"`
-	Name           string `q:"name"`
-	Description    string `q:"description"`
-	Stateful       *bool  `q:"stateful"`
-	TenantID       string `q:"tenant_id"`
-	ProjectID      string `q:"project_id"`
-	Limit          int    `q:"limit"`
-	Marker         string `q:"marker"`
-	SortKey        string `q:"sort_key"`
-	SortDir        string `q:"sort_dir"`
-	Tags           string `q:"tags"`
-	TagsAny        string `q:"tags-any"`
-	NotTags        string `q:"not-tags"`
-	NotTagsAny     string `q:"not-tags-any"`
-	RevisionNumber *int   `q:"revision_number"`
+	ID             string   `q:"id"`
+	Name           string   `q:"name"`
+	Description    string   `q:"description"`
+	Stateful       *bool    `q:"stateful"`
+	TenantID       string   `q:"tenant_id"`
+	ProjectID      string   `q:"project_id"`
+	Limit          int      `q:"limit"`
+	Marker         string   `q:"marker"`
+	SortKey        string   `q:"sort_key"`
+	SortDir        string   `q:"sort_dir"`
+	Tags           []string `q:"tags" format:"comma-separated"`
+	TagsAny        []string `q:"tags-any" format:"comma-separated"`
+	NotTags        []string `q:"not-tags" format:"comma-separated"`
+	NotTagsAny     []string `q:"not-tags-any" format:"comma-separated"`
+	RevisionNumber *int     `q:"revision_number"`
 }
 
 // ToPortListQuery formats a ListOpts into a query string.

--- a/openstack/networking/v2/extensions/subnetpools/requests.go
+++ b/openstack/networking/v2/extensions/subnetpools/requests.go
@@ -21,27 +21,27 @@ type ListOptsBuilder interface {
 // SortDir sets the direction, and is either `asc' or `desc'.
 // Marker and Limit are used for the pagination.
 type ListOpts struct {
-	ID               string `q:"id"`
-	Name             string `q:"name"`
-	DefaultQuota     int    `q:"default_quota"`
-	TenantID         string `q:"tenant_id"`
-	ProjectID        string `q:"project_id"`
-	DefaultPrefixLen int    `q:"default_prefixlen"`
-	MinPrefixLen     int    `q:"min_prefixlen"`
-	MaxPrefixLen     int    `q:"max_prefixlen"`
-	AddressScopeID   string `q:"address_scope_id"`
-	IPVersion        int    `q:"ip_version"`
-	Shared           *bool  `q:"shared"`
-	Description      string `q:"description"`
-	IsDefault        *bool  `q:"is_default"`
-	Limit            int    `q:"limit"`
-	Marker           string `q:"marker"`
-	SortKey          string `q:"sort_key"`
-	SortDir          string `q:"sort_dir"`
-	Tags             string `q:"tags"`
-	TagsAny          string `q:"tags-any"`
-	NotTags          string `q:"not-tags"`
-	NotTagsAny       string `q:"not-tags-any"`
+	ID               string   `q:"id"`
+	Name             string   `q:"name"`
+	DefaultQuota     int      `q:"default_quota"`
+	TenantID         string   `q:"tenant_id"`
+	ProjectID        string   `q:"project_id"`
+	DefaultPrefixLen int      `q:"default_prefixlen"`
+	MinPrefixLen     int      `q:"min_prefixlen"`
+	MaxPrefixLen     int      `q:"max_prefixlen"`
+	AddressScopeID   string   `q:"address_scope_id"`
+	IPVersion        int      `q:"ip_version"`
+	Shared           *bool    `q:"shared"`
+	Description      string   `q:"description"`
+	IsDefault        *bool    `q:"is_default"`
+	Limit            int      `q:"limit"`
+	Marker           string   `q:"marker"`
+	SortKey          string   `q:"sort_key"`
+	SortDir          string   `q:"sort_dir"`
+	Tags             []string `q:"tags" format:"comma-separated"`
+	TagsAny          []string `q:"tags-any" format:"comma-separated"`
+	NotTags          []string `q:"not-tags" format:"comma-separated"`
+	NotTagsAny       []string `q:"not-tags-any" format:"comma-separated"`
 	// type int does not allow to filter with revision_number=0
 	RevisionNumber int `q:"revision_number"`
 }

--- a/openstack/networking/v2/extensions/trunks/requests.go
+++ b/openstack/networking/v2/extensions/trunks/requests.go
@@ -64,22 +64,21 @@ type ListOptsBuilder interface {
 // by a particular trunk attribute. SortDir sets the direction, and is either
 // `asc' or `desc'. Marker and Limit are used for pagination.
 type ListOpts struct {
-	AdminStateUp *bool    `q:"admin_state_up"`
-	Description  string   `q:"description"`
-	ID           string   `q:"id"`
-	Name         string   `q:"name"`
-	PortID       string   `q:"port_id"`
-	Status       string   `q:"status"`
-	TenantID     string   `q:"tenant_id"`
-	ProjectID    string   `q:"project_id"`
-	SortDir      string   `q:"sort_dir"`
-	SortKey      string   `q:"sort_key"`
-	Tags         []string `q:"tags" format:"comma-separated"`
-	TagsAny      []string `q:"tags-any" format:"comma-separated"`
-	NotTags      []string `q:"not-tags" format:"comma-separated"`
-	NotTagsAny   []string `q:"not-tags-any" format:"comma-separated"`
-	// TODO change type to *int for consistency
-	RevisionNumber string `q:"revision_number"`
+	AdminStateUp   *bool    `q:"admin_state_up"`
+	Description    string   `q:"description"`
+	ID             string   `q:"id"`
+	Name           string   `q:"name"`
+	PortID         string   `q:"port_id"`
+	Status         string   `q:"status"`
+	TenantID       string   `q:"tenant_id"`
+	ProjectID      string   `q:"project_id"`
+	SortDir        string   `q:"sort_dir"`
+	SortKey        string   `q:"sort_key"`
+	Tags           []string `q:"tags" format:"comma-separated"`
+	TagsAny        []string `q:"tags-any" format:"comma-separated"`
+	NotTags        []string `q:"not-tags" format:"comma-separated"`
+	NotTagsAny     []string `q:"not-tags-any" format:"comma-separated"`
+	RevisionNumber *int     `q:"revision_number"`
 }
 
 // ToTrunkListQuery formats a ListOpts into a query string.

--- a/openstack/networking/v2/extensions/trunks/requests.go
+++ b/openstack/networking/v2/extensions/trunks/requests.go
@@ -64,20 +64,20 @@ type ListOptsBuilder interface {
 // by a particular trunk attribute. SortDir sets the direction, and is either
 // `asc' or `desc'. Marker and Limit are used for pagination.
 type ListOpts struct {
-	AdminStateUp *bool  `q:"admin_state_up"`
-	Description  string `q:"description"`
-	ID           string `q:"id"`
-	Name         string `q:"name"`
-	PortID       string `q:"port_id"`
-	Status       string `q:"status"`
-	TenantID     string `q:"tenant_id"`
-	ProjectID    string `q:"project_id"`
-	SortDir      string `q:"sort_dir"`
-	SortKey      string `q:"sort_key"`
-	Tags         string `q:"tags"`
-	TagsAny      string `q:"tags-any"`
-	NotTags      string `q:"not-tags"`
-	NotTagsAny   string `q:"not-tags-any"`
+	AdminStateUp *bool    `q:"admin_state_up"`
+	Description  string   `q:"description"`
+	ID           string   `q:"id"`
+	Name         string   `q:"name"`
+	PortID       string   `q:"port_id"`
+	Status       string   `q:"status"`
+	TenantID     string   `q:"tenant_id"`
+	ProjectID    string   `q:"project_id"`
+	SortDir      string   `q:"sort_dir"`
+	SortKey      string   `q:"sort_key"`
+	Tags         []string `q:"tags" format:"comma-separated"`
+	TagsAny      []string `q:"tags-any" format:"comma-separated"`
+	NotTags      []string `q:"not-tags" format:"comma-separated"`
+	NotTagsAny   []string `q:"not-tags-any" format:"comma-separated"`
 	// TODO change type to *int for consistency
 	RevisionNumber string `q:"revision_number"`
 }

--- a/openstack/networking/v2/networks/requests.go
+++ b/openstack/networking/v2/networks/requests.go
@@ -20,23 +20,23 @@ type ListOptsBuilder interface {
 // by a particular network attribute. SortDir sets the direction, and is either
 // `asc' or `desc'. Marker and Limit are used for pagination.
 type ListOpts struct {
-	Status         string `q:"status"`
-	Name           string `q:"name"`
-	Description    string `q:"description"`
-	AdminStateUp   *bool  `q:"admin_state_up"`
-	TenantID       string `q:"tenant_id"`
-	ProjectID      string `q:"project_id"`
-	Shared         *bool  `q:"shared"`
-	ID             string `q:"id"`
-	Marker         string `q:"marker"`
-	Limit          int    `q:"limit"`
-	SortKey        string `q:"sort_key"`
-	SortDir        string `q:"sort_dir"`
-	Tags           string `q:"tags"`
-	TagsAny        string `q:"tags-any"`
-	NotTags        string `q:"not-tags"`
-	NotTagsAny     string `q:"not-tags-any"`
-	RevisionNumber *int   `q:"revision_number"`
+	Status         string   `q:"status"`
+	Name           string   `q:"name"`
+	Description    string   `q:"description"`
+	AdminStateUp   *bool    `q:"admin_state_up"`
+	TenantID       string   `q:"tenant_id"`
+	ProjectID      string   `q:"project_id"`
+	Shared         *bool    `q:"shared"`
+	ID             string   `q:"id"`
+	Marker         string   `q:"marker"`
+	Limit          int      `q:"limit"`
+	SortKey        string   `q:"sort_key"`
+	SortDir        string   `q:"sort_dir"`
+	Tags           []string `q:"tags" format:"comma-separated"`
+	TagsAny        []string `q:"tags-any" format:"comma-separated"`
+	NotTags        []string `q:"not-tags" format:"comma-separated"`
+	NotTagsAny     []string `q:"not-tags-any" format:"comma-separated"`
+	RevisionNumber *int     `q:"revision_number"`
 }
 
 // ToNetworkListQuery formats a ListOpts into a query string.

--- a/openstack/networking/v2/ports/requests.go
+++ b/openstack/networking/v2/ports/requests.go
@@ -37,10 +37,10 @@ type ListOpts struct {
 	Marker         string   `q:"marker"`
 	SortKey        string   `q:"sort_key"`
 	SortDir        string   `q:"sort_dir"`
-	Tags           string   `q:"tags"`
-	TagsAny        string   `q:"tags-any"`
-	NotTags        string   `q:"not-tags"`
-	NotTagsAny     string   `q:"not-tags-any"`
+	Tags           []string `q:"tags" format:"comma-separated"`
+	TagsAny        []string `q:"tags-any" format:"comma-separated"`
+	NotTags        []string `q:"not-tags" format:"comma-separated"`
+	NotTagsAny     []string `q:"not-tags-any" format:"comma-separated"`
 	RevisionNumber *int     `q:"revision_number"`
 	SecurityGroups []string `q:"security_groups"`
 	FixedIPs       []FixedIPOpts

--- a/openstack/networking/v2/subnets/requests.go
+++ b/openstack/networking/v2/subnets/requests.go
@@ -20,30 +20,30 @@ type ListOptsBuilder interface {
 // by a particular subnet attribute. SortDir sets the direction, and is either
 // `asc' or `desc'. Marker and Limit are used for pagination.
 type ListOpts struct {
-	Name              string `q:"name"`
-	Description       string `q:"description"`
-	DNSPublishFixedIP *bool  `q:"dns_publish_fixed_ip"`
-	EnableDHCP        *bool  `q:"enable_dhcp"`
-	NetworkID         string `q:"network_id"`
-	TenantID          string `q:"tenant_id"`
-	ProjectID         string `q:"project_id"`
-	IPVersion         int    `q:"ip_version"`
-	GatewayIP         string `q:"gateway_ip"`
-	CIDR              string `q:"cidr"`
-	IPv6AddressMode   string `q:"ipv6_address_mode"`
-	IPv6RAMode        string `q:"ipv6_ra_mode"`
-	ID                string `q:"id"`
-	SubnetPoolID      string `q:"subnetpool_id"`
-	Limit             int    `q:"limit"`
-	Marker            string `q:"marker"`
-	SortKey           string `q:"sort_key"`
-	SortDir           string `q:"sort_dir"`
-	Tags              string `q:"tags"`
-	TagsAny           string `q:"tags-any"`
-	NotTags           string `q:"not-tags"`
-	NotTagsAny        string `q:"not-tags-any"`
-	RevisionNumber    *int   `q:"revision_number"`
-	SegmentID         string `q:"segment_id"`
+	Name              string   `q:"name"`
+	Description       string   `q:"description"`
+	DNSPublishFixedIP *bool    `q:"dns_publish_fixed_ip"`
+	EnableDHCP        *bool    `q:"enable_dhcp"`
+	NetworkID         string   `q:"network_id"`
+	TenantID          string   `q:"tenant_id"`
+	ProjectID         string   `q:"project_id"`
+	IPVersion         int      `q:"ip_version"`
+	GatewayIP         string   `q:"gateway_ip"`
+	CIDR              string   `q:"cidr"`
+	IPv6AddressMode   string   `q:"ipv6_address_mode"`
+	IPv6RAMode        string   `q:"ipv6_ra_mode"`
+	ID                string   `q:"id"`
+	SubnetPoolID      string   `q:"subnetpool_id"`
+	Limit             int      `q:"limit"`
+	Marker            string   `q:"marker"`
+	SortKey           string   `q:"sort_key"`
+	SortDir           string   `q:"sort_dir"`
+	Tags              []string `q:"tags" format:"comma-separated"`
+	TagsAny           []string `q:"tags-any" format:"comma-separated"`
+	NotTags           []string `q:"not-tags" format:"comma-separated"`
+	NotTagsAny        []string `q:"not-tags-any" format:"comma-separated"`
+	RevisionNumber    *int     `q:"revision_number"`
+	SegmentID         string   `q:"segment_id"`
 }
 
 // ToSubnetListQuery formats a ListOpts into a query string.


### PR DESCRIPTION
This was already done for the loadbalancer service. Do it for other services.

This is a breaking change that should not be backported to v2. While here, we also fix a TODO with another filter.
