### PR TITLE
feat: support for updating and deleting share access rule metadata

### DIFF
--- a/internal/acceptance/openstack/sharedfilesystems/v2/shareaccessrules.go
+++ b/internal/acceptance/openstack/sharedfilesystems/v2/shareaccessrules.go
@@ -33,6 +33,7 @@ func AccessRightToShareAccess(accessRight *shares.AccessRight) *shareaccessrules
 		AccessLevel: accessRight.AccessLevel,
 		State:       accessRight.State,
 		ID:          accessRight.ID,
+		Metadata:    accessRight.Metadata,
 	}
 }
 

--- a/internal/acceptance/openstack/sharedfilesystems/v2/shareaccessrules_test.go
+++ b/internal/acceptance/openstack/sharedfilesystems/v2/shareaccessrules_test.go
@@ -132,7 +132,7 @@ func TestShareAccessRulesMetadata(t *testing.T) {
 		t.Fatalf("Unable to grant access to share %s: %v", share.ID, err)
 	}
 
-	th.AssertDeepEquals(t, map[string]any{"key1": "value1"}, addedAccessRight.Metadata)
+	th.AssertDeepEquals(t, map[string]string{"key1": "value1"}, addedAccessRight.Metadata)
 
 	addedShareAccess := AccessRightToShareAccess(addedAccessRight)
 
@@ -162,7 +162,7 @@ func TestShareAccessRulesMetadata(t *testing.T) {
 
 	// key1 was set at creation time and must still be present; key2 was
 	// added via UpdateMetadata, which only touches the keys it is given.
-	th.AssertDeepEquals(t, map[string]any{"key1": "value1", "key2": "value2"}, accessRule.Metadata)
+	th.AssertDeepEquals(t, map[string]string{"key1": "value1", "key2": "value2"}, accessRule.Metadata)
 
 	err = shareaccessrules.DeleteMetadatum(context.TODO(), client, addedAccessRight.ID, "key1").ExtractErr()
 	if err != nil {
@@ -174,5 +174,5 @@ func TestShareAccessRulesMetadata(t *testing.T) {
 		t.Fatalf("Unable to get share access rule for share %s: %v", share.ID, err)
 	}
 
-	th.AssertDeepEquals(t, map[string]any{"key2": "value2"}, accessRule.Metadata)
+	th.AssertDeepEquals(t, map[string]string{"key2": "value2"}, accessRule.Metadata)
 }

--- a/internal/acceptance/openstack/sharedfilesystems/v2/shareaccessrules_test.go
+++ b/internal/acceptance/openstack/sharedfilesystems/v2/shareaccessrules_test.go
@@ -3,10 +3,13 @@
 package v2
 
 import (
+	"context"
 	"testing"
 
 	"github.com/gophercloud/gophercloud/v2/internal/acceptance/clients"
 	"github.com/gophercloud/gophercloud/v2/internal/acceptance/tools"
+	"github.com/gophercloud/gophercloud/v2/openstack/sharedfilesystems/v2/shareaccessrules"
+	"github.com/gophercloud/gophercloud/v2/openstack/sharedfilesystems/v2/shares"
 	th "github.com/gophercloud/gophercloud/v2/testhelper"
 )
 
@@ -99,4 +102,77 @@ func TestShareAccessRulesList(t *testing.T) {
 	th.AssertEquals(t, addedShareAccess.AccessTo, accessRule.AccessTo)
 	th.AssertEquals(t, addedShareAccess.AccessKey, accessRule.AccessKey)
 	th.AssertEquals(t, addedShareAccess.State, accessRule.State)
+}
+
+func TestShareAccessRulesMetadata(t *testing.T) {
+	client, err := clients.NewSharedFileSystemV2Client()
+	if err != nil {
+		t.Fatalf("Unable to create a shared file system client: %v", err)
+	}
+
+	// Access rule metadata requires microversion 2.45 or later.
+	client.Microversion = "2.45"
+
+	share, err := CreateShare(t, client)
+	if err != nil {
+		t.Fatalf("Unable to create a share: %v", err)
+	}
+
+	defer DeleteShare(t, client, share)
+
+	addedAccessRight, err := shares.GrantAccess(context.TODO(), client, share.ID, shares.GrantAccessOpts{
+		AccessType:  "ip",
+		AccessTo:    "0.0.0.0/32",
+		AccessLevel: "ro",
+		Metadata: map[string]string{
+			"key1": "value1",
+		},
+	}).Extract()
+	if err != nil {
+		t.Fatalf("Unable to grant access to share %s: %v", share.ID, err)
+	}
+
+	th.AssertDeepEquals(t, map[string]any{"key1": "value1"}, addedAccessRight.Metadata)
+
+	addedShareAccess := AccessRightToShareAccess(addedAccessRight)
+
+	if err = WaitForShareAccessRule(t, client, addedShareAccess, "active"); err != nil {
+		t.Fatalf("Unable to wait for share access rule to achieve 'active' state: %v", err)
+	}
+
+	tools.PrintResource(t, addedAccessRight)
+
+	updated, err := shareaccessrules.UpdateMetadata(context.TODO(), client, addedAccessRight.ID, shareaccessrules.UpdateMetadataOpts{
+		Metadata: map[string]string{
+			"key2": "value2",
+		},
+	}).Extract()
+	if err != nil {
+		t.Fatalf("Unable to update metadata for share access rule %s: %v", addedAccessRight.ID, err)
+	}
+
+	th.AssertDeepEquals(t, map[string]string{"key2": "value2"}, updated)
+
+	accessRule, err := ShareAccessRuleGet(t, client, addedAccessRight.ID)
+	if err != nil {
+		t.Fatalf("Unable to get share access rule for share %s: %v", share.ID, err)
+	}
+
+	tools.PrintResource(t, accessRule)
+
+	// key1 was set at creation time and must still be present; key2 was
+	// added via UpdateMetadata, which only touches the keys it is given.
+	th.AssertDeepEquals(t, map[string]any{"key1": "value1", "key2": "value2"}, accessRule.Metadata)
+
+	err = shareaccessrules.DeleteMetadatum(context.TODO(), client, addedAccessRight.ID, "key1").ExtractErr()
+	if err != nil {
+		t.Fatalf("Unable to delete metadatum for share access rule %s: %v", addedAccessRight.ID, err)
+	}
+
+	accessRule, err = ShareAccessRuleGet(t, client, addedAccessRight.ID)
+	if err != nil {
+		t.Fatalf("Unable to get share access rule for share %s: %v", share.ID, err)
+	}
+
+	th.AssertDeepEquals(t, map[string]any{"key2": "value2"}, accessRule.Metadata)
 }

--- a/openstack/sharedfilesystems/v2/shareaccessrules/requests.go
+++ b/openstack/sharedfilesystems/v2/shareaccessrules/requests.go
@@ -19,3 +19,56 @@ func List(ctx context.Context, client *gophercloud.ServiceClient, shareID string
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
+
+// UpdateMetadataOptsBuilder allows extensions to add additional parameters to the
+// UpdateMetadata request.
+type UpdateMetadataOptsBuilder interface {
+	ToUpdateMetadataMap() (map[string]any, error)
+}
+
+// UpdateMetadataOpts contains options for updating share access rule metadata.
+// For more information about these parameters, please, refer to the shared file systems API v2,
+// Share access rule metadata, Update share access rule metadata documentation.
+type UpdateMetadataOpts struct {
+	// One or more access rule metadata key and value pairs as a dictionary of strings.
+	Metadata map[string]string `json:"metadata"`
+}
+
+// ToUpdateMetadataMap assembles a request body based on the contents of an
+// UpdateMetadataOpts.
+func (opts UpdateMetadataOpts) ToUpdateMetadataMap() (map[string]any, error) {
+	return gophercloud.BuildRequestBody(opts, "")
+}
+
+// UpdateMetadata updates the metadata of the specified share access rule.
+// Existing metadata items that are not present in the request are left
+// untouched; items present in the request are created or overwritten.
+// To extract the updated metadata from the response, call the Extract
+// method on the MetadataResult.
+// Client must have Microversion set; minimum supported microversion for
+// UpdateMetadata is 2.45.
+func UpdateMetadata(ctx context.Context, client *gophercloud.ServiceClient, accessID string, opts UpdateMetadataOptsBuilder) (r MetadataResult) {
+	b, err := opts.ToUpdateMetadataMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	resp, err := client.Put(ctx, metadataURL(client, accessID), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// DeleteMetadatum deletes a single key-value pair from the metadata of the
+// specified share access rule.
+// Client must have Microversion set; minimum supported microversion for
+// DeleteMetadatum is 2.45.
+func DeleteMetadatum(ctx context.Context, client *gophercloud.ServiceClient, accessID, key string) (r DeleteMetadatumResult) {
+	resp, err := client.Delete(ctx, metadatumURL(client, accessID, key), &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}

--- a/openstack/sharedfilesystems/v2/shareaccessrules/results.go
+++ b/openstack/sharedfilesystems/v2/shareaccessrules/results.go
@@ -28,7 +28,7 @@ type ShareAccess struct {
 	// The access rule ID.
 	ID string `json:"id"`
 	// Access rule metadata.
-	Metadata map[string]any `json:"metadata"`
+	Metadata map[string]string `json:"metadata"`
 }
 
 func (r *ShareAccess) UnmarshalJSON(b []byte) error {

--- a/openstack/sharedfilesystems/v2/shareaccessrules/results.go
+++ b/openstack/sharedfilesystems/v2/shareaccessrules/results.go
@@ -76,3 +76,22 @@ func (r ListResult) Extract() ([]ShareAccess, error) {
 	err := r.ExtractInto(&s)
 	return s.AccessList, err
 }
+
+// MetadataResult contains the response body and error from an UpdateMetadata request.
+type MetadataResult struct {
+	gophercloud.Result
+}
+
+// Extract will get the string-string map from MetadataResult.
+func (r MetadataResult) Extract() (map[string]string, error) {
+	var s struct {
+		Metadata map[string]string `json:"metadata"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Metadata, err
+}
+
+// DeleteMetadatumResult contains the response body and error from a DeleteMetadatum request.
+type DeleteMetadatumResult struct {
+	gophercloud.ErrResult
+}

--- a/openstack/sharedfilesystems/v2/shareaccessrules/testing/fixtures_test.go
+++ b/openstack/sharedfilesystems/v2/shareaccessrules/testing/fixtures_test.go
@@ -76,3 +76,40 @@ var listResponse = `{
         }
     ]
 }`
+
+var updateMetadataRequest = `{
+    "metadata": {
+        "key1": "value1",
+        "key2": "value2"
+    }
+}`
+
+var updateMetadataResponse = `{
+    "metadata": {
+        "key1": "value1",
+        "key2": "value2"
+    }
+}`
+
+// MockUpdateMetadataResponse creates a mock update share access rule metadata response
+func MockUpdateMetadataResponse(t *testing.T, fakeServer th.FakeServer) {
+	fakeServer.Mux.HandleFunc(shareAccessRulesEndpoint+"/"+shareAccessRuleID+"/metadata", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, updateMetadataRequest)
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, updateMetadataResponse)
+	})
+}
+
+// MockDeleteMetadatumResponse creates a mock delete share access rule metadatum response
+func MockDeleteMetadatumResponse(t *testing.T, fakeServer th.FakeServer, key string) {
+	fakeServer.Mux.HandleFunc(shareAccessRulesEndpoint+"/"+shareAccessRuleID+"/metadata/"+key, func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		w.WriteHeader(http.StatusOK)
+	})
+}

--- a/openstack/sharedfilesystems/v2/shareaccessrules/testing/requests_test.go
+++ b/openstack/sharedfilesystems/v2/shareaccessrules/testing/requests_test.go
@@ -51,3 +51,44 @@ func MockListResponse(t *testing.T, fakeServer th.FakeServer) {
 		fmt.Fprint(w, listResponse)
 	})
 }
+
+func TestUpdateMetadataSuccess(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	MockUpdateMetadataResponse(t, fakeServer)
+
+	c := client.ServiceClient(fakeServer)
+	// Client c must have Microversion set; minimum supported microversion for
+	// access rule metadata is 2.45
+	c.Microversion = "2.45"
+
+	opts := shareaccessrules.UpdateMetadataOpts{
+		Metadata: map[string]string{
+			"key1": "value1",
+			"key2": "value2",
+		},
+	}
+
+	actual, err := shareaccessrules.UpdateMetadata(context.TODO(), c, shareAccessRuleID, opts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, map[string]string{
+		"key1": "value1",
+		"key2": "value2",
+	}, actual)
+}
+
+func TestDeleteMetadatumSuccess(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	MockDeleteMetadatumResponse(t, fakeServer, "key1")
+
+	c := client.ServiceClient(fakeServer)
+	// Client c must have Microversion set; minimum supported microversion for
+	// access rule metadata is 2.45
+	c.Microversion = "2.45"
+
+	err := shareaccessrules.DeleteMetadatum(context.TODO(), c, shareAccessRuleID, "key1").ExtractErr()
+	th.AssertNoErr(t, err)
+}

--- a/openstack/sharedfilesystems/v2/shareaccessrules/testing/requests_test.go
+++ b/openstack/sharedfilesystems/v2/shareaccessrules/testing/requests_test.go
@@ -34,7 +34,7 @@ func TestGet(t *testing.T) {
 		State:       "error",
 		AccessLevel: "rw",
 		ID:          "507bf114-36f2-4f56-8cf4-857985ca87c1",
-		Metadata: map[string]any{
+		Metadata: map[string]string{
 			"key1": "value1",
 			"key2": "value2",
 		},

--- a/openstack/sharedfilesystems/v2/shareaccessrules/urls.go
+++ b/openstack/sharedfilesystems/v2/shareaccessrules/urls.go
@@ -15,3 +15,11 @@ func getURL(c *gophercloud.ServiceClient, accessID string) string {
 func listURL(c *gophercloud.ServiceClient, shareID string) string {
 	return fmt.Sprintf("%s?share_id=%s", c.ServiceURL(shareAccessRulesEndpoint), shareID)
 }
+
+func metadataURL(c *gophercloud.ServiceClient, accessID string) string {
+	return c.ServiceURL(shareAccessRulesEndpoint, accessID, "metadata")
+}
+
+func metadatumURL(c *gophercloud.ServiceClient, accessID, key string) string {
+	return c.ServiceURL(shareAccessRulesEndpoint, accessID, "metadata", key)
+}

--- a/openstack/sharedfilesystems/v2/shares/requests.go
+++ b/openstack/sharedfilesystems/v2/shares/requests.go
@@ -232,6 +232,10 @@ type GrantAccessOpts struct {
 	AccessTo string `json:"access_to"`
 	// The access level to the share is either "rw" or "ro".
 	AccessLevel string `json:"access_level"`
+	// One or more access rule metadata key and value pairs as a dictionary of strings.
+	//
+	// Requires microversion 2.45 or later.
+	Metadata map[string]string `json:"metadata,omitempty"`
 }
 
 // ToGrantAccessMap assembles a request body based on the contents of a

--- a/openstack/sharedfilesystems/v2/shares/requests.go
+++ b/openstack/sharedfilesystems/v2/shares/requests.go
@@ -233,7 +233,6 @@ type GrantAccessOpts struct {
 	// The access level to the share is either "rw" or "ro".
 	AccessLevel string `json:"access_level"`
 	// One or more access rule metadata key and value pairs as a dictionary of strings.
-	//
 	// Requires microversion 2.45 or later.
 	Metadata map[string]string `json:"metadata,omitempty"`
 }

--- a/openstack/sharedfilesystems/v2/shares/results.go
+++ b/openstack/sharedfilesystems/v2/shares/results.go
@@ -284,7 +284,7 @@ type AccessRight struct {
 	// Access rule metadata.
 	//
 	// Requires microversion 2.45 or later.
-	Metadata map[string]any `json:"metadata,omitempty"`
+	Metadata map[string]string `json:"metadata,omitempty"`
 }
 
 // Extract will get the GrantAccess object from the commonResult

--- a/openstack/sharedfilesystems/v2/shares/results.go
+++ b/openstack/sharedfilesystems/v2/shares/results.go
@@ -282,7 +282,6 @@ type AccessRight struct {
 	// The access rule ID.
 	ID string `json:"id"`
 	// Access rule metadata.
-	//
 	// Requires microversion 2.45 or later.
 	Metadata map[string]string `json:"metadata,omitempty"`
 }

--- a/openstack/sharedfilesystems/v2/shares/results.go
+++ b/openstack/sharedfilesystems/v2/shares/results.go
@@ -281,6 +281,10 @@ type AccessRight struct {
 	State string `json:"state,omitempty"`
 	// The access rule ID.
 	ID string `json:"id"`
+	// Access rule metadata.
+	//
+	// Requires microversion 2.45 or later.
+	Metadata map[string]any `json:"metadata,omitempty"`
 }
 
 // Extract will get the GrantAccess object from the commonResult

--- a/openstack/sharedfilesystems/v2/shares/testing/fixtures_test.go
+++ b/openstack/sharedfilesystems/v2/shares/testing/fixtures_test.go
@@ -363,6 +363,49 @@ func MockGrantAccessResponse(t *testing.T, fakeServer th.FakeServer) {
 	})
 }
 
+var grantAccessWithMetadataRequest = `{
+		"allow_access": {
+			"access_type": "ip",
+			"access_to": "0.0.0.0/0",
+			"access_level": "rw",
+			"metadata": {
+				"key1": "value1",
+				"key2": "value2"
+			}
+		}
+	}`
+
+var grantAccessWithMetadataResponse = `{
+    "access": {
+	"share_id": "011d21e2-fbc3-4e4a-9993-9ea223f73264",
+	"access_type": "ip",
+	"access_to": "0.0.0.0/0",
+	"access_key": "",
+	"access_level": "rw",
+	"state": "new",
+	"id": "a2f226a5-cee8-430b-8a03-78a59bd84ee8",
+	"metadata": {
+		"key1": "value1",
+		"key2": "value2"
+	}
+    }
+}`
+
+// MockGrantAccessWithMetadataResponse creates a mock grant access response
+// where the request and response both include access rule metadata.
+func MockGrantAccessWithMetadataResponse(t *testing.T, fakeServer th.FakeServer) {
+	fakeServer.Mux.HandleFunc(shareEndpoint+"/"+shareID+"/action", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, grantAccessWithMetadataRequest)
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, grantAccessWithMetadataResponse)
+	})
+}
+
 var revokeAccessRequest = `{
 	"deny_access": {
 		"access_id": "a2f226a5-cee8-430b-8a03-78a59bd84ee8"

--- a/openstack/sharedfilesystems/v2/shares/testing/request_test.go
+++ b/openstack/sharedfilesystems/v2/shares/testing/request_test.go
@@ -249,6 +249,45 @@ func TestGrantAcessSuccess(t *testing.T) {
 	}, s)
 }
 
+func TestGrantAccessWithMetadataSuccess(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	MockGrantAccessWithMetadataResponse(t, fakeServer)
+
+	c := client.ServiceClient(fakeServer)
+	// Client c must have Microversion set; minimum supported microversion for
+	// access rule metadata is 2.45
+	c.Microversion = "2.45"
+
+	grantAccessReq := shares.GrantAccessOpts{
+		AccessType:  "ip",
+		AccessTo:    "0.0.0.0/0",
+		AccessLevel: "rw",
+		Metadata: map[string]string{
+			"key1": "value1",
+			"key2": "value2",
+		},
+	}
+
+	s, err := shares.GrantAccess(context.TODO(), c, shareID, grantAccessReq).Extract()
+
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, &shares.AccessRight{
+		ShareID:     "011d21e2-fbc3-4e4a-9993-9ea223f73264",
+		AccessType:  "ip",
+		AccessTo:    "0.0.0.0/0",
+		AccessKey:   "",
+		AccessLevel: "rw",
+		State:       "new",
+		ID:          "a2f226a5-cee8-430b-8a03-78a59bd84ee8",
+		Metadata: map[string]any{
+			"key1": "value1",
+			"key2": "value2",
+		},
+	}, s)
+}
+
 func TestRevokeAccessSuccess(t *testing.T) {
 	fakeServer := th.SetupHTTP()
 	defer fakeServer.Teardown()

--- a/openstack/sharedfilesystems/v2/shares/testing/request_test.go
+++ b/openstack/sharedfilesystems/v2/shares/testing/request_test.go
@@ -281,7 +281,7 @@ func TestGrantAccessWithMetadataSuccess(t *testing.T) {
 		AccessLevel: "rw",
 		State:       "new",
 		ID:          "a2f226a5-cee8-430b-8a03-78a59bd84ee8",
-		Metadata: map[string]any{
+		Metadata: map[string]string{
 			"key1": "value1",
 			"key2": "value2",
 		},


### PR DESCRIPTION
- Implement UpdateMetadata and DeleteMetadatum functions in shareaccessrules.
- Add corresponding test cases for metadata update and deletion.
- Enhance GrantAccess to include metadata options.
- Update related request and result structures to handle metadata.