### PR TITLE
[v2] CI: improve test assertions

### DIFF
--- a/docs/contributor-tutorial/.template/testing/requests_test.go
+++ b/docs/contributor-tutorial/.template/testing/requests_test.go
@@ -27,7 +27,7 @@ func TestListResources(t *testing.T) {
 		return true, nil
 	})
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, count, 1)
+	th.AssertEquals(t, 1, count)
 }
 
 func TestListResourcesAllPages(t *testing.T) {

--- a/internal/acceptance/openstack/baremetal/httpbasic/allocations_test.go
+++ b/internal/acceptance/openstack/baremetal/httpbasic/allocations_test.go
@@ -43,5 +43,5 @@ func TestAllocationsCreateDestroy(t *testing.T) {
 		return false, nil
 	})
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 }

--- a/internal/acceptance/openstack/baremetal/httpbasic/allocations_test.go
+++ b/internal/acceptance/openstack/baremetal/httpbasic/allocations_test.go
@@ -43,5 +43,5 @@ func TestAllocationsCreateDestroy(t *testing.T) {
 		return false, nil
 	})
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 }

--- a/internal/acceptance/openstack/baremetal/httpbasic/nodes_test.go
+++ b/internal/acceptance/openstack/baremetal/httpbasic/nodes_test.go
@@ -44,7 +44,7 @@ func TestNodesCreateDestroy(t *testing.T) {
 	})
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 }
 
 func TestNodesUpdate(t *testing.T) {
@@ -68,7 +68,7 @@ func TestNodesUpdate(t *testing.T) {
 	}).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, true, updated.Maintenance)
+	th.AssertTrue(t, updated.Maintenance)
 }
 
 func TestNodesRAIDConfig(t *testing.T) {

--- a/internal/acceptance/openstack/baremetal/httpbasic/nodes_test.go
+++ b/internal/acceptance/openstack/baremetal/httpbasic/nodes_test.go
@@ -44,7 +44,7 @@ func TestNodesCreateDestroy(t *testing.T) {
 	})
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 }
 
 func TestNodesUpdate(t *testing.T) {
@@ -68,7 +68,7 @@ func TestNodesUpdate(t *testing.T) {
 	}).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, updated.Maintenance, true)
+	th.AssertEquals(t, true, updated.Maintenance)
 }
 
 func TestNodesRAIDConfig(t *testing.T) {
@@ -114,9 +114,9 @@ func TestNodesFirmwareInterface(t *testing.T) {
 	th.AssertNoErr(t, err)
 	defer v1.DeleteNode(t, client, node)
 
-	th.AssertEquals(t, node.FirmwareInterface, "no-firmware")
+	th.AssertEquals(t, "no-firmware", node.FirmwareInterface)
 
 	nodeFirmwareCmps, err := nodes.ListFirmware(context.TODO(), client, node.UUID).Extract()
 	th.AssertNoErr(t, err)
-	th.AssertDeepEquals(t, nodeFirmwareCmps, []nodes.FirmwareComponent{})
+	th.AssertDeepEquals(t, []nodes.FirmwareComponent{}, nodeFirmwareCmps)
 }

--- a/internal/acceptance/openstack/baremetal/httpbasic/ports_test.go
+++ b/internal/acceptance/openstack/baremetal/httpbasic/ports_test.go
@@ -47,7 +47,7 @@ func TestPortsCreateDestroy(t *testing.T) {
 	})
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 }
 
 func TestPortsUpdate(t *testing.T) {

--- a/internal/acceptance/openstack/baremetal/httpbasic/ports_test.go
+++ b/internal/acceptance/openstack/baremetal/httpbasic/ports_test.go
@@ -47,7 +47,7 @@ func TestPortsCreateDestroy(t *testing.T) {
 	})
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 }
 
 func TestPortsUpdate(t *testing.T) {
@@ -74,5 +74,5 @@ func TestPortsUpdate(t *testing.T) {
 	}).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, updated.Address, "aa:bb:cc:dd:ee:ff")
+	th.AssertEquals(t, "aa:bb:cc:dd:ee:ff", updated.Address)
 }

--- a/internal/acceptance/openstack/baremetal/noauth/allocations_test.go
+++ b/internal/acceptance/openstack/baremetal/noauth/allocations_test.go
@@ -43,5 +43,5 @@ func TestAllocationsCreateDestroy(t *testing.T) {
 		return false, nil
 	})
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 }

--- a/internal/acceptance/openstack/baremetal/noauth/allocations_test.go
+++ b/internal/acceptance/openstack/baremetal/noauth/allocations_test.go
@@ -43,5 +43,5 @@ func TestAllocationsCreateDestroy(t *testing.T) {
 		return false, nil
 	})
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 }

--- a/internal/acceptance/openstack/baremetal/noauth/nodes_test.go
+++ b/internal/acceptance/openstack/baremetal/noauth/nodes_test.go
@@ -44,7 +44,7 @@ func TestNodesCreateDestroy(t *testing.T) {
 	})
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 }
 
 func TestNodesUpdate(t *testing.T) {
@@ -68,7 +68,7 @@ func TestNodesUpdate(t *testing.T) {
 	}).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, true, updated.Maintenance)
+	th.AssertTrue(t, updated.Maintenance)
 }
 
 func TestNodesRAIDConfig(t *testing.T) {

--- a/internal/acceptance/openstack/baremetal/noauth/nodes_test.go
+++ b/internal/acceptance/openstack/baremetal/noauth/nodes_test.go
@@ -44,7 +44,7 @@ func TestNodesCreateDestroy(t *testing.T) {
 	})
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 }
 
 func TestNodesUpdate(t *testing.T) {
@@ -68,7 +68,7 @@ func TestNodesUpdate(t *testing.T) {
 	}).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, updated.Maintenance, true)
+	th.AssertEquals(t, true, updated.Maintenance)
 }
 
 func TestNodesRAIDConfig(t *testing.T) {

--- a/internal/acceptance/openstack/baremetal/noauth/ports_test.go
+++ b/internal/acceptance/openstack/baremetal/noauth/ports_test.go
@@ -47,7 +47,7 @@ func TestPortsCreateDestroy(t *testing.T) {
 	})
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 }
 
 func TestPortsUpdate(t *testing.T) {

--- a/internal/acceptance/openstack/baremetal/noauth/ports_test.go
+++ b/internal/acceptance/openstack/baremetal/noauth/ports_test.go
@@ -47,7 +47,7 @@ func TestPortsCreateDestroy(t *testing.T) {
 	})
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 }
 
 func TestPortsUpdate(t *testing.T) {
@@ -74,5 +74,5 @@ func TestPortsUpdate(t *testing.T) {
 	}).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, updated.Address, "aa:bb:cc:dd:ee:ff")
+	th.AssertEquals(t, "aa:bb:cc:dd:ee:ff", updated.Address)
 }

--- a/internal/acceptance/openstack/baremetal/v1/allocations_test.go
+++ b/internal/acceptance/openstack/baremetal/v1/allocations_test.go
@@ -41,5 +41,5 @@ func TestAllocationsCreateDestroy(t *testing.T) {
 		return false, nil
 	})
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 }

--- a/internal/acceptance/openstack/baremetal/v1/allocations_test.go
+++ b/internal/acceptance/openstack/baremetal/v1/allocations_test.go
@@ -41,5 +41,5 @@ func TestAllocationsCreateDestroy(t *testing.T) {
 		return false, nil
 	})
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 }

--- a/internal/acceptance/openstack/baremetal/v1/nodes_test.go
+++ b/internal/acceptance/openstack/baremetal/v1/nodes_test.go
@@ -42,7 +42,7 @@ func TestNodesCreateDestroy(t *testing.T) {
 		return false, nil
 	})
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 
 	th.AssertEquals(t, node.ProvisionState, string(nodes.Enroll))
 
@@ -110,7 +110,7 @@ func TestNodesUpdate(t *testing.T) {
 	}).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, updated.Maintenance, true)
+	th.AssertEquals(t, true, updated.Maintenance)
 }
 
 func TestNodesMaintenance(t *testing.T) {
@@ -132,8 +132,8 @@ func TestNodesMaintenance(t *testing.T) {
 	updated, err := nodes.Get(context.TODO(), client, node.UUID).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, updated.Maintenance, true)
-	th.AssertEquals(t, updated.MaintenanceReason, "I'm tired")
+	th.AssertEquals(t, true, updated.Maintenance)
+	th.AssertEquals(t, "I'm tired", updated.MaintenanceReason)
 
 	err = nodes.UnsetMaintenance(context.TODO(), client, node.UUID).ExtractErr()
 	th.AssertNoErr(t, err)
@@ -141,8 +141,8 @@ func TestNodesMaintenance(t *testing.T) {
 	updated, err = nodes.Get(context.TODO(), client, node.UUID).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, updated.Maintenance, false)
-	th.AssertEquals(t, updated.MaintenanceReason, "")
+	th.AssertEquals(t, false, updated.Maintenance)
+	th.AssertEquals(t, "", updated.MaintenanceReason)
 }
 
 func TestNodesRAIDConfig(t *testing.T) {
@@ -206,11 +206,11 @@ func TestNodesFirmwareInterface(t *testing.T) {
 	th.AssertNoErr(t, err)
 	defer DeleteNode(t, client, node)
 
-	th.AssertEquals(t, node.FirmwareInterface, "no-firmware")
+	th.AssertEquals(t, "no-firmware", node.FirmwareInterface)
 
 	nodeFirmwareCmps, err := nodes.ListFirmware(context.TODO(), client, node.UUID).Extract()
 	th.AssertNoErr(t, err)
-	th.AssertDeepEquals(t, nodeFirmwareCmps, []nodes.FirmwareComponent{})
+	th.AssertDeepEquals(t, []nodes.FirmwareComponent{}, nodeFirmwareCmps)
 }
 
 func TestNodesVirtualMedia(t *testing.T) {

--- a/internal/acceptance/openstack/baremetal/v1/nodes_test.go
+++ b/internal/acceptance/openstack/baremetal/v1/nodes_test.go
@@ -42,7 +42,7 @@ func TestNodesCreateDestroy(t *testing.T) {
 		return false, nil
 	})
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 
 	th.AssertEquals(t, node.ProvisionState, string(nodes.Enroll))
 
@@ -110,7 +110,7 @@ func TestNodesUpdate(t *testing.T) {
 	}).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, true, updated.Maintenance)
+	th.AssertTrue(t, updated.Maintenance)
 }
 
 func TestNodesMaintenance(t *testing.T) {
@@ -132,7 +132,7 @@ func TestNodesMaintenance(t *testing.T) {
 	updated, err := nodes.Get(context.TODO(), client, node.UUID).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, true, updated.Maintenance)
+	th.AssertTrue(t, updated.Maintenance)
 	th.AssertEquals(t, "I'm tired", updated.MaintenanceReason)
 
 	err = nodes.UnsetMaintenance(context.TODO(), client, node.UUID).ExtractErr()
@@ -141,7 +141,7 @@ func TestNodesMaintenance(t *testing.T) {
 	updated, err = nodes.Get(context.TODO(), client, node.UUID).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, false, updated.Maintenance)
+	th.AssertFalse(t, updated.Maintenance)
 	th.AssertEquals(t, "", updated.MaintenanceReason)
 }
 

--- a/internal/acceptance/openstack/baremetal/v1/ports_test.go
+++ b/internal/acceptance/openstack/baremetal/v1/ports_test.go
@@ -45,7 +45,7 @@ func TestPortsCreateDestroy(t *testing.T) {
 	})
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 }
 
 func TestPortsUpdate(t *testing.T) {
@@ -71,5 +71,5 @@ func TestPortsUpdate(t *testing.T) {
 	}).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, updated.Address, "aa:bb:cc:dd:ee:ff")
+	th.AssertEquals(t, "aa:bb:cc:dd:ee:ff", updated.Address)
 }

--- a/internal/acceptance/openstack/baremetal/v1/ports_test.go
+++ b/internal/acceptance/openstack/baremetal/v1/ports_test.go
@@ -45,7 +45,7 @@ func TestPortsCreateDestroy(t *testing.T) {
 	})
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 }
 
 func TestPortsUpdate(t *testing.T) {

--- a/internal/acceptance/openstack/blockstorage/v2/backups_test.go
+++ b/internal/acceptance/openstack/blockstorage/v2/backups_test.go
@@ -39,7 +39,7 @@ func TestBackupsCRUD(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 }
 
 func TestBackupsResetStatus(t *testing.T) {

--- a/internal/acceptance/openstack/blockstorage/v2/backups_test.go
+++ b/internal/acceptance/openstack/blockstorage/v2/backups_test.go
@@ -39,7 +39,7 @@ func TestBackupsCRUD(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 }
 
 func TestBackupsResetStatus(t *testing.T) {

--- a/internal/acceptance/openstack/blockstorage/v2/blockstorage.go
+++ b/internal/acceptance/openstack/blockstorage/v2/blockstorage.go
@@ -82,7 +82,7 @@ func CreateVolume(t *testing.T, client *gophercloud.ServiceClient) (*volumes.Vol
 	tools.PrintResource(t, volume)
 	th.AssertEquals(t, volume.Name, volumeName)
 	th.AssertEquals(t, volume.Description, volumeDescription)
-	th.AssertEquals(t, volume.Size, 1)
+	th.AssertEquals(t, 1, volume.Size)
 
 	t.Logf("Successfully created volume: %s", volume.ID)
 
@@ -125,7 +125,7 @@ func CreateVolumeFromImage(t *testing.T, client *gophercloud.ServiceClient) (*vo
 	}
 
 	th.AssertEquals(t, newVolume.Name, volumeName)
-	th.AssertEquals(t, newVolume.Size, 1)
+	th.AssertEquals(t, 1, newVolume.Size)
 
 	t.Logf("Successfully created volume from image: %s", newVolume.ID)
 

--- a/internal/acceptance/openstack/blockstorage/v2/snapshots_test.go
+++ b/internal/acceptance/openstack/blockstorage/v2/snapshots_test.go
@@ -44,5 +44,5 @@ func TestSnapshots(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 }

--- a/internal/acceptance/openstack/blockstorage/v2/snapshots_test.go
+++ b/internal/acceptance/openstack/blockstorage/v2/snapshots_test.go
@@ -44,5 +44,5 @@ func TestSnapshots(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 }

--- a/internal/acceptance/openstack/blockstorage/v2/volumes_test.go
+++ b/internal/acceptance/openstack/blockstorage/v2/volumes_test.go
@@ -57,7 +57,7 @@ func TestVolumesCreateDestroy(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 }
 
 func TestVolumesCreateForceDestroy(t *testing.T) {

--- a/internal/acceptance/openstack/blockstorage/v2/volumes_test.go
+++ b/internal/acceptance/openstack/blockstorage/v2/volumes_test.go
@@ -57,7 +57,7 @@ func TestVolumesCreateDestroy(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 }
 
 func TestVolumesCreateForceDestroy(t *testing.T) {

--- a/internal/acceptance/openstack/blockstorage/v2/volumetenants_test.go
+++ b/internal/acceptance/openstack/blockstorage/v2/volumetenants_test.go
@@ -38,5 +38,5 @@ func TestVolumeTenants(t *testing.T) {
 
 	err = volumes.ExtractVolumesInto(allPages, &allVolumes)
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, true, len(allVolumes) > 0)
+	th.AssertTrue(t, len(allVolumes) > 0)
 }

--- a/internal/acceptance/openstack/blockstorage/v3/backups_test.go
+++ b/internal/acceptance/openstack/blockstorage/v3/backups_test.go
@@ -37,7 +37,7 @@ func TestBackupsCRUD(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 }
 
 func TestBackupsResetStatus(t *testing.T) {

--- a/internal/acceptance/openstack/blockstorage/v3/backups_test.go
+++ b/internal/acceptance/openstack/blockstorage/v3/backups_test.go
@@ -37,7 +37,7 @@ func TestBackupsCRUD(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 }
 
 func TestBackupsResetStatus(t *testing.T) {

--- a/internal/acceptance/openstack/blockstorage/v3/blockstorage.go
+++ b/internal/acceptance/openstack/blockstorage/v3/blockstorage.go
@@ -98,7 +98,7 @@ func CreateVolume(t *testing.T, client *gophercloud.ServiceClient) (*volumes.Vol
 	tools.PrintResource(t, volume)
 	th.AssertEquals(t, volume.Name, volumeName)
 	th.AssertEquals(t, volume.Description, volumeDescription)
-	th.AssertEquals(t, volume.Size, 1)
+	th.AssertEquals(t, 1, volume.Size)
 
 	t.Logf("Successfully created volume: %s", volume.ID)
 
@@ -141,7 +141,7 @@ func CreateVolumeWithType(t *testing.T, client *gophercloud.ServiceClient, vt *v
 	tools.PrintResource(t, volume)
 	th.AssertEquals(t, volume.Name, volumeName)
 	th.AssertEquals(t, volume.Description, volumeDescription)
-	th.AssertEquals(t, volume.Size, 1)
+	th.AssertEquals(t, 1, volume.Size)
 	th.AssertEquals(t, volume.VolumeType, vt.Name)
 
 	t.Logf("Successfully created volume: %s", volume.ID)
@@ -168,7 +168,7 @@ func CreateVolumeType(t *testing.T, client *gophercloud.ServiceClient) (*volumet
 	}
 
 	tools.PrintResource(t, vt)
-	th.AssertEquals(t, vt.IsPublic, true)
+	th.AssertEquals(t, true, vt.IsPublic)
 	th.AssertEquals(t, vt.Name, name)
 	th.AssertEquals(t, vt.Description, description)
 	// TODO: For some reason returned extra_specs are empty even in API reference: https://developer.openstack.org/api-ref/block-storage/v3/?expanded=create-a-volume-type-detail#volume-types-types
@@ -201,7 +201,7 @@ func CreateVolumeTypeNoExtraSpecs(t *testing.T, client *gophercloud.ServiceClien
 	}
 
 	tools.PrintResource(t, vt)
-	th.AssertEquals(t, vt.IsPublic, true)
+	th.AssertEquals(t, true, vt.IsPublic)
 	th.AssertEquals(t, vt.Name, name)
 	th.AssertEquals(t, vt.Description, description)
 
@@ -230,10 +230,10 @@ func CreateVolumeTypeMultiAttach(t *testing.T, client *gophercloud.ServiceClient
 	}
 
 	tools.PrintResource(t, vt)
-	th.AssertEquals(t, vt.IsPublic, true)
+	th.AssertEquals(t, true, vt.IsPublic)
 	th.AssertEquals(t, vt.Name, name)
 	th.AssertEquals(t, vt.Description, description)
-	th.AssertEquals(t, vt.ExtraSpecs["multiattach"], "<is> True")
+	th.AssertEquals(t, "<is> True", vt.ExtraSpecs["multiattach"])
 
 	t.Logf("Successfully created volume type: %s", vt.ID)
 
@@ -262,7 +262,7 @@ func CreatePrivateVolumeType(t *testing.T, client *gophercloud.ServiceClient) (*
 	}
 
 	tools.PrintResource(t, vt)
-	th.AssertEquals(t, vt.IsPublic, false)
+	th.AssertEquals(t, false, vt.IsPublic)
 	th.AssertEquals(t, vt.Name, name)
 	th.AssertEquals(t, vt.Description, description)
 
@@ -365,7 +365,7 @@ func CreateQoS(t *testing.T, client *gophercloud.ServiceClient) (*qos.QoS, error
 	}
 
 	tools.PrintResource(t, qs)
-	th.AssertEquals(t, qs.Consumer, "front-end")
+	th.AssertEquals(t, "front-end", qs.Consumer)
 	th.AssertEquals(t, qs.Name, name)
 	th.AssertDeepEquals(t, qs.Specs, createOpts.Specs)
 

--- a/internal/acceptance/openstack/blockstorage/v3/blockstorage.go
+++ b/internal/acceptance/openstack/blockstorage/v3/blockstorage.go
@@ -168,7 +168,7 @@ func CreateVolumeType(t *testing.T, client *gophercloud.ServiceClient) (*volumet
 	}
 
 	tools.PrintResource(t, vt)
-	th.AssertEquals(t, true, vt.IsPublic)
+	th.AssertTrue(t, vt.IsPublic)
 	th.AssertEquals(t, vt.Name, name)
 	th.AssertEquals(t, vt.Description, description)
 	// TODO: For some reason returned extra_specs are empty even in API reference: https://developer.openstack.org/api-ref/block-storage/v3/?expanded=create-a-volume-type-detail#volume-types-types
@@ -201,7 +201,7 @@ func CreateVolumeTypeNoExtraSpecs(t *testing.T, client *gophercloud.ServiceClien
 	}
 
 	tools.PrintResource(t, vt)
-	th.AssertEquals(t, true, vt.IsPublic)
+	th.AssertTrue(t, vt.IsPublic)
 	th.AssertEquals(t, vt.Name, name)
 	th.AssertEquals(t, vt.Description, description)
 
@@ -230,7 +230,7 @@ func CreateVolumeTypeMultiAttach(t *testing.T, client *gophercloud.ServiceClient
 	}
 
 	tools.PrintResource(t, vt)
-	th.AssertEquals(t, true, vt.IsPublic)
+	th.AssertTrue(t, vt.IsPublic)
 	th.AssertEquals(t, vt.Name, name)
 	th.AssertEquals(t, vt.Description, description)
 	th.AssertEquals(t, "<is> True", vt.ExtraSpecs["multiattach"])
@@ -262,7 +262,7 @@ func CreatePrivateVolumeType(t *testing.T, client *gophercloud.ServiceClient) (*
 	}
 
 	tools.PrintResource(t, vt)
-	th.AssertEquals(t, false, vt.IsPublic)
+	th.AssertFalse(t, vt.IsPublic)
 	th.AssertEquals(t, vt.Name, name)
 	th.AssertEquals(t, vt.Description, description)
 

--- a/internal/acceptance/openstack/blockstorage/v3/manageablevolumes_test.go
+++ b/internal/acceptance/openstack/blockstorage/v3/manageablevolumes_test.go
@@ -53,5 +53,5 @@ func TestManageableVolumes(t *testing.T) {
 			break
 		}
 	}
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 }

--- a/internal/acceptance/openstack/blockstorage/v3/qos_test.go
+++ b/internal/acceptance/openstack/blockstorage/v3/qos_test.go
@@ -68,7 +68,7 @@ func TestQoS(t *testing.T) {
 			}
 		}
 
-		th.AssertEquals(t, found, true)
+		th.AssertEquals(t, true, found)
 
 		return true, nil
 	})

--- a/internal/acceptance/openstack/blockstorage/v3/qos_test.go
+++ b/internal/acceptance/openstack/blockstorage/v3/qos_test.go
@@ -68,7 +68,7 @@ func TestQoS(t *testing.T) {
 			}
 		}
 
-		th.AssertEquals(t, true, found)
+		th.AssertTrue(t, found)
 
 		return true, nil
 	})

--- a/internal/acceptance/openstack/blockstorage/v3/quotaset_test.go
+++ b/internal/acceptance/openstack/blockstorage/v3/quotaset_test.go
@@ -129,7 +129,7 @@ func TestQuotasetUpdate(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, count, 3)
+	th.AssertEquals(t, 3, count)
 
 	// unpopulate resultQuotas.Extra as it is different per cloud and test
 	// rest of the quotaSet

--- a/internal/acceptance/openstack/blockstorage/v3/snapshots_test.go
+++ b/internal/acceptance/openstack/blockstorage/v3/snapshots_test.go
@@ -69,7 +69,7 @@ func TestSnapshots(t *testing.T) {
 			}
 		}
 
-		th.AssertEquals(t, found, true)
+		th.AssertEquals(t, true, found)
 
 		return true, nil
 	})
@@ -87,7 +87,7 @@ func TestSnapshots(t *testing.T) {
 			}
 		}
 
-		th.AssertEquals(t, found, true)
+		th.AssertEquals(t, true, found)
 
 		return true, nil
 	})

--- a/internal/acceptance/openstack/blockstorage/v3/snapshots_test.go
+++ b/internal/acceptance/openstack/blockstorage/v3/snapshots_test.go
@@ -69,7 +69,7 @@ func TestSnapshots(t *testing.T) {
 			}
 		}
 
-		th.AssertEquals(t, true, found)
+		th.AssertTrue(t, found)
 
 		return true, nil
 	})
@@ -87,7 +87,7 @@ func TestSnapshots(t *testing.T) {
 			}
 		}
 
-		th.AssertEquals(t, true, found)
+		th.AssertTrue(t, found)
 
 		return true, nil
 	})

--- a/internal/acceptance/openstack/blockstorage/v3/volumes_test.go
+++ b/internal/acceptance/openstack/blockstorage/v3/volumes_test.go
@@ -60,7 +60,7 @@ func TestVolumes(t *testing.T) {
 			}
 		}
 
-		th.AssertEquals(t, true, found)
+		th.AssertTrue(t, found)
 
 		return true, nil
 	})
@@ -98,7 +98,7 @@ func TestVolumesMultiAttach(t *testing.T) {
 	err = volumes.WaitForStatus(ctx, client, vol.ID, "available")
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, true, vol.Multiattach)
+	th.AssertTrue(t, vol.Multiattach)
 }
 
 func TestVolumesCascadeDelete(t *testing.T) {

--- a/internal/acceptance/openstack/blockstorage/v3/volumes_test.go
+++ b/internal/acceptance/openstack/blockstorage/v3/volumes_test.go
@@ -60,7 +60,7 @@ func TestVolumes(t *testing.T) {
 			}
 		}
 
-		th.AssertEquals(t, found, true)
+		th.AssertEquals(t, true, found)
 
 		return true, nil
 	})
@@ -98,7 +98,7 @@ func TestVolumesMultiAttach(t *testing.T) {
 	err = volumes.WaitForStatus(ctx, client, vol.ID, "available")
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, vol.Multiattach, true)
+	th.AssertEquals(t, true, vol.Multiattach)
 }
 
 func TestVolumesCascadeDelete(t *testing.T) {

--- a/internal/acceptance/openstack/blockstorage/v3/volumetenants_test.go
+++ b/internal/acceptance/openstack/blockstorage/v3/volumetenants_test.go
@@ -36,5 +36,5 @@ func TestVolumeTenants(t *testing.T) {
 
 	err = volumes.ExtractVolumesInto(allPages, &allVolumes)
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, true, len(allVolumes) > 0)
+	th.AssertTrue(t, len(allVolumes) > 0)
 }

--- a/internal/acceptance/openstack/blockstorage/v3/volumetypes_test.go
+++ b/internal/acceptance/openstack/blockstorage/v3/volumetypes_test.go
@@ -38,7 +38,7 @@ func TestVolumeTypesCRUD(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 
 	name := vt.Name + "-updated"
 	description := vt.Description + "-updated"
@@ -141,9 +141,9 @@ func TestVolumeTypesExtraSpecs(t *testing.T) {
 
 	tools.PrintResource(t, createdExtraSpecs)
 
-	th.AssertEquals(t, len(createdExtraSpecs), 2)
-	th.AssertEquals(t, createdExtraSpecs["capabilities"], "gpu")
-	th.AssertEquals(t, createdExtraSpecs["volume_backend_name"], "ssd")
+	th.AssertEquals(t, 2, len(createdExtraSpecs))
+	th.AssertEquals(t, "gpu", createdExtraSpecs["capabilities"])
+	th.AssertEquals(t, "ssd", createdExtraSpecs["volume_backend_name"])
 
 	err = volumetypes.DeleteExtraSpec(context.TODO(), client, vt.ID, "volume_backend_name").ExtractErr()
 	th.AssertNoErr(t, err)
@@ -156,22 +156,22 @@ func TestVolumeTypesExtraSpecs(t *testing.T) {
 
 	tools.PrintResource(t, updatedExtraSpec)
 
-	th.AssertEquals(t, updatedExtraSpec["capabilities"], "gpu-2")
+	th.AssertEquals(t, "gpu-2", updatedExtraSpec["capabilities"])
 
 	allExtraSpecs, err := volumetypes.ListExtraSpecs(context.TODO(), client, vt.ID).Extract()
 	th.AssertNoErr(t, err)
 
 	tools.PrintResource(t, allExtraSpecs)
 
-	th.AssertEquals(t, len(allExtraSpecs), 1)
-	th.AssertEquals(t, allExtraSpecs["capabilities"], "gpu-2")
+	th.AssertEquals(t, 1, len(allExtraSpecs))
+	th.AssertEquals(t, "gpu-2", allExtraSpecs["capabilities"])
 
 	singleSpec, err := volumetypes.GetExtraSpec(context.TODO(), client, vt.ID, "capabilities").Extract()
 	th.AssertNoErr(t, err)
 
 	tools.PrintResource(t, singleSpec)
 
-	th.AssertEquals(t, singleSpec["capabilities"], "gpu-2")
+	th.AssertEquals(t, "gpu-2", singleSpec["capabilities"])
 }
 
 func TestVolumeTypesAccess(t *testing.T) {
@@ -206,7 +206,7 @@ func TestVolumeTypesAccess(t *testing.T) {
 
 	tools.PrintResource(t, accessList)
 
-	th.AssertEquals(t, len(accessList), 1)
+	th.AssertEquals(t, 1, len(accessList))
 	th.AssertEquals(t, accessList[0].ProjectID, project.ID)
 	th.AssertEquals(t, accessList[0].VolumeTypeID, vt.ID)
 
@@ -225,7 +225,7 @@ func TestVolumeTypesAccess(t *testing.T) {
 
 	tools.PrintResource(t, accessList)
 
-	th.AssertEquals(t, len(accessList), 0)
+	th.AssertEquals(t, 0, len(accessList))
 }
 
 func TestEncryptionVolumeTypes(t *testing.T) {

--- a/internal/acceptance/openstack/blockstorage/v3/volumetypes_test.go
+++ b/internal/acceptance/openstack/blockstorage/v3/volumetypes_test.go
@@ -38,7 +38,7 @@ func TestVolumeTypesCRUD(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 
 	name := vt.Name + "-updated"
 	description := vt.Description + "-updated"

--- a/internal/acceptance/openstack/compute/v2/aggregates_test.go
+++ b/internal/acceptance/openstack/compute/v2/aggregates_test.go
@@ -56,8 +56,8 @@ func TestAggregatesCRUD(t *testing.T) {
 
 	tools.PrintResource(t, aggregate)
 
-	th.AssertEquals(t, updatedAggregate.Name, "new_aggregate_name")
-	th.AssertEquals(t, updatedAggregate.AvailabilityZone, "new_azone")
+	th.AssertEquals(t, "new_aggregate_name", updatedAggregate.Name)
+	th.AssertEquals(t, "new_azone", updatedAggregate.AvailabilityZone)
 }
 
 func TestAggregatesAddRemoveHost(t *testing.T) {
@@ -93,7 +93,7 @@ func TestAggregatesAddRemoveHost(t *testing.T) {
 
 	tools.PrintResource(t, aggregateWithRemovedHost)
 
-	th.AssertEquals(t, len(aggregateWithRemovedHost.Hosts), 0)
+	th.AssertEquals(t, 0, len(aggregateWithRemovedHost.Hosts))
 }
 
 func TestAggregatesSetRemoveMetadata(t *testing.T) {

--- a/internal/acceptance/openstack/compute/v2/attachinterfaces_test.go
+++ b/internal/acceptance/openstack/compute/v2/attachinterfaces_test.go
@@ -48,5 +48,5 @@ func TestAttachDetachInterface(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 }

--- a/internal/acceptance/openstack/compute/v2/availabilityzones_test.go
+++ b/internal/acceptance/openstack/compute/v2/availabilityzones_test.go
@@ -31,7 +31,7 @@ func TestAvailabilityZonesList(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 }
 
 func TestAvailabilityZonesListDetail(t *testing.T) {
@@ -55,5 +55,5 @@ func TestAvailabilityZonesListDetail(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 }

--- a/internal/acceptance/openstack/compute/v2/compute.go
+++ b/internal/acceptance/openstack/compute/v2/compute.go
@@ -173,7 +173,7 @@ func CreateFlavor(t *testing.T, client *gophercloud.ServiceClient) (*flavors.Fla
 	th.AssertEquals(t, 1, flavor.RAM)
 	th.AssertEquals(t, 1, flavor.Disk)
 	th.AssertEquals(t, 1, flavor.VCPUs)
-	th.AssertEquals(t, true, flavor.IsPublic)
+	th.AssertTrue(t, flavor.IsPublic)
 	th.AssertEquals(t, flavorDescription, flavor.Description)
 
 	return flavor, nil
@@ -296,7 +296,7 @@ func CreatePrivateFlavor(t *testing.T, client *gophercloud.ServiceClient) (*flav
 	th.AssertEquals(t, 1, flavor.RAM)
 	th.AssertEquals(t, 1, flavor.Disk)
 	th.AssertEquals(t, 1, flavor.VCPUs)
-	th.AssertEquals(t, false, flavor.IsPublic)
+	th.AssertFalse(t, flavor.IsPublic)
 
 	return flavor, nil
 }

--- a/internal/acceptance/openstack/compute/v2/diagnostics_test.go
+++ b/internal/acceptance/openstack/compute/v2/diagnostics_test.go
@@ -28,5 +28,5 @@ func TestDiagnostics(t *testing.T) {
 	tools.PrintResource(t, diag)
 
 	_, ok := diag["memory"]
-	th.AssertEquals(t, true, ok)
+	th.AssertTrue(t, ok)
 }

--- a/internal/acceptance/openstack/compute/v2/extension_test.go
+++ b/internal/acceptance/openstack/compute/v2/extension_test.go
@@ -31,7 +31,7 @@ func TestExtensionsList(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 }
 
 func TestExtensionsGet(t *testing.T) {

--- a/internal/acceptance/openstack/compute/v2/flavors_test.go
+++ b/internal/acceptance/openstack/compute/v2/flavors_test.go
@@ -35,7 +35,7 @@ func TestFlavorsList(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 }
 
 func TestFlavorsAccessTypeList(t *testing.T) {

--- a/internal/acceptance/openstack/compute/v2/instance_actions_test.go
+++ b/internal/acceptance/openstack/compute/v2/instance_actions_test.go
@@ -39,7 +39,7 @@ func TestInstanceActions(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 }
 
 func TestInstanceActionsMicroversions(t *testing.T) {
@@ -88,7 +88,7 @@ func TestInstanceActionsMicroversions(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 
 	listOpts = instanceactions.ListOpts{
 		Limit:         1,

--- a/internal/acceptance/openstack/compute/v2/keypairs_test.go
+++ b/internal/acceptance/openstack/compute/v2/keypairs_test.go
@@ -57,7 +57,7 @@ func TestKeyPairsCreateDelete(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 }
 
 func TestKeyPairsImportPublicKey(t *testing.T) {
@@ -146,7 +146,7 @@ func TestKeyPairsCreateDeleteByID(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 
 	deleteOpts := keypairs.DeleteOpts{
 		UserID: user.ID,

--- a/internal/acceptance/openstack/compute/v2/secgroup_test.go
+++ b/internal/acceptance/openstack/compute/v2/secgroup_test.go
@@ -32,7 +32,7 @@ func TestSecGroupsList(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 }
 
 func TestSecGroupsCRUD(t *testing.T) {
@@ -120,7 +120,7 @@ func TestSecGroupsAddGroupToServer(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 
 	t.Logf("Removing group %s from server %s", securityGroup.ID, server.ID)
 	err = secgroups.RemoveServer(context.TODO(), client, server.ID, securityGroup.Name).ExtractErr()
@@ -139,5 +139,5 @@ func TestSecGroupsAddGroupToServer(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, false, found)
+	th.AssertFalse(t, found)
 }

--- a/internal/acceptance/openstack/compute/v2/servergroup_test.go
+++ b/internal/acceptance/openstack/compute/v2/servergroup_test.go
@@ -41,7 +41,7 @@ func TestServergroupsCreateDelete(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 }
 
 func TestServergroupsAffinityPolicy(t *testing.T) {
@@ -100,5 +100,5 @@ func TestServergroupsMicroversionCreateDelete(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 }

--- a/internal/acceptance/openstack/compute/v2/servers_test.go
+++ b/internal/acceptance/openstack/compute/v2/servers_test.go
@@ -45,7 +45,7 @@ func TestServersCreateDestroy(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 
 	allAddressPages, err := servers.ListAddresses(client, server.ID).AllPages(context.TODO())
 	th.AssertNoErr(t, err)
@@ -97,8 +97,8 @@ func TestServersWithExtensionsCreateDestroy(t *testing.T) {
 	th.AssertEquals(t, servers.RUNNING, int(created.PowerState))
 	th.AssertEquals(t, "", created.TaskState)
 	th.AssertEquals(t, "active", created.VmState)
-	th.AssertEquals(t, false, created.LaunchedAt.IsZero())
-	th.AssertEquals(t, true, created.TerminatedAt.IsZero())
+	th.AssertFalse(t, created.LaunchedAt.IsZero())
+	th.AssertTrue(t, created.TerminatedAt.IsZero())
 }
 
 func TestServersWithoutImageRef(t *testing.T) {
@@ -447,7 +447,7 @@ func TestServersActionLock(t *testing.T) {
 
 	t.Logf("Attempting to delete locked server %s", server.ID)
 	err = servers.Delete(context.TODO(), client, server.ID).ExtractErr()
-	th.AssertEquals(t, true, err != nil)
+	th.AssertTrue(t, err != nil)
 
 	t.Logf("Attempting to unlock server %s", server.ID)
 	err = servers.Unlock(context.TODO(), client, server.ID).ExtractErr()
@@ -513,7 +513,7 @@ func TestServersTags(t *testing.T) {
 	// Check single tag.
 	exists, err := tags.Check(context.TODO(), client, server.ID, "tag2").Extract()
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, true, exists)
+	th.AssertTrue(t, exists)
 
 	// Add new tag.
 	newTags, err := tags.ReplaceAll(context.TODO(), client, server.ID, tags.ReplaceAllOpts{Tags: []string{"tag3", "tag4"}}).Extract()
@@ -536,7 +536,7 @@ func TestServersTags(t *testing.T) {
 	// Check that tag doesn't exist anymore.
 	exists, err = tags.Check(context.TODO(), client, server.ID, "tag4").Extract()
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, false, exists)
+	th.AssertFalse(t, exists)
 
 	// Remove all tags.
 	err = tags.DeleteAll(context.TODO(), client, server.ID).ExtractErr()
@@ -565,13 +565,13 @@ func TestServersWithExtendedAttributesCreateDestroy(t *testing.T) {
 
 	t.Logf("Server With Extended Attributes: %#v", created)
 
-	th.AssertEquals(t, true, *created.ReservationID != "")
+	th.AssertTrue(t, *created.ReservationID != "")
 	th.AssertEquals(t, 0, *created.LaunchIndex)
-	th.AssertEquals(t, true, *created.RAMDiskID == "")
-	th.AssertEquals(t, true, *created.KernelID == "")
-	th.AssertEquals(t, true, *created.Hostname != "")
-	th.AssertEquals(t, true, *created.RootDeviceName != "")
-	th.AssertEquals(t, true, created.Userdata == nil)
+	th.AssertTrue(t, *created.RAMDiskID == "")
+	th.AssertTrue(t, *created.KernelID == "")
+	th.AssertTrue(t, *created.Hostname != "")
+	th.AssertTrue(t, *created.RootDeviceName != "")
+	th.AssertTrue(t, created.Userdata == nil)
 }
 
 func TestServerNoNetworkCreateDestroy(t *testing.T) {
@@ -604,7 +604,7 @@ func TestServerNoNetworkCreateDestroy(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 
 	allAddressPages, err := servers.ListAddresses(client, server.ID).AllPages(context.TODO())
 	th.AssertNoErr(t, err)

--- a/internal/acceptance/openstack/compute/v2/services_test.go
+++ b/internal/acceptance/openstack/compute/v2/services_test.go
@@ -33,7 +33,7 @@ func TestServicesList(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 }
 
 func TestServicesListWithOpts(t *testing.T) {
@@ -62,5 +62,5 @@ func TestServicesListWithOpts(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 }

--- a/internal/acceptance/openstack/container/v1/capsules_test.go
+++ b/internal/acceptance/openstack/container/v1/capsules_test.go
@@ -52,7 +52,7 @@ func TestCapsuleBase(t *testing.T) {
 			capsule, err := capsules.Get(context.TODO(), client, capsuleUUID).ExtractBase()
 
 			th.AssertNoErr(t, err)
-			th.AssertEquals(t, capsule.MetaName, "template")
+			th.AssertEquals(t, "template", capsule.MetaName)
 
 			err = capsules.Delete(context.TODO(), client, capsuleUUID).ExtractErr()
 			th.AssertNoErr(t, err)
@@ -105,7 +105,7 @@ func TestCapsuleV132(t *testing.T) {
 			capsule, err := capsules.Get(context.TODO(), client, capsuleUUID).ExtractV132()
 
 			th.AssertNoErr(t, err)
-			th.AssertEquals(t, capsule.MetaName, "template")
+			th.AssertEquals(t, "template", capsule.MetaName)
 
 			err = capsules.Delete(context.TODO(), client, capsuleUUID).ExtractErr()
 			th.AssertNoErr(t, err)

--- a/internal/acceptance/openstack/containerinfra/v1/clusters_test.go
+++ b/internal/acceptance/openstack/containerinfra/v1/clusters_test.go
@@ -39,7 +39,7 @@ func TestClustersCRUD(t *testing.T) {
 			found = true
 		}
 	}
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 	updateOpts := []clusters.UpdateOptsBuilder{
 		clusters.UpdateOpts{
 			Op:    clusters.ReplaceOp,
@@ -63,7 +63,7 @@ func TestClustersCRUD(t *testing.T) {
 	newCluster, err := clusters.Get(context.TODO(), client, clusterID).Extract()
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, newCluster.UUID, clusterID)
-	th.AssertEquals(t, newCluster.MasterLBEnabled, false)
+	th.AssertEquals(t, false, newCluster.MasterLBEnabled)
 
 	allPagesDetail, err := clusters.ListDetail(client, nil).AllPages(context.TODO())
 	th.AssertNoErr(t, err)
@@ -77,7 +77,7 @@ func TestClustersCRUD(t *testing.T) {
 			foundDetail = true
 		}
 	}
-	th.AssertEquals(t, foundDetail, true)
+	th.AssertEquals(t, true, foundDetail)
 
 	tools.PrintResource(t, newCluster)
 }

--- a/internal/acceptance/openstack/containerinfra/v1/clusters_test.go
+++ b/internal/acceptance/openstack/containerinfra/v1/clusters_test.go
@@ -39,7 +39,7 @@ func TestClustersCRUD(t *testing.T) {
 			found = true
 		}
 	}
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 	updateOpts := []clusters.UpdateOptsBuilder{
 		clusters.UpdateOpts{
 			Op:    clusters.ReplaceOp,
@@ -63,7 +63,7 @@ func TestClustersCRUD(t *testing.T) {
 	newCluster, err := clusters.Get(context.TODO(), client, clusterID).Extract()
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, newCluster.UUID, clusterID)
-	th.AssertEquals(t, false, newCluster.MasterLBEnabled)
+	th.AssertFalse(t, newCluster.MasterLBEnabled)
 
 	allPagesDetail, err := clusters.ListDetail(client, nil).AllPages(context.TODO())
 	th.AssertNoErr(t, err)
@@ -77,7 +77,7 @@ func TestClustersCRUD(t *testing.T) {
 			foundDetail = true
 		}
 	}
-	th.AssertEquals(t, true, foundDetail)
+	th.AssertTrue(t, foundDetail)
 
 	tools.PrintResource(t, newCluster)
 }

--- a/internal/acceptance/openstack/containerinfra/v1/clustertemplates_test.go
+++ b/internal/acceptance/openstack/containerinfra/v1/clustertemplates_test.go
@@ -36,7 +36,7 @@ func TestClusterTemplatesCRUD(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 
 	template, err := clustertemplates.Get(context.TODO(), client, clusterTemplate.UUID).Extract()
 	th.AssertNoErr(t, err)

--- a/internal/acceptance/openstack/containerinfra/v1/clustertemplates_test.go
+++ b/internal/acceptance/openstack/containerinfra/v1/clustertemplates_test.go
@@ -36,7 +36,7 @@ func TestClusterTemplatesCRUD(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 
 	template, err := clustertemplates.Get(context.TODO(), client, clusterTemplate.UUID).Extract()
 	th.AssertNoErr(t, err)
@@ -63,8 +63,8 @@ func TestClusterTemplatesCRUD(t *testing.T) {
 
 	updateClusterTemplate, err := clustertemplates.Update(context.TODO(), client, clusterTemplate.UUID, updateOpts).Extract()
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, false, updateClusterTemplate.MasterLBEnabled)
-	th.AssertEquals(t, false, updateClusterTemplate.RegistryEnabled)
+	th.AssertFalse(t, updateClusterTemplate.MasterLBEnabled)
+	th.AssertFalse(t, updateClusterTemplate.RegistryEnabled)
 	th.AssertEquals(t, "test", updateClusterTemplate.Labels["test"])
 	tools.PrintResource(t, updateClusterTemplate)
 

--- a/internal/acceptance/openstack/containerinfra/v1/containerinfra.go
+++ b/internal/acceptance/openstack/containerinfra/v1/containerinfra.go
@@ -58,7 +58,7 @@ func CreateClusterTemplateCOE(t *testing.T, client *gophercloud.ServiceClient, c
 	}
 
 	requestID := res.Header.Get("X-OpenStack-Request-Id")
-	th.AssertEquals(t, true, requestID != "")
+	th.AssertTrue(t, requestID != "")
 
 	t.Logf("Cluster Template %s request ID: %s", name, requestID)
 
@@ -235,7 +235,7 @@ func CreateQuota(t *testing.T, client *gophercloud.ServiceClient) (*quotas.Quota
 	}
 
 	requestID := res.Header.Get("X-OpenStack-Request-Id")
-	th.AssertEquals(t, true, requestID != "")
+	th.AssertTrue(t, requestID != "")
 
 	t.Logf("Quota %s request ID: %s", name, requestID)
 

--- a/internal/acceptance/openstack/containerinfra/v1/nodegroups_test.go
+++ b/internal/acceptance/openstack/containerinfra/v1/nodegroups_test.go
@@ -137,7 +137,7 @@ func testNodeGroupUpdate(t *testing.T, client *gophercloud.ServiceClient, cluste
 	}
 	ng, err = nodegroups.Update(context.TODO(), client, clusterID, nodeGroupID, updateOpts).Extract()
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, false, ng.MaxNodeCount == nil)
+	th.AssertFalse(t, ng.MaxNodeCount == nil)
 	th.AssertEquals(t, 5, *ng.MaxNodeCount)
 
 	updateOpts = []nodegroups.UpdateOptsBuilder{
@@ -154,7 +154,7 @@ func testNodeGroupUpdate(t *testing.T, client *gophercloud.ServiceClient, cluste
 	}
 	ng, err = nodegroups.Update(context.TODO(), client, clusterID, nodeGroupID, updateOpts).Extract()
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, false, ng.MaxNodeCount == nil)
+	th.AssertFalse(t, ng.MaxNodeCount == nil)
 	th.AssertEquals(t, 1, ng.MinNodeCount)
 	th.AssertEquals(t, 3, *ng.MaxNodeCount)
 }

--- a/internal/acceptance/openstack/dns/v2/dns.go
+++ b/internal/acceptance/openstack/dns/v2/dns.go
@@ -79,7 +79,7 @@ func CreateZone(t *testing.T, client *gophercloud.ServiceClient) (*zones.Zone, e
 	t.Logf("Created Zone: %s", zoneName)
 
 	th.AssertEquals(t, newZone.Name, zoneName)
-	th.AssertEquals(t, newZone.TTL, 7200)
+	th.AssertEquals(t, 7200, newZone.TTL)
 
 	return newZone, nil
 }
@@ -115,7 +115,7 @@ func CreateSecondaryZone(t *testing.T, client *gophercloud.ServiceClient) (*zone
 	t.Logf("Created Zone: %s", zoneName)
 
 	th.AssertEquals(t, newZone.Name, zoneName)
-	th.AssertEquals(t, newZone.Masters[0], "10.0.0.1")
+	th.AssertEquals(t, "10.0.0.1", newZone.Masters[0])
 
 	return newZone, nil
 }
@@ -347,7 +347,7 @@ func CreateTSIGKey(t *testing.T, client *gophercloud.ServiceClient) (*tsigkeys.T
 	t.Logf("Created TSIG key: %s", keyName)
 
 	th.AssertEquals(t, newTSIGKey.Name, keyName)
-	th.AssertEquals(t, newTSIGKey.Algorithm, "hmac-sha256")
+	th.AssertEquals(t, "hmac-sha256", newTSIGKey.Algorithm)
 
 	return newTSIGKey, nil
 }

--- a/internal/acceptance/openstack/dns/v2/recordsets_test.go
+++ b/internal/acceptance/openstack/dns/v2/recordsets_test.go
@@ -36,7 +36,7 @@ func TestRecordSetsListByZone(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 
 	listOpts := recordsets.ListOpts{
 		Limit: 1,
@@ -79,7 +79,7 @@ func TestRecordSetsListAll(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 
 	listOpts := recordsets.ListOpts{
 		Limit: 1,

--- a/internal/acceptance/openstack/dns/v2/recordsets_test.go
+++ b/internal/acceptance/openstack/dns/v2/recordsets_test.go
@@ -36,7 +36,7 @@ func TestRecordSetsListByZone(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 
 	listOpts := recordsets.ListOpts{
 		Limit: 1,
@@ -46,7 +46,7 @@ func TestRecordSetsListByZone(t *testing.T) {
 	err = pager.EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
 		rr, err := recordsets.ExtractRecordSets(page)
 		th.AssertNoErr(t, err)
-		th.AssertEquals(t, len(rr), 1)
+		th.AssertEquals(t, 1, len(rr))
 		return true, nil
 	})
 	th.AssertNoErr(t, err)
@@ -79,7 +79,7 @@ func TestRecordSetsListAll(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 
 	listOpts := recordsets.ListOpts{
 		Limit: 1,
@@ -89,7 +89,7 @@ func TestRecordSetsListAll(t *testing.T) {
 	err = pager.EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
 		rr, err := recordsets.ExtractRecordSets(page)
 		th.AssertNoErr(t, err)
-		th.AssertEquals(t, len(rr), 1)
+		th.AssertEquals(t, 1, len(rr))
 		return false, nil
 	})
 	th.AssertNoErr(t, err)
@@ -134,7 +134,7 @@ func TestRecordSetsCRUD(t *testing.T) {
 	tools.PrintResource(t, &newRS)
 
 	th.AssertDeepEquals(t, newRS.Records, records)
-	th.AssertEquals(t, newRS.TTL, 3600)
+	th.AssertEquals(t, 3600, newRS.TTL)
 
 	ttl := 0
 	updateOpts = recordsets.UpdateOpts{

--- a/internal/acceptance/openstack/dns/v2/transfers_test.go
+++ b/internal/acceptance/openstack/dns/v2/transfers_test.go
@@ -41,7 +41,7 @@ func TestTransferRequestCRUD(t *testing.T) {
 			foundRequest = true
 		}
 	}
-	th.AssertEquals(t, foundRequest, true)
+	th.AssertEquals(t, true, foundRequest)
 
 	description := "new description"
 	updateOpts := transferRequests.UpdateOpts{
@@ -93,5 +93,5 @@ func TestTransferRequestAccept(t *testing.T) {
 			foundAccept = true
 		}
 	}
-	th.AssertEquals(t, foundAccept, true)
+	th.AssertEquals(t, true, foundAccept)
 }

--- a/internal/acceptance/openstack/dns/v2/transfers_test.go
+++ b/internal/acceptance/openstack/dns/v2/transfers_test.go
@@ -41,7 +41,7 @@ func TestTransferRequestCRUD(t *testing.T) {
 			foundRequest = true
 		}
 	}
-	th.AssertEquals(t, true, foundRequest)
+	th.AssertTrue(t, foundRequest)
 
 	description := "new description"
 	updateOpts := transferRequests.UpdateOpts{
@@ -93,5 +93,5 @@ func TestTransferRequestAccept(t *testing.T) {
 			foundAccept = true
 		}
 	}
-	th.AssertEquals(t, true, foundAccept)
+	th.AssertTrue(t, foundAccept)
 }

--- a/internal/acceptance/openstack/dns/v2/tsigkeys_test.go
+++ b/internal/acceptance/openstack/dns/v2/tsigkeys_test.go
@@ -39,7 +39,7 @@ func TestTSIGKeysCRUD(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 
 	updateOpts := tsigkeys.UpdateOpts{
 		Name:   tsigkey.Name + "-updated",

--- a/internal/acceptance/openstack/dns/v2/tsigkeys_test.go
+++ b/internal/acceptance/openstack/dns/v2/tsigkeys_test.go
@@ -39,7 +39,7 @@ func TestTSIGKeysCRUD(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 
 	updateOpts := tsigkeys.UpdateOpts{
 		Name:   tsigkey.Name + "-updated",
@@ -52,5 +52,5 @@ func TestTSIGKeysCRUD(t *testing.T) {
 	tools.PrintResource(t, &newTSIGKey)
 
 	th.AssertEquals(t, newTSIGKey.Name, tsigkey.Name+"-updated")
-	th.AssertEquals(t, newTSIGKey.Secret, "updated-test-secret-key==")
+	th.AssertEquals(t, "updated-test-secret-key==", newTSIGKey.Secret)
 }

--- a/internal/acceptance/openstack/dns/v2/zones_test.go
+++ b/internal/acceptance/openstack/dns/v2/zones_test.go
@@ -37,7 +37,7 @@ func TestZonesCRUD(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 
 	description := ""
 	updateOpts := zones.UpdateOpts{

--- a/internal/acceptance/openstack/dns/v2/zones_test.go
+++ b/internal/acceptance/openstack/dns/v2/zones_test.go
@@ -37,7 +37,7 @@ func TestZonesCRUD(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 
 	description := ""
 	updateOpts := zones.UpdateOpts{

--- a/internal/acceptance/openstack/identity/v2/extension_test.go
+++ b/internal/acceptance/openstack/identity/v2/extension_test.go
@@ -33,7 +33,7 @@ func TestExtensionsList(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 }
 
 func TestExtensionsGet(t *testing.T) {

--- a/internal/acceptance/openstack/identity/v2/extension_test.go
+++ b/internal/acceptance/openstack/identity/v2/extension_test.go
@@ -33,7 +33,7 @@ func TestExtensionsList(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 }
 
 func TestExtensionsGet(t *testing.T) {

--- a/internal/acceptance/openstack/identity/v2/role_test.go
+++ b/internal/acceptance/openstack/identity/v2/role_test.go
@@ -49,7 +49,7 @@ func TestRolesAddToUser(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 }
 
 func TestRolesList(t *testing.T) {
@@ -73,5 +73,5 @@ func TestRolesList(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 }

--- a/internal/acceptance/openstack/identity/v2/role_test.go
+++ b/internal/acceptance/openstack/identity/v2/role_test.go
@@ -49,7 +49,7 @@ func TestRolesAddToUser(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 }
 
 func TestRolesList(t *testing.T) {
@@ -73,5 +73,5 @@ func TestRolesList(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 }

--- a/internal/acceptance/openstack/identity/v2/tenant_test.go
+++ b/internal/acceptance/openstack/identity/v2/tenant_test.go
@@ -34,7 +34,7 @@ func TestTenantsList(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 }
 
 func TestTenantsCRUD(t *testing.T) {

--- a/internal/acceptance/openstack/identity/v2/tenant_test.go
+++ b/internal/acceptance/openstack/identity/v2/tenant_test.go
@@ -34,7 +34,7 @@ func TestTenantsList(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 }
 
 func TestTenantsCRUD(t *testing.T) {

--- a/internal/acceptance/openstack/identity/v2/user_test.go
+++ b/internal/acceptance/openstack/identity/v2/user_test.go
@@ -34,7 +34,7 @@ func TestUsersList(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 }
 
 func TestUsersCreateUpdateDelete(t *testing.T) {

--- a/internal/acceptance/openstack/identity/v2/user_test.go
+++ b/internal/acceptance/openstack/identity/v2/user_test.go
@@ -34,7 +34,7 @@ func TestUsersList(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 }
 
 func TestUsersCreateUpdateDelete(t *testing.T) {

--- a/internal/acceptance/openstack/identity/v3/applicationcredentials_test.go
+++ b/internal/acceptance/openstack/identity/v3/applicationcredentials_test.go
@@ -97,7 +97,7 @@ func TestApplicationCredentialsCRD(t *testing.T) {
 	th.AssertEquals(t, applicationCredential.ExpiresAt, expiresAt)
 	th.AssertEquals(t, applicationCredential.Name, createOpts.Name)
 	th.AssertEquals(t, applicationCredential.Description, createOpts.Description)
-	th.AssertEquals(t, false, applicationCredential.Unrestricted)
+	th.AssertFalse(t, applicationCredential.Unrestricted)
 	th.AssertEquals(t, applicationCredential.ProjectID, project.ID)
 
 	checkACroles := rolesToMap(applicationCredential.Roles)
@@ -124,7 +124,7 @@ func TestApplicationCredentialsCRD(t *testing.T) {
 	th.AssertEquals(t, getApplicationCredential.ExpiresAt, expiresAt)
 	th.AssertEquals(t, getApplicationCredential.Name, createOpts.Name)
 	th.AssertEquals(t, getApplicationCredential.Description, createOpts.Description)
-	th.AssertEquals(t, false, getApplicationCredential.Unrestricted)
+	th.AssertFalse(t, getApplicationCredential.Unrestricted)
 	th.AssertEquals(t, getApplicationCredential.ProjectID, project.ID)
 
 	checkACroles = rolesToMap(getApplicationCredential.Roles)
@@ -156,7 +156,7 @@ func TestApplicationCredentialsCRD(t *testing.T) {
 	th.AssertEquals(t, newApplicationCredential.Name, createOpts.Name)
 	th.AssertEquals(t, newApplicationCredential.Description, createOpts.Description)
 	th.AssertEquals(t, newApplicationCredential.Secret, createOpts.Secret)
-	th.AssertEquals(t, true, newApplicationCredential.Unrestricted)
+	th.AssertTrue(t, newApplicationCredential.Unrestricted)
 	th.AssertEquals(t, time.Time{}, newApplicationCredential.ExpiresAt)
 	th.AssertEquals(t, newApplicationCredential.ProjectID, project.ID)
 
@@ -235,7 +235,7 @@ func TestApplicationCredentialsAccessRules(t *testing.T) {
 	th.AssertEquals(t, applicationCredential.ExpiresAt, expiresAt)
 	th.AssertEquals(t, applicationCredential.Name, createOpts.Name)
 	th.AssertEquals(t, applicationCredential.Description, createOpts.Description)
-	th.AssertEquals(t, false, applicationCredential.Unrestricted)
+	th.AssertFalse(t, applicationCredential.Unrestricted)
 
 	for i, rule := range applicationCredential.AccessRules {
 		th.AssertEquals(t, rule.Path, apAccessRules[i].Path)
@@ -255,7 +255,7 @@ func TestApplicationCredentialsAccessRules(t *testing.T) {
 	th.AssertEquals(t, getApplicationCredential.ExpiresAt, expiresAt)
 	th.AssertEquals(t, getApplicationCredential.Name, createOpts.Name)
 	th.AssertEquals(t, getApplicationCredential.Description, createOpts.Description)
-	th.AssertEquals(t, false, getApplicationCredential.Unrestricted)
+	th.AssertFalse(t, getApplicationCredential.Unrestricted)
 
 	for i, rule := range applicationCredential.AccessRules {
 		th.AssertEquals(t, rule.Path, apAccessRules[i].Path)

--- a/internal/acceptance/openstack/identity/v3/applicationcredentials_test.go
+++ b/internal/acceptance/openstack/identity/v3/applicationcredentials_test.go
@@ -97,7 +97,7 @@ func TestApplicationCredentialsCRD(t *testing.T) {
 	th.AssertEquals(t, applicationCredential.ExpiresAt, expiresAt)
 	th.AssertEquals(t, applicationCredential.Name, createOpts.Name)
 	th.AssertEquals(t, applicationCredential.Description, createOpts.Description)
-	th.AssertEquals(t, applicationCredential.Unrestricted, false)
+	th.AssertEquals(t, false, applicationCredential.Unrestricted)
 	th.AssertEquals(t, applicationCredential.ProjectID, project.ID)
 
 	checkACroles := rolesToMap(applicationCredential.Roles)
@@ -124,7 +124,7 @@ func TestApplicationCredentialsCRD(t *testing.T) {
 	th.AssertEquals(t, getApplicationCredential.ExpiresAt, expiresAt)
 	th.AssertEquals(t, getApplicationCredential.Name, createOpts.Name)
 	th.AssertEquals(t, getApplicationCredential.Description, createOpts.Description)
-	th.AssertEquals(t, getApplicationCredential.Unrestricted, false)
+	th.AssertEquals(t, false, getApplicationCredential.Unrestricted)
 	th.AssertEquals(t, getApplicationCredential.ProjectID, project.ID)
 
 	checkACroles = rolesToMap(getApplicationCredential.Roles)
@@ -152,12 +152,12 @@ func TestApplicationCredentialsCRD(t *testing.T) {
 	defer applicationcredentials.Delete(context.TODO(), client, user.ID, newApplicationCredential.ID)
 	tools.PrintResource(t, newApplicationCredential)
 
-	th.AssertEquals(t, newApplicationCredential.ExpiresAt, time.Time{})
+	th.AssertEquals(t, time.Time{}, newApplicationCredential.ExpiresAt)
 	th.AssertEquals(t, newApplicationCredential.Name, createOpts.Name)
 	th.AssertEquals(t, newApplicationCredential.Description, createOpts.Description)
 	th.AssertEquals(t, newApplicationCredential.Secret, createOpts.Secret)
-	th.AssertEquals(t, newApplicationCredential.Unrestricted, true)
-	th.AssertEquals(t, newApplicationCredential.ExpiresAt, time.Time{})
+	th.AssertEquals(t, true, newApplicationCredential.Unrestricted)
+	th.AssertEquals(t, time.Time{}, newApplicationCredential.ExpiresAt)
 	th.AssertEquals(t, newApplicationCredential.ProjectID, project.ID)
 
 	checkACroles = rolesToMap(newApplicationCredential.Roles)
@@ -235,7 +235,7 @@ func TestApplicationCredentialsAccessRules(t *testing.T) {
 	th.AssertEquals(t, applicationCredential.ExpiresAt, expiresAt)
 	th.AssertEquals(t, applicationCredential.Name, createOpts.Name)
 	th.AssertEquals(t, applicationCredential.Description, createOpts.Description)
-	th.AssertEquals(t, applicationCredential.Unrestricted, false)
+	th.AssertEquals(t, false, applicationCredential.Unrestricted)
 
 	for i, rule := range applicationCredential.AccessRules {
 		th.AssertEquals(t, rule.Path, apAccessRules[i].Path)
@@ -255,7 +255,7 @@ func TestApplicationCredentialsAccessRules(t *testing.T) {
 	th.AssertEquals(t, getApplicationCredential.ExpiresAt, expiresAt)
 	th.AssertEquals(t, getApplicationCredential.Name, createOpts.Name)
 	th.AssertEquals(t, getApplicationCredential.Description, createOpts.Description)
-	th.AssertEquals(t, getApplicationCredential.Unrestricted, false)
+	th.AssertEquals(t, false, getApplicationCredential.Unrestricted)
 
 	for i, rule := range applicationCredential.AccessRules {
 		th.AssertEquals(t, rule.Path, apAccessRules[i].Path)
@@ -290,5 +290,5 @@ func TestApplicationCredentialsAccessRules(t *testing.T) {
 	th.AssertNoErr(t, err)
 	actual, err = applicationcredentials.ExtractAccessRules(allPages)
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, len(actual), 0)
+	th.AssertEquals(t, 0, len(actual))
 }

--- a/internal/acceptance/openstack/identity/v3/domains_test.go
+++ b/internal/acceptance/openstack/identity/v3/domains_test.go
@@ -55,7 +55,7 @@ func TestDomainsList(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 }
 
 func TestDomainsGet(t *testing.T) {

--- a/internal/acceptance/openstack/identity/v3/domains_test.go
+++ b/internal/acceptance/openstack/identity/v3/domains_test.go
@@ -55,7 +55,7 @@ func TestDomainsList(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 }
 
 func TestDomainsGet(t *testing.T) {
@@ -69,7 +69,7 @@ func TestDomainsGet(t *testing.T) {
 
 	tools.PrintResource(t, p)
 
-	th.AssertEquals(t, p.Name, "Default")
+	th.AssertEquals(t, "Default", p.Name)
 }
 
 func TestDomainsCRUD(t *testing.T) {

--- a/internal/acceptance/openstack/identity/v3/endpoint_test.go
+++ b/internal/acceptance/openstack/identity/v3/endpoint_test.go
@@ -59,7 +59,7 @@ func TestEndpointsGet(t *testing.T) {
 
 	tools.PrintResource(t, e)
 
-	th.AssertEquals(t, e.Name, e.Name)
+	th.AssertEquals(t, endpoint.Name, e.Name)
 }
 
 func TestEndpointsNavigateCatalog(t *testing.T) {

--- a/internal/acceptance/openstack/identity/v3/endpoint_test.go
+++ b/internal/acceptance/openstack/identity/v3/endpoint_test.go
@@ -36,7 +36,7 @@ func TestEndpointsList(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 }
 
 func TestEndpointsGet(t *testing.T) {

--- a/internal/acceptance/openstack/identity/v3/endpoint_test.go
+++ b/internal/acceptance/openstack/identity/v3/endpoint_test.go
@@ -36,7 +36,7 @@ func TestEndpointsList(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 }
 
 func TestEndpointsGet(t *testing.T) {
@@ -79,7 +79,7 @@ func TestEndpointsNavigateCatalog(t *testing.T) {
 	allServices, err := services.ExtractServices(allPages)
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, len(allServices), 1)
+	th.AssertEquals(t, 1, len(allServices))
 
 	computeService := allServices[0]
 	tools.PrintResource(t, computeService)
@@ -96,7 +96,7 @@ func TestEndpointsNavigateCatalog(t *testing.T) {
 	allEndpoints, err := endpoints.ExtractEndpoints(allPages)
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, len(allServices), 1)
+	th.AssertEquals(t, 1, len(allServices))
 
 	tools.PrintResource(t, allEndpoints[0])
 }
@@ -137,6 +137,6 @@ func TestEndpointCRUD(t *testing.T) {
 	}).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, newEndpoint.URL, "https://example-updated.com")
-	th.AssertEquals(t, newEndpoint.Description, "Updated Endpoint")
+	th.AssertEquals(t, "https://example-updated.com", newEndpoint.URL)
+	th.AssertEquals(t, "Updated Endpoint", newEndpoint.Description)
 }

--- a/internal/acceptance/openstack/identity/v3/federation_test.go
+++ b/internal/acceptance/openstack/identity/v3/federation_test.go
@@ -118,5 +118,5 @@ func TestMappingsCRUD(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	resp := federation.GetMapping(context.TODO(), client, mappingName)
-	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(resp.Err, http.StatusNotFound))
+	th.AssertTrue(t, gophercloud.ResponseCodeIs(resp.Err, http.StatusNotFound))
 }

--- a/internal/acceptance/openstack/identity/v3/groups_test.go
+++ b/internal/acceptance/openstack/identity/v3/groups_test.go
@@ -83,7 +83,7 @@ func TestGroupCRUD(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 
 	listOpts.Filters = map[string]string{
 		"name__contains": "TEST",
@@ -105,7 +105,7 @@ func TestGroupCRUD(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 
 	listOpts.Filters = map[string]string{
 		"name__contains": "foo",
@@ -127,7 +127,7 @@ func TestGroupCRUD(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, false)
+	th.AssertEquals(t, false, found)
 
 	// Get the recently created group by ID
 	p, err := groups.Get(context.TODO(), client, group.ID).Extract()

--- a/internal/acceptance/openstack/identity/v3/groups_test.go
+++ b/internal/acceptance/openstack/identity/v3/groups_test.go
@@ -83,7 +83,7 @@ func TestGroupCRUD(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 
 	listOpts.Filters = map[string]string{
 		"name__contains": "TEST",
@@ -105,7 +105,7 @@ func TestGroupCRUD(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 
 	listOpts.Filters = map[string]string{
 		"name__contains": "foo",
@@ -127,7 +127,7 @@ func TestGroupCRUD(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, false, found)
+	th.AssertFalse(t, found)
 
 	// Get the recently created group by ID
 	p, err := groups.Get(context.TODO(), client, group.ID).Extract()

--- a/internal/acceptance/openstack/identity/v3/oauth1_test.go
+++ b/internal/acceptance/openstack/identity/v3/oauth1_test.go
@@ -179,7 +179,7 @@ func oauth1MethodTest(t *testing.T, client *gophercloud.ServiceClient, consumer 
 				found = true
 			}
 		}
-		th.AssertEquals(t, found, true)
+		th.AssertEquals(t, true, found)
 	}
 
 	// Get access token role
@@ -193,7 +193,7 @@ func oauth1MethodTest(t *testing.T, client *gophercloud.ServiceClient, consumer 
 			found = true
 		}
 	}
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 
 	// Test auth using OAuth1
 	newClient, err := clients.NewIdentityV3UnauthenticatedClient()

--- a/internal/acceptance/openstack/identity/v3/oauth1_test.go
+++ b/internal/acceptance/openstack/identity/v3/oauth1_test.go
@@ -179,7 +179,7 @@ func oauth1MethodTest(t *testing.T, client *gophercloud.ServiceClient, consumer 
 				found = true
 			}
 		}
-		th.AssertEquals(t, true, found)
+		th.AssertTrue(t, found)
 	}
 
 	// Get access token role
@@ -193,7 +193,7 @@ func oauth1MethodTest(t *testing.T, client *gophercloud.ServiceClient, consumer 
 			found = true
 		}
 	}
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 
 	// Test auth using OAuth1
 	newClient, err := clients.NewIdentityV3UnauthenticatedClient()

--- a/internal/acceptance/openstack/identity/v3/policies_test.go
+++ b/internal/acceptance/openstack/identity/v3/policies_test.go
@@ -71,7 +71,7 @@ func TestPoliciesCRUD(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 
 	listOpts.Filters = map[string]string{
 		"type__contains": "json",
@@ -93,7 +93,7 @@ func TestPoliciesCRUD(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 
 	listOpts.Filters = map[string]string{
 		"type__contains": "foobar",
@@ -115,7 +115,7 @@ func TestPoliciesCRUD(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, false, found)
+	th.AssertFalse(t, found)
 
 	gotPolicy, err := policies.Get(context.TODO(), client, policy.ID).Extract()
 	th.AssertNoErr(t, err)

--- a/internal/acceptance/openstack/identity/v3/projects_test.go
+++ b/internal/acceptance/openstack/identity/v3/projects_test.go
@@ -55,7 +55,7 @@ func TestProjectsList(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 
 	listOpts.Filters = map[string]string{
 		"name__contains": "dmi",
@@ -76,7 +76,7 @@ func TestProjectsList(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 
 	listOpts.Filters = map[string]string{
 		"name__contains": "foo",
@@ -97,7 +97,7 @@ func TestProjectsList(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, false)
+	th.AssertEquals(t, false, found)
 }
 
 func TestProjectsGet(t *testing.T) {
@@ -247,7 +247,7 @@ func TestProjectsTags(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 
 	// Search using all tags, including a not existing one
 	listOpts = projects.ListOpts{
@@ -260,7 +260,7 @@ func TestProjectsTags(t *testing.T) {
 	allProjects, err = projects.ExtractProjects(allPages)
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, len(allProjects), 0)
+	th.AssertEquals(t, 0, len(allProjects))
 
 	// Search matching at least one tag
 	listOpts = projects.ListOpts{
@@ -282,7 +282,7 @@ func TestProjectsTags(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 
 	// Search not matching any single tag
 	listOpts = projects.ListOpts{
@@ -304,7 +304,7 @@ func TestProjectsTags(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, false)
+	th.AssertEquals(t, false, found)
 
 	// Search matching not all tags
 	listOpts = projects.ListOpts{
@@ -326,7 +326,7 @@ func TestProjectsTags(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 
 	// Update the tags
 	updateOpts := projects.UpdateOpts{
@@ -337,8 +337,8 @@ func TestProjectsTags(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	tools.PrintResource(t, updatedProject)
-	th.AssertEquals(t, len(updatedProject.Tags), 1)
-	th.AssertEquals(t, updatedProject.Tags[0], "Tag1")
+	th.AssertEquals(t, 1, len(updatedProject.Tags))
+	th.AssertEquals(t, "Tag1", updatedProject.Tags[0])
 
 	// Update the project, but not its tags
 	description := "Test description"
@@ -350,8 +350,8 @@ func TestProjectsTags(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	tools.PrintResource(t, updatedProject)
-	th.AssertEquals(t, len(updatedProject.Tags), 1)
-	th.AssertEquals(t, updatedProject.Tags[0], "Tag1")
+	th.AssertEquals(t, 1, len(updatedProject.Tags))
+	th.AssertEquals(t, "Tag1", updatedProject.Tags[0])
 
 	// Remove all Tags
 	updateOpts = projects.UpdateOpts{
@@ -362,7 +362,7 @@ func TestProjectsTags(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	tools.PrintResource(t, updatedProject)
-	th.AssertEquals(t, len(updatedProject.Tags), 0)
+	th.AssertEquals(t, 0, len(updatedProject.Tags))
 }
 
 func TestProjectsTagsCRUD(t *testing.T) {

--- a/internal/acceptance/openstack/identity/v3/projects_test.go
+++ b/internal/acceptance/openstack/identity/v3/projects_test.go
@@ -55,7 +55,7 @@ func TestProjectsList(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 
 	listOpts.Filters = map[string]string{
 		"name__contains": "dmi",
@@ -76,7 +76,7 @@ func TestProjectsList(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 
 	listOpts.Filters = map[string]string{
 		"name__contains": "foo",
@@ -97,7 +97,7 @@ func TestProjectsList(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, false, found)
+	th.AssertFalse(t, found)
 }
 
 func TestProjectsGet(t *testing.T) {
@@ -247,7 +247,7 @@ func TestProjectsTags(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 
 	// Search using all tags, including a not existing one
 	listOpts = projects.ListOpts{
@@ -282,7 +282,7 @@ func TestProjectsTags(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 
 	// Search not matching any single tag
 	listOpts = projects.ListOpts{
@@ -304,7 +304,7 @@ func TestProjectsTags(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, false, found)
+	th.AssertFalse(t, found)
 
 	// Search matching not all tags
 	listOpts = projects.ListOpts{
@@ -326,7 +326,7 @@ func TestProjectsTags(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 
 	// Update the tags
 	updateOpts := projects.UpdateOpts{

--- a/internal/acceptance/openstack/identity/v3/roles_test.go
+++ b/internal/acceptance/openstack/identity/v3/roles_test.go
@@ -96,7 +96,7 @@ func TestRolesCRUD(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 	description := "updated role test"
 	updateOpts := roles.UpdateOpts{
 		Description: &description,
@@ -115,7 +115,7 @@ func TestRolesCRUD(t *testing.T) {
 	tools.PrintResource(t, newRole.Extra)
 
 	th.AssertEquals(t, newRole.Description, description)
-	th.AssertEquals(t, newRole.Extra["email"], "updatedtestrole@example.com")
+	th.AssertEquals(t, "updatedtestrole@example.com", newRole.Extra["email"])
 
 }
 
@@ -158,7 +158,7 @@ func TestRolesFilterList(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 
 	listOpts.Filters = map[string]string{
 		"name__contains": "reader",
@@ -180,7 +180,7 @@ func TestRolesFilterList(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, false)
+	th.AssertEquals(t, false, found)
 }
 
 func TestRoleListAssignmentIncludeNamesAndSubtree(t *testing.T) {
@@ -248,7 +248,7 @@ func TestRoleListAssignmentIncludeNamesAndSubtree(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 }
 
 func TestRoleListAssignmentForUserOnProject(t *testing.T) {
@@ -310,7 +310,7 @@ func TestRoleListAssignmentForUserOnProject(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 }
 
 func TestRoleListAssignmentForUserOnDomain(t *testing.T) {
@@ -375,7 +375,7 @@ func TestRoleListAssignmentForUserOnDomain(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 }
 
 func TestRoleListAssignmentForGroupOnProject(t *testing.T) {
@@ -440,7 +440,7 @@ func TestRoleListAssignmentForGroupOnProject(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 }
 
 func TestRoleListAssignmentForGroupOnDomain(t *testing.T) {
@@ -508,7 +508,7 @@ func TestRoleListAssignmentForGroupOnDomain(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 }
 
 func TestRolesAssignToUserOnProject(t *testing.T) {
@@ -578,7 +578,7 @@ func TestRolesAssignToUserOnProject(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 }
 
 func TestRolesAssignToUserOnDomain(t *testing.T) {
@@ -651,7 +651,7 @@ func TestRolesAssignToUserOnDomain(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 }
 
 func TestRolesAssignToGroupOnDomain(t *testing.T) {
@@ -727,7 +727,7 @@ func TestRolesAssignToGroupOnDomain(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 }
 
 func TestRolesAssignToGroupOnProject(t *testing.T) {
@@ -800,7 +800,7 @@ func TestRolesAssignToGroupOnProject(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 }
 
 func TestCRUDRoleInferenceRule(t *testing.T) {

--- a/internal/acceptance/openstack/identity/v3/roles_test.go
+++ b/internal/acceptance/openstack/identity/v3/roles_test.go
@@ -96,7 +96,7 @@ func TestRolesCRUD(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 	description := "updated role test"
 	updateOpts := roles.UpdateOpts{
 		Description: &description,
@@ -158,7 +158,7 @@ func TestRolesFilterList(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 
 	listOpts.Filters = map[string]string{
 		"name__contains": "reader",
@@ -180,7 +180,7 @@ func TestRolesFilterList(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, false, found)
+	th.AssertFalse(t, found)
 }
 
 func TestRoleListAssignmentIncludeNamesAndSubtree(t *testing.T) {
@@ -248,7 +248,7 @@ func TestRoleListAssignmentIncludeNamesAndSubtree(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 }
 
 func TestRoleListAssignmentForUserOnProject(t *testing.T) {
@@ -310,7 +310,7 @@ func TestRoleListAssignmentForUserOnProject(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 }
 
 func TestRoleListAssignmentForUserOnDomain(t *testing.T) {
@@ -375,7 +375,7 @@ func TestRoleListAssignmentForUserOnDomain(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 }
 
 func TestRoleListAssignmentForGroupOnProject(t *testing.T) {
@@ -440,7 +440,7 @@ func TestRoleListAssignmentForGroupOnProject(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 }
 
 func TestRoleListAssignmentForGroupOnDomain(t *testing.T) {
@@ -508,7 +508,7 @@ func TestRoleListAssignmentForGroupOnDomain(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 }
 
 func TestRolesAssignToUserOnProject(t *testing.T) {
@@ -578,7 +578,7 @@ func TestRolesAssignToUserOnProject(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 }
 
 func TestRolesAssignToUserOnDomain(t *testing.T) {
@@ -651,7 +651,7 @@ func TestRolesAssignToUserOnDomain(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 }
 
 func TestRolesAssignToGroupOnDomain(t *testing.T) {
@@ -727,7 +727,7 @@ func TestRolesAssignToGroupOnDomain(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 }
 
 func TestRolesAssignToGroupOnProject(t *testing.T) {
@@ -800,7 +800,7 @@ func TestRolesAssignToGroupOnProject(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 }
 
 func TestCRUDRoleInferenceRule(t *testing.T) {

--- a/internal/acceptance/openstack/identity/v3/service_test.go
+++ b/internal/acceptance/openstack/identity/v3/service_test.go
@@ -37,7 +37,7 @@ func TestServicesList(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 }
 
 func TestServicesCRUD(t *testing.T) {

--- a/internal/acceptance/openstack/identity/v3/service_test.go
+++ b/internal/acceptance/openstack/identity/v3/service_test.go
@@ -37,7 +37,7 @@ func TestServicesList(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 }
 
 func TestServicesCRUD(t *testing.T) {
@@ -75,5 +75,5 @@ func TestServicesCRUD(t *testing.T) {
 	tools.PrintResource(t, newService)
 	tools.PrintResource(t, newService.Extra)
 
-	th.AssertEquals(t, newService.Extra["description"], "Test Users")
+	th.AssertEquals(t, "Test Users", newService.Extra["description"])
 }

--- a/internal/acceptance/openstack/identity/v3/trusts_test.go
+++ b/internal/acceptance/openstack/identity/v3/trusts_test.go
@@ -112,7 +112,7 @@ func TestTrustCRUD(t *testing.T) {
 	p, err := trusts.Get(context.TODO(), client, trust.ID).Extract()
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, p.ExpiresAt, expiresAt)
-	th.AssertEquals(t, true, p.DeletedAt.IsZero())
+	th.AssertTrue(t, p.DeletedAt.IsZero())
 
 	tools.PrintResource(t, p)
 

--- a/internal/acceptance/openstack/identity/v3/trusts_test.go
+++ b/internal/acceptance/openstack/identity/v3/trusts_test.go
@@ -112,7 +112,7 @@ func TestTrustCRUD(t *testing.T) {
 	p, err := trusts.Get(context.TODO(), client, trust.ID).Extract()
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, p.ExpiresAt, expiresAt)
-	th.AssertEquals(t, p.DeletedAt.IsZero(), true)
+	th.AssertEquals(t, true, p.DeletedAt.IsZero())
 
 	tools.PrintResource(t, p)
 
@@ -121,7 +121,7 @@ func TestTrustCRUD(t *testing.T) {
 	th.AssertNoErr(t, err)
 	allTrustRoles, err := trusts.ExtractRoles(rolesPages)
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, len(allTrustRoles), 1)
+	th.AssertEquals(t, 1, len(allTrustRoles))
 	th.AssertEquals(t, allTrustRoles[0].ID, memberRoleID)
 
 	// Get trust role

--- a/internal/acceptance/openstack/identity/v3/users_test.go
+++ b/internal/acceptance/openstack/identity/v3/users_test.go
@@ -41,7 +41,7 @@ func TestUsersList(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 
 	listOpts.Filters = map[string]string{
 		"name__contains": "dmi",
@@ -63,7 +63,7 @@ func TestUsersList(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 
 	listOpts.Filters = map[string]string{
 		"name__contains": "foo",
@@ -85,7 +85,7 @@ func TestUsersList(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, false)
+	th.AssertEquals(t, false, found)
 }
 
 func TestUsersGet(t *testing.T) {
@@ -172,7 +172,7 @@ func TestUserCRUD(t *testing.T) {
 	th.AssertEquals(t, newUser.Name, name)
 	th.AssertEquals(t, newUser.Description, description)
 	th.AssertEquals(t, newUser.Enabled, iFalse)
-	th.AssertEquals(t, newUser.Extra["disabled_reason"], "DDOS")
+	th.AssertEquals(t, "DDOS", newUser.Extra["disabled_reason"])
 }
 
 func TestUserChangePassword(t *testing.T) {
@@ -251,7 +251,7 @@ func TestUsersGroups(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 
 	found = false
 	allUserPages, err := users.ListInGroup(client, group.ID, nil).AllPages(context.TODO())
@@ -269,7 +269,7 @@ func TestUsersGroups(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 
 	ok, err := users.IsMemberOfGroup(context.TODO(), client, group.ID, user.ID).Extract()
 	if err != nil {
@@ -298,7 +298,7 @@ func TestUsersGroups(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, false)
+	th.AssertEquals(t, false, found)
 
 	found = false
 	allUserPages, err = users.ListInGroup(client, group.ID, nil).AllPages(context.TODO())
@@ -316,7 +316,7 @@ func TestUsersGroups(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, false)
+	th.AssertEquals(t, false, found)
 
 }
 

--- a/internal/acceptance/openstack/identity/v3/users_test.go
+++ b/internal/acceptance/openstack/identity/v3/users_test.go
@@ -41,7 +41,7 @@ func TestUsersList(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 
 	listOpts.Filters = map[string]string{
 		"name__contains": "dmi",
@@ -63,7 +63,7 @@ func TestUsersList(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 
 	listOpts.Filters = map[string]string{
 		"name__contains": "foo",
@@ -85,7 +85,7 @@ func TestUsersList(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, false, found)
+	th.AssertFalse(t, found)
 }
 
 func TestUsersGet(t *testing.T) {
@@ -251,7 +251,7 @@ func TestUsersGroups(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 
 	found = false
 	allUserPages, err := users.ListInGroup(client, group.ID, nil).AllPages(context.TODO())
@@ -269,7 +269,7 @@ func TestUsersGroups(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 
 	ok, err := users.IsMemberOfGroup(context.TODO(), client, group.ID, user.ID).Extract()
 	if err != nil {
@@ -298,7 +298,7 @@ func TestUsersGroups(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, false, found)
+	th.AssertFalse(t, found)
 
 	found = false
 	allUserPages, err = users.ListInGroup(client, group.ID, nil).AllPages(context.TODO())
@@ -316,7 +316,7 @@ func TestUsersGroups(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, false, found)
+	th.AssertFalse(t, found)
 
 }
 

--- a/internal/acceptance/openstack/image/v2/images_test.go
+++ b/internal/acceptance/openstack/image/v2/images_test.go
@@ -66,7 +66,7 @@ func TestImagesListAllPages(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 }
 
 func TestImagesListByDate(t *testing.T) {
@@ -175,7 +175,7 @@ func TestImagesUpdate(t *testing.T) {
 	tools.PrintResource(t, newImage.Properties)
 
 	th.AssertEquals(t, newImage.Name, image.Name+"foo")
-	th.AssertEquals(t, newImage.Protected, true)
+	th.AssertEquals(t, true, newImage.Protected)
 
 	sort.Strings(newTags)
 	sort.Strings(newImage.Tags)
@@ -183,7 +183,7 @@ func TestImagesUpdate(t *testing.T) {
 
 	// Because OpenStack is now adding additional properties automatically,
 	// it's not possible to do an easy AssertDeepEquals.
-	th.AssertEquals(t, newImage.Properties["hw_disk_bus"], "scsi")
+	th.AssertEquals(t, "scsi", newImage.Properties["hw_disk_bus"])
 
 	if _, ok := newImage.Properties["architecture"]; ok {
 		t.Fatal("architecture property still exists")

--- a/internal/acceptance/openstack/image/v2/images_test.go
+++ b/internal/acceptance/openstack/image/v2/images_test.go
@@ -66,7 +66,7 @@ func TestImagesListAllPages(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 }
 
 func TestImagesListByDate(t *testing.T) {
@@ -175,7 +175,7 @@ func TestImagesUpdate(t *testing.T) {
 	tools.PrintResource(t, newImage.Properties)
 
 	th.AssertEquals(t, newImage.Name, image.Name+"foo")
-	th.AssertEquals(t, true, newImage.Protected)
+	th.AssertTrue(t, newImage.Protected)
 
 	sort.Strings(newTags)
 	sort.Strings(newImage.Tags)

--- a/internal/acceptance/openstack/image/v2/imageservice.go
+++ b/internal/acceptance/openstack/image/v2/imageservice.go
@@ -56,8 +56,8 @@ func CreateEmptyImage(t *testing.T, client *gophercloud.ServiceClient) (*images.
 	t.Logf("Created image %s: %#v", name, newImage)
 
 	th.CheckEquals(t, newImage.Name, name)
-	th.CheckEquals(t, newImage.Properties["architecture"], "x86_64")
-	th.CheckEquals(t, newImage.Properties["properties"], "{'hypervisor_type': 'qemu', 'architecture': 'x86_64'}")
+	th.CheckEquals(t, "x86_64", newImage.Properties["architecture"])
+	th.CheckEquals(t, "{'hypervisor_type': 'qemu', 'architecture': 'x86_64'}", newImage.Properties["properties"])
 	return newImage, nil
 }
 

--- a/internal/acceptance/openstack/keymanager/v1/acls_test.go
+++ b/internal/acceptance/openstack/keymanager/v1/acls_test.go
@@ -50,7 +50,7 @@ func TestACLCRUD(t *testing.T) {
 	tools.PrintResource(t, acl)
 	tools.PrintResource(t, (*acl)["read"].Created)
 	th.AssertEquals(t, 1, len((*acl)["read"].Users))
-	th.AssertEquals(t, false, (*acl)["read"].ProjectAccess)
+	th.AssertFalse(t, (*acl)["read"].ProjectAccess)
 
 	newUsers := []string{}
 	updateOpts := acls.SetOpts{
@@ -69,7 +69,7 @@ func TestACLCRUD(t *testing.T) {
 	tools.PrintResource(t, acl)
 	tools.PrintResource(t, (*acl)["read"].Created)
 	th.AssertEquals(t, 0, len((*acl)["read"].Users))
-	th.AssertEquals(t, false, (*acl)["read"].ProjectAccess)
+	th.AssertFalse(t, (*acl)["read"].ProjectAccess)
 
 	container, err := CreateGenericContainer(t, client, secret)
 	th.AssertNoErr(t, err)
@@ -93,7 +93,7 @@ func TestACLCRUD(t *testing.T) {
 	tools.PrintResource(t, acl)
 	tools.PrintResource(t, (*acl)["read"].Created)
 	th.AssertEquals(t, 1, len((*acl)["read"].Users))
-	th.AssertEquals(t, false, (*acl)["read"].ProjectAccess)
+	th.AssertFalse(t, (*acl)["read"].ProjectAccess)
 
 	aclRef, err = acls.UpdateContainerACL(context.TODO(), client, containerID, updateOpts).Extract()
 	th.AssertNoErr(t, err)
@@ -104,5 +104,5 @@ func TestACLCRUD(t *testing.T) {
 	tools.PrintResource(t, acl)
 	tools.PrintResource(t, (*acl)["read"].Created)
 	th.AssertEquals(t, 0, len((*acl)["read"].Users))
-	th.AssertEquals(t, false, (*acl)["read"].ProjectAccess)
+	th.AssertFalse(t, (*acl)["read"].ProjectAccess)
 }

--- a/internal/acceptance/openstack/keymanager/v1/acls_test.go
+++ b/internal/acceptance/openstack/keymanager/v1/acls_test.go
@@ -49,8 +49,8 @@ func TestACLCRUD(t *testing.T) {
 	th.AssertNoErr(t, err)
 	tools.PrintResource(t, acl)
 	tools.PrintResource(t, (*acl)["read"].Created)
-	th.AssertEquals(t, len((*acl)["read"].Users), 1)
-	th.AssertEquals(t, (*acl)["read"].ProjectAccess, false)
+	th.AssertEquals(t, 1, len((*acl)["read"].Users))
+	th.AssertEquals(t, false, (*acl)["read"].ProjectAccess)
 
 	newUsers := []string{}
 	updateOpts := acls.SetOpts{
@@ -68,8 +68,8 @@ func TestACLCRUD(t *testing.T) {
 	th.AssertNoErr(t, err)
 	tools.PrintResource(t, acl)
 	tools.PrintResource(t, (*acl)["read"].Created)
-	th.AssertEquals(t, len((*acl)["read"].Users), 0)
-	th.AssertEquals(t, (*acl)["read"].ProjectAccess, false)
+	th.AssertEquals(t, 0, len((*acl)["read"].Users))
+	th.AssertEquals(t, false, (*acl)["read"].ProjectAccess)
 
 	container, err := CreateGenericContainer(t, client, secret)
 	th.AssertNoErr(t, err)
@@ -92,8 +92,8 @@ func TestACLCRUD(t *testing.T) {
 	th.AssertNoErr(t, err)
 	tools.PrintResource(t, acl)
 	tools.PrintResource(t, (*acl)["read"].Created)
-	th.AssertEquals(t, len((*acl)["read"].Users), 1)
-	th.AssertEquals(t, (*acl)["read"].ProjectAccess, false)
+	th.AssertEquals(t, 1, len((*acl)["read"].Users))
+	th.AssertEquals(t, false, (*acl)["read"].ProjectAccess)
 
 	aclRef, err = acls.UpdateContainerACL(context.TODO(), client, containerID, updateOpts).Extract()
 	th.AssertNoErr(t, err)
@@ -103,6 +103,6 @@ func TestACLCRUD(t *testing.T) {
 	th.AssertNoErr(t, err)
 	tools.PrintResource(t, acl)
 	tools.PrintResource(t, (*acl)["read"].Created)
-	th.AssertEquals(t, len((*acl)["read"].Users), 0)
-	th.AssertEquals(t, (*acl)["read"].ProjectAccess, false)
+	th.AssertEquals(t, 0, len((*acl)["read"].Users))
+	th.AssertEquals(t, false, (*acl)["read"].ProjectAccess)
 }

--- a/internal/acceptance/openstack/keymanager/v1/containers_test.go
+++ b/internal/acceptance/openstack/keymanager/v1/containers_test.go
@@ -53,7 +53,7 @@ func TestGenericContainersCRUD(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 }
 
 func TestCertificateContainer(t *testing.T) {
@@ -197,5 +197,5 @@ func TestContainerConsumersCRUD(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 }

--- a/internal/acceptance/openstack/keymanager/v1/containers_test.go
+++ b/internal/acceptance/openstack/keymanager/v1/containers_test.go
@@ -53,7 +53,7 @@ func TestGenericContainersCRUD(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 }
 
 func TestCertificateContainer(t *testing.T) {
@@ -172,7 +172,7 @@ func TestContainerConsumersCRUD(t *testing.T) {
 	container, err = containers.CreateConsumer(context.TODO(), client, containerID, consumerCreateOpts).Extract()
 	th.AssertNoErr(t, err)
 	tools.PrintResource(t, container.Consumers)
-	th.AssertEquals(t, len(container.Consumers), 1)
+	th.AssertEquals(t, 1, len(container.Consumers))
 	defer func() {
 		deleteOpts := containers.DeleteConsumerOpts{
 			Name: consumerName,
@@ -181,7 +181,7 @@ func TestContainerConsumersCRUD(t *testing.T) {
 
 		container, err := containers.DeleteConsumer(context.TODO(), client, containerID, deleteOpts).Extract()
 		th.AssertNoErr(t, err)
-		th.AssertEquals(t, len(container.Consumers), 0)
+		th.AssertEquals(t, 0, len(container.Consumers))
 	}()
 
 	allPages, err := containers.ListConsumers(client, containerID, nil).AllPages(context.TODO())
@@ -197,5 +197,5 @@ func TestContainerConsumersCRUD(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 }

--- a/internal/acceptance/openstack/keymanager/v1/keymanager.go
+++ b/internal/acceptance/openstack/keymanager/v1/keymanager.go
@@ -63,7 +63,7 @@ func CreateAsymmetricOrder(t *testing.T, client *gophercloud.ServiceClient) (*or
 	tools.PrintResource(t, order.Meta.Expiration)
 
 	th.AssertEquals(t, order.Meta.Name, name)
-	th.AssertEquals(t, order.Type, "asymmetric")
+	th.AssertEquals(t, "asymmetric", order.Type)
 
 	return order, nil
 }
@@ -114,7 +114,7 @@ func CreateCertificateContainer(t *testing.T, client *gophercloud.ServiceClient,
 	tools.PrintResource(t, container)
 
 	th.AssertEquals(t, container.Name, containerName)
-	th.AssertEquals(t, container.Type, "certificate")
+	th.AssertEquals(t, "certificate", container.Type)
 
 	return container, nil
 }
@@ -156,7 +156,7 @@ func CreateKeyOrder(t *testing.T, client *gophercloud.ServiceClient) (*orders.Or
 	tools.PrintResource(t, order.Meta.Expiration)
 
 	th.AssertEquals(t, order.Meta.Name, name)
-	th.AssertEquals(t, order.Type, "key")
+	th.AssertEquals(t, "key", order.Type)
 
 	return order, nil
 }
@@ -207,7 +207,7 @@ func CreateRSAContainer(t *testing.T, client *gophercloud.ServiceClient, passphr
 	tools.PrintResource(t, container)
 
 	th.AssertEquals(t, container.Name, containerName)
-	th.AssertEquals(t, container.Type, "rsa")
+	th.AssertEquals(t, "rsa", container.Type)
 
 	return container, nil
 }
@@ -249,7 +249,7 @@ func CreateCertificateSecret(t *testing.T, client *gophercloud.ServiceClient, ce
 	tools.PrintResource(t, secret)
 
 	th.AssertEquals(t, secret.Name, name)
-	th.AssertEquals(t, secret.Algorithm, "rsa")
+	th.AssertEquals(t, "rsa", secret.Algorithm)
 
 	return secret, nil
 }
@@ -289,7 +289,7 @@ func CreateEmptySecret(t *testing.T, client *gophercloud.ServiceClient) (*secret
 	tools.PrintResource(t, secret)
 
 	th.AssertEquals(t, secret.Name, secretName)
-	th.AssertEquals(t, secret.Algorithm, "aes")
+	th.AssertEquals(t, "aes", secret.Algorithm)
 
 	return secret, nil
 }
@@ -333,7 +333,7 @@ func CreateGenericContainer(t *testing.T, client *gophercloud.ServiceClient, sec
 	tools.PrintResource(t, container)
 
 	th.AssertEquals(t, container.Name, containerName)
-	th.AssertEquals(t, container.Type, "generic")
+	th.AssertEquals(t, "generic", container.Type)
 
 	return container, nil
 }
@@ -423,7 +423,7 @@ func CreatePassphraseSecret(t *testing.T, client *gophercloud.ServiceClient, pas
 	tools.PrintResource(t, secret)
 
 	th.AssertEquals(t, secret.Name, secretName)
-	th.AssertEquals(t, secret.Algorithm, "aes")
+	th.AssertEquals(t, "aes", secret.Algorithm)
 
 	return secret, nil
 }
@@ -465,7 +465,7 @@ func CreatePublicSecret(t *testing.T, client *gophercloud.ServiceClient, pub []b
 	tools.PrintResource(t, secret)
 
 	th.AssertEquals(t, secret.Name, name)
-	th.AssertEquals(t, secret.Algorithm, "rsa")
+	th.AssertEquals(t, "rsa", secret.Algorithm)
 
 	return secret, nil
 }
@@ -507,7 +507,7 @@ func CreatePrivateSecret(t *testing.T, client *gophercloud.ServiceClient, priv [
 	tools.PrintResource(t, secret)
 
 	th.AssertEquals(t, secret.Name, name)
-	th.AssertEquals(t, secret.Algorithm, "rsa")
+	th.AssertEquals(t, "rsa", secret.Algorithm)
 
 	return secret, nil
 }
@@ -551,7 +551,7 @@ func CreateSecretWithPayload(t *testing.T, client *gophercloud.ServiceClient, pa
 	tools.PrintResource(t, secret)
 
 	th.AssertEquals(t, secret.Name, secretName)
-	th.AssertEquals(t, secret.Algorithm, "aes")
+	th.AssertEquals(t, "aes", secret.Algorithm)
 	th.AssertEquals(t, secret.Expiration, expiration)
 
 	return secret, nil
@@ -597,7 +597,7 @@ func CreateSymmetricSecret(t *testing.T, client *gophercloud.ServiceClient) (*se
 	tools.PrintResource(t, secret)
 
 	th.AssertEquals(t, secret.Name, name)
-	th.AssertEquals(t, secret.Algorithm, "aes")
+	th.AssertEquals(t, "aes", secret.Algorithm)
 
 	return secret, nil
 }

--- a/internal/acceptance/openstack/keymanager/v1/orders_test.go
+++ b/internal/acceptance/openstack/keymanager/v1/orders_test.go
@@ -49,7 +49,7 @@ func TestOrdersCRUD(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 }
 
 func TestOrdersAsymmetric(t *testing.T) {

--- a/internal/acceptance/openstack/keymanager/v1/orders_test.go
+++ b/internal/acceptance/openstack/keymanager/v1/orders_test.go
@@ -49,7 +49,7 @@ func TestOrdersCRUD(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 }
 
 func TestOrdersAsymmetric(t *testing.T) {

--- a/internal/acceptance/openstack/keymanager/v1/secrets_test.go
+++ b/internal/acceptance/openstack/keymanager/v1/secrets_test.go
@@ -52,7 +52,7 @@ func TestSecretsCRUD(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 }
 
 func TestSecretsDelayedPayload(t *testing.T) {

--- a/internal/acceptance/openstack/keymanager/v1/secrets_test.go
+++ b/internal/acceptance/openstack/keymanager/v1/secrets_test.go
@@ -52,7 +52,7 @@ func TestSecretsCRUD(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 }
 
 func TestSecretsDelayedPayload(t *testing.T) {
@@ -105,8 +105,8 @@ func TestSecretsMetadataCRUD(t *testing.T) {
 	metadata, err := secrets.GetMetadata(context.TODO(), client, secretID).Extract()
 	th.AssertNoErr(t, err)
 	tools.PrintResource(t, metadata)
-	th.AssertEquals(t, metadata["foo"], "bar")
-	th.AssertEquals(t, metadata["something"], "something else")
+	th.AssertEquals(t, "bar", metadata["foo"])
+	th.AssertEquals(t, "something else", metadata["something"])
 
 	// Add a single metadatum
 	metadatumOpts := secrets.MetadatumOpts{
@@ -120,10 +120,10 @@ func TestSecretsMetadataCRUD(t *testing.T) {
 	metadata, err = secrets.GetMetadata(context.TODO(), client, secretID).Extract()
 	th.AssertNoErr(t, err)
 	tools.PrintResource(t, metadata)
-	th.AssertEquals(t, len(metadata), 3)
-	th.AssertEquals(t, metadata["foo"], "bar")
-	th.AssertEquals(t, metadata["something"], "something else")
-	th.AssertEquals(t, metadata["bar"], "baz")
+	th.AssertEquals(t, 3, len(metadata))
+	th.AssertEquals(t, "bar", metadata["foo"])
+	th.AssertEquals(t, "something else", metadata["something"])
+	th.AssertEquals(t, "baz", metadata["bar"])
 
 	// Update a metadatum
 	metadatumOpts.Key = "foo"
@@ -132,16 +132,16 @@ func TestSecretsMetadataCRUD(t *testing.T) {
 	metadatum, err := secrets.UpdateMetadatum(context.TODO(), client, secretID, metadatumOpts).Extract()
 	th.AssertNoErr(t, err)
 	tools.PrintResource(t, metadatum)
-	th.AssertDeepEquals(t, metadatum.Key, "foo")
-	th.AssertDeepEquals(t, metadatum.Value, "foo")
+	th.AssertDeepEquals(t, "foo", metadatum.Key)
+	th.AssertDeepEquals(t, "foo", metadatum.Value)
 
 	metadata, err = secrets.GetMetadata(context.TODO(), client, secretID).Extract()
 	th.AssertNoErr(t, err)
 	tools.PrintResource(t, metadata)
-	th.AssertEquals(t, len(metadata), 3)
-	th.AssertEquals(t, metadata["foo"], "foo")
-	th.AssertEquals(t, metadata["something"], "something else")
-	th.AssertEquals(t, metadata["bar"], "baz")
+	th.AssertEquals(t, 3, len(metadata))
+	th.AssertEquals(t, "foo", metadata["foo"])
+	th.AssertEquals(t, "something else", metadata["something"])
+	th.AssertEquals(t, "baz", metadata["bar"])
 
 	// Delete a metadatum
 	err = secrets.DeleteMetadatum(context.TODO(), client, secretID, "foo").ExtractErr()
@@ -150,9 +150,9 @@ func TestSecretsMetadataCRUD(t *testing.T) {
 	metadata, err = secrets.GetMetadata(context.TODO(), client, secretID).Extract()
 	th.AssertNoErr(t, err)
 	tools.PrintResource(t, metadata)
-	th.AssertEquals(t, len(metadata), 2)
-	th.AssertEquals(t, metadata["something"], "something else")
-	th.AssertEquals(t, metadata["bar"], "baz")
+	th.AssertEquals(t, 2, len(metadata))
+	th.AssertEquals(t, "something else", metadata["something"])
+	th.AssertEquals(t, "baz", metadata["bar"])
 }
 
 func TestSymmetricSecret(t *testing.T) {

--- a/internal/acceptance/openstack/loadbalancer/v2/loadbalancer.go
+++ b/internal/acceptance/openstack/loadbalancer/v2/loadbalancer.go
@@ -152,7 +152,7 @@ func CreateLoadBalancer(t *testing.T, client *gophercloud.ServiceClient, subnetI
 	th.AssertEquals(t, lb.Name, lbName)
 	th.AssertEquals(t, lb.Description, lbDescription)
 	th.AssertEquals(t, lb.VipSubnetID, subnetID)
-	th.AssertEquals(t, lb.AdminStateUp, true)
+	th.AssertEquals(t, true, lb.AdminStateUp)
 
 	if len(tags) > 0 {
 		th.AssertDeepEquals(t, lb.Tags, tags)
@@ -250,34 +250,34 @@ func CreateLoadBalancerFullyPopulated(t *testing.T, client *gophercloud.ServiceC
 	th.AssertEquals(t, lb.Name, lbName)
 	th.AssertEquals(t, lb.Description, lbDescription)
 	th.AssertEquals(t, lb.VipSubnetID, subnetID)
-	th.AssertEquals(t, lb.AdminStateUp, true)
+	th.AssertEquals(t, true, lb.AdminStateUp)
 
-	th.AssertEquals(t, len(lb.Listeners), 1)
+	th.AssertEquals(t, 1, len(lb.Listeners))
 	th.AssertEquals(t, lb.Listeners[0].Name, listenerName)
 	th.AssertEquals(t, lb.Listeners[0].Description, listenerDescription)
 	th.AssertEquals(t, lb.Listeners[0].ProtocolPort, listenerPort)
 
-	th.AssertEquals(t, len(lb.Listeners[0].L7Policies), 1)
+	th.AssertEquals(t, 1, len(lb.Listeners[0].L7Policies))
 	th.AssertEquals(t, lb.Listeners[0].L7Policies[0].Name, policyName)
 	th.AssertEquals(t, lb.Listeners[0].L7Policies[0].Description, policyDescription)
 	th.AssertEquals(t, lb.Listeners[0].L7Policies[0].Description, policyDescription)
-	th.AssertEquals(t, len(lb.Listeners[0].L7Policies[0].Rules), 1)
+	th.AssertEquals(t, 1, len(lb.Listeners[0].L7Policies[0].Rules))
 
-	th.AssertEquals(t, len(lb.Pools), 1)
+	th.AssertEquals(t, 1, len(lb.Pools))
 	th.AssertEquals(t, lb.Pools[0].Name, poolName)
 	th.AssertEquals(t, lb.Pools[0].Description, poolDescription)
 
-	th.AssertEquals(t, len(lb.Pools[0].Members), 1)
+	th.AssertEquals(t, 1, len(lb.Pools[0].Members))
 	th.AssertEquals(t, lb.Pools[0].Members[0].Name, memberName)
 	th.AssertEquals(t, lb.Pools[0].Members[0].ProtocolPort, memberPort)
 	th.AssertEquals(t, lb.Pools[0].Members[0].Weight, memberWeight)
 
-	th.AssertEquals(t, lb.Pools[0].Monitor.Delay, 10)
-	th.AssertEquals(t, lb.Pools[0].Monitor.Timeout, 5)
-	th.AssertEquals(t, lb.Pools[0].Monitor.MaxRetries, 5)
-	th.AssertEquals(t, lb.Pools[0].Monitor.MaxRetriesDown, 4)
+	th.AssertEquals(t, 10, lb.Pools[0].Monitor.Delay)
+	th.AssertEquals(t, 5, lb.Pools[0].Monitor.Timeout)
+	th.AssertEquals(t, 5, lb.Pools[0].Monitor.MaxRetries)
+	th.AssertEquals(t, 4, lb.Pools[0].Monitor.MaxRetriesDown)
 	th.AssertEquals(t, lb.Pools[0].Monitor.Type, string(monitors.TypeHTTP))
-	th.AssertEquals(t, lb.Pools[0].Monitor.HTTPVersion, "1.0")
+	th.AssertEquals(t, "1.0", lb.Pools[0].Monitor.HTTPVersion)
 
 	if len(tags) > 0 {
 		th.AssertDeepEquals(t, lb.Tags, tags)
@@ -356,11 +356,11 @@ func CreateMonitor(t *testing.T, client *gophercloud.ServiceClient, lb *loadbala
 
 	th.AssertEquals(t, monitor.Name, monitorName)
 	th.AssertEquals(t, monitor.Type, monitors.TypePING)
-	th.AssertEquals(t, monitor.Delay, 10)
-	th.AssertEquals(t, monitor.Timeout, 5)
-	th.AssertEquals(t, monitor.MaxRetries, 5)
-	th.AssertEquals(t, monitor.MaxRetriesDown, 4)
-	th.AssertEquals(t, monitor.HTTPVersion, "1.1")
+	th.AssertEquals(t, 10, monitor.Delay)
+	th.AssertEquals(t, 5, monitor.Timeout)
+	th.AssertEquals(t, 5, monitor.MaxRetries)
+	th.AssertEquals(t, 4, monitor.MaxRetriesDown)
+	th.AssertEquals(t, "1.1", monitor.HTTPVersion)
 
 	return monitor, nil
 }
@@ -472,7 +472,7 @@ func CreateL7Policy(t *testing.T, client *gophercloud.ServiceClient, listener *l
 	th.AssertEquals(t, policy.Description, policyDescription)
 	th.AssertEquals(t, policy.ListenerID, listener.ID)
 	th.AssertEquals(t, policy.Action, string(l7policies.ActionRedirectToURL))
-	th.AssertEquals(t, policy.RedirectURL, "http://www.example.com")
+	th.AssertEquals(t, "http://www.example.com", policy.RedirectURL)
 	th.AssertDeepEquals(t, policy.Tags, tags)
 
 	return policy, nil
@@ -502,7 +502,7 @@ func CreateL7Rule(t *testing.T, client *gophercloud.ServiceClient, policyID stri
 
 	th.AssertEquals(t, rule.RuleType, string(l7policies.TypePath))
 	th.AssertEquals(t, rule.CompareType, string(l7policies.CompareTypeStartWith))
-	th.AssertEquals(t, rule.Value, "/api")
+	th.AssertEquals(t, "/api", rule.Value)
 	th.AssertDeepEquals(t, rule.Tags, tags)
 
 	return rule, nil

--- a/internal/acceptance/openstack/loadbalancer/v2/loadbalancer.go
+++ b/internal/acceptance/openstack/loadbalancer/v2/loadbalancer.go
@@ -152,7 +152,7 @@ func CreateLoadBalancer(t *testing.T, client *gophercloud.ServiceClient, subnetI
 	th.AssertEquals(t, lb.Name, lbName)
 	th.AssertEquals(t, lb.Description, lbDescription)
 	th.AssertEquals(t, lb.VipSubnetID, subnetID)
-	th.AssertEquals(t, true, lb.AdminStateUp)
+	th.AssertTrue(t, lb.AdminStateUp)
 
 	if len(tags) > 0 {
 		th.AssertDeepEquals(t, lb.Tags, tags)
@@ -250,7 +250,7 @@ func CreateLoadBalancerFullyPopulated(t *testing.T, client *gophercloud.ServiceC
 	th.AssertEquals(t, lb.Name, lbName)
 	th.AssertEquals(t, lb.Description, lbDescription)
 	th.AssertEquals(t, lb.VipSubnetID, subnetID)
-	th.AssertEquals(t, true, lb.AdminStateUp)
+	th.AssertTrue(t, lb.AdminStateUp)
 
 	th.AssertEquals(t, 1, len(lb.Listeners))
 	th.AssertEquals(t, lb.Listeners[0].Name, listenerName)
@@ -747,7 +747,7 @@ func CreateFlavor(t *testing.T, client *gophercloud.ServiceClient, flavorProfile
 	th.AssertEquals(t, flavorName, flavor.Name)
 	th.AssertEquals(t, description, flavor.Description)
 	th.AssertEquals(t, flavorProfile.ID, flavor.FlavorProfileId)
-	th.AssertEquals(t, true, flavor.Enabled)
+	th.AssertTrue(t, flavor.Enabled)
 
 	return flavor, nil
 }

--- a/internal/acceptance/openstack/loadbalancer/v2/loadbalancers_test.go
+++ b/internal/acceptance/openstack/loadbalancer/v2/loadbalancers_test.go
@@ -406,7 +406,7 @@ func TestLoadbalancersCRUD(t *testing.T) {
 
 	tools.PrintResource(t, newListener)
 
-	th.AssertEquals(t, newListener.DefaultPoolID, "")
+	th.AssertEquals(t, "", newListener.DefaultPoolID)
 
 	// Member
 	member, err := CreateMember(t, lbClient, lb, pool, subnet.ID, subnet.CIDR)

--- a/internal/acceptance/openstack/metric/v1/metrics_test.go
+++ b/internal/acceptance/openstack/metric/v1/metrics_test.go
@@ -22,7 +22,7 @@ func TestMetricQuery(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	tools.PrintResource(t, result)
-	th.AssertEquals(t, result.ResultType, "vector")
+	th.AssertEquals(t, "vector", result.ResultType)
 }
 
 func TestMetricLabels(t *testing.T) {

--- a/internal/acceptance/openstack/networking/v2/extensions/attributestags_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/attributestags_test.go
@@ -65,10 +65,10 @@ func TestTags(t *testing.T) {
 	// Confirm tags exist/don't exist
 	exists, err := attributestags.Confirm(context.TODO(), client, "networks", network.ID, "d").Extract()
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, true, exists)
+	th.AssertTrue(t, exists)
 	noexists, err := attributestags.Confirm(context.TODO(), client, "networks", network.ID, "a").Extract()
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, false, noexists)
+	th.AssertFalse(t, noexists)
 
 	// Delete all tags
 	err = attributestags.DeleteAll(context.TODO(), client, "networks", network.ID).ExtractErr()

--- a/internal/acceptance/openstack/networking/v2/extensions/bgp/speakers/bgpspeakers_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/bgp/speakers/bgpspeakers_test.go
@@ -79,7 +79,7 @@ func TestBGPSpeakerCRUD(t *testing.T) {
 	th.AssertNoErr(t, err)
 	speakerGot, err = speakers.Get(context.TODO(), client, bgpSpeaker.ID).Extract()
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, len(speakerGot.Networks), 0)
+	th.AssertEquals(t, 0, len(speakerGot.Networks))
 	t.Logf("Successfully removed BGP Peer %s to BGP Speaker %s", bgpPeer.Name, speakerUpdated.Name)
 
 	// GetAdvertisedRoutes

--- a/internal/acceptance/openstack/networking/v2/extensions/bgpvpns/bgpvpns_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/bgpvpns/bgpvpns_test.go
@@ -168,7 +168,7 @@ func TestBGPVPNRouterAssociationCRUD(t *testing.T) {
 	assocUpdate, err := bgpvpns.UpdateRouterAssociation(context.TODO(), client, bgpVpnCreated.ID, assoc.ID, assocUpdOpts).Extract()
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, routerCreated.ID, assocUpdate.RouterID)
-	th.AssertEquals(t, false, assocUpdate.AdvertiseExtraRoutes)
+	th.AssertFalse(t, assocUpdate.AdvertiseExtraRoutes)
 
 	// List all Router Associations
 	allPages, err := bgpvpns.ListRouterAssociations(client, bgpVpnCreated.ID, bgpvpns.ListRouterAssociationsOpts{}).AllPages(context.TODO())
@@ -241,7 +241,7 @@ func TestBGPVPNPortAssociationCRUD(t *testing.T) {
 	assocUpdate, err := bgpvpns.UpdatePortAssociation(context.TODO(), client, bgpVpnCreated.ID, assoc.ID, assocUpdOpts).Extract()
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, port.ID, assocUpdate.PortID)
-	th.AssertEquals(t, false, assocUpdate.AdvertiseFixedIPs)
+	th.AssertFalse(t, assocUpdate.AdvertiseFixedIPs)
 
 	// List all Port Associations
 	allPages, err := bgpvpns.ListPortAssociations(client, bgpVpnCreated.ID, bgpvpns.ListPortAssociationsOpts{}).AllPages(context.TODO())

--- a/internal/acceptance/openstack/networking/v2/extensions/dns/dns_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/dns/dns_test.go
@@ -125,7 +125,7 @@ func TestDNSPortCRUDL(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	tools.PrintResource(t, newPort)
-	th.AssertEquals(t, newPort.Description, newPortName)
+	th.AssertEquals(t, newPort.Name, newPortName)
 	th.AssertEquals(t, newPort.Description, newPortDescription)
 	th.AssertEquals(t, newPort.DNSName, newDNSName)
 
@@ -242,7 +242,7 @@ func TestDNSNetwork(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	tools.PrintResource(t, newNetwork)
-	th.AssertEquals(t, newNetwork.Description, newNetworkName)
+	th.AssertEquals(t, newNetwork.Name, newNetworkName)
 	th.AssertEquals(t, newNetwork.Description, newNetworkDescription)
 	th.AssertEquals(t, newNetwork.DNSDomain, newNetworkDNSDomain)
 

--- a/internal/acceptance/openstack/networking/v2/extensions/fwaas_v2/fwaas_v2.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/fwaas_v2/fwaas_v2.go
@@ -64,7 +64,7 @@ func CreatePolicy(t *testing.T, client *gophercloud.ServiceClient, ruleID string
 
 	th.AssertEquals(t, policy.Name, policyName)
 	th.AssertEquals(t, policy.Description, policyDescription)
-	th.AssertEquals(t, len(policy.Rules), 1)
+	th.AssertEquals(t, 1, len(policy.Rules))
 
 	return policy, nil
 }

--- a/internal/acceptance/openstack/networking/v2/extensions/fwaas_v2/groups_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/fwaas_v2/groups_test.go
@@ -102,5 +102,5 @@ func TestGroupCRUD(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 }

--- a/internal/acceptance/openstack/networking/v2/extensions/fwaas_v2/groups_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/fwaas_v2/groups_test.go
@@ -73,7 +73,7 @@ func TestGroupCRUD(t *testing.T) {
 		t.Fatalf("Unable to remove ingress firewall policy from firewall group %s: %v", removeIngressPolicy.ID, err)
 	}
 
-	th.AssertEquals(t, removeIngressPolicy.IngressFirewallPolicyID, "")
+	th.AssertEquals(t, "", removeIngressPolicy.IngressFirewallPolicyID)
 	th.AssertEquals(t, removeIngressPolicy.EgressFirewallPolicyID, firewall_policy_id)
 
 	t.Logf("Ingress policy removed from firewall group %s", updatedGroup.ID)
@@ -83,7 +83,7 @@ func TestGroupCRUD(t *testing.T) {
 		t.Fatalf("Unable to remove egress firewall policy from firewall group %s: %v", removeEgressPolicy.ID, err)
 	}
 
-	th.AssertEquals(t, removeEgressPolicy.EgressFirewallPolicyID, "")
+	th.AssertEquals(t, "", removeEgressPolicy.EgressFirewallPolicyID)
 
 	t.Logf("Egress policy removed from firewall group %s", updatedGroup.ID)
 
@@ -102,5 +102,5 @@ func TestGroupCRUD(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 }

--- a/internal/acceptance/openstack/networking/v2/extensions/fwaas_v2/policy_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/fwaas_v2/policy_test.go
@@ -68,7 +68,7 @@ func TestPolicyCRUD(t *testing.T) {
 	tools.PrintResource(t, newPolicy)
 	th.AssertEquals(t, newPolicy.Name, name)
 	th.AssertEquals(t, newPolicy.Description, description)
-	th.AssertEquals(t, len(newPolicy.Rules), 0)
+	th.AssertEquals(t, 0, len(newPolicy.Rules))
 
 	allPages, err := policies.List(client, nil).AllPages(context.TODO())
 	th.AssertNoErr(t, err)
@@ -83,5 +83,5 @@ func TestPolicyCRUD(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 }

--- a/internal/acceptance/openstack/networking/v2/extensions/fwaas_v2/policy_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/fwaas_v2/policy_test.go
@@ -83,5 +83,5 @@ func TestPolicyCRUD(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 }

--- a/internal/acceptance/openstack/networking/v2/extensions/fwaas_v2/rule_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/fwaas_v2/rule_test.go
@@ -68,5 +68,5 @@ func TestRuleCRUD(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 }

--- a/internal/acceptance/openstack/networking/v2/extensions/fwaas_v2/rule_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/fwaas_v2/rule_test.go
@@ -68,5 +68,5 @@ func TestRuleCRUD(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 }

--- a/internal/acceptance/openstack/networking/v2/extensions/layer3/addressscopes_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/layer3/addressscopes_test.go
@@ -50,5 +50,5 @@ func TestAddressScopesCRUD(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 }

--- a/internal/acceptance/openstack/networking/v2/extensions/layer3/addressscopes_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/layer3/addressscopes_test.go
@@ -50,5 +50,5 @@ func TestAddressScopesCRUD(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 }

--- a/internal/acceptance/openstack/networking/v2/extensions/layer3/floatingips_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/layer3/floatingips_test.go
@@ -44,7 +44,7 @@ func TestLayer3FloatingIPsCreateDelete(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 }
 
 func TestLayer3FloatingIPsExternalCreateDelete(t *testing.T) {

--- a/internal/acceptance/openstack/networking/v2/extensions/layer3/floatingips_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/layer3/floatingips_test.go
@@ -44,7 +44,7 @@ func TestLayer3FloatingIPsCreateDelete(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 }
 
 func TestLayer3FloatingIPsExternalCreateDelete(t *testing.T) {
@@ -100,7 +100,7 @@ func TestLayer3FloatingIPsExternalCreateDelete(t *testing.T) {
 
 	tools.PrintResource(t, newFip)
 
-	th.AssertEquals(t, newFip.PortID, "")
+	th.AssertEquals(t, "", newFip.PortID)
 }
 
 func TestLayer3FloatingIPsWithFixedIPsExternalCreateDelete(t *testing.T) {

--- a/internal/acceptance/openstack/networking/v2/extensions/layer3/l3_scheduling_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/layer3/l3_scheduling_test.go
@@ -64,7 +64,7 @@ func TestLayer3RouterScheduling(t *testing.T) {
 	// List routers on hosting agent
 	routersOnHostingAgent, err := agents.ListL3Routers(context.TODO(), client, hostingAgent.ID).Extract()
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, false, containsRouterFunc(routersOnHostingAgent, router.ID))
+	th.AssertFalse(t, containsRouterFunc(routersOnHostingAgent, router.ID))
 	t.Logf("Router %s is not scheduled on %s", router.ID, hostingAgent.ID)
 
 	// schedule back
@@ -74,6 +74,6 @@ func TestLayer3RouterScheduling(t *testing.T) {
 	// List hosting agent after readding
 	routersOnHostingAgent, err = agents.ListL3Routers(context.TODO(), client, hostingAgent.ID).Extract()
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, true, containsRouterFunc(routersOnHostingAgent, router.ID))
+	th.AssertTrue(t, containsRouterFunc(routersOnHostingAgent, router.ID))
 	t.Logf("Router %s is scheduled on %s", router.ID, hostingAgent.ID)
 }

--- a/internal/acceptance/openstack/networking/v2/extensions/layer3/l3_scheduling_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/layer3/l3_scheduling_test.go
@@ -64,7 +64,7 @@ func TestLayer3RouterScheduling(t *testing.T) {
 	// List routers on hosting agent
 	routersOnHostingAgent, err := agents.ListL3Routers(context.TODO(), client, hostingAgent.ID).Extract()
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, containsRouterFunc(routersOnHostingAgent, router.ID), false)
+	th.AssertEquals(t, false, containsRouterFunc(routersOnHostingAgent, router.ID))
 	t.Logf("Router %s is not scheduled on %s", router.ID, hostingAgent.ID)
 
 	// schedule back
@@ -74,6 +74,6 @@ func TestLayer3RouterScheduling(t *testing.T) {
 	// List hosting agent after readding
 	routersOnHostingAgent, err = agents.ListL3Routers(context.TODO(), client, hostingAgent.ID).Extract()
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, containsRouterFunc(routersOnHostingAgent, router.ID), true)
+	th.AssertEquals(t, true, containsRouterFunc(routersOnHostingAgent, router.ID))
 	t.Logf("Router %s is scheduled on %s", router.ID, hostingAgent.ID)
 }

--- a/internal/acceptance/openstack/networking/v2/extensions/layer3/layer3.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/layer3/layer3.go
@@ -92,7 +92,7 @@ func CreatePortForwarding(t *testing.T, client *gophercloud.ServiceClient, fipID
 
 	t.Logf("Created Port Forwarding.")
 
-	th.AssertEquals(t, pf.Protocol, "tcp")
+	th.AssertEquals(t, "tcp", pf.Protocol)
 
 	return pf, err
 }
@@ -121,7 +121,7 @@ func CreatePortRangeForwarding(t *testing.T, client *gophercloud.ServiceClient, 
 
 	t.Logf("Created Port Range Forwarding.")
 
-	th.AssertEquals(t, pf.Protocol, "tcp")
+	th.AssertEquals(t, "tcp", pf.Protocol)
 
 	return pf, err
 }

--- a/internal/acceptance/openstack/networking/v2/extensions/layer3/portforwardings_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/layer3/portforwardings_test.go
@@ -56,13 +56,13 @@ func TestLayer3PortForwardingsCreateDelete(t *testing.T) {
 
 	pf, err := CreatePortForwarding(t, client, fip.ID, port.ID, port.FixedIPs)
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, pf.Description, "Test description")
+	th.AssertEquals(t, "Test description", pf.Description)
 	defer DeletePortForwarding(t, client, fip.ID, pf.ID)
 	tools.PrintResource(t, pf)
 
 	pfRange, err := CreatePortRangeForwarding(t, client, fip.ID, port.ID, port.FixedIPs)
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, pfRange.Description, "Test description range")
+	th.AssertEquals(t, "Test description range", pfRange.Description)
 	defer DeletePortForwarding(t, client, fip.ID, pfRange.ID)
 	tools.PrintResource(t, pfRange)
 
@@ -82,7 +82,7 @@ func TestLayer3PortForwardingsCreateDelete(t *testing.T) {
 
 	newPf, err = portforwarding.Get(context.TODO(), client, fip.ID, pf.ID).Extract()
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, newPf.Description, "")
+	th.AssertEquals(t, "", newPf.Description)
 
 	// Test updating port range
 	newRangePf, err := portforwarding.Get(context.TODO(), client, fip.ID, pfRange.ID).Extract()
@@ -100,10 +100,10 @@ func TestLayer3PortForwardingsCreateDelete(t *testing.T) {
 
 	newRangePf, err = portforwarding.Get(context.TODO(), client, fip.ID, pfRange.ID).Extract()
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, newRangePf.Description, "")
-	th.AssertEquals(t, newRangePf.Protocol, "tcp")
-	th.AssertEquals(t, newRangePf.InternalPortRange, "1300:1399")
-	th.AssertEquals(t, newRangePf.ExternalPortRange, "1300:1399")
+	th.AssertEquals(t, "", newRangePf.Description)
+	th.AssertEquals(t, "tcp", newRangePf.Protocol)
+	th.AssertEquals(t, "1300:1399", newRangePf.InternalPortRange)
+	th.AssertEquals(t, "1300:1399", newRangePf.ExternalPortRange)
 
 	allPages, err := portforwarding.List(client, portforwarding.ListOpts{}, fip.ID).AllPages(context.TODO())
 	th.AssertNoErr(t, err)

--- a/internal/acceptance/openstack/networking/v2/extensions/layer3/portforwardings_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/layer3/portforwardings_test.go
@@ -118,7 +118,7 @@ func TestLayer3PortForwardingsCreateDelete(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 
 	found = false
 	for _, pf := range allPFs {
@@ -127,6 +127,6 @@ func TestLayer3PortForwardingsCreateDelete(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 
 }

--- a/internal/acceptance/openstack/networking/v2/extensions/layer3/routers_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/layer3/routers_test.go
@@ -59,7 +59,7 @@ func TestLayer3RouterCreateDelete(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 }
 
 func TestLayer3ExternalRouterCreateDelete(t *testing.T) {
@@ -212,7 +212,7 @@ func TestLayer3RouterAgents(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 }
 
 func TestLayer3RouterRevision(t *testing.T) {

--- a/internal/acceptance/openstack/networking/v2/extensions/layer3/routers_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/layer3/routers_test.go
@@ -59,7 +59,7 @@ func TestLayer3RouterCreateDelete(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 }
 
 func TestLayer3ExternalRouterCreateDelete(t *testing.T) {
@@ -124,7 +124,7 @@ func TestLayer3ExternalRouterCreateDelete(t *testing.T) {
 
 	newRouter, err = routers.Update(context.TODO(), client, router.ID, updateOpts).Extract()
 	th.AssertNoErr(t, err)
-	th.AssertDeepEquals(t, newRouter.GatewayInfo, routers.GatewayInfo{})
+	th.AssertDeepEquals(t, routers.GatewayInfo{}, newRouter.GatewayInfo)
 
 }
 
@@ -212,7 +212,7 @@ func TestLayer3RouterAgents(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 }
 
 func TestLayer3RouterRevision(t *testing.T) {

--- a/internal/acceptance/openstack/networking/v2/extensions/portsbinding/portsbinding_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/portsbinding/portsbinding_test.go
@@ -70,7 +70,7 @@ func TestPortsbindingCRUD(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	tools.PrintResource(t, newPort)
-	th.AssertEquals(t, newPortName, newPort.Description)
+	th.AssertEquals(t, newPortName, newPort.Name)
 	th.AssertEquals(t, newPortDescription, newPort.Description)
 	th.AssertEquals(t, newHostID, newPort.HostID)
 	th.AssertEquals(t, "normal", newPort.VNICType)

--- a/internal/acceptance/openstack/networking/v2/extensions/qos/policies/policies_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/qos/policies/policies_test.go
@@ -58,7 +58,7 @@ func TestPoliciesCRUD(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 }
 
 func TestPoliciesRevision(t *testing.T) {

--- a/internal/acceptance/openstack/networking/v2/extensions/qos/policies/policies_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/qos/policies/policies_test.go
@@ -58,7 +58,7 @@ func TestPoliciesCRUD(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 }
 
 func TestPoliciesRevision(t *testing.T) {

--- a/internal/acceptance/openstack/networking/v2/extensions/qos/rules/rules_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/qos/rules/rules_test.go
@@ -43,7 +43,7 @@ func TestBandwidthLimitRulesCRUD(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	tools.PrintResource(t, newRule)
-	th.AssertEquals(t, newRule.MaxBurstKBps, 0)
+	th.AssertEquals(t, 0, newRule.MaxBurstKBps)
 
 	allPages, err := rules.ListBandwidthLimitRules(client, policy.ID, rules.BandwidthLimitRulesListOpts{}).AllPages(context.TODO())
 	th.AssertNoErr(t, err)
@@ -58,7 +58,7 @@ func TestBandwidthLimitRulesCRUD(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 }
 
 func TestDSCPMarkingRulesCRUD(t *testing.T) {
@@ -89,7 +89,7 @@ func TestDSCPMarkingRulesCRUD(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	tools.PrintResource(t, newRule)
-	th.AssertEquals(t, newRule.DSCPMark, 20)
+	th.AssertEquals(t, 20, newRule.DSCPMark)
 
 	allPages, err := rules.ListDSCPMarkingRules(client, policy.ID, rules.DSCPMarkingRulesListOpts{}).AllPages(context.TODO())
 	th.AssertNoErr(t, err)
@@ -104,7 +104,7 @@ func TestDSCPMarkingRulesCRUD(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 }
 
 func TestMinimumBandwidthRulesCRUD(t *testing.T) {
@@ -135,7 +135,7 @@ func TestMinimumBandwidthRulesCRUD(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	tools.PrintResource(t, newRule)
-	th.AssertEquals(t, newRule.MinKBps, 500)
+	th.AssertEquals(t, 500, newRule.MinKBps)
 
 	allPages, err := rules.ListMinimumBandwidthRules(client, policy.ID, rules.MinimumBandwidthRulesListOpts{}).AllPages(context.TODO())
 	th.AssertNoErr(t, err)
@@ -150,5 +150,5 @@ func TestMinimumBandwidthRulesCRUD(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 }

--- a/internal/acceptance/openstack/networking/v2/extensions/qos/rules/rules_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/qos/rules/rules_test.go
@@ -58,7 +58,7 @@ func TestBandwidthLimitRulesCRUD(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 }
 
 func TestDSCPMarkingRulesCRUD(t *testing.T) {
@@ -104,7 +104,7 @@ func TestDSCPMarkingRulesCRUD(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 }
 
 func TestMinimumBandwidthRulesCRUD(t *testing.T) {
@@ -150,5 +150,5 @@ func TestMinimumBandwidthRulesCRUD(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 }

--- a/internal/acceptance/openstack/networking/v2/extensions/security_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/security_test.go
@@ -22,7 +22,7 @@ func TestSecurityGroupsCreateUpdateDelete(t *testing.T) {
 	group, err := CreateSecurityGroup(t, client)
 	th.AssertNoErr(t, err)
 	defer DeleteSecurityGroup(t, client, group.ID)
-	th.AssertEquals(t, true, group.Stateful)
+	th.AssertTrue(t, group.Stateful)
 
 	rule, err := CreateSecurityGroupRule(t, client, group.ID)
 	th.AssertNoErr(t, err)
@@ -50,7 +50,7 @@ func TestSecurityGroupsCreateUpdateDelete(t *testing.T) {
 	tools.PrintResource(t, newGroup)
 	th.AssertEquals(t, newGroup.Name, name)
 	th.AssertEquals(t, newGroup.Description, description)
-	th.AssertEquals(t, false, newGroup.Stateful)
+	th.AssertFalse(t, newGroup.Stateful)
 
 	listOpts := groups.ListOpts{}
 	allPages, err := groups.List(client, listOpts).AllPages(context.TODO())
@@ -66,7 +66,7 @@ func TestSecurityGroupsCreateUpdateDelete(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 }
 
 func TestSecurityGroupsPort(t *testing.T) {

--- a/internal/acceptance/openstack/networking/v2/extensions/security_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/security_test.go
@@ -22,7 +22,7 @@ func TestSecurityGroupsCreateUpdateDelete(t *testing.T) {
 	group, err := CreateSecurityGroup(t, client)
 	th.AssertNoErr(t, err)
 	defer DeleteSecurityGroup(t, client, group.ID)
-	th.AssertEquals(t, group.Stateful, true)
+	th.AssertEquals(t, true, group.Stateful)
 
 	rule, err := CreateSecurityGroupRule(t, client, group.ID)
 	th.AssertNoErr(t, err)
@@ -50,7 +50,7 @@ func TestSecurityGroupsCreateUpdateDelete(t *testing.T) {
 	tools.PrintResource(t, newGroup)
 	th.AssertEquals(t, newGroup.Name, name)
 	th.AssertEquals(t, newGroup.Description, description)
-	th.AssertEquals(t, newGroup.Stateful, false)
+	th.AssertEquals(t, false, newGroup.Stateful)
 
 	listOpts := groups.ListOpts{}
 	allPages, err := groups.List(client, listOpts).AllPages(context.TODO())
@@ -66,7 +66,7 @@ func TestSecurityGroupsCreateUpdateDelete(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 }
 
 func TestSecurityGroupsPort(t *testing.T) {
@@ -154,7 +154,7 @@ func TestSecurityGroupsRevision(t *testing.T) {
 
 	tools.PrintResource(t, group)
 
-	th.AssertEquals(t, group.Name, newName)
+	th.AssertEquals(t, newName, group.Name)
 	th.AssertEquals(t, group.Description, newDescription)
 }
 

--- a/internal/acceptance/openstack/networking/v2/extensions/segments/segments.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/segments/segments.go
@@ -30,7 +30,7 @@ func CreateSegment(t *testing.T, client *gophercloud.ServiceClient, networkID st
 
 	th.AssertEquals(t, segment.Name, name)
 	th.AssertEquals(t, segment.Description, desc)
-	th.AssertEquals(t, segment.NetworkType, "geneve")
+	th.AssertEquals(t, "geneve", segment.NetworkType)
 	th.AssertEquals(t, segment.NetworkID, networkID)
 
 	return segment, nil

--- a/internal/acceptance/openstack/networking/v2/extensions/subnetpools/subnetpools_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/subnetpools/subnetpools_test.go
@@ -54,7 +54,7 @@ func TestSubnetPoolsCRUD(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 }
 
 func TestSubnetPoolsRevision(t *testing.T) {

--- a/internal/acceptance/openstack/networking/v2/extensions/subnetpools/subnetpools_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/subnetpools/subnetpools_test.go
@@ -54,7 +54,7 @@ func TestSubnetPoolsCRUD(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 }
 
 func TestSubnetPoolsRevision(t *testing.T) {

--- a/internal/acceptance/openstack/networking/v2/extensions/vlantransparent/vlantransparent_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/vlantransparent/vlantransparent_test.go
@@ -38,5 +38,5 @@ func TestVLANTransparentCRUD(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 }

--- a/internal/acceptance/openstack/networking/v2/extensions/vlantransparent/vlantransparent_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/vlantransparent/vlantransparent_test.go
@@ -38,5 +38,5 @@ func TestVLANTransparentCRUD(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 }

--- a/internal/acceptance/openstack/networking/v2/networking.go
+++ b/internal/acceptance/openstack/networking/v2/networking.go
@@ -426,7 +426,7 @@ func CreateSubnetWithNoGateway(t *testing.T, client *gophercloud.ServiceClient, 
 	t.Logf("Successfully created subnet.")
 
 	th.AssertEquals(t, subnet.Name, subnetName)
-	th.AssertEquals(t, subnet.GatewayIP, "")
+	th.AssertEquals(t, "", subnet.GatewayIP)
 	th.AssertEquals(t, subnet.CIDR, subnetCIDR)
 
 	return subnet, nil

--- a/internal/acceptance/openstack/networking/v2/networks_test.go
+++ b/internal/acceptance/openstack/networking/v2/networks_test.go
@@ -51,7 +51,7 @@ func TestNetworksExternalList(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 
 	iFalse := false
 	networkListOpts = networks.ListOpts{
@@ -118,7 +118,7 @@ func TestNetworksCRUD(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 }
 
 func TestNetworksPortSecurityCRUD(t *testing.T) {

--- a/internal/acceptance/openstack/networking/v2/networks_test.go
+++ b/internal/acceptance/openstack/networking/v2/networks_test.go
@@ -51,7 +51,7 @@ func TestNetworksExternalList(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 
 	iFalse := false
 	networkListOpts = networks.ListOpts{
@@ -67,7 +67,7 @@ func TestNetworksExternalList(t *testing.T) {
 
 	v, err := networks.ExtractNetworks(allPages)
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, len(v), 0)
+	th.AssertEquals(t, 0, len(v))
 }
 
 func TestNetworksCRUD(t *testing.T) {
@@ -118,7 +118,7 @@ func TestNetworksCRUD(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 }
 
 func TestNetworksPortSecurityCRUD(t *testing.T) {

--- a/internal/acceptance/openstack/networking/v2/ports_test.go
+++ b/internal/acceptance/openstack/networking/v2/ports_test.go
@@ -74,7 +74,7 @@ func TestPortsCRUD(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 
 	ipAddress := port.FixedIPs[0].IPAddress
 	t.Logf("Port has IP address: %s", ipAddress)

--- a/internal/acceptance/openstack/networking/v2/ports_test.go
+++ b/internal/acceptance/openstack/networking/v2/ports_test.go
@@ -74,7 +74,7 @@ func TestPortsCRUD(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 
 	ipAddress := port.FixedIPs[0].IPAddress
 	t.Logf("Port has IP address: %s", ipAddress)

--- a/internal/acceptance/openstack/networking/v2/subnets_test.go
+++ b/internal/acceptance/openstack/networking/v2/subnets_test.go
@@ -62,7 +62,7 @@ func TestSubnetCRUD(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 }
 
 func TestSubnetsServiceType(t *testing.T) {

--- a/internal/acceptance/openstack/networking/v2/subnets_test.go
+++ b/internal/acceptance/openstack/networking/v2/subnets_test.go
@@ -62,7 +62,7 @@ func TestSubnetCRUD(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 }
 
 func TestSubnetsServiceType(t *testing.T) {
@@ -275,7 +275,7 @@ func TestSubnetDNSNameservers(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	tools.PrintResource(t, newSubnet)
-	th.AssertEquals(t, len(newSubnet.DNSNameservers), 1)
+	th.AssertEquals(t, 1, len(newSubnet.DNSNameservers))
 
 	// Update Subnet again
 	dnsNameservers = []string{}
@@ -290,7 +290,7 @@ func TestSubnetDNSNameservers(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	tools.PrintResource(t, newSubnet)
-	th.AssertEquals(t, len(newSubnet.DNSNameservers), 0)
+	th.AssertEquals(t, 0, len(newSubnet.DNSNameservers))
 }
 
 func TestSubnetsRevision(t *testing.T) {

--- a/internal/acceptance/openstack/objectstorage/v1/objects_test.go
+++ b/internal/acceptance/openstack/objectstorage/v1/objects_test.go
@@ -428,5 +428,5 @@ func TestObjectsBulkDelete(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	th.AssertEquals(t, len(allObjects), 0)
+	th.AssertEquals(t, 0, len(allObjects))
 }

--- a/internal/acceptance/openstack/objectstorage/v1/versioning_test.go
+++ b/internal/acceptance/openstack/objectstorage/v1/versioning_test.go
@@ -47,7 +47,7 @@ func TestObjectsVersioning(t *testing.T) {
 	get, err := containers.Get(context.TODO(), client, cName, nil).Extract()
 	th.AssertNoErr(t, err)
 	t.Logf("Get container headers: %+v\n", get)
-	th.AssertEquals(t, true, get.VersionsEnabled)
+	th.AssertTrue(t, get.VersionsEnabled)
 
 	// Create a slice of buffers to hold the test object content.
 	oContents := make([]string, numObjects)
@@ -85,7 +85,7 @@ func TestObjectsVersioning(t *testing.T) {
 		get, err := containers.Get(context.TODO(), client, cName, nil).Extract()
 		th.AssertNoErr(t, err)
 		t.Logf("Get container headers: %+v\n", get)
-		th.AssertEquals(t, false, get.VersionsEnabled)
+		th.AssertFalse(t, get.VersionsEnabled)
 
 		// delete all object versions before deleting the container
 		currentVersionIDs := make([]string, numObjects)
@@ -154,9 +154,9 @@ func TestObjectsVersioning(t *testing.T) {
 	// ensure proper versioning attributes are set
 	for i, obj := range ois {
 		if i%2 == 0 {
-			th.AssertEquals(t, true, obj.IsLatest)
+			th.AssertTrue(t, obj.IsLatest)
 		} else {
-			th.AssertEquals(t, false, obj.IsLatest)
+			th.AssertFalse(t, obj.IsLatest)
 		}
 		if obj.VersionID == "" {
 			t.Fatalf("Unexpected empty version_id for the %s object", obj.Name)

--- a/internal/acceptance/openstack/orchestration/v1/stackevents_test.go
+++ b/internal/acceptance/openstack/orchestration/v1/stackevents_test.go
@@ -24,7 +24,7 @@ func TestStackEvents(t *testing.T) {
 	allEvents, err := stackevents.ExtractEvents(allPages)
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, len(allEvents), 4)
+	th.AssertEquals(t, 4, len(allEvents))
 
 	/*
 			allPages is currently broke

--- a/internal/acceptance/openstack/orchestration/v1/stackresources_test.go
+++ b/internal/acceptance/openstack/orchestration/v1/stackresources_test.go
@@ -53,5 +53,5 @@ func TestStackResources(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 }

--- a/internal/acceptance/openstack/orchestration/v1/stackresources_test.go
+++ b/internal/acceptance/openstack/orchestration/v1/stackresources_test.go
@@ -53,5 +53,5 @@ func TestStackResources(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 }

--- a/internal/acceptance/openstack/orchestration/v1/stacks_test.go
+++ b/internal/acceptance/openstack/orchestration/v1/stacks_test.go
@@ -48,5 +48,5 @@ func TestStacksCRUD(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, found, true)
+	th.AssertEquals(t, true, found)
 }

--- a/internal/acceptance/openstack/orchestration/v1/stacks_test.go
+++ b/internal/acceptance/openstack/orchestration/v1/stacks_test.go
@@ -48,5 +48,5 @@ func TestStacksCRUD(t *testing.T) {
 		}
 	}
 
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 }

--- a/internal/acceptance/openstack/placement/v1/allocationcandidates_test.go
+++ b/internal/acceptance/openstack/placement/v1/allocationcandidates_test.go
@@ -75,17 +75,17 @@ func TestAllocationCandidatesList(t *testing.T) {
 	result, err := allocationcandidates.ExtractAllocationCandidates(page)
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, true, len(result.AllocationRequests) > 0)
+	th.AssertTrue(t, len(result.AllocationRequests) > 0)
 
 	// Assert: The provider's summary contains the exact inventory we seeded:
 	// VCPU total=8, reserved=0 → capacity=8, used=0.
 	summary, present := result.ProviderSummaries[rpUUID]
-	th.AssertEquals(t, true, present)
+	th.AssertTrue(t, present)
 	vcpuSummary, present := summary.Resources["VCPU"]
-	th.AssertEquals(t, true, present)
+	th.AssertTrue(t, present)
 	th.AssertEquals(t, 8, vcpuSummary.Capacity)
 	th.AssertEquals(t, 0, vcpuSummary.Used)
-	th.AssertEquals(t, true, slices.Contains(*summary.Traits, "COMPUTE_NODE"))
+	th.AssertTrue(t, slices.Contains(*summary.Traits, "COMPUTE_NODE"))
 	// It is a root provider: root UUID equals its own UUID, parent is absent.
 	th.AssertEquals(t, rpUUID, *summary.RootProviderUUID)
 	th.AssertEquals(t, (*string)(nil), summary.ParentProviderUUID)
@@ -125,15 +125,15 @@ func TestAllocationCandidatesListPre129(t *testing.T) {
 	result, err := allocationcandidates.ExtractAllocationCandidates(page)
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, true, len(result.AllocationRequests) > 0)
+	th.AssertTrue(t, len(result.AllocationRequests) > 0)
 
 	summary, present := result.ProviderSummaries[rpUUID]
-	th.AssertEquals(t, true, present)
+	th.AssertTrue(t, present)
 	vcpuSummary, present := summary.Resources["VCPU"]
-	th.AssertEquals(t, true, present)
+	th.AssertTrue(t, present)
 	th.AssertEquals(t, 8, vcpuSummary.Capacity)
 	th.AssertEquals(t, 0, vcpuSummary.Used)
-	th.AssertEquals(t, true, slices.Contains(*summary.Traits, "COMPUTE_NODE"))
+	th.AssertTrue(t, slices.Contains(*summary.Traits, "COMPUTE_NODE"))
 	// Root/parent UUIDs are absent below 1.29.
 	th.AssertEquals(t, (*string)(nil), summary.RootProviderUUID)
 	th.AssertEquals(t, (*string)(nil), summary.ParentProviderUUID)
@@ -163,8 +163,8 @@ func TestAllocationCandidatesList110(t *testing.T) {
 	result, err := allocationcandidates.ExtractAllocationCandidates110(page)
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, true, len(result.AllocationRequests) > 0)
-	th.AssertEquals(t, true, len(result.ProviderSummaries) > 0)
+	th.AssertTrue(t, len(result.AllocationRequests) > 0)
+	th.AssertTrue(t, len(result.ProviderSummaries) > 0)
 
 	// Assert: UUID of the created RP present and resource amount correct.
 	var foundAlloc allocationcandidates.AllocationRequest110Resource
@@ -180,9 +180,9 @@ func TestAllocationCandidatesList110(t *testing.T) {
 
 	// Assert: The provider summary contains the expected inventory.
 	rpSummary, present := result.ProviderSummaries[rpUUID]
-	th.AssertEquals(t, true, present)
+	th.AssertTrue(t, present)
 	vcpuSummary, present := rpSummary.Resources["VCPU"]
-	th.AssertEquals(t, true, present)
+	th.AssertTrue(t, present)
 	th.AssertEquals(t, 8, vcpuSummary.Capacity)
 	th.AssertEquals(t, 0, vcpuSummary.Used)
 }
@@ -206,7 +206,7 @@ func TestAllocationCandidatesIsEmpty110(t *testing.T) {
 
 	isEmpty, err := page.IsEmpty()
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, false, isEmpty)
+	th.AssertFalse(t, isEmpty)
 }
 
 func TestAllocationCandidatesListEmpty(t *testing.T) {
@@ -230,5 +230,5 @@ func TestAllocationCandidatesListEmpty(t *testing.T) {
 
 	isEmpty, err := page.IsEmpty()
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, true, isEmpty)
+	th.AssertTrue(t, isEmpty)
 }

--- a/internal/acceptance/openstack/placement/v1/allocations_test.go
+++ b/internal/acceptance/openstack/placement/v1/allocations_test.go
@@ -159,7 +159,7 @@ func TestUpdateAllocationsConflict(t *testing.T) {
 		UserID:             "test-user",
 		ConsumerGeneration: &staleGeneration,
 	}).ExtractErr()
-	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusConflict))
+	th.AssertTrue(t, gophercloud.ResponseCodeIs(err, http.StatusConflict))
 }
 
 func TestDeleteAllocationsSuccess(t *testing.T) {
@@ -212,7 +212,7 @@ func TestDeleteAllocationsNotFound(t *testing.T) {
 
 	// Assert: An RP that was never a consumer returns 404 on DELETE.
 	err = allocations.Delete(context.TODO(), client, resourceProvider.UUID).ExtractErr()
-	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
+	th.AssertTrue(t, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
 }
 
 func TestManageAllocationsSuccess(t *testing.T) {

--- a/internal/acceptance/openstack/placement/v1/resourceclasses_test.go
+++ b/internal/acceptance/openstack/placement/v1/resourceclasses_test.go
@@ -32,7 +32,7 @@ func TestResourceClassesList(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	// Ensure VCPU is in the list
-	th.AssertEquals(t, true, slices.ContainsFunc(allResourceClasses, func(rc resourceclasses.ResourceClass) bool {
+	th.AssertTrue(t, slices.ContainsFunc(allResourceClasses, func(rc resourceclasses.ResourceClass) bool {
 		return rc.Name == "VCPU"
 	}))
 }
@@ -63,7 +63,7 @@ func TestResourceClassGetNegative(t *testing.T) {
 	client.Microversion = "1.2"
 
 	_, err = resourceclasses.Get(context.TODO(), client, "NON_EXISTENT_RC").Extract()
-	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
+	th.AssertTrue(t, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
 }
 
 func TestResourceClassCreateByPostSuccess(t *testing.T) {
@@ -111,7 +111,7 @@ func TestResourceClassCreateByPostDuplicate(t *testing.T) {
 	// Act: Try to create the same resource class again
 	err = resourceclasses.Create(context.TODO(), client, createOpts).ExtractErr()
 	// Assert: The error is a conflict
-	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusConflict))
+	th.AssertTrue(t, gophercloud.ResponseCodeIs(err, http.StatusConflict))
 }
 
 func TestResourceClassCreateByUpdateSuccess(t *testing.T) {
@@ -155,7 +155,7 @@ func TestResourceClassCreateByUpdateNonCustomName(t *testing.T) {
 	// Act: Try to create a resource class with a non-custom name using PUT (Update)
 	err = resourceclasses.Update(context.TODO(), client, name).ExtractErr()
 	// Assert: We get 400
-	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusBadRequest))
+	th.AssertTrue(t, gophercloud.ResponseCodeIs(err, http.StatusBadRequest))
 }
 
 func TestResourceClassDeleteSuccess(t *testing.T) {
@@ -187,7 +187,7 @@ func TestResourceClassDeleteSuccess(t *testing.T) {
 
 	// Assert: The resource class no longer exists
 	_, err = resourceclasses.Get(context.TODO(), client, name).Extract()
-	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
+	th.AssertTrue(t, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
 }
 
 func TestResourceClassDeleteNotFound(t *testing.T) {
@@ -202,7 +202,7 @@ func TestResourceClassDeleteNotFound(t *testing.T) {
 	// Act: Try to delete a non-existent resource class
 	err = resourceclasses.Delete(context.TODO(), client, "CUSTOM_NON_EXISTENT_RC").ExtractErr()
 	// Assert: We get 404
-	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
+	th.AssertTrue(t, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
 }
 
 func TestResourceClassDeleteStandardClass(t *testing.T) {
@@ -217,5 +217,5 @@ func TestResourceClassDeleteStandardClass(t *testing.T) {
 	// Act: Try to delete a standard resource class
 	err = resourceclasses.Delete(context.TODO(), client, "VCPU").ExtractErr()
 	// Assert: We get 400
-	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusBadRequest))
+	th.AssertTrue(t, gophercloud.ResponseCodeIs(err, http.StatusBadRequest))
 }

--- a/internal/acceptance/openstack/placement/v1/resourceproviders_test.go
+++ b/internal/acceptance/openstack/placement/v1/resourceproviders_test.go
@@ -95,7 +95,7 @@ func TestResourceProviderList139(t *testing.T) {
 	// Assert: Our resource provider is in the results and has the traits and aggregates we set.
 	allResourceProviders, err := resourceproviders.ExtractResourceProviders(allPages)
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, true, len(allResourceProviders) > 0)
+	th.AssertTrue(t, len(allResourceProviders) > 0)
 
 	found := false
 	for _, rp := range allResourceProviders {
@@ -104,7 +104,7 @@ func TestResourceProviderList139(t *testing.T) {
 			break
 		}
 	}
-	th.AssertEquals(t, true, found)
+	th.AssertTrue(t, found)
 }
 
 func TestResourceProvider(t *testing.T) {
@@ -241,7 +241,7 @@ func TestResourceProviderInventoryNotFound(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	_, err = resourceproviders.GetInventory(context.TODO(), client, resourceProvider.UUID, MissingInventoryResourceClass).Extract()
-	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
+	th.AssertTrue(t, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
 }
 
 func TestResourceProviderUpdateInventory(t *testing.T) {
@@ -297,7 +297,7 @@ func TestResourceProviderUpdateInventory(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	actualInventory, ok := updatedInventories.Inventories[InventoryResourceClass]
-	th.AssertEquals(t, true, ok)
+	th.AssertTrue(t, ok)
 	th.AssertDeepEquals(t, expectedInventory, actualInventory)
 }
 
@@ -320,7 +320,7 @@ func TestResourceProviderUpdateInventoryNotFound(t *testing.T) {
 	}
 
 	_, err = resourceproviders.UpdateInventory(context.TODO(), client, tools.RandomUUID(), InventoryResourceClass, updateOpts).Extract()
-	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
+	th.AssertTrue(t, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
 }
 
 func TestResourceProviderDeleteInventorySuccess(t *testing.T) {
@@ -360,7 +360,7 @@ func TestResourceProviderDeleteInventorySuccess(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	_, found := updatedInventories.Inventories[InventoryResourceClass]
-	th.AssertEquals(t, false, found)
+	th.AssertFalse(t, found)
 }
 
 func TestResourceProviderDeleteInventoryNotFound(t *testing.T) {
@@ -374,7 +374,7 @@ func TestResourceProviderDeleteInventoryNotFound(t *testing.T) {
 	defer DeleteResourceProvider(t, client, resourceProvider.UUID)
 
 	err = resourceproviders.DeleteInventory(context.TODO(), client, resourceProvider.UUID, MissingInventoryResourceClass).ExtractErr()
-	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
+	th.AssertTrue(t, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
 }
 
 func TestResourceProviderDeleteInventoriesSuccess(t *testing.T) {
@@ -487,7 +487,7 @@ func TestResourceProviderUpdateInventoriesNotFound(t *testing.T) {
 	}
 
 	_, err = resourceproviders.UpdateInventories(context.TODO(), client, tools.RandomUUID(), updateOpts).Extract()
-	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
+	th.AssertTrue(t, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
 }
 
 func TestResourceProviderTraits(t *testing.T) {
@@ -544,7 +544,7 @@ func TestResourceProviderAggregates(t *testing.T) {
 	client.Microversion = "1.19"
 	aggregates, err := resourceproviders.GetAggregates(context.TODO(), client, resourceProvider.UUID).Extract()
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, true, aggregates.ResourceProviderGeneration != nil)
+	th.AssertTrue(t, aggregates.ResourceProviderGeneration != nil)
 
 	// ensure that we handle older microversions where generation is missing
 	client.Microversion = "1.1"
@@ -563,11 +563,11 @@ func TestResourceProviderAggregatesNotFound(t *testing.T) {
 
 	client.Microversion = "1.19"
 	_, err = resourceproviders.GetAggregates(context.TODO(), client, tools.RandomUUID()).Extract()
-	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
+	th.AssertTrue(t, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
 
 	client.Microversion = "1.1"
 	_, err = resourceproviders.GetAggregates(context.TODO(), client, tools.RandomUUID()).Extract()
-	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
+	th.AssertTrue(t, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
 }
 
 func TestResourceProviderUpdateAggregates(t *testing.T) {
@@ -585,7 +585,7 @@ func TestResourceProviderUpdateAggregates(t *testing.T) {
 
 	before, err := resourceproviders.GetAggregates(context.TODO(), client, resourceProvider.UUID).Extract()
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, true, before.ResourceProviderGeneration != nil)
+	th.AssertTrue(t, before.ResourceProviderGeneration != nil)
 
 	updateOpts := resourceproviders.UpdateAggregatesOpts{
 		ResourceProviderGeneration: before.ResourceProviderGeneration,
@@ -603,7 +603,7 @@ func TestResourceProviderUpdateAggregates(t *testing.T) {
 	th.AssertEquals(t, len(updateOpts.Aggregates), len(after.Aggregates))
 
 	for _, aggregate := range updateOpts.Aggregates {
-		th.AssertEquals(t, true, slices.Contains(after.Aggregates, aggregate))
+		th.AssertTrue(t, slices.Contains(after.Aggregates, aggregate))
 	}
 }
 
@@ -622,7 +622,7 @@ func TestResourceProviderUpdateAggregateMismatch(t *testing.T) {
 
 	current, err := resourceproviders.GetAggregates(context.TODO(), client, resourceProvider.UUID).Extract()
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, true, current.ResourceProviderGeneration != nil)
+	th.AssertTrue(t, current.ResourceProviderGeneration != nil)
 	wrongGeneration := *current.ResourceProviderGeneration + 100
 
 	updateOpts := resourceproviders.UpdateAggregatesOpts{
@@ -633,7 +633,7 @@ func TestResourceProviderUpdateAggregateMismatch(t *testing.T) {
 	}
 
 	_, err = resourceproviders.UpdateAggregates(context.TODO(), client, resourceProvider.UUID, updateOpts).Extract()
-	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusConflict))
+	th.AssertTrue(t, gophercloud.ResponseCodeIs(err, http.StatusConflict))
 }
 
 func TestResourceProviderUpdateAggregatesPreGeneration(t *testing.T) {
@@ -664,7 +664,7 @@ func TestResourceProviderUpdateAggregatesPreGeneration(t *testing.T) {
 	th.AssertEquals(t, len(updateOpts.Aggregates), len(after.Aggregates))
 
 	for _, aggregate := range updateOpts.Aggregates {
-		th.AssertEquals(t, true, slices.Contains(after.Aggregates, aggregate))
+		th.AssertTrue(t, slices.Contains(after.Aggregates, aggregate))
 	}
 }
 
@@ -700,7 +700,7 @@ func TestResourceProviderUpdateAggregatesPreGenerationWithGenerationSuccess(t *t
 	th.AssertEquals(t, len(updateOpts.Aggregates), len(after.Aggregates))
 
 	for _, aggregate := range updateOpts.Aggregates {
-		th.AssertEquals(t, true, slices.Contains(after.Aggregates, aggregate))
+		th.AssertTrue(t, slices.Contains(after.Aggregates, aggregate))
 	}
 }
 

--- a/internal/acceptance/openstack/placement/v1/traits_test.go
+++ b/internal/acceptance/openstack/placement/v1/traits_test.go
@@ -33,7 +33,7 @@ func TestTraitsList(t *testing.T) {
 
 	// Ensure COMPUTE_NODE is in the list
 	// os-traits never removes traits, so this should always pass
-	th.AssertEquals(t, true, slices.Contains(allTraits, "COMPUTE_NODE"))
+	th.AssertTrue(t, slices.Contains(allTraits, "COMPUTE_NODE"))
 }
 
 func TestTraitGet(t *testing.T) {
@@ -62,7 +62,7 @@ func TestTraitGetNegative(t *testing.T) {
 
 	// Verify that Get returns an error for a non-existent trait
 	err = traits.Get(context.TODO(), client, "CUSTOM_NON_EXISTENT_TRAIT").ExtractErr()
-	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
+	th.AssertTrue(t, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
 }
 
 func TestTraitsListFiltering(t *testing.T) {
@@ -86,7 +86,7 @@ func TestTraitsListFiltering(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	for _, trait := range filteredTraits {
-		th.AssertEquals(t, true, strings.HasPrefix(trait, "HW_"))
+		th.AssertTrue(t, strings.HasPrefix(trait, "HW_"))
 	}
 }
 
@@ -142,7 +142,7 @@ func TestTraitsCreateInvalidName(t *testing.T) {
 	traitName := "HW_WE_CANNOT_CREATE_THIS_TRAIT"
 
 	err = traits.Create(context.TODO(), client, traitName).ExtractErr()
-	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusBadRequest))
+	th.AssertTrue(t, gophercloud.ResponseCodeIs(err, http.StatusBadRequest))
 }
 
 func TestTraitsDeleteSuccess(t *testing.T) {
@@ -166,7 +166,7 @@ func TestTraitsDeleteSuccess(t *testing.T) {
 
 	// Assert: The trait no longer exists
 	err = traits.Get(context.TODO(), client, traitName).ExtractErr()
-	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
+	th.AssertTrue(t, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
 }
 
 func TestTraitsDeleteNotFound(t *testing.T) {
@@ -181,7 +181,7 @@ func TestTraitsDeleteNotFound(t *testing.T) {
 	traitName := strings.ToUpper(tools.RandomString("CUSTOM_", 8))
 
 	err = traits.Delete(context.TODO(), client, traitName).ExtractErr()
-	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
+	th.AssertTrue(t, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
 }
 
 // API does allow manipulation solely of custom traits,
@@ -198,5 +198,5 @@ func TestTraitsDeleteStandardTraitFailure(t *testing.T) {
 	traitName := "COMPUTE_NODE"
 
 	err = traits.Delete(context.TODO(), client, traitName).ExtractErr()
-	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusBadRequest))
+	th.AssertTrue(t, gophercloud.ResponseCodeIs(err, http.StatusBadRequest))
 }

--- a/internal/acceptance/openstack/sharedfilesystems/v2/services_test.go
+++ b/internal/acceptance/openstack/sharedfilesystems/v2/services_test.go
@@ -27,6 +27,6 @@ func TestServicesList(t *testing.T) {
 
 	for _, s := range allServices {
 		tools.PrintResource(t, &s)
-		th.AssertEquals(t, s.Status, "enabled")
+		th.AssertEquals(t, "enabled", s.Status)
 	}
 }

--- a/internal/acceptance/openstack/sharedfilesystems/v2/sharetransfers_test.go
+++ b/internal/acceptance/openstack/sharedfilesystems/v2/sharetransfers_test.go
@@ -53,13 +53,13 @@ func TestTransferRequestCRUD(t *testing.T) {
 			foundRequest = true
 		}
 	}
-	th.AssertEquals(t, foundRequest, true)
+	th.AssertEquals(t, true, foundRequest)
 
 	// checking get
 	tr, err := sharetransfers.Get(context.TODO(), client, transferRequest.ID).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, transferRequest.ID == tr.ID, true)
+	th.AssertEquals(t, true, transferRequest.ID == tr.ID)
 
 	// Accept Share Transfer Request
 	err = AcceptTransfer(t, client, transferRequest)

--- a/internal/acceptance/openstack/sharedfilesystems/v2/sharetransfers_test.go
+++ b/internal/acceptance/openstack/sharedfilesystems/v2/sharetransfers_test.go
@@ -53,13 +53,13 @@ func TestTransferRequestCRUD(t *testing.T) {
 			foundRequest = true
 		}
 	}
-	th.AssertEquals(t, true, foundRequest)
+	th.AssertTrue(t, foundRequest)
 
 	// checking get
 	tr, err := sharetransfers.Get(context.TODO(), client, transferRequest.ID).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, true, transferRequest.ID == tr.ID)
+	th.AssertTrue(t, transferRequest.ID == tr.ID)
 
 	// Accept Share Transfer Request
 	err = AcceptTransfer(t, client, transferRequest)

--- a/openstack/baremetal/v1/conductors/testing/requests_test.go
+++ b/openstack/baremetal/v1/conductors/testing/requests_test.go
@@ -84,7 +84,7 @@ func TestListOpts(t *testing.T) {
 	}
 
 	_, err := optsDetail.ToConductorListQuery()
-	th.AssertEquals(t, err.Error(), "cannot have both fields and detail options for conductors")
+	th.AssertEquals(t, "cannot have both fields and detail options for conductors", err.Error())
 
 	// Regular ListOpts can
 	query, err := opts.ToConductorListQuery()

--- a/openstack/baremetal/v1/conductors/testing/requests_test.go
+++ b/openstack/baremetal/v1/conductors/testing/requests_test.go
@@ -58,9 +58,9 @@ func TestListDetailConductors(t *testing.T) {
 			t.Fatalf("Expected 2 conductors, got %d", len(actual))
 		}
 		th.AssertEquals(t, "compute1.localdomain", actual[0].Hostname)
-		th.AssertEquals(t, false, actual[0].Alive)
+		th.AssertFalse(t, actual[0].Alive)
 		th.AssertEquals(t, "compute2.localdomain", actual[1].Hostname)
-		th.AssertEquals(t, true, actual[1].Alive)
+		th.AssertTrue(t, actual[1].Alive)
 
 		return true, nil
 	})

--- a/openstack/baremetal/v1/nodes/testing/requests_test.go
+++ b/openstack/baremetal/v1/nodes/testing/requests_test.go
@@ -81,7 +81,7 @@ func TestListOpts(t *testing.T) {
 	}
 
 	_, err := opts.ToNodeListDetailQuery()
-	th.AssertEquals(t, err.Error(), "fields is not a valid option when getting a detailed listing of nodes")
+	th.AssertEquals(t, "fields is not a valid option when getting a detailed listing of nodes", err.Error())
 
 	// Regular ListOpts can
 	query, err := opts.ToNodeListQuery()
@@ -627,7 +627,7 @@ func TestListBIOSSettingsOpts(t *testing.T) {
 	}
 
 	_, err := opts.ToListBIOSSettingsOptsQuery()
-	th.AssertEquals(t, err.Error(), "cannot have both fields and detail options for BIOS settings")
+	th.AssertEquals(t, "cannot have both fields and detail options for BIOS settings", err.Error())
 }
 
 func TestGetVendorPassthruMethods(t *testing.T) {
@@ -938,5 +938,5 @@ func TestVirtualInterfaceOptsValidation(t *testing.T) {
 	}
 
 	_, err := opts.ToVirtualInterfaceMap()
-	th.AssertEquals(t, err.Error(), "cannot specify both port_uuid and portgroup_uuid")
+	th.AssertEquals(t, "cannot specify both port_uuid and portgroup_uuid", err.Error())
 }

--- a/openstack/baremetal/v1/ports/testing/requests_test.go
+++ b/openstack/baremetal/v1/ports/testing/requests_test.go
@@ -77,7 +77,7 @@ func TestListOpts(t *testing.T) {
 	}
 
 	_, err := opts.ToPortListDetailQuery()
-	th.AssertEquals(t, err.Error(), "fields is not a valid option when getting a detailed listing of ports")
+	th.AssertEquals(t, "fields is not a valid option when getting a detailed listing of ports", err.Error())
 
 	// Regular ListOpts can
 	query, err := opts.ToPortListQuery()

--- a/openstack/baremetalintrospection/v1/introspection/testing/results_test.go
+++ b/openstack/baremetalintrospection/v1/introspection/testing/results_test.go
@@ -15,5 +15,5 @@ func TestHostnameInInventory(t *testing.T) {
 		t.Fatalf("Failed to unmarshal Inventory data: %s", err)
 	}
 
-	th.CheckDeepEquals(t, IntrospectionDataRes.Inventory.Hostname, "myawesomehost")
+	th.CheckDeepEquals(t, "myawesomehost", IntrospectionDataRes.Inventory.Hostname)
 }

--- a/openstack/blockstorage/v2/backups/testing/requests_test.go
+++ b/openstack/blockstorage/v2/backups/testing/requests_test.go
@@ -111,8 +111,8 @@ func TestGet(t *testing.T) {
 	v, err := backups.Get(context.TODO(), client.ServiceClient(fakeServer), "d32019d3-bc6e-4319-9c1d-6722fc136a22").Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, v.Name, "backup-001")
-	th.AssertEquals(t, v.ID, "d32019d3-bc6e-4319-9c1d-6722fc136a22")
+	th.AssertEquals(t, "backup-001", v.Name)
+	th.AssertEquals(t, "d32019d3-bc6e-4319-9c1d-6722fc136a22", v.ID)
 }
 
 func TestCreate(t *testing.T) {
@@ -125,9 +125,9 @@ func TestCreate(t *testing.T) {
 	n, err := backups.Create(context.TODO(), client.ServiceClient(fakeServer), options).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, n.VolumeID, "1234")
-	th.AssertEquals(t, n.Name, "backup-001")
-	th.AssertEquals(t, n.ID, "d32019d3-bc6e-4319-9c1d-6722fc136a22")
+	th.AssertEquals(t, "1234", n.VolumeID)
+	th.AssertEquals(t, "backup-001", n.Name)
+	th.AssertEquals(t, "d32019d3-bc6e-4319-9c1d-6722fc136a22", n.ID)
 }
 
 func TestRestore(t *testing.T) {
@@ -140,9 +140,9 @@ func TestRestore(t *testing.T) {
 	n, err := backups.RestoreFromBackup(context.TODO(), client.ServiceClient(fakeServer), "d32019d3-bc6e-4319-9c1d-6722fc136a22", options).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, n.VolumeID, "1234")
-	th.AssertEquals(t, n.VolumeName, "vol-001")
-	th.AssertEquals(t, n.BackupID, "d32019d3-bc6e-4319-9c1d-6722fc136a22")
+	th.AssertEquals(t, "1234", n.VolumeID)
+	th.AssertEquals(t, "vol-001", n.VolumeName)
+	th.AssertEquals(t, "d32019d3-bc6e-4319-9c1d-6722fc136a22", n.BackupID)
 }
 
 func TestDelete(t *testing.T) {
@@ -164,7 +164,7 @@ func TestExport(t *testing.T) {
 	n, err := backups.Export(context.TODO(), client.ServiceClient(fakeServer), "d32019d3-bc6e-4319-9c1d-6722fc136a22").Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, n.BackupService, "cinder.backup.drivers.swift.SwiftBackupDriver")
+	th.AssertEquals(t, "cinder.backup.drivers.swift.SwiftBackupDriver", n.BackupService)
 	th.AssertDeepEquals(t, n.BackupURL, backupURL)
 
 	tmp := backups.ImportBackup{}
@@ -186,7 +186,7 @@ func TestImport(t *testing.T) {
 	n, err := backups.Import(context.TODO(), client.ServiceClient(fakeServer), options).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, n.ID, "d32019d3-bc6e-4319-9c1d-6722fc136a22")
+	th.AssertEquals(t, "d32019d3-bc6e-4319-9c1d-6722fc136a22", n.ID)
 }
 
 func TestResetStatus(t *testing.T) {

--- a/openstack/blockstorage/v2/snapshots/testing/requests_test.go
+++ b/openstack/blockstorage/v2/snapshots/testing/requests_test.go
@@ -68,8 +68,8 @@ func TestGet(t *testing.T) {
 	v, err := snapshots.Get(context.TODO(), client.ServiceClient(fakeServer), "d32019d3-bc6e-4319-9c1d-6722fc136a22").Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, v.Name, "snapshot-001")
-	th.AssertEquals(t, v.ID, "d32019d3-bc6e-4319-9c1d-6722fc136a22")
+	th.AssertEquals(t, "snapshot-001", v.Name)
+	th.AssertEquals(t, "d32019d3-bc6e-4319-9c1d-6722fc136a22", v.ID)
 }
 
 func TestCreate(t *testing.T) {
@@ -82,9 +82,9 @@ func TestCreate(t *testing.T) {
 	n, err := snapshots.Create(context.TODO(), client.ServiceClient(fakeServer), options).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, n.VolumeID, "1234")
-	th.AssertEquals(t, n.Name, "snapshot-001")
-	th.AssertEquals(t, n.ID, "d32019d3-bc6e-4319-9c1d-6722fc136a22")
+	th.AssertEquals(t, "1234", n.VolumeID)
+	th.AssertEquals(t, "snapshot-001", n.Name)
+	th.AssertEquals(t, "d32019d3-bc6e-4319-9c1d-6722fc136a22", n.ID)
 }
 
 func TestUpdateMetadata(t *testing.T) {

--- a/openstack/blockstorage/v2/transfers/testing/requests_test.go
+++ b/openstack/blockstorage/v2/transfers/testing/requests_test.go
@@ -59,7 +59,7 @@ func TestListTransfers(t *testing.T) {
 		return true, nil
 	})
 	th.AssertNoErr(t, err)
-	th.CheckEquals(t, count, 1)
+	th.CheckEquals(t, 1, count)
 }
 
 func TestListTransfersAllPages(t *testing.T) {

--- a/openstack/blockstorage/v2/volumes/testing/requests_test.go
+++ b/openstack/blockstorage/v2/volumes/testing/requests_test.go
@@ -193,8 +193,8 @@ func TestGet(t *testing.T) {
 	v, err := volumes.Get(context.TODO(), client.ServiceClient(fakeServer), "d32019d3-bc6e-4319-9c1d-6722fc136a22").Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, v.Name, "vol-001")
-	th.AssertEquals(t, v.ID, "d32019d3-bc6e-4319-9c1d-6722fc136a22")
+	th.AssertEquals(t, "vol-001", v.Name)
+	th.AssertEquals(t, "d32019d3-bc6e-4319-9c1d-6722fc136a22", v.ID)
 }
 
 func TestCreate(t *testing.T) {
@@ -207,8 +207,8 @@ func TestCreate(t *testing.T) {
 	n, err := volumes.Create(context.TODO(), client.ServiceClient(fakeServer), options, nil).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, n.Size, 75)
-	th.AssertEquals(t, n.ID, "d32019d3-bc6e-4319-9c1d-6722fc136a22")
+	th.AssertEquals(t, 75, n.Size)
+	th.AssertEquals(t, "d32019d3-bc6e-4319-9c1d-6722fc136a22", n.ID)
 }
 
 func TestCreateSchedulerHints(t *testing.T) {

--- a/openstack/blockstorage/v3/backups/testing/requests_test.go
+++ b/openstack/blockstorage/v3/backups/testing/requests_test.go
@@ -111,8 +111,8 @@ func TestGet(t *testing.T) {
 	v, err := backups.Get(context.TODO(), client.ServiceClient(fakeServer), "d32019d3-bc6e-4319-9c1d-6722fc136a22").Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, v.Name, "backup-001")
-	th.AssertEquals(t, v.ID, "d32019d3-bc6e-4319-9c1d-6722fc136a22")
+	th.AssertEquals(t, "backup-001", v.Name)
+	th.AssertEquals(t, "d32019d3-bc6e-4319-9c1d-6722fc136a22", v.ID)
 }
 
 func TestCreate(t *testing.T) {
@@ -125,9 +125,9 @@ func TestCreate(t *testing.T) {
 	n, err := backups.Create(context.TODO(), client.ServiceClient(fakeServer), options).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, n.VolumeID, "1234")
-	th.AssertEquals(t, n.Name, "backup-001")
-	th.AssertEquals(t, n.ID, "d32019d3-bc6e-4319-9c1d-6722fc136a22")
+	th.AssertEquals(t, "1234", n.VolumeID)
+	th.AssertEquals(t, "backup-001", n.Name)
+	th.AssertEquals(t, "d32019d3-bc6e-4319-9c1d-6722fc136a22", n.ID)
 }
 
 func TestRestore(t *testing.T) {
@@ -140,9 +140,9 @@ func TestRestore(t *testing.T) {
 	n, err := backups.RestoreFromBackup(context.TODO(), client.ServiceClient(fakeServer), "d32019d3-bc6e-4319-9c1d-6722fc136a22", options).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, n.VolumeID, "1234")
-	th.AssertEquals(t, n.VolumeName, "vol-001")
-	th.AssertEquals(t, n.BackupID, "d32019d3-bc6e-4319-9c1d-6722fc136a22")
+	th.AssertEquals(t, "1234", n.VolumeID)
+	th.AssertEquals(t, "vol-001", n.VolumeName)
+	th.AssertEquals(t, "d32019d3-bc6e-4319-9c1d-6722fc136a22", n.BackupID)
 }
 
 func TestDelete(t *testing.T) {
@@ -164,7 +164,7 @@ func TestExport(t *testing.T) {
 	n, err := backups.Export(context.TODO(), client.ServiceClient(fakeServer), "d32019d3-bc6e-4319-9c1d-6722fc136a22").Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, n.BackupService, "cinder.backup.drivers.swift.SwiftBackupDriver")
+	th.AssertEquals(t, "cinder.backup.drivers.swift.SwiftBackupDriver", n.BackupService)
 	th.AssertDeepEquals(t, n.BackupURL, backupURL)
 
 	tmp := backups.ImportBackup{}
@@ -186,7 +186,7 @@ func TestImport(t *testing.T) {
 	n, err := backups.Import(context.TODO(), client.ServiceClient(fakeServer), options).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, n.ID, "d32019d3-bc6e-4319-9c1d-6722fc136a22")
+	th.AssertEquals(t, "d32019d3-bc6e-4319-9c1d-6722fc136a22", n.ID)
 }
 
 func TestResetStatus(t *testing.T) {

--- a/openstack/blockstorage/v3/manageablevolumes/testing/requests_test.go
+++ b/openstack/blockstorage/v3/manageablevolumes/testing/requests_test.go
@@ -31,14 +31,14 @@ func TestManageExisting(t *testing.T) {
 	n, err := manageablevolumes.ManageExisting(context.TODO(), client.ServiceClient(fakeServer), options).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, n.Host, "host@lvm#LVM")
-	th.AssertEquals(t, n.Name, "New Volume")
-	th.AssertEquals(t, n.AvailabilityZone, "nova")
-	th.AssertEquals(t, n.Description, "Volume imported from existingLV")
-	th.AssertEquals(t, n.Bootable, "true")
-	th.AssertDeepEquals(t, n.Metadata, map[string]string{
+	th.AssertEquals(t, "host@lvm#LVM", n.Host)
+	th.AssertEquals(t, "New Volume", n.Name)
+	th.AssertEquals(t, "nova", n.AvailabilityZone)
+	th.AssertEquals(t, "Volume imported from existingLV", n.Description)
+	th.AssertEquals(t, "true", n.Bootable)
+	th.AssertDeepEquals(t, map[string]string{
 		"key1": "value1",
 		"key2": "value2",
-	})
-	th.AssertEquals(t, n.ID, "23cf872b-c781-4cd4-847d-5f2ec8cbd91c")
+	}, n.Metadata)
+	th.AssertEquals(t, "23cf872b-c781-4cd4-847d-5f2ec8cbd91c", n.ID)
 }

--- a/openstack/blockstorage/v3/snapshots/testing/requests_test.go
+++ b/openstack/blockstorage/v3/snapshots/testing/requests_test.go
@@ -124,8 +124,8 @@ func TestGet(t *testing.T) {
 	v, err := snapshots.Get(context.TODO(), client.ServiceClient(fakeServer), "d32019d3-bc6e-4319-9c1d-6722fc136a22").Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, v.Name, "snapshot-001")
-	th.AssertEquals(t, v.ID, "d32019d3-bc6e-4319-9c1d-6722fc136a22")
+	th.AssertEquals(t, "snapshot-001", v.Name)
+	th.AssertEquals(t, "d32019d3-bc6e-4319-9c1d-6722fc136a22", v.ID)
 }
 
 func TestCreate(t *testing.T) {
@@ -138,9 +138,9 @@ func TestCreate(t *testing.T) {
 	n, err := snapshots.Create(context.TODO(), client.ServiceClient(fakeServer), options).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, n.VolumeID, "1234")
-	th.AssertEquals(t, n.Name, "snapshot-001")
-	th.AssertEquals(t, n.ID, "d32019d3-bc6e-4319-9c1d-6722fc136a22")
+	th.AssertEquals(t, "1234", n.VolumeID)
+	th.AssertEquals(t, "snapshot-001", n.Name)
+	th.AssertEquals(t, "d32019d3-bc6e-4319-9c1d-6722fc136a22", n.ID)
 }
 
 func TestUpdateMetadata(t *testing.T) {

--- a/openstack/blockstorage/v3/transfers/testing/requests_test.go
+++ b/openstack/blockstorage/v3/transfers/testing/requests_test.go
@@ -59,7 +59,7 @@ func TestListTransfers(t *testing.T) {
 		return true, nil
 	})
 	th.AssertNoErr(t, err)
-	th.CheckEquals(t, count, 1)
+	th.CheckEquals(t, 1, count)
 }
 
 func TestListTransfersAllPages(t *testing.T) {

--- a/openstack/blockstorage/v3/volumes/testing/requests_test.go
+++ b/openstack/blockstorage/v3/volumes/testing/requests_test.go
@@ -197,8 +197,8 @@ func TestGet(t *testing.T) {
 	v, err := volumes.Get(context.TODO(), client.ServiceClient(fakeServer), "d32019d3-bc6e-4319-9c1d-6722fc136a22").Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, v.Name, "vol-001")
-	th.AssertEquals(t, v.ID, "d32019d3-bc6e-4319-9c1d-6722fc136a22")
+	th.AssertEquals(t, "vol-001", v.Name)
+	th.AssertEquals(t, "d32019d3-bc6e-4319-9c1d-6722fc136a22", v.ID)
 }
 
 func TestCreate(t *testing.T) {
@@ -211,8 +211,8 @@ func TestCreate(t *testing.T) {
 	n, err := volumes.Create(context.TODO(), client.ServiceClient(fakeServer), options, nil).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, n.Size, 75)
-	th.AssertEquals(t, n.ID, "d32019d3-bc6e-4319-9c1d-6722fc136a22")
+	th.AssertEquals(t, 75, n.Size)
+	th.AssertEquals(t, "d32019d3-bc6e-4319-9c1d-6722fc136a22", n.ID)
 }
 
 func TestCreateSchedulerHints(t *testing.T) {
@@ -303,9 +303,9 @@ func TestCreateFromBackup(t *testing.T) {
 	v, err := volumes.Create(context.TODO(), client.ServiceClient(fakeServer), options, nil).Extract()
 
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, v.Size, 30)
-	th.AssertEquals(t, v.ID, "d32019d3-bc6e-4319-9c1d-6722fc136a22")
-	th.AssertEquals(t, *v.BackupID, "20c792f0-bb03-434f-b653-06ef238e337e")
+	th.AssertEquals(t, 30, v.Size)
+	th.AssertEquals(t, "d32019d3-bc6e-4319-9c1d-6722fc136a22", v.ID)
+	th.AssertEquals(t, "20c792f0-bb03-434f-b653-06ef238e337e", *v.BackupID)
 }
 
 func TestAttach(t *testing.T) {

--- a/openstack/blockstorage/v3/volumetypes/testing/requests_test.go
+++ b/openstack/blockstorage/v3/volumetypes/testing/requests_test.go
@@ -64,7 +64,7 @@ func TestGet(t *testing.T) {
 	th.AssertEquals(t, "d32019d3-bc6e-4319-9c1d-6722fc136a22", v.ID)
 	th.AssertEquals(t, "gpu", v.ExtraSpecs["capabilities"])
 	th.AssertEquals(t, "d32019d3-bc6e-4319-9c1d-6722fc136a22", v.QosSpecID)
-	th.AssertEquals(t, true, v.PublicAccess)
+	th.AssertTrue(t, v.PublicAccess)
 }
 
 func TestCreate(t *testing.T) {
@@ -87,8 +87,8 @@ func TestCreate(t *testing.T) {
 
 	th.AssertEquals(t, "test_type", n.Name)
 	th.AssertEquals(t, "test_type_desc", n.Description)
-	th.AssertEquals(t, true, n.IsPublic)
-	th.AssertEquals(t, true, n.PublicAccess)
+	th.AssertTrue(t, n.IsPublic)
+	th.AssertTrue(t, n.PublicAccess)
 	th.AssertEquals(t, "6d0ff92a-0007-4780-9ece-acfe5876966a", n.ID)
 	th.AssertEquals(t, "gpu", n.ExtraSpecs["capabilities"])
 }
@@ -119,7 +119,7 @@ func TestUpdate(t *testing.T) {
 	v, err := volumetypes.Update(context.TODO(), client.ServiceClient(fakeServer), "d32019d3-bc6e-4319-9c1d-6722fc136a22", options).Extract()
 	th.AssertNoErr(t, err)
 	th.CheckEquals(t, "vol-type-002", v.Name)
-	th.CheckEquals(t, true, v.IsPublic)
+	th.CheckTrue(t, v.IsPublic)
 }
 
 func TestListIsPublicParam(t *testing.T) {
@@ -180,8 +180,8 @@ func TestListNameParam(t *testing.T) {
 	th.AssertEquals(t, "test-type", actual[0].Name)
 	th.AssertEquals(t, "996af3df-92fd-4814-a0ee-ba5f899aa1ec", actual[0].ID)
 	th.AssertEquals(t, "test", actual[0].Description)
-	th.AssertEquals(t, true, actual[0].IsPublic)
-	th.AssertEquals(t, true, actual[0].PublicAccess)
+	th.AssertTrue(t, actual[0].IsPublic)
+	th.AssertTrue(t, actual[0].PublicAccess)
 	th.AssertEquals(t, "nfs", actual[0].ExtraSpecs["storage_protocol"])
 }
 
@@ -203,8 +203,8 @@ func TestListDescriptionParam(t *testing.T) {
 	th.AssertEquals(t, "test", actual[0].Description)
 	th.AssertEquals(t, "test-type", actual[0].Name)
 	th.AssertEquals(t, "ab948f0a-13ed-47c8-b9be-cade0beb0706", actual[0].ID)
-	th.AssertEquals(t, true, actual[0].IsPublic)
-	th.AssertEquals(t, true, actual[0].PublicAccess)
+	th.AssertTrue(t, actual[0].IsPublic)
+	th.AssertTrue(t, actual[0].PublicAccess)
 	th.AssertEquals(t, "<is> True", actual[0].ExtraSpecs["multiattach"])
 }
 
@@ -432,7 +432,7 @@ func TestGetEncryption(t *testing.T) {
 
 	th.AssertEquals(t, "a5082c24-2a27-43a4-b48e-fcec1240e36b", n.VolumeTypeID)
 	th.AssertEquals(t, "front-end", n.ControlLocation)
-	th.AssertEquals(t, false, n.Deleted)
+	th.AssertFalse(t, n.Deleted)
 	th.AssertEquals(t, "2016-12-28T02:32:25.000000", n.CreatedAt)
 	th.AssertEquals(t, "", n.UpdatedAt)
 	th.AssertEquals(t, "81e069c6-7394-4856-8df7-3b237ca61f74", n.EncryptionID)

--- a/openstack/blockstorage/v3/volumetypes/testing/requests_test.go
+++ b/openstack/blockstorage/v3/volumetypes/testing/requests_test.go
@@ -48,7 +48,7 @@ func TestListAll(t *testing.T) {
 		return true, nil
 	})
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, pages, 1)
+	th.AssertEquals(t, 1, pages)
 }
 
 func TestGet(t *testing.T) {
@@ -60,11 +60,11 @@ func TestGet(t *testing.T) {
 	v, err := volumetypes.Get(context.TODO(), client.ServiceClient(fakeServer), "d32019d3-bc6e-4319-9c1d-6722fc136a22").Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, v.Name, "vol-type-001")
-	th.AssertEquals(t, v.ID, "d32019d3-bc6e-4319-9c1d-6722fc136a22")
-	th.AssertEquals(t, v.ExtraSpecs["capabilities"], "gpu")
-	th.AssertEquals(t, v.QosSpecID, "d32019d3-bc6e-4319-9c1d-6722fc136a22")
-	th.AssertEquals(t, v.PublicAccess, true)
+	th.AssertEquals(t, "vol-type-001", v.Name)
+	th.AssertEquals(t, "d32019d3-bc6e-4319-9c1d-6722fc136a22", v.ID)
+	th.AssertEquals(t, "gpu", v.ExtraSpecs["capabilities"])
+	th.AssertEquals(t, "d32019d3-bc6e-4319-9c1d-6722fc136a22", v.QosSpecID)
+	th.AssertEquals(t, true, v.PublicAccess)
 }
 
 func TestCreate(t *testing.T) {
@@ -85,12 +85,12 @@ func TestCreate(t *testing.T) {
 	n, err := volumetypes.Create(context.TODO(), client.ServiceClient(fakeServer), options).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, n.Name, "test_type")
-	th.AssertEquals(t, n.Description, "test_type_desc")
-	th.AssertEquals(t, n.IsPublic, true)
-	th.AssertEquals(t, n.PublicAccess, true)
-	th.AssertEquals(t, n.ID, "6d0ff92a-0007-4780-9ece-acfe5876966a")
-	th.AssertEquals(t, n.ExtraSpecs["capabilities"], "gpu")
+	th.AssertEquals(t, "test_type", n.Name)
+	th.AssertEquals(t, "test_type_desc", n.Description)
+	th.AssertEquals(t, true, n.IsPublic)
+	th.AssertEquals(t, true, n.PublicAccess)
+	th.AssertEquals(t, "6d0ff92a-0007-4780-9ece-acfe5876966a", n.ID)
+	th.AssertEquals(t, "gpu", n.ExtraSpecs["capabilities"])
 }
 
 func TestDelete(t *testing.T) {

--- a/openstack/compute/apiversions/testing/requests_test.go
+++ b/openstack/compute/apiversions/testing/requests_test.go
@@ -43,5 +43,5 @@ func TestGetMultipleAPIVersion(t *testing.T) {
 	MockGetMultipleResponses(t, fakeServer)
 
 	_, err := apiversions.Get(context.TODO(), client.ServiceClient(fakeServer), "v3").Extract()
-	th.AssertEquals(t, err.Error(), "Unable to find requested API version")
+	th.AssertEquals(t, "Unable to find requested API version", err.Error())
 }

--- a/openstack/compute/v2/extensions/testing/delegate_test.go
+++ b/openstack/compute/v2/extensions/testing/delegate_test.go
@@ -50,9 +50,9 @@ func TestGet(t *testing.T) {
 	ext, err := extensions.Get(context.TODO(), client.ServiceClient(fakeServer), "agent").Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, ext.Updated, "2013-02-03T10:00:00-00:00")
-	th.AssertEquals(t, ext.Name, "agent")
-	th.AssertEquals(t, ext.Namespace, "http://docs.openstack.org/ext/agent/api/v2.0")
-	th.AssertEquals(t, ext.Alias, "agent")
-	th.AssertEquals(t, ext.Description, "The agent management extension.")
+	th.AssertEquals(t, "2013-02-03T10:00:00-00:00", ext.Updated)
+	th.AssertEquals(t, "agent", ext.Name)
+	th.AssertEquals(t, "http://docs.openstack.org/ext/agent/api/v2.0", ext.Namespace)
+	th.AssertEquals(t, "agent", ext.Alias)
+	th.AssertEquals(t, "The agent management extension.", ext.Description)
 }

--- a/openstack/compute/v2/keypairs/testing/fixtures_test.go
+++ b/openstack/compute/v2/keypairs/testing/fixtures_test.go
@@ -231,7 +231,7 @@ func HandleDeleteSuccessfully(t *testing.T, fakeServer th.FakeServer) {
 	fakeServer.Mux.HandleFunc("/os-keypairs/deletedkey", func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "DELETE")
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
-		th.AssertEquals(t, r.Form.Get("user_id"), "")
+		th.AssertEquals(t, "", r.Form.Get("user_id"))
 
 		w.WriteHeader(http.StatusAccepted)
 	})

--- a/openstack/compute/v2/remoteconsoles/testing/requests_test.go
+++ b/openstack/compute/v2/remoteconsoles/testing/requests_test.go
@@ -37,5 +37,5 @@ func TestCreate(t *testing.T) {
 
 	th.AssertEquals(t, s.Protocol, string(remoteconsoles.ConsoleProtocolVNC))
 	th.AssertEquals(t, s.Type, string(remoteconsoles.ConsoleTypeNoVNC))
-	th.AssertEquals(t, s.URL, "http://192.168.0.4:6080/vnc_auto.html?token=9a2372b9-6a0e-4f71-aca1-56020e6bb677")
+	th.AssertEquals(t, "http://192.168.0.4:6080/vnc_auto.html?token=9a2372b9-6a0e-4f71-aca1-56020e6bb677", s.URL)
 }

--- a/openstack/compute/v2/servers/testing/results_test.go
+++ b/openstack/compute/v2/servers/testing/results_test.go
@@ -26,7 +26,7 @@ func TestExtractPassword_no_pwd_data(t *testing.T) {
 
 	pwd, err := resp.ExtractPassword(nil)
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, pwd, "")
+	th.AssertEquals(t, "", pwd)
 }
 
 // Ok - return encrypted password when no private key is given.

--- a/openstack/compute/v2/tags/testing/requests_test.go
+++ b/openstack/compute/v2/tags/testing/requests_test.go
@@ -47,7 +47,7 @@ func TestCheckOk(t *testing.T) {
 
 	exists, err := tags.Check(context.TODO(), client.ServiceClient(fakeServer), "uuid1", "foo").Extract()
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, true, exists)
+	th.AssertTrue(t, exists)
 }
 
 func TestCheckFail(t *testing.T) {
@@ -64,7 +64,7 @@ func TestCheckFail(t *testing.T) {
 
 	exists, err := tags.Check(context.TODO(), client.ServiceClient(fakeServer), "uuid1", "bar").Extract()
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, false, exists)
+	th.AssertFalse(t, exists)
 }
 
 func TestReplaceAll(t *testing.T) {

--- a/openstack/compute/v2/usage/testing/requests_test.go
+++ b/openstack/compute/v2/usage/testing/requests_test.go
@@ -26,7 +26,7 @@ func TestGetTenant(t *testing.T) {
 		return true, nil
 	})
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, count, 1)
+	th.AssertEquals(t, 1, count)
 }
 
 func TestAllTenants(t *testing.T) {
@@ -49,5 +49,5 @@ func TestAllTenants(t *testing.T) {
 		return true, nil
 	})
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, count, 1)
+	th.AssertEquals(t, 1, count)
 }

--- a/openstack/containerinfra/v1/clustertemplates/testing/requests_test.go
+++ b/openstack/containerinfra/v1/clustertemplates/testing/requests_test.go
@@ -211,5 +211,5 @@ func TestUpdateClusterTemplateInvalidUpdate(t *testing.T) {
 	sc := client.ServiceClient(fakeServer)
 	sc.Endpoint = sc.Endpoint + "v1/"
 	_, err := clustertemplates.Update(context.TODO(), sc, "7d85f602-a948-4a30-afd4-e84f47471c15", updateOpts).Extract()
-	th.AssertEquals(t, true, err != nil)
+	th.AssertTrue(t, err != nil)
 }

--- a/openstack/containerinfra/v1/nodegroups/testing/requests_test.go
+++ b/openstack/containerinfra/v1/nodegroups/testing/requests_test.go
@@ -38,7 +38,7 @@ func TestGetNodeGroupNotFound(t *testing.T) {
 	sc.Endpoint = sc.Endpoint + "v1/"
 
 	_, err := nodegroups.Get(context.TODO(), sc, clusterUUID, badNodeGroupUUID).Extract()
-	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
+	th.AssertTrue(t, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
 }
 
 // TestGetNodeGroupClusterNotFound tries to get a node group in
@@ -53,7 +53,7 @@ func TestGetNodeGroupClusterNotFound(t *testing.T) {
 	sc.Endpoint = sc.Endpoint + "v1/"
 
 	_, err := nodegroups.Get(context.TODO(), sc, badClusterUUID, badNodeGroupUUID).Extract()
-	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
+	th.AssertTrue(t, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
 }
 
 // TestListNodeGroupsSuccess lists the node groups of a cluster successfully.
@@ -111,7 +111,7 @@ func TestListNodeGroupsClusterNotFound(t *testing.T) {
 	sc.Endpoint = sc.Endpoint + "v1/"
 
 	_, err := nodegroups.List(sc, clusterUUID, nodegroups.ListOpts{}).AllPages(context.TODO())
-	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
+	th.AssertTrue(t, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
 }
 
 // TestCreateNodeGroupSuccess creates a node group successfully.
@@ -150,7 +150,7 @@ func TestCreateNodeGroupDuplicate(t *testing.T) {
 	}
 
 	_, err := nodegroups.Create(context.TODO(), sc, clusterUUID, createOpts).Extract()
-	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusConflict))
+	th.AssertTrue(t, gophercloud.ResponseCodeIs(err, http.StatusConflict))
 }
 
 // TestCreateNodeGroupMaster creates a node group with
@@ -170,7 +170,7 @@ func TestCreateNodeGroupMaster(t *testing.T) {
 	}
 
 	_, err := nodegroups.Create(context.TODO(), sc, clusterUUID, createOpts).Extract()
-	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusBadRequest))
+	th.AssertTrue(t, gophercloud.ResponseCodeIs(err, http.StatusBadRequest))
 }
 
 // TestCreateNodeGroupBadSizes creates a node group with
@@ -192,7 +192,7 @@ func TestCreateNodeGroupBadSizes(t *testing.T) {
 	}
 
 	_, err := nodegroups.Create(context.TODO(), sc, clusterUUID, createOpts).Extract()
-	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusConflict))
+	th.AssertTrue(t, gophercloud.ResponseCodeIs(err, http.StatusConflict))
 }
 
 // TestUpdateNodeGroupSuccess updates a node group successfully.
@@ -238,7 +238,7 @@ func TestUpdateNodeGroupInternal(t *testing.T) {
 	}
 
 	_, err := nodegroups.Update(context.TODO(), sc, clusterUUID, nodeGroup2UUID, updateOpts).Extract()
-	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusBadRequest))
+	th.AssertTrue(t, gophercloud.ResponseCodeIs(err, http.StatusBadRequest))
 }
 
 // TestUpdateNodeGroupBadField tries to update a
@@ -261,7 +261,7 @@ func TestUpdateNodeGroupBadField(t *testing.T) {
 	}
 
 	_, err := nodegroups.Update(context.TODO(), sc, clusterUUID, nodeGroup2UUID, updateOpts).Extract()
-	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusBadRequest))
+	th.AssertTrue(t, gophercloud.ResponseCodeIs(err, http.StatusBadRequest))
 }
 
 // TestUpdateNodeGroupBadMin tries to set a minimum node count
@@ -284,7 +284,7 @@ func TestUpdateNodeGroupBadMin(t *testing.T) {
 	}
 
 	_, err := nodegroups.Update(context.TODO(), sc, clusterUUID, nodeGroup2UUID, updateOpts).Extract()
-	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusConflict))
+	th.AssertTrue(t, gophercloud.ResponseCodeIs(err, http.StatusConflict))
 }
 
 // TestDeleteNodeGroupSuccess deletes a node group successfully.
@@ -312,7 +312,7 @@ func TestDeleteNodeGroupNotFound(t *testing.T) {
 	sc.Endpoint = sc.Endpoint + "v1/"
 
 	err := nodegroups.Delete(context.TODO(), sc, clusterUUID, badNodeGroupUUID).ExtractErr()
-	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
+	th.AssertTrue(t, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
 }
 
 // TestDeleteNodeGroupClusterNotFound tries to delete a node group in a cluster that does not exist.
@@ -326,7 +326,7 @@ func TestDeleteNodeGroupClusterNotFound(t *testing.T) {
 	sc.Endpoint = sc.Endpoint + "v1/"
 
 	err := nodegroups.Delete(context.TODO(), sc, badClusterUUID, badNodeGroupUUID).ExtractErr()
-	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
+	th.AssertTrue(t, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
 }
 
 // TestDeleteNodeGroupDefault tries to delete a protected default node group.
@@ -340,5 +340,5 @@ func TestDeleteNodeGroupDefault(t *testing.T) {
 	sc.Endpoint = sc.Endpoint + "v1/"
 
 	err := nodegroups.Delete(context.TODO(), sc, clusterUUID, nodeGroup2UUID).ExtractErr()
-	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusBadRequest))
+	th.AssertTrue(t, gophercloud.ResponseCodeIs(err, http.StatusBadRequest))
 }

--- a/openstack/db/v1/configurations/testing/requests_test.go
+++ b/openstack/db/v1/configurations/testing/requests_test.go
@@ -138,7 +138,7 @@ func TestListInstances(t *testing.T) {
 			return false, err
 		}
 
-		th.AssertDeepEquals(t, actual, []instances.Instance{expectedInstance})
+		th.AssertDeepEquals(t, []instances.Instance{expectedInstance}, actual)
 
 		return true, nil
 	})

--- a/openstack/db/v1/instances/testing/requests_test.go
+++ b/openstack/db/v1/instances/testing/requests_test.go
@@ -166,7 +166,7 @@ func TestIsRootEnabled(t *testing.T) {
 	isEnabled, err := instances.IsRootEnabled(context.TODO(), client.ServiceClient(fakeServer), instanceID).Extract()
 
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, true, isEnabled)
+	th.AssertTrue(t, isEnabled)
 }
 
 func TestRestart(t *testing.T) {

--- a/openstack/dns/v2/zones/testing/requests_test.go
+++ b/openstack/dns/v2/zones/testing/requests_test.go
@@ -128,7 +128,7 @@ func TestShare(t *testing.T) {
 	defer fakeServer.Teardown()
 
 	fakeServer.Mux.HandleFunc("/zones/zone-id/shares", func(w http.ResponseWriter, r *http.Request) {
-		th.AssertEquals(t, r.Method, "POST")
+		th.AssertEquals(t, "POST", r.Method)
 
 		body, err := io.ReadAll(r.Body)
 		defer r.Body.Close()
@@ -156,7 +156,7 @@ func TestUnshare(t *testing.T) {
 	defer fakeServer.Teardown()
 
 	fakeServer.Mux.HandleFunc("/zones/zone-id/shares/share-id", func(w http.ResponseWriter, r *http.Request) {
-		th.AssertEquals(t, r.Method, "DELETE")
+		th.AssertEquals(t, "DELETE", r.Method)
 		w.WriteHeader(http.StatusNoContent)
 	})
 
@@ -169,7 +169,7 @@ func TestListShares(t *testing.T) {
 	defer fakeServer.Teardown()
 
 	fakeServer.Mux.HandleFunc("/zones/zone-id/shares", func(w http.ResponseWriter, r *http.Request) {
-		th.AssertEquals(t, r.Method, "GET")
+		th.AssertEquals(t, "GET", r.Method)
 		th.AssertEquals(t, "true", r.Header.Get("X-Auth-All-Projects"))
 
 		w.Header().Add("Content-Type", "application/json")

--- a/openstack/identity/v2/tenants/testing/requests_test.go
+++ b/openstack/identity/v2/tenants/testing/requests_test.go
@@ -28,7 +28,7 @@ func TestListTenants(t *testing.T) {
 		return true, nil
 	})
 	th.AssertNoErr(t, err)
-	th.CheckEquals(t, count, 1)
+	th.CheckEquals(t, 1, count)
 }
 
 func TestCreateTenant(t *testing.T) {

--- a/openstack/identity/v3/applicationcredentials/testing/requests_test.go
+++ b/openstack/identity/v3/applicationcredentials/testing/requests_test.go
@@ -27,7 +27,7 @@ func TestListApplicationCredentials(t *testing.T) {
 		return true, nil
 	})
 	th.AssertNoErr(t, err)
-	th.CheckEquals(t, count, 1)
+	th.CheckEquals(t, 1, count)
 }
 
 func TestListApplicationCredentialsAllPages(t *testing.T) {
@@ -40,8 +40,8 @@ func TestListApplicationCredentialsAllPages(t *testing.T) {
 	actual, err := applicationcredentials.ExtractApplicationCredentials(allPages)
 	th.AssertNoErr(t, err)
 	th.CheckDeepEquals(t, ExpectedApplicationCredentialsSlice, actual)
-	th.AssertDeepEquals(t, ExpectedApplicationCredentialsSlice[0].Roles, []applicationcredentials.Role{{ID: "31f87923ae4a4d119aa0b85dcdbeed13", Name: "compute_viewer"}})
-	th.AssertDeepEquals(t, ExpectedApplicationCredentialsSlice[1].Roles, []applicationcredentials.Role{{ID: "31f87923ae4a4d119aa0b85dcdbeed13", Name: "compute_viewer"}, {ID: "4494bc5bea1a4105ad7fbba6a7eb9ef4", Name: "network_viewer"}})
+	th.AssertDeepEquals(t, []applicationcredentials.Role{{ID: "31f87923ae4a4d119aa0b85dcdbeed13", Name: "compute_viewer"}}, ExpectedApplicationCredentialsSlice[0].Roles)
+	th.AssertDeepEquals(t, []applicationcredentials.Role{{ID: "31f87923ae4a4d119aa0b85dcdbeed13", Name: "compute_viewer"}, {ID: "4494bc5bea1a4105ad7fbba6a7eb9ef4", Name: "network_viewer"}}, ExpectedApplicationCredentialsSlice[1].Roles)
 }
 
 func TestGetApplicationCredential(t *testing.T) {
@@ -148,7 +148,7 @@ func TestListAccessRules(t *testing.T) {
 		return true, nil
 	})
 	th.AssertNoErr(t, err)
-	th.CheckEquals(t, count, 1)
+	th.CheckEquals(t, 1, count)
 }
 
 func TestGetAccessRule(t *testing.T) {

--- a/openstack/identity/v3/catalog/testing/catalog_test.go
+++ b/openstack/identity/v3/catalog/testing/catalog_test.go
@@ -27,5 +27,5 @@ func TestListCatalog(t *testing.T) {
 		return true, nil
 	})
 	th.AssertNoErr(t, err)
-	th.CheckEquals(t, count, 1)
+	th.CheckEquals(t, 1, count)
 }

--- a/openstack/identity/v3/credentials/testing/requests_test.go
+++ b/openstack/identity/v3/credentials/testing/requests_test.go
@@ -27,7 +27,7 @@ func TestListCredentials(t *testing.T) {
 		return true, nil
 	})
 	th.AssertNoErr(t, err)
-	th.CheckEquals(t, count, 1)
+	th.CheckEquals(t, 1, count)
 }
 
 func TestListCredentialsAllPages(t *testing.T) {
@@ -40,8 +40,8 @@ func TestListCredentialsAllPages(t *testing.T) {
 	actual, err := credentials.ExtractCredentials(allPages)
 	th.AssertNoErr(t, err)
 	th.CheckDeepEquals(t, ExpectedCredentialsSlice, actual)
-	th.AssertDeepEquals(t, ExpectedCredentialsSlice[0].Blob, "{\"access\":\"181920\",\"secret\":\"secretKey\"}")
-	th.AssertDeepEquals(t, ExpectedCredentialsSlice[1].Blob, "{\"access\":\"7da79ff0aa364e1396f067e352b9b79a\",\"secret\":\"7a18d68ba8834b799d396f3ff6f1e98c\"}")
+	th.AssertDeepEquals(t, "{\"access\":\"181920\",\"secret\":\"secretKey\"}", ExpectedCredentialsSlice[0].Blob)
+	th.AssertDeepEquals(t, "{\"access\":\"7da79ff0aa364e1396f067e352b9b79a\",\"secret\":\"7a18d68ba8834b799d396f3ff6f1e98c\"}", ExpectedCredentialsSlice[1].Blob)
 }
 
 func TestGetCredential(t *testing.T) {

--- a/openstack/identity/v3/domains/testing/requests_test.go
+++ b/openstack/identity/v3/domains/testing/requests_test.go
@@ -27,7 +27,7 @@ func TestListAvailableDomains(t *testing.T) {
 		return true, nil
 	})
 	th.AssertNoErr(t, err)
-	th.CheckEquals(t, count, 1)
+	th.CheckEquals(t, 1, count)
 }
 
 func TestListDomains(t *testing.T) {
@@ -47,7 +47,7 @@ func TestListDomains(t *testing.T) {
 		return true, nil
 	})
 	th.AssertNoErr(t, err)
-	th.CheckEquals(t, count, 1)
+	th.CheckEquals(t, 1, count)
 }
 
 func TestListDomainsAllPages(t *testing.T) {

--- a/openstack/identity/v3/ec2credentials/testing/requests_test.go
+++ b/openstack/identity/v3/ec2credentials/testing/requests_test.go
@@ -27,7 +27,7 @@ func TestListEC2Credentials(t *testing.T) {
 		return true, nil
 	})
 	th.AssertNoErr(t, err)
-	th.CheckEquals(t, count, 1)
+	th.CheckEquals(t, 1, count)
 }
 
 func TestListEC2CredentialsAllPages(t *testing.T) {

--- a/openstack/identity/v3/federation/testing/requests_test.go
+++ b/openstack/identity/v3/federation/testing/requests_test.go
@@ -27,7 +27,7 @@ func TestListMappings(t *testing.T) {
 		return true, nil
 	})
 	th.AssertNoErr(t, err)
-	th.CheckEquals(t, count, 1)
+	th.CheckEquals(t, 1, count)
 }
 
 func TestListMappingsAllPages(t *testing.T) {

--- a/openstack/identity/v3/groups/testing/requests_test.go
+++ b/openstack/identity/v3/groups/testing/requests_test.go
@@ -27,7 +27,7 @@ func TestListGroups(t *testing.T) {
 		return true, nil
 	})
 	th.AssertNoErr(t, err)
-	th.CheckEquals(t, count, 1)
+	th.CheckEquals(t, 1, count)
 }
 
 func TestListGroupsAllPages(t *testing.T) {
@@ -40,8 +40,8 @@ func TestListGroupsAllPages(t *testing.T) {
 	actual, err := groups.ExtractGroups(allPages)
 	th.AssertNoErr(t, err)
 	th.CheckDeepEquals(t, ExpectedGroupsSlice, actual)
-	th.AssertEquals(t, ExpectedGroupsSlice[0].Extra["email"], "support@localhost")
-	th.AssertEquals(t, ExpectedGroupsSlice[1].Extra["email"], "support@example.com")
+	th.AssertEquals(t, "support@localhost", ExpectedGroupsSlice[0].Extra["email"])
+	th.AssertEquals(t, "support@example.com", ExpectedGroupsSlice[1].Extra["email"])
 }
 
 func TestListGroupsFiltersCheck(t *testing.T) {
@@ -85,7 +85,7 @@ func TestGetGroup(t *testing.T) {
 
 	th.AssertNoErr(t, err)
 	th.CheckDeepEquals(t, SecondGroup, *actual)
-	th.AssertEquals(t, SecondGroup.Extra["email"], "support@example.com")
+	th.AssertEquals(t, "support@example.com", SecondGroup.Extra["email"])
 }
 
 func TestCreateGroup(t *testing.T) {

--- a/openstack/identity/v3/limits/testing/requests_test.go
+++ b/openstack/identity/v3/limits/testing/requests_test.go
@@ -37,7 +37,7 @@ func TestListLimits(t *testing.T) {
 		return true, nil
 	})
 	th.AssertNoErr(t, err)
-	th.CheckEquals(t, count, 1)
+	th.CheckEquals(t, 1, count)
 }
 
 func TestListLimitsAllPages(t *testing.T) {

--- a/openstack/identity/v3/oauth1/testing/requests_test.go
+++ b/openstack/identity/v3/oauth1/testing/requests_test.go
@@ -75,7 +75,7 @@ func TestListConsumers(t *testing.T) {
 		return true, nil
 	})
 	th.AssertNoErr(t, err)
-	th.CheckEquals(t, count, 1)
+	th.CheckEquals(t, 1, count)
 }
 
 func TestListConsumersAllPages(t *testing.T) {
@@ -187,7 +187,7 @@ func TestListAccessTokens(t *testing.T) {
 		return true, nil
 	})
 	th.AssertNoErr(t, err)
-	th.CheckEquals(t, count, 1)
+	th.CheckEquals(t, 1, count)
 }
 
 func TestListAccessTokensAllPages(t *testing.T) {
@@ -219,7 +219,7 @@ func TestListAccessTokenRoles(t *testing.T) {
 		return true, nil
 	})
 	th.AssertNoErr(t, err)
-	th.CheckEquals(t, count, 1)
+	th.CheckEquals(t, 1, count)
 }
 
 func TestListAccessTokenRolesAllPages(t *testing.T) {

--- a/openstack/identity/v3/policies/testing/requests_test.go
+++ b/openstack/identity/v3/policies/testing/requests_test.go
@@ -28,7 +28,7 @@ func TestListPolicies(t *testing.T) {
 		return true, nil
 	})
 	th.AssertNoErr(t, err)
-	th.CheckEquals(t, count, 1)
+	th.CheckEquals(t, 1, count)
 }
 
 func TestListPoliciesAllPages(t *testing.T) {

--- a/openstack/identity/v3/projects/testing/requests_test.go
+++ b/openstack/identity/v3/projects/testing/requests_test.go
@@ -27,7 +27,7 @@ func TestListAvailableProjects(t *testing.T) {
 		return true, nil
 	})
 	th.AssertNoErr(t, err)
-	th.CheckEquals(t, count, 1)
+	th.CheckEquals(t, 1, count)
 }
 
 func TestListProjects(t *testing.T) {
@@ -51,9 +51,9 @@ func TestListProjects(t *testing.T) {
 		return true, nil
 	})
 	th.AssertNoErr(t, err)
-	th.CheckEquals(t, count, 2)
+	th.CheckEquals(t, 2, count)
 
-	th.CheckEquals(t, len(actualProjects), 2)
+	th.CheckEquals(t, 2, len(actualProjects))
 	th.CheckDeepEquals(t, ExpectedProjectSlice, actualProjects)
 }
 

--- a/openstack/identity/v3/regions/testing/requests_test.go
+++ b/openstack/identity/v3/regions/testing/requests_test.go
@@ -27,7 +27,7 @@ func TestListRegions(t *testing.T) {
 		return true, nil
 	})
 	th.AssertNoErr(t, err)
-	th.CheckEquals(t, count, 1)
+	th.CheckEquals(t, 1, count)
 }
 
 func TestListRegionsAllPages(t *testing.T) {
@@ -40,7 +40,7 @@ func TestListRegionsAllPages(t *testing.T) {
 	actual, err := regions.ExtractRegions(allPages)
 	th.AssertNoErr(t, err)
 	th.CheckDeepEquals(t, ExpectedRegionsSlice, actual)
-	th.AssertEquals(t, ExpectedRegionsSlice[1].Extra["email"], "westsupport@example.com")
+	th.AssertEquals(t, "westsupport@example.com", ExpectedRegionsSlice[1].Extra["email"])
 }
 
 func TestGetRegion(t *testing.T) {

--- a/openstack/identity/v3/registeredlimits/testing/requests_test.go
+++ b/openstack/identity/v3/registeredlimits/testing/requests_test.go
@@ -27,7 +27,7 @@ func TestListRegisteredLimits(t *testing.T) {
 		return true, nil
 	})
 	th.AssertNoErr(t, err)
-	th.CheckEquals(t, count, 1)
+	th.CheckEquals(t, 1, count)
 }
 
 func TestListRegisteredLimitsAllPages(t *testing.T) {

--- a/openstack/identity/v3/roles/testing/requests_test.go
+++ b/openstack/identity/v3/roles/testing/requests_test.go
@@ -27,7 +27,7 @@ func TestListRoles(t *testing.T) {
 		return true, nil
 	})
 	th.AssertNoErr(t, err)
-	th.CheckEquals(t, count, 1)
+	th.CheckEquals(t, 1, count)
 }
 
 func TestListRolesAllPages(t *testing.T) {
@@ -40,7 +40,7 @@ func TestListRolesAllPages(t *testing.T) {
 	actual, err := roles.ExtractRoles(allPages)
 	th.AssertNoErr(t, err)
 	th.CheckDeepEquals(t, ExpectedRolesSlice, actual)
-	th.AssertEquals(t, ExpectedRolesSlice[1].Extra["test"], "this is for the test")
+	th.AssertEquals(t, "this is for the test", ExpectedRolesSlice[1].Extra["test"])
 }
 
 func TestListUsersFiltersCheck(t *testing.T) {
@@ -171,7 +171,7 @@ func TestListAssignmentsSinglePage(t *testing.T) {
 		return true, nil
 	})
 	th.AssertNoErr(t, err)
-	th.CheckEquals(t, count, 1)
+	th.CheckEquals(t, 1, count)
 }
 
 func TestListAssignmentsWithNamesSinglePage(t *testing.T) {
@@ -195,7 +195,7 @@ func TestListAssignmentsWithNamesSinglePage(t *testing.T) {
 		return true, nil
 	})
 	th.AssertNoErr(t, err)
-	th.CheckEquals(t, count, 1)
+	th.CheckEquals(t, 1, count)
 }
 
 func TestListAssignmentsWithSubtreeSinglePage(t *testing.T) {
@@ -219,7 +219,7 @@ func TestListAssignmentsWithSubtreeSinglePage(t *testing.T) {
 		return true, nil
 	})
 	th.AssertNoErr(t, err)
-	th.CheckEquals(t, count, 1)
+	th.CheckEquals(t, 1, count)
 }
 
 func TestListAssignmentsOnResource_ProjectsUsers(t *testing.T) {
@@ -241,7 +241,7 @@ func TestListAssignmentsOnResource_ProjectsUsers(t *testing.T) {
 		return true, nil
 	})
 	th.AssertNoErr(t, err)
-	th.CheckEquals(t, count, 1)
+	th.CheckEquals(t, 1, count)
 }
 
 func TestListAssignmentsOnResource_DomainsUsers(t *testing.T) {
@@ -263,7 +263,7 @@ func TestListAssignmentsOnResource_DomainsUsers(t *testing.T) {
 		return true, nil
 	})
 	th.AssertNoErr(t, err)
-	th.CheckEquals(t, count, 1)
+	th.CheckEquals(t, 1, count)
 }
 
 func TestListAssignmentsOnResource_ProjectsGroups(t *testing.T) {
@@ -285,7 +285,7 @@ func TestListAssignmentsOnResource_ProjectsGroups(t *testing.T) {
 		return true, nil
 	})
 	th.AssertNoErr(t, err)
-	th.CheckEquals(t, count, 1)
+	th.CheckEquals(t, 1, count)
 }
 
 func TestListAssignmentsOnResource_DomainsGroups(t *testing.T) {
@@ -307,7 +307,7 @@ func TestListAssignmentsOnResource_DomainsGroups(t *testing.T) {
 		return true, nil
 	})
 	th.AssertNoErr(t, err)
-	th.CheckEquals(t, count, 1)
+	th.CheckEquals(t, 1, count)
 }
 
 func TestAssign(t *testing.T) {

--- a/openstack/identity/v3/services/testing/requests_test.go
+++ b/openstack/identity/v3/services/testing/requests_test.go
@@ -47,7 +47,7 @@ func TestListServices(t *testing.T) {
 		return true, nil
 	})
 	th.AssertNoErr(t, err)
-	th.CheckEquals(t, count, 1)
+	th.CheckEquals(t, 1, count)
 }
 
 func TestListServicesAllPages(t *testing.T) {
@@ -60,8 +60,8 @@ func TestListServicesAllPages(t *testing.T) {
 	actual, err := services.ExtractServices(allPages)
 	th.AssertNoErr(t, err)
 	th.CheckDeepEquals(t, ExpectedServicesSlice, actual)
-	th.AssertEquals(t, ExpectedServicesSlice[0].Extra["email"], "service-one@example.com")
-	th.AssertEquals(t, ExpectedServicesSlice[1].Extra["email"], "service@example.com")
+	th.AssertEquals(t, "service-one@example.com", ExpectedServicesSlice[0].Extra["email"])
+	th.AssertEquals(t, "service@example.com", ExpectedServicesSlice[1].Extra["email"])
 }
 
 func TestGetSuccessful(t *testing.T) {
@@ -73,7 +73,7 @@ func TestGetSuccessful(t *testing.T) {
 
 	th.AssertNoErr(t, err)
 	th.CheckDeepEquals(t, SecondService, *actual)
-	th.AssertEquals(t, SecondService.Extra["email"], "service@example.com")
+	th.AssertEquals(t, "service@example.com", SecondService.Extra["email"])
 }
 
 func TestUpdateSuccessful(t *testing.T) {
@@ -89,7 +89,7 @@ func TestUpdateSuccessful(t *testing.T) {
 	actual, err := services.Update(context.TODO(), client.ServiceClient(fakeServer), "9876", updateOpts).Extract()
 	th.AssertNoErr(t, err)
 	th.CheckDeepEquals(t, SecondServiceUpdated, *actual)
-	th.AssertEquals(t, SecondServiceUpdated.Description, "Service Two Updated")
+	th.AssertEquals(t, "Service Two Updated", SecondServiceUpdated.Description)
 }
 
 func TestDeleteSuccessful(t *testing.T) {

--- a/openstack/identity/v3/trusts/testing/requests_test.go
+++ b/openstack/identity/v3/trusts/testing/requests_test.go
@@ -90,7 +90,7 @@ func TestListTrusts(t *testing.T) {
 		return true, nil
 	})
 	th.AssertNoErr(t, err)
-	th.CheckEquals(t, count, 1)
+	th.CheckEquals(t, 1, count)
 }
 
 func TestListTrustsAllPages(t *testing.T) {
@@ -136,7 +136,7 @@ func TestListTrustRoles(t *testing.T) {
 		return true, nil
 	})
 	th.AssertNoErr(t, err)
-	th.CheckEquals(t, count, 1)
+	th.CheckEquals(t, 1, count)
 }
 
 func TestListTrustRolesAllPages(t *testing.T) {

--- a/openstack/identity/v3/users/testing/requests_test.go
+++ b/openstack/identity/v3/users/testing/requests_test.go
@@ -29,7 +29,7 @@ func TestListUsers(t *testing.T) {
 		return true, nil
 	})
 	th.AssertNoErr(t, err)
-	th.CheckEquals(t, count, 1)
+	th.CheckEquals(t, 1, count)
 }
 
 func TestListUsersAllPages(t *testing.T) {
@@ -42,8 +42,8 @@ func TestListUsersAllPages(t *testing.T) {
 	actual, err := users.ExtractUsers(allPages)
 	th.AssertNoErr(t, err)
 	th.CheckDeepEquals(t, ExpectedUsersSlice, actual)
-	th.AssertEquals(t, ExpectedUsersSlice[0].Extra["email"], "glance@localhost")
-	th.AssertEquals(t, ExpectedUsersSlice[1].Extra["email"], "jsmith@example.com")
+	th.AssertEquals(t, "glance@localhost", ExpectedUsersSlice[0].Extra["email"])
+	th.AssertEquals(t, "jsmith@example.com", ExpectedUsersSlice[1].Extra["email"])
 }
 
 func TestListUsersFiltersCheck(t *testing.T) {
@@ -86,7 +86,7 @@ func TestGetUser(t *testing.T) {
 	actual, err := users.Get(context.TODO(), client.ServiceClient(fakeServer), "9fe1d3").Extract()
 	th.AssertNoErr(t, err)
 	th.CheckDeepEquals(t, SecondUser, *actual)
-	th.AssertEquals(t, SecondUser.Extra["email"], "jsmith@example.com")
+	th.AssertEquals(t, "jsmith@example.com", SecondUser.Extra["email"])
 }
 
 func TestCreateUser(t *testing.T) {

--- a/openstack/identity/v3/users/testing/requests_test.go
+++ b/openstack/identity/v3/users/testing/requests_test.go
@@ -209,7 +209,7 @@ func TestIsMemberOfGroup(t *testing.T) {
 	HandleIsMemberOfGroupSuccessfully(t, fakeServer)
 	ok, err := users.IsMemberOfGroup(context.TODO(), client.ServiceClient(fakeServer), "ea167b", "9fe1d3").Extract()
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, true, ok)
+	th.AssertTrue(t, ok)
 }
 
 func TestRemoveFromGroup(t *testing.T) {

--- a/openstack/image/v2/imageimport/testing/requests_test.go
+++ b/openstack/image/v2/imageimport/testing/requests_test.go
@@ -33,8 +33,8 @@ func TestGet(t *testing.T) {
 	s, err := imageimport.Get(context.TODO(), client.ServiceClient(fakeServer)).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, s.ImportMethods.Description, "Import methods available.")
-	th.AssertEquals(t, s.ImportMethods.Type, "array")
+	th.AssertEquals(t, "Import methods available.", s.ImportMethods.Description)
+	th.AssertEquals(t, "array", s.ImportMethods.Type)
 	th.AssertDeepEquals(t, s.ImportMethods.Value, validImportMethods)
 }
 

--- a/openstack/image/v2/tasks/testing/requests_test.go
+++ b/openstack/image/v2/tasks/testing/requests_test.go
@@ -73,21 +73,21 @@ func TestGet(t *testing.T) {
 	th.AssertEquals(t, s.Status, string(tasks.TaskStatusPending))
 	th.AssertEquals(t, s.CreatedAt, time.Date(2018, 7, 25, 8, 59, 13, 0, time.UTC))
 	th.AssertEquals(t, s.UpdatedAt, time.Date(2018, 7, 25, 8, 59, 14, 0, time.UTC))
-	th.AssertEquals(t, s.Self, "/v2/tasks/1252f636-1246-4319-bfba-c47cde0efbe0")
-	th.AssertEquals(t, s.Owner, "424e7cf0243c468ca61732ba45973b3e")
-	th.AssertEquals(t, s.Message, "")
-	th.AssertEquals(t, s.Type, "import")
-	th.AssertEquals(t, s.ID, "1252f636-1246-4319-bfba-c47cde0efbe0")
-	th.AssertEquals(t, s.Schema, "/v2/schemas/task")
+	th.AssertEquals(t, "/v2/tasks/1252f636-1246-4319-bfba-c47cde0efbe0", s.Self)
+	th.AssertEquals(t, "424e7cf0243c468ca61732ba45973b3e", s.Owner)
+	th.AssertEquals(t, "", s.Message)
+	th.AssertEquals(t, "import", s.Type)
+	th.AssertEquals(t, "1252f636-1246-4319-bfba-c47cde0efbe0", s.ID)
+	th.AssertEquals(t, "/v2/schemas/task", s.Schema)
 	th.AssertDeepEquals(t, s.Result, map[string]any(nil))
-	th.AssertDeepEquals(t, s.Input, map[string]any{
+	th.AssertDeepEquals(t, map[string]any{
 		"import_from":        "http://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img",
 		"import_from_format": "raw",
 		"image_properties": map[string]any{
 			"container_format": "bare",
 			"disk_format":      "raw",
 		},
-	})
+	}, s.Input)
 }
 
 func TestCreate(t *testing.T) {
@@ -122,19 +122,19 @@ func TestCreate(t *testing.T) {
 	th.AssertEquals(t, s.Status, string(tasks.TaskStatusPending))
 	th.AssertEquals(t, s.CreatedAt, time.Date(2018, 7, 25, 11, 7, 54, 0, time.UTC))
 	th.AssertEquals(t, s.UpdatedAt, time.Date(2018, 7, 25, 11, 7, 54, 0, time.UTC))
-	th.AssertEquals(t, s.Self, "/v2/tasks/d550c87d-86ed-430a-9895-c7a1f5ce87e9")
-	th.AssertEquals(t, s.Owner, "fb57277ef2f84a0e85b9018ec2dedbf7")
-	th.AssertEquals(t, s.Message, "")
-	th.AssertEquals(t, s.Type, "import")
-	th.AssertEquals(t, s.ID, "d550c87d-86ed-430a-9895-c7a1f5ce87e9")
-	th.AssertEquals(t, s.Schema, "/v2/schemas/task")
+	th.AssertEquals(t, "/v2/tasks/d550c87d-86ed-430a-9895-c7a1f5ce87e9", s.Self)
+	th.AssertEquals(t, "fb57277ef2f84a0e85b9018ec2dedbf7", s.Owner)
+	th.AssertEquals(t, "", s.Message)
+	th.AssertEquals(t, "import", s.Type)
+	th.AssertEquals(t, "d550c87d-86ed-430a-9895-c7a1f5ce87e9", s.ID)
+	th.AssertEquals(t, "/v2/schemas/task", s.Schema)
 	th.AssertDeepEquals(t, s.Result, map[string]any(nil))
-	th.AssertDeepEquals(t, s.Input, map[string]any{
+	th.AssertDeepEquals(t, map[string]any{
 		"import_from":        "https://cloud-images.ubuntu.com/bionic/current/bionic-server-cloudimg-amd64.img",
 		"import_from_format": "raw",
 		"image_properties": map[string]any{
 			"container_format": "bare",
 			"disk_format":      "raw",
 		},
-	})
+	}, s.Input)
 }

--- a/openstack/keymanager/v1/containers/testing/requests_test.go
+++ b/openstack/keymanager/v1/containers/testing/requests_test.go
@@ -27,7 +27,7 @@ func TestListContainers(t *testing.T) {
 		return true, nil
 	})
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, count, 1)
+	th.AssertEquals(t, 1, count)
 }
 
 func TestListContainersAllPages(t *testing.T) {
@@ -99,7 +99,7 @@ func TestListConsumers(t *testing.T) {
 		return true, nil
 	})
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, count, 1)
+	th.AssertEquals(t, 1, count)
 }
 
 func TestListConsumersAllPages(t *testing.T) {

--- a/openstack/keymanager/v1/orders/testing/requests_test.go
+++ b/openstack/keymanager/v1/orders/testing/requests_test.go
@@ -27,7 +27,7 @@ func TestListOrders(t *testing.T) {
 		return true, nil
 	})
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, count, 1)
+	th.AssertEquals(t, 1, count)
 }
 
 func TestListOrdersAllPages(t *testing.T) {

--- a/openstack/keymanager/v1/secrets/testing/requests_test.go
+++ b/openstack/keymanager/v1/secrets/testing/requests_test.go
@@ -28,7 +28,7 @@ func TestListSecrets(t *testing.T) {
 		return true, nil
 	})
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, count, 1)
+	th.AssertEquals(t, 1, count)
 }
 
 func TestListSecretsAllPages(t *testing.T) {

--- a/openstack/loadbalancer/v2/loadbalancers/testing/requests_test.go
+++ b/openstack/loadbalancer/v2/loadbalancers/testing/requests_test.go
@@ -211,7 +211,7 @@ func TestCascadingDeleteLoadbalancer(t *testing.T) {
 
 	query, err := deleteOpts.ToLoadBalancerDeleteQuery()
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, query, "?cascade=true")
+	th.AssertEquals(t, "?cascade=true", query)
 
 	err = loadbalancers.Delete(context.TODO(), sc, "36e08a3e-a78f-4b40-a229-1e7e23eee1ab", deleteOpts).ExtractErr()
 	th.AssertNoErr(t, err)

--- a/openstack/messaging/v2/queues/testing/requests_test.go
+++ b/openstack/messaging/v2/queues/testing/requests_test.go
@@ -27,7 +27,7 @@ func TestList(t *testing.T) {
 		countField, err := page.(queues.QueuePage).GetCount()
 
 		th.AssertNoErr(t, err)
-		th.AssertEquals(t, countField, 2)
+		th.AssertEquals(t, 2, countField)
 
 		th.CheckDeepEquals(t, ExpectedQueueSlice[count], actual)
 		count++

--- a/openstack/networking/v2/extensions/agents/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/agents/testing/requests_test.go
@@ -72,24 +72,24 @@ func TestGet(t *testing.T) {
 	s, err := agents.Get(context.TODO(), fake.ServiceClient(fakeServer), "43583cf5-472e-4dc8-af5b-6aed4c94ee3a").Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, s.ID, "43583cf5-472e-4dc8-af5b-6aed4c94ee3a")
-	th.AssertEquals(t, s.Binary, "neutron-openvswitch-agent")
-	th.AssertEquals(t, s.AdminStateUp, true)
-	th.AssertEquals(t, s.Alive, true)
-	th.AssertEquals(t, s.Topic, "N/A")
-	th.AssertEquals(t, s.Host, "compute3")
-	th.AssertEquals(t, s.AgentType, "Open vSwitch agent")
+	th.AssertEquals(t, "43583cf5-472e-4dc8-af5b-6aed4c94ee3a", s.ID)
+	th.AssertEquals(t, "neutron-openvswitch-agent", s.Binary)
+	th.AssertEquals(t, true, s.AdminStateUp)
+	th.AssertEquals(t, true, s.Alive)
+	th.AssertEquals(t, "N/A", s.Topic)
+	th.AssertEquals(t, "compute3", s.Host)
+	th.AssertEquals(t, "Open vSwitch agent", s.AgentType)
 	th.AssertEquals(t, s.HeartbeatTimestamp, time.Date(2019, 1, 9, 11, 43, 01, 0, time.UTC))
 	th.AssertEquals(t, s.StartedAt, time.Date(2018, 6, 26, 21, 46, 20, 0, time.UTC))
 	th.AssertEquals(t, s.CreatedAt, time.Date(2017, 7, 26, 23, 2, 5, 0, time.UTC))
-	th.AssertDeepEquals(t, s.Configurations, map[string]any{
+	th.AssertDeepEquals(t, map[string]any{
 		"ovs_hybrid_plug":            false,
 		"datapath_type":              "system",
 		"vhostuser_socket_dir":       "/var/run/openvswitch",
 		"log_agent_heartbeats":       false,
 		"l2_population":              true,
 		"enable_distributed_routing": false,
-	})
+	}, s.Configurations)
 }
 
 func TestUpdate(t *testing.T) {
@@ -156,17 +156,17 @@ func TestListDHCPNetworks(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	var nilSlice []string
-	th.AssertEquals(t, len(s), 1)
-	th.AssertEquals(t, s[0].ID, "d32019d3-bc6e-4319-9c1d-6722fc136a22")
-	th.AssertEquals(t, s[0].AdminStateUp, true)
-	th.AssertEquals(t, s[0].ProjectID, "4fd44f30292945e481c7b8a0c8908869")
-	th.AssertEquals(t, s[0].Shared, false)
-	th.AssertEquals(t, s[0].Name, "net1")
-	th.AssertEquals(t, s[0].Status, "ACTIVE")
+	th.AssertEquals(t, 1, len(s))
+	th.AssertEquals(t, "d32019d3-bc6e-4319-9c1d-6722fc136a22", s[0].ID)
+	th.AssertEquals(t, true, s[0].AdminStateUp)
+	th.AssertEquals(t, "4fd44f30292945e481c7b8a0c8908869", s[0].ProjectID)
+	th.AssertEquals(t, false, s[0].Shared)
+	th.AssertEquals(t, "net1", s[0].Name)
+	th.AssertEquals(t, "ACTIVE", s[0].Status)
 	th.AssertDeepEquals(t, s[0].Tags, nilSlice)
-	th.AssertEquals(t, s[0].TenantID, "4fd44f30292945e481c7b8a0c8908869")
-	th.AssertDeepEquals(t, s[0].AvailabilityZoneHints, []string{})
-	th.AssertDeepEquals(t, s[0].Subnets, []string{"54d6f61d-db07-451c-9ab3-b9609b6b6f0b"})
+	th.AssertEquals(t, "4fd44f30292945e481c7b8a0c8908869", s[0].TenantID)
+	th.AssertDeepEquals(t, []string{}, s[0].AvailabilityZoneHints)
+	th.AssertDeepEquals(t, []string{"54d6f61d-db07-451c-9ab3-b9609b6b6f0b"}, s[0].Subnets)
 
 }
 
@@ -234,11 +234,11 @@ func TestListBGPSpeakers(t *testing.T) {
 			actual, err := agents.ExtractBGPSpeakers(page)
 
 			th.AssertNoErr(t, err)
-			th.AssertEquals(t, len(actual), 1)
-			th.AssertEquals(t, actual[0].ID, "cab00464-284d-4251-9798-2b27db7b1668")
-			th.AssertEquals(t, actual[0].Name, "gophercloud-testing-speaker")
-			th.AssertEquals(t, actual[0].LocalAS, 12345)
-			th.AssertEquals(t, actual[0].IPVersion, 4)
+			th.AssertEquals(t, 1, len(actual))
+			th.AssertEquals(t, "cab00464-284d-4251-9798-2b27db7b1668", actual[0].ID)
+			th.AssertEquals(t, "gophercloud-testing-speaker", actual[0].Name)
+			th.AssertEquals(t, 12345, actual[0].LocalAS)
+			th.AssertEquals(t, 4, actual[0].IPVersion)
 			return true, nil
 		})
 	th.AssertNoErr(t, err)
@@ -373,19 +373,19 @@ func TestListL3Routers(t *testing.T) {
 	}
 
 	var nilSlice []string
-	th.AssertEquals(t, len(s), 2)
-	th.AssertEquals(t, s[0].ID, "915a14a6-867b-4af7-83d1-70efceb146f9")
-	th.AssertEquals(t, s[0].AdminStateUp, true)
-	th.AssertEquals(t, s[0].ProjectID, "0bd18306d801447bb457a46252d82d13")
-	th.AssertEquals(t, s[0].Name, "router2")
-	th.AssertEquals(t, s[0].Status, "ACTIVE")
-	th.AssertEquals(t, s[0].TenantID, "0bd18306d801447bb457a46252d82d13")
-	th.AssertDeepEquals(t, s[0].AvailabilityZoneHints, []string{})
+	th.AssertEquals(t, 2, len(s))
+	th.AssertEquals(t, "915a14a6-867b-4af7-83d1-70efceb146f9", s[0].ID)
+	th.AssertEquals(t, true, s[0].AdminStateUp)
+	th.AssertEquals(t, "0bd18306d801447bb457a46252d82d13", s[0].ProjectID)
+	th.AssertEquals(t, "router2", s[0].Name)
+	th.AssertEquals(t, "ACTIVE", s[0].Status)
+	th.AssertEquals(t, "0bd18306d801447bb457a46252d82d13", s[0].TenantID)
+	th.AssertDeepEquals(t, []string{}, s[0].AvailabilityZoneHints)
 	th.AssertDeepEquals(t, s[0].Routes, routes)
 	th.AssertDeepEquals(t, s[0].GatewayInfo, gw)
 	th.AssertDeepEquals(t, s[0].Tags, nilSlice)
-	th.AssertEquals(t, s[1].ID, "f8a44de0-fc8e-45df-93c7-f79bf3b01c95")
-	th.AssertEquals(t, s[1].Name, "router1")
+	th.AssertEquals(t, "f8a44de0-fc8e-45df-93c7-f79bf3b01c95", s[1].ID)
+	th.AssertEquals(t, "router1", s[1].Name)
 
 }
 

--- a/openstack/networking/v2/extensions/agents/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/agents/testing/requests_test.go
@@ -74,8 +74,8 @@ func TestGet(t *testing.T) {
 
 	th.AssertEquals(t, "43583cf5-472e-4dc8-af5b-6aed4c94ee3a", s.ID)
 	th.AssertEquals(t, "neutron-openvswitch-agent", s.Binary)
-	th.AssertEquals(t, true, s.AdminStateUp)
-	th.AssertEquals(t, true, s.Alive)
+	th.AssertTrue(t, s.AdminStateUp)
+	th.AssertTrue(t, s.Alive)
 	th.AssertEquals(t, "N/A", s.Topic)
 	th.AssertEquals(t, "compute3", s.Host)
 	th.AssertEquals(t, "Open vSwitch agent", s.AgentType)
@@ -158,9 +158,9 @@ func TestListDHCPNetworks(t *testing.T) {
 	var nilSlice []string
 	th.AssertEquals(t, 1, len(s))
 	th.AssertEquals(t, "d32019d3-bc6e-4319-9c1d-6722fc136a22", s[0].ID)
-	th.AssertEquals(t, true, s[0].AdminStateUp)
+	th.AssertTrue(t, s[0].AdminStateUp)
 	th.AssertEquals(t, "4fd44f30292945e481c7b8a0c8908869", s[0].ProjectID)
-	th.AssertEquals(t, false, s[0].Shared)
+	th.AssertFalse(t, s[0].Shared)
 	th.AssertEquals(t, "net1", s[0].Name)
 	th.AssertEquals(t, "ACTIVE", s[0].Status)
 	th.AssertDeepEquals(t, s[0].Tags, nilSlice)
@@ -375,7 +375,7 @@ func TestListL3Routers(t *testing.T) {
 	var nilSlice []string
 	th.AssertEquals(t, 2, len(s))
 	th.AssertEquals(t, "915a14a6-867b-4af7-83d1-70efceb146f9", s[0].ID)
-	th.AssertEquals(t, true, s[0].AdminStateUp)
+	th.AssertTrue(t, s[0].AdminStateUp)
 	th.AssertEquals(t, "0bd18306d801447bb457a46252d82d13", s[0].ProjectID)
 	th.AssertEquals(t, "router2", s[0].Name)
 	th.AssertEquals(t, "ACTIVE", s[0].Status)

--- a/openstack/networking/v2/extensions/attributestags/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/attributestags/testing/requests_test.go
@@ -119,7 +119,7 @@ func TestConfirmTrue(t *testing.T) {
 
 	exists, err := attributestags.Confirm(context.TODO(), fake.ServiceClient(fakeServer), "networks", "fakeid", "atag").Extract()
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, true, exists)
+	th.AssertTrue(t, exists)
 }
 
 func TestConfirmFalse(t *testing.T) {
@@ -135,5 +135,5 @@ func TestConfirmFalse(t *testing.T) {
 	})
 
 	exists, _ := attributestags.Confirm(context.TODO(), fake.ServiceClient(fakeServer), "networks", "fakeid", "atag").Extract()
-	th.AssertEquals(t, false, exists)
+	th.AssertFalse(t, exists)
 }

--- a/openstack/networking/v2/extensions/attributestags/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/attributestags/testing/requests_test.go
@@ -34,7 +34,7 @@ func TestReplaceAll(t *testing.T) {
 	res, err := attributestags.ReplaceAll(context.TODO(), fake.ServiceClient(fakeServer), "networks", "fakeid", opts).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertDeepEquals(t, res, []string{"abc", "xyz"})
+	th.AssertDeepEquals(t, []string{"abc", "xyz"}, res)
 }
 
 func TestList(t *testing.T) {
@@ -54,7 +54,7 @@ func TestList(t *testing.T) {
 	res, err := attributestags.List(context.TODO(), fake.ServiceClient(fakeServer), "networks", "fakeid").Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertDeepEquals(t, res, []string{"abc", "xyz"})
+	th.AssertDeepEquals(t, []string{"abc", "xyz"}, res)
 }
 
 func TestDeleteAll(t *testing.T) {

--- a/openstack/networking/v2/extensions/bgp/speakers/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/bgp/speakers/testing/requests_test.go
@@ -88,8 +88,8 @@ func TestCreate(t *testing.T) {
 	r, err := speakers.Create(context.TODO(), fake.ServiceClient(fakeServer), opts).Extract()
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, r.Name, opts.Name)
-	th.AssertEquals(t, r.LocalAS, 2000)
-	th.AssertEquals(t, len(r.Networks), 0)
+	th.AssertEquals(t, 2000, r.LocalAS)
+	th.AssertEquals(t, 0, len(r.Networks))
 	th.AssertEquals(t, r.IPVersion, opts.IPVersion)
 	th.AssertEquals(t, r.AdvertiseFloatingIPHostRoutes, opts.AdvertiseFloatingIPHostRoutes)
 	th.AssertEquals(t, r.AdvertiseTenantNetworks, opts.AdvertiseTenantNetworks)
@@ -228,7 +228,7 @@ func TestGetAdvertisedRoutes(t *testing.T) {
 				{NextHop: "172.17.128.218", Destination: "172.17.129.0/27"},
 				{NextHop: "172.17.128.231", Destination: "172.17.129.160/27"},
 			}
-			th.CheckDeepEquals(t, count, 1)
+			th.CheckDeepEquals(t, 1, count)
 			th.CheckDeepEquals(t, expected, actual)
 			return true, nil
 		})

--- a/openstack/networking/v2/extensions/dns/testing/fixtures_test.go
+++ b/openstack/networking/v2/extensions/dns/testing/fixtures_test.go
@@ -73,7 +73,7 @@ func PortHandleListSuccessfully(t *testing.T, fakeServer th.FakeServer) {
 		th.TestMethod(t, r, "GET")
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 
-		th.AssertEquals(t, r.RequestURI, "/v2.0/ports?dns_name=test-port")
+		th.AssertEquals(t, "/v2.0/ports?dns_name=test-port", r.RequestURI)
 
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -224,7 +224,7 @@ func FloatingIPHandleList(t *testing.T, fakeServer th.FakeServer) {
 		th.TestMethod(t, r, "GET")
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 
-		th.AssertEquals(t, r.RequestURI, "/v2.0/floatingips?dns_domain=local.&dns_name=test-fip")
+		th.AssertEquals(t, "/v2.0/floatingips?dns_domain=local.&dns_name=test-fip", r.RequestURI)
 
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -273,7 +273,7 @@ func NetworkHandleList(t *testing.T, fakeServer th.FakeServer) {
 		th.TestMethod(t, r, "GET")
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 
-		th.AssertEquals(t, r.RequestURI, "/v2.0/networks?dns_domain=local.")
+		th.AssertEquals(t, "/v2.0/networks?dns_domain=local.", r.RequestURI)
 
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)

--- a/openstack/networking/v2/extensions/dns/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/dns/testing/requests_test.go
@@ -101,7 +101,7 @@ func TestPortGet(t *testing.T) {
 
 	th.AssertEquals(t, "ACTIVE", s.Status)
 	th.AssertEquals(t, "", s.Name)
-	th.AssertEquals(t, true, s.AdminStateUp)
+	th.AssertTrue(t, s.AdminStateUp)
 	th.AssertEquals(t, "a87cc70a-3e15-4acf-8205-9b711a3531b7", s.NetworkID)
 	th.AssertEquals(t, "7e02058126cc4950b75f9970368ba177", s.TenantID)
 	th.AssertEquals(t, "network:router_interface", s.DeviceOwner)
@@ -152,7 +152,7 @@ func TestPortCreate(t *testing.T) {
 
 	th.AssertEquals(t, "DOWN", s.Status)
 	th.AssertEquals(t, "private-port", s.Name)
-	th.AssertEquals(t, true, s.AdminStateUp)
+	th.AssertTrue(t, s.AdminStateUp)
 	th.AssertEquals(t, "a87cc70a-3e15-4acf-8205-9b711a3531b7", s.NetworkID)
 	th.AssertEquals(t, "d6700c0c9ffa4f1cb322cd4a1f3906fa", s.TenantID)
 	th.AssertEquals(t, "", s.DeviceOwner)

--- a/openstack/networking/v2/extensions/dns/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/dns/testing/requests_test.go
@@ -99,28 +99,28 @@ func TestPortGet(t *testing.T) {
 	err := ports.Get(context.TODO(), fake.ServiceClient(fakeServer), "46d4bfb9-b26e-41f3-bd2e-e6dcc1ccedb2").ExtractInto(&s)
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, s.Status, "ACTIVE")
-	th.AssertEquals(t, s.Name, "")
-	th.AssertEquals(t, s.AdminStateUp, true)
-	th.AssertEquals(t, s.NetworkID, "a87cc70a-3e15-4acf-8205-9b711a3531b7")
-	th.AssertEquals(t, s.TenantID, "7e02058126cc4950b75f9970368ba177")
-	th.AssertEquals(t, s.DeviceOwner, "network:router_interface")
-	th.AssertEquals(t, s.MACAddress, "fa:16:3e:23:fd:d7")
-	th.AssertDeepEquals(t, s.FixedIPs, []ports.IP{
+	th.AssertEquals(t, "ACTIVE", s.Status)
+	th.AssertEquals(t, "", s.Name)
+	th.AssertEquals(t, true, s.AdminStateUp)
+	th.AssertEquals(t, "a87cc70a-3e15-4acf-8205-9b711a3531b7", s.NetworkID)
+	th.AssertEquals(t, "7e02058126cc4950b75f9970368ba177", s.TenantID)
+	th.AssertEquals(t, "network:router_interface", s.DeviceOwner)
+	th.AssertEquals(t, "fa:16:3e:23:fd:d7", s.MACAddress)
+	th.AssertDeepEquals(t, []ports.IP{
 		{SubnetID: "a0304c3a-4f08-4c43-88af-d796509c97d2", IPAddress: "10.0.0.1"},
-	})
-	th.AssertEquals(t, s.ID, "46d4bfb9-b26e-41f3-bd2e-e6dcc1ccedb2")
-	th.AssertDeepEquals(t, s.SecurityGroups, []string{})
-	th.AssertEquals(t, s.DeviceID, "5e3898d7-11be-483e-9732-b2f5eccd2b2e")
+	}, s.FixedIPs)
+	th.AssertEquals(t, "46d4bfb9-b26e-41f3-bd2e-e6dcc1ccedb2", s.ID)
+	th.AssertDeepEquals(t, []string{}, s.SecurityGroups)
+	th.AssertEquals(t, "5e3898d7-11be-483e-9732-b2f5eccd2b2e", s.DeviceID)
 
-	th.AssertEquals(t, s.DNSName, "test-port")
-	th.AssertDeepEquals(t, s.DNSAssignment, []map[string]string{
+	th.AssertEquals(t, "test-port", s.DNSName)
+	th.AssertDeepEquals(t, []map[string]string{
 		{
 			"hostname":   "test-port",
 			"ip_address": "172.24.4.2",
 			"fqdn":       "test-port.openstack.local.",
 		},
-	})
+	}, s.DNSAssignment)
 }
 
 func TestPortCreate(t *testing.T) {
@@ -150,27 +150,27 @@ func TestPortCreate(t *testing.T) {
 	err := ports.Create(context.TODO(), fake.ServiceClient(fakeServer), createOpts).ExtractInto(&s)
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, s.Status, "DOWN")
-	th.AssertEquals(t, s.Name, "private-port")
-	th.AssertEquals(t, s.AdminStateUp, true)
-	th.AssertEquals(t, s.NetworkID, "a87cc70a-3e15-4acf-8205-9b711a3531b7")
-	th.AssertEquals(t, s.TenantID, "d6700c0c9ffa4f1cb322cd4a1f3906fa")
-	th.AssertEquals(t, s.DeviceOwner, "")
-	th.AssertEquals(t, s.MACAddress, "fa:16:3e:c9:cb:f0")
-	th.AssertDeepEquals(t, s.FixedIPs, []ports.IP{
+	th.AssertEquals(t, "DOWN", s.Status)
+	th.AssertEquals(t, "private-port", s.Name)
+	th.AssertEquals(t, true, s.AdminStateUp)
+	th.AssertEquals(t, "a87cc70a-3e15-4acf-8205-9b711a3531b7", s.NetworkID)
+	th.AssertEquals(t, "d6700c0c9ffa4f1cb322cd4a1f3906fa", s.TenantID)
+	th.AssertEquals(t, "", s.DeviceOwner)
+	th.AssertEquals(t, "fa:16:3e:c9:cb:f0", s.MACAddress)
+	th.AssertDeepEquals(t, []ports.IP{
 		{SubnetID: "a0304c3a-4f08-4c43-88af-d796509c97d2", IPAddress: "10.0.0.2"},
-	})
-	th.AssertEquals(t, s.ID, "65c0ee9f-d634-4522-8954-51021b570b0d")
-	th.AssertDeepEquals(t, s.SecurityGroups, []string{"f0ac4394-7e4a-4409-9701-ba8be283dbc3"})
+	}, s.FixedIPs)
+	th.AssertEquals(t, "65c0ee9f-d634-4522-8954-51021b570b0d", s.ID)
+	th.AssertDeepEquals(t, []string{"f0ac4394-7e4a-4409-9701-ba8be283dbc3"}, s.SecurityGroups)
 
-	th.AssertEquals(t, s.DNSName, "test-port")
-	th.AssertDeepEquals(t, s.DNSAssignment, []map[string]string{
+	th.AssertEquals(t, "test-port", s.DNSName)
+	th.AssertDeepEquals(t, []map[string]string{
 		{
 			"hostname":   "test-port",
 			"ip_address": "172.24.4.2",
 			"fqdn":       "test-port.openstack.local.",
 		},
-	})
+	}, s.DNSAssignment)
 }
 
 func TestPortRequiredCreateOpts(t *testing.T) {
@@ -209,19 +209,19 @@ func TestPortUpdate(t *testing.T) {
 	err := ports.Update(context.TODO(), fake.ServiceClient(fakeServer), "65c0ee9f-d634-4522-8954-51021b570b0d", updateOpts).ExtractInto(&s)
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, s.Name, "new_port_name")
-	th.AssertDeepEquals(t, s.FixedIPs, []ports.IP{
+	th.AssertEquals(t, "new_port_name", s.Name)
+	th.AssertDeepEquals(t, []ports.IP{
 		{SubnetID: "a0304c3a-4f08-4c43-88af-d796509c97d2", IPAddress: "10.0.0.3"},
-	})
-	th.AssertDeepEquals(t, s.SecurityGroups, []string{"f0ac4394-7e4a-4409-9701-ba8be283dbc3"})
-	th.AssertEquals(t, s.DNSName, "test-port1")
-	th.AssertDeepEquals(t, s.DNSAssignment, []map[string]string{
+	}, s.FixedIPs)
+	th.AssertDeepEquals(t, []string{"f0ac4394-7e4a-4409-9701-ba8be283dbc3"}, s.SecurityGroups)
+	th.AssertEquals(t, "test-port1", s.DNSName)
+	th.AssertDeepEquals(t, []map[string]string{
 		{
 			"hostname":   "test-port1",
 			"ip_address": "172.24.4.2",
 			"fqdn":       "test-port1.openstack.local.",
 		},
-	})
+	}, s.DNSAssignment)
 }
 
 func TestFloatingIPGet(t *testing.T) {

--- a/openstack/networking/v2/extensions/external/testing/results_test.go
+++ b/openstack/networking/v2/extensions/external/testing/results_test.go
@@ -40,7 +40,7 @@ func TestList(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	th.AssertEquals(t, "d32019d3-bc6e-4319-9c1d-6722fc136a22", actual[0].ID)
-	th.AssertEquals(t, true, actual[0].External)
+	th.AssertTrue(t, actual[0].External)
 }
 
 func TestGet(t *testing.T) {
@@ -66,7 +66,7 @@ func TestGet(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	th.AssertEquals(t, "d32019d3-bc6e-4319-9c1d-6722fc136a22", s.ID)
-	th.AssertEquals(t, true, s.External)
+	th.AssertTrue(t, s.External)
 }
 
 func TestCreate(t *testing.T) {

--- a/openstack/networking/v2/extensions/fwaas_v2/groups/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/fwaas_v2/groups/testing/requests_test.go
@@ -343,8 +343,8 @@ func TestRemoveIngressPolicy(t *testing.T) {
 
 	removeIngressPolicy, err := groups.RemoveIngressPolicy(context.TODO(), fake.ServiceClient(fakeServer), "6bfb0f10-07f7-4a40-b534-bad4b4ca3428").Extract()
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, removeIngressPolicy.IngressFirewallPolicyID, "")
-	th.AssertEquals(t, removeIngressPolicy.EgressFirewallPolicyID, "43a11f3a-ddac-4129-9469-02b9df26548e")
+	th.AssertEquals(t, "", removeIngressPolicy.IngressFirewallPolicyID)
+	th.AssertEquals(t, "43a11f3a-ddac-4129-9469-02b9df26548e", removeIngressPolicy.EgressFirewallPolicyID)
 }
 
 func TestRemoveEgressPolicy(t *testing.T) {
@@ -391,8 +391,8 @@ func TestRemoveEgressPolicy(t *testing.T) {
 
 	removeEgressPolicy, err := groups.RemoveEgressPolicy(context.TODO(), fake.ServiceClient(fakeServer), "6bfb0f10-07f7-4a40-b534-bad4b4ca3428").Extract()
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, removeEgressPolicy.IngressFirewallPolicyID, "e3f11142-3792-454b-8d3e-91ac1bf127b4")
-	th.AssertEquals(t, removeEgressPolicy.EgressFirewallPolicyID, "")
+	th.AssertEquals(t, "e3f11142-3792-454b-8d3e-91ac1bf127b4", removeEgressPolicy.IngressFirewallPolicyID)
+	th.AssertEquals(t, "", removeEgressPolicy.EgressFirewallPolicyID)
 }
 
 func TestDelete(t *testing.T) {

--- a/openstack/networking/v2/extensions/fwaas_v2/groups/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/fwaas_v2/groups/testing/requests_test.go
@@ -166,11 +166,11 @@ func TestGet(t *testing.T) {
 	th.AssertEquals(t, "some information", group.Description)
 	th.AssertEquals(t, "e3f11142-3792-454b-8d3e-91ac1bf127b4", group.IngressFirewallPolicyID)
 	th.AssertEquals(t, "", group.EgressFirewallPolicyID)
-	th.AssertEquals(t, true, group.AdminStateUp)
+	th.AssertTrue(t, group.AdminStateUp)
 	th.AssertEquals(t, 1, len(group.Ports))
 	th.AssertEquals(t, "a6af1e56-b12b-4733-8f77-49166afd5719", group.Ports[0])
 	th.AssertEquals(t, "ACTIVE", group.Status)
-	th.AssertEquals(t, false, group.Shared)
+	th.AssertFalse(t, group.Shared)
 	th.AssertEquals(t, "9f98fc0e5f944cd1b51798b668dc8778", group.TenantID)
 }
 

--- a/openstack/networking/v2/extensions/fwaas_v2/rules/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/fwaas_v2/rules/testing/requests_test.go
@@ -301,10 +301,10 @@ func TestGet(t *testing.T) {
 	th.AssertEquals(t, "ssh_form_any", rule.Name)
 	th.AssertEquals(t, "80cf934d6ffb4ef5b244f1c512ad1e61", rule.TenantID)
 	th.AssertEquals(t, "80cf934d6ffb4ef5b244f1c512ad1e61", rule.ProjectID)
-	th.AssertEquals(t, true, rule.Enabled)
+	th.AssertTrue(t, rule.Enabled)
 	th.AssertEquals(t, "allow", rule.Action)
 	th.AssertEquals(t, 4, rule.IPVersion)
-	th.AssertEquals(t, false, rule.Shared)
+	th.AssertFalse(t, rule.Shared)
 }
 
 func TestUpdate(t *testing.T) {

--- a/openstack/networking/v2/extensions/layer3/addressscopes/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/layer3/addressscopes/testing/requests_test.go
@@ -74,7 +74,7 @@ func TestGet(t *testing.T) {
 	th.AssertEquals(t, "4a9807b773404e979b19633f38370643", s.TenantID)
 	th.AssertEquals(t, "4a9807b773404e979b19633f38370643", s.ProjectID)
 	th.AssertEquals(t, 4, s.IPVersion)
-	th.AssertEquals(t, false, s.Shared)
+	th.AssertFalse(t, s.Shared)
 }
 
 func TestCreate(t *testing.T) {
@@ -103,7 +103,7 @@ func TestCreate(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	th.AssertEquals(t, "test0", s.Name)
-	th.AssertEquals(t, true, s.Shared)
+	th.AssertTrue(t, s.Shared)
 	th.AssertEquals(t, 4, s.IPVersion)
 	th.AssertEquals(t, "4a9807b773404e979b19633f38370643", s.TenantID)
 	th.AssertEquals(t, "4a9807b773404e979b19633f38370643", s.ProjectID)
@@ -137,7 +137,7 @@ func TestUpdate(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	th.AssertEquals(t, "test1", s.Name)
-	th.AssertEquals(t, true, s.Shared)
+	th.AssertTrue(t, s.Shared)
 }
 
 func TestDelete(t *testing.T) {

--- a/openstack/networking/v2/extensions/layer3/addressscopes/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/layer3/addressscopes/testing/requests_test.go
@@ -69,12 +69,12 @@ func TestGet(t *testing.T) {
 	s, err := addressscopes.Get(context.TODO(), fake.ServiceClient(fakeServer), "9cc35860-522a-4d35-974d-51d4b011801e").Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, s.ID, "9cc35860-522a-4d35-974d-51d4b011801e")
-	th.AssertEquals(t, s.Name, "scopev4")
-	th.AssertEquals(t, s.TenantID, "4a9807b773404e979b19633f38370643")
-	th.AssertEquals(t, s.ProjectID, "4a9807b773404e979b19633f38370643")
-	th.AssertEquals(t, s.IPVersion, 4)
-	th.AssertEquals(t, s.Shared, false)
+	th.AssertEquals(t, "9cc35860-522a-4d35-974d-51d4b011801e", s.ID)
+	th.AssertEquals(t, "scopev4", s.Name)
+	th.AssertEquals(t, "4a9807b773404e979b19633f38370643", s.TenantID)
+	th.AssertEquals(t, "4a9807b773404e979b19633f38370643", s.ProjectID)
+	th.AssertEquals(t, 4, s.IPVersion)
+	th.AssertEquals(t, false, s.Shared)
 }
 
 func TestCreate(t *testing.T) {
@@ -102,12 +102,12 @@ func TestCreate(t *testing.T) {
 	s, err := addressscopes.Create(context.TODO(), fake.ServiceClient(fakeServer), opts).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, s.Name, "test0")
-	th.AssertEquals(t, s.Shared, true)
-	th.AssertEquals(t, s.IPVersion, 4)
-	th.AssertEquals(t, s.TenantID, "4a9807b773404e979b19633f38370643")
-	th.AssertEquals(t, s.ProjectID, "4a9807b773404e979b19633f38370643")
-	th.AssertEquals(t, s.ID, "9cc35860-522a-4d35-974d-51d4b011801e")
+	th.AssertEquals(t, "test0", s.Name)
+	th.AssertEquals(t, true, s.Shared)
+	th.AssertEquals(t, 4, s.IPVersion)
+	th.AssertEquals(t, "4a9807b773404e979b19633f38370643", s.TenantID)
+	th.AssertEquals(t, "4a9807b773404e979b19633f38370643", s.ProjectID)
+	th.AssertEquals(t, "9cc35860-522a-4d35-974d-51d4b011801e", s.ID)
 }
 
 func TestUpdate(t *testing.T) {
@@ -136,8 +136,8 @@ func TestUpdate(t *testing.T) {
 	s, err := addressscopes.Update(context.TODO(), fake.ServiceClient(fakeServer), "9cc35860-522a-4d35-974d-51d4b011801e", updateOpts).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, s.Name, "test1")
-	th.AssertEquals(t, s.Shared, true)
+	th.AssertEquals(t, "test1", s.Name)
+	th.AssertEquals(t, true, s.Shared)
 }
 
 func TestDelete(t *testing.T) {

--- a/openstack/networking/v2/extensions/layer3/extraroutes/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/layer3/extraroutes/testing/requests_test.go
@@ -66,7 +66,7 @@ func TestAddExtraRoutes(t *testing.T) {
 	n, err := extraroutes.Add(context.TODO(), fake.ServiceClient(fakeServer), "4e8e5957-649f-477b-9e5b-f1f75b21c03c", options).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertDeepEquals(t, n.Routes, []routers.Route{
+	th.AssertDeepEquals(t, []routers.Route{
 		{
 			DestinationCIDR: "10.0.1.0/24",
 			NextHop:         "10.0.0.11",
@@ -83,7 +83,7 @@ func TestAddExtraRoutes(t *testing.T) {
 			DestinationCIDR: "10.0.4.0/24",
 			NextHop:         "10.0.0.14",
 		},
-	})
+	}, n.Routes)
 }
 
 func TestRemoveExtraRoutes(t *testing.T) {
@@ -138,7 +138,7 @@ func TestRemoveExtraRoutes(t *testing.T) {
 	n, err := extraroutes.Remove(context.TODO(), fake.ServiceClient(fakeServer), "4e8e5957-649f-477b-9e5b-f1f75b21c03c", options).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertDeepEquals(t, n.Routes, []routers.Route{
+	th.AssertDeepEquals(t, []routers.Route{
 		{
 			DestinationCIDR: "10.0.1.0/24",
 			NextHop:         "10.0.0.11",
@@ -147,5 +147,5 @@ func TestRemoveExtraRoutes(t *testing.T) {
 			DestinationCIDR: "10.0.2.0/24",
 			NextHop:         "10.0.0.12",
 		},
-	})
+	}, n.Routes)
 }

--- a/openstack/networking/v2/extensions/layer3/routers/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/layer3/routers/testing/requests_test.go
@@ -263,20 +263,20 @@ func TestGet(t *testing.T) {
 	n, err := routers.Get(context.TODO(), fake.ServiceClient(fakeServer), "a07eea83-7710-4860-931b-5fe220fae533").Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, n.Status, "ACTIVE")
-	th.AssertDeepEquals(t, n.GatewayInfo, routers.GatewayInfo{
+	th.AssertEquals(t, "ACTIVE", n.Status)
+	th.AssertDeepEquals(t, routers.GatewayInfo{
 		NetworkID: "85d76829-6415-48ff-9c63-5c5ca8c61ac6",
 		ExternalFixedIPs: []routers.ExternalFixedIP{
 			{IPAddress: "198.51.100.33", SubnetID: "1d699529-bdfd-43f8-bcaa-bff00c547af2"},
 		},
 		QoSPolicyID: "6601bae5-f15a-4687-8be9-ddec9a2f8a8b",
-	})
-	th.AssertEquals(t, n.Name, "router1")
-	th.AssertEquals(t, n.AdminStateUp, true)
-	th.AssertEquals(t, n.TenantID, "d6554fe62e2f41efbb6e026fad5c1542")
-	th.AssertEquals(t, n.ID, "a07eea83-7710-4860-931b-5fe220fae533")
-	th.AssertDeepEquals(t, n.Routes, []routers.Route{{DestinationCIDR: "40.0.1.0/24", NextHop: "10.1.0.10"}})
-	th.AssertDeepEquals(t, n.AvailabilityZoneHints, []string{"zone1", "zone2"})
+	}, n.GatewayInfo)
+	th.AssertEquals(t, "router1", n.Name)
+	th.AssertEquals(t, true, n.AdminStateUp)
+	th.AssertEquals(t, "d6554fe62e2f41efbb6e026fad5c1542", n.TenantID)
+	th.AssertEquals(t, "a07eea83-7710-4860-931b-5fe220fae533", n.ID)
+	th.AssertDeepEquals(t, []routers.Route{{DestinationCIDR: "40.0.1.0/24", NextHop: "10.1.0.10"}}, n.Routes)
+	th.AssertDeepEquals(t, []string{"zone1", "zone2"}, n.AvailabilityZoneHints)
 }
 
 func TestUpdate(t *testing.T) {
@@ -350,9 +350,9 @@ func TestUpdate(t *testing.T) {
 		{IPAddress: "192.0.2.17", SubnetID: "ab561bc4-1a8e-48f2-9fbd-376fcb1a1def"},
 	}
 
-	th.AssertEquals(t, n.Name, "new_name")
+	th.AssertEquals(t, "new_name", n.Name)
 	th.AssertDeepEquals(t, n.GatewayInfo, gwi)
-	th.AssertDeepEquals(t, n.Routes, []routers.Route{{DestinationCIDR: "40.0.1.0/24", NextHop: "10.1.0.10"}})
+	th.AssertDeepEquals(t, []routers.Route{{DestinationCIDR: "40.0.1.0/24", NextHop: "10.1.0.10"}}, n.Routes)
 }
 
 func TestUpdateWithoutRoutes(t *testing.T) {
@@ -406,8 +406,8 @@ func TestUpdateWithoutRoutes(t *testing.T) {
 	n, err := routers.Update(context.TODO(), fake.ServiceClient(fakeServer), "4e8e5957-649f-477b-9e5b-f1f75b21c03c", options).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, n.Name, "new_name")
-	th.AssertDeepEquals(t, n.Routes, []routers.Route{{DestinationCIDR: "40.0.1.0/24", NextHop: "10.1.0.10"}})
+	th.AssertEquals(t, "new_name", n.Name)
+	th.AssertDeepEquals(t, []routers.Route{{DestinationCIDR: "40.0.1.0/24", NextHop: "10.1.0.10"}}, n.Routes)
 }
 
 func TestAllRoutesRemoved(t *testing.T) {
@@ -454,7 +454,7 @@ func TestAllRoutesRemoved(t *testing.T) {
 	n, err := routers.Update(context.TODO(), fake.ServiceClient(fakeServer), "4e8e5957-649f-477b-9e5b-f1f75b21c03c", options).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertDeepEquals(t, n.Routes, []routers.Route{})
+	th.AssertDeepEquals(t, []routers.Route{}, n.Routes)
 }
 
 func TestDelete(t *testing.T) {
@@ -760,9 +760,9 @@ func TestAddExternalGateways(t *testing.T) {
 	n, err := routers.AddExternalGateways(context.TODO(), fake.ServiceClient(fakeServer), "4e8e5957-649f-477b-9e5b-f1f75b21c03c", opts).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, n.Name, "router1")
-	th.AssertEquals(t, n.ID, "4e8e5957-649f-477b-9e5b-f1f75b21c03c")
-	th.AssertEquals(t, n.GatewayInfo.NetworkID, "8ca37218-28ff-41cb-9b10-039601ea7e6b")
+	th.AssertEquals(t, "router1", n.Name)
+	th.AssertEquals(t, "4e8e5957-649f-477b-9e5b-f1f75b21c03c", n.ID)
+	th.AssertEquals(t, "8ca37218-28ff-41cb-9b10-039601ea7e6b", n.GatewayInfo.NetworkID)
 }
 
 func TestUpdateExternalGateways(t *testing.T) {
@@ -831,9 +831,9 @@ func TestUpdateExternalGateways(t *testing.T) {
 	n, err := routers.UpdateExternalGateways(context.TODO(), fake.ServiceClient(fakeServer), "4e8e5957-649f-477b-9e5b-f1f75b21c03c", opts).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, n.Name, "router1")
-	th.AssertEquals(t, n.ID, "4e8e5957-649f-477b-9e5b-f1f75b21c03c")
-	th.AssertEquals(t, *n.GatewayInfo.EnableSNAT, true)
+	th.AssertEquals(t, "router1", n.Name)
+	th.AssertEquals(t, "4e8e5957-649f-477b-9e5b-f1f75b21c03c", n.ID)
+	th.AssertEquals(t, true, *n.GatewayInfo.EnableSNAT)
 }
 
 func TestRemoveExternalGateways(t *testing.T) {
@@ -893,7 +893,7 @@ func TestRemoveExternalGateways(t *testing.T) {
 	n, err := routers.RemoveExternalGateways(context.TODO(), fake.ServiceClient(fakeServer), "4e8e5957-649f-477b-9e5b-f1f75b21c03c", opts).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, n.Name, "router1")
-	th.AssertEquals(t, n.ID, "4e8e5957-649f-477b-9e5b-f1f75b21c03c")
-	th.AssertEquals(t, n.GatewayInfo.NetworkID, "")
+	th.AssertEquals(t, "router1", n.Name)
+	th.AssertEquals(t, "4e8e5957-649f-477b-9e5b-f1f75b21c03c", n.ID)
+	th.AssertEquals(t, "", n.GatewayInfo.NetworkID)
 }

--- a/openstack/networking/v2/extensions/layer3/routers/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/layer3/routers/testing/requests_test.go
@@ -216,7 +216,7 @@ func TestCreate(t *testing.T) {
 	}}
 
 	th.AssertEquals(t, "foo_router", r.Name)
-	th.AssertEquals(t, false, r.AdminStateUp)
+	th.AssertFalse(t, r.AdminStateUp)
 	th.AssertDeepEquals(t, gwi, r.GatewayInfo)
 	th.AssertDeepEquals(t, []string{"zone1", "zone2"}, r.AvailabilityZoneHints)
 }
@@ -272,7 +272,7 @@ func TestGet(t *testing.T) {
 		QoSPolicyID: "6601bae5-f15a-4687-8be9-ddec9a2f8a8b",
 	}, n.GatewayInfo)
 	th.AssertEquals(t, "router1", n.Name)
-	th.AssertEquals(t, true, n.AdminStateUp)
+	th.AssertTrue(t, n.AdminStateUp)
 	th.AssertEquals(t, "d6554fe62e2f41efbb6e026fad5c1542", n.TenantID)
 	th.AssertEquals(t, "a07eea83-7710-4860-931b-5fe220fae533", n.ID)
 	th.AssertDeepEquals(t, []routers.Route{{DestinationCIDR: "40.0.1.0/24", NextHop: "10.1.0.10"}}, n.Routes)
@@ -833,7 +833,7 @@ func TestUpdateExternalGateways(t *testing.T) {
 
 	th.AssertEquals(t, "router1", n.Name)
 	th.AssertEquals(t, "4e8e5957-649f-477b-9e5b-f1f75b21c03c", n.ID)
-	th.AssertEquals(t, true, *n.GatewayInfo.EnableSNAT)
+	th.AssertTrue(t, *n.GatewayInfo.EnableSNAT)
 }
 
 func TestRemoveExternalGateways(t *testing.T) {

--- a/openstack/networking/v2/extensions/networkipavailabilities/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/networkipavailabilities/testing/requests_test.go
@@ -71,13 +71,13 @@ func TestGet(t *testing.T) {
 	s, err := networkipavailabilities.Get(context.TODO(), fake.ServiceClient(fakeServer), "cf11ab78-2302-49fa-870f-851a08c7afb8").Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, s.NetworkID, "cf11ab78-2302-49fa-870f-851a08c7afb8")
-	th.AssertEquals(t, s.NetworkName, "public")
-	th.AssertEquals(t, s.ProjectID, "424e7cf0243c468ca61732ba45973b3e")
-	th.AssertEquals(t, s.TenantID, "424e7cf0243c468ca61732ba45973b3e")
-	th.AssertEquals(t, s.TotalIPs, "253")
-	th.AssertEquals(t, s.UsedIPs, "3")
-	th.AssertDeepEquals(t, s.SubnetIPAvailabilities, []networkipavailabilities.SubnetIPAvailability{
+	th.AssertEquals(t, "cf11ab78-2302-49fa-870f-851a08c7afb8", s.NetworkID)
+	th.AssertEquals(t, "public", s.NetworkName)
+	th.AssertEquals(t, "424e7cf0243c468ca61732ba45973b3e", s.ProjectID)
+	th.AssertEquals(t, "424e7cf0243c468ca61732ba45973b3e", s.TenantID)
+	th.AssertEquals(t, "253", s.TotalIPs)
+	th.AssertEquals(t, "3", s.UsedIPs)
+	th.AssertDeepEquals(t, []networkipavailabilities.SubnetIPAvailability{
 		{
 			SubnetID:   "4afe6e5f-9649-40db-b18f-64c7ead942bd",
 			SubnetName: "public-subnet",
@@ -86,5 +86,5 @@ func TestGet(t *testing.T) {
 			TotalIPs:   "253",
 			UsedIPs:    "3",
 		},
-	})
+	}, s.SubnetIPAvailabilities)
 }

--- a/openstack/networking/v2/extensions/portsbinding/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/portsbinding/testing/requests_test.go
@@ -77,7 +77,7 @@ func TestGet(t *testing.T) {
 
 	th.AssertEquals(t, "ACTIVE", s.Status)
 	th.AssertEquals(t, "", s.Name)
-	th.AssertEquals(t, true, s.AdminStateUp)
+	th.AssertTrue(t, s.AdminStateUp)
 	th.AssertEquals(t, "a87cc70a-3e15-4acf-8205-9b711a3531b7", s.NetworkID)
 	th.AssertEquals(t, "7e02058126cc4950b75f9970368ba177", s.TenantID)
 	th.AssertEquals(t, "network:router_interface", s.DeviceOwner)
@@ -128,7 +128,7 @@ func TestCreate(t *testing.T) {
 
 	th.AssertEquals(t, "DOWN", s.Status)
 	th.AssertEquals(t, "private-port", s.Name)
-	th.AssertEquals(t, true, s.AdminStateUp)
+	th.AssertTrue(t, s.AdminStateUp)
 	th.AssertEquals(t, "a87cc70a-3e15-4acf-8205-9b711a3531b7", s.NetworkID)
 	th.AssertEquals(t, "d6700c0c9ffa4f1cb322cd4a1f3906fa", s.TenantID)
 	th.AssertEquals(t, "", s.DeviceOwner)

--- a/openstack/networking/v2/extensions/portsbinding/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/portsbinding/testing/requests_test.go
@@ -75,24 +75,24 @@ func TestGet(t *testing.T) {
 	err := ports.Get(context.TODO(), fake.ServiceClient(fakeServer), "46d4bfb9-b26e-41f3-bd2e-e6dcc1ccedb2").ExtractInto(&s)
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, s.Status, "ACTIVE")
-	th.AssertEquals(t, s.Name, "")
-	th.AssertEquals(t, s.AdminStateUp, true)
-	th.AssertEquals(t, s.NetworkID, "a87cc70a-3e15-4acf-8205-9b711a3531b7")
-	th.AssertEquals(t, s.TenantID, "7e02058126cc4950b75f9970368ba177")
-	th.AssertEquals(t, s.DeviceOwner, "network:router_interface")
-	th.AssertEquals(t, s.MACAddress, "fa:16:3e:23:fd:d7")
-	th.AssertDeepEquals(t, s.FixedIPs, []ports.IP{
+	th.AssertEquals(t, "ACTIVE", s.Status)
+	th.AssertEquals(t, "", s.Name)
+	th.AssertEquals(t, true, s.AdminStateUp)
+	th.AssertEquals(t, "a87cc70a-3e15-4acf-8205-9b711a3531b7", s.NetworkID)
+	th.AssertEquals(t, "7e02058126cc4950b75f9970368ba177", s.TenantID)
+	th.AssertEquals(t, "network:router_interface", s.DeviceOwner)
+	th.AssertEquals(t, "fa:16:3e:23:fd:d7", s.MACAddress)
+	th.AssertDeepEquals(t, []ports.IP{
 		{SubnetID: "a0304c3a-4f08-4c43-88af-d796509c97d2", IPAddress: "10.0.0.1"},
-	})
-	th.AssertEquals(t, s.ID, "46d4bfb9-b26e-41f3-bd2e-e6dcc1ccedb2")
-	th.AssertDeepEquals(t, s.SecurityGroups, []string{})
-	th.AssertEquals(t, s.DeviceID, "5e3898d7-11be-483e-9732-b2f5eccd2b2e")
+	}, s.FixedIPs)
+	th.AssertEquals(t, "46d4bfb9-b26e-41f3-bd2e-e6dcc1ccedb2", s.ID)
+	th.AssertDeepEquals(t, []string{}, s.SecurityGroups)
+	th.AssertEquals(t, "5e3898d7-11be-483e-9732-b2f5eccd2b2e", s.DeviceID)
 
-	th.AssertEquals(t, s.HostID, "devstack")
-	th.AssertEquals(t, s.VNICType, "normal")
-	th.AssertEquals(t, s.VIFType, "ovs")
-	th.AssertDeepEquals(t, s.VIFDetails, map[string]any{"port_filter": true, "ovs_hybrid_plug": true})
+	th.AssertEquals(t, "devstack", s.HostID)
+	th.AssertEquals(t, "normal", s.VNICType)
+	th.AssertEquals(t, "ovs", s.VIFType)
+	th.AssertDeepEquals(t, map[string]any{"port_filter": true, "ovs_hybrid_plug": true}, s.VIFDetails)
 }
 
 func TestCreate(t *testing.T) {
@@ -126,20 +126,20 @@ func TestCreate(t *testing.T) {
 	err := ports.Create(context.TODO(), fake.ServiceClient(fakeServer), createOpts).ExtractInto(&s)
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, s.Status, "DOWN")
-	th.AssertEquals(t, s.Name, "private-port")
-	th.AssertEquals(t, s.AdminStateUp, true)
-	th.AssertEquals(t, s.NetworkID, "a87cc70a-3e15-4acf-8205-9b711a3531b7")
-	th.AssertEquals(t, s.TenantID, "d6700c0c9ffa4f1cb322cd4a1f3906fa")
-	th.AssertEquals(t, s.DeviceOwner, "")
-	th.AssertEquals(t, s.MACAddress, "fa:16:3e:c9:cb:f0")
-	th.AssertDeepEquals(t, s.FixedIPs, []ports.IP{
+	th.AssertEquals(t, "DOWN", s.Status)
+	th.AssertEquals(t, "private-port", s.Name)
+	th.AssertEquals(t, true, s.AdminStateUp)
+	th.AssertEquals(t, "a87cc70a-3e15-4acf-8205-9b711a3531b7", s.NetworkID)
+	th.AssertEquals(t, "d6700c0c9ffa4f1cb322cd4a1f3906fa", s.TenantID)
+	th.AssertEquals(t, "", s.DeviceOwner)
+	th.AssertEquals(t, "fa:16:3e:c9:cb:f0", s.MACAddress)
+	th.AssertDeepEquals(t, []ports.IP{
 		{SubnetID: "a0304c3a-4f08-4c43-88af-d796509c97d2", IPAddress: "10.0.0.2"},
-	})
-	th.AssertEquals(t, s.ID, "65c0ee9f-d634-4522-8954-51021b570b0d")
-	th.AssertDeepEquals(t, s.SecurityGroups, []string{"f0ac4394-7e4a-4409-9701-ba8be283dbc3"})
-	th.AssertEquals(t, s.HostID, "HOST1")
-	th.AssertEquals(t, s.VNICType, "normal")
+	}, s.FixedIPs)
+	th.AssertEquals(t, "65c0ee9f-d634-4522-8954-51021b570b0d", s.ID)
+	th.AssertDeepEquals(t, []string{"f0ac4394-7e4a-4409-9701-ba8be283dbc3"}, s.SecurityGroups)
+	th.AssertEquals(t, "HOST1", s.HostID)
+	th.AssertEquals(t, "normal", s.VNICType)
 }
 
 func TestRequiredCreateOpts(t *testing.T) {
@@ -182,11 +182,11 @@ func TestUpdate(t *testing.T) {
 	err := ports.Update(context.TODO(), fake.ServiceClient(fakeServer), "65c0ee9f-d634-4522-8954-51021b570b0d", updateOpts).ExtractInto(&s)
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, s.Name, "new_port_name")
-	th.AssertDeepEquals(t, s.FixedIPs, []ports.IP{
+	th.AssertEquals(t, "new_port_name", s.Name)
+	th.AssertDeepEquals(t, []ports.IP{
 		{SubnetID: "a0304c3a-4f08-4c43-88af-d796509c97d2", IPAddress: "10.0.0.3"},
-	})
-	th.AssertDeepEquals(t, s.SecurityGroups, []string{"f0ac4394-7e4a-4409-9701-ba8be283dbc3"})
-	th.AssertEquals(t, s.HostID, "HOST1")
-	th.AssertEquals(t, s.VNICType, "normal")
+	}, s.FixedIPs)
+	th.AssertDeepEquals(t, []string{"f0ac4394-7e4a-4409-9701-ba8be283dbc3"}, s.SecurityGroups)
+	th.AssertEquals(t, "HOST1", s.HostID)
+	th.AssertEquals(t, "normal", s.VNICType)
 }

--- a/openstack/networking/v2/extensions/portstrustedvif/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/portstrustedvif/testing/requests_test.go
@@ -93,23 +93,23 @@ func TestGet(t *testing.T) {
 	err := ports.Get(context.TODO(), fake.ServiceClient(fakeServer), "46d4bfb9-b26e-41f3-bd2e-e6dcc1ccedb2").ExtractInto(&s)
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, s.Status, "DOWN")
-	th.AssertEquals(t, s.Name, "private-port")
-	th.AssertEquals(t, s.AdminStateUp, true)
-	th.AssertEquals(t, s.NetworkID, "a87cc70a-3e15-4acf-8205-9b711a3531b7")
-	th.AssertEquals(t, s.TenantID, "d6700c0c9ffa4f1cb322cd4a1f3906fa")
-	th.AssertEquals(t, s.DeviceOwner, "")
-	th.AssertEquals(t, s.MACAddress, "fa:16:3e:c9:cb:f0")
-	th.AssertDeepEquals(t, s.FixedIPs, []ports.IP{
+	th.AssertEquals(t, "DOWN", s.Status)
+	th.AssertEquals(t, "private-port", s.Name)
+	th.AssertEquals(t, true, s.AdminStateUp)
+	th.AssertEquals(t, "a87cc70a-3e15-4acf-8205-9b711a3531b7", s.NetworkID)
+	th.AssertEquals(t, "d6700c0c9ffa4f1cb322cd4a1f3906fa", s.TenantID)
+	th.AssertEquals(t, "", s.DeviceOwner)
+	th.AssertEquals(t, "fa:16:3e:c9:cb:f0", s.MACAddress)
+	th.AssertDeepEquals(t, []ports.IP{
 		{SubnetID: "a0304c3a-4f08-4c43-88af-d796509c97d2", IPAddress: "10.0.0.1"},
-	})
-	th.AssertEquals(t, s.ID, "46d4bfb9-b26e-41f3-bd2e-e6dcc1ccedb2")
-	th.AssertEquals(t, s.DeviceID, "")
+	}, s.FixedIPs)
+	th.AssertEquals(t, "46d4bfb9-b26e-41f3-bd2e-e6dcc1ccedb2", s.ID)
+	th.AssertEquals(t, "", s.DeviceID)
 
 	if s.PortTrustedVIF == nil {
 		t.Fatalf("Expected s.PortTrustedVIF to be not nil")
 	}
-	th.AssertEquals(t, *s.PortTrustedVIF, false)
+	th.AssertEquals(t, false, *s.PortTrustedVIF)
 }
 
 func TestGetUnset(t *testing.T) {
@@ -134,18 +134,18 @@ func TestGetUnset(t *testing.T) {
 	err := ports.Get(context.TODO(), fake.ServiceClient(fakeServer), "46d4bfb9-b26e-41f3-bd2e-e6dcc1ccedb2").ExtractInto(&s)
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, s.Status, "DOWN")
-	th.AssertEquals(t, s.Name, "private-port")
-	th.AssertEquals(t, s.AdminStateUp, true)
-	th.AssertEquals(t, s.NetworkID, "a87cc70a-3e15-4acf-8205-9b711a3531b7")
-	th.AssertEquals(t, s.TenantID, "d6700c0c9ffa4f1cb322cd4a1f3906fa")
-	th.AssertEquals(t, s.DeviceOwner, "")
-	th.AssertEquals(t, s.MACAddress, "fa:16:3e:c9:cb:f0")
-	th.AssertDeepEquals(t, s.FixedIPs, []ports.IP{
+	th.AssertEquals(t, "DOWN", s.Status)
+	th.AssertEquals(t, "private-port", s.Name)
+	th.AssertEquals(t, true, s.AdminStateUp)
+	th.AssertEquals(t, "a87cc70a-3e15-4acf-8205-9b711a3531b7", s.NetworkID)
+	th.AssertEquals(t, "d6700c0c9ffa4f1cb322cd4a1f3906fa", s.TenantID)
+	th.AssertEquals(t, "", s.DeviceOwner)
+	th.AssertEquals(t, "fa:16:3e:c9:cb:f0", s.MACAddress)
+	th.AssertDeepEquals(t, []ports.IP{
 		{SubnetID: "a0304c3a-4f08-4c43-88af-d796509c97d2", IPAddress: "10.0.0.1"},
-	})
-	th.AssertEquals(t, s.ID, "46d4bfb9-b26e-41f3-bd2e-e6dcc1ccedb2")
-	th.AssertEquals(t, s.DeviceID, "")
+	}, s.FixedIPs)
+	th.AssertEquals(t, "46d4bfb9-b26e-41f3-bd2e-e6dcc1ccedb2", s.ID)
+	th.AssertEquals(t, "", s.DeviceID)
 
 	if s.PortTrustedVIF != nil {
 		t.Fatalf("Expected s.PortTrustedVIF to be nil")
@@ -191,18 +191,18 @@ func TestCreateWithPortTrustedVIF(t *testing.T) {
 	err := ports.Create(context.TODO(), fake.ServiceClient(fakeServer), createOpts).ExtractInto(&portWithExt)
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, portWithExt.Status, "DOWN")
-	th.AssertEquals(t, portWithExt.Name, "private-port")
-	th.AssertEquals(t, portWithExt.AdminStateUp, true)
-	th.AssertEquals(t, portWithExt.NetworkID, "a87cc70a-3e15-4acf-8205-9b711a3531b7")
-	th.AssertEquals(t, portWithExt.TenantID, "d6700c0c9ffa4f1cb322cd4a1f3906fa")
-	th.AssertEquals(t, portWithExt.DeviceOwner, "")
-	th.AssertEquals(t, portWithExt.MACAddress, "fa:16:3e:c9:cb:f0")
-	th.AssertDeepEquals(t, portWithExt.FixedIPs, []ports.IP{
+	th.AssertEquals(t, "DOWN", portWithExt.Status)
+	th.AssertEquals(t, "private-port", portWithExt.Name)
+	th.AssertEquals(t, true, portWithExt.AdminStateUp)
+	th.AssertEquals(t, "a87cc70a-3e15-4acf-8205-9b711a3531b7", portWithExt.NetworkID)
+	th.AssertEquals(t, "d6700c0c9ffa4f1cb322cd4a1f3906fa", portWithExt.TenantID)
+	th.AssertEquals(t, "", portWithExt.DeviceOwner)
+	th.AssertEquals(t, "fa:16:3e:c9:cb:f0", portWithExt.MACAddress)
+	th.AssertDeepEquals(t, []ports.IP{
 		{SubnetID: "a0304c3a-4f08-4c43-88af-d796509c97d2", IPAddress: "10.0.0.2"},
-	})
-	th.AssertEquals(t, portWithExt.ID, "65c0ee9f-d634-4522-8954-51021b570b0d")
-	th.AssertEquals(t, *portWithExt.PortTrustedVIF, true)
+	}, portWithExt.FixedIPs)
+	th.AssertEquals(t, "65c0ee9f-d634-4522-8954-51021b570b0d", portWithExt.ID)
+	th.AssertEquals(t, true, *portWithExt.PortTrustedVIF)
 }
 
 func TestUpdatePortTrustedVIF(t *testing.T) {
@@ -237,6 +237,6 @@ func TestUpdatePortTrustedVIF(t *testing.T) {
 	err := ports.Update(context.TODO(), fake.ServiceClient(fakeServer), "65c0ee9f-d634-4522-8954-51021b570b0d", updateOpts).ExtractInto(&portWithExt)
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, portWithExt.Name, "private-port")
-	th.AssertDeepEquals(t, *portWithExt.PortTrustedVIF, false)
+	th.AssertEquals(t, "private-port", portWithExt.Name)
+	th.AssertDeepEquals(t, false, *portWithExt.PortTrustedVIF)
 }

--- a/openstack/networking/v2/extensions/portstrustedvif/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/portstrustedvif/testing/requests_test.go
@@ -95,7 +95,7 @@ func TestGet(t *testing.T) {
 
 	th.AssertEquals(t, "DOWN", s.Status)
 	th.AssertEquals(t, "private-port", s.Name)
-	th.AssertEquals(t, true, s.AdminStateUp)
+	th.AssertTrue(t, s.AdminStateUp)
 	th.AssertEquals(t, "a87cc70a-3e15-4acf-8205-9b711a3531b7", s.NetworkID)
 	th.AssertEquals(t, "d6700c0c9ffa4f1cb322cd4a1f3906fa", s.TenantID)
 	th.AssertEquals(t, "", s.DeviceOwner)
@@ -109,7 +109,7 @@ func TestGet(t *testing.T) {
 	if s.PortTrustedVIF == nil {
 		t.Fatalf("Expected s.PortTrustedVIF to be not nil")
 	}
-	th.AssertEquals(t, false, *s.PortTrustedVIF)
+	th.AssertFalse(t, *s.PortTrustedVIF)
 }
 
 func TestGetUnset(t *testing.T) {
@@ -136,7 +136,7 @@ func TestGetUnset(t *testing.T) {
 
 	th.AssertEquals(t, "DOWN", s.Status)
 	th.AssertEquals(t, "private-port", s.Name)
-	th.AssertEquals(t, true, s.AdminStateUp)
+	th.AssertTrue(t, s.AdminStateUp)
 	th.AssertEquals(t, "a87cc70a-3e15-4acf-8205-9b711a3531b7", s.NetworkID)
 	th.AssertEquals(t, "d6700c0c9ffa4f1cb322cd4a1f3906fa", s.TenantID)
 	th.AssertEquals(t, "", s.DeviceOwner)
@@ -193,7 +193,7 @@ func TestCreateWithPortTrustedVIF(t *testing.T) {
 
 	th.AssertEquals(t, "DOWN", portWithExt.Status)
 	th.AssertEquals(t, "private-port", portWithExt.Name)
-	th.AssertEquals(t, true, portWithExt.AdminStateUp)
+	th.AssertTrue(t, portWithExt.AdminStateUp)
 	th.AssertEquals(t, "a87cc70a-3e15-4acf-8205-9b711a3531b7", portWithExt.NetworkID)
 	th.AssertEquals(t, "d6700c0c9ffa4f1cb322cd4a1f3906fa", portWithExt.TenantID)
 	th.AssertEquals(t, "", portWithExt.DeviceOwner)
@@ -202,7 +202,7 @@ func TestCreateWithPortTrustedVIF(t *testing.T) {
 		{SubnetID: "a0304c3a-4f08-4c43-88af-d796509c97d2", IPAddress: "10.0.0.2"},
 	}, portWithExt.FixedIPs)
 	th.AssertEquals(t, "65c0ee9f-d634-4522-8954-51021b570b0d", portWithExt.ID)
-	th.AssertEquals(t, true, *portWithExt.PortTrustedVIF)
+	th.AssertTrue(t, *portWithExt.PortTrustedVIF)
 }
 
 func TestUpdatePortTrustedVIF(t *testing.T) {

--- a/openstack/networking/v2/extensions/provider/testing/results_test.go
+++ b/openstack/networking/v2/extensions/provider/testing/results_test.go
@@ -44,8 +44,8 @@ func TestList(t *testing.T) {
 	th.AssertEquals(t, "db193ab3-96e3-4cb3-8fc5-05f4296d0324", actual[1].ID)
 	th.AssertEquals(t, "local", actual[1].NetworkType)
 	th.AssertEquals(t, "1234567890", actual[1].SegmentationID)
-	th.AssertEquals(t, actual[0].Subnets[0], "54d6f61d-db07-451c-9ab3-b9609b6b6f0b")
-	th.AssertEquals(t, actual[1].Subnets[0], "08eae331-0402-425a-923c-34f7cfe39c1b")
+	th.AssertEquals(t, "54d6f61d-db07-451c-9ab3-b9609b6b6f0b", actual[0].Subnets[0])
+	th.AssertEquals(t, "08eae331-0402-425a-923c-34f7cfe39c1b", actual[1].Subnets[0])
 
 }
 

--- a/openstack/networking/v2/extensions/qos/policies/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/qos/policies/testing/requests_test.go
@@ -400,8 +400,8 @@ func TestCreatePolicy(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	th.AssertEquals(t, "shared-default-policy", p.Name)
-	th.AssertEquals(t, true, p.Shared)
-	th.AssertEquals(t, true, p.IsDefault)
+	th.AssertTrue(t, p.Shared)
+	th.AssertTrue(t, p.IsDefault)
 	th.AssertEquals(t, "use-me", p.Description)
 	th.AssertEquals(t, "a77cbe0998374aed9a6798ad6c61677e", p.TenantID)
 	th.AssertEquals(t, "a77cbe0998374aed9a6798ad6c61677e", p.ProjectID)
@@ -439,8 +439,8 @@ func TestUpdatePolicy(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	th.AssertEquals(t, "new-name", p.Name)
-	th.AssertEquals(t, true, p.Shared)
-	th.AssertEquals(t, false, p.IsDefault)
+	th.AssertTrue(t, p.Shared)
+	th.AssertFalse(t, p.IsDefault)
 	th.AssertEquals(t, "", p.Description)
 	th.AssertEquals(t, "a77cbe0998374aed9a6798ad6c61677e", p.TenantID)
 	th.AssertEquals(t, "a77cbe0998374aed9a6798ad6c61677e", p.ProjectID)

--- a/openstack/networking/v2/extensions/qos/policies/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/qos/policies/testing/requests_test.go
@@ -37,8 +37,8 @@ func TestGetPort(t *testing.T) {
 	err := ports.Get(context.TODO(), fake.ServiceClient(fakeServer), "65c0ee9f-d634-4522-8954-51021b570b0d").ExtractInto(&p)
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, p.ID, "65c0ee9f-d634-4522-8954-51021b570b0d")
-	th.AssertEquals(t, p.QoSPolicyID, "591e0597-39a6-4665-8149-2111d8de9a08")
+	th.AssertEquals(t, "65c0ee9f-d634-4522-8954-51021b570b0d", p.ID)
+	th.AssertEquals(t, "591e0597-39a6-4665-8149-2111d8de9a08", p.QoSPolicyID)
 }
 
 func TestCreatePort(t *testing.T) {
@@ -73,10 +73,10 @@ func TestCreatePort(t *testing.T) {
 	err := ports.Create(context.TODO(), fake.ServiceClient(fakeServer), createOpts).ExtractInto(&p)
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, p.NetworkID, "a87cc70a-3e15-4acf-8205-9b711a3531b7")
-	th.AssertEquals(t, p.TenantID, "d6700c0c9ffa4f1cb322cd4a1f3906fa")
-	th.AssertEquals(t, p.ID, "65c0ee9f-d634-4522-8954-51021b570b0d")
-	th.AssertEquals(t, p.QoSPolicyID, "591e0597-39a6-4665-8149-2111d8de9a08")
+	th.AssertEquals(t, "a87cc70a-3e15-4acf-8205-9b711a3531b7", p.NetworkID)
+	th.AssertEquals(t, "d6700c0c9ffa4f1cb322cd4a1f3906fa", p.TenantID)
+	th.AssertEquals(t, "65c0ee9f-d634-4522-8954-51021b570b0d", p.ID)
+	th.AssertEquals(t, "591e0597-39a6-4665-8149-2111d8de9a08", p.QoSPolicyID)
 }
 
 func TestUpdatePortWithPolicy(t *testing.T) {
@@ -111,10 +111,10 @@ func TestUpdatePortWithPolicy(t *testing.T) {
 	err := ports.Update(context.TODO(), fake.ServiceClient(fakeServer), "65c0ee9f-d634-4522-8954-51021b570b0d", updateOpts).ExtractInto(&p)
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, p.NetworkID, "a87cc70a-3e15-4acf-8205-9b711a3531b7")
-	th.AssertEquals(t, p.TenantID, "d6700c0c9ffa4f1cb322cd4a1f3906fa")
-	th.AssertEquals(t, p.ID, "65c0ee9f-d634-4522-8954-51021b570b0d")
-	th.AssertEquals(t, p.QoSPolicyID, "591e0597-39a6-4665-8149-2111d8de9a08")
+	th.AssertEquals(t, "a87cc70a-3e15-4acf-8205-9b711a3531b7", p.NetworkID)
+	th.AssertEquals(t, "d6700c0c9ffa4f1cb322cd4a1f3906fa", p.TenantID)
+	th.AssertEquals(t, "65c0ee9f-d634-4522-8954-51021b570b0d", p.ID)
+	th.AssertEquals(t, "591e0597-39a6-4665-8149-2111d8de9a08", p.QoSPolicyID)
 }
 
 func TestUpdatePortWithoutPolicy(t *testing.T) {
@@ -149,10 +149,10 @@ func TestUpdatePortWithoutPolicy(t *testing.T) {
 	err := ports.Update(context.TODO(), fake.ServiceClient(fakeServer), "65c0ee9f-d634-4522-8954-51021b570b0d", updateOpts).ExtractInto(&p)
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, p.NetworkID, "a87cc70a-3e15-4acf-8205-9b711a3531b7")
-	th.AssertEquals(t, p.TenantID, "d6700c0c9ffa4f1cb322cd4a1f3906fa")
-	th.AssertEquals(t, p.ID, "65c0ee9f-d634-4522-8954-51021b570b0d")
-	th.AssertEquals(t, p.QoSPolicyID, "")
+	th.AssertEquals(t, "a87cc70a-3e15-4acf-8205-9b711a3531b7", p.NetworkID)
+	th.AssertEquals(t, "d6700c0c9ffa4f1cb322cd4a1f3906fa", p.TenantID)
+	th.AssertEquals(t, "65c0ee9f-d634-4522-8954-51021b570b0d", p.ID)
+	th.AssertEquals(t, "", p.QoSPolicyID)
 }
 
 func TestGetNetwork(t *testing.T) {
@@ -177,8 +177,8 @@ func TestGetNetwork(t *testing.T) {
 	err := networks.Get(context.TODO(), fake.ServiceClient(fakeServer), "65c0ee9f-d634-4522-8954-51021b570b0d").ExtractInto(&n)
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, n.ID, "65c0ee9f-d634-4522-8954-51021b570b0d")
-	th.AssertEquals(t, n.QoSPolicyID, "591e0597-39a6-4665-8149-2111d8de9a08")
+	th.AssertEquals(t, "65c0ee9f-d634-4522-8954-51021b570b0d", n.ID)
+	th.AssertEquals(t, "591e0597-39a6-4665-8149-2111d8de9a08", n.QoSPolicyID)
 }
 
 func TestCreateNetwork(t *testing.T) {
@@ -213,9 +213,9 @@ func TestCreateNetwork(t *testing.T) {
 	err := networks.Create(context.TODO(), fake.ServiceClient(fakeServer), createOpts).ExtractInto(&n)
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, n.TenantID, "4fd44f30292945e481c7b8a0c8908869")
-	th.AssertEquals(t, n.ID, "65c0ee9f-d634-4522-8954-51021b570b0d")
-	th.AssertEquals(t, n.QoSPolicyID, "591e0597-39a6-4665-8149-2111d8de9a08")
+	th.AssertEquals(t, "4fd44f30292945e481c7b8a0c8908869", n.TenantID)
+	th.AssertEquals(t, "65c0ee9f-d634-4522-8954-51021b570b0d", n.ID)
+	th.AssertEquals(t, "591e0597-39a6-4665-8149-2111d8de9a08", n.QoSPolicyID)
 }
 
 func TestUpdateNetworkWithPolicy(t *testing.T) {
@@ -253,10 +253,10 @@ func TestUpdateNetworkWithPolicy(t *testing.T) {
 	err := networks.Update(context.TODO(), fake.ServiceClient(fakeServer), "65c0ee9f-d634-4522-8954-51021b570b0d", updateOpts).ExtractInto(&n)
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, n.TenantID, "4fd44f30292945e481c7b8a0c8908869")
-	th.AssertEquals(t, n.ID, "65c0ee9f-d634-4522-8954-51021b570b0d")
-	th.AssertEquals(t, n.Name, "updated")
-	th.AssertEquals(t, n.QoSPolicyID, "591e0597-39a6-4665-8149-2111d8de9a08")
+	th.AssertEquals(t, "4fd44f30292945e481c7b8a0c8908869", n.TenantID)
+	th.AssertEquals(t, "65c0ee9f-d634-4522-8954-51021b570b0d", n.ID)
+	th.AssertEquals(t, "updated", n.Name)
+	th.AssertEquals(t, "591e0597-39a6-4665-8149-2111d8de9a08", n.QoSPolicyID)
 }
 
 func TestUpdateNetworkWithoutPolicy(t *testing.T) {
@@ -291,9 +291,9 @@ func TestUpdateNetworkWithoutPolicy(t *testing.T) {
 	err := networks.Update(context.TODO(), fake.ServiceClient(fakeServer), "65c0ee9f-d634-4522-8954-51021b570b0d", updateOpts).ExtractInto(&n)
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, n.TenantID, "4fd44f30292945e481c7b8a0c8908869")
-	th.AssertEquals(t, n.ID, "65c0ee9f-d634-4522-8954-51021b570b0d")
-	th.AssertEquals(t, n.QoSPolicyID, "")
+	th.AssertEquals(t, "4fd44f30292945e481c7b8a0c8908869", n.TenantID)
+	th.AssertEquals(t, "65c0ee9f-d634-4522-8954-51021b570b0d", n.ID)
+	th.AssertEquals(t, "", n.QoSPolicyID)
 }
 
 func TestListPolicies(t *testing.T) {

--- a/openstack/networking/v2/extensions/qos/rules/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/qos/rules/testing/requests_test.go
@@ -77,10 +77,10 @@ func TestGetBandwidthLimitRule(t *testing.T) {
 	r, err := rules.GetBandwidthLimitRule(context.TODO(), fake.ServiceClient(fakeServer), "501005fa-3b56-4061-aaca-3f24995112e1", "30a57f4a-336b-4382-8275-d708babd2241").ExtractBandwidthLimitRule()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, r.ID, "30a57f4a-336b-4382-8275-d708babd2241")
-	th.AssertEquals(t, r.Direction, "egress")
-	th.AssertEquals(t, r.MaxBurstKBps, 300)
-	th.AssertEquals(t, r.MaxKBps, 3000)
+	th.AssertEquals(t, "30a57f4a-336b-4382-8275-d708babd2241", r.ID)
+	th.AssertEquals(t, "egress", r.Direction)
+	th.AssertEquals(t, 300, r.MaxBurstKBps)
+	th.AssertEquals(t, 3000, r.MaxKBps)
 }
 
 func TestCreateBandwidthLimitRule(t *testing.T) {
@@ -218,7 +218,7 @@ func TestGetDSCPMarkingRule(t *testing.T) {
 	r, err := rules.GetDSCPMarkingRule(context.TODO(), fake.ServiceClient(fakeServer), "501005fa-3b56-4061-aaca-3f24995112e1", "30a57f4a-336b-4382-8275-d708babd2241").ExtractDSCPMarkingRule()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, r.ID, "30a57f4a-336b-4382-8275-d708babd2241")
+	th.AssertEquals(t, "30a57f4a-336b-4382-8275-d708babd2241", r.ID)
 	th.AssertEquals(t, 26, r.DSCPMark)
 }
 
@@ -355,9 +355,9 @@ func TestGetMinimumBandwidthRule(t *testing.T) {
 	r, err := rules.GetMinimumBandwidthRule(context.TODO(), fake.ServiceClient(fakeServer), "501005fa-3b56-4061-aaca-3f24995112e1", "30a57f4a-336b-4382-8275-d708babd2241").ExtractMinimumBandwidthRule()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, r.ID, "30a57f4a-336b-4382-8275-d708babd2241")
-	th.AssertEquals(t, r.Direction, "egress")
-	th.AssertEquals(t, r.MinKBps, 3000)
+	th.AssertEquals(t, "30a57f4a-336b-4382-8275-d708babd2241", r.ID)
+	th.AssertEquals(t, "egress", r.Direction)
+	th.AssertEquals(t, 3000, r.MinKBps)
 }
 
 func TestCreateMinimumBandwidthRule(t *testing.T) {

--- a/openstack/networking/v2/extensions/rbacpolicies/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/rbacpolicies/testing/requests_test.go
@@ -123,11 +123,11 @@ func TestListWithAllPages(t *testing.T) {
 	err = rbacpolicies.ExtractRBACPolicesInto(allPages, &allRBACpolicies)
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, allRBACpolicies[0].ObjectType, "network")
+	th.AssertEquals(t, "network", allRBACpolicies[0].ObjectType)
 	th.AssertEquals(t, allRBACpolicies[0].Action, rbacpolicies.ActionAccessShared)
 
-	th.AssertEquals(t, allRBACpolicies[1].ProjectID, "1ae27ce0a2a54cc6ae06dc62dd0ec832")
-	th.AssertEquals(t, allRBACpolicies[1].TargetTenant, "1a547a3bcfe44702889fdeff3c3520c3")
+	th.AssertEquals(t, "1ae27ce0a2a54cc6ae06dc62dd0ec832", allRBACpolicies[1].ProjectID)
+	th.AssertEquals(t, "1a547a3bcfe44702889fdeff3c3520c3", allRBACpolicies[1].TargetTenant)
 
 }
 
@@ -166,6 +166,6 @@ func TestUpdate(t *testing.T) {
 	rbacResult, err := rbacpolicies.Update(context.TODO(), fake.ServiceClient(fakeServer), "2cf7523a-93b5-4e69-9360-6c6bf986bb7c", options).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, rbacResult.TargetTenant, "9d766060b6354c9e8e2da44cab0e8f38")
-	th.AssertEquals(t, rbacResult.ID, "2cf7523a-93b5-4e69-9360-6c6bf986bb7c")
+	th.AssertEquals(t, "9d766060b6354c9e8e2da44cab0e8f38", rbacResult.TargetTenant)
+	th.AssertEquals(t, "2cf7523a-93b5-4e69-9360-6c6bf986bb7c", rbacResult.ID)
 }

--- a/openstack/networking/v2/extensions/subnetpools/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/subnetpools/testing/requests_test.go
@@ -72,25 +72,25 @@ func TestGet(t *testing.T) {
 	s, err := subnetpools.Get(context.TODO(), fake.ServiceClient(fakeServer), "0a738452-8057-4ad3-89c2-92f6a74afa76").Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, s.ID, "0a738452-8057-4ad3-89c2-92f6a74afa76")
-	th.AssertEquals(t, s.Name, "my-ipv6-pool")
-	th.AssertEquals(t, s.DefaultQuota, 2)
-	th.AssertEquals(t, s.TenantID, "1e2b9857295a4a3e841809ef492812c5")
-	th.AssertEquals(t, s.ProjectID, "1e2b9857295a4a3e841809ef492812c5")
+	th.AssertEquals(t, "0a738452-8057-4ad3-89c2-92f6a74afa76", s.ID)
+	th.AssertEquals(t, "my-ipv6-pool", s.Name)
+	th.AssertEquals(t, 2, s.DefaultQuota)
+	th.AssertEquals(t, "1e2b9857295a4a3e841809ef492812c5", s.TenantID)
+	th.AssertEquals(t, "1e2b9857295a4a3e841809ef492812c5", s.ProjectID)
 	th.AssertEquals(t, s.CreatedAt, time.Date(2018, 1, 1, 0, 0, 1, 0, time.UTC))
 	th.AssertEquals(t, s.UpdatedAt, time.Date(2018, 1, 1, 0, 10, 10, 0, time.UTC))
-	th.AssertDeepEquals(t, s.Prefixes, []string{
+	th.AssertDeepEquals(t, []string{
 		"2001:db8::a3/64",
-	})
-	th.AssertEquals(t, s.DefaultPrefixLen, 64)
-	th.AssertEquals(t, s.MinPrefixLen, 64)
-	th.AssertEquals(t, s.MaxPrefixLen, 128)
-	th.AssertEquals(t, s.AddressScopeID, "")
-	th.AssertEquals(t, s.IPversion, 6)
-	th.AssertEquals(t, s.Shared, false)
-	th.AssertEquals(t, s.Description, "ipv6 prefixes")
-	th.AssertEquals(t, s.IsDefault, true)
-	th.AssertEquals(t, s.RevisionNumber, 2)
+	}, s.Prefixes)
+	th.AssertEquals(t, 64, s.DefaultPrefixLen)
+	th.AssertEquals(t, 64, s.MinPrefixLen)
+	th.AssertEquals(t, 128, s.MaxPrefixLen)
+	th.AssertEquals(t, "", s.AddressScopeID)
+	th.AssertEquals(t, 6, s.IPversion)
+	th.AssertEquals(t, false, s.Shared)
+	th.AssertEquals(t, "ipv6 prefixes", s.Description)
+	th.AssertEquals(t, true, s.IsDefault)
+	th.AssertEquals(t, 2, s.RevisionNumber)
 }
 func TestCreate(t *testing.T) {
 	fakeServer := th.SetupHTTP()
@@ -123,15 +123,15 @@ func TestCreate(t *testing.T) {
 	s, err := subnetpools.Create(context.TODO(), fake.ServiceClient(fakeServer), opts).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, s.Name, "my_ipv4_pool")
-	th.AssertDeepEquals(t, s.Prefixes, []string{
+	th.AssertEquals(t, "my_ipv4_pool", s.Name)
+	th.AssertDeepEquals(t, []string{
 		"10.10.0.0/16",
 		"10.11.11.0/24",
-	})
-	th.AssertEquals(t, s.MinPrefixLen, 25)
-	th.AssertEquals(t, s.MaxPrefixLen, 30)
-	th.AssertEquals(t, s.AddressScopeID, "3d4e2e2a-552b-42ad-a16d-820bbf3edaf3")
-	th.AssertEquals(t, s.Description, "ipv4 prefixes")
+	}, s.Prefixes)
+	th.AssertEquals(t, 25, s.MinPrefixLen)
+	th.AssertEquals(t, 30, s.MaxPrefixLen)
+	th.AssertEquals(t, "3d4e2e2a-552b-42ad-a16d-820bbf3edaf3", s.AddressScopeID)
+	th.AssertEquals(t, "ipv4 prefixes", s.Description)
 }
 
 func TestUpdate(t *testing.T) {
@@ -167,17 +167,17 @@ func TestUpdate(t *testing.T) {
 	n, err := subnetpools.Update(context.TODO(), fake.ServiceClient(fakeServer), "099546ca-788d-41e5-a76d-17d8cd282d3e", updateOpts).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, n.Name, "new_subnetpool_name")
-	th.AssertDeepEquals(t, n.Prefixes, []string{
+	th.AssertEquals(t, "new_subnetpool_name", n.Name)
+	th.AssertDeepEquals(t, []string{
 		"10.8.0.0/16",
 		"10.11.12.0/24",
 		"10.24.0.0/16",
-	})
-	th.AssertEquals(t, n.MaxPrefixLen, 16)
-	th.AssertEquals(t, n.ID, "099546ca-788d-41e5-a76d-17d8cd282d3e")
-	th.AssertEquals(t, n.AddressScopeID, "")
-	th.AssertEquals(t, n.DefaultQuota, 0)
-	th.AssertEquals(t, n.Description, "")
+	}, n.Prefixes)
+	th.AssertEquals(t, 16, n.MaxPrefixLen)
+	th.AssertEquals(t, "099546ca-788d-41e5-a76d-17d8cd282d3e", n.ID)
+	th.AssertEquals(t, "", n.AddressScopeID)
+	th.AssertEquals(t, 0, n.DefaultQuota)
+	th.AssertEquals(t, "", n.Description)
 }
 
 func TestDelete(t *testing.T) {

--- a/openstack/networking/v2/extensions/subnetpools/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/subnetpools/testing/requests_test.go
@@ -87,9 +87,9 @@ func TestGet(t *testing.T) {
 	th.AssertEquals(t, 128, s.MaxPrefixLen)
 	th.AssertEquals(t, "", s.AddressScopeID)
 	th.AssertEquals(t, 6, s.IPversion)
-	th.AssertEquals(t, false, s.Shared)
+	th.AssertFalse(t, s.Shared)
 	th.AssertEquals(t, "ipv6 prefixes", s.Description)
-	th.AssertEquals(t, true, s.IsDefault)
+	th.AssertTrue(t, s.IsDefault)
 	th.AssertEquals(t, 2, s.RevisionNumber)
 }
 func TestCreate(t *testing.T) {

--- a/openstack/networking/v2/extensions/testing/delegate_test.go
+++ b/openstack/networking/v2/extensions/testing/delegate_test.go
@@ -100,9 +100,9 @@ func TestGet(t *testing.T) {
 	ext, err := extensions.Get(context.TODO(), fake.ServiceClient(fakeServer), "agent").Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, ext.Updated, "2013-02-03T10:00:00-00:00")
-	th.AssertEquals(t, ext.Name, "agent")
-	th.AssertEquals(t, ext.Namespace, "http://docs.openstack.org/ext/agent/api/v2.0")
-	th.AssertEquals(t, ext.Alias, "agent")
-	th.AssertEquals(t, ext.Description, "The agent management extension.")
+	th.AssertEquals(t, "2013-02-03T10:00:00-00:00", ext.Updated)
+	th.AssertEquals(t, "agent", ext.Name)
+	th.AssertEquals(t, "http://docs.openstack.org/ext/agent/api/v2.0", ext.Namespace)
+	th.AssertEquals(t, "agent", ext.Alias)
+	th.AssertEquals(t, "The agent management extension.", ext.Description)
 }

--- a/openstack/networking/v2/extensions/trunk_details/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/trunk_details/testing/requests_test.go
@@ -35,11 +35,11 @@ func TestServerWithUsageExt(t *testing.T) {
 	err := ports.Get(context.TODO(), client.ServiceClient(fakeServer), portIDFixture).ExtractInto(&portExt)
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, portExt.TrunkID, "f170c831-8c55-4ceb-ad13-75eab4a121e5")
-	th.AssertEquals(t, len(portExt.SubPorts), 1)
+	th.AssertEquals(t, "f170c831-8c55-4ceb-ad13-75eab4a121e5", portExt.TrunkID)
+	th.AssertEquals(t, 1, len(portExt.SubPorts))
 	subPort := portExt.SubPorts[0]
-	th.AssertEquals(t, subPort.SegmentationID, 100)
-	th.AssertEquals(t, subPort.SegmentationType, "vlan")
-	th.AssertEquals(t, subPort.PortID, "20c673d8-7f9d-4570-b662-148d9ddcc5bd")
-	th.AssertEquals(t, subPort.MACAddress, "fa:16:3e:88:29:a0")
+	th.AssertEquals(t, 100, subPort.SegmentationID)
+	th.AssertEquals(t, "vlan", subPort.SegmentationType)
+	th.AssertEquals(t, "20c673d8-7f9d-4570-b662-148d9ddcc5bd", subPort.PortID)
+	th.AssertEquals(t, "fa:16:3e:88:29:a0", subPort.MACAddress)
 }

--- a/openstack/networking/v2/extensions/trunks/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/trunks/testing/requests_test.go
@@ -54,7 +54,7 @@ func TestCreate(t *testing.T) {
 	n, err := trunks.Create(context.TODO(), fake.ServiceClient(fakeServer), options).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, n.Status, "ACTIVE")
+	th.AssertEquals(t, "ACTIVE", n.Status)
 	expectedTrunks, err := ExpectedTrunkSlice()
 	th.AssertNoErr(t, err)
 	th.AssertDeepEquals(t, &expectedTrunks[1], n)
@@ -86,7 +86,7 @@ func TestCreateNoSubports(t *testing.T) {
 	n, err := trunks.Create(context.TODO(), fake.ServiceClient(fakeServer), options).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, n.Status, "ACTIVE")
+	th.AssertEquals(t, "ACTIVE", n.Status)
 	th.AssertEquals(t, 0, len(n.Subports))
 }
 

--- a/openstack/networking/v2/extensions/vlantransparent/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/vlantransparent/testing/requests_test.go
@@ -40,12 +40,12 @@ func TestList(t *testing.T) {
 
 	th.AssertEquals(t, "db193ab3-96e3-4cb3-8fc5-05f4296d0324", actual[0].ID)
 	th.AssertEquals(t, "private", actual[0].Name)
-	th.AssertEquals(t, true, actual[0].AdminStateUp)
+	th.AssertTrue(t, actual[0].AdminStateUp)
 	th.AssertEquals(t, "ACTIVE", actual[0].Status)
 	th.AssertDeepEquals(t, []string{"08eae331-0402-425a-923c-34f7cfe39c1b"}, actual[0].Subnets)
 	th.AssertEquals(t, "26a7980765d0414dbc1fc1f88cdb7e6e", actual[0].TenantID)
-	th.AssertEquals(t, false, actual[0].Shared)
-	th.AssertEquals(t, true, actual[0].VLANTransparent)
+	th.AssertFalse(t, actual[0].Shared)
+	th.AssertTrue(t, actual[0].VLANTransparent)
 }
 
 func TestGet(t *testing.T) {
@@ -72,12 +72,12 @@ func TestGet(t *testing.T) {
 
 	th.AssertEquals(t, "db193ab3-96e3-4cb3-8fc5-05f4296d0324", s.ID)
 	th.AssertEquals(t, "private", s.Name)
-	th.AssertEquals(t, true, s.AdminStateUp)
+	th.AssertTrue(t, s.AdminStateUp)
 	th.AssertEquals(t, "ACTIVE", s.Status)
 	th.AssertDeepEquals(t, []string{"08eae331-0402-425a-923c-34f7cfe39c1b"}, s.Subnets)
 	th.AssertEquals(t, "26a7980765d0414dbc1fc1f88cdb7e6e", s.TenantID)
-	th.AssertEquals(t, false, s.Shared)
-	th.AssertEquals(t, true, s.VLANTransparent)
+	th.AssertFalse(t, s.Shared)
+	th.AssertTrue(t, s.VLANTransparent)
 }
 
 func TestCreate(t *testing.T) {
@@ -117,12 +117,12 @@ func TestCreate(t *testing.T) {
 
 	th.AssertEquals(t, "db193ab3-96e3-4cb3-8fc5-05f4296d0324", s.ID)
 	th.AssertEquals(t, "private", s.Name)
-	th.AssertEquals(t, true, s.AdminStateUp)
+	th.AssertTrue(t, s.AdminStateUp)
 	th.AssertEquals(t, "ACTIVE", s.Status)
 	th.AssertDeepEquals(t, []string{"08eae331-0402-425a-923c-34f7cfe39c1b"}, s.Subnets)
 	th.AssertEquals(t, "26a7980765d0414dbc1fc1f88cdb7e6e", s.TenantID)
-	th.AssertEquals(t, false, s.Shared)
-	th.AssertEquals(t, true, s.VLANTransparent)
+	th.AssertFalse(t, s.Shared)
+	th.AssertTrue(t, s.VLANTransparent)
 }
 
 func TestUpdate(t *testing.T) {
@@ -164,10 +164,10 @@ func TestUpdate(t *testing.T) {
 
 	th.AssertEquals(t, "db193ab3-96e3-4cb3-8fc5-05f4296d0324", s.ID)
 	th.AssertEquals(t, "new_network_name", s.Name)
-	th.AssertEquals(t, false, s.AdminStateUp)
+	th.AssertFalse(t, s.AdminStateUp)
 	th.AssertEquals(t, "ACTIVE", s.Status)
 	th.AssertDeepEquals(t, []string{"08eae331-0402-425a-923c-34f7cfe39c1b"}, s.Subnets)
 	th.AssertEquals(t, "26a7980765d0414dbc1fc1f88cdb7e6e", s.TenantID)
-	th.AssertEquals(t, false, s.Shared)
-	th.AssertEquals(t, false, s.VLANTransparent)
+	th.AssertFalse(t, s.Shared)
+	th.AssertFalse(t, s.VLANTransparent)
 }

--- a/openstack/networking/v2/networks/testing/requests_test.go
+++ b/openstack/networking/v2/networks/testing/requests_test.go
@@ -81,7 +81,7 @@ func TestListWithExtensions(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	th.AssertEquals(t, "ACTIVE", allNetworks[0].Status)
-	th.AssertEquals(t, true, allNetworks[0].PortSecurityEnabled)
+	th.AssertTrue(t, allNetworks[0].PortSecurityEnabled)
 	th.AssertEquals(t, "54d6f61d-db07-451c-9ab3-b9609b6b6f0b", allNetworks[0].Subnets[0])
 	th.AssertEquals(t, "08eae331-0402-425a-923c-34f7cfe39c1b", allNetworks[1].Subnets[0])
 	th.AssertEquals(t, "2019-06-30T04:15:37Z", allNetworks[0].CreatedAt.Format(time.RFC3339))
@@ -134,7 +134,7 @@ func TestGetWithExtensions(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	th.AssertEquals(t, "ACTIVE", networkWithExtensions.Status)
-	th.AssertEquals(t, true, networkWithExtensions.PortSecurityEnabled)
+	th.AssertTrue(t, networkWithExtensions.PortSecurityEnabled)
 }
 
 func TestCreate(t *testing.T) {
@@ -215,8 +215,8 @@ func TestUpdate(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	th.AssertEquals(t, "new_network_name", n.Name)
-	th.AssertEquals(t, false, n.AdminStateUp)
-	th.AssertEquals(t, true, n.Shared)
+	th.AssertFalse(t, n.AdminStateUp)
+	th.AssertTrue(t, n.Shared)
 	th.AssertEquals(t, "4e8e5957-649f-477b-9e5b-f1f75b21c03c", n.ID)
 	th.AssertEquals(t, "2019-06-30T04:15:37Z", n.CreatedAt.Format(time.RFC3339))
 	th.AssertEquals(t, "2019-06-30T05:18:49Z", n.UpdatedAt.Format(time.RFC3339))
@@ -313,7 +313,7 @@ func TestCreatePortSecurity(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	th.AssertEquals(t, "ACTIVE", networkWithExtensions.Status)
-	th.AssertEquals(t, false, networkWithExtensions.PortSecurityEnabled)
+	th.AssertFalse(t, networkWithExtensions.PortSecurityEnabled)
 }
 
 func TestUpdatePortSecurity(t *testing.T) {
@@ -349,8 +349,8 @@ func TestUpdatePortSecurity(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	th.AssertEquals(t, "private", networkWithExtensions.Name)
-	th.AssertEquals(t, true, networkWithExtensions.AdminStateUp)
-	th.AssertEquals(t, false, networkWithExtensions.Shared)
+	th.AssertTrue(t, networkWithExtensions.AdminStateUp)
+	th.AssertFalse(t, networkWithExtensions.Shared)
 	th.AssertEquals(t, "4e8e5957-649f-477b-9e5b-f1f75b21c03c", networkWithExtensions.ID)
-	th.AssertEquals(t, false, networkWithExtensions.PortSecurityEnabled)
+	th.AssertFalse(t, networkWithExtensions.PortSecurityEnabled)
 }

--- a/openstack/networking/v2/networks/testing/requests_test.go
+++ b/openstack/networking/v2/networks/testing/requests_test.go
@@ -80,14 +80,14 @@ func TestListWithExtensions(t *testing.T) {
 	err = networks.ExtractNetworksInto(allPages, &allNetworks)
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, allNetworks[0].Status, "ACTIVE")
-	th.AssertEquals(t, allNetworks[0].PortSecurityEnabled, true)
-	th.AssertEquals(t, allNetworks[0].Subnets[0], "54d6f61d-db07-451c-9ab3-b9609b6b6f0b")
-	th.AssertEquals(t, allNetworks[1].Subnets[0], "08eae331-0402-425a-923c-34f7cfe39c1b")
-	th.AssertEquals(t, allNetworks[0].CreatedAt.Format(time.RFC3339), "2019-06-30T04:15:37Z")
-	th.AssertEquals(t, allNetworks[0].UpdatedAt.Format(time.RFC3339), "2019-06-30T05:18:49Z")
-	th.AssertEquals(t, allNetworks[1].CreatedAt.Format(time.RFC3339), "2019-06-30T04:15:37Z")
-	th.AssertEquals(t, allNetworks[1].UpdatedAt.Format(time.RFC3339), "2019-06-30T05:18:49Z")
+	th.AssertEquals(t, "ACTIVE", allNetworks[0].Status)
+	th.AssertEquals(t, true, allNetworks[0].PortSecurityEnabled)
+	th.AssertEquals(t, "54d6f61d-db07-451c-9ab3-b9609b6b6f0b", allNetworks[0].Subnets[0])
+	th.AssertEquals(t, "08eae331-0402-425a-923c-34f7cfe39c1b", allNetworks[1].Subnets[0])
+	th.AssertEquals(t, "2019-06-30T04:15:37Z", allNetworks[0].CreatedAt.Format(time.RFC3339))
+	th.AssertEquals(t, "2019-06-30T05:18:49Z", allNetworks[0].UpdatedAt.Format(time.RFC3339))
+	th.AssertEquals(t, "2019-06-30T04:15:37Z", allNetworks[1].CreatedAt.Format(time.RFC3339))
+	th.AssertEquals(t, "2019-06-30T05:18:49Z", allNetworks[1].UpdatedAt.Format(time.RFC3339))
 }
 
 func TestGet(t *testing.T) {
@@ -107,8 +107,8 @@ func TestGet(t *testing.T) {
 	n, err := networks.Get(context.TODO(), fake.ServiceClient(fakeServer), "d32019d3-bc6e-4319-9c1d-6722fc136a22").Extract()
 	th.AssertNoErr(t, err)
 	th.CheckDeepEquals(t, &Network1, n)
-	th.AssertEquals(t, n.CreatedAt.Format(time.RFC3339), "2019-06-30T04:15:37Z")
-	th.AssertEquals(t, n.UpdatedAt.Format(time.RFC3339), "2019-06-30T05:18:49Z")
+	th.AssertEquals(t, "2019-06-30T04:15:37Z", n.CreatedAt.Format(time.RFC3339))
+	th.AssertEquals(t, "2019-06-30T05:18:49Z", n.UpdatedAt.Format(time.RFC3339))
 }
 
 func TestGetWithExtensions(t *testing.T) {
@@ -133,8 +133,8 @@ func TestGetWithExtensions(t *testing.T) {
 	err := networks.Get(context.TODO(), fake.ServiceClient(fakeServer), "d32019d3-bc6e-4319-9c1d-6722fc136a22").ExtractInto(&networkWithExtensions)
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, networkWithExtensions.Status, "ACTIVE")
-	th.AssertEquals(t, networkWithExtensions.PortSecurityEnabled, true)
+	th.AssertEquals(t, "ACTIVE", networkWithExtensions.Status)
+	th.AssertEquals(t, true, networkWithExtensions.PortSecurityEnabled)
 }
 
 func TestCreate(t *testing.T) {
@@ -158,10 +158,10 @@ func TestCreate(t *testing.T) {
 	n, err := networks.Create(context.TODO(), fake.ServiceClient(fakeServer), options).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, n.Status, "ACTIVE")
+	th.AssertEquals(t, "ACTIVE", n.Status)
 	th.AssertDeepEquals(t, &Network2, n)
-	th.AssertEquals(t, n.CreatedAt.Format(time.RFC3339), "2019-06-30T04:15:37Z")
-	th.AssertEquals(t, n.UpdatedAt.Format(time.RFC3339), "2019-06-30T05:18:49Z")
+	th.AssertEquals(t, "2019-06-30T04:15:37Z", n.CreatedAt.Format(time.RFC3339))
+	th.AssertEquals(t, "2019-06-30T05:18:49Z", n.UpdatedAt.Format(time.RFC3339))
 }
 
 func TestCreateWithOptionalFields(t *testing.T) {
@@ -214,12 +214,12 @@ func TestUpdate(t *testing.T) {
 	n, err := networks.Update(context.TODO(), fake.ServiceClient(fakeServer), "4e8e5957-649f-477b-9e5b-f1f75b21c03c", options).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, n.Name, "new_network_name")
-	th.AssertEquals(t, n.AdminStateUp, false)
-	th.AssertEquals(t, n.Shared, true)
-	th.AssertEquals(t, n.ID, "4e8e5957-649f-477b-9e5b-f1f75b21c03c")
-	th.AssertEquals(t, n.CreatedAt.Format(time.RFC3339), "2019-06-30T04:15:37Z")
-	th.AssertEquals(t, n.UpdatedAt.Format(time.RFC3339), "2019-06-30T05:18:49Z")
+	th.AssertEquals(t, "new_network_name", n.Name)
+	th.AssertEquals(t, false, n.AdminStateUp)
+	th.AssertEquals(t, true, n.Shared)
+	th.AssertEquals(t, "4e8e5957-649f-477b-9e5b-f1f75b21c03c", n.ID)
+	th.AssertEquals(t, "2019-06-30T04:15:37Z", n.CreatedAt.Format(time.RFC3339))
+	th.AssertEquals(t, "2019-06-30T05:18:49Z", n.UpdatedAt.Format(time.RFC3339))
 }
 
 func TestUpdateRevision(t *testing.T) {
@@ -312,8 +312,8 @@ func TestCreatePortSecurity(t *testing.T) {
 	err := networks.Create(context.TODO(), fake.ServiceClient(fakeServer), createOpts).ExtractInto(&networkWithExtensions)
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, networkWithExtensions.Status, "ACTIVE")
-	th.AssertEquals(t, networkWithExtensions.PortSecurityEnabled, false)
+	th.AssertEquals(t, "ACTIVE", networkWithExtensions.Status)
+	th.AssertEquals(t, false, networkWithExtensions.PortSecurityEnabled)
 }
 
 func TestUpdatePortSecurity(t *testing.T) {
@@ -348,9 +348,9 @@ func TestUpdatePortSecurity(t *testing.T) {
 	err := networks.Update(context.TODO(), fake.ServiceClient(fakeServer), "4e8e5957-649f-477b-9e5b-f1f75b21c03c", updateOpts).ExtractInto(&networkWithExtensions)
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, networkWithExtensions.Name, "private")
-	th.AssertEquals(t, networkWithExtensions.AdminStateUp, true)
-	th.AssertEquals(t, networkWithExtensions.Shared, false)
-	th.AssertEquals(t, networkWithExtensions.ID, "4e8e5957-649f-477b-9e5b-f1f75b21c03c")
-	th.AssertEquals(t, networkWithExtensions.PortSecurityEnabled, false)
+	th.AssertEquals(t, "private", networkWithExtensions.Name)
+	th.AssertEquals(t, true, networkWithExtensions.AdminStateUp)
+	th.AssertEquals(t, false, networkWithExtensions.Shared)
+	th.AssertEquals(t, "4e8e5957-649f-477b-9e5b-f1f75b21c03c", networkWithExtensions.ID)
+	th.AssertEquals(t, false, networkWithExtensions.PortSecurityEnabled)
 }

--- a/openstack/networking/v2/ports/testing/requests_test.go
+++ b/openstack/networking/v2/ports/testing/requests_test.go
@@ -102,8 +102,8 @@ func TestListWithExtensions(t *testing.T) {
 	err = ports.ExtractPortsInto(allPages, &allPorts)
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, allPorts[0].Status, "ACTIVE")
-	th.AssertEquals(t, allPorts[0].PortSecurityEnabled, false)
+	th.AssertEquals(t, "ACTIVE", allPorts[0].Status)
+	th.AssertEquals(t, false, allPorts[0].PortSecurityEnabled)
 }
 
 func TestGet(t *testing.T) {
@@ -123,20 +123,20 @@ func TestGet(t *testing.T) {
 	n, err := ports.Get(context.TODO(), fake.ServiceClient(fakeServer), "46d4bfb9-b26e-41f3-bd2e-e6dcc1ccedb2").Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, n.Status, "ACTIVE")
-	th.AssertEquals(t, n.Name, "")
-	th.AssertEquals(t, n.AdminStateUp, true)
-	th.AssertEquals(t, n.NetworkID, "a87cc70a-3e15-4acf-8205-9b711a3531b7")
-	th.AssertEquals(t, n.TenantID, "7e02058126cc4950b75f9970368ba177")
-	th.AssertEquals(t, n.DeviceOwner, "network:router_interface")
-	th.AssertEquals(t, n.MACAddress, "fa:16:3e:23:fd:d7")
-	th.AssertDeepEquals(t, n.FixedIPs, []ports.IP{
+	th.AssertEquals(t, "ACTIVE", n.Status)
+	th.AssertEquals(t, "", n.Name)
+	th.AssertEquals(t, true, n.AdminStateUp)
+	th.AssertEquals(t, "a87cc70a-3e15-4acf-8205-9b711a3531b7", n.NetworkID)
+	th.AssertEquals(t, "7e02058126cc4950b75f9970368ba177", n.TenantID)
+	th.AssertEquals(t, "network:router_interface", n.DeviceOwner)
+	th.AssertEquals(t, "fa:16:3e:23:fd:d7", n.MACAddress)
+	th.AssertDeepEquals(t, []ports.IP{
 		{SubnetID: "a0304c3a-4f08-4c43-88af-d796509c97d2", IPAddress: "10.0.0.1"},
-	})
-	th.AssertEquals(t, n.ID, "46d4bfb9-b26e-41f3-bd2e-e6dcc1ccedb2")
-	th.AssertDeepEquals(t, n.SecurityGroups, []string{})
-	th.AssertEquals(t, n.Status, "ACTIVE")
-	th.AssertEquals(t, n.DeviceID, "5e3898d7-11be-483e-9732-b2f5eccd2b2e")
+	}, n.FixedIPs)
+	th.AssertEquals(t, "46d4bfb9-b26e-41f3-bd2e-e6dcc1ccedb2", n.ID)
+	th.AssertDeepEquals(t, []string{}, n.SecurityGroups)
+	th.AssertEquals(t, "ACTIVE", n.Status)
+	th.AssertEquals(t, "5e3898d7-11be-483e-9732-b2f5eccd2b2e", n.DeviceID)
 	th.AssertEquals(t, n.CreatedAt, time.Date(2019, time.June, 30, 4, 15, 37, 0, time.UTC))
 	th.AssertEquals(t, n.UpdatedAt, time.Date(2019, time.June, 30, 5, 18, 49, 0, time.UTC))
 }
@@ -163,8 +163,8 @@ func TestGetWithExtensions(t *testing.T) {
 	err := ports.Get(context.TODO(), fake.ServiceClient(fakeServer), "46d4bfb9-b26e-41f3-bd2e-e6dcc1ccedb2").ExtractInto(&portWithExtensions)
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, portWithExtensions.Status, "ACTIVE")
-	th.AssertEquals(t, portWithExtensions.PortSecurityEnabled, false)
+	th.AssertEquals(t, "ACTIVE", portWithExtensions.Status)
+	th.AssertEquals(t, false, portWithExtensions.PortSecurityEnabled)
 }
 
 func TestCreate(t *testing.T) {
@@ -200,21 +200,21 @@ func TestCreate(t *testing.T) {
 	n, err := ports.Create(context.TODO(), fake.ServiceClient(fakeServer), options).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, n.Status, "DOWN")
-	th.AssertEquals(t, n.Name, "private-port")
-	th.AssertEquals(t, n.AdminStateUp, true)
-	th.AssertEquals(t, n.NetworkID, "a87cc70a-3e15-4acf-8205-9b711a3531b7")
-	th.AssertEquals(t, n.TenantID, "d6700c0c9ffa4f1cb322cd4a1f3906fa")
-	th.AssertEquals(t, n.DeviceOwner, "")
-	th.AssertEquals(t, n.MACAddress, "fa:16:3e:c9:cb:f0")
-	th.AssertDeepEquals(t, n.FixedIPs, []ports.IP{
+	th.AssertEquals(t, "DOWN", n.Status)
+	th.AssertEquals(t, "private-port", n.Name)
+	th.AssertEquals(t, true, n.AdminStateUp)
+	th.AssertEquals(t, "a87cc70a-3e15-4acf-8205-9b711a3531b7", n.NetworkID)
+	th.AssertEquals(t, "d6700c0c9ffa4f1cb322cd4a1f3906fa", n.TenantID)
+	th.AssertEquals(t, "", n.DeviceOwner)
+	th.AssertEquals(t, "fa:16:3e:c9:cb:f0", n.MACAddress)
+	th.AssertDeepEquals(t, []ports.IP{
 		{SubnetID: "a0304c3a-4f08-4c43-88af-d796509c97d2", IPAddress: "10.0.0.2"},
-	})
-	th.AssertEquals(t, n.ID, "65c0ee9f-d634-4522-8954-51021b570b0d")
-	th.AssertDeepEquals(t, n.SecurityGroups, []string{"f0ac4394-7e4a-4409-9701-ba8be283dbc3"})
-	th.AssertDeepEquals(t, n.AllowedAddressPairs, []ports.AddressPair{
+	}, n.FixedIPs)
+	th.AssertEquals(t, "65c0ee9f-d634-4522-8954-51021b570b0d", n.ID)
+	th.AssertDeepEquals(t, []string{"f0ac4394-7e4a-4409-9701-ba8be283dbc3"}, n.SecurityGroups)
+	th.AssertDeepEquals(t, []ports.AddressPair{
 		{IPAddress: "10.0.0.4", MACAddress: "fa:16:3e:c9:cb:f0"},
-	})
+	}, n.AllowedAddressPairs)
 }
 
 func TestCreateOmitSecurityGroups(t *testing.T) {
@@ -249,21 +249,21 @@ func TestCreateOmitSecurityGroups(t *testing.T) {
 	n, err := ports.Create(context.TODO(), fake.ServiceClient(fakeServer), options).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, n.Status, "DOWN")
-	th.AssertEquals(t, n.Name, "private-port")
-	th.AssertEquals(t, n.AdminStateUp, true)
-	th.AssertEquals(t, n.NetworkID, "a87cc70a-3e15-4acf-8205-9b711a3531b7")
-	th.AssertEquals(t, n.TenantID, "d6700c0c9ffa4f1cb322cd4a1f3906fa")
-	th.AssertEquals(t, n.DeviceOwner, "")
-	th.AssertEquals(t, n.MACAddress, "fa:16:3e:c9:cb:f0")
-	th.AssertDeepEquals(t, n.FixedIPs, []ports.IP{
+	th.AssertEquals(t, "DOWN", n.Status)
+	th.AssertEquals(t, "private-port", n.Name)
+	th.AssertEquals(t, true, n.AdminStateUp)
+	th.AssertEquals(t, "a87cc70a-3e15-4acf-8205-9b711a3531b7", n.NetworkID)
+	th.AssertEquals(t, "d6700c0c9ffa4f1cb322cd4a1f3906fa", n.TenantID)
+	th.AssertEquals(t, "", n.DeviceOwner)
+	th.AssertEquals(t, "fa:16:3e:c9:cb:f0", n.MACAddress)
+	th.AssertDeepEquals(t, []ports.IP{
 		{SubnetID: "a0304c3a-4f08-4c43-88af-d796509c97d2", IPAddress: "10.0.0.2"},
-	})
-	th.AssertEquals(t, n.ID, "65c0ee9f-d634-4522-8954-51021b570b0d")
-	th.AssertDeepEquals(t, n.SecurityGroups, []string{"f0ac4394-7e4a-4409-9701-ba8be283dbc3"})
-	th.AssertDeepEquals(t, n.AllowedAddressPairs, []ports.AddressPair{
+	}, n.FixedIPs)
+	th.AssertEquals(t, "65c0ee9f-d634-4522-8954-51021b570b0d", n.ID)
+	th.AssertDeepEquals(t, []string{"f0ac4394-7e4a-4409-9701-ba8be283dbc3"}, n.SecurityGroups)
+	th.AssertDeepEquals(t, []ports.AddressPair{
 		{IPAddress: "10.0.0.4", MACAddress: "fa:16:3e:c9:cb:f0"},
-	})
+	}, n.AllowedAddressPairs)
 }
 
 func TestCreateWithNoSecurityGroup(t *testing.T) {
@@ -299,20 +299,20 @@ func TestCreateWithNoSecurityGroup(t *testing.T) {
 	n, err := ports.Create(context.TODO(), fake.ServiceClient(fakeServer), options).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, n.Status, "DOWN")
-	th.AssertEquals(t, n.Name, "private-port")
-	th.AssertEquals(t, n.AdminStateUp, true)
-	th.AssertEquals(t, n.NetworkID, "a87cc70a-3e15-4acf-8205-9b711a3531b7")
-	th.AssertEquals(t, n.TenantID, "d6700c0c9ffa4f1cb322cd4a1f3906fa")
-	th.AssertEquals(t, n.DeviceOwner, "")
-	th.AssertEquals(t, n.MACAddress, "fa:16:3e:c9:cb:f0")
-	th.AssertDeepEquals(t, n.FixedIPs, []ports.IP{
+	th.AssertEquals(t, "DOWN", n.Status)
+	th.AssertEquals(t, "private-port", n.Name)
+	th.AssertEquals(t, true, n.AdminStateUp)
+	th.AssertEquals(t, "a87cc70a-3e15-4acf-8205-9b711a3531b7", n.NetworkID)
+	th.AssertEquals(t, "d6700c0c9ffa4f1cb322cd4a1f3906fa", n.TenantID)
+	th.AssertEquals(t, "", n.DeviceOwner)
+	th.AssertEquals(t, "fa:16:3e:c9:cb:f0", n.MACAddress)
+	th.AssertDeepEquals(t, []ports.IP{
 		{SubnetID: "a0304c3a-4f08-4c43-88af-d796509c97d2", IPAddress: "10.0.0.2"},
-	})
-	th.AssertEquals(t, n.ID, "65c0ee9f-d634-4522-8954-51021b570b0d")
-	th.AssertDeepEquals(t, n.AllowedAddressPairs, []ports.AddressPair{
+	}, n.FixedIPs)
+	th.AssertEquals(t, "65c0ee9f-d634-4522-8954-51021b570b0d", n.ID)
+	th.AssertDeepEquals(t, []ports.AddressPair{
 		{IPAddress: "10.0.0.4", MACAddress: "fa:16:3e:c9:cb:f0"},
-	})
+	}, n.AllowedAddressPairs)
 }
 
 func TestCreateWithPropagateUplinkStatus(t *testing.T) {
@@ -346,17 +346,17 @@ func TestCreateWithPropagateUplinkStatus(t *testing.T) {
 	n, err := ports.Create(context.TODO(), fake.ServiceClient(fakeServer), options).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, n.Status, "DOWN")
-	th.AssertEquals(t, n.Name, "private-port")
-	th.AssertEquals(t, n.AdminStateUp, true)
-	th.AssertEquals(t, n.NetworkID, "a87cc70a-3e15-4acf-8205-9b711a3531b7")
-	th.AssertEquals(t, n.TenantID, "d6700c0c9ffa4f1cb322cd4a1f3906fa")
-	th.AssertEquals(t, n.DeviceOwner, "")
-	th.AssertEquals(t, n.MACAddress, "fa:16:3e:c9:cb:f0")
-	th.AssertDeepEquals(t, n.FixedIPs, []ports.IP{
+	th.AssertEquals(t, "DOWN", n.Status)
+	th.AssertEquals(t, "private-port", n.Name)
+	th.AssertEquals(t, true, n.AdminStateUp)
+	th.AssertEquals(t, "a87cc70a-3e15-4acf-8205-9b711a3531b7", n.NetworkID)
+	th.AssertEquals(t, "d6700c0c9ffa4f1cb322cd4a1f3906fa", n.TenantID)
+	th.AssertEquals(t, "", n.DeviceOwner)
+	th.AssertEquals(t, "fa:16:3e:c9:cb:f0", n.MACAddress)
+	th.AssertDeepEquals(t, []ports.IP{
 		{SubnetID: "a0304c3a-4f08-4c43-88af-d796509c97d2", IPAddress: "10.0.0.2"},
-	})
-	th.AssertEquals(t, n.ID, "65c0ee9f-d634-4522-8954-51021b570b0d")
+	}, n.FixedIPs)
+	th.AssertEquals(t, "65c0ee9f-d634-4522-8954-51021b570b0d", n.ID)
 	th.AssertEquals(t, n.PropagateUplinkStatus, propagateUplinkStatus)
 }
 
@@ -396,21 +396,21 @@ func TestCreateWithValueSpecs(t *testing.T) {
 	n, err := ports.Create(context.TODO(), fake.ServiceClient(fakeServer), options).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, n.Status, "DOWN")
-	th.AssertEquals(t, n.Name, "private-port")
-	th.AssertEquals(t, n.AdminStateUp, true)
-	th.AssertEquals(t, n.NetworkID, "a87cc70a-3e15-4acf-8205-9b711a3531b7")
-	th.AssertEquals(t, n.TenantID, "d6700c0c9ffa4f1cb322cd4a1f3906fa")
-	th.AssertEquals(t, n.DeviceOwner, "")
-	th.AssertEquals(t, n.MACAddress, "fa:16:3e:c9:cb:f0")
-	th.AssertDeepEquals(t, n.FixedIPs, []ports.IP{
+	th.AssertEquals(t, "DOWN", n.Status)
+	th.AssertEquals(t, "private-port", n.Name)
+	th.AssertEquals(t, true, n.AdminStateUp)
+	th.AssertEquals(t, "a87cc70a-3e15-4acf-8205-9b711a3531b7", n.NetworkID)
+	th.AssertEquals(t, "d6700c0c9ffa4f1cb322cd4a1f3906fa", n.TenantID)
+	th.AssertEquals(t, "", n.DeviceOwner)
+	th.AssertEquals(t, "fa:16:3e:c9:cb:f0", n.MACAddress)
+	th.AssertDeepEquals(t, []ports.IP{
 		{SubnetID: "a0304c3a-4f08-4c43-88af-d796509c97d2", IPAddress: "10.0.0.2"},
-	})
-	th.AssertEquals(t, n.ID, "65c0ee9f-d634-4522-8954-51021b570b0d")
-	th.AssertDeepEquals(t, n.SecurityGroups, []string{"f0ac4394-7e4a-4409-9701-ba8be283dbc3"})
-	th.AssertDeepEquals(t, n.AllowedAddressPairs, []ports.AddressPair{
+	}, n.FixedIPs)
+	th.AssertEquals(t, "65c0ee9f-d634-4522-8954-51021b570b0d", n.ID)
+	th.AssertDeepEquals(t, []string{"f0ac4394-7e4a-4409-9701-ba8be283dbc3"}, n.SecurityGroups)
+	th.AssertDeepEquals(t, []ports.AddressPair{
 		{IPAddress: "10.0.0.4", MACAddress: "fa:16:3e:c9:cb:f0"},
-	})
+	}, n.AllowedAddressPairs)
 }
 
 func TestCreateWithInvalidValueSpecs(t *testing.T) {
@@ -516,8 +516,8 @@ func TestCreatePortSecurity(t *testing.T) {
 	err := ports.Create(context.TODO(), fake.ServiceClient(fakeServer), createOpts).ExtractInto(&portWithExt)
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, portWithExt.Status, "DOWN")
-	th.AssertEquals(t, portWithExt.PortSecurityEnabled, false)
+	th.AssertEquals(t, "DOWN", portWithExt.Status)
+	th.AssertEquals(t, false, portWithExt.PortSecurityEnabled)
 }
 
 func TestUpdate(t *testing.T) {
@@ -554,14 +554,14 @@ func TestUpdate(t *testing.T) {
 	s, err := ports.Update(context.TODO(), fake.ServiceClient(fakeServer), "65c0ee9f-d634-4522-8954-51021b570b0d", options).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, s.Name, "new_port_name")
-	th.AssertDeepEquals(t, s.FixedIPs, []ports.IP{
+	th.AssertEquals(t, "new_port_name", s.Name)
+	th.AssertDeepEquals(t, []ports.IP{
 		{SubnetID: "a0304c3a-4f08-4c43-88af-d796509c97d2", IPAddress: "10.0.0.3"},
-	})
-	th.AssertDeepEquals(t, s.AllowedAddressPairs, []ports.AddressPair{
+	}, s.FixedIPs)
+	th.AssertDeepEquals(t, []ports.AddressPair{
 		{IPAddress: "10.0.0.4", MACAddress: "fa:16:3e:c9:cb:f0"},
-	})
-	th.AssertDeepEquals(t, s.SecurityGroups, []string{"f0ac4394-7e4a-4409-9701-ba8be283dbc3"})
+	}, s.AllowedAddressPairs)
+	th.AssertDeepEquals(t, []string{"f0ac4394-7e4a-4409-9701-ba8be283dbc3"}, s.SecurityGroups)
 }
 
 func TestUpdateOmitSecurityGroups(t *testing.T) {
@@ -595,14 +595,14 @@ func TestUpdateOmitSecurityGroups(t *testing.T) {
 	s, err := ports.Update(context.TODO(), fake.ServiceClient(fakeServer), "65c0ee9f-d634-4522-8954-51021b570b0d", options).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, s.Name, "new_port_name")
-	th.AssertDeepEquals(t, s.FixedIPs, []ports.IP{
+	th.AssertEquals(t, "new_port_name", s.Name)
+	th.AssertDeepEquals(t, []ports.IP{
 		{SubnetID: "a0304c3a-4f08-4c43-88af-d796509c97d2", IPAddress: "10.0.0.3"},
-	})
-	th.AssertDeepEquals(t, s.AllowedAddressPairs, []ports.AddressPair{
+	}, s.FixedIPs)
+	th.AssertDeepEquals(t, []ports.AddressPair{
 		{IPAddress: "10.0.0.4", MACAddress: "fa:16:3e:c9:cb:f0"},
-	})
-	th.AssertDeepEquals(t, s.SecurityGroups, []string{"f0ac4394-7e4a-4409-9701-ba8be283dbc3"})
+	}, s.AllowedAddressPairs)
+	th.AssertDeepEquals(t, []string{"f0ac4394-7e4a-4409-9701-ba8be283dbc3"}, s.SecurityGroups)
 }
 
 func TestUpdatePropagateUplinkStatus(t *testing.T) {
@@ -692,9 +692,9 @@ func TestUpdatePortSecurity(t *testing.T) {
 	err := ports.Update(context.TODO(), fake.ServiceClient(fakeServer), "65c0ee9f-d634-4522-8954-51021b570b0d", updateOpts).ExtractInto(&portWithExt)
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, portWithExt.Status, "DOWN")
-	th.AssertEquals(t, portWithExt.Name, "private-port")
-	th.AssertEquals(t, portWithExt.PortSecurityEnabled, false)
+	th.AssertEquals(t, "DOWN", portWithExt.Status)
+	th.AssertEquals(t, "private-port", portWithExt.Name)
+	th.AssertEquals(t, false, portWithExt.PortSecurityEnabled)
 }
 
 func TestUpdateRevision(t *testing.T) {
@@ -782,13 +782,13 @@ func TestRemoveSecurityGroups(t *testing.T) {
 	s, err := ports.Update(context.TODO(), fake.ServiceClient(fakeServer), "65c0ee9f-d634-4522-8954-51021b570b0d", options).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, s.Name, "new_port_name")
-	th.AssertDeepEquals(t, s.FixedIPs, []ports.IP{
+	th.AssertEquals(t, "new_port_name", s.Name)
+	th.AssertDeepEquals(t, []ports.IP{
 		{SubnetID: "a0304c3a-4f08-4c43-88af-d796509c97d2", IPAddress: "10.0.0.3"},
-	})
-	th.AssertDeepEquals(t, s.AllowedAddressPairs, []ports.AddressPair{
+	}, s.FixedIPs)
+	th.AssertDeepEquals(t, []ports.AddressPair{
 		{IPAddress: "10.0.0.4", MACAddress: "fa:16:3e:c9:cb:f0"},
-	})
+	}, s.AllowedAddressPairs)
 	th.AssertDeepEquals(t, s.SecurityGroups, []string(nil))
 }
 
@@ -822,12 +822,12 @@ func TestRemoveAllowedAddressPairs(t *testing.T) {
 	s, err := ports.Update(context.TODO(), fake.ServiceClient(fakeServer), "65c0ee9f-d634-4522-8954-51021b570b0d", options).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, s.Name, "new_port_name")
-	th.AssertDeepEquals(t, s.FixedIPs, []ports.IP{
+	th.AssertEquals(t, "new_port_name", s.Name)
+	th.AssertDeepEquals(t, []ports.IP{
 		{SubnetID: "a0304c3a-4f08-4c43-88af-d796509c97d2", IPAddress: "10.0.0.3"},
-	})
+	}, s.FixedIPs)
 	th.AssertDeepEquals(t, s.AllowedAddressPairs, []ports.AddressPair(nil))
-	th.AssertDeepEquals(t, s.SecurityGroups, []string{"f0ac4394-7e4a-4409-9701-ba8be283dbc3"})
+	th.AssertDeepEquals(t, []string{"f0ac4394-7e4a-4409-9701-ba8be283dbc3"}, s.SecurityGroups)
 }
 
 func TestDontUpdateAllowedAddressPairs(t *testing.T) {
@@ -859,14 +859,14 @@ func TestDontUpdateAllowedAddressPairs(t *testing.T) {
 	s, err := ports.Update(context.TODO(), fake.ServiceClient(fakeServer), "65c0ee9f-d634-4522-8954-51021b570b0d", options).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, s.Name, "new_port_name")
-	th.AssertDeepEquals(t, s.FixedIPs, []ports.IP{
+	th.AssertEquals(t, "new_port_name", s.Name)
+	th.AssertDeepEquals(t, []ports.IP{
 		{SubnetID: "a0304c3a-4f08-4c43-88af-d796509c97d2", IPAddress: "10.0.0.3"},
-	})
-	th.AssertDeepEquals(t, s.AllowedAddressPairs, []ports.AddressPair{
+	}, s.FixedIPs)
+	th.AssertDeepEquals(t, []ports.AddressPair{
 		{IPAddress: "10.0.0.4", MACAddress: "fa:16:3e:c9:cb:f0"},
-	})
-	th.AssertDeepEquals(t, s.SecurityGroups, []string{"f0ac4394-7e4a-4409-9701-ba8be283dbc3"})
+	}, s.AllowedAddressPairs)
+	th.AssertDeepEquals(t, []string{"f0ac4394-7e4a-4409-9701-ba8be283dbc3"}, s.SecurityGroups)
 }
 
 func TestDelete(t *testing.T) {
@@ -905,25 +905,25 @@ func TestGetWithExtraDHCPOpts(t *testing.T) {
 	err := ports.Get(context.TODO(), fake.ServiceClient(fakeServer), "46d4bfb9-b26e-41f3-bd2e-e6dcc1ccedb2").ExtractInto(&s)
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, s.Status, "ACTIVE")
-	th.AssertEquals(t, s.NetworkID, "a87cc70a-3e15-4acf-8205-9b711a3531b7")
-	th.AssertEquals(t, s.TenantID, "d6700c0c9ffa4f1cb322cd4a1f3906fa")
-	th.AssertEquals(t, s.AdminStateUp, true)
-	th.AssertEquals(t, s.Name, "port-with-extra-dhcp-opts")
-	th.AssertEquals(t, s.DeviceOwner, "")
-	th.AssertEquals(t, s.MACAddress, "fa:16:3e:c9:cb:f0")
-	th.AssertDeepEquals(t, s.FixedIPs, []ports.IP{
+	th.AssertEquals(t, "ACTIVE", s.Status)
+	th.AssertEquals(t, "a87cc70a-3e15-4acf-8205-9b711a3531b7", s.NetworkID)
+	th.AssertEquals(t, "d6700c0c9ffa4f1cb322cd4a1f3906fa", s.TenantID)
+	th.AssertEquals(t, true, s.AdminStateUp)
+	th.AssertEquals(t, "port-with-extra-dhcp-opts", s.Name)
+	th.AssertEquals(t, "", s.DeviceOwner)
+	th.AssertEquals(t, "fa:16:3e:c9:cb:f0", s.MACAddress)
+	th.AssertDeepEquals(t, []ports.IP{
 		{SubnetID: "a0304c3a-4f08-4c43-88af-d796509c97d2", IPAddress: "10.0.0.4"},
-	})
-	th.AssertEquals(t, s.ID, "65c0ee9f-d634-4522-8954-51021b570b0d")
-	th.AssertEquals(t, s.DeviceID, "")
+	}, s.FixedIPs)
+	th.AssertEquals(t, "65c0ee9f-d634-4522-8954-51021b570b0d", s.ID)
+	th.AssertEquals(t, "", s.DeviceID)
 
-	th.AssertDeepEquals(t, s.ExtraDHCPOpts[0].OptName, "option1")
-	th.AssertDeepEquals(t, s.ExtraDHCPOpts[0].OptValue, "value1")
-	th.AssertDeepEquals(t, s.ExtraDHCPOpts[0].IPVersion, 4)
-	th.AssertDeepEquals(t, s.ExtraDHCPOpts[1].OptName, "option2")
-	th.AssertDeepEquals(t, s.ExtraDHCPOpts[1].OptValue, "value2")
-	th.AssertDeepEquals(t, s.ExtraDHCPOpts[1].IPVersion, 4)
+	th.AssertDeepEquals(t, "option1", s.ExtraDHCPOpts[0].OptName)
+	th.AssertDeepEquals(t, "value1", s.ExtraDHCPOpts[0].OptValue)
+	th.AssertDeepEquals(t, 4, s.ExtraDHCPOpts[0].IPVersion)
+	th.AssertDeepEquals(t, "option2", s.ExtraDHCPOpts[1].OptName)
+	th.AssertDeepEquals(t, "value2", s.ExtraDHCPOpts[1].OptValue)
+	th.AssertDeepEquals(t, 4, s.ExtraDHCPOpts[1].IPVersion)
 }
 
 func TestCreateWithExtraDHCPOpts(t *testing.T) {
@@ -971,22 +971,22 @@ func TestCreateWithExtraDHCPOpts(t *testing.T) {
 	err := ports.Create(context.TODO(), fake.ServiceClient(fakeServer), createOpts).ExtractInto(&s)
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, s.Status, "DOWN")
-	th.AssertEquals(t, s.NetworkID, "a87cc70a-3e15-4acf-8205-9b711a3531b7")
-	th.AssertEquals(t, s.TenantID, "d6700c0c9ffa4f1cb322cd4a1f3906fa")
-	th.AssertEquals(t, s.AdminStateUp, true)
-	th.AssertEquals(t, s.Name, "port-with-extra-dhcp-opts")
-	th.AssertEquals(t, s.DeviceOwner, "")
-	th.AssertEquals(t, s.MACAddress, "fa:16:3e:c9:cb:f0")
-	th.AssertDeepEquals(t, s.FixedIPs, []ports.IP{
+	th.AssertEquals(t, "DOWN", s.Status)
+	th.AssertEquals(t, "a87cc70a-3e15-4acf-8205-9b711a3531b7", s.NetworkID)
+	th.AssertEquals(t, "d6700c0c9ffa4f1cb322cd4a1f3906fa", s.TenantID)
+	th.AssertEquals(t, true, s.AdminStateUp)
+	th.AssertEquals(t, "port-with-extra-dhcp-opts", s.Name)
+	th.AssertEquals(t, "", s.DeviceOwner)
+	th.AssertEquals(t, "fa:16:3e:c9:cb:f0", s.MACAddress)
+	th.AssertDeepEquals(t, []ports.IP{
 		{SubnetID: "a0304c3a-4f08-4c43-88af-d796509c97d2", IPAddress: "10.0.0.2"},
-	})
-	th.AssertEquals(t, s.ID, "65c0ee9f-d634-4522-8954-51021b570b0d")
-	th.AssertEquals(t, s.DeviceID, "")
+	}, s.FixedIPs)
+	th.AssertEquals(t, "65c0ee9f-d634-4522-8954-51021b570b0d", s.ID)
+	th.AssertEquals(t, "", s.DeviceID)
 
-	th.AssertDeepEquals(t, s.ExtraDHCPOpts[0].OptName, "option1")
-	th.AssertDeepEquals(t, s.ExtraDHCPOpts[0].OptValue, "value1")
-	th.AssertDeepEquals(t, s.ExtraDHCPOpts[0].IPVersion, 4)
+	th.AssertDeepEquals(t, "option1", s.ExtraDHCPOpts[0].OptName)
+	th.AssertDeepEquals(t, "value1", s.ExtraDHCPOpts[0].OptValue)
+	th.AssertDeepEquals(t, 4, s.ExtraDHCPOpts[0].IPVersion)
 }
 
 func TestUpdateWithExtraDHCPOpts(t *testing.T) {
@@ -1036,22 +1036,22 @@ func TestUpdateWithExtraDHCPOpts(t *testing.T) {
 	err := ports.Update(context.TODO(), fake.ServiceClient(fakeServer), "65c0ee9f-d634-4522-8954-51021b570b0d", updateOpts).ExtractInto(&s)
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, s.Status, "DOWN")
-	th.AssertEquals(t, s.NetworkID, "a87cc70a-3e15-4acf-8205-9b711a3531b7")
-	th.AssertEquals(t, s.TenantID, "d6700c0c9ffa4f1cb322cd4a1f3906fa")
-	th.AssertEquals(t, s.AdminStateUp, true)
-	th.AssertEquals(t, s.Name, "updated-port-with-dhcp-opts")
-	th.AssertEquals(t, s.DeviceOwner, "")
-	th.AssertEquals(t, s.MACAddress, "fa:16:3e:c9:cb:f0")
-	th.AssertDeepEquals(t, s.FixedIPs, []ports.IP{
+	th.AssertEquals(t, "DOWN", s.Status)
+	th.AssertEquals(t, "a87cc70a-3e15-4acf-8205-9b711a3531b7", s.NetworkID)
+	th.AssertEquals(t, "d6700c0c9ffa4f1cb322cd4a1f3906fa", s.TenantID)
+	th.AssertEquals(t, true, s.AdminStateUp)
+	th.AssertEquals(t, "updated-port-with-dhcp-opts", s.Name)
+	th.AssertEquals(t, "", s.DeviceOwner)
+	th.AssertEquals(t, "fa:16:3e:c9:cb:f0", s.MACAddress)
+	th.AssertDeepEquals(t, []ports.IP{
 		{SubnetID: "a0304c3a-4f08-4c43-88af-d796509c97d2", IPAddress: "10.0.0.3"},
-	})
-	th.AssertEquals(t, s.ID, "65c0ee9f-d634-4522-8954-51021b570b0d")
-	th.AssertEquals(t, s.DeviceID, "")
+	}, s.FixedIPs)
+	th.AssertEquals(t, "65c0ee9f-d634-4522-8954-51021b570b0d", s.ID)
+	th.AssertEquals(t, "", s.DeviceID)
 
-	th.AssertDeepEquals(t, s.ExtraDHCPOpts[0].OptName, "option2")
-	th.AssertDeepEquals(t, s.ExtraDHCPOpts[0].OptValue, "value2")
-	th.AssertDeepEquals(t, s.ExtraDHCPOpts[0].IPVersion, 4)
+	th.AssertDeepEquals(t, "option2", s.ExtraDHCPOpts[0].OptName)
+	th.AssertDeepEquals(t, "value2", s.ExtraDHCPOpts[0].OptValue)
+	th.AssertDeepEquals(t, 4, s.ExtraDHCPOpts[0].IPVersion)
 }
 
 func TestPortsListOpts(t *testing.T) {

--- a/openstack/networking/v2/ports/testing/requests_test.go
+++ b/openstack/networking/v2/ports/testing/requests_test.go
@@ -103,7 +103,7 @@ func TestListWithExtensions(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	th.AssertEquals(t, "ACTIVE", allPorts[0].Status)
-	th.AssertEquals(t, false, allPorts[0].PortSecurityEnabled)
+	th.AssertFalse(t, allPorts[0].PortSecurityEnabled)
 }
 
 func TestGet(t *testing.T) {
@@ -125,7 +125,7 @@ func TestGet(t *testing.T) {
 
 	th.AssertEquals(t, "ACTIVE", n.Status)
 	th.AssertEquals(t, "", n.Name)
-	th.AssertEquals(t, true, n.AdminStateUp)
+	th.AssertTrue(t, n.AdminStateUp)
 	th.AssertEquals(t, "a87cc70a-3e15-4acf-8205-9b711a3531b7", n.NetworkID)
 	th.AssertEquals(t, "7e02058126cc4950b75f9970368ba177", n.TenantID)
 	th.AssertEquals(t, "network:router_interface", n.DeviceOwner)
@@ -164,7 +164,7 @@ func TestGetWithExtensions(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	th.AssertEquals(t, "ACTIVE", portWithExtensions.Status)
-	th.AssertEquals(t, false, portWithExtensions.PortSecurityEnabled)
+	th.AssertFalse(t, portWithExtensions.PortSecurityEnabled)
 }
 
 func TestCreate(t *testing.T) {
@@ -202,7 +202,7 @@ func TestCreate(t *testing.T) {
 
 	th.AssertEquals(t, "DOWN", n.Status)
 	th.AssertEquals(t, "private-port", n.Name)
-	th.AssertEquals(t, true, n.AdminStateUp)
+	th.AssertTrue(t, n.AdminStateUp)
 	th.AssertEquals(t, "a87cc70a-3e15-4acf-8205-9b711a3531b7", n.NetworkID)
 	th.AssertEquals(t, "d6700c0c9ffa4f1cb322cd4a1f3906fa", n.TenantID)
 	th.AssertEquals(t, "", n.DeviceOwner)
@@ -251,7 +251,7 @@ func TestCreateOmitSecurityGroups(t *testing.T) {
 
 	th.AssertEquals(t, "DOWN", n.Status)
 	th.AssertEquals(t, "private-port", n.Name)
-	th.AssertEquals(t, true, n.AdminStateUp)
+	th.AssertTrue(t, n.AdminStateUp)
 	th.AssertEquals(t, "a87cc70a-3e15-4acf-8205-9b711a3531b7", n.NetworkID)
 	th.AssertEquals(t, "d6700c0c9ffa4f1cb322cd4a1f3906fa", n.TenantID)
 	th.AssertEquals(t, "", n.DeviceOwner)
@@ -301,7 +301,7 @@ func TestCreateWithNoSecurityGroup(t *testing.T) {
 
 	th.AssertEquals(t, "DOWN", n.Status)
 	th.AssertEquals(t, "private-port", n.Name)
-	th.AssertEquals(t, true, n.AdminStateUp)
+	th.AssertTrue(t, n.AdminStateUp)
 	th.AssertEquals(t, "a87cc70a-3e15-4acf-8205-9b711a3531b7", n.NetworkID)
 	th.AssertEquals(t, "d6700c0c9ffa4f1cb322cd4a1f3906fa", n.TenantID)
 	th.AssertEquals(t, "", n.DeviceOwner)
@@ -348,7 +348,7 @@ func TestCreateWithPropagateUplinkStatus(t *testing.T) {
 
 	th.AssertEquals(t, "DOWN", n.Status)
 	th.AssertEquals(t, "private-port", n.Name)
-	th.AssertEquals(t, true, n.AdminStateUp)
+	th.AssertTrue(t, n.AdminStateUp)
 	th.AssertEquals(t, "a87cc70a-3e15-4acf-8205-9b711a3531b7", n.NetworkID)
 	th.AssertEquals(t, "d6700c0c9ffa4f1cb322cd4a1f3906fa", n.TenantID)
 	th.AssertEquals(t, "", n.DeviceOwner)
@@ -398,7 +398,7 @@ func TestCreateWithValueSpecs(t *testing.T) {
 
 	th.AssertEquals(t, "DOWN", n.Status)
 	th.AssertEquals(t, "private-port", n.Name)
-	th.AssertEquals(t, true, n.AdminStateUp)
+	th.AssertTrue(t, n.AdminStateUp)
 	th.AssertEquals(t, "a87cc70a-3e15-4acf-8205-9b711a3531b7", n.NetworkID)
 	th.AssertEquals(t, "d6700c0c9ffa4f1cb322cd4a1f3906fa", n.TenantID)
 	th.AssertEquals(t, "", n.DeviceOwner)
@@ -517,7 +517,7 @@ func TestCreatePortSecurity(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	th.AssertEquals(t, "DOWN", portWithExt.Status)
-	th.AssertEquals(t, false, portWithExt.PortSecurityEnabled)
+	th.AssertFalse(t, portWithExt.PortSecurityEnabled)
 }
 
 func TestUpdate(t *testing.T) {
@@ -694,7 +694,7 @@ func TestUpdatePortSecurity(t *testing.T) {
 
 	th.AssertEquals(t, "DOWN", portWithExt.Status)
 	th.AssertEquals(t, "private-port", portWithExt.Name)
-	th.AssertEquals(t, false, portWithExt.PortSecurityEnabled)
+	th.AssertFalse(t, portWithExt.PortSecurityEnabled)
 }
 
 func TestUpdateRevision(t *testing.T) {
@@ -908,7 +908,7 @@ func TestGetWithExtraDHCPOpts(t *testing.T) {
 	th.AssertEquals(t, "ACTIVE", s.Status)
 	th.AssertEquals(t, "a87cc70a-3e15-4acf-8205-9b711a3531b7", s.NetworkID)
 	th.AssertEquals(t, "d6700c0c9ffa4f1cb322cd4a1f3906fa", s.TenantID)
-	th.AssertEquals(t, true, s.AdminStateUp)
+	th.AssertTrue(t, s.AdminStateUp)
 	th.AssertEquals(t, "port-with-extra-dhcp-opts", s.Name)
 	th.AssertEquals(t, "", s.DeviceOwner)
 	th.AssertEquals(t, "fa:16:3e:c9:cb:f0", s.MACAddress)
@@ -974,7 +974,7 @@ func TestCreateWithExtraDHCPOpts(t *testing.T) {
 	th.AssertEquals(t, "DOWN", s.Status)
 	th.AssertEquals(t, "a87cc70a-3e15-4acf-8205-9b711a3531b7", s.NetworkID)
 	th.AssertEquals(t, "d6700c0c9ffa4f1cb322cd4a1f3906fa", s.TenantID)
-	th.AssertEquals(t, true, s.AdminStateUp)
+	th.AssertTrue(t, s.AdminStateUp)
 	th.AssertEquals(t, "port-with-extra-dhcp-opts", s.Name)
 	th.AssertEquals(t, "", s.DeviceOwner)
 	th.AssertEquals(t, "fa:16:3e:c9:cb:f0", s.MACAddress)
@@ -1039,7 +1039,7 @@ func TestUpdateWithExtraDHCPOpts(t *testing.T) {
 	th.AssertEquals(t, "DOWN", s.Status)
 	th.AssertEquals(t, "a87cc70a-3e15-4acf-8205-9b711a3531b7", s.NetworkID)
 	th.AssertEquals(t, "d6700c0c9ffa4f1cb322cd4a1f3906fa", s.TenantID)
-	th.AssertEquals(t, true, s.AdminStateUp)
+	th.AssertTrue(t, s.AdminStateUp)
 	th.AssertEquals(t, "updated-port-with-dhcp-opts", s.Name)
 	th.AssertEquals(t, "", s.DeviceOwner)
 	th.AssertEquals(t, "fa:16:3e:c9:cb:f0", s.MACAddress)

--- a/openstack/networking/v2/subnets/testing/requests_test.go
+++ b/openstack/networking/v2/subnets/testing/requests_test.go
@@ -72,7 +72,7 @@ func TestGet(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	th.AssertEquals(t, "my_subnet", s.Name)
-	th.AssertEquals(t, true, s.EnableDHCP)
+	th.AssertTrue(t, s.EnableDHCP)
 	th.AssertEquals(t, "d32019d3-bc6e-4319-9c1d-6722fc136a22", s.NetworkID)
 	th.AssertEquals(t, "4fd44f30292945e481c7b8a0c8908869", s.TenantID)
 	th.AssertDeepEquals(t, []string{}, s.DNSNameservers)
@@ -132,8 +132,8 @@ func TestCreate(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	th.AssertEquals(t, "", s.Name)
-	th.AssertEquals(t, true, s.DNSPublishFixedIP)
-	th.AssertEquals(t, true, s.EnableDHCP)
+	th.AssertTrue(t, s.DNSPublishFixedIP)
+	th.AssertTrue(t, s.EnableDHCP)
 	th.AssertEquals(t, "d32019d3-bc6e-4319-9c1d-6722fc136a22", s.NetworkID)
 	th.AssertEquals(t, "4fd44f30292945e481c7b8a0c8908869", s.TenantID)
 	th.AssertDeepEquals(t, []string{"foo"}, s.DNSNameservers)
@@ -187,7 +187,7 @@ func TestCreateNoGateway(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	th.AssertEquals(t, "", s.Name)
-	th.AssertEquals(t, true, s.EnableDHCP)
+	th.AssertTrue(t, s.EnableDHCP)
 	th.AssertEquals(t, "d32019d3-bc6e-4319-9c1d-6722fc136a23", s.NetworkID)
 	th.AssertEquals(t, "4fd44f30292945e481c7b8a0c8908869", s.TenantID)
 	th.AssertDeepEquals(t, []subnets.AllocationPool{
@@ -236,7 +236,7 @@ func TestCreateDefaultGateway(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	th.AssertEquals(t, "", s.Name)
-	th.AssertEquals(t, true, s.EnableDHCP)
+	th.AssertTrue(t, s.EnableDHCP)
 	th.AssertEquals(t, "d32019d3-bc6e-4319-9c1d-6722fc136a23", s.NetworkID)
 	th.AssertEquals(t, "4fd44f30292945e481c7b8a0c8908869", s.TenantID)
 	th.AssertDeepEquals(t, []subnets.AllocationPool{
@@ -282,7 +282,7 @@ func TestCreateIPv6RaAddressMode(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	th.AssertEquals(t, "", s.Name)
-	th.AssertEquals(t, true, s.EnableDHCP)
+	th.AssertTrue(t, s.EnableDHCP)
 	th.AssertEquals(t, "d32019d3-bc6e-4319-9c1d-6722fc136a22", s.NetworkID)
 	th.AssertEquals(t, "4fd44f30292945e481c7b8a0c8908869", s.TenantID)
 	th.AssertEquals(t, 6, s.IPVersion)
@@ -323,8 +323,8 @@ func TestCreateWithNoCIDR(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	th.AssertEquals(t, "", s.Name)
-	th.AssertEquals(t, true, s.DNSPublishFixedIP)
-	th.AssertEquals(t, true, s.EnableDHCP)
+	th.AssertTrue(t, s.DNSPublishFixedIP)
+	th.AssertTrue(t, s.EnableDHCP)
 	th.AssertEquals(t, "d32019d3-bc6e-4319-9c1d-6722fc136a22", s.NetworkID)
 	th.AssertEquals(t, "4fd44f30292945e481c7b8a0c8908869", s.TenantID)
 	th.AssertDeepEquals(t, []string{"foo"}, s.DNSNameservers)
@@ -373,8 +373,8 @@ func TestCreateWithPrefixlen(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	th.AssertEquals(t, "", s.Name)
-	th.AssertEquals(t, true, s.DNSPublishFixedIP)
-	th.AssertEquals(t, true, s.EnableDHCP)
+	th.AssertTrue(t, s.DNSPublishFixedIP)
+	th.AssertTrue(t, s.EnableDHCP)
 	th.AssertEquals(t, "d32019d3-bc6e-4319-9c1d-6722fc136a22", s.NetworkID)
 	th.AssertEquals(t, "4fd44f30292945e481c7b8a0c8908869", s.TenantID)
 	th.AssertDeepEquals(t, []string{"foo"}, s.DNSNameservers)

--- a/openstack/networking/v2/subnets/testing/requests_test.go
+++ b/openstack/networking/v2/subnets/testing/requests_test.go
@@ -71,23 +71,23 @@ func TestGet(t *testing.T) {
 	s, err := subnets.Get(context.TODO(), fake.ServiceClient(fakeServer), "54d6f61d-db07-451c-9ab3-b9609b6b6f0b").Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, s.Name, "my_subnet")
-	th.AssertEquals(t, s.EnableDHCP, true)
-	th.AssertEquals(t, s.NetworkID, "d32019d3-bc6e-4319-9c1d-6722fc136a22")
-	th.AssertEquals(t, s.TenantID, "4fd44f30292945e481c7b8a0c8908869")
-	th.AssertDeepEquals(t, s.DNSNameservers, []string{})
-	th.AssertDeepEquals(t, s.AllocationPools, []subnets.AllocationPool{
+	th.AssertEquals(t, "my_subnet", s.Name)
+	th.AssertEquals(t, true, s.EnableDHCP)
+	th.AssertEquals(t, "d32019d3-bc6e-4319-9c1d-6722fc136a22", s.NetworkID)
+	th.AssertEquals(t, "4fd44f30292945e481c7b8a0c8908869", s.TenantID)
+	th.AssertDeepEquals(t, []string{}, s.DNSNameservers)
+	th.AssertDeepEquals(t, []subnets.AllocationPool{
 		{
 			Start: "192.0.0.2",
 			End:   "192.255.255.254",
 		},
-	})
-	th.AssertDeepEquals(t, s.HostRoutes, []subnets.HostRoute{})
-	th.AssertEquals(t, s.IPVersion, 4)
-	th.AssertEquals(t, s.GatewayIP, "192.0.0.1")
-	th.AssertEquals(t, s.CIDR, "192.0.0.0/8")
-	th.AssertEquals(t, s.ID, "54d6f61d-db07-451c-9ab3-b9609b6b6f0b")
-	th.AssertEquals(t, s.SubnetPoolID, "b80340c7-9960-4f67-a99c-02501656284b")
+	}, s.AllocationPools)
+	th.AssertDeepEquals(t, []subnets.HostRoute{}, s.HostRoutes)
+	th.AssertEquals(t, 4, s.IPVersion)
+	th.AssertEquals(t, "192.0.0.1", s.GatewayIP)
+	th.AssertEquals(t, "192.0.0.0/8", s.CIDR)
+	th.AssertEquals(t, "54d6f61d-db07-451c-9ab3-b9609b6b6f0b", s.ID)
+	th.AssertEquals(t, "b80340c7-9960-4f67-a99c-02501656284b", s.SubnetPoolID)
 }
 
 func TestCreate(t *testing.T) {
@@ -131,25 +131,25 @@ func TestCreate(t *testing.T) {
 	s, err := subnets.Create(context.TODO(), fake.ServiceClient(fakeServer), opts).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, s.Name, "")
-	th.AssertEquals(t, s.DNSPublishFixedIP, true)
-	th.AssertEquals(t, s.EnableDHCP, true)
-	th.AssertEquals(t, s.NetworkID, "d32019d3-bc6e-4319-9c1d-6722fc136a22")
-	th.AssertEquals(t, s.TenantID, "4fd44f30292945e481c7b8a0c8908869")
-	th.AssertDeepEquals(t, s.DNSNameservers, []string{"foo"})
-	th.AssertDeepEquals(t, s.ServiceTypes, []string{"network:routed"})
-	th.AssertDeepEquals(t, s.AllocationPools, []subnets.AllocationPool{
+	th.AssertEquals(t, "", s.Name)
+	th.AssertEquals(t, true, s.DNSPublishFixedIP)
+	th.AssertEquals(t, true, s.EnableDHCP)
+	th.AssertEquals(t, "d32019d3-bc6e-4319-9c1d-6722fc136a22", s.NetworkID)
+	th.AssertEquals(t, "4fd44f30292945e481c7b8a0c8908869", s.TenantID)
+	th.AssertDeepEquals(t, []string{"foo"}, s.DNSNameservers)
+	th.AssertDeepEquals(t, []string{"network:routed"}, s.ServiceTypes)
+	th.AssertDeepEquals(t, []subnets.AllocationPool{
 		{
 			Start: "192.168.199.2",
 			End:   "192.168.199.254",
 		},
-	})
-	th.AssertDeepEquals(t, s.HostRoutes, []subnets.HostRoute{})
-	th.AssertEquals(t, s.IPVersion, 4)
-	th.AssertEquals(t, s.GatewayIP, "192.168.199.1")
-	th.AssertEquals(t, s.CIDR, "192.168.199.0/24")
-	th.AssertEquals(t, s.ID, "3b80198d-4f7b-4f77-9ef5-774d54e17126")
-	th.AssertEquals(t, s.SubnetPoolID, "b80340c7-9960-4f67-a99c-02501656284b")
+	}, s.AllocationPools)
+	th.AssertDeepEquals(t, []subnets.HostRoute{}, s.HostRoutes)
+	th.AssertEquals(t, 4, s.IPVersion)
+	th.AssertEquals(t, "192.168.199.1", s.GatewayIP)
+	th.AssertEquals(t, "192.168.199.0/24", s.CIDR)
+	th.AssertEquals(t, "3b80198d-4f7b-4f77-9ef5-774d54e17126", s.ID)
+	th.AssertEquals(t, "b80340c7-9960-4f67-a99c-02501656284b", s.SubnetPoolID)
 }
 
 func TestCreateNoGateway(t *testing.T) {
@@ -186,21 +186,21 @@ func TestCreateNoGateway(t *testing.T) {
 	s, err := subnets.Create(context.TODO(), fake.ServiceClient(fakeServer), opts).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, s.Name, "")
-	th.AssertEquals(t, s.EnableDHCP, true)
-	th.AssertEquals(t, s.NetworkID, "d32019d3-bc6e-4319-9c1d-6722fc136a23")
-	th.AssertEquals(t, s.TenantID, "4fd44f30292945e481c7b8a0c8908869")
-	th.AssertDeepEquals(t, s.AllocationPools, []subnets.AllocationPool{
+	th.AssertEquals(t, "", s.Name)
+	th.AssertEquals(t, true, s.EnableDHCP)
+	th.AssertEquals(t, "d32019d3-bc6e-4319-9c1d-6722fc136a23", s.NetworkID)
+	th.AssertEquals(t, "4fd44f30292945e481c7b8a0c8908869", s.TenantID)
+	th.AssertDeepEquals(t, []subnets.AllocationPool{
 		{
 			Start: "192.168.1.2",
 			End:   "192.168.1.254",
 		},
-	})
-	th.AssertDeepEquals(t, s.HostRoutes, []subnets.HostRoute{})
-	th.AssertEquals(t, s.IPVersion, 4)
-	th.AssertEquals(t, s.GatewayIP, "")
-	th.AssertEquals(t, s.CIDR, "192.168.1.0/24")
-	th.AssertEquals(t, s.ID, "54d6f61d-db07-451c-9ab3-b9609b6b6f0c")
+	}, s.AllocationPools)
+	th.AssertDeepEquals(t, []subnets.HostRoute{}, s.HostRoutes)
+	th.AssertEquals(t, 4, s.IPVersion)
+	th.AssertEquals(t, "", s.GatewayIP)
+	th.AssertEquals(t, "192.168.1.0/24", s.CIDR)
+	th.AssertEquals(t, "54d6f61d-db07-451c-9ab3-b9609b6b6f0c", s.ID)
 }
 
 func TestCreateDefaultGateway(t *testing.T) {
@@ -235,21 +235,21 @@ func TestCreateDefaultGateway(t *testing.T) {
 	s, err := subnets.Create(context.TODO(), fake.ServiceClient(fakeServer), opts).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, s.Name, "")
-	th.AssertEquals(t, s.EnableDHCP, true)
-	th.AssertEquals(t, s.NetworkID, "d32019d3-bc6e-4319-9c1d-6722fc136a23")
-	th.AssertEquals(t, s.TenantID, "4fd44f30292945e481c7b8a0c8908869")
-	th.AssertDeepEquals(t, s.AllocationPools, []subnets.AllocationPool{
+	th.AssertEquals(t, "", s.Name)
+	th.AssertEquals(t, true, s.EnableDHCP)
+	th.AssertEquals(t, "d32019d3-bc6e-4319-9c1d-6722fc136a23", s.NetworkID)
+	th.AssertEquals(t, "4fd44f30292945e481c7b8a0c8908869", s.TenantID)
+	th.AssertDeepEquals(t, []subnets.AllocationPool{
 		{
 			Start: "192.168.1.2",
 			End:   "192.168.1.254",
 		},
-	})
-	th.AssertDeepEquals(t, s.HostRoutes, []subnets.HostRoute{})
-	th.AssertEquals(t, s.IPVersion, 4)
-	th.AssertEquals(t, s.GatewayIP, "192.168.1.1")
-	th.AssertEquals(t, s.CIDR, "192.168.1.0/24")
-	th.AssertEquals(t, s.ID, "54d6f61d-db07-451c-9ab3-b9609b6b6f0c")
+	}, s.AllocationPools)
+	th.AssertDeepEquals(t, []subnets.HostRoute{}, s.HostRoutes)
+	th.AssertEquals(t, 4, s.IPVersion)
+	th.AssertEquals(t, "192.168.1.1", s.GatewayIP)
+	th.AssertEquals(t, "192.168.1.0/24", s.CIDR)
+	th.AssertEquals(t, "54d6f61d-db07-451c-9ab3-b9609b6b6f0c", s.ID)
 }
 
 func TestCreateIPv6RaAddressMode(t *testing.T) {
@@ -281,16 +281,16 @@ func TestCreateIPv6RaAddressMode(t *testing.T) {
 	s, err := subnets.Create(context.TODO(), fake.ServiceClient(fakeServer), opts).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, s.Name, "")
-	th.AssertEquals(t, s.EnableDHCP, true)
-	th.AssertEquals(t, s.NetworkID, "d32019d3-bc6e-4319-9c1d-6722fc136a22")
-	th.AssertEquals(t, s.TenantID, "4fd44f30292945e481c7b8a0c8908869")
-	th.AssertEquals(t, s.IPVersion, 6)
-	th.AssertEquals(t, s.GatewayIP, "2001:db8:0:a::1")
-	th.AssertEquals(t, s.CIDR, "2001:db8:0:a:0:0:0:0/64")
-	th.AssertEquals(t, s.ID, "3b80198d-4f7b-4f77-9ef5-774d54e17126")
-	th.AssertEquals(t, s.IPv6AddressMode, "slaac")
-	th.AssertEquals(t, s.IPv6RAMode, "slaac")
+	th.AssertEquals(t, "", s.Name)
+	th.AssertEquals(t, true, s.EnableDHCP)
+	th.AssertEquals(t, "d32019d3-bc6e-4319-9c1d-6722fc136a22", s.NetworkID)
+	th.AssertEquals(t, "4fd44f30292945e481c7b8a0c8908869", s.TenantID)
+	th.AssertEquals(t, 6, s.IPVersion)
+	th.AssertEquals(t, "2001:db8:0:a::1", s.GatewayIP)
+	th.AssertEquals(t, "2001:db8:0:a:0:0:0:0/64", s.CIDR)
+	th.AssertEquals(t, "3b80198d-4f7b-4f77-9ef5-774d54e17126", s.ID)
+	th.AssertEquals(t, "slaac", s.IPv6AddressMode)
+	th.AssertEquals(t, "slaac", s.IPv6RAMode)
 }
 
 func TestCreateWithNoCIDR(t *testing.T) {
@@ -322,24 +322,24 @@ func TestCreateWithNoCIDR(t *testing.T) {
 	s, err := subnets.Create(context.TODO(), fake.ServiceClient(fakeServer), opts).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, s.Name, "")
-	th.AssertEquals(t, s.DNSPublishFixedIP, true)
-	th.AssertEquals(t, s.EnableDHCP, true)
-	th.AssertEquals(t, s.NetworkID, "d32019d3-bc6e-4319-9c1d-6722fc136a22")
-	th.AssertEquals(t, s.TenantID, "4fd44f30292945e481c7b8a0c8908869")
-	th.AssertDeepEquals(t, s.DNSNameservers, []string{"foo"})
-	th.AssertDeepEquals(t, s.AllocationPools, []subnets.AllocationPool{
+	th.AssertEquals(t, "", s.Name)
+	th.AssertEquals(t, true, s.DNSPublishFixedIP)
+	th.AssertEquals(t, true, s.EnableDHCP)
+	th.AssertEquals(t, "d32019d3-bc6e-4319-9c1d-6722fc136a22", s.NetworkID)
+	th.AssertEquals(t, "4fd44f30292945e481c7b8a0c8908869", s.TenantID)
+	th.AssertDeepEquals(t, []string{"foo"}, s.DNSNameservers)
+	th.AssertDeepEquals(t, []subnets.AllocationPool{
 		{
 			Start: "192.168.199.2",
 			End:   "192.168.199.254",
 		},
-	})
-	th.AssertDeepEquals(t, s.HostRoutes, []subnets.HostRoute{})
-	th.AssertEquals(t, s.IPVersion, 4)
-	th.AssertEquals(t, s.GatewayIP, "192.168.199.1")
-	th.AssertEquals(t, s.CIDR, "192.168.199.0/24")
-	th.AssertEquals(t, s.ID, "3b80198d-4f7b-4f77-9ef5-774d54e17126")
-	th.AssertEquals(t, s.SubnetPoolID, "b80340c7-9960-4f67-a99c-02501656284b")
+	}, s.AllocationPools)
+	th.AssertDeepEquals(t, []subnets.HostRoute{}, s.HostRoutes)
+	th.AssertEquals(t, 4, s.IPVersion)
+	th.AssertEquals(t, "192.168.199.1", s.GatewayIP)
+	th.AssertEquals(t, "192.168.199.0/24", s.CIDR)
+	th.AssertEquals(t, "3b80198d-4f7b-4f77-9ef5-774d54e17126", s.ID)
+	th.AssertEquals(t, "b80340c7-9960-4f67-a99c-02501656284b", s.SubnetPoolID)
 }
 
 func TestCreateWithPrefixlen(t *testing.T) {
@@ -372,24 +372,24 @@ func TestCreateWithPrefixlen(t *testing.T) {
 	s, err := subnets.Create(context.TODO(), fake.ServiceClient(fakeServer), opts).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, s.Name, "")
-	th.AssertEquals(t, s.DNSPublishFixedIP, true)
-	th.AssertEquals(t, s.EnableDHCP, true)
-	th.AssertEquals(t, s.NetworkID, "d32019d3-bc6e-4319-9c1d-6722fc136a22")
-	th.AssertEquals(t, s.TenantID, "4fd44f30292945e481c7b8a0c8908869")
-	th.AssertDeepEquals(t, s.DNSNameservers, []string{"foo"})
-	th.AssertDeepEquals(t, s.AllocationPools, []subnets.AllocationPool{
+	th.AssertEquals(t, "", s.Name)
+	th.AssertEquals(t, true, s.DNSPublishFixedIP)
+	th.AssertEquals(t, true, s.EnableDHCP)
+	th.AssertEquals(t, "d32019d3-bc6e-4319-9c1d-6722fc136a22", s.NetworkID)
+	th.AssertEquals(t, "4fd44f30292945e481c7b8a0c8908869", s.TenantID)
+	th.AssertDeepEquals(t, []string{"foo"}, s.DNSNameservers)
+	th.AssertDeepEquals(t, []subnets.AllocationPool{
 		{
 			Start: "192.168.199.2",
 			End:   "192.168.199.254",
 		},
-	})
-	th.AssertDeepEquals(t, s.HostRoutes, []subnets.HostRoute{})
-	th.AssertEquals(t, s.IPVersion, 4)
-	th.AssertEquals(t, s.GatewayIP, "192.168.199.1")
-	th.AssertEquals(t, s.CIDR, "192.168.199.0/24")
-	th.AssertEquals(t, s.ID, "3b80198d-4f7b-4f77-9ef5-774d54e17126")
-	th.AssertEquals(t, s.SubnetPoolID, "b80340c7-9960-4f67-a99c-02501656284b")
+	}, s.AllocationPools)
+	th.AssertDeepEquals(t, []subnets.HostRoute{}, s.HostRoutes)
+	th.AssertEquals(t, 4, s.IPVersion)
+	th.AssertEquals(t, "192.168.199.1", s.GatewayIP)
+	th.AssertEquals(t, "192.168.199.0/24", s.CIDR)
+	th.AssertEquals(t, "3b80198d-4f7b-4f77-9ef5-774d54e17126", s.ID)
+	th.AssertEquals(t, "b80340c7-9960-4f67-a99c-02501656284b", s.SubnetPoolID)
 }
 
 func TestRequiredCreateOpts(t *testing.T) {
@@ -441,8 +441,8 @@ func TestUpdate(t *testing.T) {
 	s, err := subnets.Update(context.TODO(), fake.ServiceClient(fakeServer), "08eae331-0402-425a-923c-34f7cfe39c1b", opts).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, s.Name, "my_new_subnet")
-	th.AssertEquals(t, s.ID, "08eae331-0402-425a-923c-34f7cfe39c1b")
+	th.AssertEquals(t, "my_new_subnet", s.Name)
+	th.AssertEquals(t, "08eae331-0402-425a-923c-34f7cfe39c1b", s.ID)
 }
 
 func TestUpdateGateway(t *testing.T) {
@@ -471,9 +471,9 @@ func TestUpdateGateway(t *testing.T) {
 	s, err := subnets.Update(context.TODO(), fake.ServiceClient(fakeServer), "08eae331-0402-425a-923c-34f7cfe39c1b", opts).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, s.Name, "my_new_subnet")
-	th.AssertEquals(t, s.ID, "08eae331-0402-425a-923c-34f7cfe39c1b")
-	th.AssertEquals(t, s.GatewayIP, "10.0.0.1")
+	th.AssertEquals(t, "my_new_subnet", s.Name)
+	th.AssertEquals(t, "08eae331-0402-425a-923c-34f7cfe39c1b", s.ID)
+	th.AssertEquals(t, "10.0.0.1", s.GatewayIP)
 }
 
 func TestUpdateRemoveGateway(t *testing.T) {
@@ -502,9 +502,9 @@ func TestUpdateRemoveGateway(t *testing.T) {
 	s, err := subnets.Update(context.TODO(), fake.ServiceClient(fakeServer), "08eae331-0402-425a-923c-34f7cfe39c1b", opts).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, s.Name, "my_new_subnet")
-	th.AssertEquals(t, s.ID, "08eae331-0402-425a-923c-34f7cfe39c1b")
-	th.AssertEquals(t, s.GatewayIP, "")
+	th.AssertEquals(t, "my_new_subnet", s.Name)
+	th.AssertEquals(t, "08eae331-0402-425a-923c-34f7cfe39c1b", s.ID)
+	th.AssertEquals(t, "", s.GatewayIP)
 }
 
 func TestUpdateHostRoutes(t *testing.T) {
@@ -539,8 +539,8 @@ func TestUpdateHostRoutes(t *testing.T) {
 	s, err := subnets.Update(context.TODO(), fake.ServiceClient(fakeServer), "08eae331-0402-425a-923c-34f7cfe39c1b", opts).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, s.Name, "my_new_subnet")
-	th.AssertEquals(t, s.ID, "08eae331-0402-425a-923c-34f7cfe39c1b")
+	th.AssertEquals(t, "my_new_subnet", s.Name)
+	th.AssertEquals(t, "08eae331-0402-425a-923c-34f7cfe39c1b", s.ID)
 	th.AssertDeepEquals(t, s.HostRoutes, HostRoutes)
 }
 
@@ -568,8 +568,8 @@ func TestUpdateRemoveHostRoutes(t *testing.T) {
 	s, err := subnets.Update(context.TODO(), fake.ServiceClient(fakeServer), "08eae331-0402-425a-923c-34f7cfe39c1b", opts).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, s.Name, "my_new_subnet")
-	th.AssertEquals(t, s.ID, "08eae331-0402-425a-923c-34f7cfe39c1b")
+	th.AssertEquals(t, "my_new_subnet", s.Name)
+	th.AssertEquals(t, "08eae331-0402-425a-923c-34f7cfe39c1b", s.ID)
 	th.AssertDeepEquals(t, s.HostRoutes, noHostRoutes)
 }
 
@@ -603,14 +603,14 @@ func TestUpdateAllocationPool(t *testing.T) {
 	s, err := subnets.Update(context.TODO(), fake.ServiceClient(fakeServer), "08eae331-0402-425a-923c-34f7cfe39c1b", opts).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, s.Name, "my_new_subnet")
-	th.AssertEquals(t, s.ID, "08eae331-0402-425a-923c-34f7cfe39c1b")
-	th.AssertDeepEquals(t, s.AllocationPools, []subnets.AllocationPool{
+	th.AssertEquals(t, "my_new_subnet", s.Name)
+	th.AssertEquals(t, "08eae331-0402-425a-923c-34f7cfe39c1b", s.ID)
+	th.AssertDeepEquals(t, []subnets.AllocationPool{
 		{
 			Start: "10.1.0.2",
 			End:   "10.1.0.254",
 		},
-	})
+	}, s.AllocationPools)
 }
 
 func TestUpdateRevision(t *testing.T) {

--- a/openstack/networking/v2/subnets/testing/results_test.go
+++ b/openstack/networking/v2/subnets/testing/results_test.go
@@ -54,6 +54,6 @@ func TestHostRoute(t *testing.T) {
 		t.Fatalf("%s", err)
 	}
 	route := subnetWrapper.Subnet.HostRoutes[0]
-	th.AssertEquals(t, route.NextHop, "172.16.0.2")
-	th.AssertEquals(t, route.DestinationCIDR, "172.20.1.0/24")
+	th.AssertEquals(t, "172.16.0.2", route.NextHop)
+	th.AssertEquals(t, "172.20.1.0/24", route.DestinationCIDR)
 }

--- a/openstack/objectstorage/v1/objects/testing/requests_test.go
+++ b/openstack/objectstorage/v1/objects/testing/requests_test.go
@@ -431,7 +431,7 @@ func TestGetObject(t *testing.T) {
 	}
 	actualHeaders, err := objects.Get(context.TODO(), client.ServiceClient(fakeServer), "testContainer", "testObject", getOpts).Extract()
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, true, actualHeaders.StaticLargeObject)
+	th.AssertTrue(t, actualHeaders.StaticLargeObject)
 }
 
 func TestETag(t *testing.T) {
@@ -444,7 +444,7 @@ func TestETag(t *testing.T) {
 	_, headers, _, err := createOpts.ToObjectCreateParams()
 	th.AssertNoErr(t, err)
 	_, ok := headers["ETag"]
-	th.AssertEquals(t, false, ok)
+	th.AssertFalse(t, ok)
 
 	hash := md5.New()
 	_, err = io.WriteString(hash, content)
@@ -471,7 +471,7 @@ func TestObjectCreateParamsWithoutSeek(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	_, ok := reader.(io.ReadSeeker)
-	th.AssertEquals(t, true, ok)
+	th.AssertTrue(t, ok)
 
 	c, err := io.ReadAll(reader)
 	th.AssertNoErr(t, err)
@@ -479,7 +479,7 @@ func TestObjectCreateParamsWithoutSeek(t *testing.T) {
 	th.AssertEquals(t, content, string(c))
 
 	_, ok = headers["ETag"]
-	th.AssertEquals(t, true, ok)
+	th.AssertTrue(t, ok)
 }
 
 func TestObjectCreateParamsWithSeek(t *testing.T) {
@@ -490,7 +490,7 @@ func TestObjectCreateParamsWithSeek(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	_, ok := reader.(io.ReadSeeker)
-	th.AssertEquals(t, true, ok)
+	th.AssertTrue(t, ok)
 
 	c, err := io.ReadAll(reader)
 	th.AssertNoErr(t, err)
@@ -498,7 +498,7 @@ func TestObjectCreateParamsWithSeek(t *testing.T) {
 	th.AssertEquals(t, content, string(c))
 
 	_, ok = headers["ETag"]
-	th.AssertEquals(t, true, ok)
+	th.AssertTrue(t, ok)
 }
 
 func TestCreateTempURL(t *testing.T) {

--- a/openstack/objectstorage/v1/objects/testing/requests_test.go
+++ b/openstack/objectstorage/v1/objects/testing/requests_test.go
@@ -490,7 +490,7 @@ func TestObjectCreateParamsWithSeek(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	_, ok := reader.(io.ReadSeeker)
-	th.AssertEquals(t, ok, true)
+	th.AssertEquals(t, true, ok)
 
 	c, err := io.ReadAll(reader)
 	th.AssertNoErr(t, err)

--- a/openstack/orchestration/v1/stackevents/testing/requests_test.go
+++ b/openstack/orchestration/v1/stackevents/testing/requests_test.go
@@ -38,7 +38,7 @@ func TestList(t *testing.T) {
 		return true, nil
 	})
 	th.AssertNoErr(t, err)
-	th.CheckEquals(t, count, 1)
+	th.CheckEquals(t, 1, count)
 }
 
 func TestListResourceEvents(t *testing.T) {
@@ -57,7 +57,7 @@ func TestListResourceEvents(t *testing.T) {
 		return true, nil
 	})
 	th.AssertNoErr(t, err)
-	th.CheckEquals(t, count, 1)
+	th.CheckEquals(t, 1, count)
 }
 
 func TestGetEvent(t *testing.T) {

--- a/openstack/orchestration/v1/stackresources/testing/requests_test.go
+++ b/openstack/orchestration/v1/stackresources/testing/requests_test.go
@@ -39,7 +39,7 @@ func TestListResources(t *testing.T) {
 		return true, nil
 	})
 	th.AssertNoErr(t, err)
-	th.CheckEquals(t, count, 1)
+	th.CheckEquals(t, 1, count)
 }
 
 func TestGetResource(t *testing.T) {

--- a/openstack/orchestration/v1/stacks/testing/requests_test.go
+++ b/openstack/orchestration/v1/stacks/testing/requests_test.go
@@ -125,7 +125,7 @@ func TestListStack(t *testing.T) {
 		return true, nil
 	})
 	th.AssertNoErr(t, err)
-	th.CheckEquals(t, count, 1)
+	th.CheckEquals(t, 1, count)
 }
 
 func TestGetStack(t *testing.T) {

--- a/openstack/orchestration/v1/stacks/utils_test.go
+++ b/openstack/orchestration/v1/stacks/utils_test.go
@@ -38,7 +38,7 @@ func TestGetHTTPClient(t *testing.T) {
 	th.AssertNoErr(t, err)
 	resp, err := client.Get(baseurl)
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, resp.StatusCode, 200)
+	th.AssertEquals(t, 200, resp.StatusCode)
 }
 
 // Implement a fakeclient that can be used to mock out HTTP requests

--- a/openstack/placement/v1/allocationcandidates/testing/requests_test.go
+++ b/openstack/placement/v1/allocationcandidates/testing/requests_test.go
@@ -103,7 +103,7 @@ func TestListAllocationCandidatesEmptySuccess(t *testing.T) {
 
 	isEmpty, err := page.IsEmpty()
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, true, isEmpty)
+	th.AssertTrue(t, isEmpty)
 }
 
 func TestIsEmpty110Success(t *testing.T) {
@@ -119,7 +119,7 @@ func TestIsEmpty110Success(t *testing.T) {
 
 	isEmpty, err := page.IsEmpty()
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, false, isEmpty)
+	th.AssertFalse(t, isEmpty)
 }
 
 func TestListAllocationCandidatesBadRequest(t *testing.T) {
@@ -132,7 +132,7 @@ func TestListAllocationCandidatesBadRequest(t *testing.T) {
 		Resources: "INVALID",
 	}).AllPages(context.TODO())
 	th.AssertErr(t, err)
-	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusBadRequest))
+	th.AssertTrue(t, gophercloud.ResponseCodeIs(err, http.StatusBadRequest))
 }
 
 func TestListAllocationCandidatesWithFullQuerySuccess(t *testing.T) {

--- a/openstack/placement/v1/allocations/testing/requests_test.go
+++ b/openstack/placement/v1/allocations/testing/requests_test.go
@@ -97,7 +97,7 @@ func TestUpdateConflict(t *testing.T) {
 		UserID:             UserID,
 		ConsumerGeneration: &staleGeneration,
 	}).ExtractErr()
-	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusConflict))
+	th.AssertTrue(t, gophercloud.ResponseCodeIs(err, http.StatusConflict))
 }
 
 func TestDeleteSuccess(t *testing.T) {
@@ -122,7 +122,7 @@ func TestDeleteNotFound(t *testing.T) {
 	HandleDeleteAllocationsNotFound(t, fakeServer)
 
 	err := allocations.Delete(context.TODO(), client.ServiceClient(fakeServer), NotFoundConsumerUUID).ExtractErr()
-	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
+	th.AssertTrue(t, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
 }
 
 func TestManageSuccess(t *testing.T) {
@@ -181,5 +181,5 @@ func TestManageConflict(t *testing.T) {
 			ConsumerGeneration: &staleGeneration,
 		},
 	}).ExtractErr()
-	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusConflict))
+	th.AssertTrue(t, gophercloud.ResponseCodeIs(err, http.StatusConflict))
 }

--- a/openstack/placement/v1/resourceclasses/testing/requests_test.go
+++ b/openstack/placement/v1/resourceclasses/testing/requests_test.go
@@ -43,7 +43,7 @@ func TestGetResourceClassNotFound(t *testing.T) {
 	HandleGetResourceClassNotFound(t, fakeServer)
 
 	_, err := resourceclasses.Get(context.TODO(), client.ServiceClient(fakeServer), AbsentResourceClass).Extract()
-	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
+	th.AssertTrue(t, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
 }
 
 func TestCreateResourceClassSuccess(t *testing.T) {
@@ -71,7 +71,7 @@ func TestCreateResourceClassConflict(t *testing.T) {
 	}
 
 	err := resourceclasses.Create(context.TODO(), client.ServiceClient(fakeServer), createOpts).ExtractErr()
-	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusConflict))
+	th.AssertTrue(t, gophercloud.ResponseCodeIs(err, http.StatusConflict))
 }
 
 func TestUpdateResourceClassCreateSuccess(t *testing.T) {
@@ -101,7 +101,7 @@ func TestUpdateResourceClassNonCustom(t *testing.T) {
 	HandleUpdateResourceClassNonCustom(t, fakeServer)
 
 	err := resourceclasses.Update(context.TODO(), client.ServiceClient(fakeServer), "VCPU").ExtractErr()
-	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusBadRequest))
+	th.AssertTrue(t, gophercloud.ResponseCodeIs(err, http.StatusBadRequest))
 }
 
 func TestDeleteResourceClassSuccess(t *testing.T) {
@@ -121,7 +121,7 @@ func TestDeleteResourceClassNotFound(t *testing.T) {
 	HandleDeleteResourceClassNotFound(t, fakeServer)
 
 	err := resourceclasses.Delete(context.TODO(), client.ServiceClient(fakeServer), AbsentResourceClass).ExtractErr()
-	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
+	th.AssertTrue(t, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
 }
 
 func TestDeleteResourceClassStandardClass(t *testing.T) {
@@ -132,5 +132,5 @@ func TestDeleteResourceClassStandardClass(t *testing.T) {
 	HandleDeleteResourceClassStandardClass(t, fakeServer)
 
 	err := resourceclasses.Delete(context.TODO(), client.ServiceClient(fakeServer), "VCPU").ExtractErr()
-	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusBadRequest))
+	th.AssertTrue(t, gophercloud.ResponseCodeIs(err, http.StatusBadRequest))
 }

--- a/openstack/placement/v1/resourceproviders/testing/requests_test.go
+++ b/openstack/placement/v1/resourceproviders/testing/requests_test.go
@@ -204,7 +204,7 @@ func TestGetResourceProviderInventoryNotFound(t *testing.T) {
 	HandleResourceProviderGetInventoryNotFound(t, fakeServer)
 
 	_, err := resourceproviders.GetInventory(context.TODO(), client.ServiceClient(fakeServer), ResourceProviderTestID, MissingInventoryResourceClass).Extract()
-	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
+	th.AssertTrue(t, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
 }
 
 func TestUpdateResourceProvidersInventories(t *testing.T) {
@@ -227,7 +227,7 @@ func TestUpdateResourceProvidersInventoriesNotFound(t *testing.T) {
 
 	opts := resourceproviders.UpdateInventoriesOpts(ExpectedInventories)
 	_, err := resourceproviders.UpdateInventories(context.TODO(), client.ServiceClient(fakeServer), NonExistentRPID, opts).Extract()
-	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
+	th.AssertTrue(t, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
 }
 
 func TestUpdateResourceProviderInventory(t *testing.T) {
@@ -250,7 +250,7 @@ func TestUpdateResourceProviderInventoryNotFound(t *testing.T) {
 
 	opts := resourceproviders.UpdateInventoryOpts(ExpectedInventory)
 	_, err := resourceproviders.UpdateInventory(context.TODO(), client.ServiceClient(fakeServer), NonExistentRPID, PresentInventoryResourceClass, opts).Extract()
-	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
+	th.AssertTrue(t, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
 }
 
 func TestDeleteResourceProviderInventorySuccess(t *testing.T) {
@@ -270,7 +270,7 @@ func TestDeleteResourceProviderInventoryInUse(t *testing.T) {
 	HandleResourceProviderDeleteInventoryInUse(t, fakeServer)
 
 	err := resourceproviders.DeleteInventory(context.TODO(), client.ServiceClient(fakeServer), ResourceProviderTestID, PresentInventoryResourceClass).ExtractErr()
-	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusConflict))
+	th.AssertTrue(t, gophercloud.ResponseCodeIs(err, http.StatusConflict))
 }
 
 func TestDeleteResourceProviderInventoriesSuccess(t *testing.T) {
@@ -290,7 +290,7 @@ func TestDeleteResourceProviderInventoriesConflict(t *testing.T) {
 	HandleResourceProviderDeleteInventoriesConflict(t, fakeServer)
 
 	err := resourceproviders.DeleteInventories(context.TODO(), client.ServiceClient(fakeServer), ResourceProviderTestID).ExtractErr()
-	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusConflict))
+	th.AssertTrue(t, gophercloud.ResponseCodeIs(err, http.StatusConflict))
 }
 
 func TestGetResourceProvidersAllocations(t *testing.T) {
@@ -366,7 +366,7 @@ func TestGetResourceProviderAggregatesNotFound(t *testing.T) {
 	HandleResourceProviderGetAggregatesNotFound(t, fakeServer)
 
 	_, err := resourceproviders.GetAggregates(context.TODO(), client.ServiceClient(fakeServer), AbsentResourceProviderID).Extract()
-	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
+	th.AssertTrue(t, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
 }
 
 func TestUpdateResourceProviderAggregatesSuccess(t *testing.T) {
@@ -441,5 +441,5 @@ func TestUpdateResourceProviderAggregatesConflict(t *testing.T) {
 
 	updateOpts := resourceproviders.UpdateAggregatesOpts(ExpectedUpdatedAggregates)
 	_, err := resourceproviders.UpdateAggregates(context.TODO(), client.ServiceClient(fakeServer), ResourceProviderTestID, updateOpts).Extract()
-	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusConflict))
+	th.AssertTrue(t, gophercloud.ResponseCodeIs(err, http.StatusConflict))
 }

--- a/openstack/placement/v1/traits/testing/requests_test.go
+++ b/openstack/placement/v1/traits/testing/requests_test.go
@@ -97,7 +97,7 @@ func TestGetTraitNotFound(t *testing.T) {
 	HandleGetTraitNotFound(t, fakeServer)
 
 	err := traits.Get(context.TODO(), client.ServiceClient(fakeServer), AbsentTrait).ExtractErr()
-	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
+	th.AssertTrue(t, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
 }
 
 func TestCreateTraitSuccess(t *testing.T) {
@@ -127,7 +127,7 @@ func TestCreateTraitInvalidName(t *testing.T) {
 	HandleCreateTraitInvalidName(t, fakeServer)
 
 	err := traits.Create(context.TODO(), client.ServiceClient(fakeServer), AbsentTrait).ExtractErr()
-	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusBadRequest))
+	th.AssertTrue(t, gophercloud.ResponseCodeIs(err, http.StatusBadRequest))
 }
 
 func TestDeleteTraitSuccess(t *testing.T) {
@@ -147,7 +147,7 @@ func TestDeleteTraitNotFound(t *testing.T) {
 	HandleDeleteTraitNotFound(t, fakeServer)
 
 	err := traits.Delete(context.TODO(), client.ServiceClient(fakeServer), AbsentTrait).ExtractErr()
-	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
+	th.AssertTrue(t, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
 }
 
 func TestDeleteStandardTraitFailure(t *testing.T) {
@@ -157,7 +157,7 @@ func TestDeleteStandardTraitFailure(t *testing.T) {
 	HandleDeleteStandardTraitFailure(t, fakeServer)
 
 	err := traits.Delete(context.TODO(), client.ServiceClient(fakeServer), StandardHardwareTrait).ExtractErr()
-	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusBadRequest))
+	th.AssertTrue(t, gophercloud.ResponseCodeIs(err, http.StatusBadRequest))
 }
 
 func TestDeleteTraitInUseFailure(t *testing.T) {
@@ -167,5 +167,5 @@ func TestDeleteTraitInUseFailure(t *testing.T) {
 	HandleDeleteTraitInUseFailure(t, fakeServer)
 
 	err := traits.Delete(context.TODO(), client.ServiceClient(fakeServer), PresentTrait).ExtractErr()
-	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusConflict))
+	th.AssertTrue(t, gophercloud.ResponseCodeIs(err, http.StatusConflict))
 }

--- a/openstack/sharedfilesystems/apiversions/testing/requests_test.go
+++ b/openstack/sharedfilesystems/apiversions/testing/requests_test.go
@@ -43,7 +43,7 @@ func TestGetNoAPIVersion(t *testing.T) {
 	MockGetNoResponse(t, fakeServer)
 
 	_, err := apiversions.Get(context.TODO(), client.ServiceClient(fakeServer), "v2").Extract()
-	th.AssertEquals(t, err.Error(), "Unable to find requested API version")
+	th.AssertEquals(t, "Unable to find requested API version", err.Error())
 }
 
 func TestGetMultipleAPIVersion(t *testing.T) {
@@ -53,5 +53,5 @@ func TestGetMultipleAPIVersion(t *testing.T) {
 	MockGetMultipleResponses(t, fakeServer)
 
 	_, err := apiversions.Get(context.TODO(), client.ServiceClient(fakeServer), "v2").Extract()
-	th.AssertEquals(t, err.Error(), "Found 2 API versions")
+	th.AssertEquals(t, "Found 2 API versions", err.Error())
 }

--- a/openstack/sharedfilesystems/v2/errors/testing/request_test.go
+++ b/openstack/sharedfilesystems/v2/errors/testing/request_test.go
@@ -28,8 +28,8 @@ func TestCreate(t *testing.T) {
 	th.AssertNoErr(t, e)
 
 	for k, msg := range detailedErr {
-		th.AssertEquals(t, k, "itemNotFound")
-		th.AssertEquals(t, msg.Code, 404)
-		th.AssertEquals(t, msg.Message, "ShareSnapshotNotFound: Snapshot 70bfbebc-d3ff-4528-8bbb-58422daa280b could not be found.")
+		th.AssertEquals(t, "itemNotFound", k)
+		th.AssertEquals(t, 404, msg.Code)
+		th.AssertEquals(t, "ShareSnapshotNotFound: Snapshot 70bfbebc-d3ff-4528-8bbb-58422daa280b could not be found.", msg.Message)
 	}
 }

--- a/openstack/sharedfilesystems/v2/replicas/testing/request_test.go
+++ b/openstack/sharedfilesystems/v2/replicas/testing/request_test.go
@@ -218,7 +218,7 @@ func TestGetExportLocationSuccess(t *testing.T) {
 	s, err := replicas.GetExportLocation(context.TODO(), getClient(fakeServer, "2.47"), replicaID, "ae73e762-e8b9-4aad-aad3-23afb7cd6825").Extract()
 
 	th.AssertNoErr(t, err)
-	th.AssertDeepEquals(t, s, &replicas.ExportLocation{
+	th.AssertDeepEquals(t, &replicas.ExportLocation{
 		Path:             "192.168.1.124:/var/lib/manila/mnt/share-3b9c33e8-b136-45c6-84a6-019c8db1d550",
 		ID:               "ae73e762-e8b9-4aad-aad3-23afb7cd6825",
 		Preferred:        false,
@@ -226,7 +226,7 @@ func TestGetExportLocationSuccess(t *testing.T) {
 		AvailabilityZone: "zone-1",
 		CreatedAt:        time.Date(2023, time.May, 26, 12, 44, 33, 987960000, time.UTC),
 		UpdatedAt:        time.Date(2023, time.May, 26, 12, 44, 33, 958363000, time.UTC),
-	})
+	}, s)
 }
 
 func TestResetStatusSuccess(t *testing.T) {

--- a/openstack/sharedfilesystems/v2/securityservices/testing/requests_test.go
+++ b/openstack/sharedfilesystems/v2/securityservices/testing/requests_test.go
@@ -30,12 +30,12 @@ func TestCreate(t *testing.T) {
 	s, err := securityservices.Create(context.TODO(), client.ServiceClient(fakeServer), options).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, s.Name, "SecServ1")
-	th.AssertEquals(t, s.Description, "Creating my first Security Service")
-	th.AssertEquals(t, s.User, "demo")
-	th.AssertEquals(t, s.DNSIP, "10.0.0.0/24")
-	th.AssertEquals(t, s.Password, "supersecret")
-	th.AssertEquals(t, s.Type, "kerberos")
+	th.AssertEquals(t, "SecServ1", s.Name)
+	th.AssertEquals(t, "Creating my first Security Service", s.Description)
+	th.AssertEquals(t, "demo", s.User)
+	th.AssertEquals(t, "10.0.0.0/24", s.DNSIP)
+	th.AssertEquals(t, "supersecret", s.Password)
+	th.AssertEquals(t, "kerberos", s.Type)
 }
 
 // Verifies that a security service cannot be created without a type

--- a/openstack/sharedfilesystems/v2/sharenetworks/testing/requests_test.go
+++ b/openstack/sharedfilesystems/v2/sharenetworks/testing/requests_test.go
@@ -28,10 +28,10 @@ func TestCreate(t *testing.T) {
 	n, err := sharenetworks.Create(context.TODO(), client.ServiceClient(fakeServer), options).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, n.Name, "my_network")
-	th.AssertEquals(t, n.Description, "This is my share network")
-	th.AssertEquals(t, n.NeutronNetID, "998b42ee-2cee-4d36-8b95-67b5ca1f2109")
-	th.AssertEquals(t, n.NeutronSubnetID, "53482b62-2c84-4a53-b6ab-30d9d9800d06")
+	th.AssertEquals(t, "my_network", n.Name)
+	th.AssertEquals(t, "This is my share network", n.Description)
+	th.AssertEquals(t, "998b42ee-2cee-4d36-8b95-67b5ca1f2109", n.NeutronNetID)
+	th.AssertEquals(t, "53482b62-2c84-4a53-b6ab-30d9d9800d06", n.NeutronSubnetID)
 }
 
 // Verifies that share network deletion works
@@ -136,7 +136,7 @@ func TestPaginatedListDetail(t *testing.T) {
 	})
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, count, 3)
+	th.AssertEquals(t, 3, count)
 }
 
 // Verifies that it is possible to get a share network

--- a/openstack/sharedfilesystems/v2/shares/testing/request_test.go
+++ b/openstack/sharedfilesystems/v2/shares/testing/request_test.go
@@ -54,7 +54,7 @@ func TestUpdate(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, "my_new_test_share", n.Name)
 	th.AssertEquals(t, "", n.Description)
-	th.AssertEquals(t, false, n.IsPublic)
+	th.AssertFalse(t, n.IsPublic)
 }
 
 func TestDelete(t *testing.T) {

--- a/openstack/sharedfilesystems/v2/shares/testing/request_test.go
+++ b/openstack/sharedfilesystems/v2/shares/testing/request_test.go
@@ -28,11 +28,11 @@ func TestCreate(t *testing.T) {
 	n, err := shares.Create(context.TODO(), client.ServiceClient(fakeServer), options).Extract()
 
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, n.Name, "my_test_share")
-	th.AssertEquals(t, n.Size, 1)
-	th.AssertEquals(t, n.ShareProto, "NFS")
-	th.AssertEquals(t, n.Metadata["__affinity_same_host"], "e268f4aa-d571-43dd-9ab3-f49ad06ffaef")
-	th.AssertEquals(t, n.Metadata["__affinity_different_host"], "e268f4aa-d571-43dd-9ab3-f49ad06ffaef")
+	th.AssertEquals(t, "my_test_share", n.Name)
+	th.AssertEquals(t, 1, n.Size)
+	th.AssertEquals(t, "NFS", n.ShareProto)
+	th.AssertEquals(t, "e268f4aa-d571-43dd-9ab3-f49ad06ffaef", n.Metadata["__affinity_same_host"])
+	th.AssertEquals(t, "e268f4aa-d571-43dd-9ab3-f49ad06ffaef", n.Metadata["__affinity_different_host"])
 }
 
 func TestUpdate(t *testing.T) {
@@ -52,9 +52,9 @@ func TestUpdate(t *testing.T) {
 	n, err := shares.Update(context.TODO(), client.ServiceClient(fakeServer), shareID, options).Extract()
 
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, n.Name, "my_new_test_share")
-	th.AssertEquals(t, n.Description, "")
-	th.AssertEquals(t, n.IsPublic, false)
+	th.AssertEquals(t, "my_new_test_share", n.Name)
+	th.AssertEquals(t, "", n.Description)
+	th.AssertEquals(t, false, n.IsPublic)
 }
 
 func TestDelete(t *testing.T) {
@@ -75,7 +75,7 @@ func TestGet(t *testing.T) {
 
 	s, err := shares.Get(context.TODO(), client.ServiceClient(fakeServer), shareID).Extract()
 	th.AssertNoErr(t, err)
-	th.AssertDeepEquals(t, s, &shares.Share{
+	th.AssertDeepEquals(t, &shares.Share{
 		AvailabilityZone:   "nova",
 		ShareNetworkID:     "713df749-aac0-4a54-af52-10f6c991e80c",
 		ShareServerID:      "e268f4aa-d571-43dd-9ab3-f49ad06ffaef",
@@ -114,7 +114,7 @@ func TestGet(t *testing.T) {
 				"rel":  "bookmark",
 			},
 		},
-	})
+	}, s)
 }
 
 func TestListDetail(t *testing.T) {
@@ -130,7 +130,7 @@ func TestListDetail(t *testing.T) {
 	actual, err := shares.ExtractShares(allPages)
 	th.AssertNoErr(t, err)
 
-	th.AssertDeepEquals(t, actual, []shares.Share{
+	th.AssertDeepEquals(t, []shares.Share{
 		{
 			AvailabilityZone:   "nova",
 			ShareNetworkID:     "713df749-aac0-4a54-af52-10f6c991e80c",
@@ -171,7 +171,7 @@ func TestListDetail(t *testing.T) {
 				},
 			},
 		},
-	})
+	}, actual)
 }
 
 func TestListExportLocationsSuccess(t *testing.T) {
@@ -187,7 +187,7 @@ func TestListExportLocationsSuccess(t *testing.T) {
 	s, err := shares.ListExportLocations(context.TODO(), c, shareID).Extract()
 
 	th.AssertNoErr(t, err)
-	th.AssertDeepEquals(t, s, []shares.ExportLocation{
+	th.AssertDeepEquals(t, []shares.ExportLocation{
 		{
 			Path:            "127.0.0.1:/var/lib/manila/mnt/share-9a922036-ad26-4d27-b955-7a1e285fa74d",
 			ShareInstanceID: "011d21e2-fbc3-4e4a-9993-9ea223f73264",
@@ -195,7 +195,7 @@ func TestListExportLocationsSuccess(t *testing.T) {
 			ID:              "80ed63fc-83bc-4afc-b881-da4a345ac83d",
 			Preferred:       false,
 		},
-	})
+	}, s)
 }
 
 func TestGetExportLocationSuccess(t *testing.T) {
@@ -211,13 +211,13 @@ func TestGetExportLocationSuccess(t *testing.T) {
 	s, err := shares.GetExportLocation(context.TODO(), c, shareID, "80ed63fc-83bc-4afc-b881-da4a345ac83d").Extract()
 
 	th.AssertNoErr(t, err)
-	th.AssertDeepEquals(t, s, &shares.ExportLocation{
+	th.AssertDeepEquals(t, &shares.ExportLocation{
 		Path:            "127.0.0.1:/var/lib/manila/mnt/share-9a922036-ad26-4d27-b955-7a1e285fa74d",
 		ShareInstanceID: "011d21e2-fbc3-4e4a-9993-9ea223f73264",
 		IsAdminOnly:     false,
 		ID:              "80ed63fc-83bc-4afc-b881-da4a345ac83d",
 		Preferred:       false,
-	})
+	}, s)
 }
 
 func TestGrantAcessSuccess(t *testing.T) {
@@ -238,7 +238,7 @@ func TestGrantAcessSuccess(t *testing.T) {
 	s, err := shares.GrantAccess(context.TODO(), c, shareID, grantAccessReq).Extract()
 
 	th.AssertNoErr(t, err)
-	th.AssertDeepEquals(t, s, &shares.AccessRight{
+	th.AssertDeepEquals(t, &shares.AccessRight{
 		ShareID:     "011d21e2-fbc3-4e4a-9993-9ea223f73264",
 		AccessType:  "ip",
 		AccessTo:    "0.0.0.0/0",
@@ -246,7 +246,7 @@ func TestGrantAcessSuccess(t *testing.T) {
 		AccessLevel: "rw",
 		State:       "new",
 		ID:          "a2f226a5-cee8-430b-8a03-78a59bd84ee8",
-	})
+	}, s)
 }
 
 func TestRevokeAccessSuccess(t *testing.T) {
@@ -278,7 +278,7 @@ func TestListAccessRightsSuccess(t *testing.T) {
 	s, err := shares.ListAccessRights(context.TODO(), c, shareID).Extract()
 
 	th.AssertNoErr(t, err)
-	th.AssertDeepEquals(t, s, []shares.AccessRight{
+	th.AssertDeepEquals(t, []shares.AccessRight{
 		{
 			ShareID:     "011d21e2-fbc3-4e4a-9993-9ea223f73264",
 			AccessType:  "ip",
@@ -288,7 +288,7 @@ func TestListAccessRightsSuccess(t *testing.T) {
 			State:       "new",
 			ID:          "a2f226a5-cee8-430b-8a03-78a59bd84ee8",
 		},
-	})
+	}, s)
 }
 
 func TestExtendSuccess(t *testing.T) {

--- a/openstack/sharedfilesystems/v2/sharetransfers/testing/requests_test.go
+++ b/openstack/sharedfilesystems/v2/sharetransfers/testing/requests_test.go
@@ -58,7 +58,7 @@ func TestListTransfers(t *testing.T) {
 		return true, nil
 	})
 	th.AssertNoErr(t, err)
-	th.CheckEquals(t, count, 1)
+	th.CheckEquals(t, 1, count)
 }
 
 func TestListTransfersDetail(t *testing.T) {
@@ -81,7 +81,7 @@ func TestListTransfersDetail(t *testing.T) {
 		return true, nil
 	})
 	th.AssertNoErr(t, err)
-	th.CheckEquals(t, count, 1)
+	th.CheckEquals(t, 1, count)
 }
 
 func TestListTransfersAllPages(t *testing.T) {

--- a/openstack/sharedfilesystems/v2/sharetypes/testing/requests_test.go
+++ b/openstack/sharedfilesystems/v2/sharetypes/testing/requests_test.go
@@ -33,7 +33,7 @@ func TestCreate(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	th.AssertEquals(t, "my_new_share_type", st.Name)
-	th.AssertEquals(t, true, st.IsPublic)
+	th.AssertTrue(t, st.IsPublic)
 }
 
 // Verifies that a share type can't be created if the required parameters are missing

--- a/openstack/sharedfilesystems/v2/sharetypes/testing/requests_test.go
+++ b/openstack/sharedfilesystems/v2/sharetypes/testing/requests_test.go
@@ -32,8 +32,8 @@ func TestCreate(t *testing.T) {
 	st, err := sharetypes.Create(context.TODO(), client.ServiceClient(fakeServer), options).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, st.Name, "my_new_share_type")
-	th.AssertEquals(t, st.IsPublic, true)
+	th.AssertEquals(t, "my_new_share_type", st.Name)
+	th.AssertEquals(t, true, st.IsPublic)
 }
 
 // Verifies that a share type can't be created if the required parameters are missing
@@ -208,9 +208,9 @@ func TestGetExtraSpecs(t *testing.T) {
 	st, err := sharetypes.GetExtraSpecs(context.TODO(), client.ServiceClient(fakeServer), "shareTypeID").Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, st["snapshot_support"], "True")
-	th.AssertEquals(t, st["driver_handles_share_servers"], "True")
-	th.AssertEquals(t, st["my_custom_extra_spec"], "False")
+	th.AssertEquals(t, "True", st["snapshot_support"])
+	th.AssertEquals(t, "True", st["driver_handles_share_servers"])
+	th.AssertEquals(t, "False", st["my_custom_extra_spec"])
 }
 
 // Verifies that an extra specs can be added to a share type
@@ -227,7 +227,7 @@ func TestSetExtraSpecs(t *testing.T) {
 	es, err := sharetypes.SetExtraSpecs(context.TODO(), client.ServiceClient(fakeServer), "shareTypeID", options).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, es["my_key"], "my_value")
+	th.AssertEquals(t, "my_value", es["my_key"])
 }
 
 // Verifies that an extra specification can be unset for a share type

--- a/openstack/sharedfilesystems/v2/snapshots/testing/request_test.go
+++ b/openstack/sharedfilesystems/v2/snapshots/testing/request_test.go
@@ -20,11 +20,11 @@ func TestCreate(t *testing.T) {
 	n, err := snapshots.Create(context.TODO(), client.ServiceClient(fakeServer), options).Extract()
 
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, n.Name, "test snapshot")
-	th.AssertEquals(t, n.Description, "test description")
-	th.AssertEquals(t, n.ShareProto, "NFS")
-	th.AssertEquals(t, n.ShareSize, 1)
-	th.AssertEquals(t, n.Size, 1)
+	th.AssertEquals(t, "test snapshot", n.Name)
+	th.AssertEquals(t, "test description", n.Description)
+	th.AssertEquals(t, "NFS", n.ShareProto)
+	th.AssertEquals(t, 1, n.ShareSize)
+	th.AssertEquals(t, 1, n.Size)
 }
 
 func TestUpdate(t *testing.T) {
@@ -42,8 +42,8 @@ func TestUpdate(t *testing.T) {
 	n, err := snapshots.Update(context.TODO(), client.ServiceClient(fakeServer), snapshotID, options).Extract()
 
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, n.Name, "my_new_test_snapshot")
-	th.AssertEquals(t, n.Description, "")
+	th.AssertEquals(t, "my_new_test_snapshot", n.Name)
+	th.AssertEquals(t, "", n.Description)
 }
 
 func TestDelete(t *testing.T) {
@@ -64,7 +64,7 @@ func TestGet(t *testing.T) {
 
 	s, err := snapshots.Get(context.TODO(), client.ServiceClient(fakeServer), snapshotID).Extract()
 	th.AssertNoErr(t, err)
-	th.AssertDeepEquals(t, s, &snapshots.Snapshot{
+	th.AssertDeepEquals(t, &snapshots.Snapshot{
 		ID:          snapshotID,
 		Name:        "new_app_snapshot",
 		Description: "",
@@ -85,7 +85,7 @@ func TestGet(t *testing.T) {
 				"rel":  "bookmark",
 			},
 		},
-	})
+	}, s)
 }
 
 func TestListDetail(t *testing.T) {
@@ -101,7 +101,7 @@ func TestListDetail(t *testing.T) {
 	actual, err := snapshots.ExtractSnapshots(allPages)
 	th.AssertNoErr(t, err)
 
-	th.AssertDeepEquals(t, actual, []snapshots.Snapshot{
+	th.AssertDeepEquals(t, []snapshots.Snapshot{
 		{
 			ID:          snapshotID,
 			Name:        "new_app_snapshot",
@@ -124,7 +124,7 @@ func TestListDetail(t *testing.T) {
 				},
 			},
 		},
-	})
+	}, actual)
 }
 
 func TestResetStatusSuccess(t *testing.T) {

--- a/pagination/testing/marker_test.go
+++ b/pagination/testing/marker_test.go
@@ -114,7 +114,7 @@ func TestEnumerateMarker(t *testing.T) {
 		return true, nil
 	})
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, callCount, 3)
+	th.AssertEquals(t, 3, callCount)
 }
 
 func TestAllPagesMarker(t *testing.T) {

--- a/testhelper/convenience.go
+++ b/testhelper/convenience.go
@@ -232,6 +232,63 @@ func CheckEquals(t *testing.T, expected, actual any) {
 	}
 }
 
+// AssertEqualsIgnoreCase compares two strings case-insensitively. If they
+// are not equal ignoring case, a fatal error is raised.
+func AssertEqualsIgnoreCase(t *testing.T, expected, actual string) {
+	t.Helper()
+
+	if !strings.EqualFold(expected, actual) {
+		logFatal(t, fmt.Sprintf("expected %s but got %s", green(expected), yellow(actual)))
+	}
+}
+
+// CheckEqualsIgnoreCase is similar to AssertEqualsIgnoreCase, except with a non-fatal error
+func CheckEqualsIgnoreCase(t *testing.T, expected, actual string) {
+	t.Helper()
+
+	if !strings.EqualFold(expected, actual) {
+		logError(t, fmt.Sprintf("expected %s but got %s", green(expected), yellow(actual)))
+	}
+}
+
+// AssertTrue checks whether the provided boolean value is true. If it is not,
+// a fatal error is raised.
+func AssertTrue(t *testing.T, v bool) {
+	t.Helper()
+
+	if !v {
+		logFatal(t, "expected true, got false")
+	}
+}
+
+// AssertFalse checks whether the provided boolean value is false. If it is not,
+// a fatal error is raised.
+func AssertFalse(t *testing.T, v bool) {
+	t.Helper()
+
+	if v {
+		logFatal(t, "expected false, got true")
+	}
+}
+
+// CheckTrue is similar to AssertTrue, except with a non-fatal error
+func CheckTrue(t *testing.T, v bool) {
+	t.Helper()
+
+	if !v {
+		logError(t, "expected true, got false")
+	}
+}
+
+// CheckFalse is similar to AssertFalse, except with a non-fatal error
+func CheckFalse(t *testing.T, v bool) {
+	t.Helper()
+
+	if v {
+		logError(t, "expected false, got true")
+	}
+}
+
 // AssertDeepEquals - like Equals - performs a comparison - but on more complex
 // structures that requires deeper inspection
 func AssertTypeEquals(t *testing.T, expected, actual any) {

--- a/testing/errors_test.go
+++ b/testing/errors_test.go
@@ -20,11 +20,11 @@ func TestErrUnexpectedResponseCode(t *testing.T) {
 	}
 
 	th.AssertEquals(t, 404, err.GetStatusCode())
-	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
-	th.AssertEquals(t, false, gophercloud.ResponseCodeIs(err, http.StatusInternalServerError))
+	th.AssertTrue(t, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
+	th.AssertFalse(t, gophercloud.ResponseCodeIs(err, http.StatusInternalServerError))
 
 	//even if application code wraps our error, ResponseCodeIs() should still work
 	errWrapped := fmt.Errorf("could not frobnicate the foobar: %w", err)
-	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(errWrapped, http.StatusNotFound))
-	th.AssertEquals(t, false, gophercloud.ResponseCodeIs(errWrapped, http.StatusInternalServerError))
+	th.AssertTrue(t, gophercloud.ResponseCodeIs(errWrapped, http.StatusNotFound))
+	th.AssertFalse(t, gophercloud.ResponseCodeIs(errWrapped, http.StatusInternalServerError))
 }

--- a/testing/errors_test.go
+++ b/testing/errors_test.go
@@ -19,12 +19,12 @@ func TestErrUnexpectedResponseCode(t *testing.T) {
 		ResponseHeader: nil,
 	}
 
-	th.AssertEquals(t, err.GetStatusCode(), 404)
-	th.AssertEquals(t, gophercloud.ResponseCodeIs(err, http.StatusNotFound), true)
-	th.AssertEquals(t, gophercloud.ResponseCodeIs(err, http.StatusInternalServerError), false)
+	th.AssertEquals(t, 404, err.GetStatusCode())
+	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
+	th.AssertEquals(t, false, gophercloud.ResponseCodeIs(err, http.StatusInternalServerError))
 
 	//even if application code wraps our error, ResponseCodeIs() should still work
 	errWrapped := fmt.Errorf("could not frobnicate the foobar: %w", err)
-	th.AssertEquals(t, gophercloud.ResponseCodeIs(errWrapped, http.StatusNotFound), true)
-	th.AssertEquals(t, gophercloud.ResponseCodeIs(errWrapped, http.StatusInternalServerError), false)
+	th.AssertEquals(t, true, gophercloud.ResponseCodeIs(errWrapped, http.StatusNotFound))
+	th.AssertEquals(t, false, gophercloud.ResponseCodeIs(errWrapped, http.StatusInternalServerError))
 }

--- a/testing/provider_client_test.go
+++ b/testing/provider_client_test.go
@@ -210,10 +210,10 @@ func TestReauthEndLoop(t *testing.T) {
 	}
 
 	wg.Wait()
-	th.AssertEquals(t, info.reauthAttempts, 6)
-	th.AssertEquals(t, info.maxReauthReached, true)
-	th.AssertEquals(t, errAfter > 1, true)
-	th.AssertEquals(t, errUnable < 20, true)
+	th.AssertEquals(t, 6, info.reauthAttempts)
+	th.AssertEquals(t, true, info.maxReauthReached)
+	th.AssertEquals(t, true, errAfter > 1)
+	th.AssertEquals(t, true, errUnable < 20)
 }
 
 func TestRequestThatCameDuringReauthWaitsUntilItIsCompleted(t *testing.T) {
@@ -569,7 +569,7 @@ func TestRequestRetryError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expecting error, got nil")
 	}
-	th.AssertEquals(t, retryCounter, uint(0))
+	th.AssertEquals(t, uint(0), retryCounter)
 }
 
 func TestRequestRetrySuccess(t *testing.T) {
@@ -594,7 +594,7 @@ func TestRequestRetrySuccess(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	th.AssertEquals(t, retryCounter, uint(0))
+	th.AssertEquals(t, uint(0), retryCounter)
 }
 
 func TestRequestRetryContext(t *testing.T) {

--- a/testing/provider_client_test.go
+++ b/testing/provider_client_test.go
@@ -211,9 +211,9 @@ func TestReauthEndLoop(t *testing.T) {
 
 	wg.Wait()
 	th.AssertEquals(t, 6, info.reauthAttempts)
-	th.AssertEquals(t, true, info.maxReauthReached)
-	th.AssertEquals(t, true, errAfter > 1)
-	th.AssertEquals(t, true, errUnable < 20)
+	th.AssertTrue(t, info.maxReauthReached)
+	th.AssertTrue(t, errAfter > 1)
+	th.AssertTrue(t, errUnable < 20)
 }
 
 func TestRequestThatCameDuringReauthWaitsUntilItIsCompleted(t *testing.T) {

--- a/testing/service_client_test.go
+++ b/testing/service_client_test.go
@@ -31,5 +31,5 @@ func TestMoreHeaders(t *testing.T) {
 	c.ProviderClient = new(gophercloud.ProviderClient)
 	resp, err := c.Get(context.TODO(), fmt.Sprintf("%s/route", fakeServer.Endpoint()), nil, nil)
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, resp.Request.Header.Get("custom"), "header")
+	th.AssertEquals(t, "header", resp.Request.Header.Get("custom"))
 }


### PR DESCRIPTION
This is a partial backport of #3777, with the last commit skipped due to the large number of merge conflicts. 2 of the 3 remaining commits also have merge conflicts but these are relatively trivial and documented in the commit message.

We want this change mainly due to the addition of the new test assertion helpers, which are relying on in `main`.

- **Fix assertion argument order: expected first, actual second**
- **Fix incorrect field assertions in acceptance tests**
- **testhelper: add new test assertion helpers**
