### PR TITLE
feat: add loadbalancer provider capabilities

### DIFF
--- a/internal/acceptance/openstack/loadbalancer/v2/providers_test.go
+++ b/internal/acceptance/openstack/loadbalancer/v2/providers_test.go
@@ -4,6 +4,7 @@ package v2
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/gophercloud/gophercloud/v2/internal/acceptance/clients"
@@ -29,5 +30,72 @@ func TestProvidersList(t *testing.T) {
 
 	for _, provider := range allProviders {
 		tools.PrintResource(t, provider)
+	}
+}
+
+func TestProviderCapabilities(t *testing.T) {
+	client, err := clients.NewLoadBalancerV2Client()
+	if err != nil {
+		t.Fatalf("Unable to create a loadbalancer client: %v", err)
+	}
+
+	allPages, err := providers.List(client, nil).AllPages(context.TODO())
+	if err != nil {
+		t.Fatalf("Unable to list providers: %v", err)
+	}
+
+	allProviders, err := providers.ExtractProviders(allPages)
+	if err != nil {
+		t.Fatalf("Unable to extract providers: %v", err)
+	}
+	provider := ""
+	for _, candidate := range allProviders {
+		if candidate.Name == "amphora" {
+			provider = candidate.Name
+			break
+		}
+	}
+	if provider == "" {
+		t.Skip("The amphora provider is not enabled")
+	}
+
+	flavorCapabilities, err := providers.ListFlavorCapabilities(context.TODO(), client, provider, nil).Extract()
+	if err != nil {
+		t.Fatalf("Unable to list flavor capabilities for provider %q: %v", provider, err)
+	}
+	const expectedFlavorCapabilityName = "loadbalancer_topology"
+	const expectedFlavorCapabilityDescription = "load balancer topology"
+	found := false
+	for _, capability := range flavorCapabilities {
+		tools.PrintResource(t, capability)
+		if capability.Name == expectedFlavorCapabilityName &&
+			strings.Contains(capability.Description, expectedFlavorCapabilityDescription) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("Expected flavor capability with name %q and description containing %q in %#v",
+			expectedFlavorCapabilityName, expectedFlavorCapabilityDescription, flavorCapabilities)
+	}
+
+	availabilityZoneCapabilities, err := providers.ListAvailabilityZoneCapabilities(context.TODO(), client, provider, nil).Extract()
+	if err != nil {
+		t.Fatalf("Unable to list availability zone capabilities for provider %q: %v", provider, err)
+	}
+	const expectedAvailabilityZoneCapabilityName = "compute_zone"
+	const expectedAvailabilityZoneCapabilityDescription = "compute availability zone"
+	found = false
+	for _, capability := range availabilityZoneCapabilities {
+		tools.PrintResource(t, capability)
+		if capability.Name == expectedAvailabilityZoneCapabilityName &&
+			strings.Contains(capability.Description, expectedAvailabilityZoneCapabilityDescription) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("Expected availability zone capability with name %q and description containing %q in %#v",
+			expectedAvailabilityZoneCapabilityName, expectedAvailabilityZoneCapabilityDescription, availabilityZoneCapabilities)
 	}
 }

--- a/openstack/loadbalancer/v2/providers/doc.go
+++ b/openstack/loadbalancer/v2/providers/doc.go
@@ -17,5 +17,27 @@ Example to List Providers
 	for _, p := range allProviders {
 		fmt.Printf("%+v\n", p)
 	}
+
+Example to List Provider Flavor Capabilities
+
+	capabilities, err := providers.ListFlavorCapabilities(context.TODO(), lbClient, "amphora", nil).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	for _, capability := range capabilities {
+		fmt.Printf("%+v\n", capability)
+	}
+
+Example to List Provider Availability Zone Capabilities
+
+	capabilities, err := providers.ListAvailabilityZoneCapabilities(context.TODO(), lbClient, "amphora", nil).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	for _, capability := range capabilities {
+		fmt.Printf("%+v\n", capability)
+	}
 */
 package providers

--- a/openstack/loadbalancer/v2/providers/requests.go
+++ b/openstack/loadbalancer/v2/providers/requests.go
@@ -1,6 +1,8 @@
 package providers
 
 import (
+	"context"
+
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/pagination"
 )
@@ -41,4 +43,80 @@ func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
 		return ProviderPage{pagination.LinkedPageBase{PageResult: r}}
 	})
+}
+
+// ListFlavorCapabilitiesOptsBuilder allows extensions to add additional
+// parameters to the ListFlavorCapabilities request.
+type ListFlavorCapabilitiesOptsBuilder interface {
+	ToFlavorCapabilitiesListQuery() (string, error)
+}
+
+// ListFlavorCapabilitiesOpts allows the result of a ListFlavorCapabilities
+// request to be filtered.
+type ListFlavorCapabilitiesOpts struct {
+	// Fields is a list of attributes to return for each capability.
+	Fields []string `q:"fields"`
+}
+
+// ToFlavorCapabilitiesListQuery formats a ListFlavorCapabilitiesOpts into a
+// query string.
+func (opts ListFlavorCapabilitiesOpts) ToFlavorCapabilitiesListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// ListFlavorCapabilities lists the flavor capabilities of a provider.
+// This operation requires Octavia API version 2.6 or later.
+func ListFlavorCapabilities(ctx context.Context, c *gophercloud.ServiceClient, provider string, opts ListFlavorCapabilitiesOptsBuilder) (r ListFlavorCapabilitiesResult) {
+	url := flavorCapabilitiesURL(c, provider)
+	if opts != nil {
+		query, err := opts.ToFlavorCapabilitiesListQuery()
+		if err != nil {
+			r.Err = err
+			return
+		}
+		url += query
+	}
+
+	resp, err := c.Get(ctx, url, &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// ListAvailabilityZoneCapabilitiesOptsBuilder allows extensions to add
+// additional parameters to the ListAvailabilityZoneCapabilities request.
+type ListAvailabilityZoneCapabilitiesOptsBuilder interface {
+	ToAvailabilityZoneCapabilitiesListQuery() (string, error)
+}
+
+// ListAvailabilityZoneCapabilitiesOpts allows the result of a
+// ListAvailabilityZoneCapabilities request to be filtered.
+type ListAvailabilityZoneCapabilitiesOpts struct {
+	// Fields is a list of attributes to return for each capability.
+	Fields []string `q:"fields"`
+}
+
+// ToAvailabilityZoneCapabilitiesListQuery formats a
+// ListAvailabilityZoneCapabilitiesOpts into a query string.
+func (opts ListAvailabilityZoneCapabilitiesOpts) ToAvailabilityZoneCapabilitiesListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// ListAvailabilityZoneCapabilities lists the availability zone capabilities
+// of a provider. This operation requires Octavia API version 2.14 or later.
+func ListAvailabilityZoneCapabilities(ctx context.Context, c *gophercloud.ServiceClient, provider string, opts ListAvailabilityZoneCapabilitiesOptsBuilder) (r ListAvailabilityZoneCapabilitiesResult) {
+	url := availabilityZoneCapabilitiesURL(c, provider)
+	if opts != nil {
+		query, err := opts.ToAvailabilityZoneCapabilitiesListQuery()
+		if err != nil {
+			r.Err = err
+			return
+		}
+		url += query
+	}
+
+	resp, err := c.Get(ctx, url, &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
 }

--- a/openstack/loadbalancer/v2/providers/results.go
+++ b/openstack/loadbalancer/v2/providers/results.go
@@ -73,3 +73,45 @@ func (r commonResult) Extract() (*Provider, error) {
 type GetResult struct {
 	commonResult
 }
+
+// Capability represents a provider-specific metadata key that can be used in
+// a flavor profile or an availability zone profile.
+type Capability struct {
+	// Name is the name of the capability.
+	Name string `json:"name"`
+
+	// Description is a human-readable description of the capability.
+	Description string `json:"description"`
+}
+
+// ListFlavorCapabilitiesResult represents the result of a request to list a
+// provider's flavor capabilities.
+type ListFlavorCapabilitiesResult struct {
+	gophercloud.Result
+}
+
+// Extract interprets a ListFlavorCapabilitiesResult as a slice of
+// capabilities.
+func (r ListFlavorCapabilitiesResult) Extract() ([]Capability, error) {
+	var s struct {
+		Capabilities []Capability `json:"flavor_capabilities"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Capabilities, err
+}
+
+// ListAvailabilityZoneCapabilitiesResult represents the result of a request
+// to list a provider's availability zone capabilities.
+type ListAvailabilityZoneCapabilitiesResult struct {
+	gophercloud.Result
+}
+
+// Extract interprets a ListAvailabilityZoneCapabilitiesResult as a slice of
+// capabilities.
+func (r ListAvailabilityZoneCapabilitiesResult) Extract() ([]Capability, error) {
+	var s struct {
+		Capabilities []Capability `json:"availability_zone_capabilities"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Capabilities, err
+}

--- a/openstack/loadbalancer/v2/providers/testing/fixtures_test.go
+++ b/openstack/loadbalancer/v2/providers/testing/fixtures_test.go
@@ -26,6 +26,40 @@ const ProvidersListBody = `
 }
 `
 
+// FlavorCapabilitiesListBody contains the canned body of a provider flavor
+// capabilities response.
+const FlavorCapabilitiesListBody = `
+{
+	"flavor_capabilities": [
+		{
+			"name": "loadbalancer_topology",
+			"description": "The load balancer topology."
+		},
+		{
+			"name": "compute_flavor",
+			"description": "The compute driver flavor ID."
+		}
+	]
+}
+`
+
+// AvailabilityZoneCapabilitiesListBody contains the canned body of a provider
+// availability zone capabilities response.
+const AvailabilityZoneCapabilitiesListBody = `
+{
+	"availability_zone_capabilities": [
+		{
+			"name": "compute_zone",
+			"description": "The compute availability zone."
+		},
+		{
+			"name": "volume_zone",
+			"description": "The volume availability zone."
+		}
+	]
+}
+`
+
 var (
 	ProviderAmphora = providers.Provider{
 		Name:        "amphora",
@@ -34,6 +68,26 @@ var (
 	ProviderOVN = providers.Provider{
 		Name:        "ovn",
 		Description: "The Octavia OVN driver",
+	}
+	FlavorCapabilities = []providers.Capability{
+		{
+			Name:        "loadbalancer_topology",
+			Description: "The load balancer topology.",
+		},
+		{
+			Name:        "compute_flavor",
+			Description: "The compute driver flavor ID.",
+		},
+	}
+	AvailabilityZoneCapabilities = []providers.Capability{
+		{
+			Name:        "compute_zone",
+			Description: "The compute availability zone.",
+		},
+		{
+			Name:        "volume_zone",
+			Description: "The volume availability zone.",
+		},
 	}
 )
 
@@ -54,5 +108,31 @@ func HandleProviderListSuccessfully(t *testing.T, fakeServer th.FakeServer) {
 		default:
 			t.Fatalf("/v2.0/lbaas/providers invoked with unexpected marker=[%s]", marker)
 		}
+	})
+}
+
+// HandleFlavorCapabilitiesListSuccessfully sets up the test server to respond
+// to a provider flavor capabilities request.
+func HandleFlavorCapabilitiesListSuccessfully(t *testing.T, fakeServer th.FakeServer) {
+	fakeServer.Mux.HandleFunc("/v2.0/lbaas/providers/amphora/flavor_capabilities", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, http.MethodGet)
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.AssertDeepEquals(t, []string{"name", "description"}, r.URL.Query()["fields"])
+
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprint(w, FlavorCapabilitiesListBody)
+	})
+}
+
+// HandleAvailabilityZoneCapabilitiesListSuccessfully sets up the test server
+// to respond to a provider availability zone capabilities request.
+func HandleAvailabilityZoneCapabilitiesListSuccessfully(t *testing.T, fakeServer th.FakeServer) {
+	fakeServer.Mux.HandleFunc("/v2.0/lbaas/providers/amphora/availability_zone_capabilities", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, http.MethodGet)
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.AssertDeepEquals(t, []string{"name", "description"}, r.URL.Query()["fields"])
+
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprint(w, AvailabilityZoneCapabilitiesListBody)
 	})
 }

--- a/openstack/loadbalancer/v2/providers/testing/requests_test.go
+++ b/openstack/loadbalancer/v2/providers/testing/requests_test.go
@@ -52,3 +52,27 @@ func TestListAllProviders(t *testing.T) {
 	th.CheckDeepEquals(t, ProviderAmphora, actual[0])
 	th.CheckDeepEquals(t, ProviderOVN, actual[1])
 }
+
+func TestListFlavorCapabilities(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	HandleFlavorCapabilitiesListSuccessfully(t, fakeServer)
+
+	actual, err := providers.ListFlavorCapabilities(context.TODO(), fake.ServiceClient(fakeServer), "amphora", providers.ListFlavorCapabilitiesOpts{
+		Fields: []string{"name", "description"},
+	}).Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, FlavorCapabilities, actual)
+}
+
+func TestListAvailabilityZoneCapabilities(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	HandleAvailabilityZoneCapabilitiesListSuccessfully(t, fakeServer)
+
+	actual, err := providers.ListAvailabilityZoneCapabilities(context.TODO(), fake.ServiceClient(fakeServer), "amphora", providers.ListAvailabilityZoneCapabilitiesOpts{
+		Fields: []string{"name", "description"},
+	}).Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, AvailabilityZoneCapabilities, actual)
+}

--- a/openstack/loadbalancer/v2/providers/urls.go
+++ b/openstack/loadbalancer/v2/providers/urls.go
@@ -3,10 +3,20 @@ package providers
 import "github.com/gophercloud/gophercloud/v2"
 
 const (
-	rootPath     = "lbaas"
-	resourcePath = "providers"
+	rootPath                         = "lbaas"
+	resourcePath                     = "providers"
+	flavorCapabilitiesPath           = "flavor_capabilities"
+	availabilityZoneCapabilitiesPath = "availability_zone_capabilities"
 )
 
 func rootURL(c *gophercloud.ServiceClient) string {
 	return c.ServiceURL(rootPath, resourcePath)
+}
+
+func flavorCapabilitiesURL(c *gophercloud.ServiceClient, provider string) string {
+	return c.ServiceURL(rootPath, resourcePath, provider, flavorCapabilitiesPath)
+}
+
+func availabilityZoneCapabilitiesURL(c *gophercloud.ServiceClient, provider string) string {
+	return c.ServiceURL(rootPath, resourcePath, provider, availabilityZoneCapabilitiesPath)
 }


### PR DESCRIPTION
<!--
Prior to starting a PR, please make sure you have read our
[contributor tutorial](https://github.com/gophercloud/gophercloud/tree/main/docs/contributor-tutorial).

Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

-->
Fixes #3931 

This PR is to support for listing flavor and availability zone capabilities in a provider specific way.
- add `ListFlavorCapabilities`
- add `ListAvailabilityZoneCapabilities`
- add unit and acceptance tests
- update `doc.go`

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

the requested codes are references here:

- https://docs.openstack.org/api-ref/load-balancer/v2/index.html#show-provider-flavor-capabilities
- https://docs.openstack.org/api-ref/load-balancer/v2/index.html#show-provider-availability-zone-capabilities
- https://opendev.org/openstack/octavia/src/branch/master/octavia/api/v2/types/provider.py
- https://opendev.org/openstack/octavia/src/branch/master/octavia/api/v2/controllers/provider.py
