### PR TITLE
core: honor context while waiting for reauthentication

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -130,6 +130,7 @@ func (e ErrTimeOut) Error() string {
 }
 
 // ErrUnableToReauthenticate is the error type returned when reauthentication fails.
+// It does not unwrap because ErrOriginal and ErrReauth are independent failures.
 type ErrUnableToReauthenticate struct {
 	BaseError
 	ErrOriginal error
@@ -142,7 +143,7 @@ func (e ErrUnableToReauthenticate) Error() string {
 }
 
 // ErrErrorAfterReauthentication is the error type returned when reauthentication
-// succeeds, but an error occurs afterword (usually an HTTP error).
+// succeeds, but an error occurs afterward (usually an HTTP error).
 type ErrErrorAfterReauthentication struct {
 	BaseError
 	ErrOriginal error
@@ -151,6 +152,11 @@ type ErrErrorAfterReauthentication struct {
 func (e ErrErrorAfterReauthentication) Error() string {
 	e.DefaultErrString = fmt.Sprintf("Successfully re-authenticated, but got error executing request: %s", e.ErrOriginal)
 	return e.choseErrString()
+}
+
+// Unwrap returns the error from the retried request.
+func (e ErrErrorAfterReauthentication) Unwrap() error {
+	return e.ErrOriginal
 }
 
 // ErrServiceNotFound is returned when no service in a service catalog matches

--- a/provider_client.go
+++ b/provider_client.go
@@ -135,16 +135,25 @@ func (f *reauthFuture) Set(err error) {
 	close(f.done)
 }
 
-func (f *reauthFuture) Get() error {
-	<-f.done
-	return f.err
+func (f *reauthFuture) Get(ctx context.Context) error {
+	select {
+	case <-f.done:
+		return f.err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 // AuthenticatedHeaders returns a map of HTTP headers that are common for all
 // authenticated service requests. Blocks if Reauthenticate is in progress.
-func (client *ProviderClient) AuthenticatedHeaders() (m map[string]string) {
+func (client *ProviderClient) AuthenticatedHeaders() map[string]string {
+	headers, _ := client.authenticatedHeaders(context.Background())
+	return headers
+}
+
+func (client *ProviderClient) authenticatedHeaders(ctx context.Context) (map[string]string, error) {
 	if client.IsThrowaway() {
-		return
+		return nil, nil
 	}
 	if client.reauthmut != nil {
 		// If a Reauthenticate is in progress, wait for it to complete.
@@ -152,14 +161,16 @@ func (client *ProviderClient) AuthenticatedHeaders() (m map[string]string) {
 		ongoing := client.reauthmut.ongoing
 		client.reauthmut.Unlock()
 		if ongoing != nil {
-			_ = ongoing.Get()
+			if err := ongoing.Get(ctx); err != nil && ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
 		}
 	}
 	t := client.Token()
 	if t == "" {
-		return
+		return nil, nil
 	}
-	return map[string]string{"X-Auth-Token": t}
+	return map[string]string{"X-Auth-Token": t}, nil
 }
 
 // UseTokenLock creates a mutex that is used to allow safe concurrent access to the auth token.
@@ -287,7 +298,7 @@ func (client *ProviderClient) Reauthenticate(ctx context.Context, previousToken 
 
 	// If Reauthenticate is running elsewhere, wait for its result.
 	if ongoing != nil {
-		return ongoing.Get()
+		return ongoing.Get(ctx)
 	}
 
 	// Perform the actual reauthentication.
@@ -410,7 +421,11 @@ func (client *ProviderClient) doRequest(ctx context.Context, method, url string,
 	}
 
 	// get latest token from client
-	for k, v := range client.AuthenticatedHeaders() {
+	authenticatedHeaders, err := client.authenticatedHeaders(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for k, v := range authenticatedHeaders {
 		req.Header.Set(k, v)
 	}
 

--- a/testing/errors_test.go
+++ b/testing/errors_test.go
@@ -28,3 +28,12 @@ func TestErrUnexpectedResponseCode(t *testing.T) {
 	th.AssertTrue(t, gophercloud.ResponseCodeIs(errWrapped, http.StatusNotFound))
 	th.AssertFalse(t, gophercloud.ResponseCodeIs(errWrapped, http.StatusInternalServerError))
 }
+
+func TestResponseCodeIsAfterReauthentication(t *testing.T) {
+	err := &gophercloud.ErrErrorAfterReauthentication{
+		ErrOriginal: gophercloud.ErrUnexpectedResponseCode{Actual: http.StatusNotFound},
+	}
+
+	th.AssertTrue(t, gophercloud.ResponseCodeIs(err, http.StatusNotFound))
+	th.AssertFalse(t, gophercloud.ResponseCodeIs(err, http.StatusInternalServerError))
+}

--- a/testing/provider_client_test.go
+++ b/testing/provider_client_test.go
@@ -2,6 +2,7 @@ package testing
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -27,6 +28,105 @@ func TestAuthenticatedHeaders(t *testing.T) {
 	expected := map[string]string{"X-Auth-Token": "1234"}
 	actual := p.AuthenticatedHeaders()
 	th.CheckDeepEquals(t, expected, actual)
+}
+
+func TestConcurrentReauthenticateHonorsContext(t *testing.T) {
+	p := new(gophercloud.ProviderClient)
+	p.UseTokenLock()
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	defer releaseOnce.Do(func() { close(release) })
+	p.ReauthFunc = func(context.Context) error {
+		close(started)
+		<-release
+		return nil
+	}
+
+	first := make(chan error, 1)
+	go func() {
+		first <- p.Reauthenticate(context.Background(), "")
+	}()
+	<-started
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	second := make(chan error, 1)
+	go func() {
+		second <- p.Reauthenticate(ctx, "")
+	}()
+
+	select {
+	case err := <-second:
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("expected context deadline exceeded, got %v", err)
+		}
+	case <-time.After(250 * time.Millisecond):
+		releaseOnce.Do(func() { close(release) })
+		<-first
+		<-second
+		t.Fatal("concurrent reauthentication ignored context cancellation")
+	}
+
+	select {
+	case err := <-first:
+		t.Fatalf("canceled waiter disrupted active reauthentication: %v", err)
+	default:
+	}
+
+	releaseOnce.Do(func() { close(release) })
+	if err := <-first; err != nil {
+		t.Fatalf("active reauthentication failed: %v", err)
+	}
+}
+
+func TestRequestWaitingForReauthenticationHonorsContext(t *testing.T) {
+	p := new(gophercloud.ProviderClient)
+	p.UseTokenLock()
+	p.SetToken("old-token")
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	defer releaseOnce.Do(func() { close(release) })
+	p.ReauthFunc = func(context.Context) error {
+		close(started)
+		<-release
+		p.SetToken("new-token")
+		return nil
+	}
+
+	first := make(chan error, 1)
+	go func() {
+		first <- p.Reauthenticate(context.Background(), "")
+	}()
+	<-started
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	request := make(chan error, 1)
+	go func() {
+		_, err := p.Request(ctx, http.MethodGet, "http://127.0.0.1:1", new(gophercloud.RequestOpts))
+		request <- err
+	}()
+
+	select {
+	case err := <-request:
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("expected context deadline exceeded, got %v", err)
+		}
+	case <-time.After(250 * time.Millisecond):
+		releaseOnce.Do(func() { close(release) })
+		<-first
+		<-request
+		t.Fatal("request ignored context while waiting for reauthentication")
+	}
+
+	releaseOnce.Do(func() { close(release) })
+	if err := <-first; err != nil {
+		t.Fatalf("active reauthentication failed: %v", err)
+	}
 }
 
 func TestUserAgent(t *testing.T) {


### PR DESCRIPTION
Fixes #3922

A request waiting for another goroutine's reauthentication ignores its context and can remain blocked past its deadline. This change lets the waiter return `ctx.Err()` without interrupting the active reauthentication.

`ErrErrorAfterReauthentication` now unwraps the retried request error, allowing `ResponseCodeIs` to detect status codes such as 404.

Links to the line numbers/files in the OpenStack source code that support the code in this PR:

N/A. This changes client-side synchronization and error handling.