### PR TITLE
identity: add OAuth2 mTLS authentication

### DIFF
--- a/internal/acceptance/openstack/identity/v3/oauth2mtls_test.go
+++ b/internal/acceptance/openstack/identity/v3/oauth2mtls_test.go
@@ -1,0 +1,65 @@
+//go:build acceptance || identity || oauth2mtls
+
+package v3
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/openstack"
+	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/servers"
+	"github.com/gophercloud/gophercloud/v2/openstack/identity/v3/oauth2mtls"
+	th "github.com/gophercloud/gophercloud/v2/testhelper"
+)
+
+func TestOAuth2MTLSAuthentication(t *testing.T) {
+	required := []string{"OS_AUTH_URL", "OS_OAUTH2_ENDPOINT", "OS_OAUTH2_CLIENT_ID", "OS_CERT", "OS_KEY"}
+	for _, name := range required {
+		if os.Getenv(name) == "" {
+			t.Skipf("%s must be set", name)
+		}
+	}
+
+	cert, err := tls.LoadX509KeyPair(os.Getenv("OS_CERT"), os.Getenv("OS_KEY"))
+	th.AssertNoErr(t, err)
+
+	tlsConfig := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		MinVersion:   tls.VersionTLS12,
+	}
+	if caPath := os.Getenv("OS_CACERT"); caPath != "" {
+		ca, err := os.ReadFile(caPath)
+		th.AssertNoErr(t, err)
+		tlsConfig.RootCAs = x509.NewCertPool()
+		if !tlsConfig.RootCAs.AppendCertsFromPEM(ca) {
+			t.Fatal("failed to parse OS_CACERT")
+		}
+	}
+
+	provider, err := openstack.NewClient(os.Getenv("OS_AUTH_URL"))
+	th.AssertNoErr(t, err)
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = tlsConfig
+	provider.HTTPClient.Transport = transport
+
+	opts := &oauth2mtls.AuthOptions{
+		OAuth2Endpoint: os.Getenv("OS_OAUTH2_ENDPOINT"),
+		ClientID:       os.Getenv("OS_OAUTH2_CLIENT_ID"),
+		AllowReauth:    true,
+	}
+	ctx := context.Background()
+	th.AssertNoErr(t, openstack.AuthenticateV3(ctx, provider, opts, gophercloud.EndpointOpts{}))
+	th.AssertNoErr(t, provider.Reauthenticate(ctx, ""))
+
+	compute, err := openstack.NewComputeV2(ctx, provider, gophercloud.EndpointOpts{
+		Region: os.Getenv("OS_REGION_NAME"),
+	})
+	th.AssertNoErr(t, err)
+	_, err = servers.List(compute, servers.ListOpts{Limit: 1}).AllPages(ctx)
+	th.AssertNoErr(t, err)
+}

--- a/openstack/client.go
+++ b/openstack/client.go
@@ -11,6 +11,7 @@ import (
 	tokens2 "github.com/gophercloud/gophercloud/v2/openstack/identity/v2/tokens"
 	"github.com/gophercloud/gophercloud/v2/openstack/identity/v3/ec2tokens"
 	"github.com/gophercloud/gophercloud/v2/openstack/identity/v3/oauth1"
+	"github.com/gophercloud/gophercloud/v2/openstack/identity/v3/oauth2mtls"
 	tokens3 "github.com/gophercloud/gophercloud/v2/openstack/identity/v3/tokens"
 	"github.com/gophercloud/gophercloud/v2/openstack/utils"
 )
@@ -222,11 +223,17 @@ func v3auth(ctx context.Context, client *gophercloud.ProviderClient, endpoint st
 		}
 	} else {
 		var result tokens3.CreateResult
+		var authenticatedHeadersFunc func(string) map[string]string
 		switch opts.(type) {
 		case *ec2tokens.AuthOptions:
 			result = ec2tokens.Create(ctx, v3Client, opts)
 		case *oauth1.AuthOptions:
 			result = oauth1.Create(ctx, v3Client, opts)
+		case *oauth2mtls.AuthOptions:
+			result = oauth2mtls.Create(ctx, v3Client, opts)
+			authenticatedHeadersFunc = func(token string) map[string]string {
+				return map[string]string{"Authorization": "Bearer " + token}
+			}
 		default:
 			result = tokens3.Create(ctx, v3Client, opts)
 		}
@@ -240,6 +247,8 @@ func v3auth(ctx context.Context, client *gophercloud.ProviderClient, endpoint st
 		if err != nil {
 			return err
 		}
+
+		client.AuthenticatedHeadersFunc = authenticatedHeadersFunc
 	}
 
 	if opts.CanReauth() {
@@ -268,6 +277,10 @@ func v3auth(ctx context.Context, client *gophercloud.ProviderClient, endpoint st
 			o.AllowReauth = false
 			tao = &o
 		case *oauth1.AuthOptions:
+			o := *ot
+			o.AllowReauth = false
+			tao = &o
+		case *oauth2mtls.AuthOptions:
 			o := *ot
 			o.AllowReauth = false
 			tao = &o

--- a/openstack/identity/v3/oauth2mtls/doc.go
+++ b/openstack/identity/v3/oauth2mtls/doc.go
@@ -1,0 +1,37 @@
+/*
+Package oauth2mtls authenticates to Keystone using OAuth 2.0 mutual TLS client
+authentication (RFC 8705).
+
+The client certificate is mapped to a Keystone user, and the returned access
+token is bound to that certificate. The same certificate must be presented to
+protected service endpoints. The user must have a default project.
+
+Example to authenticate a client using OAuth 2.0 mutual TLS
+
+	client, err := openstack.NewClient("https://keystone.example.com:5000/v3")
+	if err != nil {
+		panic(err)
+	}
+
+	tlsConfig := &tls.Config{
+		Certificates: []tls.Certificate{clientCert},
+		RootCAs:      caCertPool,
+	}
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = tlsConfig
+	client.HTTPClient.Transport = transport
+
+	authOptions := &oauth2mtls.AuthOptions{
+		OAuth2Endpoint: "https://keystone.example.com:5000/v3/OS-OAUTH2/token",
+		ClientID:       "6c3145f4-313d-4910-b3a8-9dfc72da9e75",
+		AllowReauth:    true,
+	}
+
+	err = openstack.AuthenticateV3(context.Background(), client, authOptions, gophercloud.EndpointOpts{})
+	if err != nil {
+		panic(err)
+	}
+
+See https://docs.openstack.org/keystone/latest/admin/oauth2-mtls-usage-guide.html.
+*/
+package oauth2mtls

--- a/openstack/identity/v3/oauth2mtls/requests.go
+++ b/openstack/identity/v3/oauth2mtls/requests.go
@@ -1,0 +1,130 @@
+package oauth2mtls
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/openstack/identity/v3/tokens"
+)
+
+// AuthOptions contains OAuth2 mTLS client-credentials options.
+type AuthOptions struct {
+	// OAuth2Endpoint specifies Keystone's OS-OAUTH2 token endpoint. When empty,
+	// it is derived from the identity ServiceClient endpoint.
+	OAuth2Endpoint string
+
+	// ClientID is the Keystone user ID associated with the client certificate.
+	ClientID string
+
+	// AllowReauth enables automatic reauthentication.
+	AllowReauth bool
+}
+
+type tokenResponse struct {
+	AccessToken string `json:"access_token"`
+	TokenType   string `json:"token_type"`
+}
+
+// ToTokenV3ScopeMap implements tokens.AuthOptionsBuilder.
+func (opts *AuthOptions) ToTokenV3ScopeMap() (map[string]any, error) {
+	return nil, nil
+}
+
+// ToTokenV3HeadersMap implements tokens.AuthOptionsBuilder.
+func (opts *AuthOptions) ToTokenV3HeadersMap(map[string]any) (map[string]string, error) {
+	return nil, nil
+}
+
+// ToTokenV3CreateMap implements tokens.AuthOptionsBuilder.
+func (opts *AuthOptions) ToTokenV3CreateMap(map[string]any) (map[string]any, error) {
+	return nil, nil
+}
+
+// CanReauth reports whether automatic reauthentication is enabled.
+func (opts *AuthOptions) CanReauth() bool {
+	return opts.AllowReauth
+}
+
+func (opts *AuthOptions) validate() error {
+	if opts.ClientID == "" {
+		return gophercloud.ErrMissingInput{Argument: "ClientID"}
+	}
+	return nil
+}
+
+// Create authenticates with OAuth2 mTLS client credentials.
+func Create(ctx context.Context, c *gophercloud.ServiceClient, opts tokens.AuthOptionsBuilder) (r tokens.CreateResult) {
+	mtlsOpts, ok := opts.(*AuthOptions)
+	if !ok || mtlsOpts == nil {
+		r.Err = fmt.Errorf("oauth2mtls: expected non-nil *oauth2mtls.AuthOptions, got %T", opts)
+		return
+	}
+
+	if err := mtlsOpts.validate(); err != nil {
+		r.Err = err
+		return
+	}
+
+	if c == nil || c.ProviderClient == nil {
+		r.Err = fmt.Errorf("oauth2mtls: ServiceClient or ProviderClient is nil")
+		return
+	}
+
+	oauth2Endpoint := mtlsOpts.OAuth2Endpoint
+	if oauth2Endpoint == "" {
+		oauth2Endpoint = tokenURL(c)
+	}
+
+	formData := url.Values{
+		"grant_type": {"client_credentials"},
+		"client_id":  {mtlsOpts.ClientID},
+	}
+
+	var tokenResp tokenResponse
+	authClient := unauthenticatedClient(c)
+	resp, err := authClient.Post(ctx, oauth2Endpoint, strings.NewReader(formData.Encode()), &tokenResp, &gophercloud.RequestOpts{
+		MoreHeaders: map[string]string{"Content-Type": "application/x-www-form-urlencoded"},
+		OkCodes:     []int{http.StatusOK},
+	})
+	_, _, r.Err = gophercloud.ParseResponse(resp, err)
+	if r.Err != nil {
+		return
+	}
+
+	if tokenResp.AccessToken == "" {
+		r.Err = fmt.Errorf("oauth2mtls: token response missing access_token field")
+		return
+	}
+	if !strings.EqualFold(tokenResp.TokenType, "Bearer") {
+		r.Err = fmt.Errorf("oauth2mtls: token response has unsupported token_type %q", tokenResp.TokenType)
+		return
+	}
+
+	// The OS-OAUTH2 response has no catalog, so retrieve the full token.
+	resp, err = authClient.Get(ctx, validateURL(authClient), &r.Body, &gophercloud.RequestOpts{
+		MoreHeaders: map[string]string{
+			"X-Auth-Token":    tokenResp.AccessToken,
+			"X-Subject-Token": tokenResp.AccessToken,
+		},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	if r.Err != nil {
+		return
+	}
+	r.Header.Set("X-Subject-Token", tokenResp.AccessToken)
+
+	return
+}
+
+func unauthenticatedClient(c *gophercloud.ServiceClient) *gophercloud.ServiceClient {
+	client := *c
+	provider := *c.ProviderClient
+	provider.Throwaway = true
+	provider.ReauthFunc = nil
+	client.ProviderClient = &provider
+	return &client
+}

--- a/openstack/identity/v3/oauth2mtls/requests.go
+++ b/openstack/identity/v3/oauth2mtls/requests.go
@@ -18,7 +18,7 @@ type AuthOptions struct {
 	OAuth2Endpoint string
 
 	// ClientID is the Keystone user ID associated with the client certificate.
-	ClientID string
+	ClientID string `required:"true"`
 
 	// AllowReauth enables automatic reauthentication.
 	AllowReauth bool
@@ -39,21 +39,15 @@ func (opts *AuthOptions) ToTokenV3HeadersMap(map[string]any) (map[string]string,
 	return nil, nil
 }
 
-// ToTokenV3CreateMap implements tokens.AuthOptionsBuilder.
+// ToTokenV3CreateMap validates the options without building a request body.
 func (opts *AuthOptions) ToTokenV3CreateMap(map[string]any) (map[string]any, error) {
-	return nil, nil
+	_, err := gophercloud.BuildRequestBody(opts, "")
+	return nil, err
 }
 
 // CanReauth reports whether automatic reauthentication is enabled.
 func (opts *AuthOptions) CanReauth() bool {
 	return opts.AllowReauth
-}
-
-func (opts *AuthOptions) validate() error {
-	if opts.ClientID == "" {
-		return gophercloud.ErrMissingInput{Argument: "ClientID"}
-	}
-	return nil
 }
 
 // Create authenticates with OAuth2 mTLS client credentials.
@@ -64,7 +58,7 @@ func Create(ctx context.Context, c *gophercloud.ServiceClient, opts tokens.AuthO
 		return
 	}
 
-	if err := mtlsOpts.validate(); err != nil {
+	if _, err := mtlsOpts.ToTokenV3CreateMap(nil); err != nil {
 		r.Err = err
 		return
 	}

--- a/openstack/identity/v3/oauth2mtls/testing/doc.go
+++ b/openstack/identity/v3/oauth2mtls/testing/doc.go
@@ -1,0 +1,1 @@
+package testing

--- a/openstack/identity/v3/oauth2mtls/testing/fixtures_test.go
+++ b/openstack/identity/v3/oauth2mtls/testing/fixtures_test.go
@@ -1,0 +1,59 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	th "github.com/gophercloud/gophercloud/v2/testhelper"
+)
+
+const (
+	tokenID       = "gAAAAABl-mTLS-token-abc123"
+	testClientID  = "6c3145f4-313d-4910-b3a8-9dfc72da9e75"
+	tokenResponse = `{
+		"access_token": "gAAAAABl-mTLS-token-abc123",
+		"token_type": "Bearer",
+		"expires_in": 3600
+	}`
+	validateTokenResponse = `{
+		"token": {
+			"catalog": [{
+				"type": "compute",
+				"name": "nova",
+				"endpoints": [{
+					"interface": "public",
+					"region": "iad1",
+					"url": "http://127.0.0.1:8774/v2.1"
+				}]
+			}],
+			"expires_at": "2030-06-15T18:00:00.000000Z"
+		}
+	}`
+)
+
+func handleTokenSuccessfully(t *testing.T, fakeServer th.FakeServer) {
+	fakeServer.Mux.HandleFunc("/OS-OAUTH2/token", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, http.MethodPost)
+		th.TestHeader(t, r, "Content-Type", "application/x-www-form-urlencoded")
+		th.TestHeader(t, r, "Accept", "application/json")
+		if err := r.ParseForm(); err != nil {
+			t.Fatal(err)
+		}
+		th.AssertEquals(t, "client_credentials", r.PostForm.Get("grant_type"))
+		th.AssertEquals(t, testClientID, r.PostForm.Get("client_id"))
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, tokenResponse)
+	})
+}
+
+func handleValidateTokenSuccessfully(t *testing.T, fakeServer th.FakeServer) {
+	fakeServer.Mux.HandleFunc("/auth/tokens", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, http.MethodGet)
+		th.TestHeader(t, r, "X-Auth-Token", tokenID)
+		th.TestHeader(t, r, "X-Subject-Token", tokenID)
+		w.Header().Set("X-Subject-Token", tokenID)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, validateTokenResponse)
+	})
+}

--- a/openstack/identity/v3/oauth2mtls/testing/requests_test.go
+++ b/openstack/identity/v3/oauth2mtls/testing/requests_test.go
@@ -1,0 +1,247 @@
+package testing
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/openstack"
+	"github.com/gophercloud/gophercloud/v2/openstack/identity/v3/oauth2mtls"
+	th "github.com/gophercloud/gophercloud/v2/testhelper"
+)
+
+func newClient(fakeServer th.FakeServer) *gophercloud.ServiceClient {
+	return &gophercloud.ServiceClient{
+		ProviderClient: &gophercloud.ProviderClient{},
+		Endpoint:       fakeServer.Endpoint(),
+	}
+}
+
+func TestAuthenticateV3UsesBearerToken(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	fakeServer.Mux.HandleFunc("/v3/OS-OAUTH2/token", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, tokenResponse)
+	})
+	fakeServer.Mux.HandleFunc("/v3/auth/tokens", func(w http.ResponseWriter, r *http.Request) {
+		th.TestHeader(t, r, "X-Auth-Token", tokenID)
+		th.TestHeader(t, r, "X-Subject-Token", tokenID)
+		w.Header().Set("X-Subject-Token", tokenID)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, validateTokenResponse)
+	})
+	fakeServer.Mux.HandleFunc("/service", func(w http.ResponseWriter, r *http.Request) {
+		th.TestHeader(t, r, "Authorization", "Bearer "+tokenID)
+		th.TestHeaderUnset(t, r, "X-Auth-Token")
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	provider, err := openstack.NewClient(fakeServer.Endpoint() + "v3/")
+	th.AssertNoErr(t, err)
+	th.AssertNoErr(t, openstack.AuthenticateV3(context.Background(), provider, &oauth2mtls.AuthOptions{
+		ClientID: testClientID,
+	}, gophercloud.EndpointOpts{}))
+
+	_, err = provider.Request(context.Background(), http.MethodGet, fakeServer.Endpoint()+"service", &gophercloud.RequestOpts{
+		OkCodes: []int{http.StatusNoContent},
+	})
+	th.AssertNoErr(t, err)
+}
+
+func TestAuthenticateV3Reauthenticates(t *testing.T) {
+	const refreshedToken = "refreshed-token"
+
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	var tokenRequests atomic.Int32
+	fakeServer.Mux.HandleFunc("/v3/OS-OAUTH2/token", func(w http.ResponseWriter, r *http.Request) {
+		token := tokenID
+		if tokenRequests.Add(1) > 1 {
+			token = refreshedToken
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"access_token":%q,"token_type":"Bearer"}`, token)
+	})
+	fakeServer.Mux.HandleFunc("/v3/auth/tokens", func(w http.ResponseWriter, r *http.Request) {
+		token := r.Header.Get("X-Subject-Token")
+		th.TestHeader(t, r, "X-Auth-Token", token)
+		w.Header().Set("X-Subject-Token", token)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, validateTokenResponse)
+	})
+	fakeServer.Mux.HandleFunc("/service", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer "+refreshedToken {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	provider, err := openstack.NewClient(fakeServer.Endpoint() + "v3/")
+	th.AssertNoErr(t, err)
+	th.AssertNoErr(t, openstack.AuthenticateV3(context.Background(), provider, &oauth2mtls.AuthOptions{
+		ClientID:    testClientID,
+		AllowReauth: true,
+	}, gophercloud.EndpointOpts{}))
+
+	_, err = provider.Request(context.Background(), http.MethodGet, fakeServer.Endpoint()+"service", &gophercloud.RequestOpts{
+		OkCodes: []int{http.StatusNoContent},
+	})
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, int32(2), tokenRequests.Load())
+}
+
+func TestCreate(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	handleTokenSuccessfully(t, fakeServer)
+	handleValidateTokenSuccessfully(t, fakeServer)
+
+	result := oauth2mtls.Create(context.Background(), newClient(fakeServer), &oauth2mtls.AuthOptions{
+		ClientID: testClientID,
+	})
+	th.AssertNoErr(t, result.Err)
+
+	token, err := result.ExtractTokenID()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, tokenID, token)
+	catalog, err := result.ExtractServiceCatalog()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, 1, len(catalog.Entries))
+}
+
+func TestCreateUsesExplicitOAuth2Endpoint(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	fakeServer.Mux.HandleFunc("/custom/token", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, tokenResponse)
+	})
+	handleValidateTokenSuccessfully(t, fakeServer)
+
+	result := oauth2mtls.Create(context.Background(), newClient(fakeServer), &oauth2mtls.AuthOptions{
+		OAuth2Endpoint: fakeServer.Endpoint() + "custom/token",
+		ClientID:       testClientID,
+	})
+	th.AssertNoErr(t, result.Err)
+}
+
+func TestCreateUsesProviderUserAgent(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	userAgent := "oauth2mtls-test " + gophercloud.DefaultUserAgent
+	fakeServer.Mux.HandleFunc("/OS-OAUTH2/token", func(w http.ResponseWriter, r *http.Request) {
+		th.TestHeader(t, r, "User-Agent", userAgent)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, tokenResponse)
+	})
+	fakeServer.Mux.HandleFunc("/auth/tokens", func(w http.ResponseWriter, r *http.Request) {
+		th.TestHeader(t, r, "User-Agent", userAgent)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, validateTokenResponse)
+	})
+	client := newClient(fakeServer)
+	client.UserAgent.Prepend("oauth2mtls-test")
+
+	result := oauth2mtls.Create(context.Background(), client, &oauth2mtls.AuthOptions{ClientID: testClientID})
+	th.AssertNoErr(t, result.Err)
+}
+
+func TestCreateRejectsInvalidResponses(t *testing.T) {
+	tests := map[string]struct {
+		response string
+		err      string
+	}{
+		"invalid JSON":         {response: "not JSON", err: "invalid character"},
+		"missing access token": {response: `{"token_type":"Bearer"}`, err: "missing access_token"},
+		"unsupported type":     {response: `{"access_token":"token","token_type":"MAC"}`, err: "unsupported token_type"},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			fakeServer := th.SetupHTTP()
+			defer fakeServer.Teardown()
+			fakeServer.Mux.HandleFunc("/OS-OAUTH2/token", func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprint(w, tt.response)
+			})
+
+			result := oauth2mtls.Create(context.Background(), newClient(fakeServer), &oauth2mtls.AuthOptions{ClientID: testClientID})
+			if result.Err == nil || !strings.Contains(result.Err.Error(), tt.err) {
+				t.Fatalf("expected error containing %q, got %v", tt.err, result.Err)
+			}
+		})
+	}
+}
+
+func TestCreateReturnsResponseErrors(t *testing.T) {
+	for _, status := range []int{http.StatusBadRequest, http.StatusUnauthorized} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			fakeServer := th.SetupHTTP()
+			defer fakeServer.Teardown()
+			fakeServer.Mux.HandleFunc("/OS-OAUTH2/token", func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(status)
+			})
+
+			result := oauth2mtls.Create(context.Background(), newClient(fakeServer), &oauth2mtls.AuthOptions{ClientID: testClientID})
+			if !gophercloud.ResponseCodeIs(result.Err, status) {
+				t.Fatalf("expected a %d response error, got %v", status, result.Err)
+			}
+		})
+	}
+}
+
+func TestCreateReturnsValidationError(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	handleTokenSuccessfully(t, fakeServer)
+	fakeServer.Mux.HandleFunc("/auth/tokens", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	})
+
+	result := oauth2mtls.Create(context.Background(), newClient(fakeServer), &oauth2mtls.AuthOptions{ClientID: testClientID})
+	if !gophercloud.ResponseCodeIs(result.Err, http.StatusUnauthorized) {
+		t.Fatalf("expected a 401 response error, got %v", result.Err)
+	}
+}
+
+func TestCreateValidatesInputs(t *testing.T) {
+	client := &gophercloud.ServiceClient{ProviderClient: &gophercloud.ProviderClient{}}
+	result := oauth2mtls.Create(context.Background(), client, &oauth2mtls.AuthOptions{})
+	var missing gophercloud.ErrMissingInput
+	if !errors.As(result.Err, &missing) {
+		t.Fatalf("expected ErrMissingInput, got %v", result.Err)
+	}
+
+	var opts *oauth2mtls.AuthOptions
+	result = oauth2mtls.Create(context.Background(), client, opts)
+	if result.Err == nil {
+		t.Fatal("expected typed nil options to fail")
+	}
+
+	result = oauth2mtls.Create(context.Background(), nil, &oauth2mtls.AuthOptions{ClientID: testClientID})
+	if result.Err == nil {
+		t.Fatal("expected nil client to fail")
+	}
+}
+
+func TestAuthOptions(t *testing.T) {
+	opts := &oauth2mtls.AuthOptions{AllowReauth: true}
+	th.AssertEquals(t, true, opts.CanReauth())
+
+	scope, err := opts.ToTokenV3ScopeMap()
+	th.AssertNoErr(t, err)
+	if scope != nil {
+		t.Fatalf("expected nil scope, got %v", scope)
+	}
+}

--- a/openstack/identity/v3/oauth2mtls/testing/requests_test.go
+++ b/openstack/identity/v3/oauth2mtls/testing/requests_test.go
@@ -222,6 +222,7 @@ func TestCreateValidatesInputs(t *testing.T) {
 	if !errors.As(result.Err, &missing) {
 		t.Fatalf("expected ErrMissingInput, got %v", result.Err)
 	}
+	th.CheckEquals(t, "ClientID", missing.Argument)
 
 	var opts *oauth2mtls.AuthOptions
 	result = oauth2mtls.Create(context.Background(), client, opts)
@@ -232,6 +233,27 @@ func TestCreateValidatesInputs(t *testing.T) {
 	result = oauth2mtls.Create(context.Background(), nil, &oauth2mtls.AuthOptions{ClientID: testClientID})
 	if result.Err == nil {
 		t.Fatal("expected nil client to fail")
+	}
+}
+
+func TestToTokenV3CreateMap(t *testing.T) {
+	for name, clientID := range map[string]string{"missing client ID": "", "valid": testClientID} {
+		t.Run(name, func(t *testing.T) {
+			opts := &oauth2mtls.AuthOptions{ClientID: clientID}
+			body, err := opts.ToTokenV3CreateMap(nil)
+			if clientID == "" {
+				var missing gophercloud.ErrMissingInput
+				if !errors.As(err, &missing) {
+					t.Fatalf("expected ErrMissingInput, got %v", err)
+				}
+				th.CheckEquals(t, "ClientID", missing.Argument)
+				return
+			}
+			th.AssertNoErr(t, err)
+			if body != nil {
+				t.Fatalf("expected nil body, got %v", body)
+			}
+		})
 	}
 }
 

--- a/openstack/identity/v3/oauth2mtls/urls.go
+++ b/openstack/identity/v3/oauth2mtls/urls.go
@@ -1,0 +1,11 @@
+package oauth2mtls
+
+import "github.com/gophercloud/gophercloud/v2"
+
+func tokenURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("OS-OAUTH2", "token")
+}
+
+func validateURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("auth", "tokens")
+}

--- a/provider_client.go
+++ b/provider_client.go
@@ -84,6 +84,10 @@ type ProviderClient struct {
 	// authentication functions for different Identity service versions.
 	ReauthFunc func(context.Context) error
 
+	// AuthenticatedHeadersFunc returns the headers used to authenticate service
+	// requests. When unset, X-Auth-Token is used.
+	AuthenticatedHeadersFunc func(token string) map[string]string
+
 	// Throwaway determines whether if this client is a throw-away client. It's a copy of user's provider client
 	// with the token and reauth func zeroed. Such client can be used to perform reauthorization.
 	Throwaway bool
@@ -144,16 +148,11 @@ func (f *reauthFuture) Get(ctx context.Context) error {
 	}
 }
 
-// AuthenticatedHeaders returns a map of HTTP headers that are common for all
-// authenticated service requests. Blocks if Reauthenticate is in progress.
-func (client *ProviderClient) AuthenticatedHeaders() map[string]string {
-	headers, _ := client.authenticatedHeaders(context.Background())
-	return headers
-}
-
-func (client *ProviderClient) authenticatedHeaders(ctx context.Context) (map[string]string, error) {
+// authenticatedHeaders returns the authentication headers and the token used
+// to build them.
+func (client *ProviderClient) authenticatedHeaders(ctx context.Context) (map[string]string, string, error) {
 	if client.IsThrowaway() {
-		return nil, nil
+		return nil, "", nil
 	}
 	if client.reauthmut != nil {
 		// If a Reauthenticate is in progress, wait for it to complete.
@@ -162,15 +161,25 @@ func (client *ProviderClient) authenticatedHeaders(ctx context.Context) (map[str
 		client.reauthmut.Unlock()
 		if ongoing != nil {
 			if err := ongoing.Get(ctx); err != nil && ctx.Err() != nil {
-				return nil, ctx.Err()
+				return nil, "", ctx.Err()
 			}
 		}
 	}
 	t := client.Token()
 	if t == "" {
-		return nil, nil
+		return nil, "", nil
 	}
-	return map[string]string{"X-Auth-Token": t}, nil
+	if client.AuthenticatedHeadersFunc != nil {
+		return client.AuthenticatedHeadersFunc(t), t, nil
+	}
+	return map[string]string{"X-Auth-Token": t}, t, nil
+}
+
+// AuthenticatedHeaders returns a map of HTTP headers that are common for all
+// authenticated service requests. Blocks if Reauthenticate is in progress.
+func (client *ProviderClient) AuthenticatedHeaders() map[string]string {
+	headers, _, _ := client.authenticatedHeaders(context.Background())
+	return headers
 }
 
 // UseTokenLock creates a mutex that is used to allow safe concurrent access to the auth token.
@@ -421,15 +430,13 @@ func (client *ProviderClient) doRequest(ctx context.Context, method, url string,
 	}
 
 	// get latest token from client
-	authenticatedHeaders, err := client.authenticatedHeaders(ctx)
+	authenticatedHeaders, prereqtok, err := client.authenticatedHeaders(ctx)
 	if err != nil {
 		return nil, err
 	}
 	for k, v := range authenticatedHeaders {
 		req.Header.Set(k, v)
 	}
-
-	prereqtok := req.Header.Get("X-Auth-Token")
 
 	// Issue the request.
 	resp, err := client.HTTPClient.Do(req)

--- a/provider_client.go
+++ b/provider_client.go
@@ -419,6 +419,16 @@ func (client *ProviderClient) doRequest(ctx context.Context, method, url string,
 	// Set the User-Agent header
 	req.Header.Set("User-Agent", client.UserAgent.Join())
 
+	// Keep the token snapshot for concurrent reauthentication, independent of
+	// any caller-provided authentication header.
+	authenticatedHeaders, prereqtok, err := client.authenticatedHeaders(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for k, v := range authenticatedHeaders {
+		req.Header.Set(k, v)
+	}
+
 	if options.MoreHeaders != nil {
 		for k, v := range options.MoreHeaders {
 			req.Header.Set(k, v)
@@ -427,15 +437,6 @@ func (client *ProviderClient) doRequest(ctx context.Context, method, url string,
 
 	for _, v := range options.OmitHeaders {
 		req.Header.Del(v)
-	}
-
-	// get latest token from client
-	authenticatedHeaders, prereqtok, err := client.authenticatedHeaders(ctx)
-	if err != nil {
-		return nil, err
-	}
-	for k, v := range authenticatedHeaders {
-		req.Header.Set(k, v)
 	}
 
 	// Issue the request.

--- a/testing/auth_header_precedence_test.go
+++ b/testing/auth_header_precedence_test.go
@@ -1,0 +1,79 @@
+package testing
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/v2"
+	th "github.com/gophercloud/gophercloud/v2/testhelper"
+)
+
+func TestRequestAuthenticationHeaderPrecedence(t *testing.T) {
+	for _, header := range []string{"X-Auth-Token", "Authorization"} {
+		for _, mode := range []string{"generated", "override", "omit", "override and omit"} {
+			for _, retry := range []bool{false, true} {
+				t.Run(fmt.Sprintf("%s/%s/retry=%t", header, mode, retry), func(t *testing.T) {
+					p := new(gophercloud.ProviderClient)
+					p.UseTokenLock()
+					p.SetToken("original")
+					value := func(token string) string {
+						if header == "Authorization" {
+							return "Bearer " + token
+						}
+						return token
+					}
+					if header == "Authorization" {
+						p.AuthenticatedHeadersFunc = func(token string) map[string]string {
+							return map[string]string{header: value(token)}
+						}
+					}
+					reauths := 0
+					p.ReauthFunc = func(context.Context) error {
+						reauths++
+						p.SetToken("refreshed")
+						return nil
+					}
+					opts := &gophercloud.RequestOpts{OkCodes: []int{http.StatusNoContent}}
+					if mode == "override" || mode == "override and omit" {
+						opts.MoreHeaders = map[string]string{header: value("caller")}
+					}
+					if mode == "omit" || mode == "override and omit" {
+						opts.OmitHeaders = []string{header}
+					}
+					fakeServer := th.SetupHTTP()
+					defer fakeServer.Teardown()
+					requests := 0
+					fakeServer.Mux.HandleFunc("/resource", func(w http.ResponseWriter, r *http.Request) {
+						requests++
+						expected := value("original")
+						if requests > 1 {
+							expected = value("refreshed")
+						}
+						switch mode {
+						case "override":
+							expected = value("caller")
+						case "omit", "override and omit":
+							expected = ""
+						}
+						th.CheckEquals(t, expected, r.Header.Get(header))
+						if retry && requests == 1 {
+							w.WriteHeader(http.StatusUnauthorized)
+							return
+						}
+						w.WriteHeader(http.StatusNoContent)
+					})
+					_, err := p.Request(context.Background(), http.MethodGet, fakeServer.Endpoint()+"resource", opts)
+					th.AssertNoErr(t, err)
+					expectedRequests, expectedReauths := 1, 0
+					if retry {
+						expectedRequests, expectedReauths = 2, 1
+					}
+					th.CheckEquals(t, expectedRequests, requests)
+					th.CheckEquals(t, expectedReauths, reauths)
+				})
+			}
+		}
+	}
+}

--- a/testing/provider_client_test.go
+++ b/testing/provider_client_test.go
@@ -148,6 +148,68 @@ func TestUserAgent(t *testing.T) {
 	th.CheckEquals(t, expected, actual)
 }
 
+func TestBearerRequestSkipsRedundantReauthentication(t *testing.T) {
+	const (
+		oldToken = "old-token"
+		newToken = "new-token"
+	)
+
+	p := new(gophercloud.ProviderClient)
+	p.UseTokenLock()
+	p.SetToken(oldToken)
+	p.AuthenticatedHeadersFunc = func(token string) map[string]string {
+		return map[string]string{"Authorization": "Bearer " + token}
+	}
+
+	var reauths atomic.Int32
+	p.ReauthFunc = func(context.Context) error {
+		reauths.Add(1)
+		p.SetToken(newToken)
+		return nil
+	}
+
+	firstRequest := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	var oldRequests atomic.Int32
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	fakeServer.Mux.HandleFunc("/route", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Header.Get("Authorization") {
+		case "Bearer " + oldToken:
+			if oldRequests.Add(1) == 1 {
+				close(firstRequest)
+				<-releaseFirst
+			}
+			w.WriteHeader(http.StatusUnauthorized)
+		case "Bearer " + newToken:
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			w.WriteHeader(http.StatusBadRequest)
+		}
+	})
+
+	request := func(errs chan<- error) {
+		_, err := p.Request(context.Background(), http.MethodGet, fakeServer.Endpoint()+"route", &gophercloud.RequestOpts{
+			OkCodes: []int{http.StatusNoContent},
+		})
+		errs <- err
+	}
+
+	errs := make(chan error, 2)
+	go request(errs)
+	<-firstRequest
+	go request(errs)
+	if err := <-errs; err != nil {
+		t.Fatal(err)
+	}
+	close(releaseFirst)
+	if err := <-errs; err != nil {
+		t.Fatal(err)
+	}
+
+	th.AssertEquals(t, int32(1), reauths.Load())
+}
+
 func TestConcurrentReauth(t *testing.T) {
 	var info = struct {
 		numreauths  int

--- a/testing/provider_client_test.go
+++ b/testing/provider_client_test.go
@@ -267,9 +267,6 @@ func TestConcurrentReauth(t *testing.T) {
 	wg := new(sync.WaitGroup)
 	reqopts := new(gophercloud.RequestOpts)
 	reqopts.KeepResponseBody = true
-	reqopts.MoreHeaders = map[string]string{
-		"X-Auth-Token": prereauthTok,
-	}
 
 	for i := 0; i < numconc; i++ {
 		wg.Add(1)
@@ -444,9 +441,6 @@ func TestRequestThatCameDuringReauthWaitsUntilItIsCompleted(t *testing.T) {
 	wg := new(sync.WaitGroup)
 	reqopts := new(gophercloud.RequestOpts)
 	reqopts.KeepResponseBody = true
-	reqopts.MoreHeaders = map[string]string{
-		"X-Auth-Token": prereauthTok,
-	}
 
 	for i := 0; i < numconc; i++ {
 		wg.Add(1)


### PR DESCRIPTION
Fixes #3915

Adds Identity v3 authentication using OAuth 2.0 mutual TLS client credentials. It obtains an access token from `OS-OAUTH2/token`, validates it with Keystone to populate the service catalog, and sends it as `Authorization: Bearer` on service requests. The same flow is used for reauthentication.

`ProviderClient` now supports authentication headers other than `X-Auth-Token`; existing authentication methods are unchanged.

Includes unit and acceptance tests.

Links to the line numbers/files in the OpenStack source code that support the code in this PR:

- [keystoneauth OAuth2 mTLS client-credential implementation](https://opendev.org/openstack/keystoneauth/src/commit/7472cfd32d58f673aaaedfaf1f60df219fda46fe/keystoneauth1/identity/v3/oauth2_mtls_client_credential.py#L92-L155)
- [keystonemiddleware certificate-bound Bearer-token validation](https://opendev.org/openstack/keystonemiddleware/src/commit/9401c513219f86008d1df380a10d57464bb20b2d/keystonemiddleware/oauth2_mtls_token.py#L70-L110)