### PR TITLE
identity: add WebSSO authentication

### DIFF
--- a/openstack/client.go
+++ b/openstack/client.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gophercloud/gophercloud/v2/openstack/identity/v3/ec2tokens"
 	"github.com/gophercloud/gophercloud/v2/openstack/identity/v3/oauth1"
 	tokens3 "github.com/gophercloud/gophercloud/v2/openstack/identity/v3/tokens"
+	"github.com/gophercloud/gophercloud/v2/openstack/identity/v3/websso"
 	"github.com/gophercloud/gophercloud/v2/openstack/utils"
 )
 
@@ -227,6 +228,8 @@ func v3auth(ctx context.Context, client *gophercloud.ProviderClient, endpoint st
 			result = ec2tokens.Create(ctx, v3Client, opts)
 		case *oauth1.AuthOptions:
 			result = oauth1.Create(ctx, v3Client, opts)
+		case *websso.AuthOptions:
+			result = websso.Authenticate(ctx, v3Client, opts)
 		default:
 			result = tokens3.Create(ctx, v3Client, opts)
 		}
@@ -268,6 +271,10 @@ func v3auth(ctx context.Context, client *gophercloud.ProviderClient, endpoint st
 			o.AllowReauth = false
 			tao = &o
 		case *oauth1.AuthOptions:
+			o := *ot
+			o.AllowReauth = false
+			tao = &o
+		case *websso.AuthOptions:
 			o := *ot
 			o.AllowReauth = false
 			tao = &o

--- a/openstack/identity/v3/tokencache/cache.go
+++ b/openstack/identity/v3/tokencache/cache.go
@@ -6,6 +6,8 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
+	"net/http"
 	"strings"
 	"time"
 
@@ -64,26 +66,27 @@ func (ct *cachedToken) valid(endpoint string) bool {
 	return time.Now().Add(tokenExpiryMargin).Before(ct.ExpiresAt)
 }
 
-// Load retrieves and validates a cached token against Keystone.
-func Load(ctx context.Context, client *gophercloud.ProviderClient, cache Cache, key, identityEndpoint string) (tokens.CreateResult, bool) {
+// Load retrieves and validates a cached token against Keystone. Invalid tokens
+// are cache misses; other validation errors are returned.
+func Load(ctx context.Context, client *gophercloud.ProviderClient, cache Cache, key, identityEndpoint string) (tokens.CreateResult, bool, error) {
 	var zero tokens.CreateResult
 	if client == nil || cache == nil {
-		return zero, false
+		return zero, false, nil
 	}
 
 	data, err := cache.Get(key)
 	if err != nil || data == "" {
-		return zero, false
+		return zero, false, nil
 	}
 
 	var cached cachedToken
 	if err := json.Unmarshal([]byte(data), &cached); err != nil {
 		_ = cache.Delete(key)
-		return zero, false
+		return zero, false, nil
 	}
 	if !cached.valid(identityEndpoint) {
 		_ = cache.Delete(key)
-		return zero, false
+		return zero, false, nil
 	}
 
 	endpoint := gophercloud.NormalizeURL(identityEndpoint)
@@ -91,29 +94,44 @@ func Load(ctx context.Context, client *gophercloud.ProviderClient, cache Cache, 
 		endpoint = strings.TrimRight(endpoint, "/") + "/v3/"
 	}
 	identityClient := &gophercloud.ServiceClient{
-		ProviderClient: &gophercloud.ProviderClient{
-			HTTPClient:        client.HTTPClient,
-			UserAgent:         client.UserAgent,
-			RetryBackoffFunc:  client.RetryBackoffFunc,
-			MaxBackoffRetries: client.MaxBackoffRetries,
-			RetryFunc:         client.RetryFunc,
-		},
-		Endpoint: endpoint,
-		Type:     "identity",
+		ProviderClient: client,
+		Endpoint:       endpoint,
+		Type:           "identity",
 	}
-
-	identityClient.SetToken(cached.TokenID)
-	result := tokens.Get(ctx, identityClient, cached.TokenID, nil)
+	result := Validate(ctx, identityClient, cached.TokenID)
 	if result.Err != nil {
-		_ = cache.Delete(key)
-		return zero, false
+		invalid := gophercloud.ResponseCodeIs(result.Err, http.StatusUnauthorized) ||
+			gophercloud.ResponseCodeIs(result.Err, http.StatusNotFound)
+		if invalid {
+			_ = cache.Delete(key)
+			return zero, false, nil
+		}
+		return zero, false, result.Err
+	}
+	return result, true, nil
+}
+
+// Validate retrieves token details from Keystone without changing client.
+func Validate(ctx context.Context, client *gophercloud.ServiceClient, tokenID string) (r tokens.CreateResult) {
+	if client == nil || client.ProviderClient == nil {
+		r.Err = fmt.Errorf("service client or provider client is nil")
+		return
 	}
 
-	var created tokens.CreateResult
-	created.Body = result.Body
-	created.Header = result.Header
-	created.Err = result.Err
-	return created, true
+	validationClient := *client
+	validationClient.ProviderClient = &gophercloud.ProviderClient{
+		TokenID:           tokenID,
+		HTTPClient:        client.HTTPClient,
+		UserAgent:         client.UserAgent,
+		RetryBackoffFunc:  client.RetryBackoffFunc,
+		MaxBackoffRetries: client.MaxBackoffRetries,
+		RetryFunc:         client.RetryFunc,
+	}
+	result := tokens.Get(ctx, &validationClient, tokenID, nil)
+	r.Body = result.Body
+	r.Header = result.Header
+	r.Err = result.Err
+	return
 }
 
 // Persist stores a successful token result. Cache errors are ignored.

--- a/openstack/identity/v3/tokencache/cache.go
+++ b/openstack/identity/v3/tokencache/cache.go
@@ -11,7 +11,8 @@ import (
 
 const tokenExpiryMargin = 5 * time.Minute
 
-// Cache stores authentication results. Implementations must be safe for concurrent use.
+// Cache stores authentication results. Values contain bearer tokens and must be
+// protected accordingly. Implementations must be safe for concurrent use.
 type Cache interface {
 	// Get returns ("", nil) for a cache miss.
 	Get(key string) (string, error)

--- a/openstack/identity/v3/tokencache/cache.go
+++ b/openstack/identity/v3/tokencache/cache.go
@@ -2,17 +2,11 @@
 package tokencache
 
 import (
-	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
-	"fmt"
-	"net/http"
 	"strings"
 	"time"
-
-	"github.com/gophercloud/gophercloud/v2"
-	"github.com/gophercloud/gophercloud/v2/openstack/identity/v3/tokens"
 )
 
 const tokenExpiryMargin = 5 * time.Minute
@@ -39,10 +33,6 @@ type KeyOptions struct {
 	IdentityProvider string
 	// Protocol is the Keystone federation protocol.
 	Protocol string
-	// AuthenticationEndpoint is the external identity endpoint.
-	AuthenticationEndpoint string
-	// Scope is the requested Keystone scope.
-	Scope tokens.Scope
 }
 
 // Key returns a deterministic cache identifier.
@@ -66,91 +56,39 @@ func (ct *cachedToken) valid(endpoint string) bool {
 	return time.Now().Add(tokenExpiryMargin).Before(ct.ExpiresAt)
 }
 
-// Load retrieves and validates a cached token against Keystone. Invalid tokens
-// are cache misses; other validation errors are returned.
-func Load(ctx context.Context, client *gophercloud.ProviderClient, cache Cache, key, identityEndpoint string) (tokens.CreateResult, bool, error) {
-	var zero tokens.CreateResult
-	if client == nil || cache == nil {
-		return zero, false, nil
+// Load retrieves a cached token ID. Missing, malformed, and expired entries are
+// cache misses.
+func Load(cache Cache, key, identityEndpoint string) (string, bool) {
+	if cache == nil {
+		return "", false
 	}
 
 	data, err := cache.Get(key)
 	if err != nil || data == "" {
-		return zero, false, nil
+		return "", false
 	}
 
 	var cached cachedToken
 	if err := json.Unmarshal([]byte(data), &cached); err != nil {
 		_ = cache.Delete(key)
-		return zero, false, nil
+		return "", false
 	}
-	if !cached.valid(identityEndpoint) {
+	if cached.TokenID == "" || !cached.valid(identityEndpoint) {
 		_ = cache.Delete(key)
-		return zero, false, nil
+		return "", false
 	}
-
-	endpoint := gophercloud.NormalizeURL(identityEndpoint)
-	if !strings.HasSuffix(strings.TrimRight(endpoint, "/"), "/v3") {
-		endpoint = strings.TrimRight(endpoint, "/") + "/v3/"
-	}
-	identityClient := &gophercloud.ServiceClient{
-		ProviderClient: client,
-		Endpoint:       endpoint,
-		Type:           "identity",
-	}
-	result := Validate(ctx, identityClient, cached.TokenID)
-	if result.Err != nil {
-		invalid := gophercloud.ResponseCodeIs(result.Err, http.StatusUnauthorized) ||
-			gophercloud.ResponseCodeIs(result.Err, http.StatusNotFound)
-		if invalid {
-			_ = cache.Delete(key)
-			return zero, false, nil
-		}
-		return zero, false, result.Err
-	}
-	return result, true, nil
+	return cached.TokenID, true
 }
 
-// Validate retrieves token details from Keystone without changing client.
-func Validate(ctx context.Context, client *gophercloud.ServiceClient, tokenID string) (r tokens.CreateResult) {
-	if client == nil || client.ProviderClient == nil {
-		r.Err = fmt.Errorf("service client or provider client is nil")
-		return
-	}
-
-	validationClient := *client
-	validationClient.ProviderClient = &gophercloud.ProviderClient{
-		TokenID:           tokenID,
-		HTTPClient:        client.HTTPClient,
-		UserAgent:         client.UserAgent,
-		RetryBackoffFunc:  client.RetryBackoffFunc,
-		MaxBackoffRetries: client.MaxBackoffRetries,
-		RetryFunc:         client.RetryFunc,
-	}
-	result := tokens.Get(ctx, &validationClient, tokenID, nil)
-	r.Body = result.Body
-	r.Header = result.Header
-	r.Err = result.Err
-	return
-}
-
-// Persist stores a successful token result. Cache errors are ignored.
-func Persist(cache Cache, key, identityEndpoint string, result tokens.CreateResult) {
-	if cache == nil {
-		return
-	}
-	tokenID, err := result.ExtractTokenID()
-	if err != nil || tokenID == "" {
-		return
-	}
-	token, err := result.ExtractToken()
-	if err != nil || token == nil {
+// Persist stores a token ID and expiration. Cache errors are ignored.
+func Persist(cache Cache, key, identityEndpoint, tokenID string, expiresAt time.Time) {
+	if cache == nil || tokenID == "" {
 		return
 	}
 
 	data, err := json.Marshal(cachedToken{
 		TokenID:   tokenID,
-		ExpiresAt: token.ExpiresAt,
+		ExpiresAt: expiresAt,
 		Endpoint:  identityEndpoint,
 	})
 	if err != nil {

--- a/openstack/identity/v3/tokencache/cache.go
+++ b/openstack/identity/v3/tokencache/cache.go
@@ -1,0 +1,142 @@
+// Package tokencache provides token caching for Identity v3 authentication.
+package tokencache
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"strings"
+	"time"
+
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/openstack/identity/v3/tokens"
+)
+
+const tokenExpiryMargin = 5 * time.Minute
+
+// Cache stores authentication results. Implementations must be safe for concurrent use.
+type Cache interface {
+	// Get returns ("", nil) for a cache miss.
+	Get(key string) (string, error)
+	// Set stores a value for key.
+	Set(key, value string) error
+	// Delete removes key.
+	Delete(key string) error
+}
+
+// KeyOptions identifies a cached identity.
+type KeyOptions struct {
+	// Flow identifies the authentication flow.
+	Flow string
+	// Principal identifies the client or local profile.
+	Principal string
+	// IdentityEndpoint is the Keystone endpoint.
+	IdentityEndpoint string
+	// IdentityProvider is the Keystone federation provider.
+	IdentityProvider string
+	// Protocol is the Keystone federation protocol.
+	Protocol string
+	// AuthenticationEndpoint is the external identity endpoint.
+	AuthenticationEndpoint string
+	// Scope is the requested Keystone scope.
+	Scope tokens.Scope
+}
+
+// Key returns a deterministic cache identifier.
+func Key(opts KeyOptions) string {
+	opts.IdentityEndpoint = strings.TrimRight(opts.IdentityEndpoint, "/")
+	data, _ := json.Marshal(opts)
+	digest := sha256.Sum256(data)
+	return "gophercloud-auth-" + hex.EncodeToString(digest[:])
+}
+
+type cachedToken struct {
+	TokenID   string    `json:"token_id"`
+	ExpiresAt time.Time `json:"expires_at"`
+	Endpoint  string    `json:"endpoint"`
+}
+
+func (ct *cachedToken) valid(endpoint string) bool {
+	if strings.TrimRight(ct.Endpoint, "/") != strings.TrimRight(endpoint, "/") {
+		return false
+	}
+	return time.Now().Add(tokenExpiryMargin).Before(ct.ExpiresAt)
+}
+
+// Load retrieves and validates a cached token against Keystone.
+func Load(ctx context.Context, client *gophercloud.ProviderClient, cache Cache, key, identityEndpoint string) (tokens.CreateResult, bool) {
+	var zero tokens.CreateResult
+	if client == nil || cache == nil {
+		return zero, false
+	}
+
+	data, err := cache.Get(key)
+	if err != nil || data == "" {
+		return zero, false
+	}
+
+	var cached cachedToken
+	if err := json.Unmarshal([]byte(data), &cached); err != nil {
+		_ = cache.Delete(key)
+		return zero, false
+	}
+	if !cached.valid(identityEndpoint) {
+		_ = cache.Delete(key)
+		return zero, false
+	}
+
+	endpoint := gophercloud.NormalizeURL(identityEndpoint)
+	if !strings.HasSuffix(strings.TrimRight(endpoint, "/"), "/v3") {
+		endpoint = strings.TrimRight(endpoint, "/") + "/v3/"
+	}
+	identityClient := &gophercloud.ServiceClient{
+		ProviderClient: &gophercloud.ProviderClient{
+			HTTPClient:        client.HTTPClient,
+			UserAgent:         client.UserAgent,
+			RetryBackoffFunc:  client.RetryBackoffFunc,
+			MaxBackoffRetries: client.MaxBackoffRetries,
+			RetryFunc:         client.RetryFunc,
+		},
+		Endpoint: endpoint,
+		Type:     "identity",
+	}
+
+	identityClient.SetToken(cached.TokenID)
+	result := tokens.Get(ctx, identityClient, cached.TokenID, nil)
+	if result.Err != nil {
+		_ = cache.Delete(key)
+		return zero, false
+	}
+
+	var created tokens.CreateResult
+	created.Body = result.Body
+	created.Header = result.Header
+	created.Err = result.Err
+	return created, true
+}
+
+// Persist stores a successful token result. Cache errors are ignored.
+func Persist(cache Cache, key, identityEndpoint string, result tokens.CreateResult) {
+	if cache == nil {
+		return
+	}
+	tokenID, err := result.ExtractTokenID()
+	if err != nil || tokenID == "" {
+		return
+	}
+	token, err := result.ExtractToken()
+	if err != nil || token == nil {
+		return
+	}
+
+	data, err := json.Marshal(cachedToken{
+		TokenID:   tokenID,
+		ExpiresAt: token.ExpiresAt,
+		Endpoint:  identityEndpoint,
+	})
+	if err != nil {
+		return
+	}
+	_ = cache.Set(key, string(data))
+}

--- a/openstack/identity/v3/tokencache/cache_test.go
+++ b/openstack/identity/v3/tokencache/cache_test.go
@@ -1,0 +1,22 @@
+package tokencache_test
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/v2/openstack/identity/v3/tokencache"
+)
+
+func TestKeySeparatesFields(t *testing.T) {
+	first := tokencache.Key(tokencache.KeyOptions{
+		Flow:      "flow\nprincipal=principal",
+		Principal: "",
+	})
+	second := tokencache.Key(tokencache.KeyOptions{
+		Flow:      "flow",
+		Principal: "principal\nprincipal=",
+	})
+
+	if first == second {
+		t.Fatalf("different cache identities produced the same key %q", first)
+	}
+}

--- a/openstack/identity/v3/tokencache/testing/cache_test.go
+++ b/openstack/identity/v3/tokencache/testing/cache_test.go
@@ -1,4 +1,4 @@
-package tokencache_test
+package testing
 
 import (
 	"testing"

--- a/openstack/identity/v3/tokencache/testing/cache_test.go
+++ b/openstack/identity/v3/tokencache/testing/cache_test.go
@@ -1,10 +1,38 @@
 package testing
 
 import (
+	"errors"
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/gophercloud/gophercloud/v2/openstack/identity/v3/tokencache"
 )
+
+type testCache struct {
+	value        string
+	getErr       error
+	setErr       error
+	deleteErr    error
+	setCalled    bool
+	deleteCalled bool
+}
+
+func (c *testCache) Get(string) (string, error) {
+	return c.value, c.getErr
+}
+
+func (c *testCache) Set(_ string, value string) error {
+	c.setCalled = true
+	c.value = value
+	return c.setErr
+}
+
+func (c *testCache) Delete(string) error {
+	c.deleteCalled = true
+	c.value = ""
+	return c.deleteErr
+}
 
 func TestKeySeparatesFields(t *testing.T) {
 	first := tokencache.Key(tokencache.KeyOptions{
@@ -19,4 +47,87 @@ func TestKeySeparatesFields(t *testing.T) {
 	if first == second {
 		t.Fatalf("different cache identities produced the same key %q", first)
 	}
+}
+
+func TestPersistAndLoad(t *testing.T) {
+	cache := new(testCache)
+	tokencache.Persist(cache, "key", "https://identity.example/v3/", "token", time.Now().Add(time.Hour))
+
+	if !cache.setCalled {
+		t.Fatal("Persist did not write the token")
+	}
+	actual, ok := tokencache.Load(cache, "key", "https://identity.example/v3")
+	if !ok || actual != "token" {
+		t.Fatalf("Load returned (%q, %t), want (%q, true)", actual, ok, "token")
+	}
+}
+
+func TestEmptyCacheIsMiss(t *testing.T) {
+	for _, cache := range []tokencache.Cache{nil, new(testCache)} {
+		if token, ok := tokencache.Load(cache, "key", "endpoint"); ok || token != "" {
+			t.Fatalf("Load returned (%q, %t), want cache miss", token, ok)
+		}
+	}
+}
+
+func TestPersistSkipsEmptyValues(t *testing.T) {
+	cache := new(testCache)
+	tokencache.Persist(nil, "key", "endpoint", "token", time.Now().Add(time.Hour))
+	tokencache.Persist(cache, "key", "endpoint", "", time.Now().Add(time.Hour))
+	if cache.setCalled {
+		t.Fatal("Persist stored an empty token")
+	}
+}
+
+func TestLoadDeletesInvalidEntries(t *testing.T) {
+	future := time.Now().Add(time.Hour)
+	tests := []struct {
+		name     string
+		value    string
+		endpoint string
+	}{
+		{name: "malformed", value: "not JSON", endpoint: "https://identity.example/v3"},
+		{name: "empty token", value: cacheEntry("", future), endpoint: "https://identity.example/v3"},
+		{name: "expired", value: cacheEntry("token", time.Now().Add(-time.Minute)), endpoint: "https://identity.example/v3"},
+		{name: "within expiry margin", value: cacheEntry("token", time.Now().Add(4*time.Minute)), endpoint: "https://identity.example/v3"},
+		{name: "endpoint mismatch", value: cacheEntry("token", future), endpoint: "https://other.example/v3"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cache := &testCache{value: test.value}
+			if token, ok := tokencache.Load(cache, "key", test.endpoint); ok || token != "" {
+				t.Fatalf("Load returned (%q, %t), want cache miss", token, ok)
+			}
+			if !cache.deleteCalled {
+				t.Fatal("Load did not delete the invalid entry")
+			}
+		})
+	}
+}
+
+func TestCacheErrorsAreBestEffort(t *testing.T) {
+	wantErr := errors.New("cache unavailable")
+	if token, ok := tokencache.Load(&testCache{getErr: wantErr}, "key", "endpoint"); ok || token != "" {
+		t.Fatalf("Load returned (%q, %t) after Get error", token, ok)
+	}
+
+	malformed := &testCache{value: "not JSON", deleteErr: wantErr}
+	if token, ok := tokencache.Load(malformed, "key", "endpoint"); ok || token != "" {
+		t.Fatalf("Load returned (%q, %t) after Delete error", token, ok)
+	}
+	if !malformed.deleteCalled {
+		t.Fatal("Load did not attempt to delete the malformed entry")
+	}
+
+	unavailable := &testCache{setErr: wantErr}
+	tokencache.Persist(unavailable, "key", "endpoint", "token", time.Now().Add(time.Hour))
+	if !unavailable.setCalled {
+		t.Fatal("Persist did not attempt to store the token")
+	}
+}
+
+func cacheEntry(token string, expiresAt time.Time) string {
+	return fmt.Sprintf(`{"token_id":%q,"expires_at":%q,"endpoint":%q}`,
+		token, expiresAt.UTC().Format(time.RFC3339Nano), "https://identity.example/v3")
 }

--- a/openstack/identity/v3/websso/doc.go
+++ b/openstack/identity/v3/websso/doc.go
@@ -7,10 +7,12 @@ token result. The callback origin must be registered in Keystone's
 trusted_dashboard configuration. RedirectHost is restricted to loopback
 addresses so the token listener cannot be exposed on an external interface.
 
-Keystone's WebSSO callback has no request correlation value. Authenticate
-validates the received token with Keystone, but cannot prove that the POST
-came from the browser flow it opened. Another valid token submitted during the
-callback window can therefore cause login CSRF.
+Keystone's WebSSO callback has no request correlation value. The origin must
+match a trusted_dashboard entry verbatim, so it cannot carry a per-flow nonce.
+Authenticate rejects requests that do not resemble Keystone's browser form
+POST and validates the received token with Keystone, but cannot prove that the
+POST came from the browser flow it opened. Another valid token submitted during
+the callback window can therefore cause login CSRF.
 
 Token caching is disabled by default. When TokenCache is set, the validated
 unscoped token is reused across scopes. CacheNamespace must identify the local

--- a/openstack/identity/v3/websso/doc.go
+++ b/openstack/identity/v3/websso/doc.go
@@ -7,9 +7,16 @@ token result. The callback origin must be registered in Keystone's
 trusted_dashboard configuration. RedirectHost is restricted to loopback
 addresses so the token listener cannot be exposed on an external interface.
 
+Keystone's WebSSO callback has no request correlation value. Authenticate
+validates the received token with Keystone, but cannot prove that the POST
+came from the browser flow it opened. Another valid token submitted during the
+callback window can therefore cause login CSRF.
+
 Token caching is disabled by default. When TokenCache is set, the validated
 unscoped token is reused across scopes. CacheNamespace must identify the local
-login profile so unrelated browser identities cannot share a token.
+login profile so unrelated browser identities cannot share a token. Changing
+the active browser account does not invalidate a cached token; use a different
+namespace, clear the cache, or disable caching when switching accounts.
 
 Example:
 

--- a/openstack/identity/v3/websso/doc.go
+++ b/openstack/identity/v3/websso/doc.go
@@ -34,5 +34,8 @@ Example:
 	if result.Err != nil {
 		panic(result.Err)
 	}
+
+See the Horizon WebSSO implementation:
+https://opendev.org/openstack/horizon/src/commit/3c5006efb4533e1cf0815fb80ede86b7a38a40bf/openstack_auth/views.py
 */
 package websso

--- a/openstack/identity/v3/websso/doc.go
+++ b/openstack/identity/v3/websso/doc.go
@@ -7,9 +7,9 @@ token result. The callback origin must be registered in Keystone's
 trusted_dashboard configuration. RedirectHost is restricted to loopback
 addresses so the token listener cannot be exposed on an external interface.
 
-Token caching is disabled by default. When TokenCache is set, CacheNamespace
-must identify the local login profile so unrelated browser identities cannot
-share a cached token.
+Token caching is disabled by default. When TokenCache is set, the validated
+unscoped token is reused across scopes. CacheNamespace must identify the local
+login profile so unrelated browser identities cannot share a token.
 
 Example:
 

--- a/openstack/identity/v3/websso/doc.go
+++ b/openstack/identity/v3/websso/doc.go
@@ -1,0 +1,31 @@
+/*
+Package websso authenticates through Keystone's browser-based WebSSO flow.
+
+Authenticate starts a loopback HTTP listener, opens Keystone's WebSSO
+endpoint, accepts Keystone's form POST, and returns a standard Identity v3
+token result. The callback origin must be registered in Keystone's
+trusted_dashboard configuration. RedirectHost is restricted to loopback
+addresses so the token listener cannot be exposed on an external interface.
+
+Token caching is disabled by default. When TokenCache is set, CacheNamespace
+must identify the local login profile so unrelated browser identities cannot
+share a cached token.
+
+Example:
+
+	opts := &websso.AuthOptions{
+		IdentityProviderName: "my-idp",
+		Protocol:             "openid",
+		RedirectHost:         "localhost",
+		RedirectPort:         9990,
+		Scope: tokens.Scope{
+			ProjectID: "project-id",
+		},
+	}
+
+	result := websso.Authenticate(context.TODO(), identityClient, opts)
+	if result.Err != nil {
+		panic(result.Err)
+	}
+*/
+package websso

--- a/openstack/identity/v3/websso/requests.go
+++ b/openstack/identity/v3/websso/requests.go
@@ -243,7 +243,7 @@ func captureToken(ctx context.Context, client *gophercloud.ServiceClient, opts *
 		}
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprint(w, "<html><body><h2>Authentication successful</h2><p>You may close this window.</p></body></html>")
+		fmt.Fprint(w, "<html><body><script>window.close()</script><h2>Authentication successful</h2><p>You may close this window.</p></body></html>")
 		tokenCh <- token
 	})
 

--- a/openstack/identity/v3/websso/requests.go
+++ b/openstack/identity/v3/websso/requests.go
@@ -30,7 +30,9 @@ type AuthOptions struct {
 	// Protocol is the Keystone federation protocol.
 	Protocol string
 
-	// AllowReauth enables automatic reauthentication.
+	// AllowReauth enables automatic reauthentication. If no cached token is
+	// available, reauthentication opens a new browser flow and concurrent
+	// requests wait for it to finish.
 	AllowReauth bool
 
 	// Scope controls the resulting Keystone token scope.
@@ -104,18 +106,24 @@ func Authenticate(ctx context.Context, client *gophercloud.ServiceClient, builde
 	}
 
 	var unscoped tokens.CreateResult
+	var unscopedToken string
 	haveUnscoped := false
 	cacheKey := ""
 	if opts.TokenCache != nil {
 		cacheKey = CacheKey(client.Endpoint, opts)
-		cached, ok, err := tokencache.Load(ctx, client.ProviderClient, opts.TokenCache, cacheKey, client.Endpoint)
-		if err != nil {
-			r.Err = err
-			return
-		}
+		cachedToken, ok := tokencache.Load(opts.TokenCache, cacheKey, client.Endpoint)
 		if ok {
-			unscoped = cached
-			haveUnscoped = true
+			cached := validateToken(ctx, client, cachedToken)
+			if cached.Err == nil {
+				unscoped = cached
+				unscopedToken = cachedToken
+				haveUnscoped = true
+			} else if gophercloud.ResponseCodeIs(cached.Err, http.StatusUnauthorized) ||
+				gophercloud.ResponseCodeIs(cached.Err, http.StatusNotFound) {
+				_ = opts.TokenCache.Delete(cacheKey)
+			} else {
+				return cached
+			}
 		}
 	}
 	if !haveUnscoped {
@@ -128,29 +136,47 @@ func Authenticate(ctx context.Context, client *gophercloud.ServiceClient, builde
 			timeout = defaultTimeout
 		}
 
-		unscopedToken, err := captureToken(ctx, client, opts, port, timeout)
+		unscopedToken, err = captureToken(ctx, client, opts, port, timeout)
 		if err != nil {
 			r.Err = err
 			return
 		}
-		unscoped = tokencache.Validate(ctx, client, unscopedToken)
+		unscoped = validateToken(ctx, client, unscopedToken)
 		if unscoped.Err != nil {
 			return unscoped
 		}
 		if opts.TokenCache != nil {
-			tokencache.Persist(opts.TokenCache, cacheKey, client.Endpoint, unscoped)
+			token, err := unscoped.ExtractToken()
+			if err == nil && token != nil {
+				tokencache.Persist(opts.TokenCache, cacheKey, client.Endpoint, unscopedToken, token.ExpiresAt)
+			}
 		}
 	}
 
 	if scope == nil {
 		return unscoped
 	}
-	unscopedToken, err := unscoped.ExtractTokenID()
-	if err != nil {
-		r.Err = err
-		return
-	}
 	return tokens.Create(ctx, client, &tokens.AuthOptions{TokenID: unscopedToken, Scope: opts.Scope})
+}
+
+func validateToken(ctx context.Context, client *gophercloud.ServiceClient, tokenID string) (r tokens.CreateResult) {
+	validationClient := *client
+	validationClient.ProviderClient = &gophercloud.ProviderClient{
+		TokenID:           tokenID,
+		HTTPClient:        client.HTTPClient,
+		UserAgent:         client.UserAgent,
+		RetryBackoffFunc:  client.RetryBackoffFunc,
+		MaxBackoffRetries: client.MaxBackoffRetries,
+		RetryFunc:         client.RetryFunc,
+	}
+	result := tokens.Get(ctx, &validationClient, tokenID, nil)
+	r.Body = result.Body
+	r.Header = result.Header
+	r.Err = result.Err
+	if r.Err == nil {
+		r.Header.Set("X-Subject-Token", tokenID)
+	}
+	return
 }
 
 func (opts *AuthOptions) validate() error {

--- a/openstack/identity/v3/websso/requests.go
+++ b/openstack/identity/v3/websso/requests.go
@@ -1,0 +1,280 @@
+package websso
+
+import (
+	"context"
+	"fmt"
+	"mime"
+	"net"
+	"net/http"
+	"net/url"
+	"os/exec"
+	"runtime"
+	"sync/atomic"
+	"time"
+
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/openstack/identity/v3/tokencache"
+	"github.com/gophercloud/gophercloud/v2/openstack/identity/v3/tokens"
+)
+
+const (
+	defaultRedirectPort = 9990
+	defaultTimeout      = 5 * time.Minute
+)
+
+// AuthOptions contains WebSSO authentication options.
+type AuthOptions struct {
+	// IdentityProviderName is the Keystone federation identity provider.
+	IdentityProviderName string
+
+	// Protocol is the Keystone federation protocol.
+	Protocol string
+
+	// AllowReauth enables automatic reauthentication.
+	AllowReauth bool
+
+	// Scope controls the resulting Keystone token scope.
+	Scope tokens.Scope
+
+	// RedirectHost is the loopback callback host. It defaults to localhost.
+	RedirectHost string
+
+	// RedirectPort is the callback listener port. It defaults to 9990.
+	RedirectPort int
+
+	// Timeout limits the browser flow. It defaults to five minutes.
+	Timeout time.Duration
+
+	// BrowserOpener opens the WebSSO URL. It defaults to the OS browser.
+	BrowserOpener func(string) error
+
+	// TokenCache enables token reuse and requires CacheNamespace.
+	TokenCache tokencache.Cache
+
+	// CacheNamespace identifies the local WebSSO profile.
+	CacheNamespace string
+}
+
+func (opts *AuthOptions) ToTokenV3ScopeMap() (map[string]any, error) {
+	return (&tokens.AuthOptions{Scope: opts.Scope}).ToTokenV3ScopeMap()
+}
+
+func (opts *AuthOptions) ToTokenV3HeadersMap(map[string]any) (map[string]string, error) {
+	return nil, nil
+}
+
+func (opts *AuthOptions) ToTokenV3CreateMap(map[string]any) (map[string]any, error) {
+	return nil, nil
+}
+
+func (opts *AuthOptions) CanReauth() bool {
+	return opts.AllowReauth
+}
+
+// CacheKey returns the identity-isolated cache key for opts.
+func CacheKey(identityEndpoint string, opts *AuthOptions) string {
+	return tokencache.Key(tokencache.KeyOptions{
+		Flow:             "websso",
+		Principal:        opts.CacheNamespace,
+		IdentityEndpoint: identityEndpoint,
+		IdentityProvider: opts.IdentityProviderName,
+		Protocol:         opts.Protocol,
+		Scope:            opts.Scope,
+	})
+}
+
+// Authenticate performs browser-based WebSSO authentication.
+func Authenticate(ctx context.Context, client *gophercloud.ServiceClient, builder tokens.AuthOptionsBuilder) (r tokens.CreateResult) {
+	opts, ok := builder.(*AuthOptions)
+	if !ok || opts == nil {
+		r.Err = fmt.Errorf("websso: expected non-nil *websso.AuthOptions, got %T", builder)
+		return
+	}
+	if err := opts.validate(); err != nil {
+		r.Err = err
+		return
+	}
+	if client == nil || client.ProviderClient == nil {
+		r.Err = fmt.Errorf("websso: ServiceClient or ProviderClient is nil")
+		return
+	}
+
+	cacheKey := ""
+	if opts.TokenCache != nil {
+		cacheKey = CacheKey(client.Endpoint, opts)
+		if cached, ok := tokencache.Load(ctx, client.ProviderClient, opts.TokenCache, cacheKey, client.Endpoint); ok {
+			return cached
+		}
+	}
+
+	port := opts.RedirectPort
+	if port == 0 {
+		port = defaultRedirectPort
+	}
+	timeout := opts.Timeout
+	if timeout == 0 {
+		timeout = defaultTimeout
+	}
+
+	unscopedToken, err := captureToken(ctx, client, opts, port, timeout)
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	scope, err := opts.ToTokenV3ScopeMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	if scope != nil {
+		tokenOpts := &tokens.AuthOptions{TokenID: unscopedToken, Scope: opts.Scope}
+		r = tokens.Create(ctx, client, tokenOpts)
+	} else {
+		client.SetToken(unscopedToken)
+		response, err := client.Get(ctx, client.ServiceURL("auth", "tokens"), &r.Body, &gophercloud.RequestOpts{
+			MoreHeaders: map[string]string{"X-Subject-Token": unscopedToken},
+		})
+		_, r.Header, r.Err = gophercloud.ParseResponse(response, err)
+	}
+
+	if r.Err == nil && opts.TokenCache != nil {
+		tokencache.Persist(opts.TokenCache, cacheKey, client.Endpoint, r)
+	}
+	return
+}
+
+func (opts *AuthOptions) validate() error {
+	if opts.IdentityProviderName == "" {
+		return fmt.Errorf("websso: missing required field IdentityProviderName")
+	}
+	if opts.Protocol == "" {
+		return fmt.Errorf("websso: missing required field Protocol")
+	}
+	if opts.RedirectPort < 0 || opts.RedirectPort > 65535 {
+		return fmt.Errorf("websso: RedirectPort must be 0 or between 1 and 65535")
+	}
+	if opts.Timeout < 0 {
+		return fmt.Errorf("websso: Timeout must not be negative")
+	}
+	if opts.TokenCache != nil && opts.CacheNamespace == "" {
+		return fmt.Errorf("websso: CacheNamespace is required when TokenCache is enabled")
+	}
+	if opts.RedirectHost != "" && opts.RedirectHost != "localhost" {
+		ip := net.ParseIP(opts.RedirectHost)
+		if ip == nil || !ip.IsLoopback() {
+			return fmt.Errorf("websso: RedirectHost must be a loopback address")
+		}
+	}
+	return nil
+}
+
+func captureToken(ctx context.Context, client *gophercloud.ServiceClient, opts *AuthOptions, port int, timeout time.Duration) (string, error) {
+	const callbackPath = "/auth/websso/"
+	host := opts.RedirectHost
+	if host == "" {
+		host = "localhost"
+	}
+	origin := "http://" + net.JoinHostPort(host, fmt.Sprintf("%d", port)) + callbackPath
+	webSSOURL := authURL(client, opts.IdentityProviderName, opts.Protocol) + "?origin=" + url.QueryEscape(origin)
+
+	tokenCh := make(chan string, 1)
+	errCh := make(chan error, 1)
+	var accepted atomic.Bool
+	mux := http.NewServeMux()
+	mux.HandleFunc(callbackPath, func(w http.ResponseWriter, request *http.Request) {
+		if request.Method != http.MethodPost {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		mediaType, _, err := mime.ParseMediaType(request.Header.Get("Content-Type"))
+		if err != nil || mediaType != "application/x-www-form-urlencoded" {
+			http.Error(w, "Unsupported Content-Type", http.StatusUnsupportedMediaType)
+			return
+		}
+		request.Body = http.MaxBytesReader(w, request.Body, 64<<10)
+		if err := request.ParseForm(); err != nil {
+			http.Error(w, "Bad request", http.StatusBadRequest)
+			return
+		}
+		token := request.FormValue("token")
+		if token == "" {
+			http.Error(w, "Missing token", http.StatusBadRequest)
+			return
+		}
+		if !accepted.CompareAndSwap(false, true) {
+			http.Error(w, "Token already received", http.StatusConflict)
+			return
+		}
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "<html><body><h2>Authentication successful</h2><p>You may close this window.</p></body></html>")
+		tokenCh <- token
+	})
+
+	listener, err := net.Listen("tcp", net.JoinHostPort(host, fmt.Sprintf("%d", port)))
+	if err != nil {
+		return "", fmt.Errorf("failed to start callback server on %s: %w", net.JoinHostPort(host, fmt.Sprintf("%d", port)), err)
+	}
+	server := &http.Server{
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       10 * time.Second,
+		WriteTimeout:      10 * time.Second,
+		IdleTimeout:       30 * time.Second,
+	}
+	go func() {
+		if err := server.Serve(listener); err != nil && err != http.ErrServerClosed {
+			errCh <- fmt.Errorf("callback server error: %w", err)
+		}
+	}()
+	defer func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+		if err := server.Shutdown(shutdownCtx); err != nil {
+			_ = server.Close()
+		}
+	}()
+
+	opener := opts.BrowserOpener
+	if opener == nil {
+		opener = openBrowser
+	}
+	if err := opener(webSSOURL); err != nil {
+		return "", fmt.Errorf("failed to open browser: %w", err)
+	}
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case token := <-tokenCh:
+		return token, nil
+	case err := <-errCh:
+		return "", err
+	case <-timer.C:
+		return "", fmt.Errorf("WebSSO authentication timed out after %s", timeout)
+	case <-ctx.Done():
+		return "", fmt.Errorf("WebSSO authentication cancelled: %w", ctx.Err())
+	}
+}
+
+func openBrowser(target string) error {
+	var command *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		command = exec.Command("open", target)
+	case "linux":
+		command = exec.Command("xdg-open", target)
+	case "windows":
+		command = exec.Command("rundll32", "url.dll,FileProtocolHandler", target)
+	default:
+		return fmt.Errorf("unsupported operating system %q", runtime.GOOS)
+	}
+	if err := command.Start(); err != nil {
+		return err
+	}
+	go func() {
+		_ = command.Wait()
+	}()
+	return nil
+}

--- a/openstack/identity/v3/websso/requests.go
+++ b/openstack/identity/v3/websso/requests.go
@@ -51,7 +51,7 @@ type AuthOptions struct {
 	// TokenCache enables unscoped token reuse and requires CacheNamespace.
 	TokenCache tokencache.Cache
 
-	// CacheNamespace identifies the local WebSSO profile.
+	// CacheNamespace identifies the expected browser login profile.
 	CacheNamespace string
 }
 

--- a/openstack/identity/v3/websso/requests.go
+++ b/openstack/identity/v3/websso/requests.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os/exec"
 	"runtime"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -206,6 +207,10 @@ func (opts *AuthOptions) validate() error {
 
 func captureToken(ctx context.Context, client *gophercloud.ServiceClient, opts *AuthOptions, port int, timeout time.Duration) (string, error) {
 	const callbackPath = "/auth/websso/"
+	keystoneOrigin, err := endpointOrigin(client.Endpoint)
+	if err != nil {
+		return "", fmt.Errorf("invalid identity endpoint: %w", err)
+	}
 	host := opts.RedirectHost
 	if host == "" {
 		host = "localhost"
@@ -225,6 +230,10 @@ func captureToken(ctx context.Context, client *gophercloud.ServiceClient, opts *
 		mediaType, _, err := mime.ParseMediaType(request.Header.Get("Content-Type"))
 		if err != nil || mediaType != "application/x-www-form-urlencoded" {
 			http.Error(w, "Unsupported Content-Type", http.StatusUnsupportedMediaType)
+			return
+		}
+		if !validCallbackRequest(request, keystoneOrigin) {
+			http.Error(w, "Bad request", http.StatusBadRequest)
 			return
 		}
 		request.Body = http.MaxBytesReader(w, request.Body, 64<<10)
@@ -291,6 +300,37 @@ func captureToken(ctx context.Context, client *gophercloud.ServiceClient, opts *
 	case <-ctx.Done():
 		return "", fmt.Errorf("WebSSO authentication cancelled: %w", ctx.Err())
 	}
+}
+
+func endpointOrigin(rawURL string) (string, error) {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return "", err
+	}
+	if parsed.Scheme == "" || parsed.Host == "" {
+		return "", fmt.Errorf("URL must include a scheme and host")
+	}
+	return strings.ToLower(parsed.Scheme + "://" + parsed.Host), nil
+}
+
+func validCallbackRequest(request *http.Request, keystoneOrigin string) bool {
+	if request.Header.Get("Sec-Fetch-Mode") != "navigate" ||
+		request.Header.Get("Sec-Fetch-Dest") != "document" ||
+		request.Header.Get("Sec-Fetch-Site") == "none" {
+		return false
+	}
+
+	origin := request.Header.Get("Origin")
+	if origin != "" && origin != "null" && !sameOrigin(origin, keystoneOrigin) {
+		return false
+	}
+	referer := request.Header.Get("Referer")
+	return referer == "" || sameOrigin(referer, keystoneOrigin)
+}
+
+func sameOrigin(rawURL, expected string) bool {
+	origin, err := endpointOrigin(rawURL)
+	return err == nil && origin == expected
 }
 
 func openBrowser(target string) error {

--- a/openstack/identity/v3/websso/requests.go
+++ b/openstack/identity/v3/websso/requests.go
@@ -48,7 +48,7 @@ type AuthOptions struct {
 	// BrowserOpener opens the WebSSO URL. It defaults to the OS browser.
 	BrowserOpener func(string) error
 
-	// TokenCache enables token reuse and requires CacheNamespace.
+	// TokenCache enables unscoped token reuse and requires CacheNamespace.
 	TokenCache tokencache.Cache
 
 	// CacheNamespace identifies the local WebSSO profile.
@@ -79,7 +79,6 @@ func CacheKey(identityEndpoint string, opts *AuthOptions) string {
 		IdentityEndpoint: identityEndpoint,
 		IdentityProvider: opts.IdentityProviderName,
 		Protocol:         opts.Protocol,
-		Scope:            opts.Scope,
 	})
 }
 
@@ -98,50 +97,60 @@ func Authenticate(ctx context.Context, client *gophercloud.ServiceClient, builde
 		r.Err = fmt.Errorf("websso: ServiceClient or ProviderClient is nil")
 		return
 	}
-
-	cacheKey := ""
-	if opts.TokenCache != nil {
-		cacheKey = CacheKey(client.Endpoint, opts)
-		if cached, ok := tokencache.Load(ctx, client.ProviderClient, opts.TokenCache, cacheKey, client.Endpoint); ok {
-			return cached
-		}
-	}
-
-	port := opts.RedirectPort
-	if port == 0 {
-		port = defaultRedirectPort
-	}
-	timeout := opts.Timeout
-	if timeout == 0 {
-		timeout = defaultTimeout
-	}
-
-	unscopedToken, err := captureToken(ctx, client, opts, port, timeout)
-	if err != nil {
-		r.Err = err
-		return
-	}
-
 	scope, err := opts.ToTokenV3ScopeMap()
 	if err != nil {
 		r.Err = err
 		return
 	}
-	if scope != nil {
-		tokenOpts := &tokens.AuthOptions{TokenID: unscopedToken, Scope: opts.Scope}
-		r = tokens.Create(ctx, client, tokenOpts)
-	} else {
-		client.SetToken(unscopedToken)
-		response, err := client.Get(ctx, client.ServiceURL("auth", "tokens"), &r.Body, &gophercloud.RequestOpts{
-			MoreHeaders: map[string]string{"X-Subject-Token": unscopedToken},
-		})
-		_, r.Header, r.Err = gophercloud.ParseResponse(response, err)
+
+	var unscoped tokens.CreateResult
+	haveUnscoped := false
+	cacheKey := ""
+	if opts.TokenCache != nil {
+		cacheKey = CacheKey(client.Endpoint, opts)
+		cached, ok, err := tokencache.Load(ctx, client.ProviderClient, opts.TokenCache, cacheKey, client.Endpoint)
+		if err != nil {
+			r.Err = err
+			return
+		}
+		if ok {
+			unscoped = cached
+			haveUnscoped = true
+		}
+	}
+	if !haveUnscoped {
+		port := opts.RedirectPort
+		if port == 0 {
+			port = defaultRedirectPort
+		}
+		timeout := opts.Timeout
+		if timeout == 0 {
+			timeout = defaultTimeout
+		}
+
+		unscopedToken, err := captureToken(ctx, client, opts, port, timeout)
+		if err != nil {
+			r.Err = err
+			return
+		}
+		unscoped = tokencache.Validate(ctx, client, unscopedToken)
+		if unscoped.Err != nil {
+			return unscoped
+		}
+		if opts.TokenCache != nil {
+			tokencache.Persist(opts.TokenCache, cacheKey, client.Endpoint, unscoped)
+		}
 	}
 
-	if r.Err == nil && opts.TokenCache != nil {
-		tokencache.Persist(opts.TokenCache, cacheKey, client.Endpoint, r)
+	if scope == nil {
+		return unscoped
 	}
-	return
+	unscopedToken, err := unscoped.ExtractTokenID()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	return tokens.Create(ctx, client, &tokens.AuthOptions{TokenID: unscopedToken, Scope: opts.Scope})
 }
 
 func (opts *AuthOptions) validate() error {
@@ -197,7 +206,7 @@ func captureToken(ctx context.Context, client *gophercloud.ServiceClient, opts *
 			http.Error(w, "Bad request", http.StatusBadRequest)
 			return
 		}
-		token := request.FormValue("token")
+		token := request.PostFormValue("token")
 		if token == "" {
 			http.Error(w, "Missing token", http.StatusBadRequest)
 			return

--- a/openstack/identity/v3/websso/requests.go
+++ b/openstack/identity/v3/websso/requests.go
@@ -31,9 +31,8 @@ type AuthOptions struct {
 	// Protocol is the Keystone federation protocol.
 	Protocol string
 
-	// AllowReauth enables automatic reauthentication. If no cached token is
-	// available, reauthentication opens a new browser flow and concurrent
-	// requests wait for it to finish.
+	// AllowReauth allows Gophercloud to reauthenticate automatically when the
+	// token expires.
 	AllowReauth bool
 
 	// Scope controls the resulting Keystone token scope.
@@ -58,18 +57,22 @@ type AuthOptions struct {
 	CacheNamespace string
 }
 
+// ToTokenV3ScopeMap returns the requested token scope.
 func (opts *AuthOptions) ToTokenV3ScopeMap() (map[string]any, error) {
 	return (&tokens.AuthOptions{Scope: opts.Scope}).ToTokenV3ScopeMap()
 }
 
+// ToTokenV3HeadersMap implements tokens.AuthOptionsBuilder.
 func (opts *AuthOptions) ToTokenV3HeadersMap(map[string]any) (map[string]string, error) {
 	return nil, nil
 }
 
+// ToTokenV3CreateMap implements tokens.AuthOptionsBuilder.
 func (opts *AuthOptions) ToTokenV3CreateMap(map[string]any) (map[string]any, error) {
 	return nil, nil
 }
 
+// CanReauth reports whether automatic reauthentication is enabled.
 func (opts *AuthOptions) CanReauth() bool {
 	return opts.AllowReauth
 }
@@ -209,7 +212,7 @@ func captureToken(ctx context.Context, client *gophercloud.ServiceClient, opts *
 	const callbackPath = "/auth/websso/"
 	keystoneOrigin, err := endpointOrigin(client.Endpoint)
 	if err != nil {
-		return "", fmt.Errorf("invalid identity endpoint: %w", err)
+		return "", fmt.Errorf("websso: invalid identity endpoint: %w", err)
 	}
 	host := opts.RedirectHost
 	if host == "" {
@@ -223,6 +226,10 @@ func captureToken(ctx context.Context, client *gophercloud.ServiceClient, opts *
 	var accepted atomic.Bool
 	mux := http.NewServeMux()
 	mux.HandleFunc(callbackPath, func(w http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != callbackPath {
+			http.NotFound(w, request)
+			return
+		}
 		if request.Method != http.MethodPost {
 			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 			return
@@ -232,7 +239,7 @@ func captureToken(ctx context.Context, client *gophercloud.ServiceClient, opts *
 			http.Error(w, "Unsupported Content-Type", http.StatusUnsupportedMediaType)
 			return
 		}
-		if !validCallbackRequest(request, keystoneOrigin) {
+		if !validCallbackContext(request, keystoneOrigin) {
 			http.Error(w, "Bad request", http.StatusBadRequest)
 			return
 		}
@@ -258,7 +265,11 @@ func captureToken(ctx context.Context, client *gophercloud.ServiceClient, opts *
 
 	listener, err := net.Listen("tcp", net.JoinHostPort(host, fmt.Sprintf("%d", port)))
 	if err != nil {
-		return "", fmt.Errorf("failed to start callback server on %s: %w", net.JoinHostPort(host, fmt.Sprintf("%d", port)), err)
+		return "", fmt.Errorf("websso: failed to start callback server on %s: %w", net.JoinHostPort(host, fmt.Sprintf("%d", port)), err)
+	}
+	if !isLoopbackAddr(listener.Addr()) {
+		_ = listener.Close()
+		return "", fmt.Errorf("websso: callback listener is not bound to a loopback address")
 	}
 	server := &http.Server{
 		Handler:           mux,
@@ -269,7 +280,7 @@ func captureToken(ctx context.Context, client *gophercloud.ServiceClient, opts *
 	}
 	go func() {
 		if err := server.Serve(listener); err != nil && err != http.ErrServerClosed {
-			errCh <- fmt.Errorf("callback server error: %w", err)
+			errCh <- fmt.Errorf("websso: callback server error: %w", err)
 		}
 	}()
 	defer func() {
@@ -285,7 +296,7 @@ func captureToken(ctx context.Context, client *gophercloud.ServiceClient, opts *
 		opener = openBrowser
 	}
 	if err := opener(webSSOURL); err != nil {
-		return "", fmt.Errorf("failed to open browser: %w", err)
+		return "", fmt.Errorf("websso: failed to open browser: %w", err)
 	}
 
 	timer := time.NewTimer(timeout)
@@ -296,9 +307,9 @@ func captureToken(ctx context.Context, client *gophercloud.ServiceClient, opts *
 	case err := <-errCh:
 		return "", err
 	case <-timer.C:
-		return "", fmt.Errorf("WebSSO authentication timed out after %s", timeout)
+		return "", fmt.Errorf("websso: authentication timed out after %s", timeout)
 	case <-ctx.Done():
-		return "", fmt.Errorf("WebSSO authentication cancelled: %w", ctx.Err())
+		return "", fmt.Errorf("websso: authentication cancelled: %w", ctx.Err())
 	}
 }
 
@@ -308,12 +319,12 @@ func endpointOrigin(rawURL string) (string, error) {
 		return "", err
 	}
 	if parsed.Scheme == "" || parsed.Host == "" {
-		return "", fmt.Errorf("URL must include a scheme and host")
+		return "", fmt.Errorf("url must include a scheme and host")
 	}
 	return strings.ToLower(parsed.Scheme + "://" + parsed.Host), nil
 }
 
-func validCallbackRequest(request *http.Request, keystoneOrigin string) bool {
+func validCallbackContext(request *http.Request, keystoneOrigin string) bool {
 	if request.Header.Get("Sec-Fetch-Mode") != "navigate" ||
 		request.Header.Get("Sec-Fetch-Dest") != "document" ||
 		request.Header.Get("Sec-Fetch-Site") == "none" {
@@ -326,6 +337,11 @@ func validCallbackRequest(request *http.Request, keystoneOrigin string) bool {
 	}
 	referer := request.Header.Get("Referer")
 	return referer == "" || sameOrigin(referer, keystoneOrigin)
+}
+
+func isLoopbackAddr(addr net.Addr) bool {
+	tcpAddr, ok := addr.(*net.TCPAddr)
+	return ok && tcpAddr.IP.IsLoopback()
 }
 
 func sameOrigin(rawURL, expected string) bool {

--- a/openstack/identity/v3/websso/requests.go
+++ b/openstack/identity/v3/websso/requests.go
@@ -26,10 +26,10 @@ const (
 // AuthOptions contains WebSSO authentication options.
 type AuthOptions struct {
 	// IdentityProviderName is the Keystone federation identity provider.
-	IdentityProviderName string
+	IdentityProviderName string `required:"true"`
 
 	// Protocol is the Keystone federation protocol.
-	Protocol string
+	Protocol string `required:"true"`
 
 	// AllowReauth allows Gophercloud to reauthenticate automatically when the
 	// token expires.
@@ -48,10 +48,10 @@ type AuthOptions struct {
 	Timeout time.Duration
 
 	// BrowserOpener opens the WebSSO URL. It defaults to the OS browser.
-	BrowserOpener func(string) error
+	BrowserOpener func(string) error `json:"-"`
 
 	// TokenCache enables unscoped token reuse and requires CacheNamespace.
-	TokenCache tokencache.Cache
+	TokenCache tokencache.Cache `json:"-"`
 
 	// CacheNamespace identifies the expected browser login profile.
 	CacheNamespace string
@@ -67,9 +67,12 @@ func (opts *AuthOptions) ToTokenV3HeadersMap(map[string]any) (map[string]string,
 	return nil, nil
 }
 
-// ToTokenV3CreateMap implements tokens.AuthOptionsBuilder.
+// ToTokenV3CreateMap validates the options without building a request body.
 func (opts *AuthOptions) ToTokenV3CreateMap(map[string]any) (map[string]any, error) {
-	return nil, nil
+	if _, err := gophercloud.BuildRequestBody(opts, ""); err != nil {
+		return nil, err
+	}
+	return nil, opts.validate()
 }
 
 // CanReauth reports whether automatic reauthentication is enabled.
@@ -95,7 +98,7 @@ func Authenticate(ctx context.Context, client *gophercloud.ServiceClient, builde
 		r.Err = fmt.Errorf("websso: expected non-nil *websso.AuthOptions, got %T", builder)
 		return
 	}
-	if err := opts.validate(); err != nil {
+	if _, err := opts.ToTokenV3CreateMap(nil); err != nil {
 		r.Err = err
 		return
 	}
@@ -184,12 +187,6 @@ func validateToken(ctx context.Context, client *gophercloud.ServiceClient, token
 }
 
 func (opts *AuthOptions) validate() error {
-	if opts.IdentityProviderName == "" {
-		return fmt.Errorf("websso: missing required field IdentityProviderName")
-	}
-	if opts.Protocol == "" {
-		return fmt.Errorf("websso: missing required field Protocol")
-	}
 	if opts.RedirectPort < 0 || opts.RedirectPort > 65535 {
 		return fmt.Errorf("websso: RedirectPort must be 0 or between 1 and 65535")
 	}

--- a/openstack/identity/v3/websso/requests_internal_test.go
+++ b/openstack/identity/v3/websso/requests_internal_test.go
@@ -1,0 +1,32 @@
+package websso
+
+import (
+	"net"
+	"testing"
+)
+
+func TestIsLoopbackAddr(t *testing.T) {
+	tests := []struct {
+		name string
+		addr net.Addr
+		want bool
+	}{
+		{name: "IPv4 loopback", addr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1")}, want: true},
+		{name: "IPv6 loopback", addr: &net.TCPAddr{IP: net.ParseIP("::1")}, want: true},
+		{name: "non-loopback", addr: &net.TCPAddr{IP: net.ParseIP("192.0.2.1")}},
+		{name: "non-TCP", addr: testAddr("127.0.0.1:9990")},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if actual := isLoopbackAddr(test.addr); actual != test.want {
+				t.Fatalf("isLoopbackAddr() = %t, want %t", actual, test.want)
+			}
+		})
+	}
+}
+
+type testAddr string
+
+func (testAddr) Network() string  { return "test" }
+func (a testAddr) String() string { return string(a) }

--- a/openstack/identity/v3/websso/testing/cache_test.go
+++ b/openstack/identity/v3/websso/testing/cache_test.go
@@ -2,14 +2,17 @@ package testing
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/openstack/identity/v3/tokencache"
+	"github.com/gophercloud/gophercloud/v2/openstack/identity/v3/tokens"
 	"github.com/gophercloud/gophercloud/v2/openstack/identity/v3/websso"
 	th "github.com/gophercloud/gophercloud/v2/testhelper"
 )
@@ -38,14 +41,150 @@ func TestCacheKeyIsNonEmptyAndFlowIsolated(t *testing.T) {
 	if webSSOKey == "" {
 		t.Fatal("expected non-empty WebSSO cache key")
 	}
-	oidcKey := tokencache.Key(tokencache.KeyOptions{
-		Flow:             "oidc-client-credentials",
+	otherKey := tokencache.Key(tokencache.KeyOptions{
+		Flow:             "other-flow",
 		IdentityEndpoint: endpoint,
 		Principal:        "profile",
 	})
-	if webSSOKey == oidcKey {
-		t.Fatalf("OIDC and WebSSO must not share cache key %q", webSSOKey)
+	if webSSOKey == otherKey {
+		t.Fatalf("authentication flows must not share cache key %q", webSSOKey)
 	}
+}
+
+func TestWebSSOCacheKeyIgnoresScope(t *testing.T) {
+	endpoint := "https://keystone.example.com/v3"
+	base := websso.AuthOptions{
+		IdentityProviderName: "my-idp",
+		Protocol:             "openid",
+		CacheNamespace:       "profile",
+	}
+	projectA := base
+	projectA.Scope = tokens.Scope{ProjectID: "project-a"}
+	projectB := base
+	projectB.Scope = tokens.Scope{ProjectID: "project-b"}
+
+	if first, second := websso.CacheKey(endpoint, &projectA), websso.CacheKey(endpoint, &projectB); first != second {
+		t.Fatalf("scope changed unscoped token cache key: %q != %q", first, second)
+	}
+}
+
+func TestWebSSOCacheReusesUnscopedTokenAcrossProjects(t *testing.T) {
+	fakeKeystone := th.SetupHTTP()
+	defer fakeKeystone.Teardown()
+
+	const (
+		unscopedToken = "unscoped-token"
+		projectAToken = "project-a-token"
+		projectBToken = "project-b-token"
+	)
+	var scopeRequests atomic.Int32
+	fakeKeystone.Mux.HandleFunc("/v3/auth/tokens", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodGet:
+			th.TestHeader(t, r, "X-Subject-Token", unscopedToken)
+			w.Header().Set("X-Subject-Token", unscopedToken)
+			fmt.Fprint(w, tokenResponse(""))
+		case http.MethodPost:
+			var project, token string
+			switch scopeRequests.Add(1) {
+			case 1:
+				project, token = "project-a", projectAToken
+			case 2:
+				project, token = "project-b", projectBToken
+			default:
+				t.Fatal("unexpected extra scope request")
+			}
+			th.TestJSONRequest(t, r, fmt.Sprintf(`{"auth":{"identity":{"methods":["token"],"token":{"id":%q}},"scope":{"project":{"id":%q}}}}`, unscopedToken, project))
+			w.Header().Set("X-Subject-Token", token)
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, tokenResponse(project))
+		default:
+			t.Fatalf("unexpected method %s", r.Method)
+		}
+	})
+
+	cache := newMemoryCache()
+	client := gophercloud.ServiceClient{
+		ProviderClient: newTestProviderClient(),
+		Endpoint:       fakeKeystone.Endpoint() + "v3/",
+	}
+	base := websso.AuthOptions{
+		IdentityProviderName: "my-idp",
+		Protocol:             "openid",
+		Timeout:              10 * time.Second,
+		TokenCache:           cache,
+		CacheNamespace:       "profile",
+	}
+
+	projectA := base
+	projectA.Scope = tokens.Scope{ProjectID: "project-a"}
+	projectA.RedirectPort = findAvailablePort(t)
+	results := startWebSSO(context.Background(), &client, &projectA)
+	response, err := http.PostForm(fmt.Sprintf("http://127.0.0.1:%d/auth/websso/", projectA.RedirectPort), url.Values{"token": {unscopedToken}})
+	th.AssertNoErr(t, err)
+	response.Body.Close()
+	result := <-results
+	th.AssertNoErr(t, result.Err)
+	token, err := result.ExtractTokenID()
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, projectAToken, token)
+
+	projectB := base
+	projectB.Scope = tokens.Scope{ProjectID: "project-b"}
+	projectB.RedirectPort = findAvailablePort(t)
+	projectB.BrowserOpener = func(string) error { return errors.New("browser opened on cache hit") }
+	result = websso.Authenticate(context.Background(), &client, &projectB)
+	th.AssertNoErr(t, result.Err)
+	token, err = result.ExtractTokenID()
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, projectBToken, token)
+	th.CheckEquals(t, int32(2), scopeRequests.Load())
+}
+
+func TestWebSSOCacheValidationCancellationDoesNotOpenBrowser(t *testing.T) {
+	cache := newMemoryCache()
+	endpoint := "http://127.0.0.1:1/v3/"
+	opts := &websso.AuthOptions{
+		IdentityProviderName: "my-idp",
+		Protocol:             "openid",
+		TokenCache:           cache,
+		CacheNamespace:       "profile",
+		RedirectPort:         findAvailablePort(t),
+	}
+	cacheKey := websso.CacheKey(endpoint, opts)
+	cached := fmt.Sprintf(`{"token_id":"cached-token","expires_at":%q,"endpoint":%q}`, time.Now().Add(time.Hour).UTC().Format(time.RFC3339Nano), endpoint)
+	th.AssertNoErr(t, cache.Set(cacheKey, cached))
+
+	opened := false
+	opts.BrowserOpener = func(string) error {
+		opened = true
+		return nil
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	result := websso.Authenticate(ctx, &gophercloud.ServiceClient{
+		ProviderClient: newTestProviderClient(),
+		Endpoint:       endpoint,
+	}, opts)
+
+	if !errors.Is(result.Err, context.Canceled) {
+		t.Fatalf("expected context cancellation, got %v", result.Err)
+	}
+	if opened {
+		t.Fatal("browser opened after cached token validation was canceled")
+	}
+	if value, err := cache.Get(cacheKey); err != nil || value == "" {
+		t.Fatalf("cached token removed after cancellation: value %q, error %v", value, err)
+	}
+}
+
+func tokenResponse(projectID string) string {
+	project := ""
+	if projectID != "" {
+		project = fmt.Sprintf(`,"project":{"id":%q,"name":%q,"domain":{"id":"default","name":"Default"}}`, projectID, projectID)
+	}
+	return fmt.Sprintf(`{"token":{"methods":["mapped"],"expires_at":"2035-06-03T02:19:49Z","user":{"id":"user-id","name":"user","domain":{"id":"default","name":"Default"}}%s}}`, project)
 }
 
 func newTestProviderClient() *gophercloud.ProviderClient {

--- a/openstack/identity/v3/websso/testing/cache_test.go
+++ b/openstack/identity/v3/websso/testing/cache_test.go
@@ -51,6 +51,21 @@ func TestCacheKeyIsNonEmptyAndFlowIsolated(t *testing.T) {
 	}
 }
 
+func TestWebSSOCacheKeySeparatesNamespaces(t *testing.T) {
+	endpoint := "https://keystone.example.com/v3"
+	base := websso.AuthOptions{
+		IdentityProviderName: "my-idp",
+		Protocol:             "openid",
+		CacheNamespace:       "account-a",
+	}
+	other := base
+	other.CacheNamespace = "account-b"
+
+	if first, second := websso.CacheKey(endpoint, &base), websso.CacheKey(endpoint, &other); first == second {
+		t.Fatalf("different cache namespaces share key %q", first)
+	}
+}
+
 func TestWebSSOCacheKeyIgnoresScope(t *testing.T) {
 	endpoint := "https://keystone.example.com/v3"
 	base := websso.AuthOptions{

--- a/openstack/identity/v3/websso/testing/cache_test.go
+++ b/openstack/identity/v3/websso/testing/cache_test.go
@@ -31,16 +31,13 @@ func (c memoryCache) Delete(key string) error {
 	return nil
 }
 
-func TestCacheKeyIsNonEmptyAndFlowIsolated(t *testing.T) {
+func TestWebSSOCacheKeySeparatesFlows(t *testing.T) {
 	endpoint := "https://keystone.example.com/v3"
 	webSSOKey := websso.CacheKey(endpoint, &websso.AuthOptions{
 		IdentityProviderName: "my-idp",
 		Protocol:             "openid",
 		CacheNamespace:       "profile",
 	})
-	if webSSOKey == "" {
-		t.Fatal("expected non-empty WebSSO cache key")
-	}
 	otherKey := tokencache.Key(tokencache.KeyOptions{
 		Flow:             "other-flow",
 		IdentityEndpoint: endpoint,

--- a/openstack/identity/v3/websso/testing/cache_test.go
+++ b/openstack/identity/v3/websso/testing/cache_test.go
@@ -132,7 +132,7 @@ func TestWebSSOCacheReusesUnscopedTokenAcrossProjects(t *testing.T) {
 	projectA := base
 	projectA.Scope = tokens.Scope{ProjectID: "project-a"}
 	projectA.RedirectPort = findAvailablePort(t)
-	results := startWebSSO(context.Background(), &client, &projectA)
+	results := startWebSSO(t, context.Background(), &client, &projectA)
 	response, err := http.DefaultClient.Do(newWebSSOCallbackRequest(t, fmt.Sprintf("http://127.0.0.1:%d/auth/websso/", projectA.RedirectPort), url.Values{"token": {unscopedToken}}))
 	th.AssertNoErr(t, err)
 	response.Body.Close()
@@ -221,7 +221,7 @@ func TestWebSSOKeepsKnownTokenIDAfterValidation(t *testing.T) {
 			if tt.cached {
 				result = websso.Authenticate(context.Background(), &client, opts)
 			} else {
-				results := startWebSSO(context.Background(), &client, opts)
+				results := startWebSSO(t, context.Background(), &client, opts)
 				response, err := http.DefaultClient.Do(newWebSSOCallbackRequest(t, fmt.Sprintf("http://127.0.0.1:%d/auth/websso/", opts.RedirectPort), url.Values{"token": {unscopedToken}}))
 				th.AssertNoErr(t, err)
 				response.Body.Close()
@@ -282,7 +282,7 @@ func tokenResponse(projectID string) string {
 	if projectID != "" {
 		project = fmt.Sprintf(`,"project":{"id":%q,"name":%q,"domain":{"id":"default","name":"Default"}}`, projectID, projectID)
 	}
-	return fmt.Sprintf(`{"token":{"methods":["mapped"],"expires_at":"2035-06-03T02:19:49Z","user":{"id":"user-id","name":"user","domain":{"id":"default","name":"Default"}}%s}}`, project)
+	return fmt.Sprintf(`{"token":{"methods":["mapped"],"expires_at":%q,"user":{"id":"user-id","name":"user","domain":{"id":"default","name":"Default"}}%s}}`, time.Now().Add(time.Hour).UTC().Format(time.RFC3339Nano), project)
 }
 
 func newTestProviderClient() *gophercloud.ProviderClient {
@@ -352,7 +352,7 @@ func TestWebSSOCacheHitSkipsBrowser(t *testing.T) {
 		CacheNamespace:       "test-profile",
 	}
 
-	results := startWebSSO(context.Background(), &client, opts)
+	results := startWebSSO(t, context.Background(), &client, opts)
 	callbackURL := fmt.Sprintf("http://127.0.0.1:%d/auth/websso/", port)
 	resp, err := http.DefaultClient.Do(newWebSSOCallbackRequest(t, callbackURL, url.Values{"token": {tokenID}}))
 	th.AssertNoErr(t, err)

--- a/openstack/identity/v3/websso/testing/cache_test.go
+++ b/openstack/identity/v3/websso/testing/cache_test.go
@@ -157,6 +157,92 @@ func TestWebSSOCacheReusesUnscopedTokenAcrossProjects(t *testing.T) {
 	th.CheckEquals(t, int32(2), scopeRequests.Load())
 }
 
+func TestWebSSOKeepsKnownTokenIDAfterValidation(t *testing.T) {
+	const (
+		unscopedToken = "unscoped-token"
+		scopedToken   = "scoped-token"
+	)
+
+	tests := []struct {
+		name   string
+		cached bool
+		scoped bool
+	}{
+		{name: "browser unscoped"},
+		{name: "browser scoped", scoped: true},
+		{name: "cache scoped", cached: true, scoped: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeKeystone := th.SetupHTTP()
+			defer fakeKeystone.Teardown()
+
+			fakeKeystone.Mux.HandleFunc("/v3/auth/tokens", func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch r.Method {
+				case http.MethodGet:
+					th.TestHeader(t, r, "X-Subject-Token", unscopedToken)
+					fmt.Fprint(w, tokenResponse(""))
+				case http.MethodPost:
+					if !tt.scoped {
+						t.Fatal("unexpected scope request")
+					}
+					th.TestJSONRequest(t, r, fmt.Sprintf(`{"auth":{"identity":{"methods":["token"],"token":{"id":%q}},"scope":{"project":{"id":"project-id"}}}}`, unscopedToken))
+					w.Header().Set("X-Subject-Token", scopedToken)
+					w.WriteHeader(http.StatusCreated)
+					fmt.Fprint(w, tokenResponse("project-id"))
+				default:
+					t.Fatalf("unexpected method %s", r.Method)
+				}
+			})
+
+			cache := newMemoryCache()
+			client := gophercloud.ServiceClient{
+				ProviderClient: newTestProviderClient(),
+				Endpoint:       fakeKeystone.Endpoint() + "v3/",
+			}
+			opts := &websso.AuthOptions{
+				IdentityProviderName: "my-idp",
+				Protocol:             "openid",
+				RedirectPort:         findAvailablePort(t),
+				Timeout:              10 * time.Second,
+			}
+			if tt.scoped {
+				opts.Scope = tokens.Scope{ProjectID: "project-id"}
+			}
+			if tt.cached {
+				opts.TokenCache = cache
+				opts.CacheNamespace = "profile"
+				key := websso.CacheKey(client.Endpoint, opts)
+				cached := fmt.Sprintf(`{"token_id":%q,"expires_at":%q,"endpoint":%q}`, unscopedToken, time.Now().Add(time.Hour).UTC().Format(time.RFC3339Nano), client.Endpoint)
+				th.AssertNoErr(t, cache.Set(key, cached))
+				opts.BrowserOpener = func(string) error { return errors.New("browser opened on cache hit") }
+			}
+
+			var result tokens.CreateResult
+			if tt.cached {
+				result = websso.Authenticate(context.Background(), &client, opts)
+			} else {
+				results := startWebSSO(context.Background(), &client, opts)
+				response, err := http.PostForm(fmt.Sprintf("http://127.0.0.1:%d/auth/websso/", opts.RedirectPort), url.Values{"token": {unscopedToken}})
+				th.AssertNoErr(t, err)
+				response.Body.Close()
+				result = <-results
+			}
+
+			th.AssertNoErr(t, result.Err)
+			tokenID, err := result.ExtractTokenID()
+			th.AssertNoErr(t, err)
+			wantToken := unscopedToken
+			if tt.scoped {
+				wantToken = scopedToken
+			}
+			th.CheckEquals(t, wantToken, tokenID)
+		})
+	}
+}
+
 func TestWebSSOCacheValidationCancellationDoesNotOpenBrowser(t *testing.T) {
 	cache := newMemoryCache()
 	endpoint := "http://127.0.0.1:1/v3/"

--- a/openstack/identity/v3/websso/testing/cache_test.go
+++ b/openstack/identity/v3/websso/testing/cache_test.go
@@ -133,7 +133,7 @@ func TestWebSSOCacheReusesUnscopedTokenAcrossProjects(t *testing.T) {
 	projectA.Scope = tokens.Scope{ProjectID: "project-a"}
 	projectA.RedirectPort = findAvailablePort(t)
 	results := startWebSSO(context.Background(), &client, &projectA)
-	response, err := http.PostForm(fmt.Sprintf("http://127.0.0.1:%d/auth/websso/", projectA.RedirectPort), url.Values{"token": {unscopedToken}})
+	response, err := http.DefaultClient.Do(newWebSSOCallbackRequest(t, fmt.Sprintf("http://127.0.0.1:%d/auth/websso/", projectA.RedirectPort), url.Values{"token": {unscopedToken}}))
 	th.AssertNoErr(t, err)
 	response.Body.Close()
 	result := <-results
@@ -222,7 +222,7 @@ func TestWebSSOKeepsKnownTokenIDAfterValidation(t *testing.T) {
 				result = websso.Authenticate(context.Background(), &client, opts)
 			} else {
 				results := startWebSSO(context.Background(), &client, opts)
-				response, err := http.PostForm(fmt.Sprintf("http://127.0.0.1:%d/auth/websso/", opts.RedirectPort), url.Values{"token": {unscopedToken}})
+				response, err := http.DefaultClient.Do(newWebSSOCallbackRequest(t, fmt.Sprintf("http://127.0.0.1:%d/auth/websso/", opts.RedirectPort), url.Values{"token": {unscopedToken}}))
 				th.AssertNoErr(t, err)
 				response.Body.Close()
 				result = <-results
@@ -354,7 +354,7 @@ func TestWebSSOCacheHitSkipsBrowser(t *testing.T) {
 
 	results := startWebSSO(context.Background(), &client, opts)
 	callbackURL := fmt.Sprintf("http://127.0.0.1:%d/auth/websso/", port)
-	resp, err := http.PostForm(callbackURL, url.Values{"token": {tokenID}})
+	resp, err := http.DefaultClient.Do(newWebSSOCallbackRequest(t, callbackURL, url.Values{"token": {tokenID}}))
 	th.AssertNoErr(t, err)
 	resp.Body.Close()
 	th.CheckEquals(t, http.StatusOK, resp.StatusCode)

--- a/openstack/identity/v3/websso/testing/cache_test.go
+++ b/openstack/identity/v3/websso/testing/cache_test.go
@@ -1,0 +1,155 @@
+package testing
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/openstack/identity/v3/tokencache"
+	"github.com/gophercloud/gophercloud/v2/openstack/identity/v3/websso"
+	th "github.com/gophercloud/gophercloud/v2/testhelper"
+)
+
+type memoryCache map[string]string
+
+func newMemoryCache() memoryCache { return make(memoryCache) }
+
+func (c memoryCache) Get(key string) (string, error) { return c[key], nil }
+func (c memoryCache) Set(key, value string) error {
+	c[key] = value
+	return nil
+}
+func (c memoryCache) Delete(key string) error {
+	delete(c, key)
+	return nil
+}
+
+func TestCacheKeyIsNonEmptyAndFlowIsolated(t *testing.T) {
+	endpoint := "https://keystone.example.com/v3"
+	webSSOKey := websso.CacheKey(endpoint, &websso.AuthOptions{
+		IdentityProviderName: "my-idp",
+		Protocol:             "openid",
+		CacheNamespace:       "profile",
+	})
+	if webSSOKey == "" {
+		t.Fatal("expected non-empty WebSSO cache key")
+	}
+	oidcKey := tokencache.Key(tokencache.KeyOptions{
+		Flow:             "oidc-client-credentials",
+		IdentityEndpoint: endpoint,
+		Principal:        "profile",
+	})
+	if webSSOKey == oidcKey {
+		t.Fatalf("OIDC and WebSSO must not share cache key %q", webSSOKey)
+	}
+}
+
+func newTestProviderClient() *gophercloud.ProviderClient {
+	client := new(gophercloud.ProviderClient)
+	client.UseTokenLock()
+	return client
+}
+
+func TestWebSSOCacheHitSkipsBrowser(t *testing.T) {
+	fakeKeystone := th.SetupHTTP()
+	defer fakeKeystone.Teardown()
+
+	endpoint := fakeKeystone.Endpoint()
+	tokenID := "websso-cached-token-xyz"
+	futureExpiry := time.Now().Add(2 * time.Hour).UTC().Format("2006-01-02T15:04:05.000000Z")
+
+	fakeKeystone.Mux.HandleFunc("/v3/auth/tokens", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+
+		w.Header().Set("X-Subject-Token", tokenID)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, `{
+			"token": {
+				"methods": ["token"],
+				"expires_at": "%s",
+				"catalog": [
+					{
+						"endpoints": [
+							{
+								"url": "%scompute/v2.1",
+								"interface": "public",
+								"region": "RegionOne",
+								"region_id": "RegionOne",
+								"id": "ep-001"
+							}
+						],
+						"type": "compute",
+						"id": "svc-001",
+						"name": "nova"
+					}
+				],
+				"user": {
+					"id": "user-001",
+					"name": "test-user",
+					"domain": {"id": "default", "name": "Default"}
+				}
+			}
+		}`, futureExpiry, endpoint)
+	})
+
+	cache := newMemoryCache()
+
+	v3Endpoint := endpoint + "v3/"
+	client := gophercloud.ServiceClient{
+		ProviderClient: newTestProviderClient(),
+		Endpoint:       v3Endpoint,
+	}
+
+	port := findAvailablePort(t)
+	opts := &websso.AuthOptions{
+		IdentityProviderName: "my-idp",
+		Protocol:             "openid",
+		RedirectPort:         port,
+		Timeout:              10 * time.Second,
+		TokenCache:           cache,
+		CacheNamespace:       "test-profile",
+	}
+
+	results := startWebSSO(context.Background(), &client, opts)
+	callbackURL := fmt.Sprintf("http://127.0.0.1:%d/auth/websso/", port)
+	resp, err := http.PostForm(callbackURL, url.Values{"token": {tokenID}})
+	th.AssertNoErr(t, err)
+	resp.Body.Close()
+	th.CheckEquals(t, http.StatusOK, resp.StatusCode)
+
+	result1 := <-results
+	th.AssertNoErr(t, result1.Err)
+
+	extractedID1, err := result1.ExtractTokenID()
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, tokenID, extractedID1)
+
+	cacheKey := websso.CacheKey(v3Endpoint, opts)
+	val, err := cache.Get(cacheKey)
+	th.AssertNoErr(t, err)
+	if val == "" {
+		t.Fatal("Expected token to be cached after first WebSSO call")
+	}
+
+	opts2 := *opts
+	opts2.RedirectPort = findAvailablePort(t)
+
+	result2 := websso.Authenticate(context.Background(), &client, &opts2)
+	th.AssertNoErr(t, result2.Err)
+
+	extractedID2, err := result2.ExtractTokenID()
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, tokenID, extractedID2)
+
+	catalog, err := result2.ExtractServiceCatalog()
+	th.AssertNoErr(t, err)
+	if catalog == nil || len(catalog.Entries) == 0 {
+		t.Fatal("Expected service catalog from cached token")
+	}
+	th.AssertEquals(t, "compute", catalog.Entries[0].Type)
+}

--- a/openstack/identity/v3/websso/testing/fixtures_test.go
+++ b/openstack/identity/v3/websso/testing/fixtures_test.go
@@ -1,0 +1,36 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	th "github.com/gophercloud/gophercloud/v2/testhelper"
+)
+
+const (
+	UnscopedTokenID        = "unscoped-federation-token-aaa111"
+	FederationAuthResponse = `{
+		"token": {
+			"methods": ["mapped"],
+			"user": {
+				"id": "federation-user-id-001",
+				"name": "federation-user",
+				"domain": {"id": "Federated", "name": "Federated"}
+			},
+			"expires_at": "2035-06-03T02:19:49Z",
+			"is_domain": false
+		}
+	}`
+)
+
+func HandleWebSSOTokenValidation(t *testing.T, fakeServer th.FakeServer, expectedToken string) {
+	t.Helper()
+	fakeServer.Mux.HandleFunc("/auth/tokens", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, http.MethodGet)
+		th.TestHeader(t, r, "X-Subject-Token", expectedToken)
+		w.Header().Set("X-Subject-Token", expectedToken)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, FederationAuthResponse)
+	})
+}

--- a/openstack/identity/v3/websso/testing/fixtures_test.go
+++ b/openstack/identity/v3/websso/testing/fixtures_test.go
@@ -4,13 +4,15 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	th "github.com/gophercloud/gophercloud/v2/testhelper"
 )
 
-const (
-	UnscopedTokenID        = "unscoped-federation-token-aaa111"
-	FederationAuthResponse = `{
+const unscopedTokenID = "unscoped-federation-token-aaa111"
+
+func federationAuthResponse() string {
+	return fmt.Sprintf(`{
 		"token": {
 			"methods": ["mapped"],
 			"user": {
@@ -18,19 +20,19 @@ const (
 				"name": "federation-user",
 				"domain": {"id": "Federated", "name": "Federated"}
 			},
-			"expires_at": "2035-06-03T02:19:49Z",
+			"expires_at": %q,
 			"is_domain": false
 		}
-	}`
-)
+	}`, time.Now().Add(time.Hour).UTC().Format(time.RFC3339Nano))
+}
 
-func HandleWebSSOTokenValidation(t *testing.T, fakeServer th.FakeServer, expectedToken string) {
+func handleWebSSOTokenValidation(t *testing.T, fakeServer th.FakeServer, expectedToken string) {
 	t.Helper()
 	fakeServer.Mux.HandleFunc("/auth/tokens", func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, http.MethodGet)
 		th.TestHeader(t, r, "X-Subject-Token", expectedToken)
 		w.Header().Set("X-Subject-Token", expectedToken)
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, FederationAuthResponse)
+		fmt.Fprint(w, federationAuthResponse())
 	})
 }

--- a/openstack/identity/v3/websso/testing/flow_test.go
+++ b/openstack/identity/v3/websso/testing/flow_test.go
@@ -94,53 +94,6 @@ func TestWebSSOWrongOptionsType(t *testing.T) {
 	}
 }
 
-func TestWebSSOScopeMap(t *testing.T) {
-	opts := &websso.AuthOptions{
-		IdentityProviderName: "my-idp",
-		Protocol:             "openid",
-		Scope: tokens.Scope{
-			ProjectName: "my-project",
-			DomainName:  "Default",
-		},
-	}
-
-	scopeMap, err := opts.ToTokenV3ScopeMap()
-	th.AssertNoErr(t, err)
-	if scopeMap == nil {
-		t.Fatal("Expected non-nil scope map")
-	}
-
-	project, ok := scopeMap["project"].(map[string]any)
-	if !ok {
-		t.Fatalf("Expected project in scope map, got %v", scopeMap)
-	}
-	projectName, ok := project["name"].(*string)
-	if !ok || projectName == nil || *projectName != "my-project" {
-		t.Errorf("Expected project name 'my-project', got %v", project["name"])
-	}
-}
-
-func TestWebSSONoScopeReturnsNil(t *testing.T) {
-	opts := &websso.AuthOptions{
-		IdentityProviderName: "my-idp",
-		Protocol:             "openid",
-	}
-
-	scopeMap, err := opts.ToTokenV3ScopeMap()
-	th.AssertNoErr(t, err)
-	if scopeMap != nil {
-		t.Errorf("Expected nil scope map for unscoped, got %v", scopeMap)
-	}
-}
-
-func TestWebSSOCanReauth(t *testing.T) {
-	opts := &websso.AuthOptions{AllowReauth: true}
-	th.CheckEquals(t, true, opts.CanReauth())
-
-	opts2 := &websso.AuthOptions{AllowReauth: false}
-	th.CheckEquals(t, false, opts2.CanReauth())
-}
-
 func TestWebSSOCallbackHandlerAcceptsValidPost(t *testing.T) {
 	fakeKeystone := th.SetupHTTP()
 	defer fakeKeystone.Teardown()

--- a/openstack/identity/v3/websso/testing/flow_test.go
+++ b/openstack/identity/v3/websso/testing/flow_test.go
@@ -16,7 +16,8 @@ import (
 	th "github.com/gophercloud/gophercloud/v2/testhelper"
 )
 
-func startWebSSO(ctx context.Context, client *gophercloud.ServiceClient, opts *websso.AuthOptions) <-chan tokens.CreateResult {
+func startWebSSO(t *testing.T, ctx context.Context, client *gophercloud.ServiceClient, opts *websso.AuthOptions) <-chan tokens.CreateResult {
+	t.Helper()
 	ready := make(chan struct{})
 	opts.BrowserOpener = func(string) error {
 		close(ready)
@@ -24,7 +25,11 @@ func startWebSSO(ctx context.Context, client *gophercloud.ServiceClient, opts *w
 	}
 	results := make(chan tokens.CreateResult, 1)
 	go func() { results <- websso.Authenticate(ctx, client, opts) }()
-	<-ready
+	select {
+	case <-ready:
+	case result := <-results:
+		t.Fatalf("authentication returned before opening the browser: %v", result.Err)
+	}
 	return results
 }
 
@@ -94,53 +99,17 @@ func TestWebSSOWrongOptionsType(t *testing.T) {
 	}
 }
 
-func TestWebSSOCallbackHandlerAcceptsValidPost(t *testing.T) {
-	fakeKeystone := th.SetupHTTP()
-	defer fakeKeystone.Teardown()
-
-	HandleWebSSOTokenValidation(t, fakeKeystone, UnscopedTokenID)
-
-	client := gophercloud.ServiceClient{
-		ProviderClient: &gophercloud.ProviderClient{},
-		Endpoint:       fakeKeystone.Endpoint(),
-	}
-
-	opts := &websso.AuthOptions{
-		IdentityProviderName: "my-idp",
-		Protocol:             "openid",
-		RedirectPort:         0,
-		Timeout:              10 * time.Second,
-	}
-
-	port := findAvailablePort(t)
-	opts.RedirectPort = port
-	results := startWebSSO(context.Background(), &client, opts)
-
-	callbackURL := fmt.Sprintf("http://127.0.0.1:%d/auth/websso/", port)
-	resp, err := http.DefaultClient.Do(newWebSSOCallbackRequest(t, callbackURL, url.Values{"token": {UnscopedTokenID}}))
-	th.AssertNoErr(t, err)
-	resp.Body.Close()
-	th.CheckEquals(t, http.StatusOK, resp.StatusCode)
-
-	result := <-results
-	th.AssertNoErr(t, result.Err)
-
-	token, err := result.ExtractTokenID()
-	th.AssertNoErr(t, err)
-	th.CheckEquals(t, UnscopedTokenID, token)
-}
-
 func TestWebSSOTokenValidationAccepts203(t *testing.T) {
 	fakeKeystone := th.SetupHTTP()
 	defer fakeKeystone.Teardown()
 
 	fakeKeystone.Mux.HandleFunc("/auth/tokens", func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, http.MethodGet)
-		th.TestHeader(t, r, "X-Subject-Token", UnscopedTokenID)
-		w.Header().Set("X-Subject-Token", UnscopedTokenID)
+		th.TestHeader(t, r, "X-Subject-Token", unscopedTokenID)
+		w.Header().Set("X-Subject-Token", unscopedTokenID)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusNonAuthoritativeInfo)
-		fmt.Fprint(w, FederationAuthResponse)
+		fmt.Fprint(w, federationAuthResponse())
 	})
 
 	client := gophercloud.ServiceClient{
@@ -148,14 +117,14 @@ func TestWebSSOTokenValidationAccepts203(t *testing.T) {
 		Endpoint:       fakeKeystone.Endpoint(),
 	}
 	port := findAvailablePort(t)
-	results := startWebSSO(context.Background(), &client, &websso.AuthOptions{
+	results := startWebSSO(t, context.Background(), &client, &websso.AuthOptions{
 		IdentityProviderName: "my-idp",
 		Protocol:             "openid",
 		RedirectPort:         port,
 		Timeout:              10 * time.Second,
 	})
 
-	response, err := http.DefaultClient.Do(newWebSSOCallbackRequest(t, fmt.Sprintf("http://127.0.0.1:%d/auth/websso/", port), url.Values{"token": {UnscopedTokenID}}))
+	response, err := http.DefaultClient.Do(newWebSSOCallbackRequest(t, fmt.Sprintf("http://127.0.0.1:%d/auth/websso/", port), url.Values{"token": {unscopedTokenID}}))
 	th.AssertNoErr(t, err)
 	response.Body.Close()
 
@@ -178,14 +147,14 @@ func TestWebSSOTokenValidationFailurePreservesProviderToken(t *testing.T) {
 		Endpoint:       fakeKeystone.Endpoint(),
 	}
 	port := findAvailablePort(t)
-	results := startWebSSO(context.Background(), &client, &websso.AuthOptions{
+	results := startWebSSO(t, context.Background(), &client, &websso.AuthOptions{
 		IdentityProviderName: "my-idp",
 		Protocol:             "openid",
 		RedirectPort:         port,
 		Timeout:              10 * time.Second,
 	})
 
-	response, err := http.DefaultClient.Do(newWebSSOCallbackRequest(t, fmt.Sprintf("http://127.0.0.1:%d/auth/websso/", port), url.Values{"token": {UnscopedTokenID}}))
+	response, err := http.DefaultClient.Do(newWebSSOCallbackRequest(t, fmt.Sprintf("http://127.0.0.1:%d/auth/websso/", port), url.Values{"token": {unscopedTokenID}}))
 	th.AssertNoErr(t, err)
 	response.Body.Close()
 
@@ -214,7 +183,7 @@ func TestWebSSOCallbackRejectsWrongMethod(t *testing.T) {
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	startWebSSO(ctx, &client, opts)
+	startWebSSO(t, ctx, &client, opts)
 	defer cancel()
 
 	callbackURL := fmt.Sprintf("http://127.0.0.1:%d/auth/websso/", port)
@@ -224,37 +193,11 @@ func TestWebSSOCallbackRejectsWrongMethod(t *testing.T) {
 	th.CheckEquals(t, http.StatusMethodNotAllowed, resp.StatusCode)
 }
 
-func TestWebSSOCallbackRejectsWrongContentType(t *testing.T) {
-	port := findAvailablePort(t)
-
-	client := gophercloud.ServiceClient{
-		ProviderClient: &gophercloud.ProviderClient{},
-		Endpoint:       "http://localhost/v3/",
-	}
-
-	opts := &websso.AuthOptions{
-		IdentityProviderName: "my-idp",
-		Protocol:             "openid",
-		RedirectPort:         port,
-		Timeout:              3 * time.Second,
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	startWebSSO(ctx, &client, opts)
-	defer cancel()
-
-	callbackURL := fmt.Sprintf("http://127.0.0.1:%d/auth/websso/", port)
-	resp, err := http.Post(callbackURL, "application/json", strings.NewReader(`{"token":"abc"}`)) //nolint:gosec
-	th.AssertNoErr(t, err)
-	resp.Body.Close()
-	th.CheckEquals(t, http.StatusUnsupportedMediaType, resp.StatusCode)
-}
-
 func TestWebSSOCallbackIgnoresMissingTokenThenAcceptsValidToken(t *testing.T) {
 	fakeKeystone := th.SetupHTTP()
 	defer fakeKeystone.Teardown()
 
-	HandleWebSSOTokenValidation(t, fakeKeystone, UnscopedTokenID)
+	handleWebSSOTokenValidation(t, fakeKeystone, unscopedTokenID)
 
 	port := findAvailablePort(t)
 
@@ -270,11 +213,11 @@ func TestWebSSOCallbackIgnoresMissingTokenThenAcceptsValidToken(t *testing.T) {
 		Timeout:              10 * time.Second,
 	}
 
-	results := startWebSSO(context.Background(), &client, opts)
+	results := startWebSSO(t, context.Background(), &client, opts)
 
 	callbackURL := fmt.Sprintf("http://127.0.0.1:%d/auth/websso/", port)
 
-	resp, err := http.DefaultClient.Do(newWebSSOCallbackRequest(t, callbackURL+"?token="+UnscopedTokenID, nil))
+	resp, err := http.DefaultClient.Do(newWebSSOCallbackRequest(t, callbackURL+"?token="+unscopedTokenID, nil))
 	th.AssertNoErr(t, err)
 	resp.Body.Close()
 	th.CheckEquals(t, http.StatusBadRequest, resp.StatusCode)
@@ -284,7 +227,7 @@ func TestWebSSOCallbackIgnoresMissingTokenThenAcceptsValidToken(t *testing.T) {
 	resp.Body.Close()
 	th.CheckEquals(t, http.StatusBadRequest, resp.StatusCode)
 
-	resp, err = http.DefaultClient.Do(newWebSSOCallbackRequest(t, callbackURL, url.Values{"token": {UnscopedTokenID}}))
+	resp, err = http.DefaultClient.Do(newWebSSOCallbackRequest(t, callbackURL, url.Values{"token": {unscopedTokenID}}))
 	th.AssertNoErr(t, err)
 	resp.Body.Close()
 	th.CheckEquals(t, http.StatusOK, resp.StatusCode)
@@ -307,12 +250,26 @@ func TestWebSSOCancellationDoesNotWaitForSlowCallback(t *testing.T) {
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	results := startWebSSO(ctx, &client, opts)
+	results := startWebSSO(t, ctx, &client, opts)
 	conn, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", port))
 	th.AssertNoErr(t, err)
 
-	_, err = fmt.Fprintf(conn, "POST /auth/websso/ HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/x-www-form-urlencoded\r\nContent-Length: 1000\r\n\r\ntoken=")
+	const slowRequest = "POST /auth/websso/ HTTP/1.1\r\n" +
+		"Host: localhost\r\n" +
+		"Content-Type: application/x-www-form-urlencoded\r\n" +
+		"Content-Length: 1000\r\n" +
+		"Sec-Fetch-Mode: navigate\r\n" +
+		"Sec-Fetch-Dest: document\r\n" +
+		"Sec-Fetch-Site: cross-site\r\n" +
+		"Origin: null\r\n\r\n" +
+		"token="
+	_, err = fmt.Fprint(conn, slowRequest)
 	th.AssertNoErr(t, err)
+	select {
+	case result := <-results:
+		t.Fatalf("authentication returned before cancellation: %v", result.Err)
+	case <-time.After(50 * time.Millisecond):
+	}
 	cancel()
 
 	select {
@@ -368,7 +325,7 @@ func TestWebSSOContextCancellation(t *testing.T) {
 		Timeout:              30 * time.Second,
 	}
 
-	results := startWebSSO(ctx, &client, opts)
+	results := startWebSSO(t, ctx, &client, opts)
 	cancel()
 
 	res := <-results

--- a/openstack/identity/v3/websso/testing/flow_test.go
+++ b/openstack/identity/v3/websso/testing/flow_test.go
@@ -1,0 +1,355 @@
+package testing
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/openstack/identity/v3/tokens"
+	"github.com/gophercloud/gophercloud/v2/openstack/identity/v3/websso"
+	th "github.com/gophercloud/gophercloud/v2/testhelper"
+)
+
+func startWebSSO(ctx context.Context, client *gophercloud.ServiceClient, opts *websso.AuthOptions) <-chan tokens.CreateResult {
+	ready := make(chan struct{})
+	opts.BrowserOpener = func(string) error {
+		close(ready)
+		return nil
+	}
+	results := make(chan tokens.CreateResult, 1)
+	go func() { results <- websso.Authenticate(ctx, client, opts) }()
+	<-ready
+	return results
+}
+
+var _ tokens.AuthOptionsBuilder = (*websso.AuthOptions)(nil)
+
+func TestWebSSOValidationMissingIdentityProvider(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	client := gophercloud.ServiceClient{
+		ProviderClient: &gophercloud.ProviderClient{},
+		Endpoint:       fakeServer.Endpoint(),
+	}
+
+	opts := &websso.AuthOptions{
+		Protocol: "openid",
+	}
+
+	result := websso.Authenticate(context.TODO(), &client, opts)
+	if result.Err == nil {
+		t.Fatal("Expected error for missing IdentityProviderName")
+	}
+	if !strings.Contains(result.Err.Error(), "IdentityProviderName") {
+		t.Errorf("Expected error about IdentityProviderName, got: %v", result.Err)
+	}
+}
+
+func TestWebSSOValidationMissingProtocol(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	client := gophercloud.ServiceClient{
+		ProviderClient: &gophercloud.ProviderClient{},
+		Endpoint:       fakeServer.Endpoint(),
+	}
+
+	opts := &websso.AuthOptions{
+		IdentityProviderName: "my-idp",
+	}
+
+	result := websso.Authenticate(context.TODO(), &client, opts)
+	if result.Err == nil {
+		t.Fatal("Expected error for missing Protocol")
+	}
+	if !strings.Contains(result.Err.Error(), "Protocol") {
+		t.Errorf("Expected error about Protocol, got: %v", result.Err)
+	}
+}
+
+func TestWebSSOWrongOptionsType(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	client := gophercloud.ServiceClient{
+		ProviderClient: &gophercloud.ProviderClient{},
+		Endpoint:       fakeServer.Endpoint(),
+	}
+
+	opts := &tokens.AuthOptions{}
+
+	result := websso.Authenticate(context.TODO(), &client, opts)
+	if result.Err == nil {
+		t.Fatal("Expected error for wrong options type")
+	}
+	if !strings.Contains(result.Err.Error(), "websso.AuthOptions") {
+		t.Errorf("Expected error about websso.AuthOptions, got: %v", result.Err)
+	}
+}
+
+func TestWebSSOScopeMap(t *testing.T) {
+	opts := &websso.AuthOptions{
+		IdentityProviderName: "my-idp",
+		Protocol:             "openid",
+		Scope: tokens.Scope{
+			ProjectName: "my-project",
+			DomainName:  "Default",
+		},
+	}
+
+	scopeMap, err := opts.ToTokenV3ScopeMap()
+	th.AssertNoErr(t, err)
+	if scopeMap == nil {
+		t.Fatal("Expected non-nil scope map")
+	}
+
+	project, ok := scopeMap["project"].(map[string]any)
+	if !ok {
+		t.Fatalf("Expected project in scope map, got %v", scopeMap)
+	}
+	projectName, ok := project["name"].(*string)
+	if !ok || projectName == nil || *projectName != "my-project" {
+		t.Errorf("Expected project name 'my-project', got %v", project["name"])
+	}
+}
+
+func TestWebSSONoScopeReturnsNil(t *testing.T) {
+	opts := &websso.AuthOptions{
+		IdentityProviderName: "my-idp",
+		Protocol:             "openid",
+	}
+
+	scopeMap, err := opts.ToTokenV3ScopeMap()
+	th.AssertNoErr(t, err)
+	if scopeMap != nil {
+		t.Errorf("Expected nil scope map for unscoped, got %v", scopeMap)
+	}
+}
+
+func TestWebSSOCanReauth(t *testing.T) {
+	opts := &websso.AuthOptions{AllowReauth: true}
+	th.CheckEquals(t, true, opts.CanReauth())
+
+	opts2 := &websso.AuthOptions{AllowReauth: false}
+	th.CheckEquals(t, false, opts2.CanReauth())
+}
+
+func TestWebSSOCallbackHandlerAcceptsValidPost(t *testing.T) {
+	fakeKeystone := th.SetupHTTP()
+	defer fakeKeystone.Teardown()
+
+	HandleWebSSOTokenValidation(t, fakeKeystone, UnscopedTokenID)
+
+	client := gophercloud.ServiceClient{
+		ProviderClient: &gophercloud.ProviderClient{},
+		Endpoint:       fakeKeystone.Endpoint(),
+	}
+
+	opts := &websso.AuthOptions{
+		IdentityProviderName: "my-idp",
+		Protocol:             "openid",
+		RedirectPort:         0,
+		Timeout:              10 * time.Second,
+	}
+
+	port := findAvailablePort(t)
+	opts.RedirectPort = port
+	results := startWebSSO(context.Background(), &client, opts)
+
+	callbackURL := fmt.Sprintf("http://127.0.0.1:%d/auth/websso/", port)
+	resp, err := http.PostForm(callbackURL, url.Values{"token": {UnscopedTokenID}})
+	th.AssertNoErr(t, err)
+	resp.Body.Close()
+	th.CheckEquals(t, http.StatusOK, resp.StatusCode)
+
+	result := <-results
+	th.AssertNoErr(t, result.Err)
+
+	token, err := result.ExtractTokenID()
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, UnscopedTokenID, token)
+}
+
+func TestWebSSOCallbackRejectsWrongMethod(t *testing.T) {
+	port := findAvailablePort(t)
+
+	client := gophercloud.ServiceClient{
+		ProviderClient: &gophercloud.ProviderClient{},
+		Endpoint:       "http://localhost/v3/",
+	}
+
+	opts := &websso.AuthOptions{
+		IdentityProviderName: "my-idp",
+		Protocol:             "openid",
+		RedirectPort:         port,
+		Timeout:              3 * time.Second,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	startWebSSO(ctx, &client, opts)
+	defer cancel()
+
+	callbackURL := fmt.Sprintf("http://127.0.0.1:%d/auth/websso/", port)
+	resp, err := http.Get(callbackURL) //nolint:gosec
+	th.AssertNoErr(t, err)
+	resp.Body.Close()
+	th.CheckEquals(t, http.StatusMethodNotAllowed, resp.StatusCode)
+}
+
+func TestWebSSOCallbackRejectsWrongContentType(t *testing.T) {
+	port := findAvailablePort(t)
+
+	client := gophercloud.ServiceClient{
+		ProviderClient: &gophercloud.ProviderClient{},
+		Endpoint:       "http://localhost/v3/",
+	}
+
+	opts := &websso.AuthOptions{
+		IdentityProviderName: "my-idp",
+		Protocol:             "openid",
+		RedirectPort:         port,
+		Timeout:              3 * time.Second,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	startWebSSO(ctx, &client, opts)
+	defer cancel()
+
+	callbackURL := fmt.Sprintf("http://127.0.0.1:%d/auth/websso/", port)
+	resp, err := http.Post(callbackURL, "application/json", strings.NewReader(`{"token":"abc"}`)) //nolint:gosec
+	th.AssertNoErr(t, err)
+	resp.Body.Close()
+	th.CheckEquals(t, http.StatusUnsupportedMediaType, resp.StatusCode)
+}
+
+func TestWebSSOCallbackIgnoresMissingTokenThenAcceptsValidToken(t *testing.T) {
+	fakeKeystone := th.SetupHTTP()
+	defer fakeKeystone.Teardown()
+
+	HandleWebSSOTokenValidation(t, fakeKeystone, UnscopedTokenID)
+
+	port := findAvailablePort(t)
+
+	client := gophercloud.ServiceClient{
+		ProviderClient: &gophercloud.ProviderClient{},
+		Endpoint:       fakeKeystone.Endpoint(),
+	}
+
+	opts := &websso.AuthOptions{
+		IdentityProviderName: "my-idp",
+		Protocol:             "openid",
+		RedirectPort:         port,
+		Timeout:              10 * time.Second,
+	}
+
+	results := startWebSSO(context.Background(), &client, opts)
+
+	callbackURL := fmt.Sprintf("http://127.0.0.1:%d/auth/websso/", port)
+
+	resp, err := http.PostForm(callbackURL, url.Values{"nottoken": {"abc"}})
+	th.AssertNoErr(t, err)
+	resp.Body.Close()
+	th.CheckEquals(t, http.StatusBadRequest, resp.StatusCode)
+
+	resp, err = http.PostForm(callbackURL, url.Values{"token": {UnscopedTokenID}})
+	th.AssertNoErr(t, err)
+	resp.Body.Close()
+	th.CheckEquals(t, http.StatusOK, resp.StatusCode)
+
+	result := <-results
+	th.AssertNoErr(t, result.Err)
+}
+
+func TestWebSSOCancellationDoesNotWaitForSlowCallback(t *testing.T) {
+	port := findAvailablePort(t)
+	client := gophercloud.ServiceClient{
+		ProviderClient: &gophercloud.ProviderClient{},
+		Endpoint:       "http://localhost/v3/",
+	}
+	opts := &websso.AuthOptions{
+		IdentityProviderName: "my-idp",
+		Protocol:             "openid",
+		RedirectPort:         port,
+		Timeout:              10 * time.Second,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	results := startWebSSO(ctx, &client, opts)
+	conn, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	th.AssertNoErr(t, err)
+
+	_, err = fmt.Fprintf(conn, "POST /auth/websso/ HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/x-www-form-urlencoded\r\nContent-Length: 1000\r\n\r\ntoken=")
+	th.AssertNoErr(t, err)
+	cancel()
+
+	select {
+	case result := <-results:
+		if result.Err == nil || !strings.Contains(result.Err.Error(), "cancelled") {
+			t.Fatalf("expected cancellation error, got %v", result.Err)
+		}
+	case <-time.After(500 * time.Millisecond):
+		conn.Close()
+		<-results
+		t.Fatal("WebSSO cancellation waited for a slow callback connection")
+	}
+	conn.Close()
+}
+
+func TestWebSSOTimeout(t *testing.T) {
+	client := gophercloud.ServiceClient{
+		ProviderClient: &gophercloud.ProviderClient{},
+		Endpoint:       "http://localhost/v3/",
+	}
+
+	port := findAvailablePort(t)
+	opts := &websso.AuthOptions{
+		IdentityProviderName: "my-idp",
+		Protocol:             "openid",
+		RedirectPort:         port,
+		Timeout:              500 * time.Millisecond,
+		BrowserOpener:        func(string) error { return nil },
+	}
+
+	result := websso.Authenticate(context.TODO(), &client, opts)
+	if result.Err == nil {
+		t.Fatal("Expected timeout error")
+	}
+	if !strings.Contains(result.Err.Error(), "timed out") {
+		t.Errorf("Expected timeout error, got: %v", result.Err)
+	}
+}
+
+func TestWebSSOContextCancellation(t *testing.T) {
+	client := gophercloud.ServiceClient{
+		ProviderClient: &gophercloud.ProviderClient{},
+		Endpoint:       "http://localhost/v3/",
+	}
+
+	port := findAvailablePort(t)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	opts := &websso.AuthOptions{
+		IdentityProviderName: "my-idp",
+		Protocol:             "openid",
+		RedirectPort:         port,
+		Timeout:              30 * time.Second,
+	}
+
+	results := startWebSSO(ctx, &client, opts)
+	cancel()
+
+	res := <-results
+	if res.Err == nil {
+		t.Fatal("Expected cancellation error")
+	}
+	if !strings.Contains(res.Err.Error(), "cancel") {
+		t.Errorf("Expected cancellation error, got: %v", res.Err)
+	}
+}

--- a/openstack/identity/v3/websso/testing/flow_test.go
+++ b/openstack/identity/v3/websso/testing/flow_test.go
@@ -117,7 +117,7 @@ func TestWebSSOCallbackHandlerAcceptsValidPost(t *testing.T) {
 	results := startWebSSO(context.Background(), &client, opts)
 
 	callbackURL := fmt.Sprintf("http://127.0.0.1:%d/auth/websso/", port)
-	resp, err := http.PostForm(callbackURL, url.Values{"token": {UnscopedTokenID}})
+	resp, err := http.DefaultClient.Do(newWebSSOCallbackRequest(t, callbackURL, url.Values{"token": {UnscopedTokenID}}))
 	th.AssertNoErr(t, err)
 	resp.Body.Close()
 	th.CheckEquals(t, http.StatusOK, resp.StatusCode)
@@ -155,7 +155,7 @@ func TestWebSSOTokenValidationAccepts203(t *testing.T) {
 		Timeout:              10 * time.Second,
 	})
 
-	response, err := http.PostForm(fmt.Sprintf("http://127.0.0.1:%d/auth/websso/", port), url.Values{"token": {UnscopedTokenID}})
+	response, err := http.DefaultClient.Do(newWebSSOCallbackRequest(t, fmt.Sprintf("http://127.0.0.1:%d/auth/websso/", port), url.Values{"token": {UnscopedTokenID}}))
 	th.AssertNoErr(t, err)
 	response.Body.Close()
 
@@ -185,7 +185,7 @@ func TestWebSSOTokenValidationFailurePreservesProviderToken(t *testing.T) {
 		Timeout:              10 * time.Second,
 	})
 
-	response, err := http.PostForm(fmt.Sprintf("http://127.0.0.1:%d/auth/websso/", port), url.Values{"token": {UnscopedTokenID}})
+	response, err := http.DefaultClient.Do(newWebSSOCallbackRequest(t, fmt.Sprintf("http://127.0.0.1:%d/auth/websso/", port), url.Values{"token": {UnscopedTokenID}}))
 	th.AssertNoErr(t, err)
 	response.Body.Close()
 
@@ -274,17 +274,17 @@ func TestWebSSOCallbackIgnoresMissingTokenThenAcceptsValidToken(t *testing.T) {
 
 	callbackURL := fmt.Sprintf("http://127.0.0.1:%d/auth/websso/", port)
 
-	resp, err := http.PostForm(callbackURL+"?token="+UnscopedTokenID, nil)
+	resp, err := http.DefaultClient.Do(newWebSSOCallbackRequest(t, callbackURL+"?token="+UnscopedTokenID, nil))
 	th.AssertNoErr(t, err)
 	resp.Body.Close()
 	th.CheckEquals(t, http.StatusBadRequest, resp.StatusCode)
 
-	resp, err = http.PostForm(callbackURL, url.Values{"nottoken": {"abc"}})
+	resp, err = http.DefaultClient.Do(newWebSSOCallbackRequest(t, callbackURL, url.Values{"nottoken": {"abc"}}))
 	th.AssertNoErr(t, err)
 	resp.Body.Close()
 	th.CheckEquals(t, http.StatusBadRequest, resp.StatusCode)
 
-	resp, err = http.PostForm(callbackURL, url.Values{"token": {UnscopedTokenID}})
+	resp, err = http.DefaultClient.Do(newWebSSOCallbackRequest(t, callbackURL, url.Values{"token": {UnscopedTokenID}}))
 	th.AssertNoErr(t, err)
 	resp.Body.Close()
 	th.CheckEquals(t, http.StatusOK, resp.StatusCode)

--- a/openstack/identity/v3/websso/testing/flow_test.go
+++ b/openstack/identity/v3/websso/testing/flow_test.go
@@ -177,6 +177,74 @@ func TestWebSSOCallbackHandlerAcceptsValidPost(t *testing.T) {
 	th.CheckEquals(t, UnscopedTokenID, token)
 }
 
+func TestWebSSOTokenValidationAccepts203(t *testing.T) {
+	fakeKeystone := th.SetupHTTP()
+	defer fakeKeystone.Teardown()
+
+	fakeKeystone.Mux.HandleFunc("/auth/tokens", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, http.MethodGet)
+		th.TestHeader(t, r, "X-Subject-Token", UnscopedTokenID)
+		w.Header().Set("X-Subject-Token", UnscopedTokenID)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNonAuthoritativeInfo)
+		fmt.Fprint(w, FederationAuthResponse)
+	})
+
+	client := gophercloud.ServiceClient{
+		ProviderClient: &gophercloud.ProviderClient{},
+		Endpoint:       fakeKeystone.Endpoint(),
+	}
+	port := findAvailablePort(t)
+	results := startWebSSO(context.Background(), &client, &websso.AuthOptions{
+		IdentityProviderName: "my-idp",
+		Protocol:             "openid",
+		RedirectPort:         port,
+		Timeout:              10 * time.Second,
+	})
+
+	response, err := http.PostForm(fmt.Sprintf("http://127.0.0.1:%d/auth/websso/", port), url.Values{"token": {UnscopedTokenID}})
+	th.AssertNoErr(t, err)
+	response.Body.Close()
+
+	result := <-results
+	th.AssertNoErr(t, result.Err)
+}
+
+func TestWebSSOTokenValidationFailurePreservesProviderToken(t *testing.T) {
+	fakeKeystone := th.SetupHTTP()
+	defer fakeKeystone.Teardown()
+
+	fakeKeystone.Mux.HandleFunc("/auth/tokens", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "validation failed", http.StatusInternalServerError)
+	})
+
+	provider := newTestProviderClient()
+	provider.SetToken("existing-token")
+	client := gophercloud.ServiceClient{
+		ProviderClient: provider,
+		Endpoint:       fakeKeystone.Endpoint(),
+	}
+	port := findAvailablePort(t)
+	results := startWebSSO(context.Background(), &client, &websso.AuthOptions{
+		IdentityProviderName: "my-idp",
+		Protocol:             "openid",
+		RedirectPort:         port,
+		Timeout:              10 * time.Second,
+	})
+
+	response, err := http.PostForm(fmt.Sprintf("http://127.0.0.1:%d/auth/websso/", port), url.Values{"token": {UnscopedTokenID}})
+	th.AssertNoErr(t, err)
+	response.Body.Close()
+
+	result := <-results
+	if result.Err == nil {
+		t.Fatal("expected token validation error")
+	}
+	if provider.TokenID != "existing-token" {
+		t.Fatalf("provider token changed after validation failure: got %q", provider.TokenID)
+	}
+}
+
 func TestWebSSOCallbackRejectsWrongMethod(t *testing.T) {
 	port := findAvailablePort(t)
 
@@ -253,7 +321,12 @@ func TestWebSSOCallbackIgnoresMissingTokenThenAcceptsValidToken(t *testing.T) {
 
 	callbackURL := fmt.Sprintf("http://127.0.0.1:%d/auth/websso/", port)
 
-	resp, err := http.PostForm(callbackURL, url.Values{"nottoken": {"abc"}})
+	resp, err := http.PostForm(callbackURL+"?token="+UnscopedTokenID, nil)
+	th.AssertNoErr(t, err)
+	resp.Body.Close()
+	th.CheckEquals(t, http.StatusBadRequest, resp.StatusCode)
+
+	resp, err = http.PostForm(callbackURL, url.Values{"nottoken": {"abc"}})
 	th.AssertNoErr(t, err)
 	resp.Body.Close()
 	th.CheckEquals(t, http.StatusBadRequest, resp.StatusCode)

--- a/openstack/identity/v3/websso/testing/flow_test.go
+++ b/openstack/identity/v3/websso/testing/flow_test.go
@@ -35,50 +35,6 @@ func startWebSSO(t *testing.T, ctx context.Context, client *gophercloud.ServiceC
 
 var _ tokens.AuthOptionsBuilder = (*websso.AuthOptions)(nil)
 
-func TestWebSSOValidationMissingIdentityProvider(t *testing.T) {
-	fakeServer := th.SetupHTTP()
-	defer fakeServer.Teardown()
-
-	client := gophercloud.ServiceClient{
-		ProviderClient: &gophercloud.ProviderClient{},
-		Endpoint:       fakeServer.Endpoint(),
-	}
-
-	opts := &websso.AuthOptions{
-		Protocol: "openid",
-	}
-
-	result := websso.Authenticate(context.TODO(), &client, opts)
-	if result.Err == nil {
-		t.Fatal("Expected error for missing IdentityProviderName")
-	}
-	if !strings.Contains(result.Err.Error(), "IdentityProviderName") {
-		t.Errorf("Expected error about IdentityProviderName, got: %v", result.Err)
-	}
-}
-
-func TestWebSSOValidationMissingProtocol(t *testing.T) {
-	fakeServer := th.SetupHTTP()
-	defer fakeServer.Teardown()
-
-	client := gophercloud.ServiceClient{
-		ProviderClient: &gophercloud.ProviderClient{},
-		Endpoint:       fakeServer.Endpoint(),
-	}
-
-	opts := &websso.AuthOptions{
-		IdentityProviderName: "my-idp",
-	}
-
-	result := websso.Authenticate(context.TODO(), &client, opts)
-	if result.Err == nil {
-		t.Fatal("Expected error for missing Protocol")
-	}
-	if !strings.Contains(result.Err.Error(), "Protocol") {
-		t.Errorf("Expected error about Protocol, got: %v", result.Err)
-	}
-}
-
 func TestWebSSOWrongOptionsType(t *testing.T) {
 	fakeServer := th.SetupHTTP()
 	defer fakeServer.Teardown()

--- a/openstack/identity/v3/websso/testing/requests_test.go
+++ b/openstack/identity/v3/websso/testing/requests_test.go
@@ -82,6 +82,30 @@ func TestRedirectHostMustBeLoopback(t *testing.T) {
 	}
 }
 
+func TestInvalidScopeDoesNotOpenBrowser(t *testing.T) {
+	client := serviceClient("http://identity.example/v3/")
+	opened := false
+	result := websso.Authenticate(context.Background(), client, &websso.AuthOptions{
+		IdentityProviderName: "my-idp",
+		Protocol:             "openid",
+		Scope: tokens.Scope{
+			ProjectName: "project",
+		},
+		RedirectPort: findAvailablePort(t),
+		BrowserOpener: func(string) error {
+			opened = true
+			return errors.New("browser should not open")
+		},
+	})
+
+	if result.Err == nil || !strings.Contains(result.Err.Error(), "DomainID or DomainName") {
+		t.Fatalf("expected invalid scope error, got %v", result.Err)
+	}
+	if opened {
+		t.Fatal("browser opened before scope validation")
+	}
+}
+
 func TestMalformedContentTypeDoesNotConsumeCallback(t *testing.T) {
 	fakeServer := th.SetupHTTP()
 	defer fakeServer.Teardown()

--- a/openstack/identity/v3/websso/testing/requests_test.go
+++ b/openstack/identity/v3/websso/testing/requests_test.go
@@ -1,0 +1,145 @@
+package testing
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/openstack/identity/v3/tokens"
+	"github.com/gophercloud/gophercloud/v2/openstack/identity/v3/websso"
+	th "github.com/gophercloud/gophercloud/v2/testhelper"
+)
+
+const testToken = "unscoped-websso-token"
+
+var _ tokens.AuthOptionsBuilder = (*websso.AuthOptions)(nil)
+
+func TestAuthenticateRejectsTypedNilOptions(t *testing.T) {
+	client := serviceClient("http://identity.example/v3/")
+	var opts *websso.AuthOptions
+	result := websso.Authenticate(context.Background(), client, opts)
+	if result.Err == nil || !strings.Contains(result.Err.Error(), "non-nil") {
+		t.Fatalf("expected typed nil options error, got %v", result.Err)
+	}
+}
+
+func TestBrowserOpenerFailureIsReturned(t *testing.T) {
+	port := findAvailablePort(t)
+	client := serviceClient("http://identity.example/v3/")
+	wantErr := errors.New("browser unavailable")
+	var openedURL string
+
+	result := websso.Authenticate(context.Background(), client, &websso.AuthOptions{
+		IdentityProviderName: "my-idp",
+		Protocol:             "openid",
+		RedirectHost:         "127.0.0.1",
+		RedirectPort:         port,
+		BrowserOpener: func(target string) error {
+			openedURL = target
+			return wantErr
+		},
+	})
+
+	if !errors.Is(result.Err, wantErr) {
+		t.Fatalf("expected browser opener error, got %v", result.Err)
+	}
+	parsed, err := url.Parse(openedURL)
+	th.AssertNoErr(t, err)
+	wantOrigin := fmt.Sprintf("http://127.0.0.1:%d/auth/websso/", port)
+	if got := parsed.Query().Get("origin"); got != wantOrigin {
+		t.Fatalf("unexpected WebSSO origin: got %q, want %q", got, wantOrigin)
+	}
+}
+
+func TestCacheRequiresExplicitNamespace(t *testing.T) {
+	client := serviceClient("http://identity.example/v3/")
+	result := websso.Authenticate(context.Background(), client, &websso.AuthOptions{
+		IdentityProviderName: "my-idp",
+		Protocol:             "openid",
+		TokenCache:           newMemoryCache(),
+	})
+	if result.Err == nil || !strings.Contains(result.Err.Error(), "CacheNamespace") {
+		t.Fatalf("expected CacheNamespace validation error, got %v", result.Err)
+	}
+}
+
+func TestRedirectHostMustBeLoopback(t *testing.T) {
+	client := serviceClient("http://identity.example/v3/")
+	result := websso.Authenticate(context.Background(), client, &websso.AuthOptions{
+		IdentityProviderName: "my-idp",
+		Protocol:             "openid",
+		RedirectHost:         "0.0.0.0",
+	})
+	if result.Err == nil || !strings.Contains(result.Err.Error(), "loopback") {
+		t.Fatalf("expected loopback validation error, got %v", result.Err)
+	}
+}
+
+func TestMalformedContentTypeDoesNotConsumeCallback(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	fakeServer.Mux.HandleFunc("/auth/tokens", func(w http.ResponseWriter, r *http.Request) {
+		th.TestHeader(t, r, "X-Subject-Token", testToken)
+		w.Header().Set("X-Subject-Token", testToken)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"token":{"expires_at":"2035-01-01T00:00:00Z","methods":["mapped"],"user":{"id":"user-id","name":"user","domain":{"id":"default","name":"Default"}}}}`)
+	})
+
+	port := findAvailablePort(t)
+	client := serviceClient(fakeServer.Endpoint())
+	results := startWebSSO(context.Background(), client, &websso.AuthOptions{
+		IdentityProviderName: "my-idp",
+		Protocol:             "openid",
+		RedirectHost:         "127.0.0.1",
+		RedirectPort:         port,
+		Timeout:              5 * time.Second,
+	})
+
+	callbackURL := fmt.Sprintf("http://127.0.0.1:%d/auth/websso/", port)
+	request, err := http.NewRequest(http.MethodPost, callbackURL, strings.NewReader("token="+testToken))
+	th.AssertNoErr(t, err)
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded-malformed")
+	response, err := http.DefaultClient.Do(request)
+	th.AssertNoErr(t, err)
+	response.Body.Close()
+	if response.StatusCode != http.StatusUnsupportedMediaType {
+		t.Fatalf("unexpected malformed callback status: %d", response.StatusCode)
+	}
+
+	response, err = http.PostForm(callbackURL, url.Values{"token": {testToken}})
+	th.AssertNoErr(t, err)
+	response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("unexpected valid callback status: %d", response.StatusCode)
+	}
+
+	result := <-results
+	th.AssertNoErr(t, result.Err)
+	actualToken, err := result.ExtractTokenID()
+	th.AssertNoErr(t, err)
+	if actualToken != testToken {
+		t.Fatalf("unexpected token: got %q, want %q", actualToken, testToken)
+	}
+}
+
+func serviceClient(endpoint string) *gophercloud.ServiceClient {
+	return &gophercloud.ServiceClient{
+		ProviderClient: &gophercloud.ProviderClient{},
+		Endpoint:       endpoint,
+	}
+}
+
+func findAvailablePort(t *testing.T) int {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	th.AssertNoErr(t, err)
+	defer listener.Close()
+	return listener.Addr().(*net.TCPAddr).Port
+}

--- a/openstack/identity/v3/websso/testing/requests_test.go
+++ b/openstack/identity/v3/websso/testing/requests_test.go
@@ -58,6 +58,39 @@ func TestBrowserOpenerFailureIsReturned(t *testing.T) {
 	}
 }
 
+func TestWebSSOListenerStartsBeforeBrowser(t *testing.T) {
+	fakeKeystone := th.SetupHTTP()
+	defer fakeKeystone.Teardown()
+	HandleWebSSOTokenValidation(t, fakeKeystone, testToken)
+
+	result := websso.Authenticate(context.Background(), serviceClient(fakeKeystone.Endpoint()), &websso.AuthOptions{
+		IdentityProviderName: "my-idp",
+		Protocol:             "openid",
+		RedirectHost:         "127.0.0.1",
+		RedirectPort:         findAvailablePort(t),
+		BrowserOpener: func(target string) error {
+			parsed, err := url.Parse(target)
+			if err != nil {
+				return err
+			}
+			response, err := http.PostForm(parsed.Query().Get("origin"), url.Values{"token": {testToken}})
+			if err != nil {
+				return err
+			}
+			defer response.Body.Close()
+			if response.StatusCode != http.StatusOK {
+				return fmt.Errorf("unexpected callback status: %s", response.Status)
+			}
+			return nil
+		},
+	})
+
+	th.AssertNoErr(t, result.Err)
+	token, err := result.ExtractTokenID()
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, testToken, token)
+}
+
 func TestCacheRequiresExplicitNamespace(t *testing.T) {
 	client := serviceClient("http://identity.example/v3/")
 	result := websso.Authenticate(context.Background(), client, &websso.AuthOptions{

--- a/openstack/identity/v3/websso/testing/requests_test.go
+++ b/openstack/identity/v3/websso/testing/requests_test.go
@@ -61,7 +61,7 @@ func TestBrowserOpenerFailureIsReturned(t *testing.T) {
 func TestWebSSOListenerStartsBeforeBrowser(t *testing.T) {
 	fakeKeystone := th.SetupHTTP()
 	defer fakeKeystone.Teardown()
-	HandleWebSSOTokenValidation(t, fakeKeystone, testToken)
+	handleWebSSOTokenValidation(t, fakeKeystone, testToken)
 
 	result := websso.Authenticate(context.Background(), serviceClient(fakeKeystone.Endpoint()), &websso.AuthOptions{
 		IdentityProviderName: "my-idp",
@@ -140,75 +140,28 @@ func TestInvalidScopeDoesNotOpenBrowser(t *testing.T) {
 	}
 }
 
-func TestMalformedContentTypeDoesNotConsumeCallback(t *testing.T) {
+func TestWebSSOCallbackRejectsInvalidRequest(t *testing.T) {
 	fakeServer := th.SetupHTTP()
 	defer fakeServer.Teardown()
-	fakeServer.Mux.HandleFunc("/auth/tokens", func(w http.ResponseWriter, r *http.Request) {
-		th.TestHeader(t, r, "X-Subject-Token", testToken)
-		w.Header().Set("X-Subject-Token", testToken)
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, `{"token":{"expires_at":"2035-01-01T00:00:00Z","methods":["mapped"],"user":{"id":"user-id","name":"user","domain":{"id":"default","name":"Default"}}}}`)
-	})
-
-	port := findAvailablePort(t)
-	client := serviceClient(fakeServer.Endpoint())
-	results := startWebSSO(context.Background(), client, &websso.AuthOptions{
-		IdentityProviderName: "my-idp",
-		Protocol:             "openid",
-		RedirectHost:         "127.0.0.1",
-		RedirectPort:         port,
-		Timeout:              5 * time.Second,
-	})
-
-	callbackURL := fmt.Sprintf("http://127.0.0.1:%d/auth/websso/", port)
-	request, err := http.NewRequest(http.MethodPost, callbackURL, strings.NewReader("token="+testToken))
-	th.AssertNoErr(t, err)
-	request.Header.Set("Content-Type", "application/x-www-form-urlencoded-malformed")
-	response, err := http.DefaultClient.Do(request)
-	th.AssertNoErr(t, err)
-	response.Body.Close()
-	if response.StatusCode != http.StatusUnsupportedMediaType {
-		t.Fatalf("unexpected malformed callback status: %d", response.StatusCode)
-	}
-
-	response, err = http.DefaultClient.Do(newWebSSOCallbackRequest(t, callbackURL, url.Values{"token": {testToken}}))
-	th.AssertNoErr(t, err)
-	response.Body.Close()
-	if response.StatusCode != http.StatusOK {
-		t.Fatalf("unexpected valid callback status: %d", response.StatusCode)
-	}
-
-	result := <-results
-	th.AssertNoErr(t, result.Err)
-	actualToken, err := result.ExtractTokenID()
-	th.AssertNoErr(t, err)
-	if actualToken != testToken {
-		t.Fatalf("unexpected token: got %q, want %q", actualToken, testToken)
-	}
-}
-
-func TestWebSSOCallbackRejectsUnexpectedBrowserContext(t *testing.T) {
-	fakeServer := th.SetupHTTP()
-	defer fakeServer.Teardown()
-	HandleWebSSOTokenValidation(t, fakeServer, testToken)
-
-	port := findAvailablePort(t)
-	client := serviceClient(fakeServer.Endpoint())
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	results := startWebSSO(ctx, client, &websso.AuthOptions{
-		IdentityProviderName: "my-idp",
-		Protocol:             "openid",
-		RedirectHost:         "127.0.0.1",
-		RedirectPort:         port,
-		Timeout:              5 * time.Second,
-	})
-
-	callbackURL := fmt.Sprintf("http://127.0.0.1:%d/auth/websso/", port)
+	handleWebSSOTokenValidation(t, fakeServer, testToken)
 	tests := []struct {
-		name   string
-		modify func(*http.Request)
+		name       string
+		path       string
+		statusCode int
+		modify     func(*http.Request)
 	}{
+		{
+			name:       "malformed content type",
+			statusCode: http.StatusUnsupportedMediaType,
+			modify: func(request *http.Request) {
+				request.Header.Set("Content-Type", "application/x-www-form-urlencoded-malformed")
+			},
+		},
+		{
+			name:       "unexpected path",
+			path:       "unexpected",
+			statusCode: http.StatusNotFound,
+		},
 		{
 			name: "missing fetch mode",
 			modify: func(request *http.Request) {
@@ -243,26 +196,42 @@ func TestWebSSOCallbackRejectsUnexpectedBrowserContext(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			request := newWebSSOCallbackRequest(t, callbackURL, url.Values{"token": {testToken}})
-			test.modify(request)
+			port := findAvailablePort(t)
+			results := startWebSSO(t, context.Background(), serviceClient(fakeServer.Endpoint()), &websso.AuthOptions{
+				IdentityProviderName: "my-idp",
+				Protocol:             "openid",
+				RedirectHost:         "127.0.0.1",
+				RedirectPort:         port,
+				Timeout:              5 * time.Second,
+			})
+
+			callbackURL := fmt.Sprintf("http://127.0.0.1:%d/auth/websso/", port)
+			request := newWebSSOCallbackRequest(t, callbackURL+test.path, url.Values{"token": {testToken}})
+			if test.modify != nil {
+				test.modify(request)
+			}
 			response, err := http.DefaultClient.Do(request)
 			th.AssertNoErr(t, err)
-			defer response.Body.Close()
-			if response.StatusCode != http.StatusBadRequest {
-				t.Fatalf("unexpected callback status: got %d, want %d", response.StatusCode, http.StatusBadRequest)
+			response.Body.Close()
+			wantStatus := test.statusCode
+			if wantStatus == 0 {
+				wantStatus = http.StatusBadRequest
 			}
+			if response.StatusCode != wantStatus {
+				t.Fatalf("unexpected callback status: got %d, want %d", response.StatusCode, wantStatus)
+			}
+
+			response, err = http.DefaultClient.Do(newWebSSOCallbackRequest(t, callbackURL, url.Values{"token": {testToken}}))
+			th.AssertNoErr(t, err)
+			response.Body.Close()
+			if response.StatusCode != http.StatusOK {
+				t.Fatalf("unexpected valid callback status: %d", response.StatusCode)
+			}
+
+			result := <-results
+			th.AssertNoErr(t, result.Err)
 		})
 	}
-
-	response, err := http.DefaultClient.Do(newWebSSOCallbackRequest(t, callbackURL, url.Values{"token": {testToken}}))
-	th.AssertNoErr(t, err)
-	response.Body.Close()
-	if response.StatusCode != http.StatusOK {
-		t.Fatalf("unexpected valid callback status: %d", response.StatusCode)
-	}
-
-	result := <-results
-	th.AssertNoErr(t, result.Err)
 }
 
 func newWebSSOCallbackRequest(t *testing.T, target string, values url.Values) *http.Request {

--- a/openstack/identity/v3/websso/testing/requests_test.go
+++ b/openstack/identity/v3/websso/testing/requests_test.go
@@ -73,7 +73,8 @@ func TestWebSSOListenerStartsBeforeBrowser(t *testing.T) {
 			if err != nil {
 				return err
 			}
-			response, err := http.PostForm(parsed.Query().Get("origin"), url.Values{"token": {testToken}})
+			request := newWebSSOCallbackRequest(t, parsed.Query().Get("origin"), url.Values{"token": {testToken}})
+			response, err := http.DefaultClient.Do(request)
 			if err != nil {
 				return err
 			}
@@ -170,7 +171,7 @@ func TestMalformedContentTypeDoesNotConsumeCallback(t *testing.T) {
 		t.Fatalf("unexpected malformed callback status: %d", response.StatusCode)
 	}
 
-	response, err = http.PostForm(callbackURL, url.Values{"token": {testToken}})
+	response, err = http.DefaultClient.Do(newWebSSOCallbackRequest(t, callbackURL, url.Values{"token": {testToken}}))
 	th.AssertNoErr(t, err)
 	response.Body.Close()
 	if response.StatusCode != http.StatusOK {
@@ -184,6 +185,96 @@ func TestMalformedContentTypeDoesNotConsumeCallback(t *testing.T) {
 	if actualToken != testToken {
 		t.Fatalf("unexpected token: got %q, want %q", actualToken, testToken)
 	}
+}
+
+func TestWebSSOCallbackRejectsUnexpectedBrowserContext(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+	HandleWebSSOTokenValidation(t, fakeServer, testToken)
+
+	port := findAvailablePort(t)
+	client := serviceClient(fakeServer.Endpoint())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	results := startWebSSO(ctx, client, &websso.AuthOptions{
+		IdentityProviderName: "my-idp",
+		Protocol:             "openid",
+		RedirectHost:         "127.0.0.1",
+		RedirectPort:         port,
+		Timeout:              5 * time.Second,
+	})
+
+	callbackURL := fmt.Sprintf("http://127.0.0.1:%d/auth/websso/", port)
+	tests := []struct {
+		name   string
+		modify func(*http.Request)
+	}{
+		{
+			name: "missing fetch mode",
+			modify: func(request *http.Request) {
+				request.Header.Del("Sec-Fetch-Mode")
+			},
+		},
+		{
+			name: "unexpected fetch destination",
+			modify: func(request *http.Request) {
+				request.Header.Set("Sec-Fetch-Dest", "empty")
+			},
+		},
+		{
+			name: "direct navigation",
+			modify: func(request *http.Request) {
+				request.Header.Set("Sec-Fetch-Site", "none")
+			},
+		},
+		{
+			name: "unexpected origin",
+			modify: func(request *http.Request) {
+				request.Header.Set("Origin", "https://attacker.example")
+			},
+		},
+		{
+			name: "unexpected referer",
+			modify: func(request *http.Request) {
+				request.Header.Set("Referer", "https://attacker.example/")
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			request := newWebSSOCallbackRequest(t, callbackURL, url.Values{"token": {testToken}})
+			test.modify(request)
+			response, err := http.DefaultClient.Do(request)
+			th.AssertNoErr(t, err)
+			defer response.Body.Close()
+			if response.StatusCode != http.StatusBadRequest {
+				t.Fatalf("unexpected callback status: got %d, want %d", response.StatusCode, http.StatusBadRequest)
+			}
+		})
+	}
+
+	response, err := http.DefaultClient.Do(newWebSSOCallbackRequest(t, callbackURL, url.Values{"token": {testToken}}))
+	th.AssertNoErr(t, err)
+	response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("unexpected valid callback status: %d", response.StatusCode)
+	}
+
+	result := <-results
+	th.AssertNoErr(t, result.Err)
+}
+
+func newWebSSOCallbackRequest(t *testing.T, target string, values url.Values) *http.Request {
+	t.Helper()
+	request, err := http.NewRequest(http.MethodPost, target, strings.NewReader(values.Encode()))
+	th.AssertNoErr(t, err)
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	request.Header.Set("Sec-Fetch-Mode", "navigate")
+	request.Header.Set("Sec-Fetch-Dest", "document")
+	request.Header.Set("Sec-Fetch-Site", "cross-site")
+	request.Header.Set("Origin", "null")
+	return request
 }
 
 func serviceClient(endpoint string) *gophercloud.ServiceClient {

--- a/openstack/identity/v3/websso/testing/validation_test.go
+++ b/openstack/identity/v3/websso/testing/validation_test.go
@@ -1,0 +1,94 @@
+package testing
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/openstack/identity/v3/websso"
+	th "github.com/gophercloud/gophercloud/v2/testhelper"
+)
+
+func TestAuthOptionsValidation(t *testing.T) {
+	tests := []struct {
+		name     string
+		argument string
+		missing  bool
+		modify   func(*websso.AuthOptions)
+	}{
+		{"missing identity provider", "IdentityProviderName", true, func(opts *websso.AuthOptions) { opts.IdentityProviderName = "" }},
+		{"missing protocol", "Protocol", true, func(opts *websso.AuthOptions) { opts.Protocol = "" }},
+		{"negative port", "RedirectPort", false, func(opts *websso.AuthOptions) { opts.RedirectPort = -1 }},
+		{"port too large", "RedirectPort", false, func(opts *websso.AuthOptions) { opts.RedirectPort = 65536 }},
+		{"negative timeout", "Timeout", false, func(opts *websso.AuthOptions) { opts.Timeout = -time.Second }},
+		{"cache without namespace", "CacheNamespace", false, func(opts *websso.AuthOptions) { opts.TokenCache = newMemoryCache() }},
+		{"non-loopback host", "RedirectHost", false, func(opts *websso.AuthOptions) { opts.RedirectHost = "0.0.0.0" }},
+		{"invalid host", "RedirectHost", false, func(opts *websso.AuthOptions) { opts.RedirectHost = "invalid" }},
+	}
+	validators := map[string]func(*websso.AuthOptions) error{
+		"ToTokenV3CreateMap": func(opts *websso.AuthOptions) error {
+			_, err := opts.ToTokenV3CreateMap(nil)
+			return err
+		},
+		"Authenticate": func(opts *websso.AuthOptions) error {
+			return websso.Authenticate(context.Background(), nil, opts).Err
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			for name, validate := range validators {
+				t.Run(name, func(t *testing.T) {
+					opts := &websso.AuthOptions{IdentityProviderName: "my-idp", Protocol: "openid"}
+					test.modify(opts)
+					err := validate(opts)
+					if test.missing {
+						var missing gophercloud.ErrMissingInput
+						if !errors.As(err, &missing) {
+							t.Fatalf("expected ErrMissingInput, got %v", err)
+						}
+						th.CheckEquals(t, test.argument, missing.Argument)
+					} else if err == nil || !strings.Contains(err.Error(), test.argument) {
+						t.Fatalf("expected %s validation error, got %v", test.argument, err)
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestToTokenV3CreateMap(t *testing.T) {
+	tests := map[string]websso.AuthOptions{
+		"defaults":  {},
+		"localhost": {RedirectHost: "localhost", RedirectPort: 1},
+		"IPv4":      {RedirectHost: "127.0.0.1", RedirectPort: 65535},
+		"IPv6":      {RedirectHost: "::1", RedirectPort: 9990},
+		"browser and cache hooks": {
+			BrowserOpener: func(string) error {
+				t.Fatal("validation must not open the browser")
+				return nil
+			},
+			TokenCache:     nonJSONCache{newMemoryCache()},
+			CacheNamespace: "profile",
+		},
+	}
+	for name, opts := range tests {
+		t.Run(name, func(t *testing.T) {
+			opts.IdentityProviderName = "my-idp"
+			opts.Protocol = "openid"
+			body, err := opts.ToTokenV3CreateMap(nil)
+			th.AssertNoErr(t, err)
+			if body != nil {
+				t.Fatalf("expected nil body, got %v", body)
+			}
+		})
+	}
+}
+
+type nonJSONCache struct{ memoryCache }
+
+func (nonJSONCache) MarshalJSON() ([]byte, error) {
+	return nil, errors.New("cache implementation must not be serialized")
+}

--- a/openstack/identity/v3/websso/urls.go
+++ b/openstack/identity/v3/websso/urls.go
@@ -1,0 +1,15 @@
+package websso
+
+import "github.com/gophercloud/gophercloud/v2"
+
+func authURL(client *gophercloud.ServiceClient, identityProvider, protocol string) string {
+	return client.ServiceURL(
+		"auth",
+		"OS-FEDERATION",
+		"identity_providers",
+		identityProvider,
+		"protocols",
+		protocol,
+		"websso",
+	)
+}

--- a/openstack/testing/websso_test.go
+++ b/openstack/testing/websso_test.go
@@ -1,0 +1,90 @@
+package testing
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/openstack"
+	"github.com/gophercloud/gophercloud/v2/openstack/identity/v3/websso"
+	th "github.com/gophercloud/gophercloud/v2/testhelper"
+)
+
+func TestAuthenticateV3WebSSOReauth(t *testing.T) {
+	fakeKeystone := th.SetupHTTP()
+	defer fakeKeystone.Teardown()
+
+	fakeKeystone.Mux.HandleFunc("/v3/auth/tokens", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, http.MethodGet)
+		token := r.Header.Get("X-Subject-Token")
+		w.Header().Set("X-Subject-Token", token)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"token":{"expires_at":%q,"catalog":[]}}`, time.Now().Add(time.Hour).UTC().Format(time.RFC3339Nano))
+	})
+
+	client, err := openstack.NewClient(fakeKeystone.Endpoint() + "v3/")
+	th.AssertNoErr(t, err)
+
+	var browserCalls atomic.Int32
+	opts := &websso.AuthOptions{
+		IdentityProviderName: "my-idp",
+		Protocol:             "openid",
+		AllowReauth:          true,
+		RedirectHost:         "127.0.0.1",
+		RedirectPort:         availablePort(t),
+		Timeout:              5 * time.Second,
+		BrowserOpener: func(target string) error {
+			token := fmt.Sprintf("websso-token-%d", browserCalls.Add(1))
+			parsed, err := url.Parse(target)
+			if err != nil {
+				return err
+			}
+			form := url.Values{"token": {token}}
+			request, err := http.NewRequest(http.MethodPost, parsed.Query().Get("origin"), strings.NewReader(form.Encode()))
+			if err != nil {
+				return err
+			}
+			request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			request.Header.Set("Sec-Fetch-Mode", "navigate")
+			request.Header.Set("Sec-Fetch-Dest", "document")
+			request.Header.Set("Sec-Fetch-Site", "cross-site")
+			request.Header.Set("Origin", "null")
+			response, err := http.DefaultClient.Do(request)
+			if err != nil {
+				return err
+			}
+			defer response.Body.Close()
+			if response.StatusCode != http.StatusOK {
+				return fmt.Errorf("unexpected callback status: %s", response.Status)
+			}
+			return nil
+		},
+	}
+
+	err = openstack.AuthenticateV3(context.Background(), client, opts, gophercloud.EndpointOpts{})
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, "websso-token-1", client.TokenID)
+	if client.ReauthFunc == nil {
+		t.Fatal("AuthenticateV3 did not configure reauthentication")
+	}
+
+	err = client.Reauthenticate(context.Background(), client.TokenID)
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, "websso-token-2", client.TokenID)
+	th.CheckEquals(t, int32(2), browserCalls.Load())
+}
+
+func availablePort(t *testing.T) int {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	th.AssertNoErr(t, err)
+	defer listener.Close()
+	return listener.Addr().(*net.TCPAddr).Port
+}


### PR DESCRIPTION
Fixes #3615

Adds Identity v3 authentication through Keystone's browser-based WebSSO flow. Gophercloud opens the identity-provider and protocol-specific WebSSO endpoint with a loopback origin, receives the unscoped token posted by Keystone, and validates or scopes it with the existing token API.

The callback listener is context-aware and validates the request method, content type, body size, and token. Browser opening is injectable. Reauthentication and optional caching of validated unscoped tokens are supported, allowing tokens to be rescoped without repeating browser authentication.

Links to the line numbers/files in the OpenStack source code that support the code in this PR:

- [Horizon WebSSO redirect flow](https://opendev.org/openstack/horizon/src/commit/3c5006efb4533e1cf0815fb80ede86b7a38a40bf/openstack_auth/views.py#L126-L151)
- [Horizon WebSSO token callback](https://opendev.org/openstack/horizon/src/commit/3c5006efb4533e1cf0815fb80ede86b7a38a40bf/openstack_auth/views.py#L248-L273)

Supersedes #3616, which its author closed in favor of this implementation.
