### PR TITLE
identity: add OIDC client credentials authentication

### DIFF
--- a/openstack/client.go
+++ b/openstack/client.go
@@ -11,6 +11,7 @@ import (
 	tokens2 "github.com/gophercloud/gophercloud/v2/openstack/identity/v2/tokens"
 	"github.com/gophercloud/gophercloud/v2/openstack/identity/v3/ec2tokens"
 	"github.com/gophercloud/gophercloud/v2/openstack/identity/v3/oauth1"
+	"github.com/gophercloud/gophercloud/v2/openstack/identity/v3/oidc"
 	tokens3 "github.com/gophercloud/gophercloud/v2/openstack/identity/v3/tokens"
 	"github.com/gophercloud/gophercloud/v2/openstack/utils"
 )
@@ -227,6 +228,8 @@ func v3auth(ctx context.Context, client *gophercloud.ProviderClient, endpoint st
 			result = ec2tokens.Create(ctx, v3Client, opts)
 		case *oauth1.AuthOptions:
 			result = oauth1.Create(ctx, v3Client, opts)
+		case *oidc.AuthOptions:
+			result = oidc.Create(ctx, v3Client, opts)
 		default:
 			result = tokens3.Create(ctx, v3Client, opts)
 		}
@@ -268,6 +271,10 @@ func v3auth(ctx context.Context, client *gophercloud.ProviderClient, endpoint st
 			o.AllowReauth = false
 			tao = &o
 		case *oauth1.AuthOptions:
+			o := *ot
+			o.AllowReauth = false
+			tao = &o
+		case *oidc.AuthOptions:
 			o := *ot
 			o.AllowReauth = false
 			tao = &o

--- a/openstack/identity/v3/oidc/doc.go
+++ b/openstack/identity/v3/oidc/doc.go
@@ -1,0 +1,30 @@
+/*
+Package oidc authenticates to Keystone through the OS-FEDERATION API using
+OpenID Connect client credentials.
+
+Authentication obtains an access token from the identity provider, exchanges
+it for an unscoped Keystone token, and optionally scopes the result. The OIDC
+token endpoint can be configured directly with AccessTokenEndpoint or resolved
+from DiscoveryEndpoint.
+
+Example:
+
+	authOptions := &oidc.AuthOptions{
+		IdentityProviderName: "my-idp",
+		Protocol:             "openid",
+		ClientID:             "my-client-id",
+		ClientSecret:         "my-client-secret",
+		AccessTokenEndpoint:  "https://idp.example.com/oauth2/token",
+		Scope: tokens.Scope{
+			ProjectName: "my-project",
+			DomainName:  "Default",
+		},
+	}
+
+	result := oidc.Create(context.TODO(), identityClient, authOptions)
+	token, err := result.ExtractToken()
+
+For the reference behavior, see the OpenStack 2025.1 keystoneauth OIDC plugin:
+https://opendev.org/openstack/keystoneauth/src/branch/stable/2025.1/keystoneauth1/identity/v3/oidc.py
+*/
+package oidc

--- a/openstack/identity/v3/oidc/requests.go
+++ b/openstack/identity/v3/oidc/requests.go
@@ -224,7 +224,7 @@ func fetchAccessToken(ctx context.Context, c *gophercloud.ServiceClient, opts *A
 	req.Header.Set("Accept", "application/json")
 
 	if opts.ClientSecret != "" {
-		req.SetBasicAuth(opts.ClientID, opts.ClientSecret)
+		req.SetBasicAuth(url.QueryEscape(opts.ClientID), url.QueryEscape(opts.ClientSecret))
 	}
 
 	httpClient := c.HTTPClient

--- a/openstack/identity/v3/oidc/requests.go
+++ b/openstack/identity/v3/oidc/requests.go
@@ -1,0 +1,299 @@
+package oidc
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"slices"
+	"strings"
+
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/openstack/identity/v3/tokens"
+)
+
+type discoveryDocument struct {
+	TokenEndpoint       string   `json:"token_endpoint"`
+	GrantTypesSupported []string `json:"grant_types_supported"`
+}
+
+// AuthOptions contains OIDC client-credentials authentication options.
+type AuthOptions struct {
+	// IdentityProviderName is the Keystone federation identity provider.
+	IdentityProviderName string
+
+	// Protocol is the Keystone federation protocol.
+	Protocol string
+
+	// ClientID is the OAuth 2.0 client identifier.
+	ClientID string
+
+	// ClientSecret is the OAuth 2.0 client secret.
+	ClientSecret string
+
+	// AccessTokenEndpoint is the identity provider's token endpoint.
+	AccessTokenEndpoint string
+
+	// AccessTokenType selects the token response field. It defaults to "access_token".
+	AccessTokenType string
+
+	// DiscoveryEndpoint is used when AccessTokenEndpoint is empty.
+	DiscoveryEndpoint string
+
+	// OIDCScope is the OAuth 2.0 scope. It defaults to "openid".
+	OIDCScope string
+
+	// AllowReauth enables automatic reauthentication.
+	AllowReauth bool
+
+	// Scope controls the resulting Keystone token scope.
+	Scope tokens.Scope
+}
+
+// ToTokenV3ScopeMap builds the Keystone token scope.
+func (opts *AuthOptions) ToTokenV3ScopeMap() (map[string]any, error) {
+	return (&tokens.AuthOptions{Scope: opts.Scope}).ToTokenV3ScopeMap()
+}
+
+// ToTokenV3HeadersMap implements tokens.AuthOptionsBuilder.
+func (opts *AuthOptions) ToTokenV3HeadersMap(map[string]any) (map[string]string, error) {
+	return nil, nil
+}
+
+// CanReauth reports whether automatic reauthentication is enabled.
+func (opts *AuthOptions) CanReauth() bool {
+	return opts.AllowReauth
+}
+
+// ToTokenV3CreateMap implements tokens.AuthOptionsBuilder.
+func (opts *AuthOptions) ToTokenV3CreateMap(map[string]any) (map[string]any, error) {
+	return nil, nil
+}
+
+// Create authenticates with OIDC client credentials.
+func Create(ctx context.Context, c *gophercloud.ServiceClient, opts tokens.AuthOptionsBuilder) (r tokens.CreateResult) {
+	oidcOpts, ok := opts.(*AuthOptions)
+	if !ok || oidcOpts == nil {
+		r.Err = fmt.Errorf("expected *oidc.AuthOptions, got %T", opts)
+		return
+	}
+
+	if err := validateAuthOptions(oidcOpts); err != nil {
+		r.Err = err
+		return
+	}
+	if c == nil || c.ProviderClient == nil {
+		r.Err = fmt.Errorf("oidc: ServiceClient or ProviderClient is nil")
+		return
+	}
+
+	accessTokenEndpoint, err := resolveAccessTokenEndpoint(ctx, c, oidcOpts)
+	if err != nil {
+		r.Err = fmt.Errorf("OIDC access token endpoint resolution failed: %w", err)
+		return
+	}
+
+	accessToken, err := fetchAccessToken(ctx, c, oidcOpts, accessTokenEndpoint)
+	if err != nil {
+		r.Err = fmt.Errorf("OIDC IdP token request failed: %w", err)
+		return
+	}
+
+	unscopedToken, unscopedBody, unscopedHeader, err := exchangeForKeystoneToken(ctx, c, oidcOpts, accessToken)
+	if err != nil {
+		r.Err = fmt.Errorf("OIDC federation auth failed: %w", err)
+		return
+	}
+
+	scope, err := oidcOpts.ToTokenV3ScopeMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	if scope != nil {
+		r = tokens.Create(ctx, c, &tokens.AuthOptions{TokenID: unscopedToken, Scope: oidcOpts.Scope})
+	} else {
+		r.Body = unscopedBody
+		r.Header = unscopedHeader
+	}
+
+	return
+}
+
+func validateAuthOptions(opts *AuthOptions) error {
+	if opts.IdentityProviderName == "" {
+		return fmt.Errorf("missing required field: IdentityProviderName")
+	}
+	if opts.Protocol == "" {
+		return fmt.Errorf("missing required field: Protocol")
+	}
+	if opts.ClientID == "" {
+		return fmt.Errorf("missing required field: ClientID")
+	}
+	if opts.AccessTokenEndpoint == "" && opts.DiscoveryEndpoint == "" {
+		return fmt.Errorf("at least one of AccessTokenEndpoint or DiscoveryEndpoint must be provided")
+	}
+	return nil
+}
+
+func resolveAccessTokenEndpoint(ctx context.Context, c *gophercloud.ServiceClient, opts *AuthOptions) (string, error) {
+	if opts.AccessTokenEndpoint != "" {
+		return opts.AccessTokenEndpoint, nil
+	}
+
+	discovery, err := fetchDiscoveryDocument(ctx, c, opts.DiscoveryEndpoint)
+	if err != nil {
+		return "", err
+	}
+
+	if len(discovery.GrantTypesSupported) > 0 && !slices.Contains(discovery.GrantTypesSupported, "client_credentials") {
+		return "", fmt.Errorf("IdP does not support client_credentials grant type (supported: %v)", discovery.GrantTypesSupported)
+	}
+
+	if discovery.TokenEndpoint == "" {
+		return "", fmt.Errorf("discovery document does not contain a valid token_endpoint")
+	}
+
+	return discovery.TokenEndpoint, nil
+}
+
+func fetchDiscoveryDocument(ctx context.Context, c *gophercloud.ServiceClient, discoveryURL string) (discoveryDocument, error) {
+	var doc discoveryDocument
+	if c == nil || c.ProviderClient == nil {
+		return doc, fmt.Errorf("service client or provider client is nil")
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "GET", discoveryURL, nil)
+	if err != nil {
+		return doc, fmt.Errorf("failed to create discovery request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+
+	httpClient := c.HTTPClient
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return doc, fmt.Errorf("failed to fetch discovery document from %s: %w", discoveryURL, err)
+	}
+	defer resp.Body.Close()
+
+	const maxDiscoverySize = 1 << 20 // 1 MiB
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxDiscoverySize+1))
+	if err != nil {
+		return doc, fmt.Errorf("failed to read discovery document response: %w", err)
+	}
+	if int64(len(body)) > maxDiscoverySize {
+		return doc, fmt.Errorf("discovery document exceeds maximum allowed size of %d bytes", maxDiscoverySize)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return doc, fmt.Errorf("discovery endpoint returned HTTP %d", resp.StatusCode)
+	}
+
+	if err := json.Unmarshal(body, &doc); err != nil {
+		return doc, fmt.Errorf("discovery document is not valid JSON: %w", err)
+	}
+	return doc, nil
+}
+
+func fetchAccessToken(ctx context.Context, c *gophercloud.ServiceClient, opts *AuthOptions, accessTokenEndpoint string) (string, error) {
+	if c == nil || c.ProviderClient == nil {
+		return "", fmt.Errorf("service client or provider client is nil")
+	}
+
+	scope := opts.OIDCScope
+	if scope == "" {
+		scope = "openid"
+	}
+
+	formData := url.Values{
+		"grant_type": {"client_credentials"},
+		"scope":      {scope},
+	}
+	if opts.ClientSecret == "" {
+		formData.Set("client_id", opts.ClientID)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", accessTokenEndpoint, strings.NewReader(formData.Encode()))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	if opts.ClientSecret != "" {
+		req.SetBasicAuth(opts.ClientID, opts.ClientSecret)
+	}
+
+	httpClient := c.HTTPClient
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	const maxIDPResponseSize = 1 << 20 // 1 MiB
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxIDPResponseSize+1))
+	if err != nil {
+		return "", fmt.Errorf("failed to read IdP response: %w", err)
+	}
+	if int64(len(body)) > maxIDPResponseSize {
+		return "", fmt.Errorf("IdP response body exceeded %d bytes", maxIDPResponseSize)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		snippet := string(body)
+		if len(snippet) > 512 {
+			snippet = snippet[:512] + "..."
+		}
+		return "", fmt.Errorf("IdP returned HTTP %d: %s", resp.StatusCode, snippet)
+	}
+
+	var tokenResponse map[string]any
+	if err := json.Unmarshal(body, &tokenResponse); err != nil {
+		return "", fmt.Errorf("failed to parse IdP token response: %w", err)
+	}
+
+	tokenField := opts.AccessTokenType
+	if tokenField == "" {
+		tokenField = "access_token"
+	}
+
+	accessToken, ok := tokenResponse[tokenField].(string)
+	if !ok || accessToken == "" {
+		return "", fmt.Errorf("IdP response missing %q field", tokenField)
+	}
+	if tokenField == "access_token" {
+		tokenType, ok := tokenResponse["token_type"].(string)
+		if !ok || !strings.EqualFold(tokenType, "Bearer") {
+			return "", fmt.Errorf("IdP response has unsupported token_type %q", tokenType)
+		}
+	}
+
+	return accessToken, nil
+}
+
+func exchangeForKeystoneToken(ctx context.Context, c *gophercloud.ServiceClient, opts *AuthOptions, accessToken string) (string, any, http.Header, error) {
+	federationURL := authURL(c, opts.IdentityProviderName, opts.Protocol)
+
+	var body any
+	resp, err := c.Post(ctx, federationURL, nil, &body, &gophercloud.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Authorization": "Bearer " + accessToken,
+		},
+		OkCodes:     []int{201},
+		OmitHeaders: []string{"X-Auth-Token"},
+	})
+	if err != nil {
+		return "", nil, nil, err
+	}
+
+	unscopedToken := resp.Header.Get("X-Subject-Token")
+	if unscopedToken == "" {
+		return "", nil, nil, fmt.Errorf("federation auth response missing X-Subject-Token header")
+	}
+
+	return unscopedToken, body, resp.Header, nil
+}

--- a/openstack/identity/v3/oidc/requests.go
+++ b/openstack/identity/v3/oidc/requests.go
@@ -22,19 +22,19 @@ type discoveryDocument struct {
 // AuthOptions contains OIDC client-credentials authentication options.
 type AuthOptions struct {
 	// IdentityProviderName is the Keystone federation identity provider.
-	IdentityProviderName string
+	IdentityProviderName string `required:"true"`
 
 	// Protocol is the Keystone federation protocol.
-	Protocol string
+	Protocol string `required:"true"`
 
 	// ClientID is the OAuth 2.0 client identifier.
-	ClientID string
+	ClientID string `required:"true"`
 
 	// ClientSecret is the OAuth 2.0 client secret.
 	ClientSecret string
 
 	// AccessTokenEndpoint is the identity provider's token endpoint.
-	AccessTokenEndpoint string
+	AccessTokenEndpoint string `or:"DiscoveryEndpoint"`
 
 	// AccessTokenType selects the token response field. It defaults to "access_token".
 	AccessTokenType string
@@ -67,9 +67,10 @@ func (opts *AuthOptions) CanReauth() bool {
 	return opts.AllowReauth
 }
 
-// ToTokenV3CreateMap implements tokens.AuthOptionsBuilder.
+// ToTokenV3CreateMap validates the options. The federation request has no body.
 func (opts *AuthOptions) ToTokenV3CreateMap(map[string]any) (map[string]any, error) {
-	return nil, nil
+	_, err := gophercloud.BuildRequestBody(opts, "")
+	return nil, err
 }
 
 // Create authenticates with OIDC client credentials.
@@ -80,7 +81,7 @@ func Create(ctx context.Context, c *gophercloud.ServiceClient, opts tokens.AuthO
 		return
 	}
 
-	if err := validateAuthOptions(oidcOpts); err != nil {
+	if _, err := oidcOpts.ToTokenV3CreateMap(nil); err != nil {
 		r.Err = err
 		return
 	}
@@ -121,22 +122,6 @@ func Create(ctx context.Context, c *gophercloud.ServiceClient, opts tokens.AuthO
 	}
 
 	return
-}
-
-func validateAuthOptions(opts *AuthOptions) error {
-	if opts.IdentityProviderName == "" {
-		return fmt.Errorf("missing required field: IdentityProviderName")
-	}
-	if opts.Protocol == "" {
-		return fmt.Errorf("missing required field: Protocol")
-	}
-	if opts.ClientID == "" {
-		return fmt.Errorf("missing required field: ClientID")
-	}
-	if opts.AccessTokenEndpoint == "" && opts.DiscoveryEndpoint == "" {
-		return fmt.Errorf("at least one of AccessTokenEndpoint or DiscoveryEndpoint must be provided")
-	}
-	return nil
 }
 
 func resolveAccessTokenEndpoint(ctx context.Context, c *gophercloud.ServiceClient, opts *AuthOptions) (string, error) {

--- a/openstack/identity/v3/oidc/testing/credentials_test.go
+++ b/openstack/identity/v3/oidc/testing/credentials_test.go
@@ -1,0 +1,37 @@
+package testing
+
+import (
+	"context"
+	"encoding/base64"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/openstack/identity/v3/oidc"
+	th "github.com/gophercloud/gophercloud/v2/testhelper"
+)
+
+func TestCreateWithEncodedBasicCredentials(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	// OAuth client credentials are form-encoded before HTTP Basic encoding.
+	expected := "Basic " + base64.StdEncoding.EncodeToString([]byte("client%3Awith%2Breserved:secret%2Bwith%25reserved"))
+	HandleIdPTokenSuccessfully(t, fakeServer, expected)
+	HandleFederationAuthSuccessfully(t, fakeServer, "test-idp-access-token-abc123")
+
+	client := &gophercloud.ServiceClient{
+		ProviderClient: &gophercloud.ProviderClient{},
+		Endpoint:       fakeServer.Endpoint(),
+	}
+	result := oidc.Create(context.Background(), client, &oidc.AuthOptions{
+		IdentityProviderName: "my-idp",
+		Protocol:             "openid",
+		ClientID:             "client:with+reserved",
+		ClientSecret:         "secret+with%reserved",
+		AccessTokenEndpoint:  fakeServer.Endpoint() + "oauth2/token",
+	})
+	th.AssertNoErr(t, result.Err)
+	token, err := result.ExtractTokenID()
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, UnscopedTokenID, token)
+}

--- a/openstack/identity/v3/oidc/testing/doc.go
+++ b/openstack/identity/v3/oidc/testing/doc.go
@@ -1,0 +1,1 @@
+package testing

--- a/openstack/identity/v3/oidc/testing/fixtures_test.go
+++ b/openstack/identity/v3/oidc/testing/fixtures_test.go
@@ -1,0 +1,263 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	th "github.com/gophercloud/gophercloud/v2/testhelper"
+)
+
+// IdPTokenResponse is a client-credentials token response.
+const IdPTokenResponse = `{
+	"access_token": "test-idp-access-token-abc123",
+	"token_type": "Bearer",
+	"expires_in": 3600,
+	"scope": "openid"
+}`
+
+// IdPTokenResponseIDToken contains an ID token instead of an access token.
+const IdPTokenResponseIDToken = `{
+	"id_token": "test-idp-id-token-xyz789",
+	"token_type": "Bearer",
+	"expires_in": 3600,
+	"scope": "openid"
+}`
+
+// DiscoveryDocument is a minimal OIDC discovery document.
+const DiscoveryDocument = `{
+	"token_endpoint": "%s",
+	"grant_types_supported": ["authorization_code", "client_credentials"]
+}`
+
+// DiscoveryDocumentNoGrantTypes omits grant_types_supported.
+const DiscoveryDocumentNoGrantTypes = `{
+	"issuer": "https://idp.example.com",
+	"token_endpoint": "%s"
+}`
+
+// DiscoveryDocumentUnsupportedGrant omits client_credentials.
+const DiscoveryDocumentUnsupportedGrant = `{
+	"issuer": "https://idp.example.com",
+	"token_endpoint": "https://idp.example.com/oauth2/token",
+	"grant_types_supported": ["authorization_code", "refresh_token"]
+}`
+
+// DiscoveryDocumentNoTokenEndpoint omits token_endpoint.
+const DiscoveryDocumentNoTokenEndpoint = `{
+	"issuer": "https://idp.example.com",
+	"grant_types_supported": ["client_credentials"]
+}`
+
+// FederationAuthResponse is an unscoped federation token response.
+const FederationAuthResponse = `{
+	"token": {
+		"methods": ["mapped"],
+		"user": {
+			"id": "federation-user-id-001",
+			"name": "federation-user",
+			"domain": {
+				"id": "Federated",
+				"name": "Federated"
+			},
+			"OS-FEDERATION": {
+				"identity_provider": {"id": "my-idp"},
+				"protocol": {"id": "openid"},
+				"groups": [
+					{"id": "group-abc-001"}
+				]
+			}
+		},
+		"expires_at": "2017-06-03T02:19:49.000000Z",
+		"is_domain": false
+	}
+}`
+
+// UnscopedTokenID is the unscoped federation token ID.
+const UnscopedTokenID = "unscoped-federation-token-aaa111"
+
+// RescopedTokenResponse is a project-scoped token response.
+const RescopedTokenResponse = `{
+	"token": {
+		"methods": ["token"],
+		"project": {
+			"domain": {
+				"id": "default",
+				"name": "Default"
+			},
+			"id": "project-id-001",
+			"name": "my-project"
+		},
+		"catalog": [
+			{
+				"endpoints": [
+					{
+						"url": "http://127.0.0.1:8774/v2.1/project-id-001",
+						"interface": "public",
+						"region": "RegionOne",
+						"region_id": "RegionOne",
+						"id": "endpoint-compute-001"
+					}
+				],
+				"type": "compute",
+				"id": "service-compute-001",
+				"name": "nova"
+			}
+		],
+		"user": {
+			"id": "federation-user-id-001",
+			"name": "federation-user",
+			"domain": {
+				"id": "Federated",
+				"name": "Federated"
+			}
+		},
+		"roles": [
+			{
+				"id": "role-member-001",
+				"name": "member"
+			}
+		],
+		"expires_at": "2017-06-03T02:19:49.000000Z",
+		"is_domain": false
+	}
+}`
+
+// ScopedTokenID is the X-Subject-Token returned after rescoping.
+const ScopedTokenID = "scoped-federation-token-bbb222"
+
+// HandleIdPTokenSuccessfully handles a client-credentials grant.
+func HandleIdPTokenSuccessfully(t *testing.T, fakeServer th.FakeServer, expectedBasicAuth string) {
+	fakeServer.Mux.HandleFunc("/oauth2/token", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "Content-Type", "application/x-www-form-urlencoded")
+		th.TestHeader(t, r, "Accept", "application/json")
+
+		if expectedBasicAuth != "" {
+			th.TestHeader(t, r, "Authorization", expectedBasicAuth)
+		}
+
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("Failed to parse form: %v", err)
+		}
+		if r.PostForm.Get("grant_type") != "client_credentials" {
+			t.Errorf("Expected grant_type=client_credentials, got %s", r.PostForm.Get("grant_type"))
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, IdPTokenResponse)
+	})
+}
+
+// HandleIdPTokenIDTokenSuccessfully returns an ID token.
+func HandleIdPTokenIDTokenSuccessfully(t *testing.T, fakeServer th.FakeServer) {
+	fakeServer.Mux.HandleFunc("/oauth2/token", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "Content-Type", "application/x-www-form-urlencoded")
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, IdPTokenResponseIDToken)
+	})
+}
+
+// HandleFederationAuthSuccessfully handles a federation token exchange.
+func HandleFederationAuthSuccessfully(t *testing.T, fakeServer th.FakeServer, expectedBearer string) {
+	fakeServer.Mux.HandleFunc("/OS-FEDERATION/identity_providers/my-idp/protocols/openid/auth", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "Authorization", "Bearer "+expectedBearer)
+
+		if r.Header.Get("X-Auth-Token") != "" {
+			t.Error("Expected X-Auth-Token header to be omitted")
+		}
+
+		w.Header().Set("X-Subject-Token", UnscopedTokenID)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprint(w, FederationAuthResponse)
+	})
+}
+
+// HandleRescopeSuccessfully handles token rescoping.
+func HandleRescopeSuccessfully(t *testing.T, fakeServer th.FakeServer, expectedUnscopedToken string) {
+	fakeServer.Mux.HandleFunc("/auth/tokens", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "Content-Type", "application/json")
+
+		if r.Header.Get("X-Auth-Token") != "" {
+			t.Error("Expected X-Auth-Token header to be omitted")
+		}
+
+		w.Header().Set("X-Subject-Token", ScopedTokenID)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprint(w, RescopedTokenResponse)
+	})
+}
+
+// HandleDiscoverySuccessfully returns a discovery document.
+func HandleDiscoverySuccessfully(t *testing.T, fakeServer th.FakeServer, tokenEndpointURL string) {
+	fakeServer.Mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "Accept", "application/json")
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, DiscoveryDocument, tokenEndpointURL)
+	})
+}
+
+// HandleDiscoveryNoGrantTypesSuccessfully omits grant_types_supported.
+func HandleDiscoveryNoGrantTypesSuccessfully(t *testing.T, fakeServer th.FakeServer, tokenEndpointURL string) {
+	fakeServer.Mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, DiscoveryDocumentNoGrantTypes, tokenEndpointURL)
+	})
+}
+
+// HandleDiscoveryUnsupportedGrantType omits client_credentials.
+func HandleDiscoveryUnsupportedGrantType(t *testing.T, fakeServer th.FakeServer) {
+	fakeServer.Mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, DiscoveryDocumentUnsupportedGrant)
+	})
+}
+
+// HandleDiscoveryNoTokenEndpoint omits token_endpoint.
+func HandleDiscoveryNoTokenEndpoint(t *testing.T, fakeServer th.FakeServer) {
+	fakeServer.Mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, DiscoveryDocumentNoTokenEndpoint)
+	})
+}
+
+// HandleDiscoveryHTTPError returns an HTTP error.
+func HandleDiscoveryHTTPError(t *testing.T, fakeServer th.FakeServer) {
+	fakeServer.Mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprint(w, "Internal Server Error")
+	})
+}
+
+// HandleDiscoveryInvalidJSON returns invalid JSON.
+func HandleDiscoveryInvalidJSON(t *testing.T, fakeServer th.FakeServer) {
+	fakeServer.Mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "not valid json{{{")
+	})
+}

--- a/openstack/identity/v3/oidc/testing/requests_test.go
+++ b/openstack/identity/v3/oidc/testing/requests_test.go
@@ -1,0 +1,794 @@
+package testing
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/openstack/identity/v3/oidc"
+	"github.com/gophercloud/gophercloud/v2/openstack/identity/v3/tokens"
+	th "github.com/gophercloud/gophercloud/v2/testhelper"
+)
+
+func stringPointer(s string) *string {
+	return &s
+}
+
+func TestCreateUnscoped(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	expectedBasicAuth := "Basic " + base64.StdEncoding.EncodeToString([]byte("my-client-id:my-client-secret"))
+	HandleIdPTokenSuccessfully(t, fakeServer, expectedBasicAuth)
+	HandleFederationAuthSuccessfully(t, fakeServer, "test-idp-access-token-abc123")
+
+	client := gophercloud.ServiceClient{
+		ProviderClient: &gophercloud.ProviderClient{},
+		Endpoint:       fakeServer.Endpoint(),
+	}
+
+	opts := &oidc.AuthOptions{
+		IdentityProviderName: "my-idp",
+		Protocol:             "openid",
+		ClientID:             "my-client-id",
+		ClientSecret:         "my-client-secret",
+		AccessTokenEndpoint:  fakeServer.Endpoint() + "oauth2/token",
+	}
+
+	result := oidc.Create(context.TODO(), &client, opts)
+	th.AssertNoErr(t, result.Err)
+
+	token, err := result.ExtractTokenID()
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, UnscopedTokenID, token)
+}
+
+func TestCreateScoped(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	expectedBasicAuth := "Basic " + base64.StdEncoding.EncodeToString([]byte("my-client-id:my-client-secret"))
+	HandleIdPTokenSuccessfully(t, fakeServer, expectedBasicAuth)
+	HandleFederationAuthSuccessfully(t, fakeServer, "test-idp-access-token-abc123")
+	HandleRescopeSuccessfully(t, fakeServer, UnscopedTokenID)
+
+	client := gophercloud.ServiceClient{
+		ProviderClient: &gophercloud.ProviderClient{},
+		Endpoint:       fakeServer.Endpoint(),
+	}
+
+	opts := &oidc.AuthOptions{
+		IdentityProviderName: "my-idp",
+		Protocol:             "openid",
+		ClientID:             "my-client-id",
+		ClientSecret:         "my-client-secret",
+		AccessTokenEndpoint:  fakeServer.Endpoint() + "oauth2/token",
+		Scope: tokens.Scope{
+			ProjectName: "my-project",
+			DomainName:  "Default",
+		},
+	}
+
+	result := oidc.Create(context.TODO(), &client, opts)
+	th.AssertNoErr(t, result.Err)
+
+	token, err := result.ExtractTokenID()
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, ScopedTokenID, token)
+}
+
+func TestCreateScopedByProjectID(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	expectedBasicAuth := "Basic " + base64.StdEncoding.EncodeToString([]byte("my-client-id:my-client-secret"))
+	HandleIdPTokenSuccessfully(t, fakeServer, expectedBasicAuth)
+	HandleFederationAuthSuccessfully(t, fakeServer, "test-idp-access-token-abc123")
+	HandleRescopeSuccessfully(t, fakeServer, UnscopedTokenID)
+
+	client := gophercloud.ServiceClient{
+		ProviderClient: &gophercloud.ProviderClient{},
+		Endpoint:       fakeServer.Endpoint(),
+	}
+
+	opts := &oidc.AuthOptions{
+		IdentityProviderName: "my-idp",
+		Protocol:             "openid",
+		ClientID:             "my-client-id",
+		ClientSecret:         "my-client-secret",
+		AccessTokenEndpoint:  fakeServer.Endpoint() + "oauth2/token",
+		Scope: tokens.Scope{
+			ProjectID: "project-id-001",
+		},
+	}
+
+	result := oidc.Create(context.TODO(), &client, opts)
+	th.AssertNoErr(t, result.Err)
+
+	token, err := result.ExtractTokenID()
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, ScopedTokenID, token)
+}
+
+func TestCreateScopedByDomainID(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	expectedBasicAuth := "Basic " + base64.StdEncoding.EncodeToString([]byte("my-client-id:my-client-secret"))
+	HandleIdPTokenSuccessfully(t, fakeServer, expectedBasicAuth)
+	HandleFederationAuthSuccessfully(t, fakeServer, "test-idp-access-token-abc123")
+	HandleRescopeSuccessfully(t, fakeServer, UnscopedTokenID)
+
+	client := gophercloud.ServiceClient{
+		ProviderClient: &gophercloud.ProviderClient{},
+		Endpoint:       fakeServer.Endpoint(),
+	}
+
+	opts := &oidc.AuthOptions{
+		IdentityProviderName: "my-idp",
+		Protocol:             "openid",
+		ClientID:             "my-client-id",
+		ClientSecret:         "my-client-secret",
+		AccessTokenEndpoint:  fakeServer.Endpoint() + "oauth2/token",
+		Scope: tokens.Scope{
+			DomainID: "default",
+		},
+	}
+
+	result := oidc.Create(context.TODO(), &client, opts)
+	th.AssertNoErr(t, result.Err)
+
+	token, err := result.ExtractTokenID()
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, ScopedTokenID, token)
+}
+
+func TestCreateScopedByDomainName(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	expectedBasicAuth := "Basic " + base64.StdEncoding.EncodeToString([]byte("my-client-id:my-client-secret"))
+	HandleIdPTokenSuccessfully(t, fakeServer, expectedBasicAuth)
+	HandleFederationAuthSuccessfully(t, fakeServer, "test-idp-access-token-abc123")
+	HandleRescopeSuccessfully(t, fakeServer, UnscopedTokenID)
+
+	client := gophercloud.ServiceClient{
+		ProviderClient: &gophercloud.ProviderClient{},
+		Endpoint:       fakeServer.Endpoint(),
+	}
+
+	opts := &oidc.AuthOptions{
+		IdentityProviderName: "my-idp",
+		Protocol:             "openid",
+		ClientID:             "my-client-id",
+		ClientSecret:         "my-client-secret",
+		AccessTokenEndpoint:  fakeServer.Endpoint() + "oauth2/token",
+		Scope: tokens.Scope{
+			DomainName: "Default",
+		},
+	}
+
+	result := oidc.Create(context.TODO(), &client, opts)
+	th.AssertNoErr(t, result.Err)
+
+	token, err := result.ExtractTokenID()
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, ScopedTokenID, token)
+}
+
+func TestCreateWithIDToken(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	HandleIdPTokenIDTokenSuccessfully(t, fakeServer)
+	HandleFederationAuthSuccessfully(t, fakeServer, "test-idp-id-token-xyz789")
+
+	client := gophercloud.ServiceClient{
+		ProviderClient: &gophercloud.ProviderClient{},
+		Endpoint:       fakeServer.Endpoint(),
+	}
+
+	opts := &oidc.AuthOptions{
+		IdentityProviderName: "my-idp",
+		Protocol:             "openid",
+		ClientID:             "my-client-id",
+		ClientSecret:         "my-client-secret",
+		AccessTokenEndpoint:  fakeServer.Endpoint() + "oauth2/token",
+		AccessTokenType:      "id_token",
+	}
+
+	result := oidc.Create(context.TODO(), &client, opts)
+	th.AssertNoErr(t, result.Err)
+
+	token, err := result.ExtractTokenID()
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, UnscopedTokenID, token)
+}
+
+func TestCreateRejectsUnsupportedAccessTokenType(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	fakeServer.Mux.HandleFunc("/oauth2/token", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"access_token":"opaque-token","token_type":"MAC"}`)
+	})
+	client := gophercloud.ServiceClient{
+		ProviderClient: &gophercloud.ProviderClient{},
+		Endpoint:       fakeServer.Endpoint(),
+	}
+	result := oidc.Create(context.Background(), &client, &oidc.AuthOptions{
+		IdentityProviderName: "my-idp",
+		Protocol:             "openid",
+		ClientID:             "my-client-id",
+		ClientSecret:         "my-client-secret",
+		AccessTokenEndpoint:  fakeServer.Endpoint() + "oauth2/token",
+	})
+	if result.Err == nil || !strings.Contains(result.Err.Error(), "unsupported token_type") {
+		t.Fatalf("expected unsupported token_type error, got %v", result.Err)
+	}
+}
+
+func TestCreateScopedBySystemScope(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	expectedBasicAuth := "Basic " + base64.StdEncoding.EncodeToString([]byte("my-client-id:my-client-secret"))
+	HandleIdPTokenSuccessfully(t, fakeServer, expectedBasicAuth)
+	HandleFederationAuthSuccessfully(t, fakeServer, "test-idp-access-token-abc123")
+	HandleRescopeSuccessfully(t, fakeServer, UnscopedTokenID)
+
+	client := gophercloud.ServiceClient{
+		ProviderClient: &gophercloud.ProviderClient{},
+		Endpoint:       fakeServer.Endpoint(),
+	}
+
+	opts := &oidc.AuthOptions{
+		IdentityProviderName: "my-idp",
+		Protocol:             "openid",
+		ClientID:             "my-client-id",
+		ClientSecret:         "my-client-secret",
+		AccessTokenEndpoint:  fakeServer.Endpoint() + "oauth2/token",
+		Scope: tokens.Scope{
+			System: true,
+		},
+	}
+
+	result := oidc.Create(context.TODO(), &client, opts)
+	th.AssertNoErr(t, result.Err)
+
+	token, err := result.ExtractTokenID()
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, ScopedTokenID, token)
+}
+
+func TestCanReauth(t *testing.T) {
+	opts := &oidc.AuthOptions{
+		AllowReauth: true,
+	}
+	th.CheckEquals(t, true, opts.CanReauth())
+
+	opts.AllowReauth = false
+	th.CheckEquals(t, false, opts.CanReauth())
+}
+
+func TestValidationMissingIdentityProvider(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	client := gophercloud.ServiceClient{
+		ProviderClient: &gophercloud.ProviderClient{},
+		Endpoint:       fakeServer.Endpoint(),
+	}
+
+	opts := &oidc.AuthOptions{
+		Protocol:            "openid",
+		ClientID:            "my-client-id",
+		AccessTokenEndpoint: "https://idp.example.com/oauth2/token",
+	}
+
+	result := oidc.Create(context.TODO(), &client, opts)
+	th.AssertErr(t, result.Err)
+}
+
+func TestValidationMissingProtocol(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	client := gophercloud.ServiceClient{
+		ProviderClient: &gophercloud.ProviderClient{},
+		Endpoint:       fakeServer.Endpoint(),
+	}
+
+	opts := &oidc.AuthOptions{
+		IdentityProviderName: "my-idp",
+		ClientID:             "my-client-id",
+		AccessTokenEndpoint:  "https://idp.example.com/oauth2/token",
+	}
+
+	result := oidc.Create(context.TODO(), &client, opts)
+	th.AssertErr(t, result.Err)
+}
+
+func TestValidationMissingClientID(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	client := gophercloud.ServiceClient{
+		ProviderClient: &gophercloud.ProviderClient{},
+		Endpoint:       fakeServer.Endpoint(),
+	}
+
+	opts := &oidc.AuthOptions{
+		IdentityProviderName: "my-idp",
+		Protocol:             "openid",
+		AccessTokenEndpoint:  "https://idp.example.com/oauth2/token",
+	}
+
+	result := oidc.Create(context.TODO(), &client, opts)
+	th.AssertErr(t, result.Err)
+}
+
+func TestValidationMissingAccessTokenEndpoint(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	client := gophercloud.ServiceClient{
+		ProviderClient: &gophercloud.ProviderClient{},
+		Endpoint:       fakeServer.Endpoint(),
+	}
+
+	opts := &oidc.AuthOptions{
+		IdentityProviderName: "my-idp",
+		Protocol:             "openid",
+		ClientID:             "my-client-id",
+	}
+
+	result := oidc.Create(context.TODO(), &client, opts)
+	th.AssertErr(t, result.Err)
+}
+
+func TestCreateUnscopedWithDiscovery(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	tokenEndpointURL := fakeServer.Endpoint() + "oauth2/token"
+	HandleDiscoverySuccessfully(t, fakeServer, tokenEndpointURL)
+
+	expectedBasicAuth := "Basic " + base64.StdEncoding.EncodeToString([]byte("my-client-id:my-client-secret"))
+	HandleIdPTokenSuccessfully(t, fakeServer, expectedBasicAuth)
+	HandleFederationAuthSuccessfully(t, fakeServer, "test-idp-access-token-abc123")
+
+	client := gophercloud.ServiceClient{
+		ProviderClient: &gophercloud.ProviderClient{},
+		Endpoint:       fakeServer.Endpoint(),
+	}
+
+	opts := &oidc.AuthOptions{
+		IdentityProviderName: "my-idp",
+		Protocol:             "openid",
+		ClientID:             "my-client-id",
+		ClientSecret:         "my-client-secret",
+		DiscoveryEndpoint:    fakeServer.Endpoint() + ".well-known/openid-configuration",
+	}
+
+	result := oidc.Create(context.TODO(), &client, opts)
+	th.AssertNoErr(t, result.Err)
+
+	token, err := result.ExtractTokenID()
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, UnscopedTokenID, token)
+}
+
+func TestCreateScopedWithDiscovery(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	tokenEndpointURL := fakeServer.Endpoint() + "oauth2/token"
+	HandleDiscoverySuccessfully(t, fakeServer, tokenEndpointURL)
+
+	expectedBasicAuth := "Basic " + base64.StdEncoding.EncodeToString([]byte("my-client-id:my-client-secret"))
+	HandleIdPTokenSuccessfully(t, fakeServer, expectedBasicAuth)
+	HandleFederationAuthSuccessfully(t, fakeServer, "test-idp-access-token-abc123")
+	HandleRescopeSuccessfully(t, fakeServer, UnscopedTokenID)
+
+	client := gophercloud.ServiceClient{
+		ProviderClient: &gophercloud.ProviderClient{},
+		Endpoint:       fakeServer.Endpoint(),
+	}
+
+	opts := &oidc.AuthOptions{
+		IdentityProviderName: "my-idp",
+		Protocol:             "openid",
+		ClientID:             "my-client-id",
+		ClientSecret:         "my-client-secret",
+		DiscoveryEndpoint:    fakeServer.Endpoint() + ".well-known/openid-configuration",
+		Scope: tokens.Scope{
+			ProjectName: "my-project",
+			DomainName:  "Default",
+		},
+	}
+
+	result := oidc.Create(context.TODO(), &client, opts)
+	th.AssertNoErr(t, result.Err)
+
+	token, err := result.ExtractTokenID()
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, ScopedTokenID, token)
+}
+
+func TestAccessTokenEndpointOverridesDiscovery(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	expectedBasicAuth := "Basic " + base64.StdEncoding.EncodeToString([]byte("my-client-id:my-client-secret"))
+	HandleIdPTokenSuccessfully(t, fakeServer, expectedBasicAuth)
+	HandleFederationAuthSuccessfully(t, fakeServer, "test-idp-access-token-abc123")
+
+	client := gophercloud.ServiceClient{
+		ProviderClient: &gophercloud.ProviderClient{},
+		Endpoint:       fakeServer.Endpoint(),
+	}
+
+	opts := &oidc.AuthOptions{
+		IdentityProviderName: "my-idp",
+		Protocol:             "openid",
+		ClientID:             "my-client-id",
+		ClientSecret:         "my-client-secret",
+		AccessTokenEndpoint:  fakeServer.Endpoint() + "oauth2/token",
+		DiscoveryEndpoint:    "http://should-not-be-called.example.com/.well-known/openid-configuration",
+	}
+
+	result := oidc.Create(context.TODO(), &client, opts)
+	th.AssertNoErr(t, result.Err)
+
+	token, err := result.ExtractTokenID()
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, UnscopedTokenID, token)
+}
+
+func TestDiscoveryWithNoGrantTypesField(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	tokenEndpointURL := fakeServer.Endpoint() + "oauth2/token"
+	HandleDiscoveryNoGrantTypesSuccessfully(t, fakeServer, tokenEndpointURL)
+
+	expectedBasicAuth := "Basic " + base64.StdEncoding.EncodeToString([]byte("my-client-id:my-client-secret"))
+	HandleIdPTokenSuccessfully(t, fakeServer, expectedBasicAuth)
+	HandleFederationAuthSuccessfully(t, fakeServer, "test-idp-access-token-abc123")
+
+	client := gophercloud.ServiceClient{
+		ProviderClient: &gophercloud.ProviderClient{},
+		Endpoint:       fakeServer.Endpoint(),
+	}
+
+	opts := &oidc.AuthOptions{
+		IdentityProviderName: "my-idp",
+		Protocol:             "openid",
+		ClientID:             "my-client-id",
+		ClientSecret:         "my-client-secret",
+		DiscoveryEndpoint:    fakeServer.Endpoint() + ".well-known/openid-configuration",
+	}
+
+	result := oidc.Create(context.TODO(), &client, opts)
+	th.AssertNoErr(t, result.Err)
+
+	token, err := result.ExtractTokenID()
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, UnscopedTokenID, token)
+}
+
+func TestDiscoveryUnsupportedGrantType(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	HandleDiscoveryUnsupportedGrantType(t, fakeServer)
+
+	client := gophercloud.ServiceClient{
+		ProviderClient: &gophercloud.ProviderClient{},
+		Endpoint:       fakeServer.Endpoint(),
+	}
+
+	opts := &oidc.AuthOptions{
+		IdentityProviderName: "my-idp",
+		Protocol:             "openid",
+		ClientID:             "my-client-id",
+		ClientSecret:         "my-client-secret",
+		DiscoveryEndpoint:    fakeServer.Endpoint() + ".well-known/openid-configuration",
+	}
+
+	result := oidc.Create(context.TODO(), &client, opts)
+	th.AssertErr(t, result.Err)
+}
+
+func TestDiscoveryNoTokenEndpoint(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	HandleDiscoveryNoTokenEndpoint(t, fakeServer)
+
+	client := gophercloud.ServiceClient{
+		ProviderClient: &gophercloud.ProviderClient{},
+		Endpoint:       fakeServer.Endpoint(),
+	}
+
+	opts := &oidc.AuthOptions{
+		IdentityProviderName: "my-idp",
+		Protocol:             "openid",
+		ClientID:             "my-client-id",
+		ClientSecret:         "my-client-secret",
+		DiscoveryEndpoint:    fakeServer.Endpoint() + ".well-known/openid-configuration",
+	}
+
+	result := oidc.Create(context.TODO(), &client, opts)
+	th.AssertErr(t, result.Err)
+}
+
+func TestDiscoveryHTTPError(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	HandleDiscoveryHTTPError(t, fakeServer)
+
+	client := gophercloud.ServiceClient{
+		ProviderClient: &gophercloud.ProviderClient{},
+		Endpoint:       fakeServer.Endpoint(),
+	}
+
+	opts := &oidc.AuthOptions{
+		IdentityProviderName: "my-idp",
+		Protocol:             "openid",
+		ClientID:             "my-client-id",
+		ClientSecret:         "my-client-secret",
+		DiscoveryEndpoint:    fakeServer.Endpoint() + ".well-known/openid-configuration",
+	}
+
+	result := oidc.Create(context.TODO(), &client, opts)
+	th.AssertErr(t, result.Err)
+}
+
+func TestDiscoveryInvalidJSON(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	HandleDiscoveryInvalidJSON(t, fakeServer)
+
+	client := gophercloud.ServiceClient{
+		ProviderClient: &gophercloud.ProviderClient{},
+		Endpoint:       fakeServer.Endpoint(),
+	}
+
+	opts := &oidc.AuthOptions{
+		IdentityProviderName: "my-idp",
+		Protocol:             "openid",
+		ClientID:             "my-client-id",
+		ClientSecret:         "my-client-secret",
+		DiscoveryEndpoint:    fakeServer.Endpoint() + ".well-known/openid-configuration",
+	}
+
+	result := oidc.Create(context.TODO(), &client, opts)
+	th.AssertErr(t, result.Err)
+}
+
+func TestValidationRequiresEndpointOrDiscovery(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	client := gophercloud.ServiceClient{
+		ProviderClient: &gophercloud.ProviderClient{},
+		Endpoint:       fakeServer.Endpoint(),
+	}
+
+	opts := &oidc.AuthOptions{
+		IdentityProviderName: "my-idp",
+		Protocol:             "openid",
+		ClientID:             "my-client-id",
+	}
+
+	result := oidc.Create(context.TODO(), &client, opts)
+	th.AssertErr(t, result.Err)
+}
+
+func TestValidationWrongOptionsType(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	client := gophercloud.ServiceClient{
+		ProviderClient: &gophercloud.ProviderClient{},
+		Endpoint:       fakeServer.Endpoint(),
+	}
+
+	opts := &gophercloud.AuthOptions{
+		Username: "user",
+		Password: "pass",
+	}
+
+	result := oidc.Create(context.TODO(), &client, opts)
+	th.AssertErr(t, result.Err)
+}
+
+func TestCreateRejectsNilServiceClient(t *testing.T) {
+	result := oidc.Create(context.Background(), nil, &oidc.AuthOptions{
+		IdentityProviderName: "my-idp",
+		Protocol:             "openid",
+		ClientID:             "client-id",
+		AccessTokenEndpoint:  "https://idp.example.com/token",
+	})
+	if result.Err == nil || !strings.Contains(result.Err.Error(), "ServiceClient") {
+		t.Fatalf("expected nil ServiceClient error, got %v", result.Err)
+	}
+}
+
+func TestToTokenV3ScopeMapProjectNameDomainName(t *testing.T) {
+	opts := &oidc.AuthOptions{
+		Scope: tokens.Scope{
+			ProjectName: "my-project",
+			DomainName:  "Default",
+		},
+	}
+
+	scope, err := opts.ToTokenV3ScopeMap()
+	th.AssertNoErr(t, err)
+
+	expected := map[string]any{
+		"project": map[string]any{
+			"name":   stringPointer("my-project"),
+			"domain": map[string]any{"name": stringPointer("Default")},
+		},
+	}
+	th.CheckDeepEquals(t, expected, scope)
+}
+
+func TestToTokenV3ScopeMapProjectNameDomainID(t *testing.T) {
+	opts := &oidc.AuthOptions{
+		Scope: tokens.Scope{
+			ProjectName: "my-project",
+			DomainID:    "default",
+		},
+	}
+
+	scope, err := opts.ToTokenV3ScopeMap()
+	th.AssertNoErr(t, err)
+
+	expected := map[string]any{
+		"project": map[string]any{
+			"name":   stringPointer("my-project"),
+			"domain": map[string]any{"id": stringPointer("default")},
+		},
+	}
+	th.CheckDeepEquals(t, expected, scope)
+}
+
+func TestToTokenV3ScopeMapProjectID(t *testing.T) {
+	opts := &oidc.AuthOptions{
+		Scope: tokens.Scope{
+			ProjectID: "project-id-001",
+		},
+	}
+
+	scope, err := opts.ToTokenV3ScopeMap()
+	th.AssertNoErr(t, err)
+
+	expected := map[string]any{
+		"project": map[string]any{
+			"id": stringPointer("project-id-001"),
+		},
+	}
+	th.CheckDeepEquals(t, expected, scope)
+}
+
+func TestToTokenV3ScopeMapDomainID(t *testing.T) {
+	opts := &oidc.AuthOptions{
+		Scope: tokens.Scope{
+			DomainID: "default",
+		},
+	}
+
+	scope, err := opts.ToTokenV3ScopeMap()
+	th.AssertNoErr(t, err)
+
+	expected := map[string]any{
+		"domain": map[string]any{
+			"id": stringPointer("default"),
+		},
+	}
+	th.CheckDeepEquals(t, expected, scope)
+}
+
+func TestToTokenV3ScopeMapDomainName(t *testing.T) {
+	opts := &oidc.AuthOptions{
+		Scope: tokens.Scope{
+			DomainName: "Default",
+		},
+	}
+
+	scope, err := opts.ToTokenV3ScopeMap()
+	th.AssertNoErr(t, err)
+
+	expected := map[string]any{
+		"domain": map[string]any{
+			"name": stringPointer("Default"),
+		},
+	}
+	th.CheckDeepEquals(t, expected, scope)
+}
+
+func TestToTokenV3ScopeMapSystem(t *testing.T) {
+	opts := &oidc.AuthOptions{
+		Scope: tokens.Scope{
+			System: true,
+		},
+	}
+
+	scope, err := opts.ToTokenV3ScopeMap()
+	th.AssertNoErr(t, err)
+
+	expected := map[string]any{
+		"system": map[string]any{
+			"all": true,
+		},
+	}
+	th.CheckDeepEquals(t, expected, scope)
+}
+
+func TestToTokenV3ScopeMapUnscoped(t *testing.T) {
+	opts := &oidc.AuthOptions{}
+
+	scope, err := opts.ToTokenV3ScopeMap()
+	th.AssertNoErr(t, err)
+
+	if scope != nil {
+		t.Errorf("Expected nil scope for unscoped auth, got %v", scope)
+	}
+}
+
+func TestToTokenV3ScopeMapProjectNameNoDomain(t *testing.T) {
+	opts := &oidc.AuthOptions{
+		Scope: tokens.Scope{
+			ProjectName: "my-project",
+		},
+	}
+
+	_, err := opts.ToTokenV3ScopeMap()
+	th.AssertErr(t, err)
+}
+
+func TestToTokenV3ScopeMapProjectNameAndID(t *testing.T) {
+	opts := &oidc.AuthOptions{
+		Scope: tokens.Scope{
+			ProjectName: "my-project",
+			ProjectID:   "project-id-001",
+			DomainName:  "Default",
+		},
+	}
+
+	_, err := opts.ToTokenV3ScopeMap()
+	th.AssertErr(t, err)
+}
+
+func TestToTokenV3HeadersMap(t *testing.T) {
+	opts := &oidc.AuthOptions{}
+
+	headers, err := opts.ToTokenV3HeadersMap(nil)
+	th.AssertNoErr(t, err)
+	if headers != nil {
+		t.Errorf("Expected nil headers, got %v", headers)
+	}
+}
+
+func TestToTokenV3CreateMap(t *testing.T) {
+	opts := &oidc.AuthOptions{}
+
+	body, err := opts.ToTokenV3CreateMap(nil)
+	th.AssertNoErr(t, err)
+	if body != nil {
+		t.Errorf("Expected nil body, got %v", body)
+	}
+}
+
+var _ tokens.AuthOptionsBuilder = (*oidc.AuthOptions)(nil)

--- a/openstack/identity/v3/oidc/testing/requests_test.go
+++ b/openstack/identity/v3/oidc/testing/requests_test.go
@@ -3,6 +3,7 @@ package testing
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -276,80 +277,46 @@ func TestCanReauth(t *testing.T) {
 	th.CheckEquals(t, false, opts.CanReauth())
 }
 
-func TestValidationMissingIdentityProvider(t *testing.T) {
-	fakeServer := th.SetupHTTP()
-	defer fakeServer.Teardown()
-
-	client := gophercloud.ServiceClient{
-		ProviderClient: &gophercloud.ProviderClient{},
-		Endpoint:       fakeServer.Endpoint(),
+func TestValidationMissingInput(t *testing.T) {
+	tests := []struct {
+		argument string
+		omit     func(*oidc.AuthOptions)
+	}{
+		{"IdentityProviderName", func(opts *oidc.AuthOptions) { opts.IdentityProviderName = "" }},
+		{"Protocol", func(opts *oidc.AuthOptions) { opts.Protocol = "" }},
+		{"ClientID", func(opts *oidc.AuthOptions) { opts.ClientID = "" }},
+		{"AccessTokenEndpoint/DiscoveryEndpoint", func(opts *oidc.AuthOptions) { opts.AccessTokenEndpoint = "" }},
 	}
-
-	opts := &oidc.AuthOptions{
-		Protocol:            "openid",
-		ClientID:            "my-client-id",
-		AccessTokenEndpoint: "https://idp.example.com/oauth2/token",
+	validators := map[string]func(*oidc.AuthOptions) error{
+		"ToTokenV3CreateMap": func(opts *oidc.AuthOptions) error {
+			_, err := opts.ToTokenV3CreateMap(nil)
+			return err
+		},
+		"Create": func(opts *oidc.AuthOptions) error {
+			return oidc.Create(context.Background(), nil, opts).Err
+		},
 	}
-
-	result := oidc.Create(context.TODO(), &client, opts)
-	th.AssertErr(t, result.Err)
-}
-
-func TestValidationMissingProtocol(t *testing.T) {
-	fakeServer := th.SetupHTTP()
-	defer fakeServer.Teardown()
-
-	client := gophercloud.ServiceClient{
-		ProviderClient: &gophercloud.ProviderClient{},
-		Endpoint:       fakeServer.Endpoint(),
+	for _, test := range tests {
+		t.Run(test.argument, func(t *testing.T) {
+			for name, validate := range validators {
+				t.Run(name, func(t *testing.T) {
+					opts := &oidc.AuthOptions{
+						IdentityProviderName: "my-idp",
+						Protocol:             "openid",
+						ClientID:             "my-client-id",
+						AccessTokenEndpoint:  "https://idp.example.com/oauth2/token",
+					}
+					test.omit(opts)
+					err := validate(opts)
+					var missing gophercloud.ErrMissingInput
+					if !errors.As(err, &missing) {
+						t.Fatalf("Expected ErrMissingInput, got %v", err)
+					}
+					th.CheckEquals(t, test.argument, missing.Argument)
+				})
+			}
+		})
 	}
-
-	opts := &oidc.AuthOptions{
-		IdentityProviderName: "my-idp",
-		ClientID:             "my-client-id",
-		AccessTokenEndpoint:  "https://idp.example.com/oauth2/token",
-	}
-
-	result := oidc.Create(context.TODO(), &client, opts)
-	th.AssertErr(t, result.Err)
-}
-
-func TestValidationMissingClientID(t *testing.T) {
-	fakeServer := th.SetupHTTP()
-	defer fakeServer.Teardown()
-
-	client := gophercloud.ServiceClient{
-		ProviderClient: &gophercloud.ProviderClient{},
-		Endpoint:       fakeServer.Endpoint(),
-	}
-
-	opts := &oidc.AuthOptions{
-		IdentityProviderName: "my-idp",
-		Protocol:             "openid",
-		AccessTokenEndpoint:  "https://idp.example.com/oauth2/token",
-	}
-
-	result := oidc.Create(context.TODO(), &client, opts)
-	th.AssertErr(t, result.Err)
-}
-
-func TestValidationMissingAccessTokenEndpoint(t *testing.T) {
-	fakeServer := th.SetupHTTP()
-	defer fakeServer.Teardown()
-
-	client := gophercloud.ServiceClient{
-		ProviderClient: &gophercloud.ProviderClient{},
-		Endpoint:       fakeServer.Endpoint(),
-	}
-
-	opts := &oidc.AuthOptions{
-		IdentityProviderName: "my-idp",
-		Protocol:             "openid",
-		ClientID:             "my-client-id",
-	}
-
-	result := oidc.Create(context.TODO(), &client, opts)
-	th.AssertErr(t, result.Err)
 }
 
 func TestCreateUnscopedWithDiscovery(t *testing.T) {
@@ -575,25 +542,6 @@ func TestDiscoveryInvalidJSON(t *testing.T) {
 	th.AssertErr(t, result.Err)
 }
 
-func TestValidationRequiresEndpointOrDiscovery(t *testing.T) {
-	fakeServer := th.SetupHTTP()
-	defer fakeServer.Teardown()
-
-	client := gophercloud.ServiceClient{
-		ProviderClient: &gophercloud.ProviderClient{},
-		Endpoint:       fakeServer.Endpoint(),
-	}
-
-	opts := &oidc.AuthOptions{
-		IdentityProviderName: "my-idp",
-		Protocol:             "openid",
-		ClientID:             "my-client-id",
-	}
-
-	result := oidc.Create(context.TODO(), &client, opts)
-	th.AssertErr(t, result.Err)
-}
-
 func TestValidationWrongOptionsType(t *testing.T) {
 	fakeServer := th.SetupHTTP()
 	defer fakeServer.Teardown()
@@ -782,12 +730,30 @@ func TestToTokenV3HeadersMap(t *testing.T) {
 }
 
 func TestToTokenV3CreateMap(t *testing.T) {
-	opts := &oidc.AuthOptions{}
-
-	body, err := opts.ToTokenV3CreateMap(nil)
-	th.AssertNoErr(t, err)
-	if body != nil {
-		t.Errorf("Expected nil body, got %v", body)
+	tests := []struct {
+		name      string
+		endpoint  string
+		discovery string
+	}{
+		{name: "explicit endpoint", endpoint: "https://idp.example.com/oauth2/token"},
+		{name: "discovery", discovery: "https://idp.example.com/.well-known/openid-configuration"},
+		{name: "both endpoints", endpoint: "https://idp.example.com/oauth2/token", discovery: "https://idp.example.com/.well-known/openid-configuration"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			opts := &oidc.AuthOptions{
+				IdentityProviderName: "my-idp",
+				Protocol:             "openid",
+				ClientID:             "my-client-id",
+				AccessTokenEndpoint:  test.endpoint,
+				DiscoveryEndpoint:    test.discovery,
+			}
+			body, err := opts.ToTokenV3CreateMap(nil)
+			th.AssertNoErr(t, err)
+			if body != nil {
+				t.Errorf("Expected nil body, got %v", body)
+			}
+		})
 	}
 }
 

--- a/openstack/identity/v3/oidc/urls.go
+++ b/openstack/identity/v3/oidc/urls.go
@@ -1,0 +1,14 @@
+package oidc
+
+import "github.com/gophercloud/gophercloud/v2"
+
+const (
+	rootPath              = "OS-FEDERATION"
+	identityProvidersPath = "identity_providers"
+	protocolsPath         = "protocols"
+	authPath              = "auth"
+)
+
+func authURL(c *gophercloud.ServiceClient, idpID, protocolID string) string {
+	return c.ServiceURL(rootPath, identityProvidersPath, idpID, protocolsPath, protocolID, authPath)
+}


### PR DESCRIPTION
Fixes #3283

Adds Identity v3 authentication using the OpenID Connect client-credentials grant. It obtains an access token from an explicitly configured or discovered token endpoint, exchanges it for an unscoped Keystone token through the federation API, and optionally scopes the result with the existing token API.

The same flow supports reauthentication.

Links to the line numbers/files in the OpenStack source code that support the code in this PR:

- [keystoneauth OIDC endpoint discovery and access-token request](https://github.com/openstack/keystoneauth/blob/83d4e0e73d50eaaa5a27f0cd2b2b4102f11b53a0/keystoneauth1/identity/v3/oidc.py#L192-L275)
- [keystoneauth federation token exchange](https://github.com/openstack/keystoneauth/blob/83d4e0e73d50eaaa5a27f0cd2b2b4102f11b53a0/keystoneauth1/identity/v3/oidc.py#L277-L316)
- [keystoneauth OIDC client-credentials plugin](https://github.com/openstack/keystoneauth/blob/83d4e0e73d50eaaa5a27f0cd2b2b4102f11b53a0/keystoneauth1/identity/v3/oidc.py#L493-L540)