### PR TITLE
pagination: Fix AllPages returning wrong key for empty linked pages

### DIFF
--- a/pagination/pager.go
+++ b/pagination/pager.go
@@ -165,8 +165,19 @@ func (p Pager) AllPages(ctx context.Context) (Page, error) {
 	// `[]byte`, and `[]any`.
 	switch pb := firstPage.GetBody().(type) {
 	case map[string]any:
-		// key is the map key for the page body if the body type is `map[string]any`.
+		// key is the map key for the page body if the body type is
+		// `map[string]any`. Discover it from the first page body
+		// before iterating: EachPage skips empty pages, so the
+		// callback may never run.
 		var key string
+		for k, v := range pb {
+			if !strings.HasSuffix(k, "links") {
+				if _, ok := v.([]any); ok {
+					key = k
+					break
+				}
+			}
+		}
 		// Iterate over the pages to concatenate the bodies.
 		err = p.EachPage(ctx, func(_ context.Context, page Page) (bool, error) {
 			b := page.GetBody().(map[string]any)
@@ -176,7 +187,6 @@ func (p Pager) AllPages(ctx context.Context) (Page, error) {
 					// check the field's type. we only want []any (which is really []map[string]any)
 					switch vt := v.(type) {
 					case []any:
-						key = k
 						pagesSlice = append(pagesSlice, vt...)
 					}
 				}

--- a/pagination/testing/linked_test.go
+++ b/pagination/testing/linked_test.go
@@ -100,6 +100,31 @@ func TestEnumerateLinked(t *testing.T) {
 	}
 }
 
+func TestAllPagesLinkedEmpty(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	fakeServer.Mux.HandleFunc("/page1", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprint(w, `{ "ints": [], "links": { "next": null } }`)
+	})
+
+	client := client.ServiceClient(fakeServer)
+
+	createPage := func(r pagination.PageResult) pagination.Page {
+		return LinkedPageResult{pagination.LinkedPageBase{PageResult: r}}
+	}
+
+	pager := pagination.NewPager(client, fakeServer.Server.URL+"/page1", createPage)
+
+	page, err := pager.AllPages(context.TODO())
+	th.AssertNoErr(t, err)
+
+	actual, err := ExtractLinkedInts(page)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, 0, len(actual))
+}
+
 func TestAllPagesLinked(t *testing.T) {
 	fakeServer := th.SetupHTTP()
 	defer fakeServer.Teardown()


### PR DESCRIPTION
When `AllPages()` processes a linked page where all results are empty, `EachPage` returns early without invoking the callback (because `IsEmpty` returns `true`). This left the resource key unset (empty string `""`), producing a body like `{"": nil}` instead of `{"networks": []}`.

This was harmless until b80f3715a added validation in `extractIntoPtr` that correctly rejects responses missing the expected key, causing `ExtractNetworks` (and similar) to fail with "expected response key not found in response" on empty list results.

Fix by discovering the resource key from the first page body before calling `EachPage`, rather than inside the callback.
