### PR TITLE
containerinfra: Fix wrong HTTP method and path in certificate create test

### DIFF
--- a/openstack/containerinfra/v1/certificates/testing/fixtures_test.go
+++ b/openstack/containerinfra/v1/certificates/testing/fixtures_test.go
@@ -84,8 +84,8 @@ func HandleGetCertificateSuccessfully(t *testing.T, fakeServer th.FakeServer) {
 }
 
 func HandleCreateCertificateSuccessfully(t *testing.T, fakeServer th.FakeServer) {
-	fakeServer.Mux.HandleFunc("/v1/certificates/", func(w http.ResponseWriter, r *http.Request) {
-		th.TestMethod(t, r, "GET")
+	fakeServer.Mux.HandleFunc("/v1/certificates", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 
 		w.Header().Add("Content-Type", "application/json")


### PR DESCRIPTION
The `HandleCreateCertificateSuccessfully` fixture registered its handler at `/v1/certificates/` (with trailing slash) and asserted the request method was `GET`, but `certificates.Create` issues a `POST` to `/v1/certificates` (without trailing slash).

This worked by accident prior to Go 1.26: the `ServeMux` redirected requests from `/v1/certificates` to `/v1/certificates/` via 301, and Go's HTTP client changed `POST` to `GET` when following a 301 redirect. Go 1.26 [changed these trailing-slash redirects to use 307 instead](https://go.dev/doc/go1.26), which preserves the original method, so `POST` now arrives at the handler unchanged and the incorrect assertion fails.

Fix by matching the actual URL (`/v1/certificates`, no trailing slash) and asserting the correct method (`POST`).

Fixes #3898
