### PR TITLE
pagination: Add KeyedPage interface

### DIFF
--- a/openstack/networking/v2/networks/results.go
+++ b/openstack/networking/v2/networks/results.go
@@ -139,6 +139,11 @@ type NetworkPage struct {
 	pagination.LinkedPageBase
 }
 
+// ResourceKey returns the JSON object key for network collections.
+func (r NetworkPage) ResourceKey() string {
+	return "networks"
+}
+
 // NextPageURL is invoked when a paginated collection of networks has reached
 // the end of a page and the pager seeks to traverse over a new one. In order
 // to do this, it needs to construct the next page's URL.

--- a/pagination/pager.go
+++ b/pagination/pager.go
@@ -181,15 +181,8 @@ func (p Pager) AllPages(ctx context.Context) (Page, error) {
 		// Iterate over the pages to concatenate the bodies.
 		err = p.EachPage(ctx, func(_ context.Context, page Page) (bool, error) {
 			b := page.GetBody().(map[string]any)
-			for k, v := range b {
-				// If it's a linked page, we don't want the `links`, we want the other one.
-				if !strings.HasSuffix(k, "links") {
-					// check the field's type. we only want []any (which is really []map[string]any)
-					switch vt := v.(type) {
-					case []any:
-						pagesSlice = append(pagesSlice, vt...)
-					}
-				}
+			if v, ok := b[key].([]any); ok {
+				pagesSlice = append(pagesSlice, v...)
 			}
 			return true, nil
 		})

--- a/pagination/pager.go
+++ b/pagination/pager.go
@@ -34,6 +34,16 @@ type Page interface {
 	GetBody() any
 }
 
+// KeyedPage may optionally be implemented by a Page whose body is a JSON
+// object keyed by a resource name (e.g. {"servers": [...]}). AllPages uses
+// this to determine the correct key when constructing the combined page,
+// avoiding a heuristic scan of the response body.
+type KeyedPage interface {
+	// ResourceKey returns the JSON object key that contains the resource
+	// list, e.g. "servers" or "networks".
+	ResourceKey() string
+}
+
 // Pager knows how to advance through a specific resource collection, one page at a time.
 type Pager struct {
 	client *gophercloud.ServiceClient
@@ -165,16 +175,20 @@ func (p Pager) AllPages(ctx context.Context) (Page, error) {
 	// `[]byte`, and `[]any`.
 	switch pb := firstPage.GetBody().(type) {
 	case map[string]any:
-		// key is the map key for the page body if the body type is
-		// `map[string]any`. Discover it from the first page body
-		// before iterating: EachPage skips empty pages, so the
-		// callback may never run.
+		// key is the map key for the page body if the body type is `map[string]any`.
+		// Prefer the static key from KeyedPage when available, falling back to
+		// scanning the first page body if not. We do discovery here before iterating:
+		// EachPage skips empty pages, so the callback may never run.
 		var key string
-		for k, v := range pb {
-			if !strings.HasSuffix(k, "links") {
-				if _, ok := v.([]any); ok {
-					key = k
-					break
+		if kp, ok := firstPage.(KeyedPage); ok {
+			key = kp.ResourceKey()
+		} else {
+			for k, v := range pb {
+				if !strings.HasSuffix(k, "links") {
+					if _, ok := v.([]any); ok {
+						key = k
+						break
+					}
 				}
 			}
 		}

--- a/pagination/testing/linked_test.go
+++ b/pagination/testing/linked_test.go
@@ -31,6 +31,30 @@ func ExtractLinkedInts(r pagination.Page) ([]int, error) {
 	return s.Ints, err
 }
 
+type KeyedLinkedPageResult struct {
+	pagination.LinkedPageBase
+}
+
+func (r KeyedLinkedPageResult) ResourceKey() string {
+	return "ints"
+}
+
+func (r KeyedLinkedPageResult) IsEmpty() (bool, error) {
+	var s struct {
+		Ints []int `json:"ints"`
+	}
+	err := r.ExtractInto(&s)
+	return len(s.Ints) == 0, err
+}
+
+func ExtractKeyedLinkedInts(r pagination.Page) ([]int, error) {
+	var s struct {
+		Ints []int `json:"ints"`
+	}
+	err := (r.(KeyedLinkedPageResult)).ExtractInto(&s)
+	return s.Ints, err
+}
+
 func createLinked(fakeServer th.FakeServer) pagination.Pager {
 	fakeServer.Mux.HandleFunc("/page1", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Add("Content-Type", "application/json")
@@ -136,6 +160,62 @@ func TestAllPagesLinked(t *testing.T) {
 
 	expected := []int{1, 2, 3, 4, 5, 6, 7, 8, 9}
 	actual, err := ExtractLinkedInts(page)
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, expected, actual)
+}
+
+func TestAllPagesLinkedEmptyKeyed(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	fakeServer.Mux.HandleFunc("/page1", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprint(w, `{ "ints": [], "links": { "next": null } }`)
+	})
+
+	client := client.ServiceClient(fakeServer)
+
+	createPage := func(r pagination.PageResult) pagination.Page {
+		return KeyedLinkedPageResult{pagination.LinkedPageBase{PageResult: r}}
+	}
+
+	pager := pagination.NewPager(client, fakeServer.Server.URL+"/page1", createPage)
+
+	page, err := pager.AllPages(context.TODO())
+	th.AssertNoErr(t, err)
+
+	actual, err := ExtractKeyedLinkedInts(page)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, 0, len(actual))
+}
+
+func TestAllPagesLinkedKeyed(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	fakeServer.Mux.HandleFunc("/page1", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprintf(w, `{ "ints": [1, 2, 3], "links": { "next": "%s/page2" } }`, fakeServer.Server.URL)
+	})
+
+	fakeServer.Mux.HandleFunc("/page2", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprint(w, `{ "ints": [4, 5, 6], "links": { "next": null } }`)
+	})
+
+	client := client.ServiceClient(fakeServer)
+
+	createPage := func(r pagination.PageResult) pagination.Page {
+		return KeyedLinkedPageResult{pagination.LinkedPageBase{PageResult: r}}
+	}
+
+	pager := pagination.NewPager(client, fakeServer.Server.URL+"/page1", createPage)
+
+	page, err := pager.AllPages(context.TODO())
+	th.AssertNoErr(t, err)
+
+	expected := []int{1, 2, 3, 4, 5, 6}
+	actual, err := ExtractKeyedLinkedInts(page)
 	th.AssertNoErr(t, err)
 	th.CheckDeepEquals(t, expected, actual)
 }


### PR DESCRIPTION
Currently, pagination of list resources works by scanning resource bodies, looking for the first non-"links" resource key. This mostly works but is crude. It also doesn't work for resources that have multiple non-"links" top-level keys, such as placement's list resource provider inventories API, which has [both an `inventories` envelope key and a separate `resource_provider_generation` key](https://docs.openstack.org/api-ref/placement/#list-resource-provider-inventories).

Improve this by adding a new `KeyedPage` interface, with a `ResourceKey()` string value. When a `Page` struct implements this interface, the static key will be used rather than us scanning the body for the key. When this interface is *not* implemented, we continue to fallback to the old heuristic. The latter will allow us to implement the interface incrementally, and we only do it here for `NetworkPage` in `openstack/networking/v2/networks/results.go`.
