### PR TITLE
v2: ci(magnum): deprecate heat and use magnum-cluster-api driver

### DIFF
--- a/.github/workflows/functional-containerinfra.yaml
+++ b/.github/workflows/functional-containerinfra.yaml
@@ -53,28 +53,6 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Check changed files
-        uses: ./.github/actions/file-filter
-        id: changed-files
-        with:
-          patterns: |
-            openstack/auth_env.go
-            openstack/client.go
-            openstack/endpoint.go
-            openstack/endpoint_location.go
-            openstack/config/provider_client.go
-            openstack/utils/choose_version.go
-            openstack/utils/discovery.go
-            **containerinfra**
-            .github/workflows/functional-containerinfra.yaml
-            script/stackenv
-
-      - name: Skip tests for unrelated changed-files
-        if: ${{ ! fromJSON(steps.changed-files.outputs.matches) }}
-        run: |
-          echo "No relevant files changed - skipping tests for ${{ matrix.name }}"
-          echo "TESTS_SKIPPED=true" >> $GITHUB_ENV
-
       - name: Deploy devstack
         uses: gophercloud/devstack-action@60ca1042045c0c9e3e001c64575d381654ffcba1 # v0.19
         with:

--- a/.github/workflows/functional-containerinfra.yaml
+++ b/.github/workflows/functional-containerinfra.yaml
@@ -24,12 +24,27 @@ jobs:
           - name: "master"
             openstack_version: "master"
             ubuntu_version: "24.04"
+            devstack_conf_overrides: |
+              enable_plugin magnum https://github.com/openstack/magnum master
+              enable_plugin magnum-cluster-api https://github.com/vexxhost/magnum-cluster-api main
+
+              MAGNUM_GUEST_IMAGE_URL=https://github.com/vexxhost/capo-image-elements/releases/download/2026.05-1/ubuntu-24.04-v1.35.4.qcow2
           - name: "gazpacho"
             openstack_version: "stable/2026.1"
             ubuntu_version: "24.04"
+            devstack_conf_overrides: |
+              enable_plugin magnum https://github.com/openstack/magnum stable/2026.1
+              enable_plugin magnum-cluster-api https://github.com/vexxhost/magnum-cluster-api main
+
+              MAGNUM_GUEST_IMAGE_URL=https://github.com/vexxhost/capo-image-elements/releases/download/2026.05-1/ubuntu-24.04-v1.35.4.qcow2
           - name: "epoxy"
             openstack_version: "stable/2025.1"
             ubuntu_version: "24.04"
+            devstack_conf_overrides: |
+              enable_plugin magnum https://github.com/openstack/magnum stable/2025.1
+
+              enable_plugin heat https://github.com/openstack/heat stable/2025.1
+              ENABLED_SERVICES+=h-eng,h-api,h-api-cfn,h-api,cw
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Magnum on OpenStack ${{ matrix.name }}
     steps:
@@ -37,21 +52,43 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
         with:
           persist-credentials: false
+
+      - name: Check changed files
+        uses: ./.github/actions/file-filter
+        id: changed-files
+        with:
+          patterns: |
+            openstack/auth_env.go
+            openstack/client.go
+            openstack/endpoint.go
+            openstack/endpoint_location.go
+            openstack/config/provider_client.go
+            openstack/utils/choose_version.go
+            openstack/utils/discovery.go
+            **containerinfra**
+            .github/workflows/functional-containerinfra.yaml
+            script/stackenv
+
+      - name: Skip tests for unrelated changed-files
+        if: ${{ ! fromJSON(steps.changed-files.outputs.matches) }}
+        run: |
+          echo "No relevant files changed - skipping tests for ${{ matrix.name }}"
+          echo "TESTS_SKIPPED=true" >> $GITHUB_ENV
+
       - name: Deploy devstack
         uses: gophercloud/devstack-action@60ca1042045c0c9e3e001c64575d381654ffcba1 # v0.19
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |
-            enable_plugin magnum https://github.com/openstack/magnum ${{ matrix.openstack_version }}
-            enable_plugin magnum-cluster-api https://github.com/vexxhost/magnum-cluster-api main
             enable_plugin barbican https://github.com/openstack/barbican ${{ matrix.openstack_version }}
 
             MAGNUMCLIENT_BRANCH=${{ matrix.openstack_version }}
-            MAGNUM_GUEST_IMAGE_URL=https://github.com/vexxhost/capo-image-elements/releases/download/2026.05-1/ubuntu-24.04-v1.35.4.qcow2
 
             GLANCE_LIMIT_IMAGE_SIZE_TOTAL=5000
             SWIFT_MAX_FILE_SIZE=5368709122
             KEYSTONE_ADMIN_ENDPOINT=true
+
+            ${{ matrix.devstack_conf_overrides }}
           enabled_services: "openstack-cli-server"
 
       - name: Checkout go

--- a/.github/workflows/functional-containerinfra.yaml
+++ b/.github/workflows/functional-containerinfra.yaml
@@ -24,21 +24,12 @@ jobs:
           - name: "master"
             openstack_version: "master"
             ubuntu_version: "24.04"
-            devstack_conf_overrides: |
-              enable_plugin magnum https://github.com/openstack/magnum master
-              MAGNUMCLIENT_BRANCH=master
           - name: "gazpacho"
             openstack_version: "stable/2026.1"
             ubuntu_version: "24.04"
-            devstack_conf_overrides: |
-              enable_plugin magnum https://github.com/openstack/magnum stable/2026.1
-              MAGNUMCLIENT_BRANCH=stable/2026.1
           - name: "epoxy"
             openstack_version: "stable/2025.1"
             ubuntu_version: "24.04"
-            devstack_conf_overrides: |
-              enable_plugin magnum https://github.com/openstack/magnum stable/2025.1
-              MAGNUMCLIENT_BRANCH=stable/2025.1
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Magnum on OpenStack ${{ matrix.name }}
     steps:
@@ -51,14 +42,18 @@ jobs:
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |
+            enable_plugin magnum https://github.com/openstack/magnum ${{ matrix.openstack_version }}
+            enable_plugin magnum-cluster-api https://github.com/vexxhost/magnum-cluster-api main
             enable_plugin barbican https://github.com/openstack/barbican ${{ matrix.openstack_version }}
-            enable_plugin heat https://github.com/openstack/heat ${{ matrix.openstack_version }}
+
+            MAGNUMCLIENT_BRANCH=${{ matrix.openstack_version }}
+            MAGNUM_GUEST_IMAGE_URL=https://github.com/vexxhost/capo-image-elements/releases/download/2026.05-1/ubuntu-24.04-v1.35.4.qcow2
+
             GLANCE_LIMIT_IMAGE_SIZE_TOTAL=5000
             SWIFT_MAX_FILE_SIZE=5368709122
             KEYSTONE_ADMIN_ENDPOINT=true
+          enabled_services: "openstack-cli-server"
 
-            ${{ matrix.devstack_conf_overrides }}
-          enabled_services: "h-eng,h-api,h-api-cfn,h-api-cw,openstack-cli-server"
       - name: Checkout go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:

--- a/script/stackenv
+++ b/script/stackenv
@@ -60,10 +60,7 @@ export OS_FLAVOR_ID_RESIZE="$_FLAVOR_ALT_ID"
 EOL
 
 if _=$(openstack service list | grep container-infra); then
-    _MAGNUM_IMAGE_ID=$(openstack image list --format value -c Name -c ID | grep coreos | cut -d ' ' -f 1)
-    if [ -z "$_MAGNUM_IMAGE_ID" ]; then
-        _MAGNUM_IMAGE_ID=$(openstack image list --format value -c Name -c ID | grep -i atomic | cut -d ' ' -f 1)
-    fi
+    _MAGNUM_IMAGE_ID=$(openstack image list --format value -c Name -c ID | grep ubuntu | cut -d ' ' -f 1)
     cat >> "openrc" <<EOL
 export OS_MAGNUM_IMAGE_ID="$_MAGNUM_IMAGE_ID"
 export OS_MAGNUM_KEYPAIR=magnum

--- a/script/stackenv
+++ b/script/stackenv
@@ -60,7 +60,12 @@ export OS_FLAVOR_ID_RESIZE="$_FLAVOR_ALT_ID"
 EOL
 
 if _=$(openstack service list | grep container-infra); then
-    _MAGNUM_IMAGE_ID=$(openstack image list --format value -c Name -c ID | grep ubuntu | cut -d ' ' -f 1)
+    _MAGNUM_IMAGE_ID=$(openstack image list --format value -c Name -c ID | grep ubuntu | cut -d ' ' -f 1 || true)
+
+    if [[ -z "${_MAGNUM_IMAGE_ID}" ]]; then
+        # Fallback to the CoreOS image used on Epoxy release.
+        _MAGNUM_IMAGE_ID=$(openstack image list --format value -c Name -c ID | grep coreos | cut -d ' ' -f 1)
+    fi
     cat >> "openrc" <<EOL
 export OS_MAGNUM_IMAGE_ID="$_MAGNUM_IMAGE_ID"
 export OS_MAGNUM_KEYPAIR=magnum


### PR DESCRIPTION
Manual backport of https://github.com/gophercloud/gophercloud/pull/3765 to V2