### PR TITLE
baremetal(ci): change RAM disk type from tinyipa to dib

### DIFF
--- a/.github/workflows/functional-baremetal.yaml
+++ b/.github/workflows/functional-baremetal.yaml
@@ -83,7 +83,7 @@ jobs:
             IRONIC_CALLBACK_TIMEOUT=600
             IRONIC_DEPLOY_DRIVER=ipmi
             IRONIC_INSPECTOR_BUILD_RAMDISK=False
-            IRONIC_RAMDISK_TYPE=tinyipa
+            IRONIC_RAMDISK_TYPE=dib
             IRONIC_TEMPEST_BUILD_TIMEOUT=720
             IRONIC_TEMPEST_WHOLE_DISK_IMAGE=False
             IRONIC_VM_COUNT=1


### PR DESCRIPTION
the tinyipa RAM disk type has been deprecated and the prebuilt image is no longer served, thus we can't download it in our CI. we've started seeing error in our ci 

https://github.com/gophercloud/gophercloud/actions/runs/32047256093/job/95437896359?pr=3930

This PR changes the tinyipa image to the dib prebuilt images. 