### PR TITLE
feat: add loadbalancer advanced tag filters

### DIFF
--- a/internal/acceptance/openstack/loadbalancer/v2/loadbalancer.go
+++ b/internal/acceptance/openstack/loadbalancer/v2/loadbalancer.go
@@ -197,17 +197,20 @@ func CreateLoadBalancerFullyPopulated(t *testing.T, client *gophercloud.ServiceC
 			Description:  listenerDescription,
 			Protocol:     listeners.ProtocolHTTP,
 			ProtocolPort: listenerPort,
+			Tags:         tags,
 			DefaultPool: &pools.CreateOpts{
 				Name:        poolName,
 				Description: poolDescription,
 				Protocol:    pools.ProtocolHTTP,
 				LBMethod:    pools.LBMethodLeastConnections,
+				Tags:        tags,
 				Members: []pools.CreateMemberOpts{{
 					Name:         memberName,
 					ProtocolPort: memberPort,
 					Weight:       &memberWeight,
 					Address:      "1.2.3.4",
 					SubnetID:     subnetID,
+					Tags:         tags,
 				}},
 				Monitor: &monitors.CreateOpts{
 					Delay:          10,
@@ -216,6 +219,7 @@ func CreateLoadBalancerFullyPopulated(t *testing.T, client *gophercloud.ServiceC
 					MaxRetriesDown: 4,
 					Type:           monitors.TypeHTTP,
 					HTTPVersion:    "1.0",
+					Tags:           tags,
 				},
 			},
 			L7Policies: []l7policies.CreateOpts{{
@@ -282,7 +286,11 @@ func CreateLoadBalancerFullyPopulated(t *testing.T, client *gophercloud.ServiceC
 	th.AssertEquals(t, "1.0", lb.Pools[0].Monitor.HTTPVersion)
 
 	if len(tags) > 0 {
-		th.AssertDeepEquals(t, lb.Tags, tags)
+		th.AssertTagsEqual(t, tags, lb.Tags)
+		th.AssertTagsEqual(t, tags, lb.Listeners[0].Tags)
+		th.AssertTagsEqual(t, tags, lb.Pools[0].Tags)
+		th.AssertTagsEqual(t, tags, lb.Pools[0].Members[0].Tags)
+		th.AssertTagsEqual(t, tags, lb.Pools[0].Monitor.Tags)
 	}
 
 	return lb, nil

--- a/internal/acceptance/openstack/loadbalancer/v2/tagfilters_test.go
+++ b/internal/acceptance/openstack/loadbalancer/v2/tagfilters_test.go
@@ -1,0 +1,166 @@
+//go:build acceptance || networking || loadbalancer || listeners || pools || monitors
+
+package v2
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/v2/internal/acceptance/clients"
+	networking "github.com/gophercloud/gophercloud/v2/internal/acceptance/openstack/networking/v2"
+	"github.com/gophercloud/gophercloud/v2/internal/acceptance/tools"
+	"github.com/gophercloud/gophercloud/v2/openstack/loadbalancer/v2/listeners"
+	"github.com/gophercloud/gophercloud/v2/openstack/loadbalancer/v2/monitors"
+	"github.com/gophercloud/gophercloud/v2/openstack/loadbalancer/v2/pools"
+	th "github.com/gophercloud/gophercloud/v2/testhelper"
+)
+
+func TestAdvancedTagFilters(t *testing.T) {
+	netClient, err := clients.NewNetworkV2Client()
+	th.AssertNoErr(t, err)
+
+	lbClient, err := clients.NewLoadBalancerV2Client()
+	th.AssertNoErr(t, err)
+
+	network, err := networking.CreateNetwork(t, netClient)
+	th.AssertNoErr(t, err)
+	defer networking.DeleteNetwork(t, netClient, network.ID)
+
+	subnet, err := networking.CreateSubnet(t, netClient, network.ID)
+	th.AssertNoErr(t, err)
+	defer networking.DeleteSubnet(t, netClient, subnet.ID)
+
+	tags := []string{
+		tools.RandomString("TESTACCT-TAG-", 8),
+		tools.RandomString("TESTACCT-TAG-", 8),
+	}
+	missingTag := tools.RandomString("TESTACCT-MISSING-TAG-", 8)
+
+	lb, err := CreateLoadBalancerFullyPopulated(t, lbClient, subnet.ID, tags)
+	th.AssertNoErr(t, err)
+	defer CascadeDeleteLoadBalancer(t, lbClient, lb.ID)
+
+	listener := lb.Listeners[0]
+	pool := lb.Pools[0]
+	member := pool.Members[0]
+	monitor := pool.Monitor
+	t.Run("listeners", func(t *testing.T) {
+		tests := []struct {
+			name string
+			opts listeners.ListOpts
+			want int
+		}{
+			{name: "tags-match", opts: listeners.ListOpts{LoadbalancerID: lb.ID, Tags: tags}, want: 1},
+			{name: "tags-no-match", opts: listeners.ListOpts{LoadbalancerID: lb.ID, Tags: []string{tags[0], missingTag}}, want: 0},
+			{name: "tags-any-match", opts: listeners.ListOpts{LoadbalancerID: lb.ID, TagsAny: []string{tags[0], missingTag}}, want: 1},
+			{name: "tags-any-no-match", opts: listeners.ListOpts{LoadbalancerID: lb.ID, TagsAny: []string{missingTag}}, want: 0},
+			{name: "not-tags-excluded", opts: listeners.ListOpts{LoadbalancerID: lb.ID, TagsNot: tags}, want: 0},
+			{name: "not-tags-included", opts: listeners.ListOpts{LoadbalancerID: lb.ID, TagsNot: []string{tags[0], missingTag}}, want: 1},
+			{name: "not-tags-any-excluded", opts: listeners.ListOpts{LoadbalancerID: lb.ID, TagsNotAny: []string{tags[0], missingTag}}, want: 0},
+			{name: "not-tags-any-included", opts: listeners.ListOpts{LoadbalancerID: lb.ID, TagsNotAny: []string{missingTag}}, want: 1},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				allPages, err := listeners.List(lbClient, test.opts).AllPages(context.TODO())
+				th.AssertNoErr(t, err)
+				allListeners, err := listeners.ExtractListeners(allPages)
+				th.AssertNoErr(t, err)
+				th.AssertEquals(t, test.want, len(allListeners))
+				if test.want > 0 {
+					th.AssertEquals(t, listener.ID, allListeners[0].ID)
+				}
+			})
+		}
+	})
+
+	t.Run("pools", func(t *testing.T) {
+		tests := []struct {
+			name string
+			opts pools.ListOpts
+			want int
+		}{
+			{name: "tags-match", opts: pools.ListOpts{LoadbalancerID: lb.ID, Tags: tags}, want: 1},
+			{name: "tags-no-match", opts: pools.ListOpts{LoadbalancerID: lb.ID, Tags: []string{tags[0], missingTag}}, want: 0},
+			{name: "tags-any-match", opts: pools.ListOpts{LoadbalancerID: lb.ID, TagsAny: []string{tags[0], missingTag}}, want: 1},
+			{name: "tags-any-no-match", opts: pools.ListOpts{LoadbalancerID: lb.ID, TagsAny: []string{missingTag}}, want: 0},
+			{name: "not-tags-excluded", opts: pools.ListOpts{LoadbalancerID: lb.ID, TagsNot: tags}, want: 0},
+			{name: "not-tags-included", opts: pools.ListOpts{LoadbalancerID: lb.ID, TagsNot: []string{tags[0], missingTag}}, want: 1},
+			{name: "not-tags-any-excluded", opts: pools.ListOpts{LoadbalancerID: lb.ID, TagsNotAny: []string{tags[0], missingTag}}, want: 0},
+			{name: "not-tags-any-included", opts: pools.ListOpts{LoadbalancerID: lb.ID, TagsNotAny: []string{missingTag}}, want: 1},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				allPages, err := pools.List(lbClient, test.opts).AllPages(context.TODO())
+				th.AssertNoErr(t, err)
+				allPools, err := pools.ExtractPools(allPages)
+				th.AssertNoErr(t, err)
+				th.AssertEquals(t, test.want, len(allPools))
+				if test.want > 0 {
+					th.AssertEquals(t, pool.ID, allPools[0].ID)
+				}
+			})
+		}
+	})
+
+	t.Run("members", func(t *testing.T) {
+		tests := []struct {
+			name string
+			opts pools.ListMembersOpts
+			want int
+		}{
+			{name: "tags-match", opts: pools.ListMembersOpts{Tags: tags}, want: 1},
+			{name: "tags-no-match", opts: pools.ListMembersOpts{Tags: []string{tags[0], missingTag}}, want: 0},
+			{name: "tags-any-match", opts: pools.ListMembersOpts{TagsAny: []string{tags[0], missingTag}}, want: 1},
+			{name: "tags-any-no-match", opts: pools.ListMembersOpts{TagsAny: []string{missingTag}}, want: 0},
+			{name: "not-tags-excluded", opts: pools.ListMembersOpts{TagsNot: tags}, want: 0},
+			{name: "not-tags-included", opts: pools.ListMembersOpts{TagsNot: []string{tags[0], missingTag}}, want: 1},
+			{name: "not-tags-any-excluded", opts: pools.ListMembersOpts{TagsNotAny: []string{tags[0], missingTag}}, want: 0},
+			{name: "not-tags-any-included", opts: pools.ListMembersOpts{TagsNotAny: []string{missingTag}}, want: 1},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				allPages, err := pools.ListMembers(lbClient, pool.ID, test.opts).AllPages(context.TODO())
+				th.AssertNoErr(t, err)
+				allMembers, err := pools.ExtractMembers(allPages)
+				th.AssertNoErr(t, err)
+				th.AssertEquals(t, test.want, len(allMembers))
+				if test.want > 0 {
+					th.AssertEquals(t, member.ID, allMembers[0].ID)
+				}
+			})
+		}
+	})
+
+	t.Run("health monitors", func(t *testing.T) {
+		tests := []struct {
+			name string
+			opts monitors.ListOpts
+			want int
+		}{
+			{name: "tags-match", opts: monitors.ListOpts{PoolID: pool.ID, Tags: tags}, want: 1},
+			{name: "tags-no-match", opts: monitors.ListOpts{PoolID: pool.ID, Tags: []string{tags[0], missingTag}}, want: 0},
+			{name: "tags-any-match", opts: monitors.ListOpts{PoolID: pool.ID, TagsAny: []string{tags[0], missingTag}}, want: 1},
+			{name: "tags-any-no-match", opts: monitors.ListOpts{PoolID: pool.ID, TagsAny: []string{missingTag}}, want: 0},
+			{name: "not-tags-excluded", opts: monitors.ListOpts{PoolID: pool.ID, TagsNot: tags}, want: 0},
+			{name: "not-tags-included", opts: monitors.ListOpts{PoolID: pool.ID, TagsNot: []string{tags[0], missingTag}}, want: 1},
+			{name: "not-tags-any-excluded", opts: monitors.ListOpts{PoolID: pool.ID, TagsNotAny: []string{tags[0], missingTag}}, want: 0},
+			{name: "not-tags-any-included", opts: monitors.ListOpts{PoolID: pool.ID, TagsNotAny: []string{missingTag}}, want: 1},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				allPages, err := monitors.List(lbClient, test.opts).AllPages(context.TODO())
+				th.AssertNoErr(t, err)
+				allMonitors, err := monitors.ExtractMonitors(allPages)
+				th.AssertNoErr(t, err)
+				th.AssertEquals(t, test.want, len(allMonitors))
+				if test.want > 0 {
+					th.AssertEquals(t, monitor.ID, allMonitors[0].ID)
+				}
+			})
+		}
+	})
+}

--- a/openstack/loadbalancer/v2/listeners/requests.go
+++ b/openstack/loadbalancer/v2/listeners/requests.go
@@ -58,24 +58,39 @@ type ListOptsBuilder interface {
 // sort by a particular listener attribute. SortDir sets the direction, and is
 // either `asc' or `desc'. Marker and Limit are used for pagination.
 type ListOpts struct {
-	ID                   string   `q:"id"`
-	Name                 string   `q:"name"`
-	AdminStateUp         *bool    `q:"admin_state_up"`
-	ProjectID            string   `q:"project_id"`
-	LoadbalancerID       string   `q:"loadbalancer_id"`
-	DefaultPoolID        string   `q:"default_pool_id"`
-	Protocol             string   `q:"protocol"`
-	ProtocolPort         int      `q:"protocol_port"`
-	ConnectionLimit      int      `q:"connection_limit"`
-	Limit                int      `q:"limit"`
-	Marker               string   `q:"marker"`
-	SortKey              string   `q:"sort_key"`
-	SortDir              string   `q:"sort_dir"`
-	TimeoutClientData    *int     `q:"timeout_client_data"`
-	TimeoutMemberData    *int     `q:"timeout_member_data"`
-	TimeoutMemberConnect *int     `q:"timeout_member_connect"`
-	TimeoutTCPInspect    *int     `q:"timeout_tcp_inspect"`
-	Tags                 []string `q:"tags"`
+	ID                   string `q:"id"`
+	Name                 string `q:"name"`
+	AdminStateUp         *bool  `q:"admin_state_up"`
+	ProjectID            string `q:"project_id"`
+	LoadbalancerID       string `q:"loadbalancer_id"`
+	DefaultPoolID        string `q:"default_pool_id"`
+	Protocol             string `q:"protocol"`
+	ProtocolPort         int    `q:"protocol_port"`
+	ConnectionLimit      int    `q:"connection_limit"`
+	Limit                int    `q:"limit"`
+	Marker               string `q:"marker"`
+	SortKey              string `q:"sort_key"`
+	SortDir              string `q:"sort_dir"`
+	TimeoutClientData    *int   `q:"timeout_client_data"`
+	TimeoutMemberData    *int   `q:"timeout_member_data"`
+	TimeoutMemberConnect *int   `q:"timeout_member_connect"`
+	TimeoutTCPInspect    *int   `q:"timeout_tcp_inspect"`
+
+	// Tags filters listeners that contain all of the given tags.
+	// Requires Octavia API version 2.5 or later.
+	Tags []string `q:"tags"`
+
+	// TagsAny filters listeners that contain at least one of the given tags.
+	// Requires Octavia API version 2.5 or later.
+	TagsAny []string `q:"tags-any"`
+
+	// TagsNot excludes listeners that contain all of the given tags.
+	// Requires Octavia API version 2.5 or later.
+	TagsNot []string `q:"not-tags"`
+
+	// TagsNotAny excludes listeners that contain any of the given tags.
+	// Requires Octavia API version 2.5 or later.
+	TagsNotAny []string `q:"not-tags-any"`
 }
 
 // ToListenerListQuery formats a ListOpts into a query string.

--- a/openstack/loadbalancer/v2/listeners/testing/requests_test.go
+++ b/openstack/loadbalancer/v2/listeners/testing/requests_test.go
@@ -54,6 +54,20 @@ func TestListAllListeners(t *testing.T) {
 	th.CheckDeepEquals(t, ListenerDb, actual[1])
 }
 
+func TestListListenerOpts(t *testing.T) {
+	listOpts := listeners.ListOpts{
+		Tags:       []string{"tag1", "tag2"},
+		TagsAny:    []string{"tag3", "tag4"},
+		TagsNot:    []string{"tag5", "tag6"},
+		TagsNotAny: []string{"tag7", "tag8"},
+	}
+
+	expected := "?not-tags=tag5&not-tags=tag6&not-tags-any=tag7&not-tags-any=tag8&tags=tag1&tags=tag2&tags-any=tag3&tags-any=tag4"
+	actual, err := listOpts.ToListenerListQuery()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, expected, actual)
+}
+
 func TestCreateListener(t *testing.T) {
 	fakeServer := th.SetupHTTP()
 	defer fakeServer.Teardown()

--- a/openstack/loadbalancer/v2/monitors/requests.go
+++ b/openstack/loadbalancer/v2/monitors/requests.go
@@ -20,26 +20,41 @@ type ListOptsBuilder interface {
 // sort by a particular Monitor attribute. SortDir sets the direction, and is
 // either `asc' or `desc'. Marker and Limit are used for pagination.
 type ListOpts struct {
-	ID             string   `q:"id"`
-	Name           string   `q:"name"`
-	TenantID       string   `q:"tenant_id"`
-	ProjectID      string   `q:"project_id"`
-	PoolID         string   `q:"pool_id"`
-	Type           string   `q:"type"`
-	Delay          int      `q:"delay"`
-	Timeout        int      `q:"timeout"`
-	MaxRetries     int      `q:"max_retries"`
-	MaxRetriesDown int      `q:"max_retries_down"`
-	HTTPMethod     string   `q:"http_method"`
-	URLPath        string   `q:"url_path"`
-	ExpectedCodes  string   `q:"expected_codes"`
-	AdminStateUp   *bool    `q:"admin_state_up"`
-	Status         string   `q:"status"`
-	Limit          int      `q:"limit"`
-	Marker         string   `q:"marker"`
-	SortKey        string   `q:"sort_key"`
-	SortDir        string   `q:"sort_dir"`
-	Tags           []string `q:"tags"`
+	ID             string `q:"id"`
+	Name           string `q:"name"`
+	TenantID       string `q:"tenant_id"`
+	ProjectID      string `q:"project_id"`
+	PoolID         string `q:"pool_id"`
+	Type           string `q:"type"`
+	Delay          int    `q:"delay"`
+	Timeout        int    `q:"timeout"`
+	MaxRetries     int    `q:"max_retries"`
+	MaxRetriesDown int    `q:"max_retries_down"`
+	HTTPMethod     string `q:"http_method"`
+	URLPath        string `q:"url_path"`
+	ExpectedCodes  string `q:"expected_codes"`
+	AdminStateUp   *bool  `q:"admin_state_up"`
+	Status         string `q:"status"`
+	Limit          int    `q:"limit"`
+	Marker         string `q:"marker"`
+	SortKey        string `q:"sort_key"`
+	SortDir        string `q:"sort_dir"`
+
+	// Tags filters health monitors that contain all of the given tags.
+	// Requires Octavia API version 2.5 or later.
+	Tags []string `q:"tags"`
+
+	// TagsAny filters health monitors that contain at least one of the given tags.
+	// Requires Octavia API version 2.5 or later.
+	TagsAny []string `q:"tags-any"`
+
+	// TagsNot excludes health monitors that contain all of the given tags.
+	// Requires Octavia API version 2.5 or later.
+	TagsNot []string `q:"not-tags"`
+
+	// TagsNotAny excludes health monitors that contain any of the given tags.
+	// Requires Octavia API version 2.5 or later.
+	TagsNotAny []string `q:"not-tags-any"`
 }
 
 // ToMonitorListQuery formats a ListOpts into a query string.

--- a/openstack/loadbalancer/v2/monitors/testing/requests_test.go
+++ b/openstack/loadbalancer/v2/monitors/testing/requests_test.go
@@ -53,6 +53,20 @@ func TestListAllHealthmonitors(t *testing.T) {
 	th.CheckDeepEquals(t, HealthmonitorDb, actual[1])
 }
 
+func TestListHealthmonitorOpts(t *testing.T) {
+	listOpts := monitors.ListOpts{
+		Tags:       []string{"tag1", "tag2"},
+		TagsAny:    []string{"tag3", "tag4"},
+		TagsNot:    []string{"tag5", "tag6"},
+		TagsNotAny: []string{"tag7", "tag8"},
+	}
+
+	expected := "?not-tags=tag5&not-tags=tag6&not-tags-any=tag7&not-tags-any=tag8&tags=tag1&tags=tag2&tags-any=tag3&tags-any=tag4"
+	actual, err := listOpts.ToMonitorListQuery()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, expected, actual)
+}
+
 func TestCreateHealthmonitor(t *testing.T) {
 	fakeServer := th.SetupHTTP()
 	defer fakeServer.Teardown()

--- a/openstack/loadbalancer/v2/pools/requests.go
+++ b/openstack/loadbalancer/v2/pools/requests.go
@@ -31,18 +31,33 @@ type ListOptsBuilder interface {
 // sort by a particular Pool attribute. SortDir sets the direction, and is
 // either `asc' or `desc'. Marker and Limit are used for pagination.
 type ListOpts struct {
-	LBMethod       string   `q:"lb_algorithm"`
-	Protocol       string   `q:"protocol"`
-	ProjectID      string   `q:"project_id"`
-	AdminStateUp   *bool    `q:"admin_state_up"`
-	Name           string   `q:"name"`
-	ID             string   `q:"id"`
-	LoadbalancerID string   `q:"loadbalancer_id"`
-	Limit          int      `q:"limit"`
-	Marker         string   `q:"marker"`
-	SortKey        string   `q:"sort_key"`
-	SortDir        string   `q:"sort_dir"`
-	Tags           []string `q:"tags"`
+	LBMethod       string `q:"lb_algorithm"`
+	Protocol       string `q:"protocol"`
+	ProjectID      string `q:"project_id"`
+	AdminStateUp   *bool  `q:"admin_state_up"`
+	Name           string `q:"name"`
+	ID             string `q:"id"`
+	LoadbalancerID string `q:"loadbalancer_id"`
+	Limit          int    `q:"limit"`
+	Marker         string `q:"marker"`
+	SortKey        string `q:"sort_key"`
+	SortDir        string `q:"sort_dir"`
+
+	// Tags filters pools that contain all of the given tags.
+	// Requires Octavia API version 2.5 or later.
+	Tags []string `q:"tags"`
+
+	// TagsAny filters pools that contain at least one of the given tags.
+	// Requires Octavia API version 2.5 or later.
+	TagsAny []string `q:"tags-any"`
+
+	// TagsNot excludes pools that contain all of the given tags.
+	// Requires Octavia API version 2.5 or later.
+	TagsNot []string `q:"not-tags"`
+
+	// TagsNotAny excludes pools that contain any of the given tags.
+	// Requires Octavia API version 2.5 or later.
+	TagsNotAny []string `q:"not-tags-any"`
 }
 
 // ToPoolListQuery formats a ListOpts into a query string.
@@ -344,6 +359,22 @@ type ListMembersOpts struct {
 	Marker       string `q:"marker"`
 	SortKey      string `q:"sort_key"`
 	SortDir      string `q:"sort_dir"`
+
+	// Tags filters members that contain all of the given tags.
+	// Requires Octavia API version 2.5 or later.
+	Tags []string `q:"tags"`
+
+	// TagsAny filters members that contain at least one of the given tags.
+	// Requires Octavia API version 2.5 or later.
+	TagsAny []string `q:"tags-any"`
+
+	// TagsNot excludes members that contain all of the given tags.
+	// Requires Octavia API version 2.5 or later.
+	TagsNot []string `q:"not-tags"`
+
+	// TagsNotAny excludes members that contain any of the given tags.
+	// Requires Octavia API version 2.5 or later.
+	TagsNotAny []string `q:"not-tags-any"`
 }
 
 // ToMemberListQuery formats a ListOpts into a query string.

--- a/openstack/loadbalancer/v2/pools/testing/requests_test.go
+++ b/openstack/loadbalancer/v2/pools/testing/requests_test.go
@@ -53,6 +53,20 @@ func TestListAllPools(t *testing.T) {
 	th.CheckDeepEquals(t, PoolDb, actual[1])
 }
 
+func TestListPoolOpts(t *testing.T) {
+	listOpts := pools.ListOpts{
+		Tags:       []string{"tag1", "tag2"},
+		TagsAny:    []string{"tag3", "tag4"},
+		TagsNot:    []string{"tag5", "tag6"},
+		TagsNotAny: []string{"tag7", "tag8"},
+	}
+
+	expected := "?not-tags=tag5&not-tags=tag6&not-tags-any=tag7&not-tags-any=tag8&tags=tag1&tags=tag2&tags-any=tag3&tags-any=tag4"
+	actual, err := listOpts.ToPoolListQuery()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, expected, actual)
+}
+
 func TestCreatePool(t *testing.T) {
 	fakeServer := th.SetupHTTP()
 	defer fakeServer.Teardown()
@@ -187,6 +201,20 @@ func TestListAllMembers(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.CheckDeepEquals(t, MemberWeb, actual[0])
 	th.CheckDeepEquals(t, MemberDb, actual[1])
+}
+
+func TestListMembersOpts(t *testing.T) {
+	listOpts := pools.ListMembersOpts{
+		Tags:       []string{"tag1", "tag2"},
+		TagsAny:    []string{"tag3", "tag4"},
+		TagsNot:    []string{"tag5", "tag6"},
+		TagsNotAny: []string{"tag7", "tag8"},
+	}
+
+	expected := "?not-tags=tag5&not-tags=tag6&not-tags-any=tag7&not-tags-any=tag8&tags=tag1&tags=tag2&tags-any=tag3&tags-any=tag4"
+	actual, err := listOpts.ToMembersListQuery()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, expected, actual)
 }
 
 func TestCreateMember(t *testing.T) {


### PR DESCRIPTION
<!--
Prior to starting a PR, please make sure you have read our
[contributor tutorial](https://github.com/gophercloud/gophercloud/tree/main/docs/contributor-tutorial).

Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

-->
Fixes #3956 

This PR is to add the remaining Octavia advanced tag filters to listener, pool, health monitor, and member list operations below.

- `tags-any`
- `not-tags`
- `not-tags-any`

and member list options now support all four tag filters, including `tags`.

This follows the existing naming and query encoding used by load balancers, L7 policies, and L7 rules. Unit tests cover query generation, while acceptance coverage verifies matching and non-matching behavior for every filter.

References:

- https://docs.openstack.org/api-ref/load-balancer/v2/#filtering-by-tags
- https://opendev.org/openstack/octavia/src/branch/master/octavia/api/common/pagination.py

related to https://github.com/gophercloud/gophercloud/pull/3914