### PR TITLE
dependabot: group gomod and github-actions updates into single PR

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,7 +4,8 @@ updates:
   directory: "/"
   target-branch: "main"
   schedule:
-    interval: daily
+    interval: "weekly"
+    day: "monday"
   cooldown:
     default-days: 7
   open-pull-requests-limit: 10
@@ -15,7 +16,8 @@ updates:
   directory: "/"
   target-branch: "main"
   schedule:
-    interval: daily
+    interval: "weekly"
+    day: "monday"
   cooldown:
     default-days: 7
   open-pull-requests-limit: 10
@@ -26,7 +28,8 @@ updates:
   directory: "/"
   target-branch: "v2"
   schedule:
-    interval: daily
+    interval: "weekly"
+    day: "monday"
   cooldown:
     default-days: 7
   open-pull-requests-limit: 10
@@ -37,7 +40,8 @@ updates:
   directory: "/"
   target-branch: "v2"
   schedule:
-    interval: daily
+    interval: "weekly"
+    day: "monday"
   cooldown:
     default-days: 7
   open-pull-requests-limit: 10

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -8,6 +8,9 @@ updates:
   cooldown:
     default-days: 7
   open-pull-requests-limit: 10
+  groups:
+    all-go-mod:
+      patterns: [ "*" ]
 - package-ecosystem: "github-actions"
   directory: "/"
   target-branch: "main"
@@ -16,6 +19,9 @@ updates:
   cooldown:
     default-days: 7
   open-pull-requests-limit: 10
+  groups:
+    all-github-actions:
+      patterns: [ "*" ]
 - package-ecosystem: gomod
   directory: "/"
   target-branch: "v2"
@@ -24,6 +30,9 @@ updates:
   cooldown:
     default-days: 7
   open-pull-requests-limit: 10
+  groups:
+    all-go-mod:
+      patterns: [ "*" ]
 - package-ecosystem: "github-actions"
   directory: "/"
   target-branch: "v2"
@@ -32,3 +41,6 @@ updates:
   cooldown:
     default-days: 7
   open-pull-requests-limit: 10
+  groups:
+    all-github-actions:
+      patterns: [ "*" ]


### PR DESCRIPTION
Dependabot currently opens one PR per dependency, which causes interdependent bumps to land as separate, independently-mergeable PRs. For example, https://github.com/gophercloud/gophercloud/pull/3937, https://github.com/gophercloud/gophercloud/pull/3935, and https://github.com/gophercloud/gophercloud/pull/3933 each bump one of github/codeql-action/{analyze,autobuild,init} within the same codeql-analysis.yaml workflow, instead of landing together.

Add a groups entry to each gomod and github-actions update block (for both the main and v2 target branches) so that all updates for a given ecosystem/branch are grouped into a single pull request.

Also reduce frequency to reduce noise.
