### PR TITLE
pagination: Return error on missing resource key

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -76,6 +76,22 @@ func (e ErrMissingAnyoneOfEnvironmentVariables) Error() string {
 	return e.choseErrString()
 }
 
+// ErrMissingResourceKey is returned by the Pager when a response does not contain the
+// expected envelope key.
+type ErrMissingResourceKey struct {
+	BaseError
+	Expected string
+	Actual   []string
+}
+
+func (e ErrMissingResourceKey) Error() string {
+	e.DefaultErrString = fmt.Sprintf(
+		"Expected key %v in body but got %v instead",
+		e.Expected, e.Actual,
+	)
+	return e.choseErrString()
+}
+
 // ErrUnexpectedResponseCode is returned by the Request method when a response code other than
 // those listed in OkCodes is encountered.
 type ErrUnexpectedResponseCode struct {

--- a/pagination/pager.go
+++ b/pagination/pager.go
@@ -13,6 +13,7 @@ import (
 
 var (
 	// ErrPageNotAvailable is returned from a Pager when a next or previous page is requested, but does not exist.
+	// Deprecated: This error is no longer used by Gophercloud.
 	ErrPageNotAvailable = errors.New("the requested page does not exist")
 )
 

--- a/pagination/pager.go
+++ b/pagination/pager.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"net/http"
 	"reflect"
+	"slices"
 	"strings"
 
 	"github.com/gophercloud/gophercloud/v2"
@@ -198,6 +200,12 @@ func (p Pager) AllPages(ctx context.Context) (Page, error) {
 			b := page.GetBody().(map[string]any)
 			if v, ok := b[key].([]any); ok {
 				pagesSlice = append(pagesSlice, v...)
+			} else {
+				err = gophercloud.ErrMissingResourceKey{
+					Expected: key,
+					Actual:   slices.Collect(maps.Keys(b)),
+				}
+				return false, err
 			}
 			return true, nil
 		})

--- a/pagination/testing/linked_test.go
+++ b/pagination/testing/linked_test.go
@@ -2,11 +2,14 @@ package testing
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"reflect"
+	"slices"
 	"testing"
 
+	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/pagination"
 	th "github.com/gophercloud/gophercloud/v2/testhelper"
 	"github.com/gophercloud/gophercloud/v2/testhelper/client"
@@ -53,6 +56,25 @@ func ExtractKeyedLinkedInts(r pagination.Page) ([]int, error) {
 	}
 	err := (r.(KeyedLinkedPageResult)).ExtractInto(&s)
 	return s.Ints, err
+}
+
+// MismatchedKeyedLinkedPageResult declares an envelope key ("ints") that is
+// decoupled from its emptiness check ("items"). This lets us exercise the case
+// where a non-empty page does not contain the expected envelope key.
+type MismatchedKeyedLinkedPageResult struct {
+	pagination.LinkedPageBase
+}
+
+func (r MismatchedKeyedLinkedPageResult) ResourceKey() string {
+	return "ints"
+}
+
+func (r MismatchedKeyedLinkedPageResult) IsEmpty() (bool, error) {
+	var s struct {
+		Items []int `json:"items"`
+	}
+	err := r.ExtractInto(&s)
+	return len(s.Items) == 0, err
 }
 
 func createLinked(fakeServer th.FakeServer) pagination.Pager {
@@ -218,4 +240,38 @@ func TestAllPagesLinkedKeyed(t *testing.T) {
 	actual, err := ExtractKeyedLinkedInts(page)
 	th.AssertNoErr(t, err)
 	th.CheckDeepEquals(t, expected, actual)
+}
+
+func TestAllPagesLinkedKeyedMissingKey(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	// The page is non-empty (it has "items") but does not contain the
+	// expected "ints" envelope key.
+	fakeServer.Mux.HandleFunc("/page1", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprint(w, `{ "items": [1, 2, 3], "links": { "next": null } }`)
+	})
+
+	client := client.ServiceClient(fakeServer)
+
+	createPage := func(r pagination.PageResult) pagination.Page {
+		return MismatchedKeyedLinkedPageResult{pagination.LinkedPageBase{PageResult: r}}
+	}
+
+	pager := pagination.NewPager(client, fakeServer.Server.URL+"/page1", createPage)
+
+	_, err := pager.AllPages(context.TODO())
+	th.AssertErr(t, err)
+
+	var missingKeyErr gophercloud.ErrMissingResourceKey
+	if !errors.As(err, &missingKeyErr) {
+		t.Fatalf("Expected ErrMissingResourceKey, but got %T: %v", err, err)
+	}
+	th.AssertEquals(t, "ints", missingKeyErr.Expected)
+
+	// maps.Keys does not guarantee ordering, so sort before comparing.
+	actualKeys := slices.Clone(missingKeyErr.Actual)
+	slices.Sort(actualKeys)
+	th.AssertDeepEquals(t, []string{"items", "links"}, actualKeys)
 }


### PR DESCRIPTION
A follow-up to #3947 that returns an error if the requested key was not found on a page, rather than silently ignoring the key.
