### PR TITLE
[v2] add tags on octavia loadbalancers API 

### DIFF
--- a/internal/acceptance/openstack/loadbalancer/v2/l7policies_test.go
+++ b/internal/acceptance/openstack/loadbalancer/v2/l7policies_test.go
@@ -7,8 +7,10 @@ import (
 	"testing"
 
 	"github.com/gophercloud/gophercloud/v2/internal/acceptance/clients"
+	networking "github.com/gophercloud/gophercloud/v2/internal/acceptance/openstack/networking/v2"
 	"github.com/gophercloud/gophercloud/v2/internal/acceptance/tools"
 	"github.com/gophercloud/gophercloud/v2/openstack/loadbalancer/v2/l7policies"
+	th "github.com/gophercloud/gophercloud/v2/testhelper"
 )
 
 func TestL7PoliciesList(t *testing.T) {
@@ -29,5 +31,165 @@ func TestL7PoliciesList(t *testing.T) {
 
 	for _, policy := range allL7Policies {
 		tools.PrintResource(t, policy)
+	}
+}
+
+func TestL7PoliciesListByTags(t *testing.T) {
+	netClient, err := clients.NewNetworkV2Client()
+	th.AssertNoErr(t, err)
+
+	lbClient, err := clients.NewLoadBalancerV2Client()
+	th.AssertNoErr(t, err)
+
+	network, err := networking.CreateNetwork(t, netClient)
+	th.AssertNoErr(t, err)
+	defer networking.DeleteNetwork(t, netClient, network.ID)
+
+	subnet, err := networking.CreateSubnet(t, netClient, network.ID)
+	th.AssertNoErr(t, err)
+	defer networking.DeleteSubnet(t, netClient, subnet.ID)
+
+	lb, err := CreateLoadBalancer(t, lbClient, subnet.ID, nil, "", nil)
+	th.AssertNoErr(t, err)
+	defer DeleteLoadBalancer(t, lbClient, lb.ID)
+
+	listener, err := CreateListenerHTTP(t, lbClient, lb)
+	th.AssertNoErr(t, err)
+	defer DeleteListener(t, lbClient, lb.ID, listener.ID)
+
+	tags := []string{
+		tools.RandomString("TESTACCT-TAG-", 8),
+		tools.RandomString("TESTACCT-TAG-", 8),
+	}
+	missingTag := tools.RandomString("TESTACCT-MISSING-TAG-", 8)
+
+	policy, err := CreateL7Policy(t, lbClient, listener, lb, tags)
+	th.AssertNoErr(t, err)
+	defer DeleteL7Policy(t, lbClient, lb.ID, policy.ID)
+
+	rule, err := CreateL7Rule(t, lbClient, policy.ID, lb, tags)
+	th.AssertNoErr(t, err)
+	defer DeleteL7Rule(t, lbClient, lb.ID, policy.ID, rule.ID)
+
+	policyTests := []struct {
+		name string
+		opts l7policies.ListOpts
+		want int
+	}{
+		{
+			name: "tags-match",
+			opts: l7policies.ListOpts{ListenerID: listener.ID, Tags: tags},
+			want: 1,
+		},
+		{
+			name: "tags-no-match",
+			opts: l7policies.ListOpts{ListenerID: listener.ID, Tags: []string{tags[0], missingTag}},
+			want: 0,
+		},
+		{
+			name: "tags-any-match",
+			opts: l7policies.ListOpts{ListenerID: listener.ID, TagsAny: []string{tags[0], missingTag}},
+			want: 1,
+		},
+		{
+			name: "tags-any-no-match",
+			opts: l7policies.ListOpts{ListenerID: listener.ID, TagsAny: []string{missingTag}},
+			want: 0,
+		},
+		{
+			name: "not-tags-excluded",
+			opts: l7policies.ListOpts{ListenerID: listener.ID, TagsNot: tags},
+			want: 0,
+		},
+		{
+			name: "not-tags-included",
+			opts: l7policies.ListOpts{ListenerID: listener.ID, TagsNot: []string{tags[0], missingTag}},
+			want: 1,
+		},
+		{
+			name: "not-tags-any-excluded",
+			opts: l7policies.ListOpts{ListenerID: listener.ID, TagsNotAny: []string{tags[0], missingTag}},
+			want: 0,
+		},
+		{
+			name: "not-tags-any-included",
+			opts: l7policies.ListOpts{ListenerID: listener.ID, TagsNotAny: []string{missingTag}},
+			want: 1,
+		},
+	}
+
+	for _, tt := range policyTests {
+		t.Run("L7Policies/"+tt.name, func(t *testing.T) {
+			allPages, err := l7policies.List(lbClient, tt.opts).AllPages(context.TODO())
+			th.AssertNoErr(t, err)
+
+			allPolicies, err := l7policies.ExtractL7Policies(allPages)
+			th.AssertNoErr(t, err)
+			th.AssertEquals(t, tt.want, len(allPolicies))
+			if tt.want > 0 {
+				th.AssertEquals(t, policy.ID, allPolicies[0].ID)
+			}
+		})
+	}
+
+	ruleTests := []struct {
+		name string
+		opts l7policies.ListRulesOpts
+		want int
+	}{
+		{
+			name: "tags-match",
+			opts: l7policies.ListRulesOpts{Tags: tags},
+			want: 1,
+		},
+		{
+			name: "tags-no-match",
+			opts: l7policies.ListRulesOpts{Tags: []string{tags[0], missingTag}},
+			want: 0,
+		},
+		{
+			name: "tags-any-match",
+			opts: l7policies.ListRulesOpts{TagsAny: []string{tags[0], missingTag}},
+			want: 1,
+		},
+		{
+			name: "tags-any-no-match",
+			opts: l7policies.ListRulesOpts{TagsAny: []string{missingTag}},
+			want: 0,
+		},
+		{
+			name: "not-tags-excluded",
+			opts: l7policies.ListRulesOpts{TagsNot: tags},
+			want: 0,
+		},
+		{
+			name: "not-tags-included",
+			opts: l7policies.ListRulesOpts{TagsNot: []string{tags[0], missingTag}},
+			want: 1,
+		},
+		{
+			name: "not-tags-any-excluded",
+			opts: l7policies.ListRulesOpts{TagsNotAny: []string{tags[0], missingTag}},
+			want: 0,
+		},
+		{
+			name: "not-tags-any-included",
+			opts: l7policies.ListRulesOpts{TagsNotAny: []string{missingTag}},
+			want: 1,
+		},
+	}
+
+	for _, tt := range ruleTests {
+		t.Run("L7Rules/"+tt.name, func(t *testing.T) {
+			allPages, err := l7policies.ListRules(lbClient, policy.ID, tt.opts).AllPages(context.TODO())
+			th.AssertNoErr(t, err)
+
+			allRules, err := l7policies.ExtractRules(allPages)
+			th.AssertNoErr(t, err)
+			th.AssertEquals(t, tt.want, len(allRules))
+			if tt.want > 0 {
+				th.AssertEquals(t, rule.ID, allRules[0].ID)
+			}
+		})
 	}
 }

--- a/internal/acceptance/openstack/loadbalancer/v2/loadbalancer.go
+++ b/internal/acceptance/openstack/loadbalancer/v2/loadbalancer.go
@@ -195,17 +195,20 @@ func CreateLoadBalancerFullyPopulated(t *testing.T, client *gophercloud.ServiceC
 			Description:  listenerDescription,
 			Protocol:     listeners.ProtocolHTTP,
 			ProtocolPort: listenerPort,
+			Tags:         tags,
 			DefaultPool: &pools.CreateOpts{
 				Name:        poolName,
 				Description: poolDescription,
 				Protocol:    pools.ProtocolHTTP,
 				LBMethod:    pools.LBMethodLeastConnections,
+				Tags:        tags,
 				Members: []pools.CreateMemberOpts{{
 					Name:         memberName,
 					ProtocolPort: memberPort,
 					Weight:       &memberWeight,
 					Address:      "1.2.3.4",
 					SubnetID:     subnetID,
+					Tags:         tags,
 				}},
 				Monitor: &monitors.CreateOpts{
 					Delay:          10,
@@ -214,6 +217,7 @@ func CreateLoadBalancerFullyPopulated(t *testing.T, client *gophercloud.ServiceC
 					MaxRetriesDown: 4,
 					Type:           monitors.TypeHTTP,
 					HTTPVersion:    "1.0",
+					Tags:           tags,
 				},
 			},
 			L7Policies: []l7policies.CreateOpts{{
@@ -280,7 +284,11 @@ func CreateLoadBalancerFullyPopulated(t *testing.T, client *gophercloud.ServiceC
 	th.AssertEquals(t, "1.0", lb.Pools[0].Monitor.HTTPVersion)
 
 	if len(tags) > 0 {
-		th.AssertDeepEquals(t, lb.Tags, tags)
+		th.AssertTagsEqual(t, tags, lb.Tags)
+		th.AssertTagsEqual(t, tags, lb.Listeners[0].Tags)
+		th.AssertTagsEqual(t, tags, lb.Pools[0].Tags)
+		th.AssertTagsEqual(t, tags, lb.Pools[0].Members[0].Tags)
+		th.AssertTagsEqual(t, tags, lb.Pools[0].Monitor.Tags)
 	}
 
 	return lb, nil

--- a/internal/acceptance/openstack/loadbalancer/v2/loadbalancer.go
+++ b/internal/acceptance/openstack/loadbalancer/v2/loadbalancer.go
@@ -473,7 +473,7 @@ func CreateL7Policy(t *testing.T, client *gophercloud.ServiceClient, listener *l
 	th.AssertEquals(t, policy.ListenerID, listener.ID)
 	th.AssertEquals(t, policy.Action, string(l7policies.ActionRedirectToURL))
 	th.AssertEquals(t, "http://www.example.com", policy.RedirectURL)
-	th.AssertDeepEquals(t, policy.Tags, tags)
+	th.AssertTagsEqual(t, tags, policy.Tags)
 
 	return policy, nil
 }
@@ -503,7 +503,7 @@ func CreateL7Rule(t *testing.T, client *gophercloud.ServiceClient, policyID stri
 	th.AssertEquals(t, rule.RuleType, string(l7policies.TypePath))
 	th.AssertEquals(t, rule.CompareType, string(l7policies.CompareTypeStartWith))
 	th.AssertEquals(t, "/api", rule.Value)
-	th.AssertDeepEquals(t, rule.Tags, tags)
+	th.AssertTagsEqual(t, tags, rule.Tags)
 
 	return rule, nil
 }

--- a/internal/acceptance/openstack/loadbalancer/v2/tagfilters_test.go
+++ b/internal/acceptance/openstack/loadbalancer/v2/tagfilters_test.go
@@ -1,0 +1,166 @@
+//go:build acceptance || networking || loadbalancer || listeners || pools || monitors
+
+package v2
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/v2/internal/acceptance/clients"
+	networking "github.com/gophercloud/gophercloud/v2/internal/acceptance/openstack/networking/v2"
+	"github.com/gophercloud/gophercloud/v2/internal/acceptance/tools"
+	"github.com/gophercloud/gophercloud/v2/openstack/loadbalancer/v2/listeners"
+	"github.com/gophercloud/gophercloud/v2/openstack/loadbalancer/v2/monitors"
+	"github.com/gophercloud/gophercloud/v2/openstack/loadbalancer/v2/pools"
+	th "github.com/gophercloud/gophercloud/v2/testhelper"
+)
+
+func TestAdvancedTagFilters(t *testing.T) {
+	netClient, err := clients.NewNetworkV2Client()
+	th.AssertNoErr(t, err)
+
+	lbClient, err := clients.NewLoadBalancerV2Client()
+	th.AssertNoErr(t, err)
+
+	network, err := networking.CreateNetwork(t, netClient)
+	th.AssertNoErr(t, err)
+	defer networking.DeleteNetwork(t, netClient, network.ID)
+
+	subnet, err := networking.CreateSubnet(t, netClient, network.ID)
+	th.AssertNoErr(t, err)
+	defer networking.DeleteSubnet(t, netClient, subnet.ID)
+
+	tags := []string{
+		tools.RandomString("TESTACCT-TAG-", 8),
+		tools.RandomString("TESTACCT-TAG-", 8),
+	}
+	missingTag := tools.RandomString("TESTACCT-MISSING-TAG-", 8)
+
+	lb, err := CreateLoadBalancerFullyPopulated(t, lbClient, subnet.ID, tags)
+	th.AssertNoErr(t, err)
+	defer CascadeDeleteLoadBalancer(t, lbClient, lb.ID)
+
+	listener := lb.Listeners[0]
+	pool := lb.Pools[0]
+	member := pool.Members[0]
+	monitor := pool.Monitor
+	t.Run("listeners", func(t *testing.T) {
+		tests := []struct {
+			name string
+			opts listeners.ListOpts
+			want int
+		}{
+			{name: "tags-match", opts: listeners.ListOpts{LoadbalancerID: lb.ID, Tags: tags}, want: 1},
+			{name: "tags-no-match", opts: listeners.ListOpts{LoadbalancerID: lb.ID, Tags: []string{tags[0], missingTag}}, want: 0},
+			{name: "tags-any-match", opts: listeners.ListOpts{LoadbalancerID: lb.ID, TagsAny: []string{tags[0], missingTag}}, want: 1},
+			{name: "tags-any-no-match", opts: listeners.ListOpts{LoadbalancerID: lb.ID, TagsAny: []string{missingTag}}, want: 0},
+			{name: "not-tags-excluded", opts: listeners.ListOpts{LoadbalancerID: lb.ID, TagsNot: tags}, want: 0},
+			{name: "not-tags-included", opts: listeners.ListOpts{LoadbalancerID: lb.ID, TagsNot: []string{tags[0], missingTag}}, want: 1},
+			{name: "not-tags-any-excluded", opts: listeners.ListOpts{LoadbalancerID: lb.ID, TagsNotAny: []string{tags[0], missingTag}}, want: 0},
+			{name: "not-tags-any-included", opts: listeners.ListOpts{LoadbalancerID: lb.ID, TagsNotAny: []string{missingTag}}, want: 1},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				allPages, err := listeners.List(lbClient, test.opts).AllPages(context.TODO())
+				th.AssertNoErr(t, err)
+				allListeners, err := listeners.ExtractListeners(allPages)
+				th.AssertNoErr(t, err)
+				th.AssertEquals(t, test.want, len(allListeners))
+				if test.want > 0 {
+					th.AssertEquals(t, listener.ID, allListeners[0].ID)
+				}
+			})
+		}
+	})
+
+	t.Run("pools", func(t *testing.T) {
+		tests := []struct {
+			name string
+			opts pools.ListOpts
+			want int
+		}{
+			{name: "tags-match", opts: pools.ListOpts{LoadbalancerID: lb.ID, Tags: tags}, want: 1},
+			{name: "tags-no-match", opts: pools.ListOpts{LoadbalancerID: lb.ID, Tags: []string{tags[0], missingTag}}, want: 0},
+			{name: "tags-any-match", opts: pools.ListOpts{LoadbalancerID: lb.ID, TagsAny: []string{tags[0], missingTag}}, want: 1},
+			{name: "tags-any-no-match", opts: pools.ListOpts{LoadbalancerID: lb.ID, TagsAny: []string{missingTag}}, want: 0},
+			{name: "not-tags-excluded", opts: pools.ListOpts{LoadbalancerID: lb.ID, TagsNot: tags}, want: 0},
+			{name: "not-tags-included", opts: pools.ListOpts{LoadbalancerID: lb.ID, TagsNot: []string{tags[0], missingTag}}, want: 1},
+			{name: "not-tags-any-excluded", opts: pools.ListOpts{LoadbalancerID: lb.ID, TagsNotAny: []string{tags[0], missingTag}}, want: 0},
+			{name: "not-tags-any-included", opts: pools.ListOpts{LoadbalancerID: lb.ID, TagsNotAny: []string{missingTag}}, want: 1},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				allPages, err := pools.List(lbClient, test.opts).AllPages(context.TODO())
+				th.AssertNoErr(t, err)
+				allPools, err := pools.ExtractPools(allPages)
+				th.AssertNoErr(t, err)
+				th.AssertEquals(t, test.want, len(allPools))
+				if test.want > 0 {
+					th.AssertEquals(t, pool.ID, allPools[0].ID)
+				}
+			})
+		}
+	})
+
+	t.Run("members", func(t *testing.T) {
+		tests := []struct {
+			name string
+			opts pools.ListMembersOpts
+			want int
+		}{
+			{name: "tags-match", opts: pools.ListMembersOpts{Tags: tags}, want: 1},
+			{name: "tags-no-match", opts: pools.ListMembersOpts{Tags: []string{tags[0], missingTag}}, want: 0},
+			{name: "tags-any-match", opts: pools.ListMembersOpts{TagsAny: []string{tags[0], missingTag}}, want: 1},
+			{name: "tags-any-no-match", opts: pools.ListMembersOpts{TagsAny: []string{missingTag}}, want: 0},
+			{name: "not-tags-excluded", opts: pools.ListMembersOpts{TagsNot: tags}, want: 0},
+			{name: "not-tags-included", opts: pools.ListMembersOpts{TagsNot: []string{tags[0], missingTag}}, want: 1},
+			{name: "not-tags-any-excluded", opts: pools.ListMembersOpts{TagsNotAny: []string{tags[0], missingTag}}, want: 0},
+			{name: "not-tags-any-included", opts: pools.ListMembersOpts{TagsNotAny: []string{missingTag}}, want: 1},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				allPages, err := pools.ListMembers(lbClient, pool.ID, test.opts).AllPages(context.TODO())
+				th.AssertNoErr(t, err)
+				allMembers, err := pools.ExtractMembers(allPages)
+				th.AssertNoErr(t, err)
+				th.AssertEquals(t, test.want, len(allMembers))
+				if test.want > 0 {
+					th.AssertEquals(t, member.ID, allMembers[0].ID)
+				}
+			})
+		}
+	})
+
+	t.Run("health monitors", func(t *testing.T) {
+		tests := []struct {
+			name string
+			opts monitors.ListOpts
+			want int
+		}{
+			{name: "tags-match", opts: monitors.ListOpts{PoolID: pool.ID, Tags: tags}, want: 1},
+			{name: "tags-no-match", opts: monitors.ListOpts{PoolID: pool.ID, Tags: []string{tags[0], missingTag}}, want: 0},
+			{name: "tags-any-match", opts: monitors.ListOpts{PoolID: pool.ID, TagsAny: []string{tags[0], missingTag}}, want: 1},
+			{name: "tags-any-no-match", opts: monitors.ListOpts{PoolID: pool.ID, TagsAny: []string{missingTag}}, want: 0},
+			{name: "not-tags-excluded", opts: monitors.ListOpts{PoolID: pool.ID, TagsNot: tags}, want: 0},
+			{name: "not-tags-included", opts: monitors.ListOpts{PoolID: pool.ID, TagsNot: []string{tags[0], missingTag}}, want: 1},
+			{name: "not-tags-any-excluded", opts: monitors.ListOpts{PoolID: pool.ID, TagsNotAny: []string{tags[0], missingTag}}, want: 0},
+			{name: "not-tags-any-included", opts: monitors.ListOpts{PoolID: pool.ID, TagsNotAny: []string{missingTag}}, want: 1},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				allPages, err := monitors.List(lbClient, test.opts).AllPages(context.TODO())
+				th.AssertNoErr(t, err)
+				allMonitors, err := monitors.ExtractMonitors(allPages)
+				th.AssertNoErr(t, err)
+				th.AssertEquals(t, test.want, len(allMonitors))
+				if test.want > 0 {
+					th.AssertEquals(t, monitor.ID, allMonitors[0].ID)
+				}
+			})
+		}
+	})
+}

--- a/openstack/loadbalancer/v2/l7policies/requests.go
+++ b/openstack/loadbalancer/v2/l7policies/requests.go
@@ -133,6 +133,22 @@ type ListOpts struct {
 	Marker         string `q:"marker"`
 	SortKey        string `q:"sort_key"`
 	SortDir        string `q:"sort_dir"`
+
+	// Tags filters L7 policies that contain all of the given tags.
+	// Requires Octavia API version 2.5 or later.
+	Tags []string `q:"tags"`
+
+	// TagsAny filters L7 policies that contain at least one of the given tags.
+	// Requires Octavia API version 2.5 or later.
+	TagsAny []string `q:"tags-any"`
+
+	// TagsNot excludes L7 policies that contain all of the given tags.
+	// Requires Octavia API version 2.5 or later.
+	TagsNot []string `q:"not-tags"`
+
+	// TagsNotAny excludes L7 policies that contain any of the given tags.
+	// Requires Octavia API version 2.5 or later.
+	TagsNotAny []string `q:"not-tags-any"`
 }
 
 // ToL7PolicyListQuery formats a ListOpts into a query string.
@@ -338,6 +354,22 @@ type ListRulesOpts struct {
 	Marker       string      `q:"marker"`
 	SortKey      string      `q:"sort_key"`
 	SortDir      string      `q:"sort_dir"`
+
+	// Tags filters L7 rules that contain all of the given tags.
+	// Requires Octavia API version 2.5 or later.
+	Tags []string `q:"tags"`
+
+	// TagsAny filters L7 rules that contain at least one of the given tags.
+	// Requires Octavia API version 2.5 or later.
+	TagsAny []string `q:"tags-any"`
+
+	// TagsNot excludes L7 rules that contain all of the given tags.
+	// Requires Octavia API version 2.5 or later.
+	TagsNot []string `q:"not-tags"`
+
+	// TagsNotAny excludes L7 rules that contain any of the given tags.
+	// Requires Octavia API version 2.5 or later.
+	TagsNotAny []string `q:"not-tags-any"`
 }
 
 // ToRulesListQuery formats a ListOpts into a query string.

--- a/openstack/loadbalancer/v2/l7policies/testing/requests_test.go
+++ b/openstack/loadbalancer/v2/l7policies/testing/requests_test.go
@@ -76,6 +76,20 @@ func TestListL7Policies(t *testing.T) {
 	}
 }
 
+func TestListL7PolicyOpts(t *testing.T) {
+	listOpts := l7policies.ListOpts{
+		Tags:       []string{"tag1", "tag2"},
+		TagsAny:    []string{"tag3", "tag4"},
+		TagsNot:    []string{"tag5", "tag6"},
+		TagsNotAny: []string{"tag7", "tag8"},
+	}
+
+	expected := "?not-tags=tag5&not-tags=tag6&not-tags-any=tag7&not-tags-any=tag8&tags=tag1&tags=tag2&tags-any=tag3&tags-any=tag4"
+	actual, err := listOpts.ToL7PolicyListQuery()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, expected, actual)
+}
+
 func TestListAllL7Policies(t *testing.T) {
 	fakeServer := th.SetupHTTP()
 	defer fakeServer.Teardown()
@@ -240,6 +254,20 @@ func TestListRules(t *testing.T) {
 	if pages != 1 {
 		t.Errorf("Expected 1 page, saw %d", pages)
 	}
+}
+
+func TestListRulesOpts(t *testing.T) {
+	listOpts := l7policies.ListRulesOpts{
+		Tags:       []string{"tag1", "tag2"},
+		TagsAny:    []string{"tag3", "tag4"},
+		TagsNot:    []string{"tag5", "tag6"},
+		TagsNotAny: []string{"tag7", "tag8"},
+	}
+
+	expected := "?not-tags=tag5&not-tags=tag6&not-tags-any=tag7&not-tags-any=tag8&tags=tag1&tags=tag2&tags-any=tag3&tags-any=tag4"
+	actual, err := listOpts.ToRulesListQuery()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, expected, actual)
 }
 
 func TestListAllRules(t *testing.T) {

--- a/openstack/loadbalancer/v2/listeners/requests.go
+++ b/openstack/loadbalancer/v2/listeners/requests.go
@@ -58,24 +58,39 @@ type ListOptsBuilder interface {
 // sort by a particular listener attribute. SortDir sets the direction, and is
 // either `asc' or `desc'. Marker and Limit are used for pagination.
 type ListOpts struct {
-	ID                   string   `q:"id"`
-	Name                 string   `q:"name"`
-	AdminStateUp         *bool    `q:"admin_state_up"`
-	ProjectID            string   `q:"project_id"`
-	LoadbalancerID       string   `q:"loadbalancer_id"`
-	DefaultPoolID        string   `q:"default_pool_id"`
-	Protocol             string   `q:"protocol"`
-	ProtocolPort         int      `q:"protocol_port"`
-	ConnectionLimit      int      `q:"connection_limit"`
-	Limit                int      `q:"limit"`
-	Marker               string   `q:"marker"`
-	SortKey              string   `q:"sort_key"`
-	SortDir              string   `q:"sort_dir"`
-	TimeoutClientData    *int     `q:"timeout_client_data"`
-	TimeoutMemberData    *int     `q:"timeout_member_data"`
-	TimeoutMemberConnect *int     `q:"timeout_member_connect"`
-	TimeoutTCPInspect    *int     `q:"timeout_tcp_inspect"`
-	Tags                 []string `q:"tags"`
+	ID                   string `q:"id"`
+	Name                 string `q:"name"`
+	AdminStateUp         *bool  `q:"admin_state_up"`
+	ProjectID            string `q:"project_id"`
+	LoadbalancerID       string `q:"loadbalancer_id"`
+	DefaultPoolID        string `q:"default_pool_id"`
+	Protocol             string `q:"protocol"`
+	ProtocolPort         int    `q:"protocol_port"`
+	ConnectionLimit      int    `q:"connection_limit"`
+	Limit                int    `q:"limit"`
+	Marker               string `q:"marker"`
+	SortKey              string `q:"sort_key"`
+	SortDir              string `q:"sort_dir"`
+	TimeoutClientData    *int   `q:"timeout_client_data"`
+	TimeoutMemberData    *int   `q:"timeout_member_data"`
+	TimeoutMemberConnect *int   `q:"timeout_member_connect"`
+	TimeoutTCPInspect    *int   `q:"timeout_tcp_inspect"`
+
+	// Tags filters listeners that contain all of the given tags.
+	// Requires Octavia API version 2.5 or later.
+	Tags []string `q:"tags"`
+
+	// TagsAny filters listeners that contain at least one of the given tags.
+	// Requires Octavia API version 2.5 or later.
+	TagsAny []string `q:"tags-any"`
+
+	// TagsNot excludes listeners that contain all of the given tags.
+	// Requires Octavia API version 2.5 or later.
+	TagsNot []string `q:"not-tags"`
+
+	// TagsNotAny excludes listeners that contain any of the given tags.
+	// Requires Octavia API version 2.5 or later.
+	TagsNotAny []string `q:"not-tags-any"`
 }
 
 // ToListenerListQuery formats a ListOpts into a query string.

--- a/openstack/loadbalancer/v2/listeners/testing/requests_test.go
+++ b/openstack/loadbalancer/v2/listeners/testing/requests_test.go
@@ -54,6 +54,20 @@ func TestListAllListeners(t *testing.T) {
 	th.CheckDeepEquals(t, ListenerDb, actual[1])
 }
 
+func TestListListenerOpts(t *testing.T) {
+	listOpts := listeners.ListOpts{
+		Tags:       []string{"tag1", "tag2"},
+		TagsAny:    []string{"tag3", "tag4"},
+		TagsNot:    []string{"tag5", "tag6"},
+		TagsNotAny: []string{"tag7", "tag8"},
+	}
+
+	expected := "?not-tags=tag5&not-tags=tag6&not-tags-any=tag7&not-tags-any=tag8&tags=tag1&tags=tag2&tags-any=tag3&tags-any=tag4"
+	actual, err := listOpts.ToListenerListQuery()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, expected, actual)
+}
+
 func TestCreateListener(t *testing.T) {
 	fakeServer := th.SetupHTTP()
 	defer fakeServer.Teardown()

--- a/openstack/loadbalancer/v2/monitors/requests.go
+++ b/openstack/loadbalancer/v2/monitors/requests.go
@@ -20,26 +20,41 @@ type ListOptsBuilder interface {
 // sort by a particular Monitor attribute. SortDir sets the direction, and is
 // either `asc' or `desc'. Marker and Limit are used for pagination.
 type ListOpts struct {
-	ID             string   `q:"id"`
-	Name           string   `q:"name"`
-	TenantID       string   `q:"tenant_id"`
-	ProjectID      string   `q:"project_id"`
-	PoolID         string   `q:"pool_id"`
-	Type           string   `q:"type"`
-	Delay          int      `q:"delay"`
-	Timeout        int      `q:"timeout"`
-	MaxRetries     int      `q:"max_retries"`
-	MaxRetriesDown int      `q:"max_retries_down"`
-	HTTPMethod     string   `q:"http_method"`
-	URLPath        string   `q:"url_path"`
-	ExpectedCodes  string   `q:"expected_codes"`
-	AdminStateUp   *bool    `q:"admin_state_up"`
-	Status         string   `q:"status"`
-	Limit          int      `q:"limit"`
-	Marker         string   `q:"marker"`
-	SortKey        string   `q:"sort_key"`
-	SortDir        string   `q:"sort_dir"`
-	Tags           []string `q:"tags"`
+	ID             string `q:"id"`
+	Name           string `q:"name"`
+	TenantID       string `q:"tenant_id"`
+	ProjectID      string `q:"project_id"`
+	PoolID         string `q:"pool_id"`
+	Type           string `q:"type"`
+	Delay          int    `q:"delay"`
+	Timeout        int    `q:"timeout"`
+	MaxRetries     int    `q:"max_retries"`
+	MaxRetriesDown int    `q:"max_retries_down"`
+	HTTPMethod     string `q:"http_method"`
+	URLPath        string `q:"url_path"`
+	ExpectedCodes  string `q:"expected_codes"`
+	AdminStateUp   *bool  `q:"admin_state_up"`
+	Status         string `q:"status"`
+	Limit          int    `q:"limit"`
+	Marker         string `q:"marker"`
+	SortKey        string `q:"sort_key"`
+	SortDir        string `q:"sort_dir"`
+
+	// Tags filters health monitors that contain all of the given tags.
+	// Requires Octavia API version 2.5 or later.
+	Tags []string `q:"tags"`
+
+	// TagsAny filters health monitors that contain at least one of the given tags.
+	// Requires Octavia API version 2.5 or later.
+	TagsAny []string `q:"tags-any"`
+
+	// TagsNot excludes health monitors that contain all of the given tags.
+	// Requires Octavia API version 2.5 or later.
+	TagsNot []string `q:"not-tags"`
+
+	// TagsNotAny excludes health monitors that contain any of the given tags.
+	// Requires Octavia API version 2.5 or later.
+	TagsNotAny []string `q:"not-tags-any"`
 }
 
 // ToMonitorListQuery formats a ListOpts into a query string.

--- a/openstack/loadbalancer/v2/monitors/testing/requests_test.go
+++ b/openstack/loadbalancer/v2/monitors/testing/requests_test.go
@@ -53,6 +53,20 @@ func TestListAllHealthmonitors(t *testing.T) {
 	th.CheckDeepEquals(t, HealthmonitorDb, actual[1])
 }
 
+func TestListHealthmonitorOpts(t *testing.T) {
+	listOpts := monitors.ListOpts{
+		Tags:       []string{"tag1", "tag2"},
+		TagsAny:    []string{"tag3", "tag4"},
+		TagsNot:    []string{"tag5", "tag6"},
+		TagsNotAny: []string{"tag7", "tag8"},
+	}
+
+	expected := "?not-tags=tag5&not-tags=tag6&not-tags-any=tag7&not-tags-any=tag8&tags=tag1&tags=tag2&tags-any=tag3&tags-any=tag4"
+	actual, err := listOpts.ToMonitorListQuery()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, expected, actual)
+}
+
 func TestCreateHealthmonitor(t *testing.T) {
 	fakeServer := th.SetupHTTP()
 	defer fakeServer.Teardown()

--- a/openstack/loadbalancer/v2/pools/requests.go
+++ b/openstack/loadbalancer/v2/pools/requests.go
@@ -31,18 +31,33 @@ type ListOptsBuilder interface {
 // sort by a particular Pool attribute. SortDir sets the direction, and is
 // either `asc' or `desc'. Marker and Limit are used for pagination.
 type ListOpts struct {
-	LBMethod       string   `q:"lb_algorithm"`
-	Protocol       string   `q:"protocol"`
-	ProjectID      string   `q:"project_id"`
-	AdminStateUp   *bool    `q:"admin_state_up"`
-	Name           string   `q:"name"`
-	ID             string   `q:"id"`
-	LoadbalancerID string   `q:"loadbalancer_id"`
-	Limit          int      `q:"limit"`
-	Marker         string   `q:"marker"`
-	SortKey        string   `q:"sort_key"`
-	SortDir        string   `q:"sort_dir"`
-	Tags           []string `q:"tags"`
+	LBMethod       string `q:"lb_algorithm"`
+	Protocol       string `q:"protocol"`
+	ProjectID      string `q:"project_id"`
+	AdminStateUp   *bool  `q:"admin_state_up"`
+	Name           string `q:"name"`
+	ID             string `q:"id"`
+	LoadbalancerID string `q:"loadbalancer_id"`
+	Limit          int    `q:"limit"`
+	Marker         string `q:"marker"`
+	SortKey        string `q:"sort_key"`
+	SortDir        string `q:"sort_dir"`
+
+	// Tags filters pools that contain all of the given tags.
+	// Requires Octavia API version 2.5 or later.
+	Tags []string `q:"tags"`
+
+	// TagsAny filters pools that contain at least one of the given tags.
+	// Requires Octavia API version 2.5 or later.
+	TagsAny []string `q:"tags-any"`
+
+	// TagsNot excludes pools that contain all of the given tags.
+	// Requires Octavia API version 2.5 or later.
+	TagsNot []string `q:"not-tags"`
+
+	// TagsNotAny excludes pools that contain any of the given tags.
+	// Requires Octavia API version 2.5 or later.
+	TagsNotAny []string `q:"not-tags-any"`
 }
 
 // ToPoolListQuery formats a ListOpts into a query string.
@@ -344,6 +359,22 @@ type ListMembersOpts struct {
 	Marker       string `q:"marker"`
 	SortKey      string `q:"sort_key"`
 	SortDir      string `q:"sort_dir"`
+
+	// Tags filters members that contain all of the given tags.
+	// Requires Octavia API version 2.5 or later.
+	Tags []string `q:"tags"`
+
+	// TagsAny filters members that contain at least one of the given tags.
+	// Requires Octavia API version 2.5 or later.
+	TagsAny []string `q:"tags-any"`
+
+	// TagsNot excludes members that contain all of the given tags.
+	// Requires Octavia API version 2.5 or later.
+	TagsNot []string `q:"not-tags"`
+
+	// TagsNotAny excludes members that contain any of the given tags.
+	// Requires Octavia API version 2.5 or later.
+	TagsNotAny []string `q:"not-tags-any"`
 }
 
 // ToMemberListQuery formats a ListOpts into a query string.

--- a/openstack/loadbalancer/v2/pools/testing/requests_test.go
+++ b/openstack/loadbalancer/v2/pools/testing/requests_test.go
@@ -53,6 +53,20 @@ func TestListAllPools(t *testing.T) {
 	th.CheckDeepEquals(t, PoolDb, actual[1])
 }
 
+func TestListPoolOpts(t *testing.T) {
+	listOpts := pools.ListOpts{
+		Tags:       []string{"tag1", "tag2"},
+		TagsAny:    []string{"tag3", "tag4"},
+		TagsNot:    []string{"tag5", "tag6"},
+		TagsNotAny: []string{"tag7", "tag8"},
+	}
+
+	expected := "?not-tags=tag5&not-tags=tag6&not-tags-any=tag7&not-tags-any=tag8&tags=tag1&tags=tag2&tags-any=tag3&tags-any=tag4"
+	actual, err := listOpts.ToPoolListQuery()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, expected, actual)
+}
+
 func TestCreatePool(t *testing.T) {
 	fakeServer := th.SetupHTTP()
 	defer fakeServer.Teardown()
@@ -187,6 +201,20 @@ func TestListAllMembers(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.CheckDeepEquals(t, MemberWeb, actual[0])
 	th.CheckDeepEquals(t, MemberDb, actual[1])
+}
+
+func TestListMembersOpts(t *testing.T) {
+	listOpts := pools.ListMembersOpts{
+		Tags:       []string{"tag1", "tag2"},
+		TagsAny:    []string{"tag3", "tag4"},
+		TagsNot:    []string{"tag5", "tag6"},
+		TagsNotAny: []string{"tag7", "tag8"},
+	}
+
+	expected := "?not-tags=tag5&not-tags=tag6&not-tags-any=tag7&not-tags-any=tag8&tags=tag1&tags=tag2&tags-any=tag3&tags-any=tag4"
+	actual, err := listOpts.ToMembersListQuery()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, expected, actual)
 }
 
 func TestCreateMember(t *testing.T) {

--- a/testhelper/convenience.go
+++ b/testhelper/convenience.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"sort"
 	"strings"
 	"testing"
 )
@@ -318,6 +319,20 @@ func AssertDeepEquals(t *testing.T, expected, actual any) {
 	if differed {
 		logFatal(t, "The structures were different.")
 	}
+}
+
+// AssertTagsEqual compares two slices of tags without regard to order.
+// If they are not equal, a fatal error is raised.
+func AssertTagsEqual(t *testing.T, expected, actual []string) {
+	t.Helper()
+
+	expected = append([]string(nil), expected...)
+	actual = append([]string(nil), actual...)
+
+	sort.Strings(expected)
+	sort.Strings(actual)
+
+	AssertDeepEquals(t, expected, actual)
 }
 
 // CheckDeepEquals is similar to AssertDeepEquals, except with a non-fatal error

--- a/testhelper/convenience_test.go
+++ b/testhelper/convenience_test.go
@@ -1,0 +1,20 @@
+package testhelper
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestAssertTagsEqual(t *testing.T) {
+	expected := []string{"tag1", "tag2"}
+	actual := []string{"tag2", "tag1"}
+
+	AssertTagsEqual(t, expected, actual)
+
+	if !reflect.DeepEqual(expected, []string{"tag1", "tag2"}) {
+		t.Fatalf("expected slice was modified: %v", expected)
+	}
+	if !reflect.DeepEqual(actual, []string{"tag2", "tag1"}) {
+		t.Fatalf("actual slice was modified: %v", actual)
+	}
+}


### PR DESCRIPTION
Manual backport of https://github.com/gophercloud/gophercloud/pull/3957 and https://github.com/gophercloud/gophercloud/pull/3914

The apidiff returned

```
    Incompatible changes:
    - ListOpts: old is comparable, new is not
    - ListRulesOpts: old is comparable, new is not
```

but this might be safe to backport