### PR TITLE
Add support for default security group rules

### DIFF
--- a/internal/acceptance/openstack/networking/v2/extensions/security_default_rules_test.go
+++ b/internal/acceptance/openstack/networking/v2/extensions/security_default_rules_test.go
@@ -1,0 +1,83 @@
+//go:build acceptance || networking || security
+
+package extensions
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/v2/internal/acceptance/clients"
+	networking "github.com/gophercloud/gophercloud/v2/internal/acceptance/openstack/networking/v2"
+	"github.com/gophercloud/gophercloud/v2/internal/acceptance/tools"
+	"github.com/gophercloud/gophercloud/v2/internal/ptr"
+	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/security/defaultrules"
+	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/security/rules"
+	th "github.com/gophercloud/gophercloud/v2/testhelper"
+)
+
+func TestDefaultSecurityGroupRulesCreateGetListDelete(t *testing.T) {
+	clients.RequireAdmin(t)
+
+	client, err := clients.NewNetworkV2Client()
+	th.AssertNoErr(t, err)
+
+	networking.RequireNeutronExtension(t, client, "security-groups-default-rules")
+
+	description := "Default rule description"
+	fromPort := tools.RandomInt(10080, 10089)
+	toPort := tools.RandomInt(10090, 10099)
+
+	createOpts := defaultrules.CreateOpts{
+		Description:        description,
+		Direction:          rules.DirIngress,
+		EtherType:          rules.EtherType4,
+		PortRangeMin:       ptr.To(fromPort),
+		PortRangeMax:       ptr.To(toPort),
+		Protocol:           rules.ProtocolTCP,
+		RemoteGroupID:      "PARENT",
+		UsedInDefaultSG:    ptr.To(true),
+		UsedInNonDefaultSG: ptr.To(false),
+	}
+
+	rule, err := defaultrules.Create(context.TODO(), client, createOpts).Extract()
+	th.AssertNoErr(t, err)
+	defer func() {
+		err := defaultrules.Delete(context.TODO(), client, rule.ID).ExtractErr()
+		th.AssertNoErr(t, err)
+	}()
+
+	tools.PrintResource(t, rule)
+
+	th.AssertEquals(t, description, rule.Description)
+	th.AssertEquals(t, "ingress", rule.Direction)
+	th.AssertEquals(t, "IPv4", rule.EtherType)
+	th.AssertEquals(t, fromPort, rule.PortRangeMin)
+	th.AssertEquals(t, toPort, rule.PortRangeMax)
+	th.AssertEquals(t, string(rules.ProtocolTCP), rule.Protocol)
+	th.AssertEquals(t, "PARENT", rule.RemoteGroupID)
+	th.AssertEquals(t, true, rule.UsedInDefaultSG)
+	th.AssertEquals(t, false, rule.UsedInNonDefaultSG)
+
+	getRule, err := defaultrules.Get(context.TODO(), client, rule.ID).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, rule.ID, getRule.ID)
+	th.AssertEquals(t, description, getRule.Description)
+
+	listOpts := defaultrules.ListOpts{
+		Protocol: string(rules.ProtocolTCP),
+	}
+	allPages, err := defaultrules.List(client, listOpts).AllPages(context.TODO())
+	th.AssertNoErr(t, err)
+
+	allDefaultRules, err := defaultrules.ExtractDefaultRules(allPages)
+	th.AssertNoErr(t, err)
+
+	var found bool
+	for _, r := range allDefaultRules {
+		if r.ID == rule.ID {
+			found = true
+			break
+		}
+	}
+	th.AssertTrue(t, found)
+}

--- a/openstack/networking/v2/extensions/security/defaultrules/doc.go
+++ b/openstack/networking/v2/extensions/security/defaultrules/doc.go
@@ -1,0 +1,51 @@
+/*
+Package defaultrules provides information and interaction with Security Group
+Default Rules for the OpenStack Networking service. These rules are templates
+used by Neutron to populate the rules of newly created security groups; they
+require the "security-groups-default-rules" API extension.
+
+Example to List Default Security Group Rules
+
+	listOpts := defaultrules.ListOpts{
+		Protocol: "tcp",
+	}
+
+	allPages, err := defaultrules.List(networkClient, listOpts).AllPages(context.TODO())
+	if err != nil {
+		panic(err)
+	}
+
+	allDefaultRules, err := defaultrules.ExtractDefaultRules(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, rule := range allDefaultRules {
+		fmt.Printf("%+v\n", rule)
+	}
+
+Example to Create a Default Security Group Rule
+
+	createOpts := defaultrules.CreateOpts{
+		Direction:     rules.DirIngress,
+		EtherType:     rules.EtherType4,
+		Protocol:      rules.ProtocolTCP,
+		PortRangeMin:  gophercloud.IntToPointer(443),
+		PortRangeMax:  gophercloud.IntToPointer(443),
+		RemoteGroupID: "PARENT",
+	}
+
+	rule, err := defaultrules.Create(context.TODO(), networkClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete a Default Security Group Rule
+
+	ruleID := "37d94f8a-d136-465c-ae46-144f0d8ef141"
+	err := defaultrules.Delete(context.TODO(), networkClient, ruleID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+*/
+package defaultrules

--- a/openstack/networking/v2/extensions/security/defaultrules/requests.go
+++ b/openstack/networking/v2/extensions/security/defaultrules/requests.go
@@ -1,0 +1,164 @@
+package defaultrules
+
+import (
+	"context"
+
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/security/rules"
+	"github.com/gophercloud/gophercloud/v2/pagination"
+)
+
+// ListOptsBuilder allows extensions to add additional parameters to the List
+// request.
+type ListOptsBuilder interface {
+	ToDefaultSecGroupRuleListQuery() (string, error)
+}
+
+// ListOpts allows the filtering and sorting of paginated collections through
+// the API. Filtering is achieved by passing in struct field values that map to
+// the default security group rule attributes you want to see returned. SortKey
+// allows you to sort by a particular network attribute. SortDir sets the
+// direction, and is either `asc' or `desc'. Marker and Limit are used for
+// pagination.
+type ListOpts struct {
+	ID                   string `q:"id"`
+	Description          string `q:"description"`
+	Direction            string `q:"direction"`
+	EtherType            string `q:"ethertype"`
+	PortRangeMax         int    `q:"port_range_max"`
+	PortRangeMin         int    `q:"port_range_min"`
+	Protocol             string `q:"protocol"`
+	RemoteAddressGroupID string `q:"remote_address_group_id"`
+	RemoteGroupID        string `q:"remote_group_id"`
+	RemoteIPPrefix       string `q:"remote_ip_prefix"`
+	UsedInDefaultSG      *bool  `q:"used_in_default_sg"`
+	UsedInNonDefaultSG   *bool  `q:"used_in_non_default_sg"`
+	Limit                int    `q:"limit"`
+	Marker               string `q:"marker"`
+	SortKey              string `q:"sort_key"`
+	SortDir              string `q:"sort_dir"`
+}
+
+// ToDefaultSecGroupRuleListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToDefaultSecGroupRuleListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(&opts)
+	if err != nil {
+		return "", err
+	}
+	return q.String(), nil
+}
+
+// List returns a Pager which allows you to iterate over a collection of
+// default security group rules. It accepts a ListOpts struct, which allows you
+// to filter and sort the returned collection for greater efficiency.
+func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := rootURL(c)
+	if opts != nil {
+		query, err := opts.ToDefaultSecGroupRuleListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		return DefaultSecGroupRulePage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToDefaultSecGroupRuleCreateMap() (map[string]any, error)
+}
+
+// CreateOpts contains all the values needed to create a new default security
+// group rule. Rules created through this API are templates used by Neutron to
+// populate the rules of newly created security groups; they are not applied to
+// any existing security group.
+type CreateOpts struct {
+	// Must be either "ingress" or "egress": the direction in which the
+	// security group rule will be applied.
+	Direction rules.RuleDirection `json:"direction" required:"true"`
+
+	// String description of each rule, optional.
+	Description string `json:"description,omitempty"`
+
+	// Must be "IPv4" or "IPv6". Defaults to "IPv4" when not set.
+	EtherType rules.RuleEtherType `json:"ethertype,omitempty"`
+
+	// The maximum port number in the range that will be matched by the
+	// security group rule. The PortRangeMin attribute constrains the
+	// PortRangeMax attribute. If the protocol is ICMP, this value must be an
+	// ICMP code.
+	PortRangeMax *int `json:"port_range_max,omitempty"`
+
+	// The minimum port number in the range that will be matched by the
+	// security group rule. If the protocol is TCP or UDP, this value must be
+	// less than or equal to the value of the PortRangeMax attribute. If the
+	// protocol is ICMP, this value must be an ICMP type.
+	PortRangeMin *int `json:"port_range_min,omitempty"`
+
+	// The protocol that will be matched by the security group rule. Valid
+	// values are "tcp", "udp", "icmp" or an empty string.
+	Protocol rules.RuleProtocol `json:"protocol,omitempty"`
+
+	// The remote address group ID to be associated with this security group
+	// rule. You can specify either RemoteAddressGroupID, RemoteGroupID, or
+	// RemoteIPPrefix.
+	RemoteAddressGroupID string `json:"remote_address_group_id,omitempty"`
+
+	// The remote group ID to be associated with this security group rule. You
+	// can specify either RemoteAddressGroupID, RemoteGroupID or
+	// RemoteIPPrefix. The special value "PARENT" can be used to reference the
+	// security group the rule will belong to once created from this template.
+	RemoteGroupID string `json:"remote_group_id,omitempty"`
+
+	// The remote IP prefix to be associated with this security group rule.
+	// You can specify either RemoteAddressGroupID, RemoteGroupID or
+	// RemoteIPPrefix. This attribute matches the specified IP prefix as the
+	// source IP address of the IP packet.
+	RemoteIPPrefix string `json:"remote_ip_prefix,omitempty"`
+
+	// Whether this rule template should be used in the default security group
+	// created automatically for each new project. Defaults to false.
+	UsedInDefaultSG *bool `json:"used_in_default_sg,omitempty"`
+
+	// Whether this rule template should be used in security groups created by
+	// users, other than the project default security group. Defaults to true.
+	UsedInNonDefaultSG *bool `json:"used_in_non_default_sg,omitempty"`
+}
+
+// ToDefaultSecGroupRuleCreateMap builds a request body from CreateOpts.
+func (opts CreateOpts) ToDefaultSecGroupRuleCreateMap() (map[string]any, error) {
+	return gophercloud.BuildRequestBody(opts, "default_security_group_rule")
+}
+
+// Create is an operation which adds a new default security group rule
+// template that will be used by Neutron when creating the rules of new
+// security groups.
+func Create(ctx context.Context, c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToDefaultSecGroupRuleCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := c.Post(ctx, rootURL(c), b, &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// Get retrieves a particular default security group rule based on its unique
+// ID.
+func Get(ctx context.Context, c *gophercloud.ServiceClient, id string) (r GetResult) {
+	resp, err := c.Get(ctx, resourceURL(c, id), &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// Delete will permanently delete a particular default security group rule
+// based on its unique ID. Existing security groups are not affected.
+func Delete(ctx context.Context, c *gophercloud.ServiceClient, id string) (r DeleteResult) {
+	resp, err := c.Delete(ctx, resourceURL(c, id), nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}

--- a/openstack/networking/v2/extensions/security/defaultrules/results.go
+++ b/openstack/networking/v2/extensions/security/defaultrules/results.go
@@ -1,0 +1,186 @@
+package defaultrules
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/pagination"
+)
+
+// DefaultSecGroupRule represents a rule template used by Neutron to populate
+// the rules of newly created security groups.
+type DefaultSecGroupRule struct {
+	// The UUID for this default security group rule.
+	ID string
+
+	// The direction in which the security group rule will be applied. The
+	// only values allowed are "ingress" or "egress".
+	Direction string
+
+	// Description of the rule
+	Description string `json:"description"`
+
+	// Must be IPv4 or IPv6, and addresses represented in CIDR must match the
+	// ingress or egress rules.
+	EtherType string `json:"ethertype"`
+
+	// The minimum port number in the range that will be matched by the
+	// security group rule. If the protocol is TCP or UDP, this value must be
+	// less than or equal to the value of the PortRangeMax attribute. If the
+	// protocol is ICMP, this value must be an ICMP type.
+	PortRangeMin int `json:"port_range_min"`
+
+	// The maximum port number in the range that will be matched by the
+	// security group rule. The PortRangeMin attribute constrains the
+	// PortRangeMax attribute. If the protocol is ICMP, this value must be an
+	// ICMP code.
+	PortRangeMax int `json:"port_range_max"`
+
+	// The protocol that will be matched by the security group rule. Valid
+	// values are "tcp", "udp", "icmp" or an empty string.
+	Protocol string
+
+	// The remote address group ID to be associated with this security group
+	// rule.
+	RemoteAddressGroupID string `json:"remote_address_group_id"`
+
+	// The remote group ID to be associated with this security group rule. The
+	// special value "PARENT" references the security group the rule will
+	// belong to once created from this template.
+	RemoteGroupID string `json:"remote_group_id"`
+
+	// The remote IP prefix to be associated with this security group rule.
+	// This attribute matches the specified IP prefix as the source IP address
+	// of the IP packet.
+	RemoteIPPrefix string `json:"remote_ip_prefix"`
+
+	// Whether this rule template is used in the default security group
+	// created automatically for each new project.
+	UsedInDefaultSG bool `json:"used_in_default_sg"`
+
+	// Whether this rule template is used in security groups created by users,
+	// other than the project default security group.
+	UsedInNonDefaultSG bool `json:"used_in_non_default_sg"`
+
+	// RevisionNumber optionally set via extensions/standard-attr-revisions
+	RevisionNumber int `json:"revision_number"`
+
+	// Timestamp when the rule was created
+	CreatedAt time.Time `json:"-"`
+
+	// Timestamp when the rule was last updated
+	UpdatedAt time.Time `json:"-"`
+}
+
+func (r *DefaultSecGroupRule) UnmarshalJSON(b []byte) error {
+	type tmp DefaultSecGroupRule
+
+	// Support for older neutron time format
+	var s1 struct {
+		tmp
+		CreatedAt gophercloud.JSONRFC3339NoZ `json:"created_at"`
+		UpdatedAt gophercloud.JSONRFC3339NoZ `json:"updated_at"`
+	}
+
+	err := json.Unmarshal(b, &s1)
+	if err == nil {
+		*r = DefaultSecGroupRule(s1.tmp)
+		r.CreatedAt = time.Time(s1.CreatedAt)
+		r.UpdatedAt = time.Time(s1.UpdatedAt)
+
+		return nil
+	}
+
+	// Support for newer neutron time format
+	var s2 struct {
+		tmp
+		CreatedAt time.Time `json:"created_at"`
+		UpdatedAt time.Time `json:"updated_at"`
+	}
+
+	err = json.Unmarshal(b, &s2)
+	if err != nil {
+		return err
+	}
+
+	*r = DefaultSecGroupRule(s2.tmp)
+	r.CreatedAt = time.Time(s2.CreatedAt)
+	r.UpdatedAt = time.Time(s2.UpdatedAt)
+
+	return nil
+}
+
+// DefaultSecGroupRulePage is the page returned by a pager when traversing over
+// a collection of default security group rules.
+type DefaultSecGroupRulePage struct {
+	pagination.LinkedPageBase
+}
+
+// NextPageURL is invoked when a paginated collection of default security group
+// rules has reached the end of a page and the pager seeks to traverse over a
+// new one. In order to do this, it needs to construct the next page's URL.
+func (r DefaultSecGroupRulePage) NextPageURL(endpointURL string) (string, error) {
+	var s struct {
+		Links []gophercloud.Link `json:"default_security_group_rules_links"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return gophercloud.ExtractNextURL(s.Links)
+}
+
+// IsEmpty checks whether a DefaultSecGroupRulePage struct is empty.
+func (r DefaultSecGroupRulePage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
+	is, err := ExtractDefaultRules(r)
+	return len(is) == 0, err
+}
+
+// ExtractDefaultRules accepts a Page struct, specifically a
+// DefaultSecGroupRulePage struct, and extracts the elements into a slice of
+// DefaultSecGroupRule structs. In other words, a generic collection is mapped
+// into a relevant slice.
+func ExtractDefaultRules(r pagination.Page) ([]DefaultSecGroupRule, error) {
+	var s struct {
+		DefaultSecGroupRules []DefaultSecGroupRule `json:"default_security_group_rules"`
+	}
+	err := (r.(DefaultSecGroupRulePage)).ExtractInto(&s)
+	return s.DefaultSecGroupRules, err
+}
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// Extract is a function that accepts a result and extracts a default security
+// group rule.
+func (r commonResult) Extract() (*DefaultSecGroupRule, error) {
+	var s struct {
+		DefaultSecGroupRule *DefaultSecGroupRule `json:"default_security_group_rule"`
+	}
+	err := r.ExtractInto(&s)
+	return s.DefaultSecGroupRule, err
+}
+
+// CreateResult represents the result of a create operation. Call its Extract
+// method to interpret it as a DefaultSecGroupRule.
+type CreateResult struct {
+	commonResult
+}
+
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a DefaultSecGroupRule.
+type GetResult struct {
+	commonResult
+}
+
+// DeleteResult represents the result of a delete operation. Call its
+// ExtractErr method to determine if the request succeeded or failed.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}

--- a/openstack/networking/v2/extensions/security/defaultrules/testing/doc.go
+++ b/openstack/networking/v2/extensions/security/defaultrules/testing/doc.go
@@ -1,0 +1,2 @@
+// defaultrules unit tests
+package testing

--- a/openstack/networking/v2/extensions/security/defaultrules/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/security/defaultrules/testing/requests_test.go
@@ -1,0 +1,258 @@
+package testing
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gophercloud/gophercloud/v2/internal/ptr"
+	fake "github.com/gophercloud/gophercloud/v2/openstack/networking/v2/common"
+	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/security/defaultrules"
+	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/security/rules"
+	"github.com/gophercloud/gophercloud/v2/pagination"
+	th "github.com/gophercloud/gophercloud/v2/testhelper"
+)
+
+func TestList(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	fakeServer.Mux.HandleFunc("/v2.0/default-security-group-rules", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprint(w, `
+{
+    "default_security_group_rules": [
+        {
+            "description": "",
+            "direction": "egress",
+            "ethertype": "IPv6",
+            "id": "3c0e45ff-adaf-4124-b083-bf390e5482ff",
+            "port_range_max": null,
+            "port_range_min": null,
+            "protocol": null,
+            "remote_group_id": null,
+            "remote_address_group_id": null,
+            "remote_ip_prefix": null,
+            "used_in_default_sg": true,
+            "used_in_non_default_sg": true,
+            "created_at": "2017-12-28T07:21:40Z",
+            "updated_at": "2017-12-28T07:21:40Z",
+            "revision_number": 0
+        },
+        {
+            "description": "Allow HTTPS from the parent security group",
+            "direction": "ingress",
+            "ethertype": "IPv4",
+            "id": "93aa42e5-80db-4581-9391-3a608bd0e448",
+            "port_range_max": 443,
+            "port_range_min": 443,
+            "protocol": "tcp",
+            "remote_group_id": "PARENT",
+            "remote_address_group_id": null,
+            "remote_ip_prefix": null,
+            "used_in_default_sg": false,
+            "used_in_non_default_sg": true,
+            "created_at": "2017-12-28T07:21:40",
+            "updated_at": "2017-12-28T07:21:40",
+            "revision_number": 1
+        }
+    ]
+}
+      `)
+	})
+
+	count := 0
+
+	err := defaultrules.List(fake.ServiceClient(fakeServer), defaultrules.ListOpts{}).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
+		count++
+		actual, err := defaultrules.ExtractDefaultRules(page)
+		if err != nil {
+			t.Errorf("Failed to extract default security group rules: %v", err)
+			return false, err
+		}
+
+		expected := []defaultrules.DefaultSecGroupRule{
+			{
+				Description:        "",
+				Direction:          "egress",
+				EtherType:          "IPv6",
+				ID:                 "3c0e45ff-adaf-4124-b083-bf390e5482ff",
+				PortRangeMax:       0,
+				PortRangeMin:       0,
+				Protocol:           "",
+				RemoteGroupID:      "",
+				RemoteIPPrefix:     "",
+				UsedInDefaultSG:    true,
+				UsedInNonDefaultSG: true,
+				CreatedAt:          time.Date(2017, 12, 28, 07, 21, 40, 0, time.UTC),
+				UpdatedAt:          time.Date(2017, 12, 28, 07, 21, 40, 0, time.UTC),
+			},
+			{
+				Description:        "Allow HTTPS from the parent security group",
+				Direction:          "ingress",
+				EtherType:          "IPv4",
+				ID:                 "93aa42e5-80db-4581-9391-3a608bd0e448",
+				PortRangeMax:       443,
+				PortRangeMin:       443,
+				Protocol:           "tcp",
+				RemoteGroupID:      "PARENT",
+				RemoteIPPrefix:     "",
+				UsedInDefaultSG:    false,
+				UsedInNonDefaultSG: true,
+				RevisionNumber:     1,
+				CreatedAt:          time.Date(2017, 12, 28, 07, 21, 40, 0, time.UTC),
+				UpdatedAt:          time.Date(2017, 12, 28, 07, 21, 40, 0, time.UTC),
+			},
+		}
+
+		th.CheckDeepEquals(t, expected, actual)
+
+		return true, nil
+	})
+	th.AssertNoErr(t, err)
+
+	if count != 1 {
+		t.Errorf("Expected 1 page, got %d", count)
+	}
+}
+
+func TestCreate(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	fakeServer.Mux.HandleFunc("/v2.0/default-security-group-rules", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, `
+{
+    "default_security_group_rule": {
+        "description": "Allow HTTPS from the parent security group",
+        "direction": "ingress",
+        "ethertype": "IPv4",
+        "port_range_max": 443,
+        "port_range_min": 443,
+        "protocol": "tcp",
+        "remote_group_id": "PARENT",
+        "used_in_default_sg": false,
+        "used_in_non_default_sg": true
+    }
+}
+      `)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+
+		fmt.Fprint(w, `
+{
+    "default_security_group_rule": {
+        "description": "Allow HTTPS from the parent security group",
+        "direction": "ingress",
+        "ethertype": "IPv4",
+        "id": "2bc0accf-312e-429a-956e-e4407625eb62",
+        "port_range_max": 443,
+        "port_range_min": 443,
+        "protocol": "tcp",
+        "remote_group_id": "PARENT",
+        "remote_address_group_id": null,
+        "remote_ip_prefix": null,
+        "used_in_default_sg": false,
+        "used_in_non_default_sg": true,
+        "revision_number": 0
+    }
+}
+    `)
+	})
+
+	options := defaultrules.CreateOpts{
+		Description:        "Allow HTTPS from the parent security group",
+		Direction:          rules.DirIngress,
+		EtherType:          rules.EtherType4,
+		PortRangeMax:       ptr.To(443),
+		PortRangeMin:       ptr.To(443),
+		Protocol:           rules.ProtocolTCP,
+		RemoteGroupID:      "PARENT",
+		UsedInDefaultSG:    ptr.To(false),
+		UsedInNonDefaultSG: ptr.To(true),
+	}
+	rule, err := defaultrules.Create(context.TODO(), fake.ServiceClient(fakeServer), options).Extract()
+	th.AssertNoErr(t, err)
+
+	expected := &defaultrules.DefaultSecGroupRule{
+		Description:        "Allow HTTPS from the parent security group",
+		Direction:          "ingress",
+		EtherType:          "IPv4",
+		ID:                 "2bc0accf-312e-429a-956e-e4407625eb62",
+		PortRangeMax:       443,
+		PortRangeMin:       443,
+		Protocol:           "tcp",
+		RemoteGroupID:      "PARENT",
+		UsedInDefaultSG:    false,
+		UsedInNonDefaultSG: true,
+	}
+	th.AssertDeepEquals(t, expected, rule)
+}
+
+func TestGet(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	fakeServer.Mux.HandleFunc("/v2.0/default-security-group-rules/3c0e45ff-adaf-4124-b083-bf390e5482ff", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprint(w, `
+{
+    "default_security_group_rule": {
+        "description": "",
+        "direction": "egress",
+        "ethertype": "IPv6",
+        "id": "3c0e45ff-adaf-4124-b083-bf390e5482ff",
+        "port_range_max": null,
+        "port_range_min": null,
+        "protocol": null,
+        "remote_group_id": null,
+        "remote_address_group_id": null,
+        "remote_ip_prefix": null,
+        "used_in_default_sg": true,
+        "used_in_non_default_sg": true,
+        "revision_number": 0
+    }
+}
+      `)
+	})
+
+	rule, err := defaultrules.Get(context.TODO(), fake.ServiceClient(fakeServer), "3c0e45ff-adaf-4124-b083-bf390e5482ff").Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, "egress", rule.Direction)
+	th.AssertEquals(t, "IPv6", rule.EtherType)
+	th.AssertEquals(t, "3c0e45ff-adaf-4124-b083-bf390e5482ff", rule.ID)
+	th.AssertEquals(t, true, rule.UsedInDefaultSG)
+	th.AssertEquals(t, true, rule.UsedInNonDefaultSG)
+}
+
+func TestDelete(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	fakeServer.Mux.HandleFunc("/v2.0/default-security-group-rules/4ec89087-d057-4e2c-911f-60a3b47ee304", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	res := defaultrules.Delete(context.TODO(), fake.ServiceClient(fakeServer), "4ec89087-d057-4e2c-911f-60a3b47ee304")
+	th.AssertNoErr(t, res.Err)
+}

--- a/openstack/networking/v2/extensions/security/defaultrules/urls.go
+++ b/openstack/networking/v2/extensions/security/defaultrules/urls.go
@@ -1,0 +1,13 @@
+package defaultrules
+
+import "github.com/gophercloud/gophercloud/v2"
+
+const rootPath = "default-security-group-rules"
+
+func rootURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL(rootPath)
+}
+
+func resourceURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL(rootPath, id)
+}


### PR DESCRIPTION
Add a new openstack/networking/v2/extensions/security/defaultrules package supporting the List, Create, Get and Delete operations of the Neutron /v2.0/default-security-group-rules API, provided by the security-groups-default-rules extension (Neutron 2023.2). The API does not support update nor bulk create for this resource.

The package mirrors the existing security/rules package and reuses its RuleDirection, RuleProtocol and RuleEtherType constants. Unit tests and an acceptance test are included.

Fixes #3175

List security group default rules (GET /v2.0/default-security-group-rules):
https://docs.openstack.org/api-ref/network/v2/index.html#list-security-group-default-rules

Create security group default rule (POST /v2.0/default-security-group-rules):
https://docs.openstack.org/api-ref/network/v2/index.html#create-security-group-default-rule

Show security group default rule (GET /v2.0/default-security-group-rules/{id}):
https://docs.openstack.org/api-ref/network/v2/index.html#show-security-group-default-rule

Delete security group default rule (DELETE /v2.0/default-security-group-rules/{id}):
https://docs.openstack.org/api-ref/network/v2/index.html#delete-security-group-default-rule