### PR TITLE
ci(db): add slashes to file pattern

### DIFF
--- a/.github/workflows/functional-db.yaml
+++ b/.github/workflows/functional-db.yaml
@@ -41,7 +41,7 @@ jobs:
             openstack/config/provider_client.go
             openstack/utils/choose_version.go
             openstack/utils/discovery.go
-            **db**
+            **/db/**
             .github/workflows/functional-db.yaml
 
       - name: Skip tests for unrelated changed-files


### PR DESCRIPTION
Adding slashes between the word "db" so we can match only packages related with Trove. This avoids running other unrelated jobs e.g. loadbalancer, because the filter was matching the "db" substring from the word.

