### PR TITLE
fix(config/clouds): find the clouds config file independently of each…

### DIFF
--- a/openstack/config/clouds/clouds.go
+++ b/openstack/config/clouds/clouds.go
@@ -23,6 +23,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path"
 	"reflect"
@@ -57,12 +58,14 @@ func Parse(opts ...ParseOption) (gophercloud.AuthOptions, gophercloud.EndpointOp
 		cloudName:    os.Getenv("OS_CLOUD"),
 		region:       os.Getenv("OS_REGION_NAME"),
 		endpointType: os.Getenv("OS_INTERFACE"),
-		locations: func() []string {
+		locations: func() map[CloudsType][]string {
+			out := make(map[CloudsType][]string)
 			if path := os.Getenv("OS_CLIENT_CONFIG_FILE"); path != "" {
-				return []string{path}
+				out[Default] = []string{path}
 			}
-			return nil
+			return out
 		}(),
+		readers: make(map[CloudsType]io.Reader),
 	}
 
 	for _, apply := range opts {
@@ -73,77 +76,54 @@ func Parse(opts ...ParseOption) (gophercloud.AuthOptions, gophercloud.EndpointOp
 		return gophercloud.AuthOptions{}, gophercloud.EndpointOpts{}, nil, fmt.Errorf("the empty string \"\" is not a valid cloud name")
 	}
 
-	// Set the defaults and open the files for reading. This code only runs
-	// if no override has been set, because it is fallible.
-	if options.cloudsyamlReader == nil {
-		if len(options.locations) < 1 {
-			cwd, err := os.Getwd()
-			if err != nil {
-				return gophercloud.AuthOptions{}, gophercloud.EndpointOpts{}, nil, fmt.Errorf("failed to get the current working directory: %w", err)
-			}
-			userConfig, err := getUserConfig()
-			if err != nil {
-				return gophercloud.AuthOptions{}, gophercloud.EndpointOpts{}, nil, err
-			}
-			options.locations = []string{path.Join(cwd, "clouds.yaml"), path.Join(userConfig, "openstack", "clouds.yaml"), path.Join("/etc", "openstack", "clouds.yaml")}
-		}
-
-		for _, cloudsPath := range options.locations {
-			f, err := os.Open(cloudsPath)
-			if err != nil {
-				continue
-			}
-			defer f.Close()
-			options.cloudsyamlReader = f
-
-			if options.secureyamlReader == nil {
-				securePath := path.Join(path.Dir(cloudsPath), "secure.yaml")
-				secureF, err := os.Open(securePath)
-				if err == nil {
-					defer secureF.Close()
-					options.secureyamlReader = secureF
-				}
-			}
-			break
-		}
-		if options.cloudsyamlReader == nil {
-			return gophercloud.AuthOptions{}, gophercloud.EndpointOpts{}, nil, fmt.Errorf("clouds file not found. Search locations were: %v", options.locations)
-		}
-	}
-
-	// Parse the YAML payloads.
-	var clouds Clouds
-	if err := yaml.NewDecoder(options.cloudsyamlReader).Decode(&clouds); err != nil {
+	clouds, err := readClouds(&options, Default)
+	if err != nil {
 		return gophercloud.AuthOptions{}, gophercloud.EndpointOpts{}, nil, err
 	}
 
-	cloud, ok := clouds.Clouds[options.cloudName]
+	cloud, ok := clouds[options.cloudName]
 	if !ok {
 		return gophercloud.AuthOptions{}, gophercloud.EndpointOpts{}, nil, fmt.Errorf("cloud %q not found in clouds.yaml", options.cloudName)
 	}
 
-	if options.secureyamlReader != nil {
-		var secureClouds Clouds
-		if err := yaml.NewDecoder(options.secureyamlReader).Decode(&secureClouds); err != nil {
-			return gophercloud.AuthOptions{}, gophercloud.EndpointOpts{}, nil, fmt.Errorf("failed to parse secure.yaml: %w", err)
+	secureClouds, err := readClouds(&options, Secure)
+	if err != nil {
+		// For secure.yaml we ignore if there is not secure.yaml file found
+		if _, ok := err.(ErrFileNotFound); !ok {
+			return gophercloud.AuthOptions{}, gophercloud.EndpointOpts{}, nil, err
 		}
 
-		if secureCloud, ok := secureClouds.Clouds[options.cloudName]; ok {
-			// If secureCloud has content and it differs from the cloud entry,
-			// merge the two together.
-			if !reflect.DeepEqual((gophercloud.AuthOptions{}), secureClouds) && !reflect.DeepEqual(clouds, secureClouds) {
-				var err error
-				cloud, err = mergeClouds(secureCloud, cloud)
-				if err != nil {
-					return gophercloud.AuthOptions{}, gophercloud.EndpointOpts{}, nil, fmt.Errorf("unable to merge information from clouds.yaml and secure.yaml: %w", err)
-				}
+	}
+	secure, ok := secureClouds[options.cloudName]
+	if ok {
+		if !reflect.DeepEqual(cloud, secure) {
+			cloud, err = mergeClouds(secure, cloud)
+			if err != nil {
+				return gophercloud.AuthOptions{}, gophercloud.EndpointOpts{}, nil, fmt.Errorf("unable to merge information from clouds.yaml and secure.yaml: %w", err)
 			}
 		}
 	}
 
-	cloud, err := mergeWithPublicClouds(cloud, &options)
-	if err != nil {
-		return gophercloud.AuthOptions{}, gophercloud.EndpointOpts{}, nil, err
+	var profile string
+	if cloud.Profile != "" {
+		profile = cloud.Profile
+	} else if cloud.Cloud != "" {
+		profile = cloud.Cloud
+	}
+
+	if profile != "" {
+		publicsCloud, err := readClouds(&options, Public)
+		if err != nil {
+			return gophercloud.AuthOptions{}, gophercloud.EndpointOpts{}, nil, err
+		}
+
+		public, ok := publicsCloud[profile]
+		if ok {
+			cloud, err = mergeClouds(cloud, public)
+			if err != nil {
+				return gophercloud.AuthOptions{}, gophercloud.EndpointOpts{}, nil, err
+			}
+		}
 	}
 
 	tlsConfig, err := computeTLSConfig(cloud, options)
@@ -219,6 +199,57 @@ func Parse(opts ...ParseOption) (gophercloud.AuthOptions, gophercloud.EndpointOp
 		nil
 }
 
+func readClouds(options *cloudOpts, ctype CloudsType) (map[string]Cloud, error) {
+	// Set the defaults and open the files for reading. This code only runs
+	// if no override has been set, because it is fallible.
+	if options.readers[ctype] == nil {
+		if len(options.locations[ctype]) < 1 {
+			cwd, err := os.Getwd()
+			if err != nil {
+				return map[string]Cloud{}, fmt.Errorf("failed to get the current working directory: %w", err)
+			}
+			userConfig, err := getUserConfig()
+			if err != nil {
+				return map[string]Cloud{}, err
+			}
+			options.locations[ctype] = []string{path.Join(cwd, string(ctype)), path.Join(userConfig, "openstack", string(ctype)), path.Join("/etc", "openstack", string(ctype))}
+		}
+
+		for _, cloudsPath := range options.locations[ctype] {
+			f, err := os.Open(cloudsPath)
+			if err != nil {
+				continue
+			}
+			defer f.Close()
+			options.readers[ctype] = f
+			break
+		}
+		if options.readers[ctype] == nil {
+			return map[string]Cloud{}, ErrFileNotFound{
+				file:            string(ctype),
+				searchLocations: options.locations[ctype]}
+		}
+	}
+
+	// Parse the YAML payloads.
+	var cloudsMap map[string]Cloud
+	if ctype == Public {
+		var clouds PublicClouds
+		if err := yaml.NewDecoder(options.readers[ctype]).Decode(&clouds); err != nil {
+			return map[string]Cloud{}, err
+		}
+		cloudsMap = clouds.Clouds
+	} else {
+		var clouds Clouds
+		if err := yaml.NewDecoder(options.readers[ctype]).Decode(&clouds); err != nil {
+			return map[string]Cloud{}, err
+		}
+		cloudsMap = clouds.Clouds
+	}
+
+	return cloudsMap, nil
+}
+
 func getUserConfig() (string, error) {
 	// Use XDG_CONFIG_HOME or fall back to ~/.config, matching the
 	// OpenStack convention for clouds.yaml location on all platforms.
@@ -233,65 +264,6 @@ func getUserConfig() (string, error) {
 	}
 	userConfig = path.Join(homeDir, ".config")
 	return userConfig, nil
-}
-
-func mergeWithPublicClouds(cloud Cloud, options *cloudOpts) (Cloud, error) {
-	var mergeWith string
-	if cloud.Profile != "" {
-		mergeWith = cloud.Profile
-	} else if cloud.Cloud != "" {
-		mergeWith = cloud.Cloud
-	} else {
-		return cloud, nil
-	}
-
-	// Code is executed only if cloud needs to be merged with a public
-	// profile, error are returned only loading clouds-public.yaml was
-	// needed
-	if options.cloudsPublicyamlReader == nil {
-		if len(options.publicLocations) < 1 {
-			cwd, err := os.Getwd()
-			if err != nil {
-				return cloud, fmt.Errorf("failed to get the current directory: %w", err)
-			}
-			userConfig, err := getUserConfig()
-			if err != nil {
-				return cloud, err
-			}
-			options.publicLocations = []string{path.Join(cwd, "clouds-public.yaml"), path.Join(userConfig, "openstack", "clouds-public.yaml"), path.Join("/etc", "openstack", "clouds-public.yaml")}
-		}
-		for _, publicPath := range options.publicLocations {
-			f, err := os.Open(publicPath)
-			if err != nil {
-				continue
-			}
-			defer f.Close()
-			options.cloudsPublicyamlReader = f
-			break
-		}
-		if options.cloudsPublicyamlReader == nil {
-			return cloud, fmt.Errorf("clouds file not found. Search locations were: %v", options.publicLocations)
-		}
-	}
-
-	var publicClouds PublicClouds
-	if err := yaml.NewDecoder(options.cloudsPublicyamlReader).Decode(&publicClouds); err != nil {
-		return cloud, err
-	}
-
-	pCloud, ok := publicClouds.Clouds[mergeWith]
-	if !ok {
-		return cloud, nil
-	}
-
-	var err error
-	cloud, err = mergeClouds(cloud, pCloud)
-	if err != nil {
-		return cloud, fmt.Errorf("unable to merge information from clouds-public.yaml: %w", err)
-	}
-
-	return cloud, nil
-
 }
 
 // computeAvailability is a helper method to determine the endpoint type

--- a/openstack/config/clouds/clouds_test.go
+++ b/openstack/config/clouds/clouds_test.go
@@ -340,7 +340,7 @@ func TestParse(t *testing.T) {
 	t.Run("parses clouds-public.yaml if present", func(t *testing.T) {
 		const cloudsYAML = `clouds:
   gophercloud-test-0:
-    cloud: gophercloud-test-1
+    profile: gophercloud-test-1
     auth:
       user_domain_name: CustomDomain`
 		const cloudsPublicYAML = `public-clouds:
@@ -478,6 +478,43 @@ func TestParse(t *testing.T) {
 
 		if got := ao.DomainName; got != "CustomDomain" {
 			t.Errorf("unexpected DomainName: %q", got)
+		}
+	})
+
+	t.Run("don't read fs secure.yaml if WithCloudsYAML is set", func(t *testing.T) {
+		const cloudsYAML = `clouds:
+  gophercloud-test:
+    auth:
+      auth_url: https://example.com/clouds:13000`
+		const secureYAMLFS = `clouds:
+  gophercloud-test:
+    auth:
+      auth_url: https://example.com/secure:13000`
+
+		// Create a working dir to test if fs is read
+		wDir, err := os.MkdirTemp(os.TempDir(), tempDirPrefix)
+		th.AssertNoErr(t, err)
+		defer rmTmpDirOrPanic(wDir)
+
+		th.AssertNoErr(t, os.WriteFile(path.Join(wDir, "secure.yaml"), []byte(secureYAMLFS), 0644))
+
+		cwd, err := os.Getwd()
+		th.AssertNoErr(t, err)
+		th.AssertNoErr(t, os.Chdir(wDir))
+		defer func() {
+			if err := os.Chdir(cwd); err != nil {
+				panic("unable to reset the current working directory: " + err.Error())
+			}
+		}()
+
+		ao, _, _, err := clouds.Parse(
+			clouds.WithCloudsYAML(strings.NewReader(cloudsYAML)),
+			clouds.WithCloudName("gophercloud-test"),
+		)
+		th.AssertNoErr(t, err)
+
+		if got := ao.IdentityEndpoint; got != "https://example.com/clouds:13000" {
+			t.Errorf("unexpected identity endpoint: %q", got)
 		}
 	})
 

--- a/openstack/config/clouds/errors.go
+++ b/openstack/config/clouds/errors.go
@@ -1,0 +1,16 @@
+package clouds
+
+import (
+	"fmt"
+)
+
+type ErrFileNotFound struct {
+	file            string
+	searchLocations []string
+}
+
+func (e ErrFileNotFound) Error() string {
+	return fmt.Sprintf(
+		"%s file not found. Search locations were: %v",
+		e.file, e.searchLocations)
+}

--- a/openstack/config/clouds/options.go
+++ b/openstack/config/clouds/options.go
@@ -7,12 +7,9 @@ import (
 )
 
 type cloudOpts struct {
-	cloudName              string
-	locations              []string
-	publicLocations        []string
-	cloudsyamlReader       io.Reader
-	secureyamlReader       io.Reader
-	cloudsPublicyamlReader io.Reader
+	cloudName string
+	locations map[CloudsType][]string
+	readers   map[CloudsType]io.Reader
 
 	applicationCredentialID     string
 	applicationCredentialName   string
@@ -51,7 +48,7 @@ func WithCloudName(osCloud string) ParseOption {
 // a file path pointing to a possible `clouds.yaml`.
 func WithLocations(locations ...string) ParseOption {
 	return func(co *cloudOpts) {
-		co.locations = locations
+		co.locations[Default] = locations
 	}
 }
 
@@ -60,7 +57,7 @@ func WithLocations(locations ...string) ParseOption {
 // `clouds-public.yaml`
 func WithPublicLocations(locations ...string) ParseOption {
 	return func(co *cloudOpts) {
-		co.publicLocations = locations
+		co.locations[Public] = locations
 	}
 }
 
@@ -70,7 +67,7 @@ func WithPublicLocations(locations ...string) ParseOption {
 // use in conjunction with WithSecureYAML.
 func WithCloudsYAML(clouds io.Reader) ParseOption {
 	return func(co *cloudOpts) {
-		co.cloudsyamlReader = clouds
+		co.readers[Default] = clouds
 	}
 }
 
@@ -79,7 +76,7 @@ func WithCloudsYAML(clouds io.Reader) ParseOption {
 // fetched from the filesystem, or passed with WithCloudsYAML.
 func WithSecureYAML(secure io.Reader) ParseOption {
 	return func(co *cloudOpts) {
-		co.secureyamlReader = secure
+		co.readers[Secure] = secure
 	}
 }
 
@@ -87,7 +84,7 @@ func WithSecureYAML(secure io.Reader) ParseOption {
 // clouds-public.yaml file as an io.Reader interface
 func WithCloudsPublicYAML(public io.Reader) ParseOption {
 	return func(co *cloudOpts) {
-		co.cloudsPublicyamlReader = public
+		co.readers[Public] = public
 	}
 }
 

--- a/openstack/config/clouds/types.go
+++ b/openstack/config/clouds/types.go
@@ -189,6 +189,9 @@ func (r *Region) UnmarshalYAML(unmarshal func(any) error) error {
 // AuthType respresents a valid method of authentication.
 type AuthType string
 
+// CloudsType represents a kind of clouds.yaml (clouds, secure, public)
+type CloudsType string
+
 const (
 	// AuthPassword defines an unknown version of the password
 	AuthPassword AuthType = "password"
@@ -207,4 +210,8 @@ const (
 
 	// AuthV3ApplicationCredential defines version 3 of the application credential
 	AuthV3ApplicationCredential AuthType = "v3applicationcredential"
+
+	Default CloudsType = "clouds.yaml"
+	Secure  CloudsType = "secure.yaml"
+	Public  CloudsType = "clouds-public.yaml"
 )


### PR DESCRIPTION
<!--
Prior to starting a PR, please make sure you have read our
[contributor tutorial](https://github.com/gophercloud/gophercloud/tree/main/docs/contributor-tutorial).

Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

-->
Opening the PR as a follow up of this comment: https://github.com/gophercloud/gophercloud/pull/3949#issuecomment-5345636690. (@stephenfin)

Change should make config files loading independent of each others as openstacksdk does
