### PR TITLE
config: Support Identity v3 authentication extensions

### DIFF
--- a/openstack/config/provider_client.go
+++ b/openstack/config/provider_client.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/openstack"
+	tokens3 "github.com/gophercloud/gophercloud/v2/openstack/identity/v3/tokens"
 )
 
 type options struct {
@@ -45,12 +46,44 @@ func WithTLSConfig(tlsConfig *tls.Config) func(*options) {
 // service are available, then chooses the most recent or most supported
 // version.
 func NewProviderClient(ctx context.Context, authOptions gophercloud.AuthOptions, opts ...func(*options)) (*gophercloud.ProviderClient, error) {
+	client, err := newProviderClient(authOptions.IdentityEndpoint, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	err = openstack.Authenticate(ctx, client, authOptions)
+	if err != nil {
+		return nil, err
+	}
+	return client, nil
+}
+
+// NewProviderClientV3 logs in to an OpenStack cloud using the provided
+// Identity v3 authentication options and returns an authenticated ProviderClient.
+//
+// Unlike [NewProviderClient], the identity endpoint is passed separately so
+// callers can use any Identity v3 authentication extension that implements
+// [tokens3.AuthOptionsBuilder].
+func NewProviderClientV3(ctx context.Context, identityEndpoint string, authOptions tokens3.AuthOptionsBuilder, opts ...func(*options)) (*gophercloud.ProviderClient, error) {
+	client, err := newProviderClient(identityEndpoint, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	err = openstack.AuthenticateV3(ctx, client, authOptions, gophercloud.EndpointOpts{})
+	if err != nil {
+		return nil, err
+	}
+	return client, nil
+}
+
+func newProviderClient(identityEndpoint string, opts ...func(*options)) (*gophercloud.ProviderClient, error) {
 	var options options
 	for _, apply := range opts {
 		apply(&options)
 	}
 
-	client, err := openstack.NewClient(authOptions.IdentityEndpoint)
+	client, err := openstack.NewClient(identityEndpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -61,10 +94,5 @@ func NewProviderClient(ctx context.Context, authOptions gophercloud.AuthOptions,
 		options.httpClient.Transport = transport
 	}
 	client.HTTPClient = options.httpClient
-
-	err = openstack.Authenticate(ctx, client, authOptions)
-	if err != nil {
-		return nil, err
-	}
 	return client, nil
 }

--- a/openstack/config/provider_client_test.go
+++ b/openstack/config/provider_client_test.go
@@ -11,9 +11,21 @@ import (
 	th "github.com/gophercloud/gophercloud/v2/testhelper"
 )
 
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}
+
 func TestNewProviderClientV3(t *testing.T) {
 	fakeServer := th.SetupHTTP()
 	defer fakeServer.Teardown()
+
+	transportUsed := false
+	httpClient := http.Client{Transport: roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		transportUsed = true
+		return http.DefaultTransport.RoundTrip(r)
+	})}
 
 	fakeServer.Mux.HandleFunc("/v3/auth/tokens", func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, http.MethodPost)
@@ -29,8 +41,12 @@ func TestNewProviderClientV3(t *testing.T) {
 			UserID:   "user-id",
 			Password: "password",
 		},
+		WithHTTPClient(httpClient),
 	)
 	th.AssertNoErr(t, err)
+	if !transportUsed {
+		t.Fatal("custom HTTP client was not used for authentication")
+	}
 	if client.Token() != "token" {
 		t.Fatalf("unexpected token: %q", client.Token())
 	}

--- a/openstack/config/provider_client_test.go
+++ b/openstack/config/provider_client_test.go
@@ -1,0 +1,37 @@
+package config
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/v2/openstack/identity/v3/tokens"
+	tokenstesting "github.com/gophercloud/gophercloud/v2/openstack/identity/v3/tokens/testing"
+	th "github.com/gophercloud/gophercloud/v2/testhelper"
+)
+
+func TestNewProviderClientV3(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	fakeServer.Mux.HandleFunc("/v3/auth/tokens", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, http.MethodPost)
+		w.Header().Set("X-Subject-Token", "token")
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprint(w, tokenstesting.TokenOutput)
+	})
+
+	client, err := NewProviderClientV3(
+		context.Background(),
+		fakeServer.Endpoint()+"v3/",
+		&tokens.AuthOptions{
+			UserID:   "user-id",
+			Password: "password",
+		},
+	)
+	th.AssertNoErr(t, err)
+	if client.Token() != "token" {
+		t.Fatalf("unexpected token: %q", client.Token())
+	}
+}


### PR DESCRIPTION
This is the independent constructor needed to move Identity v3 client configuration from `gophercloud/utils` into core Gophercloud.

`config.NewProviderClient` accepts the concrete `gophercloud.AuthOptions` type, so callers using Identity v3 authentication extensions cannot combine those extensions with the client setup options in `config`.

Add `NewProviderClientV3`, accepting `tokens.AuthOptionsBuilder` and an explicit identity endpoint, so WebSSO, OAuth2, and other Identity v3 authentication methods can use `WithHTTPClient` and `WithTLSConfig`. Factor common provider-client setup into an internal helper without changing `NewProviderClient` behavior.

Tests:

- `GOTOOLCHAIN=go1.25.0 go test ./openstack/config/...`
- `GOTOOLCHAIN=go1.25.0 go test ./...`