### PR TITLE
test(db): use datastore-appropriate config parameter in TestConfigurationsCRUD

### DIFF
--- a/internal/acceptance/openstack/db/v1/configurations_test.go
+++ b/internal/acceptance/openstack/db/v1/configurations_test.go
@@ -35,7 +35,11 @@ func TestConfigurationsCRUD(t *testing.T) {
 	createOpts.Datastore = &datastore
 
 	values := make(map[string]any)
-	values["collation_server"] = "latin1_swedish_ci"
+	if choices.DBDatastoreType == "postgresql" {
+		values["max_connections"] = 200
+	} else {
+		values["collation_server"] = "latin1_swedish_ci"
+	}
 	createOpts.Values = values
 
 	cgroup, err := configurations.Create(context.TODO(), client, createOpts).Extract()


### PR DESCRIPTION
Trove's devstack plugin (commit 25dde62d8f0b) now registers three datastores (mysql, mariadb, postgresql) instead of just mysql. Our script/stackenv picks whichever openstack datastore list returns first, which is non-deterministic. When postgresql is selected, the test fails because collation_server is a MySQL/MariaDB-only parameter.

Use max_connections for PostgreSQL and keep collation_server for MySQL/MariaDB.

Fixes #3982