### PR TITLE
CI: fix nova-compute crash on master with file_backed_memory

### DIFF
--- a/.github/workflows/functional-sharedfilesystems.yaml
+++ b/.github/workflows/functional-sharedfilesystems.yaml
@@ -81,6 +81,7 @@ jobs:
             [[post-config|\$NOVA_CONF]]
             [DEFAULT]
             ram_allocation_ratio = 1.0
+            reserved_host_memory_mb = 0
 
             [libvirt]
             file_backed_memory = 4096


### PR DESCRIPTION
Nova master now rejects file_backed_memory when reserved_host_memory_mb is non-zero (default: 512). Set reserved_host_memory_mb = 0 to fix the devstack deployment failure.

Upstream Nova change:
https://review.opendev.org/c/openstack/nova/+/906161