### PR TITLE
collectlogs: fix regex to capture all devstack service names

### DIFF
--- a/script/collectlogs
+++ b/script/collectlogs
@@ -12,7 +12,7 @@ mkdir -p "$LOG_DIR"
 sudo journalctl -o short-precise --no-pager &> "$LOG_DIR/journal.log"
 # shellcheck disable=SC2024
 sudo systemctl status "devstack@*" &> "$LOG_DIR/devstack-services.txt"
-for service in $(systemctl list-units --output json devstack@* | jq -r '.[].unit | capture("devstack@(?<svc>[a-z\\-]+).service") | '.svc'')
+for service in $(systemctl list-units --output json devstack@* | jq -r '.[].unit | capture("devstack@(?<svc>[a-z0-9_\\-]+).service") | '.svc'')
 do
     journalctl -u "devstack@${service}.service" --no-tail > "${LOG_DIR}/${service}.log"
 done


### PR DESCRIPTION
The jq regex `[a-z\-]+` only matched lowercase letters and hyphens, silently skipping services with digits or underscores: `q-l3`, `q-fwaas-v2`, `node_exporter`, and `openstack_exporter`. Broaden the character class to `[a-z0-9_\-]+` so every devstack service gets an individual log file in the artifacts.