### PR TITLE
reservation: add hosts resources

### DIFF
--- a/internal/acceptance/openstack/reservation/v1/hosts_test.go
+++ b/internal/acceptance/openstack/reservation/v1/hosts_test.go
@@ -1,0 +1,33 @@
+//go:build acceptance || reservation || hosts
+
+package v1
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/v2/internal/acceptance/clients"
+	"github.com/gophercloud/gophercloud/v2/internal/acceptance/tools"
+	"github.com/gophercloud/gophercloud/v2/openstack/reservation/v1/hosts"
+	th "github.com/gophercloud/gophercloud/v2/testhelper"
+)
+
+func TestHostsList(t *testing.T) {
+	clients.RequireAdmin(t)
+
+	client, err := clients.NewReservationV1Client()
+	th.AssertNoErr(t, err)
+
+	allPages, err := hosts.List(client).AllPages(context.TODO())
+	th.AssertNoErr(t, err)
+
+	allHosts, err := hosts.ExtractHosts(allPages)
+	th.AssertNoErr(t, err)
+
+	for _, host := range allHosts {
+		tools.PrintResource(t, host)
+		tools.PrintResource(t, host.CreatedAt)
+		tools.PrintResource(t, host.UpdatedAt)
+		tools.PrintResource(t, host.ExtraCapabilities)
+	}
+}

--- a/internal/acceptance/openstack/reservation/v1/hosts_test.go
+++ b/internal/acceptance/openstack/reservation/v1/hosts_test.go
@@ -31,3 +31,76 @@ func TestHostsList(t *testing.T) {
 		tools.PrintResource(t, host.ExtraCapabilities)
 	}
 }
+
+func TestHostsCRUD(t *testing.T) {
+	clients.RequireAdmin(t)
+
+	client, err := clients.NewReservationV1Client()
+	th.AssertNoErr(t, err)
+
+	computeClient, err := clients.NewComputeV2Client()
+	th.AssertNoErr(t, err)
+
+	hypervisorHostname := HypervisorHostname(t, computeClient)
+
+	host, err := CreateHost(t, client, hypervisorHostname)
+	th.AssertNoErr(t, err)
+	defer DeleteHost(t, client, host)
+
+	tools.PrintResource(t, host)
+
+	newHost, err := hosts.Get(context.TODO(), client, host.ID).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, host.ID, newHost.ID)
+	th.AssertEquals(t, "a100", newHost.ExtraCapabilities["gpu"])
+
+	allPages, err := hosts.List(client, hosts.ListOpts{}).AllPages(context.TODO())
+	th.AssertNoErr(t, err)
+
+	allHosts, err := hosts.ExtractHosts(allPages)
+	th.AssertNoErr(t, err)
+
+	var found bool
+	for _, h := range allHosts {
+		if h.ID == host.ID {
+			found = true
+		}
+	}
+	th.AssertEquals(t, true, found)
+
+	updateOpts := hosts.UpdateOpts{
+		ExtraCapabilities: map[string]any{"gpu": "h100"},
+	}
+
+	updatedHost, err := hosts.Update(context.TODO(), client, host.ID, updateOpts).Extract()
+	th.AssertNoErr(t, err)
+	tools.PrintResource(t, updatedHost)
+	th.AssertEquals(t, "h100", updatedHost.ExtraCapabilities["gpu"])
+}
+
+// Blazar removes an extra capability when it is updated to null. This requires
+// the 2026.2 release or later.
+func TestHostsRemoveCapability(t *testing.T) {
+	clients.RequireAdmin(t)
+
+	client, err := clients.NewReservationV1Client()
+	th.AssertNoErr(t, err)
+
+	computeClient, err := clients.NewComputeV2Client()
+	th.AssertNoErr(t, err)
+
+	host, err := CreateHost(t, client, HypervisorHostname(t, computeClient))
+	th.AssertNoErr(t, err)
+	defer DeleteHost(t, client, host)
+
+	updateOpts := hosts.UpdateOpts{
+		ExtraCapabilities: map[string]any{"gpu": nil},
+	}
+
+	updatedHost, err := hosts.Update(context.TODO(), client, host.ID, updateOpts).Extract()
+	th.AssertNoErr(t, err)
+	tools.PrintResource(t, updatedHost)
+
+	_, ok := updatedHost.ExtraCapabilities["gpu"]
+	th.AssertEquals(t, false, ok)
+}

--- a/internal/acceptance/openstack/reservation/v1/hosts_test.go
+++ b/internal/acceptance/openstack/reservation/v1/hosts_test.go
@@ -78,10 +78,10 @@ func TestHostsCRUD(t *testing.T) {
 	th.AssertEquals(t, "h100", updatedHost.ExtraCapabilities["gpu"])
 }
 
-// Blazar removes an extra capability when it is updated to null. This requires
-// the 2026.2 release or later.
+// Blazar removes an extra capability when it is updated to null.
 func TestHostsRemoveCapability(t *testing.T) {
 	clients.RequireAdmin(t)
+	clients.SkipReleasesBelow(t, "stable/2026.2")
 
 	client, err := clients.NewReservationV1Client()
 	th.AssertNoErr(t, err)

--- a/internal/acceptance/openstack/reservation/v1/hosts_test.go
+++ b/internal/acceptance/openstack/reservation/v1/hosts_test.go
@@ -18,7 +18,7 @@ func TestHostsList(t *testing.T) {
 	client, err := clients.NewReservationV1Client()
 	th.AssertNoErr(t, err)
 
-	allPages, err := hosts.List(client).AllPages(context.TODO())
+	allPages, err := hosts.List(client, hosts.ListOpts{}).AllPages(context.TODO())
 	th.AssertNoErr(t, err)
 
 	allHosts, err := hosts.ExtractHosts(allPages)

--- a/internal/acceptance/openstack/reservation/v1/reservation.go
+++ b/internal/acceptance/openstack/reservation/v1/reservation.go
@@ -1,0 +1,67 @@
+// Package v1 contains common functions for creating reservation-based
+// resources for use in acceptance tests. See the `*_test.go` files for example
+// usages.
+package v1
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/hypervisors"
+	"github.com/gophercloud/gophercloud/v2/openstack/reservation/v1/hosts"
+	th "github.com/gophercloud/gophercloud/v2/testhelper"
+)
+
+// HypervisorHostname returns the name of a hypervisor that can be enrolled
+// into the freepool. Blazar knows a host by the name Nova gives it, so there
+// is no way to enrol one without asking Nova first.
+func HypervisorHostname(t *testing.T, client *gophercloud.ServiceClient) string {
+	allPages, err := hypervisors.List(client, nil).AllPages(context.TODO())
+	th.AssertNoErr(t, err)
+
+	allHypervisors, err := hypervisors.ExtractHypervisors(allPages)
+	th.AssertNoErr(t, err)
+
+	if len(allHypervisors) == 0 {
+		t.Skip("no hypervisor available to enrol into the freepool")
+	}
+
+	return allHypervisors[0].HypervisorHostname
+}
+
+// CreateHost will enrol a compute host into the Blazar freepool. An error will
+// be returned if the host was unable to be created.
+func CreateHost(t *testing.T, client *gophercloud.ServiceClient, name string) (*hosts.Host, error) {
+	t.Logf("Attempting to create host: %s", name)
+
+	createOpts := hosts.CreateOpts{
+		Name: name,
+		ExtraCapabilities: map[string]any{
+			"gpu": "a100",
+		},
+	}
+
+	host, err := hosts.Create(context.TODO(), client, createOpts).Extract()
+	if err != nil {
+		return host, err
+	}
+
+	t.Logf("Created host: %s", host.ID)
+
+	th.AssertEquals(t, name, host.HypervisorHostname)
+	th.AssertEquals(t, "a100", host.ExtraCapabilities["gpu"])
+
+	return host, nil
+}
+
+// DeleteHost will remove a host from the Blazar freepool. A fatal error will
+// occur if the host could not be deleted.
+func DeleteHost(t *testing.T, client *gophercloud.ServiceClient, host *hosts.Host) {
+	err := hosts.Delete(context.TODO(), client, host.ID).ExtractErr()
+	if err != nil {
+		t.Fatalf("Unable to delete host %s: %v", host.ID, err)
+	}
+
+	t.Logf("Deleted host: %s", host.ID)
+}

--- a/openstack/reservation/v1/hosts/doc.go
+++ b/openstack/reservation/v1/hosts/doc.go
@@ -1,0 +1,23 @@
+/*
+Package hosts manages compute hosts in the OpenStack Reservation service.
+
+A host must be enrolled into Blazar's freepool before any reservation can draw
+on it. Listing the freepool is administrative.
+
+Example to list hosts
+
+	allPages, err := hosts.List(reservationClient).AllPages(context.TODO())
+	if err != nil {
+		panic(err)
+	}
+
+	allHosts, err := hosts.ExtractHosts(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, h := range allHosts {
+		fmt.Printf("%+v\n", h)
+	}
+*/
+package hosts

--- a/openstack/reservation/v1/hosts/doc.go
+++ b/openstack/reservation/v1/hosts/doc.go
@@ -6,7 +6,9 @@ on it. Listing the freepool is administrative.
 
 Example to list hosts
 
-	allPages, err := hosts.List(reservationClient).AllPages(context.TODO())
+	listOpts := hosts.ListOpts{}
+
+	allPages, err := hosts.List(reservationClient, listOpts).AllPages(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/openstack/reservation/v1/hosts/doc.go
+++ b/openstack/reservation/v1/hosts/doc.go
@@ -21,5 +21,14 @@ Example to list hosts
 	for _, h := range allHosts {
 		fmt.Printf("%+v\n", h)
 	}
+
+Example to get a host
+
+	host, err := hosts.Get(context.TODO(), reservationClient, "18").Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v\n", host)
 */
 package hosts

--- a/openstack/reservation/v1/hosts/doc.go
+++ b/openstack/reservation/v1/hosts/doc.go
@@ -22,6 +22,20 @@ Example to list hosts
 		fmt.Printf("%+v\n", h)
 	}
 
+Example to create a host
+
+	createOpts := hosts.CreateOpts{
+		Name: "compute-1.example.com",
+		ExtraCapabilities: map[string]any{
+			"gpu": "a100",
+		},
+	}
+
+	host, err := hosts.Create(context.TODO(), reservationClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
 Example to get a host
 
 	host, err := hosts.Get(context.TODO(), reservationClient, "18").Extract()

--- a/openstack/reservation/v1/hosts/doc.go
+++ b/openstack/reservation/v1/hosts/doc.go
@@ -44,5 +44,12 @@ Example to get a host
 	}
 
 	fmt.Printf("%+v\n", host)
+
+Example to delete a host
+
+	err := hosts.Delete(context.TODO(), reservationClient, "18").ExtractErr()
+	if err != nil {
+		panic(err)
+	}
 */
 package hosts

--- a/openstack/reservation/v1/hosts/doc.go
+++ b/openstack/reservation/v1/hosts/doc.go
@@ -45,6 +45,20 @@ Example to get a host
 
 	fmt.Printf("%+v\n", host)
 
+Example to update the extra capabilities of a host
+
+	updateOpts := hosts.UpdateOpts{
+		ExtraCapabilities: map[string]any{
+			"gpu":  "h100",
+			"rack": nil,
+		},
+	}
+
+	host, err := hosts.Update(context.TODO(), reservationClient, "18", updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
 Example to delete a host
 
 	err := hosts.Delete(context.TODO(), reservationClient, "18").ExtractErr()

--- a/openstack/reservation/v1/hosts/requests.go
+++ b/openstack/reservation/v1/hosts/requests.go
@@ -1,0 +1,13 @@
+package hosts
+
+import (
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/pagination"
+)
+
+// List retrieves a list of compute hosts.
+func List(client *gophercloud.ServiceClient) pagination.Pager {
+	return pagination.NewPager(client, listURL(client), func(r pagination.PageResult) pagination.Page {
+		return HostPage{pagination.SinglePageBase(r)}
+	})
+}

--- a/openstack/reservation/v1/hosts/requests.go
+++ b/openstack/reservation/v1/hosts/requests.go
@@ -3,6 +3,7 @@ package hosts
 import (
 	"context"
 	"fmt"
+	"maps"
 
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/pagination"
@@ -89,6 +90,45 @@ func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateO
 // Get retrieves a specific compute host based on its unique ID.
 func Get(ctx context.Context, client *gophercloud.ServiceClient, id string) (r GetResult) {
 	resp, err := client.Get(ctx, getURL(client, id), &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// UpdateOptsBuilder allows extensions to add parameters to the Update request.
+type UpdateOptsBuilder interface {
+	ToHostUpdateMap() (map[string]any, error)
+}
+
+// UpdateOpts specifies the parameters for updating a host. Only the extra
+// capabilities of a host can be changed.
+type UpdateOpts struct {
+	// ExtraCapabilities holds the operator-defined capabilities to set on the host.
+	ExtraCapabilities map[string]any
+}
+
+// ToHostUpdateMap formats an UpdateOpts into a request body.
+func (opts UpdateOpts) ToHostUpdateMap() (map[string]any, error) {
+	if len(opts.ExtraCapabilities) == 0 {
+		return nil, gophercloud.ErrMissingInput{Argument: "ExtraCapabilities"}
+	}
+
+	b := make(map[string]any, len(opts.ExtraCapabilities))
+	maps.Copy(b, opts.ExtraCapabilities)
+
+	return b, nil
+}
+
+// Update changes the extra capabilities of a compute host.
+func Update(ctx context.Context, client *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToHostUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	resp, err := client.Put(ctx, updateURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{200},
 	})
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)

--- a/openstack/reservation/v1/hosts/requests.go
+++ b/openstack/reservation/v1/hosts/requests.go
@@ -15,8 +15,8 @@ type ListOptsBuilder interface {
 }
 
 // ListOpts allows the filtering of paginated collections through the API.
-//
-// Blazar accepts query parameters on this endpoint but ignores them. It returns every host.
+// Blazar accepts query parameters on this endpoint but ignores them and
+// returns every host.
 type ListOpts struct{}
 
 // ToHostListQuery formats a ListOpts into a query string.

--- a/openstack/reservation/v1/hosts/requests.go
+++ b/openstack/reservation/v1/hosts/requests.go
@@ -5,9 +5,34 @@ import (
 	"github.com/gophercloud/gophercloud/v2/pagination"
 )
 
+// ListOptsBuilder allows extensions to add parameters to the List request.
+type ListOptsBuilder interface {
+	ToHostListQuery() (string, error)
+}
+
+// ListOpts allows the filtering of paginated collections through the API.
+//
+// Blazar accepts query parameters on this endpoint but ignores them. It returns every host.
+type ListOpts struct{}
+
+// ToHostListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToHostListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
 // List retrieves a list of compute hosts.
-func List(client *gophercloud.ServiceClient) pagination.Pager {
-	return pagination.NewPager(client, listURL(client), func(r pagination.PageResult) pagination.Page {
+func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(client)
+	if opts != nil {
+		query, err := opts.ToHostListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
 		return HostPage{pagination.SinglePageBase(r)}
 	})
 }

--- a/openstack/reservation/v1/hosts/requests.go
+++ b/openstack/reservation/v1/hosts/requests.go
@@ -1,6 +1,8 @@
 package hosts
 
 import (
+	"context"
+
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/pagination"
 )
@@ -35,4 +37,13 @@ func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pa
 	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
 		return HostPage{pagination.SinglePageBase(r)}
 	})
+}
+
+// Get retrieves a specific compute host based on its unique ID.
+func Get(ctx context.Context, client *gophercloud.ServiceClient, id string) (r GetResult) {
+	resp, err := client.Get(ctx, getURL(client, id), &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
 }

--- a/openstack/reservation/v1/hosts/requests.go
+++ b/openstack/reservation/v1/hosts/requests.go
@@ -94,3 +94,12 @@ func Get(ctx context.Context, client *gophercloud.ServiceClient, id string) (r G
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
+
+// Delete removes a compute host from the Blazar freepool.
+func Delete(ctx context.Context, client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+	resp, err := client.Delete(ctx, deleteURL(client, id), &gophercloud.RequestOpts{
+		OkCodes: []int{204},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}

--- a/openstack/reservation/v1/hosts/requests.go
+++ b/openstack/reservation/v1/hosts/requests.go
@@ -2,6 +2,7 @@ package hosts
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/pagination"
@@ -37,6 +38,52 @@ func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pa
 	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
 		return HostPage{pagination.SinglePageBase(r)}
 	})
+}
+
+// CreateOptsBuilder allows extensions to add parameters to the Create request.
+type CreateOptsBuilder interface {
+	ToHostCreateMap() (map[string]any, error)
+}
+
+// CreateOpts specifies the parameters for enrolling a host into the freepool.
+type CreateOpts struct {
+	// Name is the name by which Nova knows the hypervisor to enroll.
+	Name string `json:"name" required:"true"`
+
+	// ExtraCapabilities holds the operator-defined capabilities to set on the host.
+	ExtraCapabilities map[string]any `json:"-"`
+}
+
+// ToHostCreateMap formats a CreateOpts into a request body.
+func (opts CreateOpts) ToHostCreateMap() (map[string]any, error) {
+	b, err := gophercloud.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range opts.ExtraCapabilities {
+		if _, ok := b[k]; ok {
+			return nil, fmt.Errorf("extra capability %q collides with a host field", k)
+		}
+		b[k] = v
+	}
+
+	return b, nil
+}
+
+// Create enrols a compute host into the Blazar freepool.
+func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToHostCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	resp, err := client.Post(ctx, createURL(client), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{201},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
 }
 
 // Get retrieves a specific compute host based on its unique ID.

--- a/openstack/reservation/v1/hosts/results.go
+++ b/openstack/reservation/v1/hosts/results.go
@@ -1,0 +1,119 @@
+package hosts
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/pagination"
+)
+
+// Host represents a compute host enrolled in the Blazar freepool.
+type Host struct {
+	// ID is the unique identifier of the host within Blazar. It is distinct
+	// from the Nova hypervisor ID.
+	ID string `json:"id"`
+
+	// HypervisorHostname is the name by which Nova knows the hypervisor.
+	HypervisorHostname string `json:"hypervisor_hostname"`
+
+	// HypervisorType is the virtualisation technology of the hypervisor.
+	HypervisorType string `json:"hypervisor_type"`
+
+	// HypervisorVersion is the version of the hypervisor software.
+	HypervisorVersion int `json:"hypervisor_version"`
+
+	// ServiceName is the name of the nova-compute service running on the host.
+	ServiceName string `json:"service_name"`
+
+	// VCPUs is the number of virtual CPUs the host provides.
+	VCPUs int `json:"vcpus"`
+
+	// CPUInfo is the hypervisor's description of the host CPU, as a JSON string.
+	CPUInfo string `json:"cpu_info"`
+
+	// MemoryMB is the amount of memory the host provides, in megabytes.
+	MemoryMB int `json:"memory_mb"`
+
+	// LocalGB is the amount of local disk the host provides, in gigabytes.
+	LocalGB int `json:"local_gb"`
+
+	// Status is the current status of the host.
+	Status string `json:"status"`
+
+	// AvailabilityZone is the availability zone the host belongs to.
+	AvailabilityZone string `json:"availability_zone"`
+
+	// TrustID is the identifier of the Keystone trust Blazar uses to act on
+	// the host. It is created by Blazar.
+	TrustID string `json:"trust_id"`
+
+	// Reservable reports whether the host may be allocated to new reservations.
+	Reservable bool `json:"reservable"`
+
+	// CreatedAt is the time at which the host was enrolled.
+	CreatedAt time.Time `json:"-"`
+
+	// UpdatedAt is the time at which the host was last modified. It is nil
+	// if the host has never been modified.
+	UpdatedAt *time.Time `json:"-"`
+
+	// ExtraCapabilities holds the operator-defined capabilities of the host,
+	// which Blazar flattens into the top level of the host object.
+	ExtraCapabilities map[string]any `json:"-"`
+}
+
+// UnmarshalJSON implements unmarshalling custom types
+func (r *Host) UnmarshalJSON(b []byte) error {
+	type tmp Host
+	var s struct {
+		tmp
+		CreatedAt gophercloud.JSONRFC3339ZNoTNoZ  `json:"created_at"`
+		UpdatedAt *gophercloud.JSONRFC3339ZNoTNoZ `json:"updated_at"`
+	}
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+
+	*r = Host(s.tmp)
+	r.CreatedAt = time.Time(s.CreatedAt)
+	if s.UpdatedAt != nil {
+		t := time.Time(*s.UpdatedAt)
+		r.UpdatedAt = &t
+	}
+
+	var resultMap map[string]any
+	if err := json.Unmarshal(b, &resultMap); err != nil {
+		return err
+	}
+
+	delete(resultMap, "created_at")
+	delete(resultMap, "updated_at")
+	r.ExtraCapabilities = gophercloud.RemainingKeys(Host{}, resultMap)
+
+	return nil
+}
+
+// HostPage contains a single page of all hosts from a List call.
+type HostPage struct {
+	pagination.SinglePageBase
+}
+
+func (r HostPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
+	hosts, err := ExtractHosts(r)
+	return len(hosts) == 0, err
+}
+
+// ExtractHosts takes a List result and extracts the collection of hosts
+// returned by the API.
+func ExtractHosts(p pagination.Page) ([]Host, error) {
+	var s struct {
+		Hosts []Host `json:"hosts"`
+	}
+	err := (p.(HostPage)).ExtractInto(&s)
+	return s.Hosts, err
+}

--- a/openstack/reservation/v1/hosts/results.go
+++ b/openstack/reservation/v1/hosts/results.go
@@ -33,6 +33,12 @@ type CreateResult struct {
 	commonResult
 }
 
+// DeleteResult is the response from a Delete operation. Call its ExtractErr
+// method to determine whether the request succeeded.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
 // Host represents a compute host enrolled in the Blazar freepool.
 type Host struct {
 	// ID is the unique identifier of the host within Blazar. It is distinct

--- a/openstack/reservation/v1/hosts/results.go
+++ b/openstack/reservation/v1/hosts/results.go
@@ -27,6 +27,12 @@ type GetResult struct {
 	commonResult
 }
 
+// CreateResult is the response from a Create operation. Call its Extract
+// method to interpret it as a Host.
+type CreateResult struct {
+	commonResult
+}
+
 // Host represents a compute host enrolled in the Blazar freepool.
 type Host struct {
 	// ID is the unique identifier of the host within Blazar. It is distinct

--- a/openstack/reservation/v1/hosts/results.go
+++ b/openstack/reservation/v1/hosts/results.go
@@ -8,6 +8,25 @@ import (
 	"github.com/gophercloud/gophercloud/v2/pagination"
 )
 
+type commonResult struct {
+	gophercloud.Result
+}
+
+// Extract interprets any commonResult as a Host.
+func (r commonResult) Extract() (*Host, error) {
+	var s struct {
+		Host *Host `json:"host"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Host, err
+}
+
+// GetResult is the response from a Get operation. Call its Extract method to
+// interpret it as a Host.
+type GetResult struct {
+	commonResult
+}
+
 // Host represents a compute host enrolled in the Blazar freepool.
 type Host struct {
 	// ID is the unique identifier of the host within Blazar. It is distinct

--- a/openstack/reservation/v1/hosts/results.go
+++ b/openstack/reservation/v1/hosts/results.go
@@ -33,6 +33,12 @@ type CreateResult struct {
 	commonResult
 }
 
+// UpdateResult is the response from an Update operation. Call its Extract
+// method to interpret it as a Host.
+type UpdateResult struct {
+	commonResult
+}
+
 // DeleteResult is the response from a Delete operation. Call its ExtractErr
 // method to determine whether the request succeeded.
 type DeleteResult struct {

--- a/openstack/reservation/v1/hosts/testing/doc.go
+++ b/openstack/reservation/v1/hosts/testing/doc.go
@@ -1,0 +1,2 @@
+// Package testing contains hosts unit tests.
+package testing

--- a/openstack/reservation/v1/hosts/testing/fixtures_test.go
+++ b/openstack/reservation/v1/hosts/testing/fixtures_test.go
@@ -1,0 +1,136 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gophercloud/gophercloud/v2/openstack/reservation/v1/hosts"
+	th "github.com/gophercloud/gophercloud/v2/testhelper"
+	"github.com/gophercloud/gophercloud/v2/testhelper/client"
+)
+
+const HostsListResult = `
+{
+  "hosts": [
+    {
+      "id": "18",
+      "vcpus": 20,
+      "cpu_info": "{\"arch\": \"x86_64\", \"model\": \"Broadwell-IBRS\", \"vendor\": \"Intel\", \"topology\": {\"cells\": 2, \"sockets\": 1, \"cores\": 10, \"threads\": 1}, \"maxphysaddr\": {\"mode\": \"emulate\", \"bits\": 46}, \"features\": [\"lm\", \"pcid\", \"sse4.2\", \"arat\", \"fpu\", \"ssbd\", \"md-clear\", \"acpi\", \"sse2\", \"fsgsbase\", \"sse4.1\", \"pae\", \"smap\", \"invpcid\", \"pge\", \"movbe\", \"tsc\", \"mtrr\", \"f16c\", \"vme\", \"tsc_adjust\", \"msr\", \"monitor\", \"ds_cpl\", \"est\", \"syscall\", \"avx\", \"nx\", \"adx\", \"clflush\", \"pni\", \"lahf_lm\", \"hle\", \"pdcm\", \"pat\", \"fxsr\", \"bmi1\", \"de\", \"bmi2\", \"popcnt\", \"mmx\", \"tm\", \"smep\", \"pse\", \"pbe\", \"apic\", \"fma\", \"rdseed\", \"smx\", \"sep\", \"xsave\", \"ssse3\", \"cmov\", \"mce\", \"ds\", \"abm\", \"stibp\", \"sse\", \"invtsc\", \"spec-ctrl\", \"xtpr\", \"ss\", \"pclmuldq\", \"avx2\", \"xsaveopt\", \"erms\", \"3dnowprefetch\", \"intel-pt\", \"aes\", \"rdtscp\", \"cx8\", \"tsc-deadline\", \"rtm\", \"mca\", \"pse36\", \"ht\", \"rdrand\", \"vmx\", \"flush-l1d\", \"dtes64\", \"dca\", \"cx16\", \"tm2\", \"x2apic\", \"pdpe1gb\"]}",
+      "hypervisor_type": "QEMU",
+      "hypervisor_version": 9000000,
+      "hypervisor_hostname": "compute-1.example.com",
+      "service_name": "compute-1.example.com",
+      "memory_mb": 128297,
+      "local_gb": 793,
+      "status": null,
+      "availability_zone": "nova",
+      "trust_id": "e07b8b0f5c1e4b4a9d3e2c1f0a9b8c7d",
+      "reservable": true,
+      "created_at": "2026-05-27 13:01:19",
+      "updated_at": null
+    }
+  ]
+}
+`
+
+const HostsListWithCapabilitiesResult = `
+{
+  "hosts": [
+    {
+      "id": "18",
+      "vcpus": 20,
+      "cpu_info": "{\"arch\": \"x86_64\", \"model\": \"Broadwell-IBRS\", \"vendor\": \"Intel\", \"topology\": {\"cells\": 2, \"sockets\": 1, \"cores\": 10, \"threads\": 1}, \"maxphysaddr\": {\"mode\": \"emulate\", \"bits\": 46}, \"features\": [\"lm\", \"pcid\", \"sse4.2\", \"arat\", \"fpu\", \"ssbd\", \"md-clear\", \"acpi\", \"sse2\", \"fsgsbase\", \"sse4.1\", \"pae\", \"smap\", \"invpcid\", \"pge\", \"movbe\", \"tsc\", \"mtrr\", \"f16c\", \"vme\", \"tsc_adjust\", \"msr\", \"monitor\", \"ds_cpl\", \"est\", \"syscall\", \"avx\", \"nx\", \"adx\", \"clflush\", \"pni\", \"lahf_lm\", \"hle\", \"pdcm\", \"pat\", \"fxsr\", \"bmi1\", \"de\", \"bmi2\", \"popcnt\", \"mmx\", \"tm\", \"smep\", \"pse\", \"pbe\", \"apic\", \"fma\", \"rdseed\", \"smx\", \"sep\", \"xsave\", \"ssse3\", \"cmov\", \"mce\", \"ds\", \"abm\", \"stibp\", \"sse\", \"invtsc\", \"spec-ctrl\", \"xtpr\", \"ss\", \"pclmuldq\", \"avx2\", \"xsaveopt\", \"erms\", \"3dnowprefetch\", \"intel-pt\", \"aes\", \"rdtscp\", \"cx8\", \"tsc-deadline\", \"rtm\", \"mca\", \"pse36\", \"ht\", \"rdrand\", \"vmx\", \"flush-l1d\", \"dtes64\", \"dca\", \"cx16\", \"tm2\", \"x2apic\", \"pdpe1gb\"]}",
+      "hypervisor_type": "QEMU",
+      "hypervisor_version": 9000000,
+      "hypervisor_hostname": "compute-1.example.com",
+      "service_name": "compute-1.example.com",
+      "memory_mb": 128297,
+      "local_gb": 793,
+      "status": null,
+      "availability_zone": "nova",
+      "trust_id": "e07b8b0f5c1e4b4a9d3e2c1f0a9b8c7d",
+      "reservable": true,
+      "created_at": "2026-05-27 13:01:19",
+      "updated_at": null,
+      "gpu": "a100",
+      "rack": "b12"
+    }
+  ]
+}
+`
+
+// CPUInfo is a sample cpu_info string.
+const CPUInfo = `{"arch": "x86_64", "model": "Broadwell-IBRS", "vendor": "Intel", "topology": {"cells": 2, "sockets": 1, "cores": 10, "threads": 1}, "maxphysaddr": {"mode": "emulate", "bits": 46}, "features": ["lm", "pcid", "sse4.2", "arat", "fpu", "ssbd", "md-clear", "acpi", "sse2", "fsgsbase", "sse4.1", "pae", "smap", "invpcid", "pge", "movbe", "tsc", "mtrr", "f16c", "vme", "tsc_adjust", "msr", "monitor", "ds_cpl", "est", "syscall", "avx", "nx", "adx", "clflush", "pni", "lahf_lm", "hle", "pdcm", "pat", "fxsr", "bmi1", "de", "bmi2", "popcnt", "mmx", "tm", "smep", "pse", "pbe", "apic", "fma", "rdseed", "smx", "sep", "xsave", "ssse3", "cmov", "mce", "ds", "abm", "stibp", "sse", "invtsc", "spec-ctrl", "xtpr", "ss", "pclmuldq", "avx2", "xsaveopt", "erms", "3dnowprefetch", "intel-pt", "aes", "rdtscp", "cx8", "tsc-deadline", "rtm", "mca", "pse36", "ht", "rdrand", "vmx", "flush-l1d", "dtes64", "dca", "cx16", "tm2", "x2apic", "pdpe1gb"]}`
+
+var ExpectedHost = hosts.Host{
+	ID:                 "18",
+	HypervisorHostname: "compute-1.example.com",
+	HypervisorType:     "QEMU",
+	HypervisorVersion:  9000000,
+	ServiceName:        "compute-1.example.com",
+	VCPUs:              20,
+	CPUInfo:            CPUInfo,
+	MemoryMB:           128297,
+	LocalGB:            793,
+	Status:             "",
+	AvailabilityZone:   "nova",
+	TrustID:            "e07b8b0f5c1e4b4a9d3e2c1f0a9b8c7d",
+	Reservable:         true,
+	CreatedAt:          time.Date(2026, 5, 27, 13, 1, 19, 0, time.UTC),
+	UpdatedAt:          nil,
+	ExtraCapabilities:  map[string]any{},
+}
+
+var ExpectedHostsList = []hosts.Host{ExpectedHost}
+
+var ExpectedHostWithCapabilities = hosts.Host{
+	ID:                 "18",
+	HypervisorHostname: "compute-1.example.com",
+	HypervisorType:     "QEMU",
+	HypervisorVersion:  9000000,
+	ServiceName:        "compute-1.example.com",
+	VCPUs:              20,
+	CPUInfo:            CPUInfo,
+	MemoryMB:           128297,
+	LocalGB:            793,
+	Status:             "",
+	AvailabilityZone:   "nova",
+	TrustID:            "e07b8b0f5c1e4b4a9d3e2c1f0a9b8c7d",
+	Reservable:         true,
+	CreatedAt:          time.Date(2026, 5, 27, 13, 1, 19, 0, time.UTC),
+	UpdatedAt:          nil,
+	ExtraCapabilities: map[string]any{
+		"gpu":  "a100",
+		"rack": "b12",
+	},
+}
+
+var ExpectedHostsListWithCapabilities = []hosts.Host{ExpectedHostWithCapabilities}
+
+func HandleListHosts(t *testing.T, fakeServer th.FakeServer) {
+	fakeServer.Mux.HandleFunc("/os-hosts",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "GET")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+
+			fmt.Fprint(w, HostsListResult)
+		})
+}
+
+func HandleListHostsWithCapabilities(t *testing.T, fakeServer th.FakeServer) {
+	fakeServer.Mux.HandleFunc("/os-hosts",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "GET")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+
+			fmt.Fprint(w, HostsListWithCapabilitiesResult)
+		})
+}

--- a/openstack/reservation/v1/hosts/testing/fixtures_test.go
+++ b/openstack/reservation/v1/hosts/testing/fixtures_test.go
@@ -192,6 +192,16 @@ func HandleCreateHost(t *testing.T, fakeServer th.FakeServer) {
 		})
 }
 
+func HandleDeleteHost(t *testing.T, fakeServer th.FakeServer) {
+	fakeServer.Mux.HandleFunc("/os-hosts/18",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "DELETE")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+			w.WriteHeader(http.StatusNoContent)
+		})
+}
+
 func HandleGetHost(t *testing.T, fakeServer th.FakeServer) {
 	fakeServer.Mux.HandleFunc("/os-hosts/18",
 		func(w http.ResponseWriter, r *http.Request) {

--- a/openstack/reservation/v1/hosts/testing/fixtures_test.go
+++ b/openstack/reservation/v1/hosts/testing/fixtures_test.go
@@ -117,6 +117,66 @@ const HostCreateResult = `
 }
 `
 
+const HostUpdateRequest = `
+{
+  "gpu": "h100"
+}
+`
+
+const HostUpdateResult = `
+{
+  "host": {
+    "id": "18",
+    "vcpus": 20,
+    "cpu_info": "{\"arch\": \"x86_64\", \"model\": \"Broadwell-IBRS\", \"vendor\": \"Intel\", \"topology\": {\"cells\": 2, \"sockets\": 1, \"cores\": 10, \"threads\": 1}, \"maxphysaddr\": {\"mode\": \"emulate\", \"bits\": 46}, \"features\": [\"lm\", \"pcid\", \"sse4.2\", \"arat\", \"fpu\", \"ssbd\", \"md-clear\", \"acpi\", \"sse2\", \"fsgsbase\", \"sse4.1\", \"pae\", \"smap\", \"invpcid\", \"pge\", \"movbe\", \"tsc\", \"mtrr\", \"f16c\", \"vme\", \"tsc_adjust\", \"msr\", \"monitor\", \"ds_cpl\", \"est\", \"syscall\", \"avx\", \"nx\", \"adx\", \"clflush\", \"pni\", \"lahf_lm\", \"hle\", \"pdcm\", \"pat\", \"fxsr\", \"bmi1\", \"de\", \"bmi2\", \"popcnt\", \"mmx\", \"tm\", \"smep\", \"pse\", \"pbe\", \"apic\", \"fma\", \"rdseed\", \"smx\", \"sep\", \"xsave\", \"ssse3\", \"cmov\", \"mce\", \"ds\", \"abm\", \"stibp\", \"sse\", \"invtsc\", \"spec-ctrl\", \"xtpr\", \"ss\", \"pclmuldq\", \"avx2\", \"xsaveopt\", \"erms\", \"3dnowprefetch\", \"intel-pt\", \"aes\", \"rdtscp\", \"cx8\", \"tsc-deadline\", \"rtm\", \"mca\", \"pse36\", \"ht\", \"rdrand\", \"vmx\", \"flush-l1d\", \"dtes64\", \"dca\", \"cx16\", \"tm2\", \"x2apic\", \"pdpe1gb\"]}",
+    "hypervisor_type": "QEMU",
+    "hypervisor_version": 9000000,
+    "hypervisor_hostname": "compute-1.example.com",
+    "service_name": "compute-1.example.com",
+    "memory_mb": 128297,
+    "local_gb": 793,
+    "status": null,
+    "availability_zone": "nova",
+    "trust_id": "e07b8b0f5c1e4b4a9d3e2c1f0a9b8c7d",
+    "reservable": true,
+    "created_at": "2026-05-27 13:01:19",
+    "updated_at": "2026-05-28 09:12:44",
+    "gpu": "h100",
+    "rack": "b12"
+  }
+}
+`
+
+// Blazar removes an extra capability when its value is explicitly null.
+const HostRemoveCapabilityRequest = `
+{
+  "gpu": null
+}
+`
+
+const HostRemoveCapabilityResult = `
+{
+  "host": {
+    "id": "18",
+    "vcpus": 20,
+    "cpu_info": "{\"arch\": \"x86_64\", \"model\": \"Broadwell-IBRS\", \"vendor\": \"Intel\", \"topology\": {\"cells\": 2, \"sockets\": 1, \"cores\": 10, \"threads\": 1}, \"maxphysaddr\": {\"mode\": \"emulate\", \"bits\": 46}, \"features\": [\"lm\", \"pcid\", \"sse4.2\", \"arat\", \"fpu\", \"ssbd\", \"md-clear\", \"acpi\", \"sse2\", \"fsgsbase\", \"sse4.1\", \"pae\", \"smap\", \"invpcid\", \"pge\", \"movbe\", \"tsc\", \"mtrr\", \"f16c\", \"vme\", \"tsc_adjust\", \"msr\", \"monitor\", \"ds_cpl\", \"est\", \"syscall\", \"avx\", \"nx\", \"adx\", \"clflush\", \"pni\", \"lahf_lm\", \"hle\", \"pdcm\", \"pat\", \"fxsr\", \"bmi1\", \"de\", \"bmi2\", \"popcnt\", \"mmx\", \"tm\", \"smep\", \"pse\", \"pbe\", \"apic\", \"fma\", \"rdseed\", \"smx\", \"sep\", \"xsave\", \"ssse3\", \"cmov\", \"mce\", \"ds\", \"abm\", \"stibp\", \"sse\", \"invtsc\", \"spec-ctrl\", \"xtpr\", \"ss\", \"pclmuldq\", \"avx2\", \"xsaveopt\", \"erms\", \"3dnowprefetch\", \"intel-pt\", \"aes\", \"rdtscp\", \"cx8\", \"tsc-deadline\", \"rtm\", \"mca\", \"pse36\", \"ht\", \"rdrand\", \"vmx\", \"flush-l1d\", \"dtes64\", \"dca\", \"cx16\", \"tm2\", \"x2apic\", \"pdpe1gb\"]}",
+    "hypervisor_type": "QEMU",
+    "hypervisor_version": 9000000,
+    "hypervisor_hostname": "compute-1.example.com",
+    "service_name": "compute-1.example.com",
+    "memory_mb": 128297,
+    "local_gb": 793,
+    "status": null,
+    "availability_zone": "nova",
+    "trust_id": "e07b8b0f5c1e4b4a9d3e2c1f0a9b8c7d",
+    "reservable": true,
+    "created_at": "2026-05-27 13:01:19",
+    "updated_at": "2026-05-28 09:12:44",
+    "rack": "b12"
+  }
+}
+`
+
 // CPUInfo is a sample cpu_info string.
 const CPUInfo = `{"arch": "x86_64", "model": "Broadwell-IBRS", "vendor": "Intel", "topology": {"cells": 2, "sockets": 1, "cores": 10, "threads": 1}, "maxphysaddr": {"mode": "emulate", "bits": 46}, "features": ["lm", "pcid", "sse4.2", "arat", "fpu", "ssbd", "md-clear", "acpi", "sse2", "fsgsbase", "sse4.1", "pae", "smap", "invpcid", "pge", "movbe", "tsc", "mtrr", "f16c", "vme", "tsc_adjust", "msr", "monitor", "ds_cpl", "est", "syscall", "avx", "nx", "adx", "clflush", "pni", "lahf_lm", "hle", "pdcm", "pat", "fxsr", "bmi1", "de", "bmi2", "popcnt", "mmx", "tm", "smep", "pse", "pbe", "apic", "fma", "rdseed", "smx", "sep", "xsave", "ssse3", "cmov", "mce", "ds", "abm", "stibp", "sse", "invtsc", "spec-ctrl", "xtpr", "ss", "pclmuldq", "avx2", "xsaveopt", "erms", "3dnowprefetch", "intel-pt", "aes", "rdtscp", "cx8", "tsc-deadline", "rtm", "mca", "pse36", "ht", "rdrand", "vmx", "flush-l1d", "dtes64", "dca", "cx16", "tm2", "x2apic", "pdpe1gb"]}`
 
@@ -189,6 +249,34 @@ func HandleCreateHost(t *testing.T, fakeServer th.FakeServer) {
 			w.WriteHeader(http.StatusCreated)
 
 			fmt.Fprint(w, HostCreateResult)
+		})
+}
+
+func HandleUpdateHost(t *testing.T, fakeServer th.FakeServer) {
+	fakeServer.Mux.HandleFunc("/os-hosts/18",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "PUT")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+			th.TestJSONRequest(t, r, HostUpdateRequest)
+
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+
+			fmt.Fprint(w, HostUpdateResult)
+		})
+}
+
+func HandleRemoveHostCapability(t *testing.T, fakeServer th.FakeServer) {
+	fakeServer.Mux.HandleFunc("/os-hosts/18",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "PUT")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+			th.TestJSONRequest(t, r, HostRemoveCapabilityRequest)
+
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+
+			fmt.Fprint(w, HostRemoveCapabilityResult)
 		})
 }
 

--- a/openstack/reservation/v1/hosts/testing/fixtures_test.go
+++ b/openstack/reservation/v1/hosts/testing/fixtures_test.go
@@ -85,6 +85,38 @@ const HostGetResult = `
 }
 `
 
+const HostCreateRequest = `
+{
+  "name": "compute-1.example.com",
+  "gpu": "a100",
+  "rack": "b12"
+}
+`
+
+const HostCreateResult = `
+{
+  "host": {
+    "id": "18",
+    "vcpus": 20,
+    "cpu_info": "{\"arch\": \"x86_64\", \"model\": \"Broadwell-IBRS\", \"vendor\": \"Intel\", \"topology\": {\"cells\": 2, \"sockets\": 1, \"cores\": 10, \"threads\": 1}, \"maxphysaddr\": {\"mode\": \"emulate\", \"bits\": 46}, \"features\": [\"lm\", \"pcid\", \"sse4.2\", \"arat\", \"fpu\", \"ssbd\", \"md-clear\", \"acpi\", \"sse2\", \"fsgsbase\", \"sse4.1\", \"pae\", \"smap\", \"invpcid\", \"pge\", \"movbe\", \"tsc\", \"mtrr\", \"f16c\", \"vme\", \"tsc_adjust\", \"msr\", \"monitor\", \"ds_cpl\", \"est\", \"syscall\", \"avx\", \"nx\", \"adx\", \"clflush\", \"pni\", \"lahf_lm\", \"hle\", \"pdcm\", \"pat\", \"fxsr\", \"bmi1\", \"de\", \"bmi2\", \"popcnt\", \"mmx\", \"tm\", \"smep\", \"pse\", \"pbe\", \"apic\", \"fma\", \"rdseed\", \"smx\", \"sep\", \"xsave\", \"ssse3\", \"cmov\", \"mce\", \"ds\", \"abm\", \"stibp\", \"sse\", \"invtsc\", \"spec-ctrl\", \"xtpr\", \"ss\", \"pclmuldq\", \"avx2\", \"xsaveopt\", \"erms\", \"3dnowprefetch\", \"intel-pt\", \"aes\", \"rdtscp\", \"cx8\", \"tsc-deadline\", \"rtm\", \"mca\", \"pse36\", \"ht\", \"rdrand\", \"vmx\", \"flush-l1d\", \"dtes64\", \"dca\", \"cx16\", \"tm2\", \"x2apic\", \"pdpe1gb\"]}",
+    "hypervisor_type": "QEMU",
+    "hypervisor_version": 9000000,
+    "hypervisor_hostname": "compute-1.example.com",
+    "service_name": "compute-1.example.com",
+    "memory_mb": 128297,
+    "local_gb": 793,
+    "status": null,
+    "availability_zone": "nova",
+    "trust_id": "e07b8b0f5c1e4b4a9d3e2c1f0a9b8c7d",
+    "reservable": true,
+    "created_at": "2026-05-27 13:01:19",
+    "updated_at": null,
+    "gpu": "a100",
+    "rack": "b12"
+  }
+}
+`
+
 // CPUInfo is a sample cpu_info string.
 const CPUInfo = `{"arch": "x86_64", "model": "Broadwell-IBRS", "vendor": "Intel", "topology": {"cells": 2, "sockets": 1, "cores": 10, "threads": 1}, "maxphysaddr": {"mode": "emulate", "bits": 46}, "features": ["lm", "pcid", "sse4.2", "arat", "fpu", "ssbd", "md-clear", "acpi", "sse2", "fsgsbase", "sse4.1", "pae", "smap", "invpcid", "pge", "movbe", "tsc", "mtrr", "f16c", "vme", "tsc_adjust", "msr", "monitor", "ds_cpl", "est", "syscall", "avx", "nx", "adx", "clflush", "pni", "lahf_lm", "hle", "pdcm", "pat", "fxsr", "bmi1", "de", "bmi2", "popcnt", "mmx", "tm", "smep", "pse", "pbe", "apic", "fma", "rdseed", "smx", "sep", "xsave", "ssse3", "cmov", "mce", "ds", "abm", "stibp", "sse", "invtsc", "spec-ctrl", "xtpr", "ss", "pclmuldq", "avx2", "xsaveopt", "erms", "3dnowprefetch", "intel-pt", "aes", "rdtscp", "cx8", "tsc-deadline", "rtm", "mca", "pse36", "ht", "rdrand", "vmx", "flush-l1d", "dtes64", "dca", "cx16", "tm2", "x2apic", "pdpe1gb"]}`
 
@@ -143,6 +175,20 @@ func HandleListHosts(t *testing.T, fakeServer th.FakeServer) {
 			w.WriteHeader(http.StatusOK)
 
 			fmt.Fprint(w, HostsListResult)
+		})
+}
+
+func HandleCreateHost(t *testing.T, fakeServer th.FakeServer) {
+	fakeServer.Mux.HandleFunc("/os-hosts",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "POST")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+			th.TestJSONRequest(t, r, HostCreateRequest)
+
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+
+			fmt.Fprint(w, HostCreateResult)
 		})
 }
 

--- a/openstack/reservation/v1/hosts/testing/fixtures_test.go
+++ b/openstack/reservation/v1/hosts/testing/fixtures_test.go
@@ -61,6 +61,30 @@ const HostsListWithCapabilitiesResult = `
 }
 `
 
+const HostGetResult = `
+{
+  "host": {
+    "id": "18",
+    "vcpus": 20,
+    "cpu_info": "{\"arch\": \"x86_64\", \"model\": \"Broadwell-IBRS\", \"vendor\": \"Intel\", \"topology\": {\"cells\": 2, \"sockets\": 1, \"cores\": 10, \"threads\": 1}, \"maxphysaddr\": {\"mode\": \"emulate\", \"bits\": 46}, \"features\": [\"lm\", \"pcid\", \"sse4.2\", \"arat\", \"fpu\", \"ssbd\", \"md-clear\", \"acpi\", \"sse2\", \"fsgsbase\", \"sse4.1\", \"pae\", \"smap\", \"invpcid\", \"pge\", \"movbe\", \"tsc\", \"mtrr\", \"f16c\", \"vme\", \"tsc_adjust\", \"msr\", \"monitor\", \"ds_cpl\", \"est\", \"syscall\", \"avx\", \"nx\", \"adx\", \"clflush\", \"pni\", \"lahf_lm\", \"hle\", \"pdcm\", \"pat\", \"fxsr\", \"bmi1\", \"de\", \"bmi2\", \"popcnt\", \"mmx\", \"tm\", \"smep\", \"pse\", \"pbe\", \"apic\", \"fma\", \"rdseed\", \"smx\", \"sep\", \"xsave\", \"ssse3\", \"cmov\", \"mce\", \"ds\", \"abm\", \"stibp\", \"sse\", \"invtsc\", \"spec-ctrl\", \"xtpr\", \"ss\", \"pclmuldq\", \"avx2\", \"xsaveopt\", \"erms\", \"3dnowprefetch\", \"intel-pt\", \"aes\", \"rdtscp\", \"cx8\", \"tsc-deadline\", \"rtm\", \"mca\", \"pse36\", \"ht\", \"rdrand\", \"vmx\", \"flush-l1d\", \"dtes64\", \"dca\", \"cx16\", \"tm2\", \"x2apic\", \"pdpe1gb\"]}",
+    "hypervisor_type": "QEMU",
+    "hypervisor_version": 9000000,
+    "hypervisor_hostname": "compute-1.example.com",
+    "service_name": "compute-1.example.com",
+    "memory_mb": 128297,
+    "local_gb": 793,
+    "status": null,
+    "availability_zone": "nova",
+    "trust_id": "e07b8b0f5c1e4b4a9d3e2c1f0a9b8c7d",
+    "reservable": true,
+    "created_at": "2026-05-27 13:01:19",
+    "updated_at": null,
+    "gpu": "a100",
+    "rack": "b12"
+  }
+}
+`
+
 // CPUInfo is a sample cpu_info string.
 const CPUInfo = `{"arch": "x86_64", "model": "Broadwell-IBRS", "vendor": "Intel", "topology": {"cells": 2, "sockets": 1, "cores": 10, "threads": 1}, "maxphysaddr": {"mode": "emulate", "bits": 46}, "features": ["lm", "pcid", "sse4.2", "arat", "fpu", "ssbd", "md-clear", "acpi", "sse2", "fsgsbase", "sse4.1", "pae", "smap", "invpcid", "pge", "movbe", "tsc", "mtrr", "f16c", "vme", "tsc_adjust", "msr", "monitor", "ds_cpl", "est", "syscall", "avx", "nx", "adx", "clflush", "pni", "lahf_lm", "hle", "pdcm", "pat", "fxsr", "bmi1", "de", "bmi2", "popcnt", "mmx", "tm", "smep", "pse", "pbe", "apic", "fma", "rdseed", "smx", "sep", "xsave", "ssse3", "cmov", "mce", "ds", "abm", "stibp", "sse", "invtsc", "spec-ctrl", "xtpr", "ss", "pclmuldq", "avx2", "xsaveopt", "erms", "3dnowprefetch", "intel-pt", "aes", "rdtscp", "cx8", "tsc-deadline", "rtm", "mca", "pse36", "ht", "rdrand", "vmx", "flush-l1d", "dtes64", "dca", "cx16", "tm2", "x2apic", "pdpe1gb"]}`
 
@@ -119,6 +143,19 @@ func HandleListHosts(t *testing.T, fakeServer th.FakeServer) {
 			w.WriteHeader(http.StatusOK)
 
 			fmt.Fprint(w, HostsListResult)
+		})
+}
+
+func HandleGetHost(t *testing.T, fakeServer th.FakeServer) {
+	fakeServer.Mux.HandleFunc("/os-hosts/18",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "GET")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+
+			fmt.Fprint(w, HostGetResult)
 		})
 }
 

--- a/openstack/reservation/v1/hosts/testing/requests_test.go
+++ b/openstack/reservation/v1/hosts/testing/requests_test.go
@@ -1,0 +1,49 @@
+package testing
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/v2/openstack/reservation/v1/hosts"
+	th "github.com/gophercloud/gophercloud/v2/testhelper"
+	"github.com/gophercloud/gophercloud/v2/testhelper/client"
+)
+
+func TestListHosts(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	HandleListHosts(t, fakeServer)
+
+	allPages, err := hosts.List(client.ServiceClient(fakeServer)).AllPages(context.TODO())
+	th.AssertNoErr(t, err)
+
+	actual, err := hosts.ExtractHosts(allPages)
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, ExpectedHostsList, actual)
+
+	// Blazar reports a null status and updated_at for an unmodified host.
+	th.AssertEquals(t, "", actual[0].Status)
+	th.AssertEquals(t, true, actual[0].UpdatedAt == nil)
+}
+
+// Blazar flattens extra capabilities into the host object.
+func TestListHostsWithCapabilities(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	HandleListHostsWithCapabilities(t, fakeServer)
+
+	allPages, err := hosts.List(client.ServiceClient(fakeServer)).AllPages(context.TODO())
+	th.AssertNoErr(t, err)
+
+	actual, err := hosts.ExtractHosts(allPages)
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, ExpectedHostsListWithCapabilities, actual)
+
+	// The timestamps are tagged "-"
+	_, ok := actual[0].ExtraCapabilities["created_at"]
+	th.AssertEquals(t, false, ok)
+	_, ok = actual[0].ExtraCapabilities["updated_at"]
+	th.AssertEquals(t, false, ok)
+}

--- a/openstack/reservation/v1/hosts/testing/requests_test.go
+++ b/openstack/reservation/v1/hosts/testing/requests_test.go
@@ -74,6 +74,47 @@ func TestGetHost(t *testing.T) {
 	th.AssertDeepEquals(t, &ExpectedHostWithCapabilities, actual)
 }
 
+func TestUpdateHost(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	HandleUpdateHost(t, fakeServer)
+
+	updateOpts := hosts.UpdateOpts{
+		ExtraCapabilities: map[string]any{"gpu": "h100"},
+	}
+
+	actual, err := hosts.Update(context.TODO(), client.ServiceClient(fakeServer), "18", updateOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, "h100", actual.ExtraCapabilities["gpu"])
+	th.AssertEquals(t, false, actual.UpdatedAt == nil)
+}
+
+// A nil capability must reach Blazar as an explicit null, which removes it.
+func TestUpdateHostRemoveCapability(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	HandleRemoveHostCapability(t, fakeServer)
+
+	updateOpts := hosts.UpdateOpts{
+		ExtraCapabilities: map[string]any{"gpu": nil},
+	}
+
+	actual, err := hosts.Update(context.TODO(), client.ServiceClient(fakeServer), "18", updateOpts).Extract()
+	th.AssertNoErr(t, err)
+
+	_, ok := actual.ExtraCapabilities["gpu"]
+	th.AssertEquals(t, false, ok)
+	th.AssertEquals(t, "b12", actual.ExtraCapabilities["rack"])
+}
+
+// Blazar rejects an empty body, so the request should not be sent at all.
+func TestUpdateHostWithoutCapabilities(t *testing.T) {
+	_, err := hosts.UpdateOpts{}.ToHostUpdateMap()
+	th.AssertEquals(t, true, err != nil)
+}
+
 func TestDeleteHost(t *testing.T) {
 	fakeServer := th.SetupHTTP()
 	defer fakeServer.Teardown()

--- a/openstack/reservation/v1/hosts/testing/requests_test.go
+++ b/openstack/reservation/v1/hosts/testing/requests_test.go
@@ -15,7 +15,7 @@ func TestListHosts(t *testing.T) {
 
 	HandleListHosts(t, fakeServer)
 
-	allPages, err := hosts.List(client.ServiceClient(fakeServer)).AllPages(context.TODO())
+	allPages, err := hosts.List(client.ServiceClient(fakeServer), hosts.ListOpts{}).AllPages(context.TODO())
 	th.AssertNoErr(t, err)
 
 	actual, err := hosts.ExtractHosts(allPages)
@@ -34,7 +34,7 @@ func TestListHostsWithCapabilities(t *testing.T) {
 
 	HandleListHostsWithCapabilities(t, fakeServer)
 
-	allPages, err := hosts.List(client.ServiceClient(fakeServer)).AllPages(context.TODO())
+	allPages, err := hosts.List(client.ServiceClient(fakeServer), hosts.ListOpts{}).AllPages(context.TODO())
 	th.AssertNoErr(t, err)
 
 	actual, err := hosts.ExtractHosts(allPages)

--- a/openstack/reservation/v1/hosts/testing/requests_test.go
+++ b/openstack/reservation/v1/hosts/testing/requests_test.go
@@ -74,6 +74,16 @@ func TestGetHost(t *testing.T) {
 	th.AssertDeepEquals(t, &ExpectedHostWithCapabilities, actual)
 }
 
+func TestDeleteHost(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	HandleDeleteHost(t, fakeServer)
+
+	err := hosts.Delete(context.TODO(), client.ServiceClient(fakeServer), "18").ExtractErr()
+	th.AssertNoErr(t, err)
+}
+
 // Blazar flattens extra capabilities into the host object.
 func TestListHostsWithCapabilities(t *testing.T) {
 	fakeServer := th.SetupHTTP()

--- a/openstack/reservation/v1/hosts/testing/requests_test.go
+++ b/openstack/reservation/v1/hosts/testing/requests_test.go
@@ -27,6 +27,17 @@ func TestListHosts(t *testing.T) {
 	th.AssertEquals(t, true, actual[0].UpdatedAt == nil)
 }
 
+func TestGetHost(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	HandleGetHost(t, fakeServer)
+
+	actual, err := hosts.Get(context.TODO(), client.ServiceClient(fakeServer), "18").Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, &ExpectedHostWithCapabilities, actual)
+}
+
 // Blazar flattens extra capabilities into the host object.
 func TestListHostsWithCapabilities(t *testing.T) {
 	fakeServer := th.SetupHTTP()

--- a/openstack/reservation/v1/hosts/testing/requests_test.go
+++ b/openstack/reservation/v1/hosts/testing/requests_test.go
@@ -27,6 +27,42 @@ func TestListHosts(t *testing.T) {
 	th.AssertEquals(t, true, actual[0].UpdatedAt == nil)
 }
 
+func TestCreateHost(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	HandleCreateHost(t, fakeServer)
+
+	createOpts := hosts.CreateOpts{
+		Name: "compute-1.example.com",
+		ExtraCapabilities: map[string]any{
+			"gpu":  "a100",
+			"rack": "b12",
+		},
+	}
+
+	actual, err := hosts.Create(context.TODO(), client.ServiceClient(fakeServer), createOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, &ExpectedHostWithCapabilities, actual)
+}
+
+// Blazar requires a name, so the request should not reach the server without one.
+func TestCreateHostWithoutName(t *testing.T) {
+	_, err := hosts.CreateOpts{}.ToHostCreateMap()
+	th.AssertEquals(t, true, err != nil)
+}
+
+// An extra capability must not be able to overwrite a host field.
+func TestCreateHostCapabilityCollision(t *testing.T) {
+	createOpts := hosts.CreateOpts{
+		Name:              "compute-1.example.com",
+		ExtraCapabilities: map[string]any{"name": "somethingelse"},
+	}
+
+	_, err := createOpts.ToHostCreateMap()
+	th.AssertEquals(t, true, err != nil)
+}
+
 func TestGetHost(t *testing.T) {
 	fakeServer := th.SetupHTTP()
 	defer fakeServer.Teardown()

--- a/openstack/reservation/v1/hosts/urls.go
+++ b/openstack/reservation/v1/hosts/urls.go
@@ -1,0 +1,7 @@
+package hosts
+
+import "github.com/gophercloud/gophercloud/v2"
+
+func listURL(client *gophercloud.ServiceClient) string {
+	return client.ServiceURL("os-hosts")
+}

--- a/openstack/reservation/v1/hosts/urls.go
+++ b/openstack/reservation/v1/hosts/urls.go
@@ -5,3 +5,7 @@ import "github.com/gophercloud/gophercloud/v2"
 func listURL(client *gophercloud.ServiceClient) string {
 	return client.ServiceURL("os-hosts")
 }
+
+func getURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL("os-hosts", id)
+}

--- a/openstack/reservation/v1/hosts/urls.go
+++ b/openstack/reservation/v1/hosts/urls.go
@@ -13,3 +13,7 @@ func getURL(client *gophercloud.ServiceClient, id string) string {
 func createURL(client *gophercloud.ServiceClient) string {
 	return client.ServiceURL("os-hosts")
 }
+
+func deleteURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL("os-hosts", id)
+}

--- a/openstack/reservation/v1/hosts/urls.go
+++ b/openstack/reservation/v1/hosts/urls.go
@@ -9,3 +9,7 @@ func listURL(client *gophercloud.ServiceClient) string {
 func getURL(client *gophercloud.ServiceClient, id string) string {
 	return client.ServiceURL("os-hosts", id)
 }
+
+func createURL(client *gophercloud.ServiceClient) string {
+	return client.ServiceURL("os-hosts")
+}

--- a/openstack/reservation/v1/hosts/urls.go
+++ b/openstack/reservation/v1/hosts/urls.go
@@ -14,6 +14,10 @@ func createURL(client *gophercloud.ServiceClient) string {
 	return client.ServiceURL("os-hosts")
 }
 
+func updateURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL("os-hosts", id)
+}
+
 func deleteURL(client *gophercloud.ServiceClient, id string) string {
 	return client.ServiceURL("os-hosts", id)
 }


### PR DESCRIPTION
For #3987

Adds the `hosts` package to the Reservation (Blazar) v1 service client, covering the Hosts suite of the [api-ref](https://docs.openstack.org/api-ref/reservation/v1/index.html#hosts):

| Operation |           Endpoint           | Status |
| --------- | ---------------------------- | ------ |
| `List`    | `GET /os-hosts`              | 200    |
| `Create`  | `POST /os-hosts`             | 201    |
| `Get`     | `GET /os-hosts/{host_id}`    | 200    |
| `Update`  | `PUT /os-hosts/{host_id}`    | 200    |
| `Delete`  | `DELETE /os-hosts/{host_id}` | 204    |

- The blueprint is mounted at `/v1/os-hosts` ([v1_0.py#L27][1])
- and the routes are [list][2], [create][3], [get][4], [update][5] and [delete][6]
- The status codes above are the defaults of the `Rest` helper ([utils.py#L47-L59][7]).

[1]: https://opendev.org/openstack/blazar/src/branch/stable/2026.1/blazar/api/v1/oshosts/v1_0.py#L27
[2]: https://opendev.org/openstack/blazar/src/branch/stable/2026.1/blazar/api/v1/oshosts/v1_0.py#L33-L36
[3]: https://opendev.org/openstack/blazar/src/branch/stable/2026.1/blazar/api/v1/oshosts/v1_0.py#L39-L42
[4]: https://opendev.org/openstack/blazar/src/branch/stable/2026.1/blazar/api/v1/oshosts/v1_0.py#L45-L49
[5]: https://opendev.org/openstack/blazar/src/branch/stable/2026.1/blazar/api/v1/oshosts/v1_0.py#L52-L61
[6]: https://opendev.org/openstack/blazar/src/branch/stable/2026.1/blazar/api/v1/oshosts/v1_0.py#L63-L68
[7]: https://opendev.org/openstack/blazar/src/branch/stable/2026.1/blazar/api/v1/utils.py#L47-L59
