### PR TITLE
identity: add RegionID to endpoints

### DIFF
--- a/openstack/identity/v3/endpoints/results.go
+++ b/openstack/identity/v3/endpoints/results.go
@@ -58,6 +58,9 @@ type Endpoint struct {
 	// Region is the region the Endpoint is located in.
 	Region string `json:"region"`
 
+	// RegionID is the ID of the region the Endpoint is located in.
+	RegionID string `json:"region_id"`
+
 	// ServiceID is the ID of the service the Endpoint refers to.
 	ServiceID string `json:"service_id"`
 

--- a/openstack/identity/v3/endpoints/testing/requests_test.go
+++ b/openstack/identity/v3/endpoints/testing/requests_test.go
@@ -92,6 +92,7 @@ func TestListEndpoints(t *testing.T) {
 					},
 					"name": "the-endiest-of-points",
 					"region": "underground",
+					"region_id": "region-12",
 					"service_id": "asdfasdfasdfasdf",
 					"url": "https://1.2.3.4:9000/",
 					"description": "List endpoint1 test"
@@ -105,6 +106,7 @@ func TestListEndpoints(t *testing.T) {
 					},
 					"name": "shhhh",
 					"region": "underground",
+					"region_id": "region-13",
 					"service_id": "asdfasdfasdfasdf",
 					"url": "https://1.2.3.4:9001/",
 					"description": "List endpoint2 test"
@@ -133,6 +135,7 @@ func TestListEndpoints(t *testing.T) {
 				Enabled:      true,
 				Name:         "the-endiest-of-points",
 				Region:       "underground",
+				RegionID:     "region-12",
 				ServiceID:    "asdfasdfasdfasdf",
 				URL:          "https://1.2.3.4:9000/",
 				Description:  "List endpoint1 test",
@@ -143,6 +146,7 @@ func TestListEndpoints(t *testing.T) {
 				Enabled:      false,
 				Name:         "shhhh",
 				Region:       "underground",
+				RegionID:     "region-13",
 				ServiceID:    "asdfasdfasdfasdf",
 				URL:          "https://1.2.3.4:9001/",
 				Description:  "List endpoint2 test",


### PR DESCRIPTION
This adds the missing `region_id` field to Identity v3 endpoint responses and covers it in the existing list test.

Fixes #3943

Tested: `go test ./openstack/identity/v3/endpoints/...`

Assisted by Codex