### PR TITLE
[v2] auth: support more scope cases in clouds.yaml parser

### DIFF
--- a/openstack/config/clouds/clouds.go
+++ b/openstack/config/clouds/clouds.go
@@ -154,20 +154,57 @@ func Parse(opts ...ParseOption) (gophercloud.AuthOptions, gophercloud.EndpointOp
 
 	endpointType := coalesce(options.endpointType, cloud.EndpointType, cloud.Interface)
 
+	// Build the scope with proper project domain separation
 	var scope *gophercloud.AuthScope
 	if trustID := cloud.AuthInfo.TrustID; trustID != "" {
 		scope = &gophercloud.AuthScope{
 			TrustID: trustID,
 		}
+	} else if systemScope := cloud.AuthInfo.SystemScope; systemScope != "" {
+		// System scoping for admin operations
+		if systemScope != "all" {
+			return gophercloud.AuthOptions{}, gophercloud.EndpointOpts{}, nil, fmt.Errorf("only system scope of all is supported")
+		}
+		scope = &gophercloud.AuthScope{
+			System: true,
+		}
+	} else if projectID := coalesce(options.projectID, cloud.AuthInfo.ProjectID); projectID != "" {
+		// Project scoping by ID
+		scope = &gophercloud.AuthScope{
+			ProjectID: projectID,
+		}
+	} else if projectName := coalesce(options.projectName, cloud.AuthInfo.ProjectName); projectName != "" {
+		// Project scoping by name requires project domain
+		scope = &gophercloud.AuthScope{
+			ProjectName: projectName,
+			// The follow UP PR will remove the fallback to
+			// DomainID and DomainName, and will require the user
+			// to specify the project domain explicitly.
+			DomainID:   coalesce(cloud.AuthInfo.ProjectDomainID, cloud.AuthInfo.DomainID),
+			DomainName: coalesce(cloud.AuthInfo.ProjectDomainName, cloud.AuthInfo.DomainName),
+		}
+	} else if domainID := coalesce(options.domainID, cloud.AuthInfo.DomainID); domainID != "" {
+		// Domain scoping by ID (when no project is specified)
+		scope = &gophercloud.AuthScope{
+			DomainID: domainID,
+		}
+	} else if domainName := coalesce(options.domainName, cloud.AuthInfo.DomainName); domainName != "" {
+		// Domain scoping by name (when no project is specified)
+		scope = &gophercloud.AuthScope{
+			DomainName: domainName,
+		}
 	}
 
 	return gophercloud.AuthOptions{
-			IdentityEndpoint:            coalesce(options.authURL, cloud.AuthInfo.AuthURL),
-			Username:                    coalesce(options.username, cloud.AuthInfo.Username),
-			UserID:                      coalesce(options.userID, cloud.AuthInfo.UserID),
-			Password:                    coalesce(options.password, cloud.AuthInfo.Password),
-			DomainID:                    coalesce(options.domainID, cloud.AuthInfo.UserDomainID, cloud.AuthInfo.ProjectDomainID, cloud.AuthInfo.DomainID),
-			DomainName:                  coalesce(options.domainName, cloud.AuthInfo.UserDomainName, cloud.AuthInfo.ProjectDomainName, cloud.AuthInfo.DomainName),
+			IdentityEndpoint: coalesce(options.authURL, cloud.AuthInfo.AuthURL),
+			Username:         coalesce(options.username, cloud.AuthInfo.Username),
+			UserID:           coalesce(options.userID, cloud.AuthInfo.UserID),
+			Password:         coalesce(options.password, cloud.AuthInfo.Password),
+			// The follow UP PR will remove the fallback to
+			// DomainID and DomainName, and will require the user
+			// to specify the project domain explicitly.
+			DomainID:                    coalesce(options.domainID, cloud.AuthInfo.UserDomainID, cloud.AuthInfo.DomainID),
+			DomainName:                  coalesce(options.domainName, cloud.AuthInfo.UserDomainName, cloud.AuthInfo.DomainName),
 			TenantID:                    coalesce(options.projectID, cloud.AuthInfo.ProjectID),
 			TenantName:                  coalesce(options.projectName, cloud.AuthInfo.ProjectName),
 			TokenID:                     coalesce(options.token, cloud.AuthInfo.Token),

--- a/openstack/config/clouds/clouds_test.go
+++ b/openstack/config/clouds/clouds_test.go
@@ -335,4 +335,428 @@ func TestParse(t *testing.T) {
 			t.Errorf("unexpected identity endpoint: %q", got)
 		}
 	})
+
+	t.Run("supports user in one domain and project in another domain using names", func(t *testing.T) {
+		const cloudsYAML = `clouds:
+  gophercloud-test:
+    auth:
+      auth_url: https://example.com:5000/v3
+      username: myuser
+      password: mypassword
+      user_domain_name: Default
+      project_name: myproject
+      project_domain_name: some_domain`
+
+		ao, _, _, err := clouds.Parse(
+			clouds.WithCloudsYAML(strings.NewReader(cloudsYAML)),
+			clouds.WithCloudName("gophercloud-test"),
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if got := ao.Username; got != "myuser" {
+			t.Errorf("unexpected username: %q", got)
+		}
+		if got := ao.DomainName; got != "Default" {
+			t.Errorf("unexpected user domain name: %q, expected 'Default'", got)
+		}
+		if got := ao.TenantName; got != "myproject" {
+			t.Errorf("unexpected project name: %q", got)
+		}
+		if ao.Scope == nil {
+			t.Fatal("expected Scope to be set")
+		}
+		if got := ao.Scope.ProjectName; got != "myproject" {
+			t.Errorf("unexpected scope project name: %q", got)
+		}
+		if got := ao.Scope.DomainName; got != "some_domain" {
+			t.Errorf("unexpected scope domain name: %q, expected 'some_domain'", got)
+		}
+	})
+
+	t.Run("supports user in one domain and project in another domain using IDs", func(t *testing.T) {
+		const cloudsYAML = `clouds:
+  gophercloud-test:
+    auth:
+      auth_url: https://example.com:5000/v3
+      username: myuser
+      password: mypassword
+      user_domain_id: default-domain-id
+      project_id: project-123
+      project_domain_id: other-domain-id`
+
+		ao, _, _, err := clouds.Parse(
+			clouds.WithCloudsYAML(strings.NewReader(cloudsYAML)),
+			clouds.WithCloudName("gophercloud-test"),
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if got := ao.Username; got != "myuser" {
+			t.Errorf("unexpected username: %q", got)
+		}
+		if got := ao.DomainID; got != "default-domain-id" {
+			t.Errorf("unexpected user domain ID: %q, expected 'default-domain-id'", got)
+		}
+		if got := ao.TenantID; got != "project-123" {
+			t.Errorf("unexpected project ID: %q", got)
+		}
+		if ao.Scope == nil {
+			t.Fatal("expected Scope to be set")
+		}
+		if got := ao.Scope.ProjectID; got != "project-123" {
+			t.Errorf("unexpected scope project ID: %q", got)
+		}
+		// When using project_id, the domain is not needed in scope
+		if ao.Scope.DomainID != "" {
+			t.Errorf("expected scope domain ID to be empty when using project_id, got: %q", ao.Scope.DomainID)
+		}
+	})
+
+	t.Run("falls back to domain_name for both user and project when specific domains not set", func(t *testing.T) {
+		const cloudsYAML = `clouds:
+  gophercloud-test:
+    auth:
+      auth_url: https://example.com:5000/v3
+      username: myuser
+      password: mypassword
+      domain_name: shared-domain
+      project_name: myproject`
+
+		ao, _, _, err := clouds.Parse(
+			clouds.WithCloudsYAML(strings.NewReader(cloudsYAML)),
+			clouds.WithCloudName("gophercloud-test"),
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if got := ao.Username; got != "myuser" {
+			t.Errorf("unexpected username: %q", got)
+		}
+		if got := ao.DomainName; got != "shared-domain" {
+			t.Errorf("unexpected user domain name: %q, expected 'shared-domain'", got)
+		}
+		if ao.Scope == nil {
+			t.Fatal("expected Scope to be set")
+		}
+		if got := ao.Scope.ProjectName; got != "myproject" {
+			t.Errorf("unexpected scope project name: %q", got)
+		}
+		if got := ao.Scope.DomainName; got != "shared-domain" {
+			t.Errorf("unexpected scope domain name: %q, expected 'shared-domain'", got)
+		}
+	})
+
+	t.Run("user_domain_name takes precedence over domain_name for user identity", func(t *testing.T) {
+		const cloudsYAML = `clouds:
+  gophercloud-test:
+    auth:
+      auth_url: https://example.com:5000/v3
+      username: myuser
+      password: mypassword
+      user_domain_name: user-specific-domain
+      domain_name: fallback-domain
+      project_name: myproject`
+
+		ao, _, _, err := clouds.Parse(
+			clouds.WithCloudsYAML(strings.NewReader(cloudsYAML)),
+			clouds.WithCloudName("gophercloud-test"),
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if got := ao.DomainName; got != "user-specific-domain" {
+			t.Errorf("unexpected user domain name: %q, expected 'user-specific-domain'", got)
+		}
+		if ao.Scope == nil {
+			t.Fatal("expected Scope to be set")
+		}
+		if got := ao.Scope.DomainName; got != "fallback-domain" {
+			t.Errorf("unexpected scope domain name: %q, expected 'fallback-domain'", got)
+		}
+	})
+
+	t.Run("project_domain_name takes precedence over domain_name for project scope", func(t *testing.T) {
+		const cloudsYAML = `clouds:
+  gophercloud-test:
+    auth:
+      auth_url: https://example.com:5000/v3
+      username: myuser
+      password: mypassword
+      domain_name: fallback-domain
+      project_name: myproject
+      project_domain_name: project-specific-domain`
+
+		ao, _, _, err := clouds.Parse(
+			clouds.WithCloudsYAML(strings.NewReader(cloudsYAML)),
+			clouds.WithCloudName("gophercloud-test"),
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if got := ao.DomainName; got != "fallback-domain" {
+			t.Errorf("unexpected user domain name: %q, expected 'fallback-domain'", got)
+		}
+		if ao.Scope == nil {
+			t.Fatal("expected Scope to be set")
+		}
+		if got := ao.Scope.DomainName; got != "project-specific-domain" {
+			t.Errorf("unexpected scope domain name: %q, expected 'project-specific-domain'", got)
+		}
+	})
+
+	t.Run("project_id scoping does not require domain information", func(t *testing.T) {
+		const cloudsYAML = `clouds:
+  gophercloud-test:
+    auth:
+      auth_url: https://example.com:5000/v3
+      username: myuser
+      password: mypassword
+      user_domain_name: Default
+      project_id: unique-project-id-123`
+
+		ao, _, _, err := clouds.Parse(
+			clouds.WithCloudsYAML(strings.NewReader(cloudsYAML)),
+			clouds.WithCloudName("gophercloud-test"),
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if ao.Scope == nil {
+			t.Fatal("expected Scope to be set")
+		}
+		if got := ao.Scope.ProjectID; got != "unique-project-id-123" {
+			t.Errorf("unexpected scope project ID: %q", got)
+		}
+		if ao.Scope.DomainID != "" || ao.Scope.DomainName != "" {
+			t.Errorf("expected no domain information in scope when using project_id, got DomainID=%q, DomainName=%q",
+				ao.Scope.DomainID, ao.Scope.DomainName)
+		}
+	})
+
+	t.Run("supports system_scope: all for system-level operations", func(t *testing.T) {
+		const cloudsYAML = `clouds:
+  gophercloud-test:
+    auth:
+      auth_url: https://example.com:5000/v3
+      username: admin
+      password: adminpassword
+      user_domain_name: Default
+      system_scope: all`
+
+		ao, _, _, err := clouds.Parse(
+			clouds.WithCloudsYAML(strings.NewReader(cloudsYAML)),
+			clouds.WithCloudName("gophercloud-test"),
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if got := ao.Username; got != "admin" {
+			t.Errorf("unexpected username: %q", got)
+		}
+		if got := ao.DomainName; got != "Default" {
+			t.Errorf("unexpected user domain name: %q", got)
+		}
+		if ao.Scope == nil {
+			t.Fatal("expected Scope to be set")
+		}
+		if !ao.Scope.System {
+			t.Error("expected Scope.System to be true")
+		}
+		if ao.Scope.ProjectID != "" || ao.Scope.ProjectName != "" {
+			t.Errorf("expected no project information in system scope, got ProjectID=%q, ProjectName=%q",
+				ao.Scope.ProjectID, ao.Scope.ProjectName)
+		}
+	})
+
+	t.Run("system_scope takes precedence over project scope", func(t *testing.T) {
+		const cloudsYAML = `clouds:
+  gophercloud-test:
+    auth:
+      auth_url: https://example.com:5000/v3
+      username: admin
+      password: adminpassword
+      user_domain_name: Default
+      system_scope: all
+      project_name: should-be-ignored
+      project_domain_name: also-ignored`
+
+		ao, _, _, err := clouds.Parse(
+			clouds.WithCloudsYAML(strings.NewReader(cloudsYAML)),
+			clouds.WithCloudName("gophercloud-test"),
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if ao.Scope == nil {
+			t.Fatal("expected Scope to be set")
+		}
+		if !ao.Scope.System {
+			t.Error("expected Scope.System to be true")
+		}
+		if ao.Scope.ProjectName != "" {
+			t.Errorf("expected project_name to be ignored when system_scope is set, got: %q", ao.Scope.ProjectName)
+		}
+	})
+
+	t.Run("fails system_scope when value is not all", func(t *testing.T) {
+		const cloudsYAML = `clouds:
+  gophercloud-test:
+    auth:
+      auth_url: https://example.com:5000/v3
+      username: myuser
+      password: mypassword
+      user_domain_name: Default
+      system_scope: something-else
+      project_name: myproject
+      project_domain_name: Default`
+
+		_, _, _, err := clouds.Parse(
+			clouds.WithCloudsYAML(strings.NewReader(cloudsYAML)),
+			clouds.WithCloudName("gophercloud-test"),
+		)
+		if err == nil {
+			t.Fatalf("an error expected, got nil")
+		}
+	})
+
+	t.Run("supports domain scoping by domain_id when no project specified", func(t *testing.T) {
+		const cloudsYAML = `clouds:
+  gophercloud-test:
+    auth:
+      auth_url: https://example.com:5000/v3
+      username: domainadmin
+      password: mypassword
+      user_domain_name: Default
+      domain_id: domain-123`
+
+		ao, _, _, err := clouds.Parse(
+			clouds.WithCloudsYAML(strings.NewReader(cloudsYAML)),
+			clouds.WithCloudName("gophercloud-test"),
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if got := ao.Username; got != "domainadmin" {
+			t.Errorf("unexpected username: %q", got)
+		}
+		if got := ao.DomainName; got != "Default" {
+			t.Errorf("unexpected user domain name: %q", got)
+		}
+		if ao.Scope == nil {
+			t.Fatal("expected Scope to be set")
+		}
+		if got := ao.Scope.DomainID; got != "domain-123" {
+			t.Errorf("unexpected scope domain ID: %q, expected 'domain-123'", got)
+		}
+		if ao.Scope.ProjectID != "" || ao.Scope.ProjectName != "" {
+			t.Errorf("expected no project in domain scope, got ProjectID=%q, ProjectName=%q",
+				ao.Scope.ProjectID, ao.Scope.ProjectName)
+		}
+	})
+
+	t.Run("supports domain scoping by domain_name when no project specified", func(t *testing.T) {
+		const cloudsYAML = `clouds:
+  gophercloud-test:
+    auth:
+      auth_url: https://example.com:5000/v3
+      username: domainadmin
+      password: mypassword
+      user_domain_name: UserDomain
+      domain_name: ScopeDomain`
+
+		ao, _, _, err := clouds.Parse(
+			clouds.WithCloudsYAML(strings.NewReader(cloudsYAML)),
+			clouds.WithCloudName("gophercloud-test"),
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if got := ao.Username; got != "domainadmin" {
+			t.Errorf("unexpected username: %q", got)
+		}
+		if got := ao.DomainName; got != "UserDomain" {
+			t.Errorf("unexpected user domain name: %q, expected 'UserDomain'", got)
+		}
+		if ao.Scope == nil {
+			t.Fatal("expected Scope to be set")
+		}
+		if got := ao.Scope.DomainName; got != "ScopeDomain" {
+			t.Errorf("unexpected scope domain name: %q, expected 'ScopeDomain'", got)
+		}
+		if ao.Scope.ProjectID != "" || ao.Scope.ProjectName != "" {
+			t.Errorf("expected no project in domain scope, got ProjectID=%q, ProjectName=%q",
+				ao.Scope.ProjectID, ao.Scope.ProjectName)
+		}
+	})
+
+	t.Run("project scope takes precedence over domain scope", func(t *testing.T) {
+		const cloudsYAML = `clouds:
+  gophercloud-test:
+    auth:
+      auth_url: https://example.com:5000/v3
+      username: myuser
+      password: mypassword
+      user_domain_name: Default
+      project_name: myproject
+      project_domain_name: ProjectDomain
+      domain_name: should-be-ignored`
+
+		ao, _, _, err := clouds.Parse(
+			clouds.WithCloudsYAML(strings.NewReader(cloudsYAML)),
+			clouds.WithCloudName("gophercloud-test"),
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if ao.Scope == nil {
+			t.Fatal("expected Scope to be set")
+		}
+		if got := ao.Scope.ProjectName; got != "myproject" {
+			t.Errorf("expected project scope, got ProjectName=%q", got)
+		}
+		if got := ao.Scope.DomainName; got != "ProjectDomain" {
+			t.Errorf("expected project domain in scope, got DomainName=%q", got)
+		}
+	})
+
+	t.Run("domain scoping with user_domain_id and domain_id", func(t *testing.T) {
+		const cloudsYAML = `clouds:
+  gophercloud-test:
+    auth:
+      auth_url: https://example.com:5000/v3
+      username: domainadmin
+      password: mypassword
+      user_domain_id: user-domain-id-123
+      domain_id: scope-domain-id-456`
+
+		ao, _, _, err := clouds.Parse(
+			clouds.WithCloudsYAML(strings.NewReader(cloudsYAML)),
+			clouds.WithCloudName("gophercloud-test"),
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if got := ao.DomainID; got != "user-domain-id-123" {
+			t.Errorf("unexpected user domain ID: %q, expected 'user-domain-id-123'", got)
+		}
+		if ao.Scope == nil {
+			t.Fatal("expected Scope to be set")
+		}
+		if got := ao.Scope.DomainID; got != "scope-domain-id-456" {
+			t.Errorf("unexpected scope domain ID: %q, expected 'scope-domain-id-456'", got)
+		}
+	})
 }


### PR DESCRIPTION
<!--
Prior to starting a PR, please make sure you have read our
[contributor tutorial](https://github.com/gophercloud/gophercloud/tree/main/docs/contributor-tutorial).

Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

-->
Fixes #3738



Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

Manual #3739 backport
