### PR TITLE
baremetal: account for different types of CPU.Frequency

### DIFF
--- a/openstack/baremetal/inventory/testing/fixtures.go
+++ b/openstack/baremetal/inventory/testing/fixtures.go
@@ -293,10 +293,11 @@ var Inventory = inventory.InventoryType{
 		PXEInterface:    "52:54:00:4e:3d:30",
 	},
 	CPU: inventory.CPUType{
-		Count:        2,
-		Flags:        []string{"fpu", "mmx", "fxsr", "sse", "sse2"},
-		Frequency:    "2100.084",
-		Architecture: "x86_64",
+		Count:         2,
+		Flags:         []string{"fpu", "mmx", "fxsr", "sse", "sse2"},
+		Frequency:     "2100.084",
+		Architecture:  "x86_64",
+		RealFrequency: "2100.084",
 	},
 	Disks: []inventory.RootDiskType{
 		{

--- a/openstack/baremetal/inventory/testing/types_test.go
+++ b/openstack/baremetal/inventory/testing/types_test.go
@@ -16,6 +16,25 @@ func TestInventory(t *testing.T) {
 		t.Fatalf("Failed to unmarshal inventory: %s", err)
 	}
 
+	output.Compat()
+	th.CheckDeepEquals(t, Inventory, output)
+}
+
+func TestFrequencyAsNumber(t *testing.T) {
+	var output inventory.InventoryType
+	sample := strings.Replace(InventorySample,
+		`"frequency": "2100.084"`,
+		`"frequency": 2100.084`, 1)
+	if sample == InventorySample {
+		t.Fatal("TestFrequencyAsNumber needs updating")
+	}
+
+	err := json.Unmarshal([]byte(sample), &output)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal inventory: %s", err)
+	}
+
+	output.Compat()
 	th.CheckDeepEquals(t, Inventory, output)
 }
 

--- a/openstack/baremetal/inventory/types.go
+++ b/openstack/baremetal/inventory/types.go
@@ -1,16 +1,19 @@
 package inventory
 
+import "encoding/json"
+
 type BootInfoType struct {
 	CurrentBootMode string `json:"current_boot_mode"`
 	PXEInterface    string `json:"pxe_interface"`
 }
 
 type CPUType struct {
-	Architecture string   `json:"architecture"`
-	Count        int      `json:"count"`
-	Flags        []string `json:"flags"`
-	Frequency    string   `json:"frequency"`
-	ModelName    string   `json:"model_name"`
+	Architecture  string      `json:"architecture"`
+	Count         int         `json:"count"`
+	Flags         []string    `json:"flags"`
+	Frequency     string      `json:"-"`
+	ModelName     string      `json:"model_name"`
+	RealFrequency json.Number `json:"frequency"`
 }
 
 type InterfaceType struct {
@@ -68,4 +71,8 @@ type InventoryType struct {
 	Memory       MemoryType       `json:"memory"`
 	SystemVendor SystemVendorType `json:"system_vendor"`
 	Hostname     string           `json:"hostname"`
+}
+
+func (inv *InventoryType) Compat() {
+	inv.CPU.Frequency = string(inv.CPU.RealFrequency)
 }

--- a/openstack/baremetal/v1/nodes/results.go
+++ b/openstack/baremetal/v1/nodes/results.go
@@ -657,6 +657,7 @@ func (pd PluginData) AsStandardData() (result inventory.StandardPluginData, err 
 // AsInspectorData interprets plugin data as coming from ironic-inspector.
 func (pd PluginData) AsInspectorData() (result introspection.Data, err error) {
 	err = json.Unmarshal(pd.RawMessage, &result)
+	result.Inventory.Compat()
 	return
 }
 
@@ -705,6 +706,7 @@ type InventoryResult struct {
 func (r InventoryResult) Extract() (*InventoryData, error) {
 	var data InventoryData
 	err := r.ExtractInto(&data)
+	data.Inventory.Compat()
 	return &data, err
 }
 

--- a/openstack/baremetalintrospection/v1/introspection/results.go
+++ b/openstack/baremetalintrospection/v1/introspection/results.go
@@ -193,6 +193,7 @@ type BaseInterfaceType struct {
 func (r DataResult) Extract() (*Data, error) {
 	var s Data
 	err := r.ExtractInto(&s)
+	s.Inventory.Compat()
 	return &s, err
 }
 


### PR DESCRIPTION
Ironic has two full-featured inspection implementations: via IPA
(in-band) and via Redfish. Unfortunately, the implementations disagreed
on the type of the Frequency field: IPA uses a string, while the Redfish
implementation returns a proper number.

We'll eventually clean it up on the Ironic side, but existing API
versions will have to live with this duality. This patch updates
Gophercloud to handle Frequency as a number of convert it to the current
string format, while also exposing the actual value.

Ref: https://bugs.launchpad.net/ironic/+bug/2166878

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
